### PR TITLE
Add per-agent behavior packs: an opt-in per-agent behavior layer

### DIFF
--- a/apps/api/alembic/versions/0005_behavior_packs.py
+++ b/apps/api/alembic/versions/0005_behavior_packs.py
@@ -1,0 +1,31 @@
+"""add per-agent behavior_packs column
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-07-06
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "agentos"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column("behavior_packs", postgresql.JSONB(), nullable=True),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "behavior_packs", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3,6 +3,16 @@
     "schemas": {
       "AgentCreate": {
         "properties": {
+          "behavior_packs": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BehaviorPacksConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "name": {
             "title": "Name",
             "type": "string"
@@ -32,6 +42,18 @@
       },
       "AgentOut": {
         "properties": {
+          "behavior_packs": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Behavior Packs"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
@@ -67,6 +89,7 @@
           "name",
           "slack_channel",
           "repo_full_name",
+          "behavior_packs",
           "created_at"
         ],
         "title": "AgentOut",
@@ -88,6 +111,37 @@
           }
         },
         "title": "AgentUpdate",
+        "type": "object"
+      },
+      "BehaviorPacksConfig": {
+        "description": "An agent's opt-in behavior packs. Validated on write and stored as JSON on\nthe agent row; the worker parses the same JSON at bind time.",
+        "properties": {
+          "greeting": {
+            "$ref": "#/components/schemas/GreetingPackConfig",
+            "default": {
+              "enabled": false,
+              "phrases": [],
+              "reply": ""
+            }
+          },
+          "help": {
+            "$ref": "#/components/schemas/HelpPackConfig",
+            "default": {
+              "enabled": false,
+              "phrases": [],
+              "reply": ""
+            }
+          },
+          "tips": {
+            "$ref": "#/components/schemas/TipsPackConfig",
+            "default": {
+              "enabled": false,
+              "tips": [],
+              "working_lines": []
+            }
+          }
+        },
+        "title": "BehaviorPacksConfig",
         "type": "object"
       },
       "Body_upload_bundle_agents__agent_id__versions__version_id__bundle_put": {
@@ -478,6 +532,31 @@
         "title": "EvalReportResult",
         "type": "object"
       },
+      "GreetingPackConfig": {
+        "description": "The deterministic greeting short-circuit content for one agent.",
+        "properties": {
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "phrases": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Phrases",
+            "type": "array"
+          },
+          "reply": {
+            "default": "",
+            "title": "Reply",
+            "type": "string"
+          }
+        },
+        "title": "GreetingPackConfig",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -489,6 +568,31 @@
           }
         },
         "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "HelpPackConfig": {
+        "description": "The deterministic help / \"what can you do\" short-circuit for one agent.",
+        "properties": {
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "phrases": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Phrases",
+            "type": "array"
+          },
+          "reply": {
+            "default": "",
+            "title": "Reply",
+            "type": "string"
+          }
+        },
+        "title": "HelpPackConfig",
         "type": "object"
       },
       "KillState": {
@@ -732,6 +836,34 @@
           "pods"
         ],
         "title": "RunnerPods",
+        "type": "object"
+      },
+      "TipsPackConfig": {
+        "description": "The \"working...\" acknowledgment content for one agent. Mirrors the worker's\nagentos_worker.behaviorpacks.TipsPack (packs ride on agent config, not the\nfrozen ACI contract, so the shape is duplicated across the layers the way\nBudgetConfig mirrors the ACI Budget).",
+        "properties": {
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "tips": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Tips",
+            "type": "array"
+          },
+          "working_lines": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Working Lines",
+            "type": "array"
+          }
+        },
+        "title": "TipsPackConfig",
         "type": "object"
       },
       "TraceTree": {
@@ -1288,6 +1420,132 @@
         "summary": "Update Agent",
         "tags": [
           "agents"
+        ]
+      }
+    },
+    "/agents/{agent_id}/behavior-packs": {
+      "get": {
+        "operationId": "get_behavior_packs_agents__agent_id__behavior_packs_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BehaviorPacksConfig"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Behavior Packs",
+        "tags": [
+          "control"
+        ]
+      },
+      "put": {
+        "operationId": "put_behavior_packs_agents__agent_id__behavior_packs_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BehaviorPacksConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BehaviorPacksConfig"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Behavior Packs",
+        "tags": [
+          "control"
         ]
       }
     },

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -1,6 +1,7 @@
 """Database access helpers for agents, versions, and deployments."""
 
 import uuid
+from typing import Any
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,6 +34,11 @@ async def create_agent(session: AsyncSession, data: AgentCreate) -> Agent:
         name=data.name,
         slack_channel=data.slack_channel,
         repo_full_name=data.repo_full_name,
+        behavior_packs=(
+            data.behavior_packs.model_dump()
+            if data.behavior_packs is not None
+            else None
+        ),
     )
     session.add(agent)
     await session.commit()
@@ -92,6 +98,15 @@ async def update_budget(
 ) -> Agent:
     agent.max_usd_per_day = max_usd_per_day
     agent.max_output_tokens_per_run = max_output_tokens_per_run
+    await session.commit()
+    await session.refresh(agent)
+    return agent
+
+
+async def update_behavior_packs(
+    session: AsyncSession, agent: Agent, behavior_packs: dict[str, Any] | None
+) -> Agent:
+    agent.behavior_packs = behavior_packs
     await session.commit()
     await session.refresh(agent)
     return agent

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -8,9 +8,10 @@ agent_versions.commit_sha, deployments.bot_identity/commit_sha).
 import enum
 import uuid
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy import Enum, ForeignKey, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .db import SCHEMA, Base
@@ -38,6 +39,15 @@ class Agent(Base):
     # NULL means platform defaults apply.
     max_usd_per_day: Mapped[float | None] = mapped_column(default=None)
     max_output_tokens_per_run: Mapped[int | None] = mapped_column(default=None)
+    # Per-agent behavior packs: declarative, opt-in UX touches the worker applies
+    # around a turn (a sampled "working..." line, a canned greeting reply). Stored
+    # as JSON here and resolved onto the deployment by the worker's binding layer;
+    # NULL means no packs (the platform default). The shape is validated by
+    # schemas.BehaviorPacksConfig on write and parsed by
+    # agentos_worker.behaviorpacks.BehaviorPacks on read.
+    behavior_packs: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, default=None
+    )
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 
     versions: Mapped[list["AgentVersion"]] = relationship(

--- a/apps/api/src/agentos_api/routers/control.py
+++ b/apps/api/src/agentos_api/routers/control.py
@@ -15,7 +15,7 @@ from ..auth import require_api_key
 from ..config import get_settings
 from ..deps import KillSwitchDep, LangfuseDep, SessionDep
 from ..models import Agent
-from ..schemas import BudgetConfig, CostReport, KillState
+from ..schemas import BehaviorPacksConfig, BudgetConfig, CostReport, KillState
 
 router = APIRouter(
     prefix="/agents/{agent_id}",
@@ -75,6 +75,26 @@ async def put_budget(
         config.max_output_tokens_per_run,
     )
     return BudgetConfig.model_validate(updated)
+
+
+@router.get("/behavior-packs", response_model=BehaviorPacksConfig)
+async def get_behavior_packs(
+    agent_id: uuid.UUID, session: SessionDep
+) -> BehaviorPacksConfig:
+    agent = await _load_agent(session, agent_id)
+    # NULL (no packs configured) reads as the all-off default.
+    if agent.behavior_packs is None:
+        return BehaviorPacksConfig()
+    return BehaviorPacksConfig.model_validate(agent.behavior_packs)
+
+
+@router.put("/behavior-packs", response_model=BehaviorPacksConfig)
+async def put_behavior_packs(
+    agent_id: uuid.UUID, config: BehaviorPacksConfig, session: SessionDep
+) -> BehaviorPacksConfig:
+    agent = await _load_agent(session, agent_id)
+    updated = await crud.update_behavior_packs(session, agent, config.model_dump())
+    return BehaviorPacksConfig.model_validate(updated.behavior_packs)
 
 
 @router.get("/cost", response_model=CostReport)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -9,10 +9,49 @@ from pydantic import BaseModel, ConfigDict, Field
 from .models import Environment
 
 
+class TipsPackConfig(BaseModel):
+    """The "working..." acknowledgment content for one agent. Mirrors the worker's
+    agentos_worker.behaviorpacks.TipsPack (packs ride on agent config, not the
+    frozen ACI contract, so the shape is duplicated across the layers the way
+    BudgetConfig mirrors the ACI Budget)."""
+
+    enabled: bool = False
+    working_lines: list[str] = []
+    tips: list[str] = []
+
+
+class GreetingPackConfig(BaseModel):
+    """The deterministic greeting short-circuit content for one agent."""
+
+    enabled: bool = False
+    phrases: list[str] = []
+    reply: str = ""
+
+
+class HelpPackConfig(BaseModel):
+    """The deterministic help / "what can you do" short-circuit for one agent."""
+
+    enabled: bool = False
+    phrases: list[str] = []
+    reply: str = ""
+
+
+class BehaviorPacksConfig(BaseModel):
+    """An agent's opt-in behavior packs. Validated on write and stored as JSON on
+    the agent row; the worker parses the same JSON at bind time."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    tips: TipsPackConfig = TipsPackConfig()
+    greeting: GreetingPackConfig = GreetingPackConfig()
+    help: HelpPackConfig = HelpPackConfig()
+
+
 class AgentCreate(BaseModel):
     name: str
     slack_channel: str
     repo_full_name: str | None = None
+    behavior_packs: BehaviorPacksConfig | None = None
 
 
 class AgentUpdate(BaseModel):
@@ -29,6 +68,7 @@ class AgentOut(BaseModel):
     name: str
     slack_channel: str
     repo_full_name: str | None
+    behavior_packs: dict[str, Any] | None
     created_at: datetime
 
 

--- a/apps/api/tests/test_behavior_packs_integration.py
+++ b/apps/api/tests/test_behavior_packs_integration.py
@@ -1,0 +1,78 @@
+"""Behavior-packs config round-trips through the API against real Postgres.
+
+Create-with-packs, GET default (null -> all-off), PUT then GET back. The worker
+reads this same JSON at bind time; the API's only job is to store and return it.
+"""
+
+from typing import Any
+
+
+def _create_agent(client: Any, auth_headers: dict[str, str], **body: Any) -> dict[str, Any]:
+    resp = client.post(
+        "/agents",
+        json={"name": "packs-bot", "slack_channel": "C-PACKS", **body},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()  # type: ignore[no-any-return]
+
+
+def test_agent_defaults_to_no_packs(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers)
+    assert agent["behavior_packs"] is None
+
+    # GET reads null as the all-off default rather than 404/empty.
+    resp = client.get(f"/agents/{agent['id']}/behavior-packs", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    packs = resp.json()
+    assert packs["tips"]["enabled"] is False
+    assert packs["greeting"]["enabled"] is False
+
+
+def test_create_with_packs_persists(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(
+        client,
+        auth_headers,
+        behavior_packs={
+            "greeting": {"enabled": True, "phrases": ["hi"], "reply": "yo"},
+        },
+    )
+    assert agent["behavior_packs"]["greeting"]["reply"] == "yo"
+
+    resp = client.get(f"/agents/{agent['id']}/behavior-packs", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["greeting"]["phrases"] == ["hi"]
+
+
+def test_put_then_get_round_trips(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers)
+    config = {
+        "tips": {
+            "enabled": True,
+            "working_lines": ["Working on it!"],
+            "tips": ["Ask me for the top 5"],
+        },
+        "greeting": {"enabled": True, "phrases": ["hey"], "reply": "hello!"},
+        "help": {"enabled": True, "phrases": ["help"], "reply": "here is help"},
+    }
+    resp = client.put(
+        f"/agents/{agent['id']}/behavior-packs", json=config, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = client.get(f"/agents/{agent['id']}/behavior-packs", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    got = resp.json()
+    assert got["tips"]["working_lines"] == ["Working on it!"]
+    assert got["greeting"]["reply"] == "hello!"
+    assert got["help"]["reply"] == "here is help"
+
+    # And it surfaces on the agent read model too.
+    resp = client.get(f"/agents/{agent['id']}", headers=auth_headers)
+    assert resp.json()["behavior_packs"]["tips"]["enabled"] is True

--- a/apps/worker/src/agentos_worker/behaviorpacks.py
+++ b/apps/worker/src/agentos_worker/behaviorpacks.py
@@ -1,0 +1,187 @@
+"""Behavior packs: declarative, per-agent UX touches applied around a turn.
+
+Touches an agent owner may want, that other owners may not:
+
+- a sampled "working..." line (optionally with a capability tip) shown while a
+  turn runs,
+- a canned reply to a bare greeting ("hi", "hey there team"), and
+- a canned reply to a bare help / "what can you do" request,
+
+each of the last two answered without a model call.
+
+The design principle: packs are DATA, not code. An agent's packs are stored as
+JSON on its ``agents`` row (apps/api) and resolved onto the deployment by the
+binding layer; the sampler and matchers here are platform-owned and
+byte-for-byte identical for every agent -- only the phrases/lines/reply vary per
+agent. Keeping packs declarative is deliberate: pack content never executes, so
+enabling a pack can never run an agent's code, and the sandbox-isolation
+guarantee holds without any pack ever crossing into the runner. It is also why
+some template batteries are NOT expressible as packs (they are code, or need a
+Block Kit reply model AgentOS does not have) -- see ``docs/behavior-packs.md``.
+
+Pure stdlib (unicodedata, re, zlib): no Slack, no model, no I/O. This module is
+the substrate; the kernel wiring that actually calls ``sample_tip`` /
+``match_greeting`` / ``match_help`` around a turn is a separate change to the F1
+"sacred" kernel and lands under that module's adversarial-review process (see
+``docs/behavior-packs.md``).
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+import zlib
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+# Words that may trail a greeting without making it a real request: "hey there",
+# "morning team". A greeting followed only by filler is still a bare greeting;
+# a greeting followed by anything else ("hi show me the report") is not, and
+# must fall through to the model. Kept small and platform-owned on purpose.
+_FILLER = frozenset({"there", "team", "all", "everyone", "folks", "yall", "guys", "peeps", "bot"})
+
+_NON_WORD = re.compile(r"[^a-z0-9\s]+")
+_WHITESPACE = re.compile(r"\s+")
+_RUN = re.compile(r"(.)\1{2,}")  # 3+ of the same char in a row
+
+
+class TipsPack(BaseModel):
+    """The "working..." acknowledgment content for one agent."""
+
+    model_config = ConfigDict(frozen=True)
+
+    enabled: bool = False
+    # Sampled for the first line ("Working on it!", "Crunching the numbers...").
+    working_lines: tuple[str, ...] = ()
+    # Sampled for an optional capability tip line ("I can rank leaks by $").
+    tips: tuple[str, ...] = ()
+
+
+class GreetingPack(BaseModel):
+    """The deterministic greeting short-circuit content for one agent."""
+
+    model_config = ConfigDict(frozen=True)
+
+    enabled: bool = False
+    # Trigger phrases/words, matched after normalization: "hi", "hey",
+    # "good morning", "what can you do".
+    phrases: tuple[str, ...] = ()
+    # The canned reply sent on a match (no model call).
+    reply: str = ""
+
+
+class HelpPack(BaseModel):
+    """The deterministic help / "what can you do" short-circuit for one agent.
+
+    Same shape as GreetingPack (this is the niceties battery's help half): a bare
+    help request gets a canned reply with no model call."""
+
+    model_config = ConfigDict(frozen=True)
+
+    enabled: bool = False
+    # Trigger phrases/words: "help", "commands", "what can you do".
+    phrases: tuple[str, ...] = ()
+    # The canned reply sent on a match (no model call).
+    reply: str = ""
+
+
+class BehaviorPacks(BaseModel):
+    """An agent's full set of packs; every field defaults to disabled/empty."""
+
+    model_config = ConfigDict(frozen=True)
+
+    tips: TipsPack = TipsPack()
+    greeting: GreetingPack = GreetingPack()
+    help: HelpPack = HelpPack()
+
+    @classmethod
+    def from_config(cls, data: Mapping[str, Any] | None) -> BehaviorPacks:
+        """Parse the JSON stored on an agent row; ``None``/empty -> all-off."""
+        if not data:
+            return cls()
+        return cls.model_validate(data)
+
+
+def _normalize(text: str) -> str:
+    """Casefold, strip accents/punctuation/emoji, collapse whitespace."""
+    folded = unicodedata.normalize("NFKD", text)
+    folded = "".join(ch for ch in folded if not unicodedata.combining(ch))
+    folded = _NON_WORD.sub(" ", folded.lower())
+    return _WHITESPACE.sub(" ", folded).strip()
+
+
+def _deelongate(norm: str) -> str:
+    """Collapse 3+ repeated chars to one: "hiiii" -> "hi", "sooo" -> "so"."""
+    return _RUN.sub(r"\1", norm)
+
+
+def _pick(seq: Sequence[str], seed: str, salt: str = "") -> str:
+    """Deterministically pick one item, rotated by ``seed`` (``salt`` lets two
+    lists vary independently off one seed). Empty ``seed`` -> the first item."""
+    if not seq:
+        return ""
+    if not seed:
+        return seq[0]
+    return seq[zlib.crc32(f"{salt}{seed}".encode()) % len(seq)]
+
+
+def _matches_bare(phrases: Sequence[str], text: str) -> bool:
+    """True if ``text`` is a *bare* utterance of one of ``phrases`` -- the phrase
+    alone, or the phrase then only filler ("hey there team"). A phrase glued to a
+    real request ("hi show me the report") is not bare and returns False, so it
+    falls through to the model. Deterministic; the shared core of the greeting and
+    help matchers."""
+    norm = _normalize(text)
+    if not norm:
+        return False
+    tokens = norm.split()
+    squeezed = _deelongate(norm).split()
+    for raw_phrase in phrases:
+        phrase = _normalize(raw_phrase)
+        if not phrase:
+            continue
+        ptoks = phrase.split()
+        n = len(ptoks)
+        # Try the elongation-collapsed tokens too so "hiiii" matches "hi".
+        for candidate in (tokens, squeezed):
+            if candidate[:n] == ptoks and all(t in _FILLER for t in candidate[n:]):
+                return True
+    return False
+
+
+def match_greeting(packs: BehaviorPacks, text: str) -> str | None:
+    """The canned reply if ``text`` is a bare greeting for this agent, else None.
+    Deterministic; never calls the model."""
+    pack = packs.greeting
+    if not pack.enabled or not pack.reply:
+        return None
+    return pack.reply if _matches_bare(pack.phrases, text) else None
+
+
+def match_help(packs: BehaviorPacks, text: str) -> str | None:
+    """The canned reply if ``text`` is a bare help request for this agent, else
+    None. Deterministic; never calls the model."""
+    pack = packs.help
+    if not pack.enabled or not pack.reply:
+        return None
+    return pack.reply if _matches_bare(pack.phrases, text) else None
+
+
+def sample_tip(packs: BehaviorPacks, seed: str) -> str | None:
+    """The sampled "working..." acknowledgment for this agent, or None if the
+    tips pack is disabled or has no content. ``seed`` (e.g. the inbound message
+    ts) makes the choice vary per message while staying reproducible."""
+    pack = packs.tips
+    if not pack.enabled:
+        return None
+    working = _pick(pack.working_lines, seed, salt="w:")
+    tip = _pick(pack.tips, seed, salt="t:")
+    if working and tip:
+        return f"{working}\n\nTip: {tip}"
+    if working:
+        return working
+    if tip:
+        return f"Tip: {tip}"
+    return None

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -26,13 +26,16 @@ coupling the worker to a Slack token.
 
 from __future__ import annotations
 
+import json
 import uuid
+from typing import Any
 
 from aci_protocol import Budget
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from .behaviorpacks import BehaviorPacks
 from .config import WorkerConfig
 
 # Env vars the worker injects into a bound sandbox claim. AGENTOS_BUNDLE_REF is
@@ -50,6 +53,7 @@ _RESOLVE_SQL = """
 SELECT a.id AS agent_id,
        a.max_usd_per_day AS max_usd_per_day,
        a.max_output_tokens_per_run AS max_output_tokens_per_run,
+       a.behavior_packs AS behavior_packs,
        v.id AS version_id,
        v.version_label AS version_label,
        v.bundle_ref AS bundle_ref
@@ -71,6 +75,9 @@ class ResolvedDeployment(BaseModel):
     bundle_ref: str | None
     max_usd_per_day: float | None
     max_output_tokens_per_run: int | None
+    # The agent's opt-in behavior packs (declarative JSON), or None for the
+    # all-off platform default. Parsed into a BehaviorPacks via packs_for().
+    behavior_packs: dict[str, Any] | None = None
 
 
 class BindingResolver:
@@ -88,7 +95,14 @@ class BindingResolver:
             row = result.mappings().first()
         if row is None:
             return None
-        return ResolvedDeployment.model_validate(dict(row))
+        data = dict(row)
+        # asyncpg returns JSONB as a str for a raw-text SELECT (no column type to
+        # trigger SQLAlchemy's json deserializer); decode it to the dict the model
+        # expects. A dict (or None) passes through untouched.
+        packs = data.get("behavior_packs")
+        if isinstance(packs, str):
+            data["behavior_packs"] = json.loads(packs)
+        return ResolvedDeployment.model_validate(data)
 
     async def repo_full_name(self, agent_id: uuid.UUID) -> str | None:
         """The agent's GitHub repo (owner/name), for the eval PR-check report."""
@@ -100,6 +114,14 @@ class BindingResolver:
             return None
         value: str | None = row[0]
         return value
+
+    def packs_for(self, resolved: ResolvedDeployment) -> BehaviorPacks:
+        """The agent's parsed behavior packs (all-off when none are configured).
+
+        The kernel wiring that samples a working line / short-circuits a greeting
+        consumes this; it is a separate, F1-reviewed change (docs/behavior-packs.md).
+        """
+        return BehaviorPacks.from_config(resolved.behavior_packs)
 
     def budget_for(self, resolved: ResolvedDeployment) -> Budget:
         """The AGENTOS_BUDGET for the agent, applying platform defaults for NULLs."""

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -226,6 +226,82 @@ def test_deployment_pointing_at_another_agents_version_does_not_resolve() -> Non
     asyncio.run(go())
 
 
+def test_behavior_packs_round_trip_and_parse() -> None:
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            try:
+                async with engine.connect():
+                    pass
+            except SQLAlchemyError as exc:
+                pytest.skip(f"Postgres not reachable: {exc}")
+
+            token = uuid.uuid4().hex[:8]
+            channel = f"C-{token}"
+            agent_id = await _seed_agent(
+                engine, channel=channel, name=f"agent-{token}", max_usd=None, max_tokens=None
+            )
+            packs_json = (
+                '{"greeting": {"enabled": true, "phrases": ["hi"], "reply": "yo"}, '
+                '"tips": {"enabled": false, "working_lines": [], "tips": []}}'
+            )
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        f"UPDATE {_SCHEMA}.agents SET behavior_packs = CAST(:p AS jsonb) "
+                        "WHERE id = :id"
+                    ),
+                    {"p": packs_json, "id": agent_id},
+                )
+            await _seed_deployment(
+                engine, agent_id=agent_id, environment="prod", bundle_ref="bundles/x.zip"
+            )
+
+            resolved = await _resolver(engine).resolve(channel)
+            assert resolved is not None
+            packs = _resolver(engine).packs_for(resolved)
+            assert packs.greeting.enabled is True
+            assert packs.greeting.reply == "yo"
+
+            await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_no_packs_parses_to_all_off_default() -> None:
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            try:
+                async with engine.connect():
+                    pass
+            except SQLAlchemyError as exc:
+                pytest.skip(f"Postgres not reachable: {exc}")
+
+            token = uuid.uuid4().hex[:8]
+            channel = f"C-{token}"
+            agent_id = await _seed_agent(
+                engine, channel=channel, name=f"agent-{token}", max_usd=None, max_tokens=None
+            )
+            await _seed_deployment(
+                engine, agent_id=agent_id, environment="dev", bundle_ref="bundles/x.zip"
+            )
+            resolved = await _resolver(engine).resolve(channel)
+            assert resolved is not None
+            assert resolved.behavior_packs is None
+            packs = _resolver(engine).packs_for(resolved)
+            assert packs.greeting.enabled is False
+            assert packs.tips.enabled is False
+
+            await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
 def test_unknown_channel_resolves_to_none() -> None:
     async def go() -> None:
         engine = create_async_engine(_DB_URL)

--- a/apps/worker/tests/test_behaviorpacks.py
+++ b/apps/worker/tests/test_behaviorpacks.py
@@ -1,0 +1,169 @@
+"""Unit tests for the behavior-pack sampler and greeting matcher (pure, no stack).
+
+These pin the two properties that make packs safe as a per-agent, platform-owned
+feature: the greeting short-circuit fires only on a *bare* greeting (never on a
+greeting glued to a real request), and tip sampling is deterministic per seed.
+"""
+
+from __future__ import annotations
+
+from agentos_worker.behaviorpacks import (
+    BehaviorPacks,
+    GreetingPack,
+    HelpPack,
+    TipsPack,
+    match_greeting,
+    match_help,
+    sample_tip,
+)
+
+_GREETING = GreetingPack(
+    enabled=True,
+    phrases=("hi", "hey", "hello", "good morning", "what can you do"),
+    reply="Hi! Ask me about revenue leaks.",
+)
+
+
+def _packs(
+    *,
+    greeting: GreetingPack | None = None,
+    tips: TipsPack | None = None,
+    help: HelpPack | None = None,
+) -> BehaviorPacks:
+    return BehaviorPacks(
+        greeting=greeting or GreetingPack(),
+        tips=tips or TipsPack(),
+        help=help or HelpPack(),
+    )
+
+
+# -- greeting matcher ---------------------------------------------------------
+
+
+def test_bare_greeting_matches() -> None:
+    packs = _packs(greeting=_GREETING)
+    assert match_greeting(packs, "hi") == _GREETING.reply
+    assert match_greeting(packs, "Hey!") == _GREETING.reply
+    assert match_greeting(packs, "good morning") == _GREETING.reply
+
+
+def test_greeting_then_only_filler_matches() -> None:
+    packs = _packs(greeting=_GREETING)
+    assert match_greeting(packs, "hey there team") == _GREETING.reply
+    assert match_greeting(packs, "hello everyone") == _GREETING.reply
+
+
+def test_elongated_greeting_matches() -> None:
+    packs = _packs(greeting=_GREETING)
+    assert match_greeting(packs, "hiiii") == _GREETING.reply
+    assert match_greeting(packs, "heyyy there") == _GREETING.reply
+
+
+def test_greeting_glued_to_request_falls_through() -> None:
+    # The load-bearing negative: this must reach the model, not the canned reply.
+    packs = _packs(greeting=_GREETING)
+    assert match_greeting(packs, "hi show me the report") is None
+    assert match_greeting(packs, "hey what leaked last quarter") is None
+
+
+def test_intro_question_matches_only_when_a_phrase() -> None:
+    packs = _packs(greeting=_GREETING)
+    assert match_greeting(packs, "what can you do") == _GREETING.reply
+    # Not a configured phrase -> falls through.
+    assert match_greeting(packs, "who are you") is None
+
+
+def test_disabled_or_empty_pack_never_matches() -> None:
+    assert match_greeting(_packs(), "hi") is None
+    disabled = GreetingPack(enabled=False, phrases=("hi",), reply="x")
+    assert match_greeting(_packs(greeting=disabled), "hi") is None
+    # Enabled but no reply configured -> nothing to send.
+    no_reply = GreetingPack(enabled=True, phrases=("hi",), reply="")
+    assert match_greeting(_packs(greeting=no_reply), "hi") is None
+
+
+def test_empty_message_never_matches() -> None:
+    assert match_greeting(_packs(greeting=_GREETING), "   ") is None
+
+
+# -- help matcher (shares the bare-match core with greeting) ------------------
+
+_HELP = HelpPack(
+    enabled=True,
+    phrases=("help", "commands", "what can you do"),
+    reply="Here is what I can do: ...",
+)
+
+
+def test_bare_help_matches() -> None:
+    packs = _packs(help=_HELP)
+    assert match_help(packs, "help") == _HELP.reply
+    assert match_help(packs, "Commands?") == _HELP.reply
+    assert match_help(packs, "what can you do") == _HELP.reply
+
+
+def test_help_glued_to_request_falls_through() -> None:
+    assert match_help(_packs(help=_HELP), "help me reconcile the invoices") is None
+
+
+def test_help_and_greeting_are_independent() -> None:
+    # A help pack does not answer greetings and vice versa.
+    packs = _packs(help=_HELP, greeting=_GREETING)
+    assert match_help(packs, "hi") is None
+    assert match_greeting(packs, "help") is None
+
+
+def test_help_disabled_or_empty_never_matches() -> None:
+    assert match_help(_packs(), "help") is None
+    no_reply = HelpPack(enabled=True, phrases=("help",), reply="")
+    assert match_help(_packs(help=no_reply), "help") is None
+
+
+# -- tip sampler --------------------------------------------------------------
+
+_TIPS = TipsPack(
+    enabled=True,
+    working_lines=("Working on it!", "Crunching the numbers..."),
+    tips=("I can rank leaks by recoverable $", "Ask me for the top 5"),
+)
+
+
+def test_sample_tip_is_deterministic_per_seed() -> None:
+    packs = _packs(tips=_TIPS)
+    assert sample_tip(packs, "ts-123") == sample_tip(packs, "ts-123")
+
+
+def test_sample_tip_varies_across_seeds() -> None:
+    packs = _packs(tips=_TIPS)
+    seen = {sample_tip(packs, f"ts-{i}") for i in range(20)}
+    assert len(seen) > 1  # not a constant
+
+
+def test_sample_tip_composes_working_line_and_tip() -> None:
+    out = sample_tip(_packs(tips=_TIPS), "seed")
+    assert out is not None
+    assert "\n\nTip: " in out
+    first = out.split("\n\n", 1)[0]
+    assert first in _TIPS.working_lines
+
+
+def test_sample_tip_disabled_or_empty_returns_none() -> None:
+    assert sample_tip(_packs(), "seed") is None
+    assert sample_tip(_packs(tips=TipsPack(enabled=True)), "seed") is None
+
+
+def test_sample_tip_working_only_and_tip_only() -> None:
+    working_only = TipsPack(enabled=True, working_lines=("Just a sec",))
+    assert sample_tip(_packs(tips=working_only), "s") == "Just a sec"
+    tip_only = TipsPack(enabled=True, tips=("Try /help",))
+    assert sample_tip(_packs(tips=tip_only), "s") == "Tip: Try /help"
+
+
+def test_from_config_roundtrip_and_none() -> None:
+    assert BehaviorPacks.from_config(None) == BehaviorPacks()
+    assert BehaviorPacks.from_config({}) == BehaviorPacks()
+    parsed = BehaviorPacks.from_config(
+        {"greeting": {"enabled": True, "phrases": ["hi"], "reply": "yo"}}
+    )
+    assert parsed.greeting.enabled is True
+    assert match_greeting(parsed, "hi") == "yo"

--- a/docs/behavior-packs.md
+++ b/docs/behavior-packs.md
@@ -1,0 +1,122 @@
+# Behavior packs
+
+Per-agent, opt-in UX touches applied around a turn, so an agent owner can enable
+them for their deployments without imposing them on every other agent on the
+install:
+
+- **tips** -- a sampled "working..." line (optionally with a capability tip)
+  shown while a turn runs.
+- **greeting** -- a canned reply to a *bare* greeting ("hi", "hey there team")
+  that never calls the model.
+- **help** -- a canned reply to a *bare* help / "what can you do" request, also
+  without a model call (the niceties battery's help half).
+
+These three are illustrative, not the point. The point is the mechanism: a
+per-agent, opt-in, declarative config layer, resolved at bind time, that an owner
+enables for their own deployments with no effect on any other agent. New pack
+types slot into the same mechanism. The battery-by-battery mapping below shows
+which of the template's all-agent features do and do not fit it, and why.
+
+## Why packs are declarative data, not code
+
+A pack is JSON on the agent's row: phrases, working lines, a reply string. The
+sampler and greeting matcher (`agentos_worker.behaviorpacks`) are platform-owned
+and identical for every agent; only the data varies. This is deliberate: pack
+content never executes, so enabling a pack can never run an agent's code, and the
+sandbox-isolation guarantee holds without any pack crossing into the runner. If a
+future pack needs real logic, that logic must run inside the sandbox, not in the
+worker.
+
+## What is built (this PR)
+
+The substrate, end to end, minus the kernel call sites:
+
+- **Storage + API** (`apps/api`): a nullable `agents.behavior_packs` JSONB column
+  (migration `0005`), validated by `schemas.BehaviorPacksConfig`, accepted on
+  `POST /agents`, and read/written via `GET|PUT /agents/{id}/behavior-packs`
+  (mirrors the budget control endpoints). NULL reads as all-off.
+- **Logic** (`apps/worker/behaviorpacks.py`): `sample_tip(packs, seed)`,
+  `match_greeting(packs, text)`, and `match_help(packs, text)`, pure stdlib,
+  fully unit-tested. The two matchers share one bare-utterance core: they return
+  a reply only for a phrase said alone (or with trailing filler); a phrase glued
+  to a real request ("hi show me the report") returns `None` and falls through to
+  the model.
+- **Binding** (`apps/worker/binding.py`, not the sacred kernel): the resolver
+  now selects `behavior_packs`, carries it on `ResolvedDeployment`, and exposes
+  `BindingResolver.packs_for(resolved) -> BehaviorPacks`.
+
+## What is NOT built: the kernel wiring (needs F1 review)
+
+Both touches fire from inside `apps/worker/kernel.py`, which is the F1 "sacred"
+module: any change needs the escalated adversarial review (spec-vs-impl +
+side-effects-detective) per `apps/worker/CLAUDE.md`. The greeting short-circuit
+also brushes against kernel rule 3 ("the kernel never keyword-guesses intent"),
+so it must be reviewed as a deliberate, scoped exception, not slipped in. It is
+intentionally left out of this PR.
+
+The intended integration points, once that review is scheduled:
+
+1. **Greeting / help short-circuit** -- in `Kernel.process_event`, after binding
+   resolves (`resolved`/`agent_id` are known) and after the kill-switch gate,
+   before the retry loop:
+
+   ```python
+   packs = self._binding.packs_for(resolved)
+   reply = match_greeting(packs, qevent.text) or match_help(packs, qevent.text)
+   if reply is not None:
+       await self._drop_with_message(qevent, reply)   # edits placeholder, marks done
+       return
+   ```
+
+   This replies from the already-posted placeholder and never claims a sandbox
+   or calls the model -- a strict cost win on trivial turns. It runs only for a
+   *new* turn (a follow-up mid-thread is still a steer; do not short-circuit a
+   thread with a live turn).
+
+2. **Tips first-edit** -- in `Kernel._consume`, seed the `_ThrottledReply` with
+   the sampled working line so the dispatcher's generic placeholder is replaced
+   by the per-agent line before the first `text_delta` arrives:
+
+   ```python
+   opener = sample_tip(packs, qevent.thread_ts)
+   if opener is not None:
+       await self._sink.update(channel=..., ts=qevent.placeholder_ts, text=opener)
+   ```
+
+   `packs` must be threaded from `process_event` (where binding resolved) into
+   `_attempt`/`_consume`; keep the sampler call out of the streaming hot path
+   (compute the opener once, before the stream loop).
+
+Both call sites consume only `behaviorpacks` pure functions and the binding
+already built here, so the F1 diff is small and free of new control-flow races.
+
+## Every template battery, mapped to this mechanism
+
+The packs mechanism was designed against the full set of "all-agent" batteries in
+the CurieTech agent templates (`agent-ss-template`, `agent-mcp-template`,
+`agentkit`, and the newer batteries in `revenue-leak-agent`). The point of packs
+is the *declarative, per-agent, opt-in* subset. The table records where each
+battery lands, because "make everything a pack" is the wrong goal: a pack is data
+consumed by platform code, so a battery that is itself code, or that AgentOS
+already provides, or that needs a reply model AgentOS does not have, is not a
+pack.
+
+| Battery | Disposition | Why |
+|---|---|---|
+| Working status / tips | **Pack** (`tips`) | Pure data (lines + tips) sampled by a platform function. Shipped. |
+| Greeting detection | **Pack** (`greeting`) | Data (phrases + reply), deterministic pre-model matcher. Shipped. |
+| Help / "what can you do" | **Pack** (`help`) | Same shape as greeting; the niceties battery's help half. Shipped. |
+| Runtime settings / knobs | **Candidate pack (schema only)** | The editable-settings allowlist is declarative and could be a pack; the store + live-override + edit UI is a stateful subsystem that overlaps AgentOS budgets/config. Deferred. |
+| Kill switch / control | **Already native** | AgentOS has it: `apps/worker/killswitch.py` + `Kernel` kill gate + the `/agents/{id}/kill` control endpoint. A pack would duplicate it. |
+| Activity log | **Already native (observability)** | Post-model observation is Langfuse tracing; the Slack "activity" ring buffer is stateful UI code, not declarative data. |
+| Logging setup | **Not per-agent** | Pure infra, identical for every agent; belongs to the platform, not a pack. |
+| Block Kit rendering | **Not applicable** | AgentOS streams text + `chat_update` mrkdwn; there is no structured `Reply` object to render. Would need a Block Kit reply model first. |
+| Navigation (back/up) | **Not applicable** | Presupposes the Block Kit `Reply` model above. |
+| HTTP backoff, vision, polling-worker | **Runner/plugin code** | These are agentkit *libraries*. As packs they would run battery code in the worker, breaking sandbox isolation. They belong in the runner/plugin. |
+| Integrations (Jira/NetSuite/CPQ) | **MCP servers** | External-system connectors are the plugin's `.mcp.json` surface in AgentOS, not declarative UX data. |
+| Proactive notifier / digest | **Domain logic** | Revenue-leak's alerting policy; not a reusable battery. |
+
+The throughline: the moment a battery needs to *run agent-authored logic*, it
+stops being a pack and must live in the sandboxed runner (or already lives in the
+platform). Packs deliberately cover only the declarative, deterministic slice --
+that is what keeps them safe to resolve and apply outside the sandbox.


### PR DESCRIPTION
## The point of this PR: a per-agent, opt-in behavior layer

AgentOS runs every agent on one shared runtime (the runner + worker below the ACI port). That is right for genuinely universal concerns (kill switch, tracing, sandboxing), but it leaves **opinionated, per-agent behavior with no home**: a touch like the Slack placeholder is a single global config, and there is no per-agent hook at all. So an owner who wants some behavior for *their* agent can only force it on *every* agent on the install, or go without.

This PR adds the missing layer: **behavior packs** — a per-agent, opt-in, declarative config an owner enables for their own deployments, resolved at bind time, with no effect on anyone else's agent. It is designed to grow: new pack types slot into the same mechanism.

**The example packs are not the point.** `tips`, `greeting`, and `help` are three seed pack types included to exercise the mechanism end to end (one cosmetic, two deterministic/pre-model). The reviewable substance is the packs mechanism — storage, per-agent resolution, and the declarative-data safety model.

## We mapped the whole template battery set

Per the request to cover *every* all-agent feature from the templates: `docs/behavior-packs.md` now contains a table mapping all ~15 batteries to this mechanism. The key finding is that **most are not packs** — and forcing them to be would break the design:

- **Packs** (declarative data): tips, greeting, help. (`runtime-settings` schema is a candidate, deferred.)
- **Already native to AgentOS**: kill switch (`killswitch.py` + kernel gate + control endpoint), logging, env config, activity/observability (Langfuse). Re-adding would duplicate platform features.
- **Code, not data** (would run battery code in the worker, breaking isolation): http-backoff, vision, polling-worker → belong in the runner/plugin; integrations → the plugin's `.mcp.json`.
- **Need a Block Kit reply model AgentOS doesn't have**: nav (back/up), Block Kit rendering.
- **Domain logic, not a battery**: proactive notifier.

The throughline: the moment a battery needs to run agent-authored logic, it stops being a pack and must live in the sandboxed runner (or already lives in the platform). Packs cover only the declarative, deterministic slice — which is what keeps them safe to resolve and apply outside the sandbox.

## Design: declarative data, not code

A pack is JSON on the agent's row. The platform owns the logic that consumes it; only the data varies. Pack content never executes, so enabling a pack can never run an agent's code and the sandbox-isolation guarantee holds without any pack crossing into the runner.

## Scope (substrate only)

- **apps/api** — nullable `agents.behavior_packs` JSONB column (migration `0005`), `BehaviorPacksConfig` schema, accepted on `POST /agents`, read/written via `GET|PUT /agents/{id}/behavior-packs` (mirrors the budget control endpoints). NULL reads as all-off.
- **apps/worker/behaviorpacks.py** — `sample_tip`, `match_greeting`, `match_help`; pure stdlib, fully unit-tested. The matchers share one bare-utterance core; "hi show me the report" falls through to the model.
- **apps/worker/binding.py** (not the sacred kernel) — resolver selects `behavior_packs`, carries it on `ResolvedDeployment`, exposes `packs_for()`.

## Deliberately NOT in this PR: the kernel wiring

The packs fire from inside `apps/worker/kernel.py`, the F1 "sacred" module — any change there needs the escalated adversarial review per `apps/worker/CLAUDE.md`, and a greeting/help short-circuit brushes against kernel rule 3 ("never keyword-guess intent"). The exact integration points are written up in `docs/behavior-packs.md`.

## Note: this branch also carries the CI fix (#3)

The first commit here is the standalone CI fix also proposed as #3 (the `Start dev stack` step pulled a private image and failed before pytest). It is included so this PR's Python check can actually run and go green. Merge #3 first and rebase, or merge this PR directly — either way the change is identical.

## Verification

Against the real compose Postgres + MinIO (not mocks): `ruff check` clean, `mypy` clean (93 files), and **38 pytest passed** — the pack unit tests (incl. help + shared-matcher), the API round-trip, `crud`, `openapi_drift`, `migrations`, and the worker binding resolver.

Ref CUR-1586