### PR TITLE
Fix Python CI: stop pulling the private app image in the dev stack step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,13 +26,19 @@ jobs:
         run: uv run mypy
       # Integration tests dial the real dev stack (Postgres 55434, Valkey 56379,
       # MinIO 9002, Langfuse 3001 + ClickHouse + OTel Collector). Boot it after
-      # ruff/mypy so cheap failures stay fast. The first up starts every service
-      # (including the one-shot minio-init that creates the langfuse bucket); the
-      # second --waits only on the long-lived services. minio-init is kept out of
-      # the wait set because --wait treats its exit(0) completion as a failure.
+      # ruff/mypy so cheap failures stay fast. The first up starts the one-shot
+      # minio-init that creates the langfuse bucket alongside the long-lived
+      # services; the second --waits only on the long-lived ones (minio-init is
+      # kept out of the wait set because --wait treats its exit(0) as a failure).
+      # The app services (agentos-api, agentos-migrate) are deliberately NOT
+      # started: the suite runs the app in-process via uv and migrates the shared
+      # DB with alembic below, so their image is never needed here -- and it lives
+      # in a private registry, so a bare `up` that pulled it failed the job.
       - name: Start dev stack
         run: |
-          docker compose -f compose.dev.yaml up -d
+          docker compose -f compose.dev.yaml up -d \
+            postgres valkey clickhouse minio minio-init \
+            langfuse-web langfuse-worker otel-collector
           docker compose -f compose.dev.yaml up -d --wait --wait-timeout 300 \
             postgres valkey clickhouse minio \
             langfuse-web langfuse-worker otel-collector


### PR DESCRIPTION
## Problem

The **Python (ruff + mypy + pytest)** check is red on every PR (and on `main`). The `Start dev stack` step runs a bare `docker compose up -d` before the targeted one:

```yaml
docker compose -f compose.dev.yaml up -d                     # ← starts ALL services
docker compose -f compose.dev.yaml up -d --wait ... postgres valkey ... otel-collector
```

The bare up starts `agentos-api` and `agentos-migrate`, whose image is `ghcr.io/curie-eng/agentos-api:latest` — a **private** package the runner can't authenticate to. The pull fails `unauthorized` and kills the step before pytest runs:

```
agentos-migrate Error Head "https://ghcr.io/v2/curie-eng/agentos-api/manifests/latest": unauthorized
```

## Fix

Start the backing stores explicitly, keeping the one-shot `minio-init` (the only reason the bare up existed) and dropping the two app services. The suite runs the app in-process via `uv` and migrates the shared DB with `alembic` in a later step, so the app image is never needed in this job.

## Verification

`docker compose -f compose.dev.yaml up -d --dry-run postgres valkey clickhouse minio minio-init langfuse-web langfuse-worker otel-collector` brings up all eight backing services (incl. `minio-init`) with **zero references to `agentos-api`/`agentos-migrate`**.

Ref CUR-1587