### PR TITLE
Overhaul CLI terminal output: stream discipline, color, progress

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -13,11 +13,15 @@ name = "agentos"
 version = "0.1.0"
 dependencies = [
  "agentos-aci-protocol",
+ "anstream",
+ "anstyle",
+ "anstyle-query",
  "anyhow",
  "axum",
  "clap",
  "flate2",
  "futures-util",
+ "indicatif",
  "redis",
  "reqwest",
  "serde",
@@ -292,6 +296,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +348,12 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "errno"
@@ -685,6 +708,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +900,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1515,6 +1563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1732,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,9 @@ path = "src/main.rs"
 
 [dependencies]
 agentos-aci-protocol = { path = "../packages/aci-protocol/generated/rust" }
+anstream = "1"
+anstyle = "1"
+anstyle-query = "1"
 anyhow = "1"
 axum = { version = "0.8", default-features = false, features = [
     "tokio",
@@ -19,6 +22,7 @@ axum = { version = "0.8", default-features = false, features = [
 clap = { version = "4", features = ["derive", "env"] }
 flate2 = "1"
 futures-util = "0.3"
+indicatif = "0.17"
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "stream",

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,7 @@ Slack involved.
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed. |
 | `agentos start` | Boot the runner image in Docker with the ACI boot env (runner/README.md recipe), wait for health, print the boxed env summary. `--fake-model` runs offline; `--network`/`--otel-endpoint` join the compose stack for traces. |
 | `agentos send "..."` | Emulate a Slack message: POST an ACI `event` frame to the local runner and stream the NDJSON reply (text deltas, tool notes, side-effect flags, final). |
-| `agentos eval` | Run `evals/cases.json` through the runner as `eval_case` events; per-case pass/fail lines and a summary; nonzero exit on failure. |
+| `agentos eval` | Run `evals/cases.json` through the runner as `eval_case` events; prints a per-case result table plus a pass/fail roll-up; nonzero exit on failure. |
 | `agentos steer "..."` | Inject a follow-up into the runner's live turn (POST `/v1/steer`); prints `no active turn` and exits nonzero on the runner's 409. |
 | `agentos interrupt` | Hard-stop the runner's live turn (POST `/v1/interrupt`); `--reason` is recorded with it. |
 | `agentos chat "..."` | Drive the whole system with the CLI acting **as** the Slack service against the local compose stack, no Slack involved (see below). |
@@ -27,6 +27,48 @@ Slack involved.
 run from the bundle directory and resolve the runner from it, or accept `--url`.
 `start --model <id>` forwards `AGENTOS_MODEL` into the container (omit for the
 SDK default); setting it makes token usage attributable in Langfuse traces.
+
+## Output
+
+Three global flags apply to every subcommand: `--debug` shows the verbose
+plumbing (helm/kubectl/compose command lines and their output, as dim lines),
+`-q`/`--quiet` prints the payload only (suppressing all progress and diagnostics
+on stderr), and `--color <auto|always|never>` (default `auto`) controls ANSI
+color.
+
+Stream discipline is strict: the **payload** (streamed agent reply tokens,
+resolved URLs, the status table, eval results, the deploy result, `runner-status`
+JSON, the worker reply) goes to **stdout**, and every **diagnostic**
+(waiting/helm/kubectl/rollout/port-forward chatter, spinners, progress, notes)
+goes to **stderr**. So the payload pipes and redirects cleanly while progress
+still shows on the terminal:
+
+```bash
+agentos message "..." | jq        # clean JSON on stdout, progress on stderr
+agentos message "..." > reply.txt  # reply captured, progress on the terminal
+agentos eval > results.txt         # results captured, progress on the terminal
+```
+
+On an interactive terminal, progress renders as a spinner-to-checkmark checklist
+(each step spins with a live dim elapsed counter, then freezes to a green `✓` or
+red `✗` with its elapsed time), a determinate bar for real totals (eval
+`N/total`), and streamed tokens that spin only until the first token then stream
+raw to stdout. Every wait resolves: a blown timeout ends in `✗ ... timed out
+after Ns`, never a hang. Compatibility is handled automatically:
+
+- **Auto-disable off a TTY.** Rendering is gated on `stderr.is_terminal()` plus
+  the cross-tool env standards. On a non-TTY, a pipe, `CI`, `TERM=dumb`,
+  `NO_COLOR`, or `CLICOLOR=0`, output is plain discrete status lines with no ANSI
+  and no `\r` redraws. `CLICOLOR_FORCE` / `--color=always` force color on;
+  `--color=never` forces it off. Color is resolved per stream, so a colored
+  terminal stderr never leaks ANSI into a redirected stdout.
+- **Graceful degradation.** The brand palette (success green, error red, amber
+  warn, dim grey plumbing, cyan URLs/ids, bold payload) is truecolor, degrading
+  to the 16 named ANSI colors where truecolor is unsupported (Apple Terminal,
+  tmux without passthrough).
+- **Never color-only.** Every status pairs a glyph with a word (`✓ pass`,
+  `✗ fail`, `⚠ warn`), and glyphs fall back to ASCII (`v`/`x`/`!`, `- \ | /`
+  spinner) in non-UTF-8 locales.
 
 ## `agentos chat`: the CLI as the Slack service
 

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -319,7 +319,8 @@ pub async fn chat(opts: ChatOpts) -> Result<()> {
     match outcome {
         Outcome::Replied(reply) => {
             step.done("");
-            ui.payload(&reply);
+            ui.answer(&reply);
+            ui.print_tokens("\n");
             print_continue_hint("chat", &channel, &thread_ts);
             Ok(())
         }

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -246,11 +246,13 @@ pub async fn await_reply(
 }
 
 /// Print the one-liner that continues this thread: reusing the same channel and
-/// thread ts keeps the worker routing to the same agent and turn context.
+/// thread ts keeps the worker routing to the same agent and turn context. A dim
+/// diagnostic (stderr, `--debug`-independent note) so it never pollutes the
+/// captured payload.
 pub fn print_continue_hint(verb: &str, channel: &str, thread_ts: &str) {
-    println!(
+    crate::ui::ui().note(&format!(
         "continue this conversation: agentos {verb} --channel {channel} --thread {thread_ts} \"...\""
-    );
+    ));
 }
 
 /// Resolve the channel and timestamps for a turn: an explicit `--channel` is
@@ -268,15 +270,16 @@ pub fn resolve_targets(channel: Option<&str>, thread: Option<&str>) -> (String, 
 
 /// The `agentos chat` handler.
 pub async fn chat(opts: ChatOpts) -> Result<()> {
+    let ui = crate::ui::ui();
     // Connect Valkey up front so a misconfigured stream or down stack fails fast,
     // before the stub binds or any id is minted.
     let mut conn = connect(&opts.valkey_url).await?;
 
     let mut stub = SlackStub::start(&opts.listen_host, opts.listen_port, &opts.listen_host).await?;
-    println!(
+    ui.note(&format!(
         "slack stub listening; run the worker with SLACK_API_BASE_URL={}",
         stub.base_api_url()
-    );
+    ));
 
     // Invent internally-consistent synthetic ids; the CLI is both the producer
     // and the Slack endpoint that receives them back. --channel/--thread let a
@@ -292,15 +295,17 @@ pub async fn chat(opts: ChatOpts) -> Result<()> {
         &placeholder_ts,
     );
     let stream_id = xadd(&mut conn, &opts.stream, &event).await?;
-    println!(
+    ui.note(&format!(
         "enqueued {} on {} as {stream_id}",
         event.slack_event_id, opts.stream
-    );
-    println!(
+    ));
+    ui.note(&format!(
         "waiting up to {}s for the worker to finalize the turn...",
         opts.timeout_secs
-    );
+    ));
 
+    let cl = ui.checklist();
+    let step = cl.step("waiting for worker reply");
     let outcome = await_reply(
         &mut stub,
         &mut conn,
@@ -313,22 +318,22 @@ pub async fn chat(opts: ChatOpts) -> Result<()> {
 
     match outcome {
         Outcome::Replied(reply) => {
-            println!("reply    {reply}");
+            step.done("");
+            ui.payload(&reply);
             print_continue_hint("chat", &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
-            println!("the worker finished the turn but never edited the placeholder");
+            step.done("no edit");
+            ui.warn("the worker finished the turn but never edited the placeholder");
             print_continue_hint("chat", &channel, &thread_ts);
             Ok(())
         }
         Outcome::TimedOut => {
-            println!(
-                "TIMEOUT: the worker did not finalize within {}s. Stream diagnostics:",
-                opts.timeout_secs
-            );
+            step.fail(&format!("timed out after {}s", opts.timeout_secs));
+            ui.note("stream diagnostics:");
             let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
-            println!("{diag}");
+            ui.note(&diag);
             std::process::exit(1);
         }
     }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -282,7 +282,7 @@ pub async fn send(
                 // pace with no per-delta newline. Track mid-line state so a later
                 // note closes an un-terminated line first.
                 Some(TurnPart::Token(token)) => {
-                    ui.print_tokens(&token);
+                    ui.answer(&token);
                     streamed = true;
                     at_line_start = token.ends_with('\n');
                 }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -14,8 +14,8 @@ use clap::ValueEnum;
 use crate::api::{ApiClient, ChannelOutcome};
 use crate::bundle::pack_tar_gz;
 use crate::docker::{self, StartSpec};
-use crate::evals::{case_line, load_cases, summary_line, turn_passes};
-use crate::render::{boxed_summary, TurnPrinter};
+use crate::evals::{load_cases, turn_passes};
+use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::{RunnerClient, SteerOutcome};
 use crate::scaffold::{read_manifest, scaffold};
 use crate::state::{self, RunnerState};
@@ -71,11 +71,15 @@ pub struct StartOpts {
 pub fn init(name: &str, dir: Option<PathBuf>) -> Result<()> {
     let dir = dir.unwrap_or_else(|| PathBuf::from(name));
     let created = scaffold(&dir, name)?;
-    println!("Initialized plugin bundle '{name}' in {}", dir.display());
+    let ui = crate::ui::ui();
+    ui.success(&format!(
+        "initialized plugin bundle '{name}' in {}",
+        dir.display()
+    ));
     for path in created {
-        println!("  created {}", path.display());
+        ui.note(&format!("created {}", path.display()));
     }
-    println!("\nNext: cd {} && agentos start", dir.display());
+    ui.note(&format!("Next: cd {} && agentos start", dir.display()));
     Ok(())
 }
 
@@ -115,19 +119,26 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         passthrough_env: vec!["CLAUDE_CODE_OAUTH_TOKEN".into(), "ANTHROPIC_API_KEY".into()],
     };
 
-    println!(
-        "Starting runner container '{}' from image '{}'...",
+    let ui = crate::ui::ui();
+    ui.note(&format!(
+        "starting runner container '{}' from '{}'",
         opts.name, opts.image
-    );
+    ));
     let container_id = docker::docker(&spec.run_args()).await?;
 
     let base_url = format!("http://localhost:{}", opts.port);
     let client = RunnerClient::new(&base_url)?;
+    let cl = ui.checklist();
+    let step = cl.step("waiting for runner");
     if let Err(err) = client.wait_healthy(Duration::from_secs(60)).await {
+        step.fail("unhealthy");
         let logs = docker::container_logs(&opts.name, 40).await;
+        ui.note(&logs);
         let _ = docker::remove_container(&opts.name).await;
-        bail!("runner failed to become healthy: {err}\ncontainer logs:\n{logs}");
+        ui.failure(&format!("runner failed to become healthy: {err}"));
+        bail!("runner failed to become healthy: {err}");
     }
+    step.done("healthy");
 
     // State lives with the bundle: init gitignores .agentos/ there, and the
     // follow-up commands are documented to run from the bundle directory. If
@@ -160,31 +171,35 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         ("Eval runner", "agentos eval".to_string()),
         ("Version", version),
     ];
-    println!("{}", boxed_summary("agentos dev environment", &rows));
+    ui.payload_plain(&boxed_summary("agentos dev environment", &rows));
     let cwd = Path::new(".").canonicalize()?;
     if cwd != plugin_dir {
-        println!(
-            "\nState recorded in {}/.agentos/runner.json; run stop (and send/eval/status) from that directory. send and eval also accept --url.",
+        ui.note(&format!(
+            "State recorded in {}/.agentos/runner.json; run stop (and send/eval/status) from that directory. send and eval also accept --url.",
             plugin_dir.display()
-        );
+        ));
     }
     Ok(())
 }
 
 pub async fn stop() -> Result<()> {
     let dir = Path::new(".");
+    let ui = crate::ui::ui();
     let Some(saved) = state::load(dir)? else {
         bail!("no local runner recorded in .agentos/runner.json; run from the bundle directory");
     };
     match docker::remove_container(&saved.container_name).await {
-        Ok(()) => println!("Stopped and removed container '{}'", saved.container_name),
+        Ok(()) => ui.success(&format!(
+            "stopped and removed container '{}'",
+            saved.container_name
+        )),
         // The container being gone already is a success for stop: clear the
         // state instead of wedging start/stop on a stale runner.json.
         Err(err) if err.to_string().contains("No such container") => {
-            println!(
-                "Container '{}' was already gone; cleared stale state",
+            ui.note(&format!(
+                "container '{}' was already gone; cleared stale state",
                 saved.container_name
-            );
+            ));
         }
         Err(err) => return Err(err),
     }
@@ -196,21 +211,23 @@ pub async fn status(url: Option<String>) -> Result<()> {
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
     let status = client.status().await?;
-    println!("runner {url}");
-    println!("{}", serde_json::to_string_pretty(&status)?);
+    let ui = crate::ui::ui();
+    ui.note(&format!("runner {url}"));
+    ui.payload_plain(&serde_json::to_string_pretty(&status)?);
     Ok(())
 }
 
 pub async fn steer(text: &str, user: &str, url: Option<String>) -> Result<()> {
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
+    let ui = crate::ui::ui();
     match client.steer(text, user).await? {
         SteerOutcome::Delivered => {
-            println!("steered the live turn");
+            ui.success("steered the live turn");
             Ok(())
         }
         SteerOutcome::NoActiveTurn => {
-            println!("no active turn to steer; send a new message to start one");
+            ui.failure("no active turn to steer; send a new message to start one");
             std::process::exit(1);
         }
     }
@@ -220,7 +237,7 @@ pub async fn interrupt(reason: &str, url: Option<String>) -> Result<()> {
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
     client.interrupt(reason).await?;
-    println!("interrupted the runner");
+    crate::ui::ui().success("interrupted the runner");
     Ok(())
 }
 
@@ -232,16 +249,59 @@ pub async fn send(
 ) -> Result<()> {
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
+    let ui = crate::ui::ui();
     let mut printer = TurnPrinter::default();
+
+    // A "thinking" spinner marks the wait for the first token; it is cleared the
+    // instant streaming begins (committing no line) so the agent answer streams
+    // clean. `streamed` tracks whether any answer token reached stdout.
+    let cl = ui.checklist();
+    let mut step = Some(cl.step("thinking"));
+    let mut streamed = false;
+
     let events = client
         .send_event(event_type, text, user, |event| {
-            if let Some(line) = printer.line_for(event) {
-                println!("{line}");
+            let part = printer.part_for(event);
+            // Clear the "thinking" spinner on the FIRST rendered event of any
+            // kind (token, note, or failure). A Note/Fail is written to stderr
+            // immediately, so if one arrives before the first token it would
+            // garble the still-live spinner line unless we drop it first.
+            if matches!(
+                part,
+                Some(TurnPart::Token(_) | TurnPart::Note(_) | TurnPart::Fail(_))
+            ) {
+                if let Some(step) = step.take() {
+                    step.clear();
+                }
+            }
+            match part {
+                // Answer tokens are raw payload -> stdout, concatenated at network
+                // pace with no per-delta newline.
+                Some(TurnPart::Token(token)) => {
+                    ui.print_tokens(&token);
+                    streamed = true;
+                }
+                // Tool notes and errors are diagnostics -> stderr.
+                Some(TurnPart::Note(msg)) => ui.note(&msg),
+                Some(TurnPart::Fail(msg)) => ui.failure(&msg),
+                // The status trailer is emitted once at the end from events.last().
+                Some(TurnPart::Status(_)) | None => {}
             }
         })
         .await?;
 
+    // Nothing ever streamed (e.g. an empty final): drop the spinner silently.
+    if let Some(step) = step.take() {
+        step.clear();
+    }
+
     if let Some(OutboundEvent::Final { status, .. }) = events.last() {
+        // One trailing newline closes the streamed answer on stdout; the status
+        // trailer is a diagnostic -> stderr.
+        if streamed {
+            ui.print_tokens("\n");
+        }
+        ui.note(&format!("-- final ({})", status_str(status)));
         if *status == SessionStatus::ClassifiedFailure {
             std::process::exit(1);
         }
@@ -255,9 +315,13 @@ pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()
     let cases = load_cases(&cases_path)?;
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
+    let ui = crate::ui::ui();
 
     let total = cases.len();
     let mut passed = 0usize;
+    // (name, passed, seconds) rows, rendered as one table once the run finishes.
+    let mut results: Vec<(String, bool, f64)> = Vec::with_capacity(total);
+    let bar = ui.progress_bar(total as u64, "running evals");
     for case in &cases {
         let started = Instant::now();
         let events = client
@@ -268,9 +332,33 @@ pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()
         if ok {
             passed += 1;
         }
-        println!("{}", case_line(&case.name, ok, elapsed));
+        results.push((case.name.clone(), ok, elapsed));
+        bar.inc(1);
     }
-    println!("{}", summary_line(passed, total));
+    bar.finish();
+
+    // The result table is payload -> stdout; the roll-up verdict is a
+    // diagnostic -> stderr.
+    let rows: Vec<Vec<String>> = results
+        .iter()
+        .map(|(name, ok, seconds)| {
+            let result = if *ok {
+                format!("{} pass", '\u{2713}')
+            } else {
+                format!("{} fail", '\u{2717}')
+            };
+            vec![name.clone(), result, format!("{seconds:.1}s")]
+        })
+        .collect();
+    ui.payload_plain(&crate::ui::table(&["case", "result", "time"], &rows, &[2]));
+    if passed == total {
+        ui.success(&format!("{passed}/{total} passed"));
+    } else {
+        ui.warn(&format!(
+            "{passed}/{total} passed; {} failed",
+            total - passed
+        ));
+    }
     if passed < total {
         std::process::exit(1);
     }
@@ -328,51 +416,77 @@ pub async fn deploy(opts: DeployOpts) -> Result<()> {
         .unwrap_or_else(|| format!("{manifest_version}-{}", unix_now()));
     let created_by = std::env::var("USER").unwrap_or_else(|_| "agentos-cli".to_string());
 
+    let ui = crate::ui::ui();
     let archive = pack_tar_gz(&plugin_dir)?;
-    println!(
-        "Deploying '{plugin_name}' ({} bytes) as {label} to {} [{}]",
+    let env = opts.env.as_str();
+    ui.note(&format!(
+        "deploying {plugin_name} ({} bytes) to {} [{env}]",
         archive.len(),
         opts.api_url,
-        opts.env.as_str()
-    );
+    ));
 
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
-    let outcome = client
+    let cl = ui.checklist();
+    let step = cl.step(&format!("deploying {plugin_name}"));
+    let outcome = match client
         .deploy(
             &plugin_name,
             opts.slack_channel.as_deref(),
             &label,
             &created_by,
-            opts.env.as_str(),
+            env,
             archive,
         )
-        .await?;
-
-    println!("agent       {} ({})", outcome.agent.name, outcome.agent.id);
-    match &outcome.channel {
-        ChannelOutcome::Created(channel) => println!("channel     {channel}"),
-        ChannelOutcome::Updated { from, to } => {
-            println!("channel     updated to {to} (was {from})")
+        .await
+    {
+        Ok(outcome) => {
+            step.done(env);
+            outcome
         }
+        Err(err) => {
+            step.fail("failed");
+            return Err(err);
+        }
+    };
+
+    ui.payload(&format!("deployed {plugin_name} {label} -> {env}"));
+    ui.kv(
+        "agent",
+        &format!("{} ({})", outcome.agent.name, ui.url(&outcome.agent.id)),
+    );
+    ui.kv(
+        "version",
+        &format!(
+            "{} ({})",
+            outcome.version.version_label,
+            ui.url(&outcome.version.id)
+        ),
+    );
+    let channel = match &outcome.channel {
+        ChannelOutcome::Created(channel) => channel.clone(),
+        ChannelOutcome::Updated { from, to } => format!("updated to {to} (was {from})"),
         ChannelOutcome::Unchanged { channel, passed } => {
             if *passed {
-                println!("channel     unchanged ({channel})");
+                format!("unchanged ({channel})")
             } else {
-                println!("channel     unchanged ({channel}); pass --slack-channel to move it");
+                format!("unchanged ({channel}); pass --slack-channel to move it")
             }
         }
-    }
-    println!(
-        "version     {} ({})",
-        outcome.version.version_label, outcome.version.id
+    };
+    ui.kv("channel", &channel);
+    ui.kv(
+        "bundle",
+        &format!(
+            "{} sha256:{} {} bytes",
+            outcome.bundle.bundle_ref, outcome.bundle.bundle_sha256, outcome.bundle.size_bytes
+        ),
     );
-    println!(
-        "bundle      {} sha256:{} {} bytes",
-        outcome.bundle.bundle_ref, outcome.bundle.bundle_sha256, outcome.bundle.size_bytes
-    );
-    println!(
-        "deployment  {} [{}] {}",
-        outcome.deployment.id, outcome.deployment.environment, outcome.deployment.status
+    ui.kv(
+        "deployment",
+        &format!(
+            "{} [{}] {}",
+            outcome.deployment.id, outcome.deployment.environment, outcome.deployment.status
+        ),
     );
     Ok(())
 }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -254,10 +254,13 @@ pub async fn send(
 
     // A "thinking" spinner marks the wait for the first token; it is cleared the
     // instant streaming begins (committing no line) so the agent answer streams
-    // clean. `streamed` tracks whether any answer token reached stdout.
+    // clean. `streamed` tracks whether any answer token reached stdout;
+    // `at_line_start` tracks whether stdout is at a fresh line (no un-terminated
+    // streamed text) so a stderr diagnostic never glues onto a token line.
     let cl = ui.checklist();
     let mut step = Some(cl.step("thinking"));
     let mut streamed = false;
+    let mut at_line_start = true;
 
     let events = client
         .send_event(event_type, text, user, |event| {
@@ -276,14 +279,33 @@ pub async fn send(
             }
             match part {
                 // Answer tokens are raw payload -> stdout, concatenated at network
-                // pace with no per-delta newline.
+                // pace with no per-delta newline. Track mid-line state so a later
+                // note closes an un-terminated line first.
                 Some(TurnPart::Token(token)) => {
                     ui.print_tokens(&token);
                     streamed = true;
+                    at_line_start = token.ends_with('\n');
                 }
-                // Tool notes and errors are diagnostics -> stderr.
-                Some(TurnPart::Note(msg)) => ui.note(&msg),
-                Some(TurnPart::Fail(msg)) => ui.failure(&msg),
+                // Tool notes and errors are diagnostics -> stderr. If stdout is
+                // mid-line, close that streamed line with a single newline first
+                // so the note does not glue onto the token text. Under `-q` the
+                // note itself is a no-op; the lone separating newline lands in
+                // the middle of the streamed answer, which is just whitespace and
+                // harmless to `| jq` (a median newline in the payload is fine).
+                Some(TurnPart::Note(msg)) => {
+                    if !at_line_start {
+                        ui.print_tokens("\n");
+                        at_line_start = true;
+                    }
+                    ui.note(&msg);
+                }
+                Some(TurnPart::Fail(msg)) => {
+                    if !at_line_start {
+                        ui.print_tokens("\n");
+                        at_line_start = true;
+                    }
+                    ui.failure(&msg);
+                }
                 // The status trailer is emitted once at the end from events.last().
                 Some(TurnPart::Status(_)) | None => {}
             }
@@ -296,9 +318,11 @@ pub async fn send(
     }
 
     if let Some(OutboundEvent::Final { status, .. }) = events.last() {
-        // One trailing newline closes the streamed answer on stdout; the status
+        // Close the streamed answer on stdout only if the last thing written was
+        // un-terminated token text; if a note already added its own newline (or
+        // the last token ended in one) skip it to avoid a blank line. The status
         // trailer is a diagnostic -> stderr.
-        if streamed {
+        if streamed && !at_line_start {
             ui.print_tokens("\n");
         }
         ui.note(&format!("-- final ({})", status_str(status)));

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -19,3 +19,4 @@ pub mod render;
 pub mod runner;
 pub mod scaffold;
 pub mod state;
+pub mod ui;

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -6,9 +6,9 @@
 //! (or the `--dry-run` printer) consumes it, so argv construction stays
 //! unit-testable with no Docker daemon.
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 
-use crate::ops::{plain, print_dry_run, require_on_path, run_streaming, OpsCommand};
+use crate::ops::{plain, require_on_path, run_capture, run_step, OpsCommand};
 
 /// Default compose file, resolved relative to the cwd (run from the repo root).
 pub const DEFAULT_COMPOSE_FILE: &str = "compose.dev.yaml";
@@ -81,62 +81,96 @@ pub fn status_command(o: &LocalOpts) -> OpsCommand {
 // ---------------------------------------------------------------------------
 
 pub async fn up(o: LocalOpts) -> Result<()> {
+    let ui = crate::ui::ui();
     let cmd = up_command(&o);
     if o.dry_run {
-        print_dry_run(std::slice::from_ref(&cmd));
+        ui.payload_plain(&cmd.display());
         return Ok(());
     }
     require_on_path("docker")?;
-    run_streaming(&cmd).await?;
-    println!("\nDev stack is up. Endpoints:");
+    let cl = ui.checklist();
+    run_step(&cl, "starting dev stack", "up", &cmd).await?;
     for (label, url) in ENDPOINTS {
-        println!("  {label:16}{url}");
+        ui.kv(label, &ui.url(url));
     }
-    println!("\nDrive the local product loop (no Slack, no Kubernetes):");
-    println!(
-        "  agentos deploy --plugin-dir <dir> --slack-channel <C...> --api-url http://localhost:28000"
+    ui.note("Drive the local product loop (no Slack, no Kubernetes):");
+    ui.note(
+        "  agentos deploy --plugin-dir <dir> --slack-channel <C...> --api-url http://localhost:28000",
     );
-    println!("  agentos message --local \"<your question>\"");
+    ui.note("  agentos message --local \"<your question>\"");
     Ok(())
 }
 
 pub async fn status(o: LocalOpts) -> Result<()> {
+    let ui = crate::ui::ui();
     let cmd = status_command(&o);
     if o.dry_run {
-        print_dry_run(std::slice::from_ref(&cmd));
+        ui.payload_plain(&cmd.display());
         return Ok(());
     }
     require_on_path("docker")?;
-    run_streaming(&cmd).await
-}
-
-pub async fn down(o: LocalDownOpts) -> Result<()> {
-    let cmd = down_command(&o);
-    if o.common.dry_run {
-        print_dry_run(std::slice::from_ref(&cmd));
-        return Ok(());
+    // `docker compose ps` output is itself the payload table.
+    let (ok, out, err) = run_capture(&cmd).await?;
+    if !ok {
+        for line in err.lines() {
+            ui.plumbing(line);
+        }
+        let reason = err
+            .lines()
+            .rev()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .unwrap_or("command failed");
+        ui.failure(&format!("`docker compose ps` failed: {reason}"));
+        bail!("`docker compose ps` exited nonzero");
     }
-    if o.wipe && !o.yes && !confirm_wipe(&o.common.file)? {
-        println!("aborted.");
-        return Ok(());
-    }
-    require_on_path("docker")?;
-    run_streaming(&cmd).await?;
-    if o.wipe {
-        println!("\nStack stopped and volumes wiped.");
-    } else {
-        println!("\nStack stopped; volumes kept (fast restart with `agentos local up`).");
+    for line in out.lines() {
+        ui.payload_plain(line);
     }
     Ok(())
 }
 
-/// Read a y/N confirmation from stdin before `--wipe` destroys volumes.
+pub async fn down(o: LocalDownOpts) -> Result<()> {
+    let ui = crate::ui::ui();
+    let cmd = down_command(&o);
+    if o.common.dry_run {
+        ui.payload_plain(&cmd.display());
+        return Ok(());
+    }
+    if o.wipe {
+        ui.warn(&format!(
+            "this destroys all volumes for the '{}' dev stack (Postgres, ClickHouse, MinIO, Valkey data)",
+            o.common.file
+        ));
+        if !o.yes && !confirm_wipe(&o.common.file)? {
+            ui.note("aborted");
+            return Ok(());
+        }
+    }
+    require_on_path("docker")?;
+    let cl = ui.checklist();
+    let label = if o.wipe {
+        "stopping stack and wiping volumes"
+    } else {
+        "stopping stack"
+    };
+    run_step(&cl, label, "stopped", &cmd).await?;
+    if o.wipe {
+        ui.payload("dev stack stopped; volumes wiped");
+    } else {
+        ui.payload("dev stack stopped");
+        ui.note("volumes kept (fast restart with `agentos local up`)");
+    }
+    Ok(())
+}
+
+/// Read a y/N confirmation from stderr/stdin before `--wipe` destroys volumes.
 fn confirm_wipe(file: &str) -> Result<bool> {
     use std::io::Write;
-    print!(
+    eprint!(
         "This destroys all volumes for the '{file}' dev stack (Postgres, ClickHouse, MinIO, Valkey data). Continue? [y/N] "
     );
-    std::io::stdout().flush().ok();
+    std::io::stderr().flush().ok();
     let mut line = String::new();
     std::io::stdin()
         .read_line(&mut line)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,6 +12,7 @@ use agentos::commands::{self, DeployEnv, DeployOpts, SendType, StartOpts, DEFAUL
 use agentos::local::{self, LocalDownOpts, LocalOpts};
 use agentos::message::{self, MessageOpts};
 use agentos::ops::{self, CommonOpts, DownOpts, UpOpts};
+use agentos::ui::{self, ColorFlag, Ui};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
@@ -24,6 +25,30 @@ use clap::{Parser, Subcommand};
 struct Cli {
     #[command(subcommand)]
     command: Command,
+    /// Show verbose plumbing (helm/kubectl/rollout/port-forward).
+    #[arg(
+        long,
+        global = true,
+        help = "Show verbose plumbing (helm/kubectl/rollout/port-forward)"
+    )]
+    debug: bool,
+    /// Payload only; suppress progress and diagnostics.
+    #[arg(
+        short = 'q',
+        long,
+        global = true,
+        help = "Payload only; suppress progress and diagnostics"
+    )]
+    quiet: bool,
+    /// Colorize output.
+    #[arg(
+        long,
+        global = true,
+        value_enum,
+        default_value_t = ColorFlag::Auto,
+        help = "Colorize output"
+    )]
+    color: ColorFlag,
 }
 
 #[derive(Subcommand)]
@@ -377,7 +402,9 @@ enum LocalAction {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    match Cli::parse().command {
+    let cli = Cli::parse();
+    ui::init(Ui::from_process(cli.color, cli.debug, cli.quiet));
+    match cli.command {
         Command::Init { name, dir } => commands::init(&name, dir),
         Command::Start {
             plugin_dir,

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -609,7 +609,8 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     match outcome {
         Outcome::Replied(reply) => {
             step.done("");
-            ui.payload(&reply);
+            ui.answer(&reply);
+            ui.print_tokens("\n");
             print_continue_hint("message --local", &channel, &thread_ts);
             Ok(())
         }
@@ -758,7 +759,8 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     match outcome {
         Outcome::Replied(reply) => {
             step.done("");
-            ui.payload(&reply);
+            ui.answer(&reply);
+            ui.print_tokens("\n");
             print_continue_hint("message", &channel, &thread_ts);
             Ok(())
         }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -33,7 +33,7 @@ use anyhow::{bail, Context, Result};
 
 use crate::api::{Agent, ApiClient};
 use crate::chat::{await_reply, print_continue_hint, resolve_targets, Outcome, SlackStub};
-use crate::ops::{plain, require_on_path, run_capture, run_streaming, OpsCommand};
+use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
 use crate::queue::{self, connect, diagnostics, xadd, QueuedSlackEvent};
 
 pub const DEFAULT_STREAM: &str = queue::DEFAULT_STREAM;
@@ -378,7 +378,7 @@ async fn start_port_forward(
     local_port: u16,
     label: &str,
 ) -> Result<tokio::process::Child> {
-    println!("+ {}", cmd.display());
+    crate::ui::ui().plumbing(&format!("+ {}", cmd.display()));
     let child = tokio::process::Command::new(&cmd.program)
         .args(cmd.argv())
         .kill_on_drop(true)
@@ -438,12 +438,53 @@ async fn dispatcher_exists(opts: &MessageOpts) -> Result<bool> {
     Ok(ok)
 }
 
+/// Run one external command under a checklist `step`, capturing its stdio.
+/// Echoes the masked command line and replays the captured output as dim
+/// plumbing (both no-ops unless `--debug`, so default runs stay quiet and the
+/// helm/kubectl chatter is hidden). On success the step freezes done with
+/// `ok_detail`; on a nonzero exit it freezes failed, surfaces the captured
+/// stderr via `ui.failure`, and bails. Mirrors `ops::run_step`, which is scoped
+/// to that module.
+async fn run_wire_step(
+    cl: &crate::ui::Checklist,
+    label: &str,
+    ok_detail: &str,
+    cmd: &OpsCommand,
+) -> Result<()> {
+    let ui = crate::ui::ui();
+    ui.plumbing(&format!("+ {}", cmd.display()));
+    let step = cl.step(label);
+    let (ok, out, err) = run_capture(cmd).await?;
+    if ok {
+        step.done(ok_detail);
+    } else {
+        step.fail("failed");
+    }
+    for line in out.lines().chain(err.lines()) {
+        ui.plumbing(line);
+    }
+    if !ok {
+        let reason = err
+            .lines()
+            .rev()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .unwrap_or("command failed");
+        ui.failure(&format!("`{}` failed: {reason}", cmd.program));
+        bail!("`{}` exited nonzero", cmd.program);
+    }
+    Ok(())
+}
+
 /// Point the deployed worker at the stub via `helm upgrade` + rollout wait,
 /// unless it is already wired. Refuses a Slack-connected release without
 /// `--force-wire`.
 async fn wire_worker(opts: &MessageOpts, url: &str) -> Result<()> {
+    let ui = crate::ui::ui();
     if current_worker_base_url(opts).await?.as_deref() == Some(url) {
-        println!("worker already wired to {url}; skipping helm upgrade");
+        ui.note(&format!(
+            "worker already wired to {url}; skipping helm upgrade"
+        ));
         return Ok(());
     }
     if !opts.force_wire && dispatcher_exists(opts).await? {
@@ -456,17 +497,20 @@ async fn wire_worker(opts: &MessageOpts, url: &str) -> Result<()> {
         );
     }
     require_on_path("helm")?;
-    run_streaming(&wire_upgrade_command(
-        &opts.namespace,
-        &opts.release,
-        &opts.chart,
-        url,
-    ))
+    let cl = ui.checklist();
+    run_wire_step(
+        &cl,
+        "wiring worker to stub",
+        "wired",
+        &wire_upgrade_command(&opts.namespace, &opts.release, &opts.chart, url),
+    )
     .await?;
-    run_streaming(&worker_rollout_status_command(
-        &opts.namespace,
-        &opts.release,
-    ))
+    run_wire_step(
+        &cl,
+        "waiting for worker rollout",
+        "rolled out",
+        &worker_rollout_status_command(&opts.namespace, &opts.release),
+    )
     .await?;
     Ok(())
 }
@@ -481,21 +525,26 @@ async fn wire_worker(opts: &MessageOpts, url: &str) -> Result<()> {
 /// fixed to `http://localhost:{DEFAULT_LOCAL_STUB_PORT}/api/`), so there is
 /// nothing to wire.
 async fn message_local(opts: MessageOpts) -> Result<()> {
+    let ui = crate::ui::ui();
     let valkey_url = local_valkey_url(&opts.valkey_password);
     let api_base = local_api_base(opts.api_url.as_deref());
 
     if opts.dry_run {
-        println!("local mode (compose stack; no kubectl/helm)");
-        println!("enqueue onto redis {valkey_url}");
-        println!("stub advertised at http://localhost:{DEFAULT_LOCAL_STUB_PORT}/api/");
+        ui.payload_plain("local mode (compose stack; no kubectl/helm)");
+        ui.payload_plain(&format!("enqueue onto redis {valkey_url}"));
+        ui.payload_plain(&format!(
+            "stub advertised at http://localhost:{DEFAULT_LOCAL_STUB_PORT}/api/"
+        ));
         match opts.channel.as_deref() {
-            Some(channel) => println!("channel {channel}"),
-            None => println!("channel <the sole deployed agent via {api_base}/agents>"),
+            Some(channel) => ui.payload_plain(&format!("channel {channel}")),
+            None => ui.payload_plain(&format!(
+                "channel <the sole deployed agent via {api_base}/agents>"
+            )),
         }
-        println!(
+        ui.payload_plain(&format!(
             "enqueue a synthetic QueuedSlackEvent on stream {}",
             opts.stream
-        );
+        ));
         return Ok(());
     }
 
@@ -507,10 +556,10 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     // binds and is reachable; the advertised host is cosmetic here (the worker's
     // base URL is fixed in compose, not taken from this print).
     let mut stub = SlackStub::start("127.0.0.1", DEFAULT_LOCAL_STUB_PORT, "localhost").await?;
-    println!(
+    ui.note(&format!(
         "slack stub listening; the worker posts to {}",
         stub.base_api_url()
-    );
+    ));
 
     // Channel: explicit --channel, else the sole deployed agent from the compose
     // API (reached directly; routers mount at root, so the base carries no /api).
@@ -524,7 +573,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             select_channel(&agents, None)?
         }
     };
-    println!("routing to channel {channel}");
+    ui.note(&format!("routing to channel {channel}"));
 
     let (channel, thread_ts, placeholder_ts) =
         resolve_targets(Some(&channel), opts.thread.as_deref());
@@ -536,15 +585,17 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
         &placeholder_ts,
     );
     let stream_id = xadd(&mut conn, &opts.stream, &event).await?;
-    println!(
+    ui.note(&format!(
         "enqueued {} on {} as {stream_id}",
         event.slack_event_id, opts.stream
-    );
-    println!(
+    ));
+    ui.note(&format!(
         "waiting up to {}s for the worker to finalize the turn...",
         opts.timeout_secs
-    );
+    ));
 
+    let cl = ui.checklist();
+    let step = cl.step("waiting for worker reply");
     let outcome = await_reply(
         &mut stub,
         &mut conn,
@@ -557,22 +608,22 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
 
     match outcome {
         Outcome::Replied(reply) => {
-            println!("reply    {reply}");
+            step.done("");
+            ui.payload(&reply);
             print_continue_hint("message --local", &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
-            println!("the worker finished the turn but never edited the placeholder");
+            step.done("no edit");
+            ui.warn("the worker finished the turn but never edited the placeholder");
             print_continue_hint("message --local", &channel, &thread_ts);
             Ok(())
         }
         Outcome::TimedOut => {
-            println!(
-                "TIMEOUT: the worker did not finalize within {}s. Stream diagnostics:",
-                opts.timeout_secs
-            );
+            step.fail(&format!("timed out after {}s", opts.timeout_secs));
+            ui.note("stream diagnostics:");
             let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
-            println!("{diag}");
+            ui.note(&diag);
             std::process::exit(1);
         }
     }
@@ -583,13 +634,14 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     if opts.local {
         return message_local(opts).await;
     }
+    let ui = crate::ui::ui();
     if opts.dry_run {
         let host = opts
             .listen_host
             .clone()
             .unwrap_or_else(|| "<auto-detected-local-ip>".to_string());
         for line in dry_run_lines(&opts, &host) {
-            println!("{line}");
+            ui.payload_plain(&line);
         }
         return Ok(());
     }
@@ -602,7 +654,9 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     let advertise_host = resolve_advertise_host(opts.listen_host.as_deref()).await?;
     let mut stub = SlackStub::start("0.0.0.0", opts.listen_port, &advertise_host).await?;
     let url = stub.base_api_url().to_string();
-    println!("slack stub listening; the worker will post to {url}");
+    ui.note(&format!(
+        "slack stub listening; the worker will post to {url}"
+    ));
 
     // Valkey port-forward for the enqueue (killed on drop at fn end).
     let _valkey_pf = start_port_forward(
@@ -646,7 +700,7 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
             select_channel(&agents, None)?
         }
     };
-    println!("routing to channel {channel}");
+    ui.note(&format!("routing to channel {channel}"));
 
     // Wire the worker to the stub (default) or verify it is already wired.
     if opts.wire {
@@ -680,15 +734,17 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
         &placeholder_ts,
     );
     let stream_id = xadd(&mut conn, &opts.stream, &event).await?;
-    println!(
+    ui.note(&format!(
         "enqueued {} on {} as {stream_id}",
         event.slack_event_id, opts.stream
-    );
-    println!(
+    ));
+    ui.note(&format!(
         "waiting up to {}s for the worker to finalize the turn...",
         opts.timeout_secs
-    );
+    ));
 
+    let cl = ui.checklist();
+    let step = cl.step("waiting for worker reply");
     let outcome = await_reply(
         &mut stub,
         &mut conn,
@@ -701,22 +757,22 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
 
     match outcome {
         Outcome::Replied(reply) => {
-            println!("reply    {reply}");
+            step.done("");
+            ui.payload(&reply);
             print_continue_hint("message", &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
-            println!("the worker finished the turn but never edited the placeholder");
+            step.done("no edit");
+            ui.warn("the worker finished the turn but never edited the placeholder");
             print_continue_hint("message", &channel, &thread_ts);
             Ok(())
         }
         Outcome::TimedOut => {
-            println!(
-                "TIMEOUT: the worker did not finalize within {}s. Stream diagnostics:",
-                opts.timeout_secs
-            );
+            step.fail(&format!("timed out after {}s", opts.timeout_secs));
+            ui.note("stream diagnostics:");
             let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
-            println!("{diag}");
+            ui.note(&diag);
             std::process::exit(1);
         }
     }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -333,28 +333,6 @@ pub(crate) fn require_on_path(bin: &str) -> Result<()> {
     }
 }
 
-/// Print each command line (secrets masked) and exit without running anything.
-pub(crate) fn print_dry_run(cmds: &[OpsCommand]) {
-    for cmd in cmds {
-        println!("{}", cmd.display());
-    }
-}
-
-/// Run one command with inherited stdio (so helm/kubectl output streams live),
-/// echoing the masked command line first. Bails on a nonzero exit.
-pub(crate) async fn run_streaming(cmd: &OpsCommand) -> Result<()> {
-    println!("+ {}", cmd.display());
-    let status = Command::new(&cmd.program)
-        .args(cmd.argv())
-        .status()
-        .await
-        .with_context(|| format!("failed to invoke `{}`; is it on PATH?", cmd.program))?;
-    if !status.success() {
-        bail!("`{}` exited with {}", cmd.program, status);
-    }
-    Ok(())
-}
-
 /// Run one command capturing stdout; returns (success, stdout, stderr).
 pub(crate) async fn run_capture(cmd: &OpsCommand) -> Result<(bool, String, String)> {
     let output = Command::new(&cmd.program)
@@ -369,124 +347,207 @@ pub(crate) async fn run_capture(cmd: &OpsCommand) -> Result<(bool, String, Strin
     ))
 }
 
+/// Run one command under a checklist `step` labeled `label`, capturing its
+/// stdio. Echoes the masked command line and replays the captured output as dim
+/// plumbing (both no-ops unless `--debug`, so default runs stay quiet and the
+/// helm/kubectl/compose chatter is hidden). On success the step freezes done
+/// with `ok_detail`; on a nonzero exit it freezes failed, surfaces the captured
+/// stderr via `ui.failure`, and bails. Returns captured stdout.
+pub(crate) async fn run_step(
+    cl: &crate::ui::Checklist,
+    label: &str,
+    ok_detail: &str,
+    cmd: &OpsCommand,
+) -> Result<String> {
+    let ui = crate::ui::ui();
+    ui.plumbing(&format!("+ {}", cmd.display()));
+    let step = cl.step(label);
+    let (ok, out, err) = run_capture(cmd).await?;
+    if ok {
+        step.done(ok_detail);
+    } else {
+        step.fail("failed");
+    }
+    for line in out.lines().chain(err.lines()) {
+        ui.plumbing(line);
+    }
+    if !ok {
+        let reason = err
+            .lines()
+            .rev()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .unwrap_or("command failed");
+        ui.failure(&format!("`{}` failed: {reason}", cmd.program));
+        bail!("`{}` exited nonzero", cmd.program);
+    }
+    Ok(out)
+}
+
 // ---------------------------------------------------------------------------
 // Verb handlers
 // ---------------------------------------------------------------------------
 
 pub async fn up(opts: UpOpts) -> Result<()> {
+    let ui = crate::ui::ui();
     let cmds = up_commands(&opts);
     if opts.credentials.is_some() {
-        println!(
-            "Real model enabled (credentials from AGENTOS_MODEL_CREDENTIALS); egress opened to the model provider."
-        );
+        ui.note("real model enabled; egress opened to the model provider");
     } else if !opts.fake_model {
-        println!("WARNING: no AGENTOS_MODEL_CREDENTIALS set -- installing with the fake model and sealed egress.");
-        println!("         Replies will be canned. Set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) and");
-        println!(
-            "         re-run `agentos up` (an idempotent helm upgrade) to enable the real model."
+        ui.warn(
+            "no AGENTOS_MODEL_CREDENTIALS set; installing with the fake model and sealed egress",
+        );
+        ui.note(
+            "Replies will be canned. Set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) and re-run `agentos up` to enable the real model.",
         );
     }
     if opts.common.dry_run {
-        print_dry_run(&cmds);
+        for cmd in &cmds {
+            ui.payload_plain(&cmd.display());
+        }
         return Ok(());
     }
     require_on_path("helm")?;
+    let cl = ui.checklist();
+    let label = format!("installing release {}", opts.common.release);
     for cmd in &cmds {
-        run_streaming(cmd).await?;
+        run_step(&cl, &label, "installed", cmd).await?;
     }
-    println!("\nInstalled. Run `agentos status` for pod health and URLs.");
+    ui.payload("agentos is up");
+    ui.note("Run `agentos status` for pod health and URLs.");
     Ok(())
 }
 
 pub async fn status(opts: CommonOpts) -> Result<()> {
+    let ui = crate::ui::ui();
     if opts.dry_run {
-        print_dry_run(&status_commands(&opts));
+        for cmd in status_commands(&opts) {
+            ui.payload_plain(&cmd.display());
+        }
         return Ok(());
     }
     require_on_path("helm")?;
     require_on_path("kubectl")?;
 
-    // (a) Helm release state.
-    let (ok, out, err) = run_capture(&helm_status_cmd(&opts)).await?;
-    if ok {
-        let status_line = out
+    // (a) Helm release state -> a bright header line.
+    let (helm_ok, helm_out, helm_err) = run_capture(&helm_status_cmd(&opts)).await?;
+    let field = |name: &str, default: &str| -> String {
+        helm_out
             .lines()
-            .find(|l| l.trim_start().starts_with("STATUS:"))
-            .map(str::trim)
-            .unwrap_or("STATUS: unknown");
-        let revision = out
-            .lines()
-            .find(|l| l.trim_start().starts_with("REVISION:"))
-            .map(str::trim)
-            .unwrap_or("REVISION: ?");
-        println!("release  {} ({}, {})", opts.release, status_line, revision);
+            .find(|l| l.trim_start().starts_with(name))
+            .and_then(|l| l.split_once(':'))
+            .map(|(_, v)| v.trim().to_string())
+            .unwrap_or_else(|| default.to_string())
+    };
+    let (release_state, revision) = if helm_ok {
+        (field("STATUS:", "unknown"), field("REVISION:", "?"))
     } else {
-        println!(
-            "release  {} not found ({})",
+        ("not found".to_string(), "none".to_string())
+    };
+    ui.payload(&format!(
+        "agentos · namespace {} · revision {} · {}",
+        opts.namespace, revision, release_state
+    ));
+    if !helm_ok {
+        ui.note(&format!(
+            "release {} not found: {}",
             opts.release,
-            err.trim().lines().next().unwrap_or("no such release")
-        );
+            helm_err.trim().lines().next().unwrap_or("no such release")
+        ));
     }
 
     // (b) Pod health.
     let (ok, out, _) = run_capture(&pods_cmd(&opts)).await?;
-    if ok {
-        print_pod_summary(&out);
+    let (ready, total, unhealthy) = if ok {
+        print_pod_summary(&out)
     } else {
-        println!(
-            "pods     could not list pods in namespace {}",
+        ui.warn(&format!(
+            "could not list pods in namespace {}",
             opts.namespace
-        );
-    }
+        ));
+        (0, 0, Vec::new())
+    };
 
     // (c) URL discovery.
     let host = discover_host().await;
     print_service_url(&opts, "ui", "UI", &host, true).await;
     print_service_url(&opts, "langfuse-web", "Langfuse", &host, false).await;
 
+    // (d) Overall verdict.
+    if total > 0 && ready == total && unhealthy.is_empty() {
+        ui.success(&format!("healthy ({ready}/{total} pods ready)"));
+    } else if total == 0 {
+        ui.warn("no pods running");
+    } else {
+        let mut msg = format!("{ready}/{total} pods ready");
+        if !unhealthy.is_empty() {
+            msg.push_str(&format!("; not ready: {}", unhealthy.join(", ")));
+        }
+        ui.warn(&msg);
+    }
+
     Ok(())
 }
 
 pub async fn down(opts: DownOpts) -> Result<()> {
+    let ui = crate::ui::ui();
     let cmds = down_commands(&opts.common);
     if opts.common.dry_run {
-        print_dry_run(&cmds);
+        for cmd in &cmds {
+            ui.payload_plain(&cmd.display());
+        }
         return Ok(());
     }
+    ui.warn(&format!(
+        "this uninstalls release '{}' and deletes namespaces '{}' and 'agent-sandbox-system'",
+        opts.common.release, opts.common.namespace
+    ));
     if !opts.yes && !confirm(&opts.common)? {
-        println!("aborted.");
+        ui.note("aborted");
         return Ok(());
     }
     require_on_path("helm")?;
     require_on_path("kubectl")?;
 
+    let cl = ui.checklist();
+
     // helm uninstall, tolerating an already-absent release.
     let uninstall = &cmds[0];
-    println!("+ {}", uninstall.display());
+    ui.plumbing(&format!("+ {}", uninstall.display()));
+    let step = cl.step("uninstalling release");
     let (ok, out, err) = run_capture(uninstall).await?;
+    let absent = !ok && (err.contains("not found") || out.contains("not found"));
     if ok {
-        print!("{out}");
-    } else if err.contains("not found") || out.contains("not found") {
-        println!("release {} already absent; continuing", opts.common.release);
+        step.done("removed");
+    } else if absent {
+        step.done("already absent");
     } else {
-        bail!("helm uninstall failed: {}", err.trim());
+        step.fail("failed");
+    }
+    for line in out.lines().chain(err.lines()) {
+        ui.plumbing(line);
+    }
+    if !ok && !absent {
+        ui.failure(&format!("helm uninstall failed: {}", err.trim()));
+        bail!("helm uninstall failed");
     }
 
     // Namespace sweep (runtime artifacts Helm does not own).
-    run_streaming(&cmds[1]).await?;
+    run_step(&cl, "sweeping namespaces", "removed", &cmds[1]).await?;
 
-    println!("\nTorn down. The agents.x-k8s.io CRDs are left in place intentionally.");
+    ui.payload("agentos is down");
+    ui.note("The agents.x-k8s.io CRDs are left in place intentionally.");
     Ok(())
 }
 
-/// Read a y/N confirmation from stdin for `down` when `--yes` is absent.
+/// Read a y/N confirmation from stderr/stdin for `down` when `--yes` is absent.
 fn confirm(o: &CommonOpts) -> Result<bool> {
     use std::io::Write;
-    print!(
+    eprint!(
         "This uninstalls release '{}' and deletes namespaces '{}' and 'agent-sandbox-system'. Continue? [y/N] ",
         o.release, o.namespace
     );
-    std::io::stdout().flush().ok();
+    std::io::stderr().flush().ok();
     let mut line = String::new();
     std::io::stdin()
         .read_line(&mut line)
@@ -494,20 +555,19 @@ fn confirm(o: &CommonOpts) -> Result<bool> {
     Ok(matches!(line.trim(), "y" | "Y" | "yes" | "Yes"))
 }
 
-/// Parse `kubectl get pods` tabular output into an "N/M ready" line plus any
-/// pods that are not Running/Completed, by name.
-fn print_pod_summary(pods_output: &str) {
+/// Render `kubectl get pods` output as a borderless table to stdout and return
+/// (ready count, total, names of pods not Running/Completed) so the caller can
+/// summarise overall health.
+fn print_pod_summary(pods_output: &str) -> (usize, usize, Vec<String>) {
+    let ui = crate::ui::ui();
     let rows: Vec<&str> = pods_output
         .lines()
         .skip(1) // header
         .filter(|l| !l.trim().is_empty())
         .collect();
-    if rows.is_empty() {
-        println!("pods     none in namespace");
-        return;
-    }
     let mut ready = 0usize;
-    let mut unhealthy: Vec<&str> = Vec::new();
+    let mut unhealthy: Vec<String> = Vec::new();
+    let mut table_rows: Vec<Vec<String>> = Vec::new();
     for row in &rows {
         let cols: Vec<&str> = row.split_whitespace().collect();
         let name = cols.first().copied().unwrap_or("?");
@@ -522,13 +582,22 @@ fn print_pod_summary(pods_output: &str) {
             ready += 1;
         }
         if phase != "Running" && phase != "Completed" {
-            unhealthy.push(name);
+            unhealthy.push(name.to_string());
         }
+        table_rows.push(vec![
+            name.to_string(),
+            ready_col.to_string(),
+            phase.to_string(),
+        ]);
     }
-    println!("pods     {}/{} ready", ready, rows.len());
-    if !unhealthy.is_empty() {
-        println!("         not ready: {}", unhealthy.join(", "));
+    if !table_rows.is_empty() {
+        ui.payload_plain(&crate::ui::table(
+            &["pod", "ready", "status"],
+            &table_rows,
+            &[],
+        ));
     }
+    (ready, rows.len(), unhealthy)
 }
 
 /// Resolve the node host: the kubeconfig cluster server hostname, falling back
@@ -566,35 +635,43 @@ fn node_internal_ip(nodes_json: &str) -> Option<String> {
 /// Print one service's access URL: a NodePort URL when exposed, else the
 /// port-forward command to reach a ClusterIP service.
 async fn print_service_url(o: &CommonOpts, suffix: &str, label: &str, host: &str, api: bool) {
+    let ui = crate::ui::ui();
     let name = format!("{}-{}", o.release, suffix);
     let (ok, out, _) = match run_capture(&svc_cmd(o, suffix)).await {
         Ok(res) => res,
         Err(_) => {
-            println!("{label:9}service {name} not found");
+            ui.kv(label, &format!("service {name} not found"));
             return;
         }
     };
     if !ok {
-        println!("{label:9}service {name} not found");
+        ui.kv(label, &format!("service {name} not found"));
         return;
     }
     let suffix_path = if api { "/?api=1" } else { "" };
     match parse_service(&out) {
         Some((svc_type, node_port, _port)) if svc_type == "NodePort" => {
             if let Some(np) = node_port {
-                println!("{label:9}http://{host}:{np}{suffix_path}");
+                ui.kv(label, &ui.url(&format!("http://{host}:{np}{suffix_path}")));
             } else {
-                println!("{label:9}service {name} is NodePort but exposes no nodePort yet");
+                ui.kv(
+                    label,
+                    &format!("service {name} is NodePort but exposes no nodePort yet"),
+                );
             }
         }
         Some((_, _, port)) => {
             let local = if port == 0 { 8080 } else { port };
-            println!(
-                "{label:9}kubectl -n {} port-forward svc/{name} {local}:{port}  then http://localhost:{local}{suffix_path}",
-                o.namespace
+            let target = ui.url(&format!("http://localhost:{local}{suffix_path}"));
+            ui.kv(
+                label,
+                &format!(
+                    "kubectl -n {} port-forward svc/{name} {local}:{port}  then {target}",
+                    o.namespace
+                ),
             );
         }
-        None => println!("{label:9}could not read service {name}"),
+        None => ui.kv(label, &format!("could not read service {name}")),
     }
 }
 

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -15,28 +15,41 @@ pub fn status_str(status: &SessionStatus) -> &'static str {
     }
 }
 
-/// Renders the outbound events of one turn into printable lines.
+/// One piece of a streamed turn, tagged by which stream it belongs on so the
+/// caller can route it: `Token` is agent answer text (raw payload -> stdout),
+/// `Note` is tool/side-effect chatter (dim diagnostics -> stderr), `Fail` is an
+/// error line (red diagnostics -> stderr), and `Status` is the final trailer
+/// (dim diagnostics -> stderr).
+pub enum TurnPart {
+    Token(String),
+    Note(String),
+    Fail(String),
+    Status(String),
+}
+
+/// Classifies the outbound events of one turn into stream-tagged parts.
 ///
-/// Text deltas print as-is. Tool notes and side-effect flags print as dim
-/// arrow/bang lines. The final frame prints a status trailer; its text is
-/// repeated only when nothing was streamed before it (so a turn that only
-/// yields a final still shows its answer, without duplicating streamed text).
+/// Text deltas are answer tokens. Tool notes and side-effect flags are notes.
+/// Error events are failures. The final frame becomes a status trailer, except
+/// when nothing was streamed before it and it carries text: then the answer is
+/// returned as a `Token` (so a turn that only yields a final still shows its
+/// answer to stdout) and the caller appends the status trailer itself.
 #[derive(Default)]
 pub struct TurnPrinter {
     streamed_text: bool,
 }
 
 impl TurnPrinter {
-    /// The printable line for one event, if any.
-    pub fn line_for(&mut self, event: &OutboundEvent) -> Option<String> {
+    /// The stream-tagged part for one event, if any.
+    pub fn part_for(&mut self, event: &OutboundEvent) -> Option<TurnPart> {
         match event {
             OutboundEvent::TextDelta { text, .. } => {
                 self.streamed_text = true;
-                Some(text.clone())
+                Some(TurnPart::Token(text.clone()))
             }
             OutboundEvent::ToolNote { text, tool, .. } => match tool {
-                Some(tool) => Some(format!("  -> [{tool}] {text}")),
-                None => Some(format!("  -> {text}")),
+                Some(tool) => Some(TurnPart::Note(format!("  -> [{tool}] {text}"))),
+                None => Some(TurnPart::Note(format!("  -> {text}"))),
             },
             OutboundEvent::SideEffectFlag { tool, detail, .. } => {
                 let tool = tool.as_deref().unwrap_or("unknown tool");
@@ -44,7 +57,9 @@ impl TurnPrinter {
                     .as_deref()
                     .map(|d| format!(": {d}"))
                     .unwrap_or_default();
-                Some(format!("  !  side effect via {tool}{detail}"))
+                Some(TurnPart::Note(format!(
+                    "  !  side effect via {tool}{detail}"
+                )))
             }
             OutboundEvent::ErrorEvent {
                 message,
@@ -55,14 +70,18 @@ impl TurnPrinter {
                     .as_deref()
                     .map(|c| format!(" [{c}]"))
                     .unwrap_or_default();
-                Some(format!("error{class}: {message}"))
+                Some(TurnPart::Fail(format!("error{class}: {message}")))
             }
             OutboundEvent::Final { text, status, .. } => {
-                let trailer = format!("-- final ({})", status_str(status));
                 if self.streamed_text || text.is_empty() {
-                    Some(trailer)
+                    Some(TurnPart::Status(format!(
+                        "-- final ({})",
+                        status_str(status)
+                    )))
                 } else {
-                    Some(format!("{text}\n{trailer}"))
+                    // Nothing streamed: surface the final answer as a token; the
+                    // caller prints it to stdout then adds the status trailer.
+                    Some(TurnPart::Token(text.clone()))
                 }
             }
         }
@@ -114,8 +133,15 @@ mod tests {
         PROTOCOL_VERSION.to_string()
     }
 
+    /// The text of a `Token`/`Note`/`Fail`/`Status` part, for assertions.
+    fn part_text(part: Option<TurnPart>) -> String {
+        match part.expect("a part") {
+            TurnPart::Token(s) | TurnPart::Note(s) | TurnPart::Fail(s) | TurnPart::Status(s) => s,
+        }
+    }
+
     #[test]
-    fn streams_deltas_then_summarizes_final_without_repeating_text() {
+    fn streams_deltas_as_tokens_then_final_is_a_status_without_repeating_text() {
         let mut printer = TurnPrinter::default();
         let delta = OutboundEvent::TextDelta {
             version: v(),
@@ -126,26 +152,43 @@ mod tests {
             text: "all done".into(),
             status: SessionStatus::Done,
         };
-        assert_eq!(printer.line_for(&delta).unwrap(), "all done");
-        assert_eq!(printer.line_for(&final_frame).unwrap(), "-- final (done)");
+        // A delta routes to stdout as a raw token.
+        assert!(matches!(printer.part_for(&delta), Some(TurnPart::Token(t)) if t == "all done"));
+        // After streaming, the final only contributes the status trailer.
+        assert!(
+            matches!(printer.part_for(&final_frame), Some(TurnPart::Status(s)) if s == "-- final (done)")
+        );
     }
 
     #[test]
-    fn prints_final_text_when_nothing_was_streamed() {
+    fn returns_final_text_as_a_token_when_nothing_was_streamed() {
         let mut printer = TurnPrinter::default();
         let final_frame = OutboundEvent::Final {
             version: v(),
             text: "quiet answer".into(),
             status: SessionStatus::IdleAwaitingInput,
         };
-        assert_eq!(
-            printer.line_for(&final_frame).unwrap(),
-            "quiet answer\n-- final (idle-awaiting-input)"
+        // The caller prints this token to stdout, then appends the status trailer.
+        assert!(
+            matches!(printer.part_for(&final_frame), Some(TurnPart::Token(t)) if t == "quiet answer")
         );
     }
 
     #[test]
-    fn renders_tool_notes_side_effects_and_errors() {
+    fn an_empty_final_is_a_status_even_without_streaming() {
+        let mut printer = TurnPrinter::default();
+        let final_frame = OutboundEvent::Final {
+            version: v(),
+            text: String::new(),
+            status: SessionStatus::Done,
+        };
+        assert!(
+            matches!(printer.part_for(&final_frame), Some(TurnPart::Status(s)) if s == "-- final (done)")
+        );
+    }
+
+    #[test]
+    fn routes_tool_notes_side_effects_and_errors_to_note_and_fail() {
         let mut printer = TurnPrinter::default();
         let note = OutboundEvent::ToolNote {
             version: v(),
@@ -162,15 +205,21 @@ mod tests {
             message: "boom".into(),
             classification: Some("budget".into()),
         };
+        // Tool note and side-effect flag are diagnostics -> Note (stderr).
+        assert!(matches!(printer.part_for(&note), Some(TurnPart::Note(_))));
         assert_eq!(
-            printer.line_for(&note).unwrap(),
+            part_text(printer.part_for(&note)),
             "  -> [Bash] running echo hi"
         );
         assert_eq!(
-            printer.line_for(&flag).unwrap(),
+            part_text(printer.part_for(&flag)),
             "  !  side effect via Bash"
         );
-        assert_eq!(printer.line_for(&error).unwrap(), "error [budget]: boom");
+        // Error events route to Fail (red stderr).
+        assert!(matches!(
+            printer.part_for(&error),
+            Some(TurnPart::Fail(f)) if f == "error [budget]: boom"
+        ));
     }
 
     #[test]

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -223,6 +223,14 @@ impl Ui {
         role(self.truecolor, 0xE6, 0xED, 0xF3, AnsiColor::White).bold()
     }
 
+    /// Bright white without bold: the streamed/returned agent answer. Same
+    /// foreground as `payload_style` (the brightest thing on screen) but not
+    /// bold, since a bold multi-line paragraph reads too heavy; short status
+    /// lines keep `payload`'s bold.
+    fn answer_style(&self) -> Style {
+        role(self.truecolor, 0xE6, 0xED, 0xF3, AnsiColor::White)
+    }
+
     fn ok_glyph(&self) -> &'static str {
         if self.unicode {
             "\u{2713}" // check mark
@@ -338,6 +346,15 @@ impl Ui {
     pub fn print_tokens(&self, s: &str) {
         let mut out = anstream::stdout();
         let _ = write!(out, "{s}");
+        let _ = out.flush();
+    }
+
+    /// Write agent answer text to stdout in the bright payload color (non-bold),
+    /// no trailing newline, flushed. Used for streamed tokens and returned replies.
+    pub fn answer(&self, s: &str) {
+        let styled = self.paint_out(self.answer_style(), s);
+        let mut out = anstream::stdout();
+        let _ = write!(out, "{styled}");
         let _ = out.flush();
     }
 

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -1,0 +1,844 @@
+//! Shared terminal-output core: color/unicode resolution, styled message
+//! emission, an indicatif-backed step checklist, and a borderless table.
+//!
+//! The design principle is "dim plumbing, bright payload": diagnostics go to
+//! stderr in muted colors, the thing the user asked for goes to stdout in bold
+//! white. State is never encoded in color alone; every colored status carries a
+//! glyph and a word. Commands reach a process-global `Ui` via `ui::ui()` so the
+//! resolved flags do not have to thread through every options struct.
+
+use std::io::{IsTerminal, Write};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use anstyle::{AnsiColor, Color, RgbColor, Style};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+// ---------------------------------------------------------------------------
+// Palette
+// ---------------------------------------------------------------------------
+
+fn rgb(r: u8, g: u8, b: u8) -> Color {
+    Color::Rgb(RgbColor(r, g, b))
+}
+
+/// A palette role, defined by its 24-bit brand color and the nearest named
+/// ANSI color to degrade to when the terminal does not advertise truecolor.
+/// Resolved through `Ui::role`, which reads the per-`Ui` `truecolor` depth.
+///
+/// - success `#2EA043` -> `Green`
+/// - error `#CF222E` -> `Red`
+/// - amber `#BF8700` -> `Yellow`
+/// - dim `#8B949E` -> `BrightBlack`
+/// - cyan (urls) `#39C5CF` -> `Cyan`
+/// - payload `#E6EDF3` (bold) -> `White` (bold)
+fn role(truecolor: bool, r: u8, g: u8, b: u8, ansi: AnsiColor) -> Style {
+    let color = if truecolor {
+        rgb(r, g, b)
+    } else {
+        Color::Ansi(ansi)
+    };
+    Style::new().fg_color(Some(color))
+}
+
+/// Column at which a step's elapsed time is right-aligned.
+const STEP_LABEL_WIDTH: usize = 44;
+
+// ---------------------------------------------------------------------------
+// Config resolution (pure)
+// ---------------------------------------------------------------------------
+
+/// The `--color` flag: honor the terminal, force on, or force off.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum ColorFlag {
+    /// Colorize only when stderr is a terminal (respecting NO_COLOR etc.).
+    #[default]
+    Auto,
+    /// Always emit ANSI styling.
+    Always,
+    /// Never emit ANSI styling.
+    Never,
+}
+
+/// A snapshot of the process environment, passed to `resolve` so color/unicode
+/// resolution is a pure, testable function.
+pub struct UiEnv {
+    /// NO_COLOR present and non-empty (per no-color.org).
+    pub no_color: bool,
+    /// CLICOLOR=0.
+    pub clicolor_zero: bool,
+    /// CLICOLOR_FORCE present and != "0".
+    pub clicolor_force: bool,
+    /// TERM=dumb.
+    pub term_dumb: bool,
+    /// CI present.
+    pub ci: bool,
+    /// stderr is a terminal.
+    pub stderr_tty: bool,
+    /// stdout is a terminal.
+    pub stdout_tty: bool,
+    /// The locale advertises UTF-8.
+    pub utf8: bool,
+    /// The terminal advertises 24-bit truecolor (COLORTERM / terminfo).
+    pub truecolor: bool,
+}
+
+/// The resolved output configuration every command reads.
+#[derive(Copy, Clone, Debug)]
+pub struct Ui {
+    color_stdout: bool,
+    color_stderr: bool,
+    unicode: bool,
+    truecolor: bool,
+    debug: bool,
+    quiet: bool,
+    interactive: bool,
+}
+
+/// Resolve whether a given stream should embed ANSI, honoring the `--color`
+/// flag first, then the environment overrides, then the stream's own tty state.
+fn want_color(flag: ColorFlag, env: &UiEnv, stream_tty: bool) -> bool {
+    match flag {
+        ColorFlag::Never => false,
+        ColorFlag::Always => true,
+        ColorFlag::Auto => {
+            if env.clicolor_force {
+                true
+            } else if env.no_color || env.clicolor_zero || env.term_dumb {
+                false
+            } else {
+                stream_tty
+            }
+        }
+    }
+}
+
+impl Ui {
+    /// Resolve output config from the flags and an environment snapshot.
+    ///
+    /// Color precedence: `--color=never` forces off and `--color=always`
+    /// forces on (explicit intent wins over everything). Under `Auto`,
+    /// CLICOLOR_FORCE forces on, then NO_COLOR / CLICOLOR=0 / TERM=dumb force
+    /// off, otherwise it follows whether that stream is a terminal. Color is
+    /// resolved per stream: stdout (payload) and stderr (diagnostics) each
+    /// follow their own tty state, so redirecting one never taints the other.
+    /// Interactivity (spinners and redraws) is independent of color: on only
+    /// for a non-CI, non-dumb terminal. Unicode mirrors the locale.
+    pub fn resolve(color: ColorFlag, debug: bool, quiet: bool, env: &UiEnv) -> Ui {
+        let color_stdout = want_color(color, env, env.stdout_tty);
+        let color_stderr = want_color(color, env, env.stderr_tty);
+        let interactive = env.stderr_tty && !env.ci && !env.term_dumb;
+        Ui {
+            color_stdout,
+            color_stderr,
+            unicode: env.utf8,
+            truecolor: env.truecolor,
+            debug,
+            quiet,
+            interactive,
+        }
+    }
+
+    /// Snapshot the real process environment and resolve. Non-pure wrapper.
+    pub fn from_process(color: ColorFlag, debug: bool, quiet: bool) -> Ui {
+        let env = UiEnv {
+            no_color: std::env::var_os("NO_COLOR")
+                .map(|v| !v.is_empty())
+                .unwrap_or(false),
+            clicolor_zero: std::env::var("CLICOLOR").map(|v| v == "0").unwrap_or(false),
+            clicolor_force: std::env::var("CLICOLOR_FORCE")
+                .map(|v| v != "0")
+                .unwrap_or(false),
+            term_dumb: std::env::var("TERM").map(|v| v == "dumb").unwrap_or(false),
+            ci: std::env::var_os("CI").is_some(),
+            stderr_tty: std::io::stderr().is_terminal(),
+            stdout_tty: std::io::stdout().is_terminal(),
+            utf8: detect_utf8(),
+            truecolor: anstyle_query::truecolor(),
+        };
+        Ui::resolve(color, debug, quiet, &env)
+    }
+
+    // -- styling helpers ---------------------------------------------------
+
+    /// Wrap `s` in `style`'s ANSI codes when stdout color is on, else raw.
+    /// Used by every stdout (payload) emitter.
+    fn paint_out(&self, style: Style, s: &str) -> String {
+        if self.color_stdout {
+            format!("{}{}{}", style.render(), s, style.render_reset())
+        } else {
+            s.to_string()
+        }
+    }
+
+    /// Wrap `s` in `style`'s ANSI codes when stderr color is on, else raw.
+    /// Used by every stderr (diagnostics) emitter, including the indicatif
+    /// spinner and frozen step lines that bypass anstream's stripping.
+    fn paint_err(&self, style: Style, s: &str) -> String {
+        if self.color_stderr {
+            format!("{}{}{}", style.render(), s, style.render_reset())
+        } else {
+            s.to_string()
+        }
+    }
+
+    // -- palette (depth-aware: 24-bit when truecolor, else nearest ANSI-16) --
+
+    /// Success green, paired with the ok glyph and a word like "done"/"pass".
+    fn green(&self) -> Style {
+        role(self.truecolor, 0x2E, 0xA0, 0x43, AnsiColor::Green)
+    }
+
+    /// Error red, paired with the fail glyph and "failed"/"fail".
+    fn red(&self) -> Style {
+        role(self.truecolor, 0xCF, 0x22, 0x2E, AnsiColor::Red)
+    }
+
+    /// Amber warn, paired with the warn glyph and "warn".
+    fn amber(&self) -> Style {
+        role(self.truecolor, 0xBF, 0x87, 0x00, AnsiColor::Yellow)
+    }
+
+    /// Dim grey for plumbing, details, and elapsed times. Off truecolor it
+    /// degrades to the portable faint attribute (SGR 2) with no explicit
+    /// foreground rather than ANSI bright-black: faint derives from the
+    /// terminal's own default foreground, so it stays readable on both light
+    /// and dark backgrounds, and a terminal that ignores SGR 2 simply renders
+    /// at normal intensity (still readable) instead of low-contrast dark grey.
+    fn dim(&self) -> Style {
+        if self.truecolor {
+            Style::new().fg_color(Some(rgb(0x8B, 0x94, 0x9E)))
+        } else {
+            Style::new().dimmed()
+        }
+    }
+
+    /// Cyan for URLs and resource ids.
+    fn cyan(&self) -> Style {
+        role(self.truecolor, 0x39, 0xC5, 0xCF, AnsiColor::Cyan)
+    }
+
+    /// Bright bold white: the payload the user asked for.
+    fn payload_style(&self) -> Style {
+        role(self.truecolor, 0xE6, 0xED, 0xF3, AnsiColor::White).bold()
+    }
+
+    fn ok_glyph(&self) -> &'static str {
+        if self.unicode {
+            "\u{2713}" // check mark
+        } else {
+            "v"
+        }
+    }
+
+    fn fail_glyph(&self) -> &'static str {
+        if self.unicode {
+            "\u{2717}" // ballot x
+        } else {
+            "x"
+        }
+    }
+
+    fn warn_glyph(&self) -> &'static str {
+        if self.unicode {
+            "\u{26a0}" // warning sign
+        } else {
+            "!"
+        }
+    }
+
+    fn bullet_glyph(&self) -> &'static str {
+        if self.unicode {
+            "\u{00b7}" // middle dot
+        } else {
+            "-"
+        }
+    }
+
+    fn prompt_glyph(&self) -> &'static str {
+        if self.unicode {
+            "\u{276f}" // heavy right angle
+        } else {
+            ">"
+        }
+    }
+
+    /// The bold-green prompt marker, ready to embed.
+    pub fn prompt(&self) -> String {
+        self.paint_out(self.green().bold(), self.prompt_glyph())
+    }
+
+    // -- stderr diagnostics (no-op when quiet) -----------------------------
+
+    /// Dim "middot line" plumbing detail. Emitted only under `--debug`.
+    pub fn plumbing(&self, line: &str) {
+        if self.quiet || !self.debug {
+            return;
+        }
+        let out = self.paint_err(self.dim(), &format!("{} {line}", self.bullet_glyph()));
+        let _ = writeln!(anstream::stderr(), "{out}");
+    }
+
+    /// A dim informational line on stderr.
+    pub fn note(&self, msg: &str) {
+        if self.quiet {
+            return;
+        }
+        let _ = writeln!(anstream::stderr(), "{}", self.paint_err(self.dim(), msg));
+    }
+
+    /// An amber warning: "warn glyph + warn + message".
+    pub fn warn(&self, msg: &str) {
+        if self.quiet {
+            return;
+        }
+        let content = format!("{} warn  {msg}", self.warn_glyph());
+        let _ = writeln!(
+            anstream::stderr(),
+            "{}",
+            self.paint_err(self.amber(), &content)
+        );
+    }
+
+    /// A green success line: "ok glyph + message".
+    pub fn success(&self, msg: &str) {
+        if self.quiet {
+            return;
+        }
+        let line = format!("{} {msg}", self.paint_err(self.green(), self.ok_glyph()));
+        let _ = writeln!(anstream::stderr(), "{line}");
+    }
+
+    /// A red failure line: "fail glyph + message".
+    pub fn failure(&self, msg: &str) {
+        if self.quiet {
+            return;
+        }
+        let line = format!("{} {msg}", self.paint_err(self.red(), self.fail_glyph()));
+        let _ = writeln!(anstream::stderr(), "{line}");
+    }
+
+    // -- stdout payload (always emitted, even under quiet) ------------------
+
+    /// A bright bold-white payload line on stdout.
+    pub fn payload(&self, line: &str) {
+        let _ = writeln!(
+            anstream::stdout(),
+            "{}",
+            self.paint_out(self.payload_style(), line)
+        );
+    }
+
+    /// An unstyled payload line on stdout (raw data).
+    pub fn payload_plain(&self, line: &str) {
+        let _ = writeln!(anstream::stdout(), "{line}");
+    }
+
+    /// Write raw streamed tokens to stdout with no newline, flushing.
+    pub fn print_tokens(&self, s: &str) {
+        let mut out = anstream::stdout();
+        let _ = write!(out, "{s}");
+        let _ = out.flush();
+    }
+
+    /// A key/value line on stdout: dim padded key, then value. The caller
+    /// pre-styles the value (e.g. via `url`) when it is a URL or id.
+    pub fn kv(&self, key: &str, val: &str) {
+        let key_styled = self.paint_out(self.dim(), &format!("{key:<12}"));
+        let _ = writeln!(anstream::stdout(), "{key_styled}  {val}");
+    }
+
+    /// Return `s` styled as a cyan URL/id, for embedding in another line.
+    pub fn url(&self, s: &str) -> String {
+        self.paint_out(self.cyan(), s)
+    }
+
+    // -- checklist / progress ---------------------------------------------
+
+    /// Begin a checklist: a group of steps sharing one drawing area.
+    pub fn checklist(&self) -> Checklist {
+        Checklist {
+            multi: MultiProgress::new(),
+            ui: *self,
+        }
+    }
+
+    /// A minimal determinate progress bar (message/eval use it later).
+    pub fn progress_bar(&self, total: u64, label: &str) -> Bar {
+        let pb = if self.interactive && !self.quiet {
+            let pb = ProgressBar::new(total);
+            if let Ok(style) = ProgressStyle::with_template("{msg} [{bar:24}] {pos}/{len}") {
+                pb.set_style(style);
+            }
+            pb.set_message(label.to_string());
+            pb
+        } else {
+            ProgressBar::hidden()
+        };
+        Bar { pb }
+    }
+
+    /// The frozen, styled line a finished interactive step commits.
+    fn step_line(&self, ok: bool, label: &str, detail: &str, elapsed: &str) -> String {
+        let (glyph, style) = if ok {
+            (self.ok_glyph(), self.green())
+        } else {
+            (self.fail_glyph(), self.red())
+        };
+        let mut left = format!("{} {label}", self.paint_err(style, glyph));
+        if !detail.is_empty() {
+            left.push_str("   ");
+            left.push_str(&self.paint_err(self.dim(), detail));
+        }
+        let pad = STEP_LABEL_WIDTH.saturating_sub(display_width(&left));
+        format!(
+            "{left}{}{}",
+            " ".repeat(pad + 1),
+            self.paint_err(self.dim(), elapsed)
+        )
+    }
+}
+
+/// Detect whether the locale advertises UTF-8. First set of LC_ALL / LC_CTYPE /
+/// LANG decides; unset defaults to true off Windows.
+fn detect_utf8() -> bool {
+    for key in ["LC_ALL", "LC_CTYPE", "LANG"] {
+        if let Ok(val) = std::env::var(key) {
+            if !val.is_empty() {
+                let up = val.to_uppercase();
+                return up.contains("UTF-8") || up.contains("UTF8");
+            }
+        }
+    }
+    !cfg!(windows)
+}
+
+// ---------------------------------------------------------------------------
+// Process-global handle
+// ---------------------------------------------------------------------------
+
+static UI: OnceLock<Ui> = OnceLock::new();
+
+/// Install the resolved `Ui`. Color embedding is gated per stream by
+/// `paint_out`/`paint_err`, so anstream's global choice is set to a passthrough
+/// `Always`: it must not strip the ANSI we deliberately embed for a TTY stream,
+/// and a global `Never` would wrongly strip the stderr color we keep. The
+/// `anstream::stdout()`/`anstream::stderr()` wrappers still handle Windows VT
+/// enablement.
+pub fn init(ui: Ui) {
+    anstream::ColorChoice::Always.write_global();
+    let _ = UI.set(ui);
+}
+
+/// The process-global `Ui`. Falls back to a safe auto default (for tests and
+/// any pre-init caller).
+pub fn ui() -> &'static Ui {
+    UI.get_or_init(|| Ui::from_process(ColorFlag::Auto, false, false))
+}
+
+// ---------------------------------------------------------------------------
+// Checklist (indicatif-backed)
+// ---------------------------------------------------------------------------
+
+/// A group of sequential steps sharing one stderr drawing area.
+pub struct Checklist {
+    multi: MultiProgress,
+    ui: Ui,
+}
+
+impl Checklist {
+    /// Begin a step. Interactive terminals get a live spinner with a dim
+    /// label; non-interactive or quiet runs draw nothing until the step
+    /// resolves.
+    pub fn step(&self, label: &str) -> Step {
+        let pb = if self.ui.interactive && !self.ui.quiet {
+            let (frames, interval) = if self.ui.unicode {
+                ("\u{280b}\u{2819}\u{2839}\u{2838}\u{283c}\u{2834}\u{2826}\u{2827}\u{2807}\u{280f}", 80)
+            } else {
+                ("-\\|/", 130)
+            };
+            let pb = self.multi.add(ProgressBar::new_spinner());
+            if let Ok(style) = ProgressStyle::with_template("{spinner} {msg} {elapsed:.dim}") {
+                pb.set_style(style.tick_chars(frames));
+            }
+            pb.set_message(self.ui.paint_err(self.ui.dim(), label));
+            pb.enable_steady_tick(Duration::from_millis(interval));
+            Some(pb)
+        } else {
+            None
+        };
+        Step {
+            pb,
+            start: Instant::now(),
+            ui: self.ui,
+            label: label.to_string(),
+        }
+    }
+}
+
+/// One in-flight step: a spinner (when interactive) plus its start time.
+pub struct Step {
+    pb: Option<ProgressBar>,
+    start: Instant,
+    ui: Ui,
+    label: String,
+}
+
+impl Step {
+    /// Update the live spinner's "why still waiting" suffix.
+    pub fn tick_detail(&self, detail: &str) {
+        if let Some(pb) = &self.pb {
+            let msg = format!(
+                "{}   {}",
+                self.ui.paint_err(self.ui.dim(), &self.label),
+                self.ui.paint_err(self.ui.dim(), detail)
+            );
+            pb.set_message(msg);
+        }
+    }
+
+    /// Freeze the step to a success line with an optional detail.
+    pub fn done(self, detail: &str) {
+        self.finish(true, detail);
+    }
+
+    /// Freeze the step to a failure line (also used for timeouts).
+    pub fn fail(self, detail: &str) {
+        self.finish(false, detail);
+    }
+
+    /// Clear the step's spinner without committing any line. Used when a spinner
+    /// only marks "waiting for the first token" and the payload itself follows.
+    pub fn clear(self) {
+        if let Some(pb) = self.pb {
+            pb.finish_and_clear();
+        }
+    }
+
+    fn finish(self, ok: bool, detail: &str) {
+        let elapsed = fmt_elapsed(self.start.elapsed());
+        if self.ui.quiet {
+            if let Some(pb) = self.pb {
+                pb.finish_and_clear();
+            }
+            return;
+        }
+        match self.pb {
+            Some(pb) => {
+                let line = self.ui.step_line(ok, &self.label, detail, &elapsed);
+                if let Ok(style) = ProgressStyle::with_template("{msg}") {
+                    pb.set_style(style);
+                }
+                pb.finish_with_message(line);
+            }
+            None => {
+                let line = if ok {
+                    format!("{}: ok ({elapsed})", self.label)
+                } else {
+                    format!("{}: failed ({detail}) ({elapsed})", self.label)
+                };
+                let _ = writeln!(anstream::stderr(), "{line}");
+            }
+        }
+    }
+}
+
+/// A minimal determinate bar handle.
+pub struct Bar {
+    pb: ProgressBar,
+}
+
+impl Bar {
+    /// Advance the bar by `n`.
+    pub fn inc(&self, n: u64) {
+        self.pb.inc(n);
+    }
+
+    /// Clear the bar.
+    pub fn finish(self) {
+        self.pb.finish_and_clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------------------
+
+/// Format a duration: one decimal `s` under a minute, integer `s` past it.
+pub fn fmt_elapsed(d: Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs < 60.0 {
+        format!("{secs:.1}s")
+    } else {
+        format!("{}s", d.as_secs())
+    }
+}
+
+/// Display width of a string: char count with ANSI CSI sequences stripped, so
+/// pre-styled cells still align.
+fn display_width(s: &str) -> usize {
+    let mut width = 0;
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            // Skip a CSI sequence up to and including its final letter.
+            for c2 in chars.by_ref() {
+                if c2.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            width += 1;
+        }
+    }
+    width
+}
+
+/// Render a borderless aligned table. Columns are left-aligned except those in
+/// `numeric_cols`, which are right-aligned. Widths are computed on display
+/// width, so cells containing ANSI still align. Output is plain (no color) so
+/// the function stays pure; callers pre-style cells and print via
+/// `payload_plain`.
+pub fn table(headers: &[&str], rows: &[Vec<String>], numeric_cols: &[usize]) -> String {
+    let ncols = headers.len();
+    let mut widths = vec![0usize; ncols];
+    for (i, h) in headers.iter().enumerate() {
+        widths[i] = widths[i].max(display_width(h));
+    }
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            if i < ncols {
+                widths[i] = widths[i].max(display_width(cell));
+            }
+        }
+    }
+    let render = |cells: &[String]| -> String {
+        let mut parts = Vec::with_capacity(ncols);
+        for (i, width) in widths.iter().enumerate() {
+            let cell = cells.get(i).map(String::as_str).unwrap_or("");
+            let pad = width.saturating_sub(display_width(cell));
+            let padded = if numeric_cols.contains(&i) {
+                format!("{}{cell}", " ".repeat(pad))
+            } else {
+                format!("{cell}{}", " ".repeat(pad))
+            };
+            parts.push(padded);
+        }
+        parts.join("  ")
+    };
+    let header_cells: Vec<String> = headers.iter().map(|h| h.to_string()).collect();
+    let mut out = render(&header_cells);
+    for row in rows {
+        out.push('\n');
+        out.push_str(&render(row));
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_env() -> UiEnv {
+        UiEnv {
+            no_color: false,
+            clicolor_zero: false,
+            clicolor_force: false,
+            term_dumb: false,
+            ci: false,
+            stderr_tty: false,
+            stdout_tty: false,
+            utf8: true,
+            truecolor: true,
+        }
+    }
+
+    #[test]
+    fn always_beats_no_color() {
+        let env = UiEnv {
+            no_color: true,
+            ..base_env()
+        };
+        assert!(Ui::resolve(ColorFlag::Always, false, false, &env).color_stderr);
+    }
+
+    #[test]
+    fn never_beats_clicolor_force() {
+        let env = UiEnv {
+            clicolor_force: true,
+            stderr_tty: true,
+            ..base_env()
+        };
+        assert!(!Ui::resolve(ColorFlag::Never, false, false, &env).color_stderr);
+    }
+
+    #[test]
+    fn auto_tty_on_no_tty_off() {
+        let on = UiEnv {
+            stderr_tty: true,
+            ..base_env()
+        };
+        let off = base_env();
+        assert!(Ui::resolve(ColorFlag::Auto, false, false, &on).color_stderr);
+        assert!(!Ui::resolve(ColorFlag::Auto, false, false, &off).color_stderr);
+    }
+
+    #[test]
+    fn clicolor_force_wins_over_no_color_under_auto() {
+        let env = UiEnv {
+            no_color: true,
+            clicolor_force: true,
+            ..base_env()
+        };
+        assert!(Ui::resolve(ColorFlag::Auto, false, false, &env).color_stderr);
+    }
+
+    #[test]
+    fn ci_keeps_color_but_not_interactive() {
+        let env = UiEnv {
+            ci: true,
+            stderr_tty: true,
+            ..base_env()
+        };
+        let ui = Ui::resolve(ColorFlag::Auto, false, false, &env);
+        assert!(ui.color_stderr, "color follows tty under CI+Auto");
+        assert!(!ui.interactive, "CI is never interactive");
+    }
+
+    #[test]
+    fn term_dumb_forces_color_off_and_not_interactive() {
+        let env = UiEnv {
+            term_dumb: true,
+            stderr_tty: true,
+            ..base_env()
+        };
+        let ui = Ui::resolve(ColorFlag::Auto, false, false, &env);
+        assert!(!ui.color_stderr);
+        assert!(!ui.interactive);
+    }
+
+    #[test]
+    fn auto_colors_stderr_but_not_piped_stdout() {
+        let env = UiEnv {
+            stderr_tty: true,
+            stdout_tty: false,
+            ..base_env()
+        };
+        let ui = Ui::resolve(ColorFlag::Auto, false, false, &env);
+        assert!(
+            ui.color_stderr,
+            "diagnostics on a terminal stderr are colored"
+        );
+        assert!(!ui.color_stdout, "payload piped to a file/pipe stays clean");
+    }
+
+    #[test]
+    fn unicode_reflects_env() {
+        let utf8 = base_env();
+        let ascii = UiEnv {
+            utf8: false,
+            ..base_env()
+        };
+        assert!(Ui::resolve(ColorFlag::Auto, false, false, &utf8).unicode);
+        assert!(!Ui::resolve(ColorFlag::Auto, false, false, &ascii).unicode);
+    }
+
+    #[test]
+    fn palette_degrades_to_ansi16_without_truecolor() {
+        // With truecolor off, success renders the 4-bit green SGR (32), not a
+        // 24-bit 38;2 sequence.
+        let tc_off = UiEnv {
+            stderr_tty: true,
+            truecolor: false,
+            ..base_env()
+        };
+        let ui = Ui::resolve(ColorFlag::Always, false, false, &tc_off);
+        let s = ui.paint_err(ui.green(), "x");
+        assert!(
+            s.contains("\x1b[32m") || s.contains("[32m"),
+            "expected 4-bit green, got {s:?}"
+        );
+        assert!(
+            !s.contains("38;2"),
+            "must not emit truecolor when unsupported: {s:?}"
+        );
+        // And truecolor ON still emits 24-bit.
+        let tc_on = UiEnv {
+            stderr_tty: true,
+            truecolor: true,
+            ..base_env()
+        };
+        let ui2 = Ui::resolve(ColorFlag::Always, false, false, &tc_on);
+        assert!(
+            ui2.paint_err(ui2.green(), "x").contains("38;2"),
+            "truecolor path emits 24-bit"
+        );
+        // dim off truecolor degrades to the portable faint attribute (SGR 2),
+        // never ANSI bright-black (90m) which is unreadable on dark terminals,
+        // and never a 24-bit foreground.
+        let dim_off = ui.paint_err(ui.dim(), "x");
+        assert!(
+            !dim_off.contains("\x1b[90m") && !dim_off.contains("[90m"),
+            "dim must not degrade to unreadable bright-black: {dim_off:?}"
+        );
+        assert!(
+            !dim_off.contains("38;2"),
+            "dim must not emit truecolor when unsupported: {dim_off:?}"
+        );
+        assert!(
+            dim_off.contains("\x1b[2m") || dim_off.contains("[2m"),
+            "dim degrades to the faint attribute: {dim_off:?}"
+        );
+    }
+
+    #[test]
+    fn fmt_elapsed_formats_sub_minute_and_past_minute() {
+        assert_eq!(fmt_elapsed(Duration::from_millis(2900)), "2.9s");
+        assert_eq!(fmt_elapsed(Duration::from_millis(12400)), "12.4s");
+        assert_eq!(fmt_elapsed(Duration::from_secs(75)), "75s");
+    }
+
+    #[test]
+    fn display_width_strips_ansi() {
+        let styled = format!(
+            "{}ok{}",
+            Style::new().bold().render(),
+            Style::new().bold().render_reset()
+        );
+        assert_eq!(display_width(&styled), 2);
+        assert_eq!(display_width("plain"), 5);
+    }
+
+    #[test]
+    fn table_aligns_columns_with_numeric_right() {
+        let t = table(
+            &["NAME", "COUNT"],
+            &[
+                vec!["a".to_string(), "1".to_string()],
+                vec!["bb".to_string(), "20".to_string()],
+            ],
+            &[1],
+        );
+        let lines: Vec<&str> = t.lines().collect();
+        assert_eq!(lines.len(), 3);
+        let w = display_width(lines[0]);
+        for l in &lines {
+            assert_eq!(display_width(l), w, "misaligned row: {l:?}");
+        }
+        assert!(lines[0].starts_with("NAME"));
+        assert!(
+            lines[1].ends_with("    1"),
+            "row1 numeric col: {:?}",
+            lines[1]
+        );
+        assert!(
+            lines[2].ends_with("   20"),
+            "row2 numeric col: {:?}",
+            lines[2]
+        );
+    }
+}


### PR DESCRIPTION
## What

The `agentos` CLI printed an undifferentiated wall of text: ~89 `println!` calls, zero `eprintln!`, no color or progress. This makes the terminal a first-class product surface (issue #11).

- **Stream discipline.** Payload (streamed agent replies, resolved URLs, the status table, eval results, deploy result, worker reply) goes to stdout; all plumbing (helm/kubectl/rollout/port-forward chatter, spinners, progress) goes to stderr. `agentos message "..." | jq` and `agentos eval > out.txt` now capture clean data while progress still shows on the terminal.
- **Beautiful default, cruft behind `--debug`.** A shared `ui` module renders dim plumbing / bright payload, a spinner-to-checkmark checklist with a live elapsed counter, determinate bars for real totals (eval `N/total`), and raw-streamed agent tokens (spin until the first token, then flush to stdout). `--debug` resurfaces the plumbing; `-q/--quiet` is payload-only.
- **Brand palette, universally legible.** Truecolor that degrades to the 16 named ANSI colors on terminals without truecolor (Apple Terminal, tmux without passthrough); ASCII glyph fallback in non-UTF-8 locales; state is never encoded in color alone (every status pairs a glyph with a word). Color is resolved per stream, so redirected/piped stdout never receives ANSI even when the terminal stderr is colored.
- **Auto-disable.** Non-TTY, pipe, `CI`, `NO_COLOR`, `CLICOLOR=0`, or `TERM=dumb` produce plain discrete status lines: no ANSI, no `\r` redraws.

New global flags `--debug`, `-q/--quiet`, `--color=auto|always|never` apply to every subcommand. Every command is migrated (`up`/`status`/`down`, `local`, `start`/`send`/`eval`/`deploy`/`steer`/`interrupt`/`runner-status`, `message`/`chat`). Adds `anstyle`, `anstream`, `indicatif`, and `anstyle-query` (the first two were already transitive via clap).

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` (113 tests, including new pure-core tests for per-stream color resolution, truecolor-to-ANSI16 degradation, and table layout) all pass. Reviewed across correctness, scope, and spec-compliance plus a cross-model pass; the one real blocker found (styled payload leaking ANSI into a piped stdout) is fixed and locked with a regression test.

Closes #11