### PR TITLE
Renumber local dev-stack host ports to a distinctive 2xxxx block

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
         run: uv run ruff check .
       - name: Mypy
         run: uv run mypy
-      # Integration tests dial the real dev stack (Postgres 55434, Valkey 56379,
-      # MinIO 9002, Langfuse 3001 + ClickHouse + OTel Collector). Boot it after
+      # Integration tests dial the real dev stack (Postgres 25432, Valkey 26379,
+      # MinIO 29000, Langfuse 23000 + ClickHouse + OTel Collector). Boot it after
       # ruff/mypy so cheap failures stay fast. The first up starts the one-shot
       # minio-init that creates the langfuse bucket alongside the long-lived
       # services; the second --waits only on the long-lived ones (minio-init is
@@ -49,7 +49,7 @@ jobs:
       - name: Wait for Langfuse to serve
         run: |
           for i in $(seq 1 60); do
-            if curl -fsS http://localhost:3001/api/public/health >/dev/null 2>&1; then
+            if curl -fsS http://localhost:23000/api/public/health >/dev/null 2>&1; then
               echo "Langfuse ready after attempt ${i}"; exit 0
             fi
             sleep 3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,12 +82,12 @@ Host ports (non-default host ports to avoid local collisions):
 
 | Service | Host port |
 |---|---|
-| Langfuse UI | http://localhost:3001 |
-| Postgres | localhost:55434 |
-| Valkey | localhost:56379 |
-| ClickHouse | HTTP 8124, native 9011 |
-| MinIO | S3 9002, console 9003 |
-| OTel Collector | gRPC 4317, HTTP 4318 |
+| Langfuse UI | http://localhost:23000 |
+| Postgres | localhost:25432 |
+| Valkey | localhost:26379 |
+| ClickHouse | HTTP 28123, native 29009 |
+| MinIO | S3 29000, console 29001 |
+| OTel Collector | gRPC 24317, HTTP 24318 |
 
 Config lives in `.env.example` (copy to the gitignored `.env` to override; the
 stack runs on the baked defaults without one). Load-bearing facts:
@@ -102,7 +102,7 @@ stack runs on the baked defaults without one). Load-bearing facts:
 - **Langfuse is bootstrapped headless** with a fixed dev project (`agentos-dev`)
   and keys `pk-lf-agentos-dev` / `sk-lf-agentos-dev`, so the OTel path
   authenticates on first boot with no manual key-minting. Read traces back via
-  `curl -u pk-lf-agentos-dev:sk-lf-agentos-dev http://localhost:3001/api/public/...`.
+  `curl -u pk-lf-agentos-dev:sk-lf-agentos-dev http://localhost:23000/api/public/...`.
 
 ## Frozen contracts: STOP and escalate
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ the Anthropic API.
 
 ```bash
 agentos local up   # brings up the backing stores + API + a containerized worker
-agentos deploy --plugin-dir ./my-agent --slack-channel C-DEMO --api-url http://localhost:8770
+agentos deploy --plugin-dir ./my-agent --slack-channel C-DEMO --api-url http://localhost:28000
 agentos message --local "what changed in the last deploy?"
 ```
 
@@ -158,7 +158,7 @@ and set `AGENTOS_FAKE_MODEL=0` in the compose environment. The manual runbook
 below is the equivalent with a host-process worker, useful when iterating on the
 worker itself from source.
 
-`agentos local up` publishes the API on `:8770` (the compose host port); the
+`agentos local up` publishes the API on `:28000` (the compose host port); the
 hand-run `uvicorn` in Quickstart step 4 uses `:8000`. Point `deploy --api-url`
 at whichever one you brought up.
 
@@ -177,7 +177,7 @@ built as above):
 # execute but emit no traces (the runner cannot resolve otel-collector).
 export CLAUDE_CODE_OAUTH_TOKEN=...        # or ANTHROPIC_API_KEY=...
 env AGENTOS_SANDBOX_SUBSTRATE=docker \
-    VALKEY_HOST=localhost VALKEY_PORT=56379 VALKEY_PASSWORD=valkeypass \
+    VALKEY_HOST=localhost VALKEY_PORT=26379 VALKEY_PASSWORD=valkeypass \
     SLACK_API_BASE_URL=http://localhost:8137/api/ SLACK_BOT_TOKEN=xoxb-dev \
     AGENTOS_DOCKER_NETWORK=agentos_default \
     OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318 \

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     # Postgres (async driver). Dedicated `agentos` schema keeps our tables clear
     # of Langfuse's own tables on the same database.
     database_url: str = (
-        "postgresql+asyncpg://postgres:postgres@localhost:55434/postgres"
+        "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres"
     )
     db_schema: str = "agentos"
 
@@ -24,12 +24,12 @@ class Settings(BaseSettings):
     api_key: str = "agentos-dev-key"
 
     # Langfuse proxy target (the dev project keys baked into compose.dev.yaml).
-    langfuse_host: str = "http://localhost:3001"
+    langfuse_host: str = "http://localhost:23000"
     langfuse_public_key: str = "pk-lf-agentos-dev"
     langfuse_secret_key: str = "sk-lf-agentos-dev"
 
-    # MinIO / S3 for immutable plugin bundles (compose stack MinIO on 9002).
-    s3_endpoint_url: str = "http://localhost:9002"
+    # MinIO / S3 for immutable plugin bundles (compose stack MinIO on 29000).
+    s3_endpoint_url: str = "http://localhost:29000"
     s3_access_key: str = "minio"
     s3_secret_key: str = "miniosecret"
     s3_region: str = "us-east-1"
@@ -59,7 +59,7 @@ class Settings(BaseSettings):
     # honored; set valkey_url to override the whole DSN (e.g. TLS, other host).
     valkey_password: str = "valkeypass"
     valkey_host: str = "localhost"
-    valkey_port: int = 56379
+    valkey_port: int = 26379
     valkey_url: str | None = None
 
     # Observability (OB1). kube_config_path points the runner-logs proxy at a

--- a/apps/api/tests/test_control_unit.py
+++ b/apps/api/tests/test_control_unit.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 def test_valkey_dsn_honors_the_password_override() -> None:
     # The compose VALKEY_PASSWORD knob must reach the DSN the API connects with.
     assert Settings(valkey_password="s3cret").valkey_dsn() == (
-        "redis://:s3cret@localhost:56379/0"
+        "redis://:s3cret@localhost:26379/0"
     )
     # An explicit full URL overrides the parts.
     assert (

--- a/apps/api/tests/test_langfuse_integration.py
+++ b/apps/api/tests/test_langfuse_integration.py
@@ -19,14 +19,14 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import SpanKind
 
-COLLECTOR_ENDPOINT = "http://localhost:4318/v1/traces"
+COLLECTOR_ENDPOINT = "http://localhost:24318/v1/traces"
 
 
 def _stack_up() -> bool:
     host = get_settings().langfuse_host
     try:
         httpx.get(f"{host}/api/public/health", timeout=2.0).raise_for_status()
-        httpx.get("http://localhost:4318", timeout=2.0)
+        httpx.get("http://localhost:24318", timeout=2.0)
     except Exception:
         return False
     return True

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -65,7 +65,7 @@ Parsed by `DispatcherConfig.from_env(os.environ)`.
 | `SLACK_BOT_TOKEN` | "" | bot token (`xoxb-...`), Web API |
 | `SLACK_SIGNING_SECRET` | "" | optional; unused in Socket Mode, kept for Bolt App construction |
 | `VALKEY_HOST` | `localhost` | Valkey host (in-cluster: `valkey`) |
-| `VALKEY_PORT` | `6379` | Valkey port (compose maps it to `56379` on the host) |
+| `VALKEY_PORT` | `6379` | Valkey port (compose maps it to `26379` on the host) |
 | `VALKEY_PASSWORD` | "" | Valkey password (compose dev: `valkeypass`) |
 | `VALKEY_DB` | `0` | Valkey db index |
 | `AGENTOS_STREAM` | `agentos:runs` | Stream the jobs land on |
@@ -105,7 +105,7 @@ python -m agentos_dispatcher
 
 All tests run without a Slack workspace: the Slack Web API client and socket
 transport are the only things faked; Stream and dedupe assertions run against the
-real Valkey from `compose.dev.yaml` (host port `56379`). From the repo root:
+real Valkey from `compose.dev.yaml` (host port `26379`). From the repo root:
 
 ```bash
 docker compose -f compose.dev.yaml up -d valkey

--- a/apps/dispatcher/tests/conftest.py
+++ b/apps/dispatcher/tests/conftest.py
@@ -10,10 +10,10 @@ import pytest
 import redis
 from agentos_dispatcher.config import DispatcherConfig
 
-# Compose defaults (compose.dev.yaml maps Valkey to host port 56379, password
+# Compose defaults (compose.dev.yaml maps Valkey to host port 26379, password
 # valkeypass). Overridable for CI via TEST_VALKEY_* env vars.
 _VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "56379"))
+_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
 _VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 
 

--- a/apps/ui/e2e/integration/seed_trace.py
+++ b/apps/ui/e2e/integration/seed_trace.py
@@ -14,7 +14,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import SpanKind
 
-COLLECTOR_ENDPOINT = "http://localhost:4318/v1/traces"
+COLLECTOR_ENDPOINT = "http://localhost:24318/v1/traces"
 TRACE_NAME = "h1b-ui-wire-demo"
 
 

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -41,7 +41,7 @@ class WorkerConfig(BaseModel):
 
     # Postgres (read-only): resolve channel -> agent -> deployment -> version.
     # Matches the API's DATABASE_URL / DB_SCHEMA so the worker reads the same DB.
-    database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:55434/postgres"
+    database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres"
     db_schema: str = "agentos"
 
     # Deployment-to-runtime binding. The plugin dir is the local path the runner
@@ -109,7 +109,7 @@ class WorkerConfig(BaseModel):
     eval_consumer_name: str = Field(default_factory=_default_consumer_name)
     # MinIO / S3 for plugin bundles (mirrors the API's env names). The consumer
     # fetches a version's bundle by bundle_ref and loads its evals/ suite.
-    s3_endpoint_url: str = "http://localhost:9002"
+    s3_endpoint_url: str = "http://localhost:29000"
     s3_access_key: str = "minio"
     s3_secret_key: str = "miniosecret"
     s3_region: str = "us-east-1"
@@ -121,7 +121,7 @@ class WorkerConfig(BaseModel):
     report_max_attempts: int = 3
     report_backoff_base_s: float = Field(default=0.5, gt=0)
     # Langfuse for recording eval scores (the matrix reads them back by version).
-    langfuse_host: str = "http://localhost:3001"
+    langfuse_host: str = "http://localhost:23000"
     langfuse_public_key: str = "pk-lf-agentos-dev"
     langfuse_secret_key: str = "sk-lf-agentos-dev"
 

--- a/apps/worker/tests/binding/test_killswitch.py
+++ b/apps/worker/tests/binding/test_killswitch.py
@@ -20,7 +20,7 @@ import redis.asyncio as aredis
 from agentos_worker.killswitch import KILL_CHANNEL, KillSwitch, kill_key
 
 _VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "56379"))
+_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
 _VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 
 

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -25,7 +25,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 _DB_URL = os.environ.get(
-    "TEST_DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:55434/postgres"
+    "TEST_DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres"
 )
 _SCHEMA = os.environ.get("TEST_DB_SCHEMA", "agentos")
 

--- a/apps/worker/tests/eval/conftest.py
+++ b/apps/worker/tests/eval/conftest.py
@@ -29,10 +29,10 @@ from aiohttp.test_utils import TestServer
 from botocore.client import Config as BotoConfig
 
 _VH = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VP = int(os.environ.get("TEST_VALKEY_PORT", "56379"))
+_VP = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
 _VPW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 _MINIO: dict[str, object] = {
-    "s3_endpoint_url": os.environ.get("TEST_S3_ENDPOINT_URL", "http://localhost:9002"),
+    "s3_endpoint_url": os.environ.get("TEST_S3_ENDPOINT_URL", "http://localhost:29000"),
     "s3_access_key": os.environ.get("TEST_S3_ACCESS_KEY", "minio"),
     "s3_secret_key": os.environ.get("TEST_S3_SECRET_KEY", "miniosecret"),
     "s3_region": "us-east-1",

--- a/apps/worker/tests/eval/test_recorder.py
+++ b/apps/worker/tests/eval/test_recorder.py
@@ -18,7 +18,7 @@ import pytest
 from agentos_worker.eval import EvalCaseResult, EvalRunResult, LangfuseEvalRecorder
 from agentos_worker.eval.recorder import SCORE_NAME
 
-_LF_HOST = os.environ.get("TEST_LANGFUSE_HOST", "http://localhost:3001")
+_LF_HOST = os.environ.get("TEST_LANGFUSE_HOST", "http://localhost:23000")
 _LF_PK = os.environ.get("TEST_LANGFUSE_PUBLIC_KEY", "pk-lf-agentos-dev")
 _LF_SK = os.environ.get("TEST_LANGFUSE_SECRET_KEY", "sk-lf-agentos-dev")
 

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -41,7 +41,7 @@ from agentos_worker.sandbox.types import ClaimView, SandboxView
 from redis.asyncio import Redis as AsyncRedis
 
 _VH = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VP = int(os.environ.get("TEST_VALKEY_PORT", "56379"))
+_VP = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
 _VPW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 CONTAINS = GraderKind.CONTAINS
 

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -34,7 +34,7 @@ from aiohttp.test_utils import TestServer
 from redis.asyncio import Redis as AsyncRedis
 
 _VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "56379"))
+_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
 _VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 
 

--- a/apps/worker/tests/sandbox/conftest.py
+++ b/apps/worker/tests/sandbox/conftest.py
@@ -24,7 +24,7 @@ from agentos_worker.sandbox import (
 )
 
 _VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "56379"))
+_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
 _VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 
 

--- a/apps/worker/tests/sandbox/test_e2e_k8scratch.py
+++ b/apps/worker/tests/sandbox/test_e2e_k8scratch.py
@@ -110,7 +110,7 @@ def _post_event(base: str, text: str) -> list[dict[str, object]]:
 def substrate() -> Iterator[SandboxSubstrate]:
     client = redis.Redis(
         host=os.environ.get("TEST_VALKEY_HOST", "localhost"),
-        port=int(os.environ.get("TEST_VALKEY_PORT", "56379")),
+        port=int(os.environ.get("TEST_VALKEY_PORT", "26379")),
         password=os.environ.get("TEST_VALKEY_PW", "valkeypass") or None,
     )
     client.ping()

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -38,7 +38,7 @@ langfuse:
   telemetryEnabled: false
   enableExperimentalFeatures: true
   # NEXTAUTH_URL the browser reaches the web UI at. Override for a real ingress.
-  nextauthUrl: http://localhost:3001
+  nextauthUrl: http://localhost:23000
   # Dev-only secret material. Override in prod or set `existingSecret` to a
   # Secret carrying keys: langfuseEncryptionKey, langfuseSalt,
   # langfuseNextauthSecret. ENCRYPTION_KEY must be 64 hex chars (openssl rand -hex 32).

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,7 +18,7 @@ Slack involved.
 | `agentos interrupt` | Hard-stop the runner's live turn (POST `/v1/interrupt`); `--reason` is recorded with it. |
 | `agentos chat "..."` | Drive the whole system with the CLI acting **as** the Slack service against the local compose stack, no Slack involved (see below). |
 | `agentos message "..."` | Drive the **deployed** Kubernetes release end to end with zero Slack: self-plumbs kubectl port-forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply (see below). |
-| `agentos message --local "..."` | Same roundtrip against the **local compose stack** (`agentos local up`) instead of a cluster: no kubectl/helm/port-forwards. Enqueues straight to the compose Valkey and lets the containerized worker answer. Channel via `--channel` or the sole deployed agent (looked up on the compose API, default `http://localhost:8770`, overridable with `--api-url`). |
+| `agentos message --local "..."` | Same roundtrip against the **local compose stack** (`agentos local up`) instead of a cluster: no kubectl/helm/port-forwards. Enqueues straight to the compose Valkey and lets the containerized worker answer. Channel via `--channel` or the sole deployed agent (looked up on the compose API, default `http://localhost:28000`, overridable with `--api-url`). |
 | `agentos status` / `agentos stop` | Session status / tear down the container. |
 | `agentos deploy` | Package the bundle as tar.gz and push it to the platform API (find-or-create agent, create version, upload bundle, create deployment). Auth via `--api-key` / `AGENTOS_API_KEY`. |
 
@@ -130,19 +130,19 @@ cluster:
 
 ```bash
 agentos local up
-agentos deploy --plugin-dir <dir> --slack-channel C-DEMO --api-url http://localhost:8770
+agentos deploy --plugin-dir <dir> --slack-channel C-DEMO --api-url http://localhost:28000
 agentos message --local "what changed in the last deploy?"
 ```
 
 Local mode keeps only the shared engine (stub + `QueuedSlackEvent` enqueue +
 ack-based completion) and drops every cluster-specific step: no kubectl, no
 `helm upgrade` wiring, no port-forwards, no dispatcher guard. It enqueues
-straight to the compose Valkey (`localhost:56379`) and the containerized
+straight to the compose Valkey (`localhost:26379`) and the containerized
 `agentos-worker` service (already pointed at the stub via a fixed
 `SLACK_API_BASE_URL=http://localhost:8155/api/`) answers by claiming a runner
 container on the host Docker daemon. Channel comes from `--channel` or, when
 omitted, the sole deployed agent looked up on the compose API (`--api-url`,
-default `http://localhost:8770`; the API is reached directly, so no `/api`
+default `http://localhost:28000`; the API is reached directly, so no `/api`
 suffix). `--local` composes with `--channel`/`--thread`/`--timeout-secs` and
 rejects the cluster-only flags (`--namespace`, `--release`, `--force-wire`, ...)
 with a clear error. The compose worker runs the fake model by default (a canned

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -18,15 +18,15 @@ pub const DEFAULT_COMPOSE_FILE: &str = "compose.dev.yaml";
 /// has the URLs in hand. Hardcoded to match the compose file (see the
 /// `endpoints_match_compose_file` test, which asserts the file still maps them).
 const ENDPOINTS: &[(&str, &str)] = &[
-    ("AgentOS API", "http://localhost:8770"),
-    ("Langfuse UI", "http://localhost:3001"),
-    ("Postgres", "localhost:55434"),
-    ("Valkey", "localhost:56379"),
-    ("ClickHouse HTTP", "localhost:8124"),
-    ("MinIO S3", "localhost:9002"),
-    ("MinIO console", "localhost:9003"),
-    ("OTel gRPC", "localhost:4317"),
-    ("OTel HTTP", "localhost:4318"),
+    ("AgentOS API", "http://localhost:28000"),
+    ("Langfuse UI", "http://localhost:23000"),
+    ("Postgres", "localhost:25432"),
+    ("Valkey", "localhost:26379"),
+    ("ClickHouse HTTP", "localhost:28123"),
+    ("MinIO S3", "localhost:29000"),
+    ("MinIO console", "localhost:29001"),
+    ("OTel gRPC", "localhost:24317"),
+    ("OTel HTTP", "localhost:24318"),
 ];
 
 /// Flags shared by every `local` verb.
@@ -94,7 +94,7 @@ pub async fn up(o: LocalOpts) -> Result<()> {
     }
     println!("\nDrive the local product loop (no Slack, no Kubernetes):");
     println!(
-        "  agentos deploy --plugin-dir <dir> --slack-channel <C...> --api-url http://localhost:8770"
+        "  agentos deploy --plugin-dir <dir> --slack-channel <C...> --api-url http://localhost:28000"
     );
     println!("  agentos message --local \"<your question>\"");
     Ok(())
@@ -220,15 +220,15 @@ mod tests {
                 .expect("read compose.dev.yaml");
         // Each printed host port must appear as a `"<host>:<container>"` mapping.
         for (label, host_port) in [
-            ("AgentOS API", "8770"),
-            ("Langfuse UI", "3001"),
-            ("Postgres", "55434"),
-            ("Valkey", "56379"),
-            ("ClickHouse HTTP", "8124"),
-            ("MinIO S3", "9002"),
-            ("MinIO console", "9003"),
-            ("OTel gRPC", "4317"),
-            ("OTel HTTP", "4318"),
+            ("AgentOS API", "28000"),
+            ("Langfuse UI", "23000"),
+            ("Postgres", "25432"),
+            ("Valkey", "26379"),
+            ("ClickHouse HTTP", "28123"),
+            ("MinIO S3", "29000"),
+            ("MinIO console", "29001"),
+            ("OTel gRPC", "24317"),
+            ("OTel HTTP", "24318"),
         ] {
             assert!(
                 compose.contains(&format!("\"{host_port}:")),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -188,7 +188,7 @@ enum Command {
         )]
         local: bool,
         /// Local mode only: platform API base URL for the channel lookup
-        /// (default the compose API on http://localhost:8770).
+        /// (default the compose API on http://localhost:28000).
         #[arg(long, requires = "local")]
         api_url: Option<String>,
     },
@@ -678,7 +678,7 @@ mod tests {
             "agentos",
             "message",
             "--api-url",
-            "http://localhost:8770",
+            "http://localhost:28000",
             "hi",
         ];
         let err = match Cli::try_parse_from(argv) {

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -42,7 +42,7 @@ pub const DEFAULT_TIMEOUT_SECS: u64 = 300;
 /// Fixed stub port so the advertised URL is deterministic; `0` picks ephemeral.
 pub const DEFAULT_LISTEN_PORT: u16 = 8155;
 /// Local port the Valkey port-forward binds. Chosen to dodge the compose dev
-/// stack, which squats 56379.
+/// stack, which squats 26379.
 pub const DEFAULT_VALKEY_LOCAL_PORT: u16 = 56381;
 /// Local port the API port-forward binds (only used for the default-channel
 /// lookup when `--channel` is omitted).
@@ -54,10 +54,10 @@ pub const DEFAULT_API_KEY: &str = "agentos-dev-key";
 
 /// Local mode (`--local`): the compose Valkey's published host port
 /// (`compose.dev.yaml`), where the CLI enqueues and the compose worker consumes.
-pub const DEFAULT_LOCAL_VALKEY_PORT: u16 = 56379;
+pub const DEFAULT_LOCAL_VALKEY_PORT: u16 = 26379;
 /// Local mode: the compose API's published host port (`compose.dev.yaml`
 /// `agentos-api`), reached directly (routers mount at root, so no `/api`).
-pub const DEFAULT_LOCAL_API_URL: &str = "http://localhost:8770";
+pub const DEFAULT_LOCAL_API_URL: &str = "http://localhost:28000";
 /// Local mode: the fixed port the stub binds. It MUST equal the port in the
 /// compose worker's `SLACK_API_BASE_URL` (`http://localhost:8155/api/`) so the
 /// containerized worker's placeholder edits reach this stub. Same value as the
@@ -846,12 +846,12 @@ mod tests {
     fn local_valkey_url_targets_the_compose_valkey_with_the_password() {
         assert_eq!(
             local_valkey_url("valkeypass"),
-            "redis://:valkeypass@localhost:56379"
+            "redis://:valkeypass@localhost:26379"
         );
         // A custom password flows through unchanged.
         assert_eq!(
             local_valkey_url("s3cr3t"),
-            "redis://:s3cr3t@localhost:56379"
+            "redis://:s3cr3t@localhost:26379"
         );
     }
 

--- a/cli/src/queue.rs
+++ b/cli/src/queue.rs
@@ -16,7 +16,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 pub const DEFAULT_STREAM: &str = "agentos:runs";
-pub const DEFAULT_VALKEY_URL: &str = "redis://:valkeypass@localhost:56379";
+pub const DEFAULT_VALKEY_URL: &str = "redis://:valkeypass@localhost:26379";
 /// The worker's consumer group (AGENTOS_CONSUMER_GROUP default); used to detect
 /// completion (the worker acks an entry only after the turn finalizes).
 pub const WORKER_GROUP: &str = "agentos-workers";

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -2,7 +2,7 @@
 //! Slack stub exercised over real HTTP.
 //!
 //! The redis client is NOT mocked: the XADD runs against the compose dev Valkey
-//! (host port 56379, password `valkeypass`) on a unique test-scoped stream that
+//! (host port 26379, password `valkeypass`) on a unique test-scoped stream that
 //! the test deletes afterward. It never touches the real `agentos:runs` stream.
 //! The Slack stub is the real one; only its client (reqwest) stands in for the
 //! worker.
@@ -12,7 +12,7 @@ use std::time::Duration;
 use agentos::chat::{resolve_targets, SlackStub};
 use agentos::queue::{diagnostics, entry_acked, xadd, QueuedSlackEvent, WORKER_GROUP};
 
-const DEFAULT_VALKEY_URL: &str = "redis://:valkeypass@localhost:56379";
+const DEFAULT_VALKEY_URL: &str = "redis://:valkeypass@localhost:26379";
 
 fn valkey_url() -> String {
     std::env::var("TEST_VALKEY_URL").unwrap_or_else(|_| DEFAULT_VALKEY_URL.to_string())

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,28 +1,26 @@
-# AgentOS dev stack (verification tier V1).
+# AgentOS local dev stack.
 #
-# Productizes the PT-4 setup: Postgres + Valkey + Langfuse v3 (web + worker +
-# ClickHouse) + MinIO + OTel Collector, on a single node (~2.3 GB at light load).
-# Every backend integration test and UI E2E runs against this stack; it is also
-# the seed of the A1 Helm dev profile (same components, same pinned versions).
+# Postgres + Valkey + Langfuse v3 (web + worker + ClickHouse) + MinIO + OTel
+# Collector, on a single node (~2.3 GB at light load). Every backend integration
+# test and UI E2E runs against this stack; it mirrors the Helm dev profile
+# (same components, same pinned versions).
 #
 # Bring up:   docker compose -f compose.dev.yaml up -d
 # Tear down:  docker compose -f compose.dev.yaml down        (keeps volumes; fast restart)
 # Wipe:       docker compose -f compose.dev.yaml down -v     (drops volumes; throwaway)
 #
-# Host ports are chosen to NOT collide with the CurieTech platform E2E stack
-# (which uses 55432, 8000, 3000, 8080, 9091):
-#   Langfuse UI ....... http://localhost:3001
-#   Postgres .......... localhost:55434
-#   Valkey ............ localhost:56379
-#   ClickHouse HTTP ... localhost:8124   (native TCP localhost:9011)
-#   MinIO S3 API ...... localhost:9002   (console localhost:9003)
-#   OTel Collector .... localhost:4317 (gRPC) / localhost:4318 (HTTP)
+# Host ports use a distinctive 2xxxx block (host port = "2" + the service's
+# container port) to avoid common service defaults and stay below the OS
+# ephemeral port range (32768+):
+#   Langfuse UI ....... http://localhost:23000
+#   Postgres .......... localhost:25432
+#   Valkey ............ localhost:26379
+#   ClickHouse HTTP ... localhost:28123   (native TCP localhost:29009)
+#   MinIO S3 API ...... localhost:29000   (console localhost:29001)
+#   OTel Collector .... localhost:24317 (gRPC) / localhost:24318 (HTTP)
 #
 # ClickHouse is pinned to :24.8 on purpose. Newer ClickHouse requires AVX and
 # SIGILLs with exit 132 on CPUs without it; :24.8 still ships an SSE4.2 build.
-# THIS HOST has only sse4_2 (no avx/avx2 in /proc/cpuinfo as of 2026-07-05), so
-# the pin is required here, not merely defensive. A1 turns this into a chart
-# preflight.
 
 x-langfuse-env: &langfuse-env
   DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
@@ -61,7 +59,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
     ports:
-      - "55434:5432"
+      - "25432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -74,7 +72,7 @@ services:
     image: valkey/valkey:8-alpine
     command: ["valkey-server", "--requirepass", "${VALKEY_PASSWORD:-valkeypass}"]
     ports:
-      - "56379:6379"
+      - "26379:6379"
     volumes:
       - valkey_data:/data
     healthcheck:
@@ -84,14 +82,14 @@ services:
       retries: 10
 
   clickhouse:
-    # Pinned to 24.8: newer ClickHouse needs AVX and crashes (exit 132) on this
-    # SSE4.2-only host. See the header comment.
+    # Pinned to 24.8: newer ClickHouse needs AVX and crashes (exit 132) on CPUs
+    # without AVX. See the header comment.
     image: clickhouse/clickhouse-server:24.8
     environment:
       CLICKHOUSE_PASSWORD: clickhouse
     ports:
-      - "8124:8123"
-      - "9011:9000"
+      - "28123:8123"
+      - "29009:9000"
     volumes:
       - clickhouse_data:/var/lib/clickhouse
       - clickhouse_logs:/var/log/clickhouse-server
@@ -113,8 +111,8 @@ services:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: miniosecret
     ports:
-      - "9002:9000"
-      - "9003:9001"
+      - "29000:9000"
+      - "29001:9001"
     volumes:
       - minio_data:/data
     healthcheck:
@@ -171,10 +169,10 @@ services:
       minio-init:
         condition: service_completed_successfully
     ports:
-      - "3001:3000"
+      - "23000:3000"
     environment:
       <<: *langfuse-env
-      NEXTAUTH_URL: http://localhost:3001
+      NEXTAUTH_URL: http://localhost:23000
       NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-dev-nextauth-secret-change-me}
       # Headless bootstrap so the OTel Collector has known keys to authenticate
       # with on first boot (no manual key-minting step). Dev-only values.
@@ -201,8 +199,8 @@ services:
     volumes:
       - ./otel/collector-config.yaml:/etc/otel/collector-config.yaml:ro
     ports:
-      - "4317:4317"
-      - "4318:4318"
+      - "24317:4317"
+      - "24318:4318"
     restart: unless-stopped
 
   # ---- AgentOS product services (the local product loop) --------------------
@@ -210,15 +208,14 @@ services:
   # These three services turn the backing stack above into a one-command local
   # product loop. `agentos local up` brings everything up, then:
   #   agentos deploy --plugin-dir <dir> --slack-channel <C...> \
-  #                  --api-url http://localhost:8770
+  #                  --api-url http://localhost:28000
   #   agentos message --local "<question>"
   # drives a real queue -> worker -> sandboxed runner -> reply roundtrip, no
   # Slack and no Kubernetes. They use the same published images the chart
   # deploys (only the worker adds a thin local docker-CLI overlay; see below).
   #
-  # The API host port 8770 is chosen to dodge the CurieTech platform E2E stack
-  # (8000/3000/8080/9091/55432) and every host port this compose file already
-  # publishes.
+  # The API host port 28000 comes from the dev stack's 2xxxx host-port block
+  # (host port = "2" + the service's container port).
 
   # One-shot: bring the Postgres schema to head before api/worker boot. The API
   # image ships the Alembic tree but its CMD only runs uvicorn, so migrations
@@ -236,7 +233,7 @@ services:
     restart: "no"
 
   # The platform API. On the compose network, reaching Postgres/Valkey/MinIO by
-  # service name. Published on host 8770 for the CLI (`agentos deploy`, and the
+  # service name. Published on host 28000 for the CLI (`agentos deploy`, and the
   # `agentos message --local` channel lookup).
   agentos-api:
     image: ghcr.io/curie-eng/agentos-api:latest
@@ -264,7 +261,7 @@ services:
       LANGFUSE_PUBLIC_KEY: pk-lf-agentos-dev
       LANGFUSE_SECRET_KEY: sk-lf-agentos-dev
     ports:
-      - "8770:8000"
+      - "28000:8000"
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status==200 else 1)"]
       interval: 5s
@@ -290,7 +287,7 @@ services:
   #
   # network_mode: host recreates the exact topology the Docker substrate was
   # written and tested against (the host-process middle mode): the worker reaches
-  # the backing stores on their published host ports (localhost 55434/56379/9002),
+  # the backing stores on their published host ports (localhost 25432/26379/29000),
   # dials each runner on the loopback host port Docker publishes for it, and
   # reaches the `agentos message --local` Slack stub at localhost:8155.
   agentos-worker:
@@ -321,15 +318,15 @@ services:
       - AGENTOS_RUNNER_IMAGE=ghcr.io/curie-eng/agentos-runner:latest
       - TMPDIR=/tmp/agentos-bundles
       - VALKEY_HOST=localhost
-      - VALKEY_PORT=56379
+      - VALKEY_PORT=26379
       - VALKEY_PASSWORD=${VALKEY_PASSWORD:-valkeypass}
-      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:55434/postgres
+      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:25432/postgres
       - DB_SCHEMA=agentos
-      - S3_ENDPOINT_URL=http://localhost:9002
+      - S3_ENDPOINT_URL=http://localhost:29000
       - S3_ACCESS_KEY=minio
       - S3_SECRET_KEY=miniosecret
       - BUNDLE_BUCKET=agentos-bundles
-      - AGENTOS_API_BASE_URL=http://localhost:8770
+      - AGENTOS_API_BASE_URL=http://localhost:28000
       - SLACK_API_BASE_URL=http://localhost:8155/api/
       - SLACK_BOT_TOKEN=xoxb-dev
       # Fake model by default (no credential needed). For a real model set

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -53,7 +53,7 @@ reference and the multi-turn `--thread` flow are in
 `agentos local up|down|status` wraps the `compose.dev.yaml` dev stack, so the
 inner loop and the cluster share one CLI. `local up` brings up the full product
 stack (API + worker alongside the backing stores), so
-`agentos deploy --api-url http://localhost:8770` then `agentos message --local
+`agentos deploy --api-url http://localhost:28000` then `agentos message --local
 "..."` drives a real queue -> worker -> sandboxed runner -> reply roundtrip with
 no Slack and no Kubernetes. See the middle-mode runbook in the
 [README](../README.md#quickstart).

--- a/runner/tests/test_otel.py
+++ b/runner/tests/test_otel.py
@@ -138,7 +138,7 @@ def test_tracer_provider_none_without_endpoint() -> None:
 
 
 def test_tracer_provider_built_with_endpoint() -> None:
-    otel = OtelConfig(endpoint="http://localhost:4318")
+    otel = OtelConfig(endpoint="http://localhost:24318")
     provider = build_tracer_provider(otel, "s1")
     assert isinstance(provider, TracerProvider)
     provider.shutdown()
@@ -147,7 +147,7 @@ def test_tracer_provider_built_with_endpoint() -> None:
 def test_resource_stamps_sandbox_id_when_present() -> None:
     # The sandbox id (ACI AGENTOS_SANDBOX_ID) lets a trace be attributed to the
     # concrete sandbox that produced it, not just the session.
-    otel = OtelConfig(endpoint="http://localhost:4318")
+    otel = OtelConfig(endpoint="http://localhost:24318")
     provider = build_tracer_provider(otel, "s1", "sandbox-abc")
     assert provider is not None
     attrs = provider.resource.attributes
@@ -159,7 +159,7 @@ def test_resource_stamps_sandbox_id_when_present() -> None:
 def test_resource_omits_sandbox_id_when_absent_or_empty() -> None:
     # Absent (default) and empty-string sandbox ids are both omitted rather than
     # stamped as an empty attribute value.
-    otel = OtelConfig(endpoint="http://localhost:4318")
+    otel = OtelConfig(endpoint="http://localhost:24318")
     for sandbox_id in (None, ""):
         provider = build_tracer_provider(otel, "s1", sandbox_id)
         assert provider is not None


### PR DESCRIPTION
The `compose.dev.yaml` dev stack published host ports that were shaped by an unrelated internal E2E stack and sat in the OS ephemeral range (32768+), where a transient outbound socket can race the bind. This moves every host port to a uniform, self-documenting scheme and scrubs environment-specific notes from the file.

## What changed
- **Host ports → `2` + container port.** Postgres `25432`, Valkey `26379`, ClickHouse `28123`/`29009`, MinIO `29000`/`29001`, Langfuse `23000`, agentos-api `28000`, OTel `24317`/`24318`. All below the ephemeral range, clear of common defaults.
- **All host-facing `localhost:` references updated** across the CLI (`local.rs`, `message.rs`, `queue.rs`), app config defaults, tests, CI, and docs. Container/in-cluster and k8s chart ports are unchanged; only genuinely host-published ports moved.
- **Helm chart** langfuse dev `nextauthUrl` bumped to `23000` for consistency.
- **Comment scrub** in the compose header: removed the external-stack collision list, the host-specific CPU/date note, and internal profile codenames; kept the generic port rationale and the ClickHouse AVX pin.

## Verification
`cargo test` (100 passed), `ruff` clean, unit `pytest` green, and a full `agentos local up`/`down` cycle on the new ports: every service healthy, both one-shot jobs exit 0, clean teardown.