### PR TITLE
Pin UI and Langfuse NodePorts for stable up/down URLs

### DIFF
--- a/charts/agentos/templates/NOTES.txt
+++ b/charts/agentos/templates/NOTES.txt
@@ -45,6 +45,11 @@ App services:
 
 Reach the UI (port-forward):
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "agentos.fullname" . }}-ui {{ .Values.ui.service.port }}:{{ .Values.ui.service.port }}
+{{- if and (eq .Values.ui.service.type "NodePort") .Values.ui.service.nodePort }}
+When exposed as NodePort (`agentos up` does this by default), the UI is reachable at:
+  http://<any-node-ip>:{{ .Values.ui.service.nodePort }}
+The nodePort is pinned in values (ui.service.nodePort) so it survives a down/up cycle.
+{{- end }}
 {{- end }}
 
 Preflights:
@@ -125,6 +130,11 @@ Enable a real model and a Slack workspace:
 Reach the Langfuse UI (port-forward):
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "agentos.fullname" . }}-langfuse-web {{ .Values.langfuse.web.service.port }}:{{ .Values.langfuse.web.service.port }}
   open http://localhost:{{ .Values.langfuse.web.service.port }}
+{{- if and (eq .Values.langfuse.web.service.type "NodePort") .Values.langfuse.web.service.nodePort }}
+When exposed as NodePort (`agentos up` does this by default), Langfuse is reachable at:
+  http://<any-node-ip>:{{ .Values.langfuse.web.service.nodePort }}
+The nodePort is pinned in values (langfuse.web.service.nodePort) so it survives a down/up cycle.
+{{- end }}
   # Dev project keys (headless-bootstrapped): {{ .Values.langfuse.init.projectPublicKey }} / {{ .Values.langfuse.init.projectSecretKey }}
 
 App services send OTLP traces to the collector, NOT directly to Langfuse:

--- a/charts/agentos/templates/langfuse.yaml
+++ b/charts/agentos/templates/langfuse.yaml
@@ -13,6 +13,9 @@ spec:
     - name: http
       port: {{ .Values.langfuse.web.service.port }}
       targetPort: 3000
+      {{- if and (eq .Values.langfuse.web.service.type "NodePort") .Values.langfuse.web.service.nodePort }}
+      nodePort: {{ .Values.langfuse.web.service.nodePort }}
+      {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/agentos/templates/ui.yaml
+++ b/charts/agentos/templates/ui.yaml
@@ -16,6 +16,9 @@ spec:
       # The nginx-unprivileged base listens on 8080 (it cannot bind :80 as
       # non-root); the SPA Dockerfile serves there.
       targetPort: 8080
+      {{- if and (eq .Values.ui.service.type "NodePort") .Values.ui.service.nodePort }}
+      nodePort: {{ .Values.ui.service.nodePort }}
+      {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -89,6 +89,13 @@ langfuse:
     service:
       type: ClusterIP
       port: 3000
+      # Pinned NodePort used when service.type is flipped to NodePort (e.g. by
+      # `agentos up`). Empty lets Kubernetes allocate one from 30000-32767 --
+      # but an auto-allocated port changes on every helm install/upgrade, which
+      # breaks any URL or `agentos deploy --api-url` that hardcodes a port. The
+      # default pins it so a down/up cycle keeps the same URL. Override or set
+      # to "" to restore auto-allocation.
+      nodePort: 30000
     # Extra Node flags. The Langfuse web image is a Node app whose default heap
     # cap (~512Mi) OOM-crashes under a tight container limit; raise it in step
     # with the memory limit. Empty = leave the image default.
@@ -328,6 +335,13 @@ ui:
   service:
     type: ClusterIP
     port: 80
+    # Pinned NodePort used when service.type is flipped to NodePort (e.g. by
+    # `agentos up`). Empty lets Kubernetes allocate one from 30000-32767, but
+    # an auto-allocated port changes on every helm install/upgrade -- breaking
+    # `agentos deploy --api-url http://<host>:<port>/api` and any bookmarked
+    # URL across a redeploy. The default pins it so a down/up cycle keeps the
+    # same URL. Override or set to "" to restore auto-allocation.
+    nodePort: 30080
   resources:
     requests: { cpu: 25m, memory: 64Mi }
     limits: { cpu: 250m, memory: 128Mi }


### PR DESCRIPTION
The UI and Langfuse web Services are `type: ClusterIP` by default, and `agentos up` flips them to NodePort without pinning a `nodePort`. Kubernetes then allocates a fresh port from 30000-32767 on every `helm install`/`upgrade`, so a `down`/`up` cycle changes the URLs (observed: UI moved 32660 -> 30330 across two ups). This breaks any command or bookmark that hardcodes a port, notably `agentos deploy --api-url http://<host>:<port>/api`.

## What
- Pin `ui.service.nodePort` (30080) and `langfuse.web.service.nodePort` (30000) in chart values, documented and overridable.
- Templates emit `nodePort` only when `service.type` is `NodePort` and the value is non-empty, so the default `ClusterIP` render is unchanged and a caller can opt back into auto-allocation by setting `nodePort: ""`.
- `NOTES.txt` surfaces the pinned nodePort URL when the service is exposed.

`agentos up` needs no change: it only flips the `type`, and the pinned `nodePort` now flows from `values.yaml`.

## Why
Ports silently changing across a redeploy is a confusing first-run experience: a user copies a working URL, redeploys, and it "breaks" for no visible reason. Stable ports make the deploy/message loop reproducible.

Closes #37