### PR TITLE
Ship first-party weather example skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ export CLAUDE_CODE_OAUTH_TOKEN=...
 ../target/release/agentos eval
 ```
 
+A committed first-party example lives at `examples/weather/`. `cd examples/weather && agentos start` runs it from a clean clone. `agentos init` scaffolds this same weather template, so every fresh bundle starts as a runnable web-search skill to learn from and edit.
+
 For a fully offline round-trip (no credential, scripted replies), add
 `--fake-model` to `agentos start` — an explicit test-only mode that never reaches
 the Anthropic API.

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -31,7 +31,7 @@ fn manifest(name: &str) -> String {
 
 fn skill_md(name: &str) -> String {
     format!(
-        "---\nname: {name}\ndescription: What the {name} agent does and when to invoke it.\n---\n\n# {name}\n\n## When to run\n\nDescribe the situations where this skill applies.\n\n## Hard rules\n\n- State the facts this agent must never invent.\n- Name the sources answers must come from.\n"
+        "---\nname: {name}\ndescription: Look up a location's weather forecast using a live web search. Invoke whenever the user asks about the weather, whether to expect rain, temperature, or what to wear or plan for outdoor activities.\nallowed-tools:\n  - WebSearch\n  - WebFetch\n---\n\n# Weather\n\n## When to run\nThe user asks about the weather, a forecast, temperature, rain or snow chances, or whether a day suits an outdoor plan.\n\n## How to answer\n1. Determine the location and day. If the user named them, use them. If not, ask one short question instead of guessing.\n2. Run a web search for the forecast, e.g. `<city> weather forecast <day>`. Prefer a national weather service or a major forecast provider.\n3. Report, in two or three sentences: expected high and low, sky conditions, and precipitation chance. Include the location and day so there is no ambiguity.\n4. Name the source of the forecast at the end.\n\n## Hard rules\n\n- Never invent a forecast. If the search returns nothing usable, say so and name what you tried.\n- Temperatures in Fahrenheit first, Celsius in parentheses.\n- Keep the reply short enough to read in Slack without expanding.\n"
     )
 }
 
@@ -39,8 +39,8 @@ fn eval_cases(name: &str) -> String {
     serde_json::to_string_pretty(&serde_json::json!([
         {
             "name": format!("{name}-answers"),
-            "input": "Introduce yourself in one sentence.",
-            "expect_contains": [name],
+            "input": "What's the weather in San Francisco?",
+            "expect_contains": ["weather"],
         }
     ]))
     .expect("static eval cases serialize")
@@ -144,7 +144,13 @@ mod tests {
 
         let skill = std::fs::read_to_string(dir.path().join("skills/deal-desk/SKILL.md")).unwrap();
         assert!(skill.starts_with("---\nname: deal-desk\n"));
-        assert!(skill.contains("description:"));
+        assert!(skill.contains("description: Look up a location's weather forecast"));
+        assert!(skill.contains("allowed-tools:"));
+        assert!(skill.contains("- WebSearch"));
+        assert!(skill.contains("- WebFetch"));
+        assert!(skill.contains("# Weather"));
+        assert!(skill.contains("## How to answer"));
+        assert!(skill.contains("Never invent a forecast"));
 
         let mcp: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap())
@@ -156,6 +162,12 @@ mod tests {
         )
         .unwrap();
         assert!(cases.as_array().unwrap().len() == 1);
+        assert!(cases[0]["input"].as_str().unwrap().contains("weather"));
+        assert!(cases[0]["expect_contains"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|needle| needle == "weather"));
 
         assert_eq!(
             read_manifest(dir.path()).unwrap(),

--- a/examples/weather/.claude-plugin/plugin.json
+++ b/examples/weather/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "weather",
+  "description": "The weather agent plugin.",
+  "version": "0.1.0"
+}

--- a/examples/weather/.gitignore
+++ b/examples/weather/.gitignore
@@ -1,0 +1,1 @@
+.agentos/

--- a/examples/weather/.mcp.json
+++ b/examples/weather/.mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/examples/weather/evals/cases.json
+++ b/examples/weather/evals/cases.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "weather-answers",
+    "input": "What's the weather in San Francisco?",
+    "expect_contains": [
+      "weather"
+    ]
+  }
+]

--- a/examples/weather/skills/weather/SKILL.md
+++ b/examples/weather/skills/weather/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: weather
+description: Look up a location's weather forecast using a live web search. Invoke whenever the user asks about the weather, whether to expect rain, temperature, or what to wear or plan for outdoor activities.
+allowed-tools:
+  - WebSearch
+  - WebFetch
+---
+
+# Weather
+
+## When to run
+The user asks about the weather, a forecast, temperature, rain or snow chances, or whether a day suits an outdoor plan.
+
+## How to answer
+1. Determine the location and day. If the user named them, use them. If not, ask one short question instead of guessing.
+2. Run a web search for the forecast, e.g. `<city> weather forecast <day>`. Prefer a national weather service or a major forecast provider.
+3. Report, in two or three sentences: expected high and low, sky conditions, and precipitation chance. Include the location and day so there is no ambiguity.
+4. Name the source of the forecast at the end.
+
+## Hard rules
+
+- Never invent a forecast. If the search returns nothing usable, say so and name what you tried.
+- Temperatures in Fahrenheit first, Celsius in parentheses.
+- Keep the reply short enough to read in Slack without expanding.


### PR DESCRIPTION
Closes #36

- Add `examples/weather/` committed bundle (manifest, skill, eval, mcp config, gitignore) runnable from a clean clone via `agentos start`.
- Make `agentos init` scaffold the real weather web-search skill and matching eval instead of the empty placeholder, so every fresh bundle starts as a runnable example to learn from and edit.
- Wire `WebSearch` + `WebFetch` via `allowed-tools` in the skill frontmatter so the scaffolded skill can actually perform a web search (built-in Claude Code tools, no MCP server needed). Egress for the outbound search call is tracked in #43 (fail-closed network policy defaults to DNS-only).
- Point the README CLI walkthrough at the committed example.

Addresses the onboarding note on #36: the scaffold now results in a skill that can perform a web search rather than just describing one. Both this issue (tool binding) and #43 (egress) must land for the demo to answer a real question on a fresh install.