### PR TITLE
Serve the AgentOS console from the local compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ the Anthropic API.
 **One-command middle mode** (the fastest path — no host-run worker, no cluster):
 
 ```bash
-agentos local up   # brings up the backing stores + API + a containerized worker
+agentos local up   # brings up the backing stores + API + a containerized worker + the console UI
 agentos local deploy --plugin-dir ./my-agent --slack-channel C-DEMO --api-url http://localhost:28000
 agentos local message "what changed in the last deploy?"
 ```
@@ -184,7 +184,7 @@ agentos local message "what changed in the last deploy?"
 default), so there is nothing to hand-run. For a real model, export a credential
 and set `AGENTOS_FAKE_MODEL=0` in the compose environment. The manual runbook
 below is the equivalent with a host-process worker, useful when iterating on the
-worker itself from source.
+worker itself from source. The console UI is served at `http://localhost:28080/?api=1`; open it to reach the console wired to your local compose API.
 
 `agentos local up` publishes the API on `:28000` (the compose host port); the
 hand-run `uvicorn` in Quickstart step 4 uses `:8000`. Point `deploy --api-url`

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -19,6 +19,7 @@ pub const DEFAULT_COMPOSE_FILE: &str = "compose.dev.yaml";
 /// `endpoints_match_compose_file` test, which asserts the file still maps them).
 const ENDPOINTS: &[(&str, &str)] = &[
     ("AgentOS API", "http://localhost:28000"),
+    ("AgentOS Console", "http://localhost:28080/?api=1"),
     ("Langfuse UI", "http://localhost:23000"),
     ("Postgres", "localhost:25432"),
     ("Valkey", "localhost:26379"),
@@ -255,6 +256,7 @@ mod tests {
         // Each printed host port must appear as a `"<host>:<container>"` mapping.
         for (label, host_port) in [
             ("AgentOS API", "28000"),
+            ("AgentOS Console", "28080"),
             ("Langfuse UI", "23000"),
             ("Postgres", "25432"),
             ("Valkey", "26379"),
@@ -273,5 +275,17 @@ mod tests {
                 "ENDPOINTS missing {host_port} for {label}"
             );
         }
+        // The console must be advertised in wired mode (?api=1); the published UI
+        // image is fixture-by-default and only talks to the API when the URL
+        // carries this param.
+        let console = ENDPOINTS
+            .iter()
+            .find(|(label, _)| *label == "AgentOS Console")
+            .expect("AgentOS Console endpoint present");
+        assert!(
+            console.1.contains("api=1"),
+            "AgentOS Console endpoint must be the wired ?api=1 URL, got {}",
+            console.1
+        );
     }
 }

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -12,6 +12,7 @@
 # Host ports use a distinctive 2xxxx block (host port = "2" + the service's
 # container port) to avoid common service defaults and stay below the OS
 # ephemeral port range (32768+):
+#   AgentOS Console ... http://localhost:28080
 #   Langfuse UI ....... http://localhost:23000
 #   Postgres .......... localhost:25432
 #   Valkey ............ localhost:26379
@@ -267,6 +268,28 @@ services:
       interval: 5s
       timeout: 5s
       retries: 24
+      start_period: 5s
+    restart: unless-stopped
+
+  # The AgentOS console: nginx serving the static SPA, reverse-proxying `/api/`
+  # to the compose `agentos-api` (single substrate, same wiring the chart's UI
+  # uses). Talks to NOTHING else. Published on host 28080 from the 2xxxx block.
+  # The image is fixture-by-default, so the CLI advertises the wired
+  # `http://localhost:28080/?api=1` URL and `local up` opens it connected to the API.
+  agentos-ui:
+    image: ghcr.io/curie-eng/agentos-ui:latest
+    depends_on:
+      agentos-api:
+        condition: service_healthy
+    environment:
+      AGENTOS_API_TARGET: http://agentos-api:8000
+    ports:
+      - "28080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
       start_period: 5s
     restart: unless-stopped
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -71,7 +71,8 @@ reference and the multi-turn `--thread` flow are in
 
 `agentos local up|down|status` wraps the `compose.dev.yaml` dev stack, so the
 inner loop and the cluster share one CLI. `local up` brings up the full product
-stack (API + worker alongside the backing stores), so
+stack (API + worker alongside the backing stores, plus the console UI at
+`http://localhost:28080/?api=1`), so
 `agentos local deploy --api-url http://localhost:28000` then `agentos local message
 "..."` drives a real queue -> worker -> sandboxed runner -> reply roundtrip with
 no Slack and no Kubernetes. See the middle-mode runbook in the


### PR DESCRIPTION
Adds an `agentos-ui` service to `compose.dev.yaml` so `agentos local up` serves the AgentOS console, and advertises its URL in the CLI endpoint summary.

## What
- **`compose.dev.yaml`**: new `agentos-ui` service running `ghcr.io/curie-eng/agentos-ui:latest`, wired single-substrate to the compose `agentos-api` via `AGENTOS_API_TARGET=http://agentos-api:8000` (the same env the Helm chart's UI uses at `charts/agentos/templates/ui.yaml:49-50`). Published on host port `28080` (the 2xxxx block: "2" + container port 8080), `depends_on` the API being healthy, with a `wget` healthcheck so `up --wait` waits until the SPA serves.
- **`cli/src/local.rs`**: prints the console URL in the `local up` endpoint list and extends `endpoints_match_compose_file` to assert the `28080` mapping plus a guard that the advertised URL stays wired.
- Docs (`README.md`, `docs/operations.md`) mention the local console.

## Wired-URL note (why `?api=1`)
The published UI image is **fixture-by-default**: `isWired()` (`apps/ui/src/api/config.ts`) only turns on live-API paths when the URL carries `?api=1` (the image is not built with `VITE_WIRED=1`). A bare `http://localhost:28080` would open a demo talking to nothing, so the CLI advertises `http://localhost:28080/?api=1` and a test guards it.

## Known limitation (out of scope for this ticket)
Per `apps/ui/CLAUDE.md`, the Fleet / agent-list view is **still fixtures** in the shipped image; only Create-agent/Deploy, Runs, and Metrics/Logs call the real API. So literal "the console lists the agent you deployed" (AC1) is bounded by what the image wires today. Fully lighting up the agent list is an `apps/ui` change, tracked separately, not compose plumbing.

## Verification
- `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` -> 113 passed, clean.
- `docker compose -f compose.dev.yaml config` valid; `agentos-ui` service present.

Closes #42