### PR TITLE
Values-gated egress allowlist for skill web access

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ Use `--chart <path>` when developing the chart locally. The short version:
 - `agentos cluster up` runs `helm upgrade --install` of `charts/agentos`; it reads
   `AGENTOS_MODEL_CREDENTIALS` to enable a real model (absent, the release
   installs sealed with canned replies), and `--no-expose` keeps the UI and
-  Langfuse ClusterIP-only. Connecting Slack is a raw `helm upgrade
+  Langfuse ClusterIP-only. `--allow-web-egress <CIDR>` (repeatable) opens runner
+  egress for skill web access (e.g. the weather example's live web search),
+  additive to the sealed default. Connecting Slack is a raw `helm upgrade
   --reuse-values` (not a CLI verb; the chart's `NOTES.txt` prints it).
 - `agentos cluster status` reports release health and access URLs; `agentos cluster down`
   uninstalls and sweeps the runtime namespaces. Every verb takes `--dry-run`.

--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -244,6 +244,20 @@ default: a fresh install denies all egress except DNS until the operator declare
 where the model API and MCP endpoints live (`{cidr, ports}` entries). An unset
 allowlist never means allow-all.
 
+**Skill/tool web access.** The same allowlist also carries outbound web access a
+skill or tool needs (e.g. a web-search provider). `agentos cluster up --allow-web-egress
+<CIDR>` (repeatable) appends one entry per CIDR on TCP 443, additive to the model
+rule at index `[0]` and without weakening it; the raw helm equivalent is `--set
+'security.networkPolicy.allowedEgress[1].cidr=<CIDR>'` plus
+`...[1].ports[0].protocol=TCP` and `...[1].ports[0].port=443` (index `[1]`
+because the model entry is `[0]`; use index `[0]` instead when installing sealed
+with no model credential, so the array has no gap). This is the platform enablement the weather
+example (#36) depends on -- its skill answers via a live web search, which the
+sealed default denies. `--allow-web-egress 0.0.0.0/0` opens the open internet
+(still minus the `169.254.169.254` metadata endpoint the chart carves out of
+`0.0.0.0/0`); narrow the CIDR to a specific provider for a tighter posture. Omit
+the flag and the install stays fully sealed.
+
 **gVisor needs runsc on the node**, and `security.gvisor.mode` is a tri-state
 (default `auto`):
 

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -582,10 +582,13 @@ security:
     # Allow DNS egress so the runner can resolve its allowed hosts.
     allowDNS: true
     dnsNamespace: kube-system
-    # Egress allowlist = model API + declared MCP endpoints. Each entry is
-    # {cidr, ports: [{protocol, port}]}. EMPTY by default: a fresh install denies
-    # ALL egress except DNS until the operator declares where the model API and
-    # MCP servers live. Deliberately fail-closed -- an unset allowlist must never
+    # Egress allowlist = model API + declared MCP endpoints + any operator-declared
+    # skill/tool web-access egress (e.g. a web-search provider a skill calls). Each
+    # entry is {cidr, ports: [{protocol, port}]}, appended additively -- the
+    # `agentos cluster up --allow-web-egress <CIDR>` flag adds entries here after the model
+    # carve-out at index [0] without weakening it. EMPTY by default: a fresh install
+    # denies ALL egress except DNS until the operator declares where the model API
+    # and MCP servers live. Deliberately fail-closed -- an unset allowlist must never
     # mean "allow everything".
     allowedEgress: []
     #  - cidr: 160.79.104.0/23           # e.g. api.anthropic.com

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -293,6 +293,11 @@ enum ClusterAction {
             conflicts_with = "fake_model"
         )]
         local_model: Option<String>,
+        /// Open runner egress to a declared destination for skill web access,
+        /// repeatable CIDR, TCP 443. Additive to the model egress; omit to stay
+        /// fully sealed.
+        #[arg(long = "allow-web-egress", value_name = "CIDR")]
+        allow_web_egress: Vec<String>,
         /// Extra `--set KEY=VAL` passed through to helm verbatim (repeatable).
         #[arg(long = "set", value_name = "KEY=VAL")]
         set: Vec<String>,
@@ -609,6 +614,7 @@ async fn main() -> Result<()> {
                 no_expose,
                 fake_model,
                 local_model,
+                allow_web_egress,
                 set,
                 dry_run,
             } => {
@@ -637,6 +643,7 @@ async fn main() -> Result<()> {
                     chart,
                     no_expose,
                     set,
+                    allow_web_egress,
                     fake_model,
                     credentials,
                     local_model,

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -135,6 +135,10 @@ pub struct UpOpts {
     pub chart: String,
     pub no_expose: bool,
     pub set: Vec<String>,
+    /// Operator declared CIDRs to open runner egress to for skill or tool web
+    /// access, additive to the model carve out. Empty means fail closed by
+    /// default.
+    pub allow_web_egress: Vec<String>,
     /// Whether `--fake-model` was passed (forces the sealed install and
     /// suppresses the fake-model warning even when the env credential is set).
     pub fake_model: bool,
@@ -158,7 +162,27 @@ pub struct DownOpts {
 /// installed: Anthropic's published API range over TLS. The runner policy is
 /// fail-closed, so a real model call needs this allowlist entry too.
 const MODEL_EGRESS_CIDR: &str = "160.79.104.0/23";
-const MODEL_EGRESS_PORT: u16 = 443;
+/// Egress port shared by every runner allowlist entry (model + web): TLS only.
+const EGRESS_TCP_PORT: u16 = 443;
+
+/// Push the three `helm --set` args for one `security.networkPolicy.allowedEgress`
+/// entry (cidr + TCP port) at `idx`. Both the model carve-out and each declared
+/// web destination emit this identical shape, so they share one emitter to keep
+/// the array contiguous and the argv byte-identical across sources.
+fn push_egress_rule(args: &mut Vec<CmdArg>, idx: usize, cidr: &str, port: u16) {
+    args.push(plain("--set"));
+    args.push(plain(format!(
+        "security.networkPolicy.allowedEgress[{idx}].cidr={cidr}"
+    )));
+    args.push(plain("--set"));
+    args.push(plain(format!(
+        "security.networkPolicy.allowedEgress[{idx}].ports[0].protocol=TCP"
+    )));
+    args.push(plain("--set"));
+    args.push(plain(format!(
+        "security.networkPolicy.allowedEgress[{idx}].ports[0].port={port}"
+    )));
+}
 
 /// Resolve the model credential `up` installs with. `--fake-model` forces the
 /// sealed install regardless of the environment; otherwise a non-empty
@@ -170,11 +194,41 @@ pub fn resolve_up_credentials(fake_model: bool, env_value: Option<String>) -> Op
     env_value.filter(|v| !v.is_empty())
 }
 
+/// Validate every operator-supplied `--allow-web-egress` value is a real CIDR
+/// (`addr/prefix`) before it is interpolated into a `helm --set` argument. A
+/// value containing a comma or `=` would otherwise be split by helm into
+/// multiple `--set` assignments and could overwrite the model rule at index
+/// `[0]`; requiring a parseable `IpAddr` plus an in-range prefix naturally
+/// rejects those (and whitespace) because they fail to parse.
+pub fn validate_web_egress_cidrs(cidrs: &[String]) -> Result<()> {
+    for cidr in cidrs {
+        let (addr, prefix) = cidr.split_once('/').ok_or_else(|| {
+            anyhow::anyhow!("`--allow-web-egress` value `{cidr}` is not a CIDR (expected addr/prefix, e.g. 10.0.0.0/8)")
+        })?;
+        let ip: std::net::IpAddr = addr.parse().map_err(|_| {
+            anyhow::anyhow!(
+                "`--allow-web-egress` value `{cidr}` has an unparseable address `{addr}`"
+            )
+        })?;
+        let bits: u8 = prefix.parse().map_err(|_| {
+            anyhow::anyhow!(
+                "`--allow-web-egress` value `{cidr}` has an unparseable prefix `{prefix}`"
+            )
+        })?;
+        let max = if ip.is_ipv4() { 32 } else { 128 };
+        if bits > max {
+            bail!("`--allow-web-egress` value `{cidr}` has an out-of-range prefix `/{bits}` (max /{max})");
+        }
+    }
+    Ok(())
+}
+
 /// `helm upgrade --install` for the release, exposing the UI and Langfuse on
 /// node ports unless `--no-expose`, plus any pass-through `--set` values. When a
 /// model credential is present it also switches the fake model off, forwards the
-/// credential (masked when printed), and opens the fail-closed runner egress to
-/// the model provider.
+/// credential (masked when printed), opens the fail-closed runner egress to the
+/// model provider, and then adds declared web destinations additively after the
+/// model carve out.
 pub fn up_commands(o: &UpOpts) -> Vec<OpsCommand> {
     let mut args = vec![
         plain("upgrade"),
@@ -196,23 +250,23 @@ pub fn up_commands(o: &UpOpts) -> Vec<OpsCommand> {
         args.push(plain("inference.deploy=true"));
         args.push(plain("--set"));
         args.push(plain(format!("inference.model={model}")));
-    } else if let Some(credentials) = &o.credentials {
+    }
+    // Egress allowlist entries share one running index so the array stays
+    // contiguous no matter which sources contribute: the model carve-out (only
+    // when a credential is present) takes the first slot, then each declared web
+    // destination follows in order.
+    let mut egress_idx = 0;
+    if let Some(credentials) = &o.credentials {
         args.push(plain("--set"));
         args.push(plain("agentSandbox.runner.fakeModel=false"));
         args.push(plain("--set"));
         args.push(secret_set("agentSandbox.runner.credentials", credentials));
-        args.push(plain("--set"));
-        args.push(plain(format!(
-            "security.networkPolicy.allowedEgress[0].cidr={MODEL_EGRESS_CIDR}"
-        )));
-        args.push(plain("--set"));
-        args.push(plain(
-            "security.networkPolicy.allowedEgress[0].ports[0].protocol=TCP",
-        ));
-        args.push(plain("--set"));
-        args.push(plain(format!(
-            "security.networkPolicy.allowedEgress[0].ports[0].port={MODEL_EGRESS_PORT}"
-        )));
+        push_egress_rule(&mut args, egress_idx, MODEL_EGRESS_CIDR, EGRESS_TCP_PORT);
+        egress_idx += 1;
+    }
+    for cidr in &o.allow_web_egress {
+        push_egress_rule(&mut args, egress_idx, cidr, EGRESS_TCP_PORT);
+        egress_idx += 1;
     }
     for s in &o.set {
         args.push(plain("--set"));
@@ -410,6 +464,8 @@ pub(crate) async fn run_step(
 
 pub async fn up(opts: UpOpts) -> Result<()> {
     let ui = crate::ui::ui();
+    validate_web_egress_cidrs(&opts.allow_web_egress)
+        .context("invalid --allow-web-egress value")?;
     let cmds = up_commands(&opts);
     if opts.credentials.is_some() {
         ui.note("real model enabled; egress opened to the model provider");
@@ -417,11 +473,17 @@ pub async fn up(opts: UpOpts) -> Result<()> {
         ui.note("local model enabled; installing the chart inference deployment");
     } else if !opts.fake_model {
         ui.warn(
-            "no AGENTOS_MODEL_CREDENTIALS set; installing with the fake model and sealed egress",
+            "no AGENTOS_MODEL_CREDENTIALS set; installing with the fake model (model egress stays sealed)",
         );
         ui.note(
             "Replies will be canned. Set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) and re-run `agentos cluster up` to enable the real model.",
         );
+    }
+    if !opts.allow_web_egress.is_empty() {
+        ui.note(&format!(
+            "web egress opened to {} declared destination(s)",
+            opts.allow_web_egress.len()
+        ));
     }
     if opts.common.dry_run {
         for cmd in &cmds {
@@ -730,6 +792,7 @@ mod tests {
             chart: "charts/agentos".into(),
             no_expose: false,
             set: vec![],
+            allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
             local_model: None,
@@ -750,6 +813,7 @@ mod tests {
             chart: "charts/agentos".into(),
             no_expose: true,
             set: vec![],
+            allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
             local_model: None,
@@ -766,6 +830,7 @@ mod tests {
             chart: "charts/agentos".into(),
             no_expose: true,
             set: vec!["worker.replicas=2".into(), "dispatcher.deploy=false".into()],
+            allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
             local_model: None,
@@ -786,6 +851,7 @@ mod tests {
             chart: "charts/agentos".into(),
             no_expose: false,
             set: vec![],
+            allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
             local_model: None,
@@ -805,6 +871,7 @@ mod tests {
             chart: "charts/agentos".into(),
             no_expose: false,
             set: vec![],
+            allow_web_egress: vec![],
             fake_model: true,
             credentials: None,
             local_model: None,
@@ -821,6 +888,7 @@ mod tests {
             chart: "charts/agentos".into(),
             no_expose: false,
             set: vec![],
+            allow_web_egress: vec![],
             fake_model: false,
             credentials: Some("sk-ant-secretsecret".into()),
             local_model: None,
@@ -892,6 +960,7 @@ mod tests {
             chart: "charts/agentos".into(),
             no_expose: true,
             set: vec![],
+            allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
             local_model: Some("qwen3:4b".into()),
@@ -908,6 +977,7 @@ mod tests {
             chart: "charts/agentos".into(),
             no_expose: true,
             set: vec![],
+            allow_web_egress: vec![],
             fake_model: false,
             credentials: None,
             local_model: None,
@@ -915,6 +985,146 @@ mod tests {
         let line = cmds[0].display();
         assert!(!line.contains("inference.deploy"), "{line}");
         assert!(!line.contains("inference.model"), "{line}");
+    }
+
+    #[test]
+    fn up_opens_web_egress_after_model() {
+        let cmds = up_commands(&UpOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            no_expose: false,
+            set: vec![],
+            allow_web_egress: vec!["203.0.113.0/24".into()],
+            fake_model: false,
+            credentials: Some("sk-ant-secretsecret".into()),
+            local_model: None,
+        });
+        let line = cmds[0].display();
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[0].cidr=160.79.104.0/23'"),
+            "{line}"
+        );
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[1].cidr=203.0.113.0/24'"),
+            "{line}"
+        );
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[1].ports[0].protocol=TCP'"),
+            "{line}"
+        );
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[1].ports[0].port=443'"),
+            "{line}"
+        );
+    }
+
+    #[test]
+    fn up_web_egress_without_model_uses_index_zero() {
+        let cmds = up_commands(&UpOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            no_expose: false,
+            set: vec![],
+            allow_web_egress: vec!["0.0.0.0/0".into()],
+            fake_model: true,
+            credentials: None,
+            local_model: None,
+        });
+        let line = cmds[0].display();
+        assert!(!line.contains("160.79.104.0/23"), "{line}");
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[0].cidr=0.0.0.0/0'"),
+            "{line}"
+        );
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[0].ports[0].protocol=TCP'"),
+            "{line}"
+        );
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[0].ports[0].port=443'"),
+            "{line}"
+        );
+    }
+
+    #[test]
+    fn up_web_egress_multiple_cidrs_contiguous() {
+        let cmds = up_commands(&UpOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            no_expose: false,
+            set: vec![],
+            allow_web_egress: vec!["203.0.113.0/24".into(), "198.51.100.0/24".into()],
+            fake_model: false,
+            credentials: Some("sk-ant-secretsecret".into()),
+            local_model: None,
+        });
+        let line = cmds[0].display();
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[0].cidr=160.79.104.0/23'"),
+            "{line}"
+        );
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[1].cidr=203.0.113.0/24'"),
+            "{line}"
+        );
+        assert!(
+            line.contains("'security.networkPolicy.allowedEgress[2].cidr=198.51.100.0/24'"),
+            "{line}"
+        );
+    }
+
+    #[test]
+    fn up_no_web_egress_stays_sealed() {
+        let sealed_cmds = up_commands(&UpOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            no_expose: false,
+            set: vec![],
+            allow_web_egress: vec![],
+            fake_model: false,
+            credentials: None,
+            local_model: None,
+        });
+        let sealed_line = sealed_cmds[0].display();
+        assert!(!sealed_line.contains("allowedEgress"), "{sealed_line}");
+
+        let model_cmds = up_commands(&UpOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            no_expose: false,
+            set: vec![],
+            allow_web_egress: vec![],
+            fake_model: false,
+            credentials: Some("sk-ant-secretsecret".into()),
+            local_model: None,
+        });
+        let model_line = model_cmds[0].display();
+        assert!(!model_line.contains("allowedEgress[1]"), "{model_line}");
+    }
+
+    #[test]
+    fn validate_web_egress_cidrs_accepts_valid_and_rejects_bad() {
+        // Valid IPv4 CIDR and both catch-all forms pass.
+        assert!(validate_web_egress_cidrs(&["203.0.113.0/24".into()]).is_ok());
+        assert!(validate_web_egress_cidrs(&["0.0.0.0/0".into()]).is_ok());
+        assert!(validate_web_egress_cidrs(&["::/0".into()]).is_ok());
+
+        // A value with a comma is rejected (would split into multiple --set).
+        let err = validate_web_egress_cidrs(&[
+            "10.0.0.0/8,security.networkPolicy.allowedEgress[0].cidr=0.0.0.0/0".into(),
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("10.0.0.0/8,"), "{err}");
+
+        // A value with an `=` is rejected.
+        assert!(validate_web_egress_cidrs(&["10.0.0.0/8=x".into()]).is_err());
+
+        // A bare address with no /prefix is rejected.
+        assert!(validate_web_egress_cidrs(&["10.0.0.0".into()]).is_err());
+
+        // An out-of-range prefix is rejected.
+        assert!(validate_web_egress_cidrs(&["10.0.0.0/33".into()]).is_err());
     }
 
     #[test]

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -44,6 +44,19 @@ installed by the chart's preflights; see `charts/agentos/README.md`).
   installs sealed (canned replies) and `up` warns that replies stay canned
   until the env var is set and `up` is re-run. Pass `--fake-model` to force the
   sealed install even when the credential is present (a dev/CI escape hatch).
+  Pass `--allow-web-egress <CIDR>` (repeatable) to open runner egress on TCP 443
+  to each declared CIDR for skill/tool web access -- appended additively after
+  the model carve-out at index `[0]`, so it never weakens the model rule; omit it
+  and egress stays sealed. This is the platform enablement the weather example
+  (#36) needs, whose skill answers via a live web search: `agentos cluster up
+  --allow-web-egress 0.0.0.0/0` opens the open internet (still minus the
+  `169.254.169.254` metadata endpoint the chart carves out of `0.0.0.0/0`), or
+  narrow the CIDR to a specific web-search provider for a tighter posture. The
+  raw helm equivalent is
+  `--set 'security.networkPolicy.allowedEgress[1].cidr=0.0.0.0/0'` plus
+  `...[1].ports[0].protocol=TCP` and `...[1].ports[0].port=443` (index `[1]`
+  because the model entry is `[0]`; use index `[0]` instead when installing
+  sealed with no model credential, so the array has no gap).
 - `agentos cluster status` reports release health, pod readiness, and the access URLs;
   the UI URL carries `?api=1`, so it opens wired to the in-cluster API (the
   deployed UI proxies `/api/` there).


### PR DESCRIPTION
## What

Adds a repeatable `agentos up --allow-web-egress <CIDR>` flag that opens runner-sandbox egress to each declared destination on TCP 443, appended additively after the model-provider carve-out. It reuses the existing `security.networkPolicy.allowedEgress` NetworkPolicy mechanism, so there is **no chart template change**. The fail-closed default is unchanged: omit the flag and the install stays sealed exactly as today.

This is the platform half of making the weather example (#36) work; that skill answers via a live web search the sealed default denies.

## How

- **CLI** (`cli/src/ops.rs`, `cli/src/main.rs`): `--allow-web-egress` emits `allowedEgress[N]` entries through a shared `push_egress_rule` helper driven by one running index, so the model rule (index `[0]` when a credential is present) and web entries stay contiguous. Each CIDR is validated (`addr/prefix` via `std::net::IpAddr`) before it reaches helm, rejecting commas/`=`/whitespace that could otherwise split into extra `--set` assignments and overwrite the model rule.
- **Docs**: `values.yaml`, chart README, `docs/operations.md`, and the root README document the flag, the weather-demo `--allow-web-egress 0.0.0.0/0` example (the `169.254.169.254` metadata endpoint stays carved out), the raw `--set` equivalent, and the preserved fail-closed default.

## Acceptance criteria

- With the flag configured, the runner reaches the declared endpoint(s); unset, egress stays blocked exactly as today (default-deny template and enforcement probe untouched).
- Additive to the model carve-out; enabling web egress neither requires nor weakens the model egress rule.
- Documented with a concrete `--set`/flag example for the demo, tied to #36.
- Fail-closed default preserved; no broadening of the default egress.

## Security posture

Default remains fail-closed (`allowedEgress: []` unchanged; egress widens only on an explicit operator flag). CIDR validation closes the `--set` key-injection vector. `--allow-web-egress 0.0.0.0/0` opens the open internet but the chart still excepts the cloud metadata endpoint. CIDRs flow through the plain (non-secret) arg path; the masked model-credential path is untouched.

## Follow-up (out of scope, pre-existing)

The chart template adds an IPv4 `169.254.169.254/32` `except` even for an IPv6 `::/0` entry, which k8s rejects (same-family subset required). Pre-existing in the unchanged template and fail-closed (helm apply fails); worth a separate chart fix.

## Verification

- `cargo test` (118 passed), `cargo fmt --check`, `cargo clippy -- -D warnings`, `helm lint charts/agentos` all clean.
- Codex reviewed the branch and rendered `helm template ... --allow-web-egress 0.0.0.0/0`, confirming the metadata carve-out renders and the emitted argv is correct.

Closes #43