### PR TITLE
Unify CLI surface into skill/local/cluster target nouns

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -108,7 +108,7 @@ flowchart TB
 | [`apps/worker`](apps/worker) | Python (redis-py) | Concurrency kernel, substrate, eval consumer |
 | [`runner`](runner) | Python (claude-agent-sdk) | ACI session server inside the sandbox |
 | [`apps/ui`](apps/ui) | React (Vite + TS) | Console: create/deploy, Runs, Metrics, Logs, Cost |
-| [`cli`](cli) | Rust (clap + tokio) | `agentos` binary: init/deploy/chat/eval, local runner |
+| [`cli`](cli) | Rust (clap + tokio) | `agentos` binary: init, skill, local, cluster surfaces |
 | [`charts/agentos`](charts/agentos) | Helm | Umbrella chart + security rails |
 | [`tests/soak`](tests/soak) | Python | Soak/chaos harness (scaffold) |
 
@@ -148,7 +148,7 @@ container differs.
 The worker reaches Slack only through a base URL
 ([`apps/worker/src/agentos_worker/config.py:146`](apps/worker/src/agentos_worker/config.py),
 `SLACK_API_BASE_URL`). In production that points at Slack's Web API. The CLI's
-`agentos chat` starts a local Slack Web API stub
+`agentos local message` path starts a local Slack Web API stub
 ([`cli/src/chat.rs`](cli/src/chat.rs)), prints the `SLACK_API_BASE_URL` to point
 the worker at it ([`cli/src/chat.rs:269`](cli/src/chat.rs)), enqueues a synthetic
 `QueuedSlackEvent` onto the very same `agentos:runs` stream the dispatcher uses,
@@ -295,7 +295,7 @@ sequenceDiagram
 - **Git-flow fan-out** at [`apps/api/src/agentos_api/gitflow.py`](apps/api/src/agentos_api/gitflow.py): signature verify (`:35`), dev-branch archive+validate+store+create-Version (`:136`), prod-branch **promotes the same artifact without rebuilding** (`:172`), eval enqueue on a newly built dev version, deduped on redelivery (`:186`). Webhook receiver at [`apps/api/src/agentos_api/routers/github.py:20`](apps/api/src/agentos_api/routers/github.py).
 - **Eval stream** `agentos:evals` is produced by the API ([`apps/api/src/agentos_api/evalqueue.py:21`](apps/api/src/agentos_api/evalqueue.py)) and consumed by the worker's eval consumer, which is a **separate** consumer group from the runs kernel ([`apps/worker/src/agentos_worker/eval/stream.py:216`](apps/worker/src/agentos_worker/eval/stream.py)). It POSTs results to `/evals/report` ([`eval/stream.py:114`](apps/worker/src/agentos_worker/eval/stream.py)).
 - **The eval matrix endpoint** `GET /evals/matrix` reads pass/fail from Langfuse trace tags/metadata, not a scores join ([`apps/api/src/agentos_api/routers/evals.py:15`](apps/api/src/agentos_api/routers/evals.py)). Note: the API endpoint is live, but the UI matrix view is still fixture-backed (part of retiring the fixture surface, [issue #4](https://github.com/curie-eng/agentos/issues/4)).
-- **The manual path** (`GET /agents`, `/agents/{id}/versions`, `/agents/{id}/versions/{vid}/bundle`) and the webhook path terminate at the same `Version`/`Deployment` tables and the same `plugin_format.validate_bundle`, so a plugin authored in the browser, pushed by `agentos deploy`, or promoted by git-flow all go through one pipeline. Bundle store/fetch at [`apps/api/src/agentos_api/storage.py:22`](apps/api/src/agentos_api/storage.py) and [`apps/api/src/agentos_api/routers/bundles.py:79`](apps/api/src/agentos_api/routers/bundles.py).
+- **The manual path** (`GET /agents`, `/agents/{id}/versions`, `/agents/{id}/versions/{vid}/bundle`) and the webhook path terminate at the same `Version`/`Deployment` tables and the same `plugin_format.validate_bundle`, so a plugin authored in the browser, pushed by `agentos local deploy`, or promoted by git-flow all go through one pipeline. Bundle store/fetch at [`apps/api/src/agentos_api/storage.py:22`](apps/api/src/agentos_api/storage.py) and [`apps/api/src/agentos_api/routers/bundles.py:79`](apps/api/src/agentos_api/routers/bundles.py).
 
 ## 6. The credential path
 

--- a/README.md
+++ b/README.md
@@ -56,30 +56,56 @@ journeys filed as `epic`-labeled issues.
 | [`packages/aci-protocol`](packages/aci-protocol/README.md) | Python (frozen, codegen to TS + Rust) | The ACI session protocol every lane speaks |
 | [`packages/plugin-format`](packages/plugin-format/README.md) | Python (frozen, codegen to JSON Schema) | The Claude Code plugin bundle shape, verbatim |
 
-## Three ways to talk to the system
+## Which target do I want?
 
-**Real Slack** — connect a workspace, `@mention` the bot in a channel or DM it.
-The dispatcher acks, posts a placeholder, and the worker routes the turn into
-a claimed sandbox; the placeholder is edited in place as the reply streams.
-See `apps/dispatcher/README.md`'s runbook for pointing at a real workspace.
+Every CLI command that touches an environment takes a **target noun** in the
+middle: `skill`, `local`, or `cluster`. Pick the lightest one that answers your
+question. (`agentos init` is the exception: it scaffolds a bundle on disk and
+targets no environment.)
 
-**Local CLI, no Slack at all** — `agentos start` boots the runner image in
-Docker (optionally `--fake-model` for a fully offline round-trip), then
-`agentos send "..."` emulates a Slack message against it and streams the
-NDJSON reply to your terminal. `agentos eval` runs a plugin's `evals/cases.json`
-the same way. This is the fastest inner loop for developing a plugin: zero
-Slack, zero cluster. See `cli/README.md`.
+| Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
+|---|---|---|---|---|---|
+| `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
+| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | none | none | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `message` `deploy` | Operate and drive a deployed cluster release. |
 
-**`agentos chat` (middle mode)** — drive the real deployed pipeline (worker →
-sandboxed runner) without a Slack workspace in between. `agentos deploy` pushes a
-bundle to the API, then a worker run with `AGENTOS_SANDBOX_SUBSTRATE=docker`
-claims runner containers locally instead of a cluster, and `agentos chat` sends a
-message through the same path a Slack mention would take. Middle mode defaults to
-a **real model**: export `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`)
-before starting the worker and it is forwarded into each runner container. For a
-fully offline round-trip, set `AGENTOS_FAKE_MODEL=1` — an explicit test-only knob;
-without a credential and without that flag the worker refuses to start rather than
-silently faking. See the middle-mode runbook below.
+The universal quartet `up`/`down`/`status`/`message` is on all three targets;
+`skill` adds `eval`, and `local`/`cluster` add `deploy`.
+
+The distinction that matters: `skill` is the **runner-only** loop, it boots just
+the runner container and talks straight to its ACI HTTP surface with no platform
+in front. `local` and `cluster` put the **full platform** (queue, worker,
+sandbox) in front of the identical runner and ACI, so a `message` walks the same
+path a real Slack mention would take.
+
+**`skill` (runner-only, fully offline).** `agentos skill up` boots the runner
+image in Docker (add `--fake-model` for a fully offline round-trip), then
+`agentos skill message "..."` sends a synthetic Slack event to it and streams
+the NDJSON reply to your terminal. `agentos skill eval` runs a plugin's
+`evals/cases.json` the same way. Abort a live `skill message` with Ctrl-C. This
+is the fastest inner loop for developing a plugin: zero Slack, zero platform,
+zero cluster. See `cli/README.md`.
+
+**`local` (full platform via compose, no Slack).** `agentos local up` brings up
+the compose stack, `agentos local deploy` pushes a bundle to the compose API,
+and `agentos local message "..."` drives a message through the real
+queue -> worker -> sandboxed runner -> reply path with no Slack and no
+Kubernetes. The compose worker runs the fake model by default; for a real model,
+export `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) and set
+`AGENTOS_FAKE_MODEL=0` in the compose environment. See the local runbook below.
+
+**`cluster` (deployed Helm release).** `agentos cluster up` installs the platform
+on Kubernetes and `agentos cluster message "..."` drives the deployed release end
+to end with no Slack. See
+[Operating a cluster install](#operating-a-cluster-install) and
+[`docs/operations.md`](docs/operations.md).
+
+**Real Slack (production).** With a workspace connected, `@mention` the bot in a
+channel or DM it: the dispatcher acks, posts a placeholder, and the worker routes
+the turn into a claimed sandbox; the placeholder is edited in place as the reply
+streams. This is the same platform the `local` and `cluster` targets exercise,
+with Slack in front. See `apps/dispatcher/README.md`'s runbook for pointing at a
+real workspace.
 
 ## Prerequisites
 
@@ -135,21 +161,21 @@ cd cli && cargo build --release
 # Real model is the default. Export a credential first (forwarded into the runner
 # container): CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, or AGENTOS_CREDENTIALS.
 export CLAUDE_CODE_OAUTH_TOKEN=...
-../target/release/agentos start
-../target/release/agentos send "hello"
-../target/release/agentos eval
+../target/release/agentos skill up
+../target/release/agentos skill message "hello"
+../target/release/agentos skill eval
 ```
 
 For a fully offline round-trip (no credential, scripted replies), add
-`--fake-model` to `agentos start` — an explicit test-only mode that never reaches
+`--fake-model` to `agentos skill up` — an explicit test-only mode that never reaches
 the Anthropic API.
 
 **One-command middle mode** (the fastest path — no host-run worker, no cluster):
 
 ```bash
 agentos local up   # brings up the backing stores + API + a containerized worker
-agentos deploy --plugin-dir ./my-agent --slack-channel C-DEMO --api-url http://localhost:28000
-agentos message --local "what changed in the last deploy?"
+agentos local deploy --plugin-dir ./my-agent --slack-channel C-DEMO --api-url http://localhost:28000
+agentos local message "what changed in the last deploy?"
 ```
 
 `local up` runs the worker as the `agentos-worker` compose service (fake model by
@@ -162,13 +188,16 @@ worker itself from source.
 hand-run `uvicorn` in Quickstart step 4 uses `:8000`. Point `deploy --api-url`
 at whichever one you brought up.
 
-**Middle-mode runbook** (real deployed pipeline, no Slack, no cluster — the
+**Local runbook** (real deployed pipeline, no Slack, no cluster — the
 backing stack from the Quickstart plus the API on :8000 and the runner image
 built as above):
 
 ```bash
 # Deploy a plugin to the API (creates the agent bound to a Slack channel id).
-./target/release/agentos deploy --plugin-dir ./my-agent --slack-channel C-DEMO --env dev
+# This runbook hand-starts uvicorn on :8000 (Quickstart step 4), so pin
+# --api-url to it; local deploy otherwise defaults to the `local up` API on :28000.
+./target/release/agentos local deploy --plugin-dir ./my-agent --slack-channel C-DEMO \
+    --api-url http://localhost:8000 --env dev
 
 # Start a worker that claims runner containers via Docker. REAL MODEL is the
 # default: export your credential first (forwarded into each runner container).
@@ -178,15 +207,15 @@ built as above):
 export CLAUDE_CODE_OAUTH_TOKEN=...        # or ANTHROPIC_API_KEY=...
 env AGENTOS_SANDBOX_SUBSTRATE=docker \
     VALKEY_HOST=localhost VALKEY_PORT=26379 VALKEY_PASSWORD=valkeypass \
-    SLACK_API_BASE_URL=http://localhost:8137/api/ SLACK_BOT_TOKEN=xoxb-dev \
+    SLACK_API_BASE_URL=http://localhost:8155/api/ SLACK_BOT_TOKEN=xoxb-dev \
     AGENTOS_DOCKER_NETWORK=agentos_default \
     OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318 \
     uv run python -m agentos_worker &
 
 # Send a message through the same path a Slack mention takes; the fake-model
 # transcript is the identical command minus the credential, plus AGENTOS_FAKE_MODEL=1.
-./target/release/agentos chat "what changed in the last deploy?" \
-    --channel C-DEMO --listen-port 8137
+./target/release/agentos local message "what changed in the last deploy?" \
+    --channel C-DEMO
 ```
 
 For an offline round-trip add `AGENTOS_FAKE_MODEL=1` to the worker env and drop
@@ -222,14 +251,14 @@ The same `agentos` binary installs and runs the platform on a Kubernetes
 cluster, wrapping the umbrella Helm chart the way `linkerd` or `cilium` wrap
 theirs. The short version:
 
-- `agentos up` runs `helm upgrade --install` of `charts/agentos`; it reads
+- `agentos cluster up` runs `helm upgrade --install` of `charts/agentos`; it reads
   `AGENTOS_MODEL_CREDENTIALS` to enable a real model (absent, the release
   installs sealed with canned replies), and `--no-expose` keeps the UI and
   Langfuse ClusterIP-only. Connecting Slack is a raw `helm upgrade
   --reuse-values` (not a CLI verb; the chart's `NOTES.txt` prints it).
-- `agentos status` reports release health and access URLs; `agentos down`
+- `agentos cluster status` reports release health and access URLs; `agentos cluster down`
   uninstalls and sweeps the runtime namespaces. Every verb takes `--dry-run`.
-- `agentos message "..."` drives a deployed release end to end with no Slack.
+- `agentos cluster message "..."` drives a deployed release end to end with no Slack.
 
 Full runbook (the credential model, the Slack-connect command, and the
 zero-Slack `message` flow) is in [`docs/operations.md`](docs/operations.md).

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -31,7 +31,8 @@ worker, Postgres, MinIO/S3, Langfuse, and GitHub.
   be "the exact artifact that passed on dev," not a fresh build.
 - **The plugin bundle validator (`plugin_format.validate_bundle`) is the only
   gate a bundle passes through**, whether it arrives via the CLI's
-  `agentos deploy`, the UI's create-agent modal, or a git push. Do not
+  `agentos local deploy` / `agentos cluster deploy`, the UI's create-agent
+  modal, or a git push. Do not
   duplicate validation logic in a new entry point; route through
   `bundles.py`.
 - **Observability endpoints are read-only proxies, not new stores.** The

--- a/apps/ui/src/views/Terminal.tsx
+++ b/apps/ui/src/views/Terminal.tsx
@@ -19,8 +19,8 @@ function startBox(): Entry[] {
   return [
     L("out", "╭─ agentos dev environment ──────────────────────────╮"),
     L("out", "│  Local bot        http://localhost:7245          │"),
-    L("out", '│  Slack emulator   agentos send "<message>"         │'),
-    L("out", "│  Eval runner      agentos eval                     │"),
+    L("out", '│  Skill message    agentos skill message "<message>" │'),
+    L("out", "│  Eval runner      agentos skill eval               │"),
     L("out", "│  Version          v1.4.2 · claude-sonnet-5       │"),
     L("out", "╰──────────────────────────────────────────────────╯"),
   ];
@@ -30,7 +30,7 @@ function seedTerm(): Entry[] {
   return [
     L("dim", "agentos cli v0 · acme-corp · env prod → @agentos"),
     ...startBox(),
-    L("dim", 'Type a command, or tap one below. Try: agentos send "@agentos ..."'),
+    L("dim", 'Type a command, or tap one below. Try: agentos skill message "@agentos ..."'),
   ];
 }
 
@@ -67,20 +67,21 @@ function resolveCmd(cmd: string): Entry[] {
     return [
       L("dim", "commands"),
       L("out", "  agentos init            scaffold a project"),
-      L("out", "  agentos start           run the local dev bot"),
+      L("out", "  agentos skill up        run the local dev bot"),
       L("out", "  agentos dev             hot-reload skills"),
-      L("out", '  agentos send "<msg>"    message the bot (threads)'),
-      L("out", "  agentos eval            run the eval suite"),
-      L("out", "  agentos deploy          deploy to Slack"),
-      L("out", "  agentos status          agent, model & env"),
+      L("out", '  agentos skill message   message the local skill'),
+      L("out", "  agentos skill eval      run the eval suite"),
+      L("out", "  agentos local deploy    deploy to local API"),
+      L("out", "  agentos cluster deploy  deploy to cluster"),
+      L("out", "  agentos cluster status  cluster health and URLs"),
       L("out", "  agentos logs            tail recent logs"),
       L("out", "  git push origin dev   push & queue eval check"),
       L("out", "  clear                 clear the screen"),
     ];
   if (lc === "agentos init") return [L("dim", "Creating agentos.toml, skills/, evals/ …"), L("success", "✓ Project initialized · edit skills/deal-desk/skill.md")];
-  if (lc === "agentos start") return startBox();
+  if (lc === "agentos skill up") return startBox();
   if (lc === "agentos dev") return [L("success", "✓ hot reload · watching skills/"), L("dim", "bot listening on http://localhost:7245")];
-  if (lc === "agentos eval")
+  if (lc === "agentos skill eval")
     return [
       L("dim", "Running suite deal-desk core (36 cases) · model claude-sonnet-5 …"),
       L("success", "✓ approver-from-policy-source            1.2s"),
@@ -91,8 +92,9 @@ function resolveCmd(cmd: string): Entry[] {
       L("dim", "─────────────────────────────"),
       L("out", "34/36 passed · 2 failures · 12.4s"),
     ];
-  if (lc === "agentos deploy") return [L("dim", "Bundling deal-desk · uploading …"), L("success", "✓ @agentos deployed to #revenue-ops · v1.4.2")];
-  if (lc === "agentos status")
+  if (lc === "agentos local deploy" || lc === "agentos cluster deploy")
+    return [L("dim", "Bundling deal-desk · uploading …"), L("success", "✓ @agentos deployed to #revenue-ops · v1.4.2")];
+  if (lc === "agentos cluster status")
     return [
       L("out", "agent    deal-desk"),
       L("out", "env      prod  →  @agentos"),
@@ -113,10 +115,10 @@ function resolveCmd(cmd: string): Entry[] {
       L("dim", "   4f2c91a..b7e02d1  dev -> dev"),
       L("success", "→ agentos: eval check queued on PR #42"),
     ];
-  if (lc.startsWith("agentos send")) {
+  if (lc.startsWith("agentos skill message")) {
     const m = cmd.match(/"([^"]*)"|'([^']*)'/);
-    const msg = (m && (m[1] || m[2])) || cmd.replace(/^agentos send\s*/i, "").trim();
-    if (!msg) return [L("error", 'usage: agentos send "<message>"')];
+    const msg = (m && (m[1] || m[2])) || cmd.replace(/^agentos skill message\s*/i, "").trim();
+    if (!msg) return [L("error", 'usage: agentos skill message "<message>"')];
     const r = botReply(msg);
     const tid = "tr_" + Math.random().toString(16).slice(2, 8);
     const dur = (0.8 + Math.random() * 1.6).toFixed(1);
@@ -168,9 +170,10 @@ function EntryRow({ e }: { e: Entry }) {
 }
 
 const CHIPS: [string, boolean][] = [
-  ["agentos eval", true],
-  ["agentos status", true],
-  ['agentos send "@agentos approve Northwind at 12%?"', false],
+  ["agentos skill up", true],
+  ["agentos skill eval", true],
+  ["agentos cluster status", true],
+  ['agentos skill message "@agentos approve Northwind at 12%?"', false],
   ["agentos logs", true],
   ["help", true],
   ["clear", true],

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -35,7 +35,7 @@ class WorkerConfig(BaseModel):
     # Slack
     slack_bot_token: str = ""
     # Optional Slack Web API base URL override. Unset = the real Slack API; set it
-    # to point chat.update at a local Slack stub (the CLI's `agentos chat`
+    # to point chat.update at a local Slack stub (the CLI's `agentos local message`
     # no-Slack middle-mode e2e).
     slack_api_base_url: str = ""
 

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -7,7 +7,7 @@ For each entry it:
 
   1. fetches the version's immutable bundle from MinIO by ``bundle_ref`` and loads
      the suite from the bundle's own ``evals/cases.json`` (the same shape the CLI's
-     ``agentos eval`` reads); the ``suite`` field names it and tags Langfuse;
+     ``agentos skill eval`` reads); the ``suite`` field names it and tags Langfuse;
   2. runs the suite against the runner: ``target_url`` if given (the dev/test
      shortcut), otherwise provisions a sandbox for the version via the G1
      substrate (the same boot env F2 uses) and tears it down in a finally;

--- a/charts/agentos/templates/NOTES.txt
+++ b/charts/agentos/templates/NOTES.txt
@@ -82,29 +82,29 @@ Kernel isolation (gVisor, security.gvisor.mode={{ $gvisorMode }}):
 Enable a real model and a Slack workspace:
   The dispatcher is not deployed (no Slack tokens set). If you also installed
   without AGENTOS_MODEL_CREDENTIALS, the runner is in offline fake-model mode and
-  replies are canned. The `agentos up`/`message`/`status` verbs default to
+  replies are canned. The `agentos cluster up`/`cluster message`/`cluster status` verbs default to
   release/namespace {{ .Release.Name }}/{{ .Release.Namespace }} (add --dry-run to
   print the exact helm/kubectl command first); the Slack workspace is wired with a
   raw helm upgrade.
 
   # 1. Enable the real model: set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key)
-  #    and re-run `agentos up` -- an idempotent helm upgrade that switches the fake
+  #    and re-run `agentos cluster up` -- an idempotent helm upgrade that switches the fake
   #    model off and opens the fail-closed runner egress to the model provider.
   AGENTOS_MODEL_CREDENTIALS=sk-ant-... \
-    agentos up --namespace {{ .Release.Namespace }} --release {{ .Release.Name }}
+    agentos cluster up --namespace {{ .Release.Namespace }} --release {{ .Release.Name }}
 
   # 2. (optional) Exercise the deployed agent end to end with NO Slack workspace.
-  agentos message --namespace {{ .Release.Namespace }} --release {{ .Release.Name }} "hello"
+  agentos cluster message --namespace {{ .Release.Namespace }} --release {{ .Release.Name }} "hello"
 
   # 3. Wire a real Slack workspace (renders the dispatcher). The trailing
-  #    worker.slackApiBaseUrl= clears any `agentos message` stub wiring (a
+  #    worker.slackApiBaseUrl= clears any `agentos cluster message` stub wiring (a
   #    harmless no-op otherwise).
   helm upgrade {{ .Release.Name }} charts/agentos -n {{ .Release.Namespace }} --reuse-values \
     --set dispatcher.slack.appToken=xapp-... --set dispatcher.slack.botToken=xoxb-... \
     --set worker.slackApiBaseUrl=
 
   # Release health + access URLs at any point (read-only):
-  agentos status --namespace {{ .Release.Namespace }} --release {{ .Release.Name }}
+  agentos cluster status --namespace {{ .Release.Namespace }} --release {{ .Release.Name }}
 
   Or do both (model + Slack) in one helm upgrade -- the runner NetworkPolicy is
   fail-closed, so real model calls need the egress allowlist too; add more

--- a/charts/agentos/templates/worker.yaml
+++ b/charts/agentos/templates/worker.yaml
@@ -111,7 +111,7 @@ spec:
                   key: agentCredentials
             {{- end }}
             # No-Slack egress routing: when set, the worker's Slack sink posts its
-            # placeholder edits at this base URL (the `agentos message` CLI stub)
+            # placeholder edits at this base URL (the `agentos cluster message` CLI stub)
             # instead of real Slack. Empty (the default) leaves the sink on real
             # Slack. Rendered only when non-empty (values-not-templates).
             {{- if .Values.worker.slackApiBaseUrl }}

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -302,9 +302,9 @@ worker:
   claimTimeoutSeconds: 90
   # No-Slack egress routing. When non-empty, renders SLACK_API_BASE_URL on the
   # worker Deployment so the worker's Slack sink posts placeholder edits at this
-  # base URL instead of real Slack -- the seam `agentos message` drives when it
+  # base URL instead of real Slack -- the seam `agentos cluster message` drives when it
   # points the deployed worker at its local Slack Web API stub. Empty (the
-  # default) leaves the worker on real Slack. `agentos message --wire` sets this
+  # default) leaves the worker on real Slack. `agentos cluster message --wire` sets this
   # via `helm upgrade --reuse-values`; connecting real Slack (a `helm upgrade
   # --reuse-values` that sets the dispatcher tokens) clears it back to empty in
   # the same command, so that upgrade un-wires any stub routing.

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -3,12 +3,11 @@
 The `agentos` CLI: Rust, clap + tokio + reqwest. Speaks only the
 frozen contracts (the generated `agentos-aci-protocol` crate over HTTP/NDJSON,
 and the platform API's committed `apps/api/openapi.json`) and orchestrates a
-local runner container via Docker. Two command families: the **runner-session**
-verbs (`init`, `start`, `send`, `eval`, `runner-status`, `steer`, `interrupt`,
-plus `deploy`/`chat`/`message`) drive a plugin against a local runner or a
-deployed release; the **operator lifecycle** verbs (`up`, `status`, `down`, and
-`local <up|down|status>`, in `src/ops.rs` + `src/local.rs`) are a thin wrapper
-over the `helm`/`kubectl`/`docker compose` binaries. Full command reference in
+local runner container via Docker. Three command families: `skill` drives a
+plugin against a local runner with `up`, `down`, `status`, `message`, and
+`eval`; `local` wraps the compose stack and local API with `up`, `down`,
+`status`, `message`, and `deploy`; `cluster` wraps Helm and the deployed
+release with `up`, `status`, `down`, `message`, and `deploy`. Full command reference in
 `cli/README.md`.
 
 ## Load-bearing invariants
@@ -24,12 +23,12 @@ over the `helm`/`kubectl`/`docker compose` binaries. Full command reference in
   Keep `reqwest`'s feature set minimal (`json`, `stream`, `multipart`) --
   adding a feature should come with a reason in the PR, not just convenience.
 - **The queue seam is mirrored, not imported, across languages.** The CLI
-  never talks to the dispatcher's Valkey Stream directly -- `agentos send`
+  never talks to the dispatcher's Valkey Stream directly -- `agentos skill message`
   talks straight to a local runner container's ACI HTTP surface
   (`/v1/event`, `/v1/steer`, `/v1/interrupt`), bypassing the
   dispatcher/worker entirely by design (that is the point: zero Slack, zero
   cluster). If a future task wires the CLI to the real dispatcher/worker
-  queue seam (the planned `agentos chat` middle mode), mirror the
+  queue seam (the future dispatcher or worker queue surface), mirror the
   `QueuedSlackEvent` shape rather than importing Python types into Rust --
   keep the contract-mirroring discipline explicit at the boundary.
 - **`agentos init` scaffolds the plugin-format shape verbatim.** The
@@ -37,21 +36,22 @@ over the `helm`/`kubectl`/`docker compose` binaries. Full command reference in
   `.mcp.json`) must stay byte-compatible with what `plugin_format.validate_bundle`
   accepts -- if `packages/plugin-format` changes, this scaffold needs
   updating in the same reviewed change, not independently.
-- **`start` records container state in `.agentos/runner.json`** (gitignored
-  by the scaffold) so `send`/`eval`/`runner-status`/`stop` can resolve the
+- **`skill up` records container state in `.agentos/runner.json`** (gitignored
+  by the scaffold) so `skill message`/`skill eval`/`skill status`/`skill down` can resolve the
   running container from the bundle directory alone. Do not add a second
   state-tracking file for the same purpose.
-- **The local runner-session verbs stay fully offline; the cluster-facing
-  verbs are the exception.** `init`, `start`, `send`, `eval`, `runner-status`,
-  `steer`, and `interrupt` must keep working with zero network access beyond
-  the local Docker daemon and the local runner container. `deploy` is the one
-  runner-session verb that leaves the machine: it packages the bundle as
+- **The local skill verbs stay fully offline; the local and cluster
+  target verbs are the exception.** `init`, `skill up`, `skill down`,
+  `skill status`, `skill message`, and `skill eval` must keep working with
+  zero network access beyond the local Docker daemon and the local runner
+  container. `deploy` is the one bundle shipping verb that leaves the machine: it packages the bundle as
   tar.gz and pushes to the platform API (find-or-create agent, create version,
   upload bundle, create deployment) authenticated via
-  `--api-key`/`AGENTOS_API_KEY`. `chat`/`message` and every operator verb
-  (`up`, `status`, `down`) reach a Valkey/API/cluster by design.
+  `--api-key`/`AGENTOS_API_KEY`. `local message`, `local deploy`,
+  `cluster message`, `cluster deploy`, and every operator verb
+  (`local up`, `local status`, `local down`, `cluster up`, `cluster status`, `cluster down`) reach a Valkey, API, or cluster by design.
 - **The operator verbs are a thin wrapper; the chart stays the source of
-  truth.** `up`/`status`/`down` (`src/ops.rs`) and
+  truth.** `cluster up`/`cluster status`/`cluster down` (`src/ops.rs`) and
   `local <up|down|status>` (`src/local.rs`) shell out to
   `helm`/`kubectl`/`docker compose` and never re-derive what a values file
   already declares. Each verb builds its command lines as a pure function
@@ -66,7 +66,7 @@ over the `helm`/`kubectl`/`docker compose` binaries. Full command reference in
   connected with a raw `helm upgrade --reuse-values` (setting the dispatcher
   tokens and clearing `worker.slackApiBaseUrl=` to un-wire any `message` stub
   routing), not a CLI verb; see the chart NOTES.
-- **`message` self-plumbs and guards against hijacking real Slack.** It manages
+- **`cluster message` self-plumbs and guards against hijacking real Slack.** It manages
   its own kubectl port-forwards (children killed on exit) and, when wiring the
   deployed worker to its local stub, refuses if a `<release>-dispatcher`
   Deployment exists (a real workspace is connected) unless `--force-wire`. Do

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,27 +6,79 @@ HTTP/NDJSON, and the platform API's committed openapi.json) and orchestrates a
 local runner container via Docker, so a plugin runs on a dev laptop with zero
 Slack involved.
 
-## Commands
+## Which target do I want?
+
+Every environment command takes a **target noun** in the middle: `skill`,
+`local`, or `cluster`. Pick the lightest one that answers your question.
+`agentos init` is the exception, a top-level verb that scaffolds a bundle on
+disk and targets no environment.
+
+| Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
+|---|---|---|---|---|---|
+| `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
+| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | none | none | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `message` `deploy` | Operate and drive a deployed cluster release. |
+
+The universal quartet `up`/`down`/`status`/`message` is on all three targets;
+`skill` adds `eval`, and `local`/`cluster` add `deploy`. The distinction that
+matters: `skill` is the **runner-only** loop, talking straight to a runner
+container's ACI HTTP surface with no platform in front; `local` and `cluster`
+put the **full platform** (queue, worker, sandbox) in front of the identical
+runner and ACI, so a `message` walks the same path a real Slack mention would.
+
+## `init` (top-level)
 
 | Command | What it does |
 |---|---|
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed. |
-| `agentos start` | Boot the runner image in Docker with the ACI boot env (runner/README.md recipe), wait for health, print the boxed env summary. `--fake-model` runs offline; `--network`/`--otel-endpoint` join the compose stack for traces. |
-| `agentos send "..."` | Emulate a Slack message: POST an ACI `event` frame to the local runner and stream the NDJSON reply (text deltas, tool notes, side-effect flags, final). |
-| `agentos eval` | Run `evals/cases.json` through the runner as `eval_case` events; prints a per-case result table plus a pass/fail roll-up; nonzero exit on failure. |
-| `agentos steer "..."` | Inject a follow-up into the runner's live turn (POST `/v1/steer`); prints `no active turn` and exits nonzero on the runner's 409. |
-| `agentos interrupt` | Hard-stop the runner's live turn (POST `/v1/interrupt`); `--reason` is recorded with it. |
-| `agentos chat "..."` | Drive the whole system with the CLI acting **as** the Slack service against the local compose stack, no Slack involved (see below). |
-| `agentos message "..."` | Drive the **deployed** Kubernetes release end to end with zero Slack: self-plumbs kubectl port-forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply (see below). |
-| `agentos message --local "..."` | Same roundtrip against the **local compose stack** (`agentos local up`) instead of a cluster: no kubectl/helm/port-forwards. Enqueues straight to the compose Valkey and lets the containerized worker answer. Channel via `--channel` or the sole deployed agent (looked up on the compose API, default `http://localhost:28000`, overridable with `--api-url`). |
-| `agentos status` / `agentos stop` | Session status / tear down the container. |
-| `agentos deploy` | Package the bundle as tar.gz and push it to the platform API (find-or-create agent, create version, upload bundle, create deployment). Auth via `--api-key` / `AGENTOS_API_KEY`. |
 
-`start` records the container in the bundle's `.agentos/runner.json`
-(gitignored by the scaffold); `send`/`eval`/`status`/`stop`/`steer`/`interrupt`
-run from the bundle directory and resolve the runner from it, or accept `--url`.
-`start --model <id>` forwards `AGENTOS_MODEL` into the container (omit for the
-SDK default); setting it makes token usage attributable in Langfuse traces.
+## `skill` target: runner-only, fully offline
+
+Boots just the runner container on the host Docker daemon and speaks its ACI
+HTTP surface directly. No platform, no queue, no API, no Slack, no cluster.
+
+| Command | What it does |
+|---|---|
+| `agentos skill up` | Boot the local runner image in Docker with the ACI boot env (runner/README.md recipe), wait for health, print the boxed env summary. `--fake-model` runs offline; `--network` and `--otel-endpoint` join the compose stack for traces; `--model <id>` forwards `AGENTOS_MODEL` (omit for the SDK default). |
+| `agentos skill message "..."` | Send a synthetic Slack event: POST an ACI `event` frame to the local runner and stream the NDJSON reply (text deltas, tool notes, side effect flags, final). Abort a live turn with Ctrl-C. |
+| `agentos skill eval` | Run `evals/cases.json` through the runner as `eval_case` events; prints a per case result table plus a pass or fail rollup; nonzero exit on failure. |
+| `agentos skill status` | Show the local runner's session status. |
+| `agentos skill down` | Stop and remove the local runner container. |
+
+`skill up` records the container in the bundle's `.agentos/runner.json`
+(gitignored by the scaffold); `skill message` / `skill eval` / `skill status` /
+`skill down` run from the bundle directory and resolve the runner from it, or
+accept `--url`. Setting `skill up --model <id>` makes token usage attributable
+in Langfuse traces.
+
+## `local` target: full platform via compose, no Slack
+
+Wraps the `compose.dev.yaml` stack (Postgres + Valkey + Langfuse + API +
+worker) so a `message` walks the real queue -> worker -> sandboxed runner ->
+reply path on one machine, no Slack and no Kubernetes. The compose API is
+published on host port `28000`.
+
+| Command | What it does |
+|---|---|
+| `agentos local up` | Bring the compose stack up (`docker compose up -d --wait`) and print URLs. |
+| `agentos local down` | Stop the compose stack (`docker compose down`), keeping volumes. |
+| `agentos local status` | Show the compose stack's service status (`docker compose ps`). |
+| `agentos local message "..."` | Drive the local compose stack end to end with zero Slack. Enqueues straight to the compose Valkey and lets the containerized worker answer. |
+| `agentos local deploy` | Package the bundle as tar.gz and push it to the compose platform API (`--api-url`, default `http://localhost:28000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
+
+## `cluster` target: deployed Helm release
+
+Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
+`cilium` wrap theirs. Every operator verb takes `--dry-run`. Full runbook in
+[`docs/operations.md`](../docs/operations.md).
+
+| Command | What it does |
+|---|---|
+| `agentos cluster up` | Install or upgrade the release (`helm upgrade --install`). Exposes the UI and Langfuse on node ports; `--no-expose` keeps them ClusterIP-only. Set `AGENTOS_MODEL_CREDENTIALS` for a real model, or install sealed with canned replies. |
+| `agentos cluster down` | Uninstall the release and sweep its runtime namespaces (`helm uninstall` + `kubectl delete namespace`); prompts unless `--yes`. |
+| `agentos cluster status` | Report release health, pod readiness, and access URLs (read-only). |
+| `agentos cluster message "..."` | Drive the deployed release end to end with zero Slack: self plumbs kubectl port forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply. |
+| `agentos cluster deploy` | Package the bundle as tar.gz and push it to the platform API (`--api-url`, default `http://localhost:8000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
 
 ## Output
 
@@ -37,16 +89,16 @@ on stderr), and `--color <auto|always|never>` (default `auto`) controls ANSI
 color.
 
 Stream discipline is strict: the **payload** (streamed agent reply tokens,
-resolved URLs, the status table, eval results, the deploy result, `runner-status`
+resolved URLs, the status table, eval results, the deploy result, `skill status`
 JSON, the worker reply) goes to **stdout**, and every **diagnostic**
 (waiting/helm/kubectl/rollout/port-forward chatter, spinners, progress, notes)
 goes to **stderr**. So the payload pipes and redirects cleanly while progress
 still shows on the terminal:
 
 ```bash
-agentos message "..." | jq        # clean JSON on stdout, progress on stderr
-agentos message "..." > reply.txt  # reply captured, progress on the terminal
-agentos eval > results.txt         # results captured, progress on the terminal
+agentos cluster message "..." | jq         # clean JSON on stdout, progress on stderr
+agentos local message "..." > reply.txt    # reply captured, progress on the terminal
+agentos skill eval > results.txt           # results captured, progress on the terminal
 ```
 
 On an interactive terminal, progress renders as a spinner-to-checkmark checklist
@@ -70,63 +122,17 @@ after Ns`, never a hang. Compatibility is handled automatically:
   `✗ fail`, `⚠ warn`), and glyphs fall back to ASCII (`v`/`x`/`!`, `- \ | /`
   spinner) in non-UTF-8 locales.
 
-## `agentos chat`: the CLI as the Slack service
+## `agentos cluster message`: drive the deployed cluster with zero Slack
 
-`chat` exercises the real ingress-to-egress path with **no Slack at all**. It
-stands up a minimal Slack Web API stub locally, `XADD`s the exact
-`QueuedSlackEvent` the dispatcher would produce onto the real Valkey stream
-(synthetic `EvSIM-` ids and, by default, an invented internally-consistent
-channel plus thread/placeholder timestamps), then waits for the worker to
-consume and finalize the turn. Completion is the worker's XACK of the stream
-entry, not a timing guess: the worker acks only after the turn finalizes, so the
-latest `chat.update` the stub captured is the final reply (avoiding a throttled
-interim edit being mistaken for the answer). It prints the reply and exits 0, or
-on timeout prints stream diagnostics (`XLEN` + `XINFO GROUPS` + `XPENDING`) and
-exits nonzero.
-
-### Targeting a deployed agent and continuing a thread
-
-The worker binds a channel to an agent by **exact equality** on
-`agents.slack_channel`, so a random synthetic channel can never reach a deployed
-agent. Use `--channel <id>` to send as a specific channel: pass the same value
-you gave `deploy --slack-channel` and the worker routes the turn to that agent.
-Omit `--channel` to keep the old behavior (a throwaway synthetic channel).
+`cluster message` targets a **deployed** Helm release and wires everything
+itself, so a developer building an agent for someone else's Slack workspace can
+exercise the whole deployed machinery (Valkey queue -> worker -> claimed
+sandbox -> the real skill -> the reply) without any Slack access, tokens, or
+workspace.
 
 ```bash
-agentos deploy --slack-channel CSIM123 ...
-agentos chat --channel CSIM123 "first question"
-```
-
-Each turn mints a fresh thread ts by default, so a multi-turn conversation is
-otherwise impossible. On completion `chat` prints a `continue this
-conversation: ...` line with the channel and thread ts; copy-paste it (or pass
-`--thread <ts>` yourself) to send the next turn into the same thread:
-
-```bash
-agentos chat --channel CSIM123 --thread 1720000000.000100 "follow-up question"
-```
-
-Contract: run the worker with `SLACK_API_BASE_URL` pointing at the `/api/` base
-URL `chat` prints on startup. The worker reads that env var and points its Slack
-sink's `AsyncWebClient` `base_url` at it, so `chat.update` edits land at the stub
-instead of real Slack. Use `--listen-host`/`--listen-port` when the worker runs
-off-box (default `localhost` on an ephemeral port). No Slack token or real Slack
-HTTP is involved. The full worker round trip is validated end to end against a
-live cluster; `chat` itself verifies the stub, the enqueue, and the ack-based
-completion.
-
-## `agentos message`: drive the deployed cluster with zero Slack
-
-`message` is `chat`'s engine with Kubernetes-aware auto-plumbing on top. Where
-`chat` targets a local compose stack you run yourself, `message` targets a
-**deployed** Helm release and wires everything itself, so a developer building an
-agent for **someone else's** Slack workspace can exercise the whole deployed
-machinery (Valkey queue -> worker -> claimed sandbox -> the real skill -> the
-reply) without any Slack access, tokens, or workspace.
-
-```bash
-agentos message "summarize the latest deploy"          # single deployed agent
-agentos message --channel CSIM123 "another question"   # pick the agent explicitly
+agentos cluster message "summarize the latest deploy"
+agentos cluster message --channel CSIM123 "another question"
 ```
 
 What it does, in order:
@@ -157,23 +163,44 @@ What it does, in order:
    `worker.slackApiBaseUrl=` to empty in the same command) un-wires the stub when
    real Slack is connected.
 6. **Enqueue + wait**: `XADD`s the exact `QueuedSlackEvent`, waits for the worker
-   to finalize (the same ack-based completion `chat` uses), prints the reply, and
-   emits a `continue this conversation: ...` line for multi-turn threads. On
-   timeout it prints stream diagnostics and exits nonzero.
+   to finalize, prints the reply, and emits a `continue this conversation: ...`
+   line for multi turn threads. On timeout it prints stream diagnostics and
+   exits nonzero.
 
 `--dry-run` prints the kubectl/helm command lines, the stub URL, and the enqueue
 description without executing anything.
 
-### `--local`: the same roundtrip against the compose stack
+### Targeting a deployed agent and continuing a thread
 
-`agentos message --local` drives the local compose stack (`agentos local up`)
-instead of a Kubernetes release, so the whole loop is one machine with no
-cluster:
+The worker binds a channel to an agent by exact equality on
+`agents.slack_channel`, so a random synthetic channel can never reach a
+deployed agent. Use `--channel <id>` to send as a specific channel: pass the
+same value you gave `cluster deploy --slack-channel` and the worker routes the
+turn to that agent.
+
+```bash
+agentos cluster deploy --slack-channel CSIM123 ...
+agentos cluster message --channel CSIM123 "first question"
+```
+
+Each turn mints a fresh thread ts by default. On completion `cluster message`
+prints a `continue this conversation: ...` line with the channel and thread ts;
+copy paste it, or pass `--thread <ts>` yourself, to send the next turn into the
+same thread:
+
+```bash
+agentos cluster message --channel CSIM123 --thread 1720000000.000100 "follow up question"
+```
+
+## `agentos local message`: the same roundtrip against the compose stack
+
+`local message` drives the local compose stack (`agentos local up`) instead of a
+Kubernetes release, so the whole loop is one machine with no cluster:
 
 ```bash
 agentos local up
-agentos deploy --plugin-dir <dir> --slack-channel C-DEMO --api-url http://localhost:28000
-agentos message --local "what changed in the last deploy?"
+agentos local deploy --plugin-dir <dir> --slack-channel C-DEMO --api-url http://localhost:28000
+agentos local message "what changed in the last deploy?"
 ```
 
 Local mode keeps only the shared engine (stub + `QueuedSlackEvent` enqueue +
@@ -185,8 +212,9 @@ straight to the compose Valkey (`localhost:26379`) and the containerized
 container on the host Docker daemon. Channel comes from `--channel` or, when
 omitted, the sole deployed agent looked up on the compose API (`--api-url`,
 default `http://localhost:28000`; the API is reached directly, so no `/api`
-suffix). `--local` composes with `--channel`/`--thread`/`--timeout-secs` and
-rejects the cluster-only flags (`--namespace`, `--release`, `--force-wire`, ...)
+suffix). `local message` composes with `--channel`, `--thread`, and
+`--timeout-secs` and rejects the cluster only flags (`--namespace`,
+`--release`, `--force-wire`, ...)
 with a clear error. The compose worker runs the fake model by default (a canned
 reply, no credentials); export a credential and set `AGENTOS_FAKE_MODEL=0` in the
 compose environment for a real model.

--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -62,7 +62,7 @@ cat > evals/e2e-cases.json <<'EOF'
 EOF
 
 echo
-echo "=== agentos start (fake model, offline) ==="
+echo "=== agentos skill up (fake model, offline) ==="
 START_ARGS=(--plugin-dir . --image "$IMAGE" --port "$PORT" --name "$CONTAINER" --fake-model)
 if [[ -n "${AGENTOS_E2E_NETWORK:-}" ]]; then
     START_ARGS+=(--network "$AGENTOS_E2E_NETWORK")
@@ -70,31 +70,31 @@ fi
 if [[ -n "${AGENTOS_E2E_OTEL:-}" ]]; then
     START_ARGS+=(--otel-endpoint "$AGENTOS_E2E_OTEL")
 fi
-"$BIN" start "${START_ARGS[@]}"
+"$BIN" skill up "${START_ARGS[@]}"
 
 echo
-echo "=== agentos status ==="
-"$BIN" status
+echo "=== agentos skill status ==="
+"$BIN" skill status
 
 echo
-echo "=== agentos send (synthetic event, streamed NDJSON reply) ==="
-"$BIN" send "@agentos can we approve the Meridian deal at 18% discount?"
+echo "=== agentos skill message (synthetic event, streamed NDJSON reply) ==="
+"$BIN" skill message "@agentos can we approve the Meridian deal at 18% discount?"
 
 echo
-echo "=== agentos eval ==="
-"$BIN" eval --cases evals/e2e-cases.json
+echo "=== agentos skill eval ==="
+"$BIN" skill eval --cases evals/e2e-cases.json
 
 if [[ -n "${AGENTOS_E2E_API_URL:-}" ]]; then
     echo
-    echo "=== agentos deploy (against the platform API) ==="
-    "$BIN" deploy --plugin-dir . \
+    echo "=== agentos cluster deploy (against the platform API) ==="
+    "$BIN" cluster deploy --plugin-dir . \
         --api-url "$AGENTOS_E2E_API_URL" \
         --api-key "${AGENTOS_E2E_API_KEY:-agentos-dev-key}"
 fi
 
 echo
-echo "=== agentos stop ==="
-"$BIN" stop
+echo "=== agentos skill down ==="
+"$BIN" skill down
 
 echo
 echo "E2E PASS"

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1,6 +1,6 @@
 //! Client for the platform API (apps/api, committed openapi.json contract).
 //!
-//! `agentos deploy` pushes a local bundle to the platform: find-or-create the
+//! `agentos cluster deploy` pushes a local bundle to the platform: find-or-create the
 //! agent, create a version, upload the tar.gz bundle (validated server-side by
 //! the frozen plugin-format package), and create a deployment. Auth is the
 //! X-API-Key header.

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -1,11 +1,13 @@
-//! `agentos chat`: drive the whole system end to end with no Slack at all.
+//! Shared Slack-stub machinery for driving the whole system end to end with no
+//! Slack at all. Used by the `local message` and `cluster message` verbs.
 //!
 //! The CLI *is* the Slack service. It stands up a minimal Slack Web API stub on
 //! a local port, XADDs the exact `QueuedSlackEvent` the dispatcher would produce
 //! onto the real Valkey stream (synthetic, internally-consistent ids since the
 //! CLI itself is the endpoint that receives them back), then waits for the
-//! worker to consume and finalize the turn. It prints the placeholder's final
-//! text and exits 0, or on timeout prints stream diagnostics and exits nonzero.
+//! worker to consume and finalize the turn. The caller prints the placeholder's
+//! final text and exits 0, or on timeout prints stream diagnostics and exits
+//! nonzero.
 //!
 //! Completion is the worker's XACK of our stream entry, not a timing guess: the
 //! worker acks an entry only after the turn finalizes (its last `chat.update`
@@ -32,8 +34,7 @@ use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 
 use crate::queue::{
-    self, connect, diagnostics, entry_acked, synthetic_channel, synthetic_thread_and_placeholder,
-    xadd, QueuedSlackEvent, WORKER_GROUP,
+    self, entry_acked, synthetic_channel, synthetic_thread_and_placeholder, WORKER_GROUP,
 };
 
 pub const DEFAULT_STREAM: &str = queue::DEFAULT_STREAM;
@@ -47,23 +48,6 @@ pub const DEFAULT_LISTEN_PORT: u16 = 0;
 const ACK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// Bounded drain after the ack to catch a final edit still in flight.
 const FINAL_DRAIN: Duration = Duration::from_millis(100);
-
-/// Options for `agentos chat`, mirroring its clap flags.
-pub struct ChatOpts {
-    pub text: String,
-    /// Channel to send as; `None` mints a throwaway synthetic channel. Set it
-    /// to the agent's slack_channel so the worker's exact-equality binding
-    /// routes the turn to a deployed agent.
-    pub channel: Option<String>,
-    /// Thread ts to continue; `None` starts a fresh thread.
-    pub thread: Option<String>,
-    pub valkey_url: String,
-    pub stream: String,
-    pub user: String,
-    pub timeout_secs: u64,
-    pub listen_host: String,
-    pub listen_port: u16,
-}
 
 /// One captured Slack Web API call at the stub.
 #[derive(Debug, Clone)]
@@ -266,78 +250,6 @@ pub fn resolve_targets(channel: Option<&str>, thread: Option<&str>) -> (String, 
     let (synthetic_thread_ts, placeholder_ts) = synthetic_thread_and_placeholder();
     let thread_ts = thread.map_or(synthetic_thread_ts, str::to_string);
     (channel, thread_ts, placeholder_ts)
-}
-
-/// The `agentos chat` handler.
-pub async fn chat(opts: ChatOpts) -> Result<()> {
-    let ui = crate::ui::ui();
-    // Connect Valkey up front so a misconfigured stream or down stack fails fast,
-    // before the stub binds or any id is minted.
-    let mut conn = connect(&opts.valkey_url).await?;
-
-    let mut stub = SlackStub::start(&opts.listen_host, opts.listen_port, &opts.listen_host).await?;
-    ui.note(&format!(
-        "slack stub listening; run the worker with SLACK_API_BASE_URL={}",
-        stub.base_api_url()
-    ));
-
-    // Invent internally-consistent synthetic ids; the CLI is both the producer
-    // and the Slack endpoint that receives them back. --channel/--thread let a
-    // caller target a deployed agent (whose slack_channel the worker binds on)
-    // and continue an existing thread; absent, both fall back to synthetic.
-    let (channel, thread_ts, placeholder_ts) =
-        resolve_targets(opts.channel.as_deref(), opts.thread.as_deref());
-    let event = QueuedSlackEvent::synthetic(
-        &channel,
-        &opts.user,
-        &opts.text,
-        &thread_ts,
-        &placeholder_ts,
-    );
-    let stream_id = xadd(&mut conn, &opts.stream, &event).await?;
-    ui.note(&format!(
-        "enqueued {} on {} as {stream_id}",
-        event.slack_event_id, opts.stream
-    ));
-    ui.note(&format!(
-        "waiting up to {}s for the worker to finalize the turn...",
-        opts.timeout_secs
-    ));
-
-    let cl = ui.checklist();
-    let step = cl.step("waiting for worker reply");
-    let outcome = await_reply(
-        &mut stub,
-        &mut conn,
-        &opts.stream,
-        &stream_id,
-        &placeholder_ts,
-        Duration::from_secs(opts.timeout_secs),
-    )
-    .await;
-
-    match outcome {
-        Outcome::Replied(reply) => {
-            step.done("");
-            ui.answer(&reply);
-            ui.print_tokens("\n");
-            print_continue_hint("chat", &channel, &thread_ts);
-            Ok(())
-        }
-        Outcome::CompletedNoEdit => {
-            step.done("no edit");
-            ui.warn("the worker finished the turn but never edited the placeholder");
-            print_continue_hint("chat", &channel, &thread_ts);
-            Ok(())
-        }
-        Outcome::TimedOut => {
-            step.fail(&format!("timed out after {}s", opts.timeout_secs));
-            ui.note("stream diagnostics:");
-            let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
-            ui.note(&diag);
-            std::process::exit(1);
-        }
-    }
 }
 
 #[cfg(test)]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -16,7 +16,7 @@ use crate::bundle::pack_tar_gz;
 use crate::docker::{self, StartSpec};
 use crate::evals::{load_cases, turn_passes};
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
-use crate::runner::{RunnerClient, SteerOutcome};
+use crate::runner::RunnerClient;
 use crate::scaffold::{read_manifest, scaffold};
 use crate::state::{self, RunnerState};
 
@@ -55,7 +55,7 @@ impl DeployEnv {
     }
 }
 
-/// Options for `agentos start`, mirroring its clap flags.
+/// Options for `agentos skill up`, mirroring its clap flags.
 pub struct StartOpts {
     pub plugin_dir: PathBuf,
     pub image: String,
@@ -79,7 +79,7 @@ pub fn init(name: &str, dir: Option<PathBuf>) -> Result<()> {
     for path in created {
         ui.note(&format!("created {}", path.display()));
     }
-    ui.note(&format!("Next: cd {} && agentos start", dir.display()));
+    ui.note(&format!("Next: cd {} && agentos skill up", dir.display()));
     Ok(())
 }
 
@@ -94,7 +94,7 @@ pub async fn start(opts: StartOpts) -> Result<()> {
 
     if state::load(&plugin_dir)?.is_some() {
         bail!(
-            "a local runner is already recorded in {}/.agentos/runner.json; run 'agentos stop' there first",
+            "a local runner is already recorded in {}/.agentos/runner.json; run 'agentos skill down' there first",
             plugin_dir.display()
         );
     }
@@ -167,15 +167,18 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         .unwrap_or_else(|| format!("{plugin_name} @ {manifest_version}"));
     let rows = [
         ("Local bot", base_url),
-        ("Slack emulator", "agentos send \"<message>\"".to_string()),
-        ("Eval runner", "agentos eval".to_string()),
+        (
+            "Skill message",
+            "agentos skill message \"<message>\"".to_string(),
+        ),
+        ("Skill eval", "agentos skill eval".to_string()),
         ("Version", version),
     ];
     ui.payload_plain(&boxed_summary("agentos dev environment", &rows));
     let cwd = Path::new(".").canonicalize()?;
     if cwd != plugin_dir {
         ui.note(&format!(
-            "State recorded in {}/.agentos/runner.json; run stop (and send/eval/status) from that directory. send and eval also accept --url.",
+            "State recorded in {}/.agentos/runner.json; run skill down from that directory. skill message, skill eval, and skill status also work there. skill message and skill eval also accept --url.",
             plugin_dir.display()
         ));
     }
@@ -214,30 +217,6 @@ pub async fn status(url: Option<String>) -> Result<()> {
     let ui = crate::ui::ui();
     ui.note(&format!("runner {url}"));
     ui.payload_plain(&serde_json::to_string_pretty(&status)?);
-    Ok(())
-}
-
-pub async fn steer(text: &str, user: &str, url: Option<String>) -> Result<()> {
-    let url = resolve_url(url)?;
-    let client = RunnerClient::new(&url)?;
-    let ui = crate::ui::ui();
-    match client.steer(text, user).await? {
-        SteerOutcome::Delivered => {
-            ui.success("steered the live turn");
-            Ok(())
-        }
-        SteerOutcome::NoActiveTurn => {
-            ui.failure("no active turn to steer; send a new message to start one");
-            std::process::exit(1);
-        }
-    }
-}
-
-pub async fn interrupt(reason: &str, url: Option<String>) -> Result<()> {
-    let url = resolve_url(url)?;
-    let client = RunnerClient::new(&url)?;
-    client.interrupt(reason).await?;
-    crate::ui::ui().success("interrupted the runner");
     Ok(())
 }
 
@@ -391,8 +370,8 @@ pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()
 
 /// Where the eval cases live: an explicit `--cases` wins; otherwise
 /// `evals/cases.json` in the current directory, falling back to the started
-/// runner's recorded bundle directory (so `agentos eval` works from wherever
-/// `agentos start` was run).
+/// runner's recorded bundle directory (so `agentos skill eval` works from
+/// wherever `agentos skill up` was run).
 pub fn resolve_cases_path(
     explicit: Option<PathBuf>,
     cwd: &Path,

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -1,6 +1,6 @@
 //! Local runner orchestration via the Docker CLI.
 //!
-//! `agentos start` boots the D1 runner image with the ACI-frozen boot env
+//! `agentos skill up` boots the D1 runner image with the ACI-frozen boot env
 //! (runner/README.md documents the recipe); `stop` tears it down. Shelling out
 //! to `docker` keeps the CLI dependency-light: the target machine is a dev
 //! laptop that already has Docker if it can run the runner at all.

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -1,4 +1,4 @@
-//! `agentos eval`: run the bundle's eval cases through the local runner.
+//! `agentos skill eval`: run the bundle's eval cases through the local runner.
 //!
 //! Cases live in `evals/cases.json` (seeded by `agentos init`): an array of
 //! `{name, input, expect_contains}`. Each case round-trips an `eval_case` ACI

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -16,7 +16,10 @@ pub mod ndjson;
 pub mod ops;
 pub mod queue;
 pub mod render;
+pub mod retired;
 pub mod runner;
 pub mod scaffold;
 pub mod state;
 pub mod ui;
+
+pub use retired::retired_hint;

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -95,9 +95,9 @@ pub async fn up(o: LocalOpts) -> Result<()> {
     }
     ui.note("Drive the local product loop (no Slack, no Kubernetes):");
     ui.note(
-        "  agentos deploy --plugin-dir <dir> --slack-channel <C...> --api-url http://localhost:28000",
+        "  agentos local deploy --plugin-dir <dir> --slack-channel <C...> --api-url http://localhost:28000",
     );
-    ui.note("  agentos message --local \"<your question>\"");
+    ui.note("  agentos local message \"<your question>\"");
     Ok(())
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,13 +1,11 @@
-//! The `agentos` binary: init/start/send/eval a plugin against a local runner,
-//! stop/runner-status/steer/interrupt for the container lifecycle, chat to drive the
-//! whole system with the CLI acting as the Slack service, message to drive a
-//! deployed Kubernetes release the same way with zero Slack, and deploy for the
+//! The `agentos` binary: `init`, `skill <up|down|status|message|eval>` for a
+//! local runner, `local <up|down|status|message|deploy>` for the compose stack,
+//! and `cluster <up|down|status|message|deploy>` for Kubernetes and the
 //! platform API. Task I1; contracts are frozen in packages/aci-protocol and
 //! packages/plugin-format.
 
 use std::path::PathBuf;
 
-use agentos::chat::{self, ChatOpts};
 use agentos::commands::{self, DeployEnv, DeployOpts, SendType, StartOpts, DEFAULT_PORT};
 use agentos::local::{self, LocalDownOpts, LocalOpts};
 use agentos::message::{self, MessageOpts};
@@ -61,8 +59,27 @@ enum Command {
         #[arg(long)]
         dir: Option<PathBuf>,
     },
+    /// Work with a local runner session for a plugin bundle.
+    Skill {
+        #[command(subcommand)]
+        action: SkillAction,
+    },
+    /// Work with the local compose stack and local platform API.
+    Local {
+        #[command(subcommand)]
+        action: LocalAction,
+    },
+    /// Work with the deployed cluster release and platform API.
+    Cluster {
+        #[command(subcommand)]
+        action: ClusterAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum SkillAction {
     /// Boot a local runner container for the bundle and print the env summary.
-    Start {
+    Up {
         /// Plugin bundle directory.
         #[arg(long, default_value = ".")]
         plugin_dir: PathBuf,
@@ -93,16 +110,15 @@ enum Command {
         model: Option<String>,
     },
     /// Stop and remove the local runner container.
-    Stop,
+    Down,
     /// Show the local runner's session status.
-    #[command(name = "runner-status")]
-    RunnerStatus {
+    Status {
         /// Runner base URL (defaults to the started runner, then localhost).
         #[arg(long)]
         url: Option<String>,
     },
     /// Send a synthetic event to the local runner and stream the reply.
-    Send {
+    Message {
         /// The message text.
         text: String,
         /// Synthetic Slack user id.
@@ -125,13 +141,169 @@ enum Command {
         #[arg(long)]
         url: Option<String>,
     },
-    /// Drive the DEPLOYED Kubernetes release end to end with zero Slack contact.
-    /// Self-plumbs kubectl port-forwards to the in-cluster Valkey and API, points
-    /// the deployed worker at a local Slack Web API stub (helm upgrade
-    /// --reuse-values), enqueues the dispatcher's event, and prints the worker's
-    /// reply. Lets you exercise the full deployed machinery (queue -> worker ->
-    /// sandbox -> real skill -> reply) without any Slack workspace or tokens. For
-    /// the local compose-stack variant use `chat`.
+}
+
+/// Subcommands of `agentos local`.
+#[derive(Subcommand)]
+enum LocalAction {
+    /// Bring the dev stack up (docker compose up -d --wait) and print URLs.
+    Up {
+        /// Compose file (run from the repo root for the default).
+        #[arg(long, default_value = local::DEFAULT_COMPOSE_FILE)]
+        file: String,
+        /// Print the docker compose command and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Stop the dev stack (docker compose down), keeping volumes.
+    Down {
+        /// Compose file (run from the repo root for the default).
+        #[arg(long, default_value = local::DEFAULT_COMPOSE_FILE)]
+        file: String,
+        /// Also destroy volumes (adds -v). Prompts for confirmation unless --yes.
+        #[arg(long)]
+        wipe: bool,
+        /// Skip the --wipe confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Print the docker compose command and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show the dev stack's service status (docker compose ps).
+    Status {
+        /// Compose file (run from the repo root for the default).
+        #[arg(long, default_value = local::DEFAULT_COMPOSE_FILE)]
+        file: String,
+        /// Print the docker compose command and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Drive the local compose stack end to end with zero Slack contact.
+    Message {
+        /// The user message text.
+        text: String,
+        /// Slack channel id to send as; must match the target agent's
+        /// slack_channel. Omit to use the sole deployed agent's channel (errors
+        /// if zero or multiple agents are deployed).
+        #[arg(long)]
+        channel: Option<String>,
+        /// Existing thread ts to continue a conversation; omit to start a new
+        /// thread. Pair with --channel to keep multi-turn context.
+        #[arg(long)]
+        thread: Option<String>,
+        /// Valkey password (compose default `valkeypass`).
+        #[arg(long, default_value = message::DEFAULT_VALKEY_PASSWORD)]
+        valkey_password: String,
+        /// Local mode only: platform API base URL for the channel lookup.
+        #[arg(long)]
+        api_url: Option<String>,
+        /// Platform API key for the default-channel lookup.
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY)]
+        api_key: String,
+        /// Synthetic Slack user id for the enqueued event.
+        #[arg(long, default_value = message::DEFAULT_USER)]
+        user: String,
+        /// Stream the dispatcher enqueues onto.
+        #[arg(long, env = "AGENTOS_STREAM", default_value = message::DEFAULT_STREAM)]
+        stream: String,
+        /// How long to wait for the worker's reply before printing diagnostics.
+        #[arg(long, default_value_t = message::DEFAULT_TIMEOUT_SECS)]
+        timeout_secs: u64,
+        /// Print the queue and stub plan that a real run would produce, and exit.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Push the bundle to the local platform API and deploy it.
+    Deploy {
+        /// Plugin bundle directory.
+        #[arg(long, default_value = ".")]
+        plugin_dir: PathBuf,
+        /// Platform API base URL.
+        #[arg(
+            long,
+            default_value = message::DEFAULT_LOCAL_API_URL,
+            env = "AGENTOS_API_URL"
+        )]
+        api_url: String,
+        /// Platform API key.
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        /// Slack channel to bind the agent to. On first create it defaults to
+        /// #local-dev; on redeploy it is only moved when you pass this flag, so
+        /// omitting it leaves the deployed agent's channel untouched.
+        #[arg(long)]
+        slack_channel: Option<String>,
+        /// Target environment.
+        #[arg(long, value_enum, default_value_t = DeployEnv::Dev)]
+        env: DeployEnv,
+        /// Version label; defaults to <manifest version>-<unix time>.
+        #[arg(long)]
+        label: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ClusterAction {
+    /// Install or upgrade the AgentOS release via Helm (helm upgrade --install).
+    /// By default it puts the UI and Langfuse on node ports for tailnet/LAN
+    /// access; pass --no-expose to keep them ClusterIP-only. Set
+    /// AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) to install with the real
+    /// model and egress opened to the provider; without it the install is sealed
+    /// (fake model, canned replies) and re-running with the env var set goes live.
+    Up {
+        /// Kubernetes namespace.
+        #[arg(long, default_value = "agentos")]
+        namespace: String,
+        /// Helm release name.
+        #[arg(long, default_value = "agentos")]
+        release: String,
+        /// Chart path (run from the repo root for the default).
+        #[arg(long, default_value = "charts/agentos")]
+        chart: String,
+        /// Keep the UI and Langfuse services ClusterIP instead of NodePort.
+        #[arg(long)]
+        no_expose: bool,
+        /// Force the sealed fake-model install even when AGENTOS_MODEL_CREDENTIALS
+        /// is set (dev/CI escape hatch); suppresses the fake-model warning.
+        #[arg(long)]
+        fake_model: bool,
+        /// Extra `--set KEY=VAL` passed through to helm verbatim (repeatable).
+        #[arg(long = "set", value_name = "KEY=VAL")]
+        set: Vec<String>,
+        /// Print the helm command that would run and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Uninstall the release and sweep its runtime namespaces (helm uninstall +
+    /// kubectl delete namespace). The agents.x-k8s.io CRDs are left in place.
+    Down {
+        /// Kubernetes namespace.
+        #[arg(long, default_value = "agentos")]
+        namespace: String,
+        /// Helm release name.
+        #[arg(long, default_value = "agentos")]
+        release: String,
+        /// Skip the interactive confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+        /// Print the commands that would run and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Report release health and access URLs (read-only: helm status + kubectl).
+    Status {
+        /// Kubernetes namespace.
+        #[arg(long, default_value = "agentos")]
+        namespace: String,
+        /// Helm release name.
+        #[arg(long, default_value = "agentos")]
+        release: String,
+        /// Print the read-only commands that would run and exit.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Drive the deployed Kubernetes release end to end with zero Slack contact.
     Message {
         /// The user message text.
         text: String,
@@ -199,79 +371,6 @@ enum Command {
         /// a real run would produce, and exit without executing anything.
         #[arg(long)]
         dry_run: bool,
-        /// Drive the LOCAL compose stack (`agentos local up`) instead of a
-        /// Kubernetes release: enqueue straight to the compose Valkey and let the
-        /// containerized worker answer. No kubectl, helm, or port-forwards.
-        /// Composes with --channel/--thread/--timeout-secs; rejects the
-        /// cluster-only flags.
-        #[arg(
-            long,
-            conflicts_with_all = [
-                "namespace", "release", "chart", "listen_host", "listen_port",
-                "valkey_local_port", "api_local_port", "no_wire", "force_wire",
-            ]
-        )]
-        local: bool,
-        /// Local mode only: platform API base URL for the channel lookup
-        /// (default the compose API on http://localhost:28000).
-        #[arg(long, requires = "local")]
-        api_url: Option<String>,
-    },
-    /// Drive the whole system end to end with no Slack: the CLI runs a local
-    /// Slack Web API stub, enqueues the dispatcher's event onto Valkey, and waits
-    /// for the worker to finalize the turn at the stub. Run the worker with
-    /// SLACK_API_BASE_URL pointing at the stub URL this prints.
-    Chat {
-        /// The user message text.
-        text: String,
-        /// Slack channel id to send as; must match the agent's slack_channel
-        /// for the worker to route it (e.g. the value passed to deploy
-        /// --slack-channel). Omit to mint a throwaway synthetic channel.
-        #[arg(long)]
-        channel: Option<String>,
-        /// Existing thread ts to continue a conversation; omit to start a new
-        /// thread. Pair with --channel to keep multi-turn context.
-        #[arg(long)]
-        thread: Option<String>,
-        /// Valkey connection URL.
-        #[arg(long, env = "VALKEY_URL", default_value = chat::DEFAULT_VALKEY_URL)]
-        valkey_url: String,
-        /// Stream the dispatcher enqueues onto.
-        #[arg(long, env = "AGENTOS_STREAM", default_value = chat::DEFAULT_STREAM)]
-        stream: String,
-        /// Synthetic Slack user id for the enqueued event.
-        #[arg(long, default_value = chat::DEFAULT_USER)]
-        user: String,
-        /// How long to wait for the worker's reply before printing diagnostics.
-        #[arg(long, default_value_t = chat::DEFAULT_TIMEOUT_SECS)]
-        timeout_secs: u64,
-        /// Host the Slack stub binds. Use a routable host when the worker runs
-        /// off-box (e.g. in-cluster).
-        #[arg(long, default_value = chat::DEFAULT_LISTEN_HOST)]
-        listen_host: String,
-        /// Port the Slack stub binds; 0 picks an ephemeral port.
-        #[arg(long, default_value_t = chat::DEFAULT_LISTEN_PORT)]
-        listen_port: u16,
-    },
-    /// Inject a follow-up into the runner's live turn (POST /v1/steer).
-    Steer {
-        /// The follow-up message text.
-        text: String,
-        /// Synthetic Slack user id.
-        #[arg(long, default_value = "U-local")]
-        user: String,
-        /// Runner base URL (defaults to the started runner, then localhost).
-        #[arg(long)]
-        url: Option<String>,
-    },
-    /// Hard-stop the runner's live turn (POST /v1/interrupt).
-    Interrupt {
-        /// Reason recorded with the interrupt.
-        #[arg(long, default_value = "user interrupt")]
-        reason: String,
-        /// Runner base URL (defaults to the started runner, then localhost).
-        #[arg(long)]
-        url: Option<String>,
     },
     /// Push the bundle to the platform API and deploy it.
     Deploy {
@@ -296,128 +395,22 @@ enum Command {
         #[arg(long)]
         label: Option<String>,
     },
-    /// Manage the local dev stack (compose.dev.yaml: Postgres + Valkey +
-    /// Langfuse + ClickHouse + MinIO + OTel).
-    Local {
-        #[command(subcommand)]
-        action: LocalAction,
-    },
-    /// Install or upgrade the AgentOS release via Helm (helm upgrade --install).
-    /// By default it puts the UI and Langfuse on node ports for tailnet/LAN
-    /// access; pass --no-expose to keep them ClusterIP-only. Set
-    /// AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) to install with the real
-    /// model and egress opened to the provider; without it the install is sealed
-    /// (fake model, canned replies) and re-running with the env var set goes live.
-    Up {
-        /// Kubernetes namespace.
-        #[arg(long, default_value = "agentos")]
-        namespace: String,
-        /// Helm release name.
-        #[arg(long, default_value = "agentos")]
-        release: String,
-        /// Chart path (run from the repo root for the default).
-        #[arg(long, default_value = "charts/agentos")]
-        chart: String,
-        /// Keep the UI and Langfuse services ClusterIP instead of NodePort.
-        #[arg(long)]
-        no_expose: bool,
-        /// Force the sealed fake-model install even when AGENTOS_MODEL_CREDENTIALS
-        /// is set (dev/CI escape hatch); suppresses the fake-model warning.
-        #[arg(long)]
-        fake_model: bool,
-        /// Extra `--set KEY=VAL` passed through to helm verbatim (repeatable).
-        #[arg(long = "set", value_name = "KEY=VAL")]
-        set: Vec<String>,
-        /// Print the helm command that would run and exit without executing.
-        #[arg(long)]
-        dry_run: bool,
-    },
-    /// Report release health and access URLs (read-only: helm status + kubectl).
-    Status {
-        /// Kubernetes namespace.
-        #[arg(long, default_value = "agentos")]
-        namespace: String,
-        /// Helm release name.
-        #[arg(long, default_value = "agentos")]
-        release: String,
-        /// Print the read-only commands that would run and exit.
-        #[arg(long)]
-        dry_run: bool,
-    },
-    /// Uninstall the release and sweep its runtime namespaces (helm uninstall +
-    /// kubectl delete namespace). The agents.x-k8s.io CRDs are left in place.
-    Down {
-        /// Kubernetes namespace.
-        #[arg(long, default_value = "agentos")]
-        namespace: String,
-        /// Helm release name.
-        #[arg(long, default_value = "agentos")]
-        release: String,
-        /// Skip the interactive confirmation prompt.
-        #[arg(long)]
-        yes: bool,
-        /// Print the commands that would run and exit without executing.
-        #[arg(long)]
-        dry_run: bool,
-    },
-}
-
-/// Subcommands of `agentos local`.
-#[derive(Subcommand)]
-enum LocalAction {
-    /// Bring the dev stack up (docker compose up -d --wait) and print URLs.
-    Up {
-        /// Compose file (run from the repo root for the default).
-        #[arg(long, default_value = local::DEFAULT_COMPOSE_FILE)]
-        file: String,
-        /// Print the docker compose command and exit without executing.
-        #[arg(long)]
-        dry_run: bool,
-    },
-    /// Stop the dev stack (docker compose down), keeping volumes.
-    Down {
-        /// Compose file (run from the repo root for the default).
-        #[arg(long, default_value = local::DEFAULT_COMPOSE_FILE)]
-        file: String,
-        /// Also destroy volumes (adds -v). Prompts for confirmation unless --yes.
-        #[arg(long)]
-        wipe: bool,
-        /// Skip the --wipe confirmation prompt.
-        #[arg(long)]
-        yes: bool,
-        /// Print the docker compose command and exit without executing.
-        #[arg(long)]
-        dry_run: bool,
-    },
-    /// Show the dev stack's service status (docker compose ps).
-    Status {
-        /// Compose file (run from the repo root for the default).
-        #[arg(long, default_value = local::DEFAULT_COMPOSE_FILE)]
-        file: String,
-        /// Print the docker compose command and exit without executing.
-        #[arg(long)]
-        dry_run: bool,
-    },
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Some(hint) = agentos::retired_hint(&args) {
+        eprintln!("{hint}");
+        std::process::exit(2);
+    }
+
     let cli = Cli::parse();
     ui::init(Ui::from_process(cli.color, cli.debug, cli.quiet));
     match cli.command {
         Command::Init { name, dir } => commands::init(&name, dir),
-        Command::Start {
-            plugin_dir,
-            image,
-            port,
-            name,
-            fake_model,
-            network,
-            otel_endpoint,
-            budget,
-            model,
-        } => {
-            commands::start(StartOpts {
+        Command::Skill { action } => match action {
+            SkillAction::Up {
                 plugin_dir,
                 image,
                 port,
@@ -427,108 +420,30 @@ async fn main() -> Result<()> {
                 otel_endpoint,
                 budget,
                 model,
-            })
-            .await
-        }
-        Command::Stop => commands::stop().await,
-        Command::RunnerStatus { url } => commands::status(url).await,
-        Command::Send {
-            text,
-            user,
-            event_type,
-            url,
-        } => commands::send(&text, &user, event_type.into(), url).await,
-        Command::Eval { cases, url } => commands::eval(cases, url).await,
-        Command::Message {
-            text,
-            channel,
-            thread,
-            namespace,
-            release,
-            chart,
-            listen_host,
-            listen_port,
-            valkey_local_port,
-            valkey_password,
-            api_local_port,
-            api_key,
-            user,
-            stream,
-            timeout_secs,
-            no_wire,
-            force_wire,
-            dry_run,
-            local,
-            api_url,
-        } => {
-            message::message(MessageOpts {
+            } => {
+                commands::start(StartOpts {
+                    plugin_dir,
+                    image,
+                    port,
+                    name,
+                    fake_model,
+                    network,
+                    otel_endpoint,
+                    budget,
+                    model,
+                })
+                .await
+            }
+            SkillAction::Down => commands::stop().await,
+            SkillAction::Status { url } => commands::status(url).await,
+            SkillAction::Message {
                 text,
-                channel,
-                thread,
-                namespace,
-                release,
-                chart,
-                listen_host,
-                listen_port,
-                valkey_local_port,
-                valkey_password,
-                api_local_port,
-                api_key,
                 user,
-                stream,
-                timeout_secs,
-                wire: !no_wire,
-                force_wire,
-                dry_run,
-                local,
-                api_url,
-            })
-            .await
-        }
-        Command::Chat {
-            text,
-            channel,
-            thread,
-            valkey_url,
-            stream,
-            user,
-            timeout_secs,
-            listen_host,
-            listen_port,
-        } => {
-            chat::chat(ChatOpts {
-                text,
-                channel,
-                thread,
-                valkey_url,
-                stream,
-                user,
-                timeout_secs,
-                listen_host,
-                listen_port,
-            })
-            .await
-        }
-        Command::Steer { text, user, url } => commands::steer(&text, &user, url).await,
-        Command::Interrupt { reason, url } => commands::interrupt(&reason, url).await,
-        Command::Deploy {
-            plugin_dir,
-            api_url,
-            api_key,
-            slack_channel,
-            env,
-            label,
-        } => {
-            commands::deploy(DeployOpts {
-                plugin_dir,
-                api_url,
-                api_key,
-                slack_channel,
-                env,
-                label,
-            })
-            .await
-        }
+                event_type,
+                url,
+            } => commands::send(&text, &user, event_type.into(), url).await,
+            SkillAction::Eval { cases, url } => commands::eval(cases, url).await,
+        },
         Command::Local { action } => match action {
             LocalAction::Up { file, dry_run } => local::up(LocalOpts { file, dry_run }).await,
             LocalAction::Down {
@@ -547,62 +462,180 @@ async fn main() -> Result<()> {
             LocalAction::Status { file, dry_run } => {
                 local::status(LocalOpts { file, dry_run }).await
             }
-        },
-        Command::Up {
-            namespace,
-            release,
-            chart,
-            no_expose,
-            fake_model,
-            set,
-            dry_run,
-        } => {
-            let credentials = ops::resolve_up_credentials(
-                fake_model,
-                std::env::var("AGENTOS_MODEL_CREDENTIALS").ok(),
-            );
-            ops::up(UpOpts {
-                common: CommonOpts {
-                    namespace,
-                    release,
+            LocalAction::Message {
+                text,
+                channel,
+                thread,
+                valkey_password,
+                api_url,
+                api_key,
+                user,
+                stream,
+                timeout_secs,
+                dry_run,
+            } => {
+                message::message(MessageOpts {
+                    text,
+                    channel,
+                    thread,
+                    namespace: "agentos".into(),
+                    release: "agentos".into(),
+                    chart: "charts/agentos".into(),
+                    listen_host: None,
+                    listen_port: message::DEFAULT_LISTEN_PORT,
+                    valkey_local_port: message::DEFAULT_VALKEY_LOCAL_PORT,
+                    valkey_password,
+                    api_local_port: message::DEFAULT_API_LOCAL_PORT,
+                    api_key,
+                    user,
+                    stream,
+                    timeout_secs,
+                    wire: true,
+                    force_wire: false,
                     dry_run,
-                },
+                    local: true,
+                    api_url,
+                })
+                .await
+            }
+            LocalAction::Deploy {
+                plugin_dir,
+                api_url,
+                api_key,
+                slack_channel,
+                env,
+                label,
+            } => {
+                commands::deploy(DeployOpts {
+                    plugin_dir,
+                    api_url,
+                    api_key,
+                    slack_channel,
+                    env,
+                    label,
+                })
+                .await
+            }
+        },
+        Command::Cluster { action } => match action {
+            ClusterAction::Up {
+                namespace,
+                release,
                 chart,
                 no_expose,
-                set,
                 fake_model,
-                credentials,
-            })
-            .await
-        }
-        Command::Status {
-            namespace,
-            release,
-            dry_run,
-        } => {
-            ops::status(CommonOpts {
+                set,
+                dry_run,
+            } => {
+                let credentials = ops::resolve_up_credentials(
+                    fake_model,
+                    std::env::var("AGENTOS_MODEL_CREDENTIALS").ok(),
+                );
+                ops::up(UpOpts {
+                    common: CommonOpts {
+                        namespace,
+                        release,
+                        dry_run,
+                    },
+                    chart,
+                    no_expose,
+                    set,
+                    fake_model,
+                    credentials,
+                })
+                .await
+            }
+            ClusterAction::Down {
+                namespace,
+                release,
+                yes,
+                dry_run,
+            } => {
+                ops::down(DownOpts {
+                    common: CommonOpts {
+                        namespace,
+                        release,
+                        dry_run,
+                    },
+                    yes,
+                })
+                .await
+            }
+            ClusterAction::Status {
                 namespace,
                 release,
                 dry_run,
-            })
-            .await
-        }
-        Command::Down {
-            namespace,
-            release,
-            yes,
-            dry_run,
-        } => {
-            ops::down(DownOpts {
-                common: CommonOpts {
+            } => {
+                ops::status(CommonOpts {
                     namespace,
                     release,
                     dry_run,
-                },
-                yes,
-            })
-            .await
-        }
+                })
+                .await
+            }
+            ClusterAction::Message {
+                text,
+                channel,
+                thread,
+                namespace,
+                release,
+                chart,
+                listen_host,
+                listen_port,
+                valkey_local_port,
+                valkey_password,
+                api_local_port,
+                api_key,
+                user,
+                stream,
+                timeout_secs,
+                no_wire,
+                force_wire,
+                dry_run,
+            } => {
+                message::message(MessageOpts {
+                    text,
+                    channel,
+                    thread,
+                    namespace,
+                    release,
+                    chart,
+                    listen_host,
+                    listen_port,
+                    valkey_local_port,
+                    valkey_password,
+                    api_local_port,
+                    api_key,
+                    user,
+                    stream,
+                    timeout_secs,
+                    wire: !no_wire,
+                    force_wire,
+                    dry_run,
+                    local: false,
+                    api_url: None,
+                })
+                .await
+            }
+            ClusterAction::Deploy {
+                plugin_dir,
+                api_url,
+                api_key,
+                slack_channel,
+                env,
+                label,
+            } => {
+                commands::deploy(DeployOpts {
+                    plugin_dir,
+                    api_url,
+                    api_key,
+                    slack_channel,
+                    env,
+                    label,
+                })
+                .await
+            }
+        },
     }
 }
 
@@ -617,101 +650,14 @@ mod tests {
     }
 
     #[test]
-    fn message_local_composes_with_channel_thread_and_timeout() {
-        let cli = Cli::try_parse_from([
-            "agentos",
-            "message",
-            "--local",
-            "--channel",
-            "C123",
-            "--thread",
-            "1.2",
-            "--timeout-secs",
-            "42",
-            "hello",
-        ])
-        .expect("--local composes with the shared flags");
+    fn local_message_accepts_api_key() {
+        let cli = Cli::try_parse_from(["agentos", "local", "message", "--api-key", "K", "hi"])
+            .expect("local message --api-key should parse");
         match cli.command {
-            Command::Message {
-                local,
-                channel,
-                thread,
-                timeout_secs,
-                ..
-            } => {
-                assert!(local);
-                assert_eq!(channel.as_deref(), Some("C123"));
-                assert_eq!(thread.as_deref(), Some("1.2"));
-                assert_eq!(timeout_secs, 42);
-            }
-            _ => panic!("expected the message subcommand"),
+            Command::Local {
+                action: LocalAction::Message { api_key, .. },
+            } => assert_eq!(api_key, "K"),
+            _ => panic!("expected local message command"),
         }
-    }
-
-    #[test]
-    fn message_local_accepts_api_url() {
-        let cli = Cli::try_parse_from([
-            "agentos",
-            "message",
-            "--local",
-            "--api-url",
-            "http://localhost:9999",
-            "hi",
-        ])
-        .expect("--api-url is allowed with --local");
-        match cli.command {
-            Command::Message { api_url, .. } => {
-                assert_eq!(api_url.as_deref(), Some("http://localhost:9999"))
-            }
-            _ => panic!("expected the message subcommand"),
-        }
-    }
-
-    #[test]
-    fn message_local_rejects_every_cluster_only_flag() {
-        // Each cluster-only flag must conflict with --local so a mixed invocation
-        // fails loudly instead of silently ignoring half the intent.
-        let cases: &[&[&str]] = &[
-            &["--namespace", "agentos"],
-            &["--release", "agentos"],
-            &["--chart", "charts/agentos"],
-            &["--listen-host", "1.2.3.4"],
-            &["--listen-port", "9000"],
-            &["--valkey-local-port", "5555"],
-            &["--api-local-port", "5556"],
-            &["--no-wire"],
-            &["--force-wire"],
-        ];
-        for extra in cases {
-            let mut argv = vec!["agentos", "message", "--local"];
-            argv.extend_from_slice(extra);
-            argv.push("hi");
-            // `Cli` is not Debug, so match rather than expect_err on the Ok arm.
-            let err = match Cli::try_parse_from(&argv) {
-                Ok(_) => panic!("--local must reject {extra:?}"),
-                Err(err) => err,
-            };
-            assert_eq!(
-                err.kind(),
-                clap::error::ErrorKind::ArgumentConflict,
-                "{extra:?} should conflict with --local, got {err}"
-            );
-        }
-    }
-
-    #[test]
-    fn api_url_requires_local() {
-        let argv = [
-            "agentos",
-            "message",
-            "--api-url",
-            "http://localhost:28000",
-            "hi",
-        ];
-        let err = match Cli::try_parse_from(argv) {
-            Ok(_) => panic!("--api-url without --local is rejected"),
-            Err(err) => err,
-        };
-        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
     }
 }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1,12 +1,13 @@
-//! `agentos message`: drive the DEPLOYED Kubernetes release end to end from the
-//! CLI with zero Slack contact.
+//! Shared target noun message forms: drive the DEPLOYED Kubernetes release end
+//! to end from the CLI with zero Slack contact.
 //!
 //! Product rationale: a developer building an agent for someone else's Slack
 //! workspace can exercise the entire deployed machinery (Valkey queue -> worker
 //! -> claimed sandbox -> the real skill -> the reply) without any Slack access,
-//! tokens, or workspace. It is `agentos chat`'s engine (a local Slack Web API
-//! stub + the frozen `QueuedSlackEvent` enqueue + the ack-based completion
-//! signal) with Kubernetes-aware auto-plumbing bolted on top:
+//! tokens, or workspace. It is the retained chat helper engine, backed by a
+//! local Slack Web API stub plus the frozen `QueuedSlackEvent` enqueue and the
+//! ack-based completion signal, with Kubernetes-aware auto-plumbing bolted on
+//! top:
 //!
 //! 1. Self-managed `kubectl port-forward`s (children of this process, killed on
 //!    exit) reach the in-cluster Valkey (for the enqueue) and API (for the
@@ -69,7 +70,8 @@ pub const DEFAULT_LOCAL_STUB_PORT: u16 = DEFAULT_LISTEN_PORT;
 const VALKEY_REMOTE_PORT: u16 = 6379;
 const API_REMOTE_PORT: u16 = 8000;
 
-/// Options for `agentos message`, mirroring its clap flags.
+/// Options for the shared target noun message forms, mirroring their clap
+/// flags.
 pub struct MessageOpts {
     pub text: String,
     pub channel: Option<String>,
@@ -219,8 +221,8 @@ pub fn select_channel(agents: &[Agent], explicit: Option<&str>) -> Result<String
     }
     match agents {
         [] => bail!(
-            "no agents are deployed on the platform API; deploy one with `agentos deploy` \
-             or pass --channel <id>"
+            "no agents are deployed on the platform API; deploy one with `agentos local deploy` \
+             or `agentos cluster deploy`, or pass --channel <id>"
         ),
         [only] => Ok(only.slack_channel.clone()),
         many => {
@@ -420,7 +422,7 @@ async fn current_worker_base_url(opts: &MessageOpts) -> Result<Option<String>> {
     if !ok {
         bail!(
             "could not read the worker deployment '{}-worker' in namespace {} ({}). \
-             Is the release installed? Run `agentos up` first.",
+             Is the release installed? Run `agentos cluster up` first.",
             opts.release,
             opts.namespace,
             err.trim().lines().next().unwrap_or("kubectl get failed")
@@ -515,7 +517,7 @@ async fn wire_worker(opts: &MessageOpts, url: &str) -> Result<()> {
     Ok(())
 }
 
-/// The `agentos message --local` handler: drive the compose stack directly.
+/// The `agentos local message` handler: drive the compose stack directly.
 ///
 /// The cluster path's self-plumbing (kubectl port-forwards, the wiring helm
 /// upgrade, the dispatcher guard) is all cluster-specific, so local mode keeps
@@ -611,13 +613,13 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             step.done("");
             ui.answer(&reply);
             ui.print_tokens("\n");
-            print_continue_hint("message --local", &channel, &thread_ts);
+            print_continue_hint("local message", &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
             step.done("no edit");
             ui.warn("the worker finished the turn but never edited the placeholder");
-            print_continue_hint("message --local", &channel, &thread_ts);
+            print_continue_hint("local message", &channel, &thread_ts);
             Ok(())
         }
         Outcome::TimedOut => {
@@ -630,7 +632,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     }
 }
 
-/// The `agentos message` handler.
+/// The shared target noun message handler.
 pub async fn message(opts: MessageOpts) -> Result<()> {
     if opts.local {
         return message_local(opts).await;
@@ -761,13 +763,13 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
             step.done("");
             ui.answer(&reply);
             ui.print_tokens("\n");
-            print_continue_hint("message", &channel, &thread_ts);
+            print_continue_hint("cluster message", &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
             step.done("no edit");
             ui.warn("the worker finished the turn but never edited the placeholder");
-            print_continue_hint("message", &channel, &thread_ts);
+            print_continue_hint("cluster message", &channel, &thread_ts);
             Ok(())
         }
         Outcome::TimedOut => {

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1,4 +1,4 @@
-//! `agentos up | status | down`: the operator
+//! `agentos cluster up | cluster status | cluster down`: the operator
 //! day-1 lifecycle, wrapping the Helm chart and `kubectl` the way linkerd or
 //! cilium wrap theirs -- a deliberately thin CLI over the chart, which stays the
 //! source of truth. Every verb shells out to the `helm`/`kubectl` binaries; the
@@ -202,7 +202,7 @@ pub fn up_commands(o: &UpOpts) -> Vec<OpsCommand> {
     vec![OpsCommand::new("helm", args)]
 }
 
-/// The read-only commands `agentos status` runs (and prints under `--dry-run`).
+/// The read-only commands `agentos cluster status` runs (and prints under `--dry-run`).
 pub fn status_commands(o: &CommonOpts) -> Vec<OpsCommand> {
     vec![
         helm_status_cmd(o),
@@ -398,7 +398,7 @@ pub async fn up(opts: UpOpts) -> Result<()> {
             "no AGENTOS_MODEL_CREDENTIALS set; installing with the fake model and sealed egress",
         );
         ui.note(
-            "Replies will be canned. Set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) and re-run `agentos up` to enable the real model.",
+            "Replies will be canned. Set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) and re-run `agentos cluster up` to enable the real model.",
         );
     }
     if opts.common.dry_run {
@@ -414,7 +414,7 @@ pub async fn up(opts: UpOpts) -> Result<()> {
         run_step(&cl, &label, "installed", cmd).await?;
     }
     ui.payload("agentos is up");
-    ui.note("Run `agentos status` for pod health and URLs.");
+    ui.note("Run `agentos cluster status` for pod health and URLs.");
     Ok(())
 }
 

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -1,4 +1,4 @@
-//! Terminal rendering: per-event output lines and the boxed `start` summary.
+//! Terminal rendering: per-event output lines and the boxed `skill up` summary.
 //!
 //! The boxed summary follows the design canon (claude-design-prompt.md): a
 //! Supabase-style rounded box listing the local bot URL, the emulator and eval
@@ -88,7 +88,7 @@ impl TurnPrinter {
     }
 }
 
-/// Render the boxed environment summary the design specifies for `agentos start`.
+/// Render the boxed environment summary the design specifies for `agentos skill up`.
 pub fn boxed_summary(title: &str, rows: &[(&str, String)]) -> String {
     let label_width = rows.iter().map(|(label, _)| label.len()).max().unwrap_or(0);
     let body: Vec<String> = rows
@@ -226,8 +226,11 @@ mod tests {
     fn boxed_summary_lines_are_flush() {
         let rows = [
             ("Local bot", "http://localhost:7245".to_string()),
-            ("Slack emulator", "agentos send \"<message>\"".to_string()),
-            ("Eval runner", "agentos eval".to_string()),
+            (
+                "Slack emulator",
+                "agentos skill message \"<message>\"".to_string(),
+            ),
+            ("Eval runner", "agentos skill eval".to_string()),
             ("Version", "dev @ 4f2c91a".to_string()),
         ];
         let boxed = boxed_summary("agentos dev environment", &rows);

--- a/cli/src/retired.rs
+++ b/cli/src/retired.rs
@@ -1,0 +1,70 @@
+//! Retired command hints for the noun based CLI surface.
+
+/// Return a one line hint for retired command forms.
+pub fn retired_hint(args: &[String]) -> Option<String> {
+    if args.iter().any(|arg| arg == "--local") {
+        return Some(
+            "`--local` was retired in favor of the local target. Use `agentos local message` for compose stack turns and `agentos local deploy` for local API deploys.".to_string(),
+        );
+    }
+
+    // Keep this global-flag skip list in sync with the `global = true` flags on
+    // the `Cli` struct in main.rs (debug, quiet, color). A new global flag added
+    // there must be added here too, or retired_hint will misread it as the
+    // subcommand token.
+    let mut index = 0usize;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--debug" | "-q" | "--quiet" => {
+                index += 1;
+            }
+            "--color" => {
+                index += 1;
+                if index < args.len() {
+                    index += 1;
+                }
+            }
+            token if token.starts_with("--color=") => {
+                index += 1;
+            }
+            _ => break,
+        }
+    }
+
+    let token = args.get(index)?.as_str();
+    match token {
+        "init" | "skill" | "local" | "cluster" | "-h" | "--help" | "-V" | "--version" => None,
+        "start" => Some("`agentos start` was retired. Use `agentos skill up`.".to_string()),
+        "stop" => Some("`agentos stop` was retired. Use `agentos skill down`.".to_string()),
+        "send" => {
+            Some("`agentos send` was retired. Use `agentos skill message`.".to_string())
+        }
+        "runner-status" => Some(
+            "`agentos runner-status` was retired. Use `agentos skill status`.".to_string(),
+        ),
+        "eval" => Some("`agentos eval` was retired. Use `agentos skill eval`.".to_string()),
+        "chat" => {
+            Some("`agentos chat` was retired. Use `agentos local message`.".to_string())
+        }
+        "up" => Some("`agentos up` was retired. Use `agentos cluster up`.".to_string()),
+        "down" => {
+            Some("`agentos down` was retired. Use `agentos cluster down`.".to_string())
+        }
+        "status" => Some(
+            "`agentos status` was retired. Use `agentos cluster status`.".to_string(),
+        ),
+        "message" => Some(
+            "`agentos message` was retired. Use `agentos cluster message`.".to_string(),
+        ),
+        "deploy" => Some(
+            "`agentos deploy` was retired. Use `agentos cluster deploy`.".to_string(),
+        ),
+        "steer" => Some(
+            "`agentos steer` was removed. Start a new turn with `agentos skill message` instead.".to_string(),
+        ),
+        "interrupt" => Some(
+            "`agentos interrupt` was removed. Use Ctrl-C to stop the current CLI process, then restart with `agentos skill message` if you need a new turn.".to_string(),
+        ),
+        _ => None,
+    }
+}

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -3,7 +3,7 @@
 //! The layout matches the frozen `plugin-format` package: a manifest at
 //! `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md` with YAML
 //! frontmatter, a root `.mcp.json`, plus a CLI-local `evals/cases.json` seed
-//! for `agentos eval`. Names are kebab-case per the validator.
+//! for `agentos skill eval`. Names are kebab-case per the validator.
 
 use std::path::{Path, PathBuf};
 

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -1,7 +1,7 @@
-//! Local runner state: which container `agentos start` booted, and where.
+//! Local runner state: which container `agentos skill up` booted, and where.
 //!
-//! Written to `.agentos/runner.json` in the project directory so `send`,
-//! `eval`, `status`, and `stop` find the runner without flags. The file is
+//! Written to `.agentos/runner.json` in the project directory so `message`,
+//! `eval`, `cluster status`, and `cluster down` find the runner without flags. The file is
 //! local workstation state, never committed (init scaffolds the ignore rule).
 
 use std::path::{Path, PathBuf};

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -1,0 +1,232 @@
+use std::process::Command;
+
+use agentos::retired_hint;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentos")
+}
+
+fn run_help(args: &[&str]) -> std::process::Output {
+    Command::new(bin())
+        .args(args)
+        .arg("--help")
+        .output()
+        .expect("run agentos --help")
+}
+
+fn output_text(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+fn help_lists_subcommand(text: &str, name: &str) -> bool {
+    text.lines().any(|line| {
+        let line = line.trim_start();
+        line == name
+            || line.starts_with(&format!("{name} "))
+            || line.starts_with(&format!("{name}\t"))
+    })
+}
+
+#[test]
+fn process_help_routes_positive_forms() {
+    let cases: &[&[&str]] = &[
+        &["skill", "up"],
+        &["skill", "down"],
+        &["skill", "status"],
+        &["skill", "message"],
+        &["skill", "eval"],
+        &["local", "up"],
+        &["local", "down"],
+        &["local", "status"],
+        &["local", "message"],
+        &["local", "deploy"],
+        &["cluster", "up"],
+        &["cluster", "down"],
+        &["cluster", "status"],
+        &["cluster", "message"],
+        &["cluster", "deploy"],
+        &["init"],
+    ];
+
+    for args in cases.iter().copied() {
+        let output = run_help(args);
+        assert!(
+            output.status.success(),
+            "expected success for {:?}\n{}",
+            args,
+            output_text(&output)
+        );
+    }
+}
+
+#[test]
+fn process_help_rejects_retired_top_level_tokens() {
+    let cases = [
+        "start",
+        "stop",
+        "send",
+        "eval",
+        "runner-status",
+        "chat",
+        "steer",
+        "interrupt",
+        "up",
+        "down",
+        "status",
+        "message",
+        "deploy",
+    ];
+
+    for token in cases {
+        let output = run_help(&[token]);
+        assert!(
+            !output.status.success(),
+            "expected failure for {token}\n{}",
+            output_text(&output)
+        );
+    }
+}
+
+#[test]
+fn process_help_rejects_retired_local_flag_on_a_leaf_command() {
+    let output = run_help(&["skill", "message", "hello", "--local"]);
+    assert!(
+        !output.status.success(),
+        "expected failure for retired --local on a leaf command\n{}",
+        output_text(&output)
+    );
+}
+
+#[test]
+fn process_help_top_level_lists_new_surface_and_hides_retired_verbs() {
+    let output = run_help(&[]);
+    assert!(
+        output.status.success(),
+        "expected success for top level help\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+
+    for needle in ["skill", "local", "cluster", "init"] {
+        assert!(
+            help_lists_subcommand(&text, needle),
+            "missing {needle}\n{text}"
+        );
+    }
+
+    for needle in [
+        "start",
+        "stop",
+        "send",
+        "eval",
+        "runner-status",
+        "chat",
+        "steer",
+        "interrupt",
+        "up",
+        "down",
+        "status",
+        "message",
+        "deploy",
+    ] {
+        assert!(
+            !help_lists_subcommand(&text, needle),
+            "unexpected retired verb {needle}\n{text}"
+        );
+    }
+}
+
+fn to_argv(parts: &[&str]) -> Vec<String> {
+    parts.iter().map(|part| (*part).to_string()).collect()
+}
+
+fn assert_hint_contains(argv: &[&str], needle: &str) {
+    let argv = to_argv(argv);
+    let hint = retired_hint(&argv).unwrap_or_else(|| panic!("expected hint for {:?}", argv));
+    assert!(
+        hint.contains(needle),
+        "expected {needle:?} in hint {hint:?} for {:?}",
+        argv
+    );
+}
+
+fn assert_hint_contains_any(argv: &[&str], needles: &[&str]) {
+    let argv = to_argv(argv);
+    let hint = retired_hint(&argv).unwrap_or_else(|| panic!("expected hint for {:?}", argv));
+    assert!(
+        needles.iter().any(|needle| hint.contains(needle)),
+        "expected one of {needles:?} in hint {hint:?} for {:?}",
+        argv
+    );
+}
+
+fn assert_hint_none(argv: &[&str]) {
+    let argv = to_argv(argv);
+    assert_eq!(retired_hint(&argv), None, "unexpected hint for {:?}", argv);
+}
+
+#[test]
+fn retired_hint_maps_retired_tokens_and_ignores_global_flags() {
+    let cases: &[(&[&str], &str)] = &[
+        (&["start"], "skill up"),
+        (&["stop"], "skill down"),
+        (&["send"], "skill message"),
+        (&["runner-status"], "skill status"),
+        (&["eval"], "skill eval"),
+        (&["chat"], "local message"),
+        (&["up"], "cluster up"),
+        (&["down"], "cluster down"),
+        (&["status"], "cluster status"),
+        (&["message"], "cluster message"),
+        (&["deploy"], "cluster deploy"),
+        (&["steer"], "removed"),
+        (&["interrupt"], "removed"),
+        (&["--local", "start"], "local"),
+        (&["start", "--local"], "local"),
+        (&["skill", "up", "--local"], "local"),
+        (&["--debug", "start"], "skill up"),
+        (&["-q", "stop"], "skill down"),
+        (&["--quiet", "send"], "skill message"),
+        (&["--color", "always", "status"], "cluster status"),
+        (&["--color=always", "deploy"], "cluster deploy"),
+    ];
+
+    for (argv, needle) in cases.iter().copied() {
+        assert_hint_contains(argv, needle);
+    }
+
+    assert_hint_contains_any(&["interrupt"], &["Ctrl-C", "skill message"]);
+}
+
+#[test]
+fn retired_hint_returns_none_for_valid_starts_help_and_message_bodies() {
+    let cases: &[&[&str]] = &[
+        &["skill", "up"],
+        &["skill", "message", "hello"],
+        &["skill", "message", "please deploy the thing"],
+        &["local", "up"],
+        &["local", "message", "please deploy the thing"],
+        &["local", "message", "please", "deploy", "the", "thing"],
+        &["local", "deploy"],
+        &["cluster", "up"],
+        &["cluster", "message", "status of the world"],
+        &["cluster", "message", "status", "of", "the", "world"],
+        &["cluster", "deploy"],
+        &["init", "my-plugin"],
+        &["--help"],
+        &["--debug"],
+        &["--debug", "skill", "up"],
+        &["--color", "always"],
+        &["--color=always"],
+        &["--color", "always", "cluster", "status"],
+        &["--color", "always", "skill", "up"],
+        &["-h"],
+        &["-V"],
+        &["--version"],
+        &[],
+    ];
+
+    for argv in cases.iter().copied() {
+        assert_hint_none(argv);
+    }
+}

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -207,9 +207,9 @@ services:
   #
   # These three services turn the backing stack above into a one-command local
   # product loop. `agentos local up` brings everything up, then:
-  #   agentos deploy --plugin-dir <dir> --slack-channel <C...> \
+  #   agentos local deploy --plugin-dir <dir> --slack-channel <C...> \
   #                  --api-url http://localhost:28000
-  #   agentos message --local "<question>"
+  #   agentos local message "<question>"
   # drives a real queue -> worker -> sandboxed runner -> reply roundtrip, no
   # Slack and no Kubernetes. They use the same published images the chart
   # deploys (only the worker adds a thin local docker-CLI overlay; see below).
@@ -233,8 +233,8 @@ services:
     restart: "no"
 
   # The platform API. On the compose network, reaching Postgres/Valkey/MinIO by
-  # service name. Published on host 28000 for the CLI (`agentos deploy`, and the
-  # `agentos message --local` channel lookup).
+  # service name. Published on host 28000 for the CLI (`agentos local deploy`, and the
+  # `agentos local message` channel lookup).
   agentos-api:
     image: ghcr.io/curie-eng/agentos-api:latest
     depends_on:
@@ -289,7 +289,7 @@ services:
   # written and tested against (the host-process middle mode): the worker reaches
   # the backing stores on their published host ports (localhost 25432/26379/29000),
   # dials each runner on the loopback host port Docker publishes for it, and
-  # reaches the `agentos message --local` Slack stub at localhost:8155.
+  # reaches the `agentos local message` Slack stub at localhost:8155.
   agentos-worker:
     build:
       context: compose

--- a/docs/architecture-vision.md
+++ b/docs/architecture-vision.md
@@ -185,8 +185,8 @@ edit-a-placeholder reply shape.
 **Current adapter:** `apps/dispatcher` (Bolt, Socket Mode) on ingress,
 `AsyncSlackSink` on egress.
 
-**Evidence the channel is already semi-swappable:** `agentos chat` and
-`agentos message` (`cli/src/chat.rs`, `cli/src/message.rs`) drive the entire
+**Evidence the channel is already semi-swappable:** `agentos local message` and
+`agentos cluster message` (`cli/src/chat.rs`, `cli/src/message.rs`) drive the entire
 deployed system with zero Slack contact by minting the exact
 `QueuedSlackEvent` wire payload (`cli/src/queue.rs`) and standing in as the
 Slack Web API. The Slack service swaps; the Slack protocol does not yet.
@@ -210,7 +210,7 @@ routed per turn ([issue #19](https://github.com/curie-eng/agentos/issues/19)).
 flowchart TB
     subgraph channel["Job 6: communication channel"]
         Slack["Slack via Bolt (today)"]
-        CLIStub["agentos chat / message stub (swap proof)"]
+        CLIStub["agentos local message / cluster message stub (swap proof)"]
     end
 
     subgraph core["Opinionated core: agent runner platform"]

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,9 +1,28 @@
-# Operating a cluster install
+# Operating the `cluster` target
 
-The same `agentos` binary installs and runs the platform on a Kubernetes
-cluster, wrapping the umbrella Helm chart the way `linkerd` or `cilium` wrap
-theirs. Every verb takes `--dry-run` to print the exact `helm`/`kubectl`
-command line (secrets masked) without executing.
+This doc is the runbook for the **`cluster`** target: the AgentOS platform
+running on a Kubernetes cluster (a Helm release). The same `agentos` binary
+installs and runs it, wrapping the umbrella Helm chart the way `linkerd` or
+`cilium` wrap theirs. Every verb takes `--dry-run` to print the exact
+`helm`/`kubectl` command line (secrets masked) without executing.
+
+`cluster` is the heaviest of three CLI targets. Reach for a lighter one when it
+answers your question:
+
+## Which target do I want?
+
+| Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
+|---|---|---|---|---|---|
+| `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
+| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | none | none | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `message` `deploy` | Operate and drive a deployed cluster release (this doc). |
+
+The universal quartet `up`/`down`/`status`/`message` is on all three targets;
+`skill` adds `eval`, and `local`/`cluster` add `deploy`. The `skill` target is
+the runner-only loop; `local` and `cluster` add the full platform in front of
+the identical runner and ACI. For the `skill` and `local` targets see
+[`cli/README.md`](../cli/README.md) and the
+[README](../README.md#which-target-do-i-want); the rest of this doc is `cluster`.
 
 Prerequisites: `kubectl` and `helm` on PATH, pointed at a reachable cluster
 (the `agents.x-k8s.io` Agent Sandbox CRDs and a NetworkPolicy-enforcing CNI are
@@ -11,7 +30,7 @@ installed by the chart's preflights; see `charts/agentos/README.md`).
 
 ## Install and inspect
 
-- `agentos up` runs `helm upgrade --install` of `charts/agentos` into the
+- `agentos cluster up` runs `helm upgrade --install` of `charts/agentos` into the
   `agentos` namespace, exposing the UI and Langfuse on node ports (pass
   `--no-expose` to keep them ClusterIP-only). It reads
   `AGENTOS_MODEL_CREDENTIALS`: when the env var is set it switches the runner
@@ -21,10 +40,10 @@ installed by the chart's preflights; see `charts/agentos/README.md`).
   installs sealed (canned replies) and `up` warns that replies stay canned
   until the env var is set and `up` is re-run. Pass `--fake-model` to force the
   sealed install even when the credential is present (a dev/CI escape hatch).
-- `agentos status` reports release health, pod readiness, and the access URLs;
+- `agentos cluster status` reports release health, pod readiness, and the access URLs;
   the UI URL carries `?api=1`, so it opens wired to the in-cluster API (the
   deployed UI proxies `/api/` there).
-- `agentos down` uninstalls the release and sweeps its runtime namespaces; the
+- `agentos cluster down` uninstalls the release and sweeps its runtime namespaces; the
   `agents.x-k8s.io` CRDs are left in place. It prompts before deleting unless
   `--yes` is passed.
 
@@ -32,12 +51,12 @@ installed by the chart's preflights; see `charts/agentos/README.md`).
 
 Connecting a real Slack workspace is a raw `helm upgrade --reuse-values` that
 sets the dispatcher's app and bot tokens and clears `worker.slackApiBaseUrl=`
-(un-wiring any `agentos message` stub routing). It is intentionally not a CLI
+(un-wiring any `agentos cluster message` stub routing). It is intentionally not a CLI
 verb; the chart's `NOTES.txt` prints the exact command after `up`.
 
 ## Driving a deployed cluster with zero Slack
 
-`agentos message "..."` exercises a deployed release end to end with no Slack
+`agentos cluster message "..."` exercises a deployed release end to end with no Slack
 at all: it stands up a local Slack API stub, self-manages the kubectl
 port-forwards, resolves the target agent's channel from the API, points the
 deployed worker at the stub (`helm upgrade --reuse-values`), enqueues the exact
@@ -53,7 +72,7 @@ reference and the multi-turn `--thread` flow are in
 `agentos local up|down|status` wraps the `compose.dev.yaml` dev stack, so the
 inner loop and the cluster share one CLI. `local up` brings up the full product
 stack (API + worker alongside the backing stores), so
-`agentos deploy --api-url http://localhost:28000` then `agentos message --local
+`agentos local deploy --api-url http://localhost:28000` then `agentos local message
 "..."` drives a real queue -> worker -> sandboxed runner -> reply roundtrip with
 no Slack and no Kubernetes. See the middle-mode runbook in the
 [README](../README.md#quickstart).

--- a/runner/CLAUDE.md
+++ b/runner/CLAUDE.md
@@ -3,7 +3,7 @@
 The runner image and SDK adapter: a long-lived `claude-agent-sdk`
 streaming session server implementing the full ACI v0.1 contract from
 `packages/aci-protocol`. Runs inside a claimed Agent Sandbox, or locally in
-Docker via `agentos start`. Full behavior spec in `runner/README.md`.
+Docker via `agentos skill up`. Full behavior spec in `runner/README.md`.
 
 ## Load-bearing invariants
 
@@ -38,7 +38,7 @@ Docker via `agentos start`. Full behavior spec in `runner/README.md`.
   side-channel injections whose output surfaces on the already-open
   `/v1/event` stream -- do not open a second concurrent generator for a steer.
 - **`AGENTOS_FAKE_MODEL` must stay a true offline no-op.** It exists so CI,
-  the CLI's `agentos start --fake-model`, and the chart's default runner pool
+  the CLI's `agentos skill up --fake-model`, and the chart's default runner pool
   can round-trip ACI events with zero credential and zero network call. Any
   change to the fake-model path must preserve "no model call, no network"
   or it breaks all three of those consumers silently.

--- a/runner/README.md
+++ b/runner/README.md
@@ -3,7 +3,7 @@
 The runner image and SDK adapter: the productized prototype,
 a long-lived streaming session server that implements the full ACI
 v0.1 contract from `packages/aci-protocol`. Built on `claude-agent-sdk` (Python).
-Runs inside a claimed Agent Sandbox; the CLI (`agentos start`) also runs it
+Runs inside a claimed Agent Sandbox; the CLI (`agentos skill up`) also runs it
 locally in Docker.
 
 ## What it does


### PR DESCRIPTION
Reorganizes the `agentos` CLI so every environment command takes a target noun in the middle, replacing the mix of bare verbs, a `local` group, and a `--local` flag.

## Surface
- **skill** (tier 1: local runner container, offline): `up` `down` `status` `message` `eval`
- **local** (tier 2: compose stack): `up` `down` `status` `message` `deploy`
- **cluster** (tier 3: kubernetes): `up` `down` `status` `message` `deploy`
- `init` stays top-level.

## Hard cutover
- `--local` and all bare top-level env verbs are removed. Retired forms error (exit 2) via a pure, unit-tested `retired_hint()` pre-parse shim naming the replacement (`agentos start` -> "use `agentos skill up`", etc.). No silent aliases.
- `chat`/`steer`/`interrupt` CLI verbs removed: `chat` folds into `local message`; a live `skill message` is aborted with Ctrl-C. The ACI protocol and `RunnerClient::steer/interrupt` (`/v1/steer`, `/v1/interrupt`) are untouched.
- `local deploy` defaults `--api-url` to the compose API (`:28000`); `cluster deploy` keeps `:8000`. `local message` keeps `--api-key`.

## Docs
README, `cli/README.md`, and `docs/operations.md` are restructured around the three targets, each led by a "which target do I want?" decision table. No retired verb appears in the docs.

## Scope note (deliberate)
No Ctrl-C -> `/v1/interrupt` frame wiring is added. Terminal Ctrl-C already aborts the CLI process; wiring an explicit interrupt frame around the streaming path is deferred as a separate enhancement.

## Verification
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (116 passed) all green.
- E2E smoke on the built binary: retired verbs exit 2 with correct guidance, `local message` rejects cluster-only flags, `cluster message --dry-run` preserves the kubectl/helm plumbing, deploy api-url defaults verified.

Closes #40