### PR TITLE
Add the runtime-settings behavior pack

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -132,6 +132,13 @@
               "reply": ""
             }
           },
+          "settings": {
+            "$ref": "#/components/schemas/SettingsPackConfig",
+            "default": {
+              "enabled": false,
+              "settings": []
+            }
+          },
           "tips": {
             "$ref": "#/components/schemas/TipsPackConfig",
             "default": {
@@ -836,6 +843,73 @@
           "pods"
         ],
         "title": "RunnerPods",
+        "type": "object"
+      },
+      "SettingConfig": {
+        "description": "One declared user-editable runtime knob (mirrors behaviorpacks.Setting).",
+        "properties": {
+          "applies_live": {
+            "default": true,
+            "title": "Applies Live",
+            "type": "boolean"
+          },
+          "choices": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Choices",
+            "type": "array"
+          },
+          "default": {
+            "default": "",
+            "title": "Default",
+            "type": "string"
+          },
+          "help": {
+            "default": "",
+            "title": "Help",
+            "type": "string"
+          },
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "kind": {
+            "default": "str",
+            "title": "Kind",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "title": "Label",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key"
+        ],
+        "title": "SettingConfig",
+        "type": "object"
+      },
+      "SettingsPackConfig": {
+        "description": "An agent's declarative allowlist of editable runtime knobs (schema only;\nthe override store + edit UI are a deferred runtime).",
+        "properties": {
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "settings": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/SettingConfig"
+            },
+            "title": "Settings",
+            "type": "array"
+          }
+        },
+        "title": "SettingsPackConfig",
         "type": "object"
       },
       "TipsPackConfig": {

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -36,6 +36,26 @@ class HelpPackConfig(BaseModel):
     reply: str = ""
 
 
+class SettingConfig(BaseModel):
+    """One declared user-editable runtime knob (mirrors behaviorpacks.Setting)."""
+
+    key: str
+    label: str = ""
+    kind: str = "str"
+    default: str = ""
+    help: str = ""
+    choices: list[str] = []
+    applies_live: bool = True
+
+
+class SettingsPackConfig(BaseModel):
+    """An agent's declarative allowlist of editable runtime knobs (schema only;
+    the override store + edit UI are a deferred runtime)."""
+
+    enabled: bool = False
+    settings: list[SettingConfig] = []
+
+
 class BehaviorPacksConfig(BaseModel):
     """An agent's opt-in behavior packs. Validated on write and stored as JSON on
     the agent row; the worker parses the same JSON at bind time."""
@@ -45,6 +65,7 @@ class BehaviorPacksConfig(BaseModel):
     tips: TipsPackConfig = TipsPackConfig()
     greeting: GreetingPackConfig = GreetingPackConfig()
     help: HelpPackConfig = HelpPackConfig()
+    settings: SettingsPackConfig = SettingsPackConfig()
 
 
 class AgentCreate(BaseModel):

--- a/apps/api/tests/test_behavior_packs_integration.py
+++ b/apps/api/tests/test_behavior_packs_integration.py
@@ -60,6 +60,12 @@ def test_put_then_get_round_trips(
         },
         "greeting": {"enabled": True, "phrases": ["hey"], "reply": "hello!"},
         "help": {"enabled": True, "phrases": ["help"], "reply": "here is help"},
+        "settings": {
+            "enabled": True,
+            "settings": [
+                {"key": "page_size", "kind": "int", "default": "5"},
+            ],
+        },
     }
     resp = client.put(
         f"/agents/{agent['id']}/behavior-packs", json=config, headers=auth_headers
@@ -72,6 +78,7 @@ def test_put_then_get_round_trips(
     assert got["tips"]["working_lines"] == ["Working on it!"]
     assert got["greeting"]["reply"] == "hello!"
     assert got["help"]["reply"] == "here is help"
+    assert got["settings"]["settings"][0]["key"] == "page_size"
 
     # And it surfaces on the agent read model too.
     resp = client.get(f"/agents/{agent['id']}", headers=auth_headers)

--- a/apps/worker/src/agentos_worker/behaviorpacks.py
+++ b/apps/worker/src/agentos_worker/behaviorpacks.py
@@ -87,6 +87,35 @@ class HelpPack(BaseModel):
     reply: str = ""
 
 
+class Setting(BaseModel):
+    """One user-editable runtime knob, declared by the agent. Ported from the
+    template's user-settings battery, minus the env-var backing (in AgentOS the
+    pack itself is the config surface)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str
+    label: str = ""
+    kind: str = "str"  # "int" | "bool" | "choice" | "str"
+    default: str = ""
+    help: str = ""
+    choices: tuple[str, ...] = ()  # for kind == "choice"
+    # False -> the value only takes effect on the next restart (metadata for a UI).
+    applies_live: bool = True
+
+
+class SettingsPack(BaseModel):
+    """An agent's declarative allowlist of editable runtime knobs. This ships the
+    schema + validation only; the durable override store and the edit UI are the
+    deferred runtime (see docs/behavior-packs.md), the same way the tips/greeting
+    kernel wiring is deferred."""
+
+    model_config = ConfigDict(frozen=True)
+
+    enabled: bool = False
+    settings: tuple[Setting, ...] = ()
+
+
 class BehaviorPacks(BaseModel):
     """An agent's full set of packs; every field defaults to disabled/empty."""
 
@@ -95,6 +124,7 @@ class BehaviorPacks(BaseModel):
     tips: TipsPack = TipsPack()
     greeting: GreetingPack = GreetingPack()
     help: HelpPack = HelpPack()
+    settings: SettingsPack = SettingsPack()
 
     @classmethod
     def from_config(cls, data: Mapping[str, Any] | None) -> BehaviorPacks:
@@ -185,3 +215,66 @@ def sample_tip(packs: BehaviorPacks, seed: str) -> str | None:
     if tip:
         return f"Tip: {tip}"
     return None
+
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"0", "false", "no", "off"})
+
+
+class SettingError(ValueError):
+    """A user-facing validation message for a rejected setting value."""
+
+
+def coerce_setting(setting: Setting, raw: str) -> str:
+    """Validate + normalize a raw string to its stored form for ``setting``.
+    Raises ``SettingError`` with a user-facing message on bad input. Pure; the
+    platform owns this so an agent only supplies the declarative Setting."""
+    value = (raw or "").strip()
+    if setting.kind == "int":
+        try:
+            n = int(value)
+        except ValueError:
+            raise SettingError("must be a whole number") from None
+        if n < 1:
+            raise SettingError("must be 1 or more")
+        return str(n)
+    if setting.kind == "bool":
+        low = value.lower()
+        if low in _TRUTHY:
+            return "true"
+        if low in _FALSY:
+            return "false"
+        raise SettingError("use on or off")
+    if setting.kind == "choice":
+        if value not in setting.choices:
+            raise SettingError(f"choose one of: {', '.join(setting.choices)}")
+        return value
+    if not value:
+        raise SettingError("cannot be empty")
+    return value
+
+
+def resolve_settings(packs: BehaviorPacks, overrides: Mapping[str, str]) -> dict[str, str]:
+    """The effective value per declared setting: a valid override wins, else the
+    default. Unknown override keys and values that fail validation are ignored so
+    a stale or corrupt store can never break resolution. Returns {} when the pack
+    is disabled. This is the function the deferred override store / edit UI will
+    call; shipping it now makes the schema usable and testable."""
+    pack = packs.settings
+    if not pack.enabled:
+        return {}
+    resolved: dict[str, str] = {}
+    for setting in pack.settings:
+        raw = overrides.get(setting.key)
+        if raw is not None:
+            try:
+                resolved[setting.key] = coerce_setting(setting, raw)
+                continue
+            except SettingError:
+                pass  # invalid override -> fall back to the default
+        # An empty/invalid default (e.g. an opt-in left blank) is kept verbatim.
+        try:
+            resolved[setting.key] = coerce_setting(setting, setting.default)
+        except SettingError:
+            resolved[setting.key] = setting.default
+    return resolved

--- a/apps/worker/tests/test_behaviorpacks.py
+++ b/apps/worker/tests/test_behaviorpacks.py
@@ -7,13 +7,19 @@ greeting glued to a real request), and tip sampling is deterministic per seed.
 
 from __future__ import annotations
 
+import pytest
 from agentos_worker.behaviorpacks import (
     BehaviorPacks,
     GreetingPack,
     HelpPack,
+    Setting,
+    SettingError,
+    SettingsPack,
     TipsPack,
+    coerce_setting,
     match_greeting,
     match_help,
+    resolve_settings,
     sample_tip,
 )
 
@@ -29,11 +35,13 @@ def _packs(
     greeting: GreetingPack | None = None,
     tips: TipsPack | None = None,
     help: HelpPack | None = None,
+    settings: SettingsPack | None = None,
 ) -> BehaviorPacks:
     return BehaviorPacks(
         greeting=greeting or GreetingPack(),
         tips=tips or TipsPack(),
         help=help or HelpPack(),
+        settings=settings or SettingsPack(),
     )
 
 
@@ -157,6 +165,61 @@ def test_sample_tip_working_only_and_tip_only() -> None:
     assert sample_tip(_packs(tips=working_only), "s") == "Just a sec"
     tip_only = TipsPack(enabled=True, tips=("Try /help",))
     assert sample_tip(_packs(tips=tip_only), "s") == "Tip: Try /help"
+
+
+# -- settings pack (schema + coerce/resolve) ----------------------------------
+
+_SETTINGS = SettingsPack(
+    enabled=True,
+    settings=(
+        Setting(key="page_size", kind="int", default="5"),
+        Setting(key="notify", kind="bool", default="false"),
+        Setting(key="severity", kind="choice", default="High", choices=("Low", "High")),
+        Setting(key="label", kind="str", default="leaks"),
+    ),
+)
+
+
+def test_coerce_setting_validates_each_kind() -> None:
+    assert coerce_setting(Setting(key="n", kind="int"), " 7 ") == "7"
+    assert coerce_setting(Setting(key="b", kind="bool"), "ON") == "true"
+    assert coerce_setting(Setting(key="b", kind="bool"), "no") == "false"
+    ch = Setting(key="c", kind="choice", choices=("a", "b"))
+    assert coerce_setting(ch, "b") == "b"
+    assert coerce_setting(Setting(key="s", kind="str"), "hi") == "hi"
+
+
+def test_coerce_setting_rejects_bad_values() -> None:
+    for setting, raw in [
+        (Setting(key="n", kind="int"), "x"),
+        (Setting(key="n", kind="int"), "0"),
+        (Setting(key="b", kind="bool"), "maybe"),
+        (Setting(key="c", kind="choice", choices=("a",)), "z"),
+        (Setting(key="s", kind="str"), "   "),
+    ]:
+        with pytest.raises(SettingError):
+            coerce_setting(setting, raw)
+
+
+def test_resolve_settings_override_wins_else_default() -> None:
+    resolved = resolve_settings(_packs(settings=_SETTINGS), {"page_size": "12", "notify": "yes"})
+    assert resolved["page_size"] == "12"  # override
+    assert resolved["notify"] == "true"  # override, normalized
+    assert resolved["severity"] == "High"  # default
+    assert resolved["label"] == "leaks"  # default
+
+
+def test_resolve_settings_ignores_invalid_and_unknown() -> None:
+    resolved = resolve_settings(
+        _packs(settings=_SETTINGS),
+        {"page_size": "-3", "bogus": "x"},  # invalid value + unknown key
+    )
+    assert resolved["page_size"] == "5"  # invalid override -> default
+    assert "bogus" not in resolved  # unknown key dropped
+
+
+def test_resolve_settings_disabled_is_empty() -> None:
+    assert resolve_settings(_packs(), {"page_size": "9"}) == {}
 
 
 def test_from_config_roundtrip_and_none() -> None:

--- a/docs/behavior-packs.md
+++ b/docs/behavior-packs.md
@@ -10,8 +10,11 @@ install:
   that never calls the model.
 - **help** -- a canned reply to a *bare* help / "what can you do" request, also
   without a model call (the niceties battery's help half).
+- **settings** -- a declarative allowlist of user-editable runtime knobs (the
+  template's user-settings battery), with platform-owned validation. Schema only
+  in this PR; the durable override store and edit UI are a deferred runtime.
 
-These three are illustrative, not the point. The point is the mechanism: a
+These example packs are illustrative, not the point. The point is the mechanism: a
 per-agent, opt-in, declarative config layer, resolved at bind time, that an owner
 enables for their own deployments with no effect on any other agent. New pack
 types slot into the same mechanism. The battery-by-battery mapping below shows
@@ -36,18 +39,35 @@ The substrate, end to end, minus the kernel call sites:
   `POST /agents`, and read/written via `GET|PUT /agents/{id}/behavior-packs`
   (mirrors the budget control endpoints). NULL reads as all-off.
 - **Logic** (`apps/worker/behaviorpacks.py`): `sample_tip(packs, seed)`,
-  `match_greeting(packs, text)`, and `match_help(packs, text)`, pure stdlib,
-  fully unit-tested. The two matchers share one bare-utterance core: they return
-  a reply only for a phrase said alone (or with trailing filler); a phrase glued
-  to a real request ("hi show me the report") returns `None` and falls through to
-  the model.
+  `match_greeting(packs, text)`, `match_help(packs, text)`, plus the settings
+  pack's `coerce_setting(setting, raw)` and `resolve_settings(packs, overrides)`.
+  Pure stdlib, fully unit-tested. The two matchers share one bare-utterance core:
+  they return a reply only for a phrase said alone (or with trailing filler); a
+  phrase glued to a real request ("hi show me the report") returns `None` and
+  falls through to the model. `resolve_settings` layers a validated override over
+  each declared default and ignores unknown/invalid keys, so a stale store can
+  never break resolution.
 - **Binding** (`apps/worker/binding.py`, not the sacred kernel): the resolver
   now selects `behavior_packs`, carries it on `ResolvedDeployment`, and exposes
   `BindingResolver.packs_for(resolved) -> BehaviorPacks`.
 
-## What is NOT built: the kernel wiring (needs F1 review)
+## What is NOT built: the deferred runtimes
 
-Both touches fire from inside `apps/worker/kernel.py`, which is the F1 "sacred"
+Two pieces are intentionally out of this PR, each a natural follow-up on top of
+the substrate here.
+
+### The settings-pack override store + edit UI
+
+The `settings` pack ships its schema and validation (`coerce_setting`,
+`resolve_settings`). What it does not ship is the durable per-agent override
+store the resolved values layer onto, and the surface (a Slack modal / an API
+route) an owner uses to change them live. `resolve_settings(packs, overrides)`
+is already the function that runtime will call; wiring a store into it is
+additive and touches neither the kernel nor a frozen contract.
+
+### The kernel wiring for tips/greeting/help (needs F1 review)
+
+These touches fire from inside `apps/worker/kernel.py`, which is the F1 "sacred"
 module: any change needs the escalated adversarial review (spec-vs-impl +
 side-effects-detective) per `apps/worker/CLAUDE.md`. The greeting short-circuit
 also brushes against kernel rule 3 ("the kernel never keyword-guesses intent"),
@@ -106,7 +126,7 @@ pack.
 | Working status / tips | **Pack** (`tips`) | Pure data (lines + tips) sampled by a platform function. Shipped. |
 | Greeting detection | **Pack** (`greeting`) | Data (phrases + reply), deterministic pre-model matcher. Shipped. |
 | Help / "what can you do" | **Pack** (`help`) | Same shape as greeting; the niceties battery's help half. Shipped. |
-| Runtime settings / knobs | **Candidate pack (schema only)** | The editable-settings allowlist is declarative and could be a pack; the store + live-override + edit UI is a stateful subsystem that overlaps AgentOS budgets/config. Deferred. |
+| Runtime settings / knobs | **Pack** (`settings`, schema) | The editable-settings allowlist is declarative; shipped with platform-owned validation (`coerce_setting`/`resolve_settings`). The durable override store + edit UI are a deferred runtime. |
 | Kill switch / control | **Already native** | AgentOS has it: `apps/worker/killswitch.py` + `Kernel` kill gate + the `/agents/{id}/kill` control endpoint. A pack would duplicate it. |
 | Activity log | **Already native (observability)** | Post-model observation is Langfuse tracing; the Slack "activity" ring buffer is stateful UI code, not declarative data. |
 | Logging setup | **Not per-agent** | Pure infra, identical for every agent; belongs to the platform, not a pack. |


### PR DESCRIPTION
## What

A fourth behavior pack on the mechanism merged in #2: **`settings`** — a declarative, per-agent allowlist of user-editable runtime knobs (the template's user-settings battery), with platform-owned validation.

Follow-up to #2 (which shipped the mechanism + tips/greeting/help). This is the pack I flagged there as a deferred candidate; it fits the declarative model, so here it is.

## Changes

- **apps/worker/behaviorpacks.py** — `Setting` + `SettingsPack` models; `coerce_setting(setting, raw)` (per-kind validation: int/bool/choice/str, ported from the template's `coerce`) and `resolve_settings(packs, overrides)` (a valid override wins, else the declared default; unknown or invalid keys are ignored so a stale/corrupt store can never break resolution). Pure stdlib, unit-tested.
- **apps/api** — `SettingConfig` + `SettingsPackConfig` wired into `BehaviorPacksConfig`, so the pack round-trips through the existing `agents.behavior_packs` column and the `GET|PUT /agents/{id}/behavior-packs` endpoints. No new migration (column already exists).

## Scope: schema only

Same "substrate now" split as #2. This ships the declarative schema + validation. The **durable override store** (where a user's changes persist) and the **edit UI** (a Slack modal / API route) are a deferred runtime — `resolve_settings` is exactly the function that runtime will call. Documented in `docs/behavior-packs.md`, whose battery-mapping table now lists runtime-settings as a shipped pack.

## Verification

Against real compose Postgres + MinIO: `ruff check` clean, `mypy` clean (93 files), **41 pytest passed** (22 pure behaviorpacks incl. the new coerce/resolve cases, plus API round-trip, crud, openapi drift, and the worker binding resolver).

Ref CUR-1591