### PR TITLE
Render structured Slack replies (Block Kit) from an agentos-reply block

### DIFF
--- a/apps/worker/src/agentos_worker/blocks.py
+++ b/apps/worker/src/agentos_worker/blocks.py
@@ -1,0 +1,168 @@
+"""Structured Slack replies: a ``Reply`` type, a Block Kit renderer, and a
+convention for a plugin to emit one over the plain-text ACI channel.
+
+AgentOS streams the model's answer as text and edits a placeholder in place, so
+a reply is normally just markdown. This module lets a plugin opt into a richer
+reply -- a header, a two-column field section, chunked body sections, and a
+footer -- without changing the frozen ACI event contract: the plugin emits a
+fenced block as the last thing in its answer,
+
+    ```agentos-reply
+    {"header": "Top leaks", "text": "...", "fields": [["Open", "12"]],
+     "footer": "as of today"}
+    ```
+
+and the SlackSink renders it as Block Kit. Anything that is not a *complete*,
+valid block (including a half-streamed one) falls back to the existing text
+path, so streaming partials never show raw JSON and a malformed block degrades
+to plain text rather than breaking the reply.
+
+Ported from the CurieTech agent-ss-template ``blocks.py`` (the 3000-char section
+cap, mrkdwn normalization, nav-leftmost button ordering); rendering reuses this
+package's ``mrkdwn.to_mrkdwn``. Buttons are rendered here but only become
+interactive once the dispatcher handles their clicks (a separate change).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .mrkdwn import to_mrkdwn
+
+# Slack hard-caps a section's text at 3000 chars; stay under it with margin.
+_CHUNK_TARGET = 2900
+
+_FENCE = re.compile(r"```agentos-reply\s*\n(.*?)\n```", re.DOTALL)
+_FENCE_OPEN = "```agentos-reply"
+
+
+@dataclass
+class Reply:
+    """A formatted reply, independent of Block Kit. ``text`` is markdown (also
+    the plain-text fallback); ``header`` a header block; ``fields`` a two-column
+    section; ``buttons`` an actions block of ``(label, action_id)`` pairs;
+    ``footer`` a trailing context line."""
+
+    text: str = ""
+    header: str | None = None
+    fields: list[tuple[str, str]] = field(default_factory=list)
+    buttons: list[tuple[str, str]] = field(default_factory=list)
+    footer: str | None = None
+
+
+def chunk(text: str, limit: int = _CHUNK_TARGET) -> list[str]:
+    """Split ``text`` into pieces no longer than ``limit``, preferring line
+    boundaries but hard-splitting any single over-long line. Empty -> []."""
+    if not text:
+        return []
+    out: list[str] = []
+    buf = ""
+    for line in text.split("\n"):
+        while len(line) > limit:
+            if buf:
+                out.append(buf)
+                buf = ""
+            out.append(line[:limit])
+            line = line[limit:]
+        candidate = f"{buf}\n{line}" if buf else line
+        if len(candidate) > limit:
+            out.append(buf)
+            buf = line
+        else:
+            buf = candidate
+    if buf:
+        out.append(buf)
+    return out
+
+
+def _button(label: str, action_id: str) -> dict[str, Any]:
+    return {
+        "type": "button",
+        "text": {"type": "plain_text", "text": label, "emoji": True},
+        "action_id": action_id,
+    }
+
+
+def _is_nav(label: str) -> bool:
+    """Back ('<-') / up-to-hub ('^') buttons sort leftmost."""
+    return label.lstrip()[:1] in ("←", "↑")
+
+
+def to_blocks(reply: Reply) -> list[dict[str, Any]]:
+    """Render a ``Reply`` to a Block Kit blocks array. Order: header -> fields ->
+    body section(s) (chunked) -> buttons (nav-leftmost) -> footer."""
+    blocks: list[dict[str, Any]] = []
+    if reply.header:
+        blocks.append({"type": "header", "text": {"type": "plain_text", "text": reply.header}})
+    if reply.fields:
+        blocks.append(
+            {
+                "type": "section",
+                "fields": [{"type": "mrkdwn", "text": f"*{k}*\n{v}"} for k, v in reply.fields],
+            }
+        )
+    for piece in chunk(to_mrkdwn(reply.text)):
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": piece}})
+    if reply.buttons:
+        ordered = sorted(reply.buttons, key=lambda b: 0 if _is_nav(b[0]) else 1)
+        blocks.append(
+            {"type": "actions", "elements": [_button(label, aid) for label, aid in ordered]}
+        )
+    if reply.footer:
+        blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": reply.footer}]})
+    return blocks
+
+
+def _pairs(raw: Any) -> list[tuple[str, str]]:
+    """Coerce a JSON list of [k, v] pairs to tuples, dropping malformed entries."""
+    out: list[tuple[str, str]] = []
+    if isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, list | tuple) and len(item) == 2:
+                out.append((str(item[0]), str(item[1])))
+    return out
+
+
+def parse_reply(text: str) -> Reply | None:
+    """A ``Reply`` if ``text`` contains a complete, valid ``agentos-reply`` block,
+    else None. Defensive: any parse/shape error returns None so the caller falls
+    back to plain text rather than surfacing a broken reply."""
+    match = _FENCE.search(text)
+    if match is None:
+        return None
+    try:
+        data = json.loads(match.group(1))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    header = data.get("header")
+    footer = data.get("footer")
+    return Reply(
+        text=str(data.get("text", "")),
+        header=str(header) if header is not None else None,
+        fields=_pairs(data.get("fields")),
+        buttons=_pairs(data.get("buttons")),
+        footer=str(footer) if footer is not None else None,
+    )
+
+
+def render(text: str) -> tuple[str, list[dict[str, Any]] | None]:
+    """Map an outbound reply string to ``(text, blocks)`` for ``chat.update``.
+
+    - A complete ``agentos-reply`` block -> (plain fallback text, blocks).
+    - A half-streamed block (fence opened, not closed) -> (text before the fence,
+      None), so streaming never shows raw JSON.
+    - Anything else -> (mrkdwn text, None), the existing plain path.
+    """
+    reply = parse_reply(text)
+    if reply is not None:
+        return (to_mrkdwn(reply.text) or "(reply)", to_blocks(reply))
+    open_at = text.find(_FENCE_OPEN)
+    if open_at != -1:
+        prefix = text[:open_at].strip()
+        return (to_mrkdwn(prefix) if prefix else "…", None)
+    return (to_mrkdwn(text), None)

--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -13,7 +13,7 @@ from typing import Protocol
 
 from slack_sdk.web.async_client import AsyncWebClient
 
-from .mrkdwn import to_mrkdwn
+from .blocks import render
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +44,18 @@ class AsyncSlackSink:
             self._client = AsyncWebClient(token=token)
 
     async def update(self, *, channel: str, ts: str, text: str) -> None:
-        # The runner emits Markdown; Slack renders mrkdwn. Convert here, at the
-        # real-Slack seam, so both streamed partials and the final edit render
-        # correctly without the kernel knowing about Slack's dialect.
-        await self._client.chat_update(channel=channel, ts=ts, text=to_mrkdwn(text))
+        # The runner emits Markdown; Slack renders mrkdwn. ``render`` converts to
+        # mrkdwn and, if the reply carries a complete ``agentos-reply`` block,
+        # returns Block Kit to render instead -- keeping this dialect/structure
+        # knowledge at the real-Slack seam, out of the kernel. A half-streamed or
+        # malformed block falls back to text, so partials never show raw JSON.
+        rendered_text, blocks = render(text)
+        if blocks is not None:
+            await self._client.chat_update(
+                channel=channel, ts=ts, text=rendered_text, blocks=blocks
+            )
+        else:
+            await self._client.chat_update(channel=channel, ts=ts, text=rendered_text)
 
     async def clear_status(self, *, channel: str, thread_ts: str) -> None:
         # Clear the assistant-thread status by setting it empty (Slack only

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -1,0 +1,78 @@
+"""Structured-reply rendering + the agentos-reply parsing convention (pure)."""
+
+from __future__ import annotations
+
+from agentos_worker.blocks import Reply, chunk, parse_reply, render, to_blocks
+
+_BLOCK = """Here you go:
+
+```agentos-reply
+{"header": "Top leaks", "text": "**3** open", "fields": [["Open", "3"]],
+ "buttons": [["Details", "details"], ["← Back", "home"]], "footer": "now"}
+```"""
+
+
+def _types(blocks: list[dict]) -> list[str]:
+    return [b["type"] for b in blocks]
+
+
+def test_to_blocks_orders_and_renders_parts() -> None:
+    reply = Reply(
+        text="body",
+        header="Title",
+        fields=[("A", "1")],
+        buttons=[("Go", "go")],
+        footer="foot",
+    )
+    assert _types(to_blocks(reply)) == ["header", "section", "section", "actions", "context"]
+
+
+def test_to_blocks_sorts_nav_buttons_leftmost() -> None:
+    reply = Reply(text="x", buttons=[("Details", "details"), ("← Back", "home")])
+    actions = next(b for b in to_blocks(reply) if b["type"] == "actions")
+    labels = [e["text"]["text"] for e in actions["elements"]]
+    assert labels == ["← Back", "Details"]  # nav sorted to the front
+
+
+def test_chunk_splits_long_text_under_limit() -> None:
+    pieces = chunk("x" * 7000, limit=2900)
+    assert all(len(p) <= 2900 for p in pieces)
+    assert "".join(pieces) == "x" * 7000
+
+
+def test_parse_reply_extracts_a_complete_block() -> None:
+    reply = parse_reply(_BLOCK)
+    assert reply is not None
+    assert reply.header == "Top leaks"
+    assert reply.fields == [("Open", "3")]
+    assert ("← Back", "home") in reply.buttons
+
+
+def test_parse_reply_none_without_a_block() -> None:
+    assert parse_reply("just a normal answer") is None
+
+
+def test_parse_reply_defensive_on_bad_json() -> None:
+    assert parse_reply("```agentos-reply\n{not json}\n```") is None
+
+
+def test_render_complete_block_returns_blocks() -> None:
+    text, blocks = render(_BLOCK)
+    assert blocks is not None
+    assert _types(blocks)[0] == "header"
+    assert "raw" not in text.lower()  # fallback text is the reply body, not JSON
+
+
+def test_render_hides_half_streamed_block() -> None:
+    # Fence opened mid-stream, not yet closed: never show the raw JSON.
+    partial = "Working...\n```agentos-reply\n{\"header\": \"T"
+    text, blocks = render(partial)
+    assert blocks is None
+    assert "agentos-reply" not in text
+    assert text.startswith("Working")
+
+
+def test_render_plain_text_is_mrkdwn() -> None:
+    text, blocks = render("**hi** [x](http://y)")
+    assert blocks is None
+    assert text == "*hi* <http://y|x>"

--- a/apps/worker/tests/test_slack_sink.py
+++ b/apps/worker/tests/test_slack_sink.py
@@ -36,6 +36,24 @@ def test_update_converts_markdown_to_mrkdwn() -> None:
     asyncio.run(sink.update(channel="C1", ts="1.1", text="**hi** [x](http://y)"))
 
     assert captured["text"] == "*hi* <http://y|x>"
+    assert "blocks" not in captured  # plain text path passes no blocks
+
+
+def test_update_renders_blocks_for_a_reply_convention() -> None:
+    sink = AsyncSlackSink("xoxb-test")
+    captured: dict[str, object] = {}
+
+    async def _fake_chat_update(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    sink._client.chat_update = _fake_chat_update  # type: ignore[method-assign]
+
+    text = '```agentos-reply\n{"header": "Hi", "text": "body"}\n```'
+    asyncio.run(sink.update(channel="C1", ts="1.1", text=text))
+
+    assert isinstance(captured.get("blocks"), list)
+    assert captured["blocks"][0]["type"] == "header"  # type: ignore[index]
+    assert captured["text"] == "body"  # accessibility fallback, not raw JSON
 
 
 def test_clear_status_sets_empty_assistant_status() -> None:


### PR DESCRIPTION
## What

Ports the ss-template's Block Kit rendering to AgentOS as a platform capability. AgentOS replies are **text-only** today (`chat.update` with mrkdwn — no header, fields, sections, or buttons). This lets a plugin emit a richer reply by ending its answer with a fenced block:

```
` ``agentos-reply
{"header": "Top leaks", "text": "**3** open", "fields": [["Open","3"]], "footer": "as of today"}
` ``
```

and the `SlackSink` renders it as Block Kit (header → fields → chunked body sections under Slack's 3000-char cap → buttons → footer).

## Why this way (no frozen-contract change)

The rich-reply value doesn't require extending the frozen ACI event union. The structure rides the existing text channel as a convention, and all Slack knowledge stays at the `SlackSink` seam:

- A **complete, valid** `agentos-reply` block → rendered as blocks.
- A **half-streamed** block (fence opened, not closed) → falls back to the text *before* the fence, so streaming partials never flash raw JSON.
- A **malformed** block → falls back to plain text; a bad block degrades, never breaks.

## Changes (worker-only)

- `apps/worker/blocks.py` — `Reply`, `to_blocks` (ported from `agent-ss-template/blocks.py`, reusing this package's `mrkdwn.to_mrkdwn`), and a defensive `parse_reply` / `render`.
- `apps/worker/slack_sink.py` — `render()` at the seam; passes `blocks=` to `chat.update` when present, else the existing text path unchanged.

## Scope / follow-up

Buttons **render** (nav-leftmost ordering preserved) but become **interactive** only once the dispatcher handles `block_actions` clicks — that's the next PR (a button click enqueues a turn, which also brings the `nav.py` back/home navigation). This PR is the rendering half: standalone value for structured, non-interactive replies.

## Verification

`ruff check` clean, `mypy` clean (94 files), worker unit tests green (**14**: `to_blocks` ordering + nav sort, chunking, `parse_reply` valid/absent/malformed, `render` complete/half-streamed/plain, and the sink blocks-vs-text paths).

Ref CUR-1592