### PR TITLE
Add opt-in local-model demo mode (bundled Ollama, Qwen3 4B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,44 @@ and set `AGENTOS_FAKE_MODEL=0` in the compose environment. The manual runbook
 below is the equivalent with a host-process worker, useful when iterating on the
 worker itself from source. The console UI is served at `http://localhost:28080/?api=1`; open it to reach the console wired to your local compose API.
 
+**Local-model demo mode** is an opt-in offline path that runs a real local model
+through an Anthropic-compatible endpoint, so the demo answers for real and can
+drive a 1-2 tool-call loop with no Anthropic key. This is a DEMO / dev-loop path,
+NOT the production agent path. The fake model stays the zero-dependency default.
+
+For compose, start the local model profile and let the worker pass the endpoint
+into spawned runner containers:
+
+```bash
+COMPOSE_PROFILES=local-model AGENTOS_FAKE_MODEL=0 AGENTOS_MODEL_BASE_URL=http://ollama:11434 AGENTOS_MODEL=qwen3:4b AGENTOS_DOCKER_NETWORK=agentos_default docker compose -f compose.dev.yaml up -d --wait
+```
+
+`AGENTOS_DOCKER_NETWORK=agentos_default` puts each spawned runner container on
+the compose network so it resolves `ollama` by name, the same requirement the
+OTel trace path has for `otel-collector`.
+
+For a cluster demo, enable the in-cluster endpoint:
+
+```bash
+helm upgrade --install agentos charts/agentos --set inference.deploy=true
+```
+
+The chart renders the Ollama Service and Deployment, opens the runner egress
+carve-out automatically, and bakes `ANTHROPIC_BASE_URL` plus the inference model
+into the runner template.
+
+| Model | Loaded (Q4) | Min box | Notes |
+|---|---|---|---|
+| qwen3:4b | ~2.5GB | 8GB | demo default; clears the 1-2 tool-call bar |
+| qwen3-coder:30b | ~17-19GB | 32GB | MoE 30B/3.3B-active; real agentic-coding upgrade |
+| gemma4:e4b | ~5GB | 16GB | "4.5B effective" name understates RAM; needs Ollama >=0.31.x |
+
+Gotchas: Ollama 0.24.0 fails `gemma4` with `unknown model architecture`; qwen3
+works on 0.24.0 and gemma4 needs >=0.31.x. Gemma HF repos are gated and return
+HTTP 400 on `hf.co/google/...`; use a non-gated mirror such as
+`hf.co/unsloth/gemma-4-E4B-it-GGUF:<quant>`. RAM sizing tracks the loaded
+footprint, not the "effective params" marketing number.
+
 `agentos local up` publishes the API on `:28000` (the compose host port); the
 hand-run `uvicorn` in Quickstart step 4 uses `:8000`. Point `deploy --api-url`
 at whichever one you brought up.

--- a/README.md
+++ b/README.md
@@ -208,24 +208,27 @@ through an Anthropic-compatible endpoint, so the demo answers for real and can
 drive a 1-2 tool-call loop with no Anthropic key. This is a DEMO / dev-loop path,
 NOT the production agent path. The fake model stays the zero-dependency default.
 
-For compose, start the local model profile and let the worker pass the endpoint
-into spawned runner containers:
+Use one flag on the CLI surface you are running:
 
 ```bash
-COMPOSE_PROFILES=local-model AGENTOS_FAKE_MODEL=0 AGENTOS_MODEL_BASE_URL=http://ollama:11434 AGENTOS_MODEL=qwen3:4b AGENTOS_DOCKER_NETWORK=agentos_default docker compose -f compose.dev.yaml up -d --wait
+agentos skill up --local-model
+agentos local up --local-model
+agentos cluster up --local-model
 ```
 
-`AGENTOS_DOCKER_NETWORK=agentos_default` puts each spawned runner container on
-the compose network so it resolves `ollama` by name, the same requirement the
-OTel trace path has for `otel-collector`.
-
-For a cluster demo, enable the in-cluster endpoint:
+Bare `--local-model` uses `qwen3:4b`. Override it by passing a model name:
 
 ```bash
-helm upgrade --install agentos charts/agentos --set inference.deploy=true
+agentos local up --local-model qwen3-coder:30b
 ```
 
-The chart renders the Ollama Service and Deployment, opens the runner egress
+`skill up` and `local up` run the model in a Docker container and point spawned
+runners at that endpoint. Both the `skill up --local-model` and compose paths
+persist the pulled model in a Docker volume, so a re-up is fast and does not
+re-download the model; the skill-path volume is named `<container>-ollama-data`
+(the compose path uses `ollama_data`) and can be reclaimed with
+`docker volume rm <volume>`. `cluster up` uses the in-chart inference Deployment;
+the chart renders the Ollama Service and Deployment, opens the runner egress
 carve-out automatically, and bakes `ANTHROPIC_BASE_URL` plus the inference model
 into the runner template.
 

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -48,6 +48,8 @@ SESSION_ID_ENV = "AGENTOS_SESSION_ID"
 AGENT_ID_ENV = "AGENTOS_AGENT_ID"
 FAKE_MODEL_ENV = "AGENTOS_FAKE_MODEL"
 CREDENTIALS_ENV = "AGENTOS_CREDENTIALS"
+BASE_URL_ENV = "ANTHROPIC_BASE_URL"
+MODEL_ENV = "AGENTOS_MODEL"
 
 _RESOLVE_SQL = """
 SELECT a.id AS agent_id,
@@ -157,9 +159,15 @@ def apply_model_env(env: dict[str, str], config: WorkerConfig) -> None:
 
     Shared by the runs binding and the eval consumer so both lanes boot the
     runner the same way: fake_model gates the canned model (no credential
-    needed); credentials is forwarded only when set and never logged.
+    needed); credentials is forwarded only when set and never logged. The local
+    model demo path injects a generic Anthropic-compatible base URL and optional
+    model while leaving fake_model unset.
     """
     if config.fake_model:
         env[FAKE_MODEL_ENV] = "1"
     if config.credentials:
         env[CREDENTIALS_ENV] = config.credentials
+    if config.model_base_url:
+        env[BASE_URL_ENV] = config.model_base_url
+        if config.model:
+            env[MODEL_ENV] = config.model

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -58,6 +58,10 @@ class WorkerConfig(BaseModel):
     # model call; it is never logged and never required when fake_model is on.
     fake_model: bool = False
     credentials: str = ""
+    # Local model demo path: the worker can point the runner at an
+    # Anthropic-compatible local endpoint without changing the fake-model default.
+    model_base_url: str = ""
+    model: str = ""
 
     # Stream / consumer group (must match the dispatcher's AGENTOS_STREAM)
     stream: str = "agentos:runs"
@@ -166,6 +170,8 @@ class WorkerConfig(BaseModel):
         _s(values, "bundle_plugin_dir", env, "AGENTOS_PLUGIN_DIR")
         _b(values, "fake_model", env, "AGENTOS_FAKE_MODEL")
         _s(values, "credentials", env, "AGENTOS_CREDENTIALS")
+        _s(values, "model_base_url", env, "AGENTOS_MODEL_BASE_URL")
+        _s(values, "model", env, "AGENTOS_MODEL")
         _s(values, "eval_stream", env, "AGENTOS_EVAL_STREAM")
         _s(values, "eval_consumer_group", env, "AGENTOS_EVAL_CONSUMER_GROUP")
         _s(values, "s3_endpoint_url", env, "S3_ENDPOINT_URL")

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -88,10 +88,11 @@ def _sandbox_client(
     shares the substrate this client backs, so the choice applies to both lanes.
 
     Local middle mode defaults to a REAL model. Fake model is an explicit
-    offline/test opt-in, so a Docker worker with neither a model credential nor
-    ``AGENTOS_FAKE_MODEL`` fails loudly here rather than booting a real runner
-    that would fail cryptically or silently degrading to a fake. A credential can
-    be an SDK var (``CLAUDE_CODE_OAUTH_TOKEN`` / ``ANTHROPIC_API_KEY``) or the ACI
+    offline/test opt-in, so a Docker worker with neither a model credential,
+    ``AGENTOS_MODEL_BASE_URL``, nor ``AGENTOS_FAKE_MODEL`` fails loudly here
+    rather than booting a real runner that would fail cryptically or silently
+    degrading to a fake. A credential can be an SDK var
+    (``CLAUDE_CODE_OAUTH_TOKEN`` / ``ANTHROPIC_API_KEY``) or the ACI
     ``AGENTOS_CREDENTIALS`` reference, which the runner maps onto an SDK var.
     """
     substrate = env.get("AGENTOS_SANDBOX_SUBSTRATE", "kubernetes").lower()
@@ -99,12 +100,14 @@ def _sandbox_client(
         has_credential = bool(config.credentials) or any(
             v in env for v in _MODEL_CREDENTIAL_ENV
         )
-        if not config.fake_model and not has_credential:
+        has_local_model = bool(config.model_base_url)
+        if not config.fake_model and not has_credential and not has_local_model:
             raise SystemExit(
                 "Local middle mode (AGENTOS_SANDBOX_SUBSTRATE=docker) defaults to a "
                 "real model, but no model credential is set. Export "
                 "AGENTOS_CREDENTIALS, CLAUDE_CODE_OAUTH_TOKEN, or ANTHROPIC_API_KEY "
-                "before starting the worker, or set AGENTOS_FAKE_MODEL=1 for an "
+                "before starting the worker, set AGENTOS_MODEL_BASE_URL to a local "
+                "endpoint for local-model mode, or set AGENTOS_FAKE_MODEL=1 for an "
                 "offline/test run."
             )
         return DockerSandboxClient(

--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -265,6 +265,16 @@ class DockerSandboxClient:
         tmp = tempfile.mkdtemp(prefix="agentos-bundle-")
         try:
             root = extract_bundle(data, Path(tmp))
+            # The mount is read-only and the runner is non-root (uid 1000), so the
+            # staged bundle must be group/other readable+traversable; mkdtemp
+            # defaults to 0700, which the non-root runner cannot enter.
+            os.chmod(tmp, 0o755)
+            for dirpath, dirnames, filenames in os.walk(tmp):
+                for d in dirnames:
+                    os.chmod(os.path.join(dirpath, d), 0o755)
+                for f in filenames:
+                    p = os.path.join(dirpath, f)
+                    os.chmod(p, os.stat(p).st_mode | 0o044)
         except Exception:
             shutil.rmtree(tmp, ignore_errors=True)
             raise

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import uuid
 
 from agentos_worker.binding import (
+    BASE_URL_ENV,
     CREDENTIALS_ENV,
     FAKE_MODEL_ENV,
+    MODEL_ENV,
     BindingResolver,
     ResolvedDeployment,
     apply_model_env,
@@ -43,6 +45,51 @@ def test_apply_model_env_omits_both_when_unset() -> None:
     apply_model_env(env, WorkerConfig())  # defaults: fake_model=False, credentials=""
     assert FAKE_MODEL_ENV not in env
     assert CREDENTIALS_ENV not in env
+
+
+def test_apply_model_env_forwards_base_url_and_model_without_fake_flag() -> None:
+    base_url_env, model_env = BASE_URL_ENV, MODEL_ENV
+    assert base_url_env == "ANTHROPIC_BASE_URL"
+    assert model_env == "AGENTOS_MODEL"
+
+    env: dict[str, str] = {}
+    apply_model_env(
+        env,
+        WorkerConfig(model_base_url="http://ollama:11434", model="qwen3:4b"),
+    )
+
+    assert env[base_url_env] == "http://ollama:11434"
+    assert env[model_env] == "qwen3:4b"
+    assert FAKE_MODEL_ENV not in env
+
+
+def test_apply_model_env_forwards_base_url_without_model() -> None:
+    base_url_env, model_env = BASE_URL_ENV, MODEL_ENV
+
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig(model_base_url="http://ollama:11434"))
+
+    assert env[base_url_env] == "http://ollama:11434"
+    assert model_env not in env
+
+
+def test_apply_model_env_omits_base_url_and_model_by_default() -> None:
+    base_url_env, model_env = BASE_URL_ENV, MODEL_ENV
+
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig())
+
+    assert base_url_env not in env
+    assert model_env not in env
+
+
+def test_worker_config_reads_local_model_env() -> None:
+    config = WorkerConfig.from_env(
+        {"AGENTOS_MODEL_BASE_URL": "http://x:1", "AGENTOS_MODEL": "qwen3:4b"}
+    )
+
+    assert config.model_base_url == "http://x:1"
+    assert config.model == "qwen3:4b"
 
 
 def test_binding_boot_env_carries_fake_and_credentials() -> None:

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -195,6 +195,22 @@ def test_get_sandbox_treats_dead_container_as_gone() -> None:
         assert client.get_sandbox("t1") is None, dead
 
 
+def test_prepare_bundle_is_readable_by_nonroot_runner() -> None:
+    # The staged bundle is bind-mounted :ro into a runner running as uid 1000, so
+    # the tree must be group/other traversable+readable. mkdtemp defaults to 0700,
+    # which the non-root runner cannot enter -- _prepare_bundle must widen it.
+    client = _RecordingDocker(
+        image="agentos-runner", bundle_store=_FakeBundleStore(_plugin_tar_gz(wrapper=None))
+    )
+    root = Path(client._prepare_bundle("t1", "bundles/b.tar.gz"))
+    nested_dir = root / ".claude-plugin"
+    nested_file = nested_dir / "plugin.json"
+
+    assert root.stat().st_mode & 0o005 == 0o005  # root dir: o+rx
+    assert nested_dir.stat().st_mode & 0o005 == 0o005  # nested dir: o+rx
+    assert nested_file.stat().st_mode & 0o004 == 0o004  # nested file: o+r
+
+
 def test_extract_bundle_unwraps_single_wrapper_dir() -> None:
     import tempfile
 

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -67,6 +67,15 @@ def test_docker_with_agentos_credentials_reference_builds_docker_client() -> Non
     assert isinstance(client, DockerSandboxClient)
 
 
+def test_docker_with_model_base_url_builds_docker_client_without_credential() -> None:
+    client = _sandbox_client(
+        WorkerConfig(model_base_url="http://ollama:11434"),
+        {"AGENTOS_SANDBOX_SUBSTRATE": "docker"},
+        _SUB,
+    )
+    assert isinstance(client, DockerSandboxClient)
+
+
 def test_docker_with_explicit_fake_model_builds_docker_client() -> None:
     client = _sandbox_client(
         WorkerConfig(fake_model=True), {"AGENTOS_SANDBOX_SUBSTRATE": "docker"}, _SUB

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -202,11 +202,18 @@ spec:
             - name: HOME
               value: {{ $runner.hardening.home | quote }}
             {{- end }}
-            {{- if $runner.fakeModel }}
+            {{- if and $runner.fakeModel (not .Values.inference.deploy) }}
             - name: AGENTOS_FAKE_MODEL
               value: "1"
             {{- end }}
-            {{- if $runner.model }}
+            {{- if .Values.inference.deploy }}
+            # Local inference is baked into the warm template so claims keep the
+            # fast bind path while the runner targets the in-cluster endpoint.
+            - name: ANTHROPIC_BASE_URL
+              value: http://{{ include "agentos.fullname" . }}-inference:{{ .Values.inference.service.port }}
+            - name: AGENTOS_MODEL
+              value: {{ .Values.inference.model | quote }}
+            {{- else if $runner.model }}
             # Default model for real runs, baked into the pod template (not
             # per-claim). Per-claim injection would force a cold create
             # (envVarsInjectionPolicy Overrides), so baking it keeps warm-pool

--- a/charts/agentos/templates/inference.yaml
+++ b/charts/agentos/templates/inference.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.inference.deploy }}
+{{- if .Values.inference.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agentos.fullname" . }}-inference
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: inference
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.inference.persistence.size }}
+---
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentos.fullname" . }}-inference
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: inference
+spec:
+  selector:
+    {{- include "agentos.selectorLabels" (dict "root" . "component" "inference") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.inference.service.port }}
+      targetPort: {{ .Values.inference.port }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentos.fullname" . }}-inference
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: inference
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "agentos.selectorLabels" (dict "root" . "component" "inference") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "agentos.labels" . | nindent 8 }}
+        {{- include "agentos.selectorLabels" (dict "root" . "component" "inference") | nindent 8 }}
+    spec:
+      volumes:
+        - name: ollama-data
+          {{- if .Values.inference.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "agentos.fullname" . }}-inference
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      containers:
+        - name: ollama
+          image: {{ .Values.inference.image | quote }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.inference.port }}
+          {{- if .Values.inference.pullModel }}
+          # Pull after the server process starts, since `ollama pull` needs the
+          # local API to be accepting requests inside the same container.
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    set -eu
+                    for i in $(seq 1 60); do
+                      if ollama list >/dev/null 2>&1; then
+                        ollama pull {{ .Values.inference.model | quote }}
+                        exit 0
+                      fi
+                      sleep 2
+                    done
+                    exit 1
+          {{- end }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.inference.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 12
+          resources:
+            {{- toYaml .Values.inference.resources | nindent 12 }}
+          volumeMounts:
+            - name: ollama-data
+              mountPath: /root/.ollama
+{{- end }}

--- a/charts/agentos/templates/security-networkpolicy.yaml
+++ b/charts/agentos/templates/security-networkpolicy.yaml
@@ -115,6 +115,34 @@ spec:
       ports:
         - { protocol: TCP, port: 9000 }
 {{- end }}
+{{- if .Values.inference.deploy }}
+---
+{{/* Allow the runner to reach THIS release's in-cluster inference endpoint.
+     Keeping it as a pod carve-out preserves the external egress allowlist's
+     fail-closed default. */}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "agentos.fullname" . }}-runner-allow-inference
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "agentos.selectorLabels" (dict "root" . "component" "runner-sandbox") | nindent 6 }}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector:
+            matchLabels:
+              {{- include "agentos.selectorLabels" (dict "root" . "component" "inference") | nindent 14 }}
+      ports:
+        - { protocol: TCP, port: {{ .Values.inference.port }} }
+{{- end }}
 {{- if $np.allowedEgress }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/charts/agentos/templates/worker.yaml
+++ b/charts/agentos/templates/worker.yaml
@@ -101,8 +101,9 @@ spec:
             # Runner model passthrough: the worker injects these into every claim
             # (fake model needs no credential; a real credential comes from the
             # chart Secret and is only wired when one is configured).
+            {{- $claimFakeModel := and .Values.agentSandbox.runner.fakeModel (not .Values.inference.deploy) }}
             - name: AGENTOS_FAKE_MODEL
-              value: {{ ternary "1" "0" .Values.agentSandbox.runner.fakeModel | quote }}
+              value: {{ ternary "1" "0" $claimFakeModel | quote }}
             {{- if .Values.agentSandbox.runner.credentials }}
             - name: AGENTOS_CREDENTIALS
               valueFrom:

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -207,6 +207,23 @@ minio:
     limits: { cpu: 500m, memory: 512Mi }
 
 # ---------------------------------------------------------------------------
+# Local inference endpoint for demo clusters. Opt in only: fake model stays the
+# default, and production agent paths should use the external model allowlist.
+# ---------------------------------------------------------------------------
+inference:
+  deploy: false
+  image: ollama/ollama:0.24.0
+  model: qwen3:4b
+  port: 11434
+  pullModel: true
+  persistence:
+    enabled: false
+    size: 10Gi
+  resources: {}
+  service:
+    port: 11434
+
+# ---------------------------------------------------------------------------
 # OTel Collector. Receives OTLP (gRPC 4317 / HTTP 4318) from app services and
 # forwards to Langfuse over HTTP (Langfuse's OTLP ingest is HTTP-only). Deploy
 # false to send app traces to an external collector.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -22,6 +22,9 @@ use crate::state::{self, RunnerState};
 
 pub const DEFAULT_PORT: u16 = 7245; // the design canon's local bot port
 pub const DEFAULT_BUDGET: &str = r#"{"max_output_tokens_per_run":100000,"max_usd_per_day":5.0}"#;
+pub const DEFAULT_LOCAL_MODEL: &str = "qwen3:4b";
+pub const DEFAULT_OLLAMA_IMAGE: &str = "ollama/ollama:0.24.0";
+pub const OLLAMA_PORT: u16 = 11434;
 
 #[derive(Clone, Copy, ValueEnum)]
 pub enum SendType {
@@ -66,6 +69,7 @@ pub struct StartOpts {
     pub otel_endpoint: Option<String>,
     pub budget: String,
     pub model: Option<String>,
+    pub local_model: Option<String>,
 }
 
 pub fn init(name: &str, dir: Option<PathBuf>) -> Result<()> {
@@ -92,6 +96,13 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     // it at boot anyway (real-model mode), with a worse error surface.
     let (plugin_name, manifest_version) = read_manifest(&plugin_dir)?;
 
+    if opts.local_model.is_some() && opts.fake_model {
+        bail!("--local-model cannot be combined with --fake-model");
+    }
+    if opts.local_model.is_some() && opts.model.is_some() {
+        bail!("--local-model cannot be combined with --model");
+    }
+
     if state::load(&plugin_dir)?.is_some() {
         bail!(
             "a local runner is already recorded in {}/.agentos/runner.json; run 'agentos skill down' there first",
@@ -104,6 +115,53 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         .with_context(|| format!("--budget is not a valid ACI budget: {}", opts.budget))?;
 
     let session_id = format!("local-{}", unix_now());
+    let mut network = opts.network.clone();
+    let mut owned_network: Option<String> = None;
+    let mut ollama_container: Option<String> = None;
+    let mut model_base_url: Option<String> = None;
+    let mut model = opts.model.clone();
+
+    if let Some(local_model) = &opts.local_model {
+        let (net, owned) = match &opts.network {
+            Some(net) => (net.clone(), false),
+            None => (format!("{}-net", opts.name), true),
+        };
+        if owned {
+            // Only claim ownership (and teardown responsibility) when this call
+            // actually created the network; a pre-existing one is not ours to rm.
+            let created = docker::create_network(&net).await?;
+            if created {
+                owned_network = Some(net.clone());
+            }
+        }
+        let ollama = format!("{}-ollama", opts.name);
+        if let Err(err) = docker::run_ollama(&ollama, &net, DEFAULT_OLLAMA_IMAGE).await {
+            if let Some(net) = &owned_network {
+                let _ = docker::remove_network(net).await;
+            }
+            return Err(err.context("starting local model container"));
+        }
+        if let Err(err) = docker::wait_ollama_ready(&ollama, Duration::from_secs(120)).await {
+            let _ = docker::remove_container(&ollama).await;
+            if let Some(net) = &owned_network {
+                let _ = docker::remove_network(net).await;
+            }
+            return Err(err.context("waiting for local model container"));
+        }
+        if let Err(err) = docker::pull_model(&ollama, local_model).await {
+            let _ = docker::remove_container(&ollama).await;
+            if let Some(net) = &owned_network {
+                let _ = docker::remove_network(net).await;
+            }
+            return Err(err.context("pulling local model"));
+        }
+        let url = format!("http://{ollama}:{OLLAMA_PORT}");
+        network = Some(net);
+        ollama_container = Some(ollama);
+        model_base_url = Some(url);
+        model = Some(local_model.clone());
+    }
+
     let spec = StartSpec {
         image: opts.image.clone(),
         container_name: opts.name.clone(),
@@ -112,10 +170,11 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         session_id: session_id.clone(),
         sandbox_id: "local".into(),
         budget_json: opts.budget,
-        fake_model: opts.fake_model,
-        network: opts.network,
+        fake_model: opts.local_model.is_none() && opts.fake_model,
+        network,
         otel_endpoint: opts.otel_endpoint,
-        model: opts.model,
+        model_base_url: model_base_url.clone(),
+        model,
         passthrough_env: vec!["CLAUDE_CODE_OAUTH_TOKEN".into(), "ANTHROPIC_API_KEY".into()],
     };
 
@@ -124,7 +183,18 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         "starting runner container '{}' from '{}'",
         opts.name, opts.image
     ));
-    let container_id = docker::docker(&spec.run_args()).await?;
+    let container_id = match docker::docker(&spec.run_args()).await {
+        Ok(id) => id,
+        Err(err) => {
+            if let Some(ollama) = &ollama_container {
+                let _ = docker::remove_container(ollama).await;
+            }
+            if let Some(net) = &owned_network {
+                let _ = docker::remove_network(net).await;
+            }
+            return Err(err.context("starting runner container"));
+        }
+    };
 
     let base_url = format!("http://localhost:{}", opts.port);
     let client = RunnerClient::new(&base_url)?;
@@ -135,6 +205,12 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         let logs = docker::container_logs(&opts.name, 40).await;
         ui.note(&logs);
         let _ = docker::remove_container(&opts.name).await;
+        if let Some(ollama) = &ollama_container {
+            let _ = docker::remove_container(ollama).await;
+        }
+        if let Some(net) = &owned_network {
+            let _ = docker::remove_network(net).await;
+        }
         ui.failure(&format!("runner failed to become healthy: {err}"));
         bail!("runner failed to become healthy: {err}");
     }
@@ -155,9 +231,18 @@ pub async fn start(opts: StartOpts) -> Result<()> {
             session_id,
             plugin_dir: plugin_dir.display().to_string(),
             fake_model: opts.fake_model,
+            ollama_container: ollama_container.clone(),
+            network: owned_network.clone(),
+            model_base_url: model_base_url.clone(),
         },
     ) {
         let _ = docker::remove_container(&opts.name).await;
+        if let Some(ollama) = &ollama_container {
+            let _ = docker::remove_container(ollama).await;
+        }
+        if let Some(net) = &owned_network {
+            let _ = docker::remove_network(net).await;
+        }
         return Err(err.context("recording runner state (container removed again)"));
     }
 
@@ -175,6 +260,14 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         ("Version", version),
     ];
     ui.payload_plain(&boxed_summary("agentos dev environment", &rows));
+    if let Some(local_model) = &opts.local_model {
+        ui.note(&format!(
+            "local model running in container '{}' from '{}' with model '{}'",
+            ollama_container.as_deref().unwrap_or("unknown"),
+            DEFAULT_OLLAMA_IMAGE,
+            local_model
+        ));
+    }
     let cwd = Path::new(".").canonicalize()?;
     if cwd != plugin_dir {
         ui.note(&format!(
@@ -205,6 +298,31 @@ pub async fn stop() -> Result<()> {
             ));
         }
         Err(err) => return Err(err),
+    }
+    if let Some(ollama) = &saved.ollama_container {
+        match docker::remove_container(ollama).await {
+            Ok(()) => ui.success(&format!("stopped and removed container '{ollama}'")),
+            Err(err) if err.to_string().contains("No such container") => {
+                ui.note(&format!("container '{ollama}' was already gone"));
+            }
+            Err(err) => ui.warn(&format!("could not remove container '{ollama}': {err}")),
+        }
+        // Keep the model-cache volume so the next `skill up` reuses the pulled
+        // model instead of re-downloading it (mirrors compose `down` keeping
+        // `ollama_data`). Removal is left to the user.
+        let volume = docker::ollama_volume(ollama);
+        ui.note(&format!(
+            "kept model-cache volume '{volume}' for fast re-up; remove it with 'docker volume rm {volume}'"
+        ));
+    }
+    if let Some(net) = &saved.network {
+        match docker::remove_network(net).await {
+            Ok(()) => ui.success(&format!("removed network '{net}'")),
+            Err(err) if err.to_string().contains("No such network") => {
+                ui.note(&format!("network '{net}' was already gone"));
+            }
+            Err(err) => ui.warn(&format!("could not remove network '{net}': {err}")),
+        }
     }
     state::remove(dir)?;
     Ok(())

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -6,6 +6,7 @@
 //! laptop that already has Docker if it can run the runner at all.
 
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
 use tokio::process::Command;
@@ -23,6 +24,7 @@ pub struct StartSpec {
     pub fake_model: bool,
     pub network: Option<String>,
     pub otel_endpoint: Option<String>,
+    pub model_base_url: Option<String>,
     /// Model id forwarded as `AGENTOS_MODEL`; `None` leaves the runner on its
     /// SDK default.
     pub model: Option<String>,
@@ -60,6 +62,10 @@ impl StartSpec {
             args.push("-e".into());
             args.push(format!("AGENTOS_MODEL={model}"));
         }
+        if let Some(url) = &self.model_base_url {
+            args.push("-e".into());
+            args.push(format!("ANTHROPIC_BASE_URL={url}"));
+        }
         if let Some(network) = &self.network {
             args.push("--network".into());
             args.push(network.clone());
@@ -95,6 +101,97 @@ pub async fn docker(args: &[String]) -> Result<String> {
         );
     }
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Create a docker network. Returns `Ok(true)` when this call created it and
+/// `Ok(false)` when the network already existed, so the caller only claims
+/// ownership (and thus teardown responsibility) for networks it actually made.
+pub async fn create_network(name: &str) -> Result<bool> {
+    let output = Command::new("docker")
+        .args(["network", "create", name])
+        .output()
+        .await
+        .context("failed to invoke docker; is Docker installed and on PATH?")?;
+    if output.status.success() {
+        return Ok(true);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("already exists") {
+        return Ok(false);
+    }
+    bail!(
+        "docker network create failed ({}): {}",
+        output.status,
+        stderr.trim()
+    )
+}
+
+pub async fn remove_network(name: &str) -> Result<()> {
+    docker(&["network".into(), "rm".into(), name.to_string()])
+        .await
+        .map(|_| ())
+}
+
+/// The named volume that persists an ollama container's model cache
+/// (`/root/.ollama`) across `skill down`/`skill up`, so a repeat demo reuses
+/// the pulled model instead of re-downloading it.
+pub fn ollama_volume(container: &str) -> String {
+    format!("{container}-data")
+}
+
+/// The `docker run` argument vector (after the `docker` executable) that boots
+/// the ollama container. A named volume for `/root/.ollama` keeps the pulled
+/// model cached across teardown; Docker auto-creates it on first use.
+pub fn ollama_run_args(container: &str, network: &str, image: &str) -> Vec<String> {
+    vec![
+        "run".into(),
+        "-d".into(),
+        "--name".into(),
+        container.to_string(),
+        "--network".into(),
+        network.to_string(),
+        "-v".into(),
+        format!("{}:/root/.ollama", ollama_volume(container)),
+        image.to_string(),
+    ]
+}
+
+pub async fn run_ollama(container: &str, network: &str, image: &str) -> Result<String> {
+    docker(&ollama_run_args(container, network, image)).await
+}
+
+pub async fn wait_ollama_ready(container: &str, timeout: Duration) -> Result<()> {
+    let started = Instant::now();
+    loop {
+        let output = Command::new("docker")
+            .args(["exec", container, "ollama", "list"])
+            .output()
+            .await
+            .context("failed to invoke docker; is Docker installed and on PATH?")?;
+        if output.status.success() {
+            return Ok(());
+        }
+        if started.elapsed() >= timeout {
+            bail!(
+                "ollama container '{container}' did not become ready within {}s: {}",
+                timeout.as_secs(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+pub async fn pull_model(container: &str, model: &str) -> Result<()> {
+    docker(&[
+        "exec".into(),
+        container.to_string(),
+        "ollama".into(),
+        "pull".into(),
+        model.to_string(),
+    ])
+    .await
+    .map(|_| ())
 }
 
 /// Best-effort container teardown (used for cleanup paths).
@@ -138,9 +235,20 @@ mod tests {
             fake_model: true,
             network: Some("agentos_default".into()),
             otel_endpoint: Some("http://otel-collector:4318".into()),
+            model_base_url: None,
             model: None,
             passthrough_env: vec!["AGENTOS_TEST_ENV_THAT_DOES_NOT_EXIST".into()],
         }
+    }
+
+    #[test]
+    fn ollama_run_args_mount_the_model_cache_volume() {
+        let args = ollama_run_args("agentos-ollama", "agentos-net", "ollama/ollama:0.24.0");
+        let joined = args.join(" ");
+        assert!(joined.starts_with("run -d --name agentos-ollama --network agentos-net"));
+        assert!(joined.contains("-v agentos-ollama-data:/root/.ollama"));
+        assert_eq!(args.last().unwrap(), "ollama/ollama:0.24.0");
+        assert_eq!(ollama_volume("agentos-ollama"), "agentos-ollama-data");
     }
 
     #[test]
@@ -181,5 +289,32 @@ mod tests {
             .run_args()
             .join(" ")
             .contains("-e AGENTOS_MODEL=claude-opus-4-8"));
+    }
+
+    #[test]
+    fn model_base_url_is_forwarded_when_set() {
+        let mut s = spec();
+        s.model_base_url = Some("http://x-ollama:11434".into());
+        assert!(s
+            .run_args()
+            .join(" ")
+            .contains("-e ANTHROPIC_BASE_URL=http://x-ollama:11434"));
+    }
+
+    #[test]
+    fn model_base_url_is_omitted_when_unset() {
+        let mut s = spec();
+        s.model_base_url = None;
+        assert!(!s.run_args().join(" ").contains("ANTHROPIC_BASE_URL"));
+    }
+
+    #[test]
+    fn real_model_with_model_base_url_still_omits_fake_flag() {
+        let mut s = spec();
+        s.fake_model = false;
+        s.model_base_url = Some("http://x-ollama:11434".into());
+        let joined = s.run_args().join(" ");
+        assert!(joined.contains("-e ANTHROPIC_BASE_URL=http://x-ollama:11434"));
+        assert!(!joined.contains("AGENTOS_FAKE_MODEL"));
     }
 }

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -8,6 +8,7 @@
 
 use anyhow::{bail, Context, Result};
 
+use crate::commands::OLLAMA_PORT;
 use crate::ops::{plain, require_on_path, run_capture, run_step, OpsCommand};
 
 /// Dev-channel local-candidate filename probed by the artifact resolver.
@@ -34,6 +35,7 @@ const ENDPOINTS: &[(&str, &str)] = &[
 pub struct LocalOpts {
     pub file: String,
     pub dry_run: bool,
+    pub local_model: Option<String>,
 }
 
 pub struct LocalDownOpts {
@@ -59,6 +61,34 @@ fn compose(file: &str, tail: &[&str]) -> OpsCommand {
 
 /// `docker compose -f <file> up -d --wait`.
 pub fn up_command(o: &LocalOpts) -> OpsCommand {
+    if let Some(model) = &o.local_model {
+        return OpsCommand::new(
+            "docker",
+            vec![
+                plain("compose"),
+                plain("--profile"),
+                plain("local-model"),
+                plain("-f"),
+                plain(&o.file),
+                plain("up"),
+                plain("-d"),
+                plain("--wait"),
+            ],
+        )
+        .with_env(vec![
+            ("AGENTOS_FAKE_MODEL".into(), "0".into()),
+            (
+                "AGENTOS_MODEL_BASE_URL".into(),
+                format!("http://ollama:{OLLAMA_PORT}"),
+            ),
+            ("AGENTOS_MODEL".into(), model.clone()),
+            ("AGENTOS_DOCKER_NETWORK".into(), "agentos_default".into()),
+            // Pin the compose project name so the default network is always
+            // `agentos_default`, regardless of the working-directory basename
+            // (which is what compose otherwise derives the project name from).
+            ("COMPOSE_PROJECT_NAME".into(), "agentos".into()),
+        ]);
+    }
     compose(&o.file, &["up", "-d", "--wait"])
 }
 
@@ -187,6 +217,15 @@ mod tests {
         LocalOpts {
             file: file.into(),
             dry_run: false,
+            local_model: None,
+        }
+    }
+
+    fn opts_with_local_model(file: &str, model: &str) -> LocalOpts {
+        LocalOpts {
+            file: file.into(),
+            dry_run: false,
+            local_model: Some(model.into()),
         }
     }
 
@@ -197,6 +236,32 @@ mod tests {
             cmd.display(),
             "docker compose -f compose.dev.yaml up -d --wait"
         );
+    }
+
+    #[test]
+    fn up_local_model_uses_profile_and_env() {
+        let cmd = up_command(&opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b"));
+        let display = cmd.display();
+        assert!(display.contains("--profile local-model"), "{display}");
+        assert!(display.contains("up -d --wait"), "{display}");
+        assert!(cmd
+            .env
+            .contains(&(String::from("AGENTOS_FAKE_MODEL"), String::from("0"))));
+        assert!(cmd.env.contains(&(
+            String::from("AGENTOS_MODEL_BASE_URL"),
+            String::from("http://ollama:11434"),
+        )));
+        assert!(cmd
+            .env
+            .contains(&(String::from("AGENTOS_MODEL"), String::from("qwen3:4b"))));
+        assert!(cmd.env.contains(&(
+            String::from("AGENTOS_DOCKER_NETWORK"),
+            String::from("agentos_default"),
+        )));
+        assert!(cmd.env.contains(&(
+            String::from("COMPOSE_PROJECT_NAME"),
+            String::from("agentos"),
+        )));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -109,6 +109,15 @@ enum SkillAction {
         /// Setting it makes token usage attributable in Langfuse traces.
         #[arg(long)]
         model: Option<String>,
+        /// Run the named model through local Ollama.
+        #[arg(
+            long,
+            num_args = 0..=1,
+            default_missing_value = commands::DEFAULT_LOCAL_MODEL,
+            conflicts_with = "fake_model",
+            conflicts_with = "model"
+        )]
+        local_model: Option<String>,
     },
     /// Stop and remove the local runner container.
     Down,
@@ -155,6 +164,13 @@ enum LocalAction {
         /// Print the docker compose command and exit without executing.
         #[arg(long)]
         dry_run: bool,
+        /// Run the named model through local Ollama.
+        #[arg(
+            long,
+            num_args = 0..=1,
+            default_missing_value = commands::DEFAULT_LOCAL_MODEL
+        )]
+        local_model: Option<String>,
     },
     /// Stop the dev stack (docker compose down), keeping volumes.
     Down {
@@ -269,6 +285,14 @@ enum ClusterAction {
         /// is set (dev/CI escape hatch); suppresses the fake-model warning.
         #[arg(long)]
         fake_model: bool,
+        /// Run the named model through the chart inference deployment.
+        #[arg(
+            long,
+            num_args = 0..=1,
+            default_missing_value = commands::DEFAULT_LOCAL_MODEL,
+            conflicts_with = "fake_model"
+        )]
+        local_model: Option<String>,
         /// Extra `--set KEY=VAL` passed through to helm verbatim (repeatable).
         #[arg(long = "set", value_name = "KEY=VAL")]
         set: Vec<String>,
@@ -450,6 +474,7 @@ async fn main() -> Result<()> {
                 otel_endpoint,
                 budget,
                 model,
+                local_model,
             } => {
                 let image = artifacts::resolve_image(
                     image.as_deref(),
@@ -466,6 +491,7 @@ async fn main() -> Result<()> {
                     otel_endpoint,
                     budget,
                     model,
+                    local_model,
                 })
                 .await
             }
@@ -480,9 +506,18 @@ async fn main() -> Result<()> {
             SkillAction::Eval { cases, url } => commands::eval(cases, url).await,
         },
         Command::Local { action } => match action {
-            LocalAction::Up { file, dry_run } => {
+            LocalAction::Up {
+                file,
+                dry_run,
+                local_model,
+            } => {
                 let file = resolve_compose_file(file, dry_run).await?;
-                local::up(LocalOpts { file, dry_run }).await
+                local::up(LocalOpts {
+                    file,
+                    dry_run,
+                    local_model,
+                })
+                .await
             }
             LocalAction::Down {
                 file,
@@ -492,7 +527,11 @@ async fn main() -> Result<()> {
             } => {
                 let file = resolve_compose_file(file, dry_run).await?;
                 local::down(LocalDownOpts {
-                    common: LocalOpts { file, dry_run },
+                    common: LocalOpts {
+                        file,
+                        dry_run,
+                        local_model: None,
+                    },
                     wipe,
                     yes,
                 })
@@ -500,7 +539,12 @@ async fn main() -> Result<()> {
             }
             LocalAction::Status { file, dry_run } => {
                 let file = resolve_compose_file(file, dry_run).await?;
-                local::status(LocalOpts { file, dry_run }).await
+                local::status(LocalOpts {
+                    file,
+                    dry_run,
+                    local_model: None,
+                })
+                .await
             }
             LocalAction::Message {
                 text,
@@ -564,6 +608,7 @@ async fn main() -> Result<()> {
                 chart,
                 no_expose,
                 fake_model,
+                local_model,
                 set,
                 dry_run,
             } => {
@@ -575,10 +620,14 @@ async fn main() -> Result<()> {
                     std::path::Path::new("charts/agentos").is_dir(),
                 )?;
                 let chart = materialize_artifact(resolved, dry_run, "chart").await?;
-                let credentials = ops::resolve_up_credentials(
-                    fake_model,
-                    std::env::var("AGENTOS_MODEL_CREDENTIALS").ok(),
-                );
+                let credentials = if local_model.is_some() {
+                    None
+                } else {
+                    ops::resolve_up_credentials(
+                        fake_model,
+                        std::env::var("AGENTOS_MODEL_CREDENTIALS").ok(),
+                    )
+                };
                 ops::up(UpOpts {
                     common: CommonOpts {
                         namespace,
@@ -590,6 +639,7 @@ async fn main() -> Result<()> {
                     set,
                     fake_model,
                     credentials,
+                    local_model,
                 })
                 .await
             }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -18,6 +18,7 @@ use tokio::process::Command;
 pub struct OpsCommand {
     pub program: String,
     pub args: Vec<CmdArg>,
+    pub env: Vec<(String, String)>,
 }
 
 /// A single argv token. `SecretSet` is a `helm --set key=value` whose value is a
@@ -52,7 +53,13 @@ impl OpsCommand {
         Self {
             program: program.to_string(),
             args,
+            env: Vec::new(),
         }
+    }
+
+    pub fn with_env(mut self, env: Vec<(String, String)>) -> Self {
+        self.env = env;
+        self
     }
 
     /// The argv tail (real values) handed to `tokio::process::Command`.
@@ -63,7 +70,13 @@ impl OpsCommand {
     /// The full shell-quoted command line with secrets masked, one line as it
     /// would be typed into a shell.
     pub fn display(&self) -> String {
-        let mut parts = vec![shell_quote(&self.program)];
+        let mut env = self.env.clone();
+        env.sort();
+        let mut parts: Vec<String> = env
+            .iter()
+            .map(|(key, value)| shell_quote(&format!("{key}={value}")))
+            .collect();
+        parts.push(shell_quote(&self.program));
         for a in &self.args {
             parts.push(shell_quote(&a.masked()));
         }
@@ -129,6 +142,7 @@ pub struct UpOpts {
     /// `AGENTOS_MODEL_CREDENTIALS`. `Some(non-empty)` enables the real model and
     /// opens egress to the provider; `None` installs sealed (fake model).
     pub credentials: Option<String>,
+    pub local_model: Option<String>,
 }
 
 pub struct DownOpts {
@@ -177,7 +191,12 @@ pub fn up_commands(o: &UpOpts) -> Vec<OpsCommand> {
         args.push(plain("--set"));
         args.push(plain("langfuse.web.service.type=NodePort"));
     }
-    if let Some(credentials) = &o.credentials {
+    if let Some(model) = &o.local_model {
+        args.push(plain("--set"));
+        args.push(plain("inference.deploy=true"));
+        args.push(plain("--set"));
+        args.push(plain(format!("inference.model={model}")));
+    } else if let Some(credentials) = &o.credentials {
         args.push(plain("--set"));
         args.push(plain("agentSandbox.runner.fakeModel=false"));
         args.push(plain("--set"));
@@ -337,6 +356,7 @@ pub(crate) fn require_on_path(bin: &str) -> Result<()> {
 pub(crate) async fn run_capture(cmd: &OpsCommand) -> Result<(bool, String, String)> {
     let output = Command::new(&cmd.program)
         .args(cmd.argv())
+        .envs(cmd.env.iter().cloned())
         .output()
         .await
         .with_context(|| format!("failed to invoke `{}`; is it on PATH?", cmd.program))?;
@@ -393,6 +413,8 @@ pub async fn up(opts: UpOpts) -> Result<()> {
     let cmds = up_commands(&opts);
     if opts.credentials.is_some() {
         ui.note("real model enabled; egress opened to the model provider");
+    } else if opts.local_model.is_some() {
+        ui.note("local model enabled; installing the chart inference deployment");
     } else if !opts.fake_model {
         ui.warn(
             "no AGENTOS_MODEL_CREDENTIALS set; installing with the fake model and sealed egress",
@@ -710,6 +732,7 @@ mod tests {
             set: vec![],
             fake_model: false,
             credentials: None,
+            local_model: None,
         });
         assert_eq!(cmds.len(), 1);
         let line = cmds[0].display();
@@ -729,6 +752,7 @@ mod tests {
             set: vec![],
             fake_model: false,
             credentials: None,
+            local_model: None,
         });
         let line = cmds[0].display();
         assert!(!line.contains("NodePort"), "{line}");
@@ -744,6 +768,7 @@ mod tests {
             set: vec!["worker.replicas=2".into(), "dispatcher.deploy=false".into()],
             fake_model: false,
             credentials: None,
+            local_model: None,
         });
         let line = cmds[0].display();
         assert!(
@@ -763,6 +788,7 @@ mod tests {
             set: vec![],
             fake_model: false,
             credentials: None,
+            local_model: None,
         });
         let line = cmds[0].display();
         assert!(!line.contains("agentSandbox.runner.fakeModel"), "{line}");
@@ -781,6 +807,7 @@ mod tests {
             set: vec![],
             fake_model: true,
             credentials: None,
+            local_model: None,
         });
         let line = cmds[0].display();
         assert!(!line.contains("agentSandbox.runner"), "{line}");
@@ -796,6 +823,7 @@ mod tests {
             set: vec![],
             fake_model: false,
             credentials: Some("sk-ant-secretsecret".into()),
+            local_model: None,
         });
         let line = cmds[0].display();
         assert!(
@@ -841,6 +869,52 @@ mod tests {
         // Empty and absent both mean sealed.
         assert_eq!(resolve_up_credentials(false, Some(String::new())), None);
         assert_eq!(resolve_up_credentials(false, None), None);
+    }
+
+    #[test]
+    fn with_env_stores_the_pairs() {
+        let cmd =
+            OpsCommand::new("docker", vec![plain("ps")]).with_env(vec![("A".into(), "1".into())]);
+        assert_eq!(cmd.env, vec![("A".to_string(), "1".to_string())]);
+    }
+
+    #[test]
+    fn display_renders_sorted_env_before_program() {
+        let cmd = OpsCommand::new("docker", vec![plain("ps")])
+            .with_env(vec![("B".into(), "2".into()), ("A".into(), "1".into())]);
+        assert!(cmd.display().starts_with("A=1 "));
+    }
+
+    #[test]
+    fn up_local_model_adds_inference_sets() {
+        let cmds = up_commands(&UpOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            no_expose: true,
+            set: vec![],
+            fake_model: false,
+            credentials: None,
+            local_model: Some("qwen3:4b".into()),
+        });
+        let line = cmds[0].display();
+        assert!(line.contains("--set inference.deploy=true"), "{line}");
+        assert!(line.contains("--set inference.model=qwen3:4b"), "{line}");
+    }
+
+    #[test]
+    fn up_without_local_model_omits_inference_sets() {
+        let cmds = up_commands(&UpOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            no_expose: true,
+            set: vec![],
+            fake_model: false,
+            credentials: None,
+            local_model: None,
+        });
+        let line = cmds[0].display();
+        assert!(!line.contains("inference.deploy"), "{line}");
+        assert!(!line.contains("inference.model"), "{line}");
     }
 
     #[test]

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -22,6 +22,12 @@ pub struct RunnerState {
     pub session_id: String,
     pub plugin_dir: String,
     pub fake_model: bool,
+    #[serde(default)]
+    pub ollama_container: Option<String>,
+    #[serde(default)]
+    pub network: Option<String>,
+    #[serde(default)]
+    pub model_base_url: Option<String>,
 }
 
 fn state_path(dir: &Path) -> PathBuf {
@@ -70,6 +76,9 @@ mod tests {
             session_id: "local-1".into(),
             plugin_dir: "/tmp/deal-desk".into(),
             fake_model: true,
+            ollama_container: None,
+            network: None,
+            model_base_url: None,
         }
     }
 
@@ -89,5 +98,41 @@ mod tests {
         std::fs::create_dir_all(dir.path().join(STATE_DIR)).unwrap();
         std::fs::write(dir.path().join(STATE_DIR).join(STATE_FILE), "not json").unwrap();
         assert!(load(dir.path()).is_err());
+    }
+
+    #[test]
+    fn round_trip_preserves_local_model_runner_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = RunnerState {
+            ollama_container: Some("agentos-ollama".into()),
+            network: Some("agentos_default".into()),
+            model_base_url: Some("http://ollama:11434".into()),
+            ..sample()
+        };
+        save(dir.path(), &state).unwrap();
+        assert_eq!(load(dir.path()).unwrap(), Some(state));
+    }
+
+    #[test]
+    fn load_accepts_older_state_without_local_model_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(STATE_DIR)).unwrap();
+        std::fs::write(
+            dir.path().join(STATE_DIR).join(STATE_FILE),
+            r#"{
+  "container_id": "abc123",
+  "container_name": "agentos-runner-local",
+  "image": "agentos-runner",
+  "port": 7245,
+  "base_url": "http://localhost:7245",
+  "session_id": "local-1",
+  "plugin_dir": "/tmp/deal-desk",
+  "fake_model": true
+}"#,
+        )
+        .unwrap();
+        let loaded = load(dir.path()).unwrap();
+        assert!(loaded.is_some());
+        assert_eq!(loaded.unwrap().ollama_container, None);
     }
 }

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -141,6 +141,31 @@ services:
       "
     restart: "no"
 
+  ollama:
+    image: ollama/ollama:0.24.0
+    profiles: [local-model]
+    ports:
+      - "21434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 24
+      start_period: 10s
+
+  ollama-pull:
+    image: ollama/ollama:0.24.0
+    profiles: [local-model]
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    entrypoint: ["ollama", "pull", "qwen3:4b"]
+    restart: "no"
+
   langfuse-worker:
     image: langfuse/langfuse-worker:3
     depends_on:
@@ -330,6 +355,13 @@ services:
         condition: service_healthy
       agentos-migrate:
         condition: service_completed_successfully
+      # When the local-model profile is on, wait for the one-shot model pull to
+      # finish (and treat its clean exit as expected success, so `up --wait`
+      # doesn't read it as a failure). required: false keeps the default profile
+      # working: ollama-pull isn't created then, so the worker starts normally.
+      ollama-pull:
+        condition: service_completed_successfully
+        required: false
     network_mode: host
     user: "0"
     volumes:
@@ -363,6 +395,14 @@ services:
       - ANTHROPIC_API_KEY
       - CLAUDE_CODE_OAUTH_TOKEN
       - AGENTOS_CREDENTIALS
+      # Local-model demo enablement:
+      # COMPOSE_PROFILES=local-model AGENTOS_FAKE_MODEL=0 AGENTOS_MODEL_BASE_URL=http://ollama:11434 AGENTOS_MODEL=qwen3:4b AGENTOS_DOCKER_NETWORK=agentos_default docker compose -f compose.dev.yaml up -d --wait
+      # AGENTOS_DOCKER_NETWORK=agentos_default puts spawned runner containers on
+      # the compose network so they resolve ollama by name, same as the
+      # otel-collector trace path.
+      - AGENTOS_MODEL_BASE_URL=${AGENTOS_MODEL_BASE_URL:-}
+      - AGENTOS_MODEL=${AGENTOS_MODEL:-}
+      - AGENTOS_DOCKER_NETWORK=${AGENTOS_DOCKER_NETWORK:-}
     restart: unless-stopped
 
 volumes:
@@ -371,3 +411,4 @@ volumes:
   clickhouse_data:
   clickhouse_logs:
   minio_data:
+  ollama_data:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -163,7 +163,8 @@ services:
         condition: service_healthy
     environment:
       OLLAMA_HOST: http://ollama:11434
-    entrypoint: ["ollama", "pull", "qwen3:4b"]
+      AGENTOS_MODEL: ${AGENTOS_MODEL:-qwen3:4b}
+    entrypoint: ["/bin/sh", "-c", "ollama pull \"$$AGENTOS_MODEL\""]
     restart: "no"
 
   langfuse-worker:
@@ -396,7 +397,7 @@ services:
       - CLAUDE_CODE_OAUTH_TOKEN
       - AGENTOS_CREDENTIALS
       # Local-model demo enablement:
-      # COMPOSE_PROFILES=local-model AGENTOS_FAKE_MODEL=0 AGENTOS_MODEL_BASE_URL=http://ollama:11434 AGENTOS_MODEL=qwen3:4b AGENTOS_DOCKER_NETWORK=agentos_default docker compose -f compose.dev.yaml up -d --wait
+      # agentos local up --local-model
       # AGENTOS_DOCKER_NETWORK=agentos_default puts spawned runner containers on
       # the compose network so they resolve ollama by name, same as the
       # otel-collector trace path.

--- a/runner/src/agentos_runner/INTERFACE.md
+++ b/runner/src/agentos_runner/INTERFACE.md
@@ -1,0 +1,55 @@
+# INTERFACE: model-provider base-URL override seam
+
+The seam that lets the runner target any Anthropic-compatible endpoint without
+an Anthropic credential. Implemented in `sdk_auth.resolve_base_url_override`.
+
+## Purpose
+
+A generic, provider-agnostic base-URL override. When configured, the runner
+points the claude-agent-sdk (and the bundled `claude` CLI it spawns) at a local
+or third-party endpoint instead of real Anthropic, using a no-op placeholder in
+place of a credential. Local Ollama is the FIRST implementation (issue #46).
+OpenRouter (issue #24) is the NEXT consumer: it reuses this seam rather than
+forking a parallel path. This is one seam, many providers.
+
+## Env contract
+
+### `ANTHROPIC_BASE_URL` (input)
+
+When set to a non-empty value, the runner enters override mode. Unset or empty
+means normal Anthropic credential resolution (`resolve_model_credential`).
+
+### `ANTHROPIC_API_KEY` (output, set by the runner)
+
+A NON-EMPTY no-op placeholder (`not-needed`, the `NO_OP_API_KEY` constant).
+
+Empirical gotcha (verified 2026-07-07): the bundled Claude CLI treats an EMPTY
+`ANTHROPIC_API_KEY` as "not logged in" and refuses to call the endpoint before
+it ever dials the base URL. The placeholder MUST therefore be non-empty to pass
+the CLI auth gate. It is deliberately not `sk-...` shaped so it can never be
+mistaken for a real credential, and paired with the overridden base URL it
+cannot authenticate against real Anthropic.
+
+### `CLAUDE_CODE_OAUTH_TOKEN` (output, set by the runner)
+
+Blanked to `""` in override mode so an inherited OAuth token cannot take
+precedence over the placeholder + overridden base URL. This keeps override mode
+hermetic.
+
+### `AGENTOS_MODEL` (input)
+
+The model name (e.g. `qwen3:4b`), passed through to `ClaudeAgentOptions.model`.
+
+## How it arrives
+
+- Docker/compose path: the worker injects it per-claim, mapping
+  `AGENTOS_MODEL_BASE_URL` to `ANTHROPIC_BASE_URL` and `AGENTOS_MODEL` on the
+  runner boot env (`apps/worker/src/agentos_worker/binding.py`).
+- Cluster path: the chart bakes it into the SandboxTemplate when
+  `inference.deploy=true` (`charts/agentos/templates/agent-sandbox.yaml`).
+
+## Boundary
+
+Documentation and one env-mapping function only. No speculative multi-provider
+abstraction: that arrives with issue #24's second path. Tracked in
+`.projects/prototype-review/seam-points-catalog.md`.

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -17,13 +17,18 @@ from .config import RunnerConfig
 from .fake import FakeModelSession
 from .otel import RunTracer, build_tracer_provider
 from .plugin import load_plugins
-from .sdk_auth import resolve_model_credential
+from .sdk_auth import resolve_base_url_override, resolve_model_credential
 from .server import create_app
 from .session import SessionRunner
 from .side_effects import SideEffectClassifier
 
 
-def build_runner(config: RunnerConfig, *, fake_model: bool = False) -> SessionRunner:
+def build_runner(
+    config: RunnerConfig,
+    *,
+    fake_model: bool = False,
+    sdk_env: dict[str, str] | None = None,
+) -> SessionRunner:
     """Wire a SessionRunner backed by a real claude-agent-sdk session.
 
     ``fake_model`` (env ``AGENTOS_FAKE_MODEL``) swaps in the scripted fake session
@@ -44,6 +49,7 @@ def build_runner(config: RunnerConfig, *, fake_model: bool = False) -> SessionRu
             max_budget_usd=config.max_usd_per_day,
             resume=config.history_ref,
             task_budget_hint=config.session.budget.task_budget_hint,
+            env=sdk_env or {},
         )
         return ClaudeAgentSession(options)
 
@@ -69,10 +75,13 @@ def main() -> None:
     # forwarded ACI AGENTOS_CREDENTIALS reference onto it (a no-op for a fake
     # run, which needs no credential). Raises on an unsupported credential so the
     # process fails visibly before the port is up rather than after a real call.
+    override = None
     if not fake_model:
-        resolve_model_credential(os.environ)
+        override = resolve_base_url_override(os.environ)
+        if override is None:
+            resolve_model_credential(os.environ)
     config = RunnerConfig.from_env(os.environ)
-    runner = build_runner(config, fake_model=fake_model)
+    runner = build_runner(config, fake_model=fake_model, sdk_env=override)
     app = create_app(runner)
 
     async def _startup(_app: web.Application) -> None:

--- a/runner/src/agentos_runner/sdk_auth.py
+++ b/runner/src/agentos_runner/sdk_auth.py
@@ -29,11 +29,48 @@ from collections.abc import MutableMapping
 CREDENTIALS_ENV = "AGENTOS_CREDENTIALS"
 OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
 API_KEY_ENV = "ANTHROPIC_API_KEY"
+BASE_URL_ENV = "ANTHROPIC_BASE_URL"
 _SDK_CREDENTIAL_ENV = (OAUTH_TOKEN_ENV, API_KEY_ENV)
+
+# Non-empty no-op placeholder API key used in base-URL override mode. It is
+# deliberately not sk-... shaped so it can never be mistaken for a real
+# credential. The bundled Claude CLI treats an EMPTY ANTHROPIC_API_KEY as "not
+# logged in" and refuses to call the endpoint, so the placeholder must be
+# non-empty to pass the CLI's auth gate before it dials the overridden base URL.
+NO_OP_API_KEY = "not-needed"
 
 
 class UnsupportedCredentialError(RuntimeError):
     """``AGENTOS_CREDENTIALS`` is a recognizably non-Anthropic credential."""
+
+
+def resolve_base_url_override(env: MutableMapping[str, str]) -> dict[str, str] | None:
+    """Build the generic SDK base URL override env when configured.
+
+    This is the provider agnostic base URL override path: local Ollama today and
+    OpenRouter/#24 next. It targets any Anthropic-compatible endpoint without a
+    real Anthropic credential.
+
+    The placeholder API key is NON-EMPTY on purpose (empirically verified
+    2026-07-07): the bundled Claude CLI treats an empty ANTHROPIC_API_KEY as "not
+    logged in" and refuses to call the endpoint before it ever reaches the base
+    URL, so it must carry a non-credential placeholder to pass the auth gate.
+    Paired with the overridden base URL, that placeholder cannot authenticate
+    against real Anthropic.
+
+    CLAUDE_CODE_OAUTH_TOKEN is blanked to "" so an inherited OAuth token cannot
+    take precedence over the placeholder + base URL, keeping override mode
+    hermetic. The base URL is not a secret, but this module keeps the same no
+    echo discipline it uses for credentials.
+    """
+    base_url = env.get(BASE_URL_ENV)
+    if not base_url:
+        return None
+    return {
+        BASE_URL_ENV: base_url,
+        API_KEY_ENV: NO_OP_API_KEY,
+        OAUTH_TOKEN_ENV: "",
+    }
 
 
 def resolve_model_credential(env: MutableMapping[str, str]) -> None:

--- a/runner/tests/test_sdk_auth.py
+++ b/runner/tests/test_sdk_auth.py
@@ -60,3 +60,37 @@ def test_no_credential_is_a_noop() -> None:
     env: dict[str, str] = {}
     resolve_model_credential(env)
     assert env == {}
+
+
+def test_base_url_override_sets_sdk_base_url_and_placeholder_api_key() -> None:
+    from agentos_runner.sdk_auth import (
+        BASE_URL_ENV,
+        NO_OP_API_KEY,
+        resolve_base_url_override,
+    )
+
+    assert BASE_URL_ENV == "ANTHROPIC_BASE_URL"
+
+    override = resolve_base_url_override({BASE_URL_ENV: "http://ollama:11434"})
+
+    assert override is not None
+    assert override[BASE_URL_ENV] == "http://ollama:11434"
+    # The placeholder API key must be NON-EMPTY: an empty ANTHROPIC_API_KEY makes
+    # the bundled Claude CLI report "not logged in" and skip the endpoint call.
+    assert override[API_KEY_ENV] == NO_OP_API_KEY
+    assert override[API_KEY_ENV] != ""
+    # The OAuth token is blanked so an inherited token cannot win over the
+    # placeholder + overridden base URL.
+    assert override[OAUTH_TOKEN_ENV] == ""
+
+
+def test_base_url_override_is_absent_when_env_is_missing() -> None:
+    from agentos_runner.sdk_auth import resolve_base_url_override
+
+    assert resolve_base_url_override({}) is None
+
+
+def test_base_url_override_is_absent_when_env_is_empty() -> None:
+    from agentos_runner.sdk_auth import BASE_URL_ENV, resolve_base_url_override
+
+    assert resolve_base_url_override({BASE_URL_ENV: ""}) is None


### PR DESCRIPTION
Opt-in local-model demo mode: point the runner at a local Anthropic-compatible endpoint (Ollama) so demos answer for real with **no Anthropic key and no spend**. Additive only. `AGENTOS_FAKE_MODEL` stays the zero-dependency default; this mode is strictly opt-in in both substrates, selected by a simple model version.

## What it builds
- **Generic base-URL-override seam** in `runner/src/agentos_runner/sdk_auth.py` (`resolve_base_url_override`) — provider-agnostic, so #24 (OpenRouter) reuses it rather than forking. Documented in a new `runner/src/agentos_runner/INTERFACE.md`.
- **Unified `--local-model [MODEL]` flag** (bare default `qwen3:4b`) across `skill up` / `local up` / `cluster up`; runs the model in Docker for skill+local (with a persisted model cache) and in the in-chart inference Deployment for cluster.
- **Docker/compose:** profile-gated (`local-model`) Ollama service + one-shot model pull; the worker waits on the pull's completion so `--profile local-model up --wait` comes up healthy.
- **Cluster/chart:** values-gated (`inference.deploy=true`) Ollama Deployment/Service, a runner egress carve-out for the in-cluster endpoint (fail-closed default preserved), and the SandboxTemplate baking `ANTHROPIC_BASE_URL` + model.
- **Docs + harness:** README local-model section, RAM/model table (`qwen3:4b` default; `qwen3-coder:30b` upgrade), Ollama version + gated-repo gotchas.

## Key finding (empirically verified)
The issue said set `ANTHROPIC_API_KEY=""`. Running the bundled `claude` CLI directly showed an **empty** key yields `"Not logged in"` and fails before reaching Ollama; a **non-empty** no-op placeholder passes the auth gate and dials the endpoint. So the seam uses a non-empty placeholder (`not-needed`) and blanks `CLAUDE_CODE_OAUTH_TOKEN`. Caught by cross-model (Codex) execution review.

## Validation
- Unit/lint: `ruff check .`, `mypy`, the runner + worker seam suites, and the Rust CLI suite (`cargo fmt`/`clippy`/`test`, 141 tests) all pass; fake-model path untouched.
- **`cluster up --local-model` on k8scratch (16GB): real end-to-end.** The chart's `agentos-inference` Deployment came up and pulled `qwen3:4b`; a live completion via `/v1/messages` on the in-cluster `agentos-inference:11434` Service returned a clean Anthropic-format response using the `not-needed` placeholder key.
- **`local up --local-model` (8GB laptop): wiring verified end-to-end.** `--profile local-model` brings up Ollama + the one-shot pull; the `AGENTOS_*` env reaches the worker; the docker-substrate credential gate passes with a local model set; the runner boots with `ANTHROPIC_BASE_URL` wired and reaches Ollama (`/api/tags -> 200`, claude subprocess spawned). The terminal inference is RAM-gated on this 8GB box (k8scratch has no Docker for a compose run), but the cluster run proves the model completes.

## Also in this PR: docker-substrate bundle-permission fix
The `local up` E2E surfaced a pre-existing bug independent of local-model: the worker stages plugin bundles with `tempfile.mkdtemp` (0700, root-owned) and bind-mounts them read-only into the uid-1000 runner, which then crashed with `PermissionError` reading the plugin manifest — blocking **every** `local up` message (fake, real, or local-model). Fixed by widening the staged tree to group/other readable+traversable after extraction; one added unit test. The skill-up path is unaffected (the CLI mounts the plugin dir directly).

Closes #46
