### PR TITLE
Resolve CLI stack artifacts from a version-pinned remote by default

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,6 +76,49 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  worker-local:
+    name: Build and push the worker-local overlay image
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [images]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Compute version
+        id: ver
+        run: echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/agentos-worker-local
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: compose
+          file: compose/worker-local.Dockerfile
+          push: true
+          build-args: |
+            BASE_TAG=${{ steps.ver.outputs.v }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   cli-binaries:
     name: Build agentos CLI (${{ matrix.target }})
     if: startsWith(github.ref, 'refs/tags/v')
@@ -98,8 +141,19 @@ jobs:
           persist-credentials: false
       - name: Add target
         run: rustup target add ${{ matrix.target }}
+      - name: Assert tag matches Cargo.toml version
+        working-directory: cli
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(grep -m1 '^version' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
+          if [ "$tag" != "$pkg" ]; then
+            echo "tag v$tag does not match cli/Cargo.toml version $pkg" >&2
+            exit 1
+          fi
       - name: Build release
         working-directory: cli
+        env:
+          AGENTOS_BUILD_CHANNEL: release
         run: cargo build --release --target ${{ matrix.target }}
       - name: Strip and name the binary
         run: |
@@ -114,10 +168,53 @@ jobs:
           path: dist/agentos-${{ matrix.target }}
           if-no-files-found: error
 
+  chart:
+    name: Package chart and release compose
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+      - name: Pin chart image tags to the release version
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          before="$(grep -cE '^[[:space:]]*tag: latest$' charts/agentos/values.yaml)"
+          if [ "$before" -ne 5 ]; then
+            echo "expected 5 'tag: latest' entries in values.yaml, found $before" >&2
+            exit 1
+          fi
+          sed -i -E "s/^([[:space:]]*tag:) latest$/\1 \"${version}\"/" charts/agentos/values.yaml
+      - name: Package chart
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          mkdir -p dist
+          helm package charts/agentos --version "$version" --app-version "$version" -d dist
+      - name: Pin and stage the release compose
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          mkdir -p dist
+          sed -E "s|(ghcr.io/curie-eng/agentos-[a-z-]+):latest|\1:${version}|g" \
+            compose.release.yaml > dist/compose.release.yaml
+      - name: Upload chart artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentos-chart
+          path: dist/agentos-*.tgz
+          if-no-files-found: error
+      - name: Upload release compose artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentos-compose
+          path: dist/compose.release.yaml
+          if-no-files-found: error
+
   release:
     name: Attach binaries to the GitHub Release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [images, cli-binaries]
+    needs: [images, cli-binaries, chart, worker-local]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -131,5 +228,7 @@ jobs:
       - name: Create release with generated notes
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/agentos-*
+          files: |
+            dist/agentos-*
+            dist/compose.release.yaml
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -120,10 +120,27 @@ real workspace.
 
 ## Quickstart
 
-Everything below runs against the dev stack in `compose.dev.yaml`
-(Postgres + Valkey + Langfuse v3 + ClickHouse + MinIO + OTel Collector). See
-[`AGENTS.md`](AGENTS.md) for the ports each service binds and the load-bearing
-gotchas.
+Operators should start from a binary downloaded from
+[GitHub Releases](https://github.com/curie-eng/agentos/releases):
+
+```bash
+curl -L -o agentos \
+  https://github.com/curie-eng/agentos/releases/download/v<version>/agentos-x86_64-unknown-linux-gnu
+chmod +x agentos
+./agentos up
+./agentos local up
+```
+
+A release binary needs no repo checkout for `agentos up` or `agentos local up`.
+It pulls the pinned chart release asset and the pinned `compose.release.yaml`
+matching the binary version, then caches them under `~/.cache/agentos/`. For
+local development overrides, pass `-f <compose>`, `--chart <path>`, or
+`--image <ref>`.
+
+Contributors can still run from a repo checkout against the dev stack in
+`compose.dev.yaml` (Postgres + Valkey + Langfuse v3 + ClickHouse + MinIO + OTel
+Collector). See [`AGENTS.md`](AGENTS.md) for the ports each service binds and
+the load-bearing gotchas.
 
 ```bash
 # 1. Bring up the backing stack. The stack runs on baked defaults; copy
@@ -223,11 +240,11 @@ env AGENTOS_SANDBOX_SUBSTRATE=docker \
 For an offline round-trip add `AGENTOS_FAKE_MODEL=1` to the worker env and drop
 the credential. Without either, the worker refuses to start.
 
-Prefer a prebuilt binary? The
+Prefer a prebuilt binary for local commands? The
 [GitHub Releases](https://github.com/curie-eng/agentos/releases) page attaches
 `agentos-<target>` binaries on every tag push (`agentos-x86_64-unknown-linux-gnu`
 and `agentos-aarch64-apple-darwin`), so `v0.1.0` onward you can download the CLI
-instead of running `cargo build` (above).
+instead of running `cargo build` above.
 
 Each package documents its own deeper verify commands and gotchas in its own
 README (linked above) and its own scoped `CLAUDE.md` — this quickstart is
@@ -251,7 +268,11 @@ enough to see the pieces move; it is not a substitute for those.
 
 The same `agentos` binary installs and runs the platform on a Kubernetes
 cluster, wrapping the umbrella Helm chart the way `linkerd` or `cilium` wrap
-theirs. The short version:
+theirs. A downloaded release binary resolves the pinned chart release asset for
+its version, and `agentos local up` likewise resolves the pinned
+`compose.release.yaml`, caching both under `~/.cache/agentos/` with no repo
+checkout needed.
+Use `--chart <path>` when developing the chart locally. The short version:
 
 - `agentos cluster up` runs `helm upgrade --install` of `charts/agentos`; it reads
   `AGENTOS_MODEL_CREDENTIALS` to enable a real model (absent, the release

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -40,12 +40,16 @@ release with `up`, `status`, `down`, `message`, and `deploy`. Full command refer
   by the scaffold) so `skill message`/`skill eval`/`skill status`/`skill down` can resolve the
   running container from the bundle directory alone. Do not add a second
   state-tracking file for the same purpose.
-- **The local skill verbs stay fully offline; the local and cluster
-  target verbs are the exception.** `init`, `skill up`, `skill down`,
-  `skill status`, `skill message`, and `skill eval` must keep working with
-  zero network access beyond the local Docker daemon and the local runner
-  container. `deploy` is the one bundle shipping verb that leaves the machine: it packages the bundle as
-  tar.gz and pushes to the platform API (find-or-create agent, create version,
+- **The local skill verbs stay fully offline once their local inputs exist; the
+  local and cluster target verbs are the exception.** `init`, `skill up`,
+  `skill down`, `skill status`, `skill message`, and `skill eval` must keep
+  working with zero network access beyond the local Docker daemon and the local
+  runner container. `skill up` stays offline once the runner image is present
+  locally, or when `--image <local-tag>` names a local image. A release binary's
+  default runner image ref is pulled from GHCR on first run. `local deploy` and
+  `cluster deploy` are the bundle shipping verbs that leave the machine: they
+  package the bundle as
+  tar.gz and push to the platform API (find-or-create agent, create version,
   upload bundle, create deployment) authenticated via
   `--api-key`/`AGENTOS_API_KEY`. `local message`, `local deploy`,
   `cluster message`, `cluster deploy`, and every operator verb
@@ -58,6 +62,9 @@ release with `up`, `status`, `down`, `message`, and `deploy`. Full command refer
   returning `OpsCommand` vectors that the executor or the `--dry-run` printer
   consumes; keep that split so argv stays unit-testable with no cluster, and
   give any new verb a matching `--dry-run`.
+  Artifact resolution is a pure plan via `artifacts::resolve_*` plus a separate
+  fetch via `ensure_cached`; pure argv builders never fetch, and `--dry-run`
+  never touches the network.
 - **Credentials are masked, never printed.** Secret `helm --set` values use the
   `CmdArg::SecretSet` variant (only a masked prefix is echoed, in dry-run or the
   printed command line) and token flags read from env with `hide_env_values`.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentos"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agentos-aci-protocol",
  "anstream",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentos"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "AgentOS CLI: init/start/send/eval a plugin against a local runner (task I1)"
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -80,6 +80,26 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `agentos cluster message "..."` | Drive the deployed release end to end with zero Slack: self plumbs kubectl port forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply. |
 | `agentos cluster deploy` | Package the bundle as tar.gz and push it to the platform API (`--api-url`, default `http://localhost:8000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
 
+### Artifact resolution
+
+Release builds resolve default artifacts from the binary version: `agentos local
+up` fetches the self contained `compose.release.yaml` release asset, so it
+works with no checkout, `agentos cluster up` uses the pinned chart release
+asset, and runner sessions (`agentos skill up`) use the pinned GHCR runner
+image. Fetched artifacts cache under
+`${XDG_CACHE_HOME:-$HOME/.cache}/agentos/<version>/`, so repeated
+`agentos cluster up` and `agentos local up` reuse the cache.
+
+Dev builds use the local `compose.dev.yaml`, `charts/agentos`, and
+`agentos-runner` when present. A dev binary run with no local artifact errors,
+telling you to pass `-f <compose>`, `--chart <path>`, or `--image <ref>` (or use
+a released binary); those same flags override the defaults. `--dry-run` prints
+the resolved argv without fetching.
+
+`agentos cluster message` is not yet wired through this resolver: it still defaults
+`--chart` to the repo-relative `charts/agentos`, so a no-checkout binary must
+pass `--chart <path-or-tgz>` explicitly for now.
+
 ## Output
 
 Three global flags apply to every subcommand: `--debug` shows the verbose

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=AGENTOS_BUILD_CHANNEL");
+    let channel = std::env::var("AGENTOS_BUILD_CHANNEL").unwrap_or_else(|_| "dev".to_string());
+    match channel.as_str() {
+        "release" | "dev" => {}
+        other => panic!("AGENTOS_BUILD_CHANNEL must be `release` or `dev`, got `{other}`"),
+    }
+    println!("cargo:rustc-env=AGENTOS_BUILD_CHANNEL={channel}");
+}

--- a/cli/src/artifacts.rs
+++ b/cli/src/artifacts.rs
@@ -1,0 +1,399 @@
+use anyhow::{anyhow, Context, Result};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_PARTIAL_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    Release,
+    Dev,
+}
+
+impl Channel {
+    /// Read the build-stamped channel. Uses option_env! so it compiles even
+    /// before build.rs exists; defaults to Dev when unset or unrecognized.
+    pub fn current() -> Channel {
+        match option_env!("AGENTOS_BUILD_CHANNEL") {
+            Some("release") => Channel::Release,
+            _ => Channel::Dev,
+        }
+    }
+}
+
+/// The resolution outcome for one artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolved {
+    /// Use this local path verbatim (override, or dev-channel local candidate).
+    Local(PathBuf),
+    /// Download `url` into `cache_path`.
+    Fetch { url: String, cache_path: PathBuf },
+}
+
+impl Resolved {
+    /// The argv path token for this artifact WITHOUT fetching (dry-run display):
+    /// a local path as-is, or the would-be cache path for a Fetch.
+    pub fn planned_target(&self) -> PathBuf {
+        match self {
+            Resolved::Local(path) => path.clone(),
+            Resolved::Fetch { cache_path, .. } => cache_path.clone(),
+        }
+    }
+}
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// XDG_CACHE_HOME or $HOME/.cache, joined with "agentos". Err (never panic) when
+/// neither env var is set, with a message naming the vars + the override flags.
+pub fn cache_root() -> Result<PathBuf> {
+    if let Some(value) = env::var_os("XDG_CACHE_HOME").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(value).join("agentos"));
+    }
+
+    if let Some(value) = env::var_os("HOME").filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(value).join(".cache").join("agentos"));
+    }
+
+    Err(anyhow!(
+        "could not determine cache directory: XDG_CACHE_HOME and HOME are unset or empty; set HOME or pass -f/--chart override"
+    ))
+}
+
+pub fn resolve_compose(
+    override_: Option<&str>,
+    channel: Channel,
+    version: &str,
+    cache_root: impl FnOnce() -> Result<PathBuf>,
+    local_exists: bool,
+) -> Result<Resolved> {
+    if let Some(value) = override_ {
+        return Ok(Resolved::Local(PathBuf::from(value)));
+    }
+
+    match channel {
+        Channel::Release => Ok(Resolved::Fetch {
+            url: format!(
+                "https://github.com/curie-eng/agentos/releases/download/v{version}/compose.release.yaml"
+            ),
+            cache_path: cache_root()?
+                .join(format!("v{version}"))
+                .join("compose.release.yaml"),
+        }),
+        Channel::Dev if local_exists => Ok(Resolved::Local(PathBuf::from("compose.dev.yaml"))),
+        // compose.dev.yaml is not self-contained (it builds agentos-worker from
+        // ./compose, which is absent from a fetched copy), so there is nothing
+        // safe to fall back to. Error instead of fetching a file that cannot run.
+        Channel::Dev => Err(anyhow!(
+            "dev build with no local compose.dev.yaml in cwd; pass -f <compose> or use a released binary"
+        )),
+    }
+}
+
+pub fn resolve_chart(
+    override_: Option<&str>,
+    channel: Channel,
+    version: &str,
+    cache_root: impl FnOnce() -> Result<PathBuf>,
+    local_exists: bool,
+) -> Result<Resolved> {
+    if let Some(value) = override_ {
+        return Ok(Resolved::Local(PathBuf::from(value)));
+    }
+
+    match channel {
+        Channel::Release => Ok(Resolved::Fetch {
+            url: format!(
+                "https://github.com/curie-eng/agentos/releases/download/v{version}/agentos-{version}.tgz"
+            ),
+            cache_path: cache_root()?
+                .join(format!("v{version}"))
+                .join(format!("agentos-{version}.tgz")),
+        }),
+        Channel::Dev if local_exists => Ok(Resolved::Local(PathBuf::from("charts/agentos"))),
+        Channel::Dev => Err(anyhow!(
+            "dev build with no charts/agentos in cwd; pass --chart <path-or-tgz> or use a released binary"
+        )),
+    }
+}
+
+pub fn resolve_image(override_: Option<&str>, channel: Channel, version: &str) -> String {
+    if let Some(value) = override_ {
+        return value.to_string();
+    }
+
+    match channel {
+        Channel::Release => format!("ghcr.io/curie-eng/agentos-runner:{version}"),
+        Channel::Dev => "agentos-runner".to_string(),
+    }
+}
+
+/// Perform the fetch described by a `Resolved::Fetch`, returning the local path.
+/// - `Resolved::Local(p)` returns `p` unchanged (no network).
+/// - `Resolved::Fetch`: cache hit (final file exists) returns it with no network;
+///   else download.
+/// - Downloads write to a PER-PROCESS-UNIQUE temp file in the cache dir, then
+///   atomically rename to `cache_path`. Never a shared fixed `.partial` name.
+pub async fn ensure_cached(resolved: &Resolved) -> Result<PathBuf> {
+    match resolved {
+        Resolved::Local(path) => Ok(path.clone()),
+        Resolved::Fetch { url, cache_path } => {
+            if cache_path.exists() {
+                return Ok(cache_path.clone());
+            }
+
+            download_to_cache(url, cache_path).await?;
+            Ok(cache_path.clone())
+        }
+    }
+}
+
+async fn download_to_cache(url: &str, cache_path: &Path) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .build()
+        .context("building the artifact fetch client")?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("failed to fetch {url}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!("failed to fetch {url}: HTTP {status}: {body}"));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .with_context(|| format!("failed to read response body from {url}"))?;
+    let parent = cache_path.parent().ok_or_else(|| {
+        anyhow!(
+            "failed to cache {url}: cache path has no parent: {}",
+            cache_path.display()
+        )
+    })?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create cache directory for {url}: {}",
+            parent.display()
+        )
+    })?;
+
+    let partial_id = NEXT_PARTIAL_ID.fetch_add(1, Ordering::Relaxed);
+    let partial_path = parent.join(format!(
+        ".agentos.{}.{}.partial",
+        std::process::id(),
+        partial_id
+    ));
+
+    if let Err(err) = fs::write(&partial_path, &bytes).with_context(|| {
+        format!(
+            "failed to write temporary cache file for {url}: {}",
+            partial_path.display()
+        )
+    }) {
+        let _ = fs::remove_file(&partial_path);
+        return Err(err);
+    }
+
+    if let Err(err) = fs::rename(&partial_path, cache_path).with_context(|| {
+        format!(
+            "failed to install cached artifact from {url} at {}",
+            cache_path.display()
+        )
+    }) {
+        let _ = fs::remove_file(&partial_path);
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VERSION: &str = "0.1.0";
+
+    #[test]
+    fn release_compose_fetches_release_remote_and_ignores_local_candidate() {
+        let expected = Resolved::Fetch {
+            url:
+                "https://github.com/curie-eng/agentos/releases/download/v0.1.0/compose.release.yaml"
+                    .to_string(),
+            cache_path: PathBuf::from("/tmp/xdgcache/agentos/v0.1.0/compose.release.yaml"),
+        };
+
+        assert_eq!(
+            resolve_compose(
+                None,
+                Channel::Release,
+                VERSION,
+                || Ok(PathBuf::from("/tmp/xdgcache/agentos")),
+                false,
+            )
+            .unwrap(),
+            expected
+        );
+        assert_eq!(
+            resolve_compose(
+                None,
+                Channel::Release,
+                VERSION,
+                || Ok(PathBuf::from("/tmp/xdgcache/agentos")),
+                true,
+            )
+            .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn release_chart_fetches_release_archive() {
+        assert_eq!(
+            resolve_chart(
+                None,
+                Channel::Release,
+                VERSION,
+                || Ok(PathBuf::from("/tmp/xdgcache/agentos")),
+                false,
+            )
+            .unwrap(),
+            Resolved::Fetch {
+                url: "https://github.com/curie-eng/agentos/releases/download/v0.1.0/agentos-0.1.0.tgz"
+                    .to_string(),
+                cache_path: PathBuf::from("/tmp/xdgcache/agentos/v0.1.0/agentos-0.1.0.tgz"),
+            }
+        );
+    }
+
+    #[test]
+    fn release_image_uses_versioned_runner_ref_without_v_prefix() {
+        assert_eq!(
+            resolve_image(None, Channel::Release, VERSION),
+            "ghcr.io/curie-eng/agentos-runner:0.1.0".to_string()
+        );
+    }
+
+    #[test]
+    fn overrides_short_circuit_resolution_in_both_channels() {
+        for channel in [Channel::Release, Channel::Dev] {
+            for value in ["anything", "charts/agentos", "compose.dev.yaml"] {
+                assert_eq!(
+                    resolve_compose(
+                        Some(value),
+                        channel,
+                        VERSION,
+                        || panic!("cache_root should not be called for compose overrides"),
+                        false,
+                    )
+                    .unwrap(),
+                    Resolved::Local(PathBuf::from(value))
+                );
+                assert_eq!(
+                    resolve_chart(
+                        Some(value),
+                        channel,
+                        VERSION,
+                        || panic!("cache_root should not be called for chart overrides"),
+                        false,
+                    )
+                    .unwrap(),
+                    Resolved::Local(PathBuf::from(value))
+                );
+                assert_eq!(
+                    resolve_image(Some(value), channel, VERSION),
+                    value.to_string()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dev_uses_local_artifacts_when_present() {
+        assert_eq!(
+            resolve_compose(
+                None,
+                Channel::Dev,
+                VERSION,
+                || panic!("cache_root should not be called for local dev compose"),
+                true,
+            )
+            .unwrap(),
+            Resolved::Local(PathBuf::from("compose.dev.yaml"))
+        );
+        assert_eq!(
+            resolve_chart(
+                None,
+                Channel::Dev,
+                VERSION,
+                || panic!("cache_root should not be called for local dev chart"),
+                true,
+            )
+            .unwrap(),
+            Resolved::Local(PathBuf::from("charts/agentos"))
+        );
+    }
+
+    #[test]
+    fn dev_missing_local_compose_and_chart_require_override() {
+        let compose_err = resolve_compose(
+            None,
+            Channel::Dev,
+            VERSION,
+            || Ok(PathBuf::from("/tmp/xdgcache/agentos")),
+            false,
+        )
+        .unwrap_err();
+        let compose_message = compose_err.to_string();
+        assert!(
+            compose_message.contains("-f"),
+            "error was {compose_message}"
+        );
+
+        let err = resolve_chart(
+            None,
+            Channel::Dev,
+            VERSION,
+            || Ok(PathBuf::from("/tmp/xdgcache/agentos")),
+            false,
+        )
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("--chart"), "error was {message}");
+    }
+
+    #[test]
+    fn dev_image_keeps_bare_runner_default() {
+        assert_eq!(
+            resolve_image(None, Channel::Dev, VERSION),
+            "agentos-runner".to_string()
+        );
+    }
+
+    #[test]
+    fn current_channel_defaults_to_dev_in_tests() {
+        assert_eq!(Channel::current(), Channel::Dev);
+    }
+
+    #[test]
+    fn planned_target_returns_file_path_without_fetching() {
+        assert_eq!(
+            Resolved::Fetch {
+                url: "https://example.test/artifact".to_string(),
+                cache_path: PathBuf::from("/x/y"),
+            }
+            .planned_target(),
+            PathBuf::from("/x/y")
+        );
+        assert_eq!(
+            Resolved::Local(PathBuf::from("z")).planned_target(),
+            PathBuf::from("z")
+        );
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5,6 +5,7 @@
 //! the platform API's committed OpenAPI surface. Task I1.
 
 pub mod api;
+pub mod artifacts;
 pub mod bundle;
 pub mod chat;
 pub mod commands;

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Context, Result};
 
 use crate::ops::{plain, require_on_path, run_capture, run_step, OpsCommand};
 
-/// Default compose file, resolved relative to the cwd (run from the repo root).
+/// Dev-channel local-candidate filename probed by the artifact resolver.
 pub const DEFAULT_COMPOSE_FILE: &str = "compose.dev.yaml";
 
 /// The service endpoints the dev stack exposes, as committed in

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@
 
 use std::path::PathBuf;
 
+use agentos::artifacts;
 use agentos::commands::{self, DeployEnv, DeployOpts, SendType, StartOpts, DEFAULT_PORT};
 use agentos::local::{self, LocalDownOpts, LocalOpts};
 use agentos::message::{self, MessageOpts};
@@ -83,9 +84,9 @@ enum SkillAction {
         /// Plugin bundle directory.
         #[arg(long, default_value = ".")]
         plugin_dir: PathBuf,
-        /// Runner image to boot.
-        #[arg(long, default_value = "agentos-runner")]
-        image: String,
+        /// Runner image. Default: version-pinned `ghcr.io/curie-eng/agentos-runner:<version>` on release builds; local `agentos-runner` on dev builds. Pass to override.
+        #[arg(long)]
+        image: Option<String>,
         /// Host port for the local bot.
         #[arg(long, default_value_t = DEFAULT_PORT)]
         port: u16,
@@ -148,18 +149,18 @@ enum SkillAction {
 enum LocalAction {
     /// Bring the dev stack up (docker compose up -d --wait) and print URLs.
     Up {
-        /// Compose file (run from the repo root for the default).
-        #[arg(long, default_value = local::DEFAULT_COMPOSE_FILE)]
-        file: String,
+        /// Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override.
+        #[arg(short = 'f', long)]
+        file: Option<String>,
         /// Print the docker compose command and exit without executing.
         #[arg(long)]
         dry_run: bool,
     },
     /// Stop the dev stack (docker compose down), keeping volumes.
     Down {
-        /// Compose file (run from the repo root for the default).
-        #[arg(long, default_value = local::DEFAULT_COMPOSE_FILE)]
-        file: String,
+        /// Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override.
+        #[arg(short = 'f', long)]
+        file: Option<String>,
         /// Also destroy volumes (adds -v). Prompts for confirmation unless --yes.
         #[arg(long)]
         wipe: bool,
@@ -172,9 +173,9 @@ enum LocalAction {
     },
     /// Show the dev stack's service status (docker compose ps).
     Status {
-        /// Compose file (run from the repo root for the default).
-        #[arg(long, default_value = local::DEFAULT_COMPOSE_FILE)]
-        file: String,
+        /// Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override.
+        #[arg(short = 'f', long)]
+        file: Option<String>,
         /// Print the docker compose command and exit without executing.
         #[arg(long)]
         dry_run: bool,
@@ -258,9 +259,9 @@ enum ClusterAction {
         /// Helm release name.
         #[arg(long, default_value = "agentos")]
         release: String,
-        /// Chart path (run from the repo root for the default).
-        #[arg(long, default_value = "charts/agentos")]
-        chart: String,
+        /// Helm chart. Default: the version-pinned chart release asset on release builds; local `charts/agentos` on dev builds. Pass a path or ref to override.
+        #[arg(long)]
+        chart: Option<String>,
         /// Keep the UI and Langfuse services ClusterIP instead of NodePort.
         #[arg(long)]
         no_expose: bool,
@@ -397,6 +398,35 @@ enum ClusterAction {
     },
 }
 
+async fn resolve_compose_file(file: Option<String>, dry_run: bool) -> Result<String> {
+    let resolved = artifacts::resolve_compose(
+        file.as_deref(),
+        artifacts::Channel::current(),
+        artifacts::version(),
+        artifacts::cache_root,
+        std::path::Path::new(local::DEFAULT_COMPOSE_FILE).exists(),
+    )?;
+    materialize_artifact(resolved, dry_run, "compose").await
+}
+
+async fn materialize_artifact(
+    resolved: artifacts::Resolved,
+    dry_run: bool,
+    label: &str,
+) -> Result<String> {
+    if dry_run {
+        if let artifacts::Resolved::Fetch { url, .. } = &resolved {
+            ui::ui().note(&format!("{label} source: {}", ui::ui().url(url)));
+        }
+        Ok(resolved.planned_target().display().to_string())
+    } else {
+        Ok(artifacts::ensure_cached(&resolved)
+            .await?
+            .display()
+            .to_string())
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -421,6 +451,11 @@ async fn main() -> Result<()> {
                 budget,
                 model,
             } => {
+                let image = artifacts::resolve_image(
+                    image.as_deref(),
+                    artifacts::Channel::current(),
+                    artifacts::version(),
+                );
                 commands::start(StartOpts {
                     plugin_dir,
                     image,
@@ -445,13 +480,17 @@ async fn main() -> Result<()> {
             SkillAction::Eval { cases, url } => commands::eval(cases, url).await,
         },
         Command::Local { action } => match action {
-            LocalAction::Up { file, dry_run } => local::up(LocalOpts { file, dry_run }).await,
+            LocalAction::Up { file, dry_run } => {
+                let file = resolve_compose_file(file, dry_run).await?;
+                local::up(LocalOpts { file, dry_run }).await
+            }
             LocalAction::Down {
                 file,
                 wipe,
                 yes,
                 dry_run,
             } => {
+                let file = resolve_compose_file(file, dry_run).await?;
                 local::down(LocalDownOpts {
                     common: LocalOpts { file, dry_run },
                     wipe,
@@ -460,6 +499,7 @@ async fn main() -> Result<()> {
                 .await
             }
             LocalAction::Status { file, dry_run } => {
+                let file = resolve_compose_file(file, dry_run).await?;
                 local::status(LocalOpts { file, dry_run }).await
             }
             LocalAction::Message {
@@ -527,6 +567,14 @@ async fn main() -> Result<()> {
                 set,
                 dry_run,
             } => {
+                let resolved = artifacts::resolve_chart(
+                    chart.as_deref(),
+                    artifacts::Channel::current(),
+                    artifacts::version(),
+                    artifacts::cache_root,
+                    std::path::Path::new("charts/agentos").is_dir(),
+                )?;
+                let chart = materialize_artifact(resolved, dry_run, "chart").await?;
                 let credentials = ops::resolve_up_credentials(
                     fake_model,
                     std::env::var("AGENTOS_MODEL_CREDENTIALS").ok(),
@@ -658,6 +706,43 @@ mod tests {
                 action: LocalAction::Message { api_key, .. },
             } => assert_eq!(api_key, "K"),
             _ => panic!("expected local message command"),
+        }
+    }
+
+    #[test]
+    fn local_short_file_flag_parses_for_all_verbs() {
+        let cases = [
+            (["agentos", "local", "up", "-f", "custom.yaml"], "up"),
+            (["agentos", "local", "down", "-f", "custom.yaml"], "down"),
+            (
+                ["agentos", "local", "status", "-f", "custom.yaml"],
+                "status",
+            ),
+        ];
+
+        for (argv, verb) in cases {
+            let cli = Cli::try_parse_from(argv).expect("local verb accepts -f");
+            match cli.command {
+                Command::Local {
+                    action: LocalAction::Up { file, .. },
+                } => {
+                    assert_eq!(verb, "up");
+                    assert_eq!(file.as_deref(), Some("custom.yaml"));
+                }
+                Command::Local {
+                    action: LocalAction::Down { file, .. },
+                } => {
+                    assert_eq!(verb, "down");
+                    assert_eq!(file.as_deref(), Some("custom.yaml"));
+                }
+                Command::Local {
+                    action: LocalAction::Status { file, .. },
+                } => {
+                    assert_eq!(verb, "status");
+                    assert_eq!(file.as_deref(), Some("custom.yaml"));
+                }
+                _ => panic!("expected the local subcommand"),
+            }
         }
     }
 }

--- a/cli/tests/artifacts_fetch.rs
+++ b/cli/tests/artifacts_fetch.rs
@@ -1,0 +1,96 @@
+mod support;
+
+use agentos::artifacts::{ensure_cached, Resolved};
+use std::fs;
+use std::path::PathBuf;
+use support::{serve, Response};
+
+#[tokio::test]
+async fn cache_hit_skips_network_for_pinned_fetch() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = dir.path().join("compose.dev.yaml");
+    fs::write(&cache_path, b"cached compose").unwrap();
+    let resolved = Resolved::Fetch {
+        url: "http://127.0.0.1:1/compose.dev.yaml".to_string(),
+        cache_path: cache_path.clone(),
+    };
+
+    let path = ensure_cached(&resolved).await.unwrap();
+
+    assert_eq!(path, cache_path);
+    assert_eq!(fs::read(&cache_path).unwrap(), b"cached compose".to_vec());
+}
+
+#[tokio::test]
+async fn cache_miss_downloads_pinned_and_second_call_uses_cache() {
+    let expected = b"downloaded compose".to_vec();
+    let body = expected.clone();
+    let server = serve(move |req| {
+        assert_eq!(req.method, "GET");
+        assert_eq!(req.path, "/compose.dev.yaml");
+        Response {
+            status: 200,
+            content_type: "application/octet-stream".into(),
+            body: body.clone(),
+        }
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = dir.path().join("compose.dev.yaml");
+    let resolved = Resolved::Fetch {
+        url: format!("{}/compose.dev.yaml", server.base_url),
+        cache_path: cache_path.clone(),
+    };
+
+    let first = ensure_cached(&resolved).await.unwrap();
+
+    assert_eq!(first, cache_path);
+    assert_eq!(fs::read(&cache_path).unwrap(), expected);
+    assert_eq!(server.recorded().len(), 1);
+
+    let second = ensure_cached(&resolved).await.unwrap();
+
+    assert_eq!(second, cache_path);
+    assert_eq!(server.recorded().len(), 1);
+}
+
+#[tokio::test]
+async fn pinned_http_error_without_cache_reports_url_and_cleans_temp_files() {
+    let server = serve(|_req| Response {
+        status: 404,
+        content_type: "text/plain".into(),
+        body: b"not found".to_vec(),
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let cache_path = dir.path().join("compose.dev.yaml");
+    let url = format!("{}/compose.dev.yaml", server.base_url);
+    let resolved = Resolved::Fetch {
+        url: url.clone(),
+        cache_path: cache_path.clone(),
+    };
+
+    let err = ensure_cached(&resolved).await.unwrap_err();
+    let message = err.to_string();
+    let partials: Vec<PathBuf> = fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(std::result::Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains(".partial"))
+        })
+        .collect();
+
+    assert!(message.contains(&url), "error was {message}");
+    assert!(message.contains("not found"), "error was {message}");
+    assert!(!cache_path.exists());
+    assert!(partials.is_empty(), "leftover partial files: {partials:?}");
+}
+
+#[tokio::test]
+async fn local_resolution_returns_path_without_network() {
+    let path = PathBuf::from("compose.dev.yaml");
+    let resolved = Resolved::Local(path.clone());
+
+    assert_eq!(ensure_cached(&resolved).await.unwrap(), path);
+}

--- a/compose.release.yaml
+++ b/compose.release.yaml
@@ -1,3 +1,5 @@
+# Self contained no checkout release stack, published as a version pinned release asset for agentos local up on a release binary, while compose.dev.yaml remains the repo dev stack.
+#
 # AgentOS local dev stack.
 #
 # Postgres + Valkey + Langfuse v3 (web + worker + ClickHouse) + MinIO + OTel
@@ -12,7 +14,6 @@
 # Host ports use a distinctive 2xxxx block (host port = "2" + the service's
 # container port) to avoid common service defaults and stay below the OS
 # ephemeral port range (32768+):
-#   AgentOS Console ... http://localhost:28080
 #   Langfuse UI ....... http://localhost:23000
 #   Postgres .......... localhost:25432
 #   Valkey ............ localhost:26379
@@ -24,7 +25,7 @@
 # SIGILLs with exit 132 on CPUs without it; :24.8 still ships an SSE4.2 build.
 
 # Pin the Compose project name so `local up`/`down` target the same project
-# regardless of where this file sits (repo checkout or fetched cache dir).
+# regardless of which cache dir (v<version>) this file is fetched into.
 name: agentos
 
 x-langfuse-env: &langfuse-env
@@ -55,6 +56,47 @@ x-langfuse-env: &langfuse-env
   LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio:9000
   LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
   LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
+
+configs:
+  otel_collector_config:
+    content: |
+      # OTel Collector config for the AgentOS dev stack.
+      #
+      # Receives OTLP from our services over BOTH gRPC (4317) and HTTP (4318), and
+      # forwards to Langfuse. Langfuse OTLP ingest is HTTP-only (gRPC is silently
+      # unsupported), so the collector is the adapter: services may speak gRPC, but
+      # the export to Langfuse is always otlphttp. Langfuse appends /v1/traces to the
+      # otlphttp endpoint's base path itself.
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+
+      processors:
+        batch: {}
+
+      exporters:
+        otlphttp/langfuse:
+          endpoint: http://langfuse-web:3000/api/public/otel
+          headers:
+            # Basic auth for the LANGFUSE_INIT project keys baked into compose.dev.yaml.
+            # Value is base64("<public-key>:<secret-key>"), supplied via .env.
+            Authorization: $${env:LANGFUSE_OTLP_AUTH_HEADER}
+        debug:
+          verbosity: normal
+
+      service:
+        telemetry:
+          metrics:
+            level: none
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [batch]
+            exporters: [otlphttp/langfuse, debug]
 
 services:
   postgres:
@@ -201,8 +243,9 @@ services:
     environment:
       # base64("pk-lf-agentos-dev:sk-lf-agentos-dev"); matches the LANGFUSE_INIT keys above.
       LANGFUSE_OTLP_AUTH_HEADER: ${LANGFUSE_OTLP_AUTH_HEADER:-Basic cGstbGYtYWdlbnRvcy1kZXY6c2stbGYtYWdlbnRvcy1kZXY=}
-    volumes:
-      - ./otel/collector-config.yaml:/etc/otel/collector-config.yaml:ro
+    configs:
+      - source: otel_collector_config
+        target: /etc/otel/collector-config.yaml
     ports:
       - "24317:4317"
       - "24318:4318"
@@ -212,9 +255,9 @@ services:
   #
   # These three services turn the backing stack above into a one-command local
   # product loop. `agentos local up` brings everything up, then:
-  #   agentos local deploy --plugin-dir <dir> --slack-channel <C...> \
+  #   agentos deploy --plugin-dir <dir> --slack-channel <C...> \
   #                  --api-url http://localhost:28000
-  #   agentos local message "<question>"
+  #   agentos message --local "<question>"
   # drives a real queue -> worker -> sandboxed runner -> reply roundtrip, no
   # Slack and no Kubernetes. They use the same published images the chart
   # deploys (only the worker adds a thin local docker-CLI overlay; see below).
@@ -238,8 +281,8 @@ services:
     restart: "no"
 
   # The platform API. On the compose network, reaching Postgres/Valkey/MinIO by
-  # service name. Published on host 28000 for the CLI (`agentos local deploy`, and the
-  # `agentos local message` channel lookup).
+  # service name. Published on host 28000 for the CLI (`agentos deploy`, and the
+  # `agentos message --local` channel lookup).
   agentos-api:
     image: ghcr.io/curie-eng/agentos-api:latest
     depends_on:
@@ -316,11 +359,9 @@ services:
   # written and tested against (the host-process middle mode): the worker reaches
   # the backing stores on their published host ports (localhost 25432/26379/29000),
   # dials each runner on the loopback host port Docker publishes for it, and
-  # reaches the `agentos local message` Slack stub at localhost:8155.
+  # reaches the `agentos message --local` Slack stub at localhost:8155.
   agentos-worker:
-    build:
-      context: compose
-      dockerfile: worker-local.Dockerfile
+    image: ghcr.io/curie-eng/agentos-worker-local:latest
     depends_on:
       postgres:
         condition: service_healthy

--- a/compose/worker-local.Dockerfile
+++ b/compose/worker-local.Dockerfile
@@ -1,15 +1,17 @@
 # Local-dev overlay for the compose `agentos-worker` service ONLY.
 #
-# This is NOT the published image and is NOT used by the Helm deployment. The
-# hardened chart runs the worker with the KUBERNETES sandbox substrate, which
-# never shells out to docker, so the published worker image ships without a
-# docker CLI (dead weight and attack surface in production). The local compose
+# This is NOT the hardened worker image and is NOT used by the Helm deployment.
+# The hardened chart runs the worker with the KUBERNETES sandbox substrate,
+# which never shells out to docker, so the published worker image ships without
+# a docker CLI (dead weight and attack surface in production). The local compose
 # loop instead uses the DOCKER substrate (AGENTOS_SANDBOX_SUBSTRATE=docker),
 # which spawns runner containers on the host daemon via the mounted socket and
 # therefore needs the docker CLI. This overlay layers just the docker client
-# (not the daemon) onto the published image, leaving the release pipeline
-# untouched.
-FROM ghcr.io/curie-eng/agentos-worker:latest
+# (not the daemon) onto the published worker image. The release pipeline
+# publishes it as `agentos-worker-local` (BASE_TAG pins the base to the release
+# version) so `compose.release.yaml` can run the local loop with no checkout.
+ARG BASE_TAG=latest
+FROM ghcr.io/curie-eng/agentos-worker:${BASE_TAG}
 
 # Install only the static docker client binary from the official release tarball
 # (the tarball also carries dockerd/containerd, which we deliberately do not

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -30,9 +30,13 @@ installed by the chart's preflights; see `charts/agentos/README.md`).
 
 ## Install and inspect
 
-- `agentos cluster up` runs `helm upgrade --install` of `charts/agentos` into the
-  `agentos` namespace, exposing the UI and Langfuse on node ports (pass
-  `--no-expose` to keep them ClusterIP-only). It reads
+- `agentos cluster up` runs `helm upgrade --install` using the chart resolved
+  from the version-pinned release asset by default, so a downloaded release
+  binary needs no repo checkout. Pass `--chart <path-or-tgz>` to override with a
+  local chart for chart development. For local development, override resolved
+  artifacts with `-f <compose>`, `--chart <path-or-tgz>`, and `--image <ref>`.
+  It installs into the `agentos` namespace, exposing the UI and Langfuse on node
+  ports (pass `--no-expose` to keep them ClusterIP-only). It reads
   `AGENTOS_MODEL_CREDENTIALS`: when the env var is set it switches the runner
   off the fake model, forwards the credential through the masked `--set`
   machinery (so `--dry-run` never prints it), and opens the runner's
@@ -69,9 +73,11 @@ reference and the multi-turn `--thread` flow are in
 
 ## Bridging to the local dev stack
 
-`agentos local up|down|status` wraps the `compose.dev.yaml` dev stack, so the
-inner loop and the cluster share one CLI. `local up` brings up the full product
-stack (API + worker alongside the backing stores, plus the console UI at
+`agentos local up|down|status` wraps the local compose stack. A no checkout
+release binary uses the pinned `compose.release.yaml` release asset, while repo
+development still uses `compose.dev.yaml`, so the inner loop and the cluster
+share one CLI. `local up` brings up the full product stack (API + worker
+alongside the backing stores, plus the console UI at
 `http://localhost:28080/?api=1`), so
 `agentos local deploy --api-url http://localhost:28000` then `agentos local message
 "..."` drives a real queue -> worker -> sandboxed runner -> reply roundtrip with


### PR DESCRIPTION
A bare downloaded `agentos` binary can now run `skill up` / `cluster up` / `local up` in an empty directory with **no repo checkout**: the runner image, Helm chart, and compose stack resolve from a remote pinned to the CLI's build version and are cached locally. `--image` / `--chart` / `-f` still override for local repo dev, and repo-root workflows are unchanged.

## How
- **`cli/src/artifacts.rs`** — pure `resolve_image`/`resolve_chart`/`resolve_compose` plus `ensure_cached` (reqwest fetch with a connect timeout, per-process-unique temp + atomic rename, version-keyed cache under `~/.cache/agentos/<version>/`). `cli/build.rs` stamps a `release`/`dev` channel: release pins every artifact to the build version; dev prefers local files and errors (telling you to pass `--image`/`--chart`/`-f`) rather than fetching a non-standalone file.
- **clap defaults become `Option<String>` sentinels** resolved at the command boundary (`skill up` image, `cluster up` chart, `local up|down|status` file). `--dry-run` prints the resolved argv without any network I/O.
- **`compose.release.yaml`** — a self-contained release stack (published `agentos-worker-local` overlay image instead of a build, otel config inlined, stable `name: agentos` project, includes the console UI) so `local up` needs no checkout. `compose.dev.yaml` stays the repo-dev stack.
- **`.github/workflows/release.yaml`** — publishes the packaged chart and the worker-local overlay image, pins the chart's service image tags and the release compose to the build version, attaches the compose asset, and guards `tag == cli/Cargo.toml version`.
- **Docs** (`README`, `cli/README`, `docs/operations.md`, `cli/CLAUDE.md`) lead with the no-clone path and document the overrides + cache.

## Notes
- Rebased onto the now-merged **#40** (skill/local/cluster verb rename) and **#42** (compose console UI). The resolver wires into the new verbs; `compose.release.yaml` includes #42's UI service.
- `cli/Cargo.toml` is bumped to **0.1.1**: the first tag cut after merge must be `v0.1.1+` so a release binary's pinned URLs point at a release that actually publishes the chart/compose assets (the CI job guards tag==version).
- Reviewed via 3 Codex passes + Claude code/scope/spec reviewers + a `/simplify` consolidation pass.

## Follow-ups (out of scope)
- CI-generate `compose.release.yaml` from `compose.dev.yaml` at publish time (eliminate the committed duplicate).
- Route `cluster message --wire`'s `--chart` through the resolver (still defaults to `charts/agentos`).
- Optional `oci://` chart publish; artifact checksum verification.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)