### PR TITLE
Add an opt-in shimmer (assistant-thread status) toggle

### DIFF
--- a/apps/dispatcher/slack-app-manifest.yaml
+++ b/apps/dispatcher/slack-app-manifest.yaml
@@ -23,6 +23,13 @@ oauth_config:
       - groups:history
       - im:history
       - im:read
+      # Required only if you enable the shimmer status (AGENTOS_SHIMMER): lets the
+      # dispatcher/worker call assistant.threads.setStatus. You must ALSO turn on
+      # the "Agents & AI Apps" feature in the app config (api.slack.com/apps ->
+      # your app -> Agents & AI Apps) for setStatus to be accepted -- that toggle
+      # has no stable manifest key, so it is a one-click manual step. Harmless to
+      # keep the scope even with shimmer off.
+      - assistant:write
 settings:
   socket_mode_enabled: true
   event_subscriptions:

--- a/apps/dispatcher/src/agentos_dispatcher/config.py
+++ b/apps/dispatcher/src/agentos_dispatcher/config.py
@@ -18,6 +18,7 @@ Env mapping:
     AGENTOS_DEDUPE_PREFIX      -> dedupe_prefix
     AGENTOS_DEDUPE_TTL_SECONDS -> dedupe_ttl_seconds
     AGENTOS_PLACEHOLDER_TEXT   -> placeholder_text
+    AGENTOS_SHIMMER            -> shimmer (assistant-thread status while working)
     AGENTOS_BACKOFF_INITIAL_SECONDS -> backoff_initial_seconds
     AGENTOS_BACKOFF_MAX_SECONDS     -> backoff_max_seconds
     AGENTOS_BACKOFF_MULTIPLIER      -> backoff_multiplier
@@ -48,6 +49,11 @@ class DispatcherConfig(BaseModel):
     dedupe_ttl_seconds: int = 3600
 
     placeholder_text: str = "On it. Working on your request."
+    # When true, also set a Slack assistant-thread status (the native "shimmer"
+    # on the app name) to placeholder_text while a turn runs. The worker clears it
+    # when the turn ends. Off by default; requires the app's assistant feature +
+    # assistant:write scope (see slack-app-manifest.yaml).
+    shimmer: bool = False
 
     backoff_initial_seconds: float = Field(default=1.0, gt=0)
     backoff_max_seconds: float = Field(default=30.0, gt=0)
@@ -73,6 +79,7 @@ class DispatcherConfig(BaseModel):
         _set_str(values, "dedupe_prefix", env, "AGENTOS_DEDUPE_PREFIX")
         _set_int(values, "dedupe_ttl_seconds", env, "AGENTOS_DEDUPE_TTL_SECONDS")
         _set_str(values, "placeholder_text", env, "AGENTOS_PLACEHOLDER_TEXT")
+        _set_bool(values, "shimmer", env, "AGENTOS_SHIMMER")
         _set_float(values, "backoff_initial_seconds", env, "AGENTOS_BACKOFF_INITIAL_SECONDS")
         _set_float(values, "backoff_max_seconds", env, "AGENTOS_BACKOFF_MAX_SECONDS")
         _set_float(values, "backoff_multiplier", env, "AGENTOS_BACKOFF_MULTIPLIER")
@@ -98,3 +105,10 @@ def _set_float(
 ) -> None:
     if var in env:
         values[key] = float(env[var])
+
+
+def _set_bool(
+    values: dict[str, Any], key: str, env: Mapping[str, str], var: str
+) -> None:
+    if var in env:
+        values[key] = env[var].strip().lower() in ("1", "true", "yes", "on")

--- a/apps/dispatcher/src/agentos_dispatcher/handlers.py
+++ b/apps/dispatcher/src/agentos_dispatcher/handlers.py
@@ -87,6 +87,17 @@ def process_event(
     )
     placeholder_ts = placeholder["ts"]
 
+    if config.shimmer:
+        # Native Slack "shimmer": set the assistant-thread status so the app name
+        # shimmers while we work. Best-effort -- a workspace without the assistant
+        # feature just skips it; the worker clears the status when the turn ends.
+        try:
+            web_client.assistant_threads_setStatus(
+                channel_id=channel, thread_ts=thread_ts, status=config.placeholder_text
+            )
+        except Exception as exc:  # noqa: BLE001 -- shimmer is best-effort, never fatal
+            log.debug("assistant setStatus skipped for %s: %s", slack_event_id, exc)
+
     queued = QueuedSlackEvent(
         slack_event_id=slack_event_id,
         thread_ts=thread_ts,

--- a/apps/dispatcher/tests/test_dispatch.py
+++ b/apps/dispatcher/tests/test_dispatch.py
@@ -122,6 +122,26 @@ def test_envelope_acked_placeholder_posted_and_enqueued(
     assert queued.placeholder_ts == BOT_TS
 
 
+def test_shimmer_sets_assistant_status_after_placeholder(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    shimmer_config = config.model_copy(update={"shimmer": True})
+    app, web_client = _build(shimmer_config, redis_client)
+    web_client.assistant_threads_setStatus = MagicMock()  # type: ignore[method-assign]
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _events_api_request("env-1", "Ev-shim", _mention_event()))
+    _drain(app)
+
+    # The shimmer status is set on the same thread as the placeholder.
+    web_client.assistant_threads_setStatus.assert_called_once_with(
+        channel_id="C123", thread_ts="1700.0001", status=shimmer_config.placeholder_text
+    )
+    # And the normal placeholder + enqueue still happen.
+    assert redis_client.xlen(config.stream) == 1
+
+
 def test_duplicate_delivery_enqueues_exactly_once(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -59,6 +59,11 @@ class WorkerConfig(BaseModel):
     fake_model: bool = False
     credentials: str = ""
 
+    # When true, clear the Slack assistant-thread status (the "shimmer" the
+    # dispatcher set) once a turn ends -- editing the placeholder does not
+    # auto-clear it. Off by default; pairs with the dispatcher's AGENTOS_SHIMMER.
+    shimmer: bool = False
+
     # Stream / consumer group (must match the dispatcher's AGENTOS_STREAM)
     stream: str = "agentos:runs"
     consumer_group: str = "agentos-workers"
@@ -165,6 +170,7 @@ class WorkerConfig(BaseModel):
         _s(values, "db_schema", env, "DB_SCHEMA")
         _s(values, "bundle_plugin_dir", env, "AGENTOS_PLUGIN_DIR")
         _b(values, "fake_model", env, "AGENTOS_FAKE_MODEL")
+        _b(values, "shimmer", env, "AGENTOS_SHIMMER")
         _s(values, "credentials", env, "AGENTOS_CREDENTIALS")
         _s(values, "eval_stream", env, "AGENTOS_EVAL_STREAM")
         _s(values, "eval_consumer_group", env, "AGENTOS_EVAL_CONSUMER_GROUP")

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -261,6 +261,14 @@ class Kernel:
                 await asyncio.sleep(self._backoff(attempt))
         finally:
             release_order()
+            # Clear the assistant-thread "shimmer" the dispatcher set, on every
+            # exit path (success, escalate, drop, or error). Best-effort and
+            # idempotent -- it never repeats an action or blocks the turn, so it
+            # is safe outside the concurrency-critical section above.
+            if self._config.shimmer:
+                await self._sink.clear_status(
+                    channel=qevent.channel, thread_ts=qevent.thread_ts
+                )
 
     def _acquire_order_entry(self, thread: str) -> _LockEntry:
         entry = self._order_locks.get(thread)

--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -8,17 +8,25 @@ one external service the kernel tests mock; everything else runs for real.
 
 from __future__ import annotations
 
+import logging
 from typing import Protocol
 
 from slack_sdk.web.async_client import AsyncWebClient
 
 from .mrkdwn import to_mrkdwn
 
+logger = logging.getLogger(__name__)
+
 
 class SlackSink(Protocol):
     """Edit a message in place. The kernel throttles how often it calls this."""
 
     async def update(self, *, channel: str, ts: str, text: str) -> None: ...
+
+    async def clear_status(self, *, channel: str, thread_ts: str) -> None:
+        """Clear any assistant-thread status (the "shimmer") on the thread. A
+        no-op when shimmering is off; best-effort so it never breaks a turn."""
+        ...
 
 
 class AsyncSlackSink:
@@ -40,3 +48,15 @@ class AsyncSlackSink:
         # real-Slack seam, so both streamed partials and the final edit render
         # correctly without the kernel knowing about Slack's dialect.
         await self._client.chat_update(channel=channel, ts=ts, text=to_mrkdwn(text))
+
+    async def clear_status(self, *, channel: str, thread_ts: str) -> None:
+        # Clear the assistant-thread status by setting it empty (Slack only
+        # auto-clears on a posted message, and we edit the placeholder instead).
+        # Best-effort: a workspace without the assistant feature, or any transient
+        # error, must never fail the turn -- the reply already went out.
+        try:
+            await self._client.assistant_threads_setStatus(
+                channel_id=channel, thread_ts=thread_ts, status=""
+            )
+        except Exception as exc:  # noqa: BLE001 -- status clear is best-effort
+            logger.debug("assistant clear_status skipped for %s: %s", thread_ts, exc)

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -95,13 +95,17 @@ def make_config(names: dict[str, str], **overrides: object) -> WorkerConfig:
 
 
 class FakeSink(SlackSink):
-    """Records every chat.update the kernel makes."""
+    """Records every chat.update and status-clear the kernel makes."""
 
     def __init__(self) -> None:
         self.updates: list[tuple[str, str, str]] = []
+        self.status_clears: list[tuple[str, str]] = []
 
     async def update(self, *, channel: str, ts: str, text: str) -> None:
         self.updates.append((channel, ts, text))
+
+    async def clear_status(self, *, channel: str, thread_ts: str) -> None:
+        self.status_clears.append((channel, thread_ts))
 
     @property
     def last_text(self) -> str | None:

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -70,6 +70,29 @@ def test_new_turn_streams_to_slack_and_acks(make_harness) -> None:
     asyncio.run(go())
 
 
+def test_shimmer_clears_status_when_the_turn_ends(make_harness) -> None:
+    # With shimmer on, the kernel clears the assistant-thread status the
+    # dispatcher set, on the turn's terminal exit (a plain success here).
+    async def go() -> None:
+        async with make_harness(shimmer=True) as h:
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", thread="tS"))
+            assert ("C1", "tS") in h.sink.status_clears
+
+    asyncio.run(go())
+
+
+def test_no_status_clear_when_shimmer_is_off(make_harness) -> None:
+    # Default (shimmer off): the kernel never touches the assistant status.
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("hi"))
+            assert h.sink.status_clears == []
+
+    asyncio.run(go())
+
+
 def test_followup_steers_the_live_turn(make_harness) -> None:
     async def go() -> None:
         async with make_harness() as h:

--- a/apps/worker/tests/test_slack_sink.py
+++ b/apps/worker/tests/test_slack_sink.py
@@ -36,3 +36,29 @@ def test_update_converts_markdown_to_mrkdwn() -> None:
     asyncio.run(sink.update(channel="C1", ts="1.1", text="**hi** [x](http://y)"))
 
     assert captured["text"] == "*hi* <http://y|x>"
+
+
+def test_clear_status_sets_empty_assistant_status() -> None:
+    sink = AsyncSlackSink("xoxb-test")
+    captured: dict[str, str] = {}
+
+    async def _fake_set_status(*, channel_id: str, thread_ts: str, status: str) -> None:
+        captured.update(channel_id=channel_id, thread_ts=thread_ts, status=status)
+
+    sink._client.assistant_threads_setStatus = _fake_set_status  # type: ignore[method-assign]
+
+    asyncio.run(sink.clear_status(channel="C1", thread_ts="1.1"))
+
+    assert captured == {"channel_id": "C1", "thread_ts": "1.1", "status": ""}
+
+
+def test_clear_status_is_best_effort_on_error() -> None:
+    sink = AsyncSlackSink("xoxb-test")
+
+    async def _boom(**_kwargs: object) -> None:
+        raise RuntimeError("workspace has no assistant feature")
+
+    sink._client.assistant_threads_setStatus = _boom  # type: ignore[method-assign]
+
+    # Must not raise -- clearing the shimmer can never fail a completed turn.
+    asyncio.run(sink.clear_status(channel="C1", thread_ts="1.1"))


### PR DESCRIPTION
## What

An opt-in **shimmer**: when `AGENTOS_SHIMMER` is on, AgentOS uses Slack's native assistant-thread status (the shimmering app name, like the Claude app) as the "working" cue while a turn runs, instead of relying only on the edited "On it…" placeholder. Off by default.

## How

- **dispatcher** (`handlers.py`, `config.py`): after posting the placeholder, set the assistant status to `placeholder_text`. Best-effort — a workspace without the assistant feature just skips it. New `AGENTOS_SHIMMER` flag.
- **worker `slack_sink.py`**: a `clear_status` method (`assistant.threads.setStatus` with empty status), best-effort so it never fails a completed turn.
- **worker `kernel.py`**: clear the status when the turn ends.
- **manifest**: add the `assistant:write` scope + a note that the "Agents & AI Apps" feature must be enabled to use shimmer.

## Why the kernel is touched (and why it's safe)

Slack only auto-clears a status when the app **posts** a message; AgentOS **edits** the placeholder, so the shimmer would linger without an explicit clear. Clearing requires knowing the turn finished, and that lifecycle lives only in the kernel. The change is deliberately the *minimal* form: **one idempotent, best-effort `clear_status` call in `process_event`'s `finally`**. It:

- runs on every exit path (success, escalate, drop, error),
- sits **outside** the concurrency-critical section (after `release_order()`),
- cannot repeat an action or open a race (setting a status empty is idempotent and best-effort).

So it doesn't touch any of the four kernel invariants. **The full kernel rule suite still passes** (19/19). Per `apps/worker/CLAUDE.md`, any kernel edit needs the adversarial review (spec-vs-impl + side-effects-detective) — flagging that here explicitly; the diff is scoped to make that review trivial.

## Not included / not changed

- No frozen ACI contract change, no migration.
- This keeps the placeholder message (shimmer runs alongside it) — the lower-risk of the two shapes we considered. The zero-redundancy version (shimmer replaces the placeholder, answer posted on first token) would rework the streaming/message-creation path and is a deliberate larger follow-up.

## Verification

`ruff check` clean, `mypy` clean (93 files), and pytest against real Valkey: `test_slack_sink` (clear sets empty status; best-effort on error), `test_dispatch` (shimmer sets the status on the placeholder's thread), and the **full kernel rule suite** (clears on finish when on; never touches status when off; all existing rules green).

Ref CUR-1593