### PR TITLE
Turn Block Kit button clicks into turns (interactivity)

### DIFF
--- a/apps/dispatcher/slack-app-manifest.yaml
+++ b/apps/dispatcher/slack-app-manifest.yaml
@@ -3,8 +3,9 @@
 # Paste this at https://api.slack.com/apps -> Create New App -> From a manifest,
 # to create the app the dispatcher connects to. It encodes exactly what the
 # dispatcher runbook (README "point it at a real workspace") requires: Socket
-# Mode on, the six bot scopes, and the app_mention + message.im event
-# subscriptions. After creating: generate an App-Level Token with
+# Mode on, the bot scopes, the app_mention + message.im event subscriptions, and
+# interactivity on (so button clicks arrive over Socket Mode). After creating:
+# generate an App-Level Token with
 # connections:write -> SLACK_APP_TOKEN; install to the workspace and copy the
 # Bot User OAuth Token -> SLACK_BOT_TOKEN.
 display_information:
@@ -30,6 +31,9 @@ settings:
       - app_mention
       - message.im
   interactivity:
-    is_enabled: false
+    # Enabled so Slack delivers block_actions (button clicks) over Socket Mode;
+    # the dispatcher turns a click into a turn (its action id/value becomes the
+    # message). No request URL is needed under Socket Mode.
+    is_enabled: true
   org_deploy_enabled: false
   token_rotation_enabled: false

--- a/apps/dispatcher/src/agentos_dispatcher/handlers.py
+++ b/apps/dispatcher/src/agentos_dispatcher/handlers.py
@@ -17,6 +17,7 @@ dispatcher's.
 """
 
 import logging
+import re
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -101,6 +102,75 @@ def process_event(
     return stream_id
 
 
+def action_command(action: dict[str, Any]) -> str:
+    """The command a clicked Block Kit action carries: its ``value`` if set, else
+    its ``action_id`` (the ss-template convention where a button's id is the
+    command it runs)."""
+    value = action.get("value")
+    return str(value) if value else str(action.get("action_id", ""))
+
+
+def process_action(
+    *,
+    body: dict[str, Any],
+    web_client: WebClient,
+    redis_client: "Redis",
+    config: DispatcherConfig,
+    clock: Clock = _utc_now_iso,
+    logger: logging.Logger | None = None,
+) -> str | None:
+    """Normalize a Block Kit button click into a turn: dedupe, post an in-thread
+    placeholder, and enqueue a ``QueuedSlackEvent`` whose text is the button's
+    command. The worker answers it exactly as if the user had typed that command.
+
+    Same four steps as ``process_event`` (ack is Bolt's, before this runs); no
+    decision about *how* the turn is answered lives here -- that is the worker's.
+    """
+    log = logger or logging.getLogger(__name__)
+
+    actions = body.get("actions") or []
+    if not actions:
+        return None
+    command = action_command(actions[0])
+    if not command:
+        return None
+
+    # A click carries no Slack event_id, so synthesize a stable idempotency key
+    # from the interaction; a re-delivered click cannot enqueue (or post a second
+    # placeholder) twice, same as the event dedupe.
+    interaction = body.get("trigger_id") or (
+        f"{actions[0].get('action_ts', '')}-{actions[0].get('action_id', '')}"
+    )
+    slack_event_id = f"action-{interaction}"
+    if not claim_event(redis_client, config, slack_event_id):
+        log.info("duplicate block action %s, skipping", slack_event_id)
+        return None
+
+    channel = body["channel"]["id"]
+    message = body.get("message") or {}
+    # Reply in the clicked message's thread (its thread_ts, or its own ts if root).
+    thread_ts = message.get("thread_ts") or message.get("ts") or ""
+    user = (body.get("user") or {}).get("id", "")
+
+    placeholder = web_client.chat_postMessage(
+        channel=channel,
+        thread_ts=thread_ts,
+        text=config.placeholder_text,
+    )
+    queued = QueuedSlackEvent(
+        slack_event_id=slack_event_id,
+        thread_ts=thread_ts,
+        channel=channel,
+        user=user,
+        text=command,
+        placeholder_ts=placeholder["ts"],
+        received_at=clock(),
+    )
+    stream_id = enqueue(redis_client, config, queued)
+    log.info("enqueued block action %s as stream entry %s", slack_event_id, stream_id)
+    return stream_id
+
+
 def register_handlers(
     app: App,
     *,
@@ -110,7 +180,7 @@ def register_handlers(
     clock: Clock = _utc_now_iso,
     logger: logging.Logger | None = None,
 ) -> None:
-    """Wire the app_mention and (direct-message) message listeners onto the app."""
+    """Wire the app_mention, (direct-message) message, and block-action listeners."""
 
     @app.event("app_mention")
     def _on_app_mention(body: dict[str, Any], event: dict[str, Any]) -> None:
@@ -131,6 +201,20 @@ def register_handlers(
         process_event(
             body=body,
             event=event,
+            web_client=web_client,
+            redis_client=redis_client,
+            config=config,
+            clock=clock,
+            logger=logger,
+        )
+
+    # Any Block Kit button click (a reply's action) becomes a turn. The catch-all
+    # matches every action_id; ack first (Bolt's 3s budget), then normalize+enqueue.
+    @app.action(re.compile(r".+"))
+    def _on_action(ack: Callable[..., None], body: dict[str, Any]) -> None:
+        ack()
+        process_action(
+            body=body,
             web_client=web_client,
             redis_client=redis_client,
             config=config,

--- a/apps/dispatcher/tests/test_dispatch.py
+++ b/apps/dispatcher/tests/test_dispatch.py
@@ -91,6 +91,35 @@ def _mention_event(text: str = "hi there") -> dict[str, Any]:
     }
 
 
+def _block_action_request(
+    envelope_id: str,
+    *,
+    action_id: str = "reports",
+    value: str | None = None,
+    trigger_id: str | None = None,
+    message: dict[str, Any] | None = None,
+) -> SocketModeRequest:
+    action: dict[str, Any] = {"type": "button", "action_id": action_id, "action_ts": "1.5"}
+    if value is not None:
+        action["value"] = value
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "block_actions",
+            "trigger_id": trigger_id or f"trig-{envelope_id}",
+            "team": {"id": "T1"},
+            "user": {"id": "U123"},
+            "api_app_id": "A1",
+            "token": "verif",
+            "container": {"type": "message", "message_ts": "1700.0001"},
+            "channel": {"id": "C123"},
+            "message": message or {"ts": "1700.0001", "thread_ts": "1700.0001"},
+            "actions": [action],
+        },
+    )
+
+
 def test_envelope_acked_placeholder_posted_and_enqueued(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:
@@ -184,6 +213,61 @@ def test_message_in_channel_is_ignored(
     # Ordinary channel chatter is acked but never enqueued.
     assert sock.acked_envelope_ids == ["env-1"]
     assert redis_client.xlen(config.stream) == 0
+
+
+def test_button_click_enqueues_a_turn(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    app, web_client = _build(config, redis_client)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _block_action_request("env-1", action_id="reports"))
+    _drain(app)
+
+    # A placeholder is posted in the clicked message's thread, and one turn is
+    # enqueued whose text is the button's command (its action_id here).
+    web_client.chat_postMessage.assert_called_once_with(
+        channel="C123", thread_ts="1700.0001", text=config.placeholder_text
+    )
+    assert redis_client.xlen(config.stream) == 1
+    _, fields = redis_client.xrange(config.stream)[0]
+    queued = QueuedSlackEvent.from_stream_fields(fields)
+    assert queued.text == "reports"
+    assert queued.channel == "C123"
+    assert queued.thread_ts == "1700.0001"
+    assert queued.placeholder_ts == BOT_TS
+    assert queued.slack_event_id == "action-trig-env-1"
+
+
+def test_button_click_prefers_value_over_action_id(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    app, _ = _build(config, redis_client)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _block_action_request("env-1", action_id="btn", value="show top 5"))
+    _drain(app)
+
+    _, fields = redis_client.xrange(config.stream)[0]
+    assert QueuedSlackEvent.from_stream_fields(fields).text == "show top 5"
+
+
+def test_duplicate_click_enqueues_exactly_once(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    app, web_client = _build(config, redis_client)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    # Same interaction (trigger_id) redelivered: dedupe drops the second.
+    handler.handle(sock, _block_action_request("env-1", trigger_id="trig-dup"))
+    handler.handle(sock, _block_action_request("env-2", trigger_id="trig-dup"))
+    _drain(app)
+
+    assert web_client.chat_postMessage.call_count == 1
+    assert redis_client.xlen(config.stream) == 1
 
 
 def test_bot_authored_message_is_ignored(


### PR DESCRIPTION
## What

Makes the buttons rendered by #54 actually work. The dispatcher now handles Slack **`block_actions`** (button clicks) and turns each into a turn, reusing the existing queue. The button's `value` (or its `action_id`) becomes the message text, so the worker answers a click exactly as if the user had typed that command.

## How

- **`handlers.py`**: `process_action` + a catch-all `@app.action` listener. Same four dispatcher steps as a message — **ack, dedupe, placeholder, enqueue** — nothing more (routing stays the worker's job). A click carries no Slack `event_id`, so dedupe keys on the interaction's `trigger_id`. The reply posts in the clicked message's thread.
- **manifest**: `interactivity.is_enabled: true` so Socket Mode delivers clicks (no request URL needed under Socket Mode).

## Scope

Dispatcher-only: **no kernel change, no frozen-contract change.** This is the interactivity half of the ss-template rich-reply port (rendering landed in #54). Together, #54 + this give plugins working buttons; the **`nav` pack** (the no-dead-ends home button) is the natural follow-up now that clicks work.

## Verification

`ruff` + `mypy` clean, and dispatcher tests against real Valkey (Bolt's real `SocketModeHandler` driving `block_actions` end to end):
- a click enqueues one turn with the right thread + command, and posts a placeholder;
- `value` is preferred over `action_id`;
- a duplicate click (same `trigger_id`) deduplicates to one turn.
All 5 existing dispatch tests still pass.

Ref CUR-1594