### PR TITLE
Split the tips pack into separate load and tips packs

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -132,6 +132,13 @@
               "reply": ""
             }
           },
+          "load": {
+            "$ref": "#/components/schemas/LoadPackConfig",
+            "default": {
+              "enabled": false,
+              "lines": []
+            }
+          },
           "settings": {
             "$ref": "#/components/schemas/SettingsPackConfig",
             "default": {
@@ -143,8 +150,7 @@
             "$ref": "#/components/schemas/TipsPackConfig",
             "default": {
               "enabled": false,
-              "tips": [],
-              "working_lines": []
+              "tips": []
             }
           }
         },
@@ -616,6 +622,26 @@
         "title": "KillState",
         "type": "object"
       },
+      "LoadPackConfig": {
+        "description": "Rotating \"working...\" load lines for one agent. Mirrors the worker's\nagentos_worker.behaviorpacks.LoadPack (packs ride on agent config, not the\nfrozen ACI contract, so the shape is duplicated across the layers the way\nBudgetConfig mirrors the ACI Budget).",
+        "properties": {
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "lines": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Lines",
+            "type": "array"
+          }
+        },
+        "title": "LoadPackConfig",
+        "type": "object"
+      },
       "MetricPoint": {
         "properties": {
           "ts": {
@@ -913,7 +939,7 @@
         "type": "object"
       },
       "TipsPackConfig": {
-        "description": "The \"working...\" acknowledgment content for one agent. Mirrors the worker's\nagentos_worker.behaviorpacks.TipsPack (packs ride on agent config, not the\nfrozen ACI contract, so the shape is duplicated across the layers the way\nBudgetConfig mirrors the ACI Budget).",
+        "description": "Rotating capability tips for one agent (mirrors behaviorpacks.TipsPack).\nSeparate from LoadPackConfig: a load line is what the agent is doing now, a\ntip advertises what it can do.",
         "properties": {
           "enabled": {
             "default": false,
@@ -926,14 +952,6 @@
               "type": "string"
             },
             "title": "Tips",
-            "type": "array"
-          },
-          "working_lines": {
-            "default": [],
-            "items": {
-              "type": "string"
-            },
-            "title": "Working Lines",
             "type": "array"
           }
         },

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -9,14 +9,22 @@ from pydantic import BaseModel, ConfigDict, Field
 from .models import Environment
 
 
-class TipsPackConfig(BaseModel):
-    """The "working..." acknowledgment content for one agent. Mirrors the worker's
-    agentos_worker.behaviorpacks.TipsPack (packs ride on agent config, not the
+class LoadPackConfig(BaseModel):
+    """Rotating "working..." load lines for one agent. Mirrors the worker's
+    agentos_worker.behaviorpacks.LoadPack (packs ride on agent config, not the
     frozen ACI contract, so the shape is duplicated across the layers the way
     BudgetConfig mirrors the ACI Budget)."""
 
     enabled: bool = False
-    working_lines: list[str] = []
+    lines: list[str] = []
+
+
+class TipsPackConfig(BaseModel):
+    """Rotating capability tips for one agent (mirrors behaviorpacks.TipsPack).
+    Separate from LoadPackConfig: a load line is what the agent is doing now, a
+    tip advertises what it can do."""
+
+    enabled: bool = False
     tips: list[str] = []
 
 
@@ -62,6 +70,7 @@ class BehaviorPacksConfig(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+    load: LoadPackConfig = LoadPackConfig()
     tips: TipsPackConfig = TipsPackConfig()
     greeting: GreetingPackConfig = GreetingPackConfig()
     help: HelpPackConfig = HelpPackConfig()

--- a/apps/api/tests/test_behavior_packs_integration.py
+++ b/apps/api/tests/test_behavior_packs_integration.py
@@ -53,11 +53,8 @@ def test_put_then_get_round_trips(
 ) -> None:
     agent = _create_agent(client, auth_headers)
     config = {
-        "tips": {
-            "enabled": True,
-            "working_lines": ["Working on it!"],
-            "tips": ["Ask me for the top 5"],
-        },
+        "load": {"enabled": True, "lines": ["Working on it!"]},
+        "tips": {"enabled": True, "tips": ["Ask me for the top 5"]},
         "greeting": {"enabled": True, "phrases": ["hey"], "reply": "hello!"},
         "help": {"enabled": True, "phrases": ["help"], "reply": "here is help"},
         "settings": {
@@ -75,7 +72,8 @@ def test_put_then_get_round_trips(
     resp = client.get(f"/agents/{agent['id']}/behavior-packs", headers=auth_headers)
     assert resp.status_code == 200, resp.text
     got = resp.json()
-    assert got["tips"]["working_lines"] == ["Working on it!"]
+    assert got["load"]["lines"] == ["Working on it!"]
+    assert got["tips"]["tips"] == ["Ask me for the top 5"]
     assert got["greeting"]["reply"] == "hello!"
     assert got["help"]["reply"] == "here is help"
     assert got["settings"]["settings"][0]["key"] == "page_size"

--- a/apps/worker/src/agentos_worker/behaviorpacks.py
+++ b/apps/worker/src/agentos_worker/behaviorpacks.py
@@ -47,15 +47,25 @@ _WHITESPACE = re.compile(r"\s+")
 _RUN = re.compile(r"(.)\1{2,}")  # 3+ of the same char in a row
 
 
-class TipsPack(BaseModel):
-    """The "working..." acknowledgment content for one agent."""
+class LoadPack(BaseModel):
+    """Rotating "working..." load lines for one agent (the status of what it is
+    doing: "Working on it!", "Crunching the numbers..."). A separate pack from
+    tips so an agent can enable one without the other."""
 
     model_config = ConfigDict(frozen=True)
 
     enabled: bool = False
-    # Sampled for the first line ("Working on it!", "Crunching the numbers...").
-    working_lines: tuple[str, ...] = ()
-    # Sampled for an optional capability tip line ("I can rank leaks by $").
+    lines: tuple[str, ...] = ()
+
+
+class TipsPack(BaseModel):
+    """Rotating capability tips for one agent ("I can rank leaks by $"). Distinct
+    from load lines: a load line says what the agent is doing right now; a tip
+    advertises what it can do."""
+
+    model_config = ConfigDict(frozen=True)
+
+    enabled: bool = False
     tips: tuple[str, ...] = ()
 
 
@@ -121,6 +131,7 @@ class BehaviorPacks(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
+    load: LoadPack = LoadPack()
     tips: TipsPack = TipsPack()
     greeting: GreetingPack = GreetingPack()
     help: HelpPack = HelpPack()
@@ -199,22 +210,25 @@ def match_help(packs: BehaviorPacks, text: str) -> str | None:
     return pack.reply if _matches_bare(pack.phrases, text) else None
 
 
+def sample_load(packs: BehaviorPacks, seed: str) -> str | None:
+    """The sampled "working..." load line for this agent, or None if the load
+    pack is disabled or empty. ``seed`` (e.g. the inbound message ts) makes the
+    choice vary per message while staying reproducible."""
+    pack = packs.load
+    if not pack.enabled:
+        return None
+    return _pick(pack.lines, seed, salt="w:") or None
+
+
 def sample_tip(packs: BehaviorPacks, seed: str) -> str | None:
-    """The sampled "working..." acknowledgment for this agent, or None if the
-    tips pack is disabled or has no content. ``seed`` (e.g. the inbound message
-    ts) makes the choice vary per message while staying reproducible."""
+    """The sampled capability tip for this agent, or None if the tips pack is
+    disabled or empty. Seeded independently of the load line so both can vary off
+    the same message ts. The display surface composes load + tip as it sees fit
+    (e.g. ``"{load}\\n\\nTip: {tip}"``)."""
     pack = packs.tips
     if not pack.enabled:
         return None
-    working = _pick(pack.working_lines, seed, salt="w:")
-    tip = _pick(pack.tips, seed, salt="t:")
-    if working and tip:
-        return f"{working}\n\nTip: {tip}"
-    if working:
-        return working
-    if tip:
-        return f"Tip: {tip}"
-    return None
+    return _pick(pack.tips, seed, salt="t:") or None
 
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -243,7 +243,7 @@ def test_behavior_packs_round_trip_and_parse() -> None:
             )
             packs_json = (
                 '{"greeting": {"enabled": true, "phrases": ["hi"], "reply": "yo"}, '
-                '"tips": {"enabled": false, "working_lines": [], "tips": []}}'
+                '"load": {"enabled": true, "lines": ["Working..."]}}'
             )
             async with engine.begin() as conn:
                 await conn.execute(

--- a/apps/worker/tests/test_behaviorpacks.py
+++ b/apps/worker/tests/test_behaviorpacks.py
@@ -12,6 +12,7 @@ from agentos_worker.behaviorpacks import (
     BehaviorPacks,
     GreetingPack,
     HelpPack,
+    LoadPack,
     Setting,
     SettingError,
     SettingsPack,
@@ -20,6 +21,7 @@ from agentos_worker.behaviorpacks import (
     match_greeting,
     match_help,
     resolve_settings,
+    sample_load,
     sample_tip,
 )
 
@@ -34,12 +36,14 @@ def _packs(
     *,
     greeting: GreetingPack | None = None,
     tips: TipsPack | None = None,
+    load: LoadPack | None = None,
     help: HelpPack | None = None,
     settings: SettingsPack | None = None,
 ) -> BehaviorPacks:
     return BehaviorPacks(
         greeting=greeting or GreetingPack(),
         tips=tips or TipsPack(),
+        load=load or LoadPack(),
         help=help or HelpPack(),
         settings=settings or SettingsPack(),
     )
@@ -127,44 +131,47 @@ def test_help_disabled_or_empty_never_matches() -> None:
     assert match_help(_packs(help=no_reply), "help") is None
 
 
-# -- tip sampler --------------------------------------------------------------
+# -- load + tip samplers (two independent packs) ------------------------------
 
-_TIPS = TipsPack(
-    enabled=True,
-    working_lines=("Working on it!", "Crunching the numbers..."),
-    tips=("I can rank leaks by recoverable $", "Ask me for the top 5"),
-)
+_LOAD = LoadPack(enabled=True, lines=("Working on it!", "Crunching the numbers..."))
+_TIPS = TipsPack(enabled=True, tips=("I can rank leaks by recoverable $", "Ask me for the top 5"))
 
 
-def test_sample_tip_is_deterministic_per_seed() -> None:
-    packs = _packs(tips=_TIPS)
+def test_samplers_are_deterministic_per_seed() -> None:
+    packs = _packs(load=_LOAD, tips=_TIPS)
+    assert sample_load(packs, "ts-123") == sample_load(packs, "ts-123")
     assert sample_tip(packs, "ts-123") == sample_tip(packs, "ts-123")
 
 
-def test_sample_tip_varies_across_seeds() -> None:
-    packs = _packs(tips=_TIPS)
-    seen = {sample_tip(packs, f"ts-{i}") for i in range(20)}
-    assert len(seen) > 1  # not a constant
+def test_samplers_vary_across_seeds() -> None:
+    packs = _packs(load=_LOAD, tips=_TIPS)
+    assert len({sample_load(packs, f"ts-{i}") for i in range(20)}) > 1
+    assert len({sample_tip(packs, f"ts-{i}") for i in range(20)}) > 1
 
 
-def test_sample_tip_composes_working_line_and_tip() -> None:
-    out = sample_tip(_packs(tips=_TIPS), "seed")
-    assert out is not None
-    assert "\n\nTip: " in out
-    first = out.split("\n\n", 1)[0]
-    assert first in _TIPS.working_lines
+def test_sample_load_returns_a_configured_line() -> None:
+    assert sample_load(_packs(load=_LOAD), "seed") in _LOAD.lines
 
 
-def test_sample_tip_disabled_or_empty_returns_none() -> None:
-    assert sample_tip(_packs(), "seed") is None
-    assert sample_tip(_packs(tips=TipsPack(enabled=True)), "seed") is None
+def test_sample_tip_returns_a_configured_tip() -> None:
+    assert sample_tip(_packs(tips=_TIPS), "seed") in _TIPS.tips
 
 
-def test_sample_tip_working_only_and_tip_only() -> None:
-    working_only = TipsPack(enabled=True, working_lines=("Just a sec",))
-    assert sample_tip(_packs(tips=working_only), "s") == "Just a sec"
-    tip_only = TipsPack(enabled=True, tips=("Try /help",))
-    assert sample_tip(_packs(tips=tip_only), "s") == "Tip: Try /help"
+def test_load_and_tips_sample_independently() -> None:
+    # Distinct salts: the two packs vary independently off the same seed, and
+    # each returns its own content only (no composition here).
+    packs = _packs(load=_LOAD, tips=_TIPS)
+    assert sample_load(packs, "s") in _LOAD.lines
+    assert sample_tip(packs, "s") in _TIPS.tips
+
+
+def test_each_pack_off_or_empty_returns_none() -> None:
+    # load off, tips on -> only tips; and vice versa.
+    assert sample_load(_packs(tips=_TIPS), "s") is None
+    assert sample_tip(_packs(load=_LOAD), "s") is None
+    # enabled but empty -> None.
+    assert sample_load(_packs(load=LoadPack(enabled=True)), "s") is None
+    assert sample_tip(_packs(tips=TipsPack(enabled=True)), "s") is None
 
 
 # -- settings pack (schema + coerce/resolve) ----------------------------------

--- a/docs/behavior-packs.md
+++ b/docs/behavior-packs.md
@@ -4,8 +4,10 @@ Per-agent, opt-in UX touches applied around a turn, so an agent owner can enable
 them for their deployments without imposing them on every other agent on the
 install:
 
-- **tips** -- a sampled "working..." line (optionally with a capability tip)
-  shown while a turn runs.
+- **load** -- a sampled "working..." load line shown while a turn runs.
+- **tips** -- a sampled capability tip ("I can rank leaks by $"). Separate from
+  load: a load line is what the agent is doing now, a tip advertises what it can
+  do, and an agent can enable either without the other.
 - **greeting** -- a canned reply to a *bare* greeting ("hi", "hey there team")
   that never calls the model.
 - **help** -- a canned reply to a *bare* help / "what can you do" request, also
@@ -14,7 +16,7 @@ install:
   template's user-settings battery), with platform-owned validation. Schema only
   in this PR; the durable override store and edit UI are a deferred runtime.
 
-These example packs are illustrative, not the point. The point is the mechanism: a
+These are illustrative, not the point. The point is the mechanism: a
 per-agent, opt-in, declarative config layer, resolved at bind time, that an owner
 enables for their own deployments with no effect on any other agent. New pack
 types slot into the same mechanism. The battery-by-battery mapping below shows
@@ -38,15 +40,17 @@ The substrate, end to end, minus the kernel call sites:
   (migration `0005`), validated by `schemas.BehaviorPacksConfig`, accepted on
   `POST /agents`, and read/written via `GET|PUT /agents/{id}/behavior-packs`
   (mirrors the budget control endpoints). NULL reads as all-off.
-- **Logic** (`apps/worker/behaviorpacks.py`): `sample_tip(packs, seed)`,
-  `match_greeting(packs, text)`, `match_help(packs, text)`, plus the settings
-  pack's `coerce_setting(setting, raw)` and `resolve_settings(packs, overrides)`.
-  Pure stdlib, fully unit-tested. The two matchers share one bare-utterance core:
-  they return a reply only for a phrase said alone (or with trailing filler); a
-  phrase glued to a real request ("hi show me the report") returns `None` and
-  falls through to the model. `resolve_settings` layers a validated override over
-  each declared default and ignores unknown/invalid keys, so a stale store can
-  never break resolution.
+- **Logic** (`apps/worker/behaviorpacks.py`): `sample_load(packs, seed)`,
+  `sample_tip(packs, seed)`, `match_greeting(packs, text)`,
+  `match_help(packs, text)`, plus the settings pack's `coerce_setting(setting,
+  raw)` and `resolve_settings(packs, overrides)`. Pure stdlib, fully unit-tested.
+  `load` and `tips` sample independently off the same seed (distinct salts), each
+  returning only its own content; the display surface composes them. The two
+  matchers share one bare-utterance core: a reply only for a phrase said alone
+  (or with trailing filler); a phrase glued to a real request ("hi show me the
+  report") returns `None` and falls through to the model. `resolve_settings`
+  layers a validated override over each declared default and ignores
+  unknown/invalid keys, so a stale store can never break resolution.
 - **Binding** (`apps/worker/binding.py`, not the sacred kernel): the resolver
   now selects `behavior_packs`, carries it on `ResolvedDeployment`, and exposes
   `BindingResolver.packs_for(resolved) -> BehaviorPacks`.
@@ -93,12 +97,16 @@ The intended integration points, once that review is scheduled:
    *new* turn (a follow-up mid-thread is still a steer; do not short-circuit a
    thread with a live turn).
 
-2. **Tips first-edit** -- in `Kernel._consume`, seed the `_ThrottledReply` with
-   the sampled working line so the dispatcher's generic placeholder is replaced
-   by the per-agent line before the first `text_delta` arrives:
+2. **Load/tips first-edit** -- in `Kernel._consume`, seed the `_ThrottledReply`
+   with the sampled load line (optionally plus a tip) so the dispatcher's generic
+   placeholder is replaced by the per-agent line before the first `text_delta`
+   arrives. (This is also the surface the shimmer status can draw from instead of
+   generic text, once wired.)
 
    ```python
-   opener = sample_tip(packs, qevent.thread_ts)
+   load = sample_load(packs, qevent.thread_ts)
+   tip = sample_tip(packs, qevent.thread_ts)
+   opener = "\n\nTip: ".join(x for x in (load, tip) if x) or None
    if opener is not None:
        await self._sink.update(channel=..., ts=qevent.placeholder_ts, text=opener)
    ```
@@ -123,7 +131,8 @@ pack.
 
 | Battery | Disposition | Why |
 |---|---|---|
-| Working status / tips | **Pack** (`tips`) | Pure data (lines + tips) sampled by a platform function. Shipped. |
+| Working status (load lines) | **Pack** (`load`) | Pure data (rotating load lines) sampled by a platform function. |
+| Capability tips | **Pack** (`tips`) | Pure data (rotating tips), sampled independently of load lines. |
 | Greeting detection | **Pack** (`greeting`) | Data (phrases + reply), deterministic pre-model matcher. Shipped. |
 | Help / "what can you do" | **Pack** (`help`) | Same shape as greeting; the niceties battery's help half. Shipped. |
 | Runtime settings / knobs | **Pack** (`settings`, schema) | The editable-settings allowlist is declarative; shipped with platform-owned validation (`coerce_setting`/`resolve_settings`). The durable override store + edit UI are a deferred runtime. |


### PR DESCRIPTION
## What

The `tips` pack bundled two distinct things: rotating **load lines** ("Working on it…" — what the agent is doing now) and **capability tips** ("I can rank leaks by \$" — what it can do). This splits them into two independent packs, so an agent can enable either without the other.

- **`behaviorpacks.py`**: `LoadPack {enabled, lines}` and `TipsPack {enabled, tips}`; `sample_load` + `sample_tip` sample independently off the same seed (distinct salts) and each returns only its own content. Composing a load line with a tip is the display surface's job (e.g. the future shimmer/first-edit).
- **api schemas**: `LoadPackConfig` + `TipsPackConfig` wired into `BehaviorPacksConfig`; both round-trip through the existing `behavior_packs` column + endpoints.

## Compatibility

No migration (`behavior_packs` is JSONB), no frozen-contract change, and no live agent used the old bundled shape — so this is a clean restructure, not a breaking change in practice.

## Verification

`ruff` + `mypy` clean, and pytest against real Postgres + MinIO: pure `behaviorpacks` (load/tips sample independently, each off-or-empty returns None), the API round-trip (both packs persist and read back), OpenAPI drift, and the binding resolver.

Ref CUR-1595