### PR TITLE
Add the nav pack (no-dead-ends hub button)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -139,6 +139,14 @@
               "lines": []
             }
           },
+          "nav": {
+            "$ref": "#/components/schemas/NavPackConfig",
+            "default": {
+              "enabled": false,
+              "hub_command": "",
+              "hub_label": ""
+            }
+          },
           "settings": {
             "$ref": "#/components/schemas/SettingsPackConfig",
             "default": {
@@ -739,6 +747,28 @@
           "error_rate"
         ],
         "title": "MetricsSummary",
+        "type": "object"
+      },
+      "NavPackConfig": {
+        "description": "The no-dead-ends hub button for one agent (mirrors behaviorpacks.NavPack).",
+        "properties": {
+          "enabled": {
+            "default": false,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "hub_command": {
+            "default": "",
+            "title": "Hub Command",
+            "type": "string"
+          },
+          "hub_label": {
+            "default": "",
+            "title": "Hub Label",
+            "type": "string"
+          }
+        },
+        "title": "NavPackConfig",
         "type": "object"
       },
       "ObservationNode": {

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -64,6 +64,14 @@ class SettingsPackConfig(BaseModel):
     settings: list[SettingConfig] = []
 
 
+class NavPackConfig(BaseModel):
+    """The no-dead-ends hub button for one agent (mirrors behaviorpacks.NavPack)."""
+
+    enabled: bool = False
+    hub_label: str = ""
+    hub_command: str = ""
+
+
 class BehaviorPacksConfig(BaseModel):
     """An agent's opt-in behavior packs. Validated on write and stored as JSON on
     the agent row; the worker parses the same JSON at bind time."""
@@ -75,6 +83,7 @@ class BehaviorPacksConfig(BaseModel):
     greeting: GreetingPackConfig = GreetingPackConfig()
     help: HelpPackConfig = HelpPackConfig()
     settings: SettingsPackConfig = SettingsPackConfig()
+    nav: NavPackConfig = NavPackConfig()
 
 
 class AgentCreate(BaseModel):

--- a/apps/api/tests/test_behavior_packs_integration.py
+++ b/apps/api/tests/test_behavior_packs_integration.py
@@ -63,6 +63,7 @@ def test_put_then_get_round_trips(
                 {"key": "page_size", "kind": "int", "default": "5"},
             ],
         },
+        "nav": {"enabled": True, "hub_label": "Help", "hub_command": "help"},
     }
     resp = client.put(
         f"/agents/{agent['id']}/behavior-packs", json=config, headers=auth_headers
@@ -77,6 +78,7 @@ def test_put_then_get_round_trips(
     assert got["greeting"]["reply"] == "hello!"
     assert got["help"]["reply"] == "here is help"
     assert got["settings"]["settings"][0]["key"] == "page_size"
+    assert got["nav"]["hub_command"] == "help"
 
     # And it surfaces on the agent read model too.
     resp = client.get(f"/agents/{agent['id']}", headers=auth_headers)

--- a/apps/worker/src/agentos_worker/behaviorpacks.py
+++ b/apps/worker/src/agentos_worker/behaviorpacks.py
@@ -126,6 +126,18 @@ class SettingsPack(BaseModel):
     settings: tuple[Setting, ...] = ()
 
 
+class NavPack(BaseModel):
+    """The no-dead-ends hub button for one agent: a way back to the home/help
+    screen, appended to a structured reply's buttons when none already links
+    there. Data-only; the platform owns the append policy (ensure_hub_button)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    enabled: bool = False
+    hub_label: str = ""  # display text, e.g. "Help", "Home"
+    hub_command: str = ""  # the action_id/command that returns to the hub
+
+
 class BehaviorPacks(BaseModel):
     """An agent's full set of packs; every field defaults to disabled/empty."""
 
@@ -136,6 +148,7 @@ class BehaviorPacks(BaseModel):
     greeting: GreetingPack = GreetingPack()
     help: HelpPack = HelpPack()
     settings: SettingsPack = SettingsPack()
+    nav: NavPack = NavPack()
 
     @classmethod
     def from_config(cls, data: Mapping[str, Any] | None) -> BehaviorPacks:
@@ -292,3 +305,24 @@ def resolve_settings(packs: BehaviorPacks, overrides: Mapping[str, str]) -> dict
         except SettingError:
             resolved[setting.key] = setting.default
     return resolved
+
+
+def ensure_hub_button(
+    packs: BehaviorPacks, buttons: Sequence[tuple[str, str]]
+) -> list[tuple[str, str]]:
+    """The no-dead-ends policy: return ``buttons`` with the agent's hub button
+    appended, unless nav is off or a button already links to the hub. The arrow
+    is ``^`` (up) when a back button is already present (the hub is above), else
+    ``<-`` (the hub is where you came from). Pure and idempotent; operates on
+    (label, command) pairs so it needs no reply model. The display surface calls
+    this on a rendered reply's buttons (deferred wiring, see docs)."""
+    nav = packs.nav
+    result = list(buttons)
+    if not nav.enabled or not nav.hub_command:
+        return result
+    if any(command == nav.hub_command for _, command in result):
+        return result
+    arrow = "↑" if any(label.lstrip().startswith("←") for label, _ in result) else "←"
+    label = f"{arrow} {nav.hub_label}".strip()
+    result.append((label, nav.hub_command))
+    return result

--- a/apps/worker/tests/test_behaviorpacks.py
+++ b/apps/worker/tests/test_behaviorpacks.py
@@ -13,11 +13,13 @@ from agentos_worker.behaviorpacks import (
     GreetingPack,
     HelpPack,
     LoadPack,
+    NavPack,
     Setting,
     SettingError,
     SettingsPack,
     TipsPack,
     coerce_setting,
+    ensure_hub_button,
     match_greeting,
     match_help,
     resolve_settings,
@@ -39,6 +41,7 @@ def _packs(
     load: LoadPack | None = None,
     help: HelpPack | None = None,
     settings: SettingsPack | None = None,
+    nav: NavPack | None = None,
 ) -> BehaviorPacks:
     return BehaviorPacks(
         greeting=greeting or GreetingPack(),
@@ -46,6 +49,7 @@ def _packs(
         load=load or LoadPack(),
         help=help or HelpPack(),
         settings=settings or SettingsPack(),
+        nav=nav or NavPack(),
     )
 
 
@@ -237,3 +241,35 @@ def test_from_config_roundtrip_and_none() -> None:
     )
     assert parsed.greeting.enabled is True
     assert match_greeting(parsed, "hi") == "yo"
+
+
+# -- nav pack (no-dead-ends hub button) ---------------------------------------
+
+_NAV = NavPack(enabled=True, hub_label="Help", hub_command="help")
+
+
+def test_nav_appends_left_arrow_hub_when_no_back_button() -> None:
+    out = ensure_hub_button(_packs(nav=_NAV), [("Details", "details")])
+    assert out == [("Details", "details"), ("← Help", "help")]
+
+
+def test_nav_appends_up_arrow_hub_when_a_back_button_is_present() -> None:
+    # A "← Reports" back means the hub is above -> use the up arrow.
+    out = ensure_hub_button(_packs(nav=_NAV), [("← Reports", "reports")])
+    assert out[-1] == ("↑ Help", "help")
+
+
+def test_nav_appends_hub_to_empty_buttons() -> None:
+    assert ensure_hub_button(_packs(nav=_NAV), []) == [("← Help", "help")]
+
+
+def test_nav_does_not_duplicate_an_existing_hub_link() -> None:
+    buttons = [("Home", "help")]  # already links to the hub command
+    assert ensure_hub_button(_packs(nav=_NAV), buttons) == buttons
+
+
+def test_nav_off_or_unconfigured_leaves_buttons_untouched() -> None:
+    buttons = [("Details", "details")]
+    assert ensure_hub_button(_packs(), buttons) == buttons  # nav disabled
+    no_cmd = NavPack(enabled=True, hub_label="Help", hub_command="")
+    assert ensure_hub_button(_packs(nav=no_cmd), buttons) == buttons

--- a/docs/behavior-packs.md
+++ b/docs/behavior-packs.md
@@ -15,6 +15,8 @@ install:
 - **settings** -- a declarative allowlist of user-editable runtime knobs (the
   template's user-settings battery), with platform-owned validation. Schema only
   in this PR; the durable override store and edit UI are a deferred runtime.
+- **nav** -- the no-dead-ends hub button: a way back to the agent's home/help
+  screen, appended to a structured reply's buttons when none links there.
 
 These are illustrative, not the point. The point is the mechanism: a
 per-agent, opt-in, declarative config layer, resolved at bind time, that an owner
@@ -140,7 +142,7 @@ pack.
 | Activity log | **Already native (observability)** | Post-model observation is Langfuse tracing; the Slack "activity" ring buffer is stateful UI code, not declarative data. |
 | Logging setup | **Not per-agent** | Pure infra, identical for every agent; belongs to the platform, not a pack. |
 | Block Kit rendering | **Not applicable** | AgentOS streams text + `chat_update` mrkdwn; there is no structured `Reply` object to render. Would need a Block Kit reply model first. |
-| Navigation (back/up) | **Not applicable** | Presupposes the Block Kit `Reply` model above. |
+| Navigation (back/up) | **Pack** (`nav`) | The hub button is declarative (label + command); `ensure_hub_button` is the platform-owned no-dead-ends policy over a reply's buttons. Viable now that buttons render + respond; applying it during render is the deferred wiring. |
 | HTTP backoff, vision, polling-worker | **Runner/plugin code** | These are agentkit *libraries*. As packs they would run battery code in the worker, breaking sandbox isolation. They belong in the runner/plugin. |
 | Integrations (Jira/NetSuite/CPQ) | **MCP servers** | External-system connectors are the plugin's `.mcp.json` surface in AgentOS, not declarative UX data. |
 | Proactive notifier / digest | **Domain logic** | Revenue-leak's alerting policy; not a reusable battery. |


### PR DESCRIPTION
## What

The fifth behavior pack — **`nav`**, ported from the ss-template's `nav.py`. An agent declares a **hub button** (`hub_label` + `hub_command`); the platform enforces the **no-dead-ends** policy: append a way back to the hub to a structured reply's buttons unless one already links there. The arrow is `↑` (up) when a back button is already present (the hub is above), otherwise `←` (the hub is where you came from).

## Why it's viable now

`nav` was previously "not applicable" because it presupposes rendered, clickable buttons. With #54 (Block Kit rendering) + #90 (clicks become turns), buttons now render and respond — so the hub button is real, and its config is declarative data. The mapping table in `docs/behavior-packs.md` is updated accordingly.

## Changes

- **`behaviorpacks.py`**: `NavPack {enabled, hub_label, hub_command}` and `ensure_hub_button(packs, buttons)`. The policy is pure and operates on `(label, command)` pairs, so it needs no reply model and doesn't depend on the rendering code (keeps this PR independent of #54's internals).
- **api schemas**: `NavPackConfig` wired into `BehaviorPacksConfig`; round-trips through the existing `behavior_packs` column + endpoints.

## Scope

Substrate only, same split as the other packs: applying `ensure_hub_button` *during render* is the deferred wiring (the packs must reach the render path). No migration, no frozen-contract change.

## Verification

`ruff` + `mypy` clean, and pytest against real Postgres + MinIO: pure `behaviorpacks` (up vs left arrow, no-duplicate, off/unconfigured no-op, empty buttons) and the API round-trip.

Ref CUR-1596