### PR TITLE
Feed the sampled load/tips line into the shimmer caption

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -43,7 +43,8 @@ from aci_protocol import (
 )
 from agentos_dispatcher.queue import QueuedSlackEvent
 
-from .binding import BindingResolver
+from .behaviorpacks import sample_load, sample_tip
+from .binding import BindingResolver, ResolvedDeployment
 from .config import WorkerConfig
 from .killswitch import KillSwitch
 from .markers import Markers
@@ -229,6 +230,11 @@ class Kernel:
                     return
                 agent_id = resolved.agent_id
                 boot_env = self._binding.boot_env(resolved, thread)
+                # Personalize the shimmer: replace the dispatcher's generic status
+                # with this agent's sampled load line (+ tip). Best-effort and
+                # outside the concurrency-critical section, like the clear below.
+                if self._config.shimmer:
+                    await self._set_shimmer(qevent, resolved)
 
             attempt = 0
             while True:
@@ -331,6 +337,26 @@ class Kernel:
             channel=qevent.channel, ts=qevent.placeholder_ts, text=message
         )
         await self._markers.mark_done(qevent.slack_event_id)
+
+    async def _set_shimmer(self, qevent: QueuedSlackEvent, resolved: ResolvedDeployment) -> None:
+        """Set the shimmer caption to this agent's sampled load line (+ tip),
+        seeded by the thread ts. No-op when the agent enables neither pack, so the
+        dispatcher's generic status stays. Best-effort (the sink swallows errors)."""
+        assert self._binding is not None
+        packs = self._binding.packs_for(resolved)
+        load = sample_load(packs, qevent.thread_ts)
+        tip = sample_tip(packs, qevent.thread_ts)
+        if load and tip:
+            caption = f"{load}\n\nTip: {tip}"
+        elif load:
+            caption = load
+        elif tip:
+            caption = f"Tip: {tip}"
+        else:
+            return
+        await self._sink.set_status(
+            channel=qevent.channel, thread_ts=qevent.thread_ts, status=caption
+        )
 
     # -- internals ------------------------------------------------------------
 

--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -23,6 +23,11 @@ class SlackSink(Protocol):
 
     async def update(self, *, channel: str, ts: str, text: str) -> None: ...
 
+    async def set_status(self, *, channel: str, thread_ts: str, status: str) -> None:
+        """Set the assistant-thread status (the "shimmer" caption) on the thread.
+        Best-effort so it never breaks a turn."""
+        ...
+
     async def clear_status(self, *, channel: str, thread_ts: str) -> None:
         """Clear any assistant-thread status (the "shimmer") on the thread. A
         no-op when shimmering is off; best-effort so it never breaks a turn."""
@@ -57,14 +62,17 @@ class AsyncSlackSink:
         else:
             await self._client.chat_update(channel=channel, ts=ts, text=rendered_text)
 
+    async def set_status(self, *, channel: str, thread_ts: str, status: str) -> None:
+        # Best-effort: a workspace without the assistant feature, or any transient
+        # error, must never fail the turn.
+        try:
+            await self._client.assistant_threads_setStatus(
+                channel_id=channel, thread_ts=thread_ts, status=status
+            )
+        except Exception as exc:  # noqa: BLE001 -- status set is best-effort
+            logger.debug("assistant set_status skipped for %s: %s", thread_ts, exc)
+
     async def clear_status(self, *, channel: str, thread_ts: str) -> None:
         # Clear the assistant-thread status by setting it empty (Slack only
         # auto-clears on a posted message, and we edit the placeholder instead).
-        # Best-effort: a workspace without the assistant feature, or any transient
-        # error, must never fail the turn -- the reply already went out.
-        try:
-            await self._client.assistant_threads_setStatus(
-                channel_id=channel, thread_ts=thread_ts, status=""
-            )
-        except Exception as exc:  # noqa: BLE001 -- status clear is best-effort
-            logger.debug("assistant clear_status skipped for %s: %s", thread_ts, exc)
+        await self.set_status(channel=channel, thread_ts=thread_ts, status="")

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -99,10 +99,14 @@ class FakeSink(SlackSink):
 
     def __init__(self) -> None:
         self.updates: list[tuple[str, str, str]] = []
+        self.status_sets: list[tuple[str, str, str]] = []
         self.status_clears: list[tuple[str, str]] = []
 
     async def update(self, *, channel: str, ts: str, text: str) -> None:
         self.updates.append((channel, ts, text))
+
+    async def set_status(self, *, channel: str, thread_ts: str, status: str) -> None:
+        self.status_sets.append((channel, thread_ts, status))
 
     async def clear_status(self, *, channel: str, thread_ts: str) -> None:
         self.status_clears.append((channel, thread_ts))

--- a/apps/worker/tests/kernel/test_binding_integration.py
+++ b/apps/worker/tests/kernel/test_binding_integration.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 
 from aci_protocol import Final, SessionStatus, TextDelta
 from agentos_dispatcher.queue import QueuedSlackEvent
+from agentos_worker.behaviorpacks import BehaviorPacks
 from agentos_worker.binding import (
     AGENT_ID_ENV,
     BUDGET_ENV,
@@ -43,6 +44,9 @@ class StubBinding:
         if resolved.bundle_ref is not None:
             env[BUNDLE_REF_ENV] = resolved.bundle_ref
         return env
+
+    def packs_for(self, resolved: ResolvedDeployment) -> BehaviorPacks:
+        return BehaviorPacks.from_config(resolved.behavior_packs)
 
 
 def _resolved(agent_id: uuid.UUID, *, bundle: str | None = "bundles/x.zip") -> ResolvedDeployment:
@@ -185,5 +189,60 @@ def test_kill_interrupts_a_live_turn(make_harness) -> None:
 
             await t1
             assert h.sink.last_text == "stopped"
+
+    asyncio.run(go())
+
+
+def _resolved_with_packs(behavior_packs: dict) -> ResolvedDeployment:
+    return ResolvedDeployment(
+        agent_id=uuid.uuid4(),
+        version_id=uuid.uuid4(),
+        version_label="v1",
+        bundle_ref="bundles/x.zip",
+        max_usd_per_day=None,
+        max_output_tokens_per_run=None,
+        behavior_packs=behavior_packs,
+    )
+
+
+def test_shimmer_caption_uses_the_agents_load_pack(make_harness) -> None:
+    # Connector: with shimmer on, the kernel sets the assistant status to the
+    # agent's sampled load line (+ tip), not the dispatcher's generic text.
+    async def go() -> None:
+        packs = {
+            "load": {"enabled": True, "lines": ["Crunching the numbers..."]},
+            "tips": {"enabled": True, "tips": ["I can rank leaks by $"]},
+        }
+        binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
+        async with make_harness(binding=binding, shimmer=True) as h:
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", channel="C-bound", thread="tSh"))
+            assert h.sink.status_sets, "expected a shimmer caption to be set"
+            _, thread_ts, caption = h.sink.status_sets[-1]
+            assert thread_ts == "tSh"
+            assert caption == "Crunching the numbers...\n\nTip: I can rank leaks by $"
+
+    asyncio.run(go())
+
+
+def test_shimmer_no_caption_when_agent_has_no_load_or_tips(make_harness) -> None:
+    # Shimmer on but the agent enables neither pack: the kernel sets no caption,
+    # so the dispatcher's generic status stays.
+    async def go() -> None:
+        binding = StubBinding({"C-bound": _resolved_with_packs({})})
+        async with make_harness(binding=binding, shimmer=True) as h:
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", channel="C-bound"))
+            assert h.sink.status_sets == []
+
+
+def test_shimmer_off_never_sets_a_caption(make_harness) -> None:
+    async def go() -> None:
+        packs = {"load": {"enabled": True, "lines": ["Working..."]}}
+        binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
+        async with make_harness(binding=binding) as h:  # shimmer defaults off
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", channel="C-bound"))
+            assert h.sink.status_sets == []
 
     asyncio.run(go())


### PR DESCRIPTION
## What

Connects two already-shipped pieces so they actually work together: the **`load`/`tips` packs** (sampled content) and the **shimmer** (the assistant-thread status surface). Until now the shimmer showed the dispatcher's *generic* text; now the worker overrides it with the agent's **sampled load line** (+ a tip, if the tips pack is on), so the shimmering app name reads e.g. "Crunching the numbers…" and rotates per message — the ss-template behavior.

## ⚠️ Stacked PR — depends on #89 and #91

This branch **includes** the commits from **#89 (shimmer)** and **#91 (load/tips split)** because the connector builds directly on both, and neither is in `main` yet. Its own change is the **top commit** (`Feed the sampled load/tips line…`); the other two are #89 and #91 verbatim. **Merge #89 and #91 first**, then this rebases down to just the connector commit. (A cross-fork PR can only show commits not yet in `main`, hence the stack.)

## The connector commit

- **`slack_sink.py`**: add `set_status`; `clear_status` now calls it with an empty status.
- **`kernel.py`**: after binding resolves, if shimmer is on, set the caption from `sample_load` + `sample_tip` over the agent's packs. One best-effort, idempotent call **outside** the concurrency-critical section, right next to the existing shimmer clear. It doesn't touch any of the four kernel invariants — **the full kernel rule suite still passes** — but per `apps/worker/CLAUDE.md` any kernel edit gets the F1 adversarial review; flagging that.

Dispatcher still sets a generic status instantly on ingest; the worker overrides it with the per-agent caption once bound (instant feedback, then personalization). An agent with neither pack enabled leaves the generic status untouched.

## Verification

`ruff` + `mypy` clean, and pytest against the real stack: `slack_sink`, pure `behaviorpacks`, the **full kernel rule + binding suite** (incl. 3 new connector tests: caption uses the load pack; no caption when neither pack is set; nothing set when shimmer is off), dispatcher, and the API round-trip.

Ref CUR-1597