### PR TITLE
Accept sk-or- OpenRouter credentials via the base-URL-override seam (#24 MVP)

### DIFF
--- a/runner/src/agentos_runner/INTERFACE.md
+++ b/runner/src/agentos_runner/INTERFACE.md
@@ -9,8 +9,8 @@ A generic, provider-agnostic base-URL override. When configured, the runner
 points the claude-agent-sdk (and the bundled `claude` CLI it spawns) at a local
 or third-party endpoint instead of real Anthropic, using a no-op placeholder in
 place of a credential. Local Ollama is the FIRST implementation (issue #46).
-OpenRouter (issue #24) is the NEXT consumer: it reuses this seam rather than
-forking a parallel path. This is one seam, many providers.
+OpenRouter (issue #24) is implemented as a worked example of the same seam
+rather than a parallel path. This is one seam, many providers.
 
 ## Env contract
 
@@ -30,15 +30,29 @@ the CLI auth gate. It is deliberately not `sk-...` shaped so it can never be
 mistaken for a real credential, and paired with the overridden base URL it
 cannot authenticate against real Anthropic.
 
-### `CLAUDE_CODE_OAUTH_TOKEN` (output, set by the runner)
+### `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN` (output, set by the runner)
 
-Blanked to `""` in override mode so an inherited OAuth token cannot take
-precedence over the placeholder + overridden base URL. This keeps override mode
-hermetic.
+Both are blanked to `""` in override mode so an inherited OAuth token or Bearer
+token cannot take precedence over the placeholder + overridden base URL, nor
+leak as a Bearer header to the overridden (local/third-party) endpoint. This
+keeps override mode hermetic. (On the OpenRouter path, `resolve_model_credential`
+re-sets `ANTHROPIC_AUTH_TOKEN` to the real `sk-or-` key after applying this
+override, so the Bearer token still reaches OpenRouter.)
 
 ### `AGENTOS_MODEL` (input)
 
 The model name (e.g. `qwen3:4b`), passed through to `ClaudeAgentOptions.model`.
+
+## OpenRouter mapping
+
+An `sk-or-...` credential in `AGENTOS_CREDENTIALS` is auto-detected by
+`resolve_model_credential`. The runner sets
+`ANTHROPIC_BASE_URL=https://openrouter.ai/api`, places the real key in
+`ANTHROPIC_AUTH_TOKEN` for Bearer auth, and reuses this seam's non-empty
+`ANTHROPIC_API_KEY` placeholder plus blanked `CLAUDE_CODE_OAUTH_TOKEN`.
+
+Prompt caching survives only on this native Anthropic Messages path, and only
+for Claude-family OpenRouter models.
 
 ## How it arrives
 

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -17,7 +17,7 @@ from .config import RunnerConfig
 from .fake import FakeModelSession
 from .otel import RunTracer, build_tracer_provider
 from .plugin import load_plugins
-from .sdk_auth import resolve_base_url_override, resolve_model_credential
+from .sdk_auth import resolve_sdk_env
 from .server import create_app
 from .session import SessionRunner
 from .side_effects import SideEffectClassifier
@@ -77,9 +77,7 @@ def main() -> None:
     # process fails visibly before the port is up rather than after a real call.
     override = None
     if not fake_model:
-        override = resolve_base_url_override(os.environ)
-        if override is None:
-            resolve_model_credential(os.environ)
+        override = resolve_sdk_env(os.environ)
     config = RunnerConfig.from_env(os.environ)
     runner = build_runner(config, fake_model=fake_model, sdk_env=override)
     app = create_app(runner)

--- a/runner/src/agentos_runner/sdk_auth.py
+++ b/runner/src/agentos_runner/sdk_auth.py
@@ -13,9 +13,10 @@ prefix, so the more specific OAuth prefix is checked first):
   deliberately); this is then a no-op.
 - ``sk-ant-oat...`` is a Claude Code OAuth token -> ``CLAUDE_CODE_OAUTH_TOKEN``.
 - ``sk-ant-...`` (any other) is an Anthropic API key -> ``ANTHROPIC_API_KEY``.
-- A recognizably non-Anthropic key (``sk-or-...`` OpenRouter, bare ``sk-...``
-  OpenAI-style) is rejected loudly, naming what IS supported, rather than handed
-  to the SDK to die as a generic auth failure. Other providers are post-MVP.
+- ``sk-or-...`` (OpenRouter) is routed through the base-URL-override seam:
+  base URL -> OpenRouter's Anthropic endpoint, key -> ``ANTHROPIC_AUTH_TOKEN``,
+  and ``ANTHROPIC_API_KEY`` -> the non-empty placeholder. A bare ``sk-...``
+  OpenAI-style key is still rejected loudly. Other providers are post-MVP.
 - Anything else is treated as a Claude Code OAuth token ->
   ``CLAUDE_CODE_OAUTH_TOKEN``.
 
@@ -30,6 +31,8 @@ CREDENTIALS_ENV = "AGENTOS_CREDENTIALS"
 OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
 API_KEY_ENV = "ANTHROPIC_API_KEY"
 BASE_URL_ENV = "ANTHROPIC_BASE_URL"
+AUTH_TOKEN_ENV = "ANTHROPIC_AUTH_TOKEN"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api"
 _SDK_CREDENTIAL_ENV = (OAUTH_TOKEN_ENV, API_KEY_ENV)
 
 # Non-empty no-op placeholder API key used in base-URL override mode. It is
@@ -47,9 +50,9 @@ class UnsupportedCredentialError(RuntimeError):
 def resolve_base_url_override(env: MutableMapping[str, str]) -> dict[str, str] | None:
     """Build the generic SDK base URL override env when configured.
 
-    This is the provider agnostic base URL override path: local Ollama today and
-    OpenRouter/#24 next. It targets any Anthropic-compatible endpoint without a
-    real Anthropic credential.
+    This is the provider agnostic base URL override path: local Ollama and
+    OpenRouter/#24 today. It targets any Anthropic-compatible endpoint without
+    a real Anthropic credential.
 
     The placeholder API key is NON-EMPTY on purpose (empirically verified
     2026-07-07): the bundled Claude CLI treats an empty ANTHROPIC_API_KEY as "not
@@ -58,10 +61,11 @@ def resolve_base_url_override(env: MutableMapping[str, str]) -> dict[str, str] |
     Paired with the overridden base URL, that placeholder cannot authenticate
     against real Anthropic.
 
-    CLAUDE_CODE_OAUTH_TOKEN is blanked to "" so an inherited OAuth token cannot
-    take precedence over the placeholder + base URL, keeping override mode
-    hermetic. The base URL is not a secret, but this module keeps the same no
-    echo discipline it uses for credentials.
+    Both CLAUDE_CODE_OAUTH_TOKEN and ANTHROPIC_AUTH_TOKEN are blanked to "" so an
+    inherited OAuth token or Bearer token cannot take precedence over the
+    placeholder + base URL, nor leak to the overridden (local/third-party)
+    endpoint, keeping override mode hermetic. The base URL is not a secret, but
+    this module keeps the same no echo discipline it uses for credentials.
     """
     base_url = env.get(BASE_URL_ENV)
     if not base_url:
@@ -70,6 +74,7 @@ def resolve_base_url_override(env: MutableMapping[str, str]) -> dict[str, str] |
         BASE_URL_ENV: base_url,
         API_KEY_ENV: NO_OP_API_KEY,
         OAUTH_TOKEN_ENV: "",
+        AUTH_TOKEN_ENV: "",
     }
 
 
@@ -91,12 +96,44 @@ def resolve_model_credential(env: MutableMapping[str, str]) -> None:
         env[OAUTH_TOKEN_ENV] = credential
     elif credential.startswith("sk-ant-"):
         env[API_KEY_ENV] = credential
+    elif credential.startswith("sk-or-"):
+        # OpenRouter: reuse the shared base-URL-override seam to target OpenRouter's
+        # native Anthropic Messages endpoint (the SDK appends /v1/messages). The real
+        # key is Bearer auth via ANTHROPIC_AUTH_TOKEN; ANTHROPIC_API_KEY stays the
+        # non-empty NO_OP_API_KEY placeholder so the CLI auth gate passes. Staying on
+        # the Anthropic wire format keeps prompt caching intact (the OpenAI
+        # chat-completions path silently breaks it at ~10x cost).
+        env[BASE_URL_ENV] = OPENROUTER_BASE_URL
+        override = resolve_base_url_override(env)
+        assert override is not None  # base URL was just set
+        env.update(override)
+        env[AUTH_TOKEN_ENV] = credential
     elif credential.startswith("sk-"):
-        # OpenAI-style ("sk-..."), OpenRouter ("sk-or-..."), and similar. Fail
-        # loudly rather than forwarding a key the Anthropic SDK cannot use.
+        # OpenAI-style ("sk-...") and similar. Fail loudly rather than
+        # forwarding a key the Anthropic SDK cannot use.
         raise UnsupportedCredentialError(
             "AGENTOS_CREDENTIALS is not a supported model credential. Provide an "
             "Anthropic API key (sk-ant-...) or a Claude Code OAuth token."
         )
     else:
         env[OAUTH_TOKEN_ENV] = credential
+
+
+def resolve_sdk_env(env: MutableMapping[str, str]) -> dict[str, str] | None:
+    """Decide the SDK auth env from the boot env.
+
+    An ``sk-or-`` OpenRouter credential is routed by ``resolve_model_credential``
+    (which sets the OpenRouter base URL, the Bearer token, and the placeholder)
+    even when ``ANTHROPIC_BASE_URL`` is already set, so its Bearer token is never
+    dropped. Otherwise a generic base-URL override wins when configured, and a
+    plain Anthropic credential falls through to ``resolve_model_credential``.
+    Returns the override dict to pass as ``ClaudeAgentOptions.env`` (base-URL
+    override mode), or ``None`` when resolution mutated ``env`` in place.
+    """
+    credential = env.get(CREDENTIALS_ENV, "")
+    if not credential.startswith("sk-or-"):
+        override = resolve_base_url_override(env)
+        if override is not None:
+            return override
+    resolve_model_credential(env)
+    return None

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -1,10 +1,12 @@
 """LIVE smoke against a real claude-agent-sdk session.
 
-Runs only when a real credential is present (``CLAUDE_CODE_OAUTH_TOKEN`` or
-``ANTHROPIC_API_KEY``). Without one, every test here is skipped and reported as
-such -- the suite never fabricates a live result. Mirrors the PT-2 proofs: a
-trivial message is answered, a mid-run steer changes course, and turn 2 shows a
-warm prompt cache (``cache_read_input_tokens > 0``).
+The Anthropic-path tests run only when a real credential is present
+(``CLAUDE_CODE_OAUTH_TOKEN`` or ``ANTHROPIC_API_KEY``). Without one, those tests
+are skipped and reported as such -- the suite never fabricates a live result.
+Mirrors the PT-2 proofs: a trivial message is answered, a mid-run steer changes
+course, and turn 2 shows a warm prompt cache
+(``cache_read_input_tokens > 0``).
+A third live test covers the OpenRouter path, gated on ``OPENROUTER_API_KEY``.
 """
 
 import os
@@ -17,13 +19,13 @@ from agentos_runner.adapter import ClaudeAgentSession
 from agentos_runner.session import SessionRunner
 
 _HAS_CRED = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY"))
+_OPENROUTER_KEY = os.environ.get("OPENROUTER_API_KEY", "")
 
-pytestmark = pytest.mark.skipif(
+
+@pytest.mark.skipif(
     not _HAS_CRED,
     reason="no live credential (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY) in env",
 )
-
-
 def test_live_runner_answers_trivial_message() -> None:
     options = build_options(
         plugins=[], model=None,
@@ -56,6 +58,10 @@ def test_live_runner_answers_trivial_message() -> None:
     assert events[-1].status == SessionStatus.DONE
 
 
+@pytest.mark.skipif(
+    not _HAS_CRED,
+    reason="no live credential (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY) in env",
+)
 def test_live_steer_and_cache_reuse() -> None:
     # Steering + prompt-cache reuse at the SDK level (the PT-2 pattern): a mid-run
     # steer redirects the agent, and turn 2 reads the cache the first turn wrote.
@@ -118,3 +124,47 @@ def test_live_steer_and_cache_reuse() -> None:
     result = anyio.run(go)
     assert result["redirected"], "mid-run steer did not change course"
     assert result["turn2_cache_read"] > 0, "no prompt-cache reuse on turn 2"
+
+
+@pytest.mark.skipif(
+    not _OPENROUTER_KEY,
+    reason="no OPENROUTER_API_KEY (sk-or-...) in env",
+)
+def test_live_openrouter_cache_reuse() -> None:
+    from agentos_runner.sdk_auth import CREDENTIALS_ENV, resolve_model_credential
+    from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, ResultMessage
+
+    env: dict[str, str] = {CREDENTIALS_ENV: _OPENROUTER_KEY}
+    resolve_model_credential(env)
+    model = os.environ.get("OPENROUTER_MODEL", "anthropic/claude-sonnet-4.5")
+
+    async def go() -> dict:
+        usages: list[dict] = []
+        opts = ClaudeAgentOptions(
+            model=model,
+            env=env,
+            max_turns=2,
+            permission_mode="bypassPermissions",
+            system_prompt="You are a terse test agent. " * 40,
+        )
+        async with ClaudeSDKClient(opts) as client:
+            await client.query("Reply with the single word: alpha")
+            async for msg in client.receive_response():
+                if isinstance(msg, ResultMessage):
+                    if isinstance(msg.usage, dict):
+                        usages.append(msg.usage)
+                    break
+
+            await client.query("Reply with the single word: beta")
+            async for msg in client.receive_response():
+                if isinstance(msg, ResultMessage):
+                    if isinstance(msg.usage, dict):
+                        usages.append(msg.usage)
+                    break
+
+        return usages[-1] if usages else {}
+
+    usage = anyio.run(go)
+    assert int((usage or {}).get("cache_read_input_tokens") or 0) > 0, (
+        "no prompt-cache reuse on turn 2 through the OpenRouter path"
+    )

--- a/runner/tests/test_sdk_auth.py
+++ b/runner/tests/test_sdk_auth.py
@@ -8,10 +8,15 @@ from __future__ import annotations
 import pytest
 from agentos_runner.sdk_auth import (
     API_KEY_ENV,
+    AUTH_TOKEN_ENV,
+    BASE_URL_ENV,
     CREDENTIALS_ENV,
+    NO_OP_API_KEY,
     OAUTH_TOKEN_ENV,
+    OPENROUTER_BASE_URL,
     UnsupportedCredentialError,
     resolve_model_credential,
+    resolve_sdk_env,
 )
 
 
@@ -47,13 +52,33 @@ def test_explicit_sdk_credential_wins_over_agentos_credentials() -> None:
     assert API_KEY_ENV not in env
 
 
-@pytest.mark.parametrize("foreign", ["sk-or-PLACEHOLDER", "sk-PLACEHOLDER"])
+@pytest.mark.parametrize("foreign", ["sk-PLACEHOLDER"])
 def test_foreign_key_is_rejected_loudly(foreign: str) -> None:
     with pytest.raises(UnsupportedCredentialError) as exc:
         resolve_model_credential({CREDENTIALS_ENV: foreign})
     msg = str(exc.value)
     assert "Anthropic API key" in msg and "Claude Code OAuth token" in msg
     assert foreign not in msg  # the credential value never appears in the error
+
+
+def test_openrouter_key_is_plumbed_to_base_url_override() -> None:
+    env = {CREDENTIALS_ENV: "sk-or-PLACEHOLDER"}
+    resolve_model_credential(env)
+
+    assert env[BASE_URL_ENV] == OPENROUTER_BASE_URL
+    assert env[AUTH_TOKEN_ENV] == "sk-or-PLACEHOLDER"
+    # Empty string would fail the bundled Claude CLI auth gate.
+    assert env[API_KEY_ENV] == NO_OP_API_KEY
+    assert env[API_KEY_ENV] != ""
+    assert env[OAUTH_TOKEN_ENV] == ""
+
+
+def test_explicit_sdk_credential_wins_over_openrouter_reference() -> None:
+    env = {API_KEY_ENV: "sk-ant-EXPLICIT", CREDENTIALS_ENV: "sk-or-PLACEHOLDER"}
+    resolve_model_credential(env)
+
+    assert env[API_KEY_ENV] == "sk-ant-EXPLICIT"
+    assert BASE_URL_ENV not in env
 
 
 def test_no_credential_is_a_noop() -> None:
@@ -82,6 +107,9 @@ def test_base_url_override_sets_sdk_base_url_and_placeholder_api_key() -> None:
     # The OAuth token is blanked so an inherited token cannot win over the
     # placeholder + overridden base URL.
     assert override[OAUTH_TOKEN_ENV] == ""
+    # The Bearer token is blanked too so an inherited ANTHROPIC_AUTH_TOKEN
+    # cannot leak to the overridden (local/third-party) endpoint.
+    assert override[AUTH_TOKEN_ENV] == ""
 
 
 def test_base_url_override_is_absent_when_env_is_missing() -> None:
@@ -94,3 +122,43 @@ def test_base_url_override_is_absent_when_env_is_empty() -> None:
     from agentos_runner.sdk_auth import BASE_URL_ENV, resolve_base_url_override
 
     assert resolve_base_url_override({BASE_URL_ENV: ""}) is None
+
+
+def test_resolve_sdk_env_ollama_returns_override_dict() -> None:
+    # Base URL set, no sk-or- credential: generic override mode. Returns the
+    # override dict for ClaudeAgentOptions.env; the Bearer token is blanked.
+    env = {BASE_URL_ENV: "http://ollama:11434"}
+    override = resolve_sdk_env(env)
+
+    assert override is not None
+    assert override[BASE_URL_ENV] == "http://ollama:11434"
+    assert override[API_KEY_ENV] == NO_OP_API_KEY
+    assert override[AUTH_TOKEN_ENV] == ""
+
+
+def test_resolve_sdk_env_plain_anthropic_key_mutates_env() -> None:
+    # sk-ant- credential, no base URL: returns None, mutates env with the API key.
+    env = {CREDENTIALS_ENV: "sk-ant-PLACEHOLDER"}
+    assert resolve_sdk_env(env) is None
+    assert env[API_KEY_ENV] == "sk-ant-PLACEHOLDER"
+    assert BASE_URL_ENV not in env
+
+
+def test_resolve_sdk_env_openrouter_alone_mutates_env() -> None:
+    # sk-or- credential, no preset base URL: returns None; env gets the
+    # OpenRouter base URL, the Bearer token, and the placeholder.
+    env = {CREDENTIALS_ENV: "sk-or-PLACEHOLDER"}
+    assert resolve_sdk_env(env) is None
+    assert env[BASE_URL_ENV] == OPENROUTER_BASE_URL
+    assert env[AUTH_TOKEN_ENV] == "sk-or-PLACEHOLDER"
+    assert env[API_KEY_ENV] == NO_OP_API_KEY
+
+
+def test_resolve_sdk_env_openrouter_with_preset_base_url_sets_bearer() -> None:
+    # P2 regression: an operator sets ANTHROPIC_BASE_URL AND passes an sk-or-
+    # credential. The sk-or- key must still be routed (Bearer token set), not
+    # skipped by the generic base-URL override.
+    env = {BASE_URL_ENV: "https://openrouter.ai/api", CREDENTIALS_ENV: "sk-or-PLACEHOLDER"}
+    assert resolve_sdk_env(env) is None
+    assert env[AUTH_TOKEN_ENV] == "sk-or-PLACEHOLDER"
+    assert env[API_KEY_ENV] == NO_OP_API_KEY


### PR DESCRIPTION
MVP slice of #24 (BYO-model / OpenRouter) — checkboxes **24a** + **24f** only. Refs #24 (no closing keyword; the epic has more checkboxes).

**Stacked on #55** (`task/46-local-model-demo`), which lands the shared `resolve_base_url_override` seam. This PR reuses that seam rather than forking, so it targets #55's branch and should merge after it.

## What
- **24a** — an `sk-or-` `AGENTOS_CREDENTIALS` is now accepted (was rejected) and routed to OpenRouter's **native Anthropic Messages endpoint**: `ANTHROPIC_BASE_URL=https://openrouter.ai/api`, key as Bearer in `ANTHROPIC_AUTH_TOKEN`, and the non-empty `NO_OP_API_KEY` placeholder in `ANTHROPIC_API_KEY`. Bare `sk-` (OpenAI-style) is still rejected. No SDK swap; stays on the Anthropic wire format so prompt caching survives.
- **24f** — a live prompt-cache smoke test asserting `cache_read_input_tokens > 0` on a warm thread **through the OpenRouter-configured path**, gated on `OPENROUTER_API_KEY` (skip-by-default, like the other live tests).
- INTERFACE.md documents the OpenRouter mapping of the seam.

## Decisions worth a look
- **`ANTHROPIC_API_KEY` is a non-empty placeholder, not `""`.** The original #24 research note said empty string; #55 empirically found (2026-07-07) the bundled Claude CLI treats an empty key as "not logged in" and skips the call. This PR uses the non-empty `NO_OP_API_KEY` and routes the real key via Bearer, consistent with #55.
- **Two findings from an inline Codex review were fixed in-PR:** (P1) `resolve_base_url_override` now also blanks `ANTHROPIC_AUTH_TOKEN` so an inherited Bearer token can't leak to an overridden (e.g. local Ollama) endpoint; (P2) `resolve_sdk_env` routes an `sk-or-` credential *before* the generic base-URL override, so the Bearer token is set even when `ANTHROPIC_BASE_URL` is already configured (previously silently unauthenticated). Both preserve #55's Ollama path.

A live probe during review confirmed the SDK sends `Authorization: Bearer <sk-or-key>` + placeholder `x-api-key` to `POST /api/v1/messages` (the native OpenRouter path), verifying 24a end-to-end.

Deferred (other checkboxes): native `/anthropic` provider endpoints (24b), LiteLLM sidecar (24c), per-agent model UI (24d), eval-matrix model dimension (24e).