### PR TITLE
Simplify architecture diagrams and fix broken mermaid

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,69 +33,58 @@ design property of the whole system.
 
 ## 2. Component map
 
+This is the static "who talks to whom." For the flows through it, read the
+focused diagram docs, each a single clean picture:
+
+- **[How a message comes in and a reply goes out](docs/diagrams/message-flow.md)** — the core loop.
+- **[Kubernetes architecture](docs/diagrams/kubernetes.md)** — the cluster and how a sandbox pod is built.
+- **[The ACI](docs/diagrams/aci.md)** — the frozen contract between the worker and the agent in the box.
+
 ```mermaid
 flowchart TB
-    Slack["Slack workspace<br/>(Socket Mode)"]
-    GH["GitHub<br/>(push webhook)"]
-    CLIuser["Developer laptop"]
+    Slack["Slack"]
+    CLI["CLI / laptop"]
+    GH["GitHub push"]
 
-    subgraph platform["apps/ (Python services)"]
-        Dispatcher["apps/dispatcher<br/>Slack Bolt, Socket Mode"]
-        Worker["apps/worker<br/>concurrency kernel"]
-        API["apps/api<br/>FastAPI"]
+    subgraph core["Agent runner core (apps/)"]
+        Dispatcher["dispatcher<br/>ingress + dedupe"]
+        Queue["Valkey<br/>queue + routing"]
+        Worker["worker kernel<br/>one session per thread"]
+        API["api<br/>git-flow · bundles · read proxy"]
     end
 
-    subgraph queue["Valkey (redis-py)"]
-        Runs["stream: agentos:runs"]
-        Evals["stream: agentos:evals"]
-        Locks["thread locks · dedupe keys ·<br/>affinity routes · kill events"]
-    end
+    Sandbox["runner pod<br/>Claude Code + skill"]
+    Anthropic["Model<br/>(Anthropic default)"]
 
-    subgraph substrate["Sandbox substrate (SandboxClient)"]
-        K8s["KubernetesSandboxClient<br/>(agent-sandbox claims)"]
-        Docker["DockerSandboxClient<br/>(local middle mode)"]
-        Runner["runner/<br/>claude-agent-sdk<br/>ACI over NDJSON"]
-        K8s --> Runner
-        Docker --> Runner
-    end
-
-    PG[("Postgres<br/>agents / versions / deployments")]
-    Store[("MinIO / S3<br/>plugin bundles")]
-    Anthropic["Anthropic API"]
+    UI["ui console"]
+    Store[("MinIO / S3<br/>skill bundles")]
+    PG[("Postgres<br/>agents · versions · deployments")]
 
     subgraph obs["Observability"]
-        Collector["OTel Collector<br/>OTLP gRPC+HTTP in, HTTP out"]
-        Langfuse["Langfuse v3<br/>(+ ClickHouse)"]
-        Collector --> Langfuse
+        OTel["OTel Collector"]
+        LF["Langfuse (+ ClickHouse)"]
+        OTel --> LF
     end
 
-    UI["apps/ui<br/>React console"]
-    CLI["cli/<br/>agentos (Rust)"]
-
-    Slack -- "app_mention / message" --> Dispatcher
-    Dispatcher -- "XADD QueuedSlackEvent" --> Runs
-    Runs -- "XREADGROUP" --> Worker
-    Worker -- "claim / resume" --> K8s
-    Worker -- "claim / resume" --> Docker
-    Worker -- "POST /v1/event,/steer,/interrupt" --> Runner
-    Worker -- "chat.update placeholder" --> Slack
-    Runner -- "model call" --> Anthropic
-    Runner -- "OTLP spans" --> Collector
-    Worker -- "OTLP spans" --> Collector
-
-    GH -- "push (dev/prod branch)" --> API
-    API -- "validated bundle" --> Store
-    API -- "agents/versions/deployments" --> PG
-    API -- "XADD eval jobs" --> Evals
-    Evals -- "XREADGROUP" --> Worker
-    Store -. "bundle-fetch init container" .-> Runner
-
-    UI -- "same-origin /api" --> API
-    API -- "trace/metric proxy" --> Langfuse
-    CLIuser --> CLI
-    CLI -- "deploy (tar.gz)" --> API
-    CLI -- "chat: XADD synthetic event<br/>+ local Slack stub" --> Runs
+    Slack --> Dispatcher
+    CLI --> Dispatcher
+    CLI --> API
+    GH --> API
+    Dispatcher --> Queue --> Worker --> Sandbox --> Anthropic
+    Sandbox -. bundle-fetch .-> Store
+    API --> Store
+    API --> PG
+    UI --> API
+    Worker --> OTel
+    Sandbox --> OTel
+    API -- read --> LF
 ```
+
+The reply travels back out the way it came in — sandbox to worker to the
+originating thread — kept off the diagram to avoid a tangle of return arrows;
+[the message-flow doc](docs/diagrams/message-flow.md) shows that round trip.
+Two substrate implementations sit behind the single `runner pod` box
+(Kubernetes for production, Docker for local); §3 covers that seam.
 
 ### Directory ownership and language
 
@@ -176,7 +165,7 @@ sequenceDiagram
 
     U->>D: app_mention / DM message
     D->>V: SET dedupe:<event_id> NX EX ttl
-    Note over D: retried delivery finds the key set,<br/>is dropped (still acked, never re-posted)
+    Note over D: retried delivery finds the key set, is dropped (still acked, never re-posted)
     D->>U: post placeholder ("On it...")
     D->>V: XADD agentos:runs {QueuedSlackEvent}
 
@@ -189,7 +178,7 @@ sequenceDiagram
         W->>R: POST /v1/event {message}
     else turn already live for this thread
         W->>R: POST /v1/steer {text}
-        Note over W,R: 409 if the turn finished first (finish race);<br/>worker opens a fresh turn on the same idle sandbox
+        Note over W,R: 409 if the turn finished first (finish race), worker opens a fresh turn on the same idle sandbox
     end
 
     R->>A: model call (streaming)
@@ -230,36 +219,9 @@ is what routes a thread back to its sandbox.
 ## 5. Data flow: a git push deploys a bundle and runs evals
 
 A push is HMAC-verified, archived, validated, and stored as an immutable
-versioned bundle. A dev-branch push builds the artifact; a prod-branch push
-promotes that same artifact without rebuilding.
-
-```mermaid
-sequenceDiagram
-    participant Dev as Developer
-    participant GH as GitHub
-    participant API as apps/api (gitflow.py)
-    participant PF as plugin-format validator
-    participant S3 as MinIO / S3
-    participant PG as Postgres
-
-    Dev->>GH: git push (dev or prod branch)
-    GH->>API: POST /github/webhook (push, HMAC-signed)
-    API->>API: verify_signature(x-hub-signature-256)
-    alt push to dev branch
-        API->>API: clone_and_archive(sha)
-        API->>PF: validate_bundle(archived tree)
-        PF-->>API: ValidationResult (path-qualified errors)
-        API->>S3: store immutable versioned bundle
-        API->>PG: create Version + Deployment (env=dev)
-        Note over API: the dev bot identity now serves this sha
-    else push to prod branch
-        API->>PG: find the already-built Version for this sha
-        API->>PG: create Deployment (env=prod)
-        Note over API: promotes the same artifact, no separate prod build
-    end
-```
-
-A newly built dev version additionally fans out its eval suite as a CI check:
+versioned bundle. A **dev-branch** push builds the artifact and fans out its
+eval suite as a CI check; a **prod-branch** push promotes that same artifact
+without rebuilding. One diagram, both branches:
 
 ```mermaid
 sequenceDiagram
@@ -271,25 +233,29 @@ sequenceDiagram
     participant PG as Postgres
     participant V as Valkey (agentos:evals)
     participant W as Worker eval consumer
-    participant R as Runner
     participant LF as Langfuse
 
-    Dev->>GH: git push (dev branch)
+    Dev->>GH: git push (dev or prod branch)
     GH->>API: POST /github/webhook (push, HMAC-signed)
     API->>API: verify_signature(x-hub-signature-256)
-    API->>API: clone_and_archive(sha)
-    API->>PF: validate_bundle(archived tree)
-    PF-->>API: ValidationResult (path-qualified errors)
-    API->>S3: store immutable versioned bundle
-    API->>PG: create Version + Deployment (env=dev)
-    API->>V: XADD agentos:evals {job} (one per new version, deduped)
-
-    W->>V: XREADGROUP (eval consumer group)
-    W->>S3: load eval cases from the bundle
-    W->>R: run each case in a provisioned runner
-    R--)LF: record trace with eval / suite tags
-    W->>API: POST /evals/report
-    API->>GH: set commit status (pass/fail)
+    alt push to dev branch
+        API->>API: clone_and_archive(sha)
+        API->>PF: validate_bundle(archived tree)
+        PF-->>API: ValidationResult (path-qualified errors)
+        API->>S3: store immutable versioned bundle
+        API->>PG: create Version + Deployment (env=dev)
+        Note over API: the dev bot now serves this sha
+        API->>V: XADD agentos:evals {job} (deduped)
+        W->>V: XREADGROUP (separate eval consumer group)
+        W->>S3: load eval cases from the bundle
+        W-->>LF: run each case, record trace with eval tags
+        W->>API: POST /evals/report
+        API->>GH: set commit status (pass/fail)
+    else push to prod branch
+        API->>PG: find the already-built Version for this sha
+        API->>PG: create Deployment (env=prod)
+        Note over API: promotes the same artifact, no rebuild
+    end
 ```
 
 - **Git-flow fan-out** at [`apps/api/src/agentos_api/gitflow.py`](apps/api/src/agentos_api/gitflow.py): signature verify (`:35`), dev-branch archive+validate+store+create-Version (`:136`), prod-branch **promotes the same artifact without rebuilding** (`:172`), eval enqueue on a newly built dev version, deduped on redelivery (`:186`). Webhook receiver at [`apps/api/src/agentos_api/routers/github.py:20`](apps/api/src/agentos_api/routers/github.py).
@@ -316,8 +282,11 @@ The runner's mapping is prefix-based and fails loud on anything it cannot use
 
 - `sk-ant-oat...` -> `CLAUDE_CODE_OAUTH_TOKEN` (checked first; OAuth tokens share the `sk-ant-` prefix).
 - `sk-ant-...` -> `ANTHROPIC_API_KEY`.
-- `sk-...` (OpenAI-style, OpenRouter `sk-or-`) -> raises `UnsupportedCredentialError` rather than forwarding a key the Anthropic SDK cannot use.
+- `sk-or-...` (OpenRouter) -> routed through the shared **base-URL-override seam**: base URL points at OpenRouter's native Anthropic Messages endpoint, the key becomes `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_API_KEY` is set to a non-empty placeholder so the bundled CLI's auth gate passes. Staying on the Anthropic wire format keeps prompt caching intact.
+- `sk-...` (bare OpenAI-style) -> raises `UnsupportedCredentialError` rather than forwarding a key the Anthropic SDK cannot use.
 - Anything else -> treated as an OAuth token.
+
+The same base-URL-override seam ([`resolve_base_url_override`](runner/src/agentos_runner/sdk_auth.py)) also targets a **bundled local model** (opt-in Ollama / Qwen3 demo mode, `--local-model`), so the SDK can talk to any Anthropic-compatible endpoint without a real Anthropic credential.
 
 An explicit SDK credential already in the env always wins; the mapping is a
 no-op when `AGENTOS_CREDENTIALS` is unset.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,18 @@ git history (`git log -- docs/`).
 - [`vision.md`](vision.md): the north star. What AgentOS is, who it is for, and
   what it could become. The document we hold new features against. Read this to
   understand *why* the project exists before *how* it works.
-- [`../ARCHITECTURE.md`](../ARCHITECTURE.md): the as-built architecture, with the
-  component map and the message-flow and deploy-flow sequence diagrams. Start
-  here.
+- [`../ARCHITECTURE.md`](../ARCHITECTURE.md): the as-built architecture reference
+  (the deep "what talks to what," with file:line citations). Start here for
+  detail.
+- [`diagrams/`](diagrams/): three focused, presentation-grade flow docs, each a
+  single clean diagram with narration. Start here to explain the system to
+  someone:
+  - [`diagrams/message-flow.md`](diagrams/message-flow.md): how a message comes
+    in and a reply goes out (the core loop).
+  - [`diagrams/kubernetes.md`](diagrams/kubernetes.md): the cluster and how a
+    sandbox pod is built.
+  - [`diagrams/aci.md`](diagrams/aci.md): the agent container interface, the
+    frozen contract between the worker and the agent in the box.
 - [`architecture.md`](architecture.md): a redirect stub pointing at the root
   `ARCHITECTURE.md` above.
 - [`architecture-vision.md`](architecture-vision.md): the forward-looking

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,3 +3,7 @@
 Superseded. The as-built architecture reference now lives at
 [`../ARCHITECTURE.md`](../ARCHITECTURE.md), including the component map and the
 message-flow and deploy-flow sequence diagrams.
+
+For focused, presentation-grade flow diagrams, see [`diagrams/`](diagrams/):
+[message flow](diagrams/message-flow.md), [Kubernetes
+architecture](diagrams/kubernetes.md), and [the ACI](diagrams/aci.md).

--- a/docs/diagrams/aci.md
+++ b/docs/diagrams/aci.md
@@ -1,0 +1,115 @@
+# The ACI: agent container interface
+
+The **ACI** is the frozen contract between the worker and the agent running
+inside a sandbox pod. The worker never talks to Claude Code or the model
+directly; it talks to a **runner** over a small HTTP/NDJSON protocol. That seam
+is what lets the platform stay the same while the thing inside the box (the
+harness, the skill, the model) varies.
+
+Think of the sandbox pod as a sealed box with one door. The worker knocks on the
+door with an event; the box streams back deltas and a final answer. What happens
+inside the box is the runner's business.
+
+## The protocol (worker to runner)
+
+Three routes, served by the runner at
+[`runner/src/agentos_runner/server.py`](../../runner/src/agentos_runner/server.py):
+
+| Route | Meaning |
+|---|---|
+| `POST /v1/event` | Open a turn. Body is an ACI `event` frame; the response streams NDJSON until a `final`. |
+| `POST /v1/steer` | Inject a follow-up into the **live** turn (same frame type as `/v1/event`). Returns **409** if no turn is running, so the worker falls back to a fresh `/v1/event`. |
+| `POST /v1/interrupt` | Hard-stop the live turn. Body is an ACI `interrupt` frame. |
+
+The reply is a stream of NDJSON events defined in
+[`packages/aci-protocol`](../../packages/aci-protocol):
+
+- `text_delta` — streamed answer tokens
+- `tool_note` — a tool call the agent made
+- `side_effect_flag` — the turn did something with side effects
+- `final` — the turn is done (carries the final text + status)
+- `error`
+
+## Inside the box
+
+```mermaid
+flowchart LR
+    Worker["Worker kernel"]
+
+    subgraph pod["Sandbox pod"]
+        direction TB
+        Runner["Runner<br/>ACI server"]
+        SDK["claude-agent-sdk<br/>(the harness)"]
+        Skill["skill bundle<br/>(fetched from MinIO)"]
+        Cred["credential"]
+        Runner --> SDK
+        Skill -. loaded .-> SDK
+        Cred -. injected .-> SDK
+    end
+
+    Model["Model<br/>(Anthropic default)"]
+    OTel["OTel Collector"]
+
+    Worker -- "POST /v1/event · /steer · /interrupt" --> Runner
+    Runner -- "NDJSON: text_delta · tool_note · final" --> Worker
+    SDK -- "model call" --> Model
+    Runner -- "gen_ai spans" --> OTel
+```
+
+The runner's job on each turn:
+
+1. Accept the ACI `event` frame from the worker.
+2. Drive the **harness** (today `claude-agent-sdk`, i.e. Claude Code) loaded with
+   the **skill bundle** the init container fetched and the injected
+   **credential**.
+3. Stream `text_delta` / `tool_note` events back, then a `final`.
+4. Emit `gen_ai`-style OTLP spans (`agent.run -> generation -> tool`) tagged with
+   the session and sandbox id, so a trace ties back to the pod that served it.
+
+## The credential path
+
+The credential reaches the model without any app process brokering it. The
+runner maps a prefixed credential onto the SDK's env var and **fails loud** on
+anything it cannot use
+([`runner/src/agentos_runner/sdk_auth.py`](../../runner/src/agentos_runner/sdk_auth.py)):
+
+| Credential prefix | Maps to |
+|---|---|
+| `sk-ant-oat...` | `CLAUDE_CODE_OAUTH_TOKEN` (checked first) |
+| `sk-ant-...` | `ANTHROPIC_API_KEY` |
+| `sk-or-...` (OpenRouter) | routed through the base-URL-override seam to OpenRouter's Anthropic endpoint |
+| `sk-...` (bare OpenAI style) | rejected — the Anthropic SDK cannot use it |
+| anything else | treated as an OAuth token |
+
+The **base-URL-override seam** (`resolve_base_url_override`) is how the runner
+talks to any Anthropic-compatible endpoint without a real Anthropic credential:
+it points `ANTHROPIC_BASE_URL` at the target and carries a non-empty placeholder
+`ANTHROPIC_API_KEY` so the bundled CLI's auth gate passes. Both OpenRouter and
+the opt-in **bundled local model** (Ollama / Qwen3 demo mode) ride this seam.
+
+**Real model is the default.** The runner makes a real model call unless
+`AGENTOS_FAKE_MODEL` is set (a test-only knob that swaps in a scripted fake). A
+missing credential is fail-closed, not a silent downgrade to fake.
+
+## Why it is frozen
+
+`packages/aci-protocol` is a **frozen interface** compiled against in Python,
+TypeScript, and Rust. The Pydantic models are the source of truth; the JSON
+Schema and generated TypeScript/Rust are derivatives, and a CI compat gate fails
+on drift. An unreviewed change in one language would silently break the others,
+so a task that needs the protocol to change **stops and escalates** rather than
+working around it (ADR-0005; see [`ARCHITECTURE.md` §9](../../ARCHITECTURE.md)).
+
+Choosing the real Claude Code plugin shape for skills (rather than an invented
+format) is the distribution wedge: a skill authored for Claude Code runs here
+unchanged.
+
+## Where this lives in the code
+
+| Piece | Path |
+|---|---|
+| ACI protocol (frozen) | [`packages/aci-protocol/`](../../packages/aci-protocol) |
+| Runner / ACI server | [`runner/src/agentos_runner/server.py`](../../runner/src/agentos_runner/server.py) |
+| Runner interface contract | [`runner/src/agentos_runner/INTERFACE.md`](../../runner/src/agentos_runner/INTERFACE.md) |
+| Credential mapping + base-URL override | [`runner/src/agentos_runner/sdk_auth.py`](../../runner/src/agentos_runner/sdk_auth.py) |
+| Plugin / skill bundle shape | [`packages/plugin-format/`](../../packages/plugin-format) |

--- a/docs/diagrams/kubernetes.md
+++ b/docs/diagrams/kubernetes.md
@@ -1,0 +1,116 @@
+# Kubernetes architecture
+
+What actually runs in the cluster, and how a sandbox pod gets built to serve one
+agent turn. This is the "machinery under the hood" that [the message
+flow](message-flow.md) glosses over.
+
+The whole thing installs from one umbrella Helm chart
+([`charts/agentos`](../../charts/agentos)): the platform services, the backing
+stores, the sandbox substrate, and the security rails all come up together.
+
+## The cluster at a glance
+
+```mermaid
+flowchart TB
+    subgraph platform["Platform services (Deployments)"]
+        API["api"]
+        Disp["dispatcher"]
+        Worker["worker"]
+        UI["ui"]
+    end
+
+    subgraph backing["Backing stores"]
+        PG[("Postgres")]
+        Valkey[("Valkey")]
+        MinIO[("MinIO / S3")]
+        LF["Langfuse + ClickHouse"]
+        OTel["OTel Collector"]
+    end
+
+    subgraph sandbox["Sandbox substrate (agent-sandbox controller)"]
+        Pool["SandboxWarmPool<br/>pre-warmed pods"]
+        Pod["Runner pod<br/>(one per live thread)"]
+        Pool -- "bind on claim" --> Pod
+    end
+
+    UI --> API
+    API --> PG
+    API --> MinIO
+    Disp --> Valkey
+    Worker --> Valkey
+    Worker -- "create SandboxClaim" --> Pod
+    Pod -- "bundle-fetch init" --> MinIO
+    Worker --> OTel
+    Pod --> OTel
+    OTel --> LF
+    API -- "read traces / cost" --> LF
+```
+
+## How a sandbox pod is built
+
+A runner pod on its own is just Claude Code with no skill. The agent-sandbox
+Kubernetes feature turns it into a ready agent at claim time:
+
+```mermaid
+flowchart LR
+    Worker["Worker<br/>KubernetesSandboxClient"]
+    Claim["SandboxClaim CRD"]
+    Pool["SandboxWarmPool<br/>(pre-warmed, replicas>0)"]
+    Init["init: bundle-fetch<br/>pull skill from MinIO"]
+    Runner["Runner container<br/>Claude Code + skill + credential"]
+
+    Worker -- "1. claim(thread)" --> Claim
+    Claim -- "2. bind a warm pod" --> Pool
+    Pool -- "3. start pod" --> Init
+    Init -- "4. bundle in place" --> Runner
+    Worker -- "5. POST /v1/event" --> Runner
+```
+
+1. The worker's **`KubernetesSandboxClient`** creates a **`SandboxClaim`** CRD.
+2. The controller binds a pod from the **`SandboxWarmPool`** (pre-warmed so the
+   claim is fast; `replicas: 0` means every claim fails `WarmPoolNotFound`).
+3. The pod's **`bundle-fetch` init container** pulls the skill bundle for this
+   channel from MinIO before the runner starts. It is **fail-closed**: if a
+   bundle ref is set but the archive cannot be fetched, the pod does not start.
+4. The runner comes up as a ready agent and the worker drives it over
+   [the ACI](aci.md).
+
+Pods are **warm for ~1 hour** after their last turn (see [message
+flow](message-flow.md)); after that the claim is released and the next turn on
+that thread gets a fresh pod.
+
+## Security rails (all chart defaults)
+
+These are on by default, not opt-in (ADR-0006):
+
+- **Default-deny egress** NetworkPolicy, with a carve-out that keeps the cloud
+  metadata endpoint (`169.254.169.254`) blocked and a narrow allow for the MinIO
+  bundle fetch. [`security-networkpolicy.yaml`](../../charts/agentos/templates/security-networkpolicy.yaml)
+- **gVisor RuntimeClass** on the runner, plus a preflight Job that fails the
+  install if the kernel is not gVisor.
+  [`preflight-gvisor.yaml`](../../charts/agentos/templates/preflight-gvisor.yaml)
+- **AVX / ClickHouse preflight** that blocks install when the CPU cannot run the
+  chosen ClickHouse image.
+  [`preflight-avx.yaml`](../../charts/agentos/templates/preflight-avx.yaml)
+- **One chart-managed Secret** holding the model credential, backing-store
+  passwords, Langfuse keys, the API key, the GitHub webhook secret, and Slack
+  tokens. [`secrets.yaml`](../../charts/agentos/templates/secrets.yaml)
+
+## The same worker runs without Kubernetes
+
+The worker talks to a `SandboxClient` interface, not to Kubernetes directly.
+Swap `KubernetesSandboxClient` for `DockerSandboxClient` and the same worker runs
+the same runner image as a local Docker container — a full backend on a laptop,
+no cluster. Everything above that seam (routing, budgets, kill switch, resume)
+is identical. That substrate-agnosticism is the load-bearing design property;
+see [`ARCHITECTURE.md` §3](../../ARCHITECTURE.md).
+
+## Where this lives in the code
+
+| Piece | Path |
+|---|---|
+| Umbrella chart + templates | [`charts/agentos/templates/`](../../charts/agentos/templates) |
+| Sandbox template + warm pool | [`charts/agentos/templates/agent-sandbox.yaml`](../../charts/agentos/templates/agent-sandbox.yaml) |
+| Worker's Kubernetes client | [`apps/worker/src/agentos_worker/sandbox/k8s.py`](../../apps/worker/src/agentos_worker/sandbox/k8s.py) |
+| Local Docker client | [`apps/worker/src/agentos_worker/sandbox/docker.py`](../../apps/worker/src/agentos_worker/sandbox/docker.py) |
+| Install / operations notes | [`operations.md`](../operations.md) |

--- a/docs/diagrams/message-flow.md
+++ b/docs/diagrams/message-flow.md
@@ -1,0 +1,111 @@
+# Message flow: how a message comes in and a reply goes out
+
+This is the core loop. Everything else in AgentOS (the UI, git-flow, evals,
+observability) is machinery around this one path: **a message comes into the
+system, an agent handles it, and a reply goes back to the same thread.**
+
+## The one-sentence version
+
+A message arrives on a channel, the dispatcher normalizes it and drops it on a
+queue, the worker routes it to a sandbox pod running the right skill, the agent
+inside that pod calls the model and streams an answer back, and the worker edits
+that answer into the thread the message came from.
+
+## The round trip
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as User (Slack / CLI)
+    participant Disp as Dispatcher
+    participant Queue as Valkey queue
+    participant Worker as Worker kernel
+    participant Pod as Sandbox pod (runner + skill)
+    participant Model as Model
+
+    User->>Disp: message ("@agent do X")
+    Disp->>User: post placeholder ("On it...")
+    Disp->>Queue: enqueue (deduped)
+    Queue->>Worker: deliver
+    Worker->>Pod: route to warm pod, send message
+    Pod->>Model: model call (skill + thread history)
+    Model-->>Pod: streamed reply
+    Pod-->>Worker: reply text
+    Worker-->>User: edit the placeholder into the answer
+```
+
+## The pieces, in the order a message hits them
+
+```mermaid
+flowchart LR
+    In["Message in"]
+    Disp["Dispatcher<br/>normalize + dedupe"]
+    Queue["Valkey queue<br/>route · affinity · steer/queue"]
+    Worker["Worker kernel<br/>one session per thread"]
+    Pod["Sandbox pod<br/>runner + skill + credential"]
+    Out["Reply out<br/>same thread"]
+
+    In --> Disp --> Queue --> Worker --> Pod --> Out
+```
+
+### 1. The channel is pluggable
+
+Today a message comes from **Slack** (Socket Mode) or the **CLI** (`agentos
+local message` / `agentos skill message`, which posts a synthetic event onto the
+same queue). The system does not
+care which: a message is just a message. Email, Teams, or a Jira comment are the
+same integration point later. The dispatcher's whole job is to turn any of those
+into one normalized queue event.
+
+### 2. Valkey routes and dedupes
+
+Valkey (a Redis-compatible store) is the traffic controller. It dedupes retried
+deliveries, and it holds the **affinity** rules that decide whether this message
+goes to a **new** sandbox pod or an **existing** one. Affinity matters because of
+caching and steering (below): a follow-up in a live thread must reach the exact
+pod already working on it.
+
+### 3. The worker builds (or reuses) a sandbox pod
+
+The worker owns **one live session per thread**. For a new thread it starts a
+**sandbox pod** — a Kubernetes-isolated container that is, on its own, just a
+bare runner (Claude Code). The pod is assembled at request time:
+
+- pull the **runner** image (Claude Code),
+- inject the **skill bundle** for this channel, fetched from MinIO (blob store),
+- inject the **credential** and the **thread history**.
+
+That assembled environment is the agent. It runs, emits an answer, and the
+worker routes the answer back to the thread.
+
+### 4. Warm pods (the 1-hour rule)
+
+A pod stays warm for about an hour after its last turn. Send a follow-up seven
+minutes later and the same warm pod handles it (prompt cache intact). Come back
+to yesterday's thread and the old pod is gone, so the worker starts a fresh one
+and rehydrates the history.
+
+## Steering vs. queuing
+
+While a turn is running, a follow-up message is **steered** into the live turn
+(same as typing a new message to Claude Code mid-task) rather than waiting for it
+to finish. That is the default. If the turn happens to finish first, the worker
+just opens a fresh turn on the same idle pod — so from the user's side steering
+and queuing look the same.
+
+This is why routing to the *right* pod matters: you can only steer a turn if you
+know which pod is running it.
+
+## Where this lives in the code
+
+| Step | Code |
+|---|---|
+| Slack ingress, dedupe, placeholder, enqueue | [`apps/dispatcher/`](../../apps/dispatcher) |
+| CLI channel + synthetic event | [`cli/src/chat.rs`](../../cli/src/chat.rs) |
+| Queue, thread locks, affinity | [`apps/worker/src/agentos_worker/`](../../apps/worker/src/agentos_worker) |
+| Sandbox pod substrate | [`apps/worker/src/agentos_worker/sandbox/`](../../apps/worker/src/agentos_worker/sandbox) |
+| The agent inside the pod | [`runner/`](../../runner) — see [the ACI](aci.md) |
+
+For the low-level version (dedupe keys, consumer groups, the finish-race and
+crash-recovery invariants), see [`ARCHITECTURE.md` §4](../../ARCHITECTURE.md).
+For the pods themselves, see [the Kubernetes architecture](kubernetes.md).


### PR DESCRIPTION
Cleans up the architecture docs, which were hard to present from and contained one diagram that did not render.

## What changed

- **Fixed the broken diagram.** The §4 message-flow sequence diagram silently failed to render on GitHub: a `Note` contained a semicolon (and a `<br/>`), both of which the mermaid sequence parser rejects. Reworded the two Notes.
- **Simplified the §2 component map** from a ~20-node tangle to a clean top-down map of the major blocks; round-trip and substrate detail moved into prose and the focused docs.
- **Merged** the two near-identical §5 deploy sequence diagrams into one covering both branches plus the eval fan-out.
- **Added `docs/diagrams/`** — three focused, presentation-grade flow docs, each a single diagram with narration:
  - `message-flow.md` — how a message comes in and a reply goes out (the core loop), steering vs queuing, warm pods
  - `kubernetes.md` — the cluster and how a sandbox pod is built (warm pool, SandboxClaim, bundle-fetch, security rails)
  - `aci.md` — the frozen worker↔runner contract, the credential path, why the protocol is frozen
- Pointed `docs/README.md` and `docs/architecture.md` at the new diagrams. `ARCHITECTURE.md` stays the deep as-built reference.

All 9 mermaid diagrams across the docs verified to render with `mmdc` (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)