### PR TITLE
Add product vision doc as the project north star

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Slack, author a Claude-Code-format plugin (skills + tools + MCP), deploy it as
 a versioned bot identity, and get traces, evals, budgets, and git-flow for
 free.
 
+New here? Read [`docs/vision.md`](docs/vision.md) for what AgentOS is, who it
+is for, and what it could become. It is the north star we hold new features
+against.
+
 "Relay" is this project's internal codename (repo, commits, internal docs);
 "agentos" is the product-surface name — the CLI binary, the bot handle, the
 console. Both names refer to the same system.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,9 @@ git history (`git log -- docs/`).
 
 ## Living documentation
 
+- [`vision.md`](vision.md): the north star. What AgentOS is, who it is for, and
+  what it could become. The document we hold new features against. Read this to
+  understand *why* the project exists before *how* it works.
 - [`../ARCHITECTURE.md`](../ARCHITECTURE.md): the as-built architecture, with the
   component map and the message-flow and deploy-flow sequence diagrams. Start
   here.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,84 @@
+# Vision
+
+This is the north star for AgentOS: what the project is, who it is for, and what
+it could become. It is deliberately not a feature list or a roadmap (those live
+in [GitHub issues](https://github.com/curie-eng/agentos/issues)). When we weigh
+a new feature, this is the document we hold it against. If a change does not
+serve the vision below, it needs a very good reason to exist.
+
+## What AgentOS is
+
+The open source platform for building, running, and operating production AI
+agents. A developer authors an agent locally, tests it in a loop identical to
+production, and ships it through git flow: a pull request opens a dev agent, a
+merge promotes it to prod. Agents answer in Slack, run in isolated sandboxes,
+and get observability and evals out of the box. One command brings the whole
+thing up, locally or on any cluster.
+
+If Supabase is the box that tells a developer they need auth, storage, and a
+realtime database before they know they need them, AgentOS is the box that tells
+them they need evals, traces, and CI/CD for their agent before it breaks
+silently in production.
+
+## Why it exists
+
+Building a production agent today means assembling a channel, a runtime, skills,
+connectors, observability, and a deploy pipeline from scratch, and most people
+skip the last three. The result is a familiar failure: the agent works on the
+author's laptop, drifts when someone else runs it, and degrades in production
+with no one watching. The industry data says the same thing (most GenAI pilots
+show no measurable impact; a large share of agentic projects get canceled), and
+the diagnosis is missing engineering discipline, not missing model capability.
+
+AgentOS ships that discipline as the default path, not an advanced option.
+
+## Who it is for
+
+Developers building production agents. Not business users, not operators.
+
+Cost reduction is the boss's pain. The local dev loop, evals, and CI/CD are the
+developer's pain, and the developer is who adopts open source. Most developers
+think building an agent means writing a `skill.md`; they do not yet know they
+need evals, traces, and promotion gates. AgentOS gives them those before they
+learn the hard way, and it does so as a tool they can build on, own, and run on
+their own infrastructure rather than a black box they rent.
+
+## What makes it AgentOS
+
+Five commitments that should hold across every feature we build:
+
+- **The local loop is the production loop.** What a developer tests locally is
+  what runs in prod, down to the sandbox and the harness. Local-first is a
+  load-bearing promise, not a convenience.
+- **Git flow is the deploy model.** Branches map to bot environments; a PR is a
+  dev agent, a merge is a promotion. Shipping an agent should feel like shipping
+  code, because it is.
+- **Opinionated core, swappable jobs.** One curated default for every job a
+  production agent platform must do (harness, channel, observability, evals,
+  blob storage, relational store), each replaceable behind a clean seam. The
+  defaults are the draw; the seams are why you stay. You own your stack and your
+  model choice.
+- **The whole box.** Build, test, deploy, observe, and evaluate in one platform.
+  The full loop is the product, not any single piece of it.
+- **Open, self-hostable, model-agnostic.** Runs on your infrastructure, with any
+  model, with nothing locked away. The same eval suite across models is how a
+  developer learns which model each job actually needs.
+
+## What it could become
+
+Near term, AgentOS is how we deliver agent work faster: a repeatable delivery
+artifact where each project costs a fraction of the last, and the platform is
+the boundary that keeps bespoke agent development from becoming
+"Accenture for agents."
+
+If it proves out internally, the longer arc is a developer-first open source
+platform that grows the way Supabase and PostHog did: adoption from developers
+who want to own their agent stack instead of renting an expensive black box, a
+comparison the market makes on its own once the box is good enough. We do not
+lead with "the cheap one." We lead with "build agents as code, test them with
+evals, ship them through git flow, run them on your infrastructure with any
+model," and let owning your stack be the reason people arrive.
+
+The test for any feature is simple: does it make that developer's loop tighter,
+that box more complete, or that ownership more real? If yes, it belongs. If no,
+it is someone else's product.


### PR DESCRIPTION
Adds `docs/vision.md`: a short, grounding "north star" doc capturing what AgentOS is, who it is for, and what it could become. It is deliberately distinct from `docs/architecture-vision.md` (the technical hexagonal *how*); this is the product *why*, and the document we hold new features against.

Sourced from the July 6 prototype-review executive summary, the roadmap/architecture direction, the committed architecture-vision doc, and the synthesis of recent calls (developer-first verdict, the "keeps bespoke agent dev from becoming Accenture for agents" framing, and the Supabase/PostHog distribution arc).

Contents:
- What AgentOS is (Supabase-for-agents framing)
- Why it exists (fragmented inner loop, dev-to-prod drift, no evals = silent failure)
- Who it is for (developer-first, explicitly not operators)
- What makes it AgentOS (five commitments: local loop = prod loop, git-flow deploy, opinionated core + swappable jobs, the whole box, open/self-hostable/model-agnostic)
- What it could become (repeatable delivery artifact, Supabase-style OSS arc, own-your-stack over rented black box)
- A grounding test for weighing features

Also wired in for discoverability: a "New here?" pointer near the top of `README.md` and a first entry in the `docs/README.md` living-docs index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)