### PR TITLE
Route OpenRouter sk-or- key to x-api-key instead of Bearer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -282,7 +282,7 @@ The runner's mapping is prefix-based and fails loud on anything it cannot use
 
 - `sk-ant-oat...` -> `CLAUDE_CODE_OAUTH_TOKEN` (checked first; OAuth tokens share the `sk-ant-` prefix).
 - `sk-ant-...` -> `ANTHROPIC_API_KEY`.
-- `sk-or-...` (OpenRouter) -> routed through the shared **base-URL-override seam**: base URL points at OpenRouter's native Anthropic Messages endpoint, the key becomes `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_API_KEY` is set to a non-empty placeholder so the bundled CLI's auth gate passes. Staying on the Anthropic wire format keeps prompt caching intact.
+- `sk-or-...` (OpenRouter) -> routed through the shared **base-URL-override seam**: base URL points at OpenRouter's native Anthropic Messages endpoint, and the real key is placed in `ANTHROPIC_API_KEY` (sent as the `x-api-key` header, which OpenRouter's Anthropic endpoint authenticates on), overriding the non-empty placeholder the seam sets; `ANTHROPIC_AUTH_TOKEN` is left blank. Staying on the Anthropic wire format keeps prompt caching intact.
 - `sk-...` (bare OpenAI-style) -> raises `UnsupportedCredentialError` rather than forwarding a key the Anthropic SDK cannot use.
 - Anything else -> treated as an OAuth token.
 

--- a/runner/src/agentos_runner/INTERFACE.md
+++ b/runner/src/agentos_runner/INTERFACE.md
@@ -36,8 +36,9 @@ Both are blanked to `""` in override mode so an inherited OAuth token or Bearer
 token cannot take precedence over the placeholder + overridden base URL, nor
 leak as a Bearer header to the overridden (local/third-party) endpoint. This
 keeps override mode hermetic. (On the OpenRouter path, `resolve_model_credential`
-re-sets `ANTHROPIC_AUTH_TOKEN` to the real `sk-or-` key after applying this
-override, so the Bearer token still reaches OpenRouter.)
+re-sets `ANTHROPIC_API_KEY` to the real `sk-or-` key (the `x-api-key` header
+OpenRouter's Anthropic endpoint reads) after applying this override;
+`ANTHROPIC_AUTH_TOKEN` stays blank.)
 
 ### `AGENTOS_MODEL` (input)
 
@@ -47,9 +48,11 @@ The model name (e.g. `qwen3:4b`), passed through to `ClaudeAgentOptions.model`.
 
 An `sk-or-...` credential in `AGENTOS_CREDENTIALS` is auto-detected by
 `resolve_model_credential`. The runner sets
-`ANTHROPIC_BASE_URL=https://openrouter.ai/api`, places the real key in
-`ANTHROPIC_AUTH_TOKEN` for Bearer auth, and reuses this seam's non-empty
-`ANTHROPIC_API_KEY` placeholder plus blanked `CLAUDE_CODE_OAUTH_TOKEN`.
+`ANTHROPIC_BASE_URL=https://openrouter.ai/api` and places the real key in
+`ANTHROPIC_API_KEY` (sent as the `x-api-key` header, which OpenRouter's Anthropic
+Messages endpoint authenticates on), overriding this seam's `not-needed`
+placeholder, and leaves `ANTHROPIC_AUTH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN`
+blank.
 
 Prompt caching survives only on this native Anthropic Messages path, and only
 for Claude-family OpenRouter models.

--- a/runner/src/agentos_runner/sdk_auth.py
+++ b/runner/src/agentos_runner/sdk_auth.py
@@ -14,9 +14,10 @@ prefix, so the more specific OAuth prefix is checked first):
 - ``sk-ant-oat...`` is a Claude Code OAuth token -> ``CLAUDE_CODE_OAUTH_TOKEN``.
 - ``sk-ant-...`` (any other) is an Anthropic API key -> ``ANTHROPIC_API_KEY``.
 - ``sk-or-...`` (OpenRouter) is routed through the base-URL-override seam:
-  base URL -> OpenRouter's Anthropic endpoint, key -> ``ANTHROPIC_AUTH_TOKEN``,
-  and ``ANTHROPIC_API_KEY`` -> the non-empty placeholder. A bare ``sk-...``
-  OpenAI-style key is still rejected loudly. Other providers are post-MVP.
+  base URL -> OpenRouter's Anthropic endpoint, key -> ``ANTHROPIC_API_KEY``
+  (the ``x-api-key`` header OpenRouter reads), and ``ANTHROPIC_AUTH_TOKEN``
+  left blank. A bare ``sk-...`` OpenAI-style key is still rejected loudly.
+  Other providers are post-MVP.
 - Anything else is treated as a Claude Code OAuth token ->
   ``CLAUDE_CODE_OAUTH_TOKEN``.
 
@@ -99,15 +100,16 @@ def resolve_model_credential(env: MutableMapping[str, str]) -> None:
     elif credential.startswith("sk-or-"):
         # OpenRouter: reuse the shared base-URL-override seam to target OpenRouter's
         # native Anthropic Messages endpoint (the SDK appends /v1/messages). The real
-        # key is Bearer auth via ANTHROPIC_AUTH_TOKEN; ANTHROPIC_API_KEY stays the
-        # non-empty NO_OP_API_KEY placeholder so the CLI auth gate passes. Staying on
-        # the Anthropic wire format keeps prompt caching intact (the OpenAI
+        # key goes in ANTHROPIC_API_KEY (sent as the x-api-key header, which is what
+        # OpenRouter's Anthropic endpoint reads), overriding the NO_OP_API_KEY
+        # placeholder the override just set; ANTHROPIC_AUTH_TOKEN stays blank. Staying
+        # on the Anthropic wire format keeps prompt caching intact (the OpenAI
         # chat-completions path silently breaks it at ~10x cost).
         env[BASE_URL_ENV] = OPENROUTER_BASE_URL
         override = resolve_base_url_override(env)
         assert override is not None  # base URL was just set
         env.update(override)
-        env[AUTH_TOKEN_ENV] = credential
+        env[API_KEY_ENV] = credential  # real key -> x-api-key (what OpenRouter reads)
     elif credential.startswith("sk-"):
         # OpenAI-style ("sk-...") and similar. Fail loudly rather than
         # forwarding a key the Anthropic SDK cannot use.
@@ -123,10 +125,11 @@ def resolve_sdk_env(env: MutableMapping[str, str]) -> dict[str, str] | None:
     """Decide the SDK auth env from the boot env.
 
     An ``sk-or-`` OpenRouter credential is routed by ``resolve_model_credential``
-    (which sets the OpenRouter base URL, the Bearer token, and the placeholder)
-    even when ``ANTHROPIC_BASE_URL`` is already set, so its Bearer token is never
-    dropped. Otherwise a generic base-URL override wins when configured, and a
-    plain Anthropic credential falls through to ``resolve_model_credential``.
+    (which sets the OpenRouter base URL and the real key in ``ANTHROPIC_API_KEY``,
+    the ``x-api-key`` header OpenRouter reads) even when ``ANTHROPIC_BASE_URL`` is
+    already set, so its key is never dropped. Otherwise a generic base-URL override
+    wins when configured, and a plain Anthropic credential falls through to
+    ``resolve_model_credential``.
     Returns the override dict to pass as ``ClaudeAgentOptions.env`` (base-URL
     override mode), or ``None`` when resolution mutated ``env`` in place.
     """

--- a/runner/tests/test_sdk_auth.py
+++ b/runner/tests/test_sdk_auth.py
@@ -61,15 +61,16 @@ def test_foreign_key_is_rejected_loudly(foreign: str) -> None:
     assert foreign not in msg  # the credential value never appears in the error
 
 
-def test_openrouter_key_is_plumbed_to_base_url_override() -> None:
+def test_openrouter_key_maps_to_api_key_not_bearer() -> None:
     env = {CREDENTIALS_ENV: "sk-or-PLACEHOLDER"}
     resolve_model_credential(env)
 
     assert env[BASE_URL_ENV] == OPENROUTER_BASE_URL
-    assert env[AUTH_TOKEN_ENV] == "sk-or-PLACEHOLDER"
-    # Empty string would fail the bundled Claude CLI auth gate.
-    assert env[API_KEY_ENV] == NO_OP_API_KEY
-    assert env[API_KEY_ENV] != ""
+    # The real key goes in ANTHROPIC_API_KEY (the x-api-key header OpenRouter's
+    # Anthropic endpoint reads), overriding the NO_OP_API_KEY placeholder.
+    assert env[API_KEY_ENV] == "sk-or-PLACEHOLDER"
+    # It must NOT land in ANTHROPIC_AUTH_TOKEN (Bearer); that stays blank.
+    assert env[AUTH_TOKEN_ENV] == ""
     assert env[OAUTH_TOKEN_ENV] == ""
 
 
@@ -146,19 +147,19 @@ def test_resolve_sdk_env_plain_anthropic_key_mutates_env() -> None:
 
 def test_resolve_sdk_env_openrouter_alone_mutates_env() -> None:
     # sk-or- credential, no preset base URL: returns None; env gets the
-    # OpenRouter base URL, the Bearer token, and the placeholder.
+    # OpenRouter base URL and the real key in ANTHROPIC_API_KEY (x-api-key).
     env = {CREDENTIALS_ENV: "sk-or-PLACEHOLDER"}
     assert resolve_sdk_env(env) is None
     assert env[BASE_URL_ENV] == OPENROUTER_BASE_URL
-    assert env[AUTH_TOKEN_ENV] == "sk-or-PLACEHOLDER"
-    assert env[API_KEY_ENV] == NO_OP_API_KEY
+    assert env[API_KEY_ENV] == "sk-or-PLACEHOLDER"
+    assert env[AUTH_TOKEN_ENV] == ""
 
 
-def test_resolve_sdk_env_openrouter_with_preset_base_url_sets_bearer() -> None:
+def test_resolve_sdk_env_openrouter_with_preset_base_url_sets_api_key() -> None:
     # P2 regression: an operator sets ANTHROPIC_BASE_URL AND passes an sk-or-
-    # credential. The sk-or- key must still be routed (Bearer token set), not
-    # skipped by the generic base-URL override.
+    # credential. The sk-or- key must still be routed (into ANTHROPIC_API_KEY, the
+    # x-api-key header), not skipped by the generic base-URL override.
     env = {BASE_URL_ENV: "https://openrouter.ai/api", CREDENTIALS_ENV: "sk-or-PLACEHOLDER"}
     assert resolve_sdk_env(env) is None
-    assert env[AUTH_TOKEN_ENV] == "sk-or-PLACEHOLDER"
-    assert env[API_KEY_ENV] == NO_OP_API_KEY
+    assert env[API_KEY_ENV] == "sk-or-PLACEHOLDER"
+    assert env[AUTH_TOKEN_ENV] == ""


### PR DESCRIPTION
## Problem
OpenRouter's Anthropic Messages endpoint authenticates on the `x-api-key` header (`ANTHROPIC_API_KEY`), not `Authorization: Bearer`. The runner placed the real `sk-or-` key in `ANTHROPIC_AUTH_TOKEN` (Bearer) and left the `not-needed` placeholder in `ANTHROPIC_API_KEY`, so OpenRouter read the placeholder and returned `404 model_not_found` on every run.

## Fix
Route the real `sk-or-` key to `ANTHROPIC_API_KEY` (x-api-key), overriding the placeholder that the base-URL override seam sets; `ANTHROPIC_AUTH_TOKEN` stays blank. The base-URL override path is unchanged, so the prompt-cache-preserving Anthropic wire format is retained. The CLI auth gate still passes because `ANTHROPIC_API_KEY` is now the real (non-empty) key.

## Changes
- `runner/src/agentos_runner/sdk_auth.py`: sk-or- branch sets `ANTHROPIC_API_KEY` (not `ANTHROPIC_AUTH_TOKEN`); docstrings/comment updated to describe x-api-key routing.
- `runner/tests/test_sdk_auth.py`: sk-or- tests flipped to assert the real key lands in `ANTHROPIC_API_KEY` and NOT in `ANTHROPIC_AUTH_TOKEN`.
- `runner/src/agentos_runner/INTERFACE.md`: OpenRouter mapping doc updated.

Verified: `uv run pytest runner/tests -q` (67 passed, 3 skipped live), `ruff` clean, `mypy` clean. Wire-level evidence in the issue: real key as x-api-key returns 200 OK; the runner's old Bearer shape returned 404.

Closes #97