### PR TITLE
Build worker-local image on main pushes, not only tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,16 +78,20 @@ jobs:
 
   worker-local:
     name: Build and push the worker-local overlay image
-    if: startsWith(github.ref, 'refs/tags/v')
     needs: [images]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Compute version
+      - name: Compute base tag
         id: ver
-        run: echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "v=latest" >> "$GITHUB_OUTPUT"
+          fi
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR


### PR DESCRIPTION
The `worker-local` job was gated `if: startsWith(github.ref, 'refs/tags/v')`, so `ghcr.io/curie-eng/agentos-worker-local` never publishes until a `v*` tag is cut, and its `:latest` never exists. The five core images build on every `main` push and get `:latest`; this brings worker-local into that same continuous cadence.

worker-local can't be a peer in the `images` matrix because it's an overlay: `compose/worker-local.Dockerfile` is `FROM ghcr.io/curie-eng/agentos-worker:${BASE_TAG}` plus a docker CLI, so the core `agentos-worker` image must be pushed first (`needs: [images]` is kept). But it doesn't need to be tag-only. The old step computed `BASE_TAG=${GITHUB_REF_NAME#v}`, which on a `main` push resolves to the nonexistent `agentos-worker:main` — hence the tag gate. This PR:

- Removes the `if:` tag gate so the job runs on `main` pushes and `v*` tags.
- Pins `BASE_TAG` per ref: `latest` on the default branch (base is only tagged `:latest`/`:sha` there), stripped version (e.g. `0.1.1`) on a `v*` tag.

The job's tag-metadata already carries `type=raw,value=latest,enable={{is_default_branch}}`, so once it runs on `main` it publishes `:latest` automatically — no tag-metadata change needed.

Note: new ghcr packages default to private, so `agentos-worker-local` will need to be flipped to public once after it first publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)