### PR TITLE
Fix container healthchecks to use 127.0.0.1 (IPv6 localhost footgun)

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -103,7 +103,7 @@ services:
         soft: 262144
         hard: 262144
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:8123/ping || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 12
@@ -294,7 +294,7 @@ services:
     ports:
       - "28000:8000"
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status==200 else 1)"]
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health').status==200 else 1)"]
       interval: 5s
       timeout: 5s
       retries: 24
@@ -316,7 +316,7 @@ services:
     ports:
       - "28080:8080"
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:8080/ || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 12

--- a/compose.release.yaml
+++ b/compose.release.yaml
@@ -145,7 +145,7 @@ services:
         soft: 262144
         hard: 262144
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:8123/ping || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 12
@@ -311,7 +311,7 @@ services:
     ports:
       - "28000:8000"
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status==200 else 1)"]
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health').status==200 else 1)"]
       interval: 5s
       timeout: 5s
       retries: 24
@@ -333,7 +333,7 @@ services:
     ports:
       - "28080:8080"
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:8080/ || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
`agentos local up` failed `--wait` with `container agentos-ui-1 is unhealthy` even though the stack was fully functional. The UI healthcheck probed `http://localhost:8080/`, which resolves to IPv6 `::1` inside the container while the UI server binds IPv4, so the probe got `Connection refused`.

Switch the UI, API, and ClickHouse loopback healthchecks in both `compose.dev.yaml` and `compose.release.yaml` to `127.0.0.1` so probes target IPv4 unambiguously.

Verified against the published `agentos-ui:latest` image: `wget localhost:8080` connects to `[::1]:8080` -> Connection refused; `wget 127.0.0.1:8080` -> remote file exists. Both compose files pass `docker compose config`.

Closes #101