### PR TITLE
Add QUICKSTART and fix stale CLI references in docs

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,65 @@
+# AgentOS quickstart
+
+Welcome. This gets you from nothing to your first agent reply in about a minute,
+with no credentials, no cluster, and no Slack. It runs the `skill` target: just
+the runner container on your host Docker daemon, talking straight to the agent.
+
+## Before you start
+
+- **Docker** running locally.
+- The **`agentos`** binary on your PATH. Grab it from
+  [GitHub Releases](https://github.com/curie-eng/agentos/releases) (or build the
+  CLI from `cli/` with `cargo build --release`).
+
+## Your first agent reply
+
+```bash
+# 1. Scaffold a bundle. This creates a runnable weather skill you can edit later.
+agentos init weather-bot
+cd weather-bot
+
+# 2. Boot the runner with the built-in fake model (offline, instant, no key).
+agentos skill up --fake-model
+
+# 3. Ask it something and watch the reply stream back.
+agentos skill message "hello, are you there?"
+
+# 4. Done. Tear the runner down.
+agentos skill down
+```
+
+That is the full loop. `agentos skill up` starts the runner container,
+`agentos skill message` sends a synthetic event and streams the reply, and
+`agentos skill down` stops it. Edit `skills/weather-bot/SKILL.md` in the bundle
+and re-run steps 2 and 3 to see your change answer.
+
+## Level up: a real model
+
+The fake model returns scripted replies. To get a genuine answer, bring your own
+model through OpenRouter on the same `skill` path. Set `AGENTOS_CREDENTIALS` to
+your OpenRouter key (it must arrive on that variable, not `ANTHROPIC_API_KEY`)
+and name a model slug:
+
+```bash
+AGENTOS_CREDENTIALS="$OPENROUTER_TOKEN" agentos skill up \
+  --image ghcr.io/curie-eng/agentos-runner:latest \
+  --model z-ai/glm-5.2
+
+agentos skill message "What's the weather in Paris? Answer in one short sentence."
+agentos skill down
+```
+
+You should get a real answer instead of the canned loop.
+
+## Going further
+
+The `skill` loop is the fastest way to iterate on a plugin, but it is only the
+runner. When you want the full platform (queue, worker, sandbox, traces):
+
+- **`local`** runs the whole platform via docker compose on your machine.
+- **`cluster`** runs it on Kubernetes as a Helm release, with tracing in
+  Langfuse.
+
+See [`docs/operations.md`](docs/operations.md) for the cluster runbook and
+[`cli/README.md`](cli/README.md) for the complete command reference. The
+[README](README.md#which-target-do-i-want) has a table to help you pick a target.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -51,15 +51,51 @@ agentos skill down
 
 You should get a real answer instead of the canned loop.
 
-## Going further
+## Still have time? Run your skill on your local box or on a Kubernetes cluster
 
-The `skill` loop is the fastest way to iterate on a plugin, but it is only the
-runner. When you want the full platform (queue, worker, sandbox, traces):
+The `skill` loop is just the runner container. To see your skill run through the
+real product path (queue, worker, sandbox, traces), the same way a Slack mention
+would, put the full platform in front of it. Two options, lightest first.
 
-- **`local`** runs the whole platform via docker compose on your machine.
-- **`cluster`** runs it on Kubernetes as a Helm release, with tracing in
-  Langfuse.
+### On your local box (Docker stack)
 
-See [`docs/operations.md`](docs/operations.md) for the cluster runbook and
-[`cli/README.md`](cli/README.md) for the complete command reference. The
-[README](README.md#which-target-do-i-want) has a table to help you pick a target.
+`local` brings up the whole platform with docker compose (API, worker, backing
+stores, and the console UI) and runs your skill through it. Same runner, now with
+the queue and worker in front, all on your machine. Run these from your bundle
+directory:
+
+```bash
+agentos local up                      # start the full compose stack
+agentos local deploy --plugin-dir .   # push the bundle to the local API on :28000
+agentos local message "What's the weather in Paris?"
+agentos local down                    # tear it all down
+```
+
+Watch the run land in the console UI at `http://localhost:28080/?api=1`. Like
+`skill`, the local stack runs the fake model by default, so replies are scripted
+until you wire a real model.
+
+> If `local up` prints `agentos-ui-1 is unhealthy`, ignore it: that is a known
+> UI healthcheck quirk. The stack is fine and the UI answers on `:28080`.
+
+### On a Kubernetes cluster (Helm)
+
+`cluster` installs the platform as a Helm release and drives your skill on real
+Kubernetes, with runs traced in Langfuse. The short arc:
+
+```bash
+agentos cluster up                    # install the platform (Helm release)
+kubectl port-forward svc/agentos-api 8000:8000 -n agentos &   # deploy needs this
+agentos cluster deploy --plugin-dir . # push the bundle to the in-cluster API
+kill %1
+agentos cluster message "What's the weather in Paris?"
+agentos cluster down --yes            # uninstall
+```
+
+For a real model on the cluster, the runner model key is
+`--set agentSandbox.runner.model=<slug>` (not `runner.model`, which silently
+no-ops). The full cluster runbook, including credentials, web egress, and the
+Langfuse login, is in [`docs/operations.md`](docs/operations.md).
+
+See [`cli/README.md`](cli/README.md) for the complete command reference, and the
+[README](README.md#which-target-do-i-want) for a table to help you pick a target.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Slack, author a Claude-Code-format plugin (skills + tools + MCP), deploy it as
 a versioned bot identity, and get traces, evals, budgets, and git-flow for
 free.
 
-New here? Read [`docs/vision.md`](docs/vision.md) for what AgentOS is, who it
-is for, and what it could become. It is the north star we hold new features
-against.
+New here? Start with [`QUICKSTART.md`](QUICKSTART.md) to get your first agent
+reply in about a minute. Then read [`docs/vision.md`](docs/vision.md) for what
+AgentOS is, who it is for, and what it could become. It is the north star we
+hold new features against.
 
 "Relay" is this project's internal codename (repo, commits, internal docs);
 "agentos" is the product-surface name — the CLI binary, the bot handle, the
@@ -131,11 +132,11 @@ Operators should start from a binary downloaded from
 curl -L -o agentos \
   https://github.com/curie-eng/agentos/releases/download/v<version>/agentos-x86_64-unknown-linux-gnu
 chmod +x agentos
-./agentos up
+./agentos cluster up
 ./agentos local up
 ```
 
-A release binary needs no repo checkout for `agentos up` or `agentos local up`.
+A release binary needs no repo checkout for `agentos cluster up` or `agentos local up`.
 It pulls the pinned chart release asset and the pinned `compose.release.yaml`
 matching the binary version, then caches them under `~/.cache/agentos/`. For
 local development overrides, pass `-f <compose>`, `--chart <path>`, or
@@ -187,7 +188,7 @@ export CLAUDE_CODE_OAUTH_TOKEN=...
 ../target/release/agentos skill eval
 ```
 
-A committed first-party example lives at `examples/weather/`. `cd examples/weather && agentos start` runs it from a clean clone. `agentos init` scaffolds this same weather template, so every fresh bundle starts as a runnable web-search skill to learn from and edit.
+A committed first-party example lives at `examples/weather/`. `cd examples/weather && agentos skill up` runs it from a clean clone. `agentos init` scaffolds this same weather template, so every fresh bundle starts as a runnable web-search skill to learn from and edit.
 
 For a fully offline round-trip (no credential, scripted replies), add
 `--fake-model` to `agentos skill up` — an explicit test-only mode that never reaches

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -71,6 +71,24 @@ sets the dispatcher's app and bot tokens and clears `worker.slackApiBaseUrl=`
 (un-wiring any `agentos cluster message` stub routing). It is intentionally not a CLI
 verb; the chart's `NOTES.txt` prints the exact command after `up`.
 
+## Deploy a bundle to the cluster
+
+Before `agentos cluster message` can drive an agent, a bundle must be deployed to
+the in-cluster platform API with `agentos cluster deploy`. Unlike `cluster
+message`, `cluster deploy` does not self-manage a port-forward, so its default
+`--api-url http://localhost:8000` is unreachable until you forward the API
+service yourself. Run the port-forward first, deploy, then release it:
+
+```bash
+kubectl port-forward svc/agentos-api 8000:8000 -n agentos &
+agentos cluster deploy --plugin-dir <bundle-dir> \
+  --api-url http://localhost:8000 --api-key agentos-dev-key
+kill %1   # cluster message plumbs its own forwards, so this one is no longer needed
+```
+
+Without a deploy, `agentos cluster message` fails with `no agents are deployed on
+the platform API`.
+
 ## Driving a deployed cluster with zero Slack
 
 `agentos cluster message "..."` exercises a deployed release end to end with no Slack


### PR DESCRIPTION
## What

- Add a light welcome/demo `QUICKSTART.md` at the repo root that gets a new user from install to their first agent reply fast, using the `skill` target with the fake model (instant, no credentials, no cluster). Includes a short optional OpenRouter real-model section and links onward to `docs/operations.md` and `cli/README.md`.
- Link `QUICKSTART.md` from the top of `README.md`.
- Fix stale retired-verb references found in a docs audit:
  - `README.md` quickstart: `agentos up` corrected to `agentos cluster up` (command and prose).
  - `README.md` weather example: `agentos start` corrected to `agentos skill up`.
  - `docs/operations.md` cluster runbook: add the required `agentos cluster deploy` step and the `kubectl port-forward svc/agentos-api 8000:8000` prerequisite before `cluster message`, matching the validated flow.

## Why

The README quickstart and the weather example both used commands that were retired (they now exit 2 with a hint), so a user following the docs top-to-bottom died on the first command. The cluster runbook was missing the `deploy` + port-forward steps, so `cluster message` failed with `no agents are deployed`. Every command in QUICKSTART.md was verified against the clap definitions in `cli/src/main.rs`.