### PR TITLE
Forward AGENTOS_MODEL on the credentials-only path

### DIFF
--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -160,8 +160,8 @@ def apply_model_env(env: dict[str, str], config: WorkerConfig) -> None:
     Shared by the runs binding and the eval consumer so both lanes boot the
     runner the same way: fake_model gates the canned model (no credential
     needed); credentials is forwarded only when set and never logged. The local
-    model demo path injects a generic Anthropic-compatible base URL and optional
-    model while leaving fake_model unset.
+    model demo path injects a generic Anthropic compatible base URL when
+    configured; an explicit model is forwarded whenever set.
     """
     if config.fake_model:
         env[FAKE_MODEL_ENV] = "1"
@@ -169,5 +169,5 @@ def apply_model_env(env: dict[str, str], config: WorkerConfig) -> None:
         env[CREDENTIALS_ENV] = config.credentials
     if config.model_base_url:
         env[BASE_URL_ENV] = config.model_base_url
-        if config.model:
-            env[MODEL_ENV] = config.model
+    if config.model:
+        env[MODEL_ENV] = config.model

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -63,6 +63,14 @@ def test_apply_model_env_forwards_base_url_and_model_without_fake_flag() -> None
     assert FAKE_MODEL_ENV not in env
 
 
+def test_apply_model_env_forwards_model_without_base_url() -> None:
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig(credentials="sk-or-xyz", model="z-ai/glm-5.2"))
+    assert env[MODEL_ENV] == "z-ai/glm-5.2"
+    assert env[CREDENTIALS_ENV] == "sk-or-xyz"
+    assert BASE_URL_ENV not in env
+
+
 def test_apply_model_env_forwards_base_url_without_model() -> None:
     base_url_env, model_env = BASE_URL_ENV, MODEL_ENV
 

--- a/compose.release.yaml
+++ b/compose.release.yaml
@@ -404,6 +404,7 @@ services:
       - ANTHROPIC_API_KEY
       - CLAUDE_CODE_OAUTH_TOKEN
       - AGENTOS_CREDENTIALS
+      - AGENTOS_MODEL
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Problem

On the `local` compose path a real OpenRouter (`sk-or-`) credential works, but the chosen model never reaches the runner: `apply_model_env` only forwarded `AGENTOS_MODEL` when `model_base_url` was set (the local-Ollama path). On the OpenRouter path the runner derives the base URL from the `sk-or-` key itself, so `model_base_url` is empty and the model id was dropped, yielding `model_not_found`.

## Fix

- `apply_model_env` (`apps/worker/src/agentos_worker/binding.py`): forward `AGENTOS_MODEL` whenever `config.model` is set, independent of `model_base_url`. The Ollama path (base URL + model) is unchanged.
- `compose.release.yaml`: add a bare `- AGENTOS_MODEL` passthrough to the worker-local env block. (`compose.dev.yaml` already forwards it.)
- New unit test covering the credentials-only-with-model path.

The sole downstream consumer (`runner/src/agentos_runner/config.py` `env.get("AGENTOS_MODEL")`) tolerates the value being present or absent.

Closes #102