### PR TITLE
Deliver reasoning-model text when result extraction returns empty

### DIFF
--- a/runner/src/agentos_runner/translate.py
+++ b/runner/src/agentos_runner/translate.py
@@ -44,6 +44,12 @@ class TurnState:
 
     side_effect_emitted: bool = False
     error_classification: str | None = None
+    # Assistant text streamed during the turn, accumulated so a DONE result with
+    # an empty ``result`` can still deliver the model's answer. Reasoning models
+    # routed through OpenRouter (e.g. z-ai/glm-5.2) emit the answer as a TextBlock
+    # but their empty-signature thinking block trips the SDK's result extraction,
+    # leaving ``ResultMessage.result`` empty (issue #107).
+    assistant_text: str = ""
 
 
 def translate_message(
@@ -93,6 +99,7 @@ def _translate_assistant(
     for block in message.content:
         if isinstance(block, TextBlock):
             if block.text:
+                state.assistant_text += block.text
                 events.append(TextDelta(text=block.text))
         elif isinstance(block, ToolUseBlock):
             events.append(ToolNote(text=f"running tool {block.name}", tool=block.name))
@@ -125,4 +132,9 @@ def _translate_result(
         events.append(Final(text=text, status=SessionStatus.CLASSIFIED_FAILURE))
         return events
 
-    return [Final(text=message.result or "", status=SessionStatus.DONE)]
+    # The SDK's ``result`` is authoritative when present. When it is empty on an
+    # otherwise-successful turn, fall back to the assistant text streamed this turn
+    # so a reasoning model whose result-extraction returned empty (issue #107)
+    # still delivers its answer. Provider-agnostic: it only fires when result is
+    # empty, so non-reasoning models and the fake-model path are unaffected.
+    return [Final(text=message.result or state.assistant_text, status=SessionStatus.DONE)]

--- a/runner/tests/test_translate.py
+++ b/runner/tests/test_translate.py
@@ -8,6 +8,7 @@ from claude_agent_sdk import (
     RateLimitEvent,
     ResultMessage,
     TextBlock,
+    ThinkingBlock,
     ToolUseBlock,
 )
 from claude_agent_sdk.types import RateLimitInfo
@@ -56,6 +57,44 @@ def test_result_success_is_final_done() -> None:
     assert [e.type for e in events] == ["final"]
     assert events[0].status == SessionStatus.DONE
     assert events[0].text == "answer"
+
+
+def test_reasoning_model_empty_result_falls_back_to_assistant_text() -> None:
+    # A reasoning model routed through OpenRouter (e.g. z-ai/glm-5.2) streams the
+    # answer as a TextBlock but the terminal ResultMessage reports success with an
+    # EMPTY result (the empty-signature thinking block trips result extraction).
+    # The delivered Final must carry the assistant text, not "".
+    state = TurnState()
+    assistant = AssistantMessage(
+        content=[
+            TextBlock(text="The sky is blue on a clear day."),
+            ThinkingBlock(thinking="the user asked...", signature=""),
+        ],
+        model="z-ai/glm-5.2",
+    )
+    _translate(assistant, state)  # accumulates text into state
+    result = ResultMessage(
+        subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
+        num_turns=1, session_id="s", result="",
+    )
+    events = _translate(result, state)
+    assert [e.type for e in events] == ["final"]
+    assert events[0].status == SessionStatus.DONE
+    assert events[0].text == "The sky is blue on a clear day."
+
+
+def test_result_with_own_text_ignores_accumulated_fallback() -> None:
+    # When the ResultMessage carries its own result, it wins over accumulated text
+    # (non-reasoning models are unaffected by the empty-result fallback).
+    state = TurnState()
+    _translate(AssistantMessage(content=[TextBlock(text="streamed")], model="m"), state)
+    result = ResultMessage(
+        subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
+        num_turns=1, session_id="s", result="authoritative",
+    )
+    events = _translate(result, state)
+    assert [e.type for e in events] == ["final"]
+    assert events[0].text == "authoritative"
 
 
 def test_result_error_is_error_then_classified_final() -> None:


### PR DESCRIPTION
Reasoning models routed through OpenRouter (e.g. `z-ai/glm-5.2`) complete a turn successfully but deliver an empty reply, surfacing as `(no response)`. Non-reasoning models work fine.

## Confirmed mechanism (step 1): A

Reproduced the raw SDK message stream for a GLM turn (OpenRouter Anthropic endpoint, `x-api-key`, blank Anthropic tokens). The observed shape:

- `AssistantMessage` with `TextBlock text='The sky is blue on a clear day.'` **does reach the translator**
- `AssistantMessage` with `ThinkingBlock signature=''` (empty signature)
- `ResultMessage subtype='success' is_error=False result=''` -- DONE with an **empty** `result`

So the answer arrives as a `TextBlock` (emitted as a `text_delta`), but the final reply was derived from `ResultMessage.result`, which the empty-signature thinking block leaves empty. The runner delivered `""`.

## Fix

Accumulate assistant `TextBlock` text in `TurnState` during the turn and fall back to it when a DONE `ResultMessage` carries an empty `result`. The fallback fires only when `result` is empty, so the SDK's own result stays authoritative for non-reasoning models and the fake-model path is unaffected. Smallest change; no SDK-boundary normalization needed, and the one-long-lived-session / prompt-cache invariant is untouched.

## Verification

- New unit test `test_reasoning_model_empty_result_falls_back_to_assistant_text` feeds the reasoning-shaped sequence (TextBlock + empty-signature ThinkingBlock, then DONE result="") and asserts the delivered Final is non-empty and equals the text block. It **fails on pre-fix code** (`assert '' == 'The sky is...'`) and passes after. Added `test_result_with_own_text_ignores_accumulated_fallback` to lock the non-reasoning path.
- `uv run pytest runner/tests -q` -> 69 passed, 3 skipped; `ruff` and `mypy` clean.
- End to end: built the runner image from this branch, booted the local runner with `AGENTOS_MODEL=z-ai/glm-5.2` and the OpenRouter credential (Anthropic tokens blank), and `skill message` returned `The sky is blue on a clear day.` with `final (done)` instead of `(no response)`.

Closes #107