### PR TITLE
Stop ambient Anthropic creds from shadowing an explicit AGENTOS_CREDENTIALS

### DIFF
--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -60,13 +60,14 @@ logger = logging.getLogger(__name__)
 # is published to is Docker-assigned and read back per-container.
 RUNNER_CONTAINER_PORT = 8080
 
-# Credentials the runner needs, all forwarded into the container BY NAME (docker
+# The ambient SDK credential vars, forwarded into the container BY NAME (docker
 # reads the value from the worker env; this code never does, and no secret ever
-# lands in the docker argv). AGENTOS_CREDENTIALS is the ACI reference the runner
-# maps onto an SDK var; the SDK vars authenticate directly. Mirrors the CLI
-# (cli/src/docker.rs, cli/src/commands.rs).
-CREDENTIAL_PASSTHROUGH_ENV = (
-    CREDENTIALS_ENV,
+# lands in the docker argv). These authenticate the runner directly on the legacy
+# real-Anthropic path, and are forwarded only when no explicit AGENTOS_CREDENTIALS
+# is chosen. AGENTOS_CREDENTIALS (the ACI reference the runner maps onto an SDK
+# var) is selected positively and alone. Mirrors the CLI (cli/src/docker.rs,
+# cli/src/commands.rs).
+_SDK_PASSTHROUGH_ENV = (
     "CLAUDE_CODE_OAUTH_TOKEN",
     "ANTHROPIC_API_KEY",
 )
@@ -170,13 +171,21 @@ class DockerSandboxClient:
         for key, value in sorted(env.items()):
             if key not in _WORKER_OWNED_ENV:
                 args += ["-e", f"{key}={value}"]
-        # Forward every credential BY NAME only (no value in the argv) when the
-        # worker has it set, so a real-model run authenticates without this code
-        # ever reading the token and without the secret landing in the docker
-        # process arguments. Fake-model runs simply have none set.
-        for var in CREDENTIAL_PASSTHROUGH_ENV:
-            if var in self._environ:
-                args += ["-e", var]
+        # Forward exactly one model credential into the runner, always BY NAME (docker
+        # reads the value from the worker env; the secret never lands in the argv). An
+        # explicit AGENTOS_CREDENTIALS is the operator's chosen BYO credential and is
+        # forwarded alone, so an ambient SDK token (leaked into the worker via compose's
+        # .env auto-load or the operator shell) can neither shadow it nor ride into the
+        # sandbox. With no BYO credential set, fall back to the ambient SDK credential(s)
+        # for the legacy real-Anthropic path. Selection keys on the worker environ (the
+        # by-name forward reads the value from there); an empty AGENTOS_CREDENTIALS is
+        # treated as unset.
+        if self._environ.get(CREDENTIALS_ENV):
+            args += ["-e", CREDENTIALS_ENV]
+        else:
+            for var in _SDK_PASSTHROUGH_ENV:
+                if var in self._environ:
+                    args += ["-e", var]
         args.append(self._image)
 
         try:

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -47,6 +47,15 @@ def test_apply_model_env_omits_both_when_unset() -> None:
     assert CREDENTIALS_ENV not in env
 
 
+def test_apply_model_env_leaves_sdk_creds_absent_without_credentials() -> None:
+    # No BYO credential -> the SDK vars are neither added nor blanked, so the
+    # legacy ambient-token real-model path still flows the operator's token.
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig())
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+
+
 def test_apply_model_env_forwards_base_url_and_model_without_fake_flag() -> None:
     base_url_env, model_env = BASE_URL_ENV, MODEL_ENV
     assert base_url_env == "ANTHROPIC_BASE_URL"

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -162,6 +162,50 @@ def test_agentos_credentials_forwarded_by_name_never_as_value() -> None:
     assert "AGENTOS_CREDENTIALS=sk-ant-PLACEHOLDER-secret" not in envs
 
 
+def test_ambient_sdk_creds_not_forwarded_when_agentos_credentials_set() -> None:
+    # BYO model: an explicit AGENTOS_CREDENTIALS is present, and the operator's
+    # shell also carries ambient SDK tokens. Positive selection forwards exactly
+    # AGENTOS_CREDENTIALS by name and does NOT forward the ambient SDK vars (which
+    # would re-inject the operator's token and shadow the BYO credential in the
+    # runner).
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        environ={
+            "CLAUDE_CODE_OAUTH_TOKEN": "sk-PLACEHOLDER-oauth",
+            "ANTHROPIC_API_KEY": "sk-ant-PLACEHOLDER-key",
+            "AGENTOS_CREDENTIALS": "sk-or-PLACEHOLDER-byo",
+        },
+    )
+    client.create_claim("t1", pool="pool", env={"AGENTOS_BUDGET": "{}"})
+    argv = client.calls[0]
+    envs = _flag_values(argv, "-e")
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in envs  # ambient OAuth token not forwarded by name
+    assert "ANTHROPIC_API_KEY" not in envs  # ambient API key not forwarded by name
+    assert "AGENTOS_CREDENTIALS" in envs  # explicit BYO reference still forwarded by name
+    assert all("PLACEHOLDER" not in a for a in argv)  # no secret value leaks into argv
+
+
+def test_ambient_sdk_creds_forwarded_when_agentos_credentials_empty() -> None:
+    # Legacy real-model path: an empty AGENTOS_CREDENTIALS placeholder (a blank
+    # line in compose's .env) must NOT suppress a real ambient OAuth token.
+    # Positive selection keys on VALUE-truthiness, not key-presence, so an empty
+    # AGENTOS_CREDENTIALS is treated as absent and the ambient SDK var is forwarded.
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        environ={
+            "AGENTOS_CREDENTIALS": "",
+            "CLAUDE_CODE_OAUTH_TOKEN": "sk-PLACEHOLDER-oauth",
+        },
+    )
+    client.create_claim("t1", pool="pool", env={"AGENTOS_BUDGET": "{}"})
+    argv = client.calls[0]
+    envs = _flag_values(argv, "-e")
+    assert "CLAUDE_CODE_OAUTH_TOKEN" in envs  # ambient OAuth token forwarded by name
+    assert all("PLACEHOLDER" not in a for a in argv)  # the value never leaks into argv
+
+
 def test_get_sandbox_reports_published_port_and_mode() -> None:
     client = _RecordingDocker(image="agentos-runner", bundle_store=_FakeBundleStore())
     client.outputs = {


### PR DESCRIPTION
On a local/compose stack, docker compose auto-loads `$REPO/.env` (and the operator shell), so `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` land in the worker and were forwarded by name into every runner, silently beating an explicit `AGENTOS_CREDENTIALS` (BYO model). The runner short-circuits on any ambient SDK credential, so the BYO credential was ignored and the operator's real Anthropic token leaked into every sandboxed runner.

## Fix (worker-level defense in depth)
- `apply_model_env`: when an explicit `AGENTOS_CREDENTIALS` is set, remove the inherited ambient SDK credential from the runner boot env. Pop (not blank to `""`) so no empty `ANTHROPIC_API_KEY` trips the bundled CLI's not-logged-in gate for an OAuth-token credential.
- `docker create_claim`: skip the by-name passthrough of the ambient SDK vars when `AGENTOS_CREDENTIALS` has a **truthy** value. That loop appends after the boot-env loop, so under docker last-wins it would otherwise re-inject the ambient token. `AGENTOS_CREDENTIALS` itself is still forwarded by name. Gating on truthiness (not key presence) means an empty `.env` placeholder does not suppress a real ambient token.

The k8s substrate never reads the worker's ambient env, so the leak was docker/compose-only; the fix is a no-op there. Compose-level gating is intentionally not attempted (not cleanly expressible under `.env` auto-load); the worker-level fix subsumes it, per the ticket's follow-up.

## Tests
- `apply_model_env` removes ambient SDK creds when `AGENTOS_CREDENTIALS` is set; leaves them absent otherwise.
- docker: ambient SDK creds not forwarded when `AGENTOS_CREDENTIALS` is set; still forwarded when it is empty.

Closes #106