### PR TITLE
Ground weather demo skill in a fetched, date-matched source

### DIFF
--- a/examples/weather/skills/weather/SKILL.md
+++ b/examples/weather/skills/weather/SKILL.md
@@ -12,13 +12,16 @@ allowed-tools:
 The user asks about the weather, a forecast, temperature, rain or snow chances, or whether a day suits an outdoor plan.
 
 ## How to answer
-1. Determine the location and day. If the user named them, use them. If not, ask one short question instead of guessing.
-2. Run a web search for the forecast, e.g. `<city> weather forecast <day>`. Prefer a national weather service or a major forecast provider.
-3. Report, in two or three sentences: expected high and low, sky conditions, and precipitation chance. Include the location and day so there is no ambiguity.
-4. Name the source of the forecast at the end.
+1. **Fix the date first.** Note today's date from the environment. Resolve "today", "tomorrow", or a weekday into an explicit calendar date (e.g. "Wed, July 8, 2026"). Carry that date through every step.
+2. **Resolve the location.** If the user named it, use it. If not, ask one short question instead of guessing.
+3. **Search to find a source, not to get the answer.** Run a web search like `<city> weather forecast <date>` to locate a forecast page. Do NOT report numbers from the search-result summary itself. Those summaries frequently merge the wrong day or location and are the top cause of a wrong forecast.
+4. **Fetch the actual source.** `WebFetch` the forecast page (prefer a national weather service such as weather.gov, or a major provider). Read the high, low, sky, and precipitation for **the exact date you fixed in step 1**.
+5. **Verify the date matches before you report.** The fetched forecast must state the day you were asked about. If the page shows a different date, or you cannot fetch a page whose date matches, do not report a number. Say what you tried and that you could not confirm a current forecast. A plausible-looking summary for the wrong day is worse than saying you could not confirm.
+6. **Report** in two or three sentences: expected high and low, sky conditions, and precipitation chance, with the location and the explicit date. Then name the source you actually fetched.
 
 ## Hard rules
 
-- Never invent a forecast. If the search returns nothing usable, say so and name what you tried.
+- **Report only numbers you read from a page you fetched for the matching date.** Never report figures that came only from a search-result summary, and never cite a source you did not open.
+- If nothing usable can be fetched and date-matched, say so and name what you tried. Do not fill the gap with a guess.
 - Temperatures in Fahrenheit first, Celsius in parentheses.
 - Keep the reply short enough to read in Slack without expanding.


### PR DESCRIPTION
## Problem

The weather demo skill (`examples/weather/skills/weather/SKILL.md`) told the model to run a web search and report the result, then "name the source" without ever fetching one. `WebSearch` returns a synthesized summary that can merge the wrong day or location, so the summary becomes the forecast.

Observed in the `agentos-dev` Slack demo: for a July 8 Boston query the bot reported a phantom "Extreme Heat Warning" and a 100F high referencing July 3-4 dates, citing AccuWeather / NWS / NBC10 pages it had not opened. It only produced the correct \~78F high after a user pushed back and forced a re-check.

## Fix

Rewrite the procedure so the reported number must come from a fetched source for the matching date, not from the search summary:

* Anchor an explicit calendar date up front and carry it through every step
* Search only to *locate* a source; forbid reporting numbers from the search-result summary
* Require a `WebFetch` of a real forecast page and read figures for the fixed date
* Verify the fetched forecast's date matches before reporting; refuse rather than guess when no date-matched source is fetchable
* Replace the unenforceable "never invent a forecast" rule with "only report numbers you read from a page you fetched"

Docs-only change to the example skill; no code paths touched.