### PR TITLE
Reap runner containers on local down

### DIFF
--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -201,6 +201,39 @@ pub async fn remove_container(name_or_id: &str) -> Result<()> {
         .map(|_| ())
 }
 
+/// Remove all containers matching a Docker label filter. Best-effort on the
+/// list step (if no containers match or Docker is unreachable we silently
+/// return 0); bails on a removal failure.
+pub async fn reap_labeled(label: &str) -> Result<usize> {
+    let list_args: Vec<String> = vec![
+        "ps".into(),
+        "-a".into(),
+        "--filter".into(),
+        format!("label={label}"),
+        "-q".into(),
+    ];
+    let ids = match docker(&list_args).await {
+        Ok(out) => out
+            .lines()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>(),
+        Err(_) => return Ok(0),
+    };
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let count = ids.len();
+    let mut rm_args: Vec<String> = vec!["rm".into(), "-f".into()];
+    rm_args.extend(ids);
+    docker(&rm_args).await?;
+    Ok(count)
+}
+
+/// The label that worker-local stamps on every runner container it spawns.
+pub const SANDBOX_LABEL: &str = "agentos.dev/managed-by=agentos-sandbox-substrate";
+
 /// The last log lines of a container, for boot-failure diagnostics.
 pub async fn container_logs(name_or_id: &str, tail: u32) -> String {
     let args: Vec<String> = vec![

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -9,6 +9,7 @@
 use anyhow::{bail, Context, Result};
 
 use crate::commands::OLLAMA_PORT;
+use crate::docker;
 use crate::ops::{plain, require_on_path, run_capture, run_step, OpsCommand};
 
 /// Dev-channel local-candidate filename probed by the artifact resolver.
@@ -166,6 +167,10 @@ pub async fn down(o: LocalDownOpts) -> Result<()> {
     let cmd = down_command(&o);
     if o.common.dry_run {
         ui.payload_plain(&cmd.display());
+        ui.payload_plain(&format!(
+            "docker rm -f $(docker ps -a --filter label={} -q)",
+            docker::SANDBOX_LABEL
+        ));
         return Ok(());
     }
     if o.wipe {
@@ -186,6 +191,10 @@ pub async fn down(o: LocalDownOpts) -> Result<()> {
         "stopping stack"
     };
     run_step(&cl, label, "stopped", &cmd).await?;
+    let count = docker::reap_labeled(docker::SANDBOX_LABEL).await?;
+    if count > 0 {
+        ui.note(&format!("removed {count} runner container(s)"));
+    }
     if o.wipe {
         ui.payload("dev stack stopped; volumes wiped");
     } else {


### PR DESCRIPTION
Closes #117

`local down` now removes runner containers worker-local spawned on the host Docker socket by filtering on the sandbox label `agentos.dev/managed-by=agentos-sandbox-substrate`. These containers were outside the compose project and accumulated across runs.