### PR TITLE
Add --continue to cluster/local message to reuse the last turn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ build/
 # Local working files (plans, scratch, analysis) — never committed
 .projects/
 
+# Local AgentOS runner and turn state
+.agentos/
+
 # Big-plan server sidecars (belong with the .projects working copies, not the repo)
 *.snapshot
 *.comments.json

--- a/cli/README.md
+++ b/cli/README.md
@@ -190,6 +190,15 @@ What it does, in order:
 `--dry-run` prints the kubectl/helm command lines, the stub URL, and the enqueue
 description without executing anything.
 
+Use `--continue` to reuse the last successful `cluster message` context from
+`.agentos/last-turn.json` in the current working directory, so only the new text
+is required. Explicit flags override the saved channel, thread, and transport
+settings, the verb must match, and the API key is re-read from
+`$AGENTOS_API_KEY` because the value is never stored. Note that `--continue`
+does not replay `--stream`, `--listen-port`, `--valkey-local-port`,
+`--api-local-port`, or `--user`, so pass any of those again explicitly if the
+original turn used a non-default value.
+
 ### Targeting a deployed agent and continuing a thread
 
 The worker binds a channel to an agent by exact equality on
@@ -238,6 +247,15 @@ suffix). `local message` composes with `--channel`, `--thread`, and
 with a clear error. The compose worker runs the fake model by default (a canned
 reply, no credentials); export a credential and set `AGENTOS_FAKE_MODEL=0` in the
 compose environment for a real model.
+
+Use `--continue` to reuse the last successful `local message` context from
+`.agentos/last-turn.json` in the current working directory, so only the new text
+is required. Explicit flags override the saved channel, thread, and transport
+settings, the verb must match, and the API key is re-read from
+`$AGENTOS_API_KEY` because the value is never stored. Note that `--continue`
+does not replay `--stream`, `--listen-port`, `--valkey-local-port`,
+`--api-local-port`, or `--user`, so pass any of those again explicitly if the
+original turn used a non-default value.
 
 ## Verify
 

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -229,14 +229,14 @@ pub async fn await_reply(
     }
 }
 
-/// Print the one-liner that continues this thread: reusing the same channel and
-/// thread ts keeps the worker routing to the same agent and turn context. A dim
-/// diagnostic (stderr, `--debug`-independent note) so it never pollutes the
-/// captured payload.
-pub fn print_continue_hint(verb: &str, channel: &str, thread_ts: &str) {
-    crate::ui::ui().note(&format!(
-        "continue this conversation: agentos {verb} --channel {channel} --thread {thread_ts} \"...\""
-    ));
+pub fn continue_hint_line(verb: &str) -> String {
+    format!("continue this conversation: agentos {verb} --continue \"...\"")
+}
+
+pub fn continue_hint_long_line(verb: &str, channel: &str, thread_ts: &str) -> String {
+    format!(
+        "continue this conversation: agentos {verb} --channel '{channel}' --thread {thread_ts} \"...\""
+    )
 }
 
 /// Resolve the channel and timestamps for a turn: an explicit `--channel` is
@@ -292,5 +292,23 @@ mod tests {
             ..update.clone()
         };
         assert_eq!(placeholder_update_text(&post, "1.2"), None);
+    }
+
+    #[test]
+    fn continue_hint_is_the_short_form() {
+        let line = continue_hint_line("cluster message");
+
+        assert!(line.contains("--continue"));
+        assert!(line.contains("agentos cluster message"));
+        assert!(!line.contains("--channel"));
+        assert!(!line.contains("--thread"));
+    }
+
+    #[test]
+    fn long_fallback_hint_quotes_the_channel() {
+        let line = continue_hint_long_line("local message", "#local-dev", "123.45");
+
+        assert!(line.contains("'#local-dev'"));
+        assert!(line.contains("--thread 123.45"));
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,6 +11,7 @@ use agentos::commands::{self, DeployEnv, DeployOpts, SendType, StartOpts, DEFAUL
 use agentos::local::{self, LocalDownOpts, LocalOpts};
 use agentos::message::{self, MessageOpts};
 use agentos::ops::{self, CommonOpts, DownOpts, UpOpts};
+use agentos::state::{apply_continue, load_turn, CliTurnArgs, TurnVerb};
 use agentos::ui::{self, ColorFlag, Ui};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -209,6 +210,11 @@ enum LocalAction {
         /// thread. Pair with --channel to keep multi-turn context.
         #[arg(long)]
         thread: Option<String>,
+        /// Reuse the last turn's context (channel, thread, transport) recorded
+        /// in .agentos/last-turn.json in the working directory; type only the
+        /// new message text.
+        #[arg(long = "continue")]
+        r#continue: bool,
         /// Valkey password (compose default `valkeypass`).
         #[arg(long, default_value = message::DEFAULT_VALKEY_PASSWORD)]
         valkey_password: String,
@@ -225,8 +231,9 @@ enum LocalAction {
         #[arg(long, env = "AGENTOS_STREAM", default_value = message::DEFAULT_STREAM)]
         stream: String,
         /// How long to wait for the worker's reply before printing diagnostics.
-        #[arg(long, default_value_t = message::DEFAULT_TIMEOUT_SECS)]
-        timeout_secs: u64,
+        /// Default: 300 seconds.
+        #[arg(long)]
+        timeout_secs: Option<u64>,
         /// Print the queue and stub plan that a real run would produce, and exit.
         #[arg(long)]
         dry_run: bool,
@@ -346,16 +353,21 @@ enum ClusterAction {
         /// thread. Pair with --channel to keep multi-turn context.
         #[arg(long)]
         thread: Option<String>,
-        /// Kubernetes namespace of the release.
-        #[arg(long, default_value = "agentos")]
-        namespace: String,
-        /// Helm release name.
-        #[arg(long, default_value = "agentos")]
-        release: String,
+        /// Reuse the last turn's context (channel, thread, transport) recorded
+        /// in .agentos/last-turn.json in the working directory; type only the
+        /// new message text.
+        #[arg(long = "continue")]
+        r#continue: bool,
+        /// Kubernetes namespace of the release. Default: agentos.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Helm release name. Default: agentos.
+        #[arg(long)]
+        release: Option<String>,
         /// Chart path for the wiring `helm upgrade` (run from the repo root for
-        /// the default).
-        #[arg(long, default_value = "charts/agentos")]
-        chart: String,
+        /// the default). Default: charts/agentos.
+        #[arg(long)]
+        chart: Option<String>,
         /// Host the in-cluster worker uses to reach the stub. Omit to auto-detect
         /// the local IP the kernel would use to reach the cluster.
         #[arg(long)]
@@ -385,8 +397,9 @@ enum ClusterAction {
         /// Defaults high because the worker kernel can retry a run up to 3 times
         /// with a 90s sandbox-claim timeout each (worst case near 270s of claim
         /// waits alone), so a shorter ceiling can time out while it is still working.
-        #[arg(long, default_value_t = message::DEFAULT_TIMEOUT_SECS)]
-        timeout_secs: u64,
+        /// Default: 300 seconds.
+        #[arg(long)]
+        timeout_secs: Option<u64>,
         /// Skip pointing the worker at the stub. Wiring is on by default (helm
         /// upgrade + rollout wait); with --no-wire the command refuses to run
         /// unless the worker is already wired, printing the exact command to run.
@@ -555,6 +568,7 @@ async fn main() -> Result<()> {
                 text,
                 channel,
                 thread,
+                r#continue,
                 valkey_password,
                 api_url,
                 api_key,
@@ -563,10 +577,36 @@ async fn main() -> Result<()> {
                 timeout_secs,
                 dry_run,
             } => {
+                let state = if r#continue {
+                    match load_turn(&std::env::current_dir()?)? {
+                        Some(state) => Some(state),
+                        None => anyhow::bail!(
+                            "no previous turn recorded in .agentos/last-turn.json; run a message without --continue first"
+                        ),
+                    }
+                } else {
+                    None
+                };
+                let resolved = apply_continue(
+                    TurnVerb::Local,
+                    CliTurnArgs {
+                        channel,
+                        thread,
+                        namespace: None,
+                        release: None,
+                        chart: None,
+                        listen_host: None,
+                        timeout_secs,
+                        api_url,
+                        api_key,
+                    },
+                    state,
+                    std::env::var("AGENTOS_API_KEY").ok(),
+                )?;
                 message::message(MessageOpts {
                     text,
-                    channel,
-                    thread,
+                    channel: resolved.channel,
+                    thread: resolved.thread,
                     namespace: "agentos".into(),
                     release: "agentos".into(),
                     chart: "charts/agentos".into(),
@@ -575,15 +615,15 @@ async fn main() -> Result<()> {
                     valkey_local_port: message::DEFAULT_VALKEY_LOCAL_PORT,
                     valkey_password,
                     api_local_port: message::DEFAULT_API_LOCAL_PORT,
-                    api_key,
+                    api_key: resolved.api_key,
                     user,
                     stream,
-                    timeout_secs,
+                    timeout_secs: resolved.timeout_secs,
                     wire: true,
                     force_wire: false,
                     dry_run,
                     local: true,
-                    api_url,
+                    api_url: resolved.api_url,
                 })
                 .await
             }
@@ -682,6 +722,7 @@ async fn main() -> Result<()> {
                 text,
                 channel,
                 thread,
+                r#continue,
                 namespace,
                 release,
                 chart,
@@ -698,22 +739,48 @@ async fn main() -> Result<()> {
                 force_wire,
                 dry_run,
             } => {
+                let state = if r#continue {
+                    match load_turn(&std::env::current_dir()?)? {
+                        Some(state) => Some(state),
+                        None => anyhow::bail!(
+                            "no previous turn recorded in .agentos/last-turn.json; run a message without --continue first"
+                        ),
+                    }
+                } else {
+                    None
+                };
+                let resolved = apply_continue(
+                    TurnVerb::Cluster,
+                    CliTurnArgs {
+                        channel,
+                        thread,
+                        namespace,
+                        release,
+                        chart,
+                        listen_host,
+                        timeout_secs,
+                        api_url: None,
+                        api_key,
+                    },
+                    state,
+                    std::env::var("AGENTOS_API_KEY").ok(),
+                )?;
                 message::message(MessageOpts {
                     text,
-                    channel,
-                    thread,
-                    namespace,
-                    release,
-                    chart,
-                    listen_host,
+                    channel: resolved.channel,
+                    thread: resolved.thread,
+                    namespace: resolved.namespace,
+                    release: resolved.release,
+                    chart: resolved.chart,
+                    listen_host: resolved.listen_host,
                     listen_port,
                     valkey_local_port,
                     valkey_password,
                     api_local_port,
-                    api_key,
+                    api_key: resolved.api_key,
                     user,
                     stream,
-                    timeout_secs,
+                    timeout_secs: resolved.timeout_secs,
                     wire: !no_wire,
                     force_wire,
                     dry_run,

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -27,15 +27,19 @@
 //! the guard never fires there; and the helm upgrade that connects Slack clears
 //! `worker.slackApiBaseUrl` back to empty, un-wiring the stub in the same step.
 
+use std::env;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
 
 use crate::api::{Agent, ApiClient};
-use crate::chat::{await_reply, print_continue_hint, resolve_targets, Outcome, SlackStub};
+use crate::chat::{
+    await_reply, continue_hint_line, continue_hint_long_line, resolve_targets, Outcome, SlackStub,
+};
 use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
 use crate::queue::{self, connect, diagnostics, xadd, QueuedSlackEvent};
+use crate::state::{save_turn, TurnContext, TurnVerb};
 
 pub const DEFAULT_STREAM: &str = queue::DEFAULT_STREAM;
 pub const DEFAULT_USER: &str = "U-agentos-message";
@@ -102,6 +106,35 @@ pub struct MessageOpts {
     /// Local mode only: platform API base URL for the channel lookup. None uses
     /// the compose API default ([`DEFAULT_LOCAL_API_URL`]).
     pub api_url: Option<String>,
+}
+
+fn persist_and_hint(opts: &MessageOpts, verb: TurnVerb, channel: &str, thread_ts: &str) {
+    let ui = crate::ui::ui();
+    let verb_str = match verb {
+        TurnVerb::Local => "local message",
+        TurnVerb::Cluster => "cluster message",
+    };
+    let ctx = TurnContext::from_turn(
+        opts,
+        verb,
+        channel,
+        thread_ts,
+        env::var("AGENTOS_API_KEY").ok(),
+    );
+
+    match env::current_dir().context("resolving the current working directory") {
+        Ok(cwd) => match save_turn(&cwd, &ctx) {
+            Ok(()) => ui.note(&continue_hint_line(verb_str)),
+            Err(err) => {
+                ui.warn(&format!("could not save turn context: {err}"));
+                ui.note(&continue_hint_long_line(verb_str, channel, thread_ts));
+            }
+        },
+        Err(err) => {
+            ui.warn(&format!("could not save turn context: {err}"));
+            ui.note(&continue_hint_long_line(verb_str, channel, thread_ts));
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -613,13 +646,13 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             step.done("");
             ui.answer(&reply);
             ui.print_tokens("\n");
-            print_continue_hint("local message", &channel, &thread_ts);
+            persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
             step.done("no edit");
             ui.warn("the worker finished the turn but never edited the placeholder");
-            print_continue_hint("local message", &channel, &thread_ts);
+            persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
         Outcome::TimedOut => {
@@ -763,13 +796,13 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
             step.done("");
             ui.answer(&reply);
             ui.print_tokens("\n");
-            print_continue_hint("cluster message", &channel, &thread_ts);
+            persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
             step.done("no edit");
             ui.warn("the worker finished the turn but never edited the placeholder");
-            print_continue_hint("cluster message", &channel, &thread_ts);
+            persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }
         Outcome::TimedOut => {

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -1,8 +1,10 @@
-//! Local runner state: which container `agentos skill up` booted, and where.
+//! Local runner state and message turn context.
 //!
 //! Written to `.agentos/runner.json` in the project directory so `message`,
 //! `eval`, `cluster status`, and `cluster down` find the runner without flags. The file is
 //! local workstation state, never committed (init scaffolds the ignore rule).
+//! Message verbs also write `.agentos/last-turn.json` with the last successful
+//! turn's non-secret continuation context.
 
 use std::path::{Path, PathBuf};
 
@@ -11,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 pub const STATE_DIR: &str = ".agentos";
 pub const STATE_FILE: &str = "runner.json";
+pub const TURN_FILE: &str = "last-turn.json";
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RunnerState {
@@ -32,6 +35,10 @@ pub struct RunnerState {
 
 fn state_path(dir: &Path) -> PathBuf {
     dir.join(STATE_DIR).join(STATE_FILE)
+}
+
+fn turn_state_path(dir: &Path) -> PathBuf {
+    dir.join(STATE_DIR).join(TURN_FILE)
 }
 
 pub fn save(dir: &Path, state: &RunnerState) -> Result<()> {
@@ -62,9 +69,169 @@ pub fn remove(dir: &Path) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TurnVerb {
+    Local,
+    Cluster,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TurnContext {
+    pub verb: TurnVerb,
+    pub channel: String,
+    pub thread_ts: String,
+    pub namespace: String,
+    pub release: String,
+    pub chart: String,
+    pub listen_host: Option<String>,
+    pub timeout_secs: u64,
+    pub api_url: Option<String>,
+    pub api_key_env: Option<String>,
+}
+
+impl TurnContext {
+    pub fn from_turn(
+        opts: &crate::message::MessageOpts,
+        verb: TurnVerb,
+        channel: &str,
+        thread_ts: &str,
+        env_api_key: Option<String>,
+    ) -> TurnContext {
+        TurnContext {
+            verb,
+            channel: channel.to_string(),
+            thread_ts: thread_ts.to_string(),
+            namespace: opts.namespace.clone(),
+            release: opts.release.clone(),
+            chart: opts.chart.clone(),
+            listen_host: opts.listen_host.clone(),
+            timeout_secs: opts.timeout_secs,
+            api_url: opts.api_url.clone(),
+            api_key_env: env_api_key
+                .filter(|value| value == &opts.api_key)
+                .map(|_| "AGENTOS_API_KEY".to_string()),
+        }
+    }
+}
+
+pub fn save_turn(dir: &Path, ctx: &TurnContext) -> Result<()> {
+    let path = turn_state_path(dir);
+    std::fs::create_dir_all(path.parent().expect("state path has a parent"))?;
+    let body = serde_json::to_string_pretty(ctx)?;
+    std::fs::write(&path, body).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+pub fn load_turn(dir: &Path) -> Result<Option<TurnContext>> {
+    let path = turn_state_path(dir);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let body =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let state = serde_json::from_str(&body)
+        .with_context(|| format!("{} is not a valid turn state file", path.display()))?;
+    Ok(Some(state))
+}
+
+pub struct CliTurnArgs {
+    pub channel: Option<String>,
+    pub thread: Option<String>,
+    pub namespace: Option<String>,
+    pub release: Option<String>,
+    pub chart: Option<String>,
+    pub listen_host: Option<String>,
+    pub timeout_secs: Option<u64>,
+    pub api_url: Option<String>,
+    pub api_key: String,
+}
+
+pub struct ResolvedTurnArgs {
+    pub channel: Option<String>,
+    pub thread: Option<String>,
+    pub namespace: String,
+    pub release: String,
+    pub chart: String,
+    pub listen_host: Option<String>,
+    pub timeout_secs: u64,
+    pub api_url: Option<String>,
+    pub api_key: String,
+}
+
+pub fn apply_continue(
+    verb: TurnVerb,
+    cli: CliTurnArgs,
+    state: Option<TurnContext>,
+    env_api_key: Option<String>,
+) -> Result<ResolvedTurnArgs> {
+    if let Some(state) = state.as_ref() {
+        if state.verb != verb {
+            anyhow::bail!(
+                "the last turn was '{} message'; re-run that verb with --continue, or drop --continue",
+                turn_verb_name(state.verb)
+            );
+        }
+    }
+
+    let api_key = if cli.api_key != crate::message::DEFAULT_API_KEY {
+        cli.api_key
+    } else if let Some(name) = state
+        .as_ref()
+        .and_then(|state| state.api_key_env.as_deref())
+        .filter(|_| env_api_key.is_none())
+    {
+        anyhow::bail!(
+            "this conversation was started with the api key from ${name}, which is not set now; re-export it or pass --api-key"
+        );
+    } else {
+        cli.api_key
+    };
+
+    Ok(ResolvedTurnArgs {
+        channel: cli
+            .channel
+            .or_else(|| state.as_ref().map(|state| state.channel.clone())),
+        thread: cli
+            .thread
+            .or_else(|| state.as_ref().map(|state| state.thread_ts.clone())),
+        namespace: cli
+            .namespace
+            .or_else(|| state.as_ref().map(|state| state.namespace.clone()))
+            .unwrap_or_else(|| "agentos".to_string()),
+        release: cli
+            .release
+            .or_else(|| state.as_ref().map(|state| state.release.clone()))
+            .unwrap_or_else(|| "agentos".to_string()),
+        chart: cli
+            .chart
+            .or_else(|| state.as_ref().map(|state| state.chart.clone()))
+            .unwrap_or_else(|| "charts/agentos".to_string()),
+        listen_host: cli
+            .listen_host
+            .or_else(|| state.as_ref().and_then(|state| state.listen_host.clone())),
+        timeout_secs: cli
+            .timeout_secs
+            .or_else(|| state.as_ref().map(|state| state.timeout_secs))
+            .unwrap_or(crate::message::DEFAULT_TIMEOUT_SECS),
+        api_url: cli
+            .api_url
+            .or_else(|| state.as_ref().and_then(|state| state.api_url.clone())),
+        api_key,
+    })
+}
+
+fn turn_verb_name(verb: TurnVerb) -> &'static str {
+    match verb {
+        TurnVerb::Local => "local",
+        TurnVerb::Cluster => "cluster",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::{MessageOpts, DEFAULT_API_KEY, DEFAULT_TIMEOUT_SECS};
 
     fn sample() -> RunnerState {
         RunnerState {
@@ -134,5 +301,300 @@ mod tests {
         let loaded = load(dir.path()).unwrap();
         assert!(loaded.is_some());
         assert_eq!(loaded.unwrap().ollama_container, None);
+    }
+
+    fn default_cli_turn_args() -> CliTurnArgs {
+        CliTurnArgs {
+            channel: None,
+            thread: None,
+            namespace: None,
+            release: None,
+            chart: None,
+            listen_host: None,
+            timeout_secs: None,
+            api_url: None,
+            api_key: DEFAULT_API_KEY.into(),
+        }
+    }
+
+    fn persisted_turn(verb: TurnVerb) -> TurnContext {
+        TurnContext {
+            verb,
+            channel: "C-persisted".into(),
+            thread_ts: "9.9".into(),
+            namespace: "persisted-ns".into(),
+            release: "persisted-release".into(),
+            chart: "charts/persisted".into(),
+            listen_host: Some("127.0.0.1".into()),
+            api_key_env: Some("AGENTOS_API_KEY".into()),
+            timeout_secs: 777,
+            api_url: Some("http://persisted-api".into()),
+        }
+    }
+
+    #[test]
+    fn turn_context_round_trips_through_the_state_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = TurnContext {
+            verb: TurnVerb::Cluster,
+            channel: "C1".into(),
+            thread_ts: "9.9".into(),
+            namespace: "agentos-turns".into(),
+            release: "agentos-turns".into(),
+            chart: "charts/agentos-turns".into(),
+            listen_host: Some("127.0.0.1".into()),
+            api_key_env: Some("AGENTOS_API_KEY".into()),
+            timeout_secs: 321,
+            api_url: Some("http://turn-api".into()),
+        };
+
+        save_turn(dir.path(), &state).unwrap();
+        assert_eq!(load_turn(dir.path()).unwrap(), Some(state));
+
+        let empty = tempfile::tempdir().unwrap();
+        assert_eq!(load_turn(empty.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn corrupt_turn_state_is_an_error_not_a_silent_none() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(STATE_DIR)).unwrap();
+        std::fs::write(dir.path().join(STATE_DIR).join(TURN_FILE), "not json").unwrap();
+        assert!(load_turn(dir.path()).is_err());
+    }
+
+    #[test]
+    fn turn_state_never_contains_secret_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let opts = MessageOpts {
+            text: "hi".into(),
+            channel: None,
+            thread: None,
+            namespace: "agentos".into(),
+            release: "agentos".into(),
+            chart: "charts/agentos".into(),
+            listen_host: None,
+            listen_port: 8155,
+            valkey_local_port: 56381,
+            valkey_password: "vk-secret".into(),
+            api_local_port: 8123,
+            api_key: "sk-super-secret".into(),
+            user: "U".into(),
+            stream: "s".into(),
+            timeout_secs: 300,
+            wire: true,
+            force_wire: false,
+            dry_run: false,
+            local: false,
+            api_url: None,
+        };
+
+        let turn = TurnContext::from_turn(
+            &opts,
+            TurnVerb::Cluster,
+            "C1",
+            "9.9",
+            Some("sk-super-secret".into()),
+        );
+        save_turn(dir.path(), &turn).unwrap();
+
+        let raw = std::fs::read_to_string(dir.path().join(STATE_DIR).join(TURN_FILE)).unwrap();
+        assert!(!raw.contains("sk-super-secret"));
+        assert!(!raw.contains("vk-secret"));
+        assert!(raw.contains("AGENTOS_API_KEY"));
+    }
+
+    #[test]
+    fn from_turn_records_env_source_only_when_env_value_matches() {
+        let opts = MessageOpts {
+            text: "hi".into(),
+            channel: None,
+            thread: None,
+            namespace: "agentos".into(),
+            release: "agentos".into(),
+            chart: "charts/agentos".into(),
+            listen_host: None,
+            listen_port: 8155,
+            valkey_local_port: 56381,
+            valkey_password: "vk-secret".into(),
+            api_local_port: 8123,
+            api_key: "sk-super-secret".into(),
+            user: "U".into(),
+            stream: "s".into(),
+            timeout_secs: 300,
+            wire: true,
+            force_wire: false,
+            dry_run: false,
+            local: false,
+            api_url: None,
+        };
+
+        let from_equal = TurnContext::from_turn(
+            &opts,
+            TurnVerb::Cluster,
+            "C1",
+            "9.9",
+            Some("sk-super-secret".into()),
+        );
+        assert_eq!(from_equal.api_key_env.as_deref(), Some("AGENTOS_API_KEY"));
+
+        let from_different = TurnContext::from_turn(
+            &opts,
+            TurnVerb::Cluster,
+            "C1",
+            "9.9",
+            Some("different".into()),
+        );
+        assert_eq!(from_different.api_key_env, None);
+
+        let from_none = TurnContext::from_turn(&opts, TurnVerb::Cluster, "C1", "9.9", None);
+        assert_eq!(from_none.api_key_env, None);
+    }
+
+    #[test]
+    fn turn_state_coexists_with_runner_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = sample();
+        let turn = persisted_turn(TurnVerb::Cluster);
+
+        save(dir.path(), &runner).unwrap();
+        save_turn(dir.path(), &turn).unwrap();
+
+        assert_eq!(load(dir.path()).unwrap(), Some(runner));
+        assert_eq!(load_turn(dir.path()).unwrap(), Some(turn));
+    }
+
+    #[test]
+    fn continue_verb_mismatch_errors() {
+        assert!(apply_continue(
+            TurnVerb::Local,
+            default_cli_turn_args(),
+            Some(persisted_turn(TurnVerb::Cluster)),
+            None,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn explicit_flags_beat_persisted_state() {
+        let mut cli = default_cli_turn_args();
+        cli.channel = Some("C-explicit".into());
+        cli.thread = Some("1.2".into());
+        cli.namespace = Some("explicit-ns".into());
+        cli.release = Some("explicit-release".into());
+        cli.chart = Some("charts/explicit".into());
+        cli.listen_host = Some("192.0.2.10".into());
+        cli.timeout_secs = Some(12);
+        cli.api_url = Some("http://explicit-api".into());
+        cli.api_key = "cli-explicit-key".into();
+
+        let resolved = apply_continue(
+            TurnVerb::Cluster,
+            cli,
+            Some(persisted_turn(TurnVerb::Cluster)),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(resolved.channel.as_deref(), Some("C-explicit"));
+        assert_eq!(resolved.thread, Some("1.2".into()));
+        assert_eq!(resolved.namespace, "explicit-ns");
+        assert_eq!(resolved.release, "explicit-release");
+        assert_eq!(resolved.chart, "charts/explicit");
+        assert_eq!(resolved.listen_host.as_deref(), Some("192.0.2.10"));
+        assert_eq!(resolved.timeout_secs, 12);
+        assert_eq!(resolved.api_url.as_deref(), Some("http://explicit-api"));
+        assert_eq!(resolved.api_key, "cli-explicit-key");
+    }
+
+    #[test]
+    fn persisted_state_beats_builtin_defaults() {
+        let cli = default_cli_turn_args();
+
+        let persisted = TurnContext {
+            verb: TurnVerb::Cluster,
+            channel: "C-persisted".into(),
+            thread_ts: "9.9".into(),
+            namespace: "persisted-ns".into(),
+            release: "persisted-release".into(),
+            chart: "charts/persisted".into(),
+            listen_host: Some("127.0.0.1".into()),
+            api_key_env: None,
+            timeout_secs: 777,
+            api_url: Some("http://persisted-api".into()),
+        };
+
+        let resolved = apply_continue(TurnVerb::Cluster, cli, Some(persisted), None).unwrap();
+
+        assert_eq!(resolved.channel.as_deref(), Some("C-persisted"));
+        assert_eq!(resolved.thread, Some("9.9".into()));
+        assert_eq!(resolved.namespace, "persisted-ns");
+        assert_eq!(resolved.release, "persisted-release");
+        assert_eq!(resolved.chart, "charts/persisted");
+        assert_eq!(resolved.listen_host.as_deref(), Some("127.0.0.1"));
+        assert_eq!(resolved.timeout_secs, 777);
+        assert_eq!(resolved.api_url.as_deref(), Some("http://persisted-api"));
+    }
+
+    #[test]
+    fn absent_continue_ignores_existing_state() {
+        let cli = default_cli_turn_args();
+
+        let resolved = apply_continue(TurnVerb::Cluster, cli, None, None).unwrap();
+
+        assert_eq!(resolved.channel, None);
+        assert_eq!(resolved.thread, None);
+        assert_eq!(resolved.namespace, "agentos");
+        assert_eq!(resolved.release, "agentos");
+        assert_eq!(resolved.chart, "charts/agentos");
+        assert_eq!(resolved.timeout_secs, DEFAULT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn api_key_env_recorded_but_unset_now_errors() {
+        let cli = default_cli_turn_args();
+
+        assert!(apply_continue(
+            TurnVerb::Cluster,
+            cli,
+            Some(persisted_turn(TurnVerb::Cluster)),
+            None,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn api_key_explicit_value_wins_over_recorded_env() {
+        let mut cli = default_cli_turn_args();
+        cli.api_key = "sk-live-flag".into();
+
+        let resolved = apply_continue(
+            TurnVerb::Cluster,
+            cli,
+            Some(persisted_turn(TurnVerb::Cluster)),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(resolved.api_key, "sk-live-flag");
+    }
+
+    #[test]
+    fn api_key_env_recorded_and_still_set_is_reread_without_error() {
+        // Turn 1 recorded api_key_env = Some("AGENTOS_API_KEY"); on continue the env is still
+        // set, so clap re-reads it into cli.api_key (!= default) and apply_continue must succeed
+        // using that live value, never erroring and never touching the stored source name.
+        let mut cli = default_cli_turn_args();
+        cli.api_key = "sk-live-from-env".into(); // what clap's `env = AGENTOS_API_KEY` re-read
+
+        let resolved = apply_continue(
+            TurnVerb::Cluster,
+            cli,
+            Some(persisted_turn(TurnVerb::Cluster)), // api_key_env = Some("AGENTOS_API_KEY")
+            Some("sk-live-from-env".into()),         // env still set
+        )
+        .unwrap();
+
+        assert_eq!(resolved.api_key, "sk-live-from-env");
     }
 }


### PR DESCRIPTION
Kills the continue-conversation friction from the printed hint. Every successful `cluster message` / `local message` turn now persists its resolved context to a gitignored `.agentos/last-turn.json` (mirroring the `runner.json` state pattern), and `agentos <verb> message --continue "next text"` rehydrates it so the operator types only the message.

## What changed

* **Persist on success:** `TurnContext` (verb, channel, thread_ts, namespace, release, chart, listen-host, timeout, api-url, and the `AGENTOS_API_KEY` *source name*) written on both the `Replied` and `CompletedNoEdit` outcomes; never on timeout or `--dry-run`.
* `--continue` **flag** on both message verbs. Rehydratable clap flags became `Option<T>` so a pure `apply_continue` can resolve **explicit CLI > persisted state > built-in default**. Verb mismatch and a now-unset api-key env source are hard errors; `--continue` with no prior state errors clearly.
* **Secrets discipline:** the api key value is never written to disk. Only the env var name is recorded (and only when the env value matches the resolved key), then re-read at continue time. Enforced by a test asserting the raw state file contains neither the api key nor the Valkey password value.
* **Hint** shortened to the `--continue` form; a corrected long-form fallback (single-quoted channel) prints only if the state save fails.

## Known limitation

`--continue` does not replay `--stream`, `--listen-port`, `--valkey-local-port`, `--api-local-port`, or `--user` (a deliberate scope boundary; the ticket's persist list and the plan excluded these). If a turn used a non-default value for one of those, pass it again explicitly. Documented in `cli/README.md`; a follow-up could persist them for fully faithful replay. Flagged by the Codex review pass as P2.

## Verification

`cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` → 160 pass, lint clean. Manual `--dry-run --continue` confirmed rehydration of namespace/release/chart/channel/thread and the verb-mismatch error. Reviewed by code / scope-creep / spec-vs-impl / security reviewers plus a Codex pass.

Closes [#112](<https://github.com/curie-eng/agentos/issues/112>)