### PR TITLE
runner: add stdout logging so a turn is observable

### DIFF
--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -8,7 +8,9 @@ or connect failure fails the process visibly rather than after the port is up.
 
 from __future__ import annotations
 
+import logging
 import os
+import sys
 
 from aiohttp import web
 
@@ -17,10 +19,12 @@ from .config import RunnerConfig
 from .fake import FakeModelSession
 from .otel import RunTracer, build_tracer_provider
 from .plugin import load_plugins
-from .sdk_auth import resolve_sdk_env
+from .sdk_auth import UnsupportedCredentialError, resolve_sdk_env
 from .server import create_app
 from .session import SessionRunner
 from .side_effects import SideEffectClassifier
+
+logger = logging.getLogger(__name__)
 
 
 def build_runner(
@@ -70,20 +74,37 @@ def build_runner(
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
     fake_model = os.environ.get("AGENTOS_FAKE_MODEL", "").lower() in ("1", "true", "yes")
+    logger.info("runner starting fake_model=%s", fake_model)
     # A real session authenticates from the SDK's own credential env; map the
     # forwarded ACI AGENTOS_CREDENTIALS reference onto it (a no-op for a fake
     # run, which needs no credential). Raises on an unsupported credential so the
     # process fails visibly before the port is up rather than after a real call.
     override = None
     if not fake_model:
-        override = resolve_sdk_env(os.environ)
+        try:
+            override = resolve_sdk_env(os.environ)
+        except UnsupportedCredentialError as exc:
+            logger.error("credential resolution failed: %s", exc)
+            raise
     config = RunnerConfig.from_env(os.environ)
+    logger.info(
+        "runner configured session=%s model=%s port=%d",
+        config.session.session_id,
+        config.model,
+        config.port,
+    )
     runner = build_runner(config, fake_model=fake_model, sdk_env=override)
     app = create_app(runner)
 
     async def _startup(_app: web.Application) -> None:
-        await runner.start()
+        try:
+            await runner.start()
+        except Exception as exc:
+            logger.error("session start failed error_class=%s: %s", type(exc).__name__, exc)
+            raise
+        logger.info("session started session=%s", config.session.session_id)
 
     app.on_startup.append(_startup)
     web.run_app(app, host="0.0.0.0", port=config.port)

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -20,6 +20,8 @@ Responsibilities layered on the translation:
 from __future__ import annotations
 
 import contextlib
+import logging
+import time
 from collections.abc import AsyncIterator, Callable
 
 import anyio
@@ -29,6 +31,7 @@ from aci_protocol import (
     Final,
     Interrupt,
     SessionStatus,
+    ToolNote,
     to_ndjson_line,
 )
 from claude_agent_sdk import ResultMessage
@@ -38,6 +41,8 @@ from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .otel import RunTracer, _GenerationSpan
 from .side_effects import SideEffectClassifier
 from .translate import TurnState, translate_message
+
+logger = logging.getLogger(__name__)
 
 SessionFactory = Callable[[], ModelSession]
 
@@ -146,6 +151,8 @@ class SessionRunner:
             raise RuntimeError("session not started")
 
         async with self._turn_lock:
+            start = time.monotonic()
+            logger.info("turn start session=%s user=%s", self._session_id, event.user)
             self._interrupt_requested = False
             self._turn_open = True
             state = TurnState()
@@ -157,6 +164,12 @@ class SessionRunner:
                 try:
                     async for line in self._drive_turn(event, state, tracker, gen):
                         yield line
+                    logger.info(
+                        "turn end session=%s status=%s duration_ms=%d",
+                        self._session_id,
+                        self._status.value,
+                        int((time.monotonic() - start) * 1000),
+                    )
                 except Exception as exc:  # noqa: BLE001 - the ACI stream must
                     # always terminate in a final; a raised SDK/transport error
                     # (CLI disconnect, auth expiry, model error) becomes a
@@ -164,6 +177,13 @@ class SessionRunner:
                     # stream. GeneratorExit (consumer disconnect) is a
                     # BaseException and is intentionally not caught here -- the
                     # finally handles that abandonment case.
+                    logger.error(
+                        "turn failed session=%s error_class=%s: %s duration_ms=%d",
+                        self._session_id,
+                        type(exc).__name__,
+                        exc,
+                        int((time.monotonic() - start) * 1000),
+                    )
                     self._turn_open = False
                     self._status = SessionStatus.CLASSIFIED_FAILURE
                     yield to_ndjson_line(
@@ -207,6 +227,14 @@ class SessionRunner:
             events = translate_message(message, state, self._classifier, gen)
 
             for outbound in events:
+                if isinstance(outbound, ToolNote):
+                    logger.info("tool call session=%s tool=%s", self._session_id, outbound.tool)
+                if isinstance(outbound, ErrorEvent):
+                    logger.warning(
+                        "model error session=%s classification=%s",
+                        self._session_id,
+                        outbound.classification,
+                    )
                 if isinstance(outbound, Final):
                     if budget_hit:
                         for line in self._budget_halt_lines():
@@ -246,6 +274,7 @@ class SessionRunner:
         tell a budget halt from any other classified failure.
         """
 
+        logger.warning("budget halt session=%s: output token budget exceeded", self._session_id)
         self._turn_open = False
         self._status = SessionStatus.CLASSIFIED_FAILURE
         return [

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -1,5 +1,7 @@
 """SessionRunner: turn streaming, interrupt reclassification, rehydrate options."""
 
+import logging
+
 import anyio
 from aci_protocol import Event, Interrupt, SessionStatus, parse_ndjson
 from agentos_runner import RunTracer, SideEffectClassifier, build_options
@@ -45,6 +47,20 @@ def test_happy_turn_stream_shape() -> None:
     assert events[-1].status == SessionStatus.DONE
     assert fake.queries == ["go"]  # the event text was pushed into the session
     assert runner.status == SessionStatus.DONE
+
+
+def test_turn_lifecycle_logged(caplog) -> None:
+    runner, _ = _runner()
+    event = Event(type="message", text="go", user="U-log", ts="1")
+
+    with caplog.at_level(logging.INFO, logger="agentos_runner.session"):
+        events = _drain(runner, event)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert events[-1].status == SessionStatus.DONE
+    assert any("turn start" in message and "user=U-log" in message for message in messages)
+    assert any("turn end" in message and "status=done" in message for message in messages)
+    assert any("tool call" in message and "tool=Bash" in message for message in messages)
 
 
 def test_bare_interrupt_yields_idle_final() -> None:
@@ -133,6 +149,106 @@ def test_sdk_exception_still_terminates_in_final() -> None:
     assert events[0].classification == "runner-error"
     assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
     assert runner.status == SessionStatus.CLASSIFIED_FAILURE
+
+
+def test_sdk_exception_logs_turn_failure(caplog) -> None:
+    class RaisingSession:
+        async def connect(self) -> None: ...
+
+        async def query(self, text: str) -> None:
+            raise RuntimeError("authentication_failed")
+
+        async def receive_turn(self):  # pragma: no cover - never reached
+            if False:
+                yield None
+
+        async def interrupt(self) -> None: ...
+
+        async def close(self) -> None: ...
+
+    runner = SessionRunner(
+        session_factory=RaisingSession,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+    )
+    with caplog.at_level(logging.ERROR, logger="agentos_runner.session"):
+        events = _drain(runner, Event(type="message", text="go", user="U", ts="1"))
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert [e.type for e in events] == ["error", "final"]
+    assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
+    assert any(
+        record.levelno == logging.ERROR
+        and "turn failed" in record.getMessage()
+        and "RuntimeError" in record.getMessage()
+        for record in caplog.records
+    )
+    assert any("authentication_failed" in message for message in messages)
+
+
+def test_budget_halt_logged(caplog) -> None:
+    script = [
+        AssistantMessage(
+            content=[TextBlock(text="thinking hard")],
+            model="fake",
+            usage={"output_tokens": 500},
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="done",
+            usage={"output_tokens": 500},
+        ),
+    ]
+    runner, _ = _runner(lambda: script, ceiling=10)
+
+    with caplog.at_level(logging.WARNING, logger="agentos_runner.session"):
+        events = _drain(runner, Event(type="message", text="go", user="U", ts="1"))
+
+    assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
+    assert any(
+        record.levelno == logging.WARNING and "budget halt" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_error_result_body_not_logged(caplog) -> None:
+    # An error *result* turn builds ErrorEvent(message=result); the "model error"
+    # WARNING must log only the structural classification, never the result body
+    # (which is the model output / Final.text). No prior interrupt, so the turn is
+    # a plain classified failure and translate takes the ErrorEvent(message=text)
+    # branch.
+    sentinel = "SENTINEL-RESULT-BODY-7c2e"
+    script = [
+        AssistantMessage(content=[TextBlock(text="working")], model="m"),
+        ResultMessage(
+            subtype="error_during_execution", duration_ms=1, duration_api_ms=1,
+            is_error=True, num_turns=1, session_id="s", result=sentinel,
+        ),
+    ]
+    runner, _ = _runner(lambda: script)
+
+    with caplog.at_level(logging.WARNING, logger="agentos_runner.session"):
+        events = _drain(runner, Event(type="message", text="go", user="U", ts="1"))
+
+    assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
+    assert all(sentinel not in record.getMessage() for record in caplog.records)
+
+
+def test_turn_logging_does_not_include_message_body(caplog) -> None:
+    runner, _ = _runner()
+    sentinel = "SENTINEL-SECRET-BODY-9f3a"
+
+    with caplog.at_level(logging.INFO, logger="agentos_runner.session"):
+        _drain(runner, Event(type="message", text=sentinel, user="U", ts="1"))
+
+    assert all(sentinel not in record.getMessage() for record in caplog.records)
 
 
 def test_steer_rejected_once_final_is_produced() -> None:


### PR DESCRIPTION
The runner configured no stdlib logging, so `docker logs <runner>` was empty and a hung or failing turn on the skill path (no collector, no Langfuse) was completely invisible. This adds `logging.basicConfig` at INFO to stdout in the entrypoint and logs the turn lifecycle and error paths.

## What now shows up in `docker logs`

* `__main__`**:** runner start / config / session-start lines; explicit `ERROR` on credential-resolution failure and session-start failure.
* `session`**:** turn start (session/user), turn end (status + `duration_ms`), tool-call notes, model-error and budget-halt `WARNING`s, and a `turn failed` `ERROR` carrying the exception class so a failing turn shows WHY.

## Secret safety

Never logs the credential value or its length, message bodies (`event.text`), or `Final.text` -- only structural facts (ids, status, tool name, error class, classification). During review two reviewers caught that the model-error warning was logging `ErrorEvent.message`, which equals the SDK result body (`Final.text`) on an error-result turn; that was fixed to log only the classification, with a regression test that fails against the pre-fix code.

Scope is logging only; the auth-retry / fail-fast behavior and credential-shape validation stay in [#121](<https://github.com/curie-eng/agentos/issues/121>) (deferred).

`uv run pytest runner/tests` -> 74 passed, 3 skipped. `ruff` + `mypy` clean.

Closes [#123](<https://github.com/curie-eng/agentos/issues/123>)