### PR TITLE
Add optional local Slack dispatcher to the compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,7 @@ VALKEY_PASSWORD=valkeypass
 # SLACK_BOT_TOKEN=
 # SLACK_APP_TOKEN_DEV=
 # SLACK_BOT_TOKEN_DEV=
+# To run a real Slack workspace against the local compose stack: export
+# SLACK_APP_TOKEN + SLACK_BOT_TOKEN, set SLACK_API_BASE_URL= (empty) to un-wire
+# the worker's Slack stub, then start the stack with `--profile slack` (brings up
+# the optional agentos-dispatcher). See README "Connect a real Slack workspace".

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,3 +158,30 @@ jobs:
       # webServer builds and serves the preview for the run.
       - name: E2E (Playwright, stackless)
         run: pnpm exec playwright test
+
+  compose:
+    name: Compose (release stack validates)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      # compose.release.yaml (the `agentos local up` stack) has no other CI
+      # coverage. Validate it parses with the Slack profile off (default: the
+      # optional dispatcher is absent) and on (dispatcher rendered), and assert
+      # the profile actually gates the service, so the #111 opt-in cannot silently
+      # break the default zero-Slack `agentos local up`.
+      - name: Default profile parses and omits the dispatcher
+        run: |
+          docker compose -f compose.release.yaml config -q
+          if docker compose -f compose.release.yaml config --services | grep -qx agentos-dispatcher; then
+            echo "agentos-dispatcher must NOT be present without the slack profile" >&2
+            exit 1
+          fi
+      - name: Slack profile parses and includes the dispatcher
+        run: |
+          export SLACK_APP_TOKEN=xapp-ci SLACK_BOT_TOKEN=xoxb-ci
+          docker compose -f compose.release.yaml --profile slack config -q
+          docker compose -f compose.release.yaml --profile slack config --services \
+            | grep -qx agentos-dispatcher \
+            || { echo "agentos-dispatcher must be present under the slack profile" >&2; exit 1; }

--- a/README.md
+++ b/README.md
@@ -112,6 +112,27 @@ streams. This is the same platform the `local` and `cluster` targets exercise,
 with Slack in front. See `apps/dispatcher/README.md`'s runbook for pointing at a
 real workspace.
 
+**Connect a real Slack workspace (local).** The `local` target is Slack-free by
+default, but you can exercise real Slack routing, mentions and threads on the
+compose stack without a cluster. Export the two Slack tokens, empty
+`SLACK_API_BASE_URL` to un-wire the worker's Slack stub, and bring up the
+optional `slack` profile (the `agentos-dispatcher` service in
+`compose.release.yaml`):
+
+```bash
+export SLACK_APP_TOKEN=xapp-... SLACK_BOT_TOKEN=xoxb-...
+export SLACK_API_BASE_URL=          # empty un-wires the worker's Slack stub
+docker compose -f compose.release.yaml --profile slack up -d
+```
+
+Slack allows exactly one Socket Mode owner per app token at a time, so do not
+also run a cluster dispatcher on the same Slack app: it is either/or per app.
+Because these are shell exports they persist for the session, so a later plain
+`agentos local up` in the same shell keeps the worker pointed at real Slack
+(empty `SLACK_API_BASE_URL`) with the real bot token but no dispatcher feeding
+the queue; open a fresh shell (or `unset SLACK_API_BASE_URL`) to return to the
+Slack-free stub.
+
 ## Prerequisites
 
 - **[uv](https://docs.astral.sh/uv/)**: the Python workspace manager.

--- a/compose.release.yaml
+++ b/compose.release.yaml
@@ -395,8 +395,12 @@ services:
       - S3_SECRET_KEY=miniosecret
       - BUNDLE_BUCKET=agentos-bundles
       - AGENTOS_API_BASE_URL=http://localhost:28000
-      - SLACK_API_BASE_URL=http://localhost:8155/api/
-      - SLACK_BOT_TOKEN=xoxb-dev
+      # Slack stub by default (the `agentos message --local` emulator at :8155).
+      # To connect a real workspace instead, export SLACK_BOT_TOKEN=xoxb-... and
+      # set SLACK_API_BASE_URL= (empty) to point the worker at real slack.com,
+      # then bring up the `slack` profile (agentos-dispatcher above). See README.
+      - SLACK_API_BASE_URL=${SLACK_API_BASE_URL-http://localhost:8155/api/}
+      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-xoxb-dev}
       # Fake model by default (no credential needed). For a real model set
       # AGENTOS_FAKE_MODEL=0 and provide a credential in your SHELL (never in this
       # file): the bare names below forward it from your environment only if set.
@@ -405,6 +409,46 @@ services:
       - CLAUDE_CODE_OAUTH_TOKEN
       - AGENTOS_CREDENTIALS
       - AGENTOS_MODEL
+    restart: unless-stopped
+
+  # OPTIONAL real-Slack ingress for local development, OFF by default.
+  #
+  # `local` is Slack-free by design: the worker above talks to the
+  # `agentos message --local` stub (its SLACK_API_BASE_URL / SLACK_BOT_TOKEN
+  # defaults below), so the product loop runs with zero external dependency. This
+  # service is the opt-in that swaps that stub for a real Slack workspace, letting
+  # you exercise routing, mentions and threads on the compose stack without a
+  # cluster -- a faster loop for dispatcher / Slack-routing work.
+  #
+  # It reuses the SAME dispatcher image and env contract the Helm chart renders
+  # (charts/agentos/templates/dispatcher.yaml). Socket Mode dials Slack OUTBOUND
+  # over a websocket, so it needs no inbound port, no Service, and no public
+  # ingress or tunnel: a laptop dispatcher connects fine.
+  #
+  # Enable it (see README "Connect a real Slack workspace"):
+  #   export SLACK_APP_TOKEN=xapp-... SLACK_BOT_TOKEN=xoxb-...
+  #   export SLACK_API_BASE_URL=          # empty: un-wire the worker's stub
+  #   docker compose -f compose.release.yaml --profile slack up -d
+  #
+  # CAVEAT: Slack allows exactly ONE Socket Mode owner per app token at a time
+  # (docs/operations.md). A local dispatcher and a cluster dispatcher on the same
+  # Slack app CONFLICT, so this is either/or per app -- run one, never both. That
+  # is why this service is behind the `slack` profile and off by default.
+  agentos-dispatcher:
+    image: ghcr.io/curie-eng/agentos-dispatcher:latest
+    profiles: [slack]
+    depends_on:
+      valkey:
+        condition: service_healthy
+    environment:
+      VALKEY_HOST: valkey
+      VALKEY_PORT: "6379"
+      VALKEY_PASSWORD: ${VALKEY_PASSWORD:-valkeypass}
+      # Provide these in your SHELL, never in this file. The `slack` profile is
+      # meaningless without them; a token-less dispatcher just backoff-reconnects.
+      SLACK_APP_TOKEN: ${SLACK_APP_TOKEN:-}
+      SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
+      SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:-}
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Adds an optional real-Slack path to the `local` docker-compose stack, mirroring the Helm chart's `dispatcher.enabled` idiom. `local` stays Slack-free by default; a developer can now exercise real Slack routing, mentions, and threads on compose without a cluster.

## Changes
- **compose.release.yaml**: new `agentos-dispatcher` service behind a `slack` profile (off by default), reusing the chart's dispatcher image (`ghcr.io/curie-eng/agentos-dispatcher`) and its exact Slack Socket Mode env contract (`VALKEY_*`, `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`). No compose-only fork. Socket Mode is outbound-only, so no port/ingress/tunnel is needed.
- **compose.release.yaml (worker)**: `SLACK_API_BASE_URL` / `SLACK_BOT_TOKEN` are now overridable. Setting `SLACK_API_BASE_URL=` (empty) un-wires the `message --local` stub and points the worker at real slack.com; unset keeps the stub, so the default path is unchanged.
- **README.md / .env.example**: document the enable path and the one-Socket-Mode-owner-per-app-token caveat (local vs cluster dispatcher is either/or per app).
- **.github/workflows/ci.yaml**: new `compose` job validating `compose.release.yaml` parses and that the `slack` profile gates the dispatcher in both directions (the repo had no CI coverage of this file before).

## Verification
`docker compose config` confirms: default profile omits the dispatcher and keeps the stub (`http://localhost:8155/api/`, `xoxb-dev`); `--profile slack` renders the dispatcher; empty `SLACK_API_BASE_URL` clears the worker stub to real Slack. The live real-workspace check (real tokens) is the runbook in #127 and is out of scope here.

## Scope notes
- `compose.dev.yaml` and a CLI convenience flag were deliberately left out; the issue scopes to `compose.release.yaml`, and the chart keeps Slack-connect a raw command rather than a verb.
- The compose service gates on the profile only (not token presence like the chart's dual gate); off-by-default plus the inline comment cover this, and a token-less start just backoff-reconnects.

Closes #111