### PR TITLE
Minimal local up profile (core services) + optional local Slack dispatcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,5 +28,6 @@ VALKEY_PASSWORD=valkeypass
 # SLACK_BOT_TOKEN_DEV=
 # To run a real Slack workspace against the local compose stack: export
 # SLACK_APP_TOKEN + SLACK_BOT_TOKEN, set SLACK_API_BASE_URL= (empty) to un-wire
-# the worker's Slack stub, then start the stack with `--profile slack` (brings up
-# the optional agentos-dispatcher). See README "Connect a real Slack workspace".
+# the worker's Slack stub, then start the stack with `--profile full --profile
+# slack` (brings up the optional agentos-dispatcher). See README "Connect a real
+# Slack workspace".

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,7 +181,21 @@ jobs:
       - name: Slack profile parses and includes the dispatcher
         run: |
           export SLACK_APP_TOKEN=xapp-ci SLACK_BOT_TOKEN=xoxb-ci
-          docker compose -f compose.release.yaml --profile slack config -q
-          docker compose -f compose.release.yaml --profile slack config --services \
+          # The dispatcher depends on valkey (a core service), so the slack
+          # profile is paired with a base profile; the CLI does the same.
+          docker compose -f compose.release.yaml --profile full --profile slack config -q
+          docker compose -f compose.release.yaml --profile full --profile slack config --services \
             | grep -qx agentos-dispatcher \
             || { echo "agentos-dispatcher must be present under the slack profile" >&2; exit 1; }
+      # `agentos local up --minimal` selects the `core` profile and plain
+      # `agentos local up` the `full` profile; assert the release stack renders
+      # exactly those service counts so a profile regression cannot silently
+      # start the wrong set.
+      - name: Core profile renders 7 services
+        run: |
+          count=$(docker compose -f compose.release.yaml --profile core config --services | wc -l)
+          [ "$count" -eq 7 ] || { echo "core profile must render 7 services, got $count" >&2; exit 1; }
+      - name: Full profile renders 12 services
+        run: |
+          count=$(docker compose -f compose.release.yaml --profile full config --services | wc -l)
+          [ "$count" -eq 12 ] || { echo "full profile must render 12 services, got $count" >&2; exit 1; }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,16 +67,20 @@ pass by weakening assertions is a regression.
 
 ## The dev stack: compose.dev.yaml
 
-One command brings up the whole backing stack (Postgres + Valkey + Langfuse v3 +
-ClickHouse + MinIO + OTel Collector). Every backend integration test and UI E2E
-runs against it.
+The compose stack now has two profiles. `full` brings up the whole backing
+stack (Postgres + Valkey + Langfuse v3 + ClickHouse + MinIO + OTel Collector).
+`core` brings up the smaller local product loop (Postgres + Valkey + MinIO +
+API + worker). Every backend integration test and UI E2E runs against `full`.
 
 ```bash
-docker compose -f compose.dev.yaml up -d     # bring up (idempotent)
+docker compose --profile full -f compose.dev.yaml up -d   # full stack
+docker compose --profile core -f compose.dev.yaml up -d   # 7-service minimal stack (no Langfuse/ClickHouse/OTel/UI)
 docker compose -f compose.dev.yaml ps        # check health
 docker compose -f compose.dev.yaml down      # stop, KEEP volumes (fast restart)
 docker compose -f compose.dev.yaml down -v   # stop and WIPE volumes (throwaway)
 ```
+
+Add `--profile slack` through `agentos local up --slack` to start the optional dispatcher for real Slack.
 
 Host ports (non-default host ports to avoid local collisions):
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -59,13 +59,15 @@ would, put the full platform in front of it. Two options, lightest first.
 
 ### On your local box (Docker stack)
 
-`local` brings up the whole platform with docker compose (API, worker, backing
-stores, and the console UI) and runs your skill through it. Same runner, now with
-the queue and worker in front, all on your machine. Run these from your bundle
-directory:
+`local` brings up the platform with docker compose and runs your skill through
+it. `agentos local up` uses the `full` profile, which includes Langfuse and the
+console UI. `agentos local up --minimal` boots only the 7 core services for low
+RAM machines and the CLI turn path. Same runner, now with the queue and worker
+in front, all on your machine. Run these from your bundle directory:
 
 ```bash
-agentos local up                      # start the full compose stack
+agentos local up                      # full profile
+# or: agentos local up --minimal      # core profile
 agentos local deploy --plugin-dir .   # push the bundle to the local API on :28000
 agentos local message "What's the weather in Paris?"
 agentos local down                    # tear it all down

--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ is the fastest inner loop for developing a plugin: zero Slack, zero platform,
 zero cluster. See `cli/README.md`.
 
 **`local` (full platform via compose, no Slack).** `agentos local up` brings up
-the compose stack, `agentos local deploy` pushes a bundle to the compose API,
-and `agentos local message "..."` drives a message through the real
+the `full` compose profile by default. `agentos local up --minimal` brings up
+the smaller `core` profile (API, worker, Postgres, Valkey, MinIO). Then
+`agentos local deploy` pushes a bundle to the compose API, and
+`agentos local message "..."` drives a message through the real
 queue -> worker -> sandboxed runner -> reply path with no Slack and no
 Kubernetes. The compose worker runs the fake model by default; for a real model,
 export `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) and set
@@ -112,17 +114,21 @@ streams. This is the same platform the `local` and `cluster` targets exercise,
 with Slack in front. See `apps/dispatcher/README.md`'s runbook for pointing at a
 real workspace.
 
-**Connect a real Slack workspace (local).** The `local` target is Slack-free by
-default, but you can exercise real Slack routing, mentions and threads on the
-compose stack without a cluster. Export the two Slack tokens, empty
-`SLACK_API_BASE_URL` to un-wire the worker's Slack stub, and bring up the
-optional `slack` profile (the `agentos-dispatcher` service in
-`compose.release.yaml`):
+**Connect a real Slack workspace (local).** The `local` target uses the Slack
+stub by default, but you can exercise real Slack routing, mentions and threads
+on the compose stack without a cluster. Export the two Slack tokens, empty
+`SLACK_API_BASE_URL` to un-wire the worker's Slack stub, and start the optional
+dispatcher:
 
 ```bash
 export SLACK_APP_TOKEN=xapp-... SLACK_BOT_TOKEN=xoxb-...
 export SLACK_API_BASE_URL=          # empty un-wires the worker's Slack stub
-docker compose -f compose.release.yaml --profile slack up -d
+agentos local up --slack
+
+# Raw Docker needs the base profile plus Slack (the dispatcher depends on
+# valkey, a core service), for either compose file:
+docker compose --profile full --profile slack -f compose.dev.yaml up -d
+docker compose --profile full --profile slack -f compose.release.yaml up -d
 ```
 
 Slack allows exactly one Socket Mode owner per app token at a time, so do not
@@ -172,7 +178,7 @@ the load-bearing gotchas.
 # 1. Bring up the backing stack. The stack runs on baked defaults; copy
 #    .env.example to the gitignored .env only if you need to override anything.
 cp .env.example .env    # optional
-docker compose -f compose.dev.yaml up -d
+docker compose --profile full -f compose.dev.yaml up -d
 docker compose -f compose.dev.yaml ps    # wait for all services healthy
 
 # 2. Install the Python workspace (uv workspace: aci-protocol, plugin-format,
@@ -218,7 +224,8 @@ the Anthropic API.
 **One-command middle mode** (the fastest path — no host-run worker, no cluster):
 
 ```bash
-agentos local up   # brings up the backing stores + API + a containerized worker + the console UI
+agentos local up   # full profile: stores + API + worker + Langfuse + UI
+# or: agentos local up --minimal   # core profile: stores + API + worker only
 agentos local deploy --plugin-dir ./my-agent --slack-channel C-DEMO --api-url http://localhost:28000
 agentos local message "what changed in the last deploy?"
 ```
@@ -227,7 +234,8 @@ agentos local message "what changed in the last deploy?"
 default), so there is nothing to hand-run. For a real model, export a credential
 and set `AGENTOS_FAKE_MODEL=0` in the compose environment. The manual runbook
 below is the equivalent with a host-process worker, useful when iterating on the
-worker itself from source. The console UI is served at `http://localhost:28080/?api=1`; open it to reach the console wired to your local compose API.
+worker itself from source. The console UI is served at
+`http://localhost:28080/?api=1` when you use the default `full` profile.
 
 **Local-model demo mode** is an opt-in offline path that runs a real local model
 through an Anthropic-compatible endpoint, so the demo answers for real and can
@@ -246,6 +254,13 @@ Bare `--local-model` uses `qwen3:4b`. Override it by passing a model name:
 
 ```bash
 agentos local up --local-model qwen3-coder:30b
+```
+
+Combine `--minimal` with `--local-model` when you want the core local loop plus
+Ollama, without Langfuse or the UI:
+
+```bash
+agentos local up --minimal --local-model
 ```
 
 `skill up` and `local up` run the model in a Docker container and point spawned

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,7 +16,7 @@ disk and targets no environment.
 | Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
 |---|---|---|---|---|---|
 | `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
-| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | none | none | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
 | `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `message` `deploy` | Operate and drive a deployed cluster release. |
 
 The universal quartet `up`/`down`/`status`/`message` is on all three targets;
@@ -53,14 +53,16 @@ in Langfuse traces.
 
 ## `local` target: full platform via compose, no Slack
 
-Wraps the `compose.dev.yaml` stack (Postgres + Valkey + Langfuse + API +
-worker) so a `message` walks the real queue -> worker -> sandboxed runner ->
-reply path on one machine, no Slack and no Kubernetes. The compose API is
-published on host port `28000`.
+Wraps the `compose.dev.yaml` stack so a `message` walks the real
+queue -> worker -> sandboxed runner -> reply path on one machine, no Slack and
+no Kubernetes. `agentos local up` uses the `full` compose profile by default.
+`agentos local up --minimal` uses the smaller `core` profile. The compose API is
+published on host port `28000`. Add `agentos local up --slack` to also start
+the optional Slack dispatcher.
 
 | Command | What it does |
 |---|---|
-| `agentos local up` | Bring the compose stack up (`docker compose up -d --wait`) and print URLs. |
+| `agentos local up` | Bring the compose stack up (`docker compose --profile full up -d --wait` by default, `docker compose --profile core up -d --wait` with `--minimal`) and print URLs. Add `--slack` to append `--profile slack`. |
 | `agentos local down` | Stop the compose stack (`docker compose down`), keeping volumes. |
 | `agentos local status` | Show the compose stack's service status (`docker compose ps`). |
 | `agentos local message "..."` | Drive the local compose stack end to end with zero Slack. Enqueues straight to the compose Valkey and lets the containerized worker answer. |

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -19,24 +19,30 @@ pub const DEFAULT_COMPOSE_FILE: &str = "compose.dev.yaml";
 /// `compose.dev.yaml`'s port mappings. Printed after `local up` so the operator
 /// has the URLs in hand. Hardcoded to match the compose file (see the
 /// `endpoints_match_compose_file` test, which asserts the file still maps them).
-const ENDPOINTS: &[(&str, &str)] = &[
-    ("AgentOS API", "http://localhost:28000"),
-    ("AgentOS Console", "http://localhost:28080/?api=1"),
-    ("Langfuse UI", "http://localhost:23000"),
-    ("Postgres", "localhost:25432"),
-    ("Valkey", "localhost:26379"),
-    ("ClickHouse HTTP", "localhost:28123"),
-    ("MinIO S3", "localhost:29000"),
-    ("MinIO console", "localhost:29001"),
-    ("OTel gRPC", "localhost:24317"),
-    ("OTel HTTP", "localhost:24318"),
+///
+/// The `core` flag marks endpoints backed by a service in the `core` profile
+/// (started under `--minimal`); the rest are `full`-only and are hidden under
+/// `--minimal` so `up` never advertises a URL for a service it did not start.
+const ENDPOINTS: &[(&str, &str, bool)] = &[
+    ("AgentOS API", "http://localhost:28000", true),
+    ("AgentOS Console", "http://localhost:28080/?api=1", false),
+    ("Langfuse UI", "http://localhost:23000", false),
+    ("Postgres", "localhost:25432", true),
+    ("Valkey", "localhost:26379", true),
+    ("ClickHouse HTTP", "localhost:28123", false),
+    ("MinIO S3", "localhost:29000", true),
+    ("MinIO console", "localhost:29001", true),
+    ("OTel gRPC", "localhost:24317", false),
+    ("OTel HTTP", "localhost:24318", false),
 ];
 
 /// Flags shared by every `local` verb.
 pub struct LocalOpts {
     pub file: String,
     pub dry_run: bool,
+    pub minimal: bool,
     pub local_model: Option<String>,
+    pub slack: bool,
 }
 
 pub struct LocalDownOpts {
@@ -60,23 +66,28 @@ fn compose(file: &str, tail: &[&str]) -> OpsCommand {
     OpsCommand::new("docker", args)
 }
 
-/// `docker compose -f <file> up -d --wait`.
+/// `docker compose --profile <core|full> [--profile local-model] [--profile slack] -f <file> up -d --wait`.
 pub fn up_command(o: &LocalOpts) -> OpsCommand {
+    let profile = if o.minimal { "core" } else { "full" };
+    let mut args = vec![plain("compose"), plain("--profile"), plain(profile)];
+    if o.local_model.is_some() {
+        args.push(plain("--profile"));
+        args.push(plain("local-model"));
+    }
+    if o.slack {
+        args.push(plain("--profile"));
+        args.push(plain("slack"));
+    }
+    args.extend([
+        plain("-f"),
+        plain(&o.file),
+        plain("up"),
+        plain("-d"),
+        plain("--wait"),
+    ]);
+    let mut cmd = OpsCommand::new("docker", args);
     if let Some(model) = &o.local_model {
-        return OpsCommand::new(
-            "docker",
-            vec![
-                plain("compose"),
-                plain("--profile"),
-                plain("local-model"),
-                plain("-f"),
-                plain(&o.file),
-                plain("up"),
-                plain("-d"),
-                plain("--wait"),
-            ],
-        )
-        .with_env(vec![
+        cmd = cmd.with_env(vec![
             ("AGENTOS_FAKE_MODEL".into(), "0".into()),
             (
                 "AGENTOS_MODEL_BASE_URL".into(),
@@ -90,7 +101,7 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
             ("COMPOSE_PROJECT_NAME".into(), "agentos".into()),
         ]);
     }
-    compose(&o.file, &["up", "-d", "--wait"])
+    cmd
 }
 
 /// `docker compose -f <file> down` (keep volumes), or `... down -v` with
@@ -122,8 +133,15 @@ pub async fn up(o: LocalOpts) -> Result<()> {
     require_on_path("docker")?;
     let cl = ui.checklist();
     run_step(&cl, "starting dev stack", "up", &cmd).await?;
-    for (label, url) in ENDPOINTS {
-        ui.kv(label, &ui.url(url));
+    for (label, url, is_core) in ENDPOINTS {
+        // Under `--minimal` only the `core` services started, so advertise only
+        // their endpoints; the `full`-only URLs would 404.
+        if !o.minimal || *is_core {
+            ui.kv(label, &ui.url(url));
+        }
+    }
+    if o.slack {
+        ui.note("Slack dispatcher started (Socket Mode; no host port).");
     }
     ui.note("Drive the local product loop (no Slack, no Kubernetes):");
     ui.note(
@@ -226,7 +244,9 @@ mod tests {
         LocalOpts {
             file: file.into(),
             dry_run: false,
+            minimal: false,
             local_model: None,
+            slack: false,
         }
     }
 
@@ -234,8 +254,15 @@ mod tests {
         LocalOpts {
             file: file.into(),
             dry_run: false,
+            minimal: false,
             local_model: Some(model.into()),
+            slack: false,
         }
+    }
+
+    fn read_compose(name: &str) -> String {
+        std::fs::read_to_string(format!("{}/../{}", env!("CARGO_MANIFEST_DIR"), name))
+            .unwrap_or_else(|e| panic!("read {name}: {e}"))
     }
 
     #[test]
@@ -243,7 +270,7 @@ mod tests {
         let cmd = up_command(&opts(DEFAULT_COMPOSE_FILE));
         assert_eq!(
             cmd.display(),
-            "docker compose -f compose.dev.yaml up -d --wait"
+            "docker compose --profile full -f compose.dev.yaml up -d --wait"
         );
     }
 
@@ -251,6 +278,7 @@ mod tests {
     fn up_local_model_uses_profile_and_env() {
         let cmd = up_command(&opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b"));
         let display = cmd.display();
+        assert!(display.contains("--profile full"), "{display}");
         assert!(display.contains("--profile local-model"), "{display}");
         assert!(display.contains("up -d --wait"), "{display}");
         assert!(cmd
@@ -267,6 +295,68 @@ mod tests {
             String::from("AGENTOS_DOCKER_NETWORK"),
             String::from("agentos_default"),
         )));
+        assert!(cmd.env.contains(&(
+            String::from("COMPOSE_PROJECT_NAME"),
+            String::from("agentos"),
+        )));
+    }
+
+    #[test]
+    fn up_slack_appends_slack_profile() {
+        let mut opts = opts(DEFAULT_COMPOSE_FILE);
+        opts.slack = true;
+        let cmd = up_command(&opts);
+        assert_eq!(
+            cmd.display(),
+            "docker compose --profile full --profile slack -f compose.dev.yaml up -d --wait"
+        );
+    }
+
+    #[test]
+    fn up_minimal_slack_uses_core_and_slack() {
+        let mut opts = opts(DEFAULT_COMPOSE_FILE);
+        opts.minimal = true;
+        opts.slack = true;
+        let display = up_command(&opts).display();
+        assert!(display.contains("--profile core"), "{display}");
+        assert!(display.contains("--profile slack"), "{display}");
+        assert!(!display.contains("--profile full"), "{display}");
+    }
+
+    #[test]
+    fn up_local_model_and_slack_keep_profile_order() {
+        let mut opts = opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b");
+        opts.slack = true;
+        let display = up_command(&opts).display();
+        assert!(
+            display.contains("--profile full --profile local-model --profile slack"),
+            "{display}"
+        );
+    }
+
+    #[test]
+    fn up_minimal_uses_core_profile() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.minimal = true;
+        let cmd = up_command(&o);
+        assert_eq!(
+            cmd.display(),
+            "docker compose --profile core -f compose.dev.yaml up -d --wait"
+        );
+    }
+
+    #[test]
+    fn minimal_and_local_model_combine() {
+        let mut o = opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b");
+        o.minimal = true;
+        let cmd = up_command(&o);
+        let display = cmd.display();
+        assert!(display.contains("--profile core"), "{display}");
+        assert!(display.contains("--profile local-model"), "{display}");
+        assert!(!display.contains("--profile full"), "{display}");
+        assert!(cmd
+            .env
+            .contains(&(String::from("AGENTOS_MODEL"), String::from("qwen3:4b"))));
         assert!(cmd.env.contains(&(
             String::from("COMPOSE_PROJECT_NAME"),
             String::from("agentos"),
@@ -324,9 +414,7 @@ mod tests {
     /// file" the task asks for, kept mechanical).
     #[test]
     fn endpoints_match_compose_file() {
-        let compose =
-            std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../compose.dev.yaml"))
-                .expect("read compose.dev.yaml");
+        let compose = read_compose("compose.dev.yaml");
         // Each printed host port must appear as a `"<host>:<container>"` mapping.
         for (label, host_port) in [
             ("AgentOS API", "28000"),
@@ -345,7 +433,7 @@ mod tests {
                 "compose.dev.yaml no longer maps host port {host_port} for {label}"
             );
             assert!(
-                ENDPOINTS.iter().any(|(_, url)| url.contains(host_port)),
+                ENDPOINTS.iter().any(|(_, url, _)| url.contains(host_port)),
                 "ENDPOINTS missing {host_port} for {label}"
             );
         }
@@ -354,12 +442,156 @@ mod tests {
         // carries this param.
         let console = ENDPOINTS
             .iter()
-            .find(|(label, _)| *label == "AgentOS Console")
+            .find(|(label, _, _)| *label == "AgentOS Console")
             .expect("AgentOS Console endpoint present");
         assert!(
             console.1.contains("api=1"),
             "AgentOS Console endpoint must be the wired ?api=1 URL, got {}",
             console.1
         );
+    }
+
+    /// The 7 services that must carry `profiles: *core_profiles`.
+    const CORE_SERVICES: &[&str] = &[
+        "postgres",
+        "valkey",
+        "minio",
+        "minio-init",
+        "agentos-migrate",
+        "agentos-api",
+        "agentos-worker",
+    ];
+
+    /// The 5 services that must carry `profiles: *full_profiles`.
+    const FULL_SERVICES: &[&str] = &[
+        "clickhouse",
+        "langfuse-worker",
+        "langfuse-web",
+        "otel-collector",
+        "agentos-ui",
+    ];
+
+    /// Return the YAML block for `service`: everything from its `  <service>:`
+    /// header up to the next top-level (2-space-indented) service header. Used
+    /// to assert a profile anchor lives inside the *right* service block, so a
+    /// per-service profile swap fails the test rather than passing on counts.
+    fn service_block<'a>(compose: &'a str, service: &str) -> &'a str {
+        let header = format!("\n  {service}:\n");
+        let start = compose
+            .find(&header)
+            .unwrap_or_else(|| panic!("service {service} not found"));
+        let after = start + header.len();
+        let rest = &compose[after..];
+        // The next service header is the next "\n  " whose following char is not
+        // a space (deeper-indented keys start with "\n    ").
+        let end = rest
+            .match_indices("\n  ")
+            .find(|(i, _)| rest[i + 3..].starts_with(|c: char| c != ' '))
+            .map(|(i, _)| i)
+            .unwrap_or(rest.len());
+        &rest[..end]
+    }
+
+    /// Assert the shared core(7)/full(5) profile binding in a compose file:
+    /// the anchors are declared, the counts hold, AND each service block carries
+    /// the anchor it should (so swapping a service's profile fails the test).
+    fn assert_core_full_bindings(compose: &str, file: &str) {
+        assert!(
+            compose.contains("x-core-profiles: &core_profiles [core, full]"),
+            "{file} missing core anchor"
+        );
+        assert!(
+            compose.contains("x-full-profiles: &full_profiles [full]"),
+            "{file} missing full anchor"
+        );
+        assert_eq!(
+            compose.matches("profiles: *core_profiles").count(),
+            7,
+            "{file} core-profile count"
+        );
+        assert_eq!(
+            compose.matches("profiles: *full_profiles").count(),
+            5,
+            "{file} full-profile count"
+        );
+        for service in CORE_SERVICES {
+            let block = service_block(compose, service);
+            assert!(
+                block.contains("profiles: *core_profiles"),
+                "{file}: {service} block must bind *core_profiles"
+            );
+            assert!(
+                !block.contains("profiles: *full_profiles"),
+                "{file}: {service} block must not bind *full_profiles"
+            );
+        }
+        for service in FULL_SERVICES {
+            let block = service_block(compose, service);
+            assert!(
+                block.contains("profiles: *full_profiles"),
+                "{file}: {service} block must bind *full_profiles"
+            );
+            assert!(
+                !block.contains("profiles: *core_profiles"),
+                "{file}: {service} block must not bind *core_profiles"
+            );
+        }
+    }
+
+    /// Lock which endpoints are advertised under `--minimal`: exactly the five
+    /// backed by a `core`-profile service. A core/full mislabel here would print
+    /// a dead URL (or hide a live one) under `--minimal`.
+    #[test]
+    fn minimal_advertises_only_core_endpoints() {
+        let core: Vec<&str> = ENDPOINTS
+            .iter()
+            .filter(|(_, _, is_core)| *is_core)
+            .map(|(label, _, _)| *label)
+            .collect();
+        assert_eq!(
+            core,
+            vec![
+                "AgentOS API",
+                "Postgres",
+                "Valkey",
+                "MinIO S3",
+                "MinIO console",
+            ]
+        );
+    }
+
+    #[test]
+    fn compose_file_declares_core_and_full_profiles() {
+        let compose = read_compose("compose.dev.yaml");
+        assert_core_full_bindings(&compose, "compose.dev.yaml");
+    }
+
+    #[test]
+    fn release_compose_file_declares_core_and_full_profiles() {
+        let compose = read_compose("compose.release.yaml");
+        assert_core_full_bindings(&compose, "compose.release.yaml");
+    }
+
+    #[test]
+    fn compose_file_makes_worker_slack_stub_overridable() {
+        let compose = read_compose("compose.dev.yaml");
+        assert!(compose.contains(
+            "      - SLACK_API_BASE_URL=${SLACK_API_BASE_URL-http://localhost:8155/api/}"
+        ));
+        assert!(compose.contains("      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-xoxb-dev}"));
+    }
+
+    #[test]
+    fn compose_file_declares_slack_dispatcher_profile() {
+        let compose = read_compose("compose.dev.yaml");
+        let dispatcher = compose
+            .split("  agentos-dispatcher:")
+            .nth(1)
+            .expect("agentos-dispatcher service present");
+        assert!(dispatcher.contains("    profiles: [slack]"));
+        assert!(!dispatcher.contains("profiles: *core_profiles"));
+        assert!(!dispatcher.contains("profiles: *full_profiles"));
+        assert!(dispatcher.contains("      VALKEY_HOST: valkey"));
+        assert!(dispatcher.contains("      SLACK_APP_TOKEN: ${SLACK_APP_TOKEN:-}"));
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -157,7 +157,7 @@ enum SkillAction {
 /// Subcommands of `agentos local`.
 #[derive(Subcommand)]
 enum LocalAction {
-    /// Bring the dev stack up (docker compose up -d --wait) and print URLs.
+    /// Bring the dev stack up (`core` with `--minimal`, else `full`) and print URLs. Add `--slack` for the optional dispatcher.
     Up {
         /// Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override.
         #[arg(short = 'f', long)]
@@ -165,6 +165,9 @@ enum LocalAction {
         /// Print the docker compose command and exit without executing.
         #[arg(long)]
         dry_run: bool,
+        /// Bring up only the 7 core services (skip Langfuse/ClickHouse/OTel/UI).
+        #[arg(long)]
+        minimal: bool,
         /// Run the named model through local Ollama.
         #[arg(
             long,
@@ -172,6 +175,9 @@ enum LocalAction {
             default_missing_value = commands::DEFAULT_LOCAL_MODEL
         )]
         local_model: Option<String>,
+        /// Also start the optional Slack dispatcher (adds --profile slack).
+        #[arg(long)]
+        slack: bool,
     },
     /// Stop the dev stack (docker compose down), keeping volumes.
     Down {
@@ -527,13 +533,17 @@ async fn main() -> Result<()> {
             LocalAction::Up {
                 file,
                 dry_run,
+                minimal,
                 local_model,
+                slack,
             } => {
                 let file = resolve_compose_file(file, dry_run).await?;
                 local::up(LocalOpts {
                     file,
                     dry_run,
+                    minimal,
                     local_model,
+                    slack,
                 })
                 .await
             }
@@ -548,7 +558,9 @@ async fn main() -> Result<()> {
                     common: LocalOpts {
                         file,
                         dry_run,
+                        minimal: false,
                         local_model: None,
+                        slack: false,
                     },
                     wipe,
                     yes,
@@ -560,7 +572,9 @@ async fn main() -> Result<()> {
                 local::status(LocalOpts {
                     file,
                     dry_run,
+                    minimal: false,
                     local_model: None,
+                    slack: false,
                 })
                 .await
             }
@@ -867,6 +881,30 @@ mod tests {
                 }
                 _ => panic!("expected the local subcommand"),
             }
+        }
+    }
+
+    #[test]
+    fn local_up_parses_minimal_flag() {
+        let cli = Cli::try_parse_from(["agentos", "local", "up", "--minimal"])
+            .expect("local up --minimal should parse");
+        match cli.command {
+            Command::Local {
+                action: LocalAction::Up { minimal, .. },
+            } => assert!(minimal),
+            _ => panic!("expected local up command"),
+        }
+    }
+
+    #[test]
+    fn local_up_parses_slack_flag() {
+        let cli = Cli::try_parse_from(["agentos", "local", "up", "--slack"])
+            .expect("local up --slack should parse");
+        match cli.command {
+            Command::Local {
+                action: LocalAction::Up { slack, .. },
+            } => assert!(slack),
+            _ => panic!("expected local up command"),
         }
     }
 }

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -5,7 +5,11 @@
 # test and UI E2E runs against this stack; it mirrors the Helm dev profile
 # (same components, same pinned versions).
 #
-# Bring up:   docker compose -f compose.dev.yaml up -d
+# Bring up full:  docker compose --profile full -f compose.dev.yaml up -d
+# Bring up core:  docker compose --profile core -f compose.dev.yaml up -d
+# core = postgres, valkey, minio, minio-init, agentos-migrate, agentos-api, agentos-worker
+# full = core + clickhouse, langfuse-web, langfuse-worker, otel-collector, agentos-ui
+# The CLI `agentos local up` wraps these compose profile invocations.
 # Tear down:  docker compose -f compose.dev.yaml down        (keeps volumes; fast restart)
 # Wipe:       docker compose -f compose.dev.yaml down -v     (drops volumes; throwaway)
 #
@@ -56,9 +60,16 @@ x-langfuse-env: &langfuse-env
   LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
   LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
 
+# `core` is the minimal stack for `agentos local message`; `full` is the whole
+# dev stack. Core services belong to both profiles. `agentos local up` selects
+# `full`, and `agentos local up --minimal` selects `core`.
+x-core-profiles: &core_profiles [core, full]
+x-full-profiles: &full_profiles [full]
+
 services:
   postgres:
     image: postgres:16-alpine
+    profiles: *core_profiles
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -75,6 +86,7 @@ services:
 
   valkey:
     image: valkey/valkey:8-alpine
+    profiles: *core_profiles
     command: ["valkey-server", "--requirepass", "${VALKEY_PASSWORD:-valkeypass}"]
     ports:
       - "26379:6379"
@@ -90,6 +102,7 @@ services:
     # Pinned to 24.8: newer ClickHouse needs AVX and crashes (exit 132) on CPUs
     # without AVX. See the header comment.
     image: clickhouse/clickhouse-server:24.8
+    profiles: *full_profiles
     environment:
       CLICKHOUSE_PASSWORD: clickhouse
     ports:
@@ -111,6 +124,7 @@ services:
 
   minio:
     image: minio/minio
+    profiles: *core_profiles
     command: ["server", "/data", "--console-address", ":9001"]
     environment:
       MINIO_ROOT_USER: minio
@@ -130,6 +144,7 @@ services:
   # Creates the langfuse bucket so the web/worker never race a missing bucket.
   minio-init:
     image: minio/mc
+    profiles: *core_profiles
     depends_on:
       minio:
         condition: service_healthy
@@ -169,6 +184,7 @@ services:
 
   langfuse-worker:
     image: langfuse/langfuse-worker:3
+    profiles: *full_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -188,6 +204,7 @@ services:
 
   langfuse-web:
     image: langfuse/langfuse:3
+    profiles: *full_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -220,6 +237,7 @@ services:
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.119.0
+    profiles: *full_profiles
     command: ["--config=/etc/otel/collector-config.yaml"]
     depends_on:
       langfuse-web:
@@ -254,6 +272,7 @@ services:
   # creates the `agentos` schema, so this also gates on Postgres being reachable.
   agentos-migrate:
     image: ghcr.io/curie-eng/agentos-api:latest
+    profiles: *core_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -268,6 +287,7 @@ services:
   # `agentos local message` channel lookup).
   agentos-api:
     image: ghcr.io/curie-eng/agentos-api:latest
+    profiles: *core_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -308,6 +328,7 @@ services:
   # `http://localhost:28080/?api=1` URL and `local up` opens it connected to the API.
   agentos-ui:
     image: ghcr.io/curie-eng/agentos-ui:latest
+    profiles: *full_profiles
     depends_on:
       agentos-api:
         condition: service_healthy
@@ -347,6 +368,7 @@ services:
     build:
       context: compose
       dockerfile: worker-local.Dockerfile
+    profiles: *core_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -387,8 +409,8 @@ services:
       - S3_SECRET_KEY=miniosecret
       - BUNDLE_BUCKET=agentos-bundles
       - AGENTOS_API_BASE_URL=http://localhost:28000
-      - SLACK_API_BASE_URL=http://localhost:8155/api/
-      - SLACK_BOT_TOKEN=xoxb-dev
+      - SLACK_API_BASE_URL=${SLACK_API_BASE_URL-http://localhost:8155/api/}
+      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-xoxb-dev}
       # Fake model by default (no credential needed). For a real model set
       # AGENTOS_FAKE_MODEL=0 and provide a credential in your SHELL (never in this
       # file): the bare names below forward it from your environment only if set.
@@ -404,6 +426,37 @@ services:
       - AGENTOS_MODEL_BASE_URL=${AGENTOS_MODEL_BASE_URL:-}
       - AGENTOS_MODEL=${AGENTOS_MODEL:-}
       - AGENTOS_DOCKER_NETWORK=${AGENTOS_DOCKER_NETWORK:-}
+    restart: unless-stopped
+
+  # Optional real Slack ingress for local development.
+  #
+  # This service swaps the worker's Slack stub for a real workspace on the
+  # compose stack. It is opt in through the `slack` profile and disabled by
+  # default, so the normal local loop stays offline.
+  #
+  # Enable it:
+  #   export SLACK_APP_TOKEN=xapp-... SLACK_BOT_TOKEN=xoxb-...
+  #   export SLACK_API_BASE_URL=          # empty: un-wire the worker's stub
+  #   docker compose --profile full --profile slack -f compose.dev.yaml up -d
+  #   (or: agentos local up --slack)
+  #
+  # Caveat: Slack allows exactly one Socket Mode owner per app token at a time.
+  # A local dispatcher and a cluster dispatcher on the same Slack app conflict.
+  # Use one dispatcher per app. This is why the service is behind the `slack`
+  # profile and disabled by default.
+  agentos-dispatcher:
+    image: ghcr.io/curie-eng/agentos-dispatcher:latest
+    profiles: [slack]
+    depends_on:
+      valkey:
+        condition: service_healthy
+    environment:
+      VALKEY_HOST: valkey
+      VALKEY_PORT: "6379"
+      VALKEY_PASSWORD: ${VALKEY_PASSWORD:-valkeypass}
+      SLACK_APP_TOKEN: ${SLACK_APP_TOKEN:-}
+      SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
+      SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:-}
     restart: unless-stopped
 
 volumes:

--- a/compose.release.yaml
+++ b/compose.release.yaml
@@ -7,9 +7,13 @@
 # test and UI E2E runs against this stack; it mirrors the Helm dev profile
 # (same components, same pinned versions).
 #
-# Bring up:   docker compose -f compose.dev.yaml up -d
-# Tear down:  docker compose -f compose.dev.yaml down        (keeps volumes; fast restart)
-# Wipe:       docker compose -f compose.dev.yaml down -v     (drops volumes; throwaway)
+# Bring up full:  docker compose --profile full -f compose.release.yaml up -d
+# Bring up core:  docker compose --profile core -f compose.release.yaml up -d
+# core = postgres, valkey, minio, minio-init, agentos-migrate, agentos-api, agentos-worker
+# full = core + clickhouse, langfuse-web, langfuse-worker, otel-collector, agentos-ui
+# The CLI `agentos local up` wraps these compose profile invocations.
+# Tear down:  docker compose -f compose.release.yaml down        (keeps volumes; fast restart)
+# Wipe:       docker compose -f compose.release.yaml down -v     (drops volumes; throwaway)
 #
 # Host ports use a distinctive 2xxxx block (host port = "2" + the service's
 # container port) to avoid common service defaults and stay below the OS
@@ -98,9 +102,16 @@ configs:
             processors: [batch]
             exporters: [otlphttp/langfuse, debug]
 
+# `core` is the minimal stack for `agentos local message`; `full` is the whole
+# release stack. Core services belong to both profiles. `agentos local up` selects
+# `full`, and `agentos local up --minimal` selects `core`.
+x-core-profiles: &core_profiles [core, full]
+x-full-profiles: &full_profiles [full]
+
 services:
   postgres:
     image: postgres:16-alpine
+    profiles: *core_profiles
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -117,6 +128,7 @@ services:
 
   valkey:
     image: valkey/valkey:8-alpine
+    profiles: *core_profiles
     command: ["valkey-server", "--requirepass", "${VALKEY_PASSWORD:-valkeypass}"]
     ports:
       - "26379:6379"
@@ -132,6 +144,7 @@ services:
     # Pinned to 24.8: newer ClickHouse needs AVX and crashes (exit 132) on CPUs
     # without AVX. See the header comment.
     image: clickhouse/clickhouse-server:24.8
+    profiles: *full_profiles
     environment:
       CLICKHOUSE_PASSWORD: clickhouse
     ports:
@@ -153,6 +166,7 @@ services:
 
   minio:
     image: minio/minio
+    profiles: *core_profiles
     command: ["server", "/data", "--console-address", ":9001"]
     environment:
       MINIO_ROOT_USER: minio
@@ -172,6 +186,7 @@ services:
   # Creates the langfuse bucket so the web/worker never race a missing bucket.
   minio-init:
     image: minio/mc
+    profiles: *core_profiles
     depends_on:
       minio:
         condition: service_healthy
@@ -185,6 +200,7 @@ services:
 
   langfuse-worker:
     image: langfuse/langfuse-worker:3
+    profiles: *full_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -204,6 +220,7 @@ services:
 
   langfuse-web:
     image: langfuse/langfuse:3
+    profiles: *full_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -236,6 +253,7 @@ services:
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.119.0
+    profiles: *full_profiles
     command: ["--config=/etc/otel/collector-config.yaml"]
     depends_on:
       langfuse-web:
@@ -271,6 +289,7 @@ services:
   # creates the `agentos` schema, so this also gates on Postgres being reachable.
   agentos-migrate:
     image: ghcr.io/curie-eng/agentos-api:latest
+    profiles: *core_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -285,6 +304,7 @@ services:
   # `agentos message --local` channel lookup).
   agentos-api:
     image: ghcr.io/curie-eng/agentos-api:latest
+    profiles: *core_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -325,6 +345,7 @@ services:
   # `http://localhost:28080/?api=1` URL and `local up` opens it connected to the API.
   agentos-ui:
     image: ghcr.io/curie-eng/agentos-ui:latest
+    profiles: *full_profiles
     depends_on:
       agentos-api:
         condition: service_healthy
@@ -362,6 +383,7 @@ services:
   # reaches the `agentos message --local` Slack stub at localhost:8155.
   agentos-worker:
     image: ghcr.io/curie-eng/agentos-worker-local:latest
+    profiles: *core_profiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -428,7 +450,8 @@ services:
   # Enable it (see README "Connect a real Slack workspace"):
   #   export SLACK_APP_TOKEN=xapp-... SLACK_BOT_TOKEN=xoxb-...
   #   export SLACK_API_BASE_URL=          # empty: un-wire the worker's stub
-  #   docker compose -f compose.release.yaml --profile slack up -d
+  #   docker compose --profile full --profile slack -f compose.release.yaml up -d
+  #   (the dispatcher depends on valkey, so pair `slack` with a base profile)
   #
   # CAVEAT: Slack allows exactly ONE Socket Mode owner per app token at a time
   # (docs/operations.md). A local dispatcher and a cluster dispatcher on the same


### PR DESCRIPTION
## What

Adds a minimal `local up` profile and, per follow-on request, the optional local Slack dispatcher.

**Minimal profile (#125)**
- `core` compose profile = the 7 services on the CLI `local message` turn path (`postgres`, `valkey`, `minio`, `minio-init`, `agentos-migrate`, `agentos-api`, `agentos-worker`); `full` = all 12. Declared with YAML anchors in **both** `compose.dev.yaml` and `compose.release.yaml` (release matters because a released binary fetches `compose.release.yaml`, where unprofiled services would otherwise all start under `--minimal`).
- `agentos local up` selects `--profile full` (same 12-service stack as before, unchanged). `agentos local up --minimal` selects `--profile core` and advertises only the endpoints it actually started.

**Optional local Slack (folded in on request)**
- `agentos-dispatcher` behind a `slack` profile (off by default) in `compose.dev.yaml`, mirroring `compose.release.yaml`. Dev worker `SLACK_API_BASE_URL`/`SLACK_BOT_TOKEN` made overridable so the stub can be un-wired.
- `agentos local up --slack` appends `--profile slack`; composes with `--minimal` and `--local-model`.

## Notes for review
- Docker Compose profiles are opt-in, so gating the stack means bare `docker compose up` (no `--profile`) now starts nothing; the CLI and docs always pass a profile. Docs (AGENTS.md, README, QUICKSTART, cli/README) updated accordingly.
- Profile scheme locked by per-service binding tests over both compose files and release-stack CI checks (`core` renders 7, `full` renders 12; pure `config --services`, no image pulls).
- Verified with real `docker compose config`: `core`=7, `full`=12, dispatcher absent from core, present under `--profile slack`, for both files. `cargo fmt`/`clippy`/`test` (174) green.
- Not live-booted: the actual `local message` turn against the minimal stack is verified by the 7-service dependency-closure analysis (no core service hard-depends on a droppable one) and config resolution, not a live run (booting needs the private app + runner images). A `agentos local up --minimal && agentos local message "hi"` smoke test is a quick manual confirm.

Closes #125
