### PR TITLE
Configurable organization/workspace name

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -113,6 +113,20 @@
         "title": "AgentUpdate",
         "type": "object"
       },
+      "AppConfig": {
+        "description": "Open app-level config the UI reads before auth (org/workspace name).",
+        "properties": {
+          "org_name": {
+            "title": "Org Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "org_name"
+        ],
+        "title": "AppConfig",
+        "type": "object"
+      },
       "BehaviorPacksConfig": {
         "description": "An agent's opt-in behavior packs. Validated on write and stored as JSON on\nthe agent row; the worker parses the same JSON at bind time.",
         "properties": {
@@ -2403,6 +2417,27 @@
         "summary": "Read Version Files",
         "tags": [
           "agents"
+        ]
+      }
+    },
+    "/config": {
+      "get": {
+        "operationId": "get_config_config_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppConfig"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Config",
+        "tags": [
+          "config"
         ]
       }
     },

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     # Single shared API key. Dev-only default; override in any shared deployment.
     api_key: str = "agentos-dev-key"
 
+    # Human-readable org/workspace name the UI reads (open /config endpoint) to
+    # brand the app. Overridable via ORG_NAME for a white-labeled deployment.
+    org_name: str = "AgentOS"
+
     # Langfuse proxy target (the dev project keys baked into compose.dev.yaml).
     langfuse_host: str = "http://localhost:23000"
     langfuse_public_key: str = "pk-lf-agentos-dev"

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -21,6 +21,7 @@ from .langfuse import LangfuseClient
 from .routers import (
     agents,
     bundles,
+    config,
     control,
     deployments,
     evals,
@@ -73,6 +74,7 @@ def create_app() -> FastAPI:
     async def health() -> dict[str, str]:
         return {"status": "ok"}
 
+    app.include_router(config.router)
     app.include_router(agents.router)
     app.include_router(deployments.router)
     app.include_router(bundles.router)

--- a/apps/api/src/agentos_api/routers/config.py
+++ b/apps/api/src/agentos_api/routers/config.py
@@ -1,0 +1,19 @@
+"""The open `/config` endpoint: it exposes the configurable org name.
+
+Like `/health`, this route carries no `require_api_key` dependency so the UI can
+read the workspace name before the user has supplied a key. The org name comes
+from `get_settings()`, which reads it from the environment at first-call time
+(env vars are fixed at pod start in practice).
+"""
+
+from fastapi import APIRouter
+
+from ..config import get_settings
+from ..schemas import AppConfig
+
+router = APIRouter(tags=["config"])
+
+
+@router.get("/config", response_model=AppConfig)
+async def get_config() -> AppConfig:
+    return AppConfig(org_name=get_settings().org_name)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -9,6 +9,12 @@ from pydantic import BaseModel, ConfigDict, Field
 from .models import Environment
 
 
+class AppConfig(BaseModel):
+    """Open app-level config the UI reads before auth (org/workspace name)."""
+
+    org_name: str
+
+
 class LoadPackConfig(BaseModel):
     """Rotating "working..." load lines for one agent. Mirrors the worker's
     agentos_worker.behaviorpacks.LoadPack (packs ride on agent config, not the

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -1,0 +1,46 @@
+"""The open `/config` endpoint: it exposes the configurable org name.
+
+Mirrors the `/health`-is-open test in test_auth.py: `/config` carries no
+`require_api_key` dependency, so the UI can read the workspace name before the
+user has supplied a key. The org name defaults to "AgentOS" and is overridable
+via the `ORG_NAME` environment variable (the same env-driven Settings mechanism
+conftest uses for DATABASE_URL).
+"""
+
+from typing import Any
+
+import pytest
+from agentos_api.config import get_settings
+
+
+def test_config_is_open(client: Any) -> None:
+    # No X-API-Key header, exactly like the health probe: the endpoint is open.
+    resp = client.get("/config")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "org_name" in body
+    assert isinstance(body["org_name"], str)
+
+
+def test_config_ignores_a_bogus_key(client: Any) -> None:
+    # A wrong key does not 401 the way /agents does -- /config is unauthenticated.
+    resp = client.get("/config", headers={"X-API-Key": "wrong"})
+    assert resp.status_code == 200
+
+
+def test_config_defaults_to_agentos(client: Any) -> None:
+    # With no ORG_NAME override the documented default is surfaced.
+    assert client.get("/config").json()["org_name"] == "AgentOS"
+
+
+def test_config_reflects_the_configured_org_name(
+    client: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Override via the env-driven setting and clear the cache so a fresh Settings
+    # reads it (the same override path conftest uses for DATABASE_URL).
+    monkeypatch.setenv("ORG_NAME", "Globex Corporation")
+    get_settings.cache_clear()
+    try:
+        assert client.get("/config").json()["org_name"] == "Globex Corporation"
+    finally:
+        get_settings.cache_clear()

--- a/apps/ui/src/api/api.test.ts
+++ b/apps/ui/src/api/api.test.ts
@@ -11,6 +11,7 @@ import {
   createDeployment,
   listTraces,
   listRunnerPods,
+  getConfig,
 } from "./client";
 
 afterEach(() => {
@@ -89,6 +90,14 @@ describe("api client", () => {
     expect(fetchMock.mock.calls[0][0]).toBe("/api/langfuse/traces?limit=20");
     await listTraces(5, "agent-uuid-1");
     expect(fetchMock.mock.calls[1][0]).toBe("/api/langfuse/traces?limit=5&agent_id=agent-uuid-1");
+  });
+
+  it("reads the open /config endpoint and returns the parsed org name", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { org_name: "Globex Corporation" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const config = await getConfig();
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/config");
+    expect(config.org_name).toBe("Globex Corporation");
   });
 
   it("lists runner pods and surfaces a 503 no-cluster as ApiError(status=503)", async () => {

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -3,6 +3,11 @@
 
 import { API_PREFIX, apiKey } from "./config";
 
+// Open (unauthenticated) app config: the configurable org/workspace name.
+export interface AppConfig {
+  org_name: string;
+}
+
 export interface AgentOut {
   id: string;
   name: string;
@@ -311,6 +316,13 @@ export interface KillState {
 export async function getAgents(): Promise<AgentOut[]> {
   const resp = await fetch(url("/agents"), { headers: headers() });
   return jsonOrThrow<AgentOut[]>(resp);
+}
+
+// The open /config endpoint (no API key required) carries the configurable
+// org/workspace name the shared chrome renders.
+export async function getConfig(): Promise<AppConfig> {
+  const resp = await fetch(url("/config"));
+  return jsonOrThrow<AppConfig>(resp);
 }
 
 // Delete an agent (cascades its versions/deployments server-side; 204 No Content

--- a/apps/ui/src/components/Sidebar.tsx
+++ b/apps/ui/src/components/Sidebar.tsx
@@ -85,7 +85,7 @@ export function Sidebar() {
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontSize: 13, fontWeight: 500, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-            acme-corp
+            {isWired() ? wired.orgName : "acme-corp"}
           </div>
           <div style={{ fontSize: 11, color: C.muted }}>production</div>
         </div>

--- a/apps/ui/src/components/Topbar.tsx
+++ b/apps/ui/src/components/Topbar.tsx
@@ -1,6 +1,8 @@
 import { C } from "../tokens";
 import { hoverBg } from "../lib/style";
 import { useStore } from "../state/store";
+import { useWired } from "../state/wired";
+import { isWired } from "../api/config";
 import type { Nav } from "../state/types";
 
 const CRUMB: Record<Nav, string> = {
@@ -15,6 +17,8 @@ const CRUMB: Record<Nav, string> = {
 
 export function Topbar() {
   const { state, dispatch, ghOn, envDev } = useStore();
+  const wired = useWired();
+  const orgName = isWired() ? wired.orgName : "acme-corp";
   const envDisabled = !ghOn;
   const isProd = state.env === "prod" && !envDev;
 
@@ -53,7 +57,7 @@ export function Topbar() {
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 14 }}>
-        <span style={{ color: C.muted }}>acme-corp</span>
+        <span style={{ color: C.muted }}>{orgName}</span>
         <span style={{ color: C.disabled }}>/</span>
         <span style={{ color: C.text }}>{state.terminal ? "CLI view" : CRUMB[state.nav]}</span>
       </div>

--- a/apps/ui/src/components/chrome.test.tsx
+++ b/apps/ui/src/components/chrome.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Topbar } from "./Topbar";
+import { Sidebar } from "./Sidebar";
+import { StoreProvider } from "../state/store";
+import { isWired } from "../api/config";
+import { useWired, type WiredData } from "../state/wired";
+
+// The shared chrome (Topbar + Sidebar) shows the workspace name. In wired mode
+// it comes from the real config the wired data layer exposes as `orgName`; in
+// fixture/demo mode it stays the hardcoded `acme-corp`. We mock the mode gate
+// (isWired) and the wired data layer (useWired) so we can render just the chrome
+// deterministically, without a live fetch — the same wired-vs-fixture split the
+// App.test.tsx harness relies on, isolated to the two chrome components.
+vi.mock("../api/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/config")>();
+  return { ...actual, isWired: vi.fn() };
+});
+vi.mock("../state/wired", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../state/wired")>();
+  return { ...actual, useWired: vi.fn() };
+});
+
+// A full WiredData, plus the new `orgName` field, cast so this test compiles
+// before the field lands on the interface.
+function wiredValue(over: Record<string, unknown>): WiredData {
+  return {
+    wired: false,
+    agents: [],
+    loading: false,
+    error: null,
+    refetch: () => {},
+    justDeployed: null,
+    markDeployed: () => {},
+    clearDeployed: () => {},
+    ...over,
+  } as unknown as WiredData;
+}
+
+function renderChrome() {
+  return render(
+    <StoreProvider level={6}>
+      <Topbar />
+      <Sidebar />
+    </StoreProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("chrome workspace name", () => {
+  it("renders the configured org name in wired mode (Topbar + Sidebar)", () => {
+    vi.mocked(isWired).mockReturnValue(true);
+    vi.mocked(useWired).mockReturnValue(wiredValue({ wired: true, orgName: "Globex Corporation" }));
+    renderChrome();
+    // Both the Topbar breadcrumb and the Sidebar workspace button show it.
+    expect(screen.getAllByText("Globex Corporation").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("acme-corp")).toBeNull();
+  });
+
+  it("keeps the hardcoded acme-corp in fixture/demo mode", () => {
+    vi.mocked(isWired).mockReturnValue(false);
+    vi.mocked(useWired).mockReturnValue(wiredValue({ wired: false, orgName: "AgentOS" }));
+    renderChrome();
+    expect(screen.getAllByText("acme-corp").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("Globex Corporation")).toBeNull();
+  });
+});

--- a/apps/ui/src/state/wired.tsx
+++ b/apps/ui/src/state/wired.tsx
@@ -1,6 +1,9 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
-import { getAgents, type AgentOut } from "../api/client";
+import { getAgents, getConfig, type AgentOut } from "../api/client";
 import { isWired } from "../api/config";
+
+// Fallback workspace name shown while config is loading or when unwired.
+const DEFAULT_ORG_NAME = "AgentOS";
 
 // The real-data layer for wired mode. It fetches GET /agents and derives whether
 // the account is fresh (onboarding) or has agents (live shell). The fixture demo
@@ -12,9 +15,11 @@ export interface JustDeployed {
   channel: string;
 }
 
-interface WiredData {
+export interface WiredData {
   wired: boolean;
   agents: AgentOut[];
+  /** Configurable org/workspace name from GET /config; falls back to a default. */
+  orgName: string;
   loading: boolean;
   error: string | null;
   refetch: () => void;
@@ -29,6 +34,7 @@ const Ctx = createContext<WiredData | null>(null);
 export function WiredProvider({ children }: { children: ReactNode }) {
   const wired = isWired();
   const [agents, setAgents] = useState<AgentOut[]>([]);
+  const [orgName, setOrgName] = useState(DEFAULT_ORG_NAME);
   const [loading, setLoading] = useState(wired);
   const [error, setError] = useState<string | null>(null);
   const [justDeployed, setJustDeployed] = useState<JustDeployed | null>(null);
@@ -52,6 +58,13 @@ export function WiredProvider({ children }: { children: ReactNode }) {
         setError(String(e));
         setLoading(false);
       });
+    // Org name is chrome-only; a failure here must not block the agent list, so
+    // it swallows errors and keeps the default rather than surfacing on `error`.
+    getConfig()
+      .then((cfg) => {
+        if (live && cfg.org_name) setOrgName(cfg.org_name);
+      })
+      .catch(() => {});
     return () => {
       live = false;
     };
@@ -61,6 +74,7 @@ export function WiredProvider({ children }: { children: ReactNode }) {
     () => ({
       wired,
       agents,
+      orgName,
       loading,
       error,
       refetch,
@@ -68,7 +82,7 @@ export function WiredProvider({ children }: { children: ReactNode }) {
       markDeployed: (d) => setJustDeployed(d),
       clearDeployed: () => setJustDeployed(null),
     }),
-    [wired, agents, loading, error, refetch, justDeployed],
+    [wired, agents, orgName, loading, error, refetch, justDeployed],
   );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;

--- a/apps/ui/src/views/wired/WiredStubs.tsx
+++ b/apps/ui/src/views/wired/WiredStubs.tsx
@@ -1,6 +1,7 @@
 import { C } from "../../tokens";
 import { Card, SectionTitle, Chip } from "../../primitives";
 import { ConnectSlackPanel } from "../../components/ConnectSlackPanel";
+import { useWired } from "../../state/wired";
 
 // Honest placeholders for the views not yet backend-driven, so wired mode never
 // leaks fixture data (no fictional deal-desk / eval cases / version rows). They
@@ -64,13 +65,23 @@ export function WiredUsage() {
 }
 
 export function WiredSettings() {
+  const { orgName } = useWired();
   return (
     <div>
       <SectionTitle title="Settings" />
-      <ComingSoon
-        title="Project settings are not wired yet"
-        body="Project name, default model, and provider keys are managed outside the console for now. This view will bind to real settings in a later pass."
-      />
+      <div style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 720 }}>
+        <Card>
+          <div style={{ fontSize: 13, color: C.muted, marginBottom: 6 }}>Workspace name</div>
+          <div style={{ fontSize: 15, color: C.text }}>{orgName}</div>
+          <div style={{ fontSize: 12, color: C.muted, marginTop: 8 }}>
+            Configured on the server. Read-only here for now.
+          </div>
+        </Card>
+        <ComingSoon
+          title="More project settings are not wired yet"
+          body="Default model and provider keys are managed outside the console for now. This view will bind to real settings in a later pass."
+        />
+      </div>
     </div>
   );
 }

--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -69,6 +69,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentos.secretName" . }}
                   key: githubWebhookSecret
+            - name: ORG_NAME
+              value: {{ .Values.api.orgName | quote }}
             - name: LANGFUSE_HOST
               value: http://{{ include "agentos.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}
             - name: LANGFUSE_PUBLIC_KEY

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -269,6 +269,9 @@ api:
   # Single shared API key the UI and CLI authenticate with. Dev default; override
   # (or point at an existingSecret) in any shared deployment.
   apiKey: agentos-dev-key
+  # Human-readable org/workspace name the UI reads from the open /config endpoint.
+  # Override to white-label the app for a deployment.
+  orgName: AgentOS
   # HMAC secret the GitHub git-flow webhook authenticates inbound events with.
   githubWebhookSecret: dev-webhook-secret
   service:


### PR DESCRIPTION
Closes #5.

## What
A deployed install had no organization/workspace-name concept and carried the fixture's demo branding. This makes the workspace name a first-class, brandable setting that flows from config → API → UI chrome.

## How
- **API** — `Settings.org_name` (env `ORG_NAME`, default `"AgentOS"`) surfaced via a new **open** `GET /config` endpoint returning `{"org_name": ...}`. Response schema added and committed `openapi.json` regenerated (guarded by `test_openapi_drift.py`).
- **Chart** — new `api.orgName` value threaded to the API container as the `ORG_NAME` env var.
- **UI** — the wired data layer fetches the name on mount (alongside `GET /agents`, errors swallowed so it can't block the agent list) and exposes `orgName`; **Topbar**, **Sidebar**, and the wired **Settings** view render it. Fixture/demo mode is untouched and still shows `acme-corp`.

## Decisions (defaults, grounded in the ticket)
- Term: **`org_name`** (API/JSON) / `orgName` (UI) / `api.orgName` (chart).
- **Read-only / install-time** — the ticket frames it as an API setting or chart value, so there's no write endpoint or editable field.
- Replacement scoped to the **wired chrome only**; fixture demo views keep demo branding per the ticket's intent.

## Tests
- API: `tests/test_config.py` — `/config` is open (works without / with a bogus key), defaults to `AgentOS`, and reflects an `ORG_NAME` override. OpenAPI drift test passes.
- UI: `api.test.ts` covers `getConfig()`; new `chrome.test.tsx` asserts Topbar+Sidebar show the configured name in wired mode and `acme-corp` in fixture mode.
- Full API suite green except one pre-existing failure requiring the ClickHouse/observability stack (unrelated). UI: 55 tests pass, typecheck + lint clean.