### PR TITLE
UI: dev/prod environment switcher + promote-to-prod flow

### DIFF
--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -384,6 +384,14 @@ export async function listDeployments(agentId: string): Promise<DeploymentOut[]>
   return jsonOrThrow<DeploymentOut[]>(resp);
 }
 
+// Every deployment across all agents (GET /deployments with no agent_id). Used
+// by the env-scoped Agents/Overview views to decide which agents are live in the
+// selected environment.
+export async function listAllDeployments(): Promise<DeploymentOut[]> {
+  const resp = await fetch(url("/deployments"), { headers: headers() });
+  return jsonOrThrow<DeploymentOut[]>(resp);
+}
+
 /**
  * Read the unwrapped files of a version's stored bundle (FX2 headline: the agent
  * detail surface renders and edits these). A 404 means no bundle is stored for

--- a/apps/ui/src/api/hooks.ts
+++ b/apps/ui/src/api/hooks.ts
@@ -8,6 +8,7 @@ import {
   getCost,
   listVersions,
   listDeployments,
+  listAllDeployments,
   getVersionFiles,
   ApiError,
   type RawTrace,
@@ -100,6 +101,25 @@ export function useAgents(enabled: boolean): Async<AgentOut[]> {
     let live = true;
     setState({ data: null, loading: true, error: null });
     getAgents()
+      .then((data) => live && setState({ data, loading: false, error: null }))
+      .catch((e: unknown) => live && setState({ data: null, loading: false, error: String(e) }));
+    return () => {
+      live = false;
+    };
+  }, [enabled]);
+  return state;
+}
+
+// Fetch every deployment across all agents, for env-scoping the Agents/Overview
+// views. Refetches on mount (navigating back after a promote/deploy remounts the
+// view), which is enough to reflect a fresh deployment.
+export function useAllDeployments(enabled: boolean): Async<DeploymentOut[]> {
+  const [state, setState] = useState<Async<DeploymentOut[]>>({ data: null, loading: enabled, error: null });
+  useEffect(() => {
+    if (!enabled) return;
+    let live = true;
+    setState({ data: null, loading: true, error: null });
+    listAllDeployments()
       .then((data) => live && setState({ data, loading: false, error: null }))
       .catch((e: unknown) => live && setState({ data: null, loading: false, error: String(e) }));
     return () => {

--- a/apps/ui/src/components/Topbar.test.tsx
+++ b/apps/ui/src/components/Topbar.test.tsx
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Topbar } from "./Topbar";
+import { StoreProvider, useStore } from "../state/store";
+import { isWired } from "../api/config";
+import type { FixtureLevel } from "../state/types";
+
+// The env switcher's enablement is derived in the store. After the fix it is
+// driven by isWired() OR a level>=4 fixture, so we mock the wiring flag and
+// assert the pill behaviour through the store.
+vi.mock("../api/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/config")>();
+  return { ...actual, isWired: vi.fn(() => false) };
+});
+
+afterEach(() => {
+  vi.mocked(isWired).mockReset();
+  vi.mocked(isWired).mockReturnValue(false);
+});
+
+// Surfaces the store's derived env-switch state so the assertions do not depend
+// on pill styling internals.
+function Probe() {
+  const { state, ghOn } = useStore();
+  return (
+    <>
+      <span data-testid="env">{state.env}</span>
+      <span data-testid="ghon">{String(ghOn)}</span>
+    </>
+  );
+}
+
+function renderTopbar(level: FixtureLevel) {
+  return render(
+    <StoreProvider level={level}>
+      <Topbar />
+      <Probe />
+    </StoreProvider>,
+  );
+}
+
+describe("Topbar env switcher enablement", () => {
+  it("is enabled in wired mode even at a low fixture level, and DEV dispatches setEnv('dev')", async () => {
+    vi.mocked(isWired).mockReturnValue(true);
+    const user = userEvent.setup();
+    renderTopbar(1);
+
+    // Enabled: the store reports environments are available.
+    expect(screen.getByTestId("ghon")).toHaveTextContent("true");
+    expect(screen.getByTestId("env")).toHaveTextContent("prod");
+
+    await user.click(screen.getByRole("button", { name: "DEV" }));
+    expect(screen.getByTestId("env")).toHaveTextContent("dev");
+
+    await user.click(screen.getByRole("button", { name: "PROD" }));
+    expect(screen.getByTestId("env")).toHaveTextContent("prod");
+  });
+
+  it("stays disabled in fixture mode below level 4 — clicking DEV is a no-op", async () => {
+    vi.mocked(isWired).mockReturnValue(false);
+    const user = userEvent.setup();
+    renderTopbar(1);
+
+    expect(screen.getByTestId("ghon")).toHaveTextContent("false");
+
+    await user.click(screen.getByRole("button", { name: "DEV" }));
+    // Disabled pill: env is unchanged.
+    expect(screen.getByTestId("env")).toHaveTextContent("prod");
+  });
+});

--- a/apps/ui/src/state/env.test.ts
+++ b/apps/ui/src/state/env.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { agentIdsForEnv, hiddenAgentIdsForEnv } from "./env";
+import type { DeploymentOut, Environment } from "../api/client";
+
+// Deployment builder mirroring the fixtures used in hooks.test.ts / WiredVersions.test.ts.
+const dep = (
+  agent_id: string,
+  environment: Environment,
+  status = "active",
+): DeploymentOut => ({
+  id: `dep-${agent_id}-${environment}-${status}`,
+  agent_id,
+  version_id: `ver-${agent_id}-${environment}`,
+  environment,
+  bot_identity: null,
+  commit_sha: null,
+  status,
+  deployed_at: "2026-07-08T00:00:00Z",
+});
+
+describe("agentIdsForEnv (client-side env scoping)", () => {
+  it("returns the agent_ids with an ACTIVE deployment in the target env", () => {
+    const deployments = [
+      dep("a1", "prod"),
+      dep("a2", "prod"),
+      dep("a3", "dev"),
+    ];
+    const prod = agentIdsForEnv(deployments, "prod");
+    expect(prod).toBeInstanceOf(Set);
+    expect(prod.has("a1")).toBe(true);
+    expect(prod.has("a2")).toBe(true);
+    // a3 lives only in dev, so it is NOT in the prod set.
+    expect(prod.has("a3")).toBe(false);
+    expect(prod.size).toBe(2);
+  });
+
+  it("an agent deployed only to dev is absent from the prod set and present in the dev set", () => {
+    const deployments = [dep("dev-only", "dev")];
+    expect(agentIdsForEnv(deployments, "prod").has("dev-only")).toBe(false);
+    expect(agentIdsForEnv(deployments, "dev").has("dev-only")).toBe(true);
+  });
+
+  it("an agent deployed to both envs appears in both sets", () => {
+    const deployments = [dep("both", "prod"), dep("both", "dev")];
+    expect(agentIdsForEnv(deployments, "prod").has("both")).toBe(true);
+    expect(agentIdsForEnv(deployments, "dev").has("both")).toBe(true);
+  });
+
+  it("ignores non-active deployments (superseded/stopped do not count)", () => {
+    const deployments = [
+      dep("a1", "prod", "superseded"),
+      dep("a2", "prod", "stopped"),
+      dep("a3", "prod", "active"),
+    ];
+    const prod = agentIdsForEnv(deployments, "prod");
+    expect(prod.has("a1")).toBe(false);
+    expect(prod.has("a2")).toBe(false);
+    expect(prod.has("a3")).toBe(true);
+    expect(prod.size).toBe(1);
+  });
+
+  it("returns an empty set when there are no deployments", () => {
+    const empty = agentIdsForEnv([], "prod");
+    expect(empty).toBeInstanceOf(Set);
+    expect(empty.size).toBe(0);
+  });
+});
+
+describe("hiddenAgentIdsForEnv (client-side env visibility)", () => {
+  it("does NOT hide an undeployed agent (no active deployments anywhere)", () => {
+    // An agent with no deployment records at all is not represented here, and an
+    // agent whose only deployment is non-active must not be hidden either.
+    const deployments = [dep("never-deployed", "dev", "stopped")];
+    expect(hiddenAgentIdsForEnv(deployments, "prod").has("never-deployed")).toBe(false);
+    expect(hiddenAgentIdsForEnv([], "prod").size).toBe(0);
+  });
+
+  it("does NOT hide an agent active in the selected env", () => {
+    const deployments = [dep("here", "prod")];
+    expect(hiddenAgentIdsForEnv(deployments, "prod").has("here")).toBe(false);
+  });
+
+  it("HIDES an agent active only in the other env", () => {
+    const deployments = [dep("dev-only", "dev")];
+    const hiddenInProd = hiddenAgentIdsForEnv(deployments, "prod");
+    expect(hiddenInProd.has("dev-only")).toBe(true);
+    // ...but it is visible in its own env.
+    expect(hiddenAgentIdsForEnv(deployments, "dev").has("dev-only")).toBe(false);
+  });
+
+  it("does NOT hide an agent active in both envs", () => {
+    const deployments = [dep("both", "prod"), dep("both", "dev")];
+    expect(hiddenAgentIdsForEnv(deployments, "prod").has("both")).toBe(false);
+    expect(hiddenAgentIdsForEnv(deployments, "dev").has("both")).toBe(false);
+  });
+
+  it("a non-active other-env deployment does NOT hide the agent", () => {
+    // superseded/stopped deployments in the other env are not live, so they
+    // neither place the agent in that env nor hide it from this one.
+    const deployments = [dep("stale", "dev", "superseded"), dep("stale", "dev", "stopped")];
+    expect(hiddenAgentIdsForEnv(deployments, "prod").has("stale")).toBe(false);
+  });
+});
+

--- a/apps/ui/src/state/env.ts
+++ b/apps/ui/src/state/env.ts
@@ -1,0 +1,32 @@
+import type { DeploymentOut, Environment } from "../api/client";
+
+// Client-side env scoping: the agent_ids that have an ACTIVE deployment in the
+// given environment. A deployment only counts when it is live (status "active")
+// — superseded/stopped deployments do not place an agent in an environment.
+export function agentIdsForEnv(deployments: DeploymentOut[], env: Environment): Set<string> {
+  const ids = new Set<string>();
+  for (const d of deployments) {
+    if (d.status === "active" && d.environment === env) ids.add(d.agent_id);
+  }
+  return ids;
+}
+
+// Client-side env visibility: the agent_ids that should be HIDDEN in `env`
+// because they are deployed EXCLUSIVELY to the other env(s). An agent is hidden
+// only when it has >=1 ACTIVE deployment but NONE active in `env`. Agents with
+// no active deployments anywhere (e.g. just created, never deployed) are never
+// hidden — they remain visible in every environment.
+export function hiddenAgentIdsForEnv(deployments: DeploymentOut[], env: Environment): Set<string> {
+  const activeAnywhere = new Set<string>();
+  const activeHere = new Set<string>();
+  for (const d of deployments) {
+    if (d.status !== "active") continue;
+    activeAnywhere.add(d.agent_id);
+    if (d.environment === env) activeHere.add(d.agent_id);
+  }
+  const hidden = new Set<string>();
+  for (const id of activeAnywhere) {
+    if (!activeHere.has(id)) hidden.add(id);
+  }
+  return hidden;
+}

--- a/apps/ui/src/state/store.tsx
+++ b/apps/ui/src/state/store.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import type { Action, AppState, FixtureLevel } from "./types";
+import { isWired } from "../api/config";
 
 const max = (a: FixtureLevel, b: FixtureLevel): FixtureLevel =>
   (a > b ? a : b) as FixtureLevel;
@@ -241,16 +242,19 @@ export function StoreProvider({
     return () => clearTimeout(id);
   }, [state.toast]);
 
-  const value = useMemo<Store>(
-    () => ({
+  const value = useMemo<Store>(() => {
+    // Environments are real in wired mode; in the fixture demo they unlock at
+    // level 4 (GitHub connected). Keep the reducer's env clamp untouched — this
+    // is only the derived enablement the chrome reads.
+    const envAvailable = isWired() || state.level >= 4;
+    return {
       state,
       dispatch,
       slackOn: state.level >= 2,
-      ghOn: state.level >= 4,
-      envDev: state.level >= 4 && state.env === "dev",
-    }),
-    [state],
-  );
+      ghOn: envAvailable,
+      envDev: envAvailable && state.env === "dev",
+    };
+  }, [state]);
 
   return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>;
 }

--- a/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useEffect } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WiredAgentDetail } from "./WiredAgentDetail";
+import { StoreProvider, useStore } from "../../state/store";
+import { WiredProvider } from "../../state/wired";
+import {
+  getAgents,
+  listVersions,
+  listDeployments,
+  getVersionFiles,
+  createDeployment,
+} from "../../api/client";
+import type { AgentOut, VersionOut, DeploymentOut } from "../../api/client";
+
+// Wire the account on so WiredProvider fetches agents and the detail surface renders.
+vi.mock("../../api/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/config")>();
+  return { ...actual, isWired: vi.fn(() => true) };
+});
+
+// Mock only the network functions; keep ApiError / BundleValidationError real so
+// the component's instanceof checks behave.
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    getAgents: vi.fn(),
+    listVersions: vi.fn(),
+    listDeployments: vi.fn(),
+    getVersionFiles: vi.fn(),
+    createVersion: vi.fn(),
+    uploadBundle: vi.fn(),
+    createDeployment: vi.fn(),
+  };
+});
+
+const AGENT: AgentOut = { id: "a1", name: "deal-desk", slack_channel: "#revenue-ops", created_at: "2026-07-01T00:00:00Z" };
+
+const version = (id: string, label: string): VersionOut => ({
+  id,
+  agent_id: "a1",
+  version_label: label,
+  bundle_ref: "ref",
+  bundle_sha256: "sha",
+  created_by: "ui",
+  created_at: "2026-07-01T00:00:00Z",
+});
+
+const deployment = (version_id: string, environment: "prod" | "dev", deployed_at: string): DeploymentOut => ({
+  id: `dep-${version_id}-${environment}`,
+  agent_id: "a1",
+  version_id,
+  environment,
+  bot_identity: null,
+  commit_sha: null,
+  status: "active",
+  deployed_at,
+});
+
+// v1 is the prod-active version (what the editor loads); v2 is the dev-active
+// version — the one promote-to-prod must ship.
+const VERSIONS = [version("v1", "v0.1.0"), version("v2", "v0.2.0")];
+const DEPLOYMENTS = [
+  deployment("v1", "prod", "2026-07-05T00:00:00Z"),
+  deployment("v2", "dev", "2026-07-07T00:00:00Z"),
+];
+const FILES = {
+  files: [{ path: "skills/deal-desk/SKILL.md", content: "---\nname: deal-desk\ndescription: d\n---\nbody" }],
+};
+
+function Harness() {
+  const { state, dispatch } = useStore();
+  useEffect(() => {
+    dispatch({ type: "openAgentDetail", id: "a1" });
+  }, [dispatch]);
+  return state.agentDetail === "a1" ? <WiredAgentDetail /> : null;
+}
+
+function renderDetail() {
+  return render(
+    <StoreProvider level={1}>
+      <WiredProvider>
+        <Harness />
+      </WiredProvider>
+    </StoreProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(getAgents).mockResolvedValue([AGENT]);
+  vi.mocked(listVersions).mockResolvedValue(VERSIONS);
+  vi.mocked(listDeployments).mockResolvedValue(DEPLOYMENTS);
+  vi.mocked(getVersionFiles).mockResolvedValue(FILES);
+  vi.mocked(createDeployment).mockResolvedValue(deployment("v2", "prod", "2026-07-08T00:00:00Z"));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("WiredAgentDetail promote-to-prod", () => {
+  it("promotes the dev-active version to prod on confirm, then refreshes", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    // The detail body renders once agents + versions + files have loaded.
+    expect(await screen.findByTestId("agent-detail-name")).toHaveTextContent("deal-desk");
+
+    const promote = await screen.findByRole("button", { name: "Promote to prod" });
+    expect(vi.mocked(listDeployments)).toHaveBeenCalledTimes(1);
+
+    await user.click(promote);
+    // Inline confirm (kill-switch pattern): nothing deployed until confirmed.
+    await user.click(await screen.findByRole("button", { name: "Confirm promote" }));
+
+    await waitFor(() => expect(vi.mocked(createDeployment)).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(createDeployment)).toHaveBeenCalledWith({
+      agent_id: "a1",
+      version_id: "v2",
+      environment: "prod",
+    });
+
+    // A refresh follows the promote (re-fetch versions + deployments).
+    await waitFor(() => expect(vi.mocked(listDeployments).mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it("deploys nothing when the promote confirm is cancelled", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    const promote = await screen.findByRole("button", { name: "Promote to prod" });
+    await user.click(promote);
+    await user.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    expect(vi.mocked(createDeployment)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/views/wired/WiredAgentDetail.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.tsx
@@ -46,8 +46,22 @@ export function WiredAgentDetail() {
   const [deployError, setDeployError] = useState<string | null>(null);
   const [issues, setIssues] = useState<BundleIssue[]>([]);
   const [deployedLabel, setDeployedLabel] = useState<string | null>(null);
+  const [confirmingPromote, setConfirmingPromote] = useState(false);
+  const [promoting, setPromoting] = useState(false);
+  const [promoteError, setPromoteError] = useState<string | null>(null);
 
   const skillFiles = useMemo(() => (files.files ?? []).filter((f) => isSkillFile(f.path)), [files.files]);
+
+  // The version currently active in dev — the one promote-to-prod ships. Newest
+  // active dev deployment whose version still exists; null when there is nothing
+  // in dev to promote (the button is then hidden).
+  const devActiveVersionId = useMemo(() => {
+    const dev = versions.deployments
+      .filter((d) => d.status === "active" && d.environment === "dev")
+      .sort((a, b) => b.deployed_at.localeCompare(a.deployed_at))
+      .find((d) => versions.versions.some((v) => v.id === d.version_id));
+    return dev?.version_id ?? null;
+  }, [versions.deployments, versions.versions]);
 
   useEffect(() => {
     // Reseed the editor whenever a new version's files arrive.
@@ -81,7 +95,7 @@ export function WiredAgentDetail() {
       const version = await createVersion(agentId, { version_label: label, created_by: "ui" });
       const archive = await buildBundleZipFromFiles(agent.name, merged);
       await uploadBundle(agentId, version.id, archive);
-      await createDeployment({ agent_id: agentId, version_id: version.id, environment: "prod" });
+      await createDeployment({ agent_id: agentId, version_id: version.id, environment: state.env });
       setDeployedLabel(label);
       dispatch({ type: "toast", message: `Deployed ${label}` });
       versions.reload(); // refetch versions + deployments -> active version flips to the new one
@@ -93,6 +107,25 @@ export function WiredAgentDetail() {
       }
     } finally {
       setDeploying(false);
+    }
+  };
+
+  // Promote the dev-active version to prod: a single createDeployment (prod gets
+  // the server-default active status — no gitflow bot_identity plumbing here),
+  // then refresh so the Versions/active state reflects the new prod deployment.
+  const promote = async () => {
+    if (!agentId || promoting || !devActiveVersionId) return;
+    setPromoting(true);
+    setPromoteError(null);
+    try {
+      await createDeployment({ agent_id: agentId, version_id: devActiveVersionId, environment: "prod" });
+      dispatch({ type: "toast", message: "Promoted dev → prod" });
+      setConfirmingPromote(false);
+      versions.reload();
+    } catch (e) {
+      setPromoteError(e instanceof ApiError ? e.message : e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoting(false);
     }
   };
 
@@ -130,6 +163,29 @@ export function WiredAgentDetail() {
         ) : null}
         <span style={{ marginLeft: "auto", fontSize: 12.5, color: C.muted, fontFamily: C.mono }}>{agent.slack_channel}</span>
       </div>
+
+      {devActiveVersionId ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 16 }}>
+          {confirmingPromote ? (
+            <>
+              <span style={{ fontSize: 12.5, color: C.text2, fontFamily: C.mono }}>Promote the dev-active version to prod?</span>
+              <Button label="Cancel" variant="ghost" size="sm" onClick={() => setConfirmingPromote(false)} />
+              {promoting ? (
+                <Button label="Promoting…" variant="primary" size="sm" disabled />
+              ) : (
+                <Button label="Confirm promote" variant="primary" size="sm" onClick={() => void promote()} />
+              )}
+            </>
+          ) : (
+            <Button label="Promote to prod" size="sm" onClick={() => setConfirmingPromote(true)} />
+          )}
+          {promoteError ? (
+            <span data-testid="promote-error" style={{ fontSize: 12, color: C.destructive, fontFamily: C.mono }}>
+              Promote failed: {promoteError}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
 
       {versions.loading ? (
         <Notice>Loading versions…</Notice>

--- a/apps/ui/src/views/wired/WiredAgents.tsx
+++ b/apps/ui/src/views/wired/WiredAgents.tsx
@@ -3,6 +3,8 @@ import { C } from "../../tokens";
 import { Card, SectionTitle, Button, Dot, EmptyState } from "../../primitives";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
+import { useAllDeployments } from "../../api/hooks";
+import { hiddenAgentIdsForEnv } from "../../state/env";
 import { deleteAgent } from "../../api/client";
 
 function Notice({ children }: { children: string }) {
@@ -10,8 +12,9 @@ function Notice({ children }: { children: string }) {
 }
 
 export function WiredAgents() {
-  const { dispatch } = useStore();
-  const { agents, loading, error, refetch } = useWired();
+  const { state, dispatch } = useStore();
+  const { agents, loading, error, refetch, wired } = useWired();
+  const deps = useAllDeployments(wired);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   async function onDelete(id: string, name: string) {
@@ -32,6 +35,13 @@ export function WiredAgents() {
 
   if (loading) return <Notice>Loading agents…</Notice>;
   if (error) return <Notice>{`Could not load agents: ${error}`}</Notice>;
+
+  // Env-gating is best-effort: hide agents deployed exclusively to the other
+  // env, but never gate (and never error the view out) while deployments are
+  // still loading or the fetch failed — show the full list instead.
+  const gate = deps.data && !deps.error;
+  const hiddenIds = gate ? hiddenAgentIdsForEnv(deps.data ?? [], state.env) : new Set<string>();
+  const shown = agents.filter((a) => !hiddenIds.has(a.id));
 
   if (agents.length === 0) {
     return (
@@ -58,8 +68,11 @@ export function WiredAgents() {
           <Button label="New agent" variant="primary" icon="+" onClick={() => dispatch({ type: "openModal", modal: "new-agent" })} />
         </div>
       </div>
+      {shown.length === 0 ? (
+        <Notice>{`No agents deployed to ${state.env} yet.`}</Notice>
+      ) : (
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(320px,1fr))", gap: 16 }}>
-        {agents.map((a) => (
+        {shown.map((a) => (
           <Card key={a.id}>
             <div style={{ display: "flex", alignItems: "center", gap: 9, marginBottom: 12 }}>
               <Dot color={C.brand} size={9} />
@@ -143,6 +156,7 @@ export function WiredAgents() {
           </Card>
         ))}
       </div>
+      )}
     </div>
   );
 }

--- a/apps/ui/src/views/wired/WiredOverview.tsx
+++ b/apps/ui/src/views/wired/WiredOverview.tsx
@@ -5,7 +5,8 @@ import { hoverBg } from "../../lib/style";
 import { formatLatency } from "../../lib/format";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
-import { useMetricsSummary, useTraces } from "../../api/hooks";
+import { useMetricsSummary, useTraces, useAllDeployments } from "../../api/hooks";
+import { hiddenAgentIdsForEnv } from "../../state/env";
 import { ConnectSlackPanel } from "../../components/ConnectSlackPanel";
 import type { AgentOut, RawTrace } from "../../api/client";
 
@@ -90,10 +91,16 @@ function traceMsg(t: RawTrace): string {
 }
 
 function LiveOverview({ agents }: { agents: AgentOut[] }) {
-  const { dispatch } = useStore();
-  const { justDeployed } = useWired();
-  const summary = useMetricsSummary(true, {});
+  const { state, dispatch } = useStore();
+  const { justDeployed, wired } = useWired();
+  const summary = useMetricsSummary(true, { environment: state.env });
   const traces = useTraces(true);
+  const deps = useAllDeployments(wired);
+  // Agents visible in the selected environment: hide only those deployed
+  // exclusively to the other env (undeployed agents stay visible). Fall back to
+  // the full list until deployments load so the count does not flash to zero.
+  const hiddenIds = deps.data ? hiddenAgentIdsForEnv(deps.data, state.env) : new Set<string>();
+  const scoped = deps.data ? agents.filter((a) => !hiddenIds.has(a.id)) : agents;
 
   const stat = (label: string, value: string) => (
     <Card key={label} style={{ padding: "16px 18px" }}>
@@ -107,7 +114,7 @@ function LiveOverview({ agents }: { agents: AgentOut[] }) {
   const metric = (fmt: (d: NonNullable<typeof s>) => string): string =>
     s ? fmt(s) : summary.loading ? "…" : "—";
   const stats: [string, string][] = [
-    ["Agents", String(agents.length)],
+    ["Agents", String(scoped.length)],
     ["Runs (7d)", metric((d) => String(d.runs))],
     ["Latency p95", metric((d) => formatLatency(d.latency_p95_seconds))],
     ["Cost (7d)", metric((d) => "$" + d.cost_usd.toFixed(2))],
@@ -117,7 +124,7 @@ function LiveOverview({ agents }: { agents: AgentOut[] }) {
   return (
     <div>
       {justDeployed ? <DeployedPanel name={justDeployed.name} channel={justDeployed.channel} /> : null}
-      <SectionTitle title="Overview" sub={`${agents.length} ${agents.length === 1 ? "agent" : "agents"} · live data`} />
+      <SectionTitle title="Overview" sub={`${scoped.length} ${scoped.length === 1 ? "agent" : "agents"} · ${state.env} · live data`} />
       <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 14, marginBottom: 22 }}>
         {stats.map((x) => stat(x[0], x[1]))}
       </div>
@@ -164,7 +171,7 @@ function LiveOverview({ agents }: { agents: AgentOut[] }) {
         </Card>
         <Card>
           <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 14 }}>Agents</div>
-          {agents.map((a, i) => (
+          {scoped.map((a, i) => (
             <button
               key={a.id}
               type="button"

--- a/apps/ui/src/views/wired/WiredVersions.tsx
+++ b/apps/ui/src/views/wired/WiredVersions.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { C } from "../../tokens";
 import { Card, SectionTitle, Chip, Dot } from "../../primitives";
+import { useStore } from "../../state/store";
 import { useAgents, useAgentVersions } from "../../api/hooks";
 import { ComingSoon } from "./WiredStubs";
 import type { DeploymentOut, VersionOut } from "../../api/client";
@@ -40,6 +41,7 @@ function statusColor(status: string | null): string {
 // selector, matching the Cost view. Falls back to ComingSoon when the API is
 // unreachable (there is no fixture leak in wired mode).
 function VersionsTable({ agentId }: { agentId: string }) {
+  const { state } = useStore();
   const { versions, deployments, activeVersionId, loading, error } = useAgentVersions(agentId);
 
   if (error) {
@@ -60,7 +62,9 @@ function VersionsTable({ agentId }: { agentId: string }) {
     );
   }
 
-  const rows = buildRows(versions, deployments);
+  // Only deployments in the selected environment; the env chip still renders.
+  const scopedDeployments = deployments.filter((d) => d.environment === state.env);
+  const rows = buildRows(versions, scopedDeployments);
   const grid = "1.1fr 0.9fr 1fr 1.3fr 1fr";
   return (
     <Card>


### PR DESCRIPTION
Closes #6.

The env model already exists (deployments carry `dev|prod`; the metrics endpoint takes an `environment` filter; the CLI has `--env`). But the wired UI showed a single undifferentiated view and the DEV/PROD pill was gated behind the *fixture* level, so it did nothing on a real install. This wires it up — entirely client-side, no backend change.

## Switcher
The env state, `setEnv` action, and Topbar pill already existed. The only reason the pill was dead in wired mode is the derived `ghOn = state.level >= 4` (a fixture concept). Changed to `isWired() || state.level >= 4`, so the switcher is live in wired mode. The reducer `setEnv` and the `levelReset` env-clamp are **untouched**, so fixture behavior (and its tests) are unchanged.

## Env scoping (client-side)
Deployments already carry `environment`, so scoping is a client-side filter:
- **Agents / Overview**: hide agents deployed *exclusively* to the other env. Agents with no deployment yet (e.g. just created) stay visible in every env, and gating is best-effort — the full list shows while `/deployments` is loading or errors, so the view never blanks on a deployments hiccup. Pure helpers `agentIdsForEnv` / `hiddenAgentIdsForEnv` (unit-tested).
- **Versions**: filters its deployment rows to the selected env.
- **Metrics summary**: passes `{ environment: state.env }` (existing server param).
- **Traces & per-agent cost**: left agent-scoped — they have **no** server-side env dimension, so env-filtering them would be faked. Called out deliberately rather than pretending.

## Promote-to-prod
There is no REST promote endpoint (promote lives in the git webhook path). The UI replicates its exact semantics: on an agent with a dev-active version, a confirmed "Promote to prod" creates a **new prod deployment of that same version** via the existing `POST /deployments` — reusing the dev-built bundle, no rebuild. Deploying a new version now targets the selected env. (This produces a `status:"active"` prod deployment rather than git-flow's `"promoted"`/`bot_identity` labeling; the worker resolves the bot by env, so that's acceptable — flagged here for transparency.)

## Tests
- `state/env.test.ts` — the two pure env helpers (active-only; undeployed never hidden; other-env-exclusive hidden; dual-env visible).
- `components/Topbar.test.tsx` — switcher enabled + dispatches in wired mode; still disabled below fixture level 4 in fixture mode.
- `views/wired/WiredAgentDetail.test.tsx` — promote calls `createDeployment` once with `{version_id: <dev-active>, environment:"prod"}` and refreshes; Cancel deploys nothing.
- `pnpm test` (66), `typecheck`, `lint --max-warnings 0` all clean.

## Scope
UI-only — no `apps/api`, `cli`, chart, or toolchain/config changes. The existing stackless e2e specs are unchanged; I reasoned through `delete-agent`, `cold-start` (create), `agent-detail`, and `observability` and each still renders its agent card under the best-effort gate (I couldn't execute Playwright in my environment, so that reconciliation is by code reasoning, not a run — worth a CI check).