### PR TITLE
UI: adopt react-query for data hooks + extract shared Notice component

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -14,9 +14,10 @@
     "e2e": "playwright test"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.101.2",
+    "jszip": "^3.10.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "jszip": "^3.10.1"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@18.3.1)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -546,6 +549,14 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/react-query@5.101.2':
+    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1989,6 +2000,13 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/react-query@5.101.2(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      react: 18.3.1
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/apps/ui/src/api/hooks.rq.test.tsx
+++ b/apps/ui/src/api/hooks.rq.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { createElement } from "react";
+import { useTrace, useVersionFiles } from "./hooks";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// A fresh client per test with retry off, mirroring main.tsx, so error/404
+// sentinels resolve on the first response instead of being retried.
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client }, children);
+}
+
+describe("useTrace (react-query)", () => {
+  it("maps a 404 to notFound=true with error===null (not an error)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse(404, { detail: "trace has no observations yet" })),
+    );
+    const { result } = renderHook(() => useTrace("t1"), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.notFound).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toBeNull();
+  });
+
+  it("returns the trace tree on a 200", async () => {
+    const tree = { trace: { id: "t1" }, tree: [] };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, tree)));
+    const { result } = renderHook(() => useTrace("t1"), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.notFound).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toEqual(tree);
+  });
+});
+
+describe("useVersionFiles (react-query)", () => {
+  it("maps a 404 to noBundle=true with error===null (not an error)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse(404, { detail: "no bundle stored for this version" })),
+    );
+    const { result } = renderHook(() => useVersionFiles("a1", "v9"), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.noBundle).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.files).toBeNull();
+  });
+
+  it("returns the bundle files on a 200", async () => {
+    const files = [{ path: "skills/x/SKILL.md", content: "body" }];
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, { files })));
+    const { result } = renderHook(() => useVersionFiles("a1", "v1"), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.noBundle).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.files).toEqual(files);
+  });
+});

--- a/apps/ui/src/api/hooks.ts
+++ b/apps/ui/src/api/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
   getTrace,
   listTraces,
@@ -30,42 +30,44 @@ interface Async<T> {
   error: string | null;
 }
 
+// Shared mapping from a react-query result to the legacy Async<T> shape.
+// `gate` is the hook's enable predicate: loading must read false whenever the
+// hook is gated off, matching the pre-react-query hooks (which seeded
+// `loading: enabled` / `loading: !!id` and never flipped it on while disabled).
+// react-query keeps status "pending" for a disabled query, so we AND it with
+// the gate rather than surfacing isPending directly. Errors keep the exact
+// `String(e)` stringification the old catch handlers used, and data defaults to
+// null (never undefined).
+function asyncFrom<T>(
+  gate: boolean,
+  query: { data: T | undefined; error: unknown; isPending: boolean; isFetching: boolean },
+): Async<T> {
+  return {
+    data: query.data ?? null,
+    loading: gate && (query.isPending || query.isFetching),
+    error: query.error ? String(query.error) : null,
+  };
+}
+
 // Fetch the real Langfuse trace list through the API proxy. Used only in wired
 // mode; the fixture Traces list is rendered otherwise.
 export function useTraces(enabled: boolean, agentId?: string | null): Async<RawTrace[]> {
-  const [state, setState] = useState<Async<RawTrace[]>>({ data: null, loading: enabled, error: null });
-  useEffect(() => {
-    if (!enabled) return;
-    let live = true;
-    setState({ data: null, loading: true, error: null });
-    listTraces(20, agentId ?? undefined)
-      .then((data) => live && setState({ data, loading: false, error: null }))
-      .catch((e: unknown) => live && setState({ data: null, loading: false, error: String(e) }));
-    return () => {
-      live = false;
-    };
-  }, [enabled, agentId]);
-  return state;
+  const query = useQuery({
+    queryKey: ["traces", agentId ?? null],
+    enabled,
+    queryFn: () => listTraces(20, agentId ?? undefined),
+  });
+  return asyncFrom(enabled, query);
 }
 
 // Fetch the metrics summary (scalar stat row) for the filter.
 export function useMetricsSummary(enabled: boolean, filter: MetricFilter): Async<MetricsSummary> {
-  const [state, setState] = useState<Async<MetricsSummary>>({ data: null, loading: enabled, error: null });
-  const key = JSON.stringify(filter);
-  useEffect(() => {
-    if (!enabled) return;
-    let live = true;
-    setState({ data: null, loading: true, error: null });
-    getMetricsSummary(filter)
-      .then((data) => live && setState({ data, loading: false, error: null }))
-      .catch((e: unknown) => live && setState({ data: null, loading: false, error: String(e) }));
-    return () => {
-      live = false;
-    };
-    // filter is captured by value via its JSON key.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, key]);
-  return state;
+  const query = useQuery({
+    queryKey: ["metricsSummary", filter],
+    enabled,
+    queryFn: () => getMetricsSummary(filter),
+  });
+  return asyncFrom(enabled, query);
 }
 
 // Fetch one metric as a time series for the chart.
@@ -75,55 +77,32 @@ export function useMetricSeries(
   granularity: Granularity,
   filter: MetricFilter,
 ): Async<MetricSeries> {
-  const [state, setState] = useState<Async<MetricSeries>>({ data: null, loading: enabled, error: null });
-  const key = JSON.stringify(filter);
-  useEffect(() => {
-    if (!enabled) return;
-    let live = true;
-    setState({ data: null, loading: true, error: null });
-    getMetricSeries(metric, granularity, filter)
-      .then((data) => live && setState({ data, loading: false, error: null }))
-      .catch((e: unknown) => live && setState({ data: null, loading: false, error: String(e) }));
-    return () => {
-      live = false;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, metric, granularity, key]);
-  return state;
+  const query = useQuery({
+    queryKey: ["metricSeries", metric, granularity, filter],
+    enabled,
+    queryFn: () => getMetricSeries(metric, granularity, filter),
+  });
+  return asyncFrom(enabled, query);
 }
 
 // Fetch the agent list (for the Cost view's agent selector).
 export function useAgents(enabled: boolean): Async<AgentOut[]> {
-  const [state, setState] = useState<Async<AgentOut[]>>({ data: null, loading: enabled, error: null });
-  useEffect(() => {
-    if (!enabled) return;
-    let live = true;
-    setState({ data: null, loading: true, error: null });
-    getAgents()
-      .then((data) => live && setState({ data, loading: false, error: null }))
-      .catch((e: unknown) => live && setState({ data: null, loading: false, error: String(e) }));
-    return () => {
-      live = false;
-    };
-  }, [enabled]);
-  return state;
+  const query = useQuery({
+    queryKey: ["agents"],
+    enabled,
+    queryFn: () => getAgents(),
+  });
+  return asyncFrom(enabled, query);
 }
 
 // Fetch the per-agent cost report (total + daily points).
 export function useCost(agentId: string | null): Async<CostReport> {
-  const [state, setState] = useState<Async<CostReport>>({ data: null, loading: !!agentId, error: null });
-  useEffect(() => {
-    if (!agentId) return;
-    let live = true;
-    setState({ data: null, loading: true, error: null });
-    getCost(agentId)
-      .then((data) => live && setState({ data, loading: false, error: null }))
-      .catch((e: unknown) => live && setState({ data: null, loading: false, error: String(e) }));
-    return () => {
-      live = false;
-    };
-  }, [agentId]);
-  return state;
+  const query = useQuery({
+    queryKey: ["cost", agentId],
+    enabled: !!agentId,
+    queryFn: () => getCost(agentId!),
+  });
+  return asyncFrom(!!agentId, query);
 }
 
 interface TraceAsync extends Async<TraceTree> {
@@ -135,26 +114,28 @@ interface TraceAsync extends Async<TraceTree> {
 
 // Fetch a single reconstructed trace tree by id.
 export function useTrace(traceId: string | null): TraceAsync {
-  const [state, setState] = useState<TraceAsync>({ data: null, loading: !!traceId, error: null, notFound: false });
-  useEffect(() => {
-    if (!traceId) return;
-    let live = true;
-    setState({ data: null, loading: true, error: null, notFound: false });
-    getTrace(traceId)
-      .then((data) => live && setState({ data, loading: false, error: null, notFound: false }))
-      .catch((e: unknown) => {
-        if (!live) return;
-        if (e instanceof ApiError && e.status === 404) {
-          setState({ data: null, loading: false, error: null, notFound: true });
-        } else {
-          setState({ data: null, loading: false, error: String(e), notFound: false });
-        }
-      });
-    return () => {
-      live = false;
-    };
-  }, [traceId]);
-  return state;
+  const gate = !!traceId;
+  // A 404 is resolved (not thrown) into a sentinel so it surfaces as
+  // notFound=true with error===null, exactly as the old catch handler did.
+  const query = useQuery({
+    queryKey: ["trace", traceId],
+    enabled: gate,
+    queryFn: async (): Promise<{ data: TraceTree | null; notFound: boolean }> => {
+      try {
+        const data = await getTrace(traceId!);
+        return { data, notFound: false };
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 404) return { data: null, notFound: true };
+        throw e;
+      }
+    },
+  });
+  return {
+    data: query.data?.data ?? null,
+    loading: gate && (query.isPending || query.isFetching),
+    error: query.error ? String(query.error) : null,
+    notFound: query.data?.notFound ?? false,
+  };
 }
 
 // ---- FX2: agent detail — versions + active version + bundle files ----
@@ -189,37 +170,32 @@ export function pickActiveVersion(versions: VersionOut[], deployments: Deploymen
 }
 
 export function useAgentVersions(agentId: string | null): AgentVersionsData {
-  const [versions, setVersions] = useState<VersionOut[]>([]);
-  const [deployments, setDeployments] = useState<DeploymentOut[]>([]);
-  const [loading, setLoading] = useState(!!agentId);
-  const [error, setError] = useState<string | null>(null);
-  const [reloadKey, setReloadKey] = useState(0);
-  const reload = () => setReloadKey((n) => n + 1);
-
-  useEffect(() => {
-    if (!agentId) return;
-    let live = true;
-    setLoading(true);
-    setError(null);
-    Promise.all([listVersions(agentId), listDeployments(agentId)])
-      .then(([vs, ds]) => {
-        if (!live) return;
-        setVersions(vs);
-        setDeployments(ds);
-        setLoading(false);
-      })
-      .catch((e: unknown) => {
-        if (!live) return;
-        setError(String(e));
-        setLoading(false);
-      });
-    return () => {
-      live = false;
-    };
-  }, [agentId, reloadKey]);
-
+  const gate = !!agentId;
+  // Keep the two-call Promise.all semantics in a single query so both lists
+  // resolve together; reload() maps to refetch(), which re-runs the pair while
+  // the previously fetched lists stay visible (loading flips true via isFetching
+  // during the refetch, as it did when the old reloadKey re-ran the effect).
+  const query = useQuery({
+    queryKey: ["agentVersions", agentId],
+    enabled: gate,
+    queryFn: async () => {
+      const [versions, deployments] = await Promise.all([listVersions(agentId!), listDeployments(agentId!)]);
+      return { versions, deployments };
+    },
+  });
+  const versions = query.data?.versions ?? [];
+  const deployments = query.data?.deployments ?? [];
   const activeVersionId = pickActiveVersion(versions, deployments);
-  return { versions, deployments, activeVersionId, loading, error, reload };
+  return {
+    versions,
+    deployments,
+    activeVersionId,
+    loading: gate && (query.isPending || query.isFetching),
+    error: query.error ? String(query.error) : null,
+    reload: () => {
+      void query.refetch();
+    },
+  };
 }
 
 export interface VersionFilesData {
@@ -231,29 +207,27 @@ export interface VersionFilesData {
 }
 
 export function useVersionFiles(agentId: string | null, versionId: string | null, reloadKey = 0): VersionFilesData {
-  const [state, setState] = useState<VersionFilesData>({
-    files: null,
-    loading: !!(agentId && versionId),
-    error: null,
-    noBundle: false,
+  const gate = !!(agentId && versionId);
+  // reloadKey is folded into the queryKey so bumping it re-runs the fetch, the
+  // same way it was an effect dependency before. A 404 resolves to a sentinel
+  // (noBundle=true, error===null) instead of throwing.
+  const query = useQuery({
+    queryKey: ["versionFiles", agentId, versionId, reloadKey],
+    enabled: gate,
+    queryFn: async (): Promise<{ files: BundleFile[] | null; noBundle: boolean }> => {
+      try {
+        const data = await getVersionFiles(agentId!, versionId!);
+        return { files: data.files, noBundle: false };
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 404) return { files: null, noBundle: true };
+        throw e;
+      }
+    },
   });
-  useEffect(() => {
-    if (!agentId || !versionId) return;
-    let live = true;
-    setState({ files: null, loading: true, error: null, noBundle: false });
-    getVersionFiles(agentId, versionId)
-      .then((data) => live && setState({ files: data.files, loading: false, error: null, noBundle: false }))
-      .catch((e: unknown) => {
-        if (!live) return;
-        if (e instanceof ApiError && e.status === 404) {
-          setState({ files: null, loading: false, error: null, noBundle: true });
-        } else {
-          setState({ files: null, loading: false, error: String(e), noBundle: false });
-        }
-      });
-    return () => {
-      live = false;
-    };
-  }, [agentId, versionId, reloadKey]);
-  return state;
+  return {
+    files: query.data?.files ?? null,
+    loading: gate && (query.isPending || query.isFetching),
+    error: query.error ? String(query.error) : null,
+    noBundle: query.data?.noBundle ?? false,
+  };
 }

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -1,16 +1,25 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./styles.css";
 import { App } from "./App";
 import { StoreProvider } from "./state/store";
 import { WiredProvider } from "./state/wired";
 
+// retry off so error / notFound / noBundle states surface on the first response
+// (deterministic, matching the pre-react-query hooks); no refetch-on-focus.
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+});
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <StoreProvider>
-      <WiredProvider>
-        <App />
-      </WiredProvider>
-    </StoreProvider>
+    <QueryClientProvider client={queryClient}>
+      <StoreProvider>
+        <WiredProvider>
+          <App />
+        </WiredProvider>
+      </StoreProvider>
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/ui/src/primitives/Notice.tsx
+++ b/apps/ui/src/primitives/Notice.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import { C } from "../tokens";
+
+// Centered muted one-liner for inline loading/empty/error states inside a card
+// or view. Padding and font size default to the common treatment; the two
+// outlier call sites (a taller drill-in, a roomier traces list) override them.
+export function Notice({
+  children,
+  padding = "30px 20px",
+  fontSize = 13,
+}: {
+  children: ReactNode;
+  padding?: string;
+  fontSize?: number;
+}) {
+  return <div style={{ padding, textAlign: "center", color: C.muted, fontSize }}>{children}</div>;
+}

--- a/apps/ui/src/primitives/index.ts
+++ b/apps/ui/src/primitives/index.ts
@@ -6,6 +6,7 @@ export { Card } from "./Card";
 export { CopyButton } from "./CopyButton";
 export { SectionTitle } from "./SectionTitle";
 export { EmptyState } from "./EmptyState";
+export { Notice } from "./Notice";
 export { Sparkline, AreaChart } from "./Charts";
 export { Tabs } from "./Tabs";
 export { Modal } from "./Modal";

--- a/apps/ui/src/views/obs/RealCost.tsx
+++ b/apps/ui/src/views/obs/RealCost.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { C } from "../../tokens";
-import { Card, Button, AreaChart, Chip } from "../../primitives";
+import { Card, Button, AreaChart, Chip, Notice } from "../../primitives";
 import { useAgents, useCost } from "../../api/hooks";
 import {
   getBudget,
@@ -11,10 +11,6 @@ import {
   ApiError,
   type BudgetConfig,
 } from "../../api/client";
-
-function Notice({ children }: { children: ReactNode }) {
-  return <div style={{ padding: "30px 20px", textAlign: "center", color: C.muted, fontSize: 13 }}>{children}</div>;
-}
 
 const numInput = {
   width: 160,

--- a/apps/ui/src/views/obs/RealMetrics.tsx
+++ b/apps/ui/src/views/obs/RealMetrics.tsx
@@ -1,6 +1,6 @@
-import { useState, type ReactNode } from "react";
+import { useState } from "react";
 import { C } from "../../tokens";
-import { Card, Chip, AreaChart } from "../../primitives";
+import { Card, Chip, AreaChart, Notice } from "../../primitives";
 import { useStore } from "../../state/store";
 import { useMetricsSummary, useMetricSeries } from "../../api/hooks";
 import { formatLatency } from "../../lib/format";
@@ -33,10 +33,6 @@ function fmt(key: MetricKey, v: number): string {
 
 function summaryValue(s: MetricsSummary, key: MetricKey): number {
   return s[key];
-}
-
-function Notice({ children }: { children: ReactNode }) {
-  return <div style={{ padding: "30px 20px", textAlign: "center", color: C.muted, fontSize: 13 }}>{children}</div>;
 }
 
 // Wired Metrics tab: the summary stat row + a selectable time-series chart, both

--- a/apps/ui/src/views/obs/RealTraces.tsx
+++ b/apps/ui/src/views/obs/RealTraces.tsx
@@ -1,6 +1,5 @@
-import type { ReactNode } from "react";
 import { C } from "../../tokens";
-import { Card, Chip, Dot, EmptyState } from "../../primitives";
+import { Card, Chip, Dot, EmptyState, Notice } from "../../primitives";
 import { hoverBg } from "../../lib/style";
 import { useStore } from "../../state/store";
 import { useTraces, useTrace } from "../../api/hooks";
@@ -11,12 +10,6 @@ function str(o: RawTrace, key: string): string | null {
   return typeof v === "string" ? v : typeof v === "number" ? String(v) : null;
 }
 
-function Notice({ children }: { children: ReactNode }) {
-  return (
-    <div style={{ padding: "40px 20px", textAlign: "center", color: C.muted, fontSize: 13.5 }}>{children}</div>
-  );
-}
-
 // Live Runs list: real Langfuse traces via the API proxy. Rendered in place of
 // the fixture list when the app is wired to a backend.
 export function RealTracesList() {
@@ -25,12 +18,12 @@ export function RealTracesList() {
   const { data, loading, error } = useTraces(true, agentId);
   const grid = "1.9fr 1.1fr 1fr";
 
-  if (loading) return <Notice>Loading traces…</Notice>;
-  if (error) return <Notice>Could not load traces: {error}</Notice>;
+  if (loading) return <Notice padding="40px 20px" fontSize={13.5}>Loading traces…</Notice>;
+  if (error) return <Notice padding="40px 20px" fontSize={13.5}>Could not load traces: {error}</Notice>;
   const traces = data ?? [];
   if (traces.length === 0)
     return (
-      <Notice>
+      <Notice padding="40px 20px" fontSize={13.5}>
         {agentId
           ? "No traces for this agent yet. Send it a message to generate one."
           : "No traces yet. Send the agent a message to generate one."}
@@ -213,8 +206,8 @@ export function RealTraceDetail() {
       >
         ← Traces
       </button>
-      {loading ? <Notice>Loading trace…</Notice> : null}
-      {error ? <Notice>Could not load trace: {error}</Notice> : null}
+      {loading ? <Notice padding="40px 20px" fontSize={13.5}>Loading trace…</Notice> : null}
+      {error ? <Notice padding="40px 20px" fontSize={13.5}>Could not load trace: {error}</Notice> : null}
       {notFound ? (
         <EmptyState
           title="No spans recorded for this run yet"

--- a/apps/ui/src/views/wired/WiredAgentDetail.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { C } from "../../tokens";
-import { Button, Card, Chip, Dot } from "../../primitives";
+import { Button, Card, Chip, Dot, Notice } from "../../primitives";
 import { SkillEditor } from "../../components/SkillEditor";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
@@ -15,10 +15,6 @@ import {
   type BundleIssue,
 } from "../../api/client";
 import { buildBundleZipFromFiles, nextVersionLabel } from "../../api/bundle";
-
-function Notice({ children }: { children: ReactNode }) {
-  return <div style={{ padding: "34px 20px", textAlign: "center", color: C.muted, fontSize: 13 }}>{children}</div>;
-}
 
 function isSkillFile(path: string): boolean {
   return path.endsWith("/SKILL.md") || path === "SKILL.md";
@@ -110,7 +106,7 @@ export function WiredAgentDetail() {
     return (
       <div>
         {backLink}
-        <Notice>Agent not found.</Notice>
+        <Notice padding="34px 20px">Agent not found.</Notice>
       </div>
     );
   }
@@ -132,13 +128,13 @@ export function WiredAgentDetail() {
       </div>
 
       {versions.loading ? (
-        <Notice>Loading versions…</Notice>
+        <Notice padding="34px 20px">Loading versions…</Notice>
       ) : versions.error ? (
-        <Notice>{`Could not load versions: ${versions.error}`}</Notice>
+        <Notice padding="34px 20px">{`Could not load versions: ${versions.error}`}</Notice>
       ) : versions.versions.length === 0 ? (
-        <Notice>No versions yet for this agent.</Notice>
+        <Notice padding="34px 20px">No versions yet for this agent.</Notice>
       ) : files.loading ? (
-        <Notice>Loading skills…</Notice>
+        <Notice padding="34px 20px">Loading skills…</Notice>
       ) : files.noBundle ? (
         <Card>
           <div data-testid="agent-detail-nobundle" style={{ padding: "8px 4px", color: C.text2, fontSize: 13.5 }}>
@@ -147,10 +143,10 @@ export function WiredAgentDetail() {
           </div>
         </Card>
       ) : files.error ? (
-        <Notice>{`Could not load skills: ${files.error}`}</Notice>
+        <Notice padding="34px 20px">{`Could not load skills: ${files.error}`}</Notice>
       ) : skillFiles.length === 0 ? (
         <Card>
-          <Notice>This bundle has no skills/*/SKILL.md files.</Notice>
+          <Notice padding="34px 20px">This bundle has no skills/*/SKILL.md files.</Notice>
         </Card>
       ) : (
         <div>

--- a/apps/ui/src/views/wired/WiredAgents.tsx
+++ b/apps/ui/src/views/wired/WiredAgents.tsx
@@ -1,13 +1,9 @@
 import { useState } from "react";
 import { C } from "../../tokens";
-import { Card, SectionTitle, Button, Dot, EmptyState } from "../../primitives";
+import { Card, SectionTitle, Button, Dot, EmptyState, Notice } from "../../primitives";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
 import { deleteAgent } from "../../api/client";
-
-function Notice({ children }: { children: string }) {
-  return <div style={{ padding: "30px 20px", textAlign: "center", color: C.muted, fontSize: 13 }}>{children}</div>;
-}
 
 export function WiredAgents() {
   const { dispatch } = useStore();

--- a/apps/ui/src/views/wired/WiredOverview.tsx
+++ b/apps/ui/src/views/wired/WiredOverview.tsx
@@ -1,6 +1,5 @@
-import type { ReactNode } from "react";
 import { C } from "../../tokens";
-import { Card, SectionTitle, Button, Dot } from "../../primitives";
+import { Card, SectionTitle, Button, Dot, Notice } from "../../primitives";
 import { hoverBg } from "../../lib/style";
 import { formatLatency } from "../../lib/format";
 import { useStore } from "../../state/store";
@@ -8,10 +7,6 @@ import { useWired } from "../../state/wired";
 import { useMetricsSummary, useTraces } from "../../api/hooks";
 import { ConnectSlackPanel } from "../../components/ConnectSlackPanel";
 import type { AgentOut, RawTrace } from "../../api/client";
-
-function Notice({ children }: { children: ReactNode }) {
-  return <div style={{ padding: "30px 20px", textAlign: "center", color: C.muted, fontSize: 13 }}>{children}</div>;
-}
 
 // Honest post-deploy panel: the real next step, not a fictional "replied in 42ms".
 function DeployedPanel({ name, channel }: { name: string; channel: string }) {

--- a/apps/ui/src/views/wired/WiredVersions.tsx
+++ b/apps/ui/src/views/wired/WiredVersions.tsx
@@ -1,13 +1,9 @@
-import { useState, type ReactNode } from "react";
+import { useState } from "react";
 import { C } from "../../tokens";
-import { Card, SectionTitle, Chip, Dot } from "../../primitives";
+import { Card, SectionTitle, Chip, Dot, Notice } from "../../primitives";
 import { useAgents, useAgentVersions } from "../../api/hooks";
 import { ComingSoon } from "./WiredStubs";
 import type { DeploymentOut, VersionOut } from "../../api/client";
-
-function Notice({ children }: { children: ReactNode }) {
-  return <div style={{ padding: "30px 20px", textAlign: "center", color: C.muted, fontSize: 13 }}>{children}</div>;
-}
 
 export interface Row {
   version: VersionOut;


### PR DESCRIPTION
Addresses the **UI portion** of #80 (react-query + duplicated `Notice`). The two CLI dedup items in that batch are out of scope — does not close #80.

Quality refactor, no behavior change:
- 8 hand-rolled `useState`+`useEffect` hooks in `api/hooks.ts` reimplemented with `@tanstack/react-query` (`useQuery`), preserving every hook name/return shape (`Async<T>`, `notFound`, `noBundle`, `reload`) so **consumers need zero edits**. `QueryClientProvider` at the app root (`retry:false`, no refetch-on-focus).
- `Notice` (duplicated in 7 views) promoted to `primitives/Notice.tsx`; two outliers pass props to stay pixel-exact.

Existing suite stays green unmodified (proves the surface didn't drift); new `hooks.rq.test.tsx` pins the 404→`notFound`/`noBundle` paths. 56 tests, typecheck/lint clean.