### PR TITLE
UI: roll back to a prior version from the versions view

### DIFF
--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -406,10 +406,15 @@ export async function getVersionFiles(agentId: string, versionId: string): Promi
   return jsonOrThrow<BundleFiles>(resp);
 }
 
+export type DeploymentStatus = "active" | "inactive";
+
 export interface DeploymentCreate {
   agent_id: string;
   version_id: string;
   environment: Environment;
+  // Optional; the API's DeploymentCreate defaults to "active" server-side. The
+  // rollback path sets it explicitly to redeploy an old version as active.
+  status?: DeploymentStatus;
 }
 
 // Activate a version by creating a deployment for it (status defaults to active

--- a/apps/ui/src/views/wired/WiredVersions.rollback.test.tsx
+++ b/apps/ui/src/views/wired/WiredVersions.rollback.test.tsx
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { createElement } from "react";
+import { WiredVersions } from "./WiredVersions";
+import type { AgentOut, DeploymentOut, VersionOut } from "../../api/client";
+import { createDeployment, getAgents, listDeployments, listVersions } from "../../api/client";
+
+// -----------------------------------------------------------------------------
+// Data-layer seam (see file-tail note): we mock the API *client* and let the
+// real useAgents / useAgentVersions hooks run against the stubbed fetchers, so
+// the component + hook wiring is exercised end to end. `createDeployment` is a
+// spy we assert on directly; `reload()` is observed indirectly — the only thing
+// that re-fetches versions is the hook's reload(), so a second listVersions call
+// after a confirmed rollback proves reload() fired.
+//
+// vi.importActual keeps the real ApiError class (used with `instanceof` inside
+// hooks.ts) and every other export intact; we override only the four calls the
+// versions surface touches.
+// -----------------------------------------------------------------------------
+vi.mock("../../api/client", async (importActual) => {
+  const actual = await importActual<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    getAgents: vi.fn(),
+    listVersions: vi.fn(),
+    listDeployments: vi.fn(),
+    createDeployment: vi.fn(),
+  };
+});
+
+const mkVersion = (id: string, version_label: string, created_at: string): VersionOut => ({
+  id,
+  agent_id: "a1",
+  version_label,
+  bundle_ref: "r",
+  bundle_sha256: "s",
+  created_by: "ui",
+  created_at,
+});
+
+const mkDep = (
+  id: string,
+  version_id: string,
+  environment: "prod" | "dev",
+  deployed_at: string,
+  status = "active",
+): DeploymentOut => ({
+  id,
+  agent_id: "a1",
+  version_id,
+  environment,
+  bot_identity: null,
+  commit_sha: null,
+  status,
+  deployed_at,
+});
+
+const AGENT: AgentOut = {
+  id: "a1",
+  name: "deal-desk",
+  slack_channel: "#revenue-ops",
+  created_at: "2026-06-01T00:00:00Z",
+};
+
+// v2 is the version the agent currently serves; v1 was previously deployed (to
+// dev) and is no longer active. Append-only: v1's deployment record is left as
+// "active" — pickActiveVersion ranks prod-first then newest, so v2 (prod) wins
+// and v1's row is a previously-deployed, non-active row.
+const V_OLD = mkVersion("v1", "v0.1.0", "2026-07-01T00:00:00Z");
+const V_ACTIVE = mkVersion("v2", "v0.1.1", "2026-07-05T00:00:00Z");
+const DEP_OLD = mkDep("dep-old", "v1", "dev", "2026-07-02T00:00:00Z", "active");
+const DEP_ACTIVE = mkDep("dep-active", "v2", "prod", "2026-07-06T00:00:00Z", "active");
+
+const VERSIONS = [V_OLD, V_ACTIVE];
+const DEPLOYMENTS = [DEP_OLD, DEP_ACTIVE];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getAgents).mockResolvedValue([AGENT]);
+  vi.mocked(listVersions).mockResolvedValue(VERSIONS);
+  vi.mocked(listDeployments).mockResolvedValue(DEPLOYMENTS);
+  vi.mocked(createDeployment).mockResolvedValue(
+    mkDep("dep-new", "v1", "dev", "2026-07-08T00:00:00Z", "active"),
+  );
+});
+
+// Find a rendered version-history row by the version label it displays.
+async function rowFor(label: string): Promise<HTMLElement> {
+  const rows = await screen.findAllByTestId("version-row");
+  const row = rows.find((r) => within(r).queryByText(label));
+  if (!row) throw new Error(`no version-row rendering label ${label}`);
+  return row;
+}
+
+const ROLLBACK = /roll ?back/i;
+const CANCEL = /cancel/i;
+
+// A fresh client per render with retry off, mirroring main.tsx, so the wired
+// hooks (now react-query) resolve on the first response instead of retrying.
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: PropsWithChildren) =>
+    createElement(QueryClientProvider, { client }, children);
+}
+
+describe("WiredVersions rollback", () => {
+  it("offers Roll back on a previously-deployed non-active row, not on the active row", async () => {
+    render(<WiredVersions />, { wrapper: wrapper() });
+
+    const oldRow = await rowFor("v0.1.0");
+    const activeRow = await rowFor("v0.1.1");
+
+    // The active row carries the "active" chip and must NOT offer rollback.
+    expect(within(activeRow).getByTestId("version-status")).toHaveTextContent("active");
+    expect(within(activeRow).queryByRole("button", { name: ROLLBACK })).toBeNull();
+
+    // The previously-deployed, non-active row offers a Roll back action.
+    expect(within(oldRow).getByRole("button", { name: ROLLBACK })).toBeInTheDocument();
+  });
+
+  it("opens a dialog naming the target version; Cancel closes it without deploying", async () => {
+    const user = userEvent.setup();
+    render(<WiredVersions />, { wrapper: wrapper() });
+
+    const oldRow = await rowFor("v0.1.0");
+    await user.click(within(oldRow).getByRole("button", { name: ROLLBACK }));
+
+    const dialog = await screen.findByRole("dialog");
+    // The confirmation names the version being rolled back to.
+    expect(dialog).toHaveTextContent("v0.1.0");
+
+    await user.click(within(dialog).getByRole("button", { name: CANCEL }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(createDeployment).not.toHaveBeenCalled();
+  });
+
+  it("confirming deploys the old version as active and refreshes the list", async () => {
+    const user = userEvent.setup();
+    render(<WiredVersions />, { wrapper: wrapper() });
+
+    // one fetch pass on mount (versions + deployments)
+    await waitFor(() => expect(listVersions).toHaveBeenCalledTimes(1));
+
+    const oldRow = await rowFor("v0.1.0");
+    await user.click(within(oldRow).getByRole("button", { name: ROLLBACK }));
+
+    const dialog = await screen.findByRole("dialog");
+    // Confirm is the dialog's affirmative action (Cancel is separate).
+    const confirm = within(dialog).getByRole("button", { name: /roll ?back|confirm/i });
+    await user.click(confirm);
+
+    // Rollback = a NEW deployment of the old version, in that row's environment,
+    // marked active. Exactly once, exact arg shape.
+    await waitFor(() => expect(createDeployment).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(createDeployment)).toHaveBeenCalledWith({
+      agent_id: "a1",
+      version_id: "v1",
+      environment: "dev",
+      status: "active",
+    });
+
+    // reload() is the only thing that re-fetches versions -> a second pass proves
+    // the list was refreshed after the rollback.
+    await waitFor(() => expect(listVersions).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/ui/src/views/wired/WiredVersions.tsx
+++ b/apps/ui/src/views/wired/WiredVersions.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { C } from "../../tokens";
-import { Card, SectionTitle, Chip, Dot, Notice } from "../../primitives";
+import { Button, Card, SectionTitle, Chip, Dot, Modal, Notice } from "../../primitives";
 import { useAgents, useAgentVersions } from "../../api/hooks";
 import { ComingSoon } from "./WiredStubs";
-import type { DeploymentOut, VersionOut } from "../../api/client";
+import { createDeployment, type DeploymentOut, type Environment, type VersionOut } from "../../api/client";
 
 export interface Row {
   version: VersionOut;
@@ -35,8 +35,45 @@ function statusColor(status: string | null): string {
 // (environment, status, deployed_at). No Eval column. Agent-scoped via a
 // selector, matching the Cost view. Falls back to ComingSoon when the API is
 // unreachable (there is no fixture leak in wired mode).
+// The version+environment a rollback confirmation is pending for. Local to the
+// table — no global ModalKind — so the confirm dialog is self-contained.
+interface RollbackTarget {
+  versionId: string;
+  versionLabel: string;
+  environment: Environment;
+}
+
 function VersionsTable({ agentId }: { agentId: string }) {
-  const { versions, deployments, activeVersionId, loading, error } = useAgentVersions(agentId);
+  const { versions, deployments, activeVersionId, loading, error, reload } = useAgentVersions(agentId);
+  const [target, setTarget] = useState<RollbackTarget | null>(null);
+  const [rolling, setRolling] = useState(false);
+  const [rollbackError, setRollbackError] = useState<string | null>(null);
+
+  const confirmRollback = async () => {
+    if (!target || rolling) return;
+    setRolling(true);
+    setRollbackError(null);
+    try {
+      await createDeployment({
+        agent_id: agentId,
+        version_id: target.versionId,
+        environment: target.environment,
+        status: "active",
+      });
+      setTarget(null);
+      reload(); // refetch versions + deployments -> the rolled-back version becomes active
+    } catch (e) {
+      setRollbackError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRolling(false);
+    }
+  };
+
+  const cancelRollback = () => {
+    if (rolling) return;
+    setTarget(null);
+    setRollbackError(null);
+  };
 
   if (error) {
     return (
@@ -57,7 +94,7 @@ function VersionsTable({ agentId }: { agentId: string }) {
   }
 
   const rows = buildRows(versions, deployments);
-  const grid = "1.1fr 0.9fr 1fr 1.3fr 1fr";
+  const grid = "1.1fr 0.9fr 1fr 1.3fr 1fr 0.8fr";
   return (
     <Card>
       <div
@@ -71,13 +108,15 @@ function VersionsTable({ agentId }: { agentId: string }) {
           borderBottom: "1px solid " + C.border,
         }}
       >
-        {["Version", "Environment", "Status", "Deployed", "Created by"].map((c) => (
-          <div key={c}>{c}</div>
+        {["Version", "Environment", "Status", "Deployed", "Created by", ""].map((c, i) => (
+          <div key={c || `col-${i}`}>{c}</div>
         ))}
       </div>
       {rows.map((r, i) => {
-        const env = r.deployment?.environment ?? null;
-        const isActive = r.deployment?.status === "active" && r.version.id === activeVersionId;
+        const dep = r.deployment;
+        const env = dep?.environment ?? null;
+        const isActive = dep?.status === "active" && r.version.id === activeVersionId;
+        const canRollback = dep !== null && !isActive;
         return (
           <div
             key={`${r.version.id}-${r.deployment?.id ?? "none"}-${i}`}
@@ -109,16 +148,63 @@ function VersionsTable({ agentId }: { agentId: string }) {
               )}
             </div>
             <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
-              <Dot color={statusColor(r.deployment?.status ?? null)} size={7} />
-              <span style={{ fontSize: 12.5, color: C.text2 }}>{r.deployment?.status ?? "not deployed"}</span>
+              <Dot color={statusColor(dep?.status ?? null)} size={7} />
+              {/* The currently-served row reads "active" (the live version, named
+                  by the chip too); other rows show their raw deployment status. */}
+              <span data-testid="version-status" style={{ fontSize: 12.5, color: C.text2 }}>
+                {isActive ? "active" : (dep?.status ?? "not deployed")}
+              </span>
             </div>
             <span style={{ color: C.muted, fontFamily: C.mono, fontSize: 12 }}>
               {r.deployment ? new Date(r.deployment.deployed_at).toLocaleString() : "—"}
             </span>
             <span style={{ color: C.text2, fontFamily: C.mono, fontSize: 12 }}>{r.version.created_by}</span>
+            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+              {canRollback && dep ? (
+                <Button
+                  label="Roll back"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() =>
+                    setTarget({
+                      versionId: r.version.id,
+                      versionLabel: r.version.version_label,
+                      environment: dep.environment,
+                    })
+                  }
+                />
+              ) : null}
+            </div>
           </div>
         );
       })}
+      {target ? (
+        <Modal onClose={cancelRollback}>
+          <Card style={{ maxWidth: 420 }}>
+            <div style={{ fontSize: 15, fontWeight: 500, color: C.text, marginBottom: 8 }}>Roll back version</div>
+            <div style={{ fontSize: 13, color: C.text2, lineHeight: 1.5, marginBottom: 16 }}>
+              Redeploy{" "}
+              <span style={{ fontFamily: C.mono, color: C.text }}>{target.versionLabel}</span> to{" "}
+              <span style={{ fontFamily: C.mono, color: C.text }}>{target.environment}</span> as the active version.
+              This creates a new deployment; it does not remove existing history.
+            </div>
+            {rollbackError ? (
+              <div style={{ fontSize: 12.5, color: C.destructive, fontFamily: C.mono, marginBottom: 12 }}>
+                Roll back failed: {rollbackError}
+              </div>
+            ) : null}
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 10 }}>
+              <Button label="Cancel" variant="ghost" onClick={cancelRollback} disabled={rolling} />
+              <Button
+                label={rolling ? "Rolling back…" : "Roll back"}
+                variant="primary"
+                onClick={() => void confirmRollback()}
+                disabled={rolling}
+              />
+            </div>
+          </Card>
+        </Modal>
+      ) : null}
     </Card>
   );
 }


### PR DESCRIPTION
Closes #32.

The version history view already existed; this adds the missing rollback action.

Append-only rollback (no API change): a confirmed "Roll back" on previously-deployed, non-active rows reuses `POST /deployments` to create a **new active deployment** of the chosen prior version (that version's id + the env its row was deployed to), then refetches. The worker resolves newest-active-prod-first, so the rolled-back version is served next. Active/never-deployed rows offer no rollback.

- `WiredVersions.tsx`: rollback button + confirm `Modal` (local state) + in-flight/error; `client.ts`: widened `createDeployment` with optional `status` (API already accepts it).

Tests: `WiredVersions.rollback.test.tsx` (button gating, confirm/cancel, exact `createDeployment` args + refetch). 55 tests, typecheck/lint clean. UI-only.