### PR TITLE
UI: dev/prod environment switcher + promote-to-prod flow

### DIFF
--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -409,6 +409,14 @@ export async function listDeployments(agentId: string): Promise<DeploymentOut[]>
   return jsonOrThrow<DeploymentOut[]>(resp);
 }
 
+// Every deployment across all agents (GET /deployments with no agent_id). Used
+// by the env-scoped Agents/Overview views to decide which agents are live in the
+// selected environment.
+export async function listAllDeployments(): Promise<DeploymentOut[]> {
+  const resp = await fetch(url("/deployments"), { headers: headers() });
+  return jsonOrThrow<DeploymentOut[]>(resp);
+}
+
 /**
  * Read the unwrapped files of a version's stored bundle (FX2 headline: the agent
  * detail surface renders and edits these). A 404 means no bundle is stored for

--- a/apps/ui/src/api/hooks.ts
+++ b/apps/ui/src/api/hooks.ts
@@ -8,6 +8,7 @@ import {
   getCost,
   listVersions,
   listDeployments,
+  listAllDeployments,
   getVersionFiles,
   ApiError,
   type RawTrace,
@@ -91,6 +92,18 @@ export function useAgents(enabled: boolean): Async<AgentOut[]> {
     queryKey: ["agents"],
     enabled,
     queryFn: () => getAgents(),
+  });
+  return asyncFrom(enabled, query);
+}
+
+// Fetch every deployment across all agents, for env-scoping the Agents/Overview
+// views. Gated on wired mode; reload happens naturally via react-query when the
+// view remounts after a promote/deploy.
+export function useAllDeployments(enabled: boolean): Async<DeploymentOut[]> {
+  const query = useQuery({
+    queryKey: ["allDeployments"],
+    enabled,
+    queryFn: () => listAllDeployments(),
   });
   return asyncFrom(enabled, query);
 }

--- a/apps/ui/src/components/Topbar.test.tsx
+++ b/apps/ui/src/components/Topbar.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Topbar } from "./Topbar";
+import { StoreProvider, useStore } from "../state/store";
+import { WiredProvider } from "../state/wired";
+import { isWired } from "../api/config";
+import type { FixtureLevel } from "../state/types";
+
+// The env switcher's enablement is derived in the store. After the fix it is
+// driven by isWired() OR a level>=4 fixture, so we mock the wiring flag and
+// assert the pill behaviour through the store.
+vi.mock("../api/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/config")>();
+  return { ...actual, isWired: vi.fn(() => false) };
+});
+
+afterEach(() => {
+  vi.mocked(isWired).mockReset();
+  vi.mocked(isWired).mockReturnValue(false);
+});
+
+// Surfaces the store's derived env-switch state so the assertions do not depend
+// on pill styling internals.
+function Probe() {
+  const { state, ghOn } = useStore();
+  return (
+    <>
+      <span data-testid="env">{state.env}</span>
+      <span data-testid="ghon">{String(ghOn)}</span>
+    </>
+  );
+}
+
+function renderTopbar(level: FixtureLevel) {
+  // Topbar now reads useWired() (org name) and the tree mounts react-query
+  // hooks, so wrap in the same provider stack main.tsx uses. retry off keeps
+  // any incidental query deterministic.
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <StoreProvider level={level}>
+        <WiredProvider>
+          <Topbar />
+          <Probe />
+        </WiredProvider>
+      </StoreProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("Topbar env switcher enablement", () => {
+  it("is enabled in wired mode even at a low fixture level, and DEV dispatches setEnv('dev')", async () => {
+    vi.mocked(isWired).mockReturnValue(true);
+    const user = userEvent.setup();
+    renderTopbar(1);
+
+    // Enabled: the store reports environments are available.
+    expect(screen.getByTestId("ghon")).toHaveTextContent("true");
+    expect(screen.getByTestId("env")).toHaveTextContent("prod");
+
+    await user.click(screen.getByRole("button", { name: "DEV" }));
+    expect(screen.getByTestId("env")).toHaveTextContent("dev");
+
+    await user.click(screen.getByRole("button", { name: "PROD" }));
+    expect(screen.getByTestId("env")).toHaveTextContent("prod");
+  });
+
+  it("stays disabled in fixture mode below level 4 — clicking DEV is a no-op", async () => {
+    vi.mocked(isWired).mockReturnValue(false);
+    const user = userEvent.setup();
+    renderTopbar(1);
+
+    expect(screen.getByTestId("ghon")).toHaveTextContent("false");
+
+    await user.click(screen.getByRole("button", { name: "DEV" }));
+    // Disabled pill: env is unchanged.
+    expect(screen.getByTestId("env")).toHaveTextContent("prod");
+  });
+});

--- a/apps/ui/src/state/env.test.ts
+++ b/apps/ui/src/state/env.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { agentIdsForEnv, hiddenAgentIdsForEnv } from "./env";
+import type { DeploymentOut, Environment } from "../api/client";
+
+// Deployment builder mirroring the fixtures used in hooks.test.ts / WiredVersions.test.ts.
+const dep = (
+  agent_id: string,
+  environment: Environment,
+  status = "active",
+): DeploymentOut => ({
+  id: `dep-${agent_id}-${environment}-${status}`,
+  agent_id,
+  version_id: `ver-${agent_id}-${environment}`,
+  environment,
+  bot_identity: null,
+  commit_sha: null,
+  status,
+  deployed_at: "2026-07-08T00:00:00Z",
+});
+
+describe("agentIdsForEnv (client-side env scoping)", () => {
+  it("returns the agent_ids with an ACTIVE deployment in the target env", () => {
+    const deployments = [
+      dep("a1", "prod"),
+      dep("a2", "prod"),
+      dep("a3", "dev"),
+    ];
+    const prod = agentIdsForEnv(deployments, "prod");
+    expect(prod).toBeInstanceOf(Set);
+    expect(prod.has("a1")).toBe(true);
+    expect(prod.has("a2")).toBe(true);
+    // a3 lives only in dev, so it is NOT in the prod set.
+    expect(prod.has("a3")).toBe(false);
+    expect(prod.size).toBe(2);
+  });
+
+  it("an agent deployed only to dev is absent from the prod set and present in the dev set", () => {
+    const deployments = [dep("dev-only", "dev")];
+    expect(agentIdsForEnv(deployments, "prod").has("dev-only")).toBe(false);
+    expect(agentIdsForEnv(deployments, "dev").has("dev-only")).toBe(true);
+  });
+
+  it("an agent deployed to both envs appears in both sets", () => {
+    const deployments = [dep("both", "prod"), dep("both", "dev")];
+    expect(agentIdsForEnv(deployments, "prod").has("both")).toBe(true);
+    expect(agentIdsForEnv(deployments, "dev").has("both")).toBe(true);
+  });
+
+  it("ignores non-active deployments (superseded/stopped do not count)", () => {
+    const deployments = [
+      dep("a1", "prod", "superseded"),
+      dep("a2", "prod", "stopped"),
+      dep("a3", "prod", "active"),
+    ];
+    const prod = agentIdsForEnv(deployments, "prod");
+    expect(prod.has("a1")).toBe(false);
+    expect(prod.has("a2")).toBe(false);
+    expect(prod.has("a3")).toBe(true);
+    expect(prod.size).toBe(1);
+  });
+
+  it("returns an empty set when there are no deployments", () => {
+    const empty = agentIdsForEnv([], "prod");
+    expect(empty).toBeInstanceOf(Set);
+    expect(empty.size).toBe(0);
+  });
+});
+
+describe("hiddenAgentIdsForEnv (client-side env visibility)", () => {
+  it("does NOT hide an undeployed agent (no active deployments anywhere)", () => {
+    // An agent with no deployment records at all is not represented here, and an
+    // agent whose only deployment is non-active must not be hidden either.
+    const deployments = [dep("never-deployed", "dev", "stopped")];
+    expect(hiddenAgentIdsForEnv(deployments, "prod").has("never-deployed")).toBe(false);
+    expect(hiddenAgentIdsForEnv([], "prod").size).toBe(0);
+  });
+
+  it("does NOT hide an agent active in the selected env", () => {
+    const deployments = [dep("here", "prod")];
+    expect(hiddenAgentIdsForEnv(deployments, "prod").has("here")).toBe(false);
+  });
+
+  it("HIDES an agent active only in the other env", () => {
+    const deployments = [dep("dev-only", "dev")];
+    const hiddenInProd = hiddenAgentIdsForEnv(deployments, "prod");
+    expect(hiddenInProd.has("dev-only")).toBe(true);
+    // ...but it is visible in its own env.
+    expect(hiddenAgentIdsForEnv(deployments, "dev").has("dev-only")).toBe(false);
+  });
+
+  it("does NOT hide an agent active in both envs", () => {
+    const deployments = [dep("both", "prod"), dep("both", "dev")];
+    expect(hiddenAgentIdsForEnv(deployments, "prod").has("both")).toBe(false);
+    expect(hiddenAgentIdsForEnv(deployments, "dev").has("both")).toBe(false);
+  });
+
+  it("a non-active other-env deployment does NOT hide the agent", () => {
+    // superseded/stopped deployments in the other env are not live, so they
+    // neither place the agent in that env nor hide it from this one.
+    const deployments = [dep("stale", "dev", "superseded"), dep("stale", "dev", "stopped")];
+    expect(hiddenAgentIdsForEnv(deployments, "prod").has("stale")).toBe(false);
+  });
+});
+

--- a/apps/ui/src/state/env.ts
+++ b/apps/ui/src/state/env.ts
@@ -1,0 +1,32 @@
+import type { DeploymentOut, Environment } from "../api/client";
+
+// Client-side env scoping: the agent_ids that have an ACTIVE deployment in the
+// given environment. A deployment only counts when it is live (status "active")
+// — superseded/stopped deployments do not place an agent in an environment.
+export function agentIdsForEnv(deployments: DeploymentOut[], env: Environment): Set<string> {
+  const ids = new Set<string>();
+  for (const d of deployments) {
+    if (d.status === "active" && d.environment === env) ids.add(d.agent_id);
+  }
+  return ids;
+}
+
+// Client-side env visibility: the agent_ids that should be HIDDEN in `env`
+// because they are deployed EXCLUSIVELY to the other env(s). An agent is hidden
+// only when it has >=1 ACTIVE deployment but NONE active in `env`. Agents with
+// no active deployments anywhere (e.g. just created, never deployed) are never
+// hidden — they remain visible in every environment.
+export function hiddenAgentIdsForEnv(deployments: DeploymentOut[], env: Environment): Set<string> {
+  const activeAnywhere = new Set<string>();
+  const activeHere = new Set<string>();
+  for (const d of deployments) {
+    if (d.status !== "active") continue;
+    activeAnywhere.add(d.agent_id);
+    if (d.environment === env) activeHere.add(d.agent_id);
+  }
+  const hidden = new Set<string>();
+  for (const id of activeAnywhere) {
+    if (!activeHere.has(id)) hidden.add(id);
+  }
+  return hidden;
+}

--- a/apps/ui/src/state/store.tsx
+++ b/apps/ui/src/state/store.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import type { Action, AppState, FixtureLevel } from "./types";
+import { isWired } from "../api/config";
 
 const max = (a: FixtureLevel, b: FixtureLevel): FixtureLevel =>
   (a > b ? a : b) as FixtureLevel;
@@ -235,16 +236,19 @@ export function StoreProvider({
     return () => clearTimeout(id);
   }, [state.toast]);
 
-  const value = useMemo<Store>(
-    () => ({
+  const value = useMemo<Store>(() => {
+    // Environments are real in wired mode; in the fixture demo they unlock at
+    // level 4 (GitHub connected). Keep the reducer's env clamp untouched — this
+    // is only the derived enablement the chrome reads.
+    const envAvailable = isWired() || state.level >= 4;
+    return {
       state,
       dispatch,
       slackOn: state.level >= 2,
-      ghOn: state.level >= 4,
-      envDev: state.level >= 4 && state.env === "dev",
-    }),
-    [state],
-  );
+      ghOn: envAvailable,
+      envDev: envAvailable && state.env === "dev",
+    };
+  }, [state]);
 
   return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>;
 }

--- a/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
@@ -12,6 +12,7 @@ import {
   listDeployments,
   getVersionFiles,
   updateAgent,
+  createDeployment,
   type AgentOut,
   type VersionOut,
   type DeploymentOut,
@@ -27,8 +28,9 @@ vi.mock("../../api/config", async (importOriginal) => ({
 
 // Mock only the data-layer calls; preserve the real ApiError/BundleValidationError
 // classes (the hooks branch on `instanceof ApiError`) and the untouched helpers.
-// `updateAgent` is mocked so the channel-edit tests can assert the save button
-// issues the PATCH call with the right args without hitting the network.
+// `updateAgent` is mocked for the channel-edit tests; `createDeployment` for the
+// promote-to-prod tests; createVersion/uploadBundle are stubbed so the deploy path
+// never hits the network even though these tests don't exercise it.
 vi.mock("../../api/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../api/client")>();
   return {
@@ -38,9 +40,14 @@ vi.mock("../../api/client", async (importOriginal) => {
     listDeployments: vi.fn(),
     getVersionFiles: vi.fn(),
     updateAgent: vi.fn(),
+    createVersion: vi.fn(),
+    uploadBundle: vi.fn(),
+    createDeployment: vi.fn(),
   };
 });
 
+// The mocked agent carries a Slack channel ID (the channel-edit test pre-fills the
+// input with it; the promote/bundle tests only need the detail to render).
 const AGENT: AgentOut = {
   id: "a1",
   name: "deal-desk",
@@ -48,28 +55,38 @@ const AGENT: AgentOut = {
   created_at: "2026-07-01T00:00:00Z",
 };
 
-const VERSION: VersionOut = {
-  id: "v1",
+const version = (id: string, label: string): VersionOut => ({
+  id,
   agent_id: "a1",
-  version_label: "v0.1.0",
-  bundle_ref: "r",
-  bundle_sha256: "s",
+  version_label: label,
+  bundle_ref: "ref",
+  bundle_sha256: "sha",
   created_by: "ui",
   created_at: "2026-07-01T00:00:00Z",
-};
+});
 
-const DEPLOYMENT: DeploymentOut = {
-  id: "d1",
+const deployment = (version_id: string, environment: "prod" | "dev", deployed_at: string): DeploymentOut => ({
+  id: `dep-${version_id}-${environment}`,
   agent_id: "a1",
-  version_id: "v1",
-  environment: "prod",
+  version_id,
+  environment,
   bot_identity: null,
   commit_sha: null,
   status: "active",
-  deployed_at: "2026-07-01T00:00:00Z",
-};
+  deployed_at,
+});
 
-// A bundle with a SKILL.md AND the two non-skill files item 4 must surface.
+// v1 is the prod-active version (what the editor loads); v2 is the dev-active
+// version — the one promote-to-prod must ship. Both versions exist so the detail
+// renders and devActiveVersionId resolves to v2.
+const VERSIONS = [version("v1", "v0.1.0"), version("v2", "v0.2.0")];
+const DEPLOYMENTS = [
+  deployment("v1", "prod", "2026-07-05T00:00:00Z"),
+  deployment("v2", "dev", "2026-07-07T00:00:00Z"),
+];
+
+// A bundle with a SKILL.md AND the two non-skill files the bundle-tree test must
+// surface (item 4): the manifest and evals/cases.json.
 const FILES: BundleFiles = {
   files: [
     { path: "skills/deal-desk/SKILL.md", content: "---\nname: deal-desk\ndescription: d\n---\n# body" },
@@ -81,22 +98,24 @@ const FILES: BundleFiles = {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getAgents).mockResolvedValue([AGENT]);
-  vi.mocked(listVersions).mockResolvedValue([VERSION]);
-  vi.mocked(listDeployments).mockResolvedValue([DEPLOYMENT]);
+  vi.mocked(listVersions).mockResolvedValue(VERSIONS);
+  vi.mocked(listDeployments).mockResolvedValue(DEPLOYMENTS);
   vi.mocked(getVersionFiles).mockResolvedValue(FILES);
   vi.mocked(updateAgent).mockResolvedValue({ ...AGENT, slack_channel: "C9999ZZZZ" });
+  vi.mocked(createDeployment).mockResolvedValue(deployment("v2", "prod", "2026-07-08T00:00:00Z"));
 });
 
 // Render the detail surface directly, dispatching openAgentDetail on mount so the
 // store points at the mocked agent (the same action the Agents list dispatches).
+function Harness() {
+  const { dispatch } = useStore();
+  useEffect(() => {
+    dispatch({ type: "openAgentDetail", id: AGENT.id });
+  }, [dispatch]);
+  return <WiredAgentDetail />;
+}
+
 function renderDetail() {
-  function Harness() {
-    const { dispatch } = useStore();
-    useEffect(() => {
-      dispatch({ type: "openAgentDetail", id: AGENT.id });
-    }, [dispatch]);
-    return <WiredAgentDetail />;
-  }
   // WiredAgentDetail consumes react-query hooks (useAgentVersions/useVersionFiles),
   // so it needs a QueryClientProvider. A fresh client per render with retry off,
   // mirroring main.tsx and hooks.rq.test.tsx, so error/404 sentinels resolve on the
@@ -181,5 +200,43 @@ describe("WiredAgentDetail — bundle tree (item 4)", () => {
 
     // SKILL.md is still present so the existing edit/deploy path is not lost.
     expect(screen.getAllByText("skills/deal-desk/SKILL.md").length).toBeGreaterThan(0);
+  });
+});
+
+describe("WiredAgentDetail — promote-to-prod (item 6)", () => {
+  it("promotes the dev-active version to prod on confirm, then refreshes", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    // The detail body renders once agents + versions + files have loaded.
+    expect(await screen.findByTestId("agent-detail-name")).toHaveTextContent("deal-desk");
+
+    const promote = await screen.findByRole("button", { name: "Promote to prod" });
+    expect(vi.mocked(listDeployments)).toHaveBeenCalledTimes(1);
+
+    await user.click(promote);
+    // Inline confirm (kill-switch pattern): nothing deployed until confirmed.
+    await user.click(await screen.findByRole("button", { name: "Confirm promote" }));
+
+    await waitFor(() => expect(vi.mocked(createDeployment)).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(createDeployment)).toHaveBeenCalledWith({
+      agent_id: "a1",
+      version_id: "v2",
+      environment: "prod",
+    });
+
+    // A refresh follows the promote (re-fetch versions + deployments).
+    await waitFor(() => expect(vi.mocked(listDeployments).mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it("deploys nothing when the promote confirm is cancelled", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    const promote = await screen.findByRole("button", { name: "Promote to prod" });
+    await user.click(promote);
+    await user.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    expect(vi.mocked(createDeployment)).not.toHaveBeenCalled();
   });
 });

--- a/apps/ui/src/views/wired/WiredAgentDetail.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.tsx
@@ -89,6 +89,9 @@ export function WiredAgentDetail() {
   const [deployError, setDeployError] = useState<string | null>(null);
   const [issues, setIssues] = useState<BundleIssue[]>([]);
   const [deployedLabel, setDeployedLabel] = useState<string | null>(null);
+  const [confirmingPromote, setConfirmingPromote] = useState(false);
+  const [promoting, setPromoting] = useState(false);
+  const [promoteError, setPromoteError] = useState<string | null>(null);
 
   // Editable Slack channel (item 5). Seeded from the agent, re-seeded if it changes.
   const [channel, setChannel] = useState("");
@@ -107,6 +110,17 @@ export function WiredAgentDetail() {
   // are editable, the rest are read-only views.
   const allFiles = files.files ?? [];
   const skillFiles = useMemo(() => (files.files ?? []).filter((f) => isSkillFile(f.path)), [files.files]);
+
+  // The version currently active in dev — the one promote-to-prod ships. Newest
+  // active dev deployment whose version still exists; null when there is nothing
+  // in dev to promote (the button is then hidden).
+  const devActiveVersionId = useMemo(() => {
+    const dev = versions.deployments
+      .filter((d) => d.status === "active" && d.environment === "dev")
+      .sort((a, b) => b.deployed_at.localeCompare(a.deployed_at))
+      .find((d) => versions.versions.some((v) => v.id === d.version_id));
+    return dev?.version_id ?? null;
+  }, [versions.deployments, versions.versions]);
 
   useEffect(() => {
     // Reseed the editor whenever a new version's files arrive.
@@ -157,7 +171,7 @@ export function WiredAgentDetail() {
       const version = await createVersion(agentId, { version_label: label, created_by: "ui" });
       const archive = await buildBundleZipFromFiles(agent.name, merged);
       await uploadBundle(agentId, version.id, archive);
-      await createDeployment({ agent_id: agentId, version_id: version.id, environment: "prod" });
+      await createDeployment({ agent_id: agentId, version_id: version.id, environment: state.env });
       setDeployedLabel(label);
       dispatch({ type: "toast", message: `Deployed ${label}` });
       versions.reload(); // refetch versions + deployments -> active version flips to the new one
@@ -169,6 +183,25 @@ export function WiredAgentDetail() {
       }
     } finally {
       setDeploying(false);
+    }
+  };
+
+  // Promote the dev-active version to prod: a single createDeployment (prod gets
+  // the server-default active status — no gitflow bot_identity plumbing here),
+  // then refresh so the Versions/active state reflects the new prod deployment.
+  const promote = async () => {
+    if (!agentId || promoting || !devActiveVersionId) return;
+    setPromoting(true);
+    setPromoteError(null);
+    try {
+      await createDeployment({ agent_id: agentId, version_id: devActiveVersionId, environment: "prod" });
+      dispatch({ type: "toast", message: "Promoted dev → prod" });
+      setConfirmingPromote(false);
+      versions.reload();
+    } catch (e) {
+      setPromoteError(e instanceof ApiError ? e.message : e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoting(false);
     }
   };
 
@@ -253,6 +286,29 @@ export function WiredAgentDetail() {
           )}
         </div>
       </div>
+
+      {devActiveVersionId ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 16 }}>
+          {confirmingPromote ? (
+            <>
+              <span style={{ fontSize: 12.5, color: C.text2, fontFamily: C.mono }}>Promote the dev-active version to prod?</span>
+              <Button label="Cancel" variant="ghost" size="sm" onClick={() => setConfirmingPromote(false)} />
+              {promoting ? (
+                <Button label="Promoting…" variant="primary" size="sm" disabled />
+              ) : (
+                <Button label="Confirm promote" variant="primary" size="sm" onClick={() => void promote()} />
+              )}
+            </>
+          ) : (
+            <Button label="Promote to prod" size="sm" onClick={() => setConfirmingPromote(true)} />
+          )}
+          {promoteError ? (
+            <span data-testid="promote-error" style={{ fontSize: 12, color: C.destructive, fontFamily: C.mono }}>
+              Promote failed: {promoteError}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
 
       {versions.loading ? (
         <Notice padding="34px 20px">Loading versions…</Notice>

--- a/apps/ui/src/views/wired/WiredAgents.tsx
+++ b/apps/ui/src/views/wired/WiredAgents.tsx
@@ -3,11 +3,14 @@ import { C } from "../../tokens";
 import { Card, SectionTitle, Button, Dot, EmptyState, Notice } from "../../primitives";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
+import { useAllDeployments } from "../../api/hooks";
+import { hiddenAgentIdsForEnv } from "../../state/env";
 import { deleteAgent } from "../../api/client";
 
 export function WiredAgents() {
-  const { dispatch } = useStore();
-  const { agents, loading, error, refetch } = useWired();
+  const { state, dispatch } = useStore();
+  const { agents, loading, error, refetch, wired } = useWired();
+  const deps = useAllDeployments(wired);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   async function onDelete(id: string, name: string) {
@@ -28,6 +31,13 @@ export function WiredAgents() {
 
   if (loading) return <Notice>Loading agents…</Notice>;
   if (error) return <Notice>{`Could not load agents: ${error}`}</Notice>;
+
+  // Env-gating is best-effort: hide agents deployed exclusively to the other
+  // env, but never gate (and never error the view out) while deployments are
+  // still loading or the fetch failed — show the full list instead.
+  const gate = deps.data && !deps.error;
+  const hiddenIds = gate ? hiddenAgentIdsForEnv(deps.data ?? [], state.env) : new Set<string>();
+  const shown = agents.filter((a) => !hiddenIds.has(a.id));
 
   if (agents.length === 0) {
     return (
@@ -54,8 +64,11 @@ export function WiredAgents() {
           <Button label="New agent" variant="primary" icon="+" onClick={() => dispatch({ type: "openModal", modal: "new-agent" })} />
         </div>
       </div>
+      {shown.length === 0 ? (
+        <Notice>{`No agents deployed to ${state.env} yet.`}</Notice>
+      ) : (
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill,minmax(320px,1fr))", gap: 16 }}>
-        {agents.map((a) => (
+        {shown.map((a) => (
           <Card key={a.id}>
             <div style={{ display: "flex", alignItems: "center", gap: 9, marginBottom: 12 }}>
               <Dot color={C.brand} size={9} />
@@ -139,6 +152,7 @@ export function WiredAgents() {
           </Card>
         ))}
       </div>
+      )}
     </div>
   );
 }

--- a/apps/ui/src/views/wired/WiredOverview.tsx
+++ b/apps/ui/src/views/wired/WiredOverview.tsx
@@ -4,7 +4,8 @@ import { hoverBg } from "../../lib/style";
 import { formatLatency } from "../../lib/format";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
-import { useMetricsSummary, useTraces } from "../../api/hooks";
+import { useMetricsSummary, useTraces, useAllDeployments } from "../../api/hooks";
+import { hiddenAgentIdsForEnv } from "../../state/env";
 import { ConnectSlackPanel } from "../../components/ConnectSlackPanel";
 import type { AgentOut, RawTrace } from "../../api/client";
 
@@ -85,10 +86,16 @@ function traceMsg(t: RawTrace): string {
 }
 
 function LiveOverview({ agents }: { agents: AgentOut[] }) {
-  const { dispatch } = useStore();
-  const { justDeployed } = useWired();
-  const summary = useMetricsSummary(true, {});
+  const { state, dispatch } = useStore();
+  const { justDeployed, wired } = useWired();
+  const summary = useMetricsSummary(true, { environment: state.env });
   const traces = useTraces(true);
+  const deps = useAllDeployments(wired);
+  // Agents visible in the selected environment: hide only those deployed
+  // exclusively to the other env (undeployed agents stay visible). Fall back to
+  // the full list until deployments load so the count does not flash to zero.
+  const hiddenIds = deps.data ? hiddenAgentIdsForEnv(deps.data, state.env) : new Set<string>();
+  const scoped = deps.data ? agents.filter((a) => !hiddenIds.has(a.id)) : agents;
 
   const stat = (label: string, value: string) => (
     <Card key={label} style={{ padding: "16px 18px" }}>
@@ -102,7 +109,7 @@ function LiveOverview({ agents }: { agents: AgentOut[] }) {
   const metric = (fmt: (d: NonNullable<typeof s>) => string): string =>
     s ? fmt(s) : summary.loading ? "…" : "—";
   const stats: [string, string][] = [
-    ["Agents", String(agents.length)],
+    ["Agents", String(scoped.length)],
     ["Runs (7d)", metric((d) => String(d.runs))],
     ["Latency p95", metric((d) => formatLatency(d.latency_p95_seconds))],
     ["Cost (7d)", metric((d) => "$" + d.cost_usd.toFixed(2))],
@@ -112,7 +119,7 @@ function LiveOverview({ agents }: { agents: AgentOut[] }) {
   return (
     <div>
       {justDeployed ? <DeployedPanel name={justDeployed.name} channel={justDeployed.channel} /> : null}
-      <SectionTitle title="Overview" sub={`${agents.length} ${agents.length === 1 ? "agent" : "agents"} · live data`} />
+      <SectionTitle title="Overview" sub={`${scoped.length} ${scoped.length === 1 ? "agent" : "agents"} · ${state.env} · live data`} />
       <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 14, marginBottom: 22 }}>
         {stats.map((x) => stat(x[0], x[1]))}
       </div>
@@ -159,7 +166,7 @@ function LiveOverview({ agents }: { agents: AgentOut[] }) {
         </Card>
         <Card>
           <div style={{ fontSize: 14, fontWeight: 500, marginBottom: 14 }}>Agents</div>
-          {agents.map((a, i) => (
+          {scoped.map((a, i) => (
             <button
               key={a.id}
               type="button"

--- a/apps/ui/src/views/wired/WiredVersions.rollback.test.tsx
+++ b/apps/ui/src/views/wired/WiredVersions.rollback.test.tsx
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { PropsWithChildren } from "react";
-import { createElement } from "react";
+import { Fragment, createElement, useEffect, type PropsWithChildren } from "react";
 import { WiredVersions } from "./WiredVersions";
+import { StoreProvider, useStore } from "../../state/store";
 import type { AgentOut, DeploymentOut, VersionOut } from "../../api/client";
 import { createDeployment, getAgents, listDeployments, listVersions } from "../../api/client";
 
@@ -65,14 +65,16 @@ const AGENT: AgentOut = {
   created_at: "2026-06-01T00:00:00Z",
 };
 
-// v2 is the version the agent currently serves; v1 was previously deployed (to
-// dev) and is no longer active. Append-only: v1's deployment record is left as
-// "active" — pickActiveVersion ranks prod-first then newest, so v2 (prod) wins
-// and v1's row is a previously-deployed, non-active row.
+// v2 is the version the agent currently serves; v1 was previously deployed and is
+// no longer active. Both deployments live in the "dev" environment so the
+// env-scoped versions table (which filters rows to the selected env) shows both
+// rows once the store is switched to dev. Append-only: v1's record is left as
+// "active" — pickActiveVersion ranks by newest here (same env), so v2 wins and
+// v1's row is a previously-deployed, non-active row.
 const V_OLD = mkVersion("v1", "v0.1.0", "2026-07-01T00:00:00Z");
 const V_ACTIVE = mkVersion("v2", "v0.1.1", "2026-07-05T00:00:00Z");
 const DEP_OLD = mkDep("dep-old", "v1", "dev", "2026-07-02T00:00:00Z", "active");
-const DEP_ACTIVE = mkDep("dep-active", "v2", "prod", "2026-07-06T00:00:00Z", "active");
+const DEP_ACTIVE = mkDep("dep-active", "v2", "dev", "2026-07-06T00:00:00Z", "active");
 
 const VERSIONS = [V_OLD, V_ACTIVE];
 const DEPLOYMENTS = [DEP_OLD, DEP_ACTIVE];
@@ -98,12 +100,29 @@ async function rowFor(label: string): Promise<HTMLElement> {
 const ROLLBACK = /roll ?back/i;
 const CANCEL = /cancel/i;
 
+// The versions table is env-scoped: it reads the store's selected environment and
+// only shows deployment rows in that env. Flip the store to "dev" (the env both
+// fixture deployments live in) on mount so the previously-deployed and active rows
+// both render.
+function EnvDev({ children }: PropsWithChildren) {
+  const { dispatch } = useStore();
+  useEffect(() => {
+    dispatch({ type: "setEnv", env: "dev" });
+  }, [dispatch]);
+  return createElement(Fragment, null, children);
+}
+
 // A fresh client per render with retry off, mirroring main.tsx, so the wired
-// hooks (now react-query) resolve on the first response instead of retrying.
+// hooks (now react-query) resolve on the first response instead of retrying. The
+// StoreProvider supplies the env the table scopes to (WiredVersions uses useStore).
 function wrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return ({ children }: PropsWithChildren) =>
-    createElement(QueryClientProvider, { client }, children);
+    createElement(
+      QueryClientProvider,
+      { client },
+      createElement(StoreProvider, null, createElement(EnvDev, null, children)),
+    );
 }
 
 describe("WiredVersions rollback", () => {

--- a/apps/ui/src/views/wired/WiredVersions.tsx
+++ b/apps/ui/src/views/wired/WiredVersions.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { C } from "../../tokens";
 import { Button, Card, SectionTitle, Chip, Dot, Modal, Notice } from "../../primitives";
+import { useStore } from "../../state/store";
 import { useAgents, useAgentVersions } from "../../api/hooks";
 import { ComingSoon } from "./WiredStubs";
 import { createDeployment, type DeploymentOut, type Environment, type VersionOut } from "../../api/client";
@@ -44,6 +45,7 @@ interface RollbackTarget {
 }
 
 function VersionsTable({ agentId }: { agentId: string }) {
+  const { state } = useStore();
   const { versions, deployments, activeVersionId, loading, error, reload } = useAgentVersions(agentId);
   const [target, setTarget] = useState<RollbackTarget | null>(null);
   const [rolling, setRolling] = useState(false);
@@ -93,7 +95,12 @@ function VersionsTable({ agentId }: { agentId: string }) {
     );
   }
 
-  const rows = buildRows(versions, deployments);
+  // Scope to the selected environment first, then join with versions. Rollback
+  // eligibility (previously-deployed, non-active) composes on top: a row shows
+  // only if its deployment is in state.env, and gets a Roll back button if
+  // eligible. The rollback column keeps the 6-col grid from the rollback work.
+  const scopedDeployments = deployments.filter((d) => d.environment === state.env);
+  const rows = buildRows(versions, scopedDeployments);
   const grid = "1.1fr 0.9fr 1fr 1.3fr 1fr 0.8fr";
   return (
     <Card>


### PR DESCRIPTION
Closes #6.

The env model already existed (deployments carry `dev|prod`; metrics take an `environment` filter). This wires the UI half — client-side, no backend change.

- **Switcher**: the env pill was gated behind the *fixture* level; changed derived `ghOn` to `isWired() || level>=4` so it's live in wired mode. Reducer/level-clamp untouched (fixture behavior unchanged).
- **Scoping**: Agents/Overview hide agents deployed *exclusively* to the other env (undeployed agents stay visible; best-effort while deployments load); Versions filters its rows; metrics summary passes the env. Traces & per-agent cost stay agent-scoped (no server env dimension — not faked).
- **Promote-to-prod**: no REST promote endpoint exists (git-webhook only); the UI replicates it — a confirmed action creates a new prod deployment of the dev-active version via `POST /deployments`. Produces `status:"active"` (not git-flow's `promoted`); flagged.

Pure helpers `agentIdsForEnv`/`hiddenAgentIdsForEnv` + a small `listAllDeployments`/`useAllDeployments`. Tests: `env.test.ts`, `Topbar.test.tsx`, `WiredAgentDetail.test.tsx` (66). typecheck/lint clean, no toolchain changes. UI-only.

Note: existing stackless e2e specs are unchanged; I reasoned through them (best-effort gate keeps agent cards rendering) but couldn't run Playwright in my env — worth a CI check.