### PR TITLE
UI: change an agent's Slack channel + show the full bundle tree (part of #18)

### DIFF
--- a/apps/ui/src/api/api.test.ts
+++ b/apps/ui/src/api/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { bundleFileTree, buildBundleZip, bundleTreeFromFiles, nextVersionLabel } from "./bundle";
 import {
   createAgent,
+  updateAgent,
   uploadBundle,
   BundleValidationError,
   ApiError,
@@ -188,6 +189,20 @@ describe("agent-detail client calls", () => {
     const err = (await getVersionFiles("a1", "v9").catch((e: unknown) => e)) as ApiError;
     expect(err).toBeInstanceOf(ApiError);
     expect(err.status).toBe(404);
+  });
+
+  it("PATCHes the agent's Slack channel and returns the updated agent", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(200, { id: "a1", name: "deal-desk", slack_channel: "C9999ZZZZ", created_at: "now" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const agent = await updateAgent("a1", { slack_channel: "C9999ZZZZ" });
+    expect(agent.slack_channel).toBe("C9999ZZZZ");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/agents/a1");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body)).toEqual({ slack_channel: "C9999ZZZZ" });
+    expect((init.headers as Record<string, string>)["X-API-Key"]).toBeTruthy();
   });
 
   it("activates a version by POSTing a deployment", async () => {

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -325,6 +325,19 @@ export async function getConfig(): Promise<AppConfig> {
   return jsonOrThrow<AppConfig>(resp);
 }
 
+// PATCH an agent's mutable fields (currently just its Slack channel). Returns
+// the updated agent. Mirrors createAgent's JSON-body shape; non-2xx throws
+// ApiError. The live worker keeps its channel until the next deploy — this only
+// updates the stored config the next deployment reads.
+export async function updateAgent(agentId: string, patch: { slack_channel: string }): Promise<AgentOut> {
+  const resp = await fetch(url(`/agents/${agentId}`), {
+    method: "PATCH",
+    headers: headers({ "Content-Type": "application/json" }),
+    body: JSON.stringify(patch),
+  });
+  return jsonOrThrow<AgentOut>(resp);
+}
+
 // Delete an agent (cascades its versions/deployments server-side; 204 No Content
 // on success). A 409 (active deployment) surfaces via the thrown ApiError.
 export async function deleteAgent(agentId: string): Promise<void> {

--- a/apps/ui/src/primitives/Button.tsx
+++ b/apps/ui/src/primitives/Button.tsx
@@ -19,6 +19,7 @@ export function Button({
   full,
   disabled,
   title,
+  testId,
   onClick,
 }: {
   label: ReactNode;
@@ -28,6 +29,7 @@ export function Button({
   full?: boolean;
   disabled?: boolean;
   title?: string;
+  testId?: string;
   onClick?: () => void;
 }) {
   const base = VARIANTS[variant];
@@ -51,7 +53,7 @@ export function Button({
   };
   const hover = disabled ? {} : hoverBg(base.bg, base.hbg);
   return (
-    <button type="button" onClick={onClick} disabled={disabled} title={title} style={style} {...hover}>
+    <button type="button" onClick={onClick} disabled={disabled} title={title} data-testid={testId} style={style} {...hover}>
       {icon ? <span style={{ fontFamily: C.mono, fontSize: 12 }}>{icon}</span> : null}
       {label}
     </button>

--- a/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { WiredAgentDetail } from "./WiredAgentDetail";
+import { StoreProvider, useStore } from "../../state/store";
+import { WiredProvider } from "../../state/wired";
+import {
+  getAgents,
+  listVersions,
+  listDeployments,
+  getVersionFiles,
+  updateAgent,
+  type AgentOut,
+  type VersionOut,
+  type DeploymentOut,
+  type BundleFiles,
+} from "../../api/client";
+
+// Force wired mode so <WiredProvider> fetches getAgents and App/Main would route
+// to <WiredAgentDetail>. isWired() otherwise reads window.location (empty in jsdom).
+vi.mock("../../api/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api/config")>()),
+  isWired: () => true,
+}));
+
+// Mock only the data-layer calls; preserve the real ApiError/BundleValidationError
+// classes (the hooks branch on `instanceof ApiError`) and the untouched helpers.
+// `updateAgent` is mocked so the channel-edit tests can assert the save button
+// issues the PATCH call with the right args without hitting the network.
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    getAgents: vi.fn(),
+    listVersions: vi.fn(),
+    listDeployments: vi.fn(),
+    getVersionFiles: vi.fn(),
+    updateAgent: vi.fn(),
+  };
+});
+
+const AGENT: AgentOut = {
+  id: "a1",
+  name: "deal-desk",
+  slack_channel: "C0123ABCD",
+  created_at: "2026-07-01T00:00:00Z",
+};
+
+const VERSION: VersionOut = {
+  id: "v1",
+  agent_id: "a1",
+  version_label: "v0.1.0",
+  bundle_ref: "r",
+  bundle_sha256: "s",
+  created_by: "ui",
+  created_at: "2026-07-01T00:00:00Z",
+};
+
+const DEPLOYMENT: DeploymentOut = {
+  id: "d1",
+  agent_id: "a1",
+  version_id: "v1",
+  environment: "prod",
+  bot_identity: null,
+  commit_sha: null,
+  status: "active",
+  deployed_at: "2026-07-01T00:00:00Z",
+};
+
+// A bundle with a SKILL.md AND the two non-skill files item 4 must surface.
+const FILES: BundleFiles = {
+  files: [
+    { path: "skills/deal-desk/SKILL.md", content: "---\nname: deal-desk\ndescription: d\n---\n# body" },
+    { path: ".claude-plugin/plugin.json", content: '{"name":"deal-desk","version":"v0.1.0"}' },
+    { path: "evals/cases.json", content: "[]" },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getAgents).mockResolvedValue([AGENT]);
+  vi.mocked(listVersions).mockResolvedValue([VERSION]);
+  vi.mocked(listDeployments).mockResolvedValue([DEPLOYMENT]);
+  vi.mocked(getVersionFiles).mockResolvedValue(FILES);
+  vi.mocked(updateAgent).mockResolvedValue({ ...AGENT, slack_channel: "C9999ZZZZ" });
+});
+
+// Render the detail surface directly, dispatching openAgentDetail on mount so the
+// store points at the mocked agent (the same action the Agents list dispatches).
+function renderDetail() {
+  function Harness() {
+    const { dispatch } = useStore();
+    useEffect(() => {
+      dispatch({ type: "openAgentDetail", id: AGENT.id });
+    }, [dispatch]);
+    return <WiredAgentDetail />;
+  }
+  // WiredAgentDetail consumes react-query hooks (useAgentVersions/useVersionFiles),
+  // so it needs a QueryClientProvider. A fresh client per render with retry off,
+  // mirroring main.tsx and hooks.rq.test.tsx, so error/404 sentinels resolve on the
+  // first response instead of being retried.
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <StoreProvider level={3}>
+        <WiredProvider>
+          <Harness />
+        </WiredProvider>
+      </StoreProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("WiredAgentDetail — channel edit (item 5)", () => {
+  it("saves an edited Slack channel via updateAgent and refetches the agent list", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    // Agent header loads once getAgents resolves; getAgents fired exactly once.
+    expect(await screen.findByTestId("agent-detail-name")).toHaveTextContent("deal-desk");
+    await waitFor(() => expect(getAgents).toHaveBeenCalledTimes(1));
+
+    // The channel is now an editable input pre-filled with the current value.
+    const input = await screen.findByTestId("channel-input");
+    expect(input).toHaveValue("C0123ABCD");
+
+    await user.clear(input);
+    await user.type(input, "C9999ZZZZ");
+    await user.click(screen.getByTestId("channel-save"));
+
+    // Exactly one PATCH, with the right args.
+    await waitFor(() => expect(updateAgent).toHaveBeenCalledTimes(1));
+    expect(updateAgent).toHaveBeenCalledWith("a1", { slack_channel: "C9999ZZZZ" });
+
+    // Save triggers a refetch of the wired agent data (getAgents runs a 2nd time).
+    await waitFor(() => expect(getAgents).toHaveBeenCalledTimes(2));
+  });
+
+  it("blocks saving an empty channel (no updateAgent call)", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    const input = await screen.findByTestId("channel-input");
+    await user.clear(input);
+
+    // Save is disabled / a no-op while the channel is empty.
+    const save = screen.getByTestId("channel-save");
+    await user.click(save).catch(() => {});
+    expect(updateAgent).not.toHaveBeenCalled();
+  });
+
+  it("warns on a non-Slack-ID channel but still allows saving (soft check)", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    const input = await screen.findByTestId("channel-input");
+    await user.clear(input);
+    await user.type(input, "revenue-ops");
+
+    // Soft warning shows (mirrors NewAgentModal's CHANNEL_ID_RE warning)…
+    expect(screen.getByTestId("channel-warn")).toBeInTheDocument();
+
+    // …but the value still saves.
+    await user.click(screen.getByTestId("channel-save"));
+    await waitFor(() => expect(updateAgent).toHaveBeenCalledWith("a1", { slack_channel: "revenue-ops" }));
+  });
+});
+
+describe("WiredAgentDetail — bundle tree (item 4)", () => {
+  it("renders every bundle file, not just SKILL.md", async () => {
+    renderDetail();
+    expect(await screen.findByTestId("agent-detail-name")).toBeInTheDocument();
+
+    // The full bundle tree is visible: the non-skill files are findable in the DOM.
+    await waitFor(() => {
+      expect(screen.getAllByText("evals/cases.json").length).toBeGreaterThan(0);
+      expect(screen.getAllByText(".claude-plugin/plugin.json").length).toBeGreaterThan(0);
+    });
+
+    // SKILL.md is still present so the existing edit/deploy path is not lost.
+    expect(screen.getAllByText("skills/deal-desk/SKILL.md").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/ui/src/views/wired/WiredAgentDetail.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.tsx
@@ -9,6 +9,7 @@ import {
   createVersion,
   uploadBundle,
   createDeployment,
+  updateAgent,
   BundleValidationError,
   ApiError,
   type BundleFile,
@@ -20,6 +21,52 @@ function isSkillFile(path: string): boolean {
   return path.endsWith("/SKILL.md") || path === "SKILL.md";
 }
 
+// Read-only view of a non-SKILL bundle file (manifest, evals/cases.json, …). Only
+// SKILL.md files are editable; everything else in the tree is viewable, not edited.
+function FileView({ path, content }: { path: string; content: string }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", minHeight: 0 }}>
+      <div
+        style={{
+          padding: "8px 14px",
+          borderBottom: "1px solid " + C.border,
+          fontFamily: C.mono,
+          fontSize: 12,
+          color: C.muted,
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
+        <span style={{ color: C.text2 }}>{path}</span>
+        <span style={{ marginLeft: "auto", fontSize: 11 }}>read-only</span>
+      </div>
+      <pre
+        data-testid="file-view"
+        style={{
+          margin: 0,
+          padding: "12px 16px",
+          height: 360,
+          overflow: "auto",
+          background: C.darkest,
+          color: C.text2,
+          fontFamily: C.mono,
+          fontSize: 12.5,
+          lineHeight: 1.55,
+          whiteSpace: "pre",
+        }}
+      >
+        {content}
+      </pre>
+    </div>
+  );
+}
+
+// The worker resolves agents.slack_channel against the Slack channel ID, not the
+// name. Soft check (mirrors NewAgentModal): a non-ID value warns but still saves;
+// only an empty value blocks. Copied CLI-synthetic channels are arbitrary strings.
+const CHANNEL_ID_RE = /^[CDG][A-Z0-9]+$/;
+
 // The wired agent-detail surface (FX2 headline). Opens from the Agents list:
 // loads the agent's active version, shows its bundle's skills, lets you edit each
 // skills/*/SKILL.md in the same editor as the create modal, and ships a new
@@ -27,7 +74,7 @@ function isSkillFile(path: string): boolean {
 // deployment) carrying the edited content — nothing else in the bundle is lost.
 export function WiredAgentDetail() {
   const { state, dispatch } = useStore();
-  const { agents } = useWired();
+  const { agents, refetch } = useWired();
   const agentId = state.agentDetail;
   const agent = agents.find((a) => a.id === agentId) ?? null;
 
@@ -43,6 +90,22 @@ export function WiredAgentDetail() {
   const [issues, setIssues] = useState<BundleIssue[]>([]);
   const [deployedLabel, setDeployedLabel] = useState<string | null>(null);
 
+  // Editable Slack channel (item 5). Seeded from the agent, re-seeded if it changes.
+  const [channel, setChannel] = useState("");
+  const [savingChannel, setSavingChannel] = useState(false);
+  const [channelError, setChannelError] = useState<string | null>(null);
+  const channelValue = channel.trim();
+  const channelBlank = channelValue === "";
+  const channelLooksOff = channelValue !== "" && !CHANNEL_ID_RE.test(channelValue);
+
+  useEffect(() => {
+    setChannel(agent?.slack_channel ?? "");
+    setChannelError(null);
+  }, [agent?.id, agent?.slack_channel]);
+
+  // The whole bundle tree (item 4): every file is browsable; only SKILL.md files
+  // are editable, the rest are read-only views.
+  const allFiles = files.files ?? [];
   const skillFiles = useMemo(() => (files.files ?? []).filter((f) => isSkillFile(f.path)), [files.files]);
 
   useEffect(() => {
@@ -50,12 +113,29 @@ export function WiredAgentDetail() {
     const map: Record<string, string> = {};
     for (const f of files.files ?? []) map[f.path] = f.content;
     setEdited(map);
-    setSelectedPath(skillFiles[0]?.path ?? null);
+    // Prefer a SKILL.md so the edit/deploy path is front and center, else the
+    // first file in the tree.
+    setSelectedPath(skillFiles[0]?.path ?? files.files?.[0]?.path ?? null);
     setDeployError(null);
     setIssues([]);
     // skillFiles is derived from files.files, so files.files is the real dep.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [files.files]);
+
+  const saveChannel = async () => {
+    if (!agent || savingChannel || channelBlank) return;
+    setSavingChannel(true);
+    setChannelError(null);
+    try {
+      await updateAgent(agent.id, { slack_channel: channelValue });
+      refetch(); // refresh the wired agent data so the displayed channel updates
+      dispatch({ type: "toast", message: `Channel set to ${channelValue}` });
+    } catch (e) {
+      setChannelError(e instanceof ApiError ? e.message : e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingChannel(false);
+    }
+  };
 
   // Return to the Agents list this detail was opened from. closeAgentDetail's
   // reducer lands on Overview, so navigate explicitly instead.
@@ -124,7 +204,54 @@ export function WiredAgentDetail() {
             active {activeVersion.version_label}
           </Chip>
         ) : null}
-        <span style={{ marginLeft: "auto", fontSize: 12.5, color: C.muted, fontFamily: C.mono }}>{agent.slack_channel}</span>
+        <div style={{ marginLeft: "auto", display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ fontSize: 11, color: C.muted, fontFamily: C.mono }}>channel</span>
+            <input
+              data-testid="channel-input"
+              value={channel}
+              onChange={(e) => {
+                setChannel(e.target.value);
+                setChannelError(null);
+              }}
+              placeholder="C0123ABCD"
+              style={{
+                background: C.input,
+                border: "1px solid " + (channelLooksOff ? C.warn : C.borderStrong),
+                borderRadius: 7,
+                padding: "5px 9px",
+                color: C.text,
+                fontFamily: C.mono,
+                fontSize: 12.5,
+                width: 150,
+              }}
+            />
+            <Button
+              label={savingChannel ? "Saving…" : "Save"}
+              variant="secondary"
+              size="sm"
+              testId="channel-save"
+              disabled={channelBlank || savingChannel}
+              title={channelBlank ? "Enter the Slack channel ID first" : undefined}
+              onClick={() => void saveChannel()}
+            />
+          </div>
+          {channelLooksOff ? (
+            <div data-testid="channel-warn" style={{ fontSize: 11, color: C.warn, maxWidth: 280, textAlign: "right", lineHeight: 1.4 }}>
+              That does not look like a channel ID (C…). Mentions match on the ID, not the name — save anyway if you are
+              using the CLI.
+            </div>
+          ) : null}
+          {channelError ? (
+            <div data-testid="channel-error" style={{ fontSize: 11, color: C.destructive, maxWidth: 280, textAlign: "right", lineHeight: 1.4 }}>
+              Could not update channel: {channelError}
+            </div>
+          ) : (
+            <div style={{ fontSize: 10.5, color: C.muted, maxWidth: 280, textAlign: "right", lineHeight: 1.4 }}>
+              Saved to the stored config; the live worker keeps its channel until the next deploy.
+            </div>
+          )}
+        </div>
       </div>
 
       {versions.loading ? (
@@ -144,34 +271,38 @@ export function WiredAgentDetail() {
         </Card>
       ) : files.error ? (
         <Notice padding="34px 20px">{`Could not load skills: ${files.error}`}</Notice>
-      ) : skillFiles.length === 0 ? (
+      ) : allFiles.length === 0 ? (
         <Card>
-          <Notice padding="34px 20px">This bundle has no skills/*/SKILL.md files.</Notice>
+          <Notice padding="34px 20px">This bundle has no files.</Notice>
         </Card>
       ) : (
         <div>
-          {skillFiles.length > 1 ? (
+          {allFiles.length > 1 ? (
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
-              {skillFiles.map((f) => (
-                <button
-                  key={f.path}
-                  type="button"
-                  data-testid="skill-tab"
-                  onClick={() => setSelectedPath(f.path)}
-                  style={{
-                    fontFamily: C.mono,
-                    fontSize: 12,
-                    padding: "5px 10px",
-                    borderRadius: 7,
-                    cursor: "pointer",
-                    background: f.path === selectedPath ? C.hover : C.card,
-                    color: f.path === selectedPath ? C.text : C.text2,
-                    border: "1px solid " + (f.path === selectedPath ? C.borderStrong : C.border),
-                  }}
-                >
-                  {f.path}
-                </button>
-              ))}
+              {allFiles.map((f) => {
+                const editable = isSkillFile(f.path);
+                return (
+                  <button
+                    key={f.path}
+                    type="button"
+                    data-testid={editable ? "skill-tab" : "file-tab"}
+                    onClick={() => setSelectedPath(f.path)}
+                    title={editable ? undefined : "read-only"}
+                    style={{
+                      fontFamily: C.mono,
+                      fontSize: 12,
+                      padding: "5px 10px",
+                      borderRadius: 7,
+                      cursor: "pointer",
+                      background: f.path === selectedPath ? C.hover : C.card,
+                      color: f.path === selectedPath ? C.text : editable ? C.text2 : C.muted,
+                      border: "1px solid " + (f.path === selectedPath ? C.borderStrong : C.border),
+                    }}
+                  >
+                    {f.path}
+                  </button>
+                );
+              })}
             </div>
           ) : null}
 
@@ -185,7 +316,7 @@ export function WiredAgentDetail() {
               marginBottom: 16,
             }}
           >
-            {selectedPath ? (
+            {selectedPath && isSkillFile(selectedPath) ? (
               <SkillEditor
                 key={selectedPath}
                 path={selectedPath}
@@ -200,6 +331,12 @@ export function WiredAgentDetail() {
                 }}
                 testId="skill-editor"
                 height={360}
+              />
+            ) : selectedPath ? (
+              <FileView
+                key={selectedPath}
+                path={selectedPath}
+                content={allFiles.find((f) => f.path === selectedPath)?.content ?? ""}
               />
             ) : null}
             {issues.length > 0 ? (


### PR DESCRIPTION
Two items from the #18 hygiene batch (Alex's lane) — does **not** close #18 (the eval/hermetic-test/gitignore items are other lanes). Both UI-only; backends already exist.

- **Channel change (item 5)**: the detail showed the channel read-only though `PATCH /agents/{id}` exists. Added `updateAgent` client fn; made the channel editable with Save→PATCH→`refetch()`. Empty blocks; a non-Slack-ID value soft-warns but still saves (mirrors NewAgentModal). PATCH is metadata-only (no redeploy) — the hint says so.
- **Bundle tree (item 4)**: the detail fetched the full file list but filtered to SKILL.md. Now renders all returned files (manifest + `evals/cases.json` read-only) with SKILL.md still editable and the deploy path intact. The read endpoint (`GET /agents/{id}/versions/{vid}/files`) already returns these — **no API change** (the ticket's "add a bundle-files endpoint" already exists; flagged).

`Button` gains one optional `testId` prop (additive). Tests: `api.test.ts` PATCH shape + `WiredAgentDetail.test.tsx` (57). typecheck/lint/build clean. Touches `WiredAgentDetail.tsx` (also touched by #6/#32) — mechanical conflict possible by order.