### PR TITLE
UI: drop the stale CLI-view e2e test that broke main

### DIFF
--- a/apps/ui/e2e/dx-fixes.spec.ts
+++ b/apps/ui/e2e/dx-fixes.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-// FX2 item 5: ship a favicon (no console 404) and label the CLI view as a demo
-// mock so its canned version/model strings do not read as live.
+// FX2 item 5: ship a favicon (no console 404).
 
 test("a favicon is declared and served", async ({ page }) => {
   await page.goto("/?state=3");
@@ -10,11 +9,4 @@ test("a favicon is declared and served", async ({ page }) => {
   const resp = await page.request.get("/favicon.svg");
   expect(resp.status()).toBe(200);
   expect(resp.headers()["content-type"]).toContain("svg");
-});
-
-test("the CLI view is labeled as a demo mock", async ({ page }) => {
-  await page.goto("/?state=3");
-  await page.getByRole("button", { name: /CLI view/ }).click();
-  await expect(page.getByText("Demo mock")).toBeVisible();
-  await expect(page.getByTestId("cli-demo-note")).toContainText("not the live CLI");
 });


### PR DESCRIPTION
The CLI-terminal view and its Topbar toggle were removed in `b789b31` (#139), but the `dx-fixes` "CLI view is labeled as a demo mock" e2e case still clicked the now-gone button and timed out (30s), reddening `main`.

Delete the obsolete test; the favicon case in the same file stays.

Verified in a worktree off `origin/main`: `pnpm e2e` → 58 passed, `pnpm lint` clean, `pnpm typecheck` clean.

Ref #4