### PR TITLE
cluster message: resolve --chart like cluster up (no-clone flow)

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -370,8 +370,7 @@ enum ClusterAction {
         /// Helm release name. Default: agentos.
         #[arg(long)]
         release: Option<String>,
-        /// Chart path for the wiring `helm upgrade` (run from the repo root for
-        /// the default). Default: charts/agentos.
+        /// Helm chart. Default: the version-pinned chart release asset on release builds; local `charts/agentos` on dev builds. Pass a path or ref to override.
         #[arg(long)]
         chart: Option<String>,
         /// Host the in-cluster worker uses to reach the stub. Omit to auto-detect
@@ -779,13 +778,21 @@ async fn main() -> Result<()> {
                     state,
                     std::env::var("AGENTOS_API_KEY").ok(),
                 )?;
+                let resolved_chart = artifacts::resolve_chart(
+                    resolved.chart.as_deref(),
+                    artifacts::Channel::current(),
+                    artifacts::version(),
+                    artifacts::cache_root,
+                    std::path::Path::new("charts/agentos").is_dir(),
+                )?;
+                let chart = materialize_artifact(resolved_chart, dry_run, "chart").await?;
                 message::message(MessageOpts {
                     text,
                     channel: resolved.channel,
                     thread: resolved.thread,
                     namespace: resolved.namespace,
                     release: resolved.release,
-                    chart: resolved.chart,
+                    chart,
                     listen_host: resolved.listen_host,
                     listen_port,
                     valkey_local_port,

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -152,7 +152,7 @@ pub struct ResolvedTurnArgs {
     pub thread: Option<String>,
     pub namespace: String,
     pub release: String,
-    pub chart: String,
+    pub chart: Option<String>,
     pub listen_host: Option<String>,
     pub timeout_secs: u64,
     pub api_url: Option<String>,
@@ -205,8 +205,7 @@ pub fn apply_continue(
             .unwrap_or_else(|| "agentos".to_string()),
         chart: cli
             .chart
-            .or_else(|| state.as_ref().map(|state| state.chart.clone()))
-            .unwrap_or_else(|| "charts/agentos".to_string()),
+            .or_else(|| state.as_ref().map(|state| state.chart.clone())),
         listen_host: cli
             .listen_host
             .or_else(|| state.as_ref().and_then(|state| state.listen_host.clone())),
@@ -500,7 +499,7 @@ mod tests {
         assert_eq!(resolved.thread, Some("1.2".into()));
         assert_eq!(resolved.namespace, "explicit-ns");
         assert_eq!(resolved.release, "explicit-release");
-        assert_eq!(resolved.chart, "charts/explicit");
+        assert_eq!(resolved.chart.as_deref(), Some("charts/explicit"));
         assert_eq!(resolved.listen_host.as_deref(), Some("192.0.2.10"));
         assert_eq!(resolved.timeout_secs, 12);
         assert_eq!(resolved.api_url.as_deref(), Some("http://explicit-api"));
@@ -530,7 +529,7 @@ mod tests {
         assert_eq!(resolved.thread, Some("9.9".into()));
         assert_eq!(resolved.namespace, "persisted-ns");
         assert_eq!(resolved.release, "persisted-release");
-        assert_eq!(resolved.chart, "charts/persisted");
+        assert_eq!(resolved.chart.as_deref(), Some("charts/persisted"));
         assert_eq!(resolved.listen_host.as_deref(), Some("127.0.0.1"));
         assert_eq!(resolved.timeout_secs, 777);
         assert_eq!(resolved.api_url.as_deref(), Some("http://persisted-api"));
@@ -546,7 +545,7 @@ mod tests {
         assert_eq!(resolved.thread, None);
         assert_eq!(resolved.namespace, "agentos");
         assert_eq!(resolved.release, "agentos");
-        assert_eq!(resolved.chart, "charts/agentos");
+        assert_eq!(resolved.chart, None);
         assert_eq!(resolved.timeout_secs, DEFAULT_TIMEOUT_SECS);
     }
 


### PR DESCRIPTION
## Problem
`agentos cluster message` defaulted `--chart` to the local path `charts/agentos`, so in a no-clone dir (a release binary with no repo checkout) the stub-wiring `helm upgrade` failed. `cluster up` already resolves the chart remotely via `artifacts::resolve_chart` (fetching/caching the release tgz), so the two verbs disagreed and the "no charts" onboarding story broke on the first `cluster message`.

## Fix
`cluster message` now resolves the wiring chart through the same `artifacts::resolve_chart` + `materialize_artifact` path `cluster up` uses when `--chart` is omitted:
- `ResolvedTurnArgs.chart` is now `Option<String>`; `apply_continue` no longer hard-defaults to `charts/agentos`. When neither `--chart` nor a continued-turn chart is present, `None` flows into `resolve_chart` (Release -> cached `agentos-<ver>.tgz`, Dev -> local `charts/agentos` or the same helpful error `cluster up` gives).
- Explicit `--chart <path>` and continued-turn charts are still honored verbatim.
- `cluster up` and `local message` behavior are unchanged.
- Corrected the now-stale `--chart` help text to match `cluster up`'s wording.

## Verification
- `cargo test --lib` 137 passed; `cargo clippy --all-targets -- -D warnings` clean.
- Release binary in a no-clone dir: `cluster message --dry-run` prints `chart source: .../releases/download/v0.2.0/agentos-0.2.0.tgz` and `helm upgrade agentos ~/.cache/agentos/v0.2.0/agentos-0.2.0.tgz ...` (was `charts/agentos`).
- `--chart /custom` still honored; dev-channel no-clone errors with the same guidance `cluster up` gives.

## Noted follow-up (not in this PR's scope)
Codex review flagged (P2) that the chart is materialized eagerly, so a release run that skips Helm (`--no-wire`, or an already-wired worker) with a cold cache would fetch a chart it never uses. Within the intended flow this is a no-op (a prior `cluster up` warms the cache; dry-run never fetches), so it is left as a potential later improvement: defer materialization into the wiring path so it only fetches when `helm upgrade` actually runs.

Closes #118