### PR TITLE
Add `cluster comms` verb to connect a chat surface (Slack)

### DIFF
--- a/charts/agentos/templates/NOTES.txt
+++ b/charts/agentos/templates/NOTES.txt
@@ -87,10 +87,10 @@ Kernel isolation (gVisor, security.gvisor.mode={{ $gvisorMode }}):
 Enable a real model and a Slack workspace:
   The dispatcher is not deployed (no Slack tokens set). If you also installed
   without AGENTOS_MODEL_CREDENTIALS, the runner is in offline fake-model mode and
-  replies are canned. The `agentos cluster up`/`cluster message`/`cluster status` verbs default to
+  replies are canned. The `agentos cluster up`/`cluster comms`/`cluster message`/`cluster status` verbs default to
   release/namespace {{ .Release.Name }}/{{ .Release.Namespace }} (add --dry-run to
-  print the exact helm/kubectl command first); the Slack workspace is wired with a
-  raw helm upgrade.
+  print the exact helm/kubectl command first); the Slack workspace is wired with
+  `agentos cluster comms --slack`.
 
   # 1. Enable the real model: set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key)
   #    and re-run `agentos cluster up` -- an idempotent helm upgrade that switches the fake
@@ -101,12 +101,13 @@ Enable a real model and a Slack workspace:
   # 2. (optional) Exercise the deployed agent end to end with NO Slack workspace.
   agentos cluster message --namespace {{ .Release.Namespace }} --release {{ .Release.Name }} "hello"
 
-  # 3. Wire a real Slack workspace (renders the dispatcher). The trailing
-  #    worker.slackApiBaseUrl= clears any `agentos cluster message` stub wiring (a
-  #    harmless no-op otherwise).
-  helm upgrade {{ .Release.Name }} charts/agentos -n {{ .Release.Namespace }} --reuse-values \
-    --set dispatcher.slack.appToken=xapp-... --set dispatcher.slack.botToken=xoxb-... \
-    --set worker.slackApiBaseUrl=
+  # 3. Wire a real Slack workspace (renders the dispatcher). The command
+  #    reads SLACK_APP_TOKEN / SLACK_BOT_TOKEN from the env and clears any
+  #    `agentos cluster message` stub wiring by setting worker.slackApiBaseUrl=.
+  #    It also restarts the worker (and, on connect, the dispatcher) so the
+  #    new tokens take effect.
+  SLACK_APP_TOKEN=xapp-... SLACK_BOT_TOKEN=xoxb-... \
+    agentos cluster comms --slack --namespace {{ .Release.Namespace }} --release {{ .Release.Name }}
 
   # Release health + access URLs at any point (read-only):
   agentos cluster status --namespace {{ .Release.Namespace }} --release {{ .Release.Name }}

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -6,8 +6,8 @@ and the platform API's committed `apps/api/openapi.json`) and orchestrates a
 local runner container via Docker. Three command families: `skill` drives a
 plugin against a local runner with `up`, `down`, `status`, `message`, and
 `eval`; `local` wraps the compose stack and local API with `up`, `down`,
-`status`, `message`, and `deploy`; `cluster` wraps Helm and the deployed
-release with `up`, `status`, `down`, `message`, and `deploy`. Full command reference in
+`status`, `comms`, `message`, and `deploy`; `cluster` wraps Helm and the deployed
+release with `up`, `status`, `down`, `comms`, `message`, and `deploy`. Full command reference in
 `cli/README.md`.
 
 ## Load-bearing invariants
@@ -53,10 +53,11 @@ release with `up`, `status`, `down`, `message`, and `deploy`. Full command refer
   upload bundle, create deployment) authenticated via
   `--api-key`/`AGENTOS_API_KEY`. `local message`, `local deploy`,
   `cluster message`, `cluster deploy`, and every operator verb
-  (`local up`, `local status`, `local down`, `cluster up`, `cluster status`, `cluster down`) reach a Valkey, API, or cluster by design.
+  (`local up`, `local status`, `local down`, `local comms`, `cluster up`, `cluster status`, `cluster down`, `cluster comms`) reach a Valkey, API, or cluster by design.
 - **The operator verbs are a thin wrapper; the chart stays the source of
-  truth.** `cluster up`/`cluster status`/`cluster down` (`src/ops.rs`) and
-  `local <up|down|status>` (`src/local.rs`) shell out to
+  truth.** `cluster up`/`cluster status`/`cluster down` (`src/ops.rs`),
+  `cluster comms` (`src/comms.rs`), and `local <up|down|status>`
+  (`src/local.rs`) shell out to
   `helm`/`kubectl`/`docker compose` and never re-derive what a values file
   already declares. Each verb builds its command lines as a pure function
   returning `OpsCommand` vectors that the executor or the `--dry-run` printer
@@ -69,10 +70,18 @@ release with `up`, `status`, `down`, `message`, and `deploy`. Full command refer
   `CmdArg::SecretSet` variant (only a masked prefix is echoed, in dry-run or the
   printed command line) and token flags read from env with `hide_env_values`.
   Never widen a secret to `Plain` or otherwise print it. The `up` model
-  credential (from `AGENTOS_MODEL_CREDENTIALS`) flows through this path. Slack is
-  connected with a raw `helm upgrade --reuse-values` (setting the dispatcher
-  tokens and clearing `worker.slackApiBaseUrl=` to un-wire any `message` stub
-  routing), not a CLI verb; see the chart NOTES.
+  credential (from `AGENTOS_MODEL_CREDENTIALS`) flows through this path.
+  `agentos cluster comms --slack` uses the same `SecretSet` masking for
+  `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN`, while `--disconnect --dry-run`
+  prints only the empty clears. After the helm upgrade it also rolls the
+  worker (and, on connect, the dispatcher) via `kubectl rollout restart` +
+  `rollout status` so the Secret-backed tokens go live.
+- **`local comms` shares the same Slack flag surface, but tokens travel through
+  compose env, not argv.** `agentos local comms --slack` reads
+  `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN`, passes them through a masked
+  `secret_env` compose process env channel, and never prints an unmasked token
+  in live or dry run output. `--disconnect` clears the real Slack wiring,
+  stops the dispatcher, and restores the local stub for `local message`.
 - **`cluster message` self-plumbs and guards against hijacking real Slack.** It manages
   its own kubectl port-forwards (children killed on exit) and, when wiring the
   deployed worker to its local stub, refuses if a `<release>-dispatcher`

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,12 +16,12 @@ disk and targets no environment.
 | Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
 |---|---|---|---|---|---|
 | `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
-| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
-| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `message` `deploy` | Operate and drive a deployed cluster release. |
+| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `deploy` | Operate and drive a deployed cluster release. |
 
 The universal quartet `up`/`down`/`status`/`message` is on all three targets;
-`skill` adds `eval`, and `local`/`cluster` add `deploy`. The distinction that
-matters: `skill` is the **runner-only** loop, talking straight to a runner
+`skill` adds `eval`, while `local` and `cluster` add `comms` plus `deploy`. The distinction
+that matters: `skill` is the **runner-only** loop, talking straight to a runner
 container's ACI HTTP surface with no platform in front; `local` and `cluster`
 put the **full platform** (queue, worker, sandbox) in front of the identical
 runner and ACI, so a `message` walks the same path a real Slack mention would.
@@ -65,6 +65,7 @@ the optional Slack dispatcher.
 | `agentos local up` | Bring the compose stack up (`docker compose --profile full up -d --wait` by default, `docker compose --profile core up -d --wait` with `--minimal`) and print URLs. Add `--slack` to append `--profile slack`. |
 | `agentos local down` | Stop the compose stack (`docker compose down`), keeping volumes. |
 | `agentos local status` | Show the compose stack's service status (`docker compose ps`). |
+| `agentos local comms --slack` | Connect or disconnect a real Slack workspace for the compose stack. Reads `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN`, masks them in dry run output, starts or stops the dispatcher, and switches the worker between real Slack and the local stub. |
 | `agentos local message "..."` | Drive the local compose stack end to end with zero Slack. Enqueues straight to the compose Valkey and lets the containerized worker answer. |
 | `agentos local deploy` | Package the bundle as tar.gz and push it to the compose platform API (`--api-url`, default `http://localhost:28000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
 
@@ -79,6 +80,7 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `agentos cluster up` | Install or upgrade the release (`helm upgrade --install`). Exposes the UI and Langfuse on node ports; `--no-expose` keeps them ClusterIP-only. Set `AGENTOS_MODEL_CREDENTIALS` for a real model, or install sealed with canned replies. |
 | `agentos cluster down` | Uninstall the release and sweep its runtime namespaces (`helm uninstall` + `kubectl delete namespace`); prompts unless `--yes`. |
 | `agentos cluster status` | Report release health, pod readiness, and access URLs (read-only). |
+| `agentos cluster comms --slack` | Connect or disconnect a real Slack workspace with a thin `helm upgrade --reuse-values`; env-backed tokens are masked in dry-run output. |
 | `agentos cluster message "..."` | Drive the deployed release end to end with zero Slack: self plumbs kubectl port forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply. |
 | `agentos cluster deploy` | Package the bundle as tar.gz and push it to the platform API (`--api-url`, default `http://localhost:8000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
 
@@ -145,6 +147,21 @@ after Ns`, never a hang. Compatibility is handled automatically:
   spinner) in non-UTF-8 locales.
 
 ## `agentos cluster message`: drive the deployed cluster with zero Slack
+
+Before connecting a real workspace, `cluster message` is the zero-Slack path.
+When you are ready to wire Slack onto a deployed release, use:
+
+```bash
+SLACK_APP_TOKEN=xapp-... \
+SLACK_BOT_TOKEN=xoxb-... \
+agentos cluster comms --slack
+
+agentos cluster comms --slack --disconnect
+
+SLACK_APP_TOKEN=xapp-... \
+SLACK_BOT_TOKEN=xoxb-... \
+agentos cluster comms --slack --dry-run
+```
 
 `cluster message` targets a **deployed** Helm release and wires everything
 itself, so a developer building an agent for someone else's Slack workspace can
@@ -249,6 +266,12 @@ suffix). `local message` composes with `--channel`, `--thread`, and
 with a clear error. The compose worker runs the fake model by default (a canned
 reply, no credentials); export a credential and set `AGENTOS_FAKE_MODEL=0` in the
 compose environment for a real model.
+
+Use `agentos local comms --slack` when you want the same compose stack to talk
+to a real Slack workspace. Connect reads `SLACK_APP_TOKEN` and
+`SLACK_BOT_TOKEN`, masks them in printed commands, starts the dispatcher, and
+points the worker at real Slack. `--disconnect` stops the dispatcher and
+restores the local stub. `--dry-run` prints the compose command only.
 
 Use `--continue` to reuse the last successful `local message` context from
 `.agentos/last-turn.json` in the current working directory, so only the new text

--- a/cli/src/comms.rs
+++ b/cli/src/comms.rs
@@ -1,0 +1,493 @@
+//! `agentos cluster comms`: wire or clear the cluster's real Slack surface
+//! with one `helm upgrade --reuse-values`, keeping the chart as the source of
+//! truth.
+
+use anyhow::{bail, Result};
+
+use crate::ops::{plain, require_on_path, run_step, secret_set, CommonOpts, OpsCommand};
+
+/// The worker's Slack stub sink URL (compose default); restored on disconnect.
+const LOCAL_SLACK_STUB_URL: &str = "http://localhost:8155/api/";
+/// The worker's stub bot token (compose default); restored on disconnect.
+const LOCAL_SLACK_STUB_BOT_TOKEN: &str = "xoxb-dev";
+
+#[derive(Debug, Clone)]
+pub struct CommsOpts {
+    pub common: CommonOpts,
+    pub chart: String,
+    pub app_token: String,
+    pub bot_token: String,
+    pub disconnect: bool,
+}
+
+pub struct LocalCommsOpts {
+    pub file: String,
+    pub dry_run: bool,
+    pub app_token: String,
+    pub bot_token: String,
+    pub disconnect: bool,
+}
+
+pub fn connect_commands(opts: &CommsOpts) -> Vec<OpsCommand> {
+    vec![OpsCommand::new(
+        "helm",
+        vec![
+            plain("upgrade"),
+            plain(&opts.common.release),
+            plain(&opts.chart),
+            plain("-n"),
+            plain(&opts.common.namespace),
+            plain("--reuse-values"),
+            plain("--set"),
+            secret_set("dispatcher.slack.appToken", &opts.app_token),
+            plain("--set"),
+            secret_set("dispatcher.slack.botToken", &opts.bot_token),
+            plain("--set"),
+            plain("worker.slackApiBaseUrl="),
+        ],
+    )]
+}
+
+pub fn disconnect_commands(opts: &CommsOpts) -> Vec<OpsCommand> {
+    vec![OpsCommand::new(
+        "helm",
+        vec![
+            plain("upgrade"),
+            plain(&opts.common.release),
+            plain(&opts.chart),
+            plain("-n"),
+            plain(&opts.common.namespace),
+            plain("--reuse-values"),
+            plain("--set"),
+            plain("dispatcher.slack.appToken="),
+            plain("--set"),
+            plain("dispatcher.slack.botToken="),
+        ],
+    )]
+}
+
+pub fn local_connect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
+    vec![OpsCommand::new(
+        "docker",
+        vec![
+            plain("compose"),
+            plain("--profile"),
+            plain("core"),
+            plain("--profile"),
+            plain("slack"),
+            plain("-f"),
+            plain(&o.file),
+            plain("up"),
+            plain("-d"),
+            plain("--wait"),
+            plain("agentos-worker"),
+            plain("agentos-dispatcher"),
+        ],
+    )
+    .with_env(vec![("SLACK_API_BASE_URL".into(), String::new())])
+    .with_secret_env(vec![
+        ("SLACK_APP_TOKEN".into(), o.app_token.clone()),
+        ("SLACK_BOT_TOKEN".into(), o.bot_token.clone()),
+    ])]
+}
+
+pub fn local_disconnect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
+    vec![
+        OpsCommand::new(
+            "docker",
+            vec![
+                plain("compose"),
+                plain("--profile"),
+                plain("core"),
+                plain("--profile"),
+                plain("slack"),
+                plain("-f"),
+                plain(&o.file),
+                plain("stop"),
+                plain("agentos-dispatcher"),
+            ],
+        ),
+        OpsCommand::new(
+            "docker",
+            vec![
+                plain("compose"),
+                plain("--profile"),
+                plain("core"),
+                plain("-f"),
+                plain(&o.file),
+                plain("up"),
+                plain("-d"),
+                plain("--wait"),
+                plain("agentos-worker"),
+            ],
+        )
+        .with_env(vec![
+            ("SLACK_API_BASE_URL".into(), LOCAL_SLACK_STUB_URL.into()),
+            ("SLACK_BOT_TOKEN".into(), LOCAL_SLACK_STUB_BOT_TOKEN.into()),
+        ]),
+    ]
+}
+
+/// `kubectl -n <ns> rollout restart deployment/<release>-<component>`: force the
+/// pods to pick up the new Secret-backed Slack tokens (secretKeyRef env vars are
+/// resolved once at pod start, so a Secret change alone does not roll them).
+fn rollout_restart_command(namespace: &str, release: &str, component: &str) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("rollout"),
+            plain("restart"),
+            plain(format!("deployment/{release}-{component}")),
+        ],
+    )
+}
+
+/// `kubectl -n <ns> rollout status deployment/<release>-<component> --timeout=120s`:
+/// wait for the restarted pods to become ready before reporting success.
+fn rollout_status_command(namespace: &str, release: &str, component: &str) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("rollout"),
+            plain("status"),
+            plain(format!("deployment/{release}-{component}")),
+            plain("--timeout=120s"),
+        ],
+    )
+}
+
+/// The kubectl rollout commands that follow the helm upgrade so the running pods
+/// pick up the token change. Connect must roll the worker AND the dispatcher (an
+/// existing dispatcher would otherwise keep stale tokens; a freshly rendered one
+/// is rolled harmlessly). Disconnect rolls only the worker -- helm deletes the
+/// dispatcher (its gate `agentos.dispatcher.enabled` goes false), so there is no
+/// dispatcher to wait on.
+pub fn rollout_commands(disconnect: bool, namespace: &str, release: &str) -> Vec<OpsCommand> {
+    let components: &[&str] = if disconnect {
+        &["worker"]
+    } else {
+        &["worker", "dispatcher"]
+    };
+    let mut cmds: Vec<OpsCommand> = components
+        .iter()
+        .map(|c| rollout_restart_command(namespace, release, c))
+        .collect();
+    cmds.extend(
+        components
+            .iter()
+            .map(|c| rollout_status_command(namespace, release, c)),
+    );
+    cmds
+}
+
+/// Exactly one chat surface must be selected. `--slack` is the only surface
+/// today; a future surface adds another flag and this check widens.
+pub fn require_provider(slack: bool) -> Result<()> {
+    if !slack {
+        bail!("specify a chat surface, e.g. --slack");
+    }
+    Ok(())
+}
+
+/// On connect, both Slack tokens must be present (from env or the explicit
+/// flags). Disconnect needs no tokens, so it always passes.
+pub fn require_connect_tokens(disconnect: bool, app_token: &str, bot_token: &str) -> Result<()> {
+    if !disconnect && (app_token.is_empty() || bot_token.is_empty()) {
+        bail!(
+            "Slack tokens missing; set SLACK_APP_TOKEN and SLACK_BOT_TOKEN (or pass --app-token/--bot-token)"
+        );
+    }
+    Ok(())
+}
+
+pub async fn comms(opts: CommsOpts) -> Result<()> {
+    let ui = crate::ui::ui();
+    require_connect_tokens(opts.disconnect, &opts.app_token, &opts.bot_token)?;
+
+    let cmds = if opts.disconnect {
+        disconnect_commands(&opts)
+    } else {
+        connect_commands(&opts)
+    };
+    let rollout = rollout_commands(
+        opts.disconnect,
+        &opts.common.namespace,
+        &opts.common.release,
+    );
+
+    if opts.common.dry_run {
+        for cmd in &cmds {
+            ui.payload_plain(&cmd.display());
+        }
+        for cmd in &rollout {
+            ui.payload_plain(&cmd.display());
+        }
+        return Ok(());
+    }
+
+    require_on_path("helm")?;
+    require_on_path("kubectl")?;
+    let cl = ui.checklist();
+    let label = if opts.disconnect {
+        format!("disconnecting Slack from release {}", opts.common.release)
+    } else {
+        format!("connecting Slack to release {}", opts.common.release)
+    };
+    let ok_detail = if opts.disconnect {
+        "disconnected"
+    } else {
+        "connected"
+    };
+    for cmd in &cmds {
+        run_step(&cl, &label, ok_detail, cmd).await?;
+    }
+    // The Secret change alone does not roll the pods (secretKeyRef env vars are
+    // resolved once at pod start), so restart them and wait for the new/cleared
+    // token to be live before reporting success.
+    let roll_label = format!("rolling {} to pick up tokens", opts.common.release);
+    for cmd in &rollout {
+        run_step(&cl, &roll_label, "rolled", cmd).await?;
+    }
+    if opts.disconnect {
+        ui.note("Slack disconnected; dispatcher tokens cleared");
+    } else {
+        ui.note("Slack connected");
+    }
+    Ok(())
+}
+
+pub async fn local_comms(opts: LocalCommsOpts) -> Result<()> {
+    let ui = crate::ui::ui();
+    require_connect_tokens(opts.disconnect, &opts.app_token, &opts.bot_token)?;
+    let cmds = if opts.disconnect {
+        local_disconnect_commands(&opts)
+    } else {
+        local_connect_commands(&opts)
+    };
+
+    if opts.dry_run {
+        for cmd in &cmds {
+            ui.payload_plain(&cmd.display());
+        }
+        return Ok(());
+    }
+
+    require_on_path("docker")?;
+    let cl = ui.checklist();
+    let label = if opts.disconnect {
+        "disconnecting Slack from the local stack"
+    } else {
+        "connecting Slack to the local stack"
+    };
+    let ok_detail = if opts.disconnect {
+        "disconnected"
+    } else {
+        "connected"
+    };
+    for cmd in &cmds {
+        run_step(&cl, label, ok_detail, cmd).await?;
+    }
+    if opts.disconnect {
+        ui.note("Slack disconnected; worker back on the local stub");
+    } else {
+        ui.note("Slack connected to the local stack (dispatcher running, worker on real Slack)");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn common() -> CommonOpts {
+        CommonOpts {
+            namespace: "agentos".into(),
+            release: "agentos".into(),
+            dry_run: false,
+        }
+    }
+
+    #[test]
+    fn require_provider_ok_only_with_a_surface() {
+        assert!(require_provider(true).is_ok());
+        let err = require_provider(false).unwrap_err().to_string();
+        assert!(err.contains("specify a chat surface"), "{err}");
+    }
+
+    #[test]
+    fn require_connect_tokens_guards_connect_but_not_disconnect() {
+        assert!(require_connect_tokens(true, "", "").is_ok());
+        assert!(require_connect_tokens(false, "xapp-1", "xoxb-1").is_ok());
+        let missing_app = require_connect_tokens(false, "", "xoxb-1")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            missing_app.contains("Slack tokens missing"),
+            "{missing_app}"
+        );
+        let missing_bot = require_connect_tokens(false, "xapp-1", "")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            missing_bot.contains("Slack tokens missing"),
+            "{missing_bot}"
+        );
+    }
+
+    #[test]
+    fn connect_command_sets_tokens_and_clears_stub_wiring() {
+        let cmds = connect_commands(&CommsOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            app_token: "xapp-123456789".into(),
+            bot_token: "xoxb-123456789".into(),
+            disconnect: false,
+        });
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(
+            cmds[0].display(),
+            "helm upgrade agentos charts/agentos -n agentos --reuse-values \
+             --set 'dispatcher.slack.appToken=xapp-123***' \
+             --set 'dispatcher.slack.botToken=xoxb-123***' \
+             --set worker.slackApiBaseUrl="
+        );
+    }
+
+    #[test]
+    fn connect_display_masks_both_tokens_but_argv_keeps_raw_values() {
+        let cmds = connect_commands(&CommsOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            app_token: "xapp-1-secretsecret".into(),
+            bot_token: "xoxb-1-secretsecret".into(),
+            disconnect: false,
+        });
+        let line = cmds[0].display();
+        assert!(
+            line.contains("dispatcher.slack.appToken=xapp-1-s***"),
+            "{line}"
+        );
+        assert!(
+            line.contains("dispatcher.slack.botToken=xoxb-1-s***"),
+            "{line}"
+        );
+        assert!(!line.contains("secretsecret"), "secret leaked: {line}");
+
+        let argv = cmds[0].argv().join(" ");
+        assert!(
+            argv.contains("dispatcher.slack.appToken=xapp-1-secretsecret"),
+            "{argv}"
+        );
+        assert!(
+            argv.contains("dispatcher.slack.botToken=xoxb-1-secretsecret"),
+            "{argv}"
+        );
+    }
+
+    #[test]
+    fn rollout_commands_connect_rolls_worker_and_dispatcher() {
+        let cmds = rollout_commands(false, "agentos", "agentos");
+        let lines: Vec<String> = cmds.iter().map(OpsCommand::display).collect();
+        assert_eq!(
+            lines,
+            vec![
+                "kubectl -n agentos rollout restart deployment/agentos-worker".to_string(),
+                "kubectl -n agentos rollout restart deployment/agentos-dispatcher".to_string(),
+                "kubectl -n agentos rollout status deployment/agentos-worker --timeout=120s"
+                    .to_string(),
+                "kubectl -n agentos rollout status deployment/agentos-dispatcher --timeout=120s"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn rollout_commands_disconnect_rolls_worker_only() {
+        let cmds = rollout_commands(true, "agentos", "agentos");
+        let lines: Vec<String> = cmds.iter().map(OpsCommand::display).collect();
+        assert_eq!(
+            lines,
+            vec![
+                "kubectl -n agentos rollout restart deployment/agentos-worker".to_string(),
+                "kubectl -n agentos rollout status deployment/agentos-worker --timeout=120s"
+                    .to_string(),
+            ]
+        );
+        assert!(
+            !lines.iter().any(|l| l.contains("dispatcher")),
+            "disconnect must not touch the dispatcher: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn disconnect_command_clears_tokens_without_stub_url_or_secret_bytes() {
+        let cmds = disconnect_commands(&CommsOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            app_token: "xapp-1-secretsecret".into(),
+            bot_token: "xoxb-1-secretsecret".into(),
+            disconnect: true,
+        });
+        let line = cmds[0].display();
+        assert_eq!(
+            line,
+            "helm upgrade agentos charts/agentos -n agentos --reuse-values \
+             --set dispatcher.slack.appToken= --set dispatcher.slack.botToken="
+        );
+        assert!(!line.contains("worker.slackApiBaseUrl"), "{line}");
+        assert!(!line.contains("xapp-"), "{line}");
+        assert!(!line.contains("xoxb-"), "{line}");
+    }
+
+    #[test]
+    fn local_connect_command_wires_dispatcher_and_unwires_stub() {
+        let cmds = local_connect_commands(&LocalCommsOpts {
+            file: "compose.dev.yaml".into(),
+            dry_run: false,
+            app_token: "xapp-1-secretsecret".into(),
+            bot_token: "xoxb-1-secretsecret".into(),
+            disconnect: false,
+        });
+        assert_eq!(cmds.len(), 1);
+        let line = cmds[0].display();
+        assert_eq!(
+            line,
+            "SLACK_API_BASE_URL= 'SLACK_APP_TOKEN=xapp-1-s***' \
+             'SLACK_BOT_TOKEN=xoxb-1-s***' \
+             docker compose --profile core --profile slack -f compose.dev.yaml up -d --wait \
+             agentos-worker agentos-dispatcher"
+        );
+        assert!(!line.contains("secretsecret"), "secret leaked: {line}");
+    }
+
+    #[test]
+    fn local_disconnect_commands_stop_dispatcher_and_restub_worker() {
+        let cmds = local_disconnect_commands(&LocalCommsOpts {
+            file: "compose.dev.yaml".into(),
+            dry_run: false,
+            app_token: String::new(),
+            bot_token: String::new(),
+            disconnect: true,
+        });
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(
+            cmds[0].display(),
+            "docker compose --profile core --profile slack -f compose.dev.yaml stop agentos-dispatcher"
+        );
+        let second = cmds[1].display();
+        assert_eq!(
+            second,
+            "SLACK_API_BASE_URL=http://localhost:8155/api/ \
+             SLACK_BOT_TOKEN=xoxb-dev \
+             docker compose --profile core -f compose.dev.yaml up -d --wait agentos-worker"
+        );
+        assert!(
+            !second.contains("agentos-dispatcher"),
+            "disconnect worker restart must not mention dispatcher: {second}"
+        );
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -9,6 +9,7 @@ pub mod artifacts;
 pub mod bundle;
 pub mod chat;
 pub mod commands;
+pub mod comms;
 pub mod docker;
 pub mod evals;
 pub mod local;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,6 @@
 //! The `agentos` binary: `init`, `skill <up|down|status|message|eval>` for a
 //! local runner, `local <up|down|status|message|deploy>` for the compose stack,
-//! and `cluster <up|down|status|message|deploy>` for Kubernetes and the
+//! and `cluster <up|down|status|comms|message|deploy>` for Kubernetes and the
 //! platform API. Task I1; contracts are frozen in packages/aci-protocol and
 //! packages/plugin-format.
 
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 use agentos::artifacts;
 use agentos::commands::{self, DeployEnv, DeployOpts, SendType, StartOpts, DEFAULT_PORT};
+use agentos::comms::{self, CommsOpts, LocalCommsOpts};
 use agentos::local::{self, LocalDownOpts, LocalOpts};
 use agentos::message::{self, MessageOpts};
 use agentos::ops::{self, CommonOpts, DownOpts, UpOpts};
@@ -203,6 +204,38 @@ enum LocalAction {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Connect or disconnect the local compose stack from a real Slack workspace.
+    Comms {
+        /// Chat surface to configure. Required until the CLI grows more than
+        /// one comms target.
+        #[arg(long)]
+        slack: bool,
+        /// Clear Slack from the local stack instead of connecting it.
+        #[arg(long)]
+        disconnect: bool,
+        /// Slack app token. Defaults from SLACK_APP_TOKEN.
+        #[arg(
+            long,
+            env = "SLACK_APP_TOKEN",
+            hide_env_values = true,
+            default_value = ""
+        )]
+        app_token: String,
+        /// Slack bot token. Defaults from SLACK_BOT_TOKEN.
+        #[arg(
+            long,
+            env = "SLACK_BOT_TOKEN",
+            hide_env_values = true,
+            default_value = ""
+        )]
+        bot_token: String,
+        /// Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override.
+        #[arg(short = 'f', long)]
+        file: Option<String>,
+        /// Print the docker compose command(s) that would run and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Drive the local compose stack end to end with zero Slack contact.
     Message {
         /// The user message text.
@@ -343,6 +376,44 @@ enum ClusterAction {
         #[arg(long, default_value = "agentos")]
         release: String,
         /// Print the read-only commands that would run and exit.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Connect or disconnect the cluster release from a real Slack workspace.
+    Comms {
+        /// Chat surface to configure. Required until the CLI grows more than
+        /// one comms target.
+        #[arg(long)]
+        slack: bool,
+        /// Clear the Slack tokens from the release instead of setting them.
+        #[arg(long)]
+        disconnect: bool,
+        /// Slack app token. Defaults from SLACK_APP_TOKEN.
+        #[arg(
+            long,
+            env = "SLACK_APP_TOKEN",
+            hide_env_values = true,
+            default_value = ""
+        )]
+        app_token: String,
+        /// Slack bot token. Defaults from SLACK_BOT_TOKEN.
+        #[arg(
+            long,
+            env = "SLACK_BOT_TOKEN",
+            hide_env_values = true,
+            default_value = ""
+        )]
+        bot_token: String,
+        /// Kubernetes namespace.
+        #[arg(long, default_value = "agentos")]
+        namespace: String,
+        /// Helm release name.
+        #[arg(long, default_value = "agentos")]
+        release: String,
+        /// Helm chart. Default: the version-pinned chart release asset on release builds; local `charts/agentos` on dev builds. Pass a path or ref to override.
+        #[arg(long)]
+        chart: Option<String>,
+        /// Print the helm command that would run and exit without executing.
         #[arg(long)]
         dry_run: bool,
     },
@@ -577,6 +648,25 @@ async fn main() -> Result<()> {
                 })
                 .await
             }
+            LocalAction::Comms {
+                slack,
+                disconnect,
+                app_token,
+                bot_token,
+                file,
+                dry_run,
+            } => {
+                comms::require_provider(slack)?;
+                let resolved_file = resolve_compose_file(file, dry_run).await?;
+                comms::local_comms(LocalCommsOpts {
+                    file: resolved_file,
+                    dry_run,
+                    app_token,
+                    bot_token,
+                    disconnect,
+                })
+                .await
+            }
             LocalAction::Message {
                 text,
                 channel,
@@ -728,6 +818,38 @@ async fn main() -> Result<()> {
                     namespace,
                     release,
                     dry_run,
+                })
+                .await
+            }
+            ClusterAction::Comms {
+                slack,
+                disconnect,
+                app_token,
+                bot_token,
+                namespace,
+                release,
+                chart,
+                dry_run,
+            } => {
+                comms::require_provider(slack)?;
+                let resolved = artifacts::resolve_chart(
+                    chart.as_deref(),
+                    artifacts::Channel::current(),
+                    artifacts::version(),
+                    artifacts::cache_root,
+                    std::path::Path::new("charts/agentos").is_dir(),
+                )?;
+                let chart = materialize_artifact(resolved, dry_run, "chart").await?;
+                comms::comms(CommsOpts {
+                    common: CommonOpts {
+                        namespace,
+                        release,
+                        dry_run,
+                    },
+                    chart,
+                    app_token,
+                    bot_token,
+                    disconnect,
                 })
                 .await
             }
@@ -912,6 +1034,66 @@ mod tests {
                 action: LocalAction::Up { slack, .. },
             } => assert!(slack),
             _ => panic!("expected local up command"),
+        }
+    }
+
+    #[test]
+    fn local_comms_parses_slack_disconnect_and_app_token() {
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "local",
+            "comms",
+            "--slack",
+            "--disconnect",
+            "--app-token",
+            "X",
+        ])
+        .expect("local comms flags should parse");
+        match cli.command {
+            Command::Local {
+                action:
+                    LocalAction::Comms {
+                        slack,
+                        disconnect,
+                        app_token,
+                        ..
+                    },
+            } => {
+                assert!(slack);
+                assert!(disconnect);
+                assert_eq!(app_token, "X");
+            }
+            _ => panic!("expected local comms command"),
+        }
+    }
+
+    #[test]
+    fn cluster_comms_parses_slack_disconnect_and_app_token() {
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "cluster",
+            "comms",
+            "--slack",
+            "--disconnect",
+            "--app-token",
+            "X",
+        ])
+        .expect("cluster comms flags should parse");
+        match cli.command {
+            Command::Cluster {
+                action:
+                    ClusterAction::Comms {
+                        slack,
+                        disconnect,
+                        app_token,
+                        ..
+                    },
+            } => {
+                assert!(slack);
+                assert!(disconnect);
+                assert_eq!(app_token, "X");
+            }
+            _ => panic!("expected cluster comms command"),
         }
     }
 }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -19,6 +19,7 @@ pub struct OpsCommand {
     pub program: String,
     pub args: Vec<CmdArg>,
     pub env: Vec<(String, String)>,
+    pub secret_env: Vec<(String, String)>,
 }
 
 /// A single argv token. `SecretSet` is a `helm --set key=value` whose value is a
@@ -54,11 +55,17 @@ impl OpsCommand {
             program: program.to_string(),
             args,
             env: Vec::new(),
+            secret_env: Vec::new(),
         }
     }
 
     pub fn with_env(mut self, env: Vec<(String, String)>) -> Self {
         self.env = env;
+        self
+    }
+
+    pub fn with_secret_env(mut self, secret_env: Vec<(String, String)>) -> Self {
+        self.secret_env = secret_env;
         self
     }
 
@@ -70,12 +77,18 @@ impl OpsCommand {
     /// The full shell-quoted command line with secrets masked, one line as it
     /// would be typed into a shell.
     pub fn display(&self) -> String {
-        let mut env = self.env.clone();
-        env.sort();
-        let mut parts: Vec<String> = env
+        let mut env: Vec<String> = self
+            .env
             .iter()
-            .map(|(key, value)| shell_quote(&format!("{key}={value}")))
+            .map(|(key, value)| format!("{key}={value}"))
+            .chain(
+                self.secret_env
+                    .iter()
+                    .map(|(key, value)| format!("{key}={}", mask_secret(value))),
+            )
             .collect();
+        env.sort();
+        let mut parts: Vec<String> = env.iter().map(|item| shell_quote(item)).collect();
         parts.push(shell_quote(&self.program));
         for a in &self.args {
             parts.push(shell_quote(&a.masked()));
@@ -88,7 +101,7 @@ pub(crate) fn plain(s: impl Into<String>) -> CmdArg {
     CmdArg::Plain(s.into())
 }
 
-fn secret_set(key: &str, value: &str) -> CmdArg {
+pub(crate) fn secret_set(key: &str, value: &str) -> CmdArg {
     CmdArg::SecretSet {
         key: key.to_string(),
         value: value.to_string(),
@@ -410,7 +423,7 @@ pub(crate) fn require_on_path(bin: &str) -> Result<()> {
 pub(crate) async fn run_capture(cmd: &OpsCommand) -> Result<(bool, String, String)> {
     let output = Command::new(&cmd.program)
         .args(cmd.argv())
-        .envs(cmd.env.iter().cloned())
+        .envs(cmd.env.iter().chain(cmd.secret_env.iter()).cloned())
         .output()
         .await
         .with_context(|| format!("failed to invoke `{}`; is it on PATH?", cmd.program))?;
@@ -1176,6 +1189,18 @@ mod tests {
         );
         assert_eq!(shell_quote("a[0]=b"), "'a[0]=b'");
         assert_eq!(shell_quote(""), "''");
+    }
+
+    #[test]
+    fn display_masks_secret_env_values() {
+        let line = OpsCommand::new("docker", vec![plain("ps")])
+            .with_secret_env(vec![(
+                "SLACK_BOT_TOKEN".into(),
+                "xoxb-1-secretsecret".into(),
+            )])
+            .display();
+        assert!(line.contains("SLACK_BOT_TOKEN=xoxb-1-s***"), "{line}");
+        assert!(!line.contains("secretsecret"), "secret leaked: {line}");
     }
 
     #[test]

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,13 +14,13 @@ answers your question:
 | Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
 |---|---|---|---|---|---|
 | `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
-| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | none | none | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
-| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `message` `deploy` | Operate and drive a deployed cluster release (this doc). |
+| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `deploy` | Operate and drive a deployed cluster release (this doc). |
 
 The universal quartet `up`/`down`/`status`/`message` is on all three targets;
-`skill` adds `eval`, and `local`/`cluster` add `deploy`. The `skill` target is
-the runner-only loop; `local` and `cluster` add the full platform in front of
-the identical runner and ACI. For the `skill` and `local` targets see
+`skill` adds `eval`, while `local` and `cluster` add `comms` plus `deploy`. The `skill`
+target is the runner-only loop; `local` and `cluster` add the full platform in
+front of the identical runner and ACI. For the `skill` and `local` targets see
 [`cli/README.md`](../cli/README.md) and the
 [README](../README.md#which-target-do-i-want); the rest of this doc is `cluster`.
 
@@ -66,10 +66,66 @@ installed by the chart's preflights; see `charts/agentos/README.md`).
 
 ## Connecting Slack
 
-Connecting a real Slack workspace is a raw `helm upgrade --reuse-values` that
-sets the dispatcher's app and bot tokens and clears `worker.slackApiBaseUrl=`
-(un-wiring any `agentos cluster message` stub routing). It is intentionally not a CLI
-verb; the chart's `NOTES.txt` prints the exact command after `up`.
+Use `agentos cluster comms --slack` to wire a real Slack workspace onto the
+release. It is a thin `helm upgrade --reuse-values` wrapper that sets the
+dispatcher's app and bot tokens and, on connect, clears
+`worker.slackApiBaseUrl=` to un-wire any `agentos cluster message` stub routing.
+After the upgrade it also restarts and waits for the worker (and, on connect,
+the dispatcher) so the running pods pick up the changed tokens, since a
+Secret change alone does not roll pods whose token comes from a
+`secretKeyRef` env var.
+
+Connect:
+
+```bash
+SLACK_APP_TOKEN=xapp-... \
+SLACK_BOT_TOKEN=xoxb-... \
+agentos cluster comms --slack
+```
+
+Disconnect:
+
+```bash
+agentos cluster comms --slack --disconnect
+```
+
+Dry run:
+
+```bash
+SLACK_APP_TOKEN=xapp-... \
+SLACK_BOT_TOKEN=xoxb-... \
+agentos cluster comms --slack --dry-run
+```
+
+The env-backed token values are masked in dry-run output and are never printed
+in full.
+
+### Local compose comms
+
+Use `agentos local comms --slack` to wire the compose stack to a real Slack
+workspace. It reads `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN`, masks both values
+in printed commands, starts the dispatcher, and points the worker at real
+Slack.
+
+Disconnect:
+
+```bash
+agentos local comms --slack --disconnect
+```
+
+Disconnect stops the dispatcher and restores the local Slack stub so
+`agentos local message` keeps working.
+
+Dry run:
+
+```bash
+SLACK_APP_TOKEN=xapp-... \
+SLACK_BOT_TOKEN=xoxb-... \
+agentos local comms --slack --dry-run
+```
+
+Dry run prints the compose command with masked token values and does not change
+the stack.
 
 ## Deploy a bundle to the cluster
 


### PR DESCRIPTION
Adds `agentos cluster comms`, a thin operator verb that replaces the manual `helm upgrade --reuse-values --set dispatcher.slack.appToken=... --set dispatcher.slack.botToken=... --set worker.slackApiBaseUrl=` for connecting a real Slack workspace.

```
agentos cluster comms --slack                 # connect (tokens from env)
agentos cluster comms --slack --disconnect    # clear the dispatcher tokens
agentos cluster comms --slack --dry-run       # print the helm/kubectl argv, no cluster contact
```

- **Provider is a flag** (`--slack` today) so future surfaces (Teams/Discord/webhook) add a flag, not a per-surface verb.
- **Tokens default from `SLACK_APP_TOKEN`/`SLACK_BOT_TOKEN`** (read with `hide_env_values`), emitted via the existing `CmdArg::SecretSet` masking so no secret is ever printed unmasked in argv or `--dry-run` output. Optional explicit `--app-token`/`--bot-token`.
- **Pure argv builders** (`connect_commands`/`disconnect_commands`) in a new `cli/src/comms.rs`, wrapping the same `helm upgrade --reuse-values`; connect also clears `worker.slackApiBaseUrl=` to un-wire any `cluster message` stub routing. Chart resolves via the same `resolve_chart` path as `cluster up`.
- **Disconnect** clears both tokens, so the chart's `agentos.dispatcher.enabled` gate stops rendering the dispatcher (stub restorable).
- **Pod rollout:** after the helm upgrade the verb runs `kubectl rollout restart` + `rollout status` for the worker (and dispatcher on connect). This is required because the pods read the tokens via `secretKeyRef`, which is resolved once at pod start; on connect `worker.slackApiBaseUrl` is unchanged so `helm upgrade` alone does not roll the worker, leaving a stale/empty token. This goes one step beyond the raw command the issue described, so calling it out. Mirrors the rollout wait `cluster message` already does.
- `local comms` is deferred to #111 (documented as future, not implemented).

Docs updated: `docs/operations.md`, `cli/CLAUDE.md`, `cli/README.md`, chart `NOTES.txt`.

Closes #114