### PR TITLE
Scrub team-size detail from ADR-0007; document ADRs as the decision system of record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,22 @@
 See [AGENTS.md](AGENTS.md) - the agent instructions for this repo live there.
+
+## Architecture Decision Records (ADRs)
+
+`docs/adr/` is the system of record for architecture decisions. Each ADR captures
+**what was decided and when**, along with the reasoning and the alternatives
+weighed at that time. That record is durable even after a decision evolves: ADRs
+are immutable once Accepted, so when the thinking changes you add a **new ADR that
+supersedes** the old one rather than editing it. The chain of supersessions is the
+history of how intent shifted over time (the intent-gap record), not just a
+snapshot of the current state.
+
+Workflow for non-trivial work:
+
+- **Write an ADR for the decision** before or alongside the work, numbered
+  sequentially in `docs/adr/`.
+- **Issues reference their ADR(s).** A GitHub issue that implements a decision
+  links the ADR, so an agent picking up the issue reads the decision's intent
+  first and builds to it.
+- Division of labor: **ADRs are the "why + when"**, **issues are the "what + track
+  the work"**, and **`ARCHITECTURE.md` is the "what talks to what."** Keep decision
+  rationale in the ADR, not duplicated across issues.

--- a/docs/adr/0007-adopt-not-build-boundaries.md
+++ b/docs/adr/0007-adopt-not-build-boundaries.md
@@ -5,7 +5,7 @@ Status: Accepted
 
 ## Context
 
-A small team (CT is ~7 people) cannot maintain a bespoke telemetry datastore, eval engine, queue, or agent runtime and still ship a product. The guiding principle from the on-prem research (`docs/reference/on-prem-architecture.md`, removed post-MVP; see git history) is to minimize what gets built and lean on license-clean open source for everything else.
+A small team cannot maintain a bespoke telemetry datastore, eval engine, queue, or agent runtime and still ship a product. The guiding principle from the on-prem research (`docs/reference/on-prem-architecture.md`, removed post-MVP; see git history) is to minimize what gets built and lean on license-clean open source for everything else.
 
 ## Decision
 


### PR DESCRIPTION
Removes the internal "CT is ~7 people" parenthetical from ADR-0007 (this is a public repo) and adds a CLAUDE.md section establishing ADRs as the system of record: they capture what was decided and when, are immutable and superseded (not edited) as intent evolves, and issues reference their ADRs so implementing agents read the decision's intent first.