### PR TITLE
Add ADR-vs-issue heuristic and ADRs 0009-0011 for agent-development decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,25 @@ for the install and probe commands.
   commit messages, and never add `Co-Authored-By` lines referencing AI.**
 - No dashes/emdashes in prose content; no emojis in code or docs.
 
+## Decisions: ADR vs. GitHub issue
+
+Two different tools; do not conflate them.
+
+- Write an **ADR** (`docs/adr/`, see ADR-0001) only for a **cross-cutting
+  architectural decision that closes the door on alternatives.** It is a choice
+  about the *shape* of the system (a contract, a seam, a substrate, an invariant)
+  that is expensive to reverse and whose *why* a future contributor must understand
+  before touching that area. An ADR is not just what we chose; it **must record what
+  we decided against and why** (the alternatives and their rejection). If no real
+  alternative is being closed off, it is not an ADR.
+- Write a **GitHub issue** (with a rich description) for a **feature**, however
+  large. A new CLI command, a UI surface, a connector: it may be a lot of code, but
+  it is deletable and does not change the architecture, so it is a feature, not an
+  architectural decision. The issue carries the what and the why; the *how* lives in
+  the PR. An issue may cite an ADR.
+- **When in doubt, write the issue.** Promote to an ADR only when the same decision
+  gets re-explained across a third issue or PR.
+
 ## Gotchas discovered during the build
 
 - **Deployment-to-runtime binding is wired; it binds per fresh mention.** The

--- a/docs/adr/0009-per-agent-connector-auth.md
+++ b/docs/adr/0009-per-agent-connector-auth.md
@@ -1,0 +1,83 @@
+# 9. Per-agent secrets and connector credentials
+
+Date: 2026-07-09
+Status: Proposed
+
+## Context
+
+An agent's usefulness comes largely from connectors: MCP servers that reach
+GitHub, Jira, an internal API. A bundle declares those servers in `.mcp.json`,
+and a stdio or remote MCP server almost always needs a secret (an API key, a
+bearer token). The platform has no place for that secret today.
+
+The only credential the platform resolves is the single model credential: it
+flows from a chart Secret through `AGENTOS_CREDENTIALS` and is mapped by prefix
+onto the SDK's auth env (`runner/src/agentos_runner/sdk_auth.py`), and an
+explicit SDK credential already in the env wins. An `McpServer.env` field exists
+in the plugin format but is static (literal strings baked into `.mcp.json`); the
+Claude Code CLI expands `${VAR}` in those values, but the platform injects no
+operator-provided variables into the runtime for such an expansion to resolve
+against. Egress is default-deny (`charts/agentos/templates/security-networkpolicy.yaml`),
+so a connector that reaches an external endpoint is dropped unless allowlisted.
+
+Notably the frozen ACI already anticipates this: `SessionConfig.credentials_ref`
+is documented as "per-tool secrets via K8s Secret refs ... the contract carries
+the reference, not the secret material" (`packages/aci-protocol`). The seam
+exists; only the resolution of it to more than the one model credential is
+missing. This decision is about how a connector's secret is delivered into the
+runtime, and it is independent of which harness runs the bundle.
+
+## Decision
+
+Adopt a **named, per-agent secret model, delivered as environment into the
+sandbox, consumed by `.mcp.json` `${VAR}` expansion**, with a co-managed
+per-agent egress allowlist.
+
+- A bundle **declares which named secrets it needs** (versioned policy that ships
+  and evaluates with the agent). The **values** are supplied as per-agent
+  deployment configuration, never in the bundle.
+- The platform resolves those bindings into a **per-agent Kubernetes Secret** and
+  surfaces them into the runner/sandbox environment as named variables; the
+  bundle's `.mcp.json` references them as `${VAR}`. Binding or rotating a secret
+  requires a pod rollout, because `secretKeyRef` env resolves once at pod start.
+- Reaching an external connector endpoint requires a **per-agent egress
+  allowlist** entry; the default-deny posture is preserved.
+- OAuth for remote MCP servers (dynamic client registration, token refresh) is
+  **explicitly out of scope** here and deferred until a concrete need exists.
+
+## Alternatives considered and rejected
+
+1. **Bake secrets into the bundle's `.mcp.json`.** Rejected. Bundles are
+   versioned, evaluable, reviewable artifacts that are often shared; a secret in
+   the artifact leaks, appears in traces and git history, and cannot rotate
+   without a redeploy. This breaks the "bundle is a reviewable artifact" premise.
+2. **Extend the single-credential prefix map to carry N credentials in one blob.**
+   Rejected. That path is Anthropic-model-auth-specific; overloading it with
+   arbitrary third-party tool secrets conflates model authentication with tool
+   authentication and does not scale to arbitrary named secrets.
+3. **Put secret values (not just references) in the bundle manifest as deployment
+   config.** Rejected. It conflates versioned policy (which secrets an agent
+   needs) with workspace-specific values (the actual secret). The established
+   behavior-packs split keeps policy in the bundle and bindings in deployment.
+4. **A networked secret broker/vault the runner calls at tool-invocation time.**
+   Rejected for now. It adds a runtime dependency and a new trust boundary reached
+   from inside the untrusted sandbox path, and it is over-built versus a
+   Kubernetes Secret plus env for the near term. Revisit only if short-lived or
+   dynamically-minted secrets become a real requirement.
+5. **Skip the platform-side mechanism and rely on the harness (OpenCode ships
+   `{env:}` interpolation and MCP OAuth natively).** Not a rejection but a
+   boundary: whatever the harness, the platform still must *deliver* the secret
+   into the runtime environment. This decision is that delivery mechanism and is
+   harness-independent; the harness only changes the consumption syntax. See the
+   harness-strategy ADR.
+
+## Consequences
+
+- Connectors that need a secret become possible, which is most useful connectors.
+- Egress must be co-managed with secrets: a credential without an allowlisted
+  destination still fails closed, and an allowlist without a credential is inert.
+- The rollout-restart requirement on bind is an operational cost to document
+  (the same pattern the Slack connect verb already uses).
+- OAuth-only remote MCP servers remain unsupported until the deferred OAuth work
+  lands; if the harness strategy adopts OpenCode, its native OAuth may satisfy
+  this instead of a bespoke broker.

--- a/docs/adr/0010-approval-gates-and-human-in-the-loop.md
+++ b/docs/adr/0010-approval-gates-and-human-in-the-loop.md
@@ -1,0 +1,78 @@
+# 10. Approval gates and human-in-the-loop
+
+Date: 2026-07-09
+Status: Proposed
+
+## Context
+
+Production business agents pause for a human decision: a discount needs sign-off,
+a remediation needs a yes before it runs. Today the platform offers nothing for
+this and builders would hand-roll all of it. Concretely, the runner hardcodes
+`permission_mode="bypassPermissions"` (`runner/src/agentos_runner/adapter.py`),
+there is no tool-permission callback, and the ACI `SessionStatus` has only
+`done` / `idle-awaiting-input` / `classified-failure` - no awaiting-approval
+state (`packages/aci-protocol`). The suspend/resume path (ADR-0003) is built but
+has no production trigger; an approval is exactly the hours-to-days pause it was
+designed for.
+
+This is a cross-cutting decision because it changes a frozen contract (the
+session status enum), replaces a hardcoded runtime posture (permission bypass),
+and defines a durable lifecycle that the worker, runner, and channel all
+participate in. It is not a single feature that can be deleted cleanly.
+
+## Decision
+
+Provide **one approval primitive with two trigger types**, policy-driven and
+never phase-hardcoded by the platform.
+
+- **Policy gates** (business-level): the agent's own logic (a skill or the
+  deterministic engine) decides something needs approval and raises an
+  approval request.
+- **Permission gates** (tool-level): configuration marks a tool as
+  approval-required and the runner intercepts the call via a `canUseTool`
+  callback that **replaces the hardcoded bypass**.
+- Add an **`awaiting-approval`** value to the ACI `SessionStatus` (a
+  backward-compatible frozen-contract change, versioned and regenerated across
+  all three language targets).
+- Back it with a **durable `Approval` record** (Postgres) using resolve-once
+  compare-and-set claim semantics; **suspend** the session on a pending approval
+  and **resume** on resolution (the first live use of the dormant suspend/resume
+  path).
+- **Approval policy** (gate points) ships in the bundle (versioned, evaluable);
+  **route bindings** (which channel, who may approve) are per-agent deployment
+  config. The authorizer is enforced server-side at resolution time.
+
+## Alternatives considered and rejected
+
+1. **Builders hand-roll approvals in bundle code.** Rejected. Every agent would
+   re-implement Slack buttons, pending state, idempotent claim races, and actor
+   attribution; the result is error-prone, unauditable, and not portable across
+   agents. The platform is supposed to ship this discipline as the default path.
+2. **Platform-forced approval phases (a built-in "approve before write" step).**
+   Rejected. The platform must never hardcode when an approval fires; that is the
+   agent's policy to decide. Gates are policy-triggered, not phase-hardcoded.
+3. **Keep `bypassPermissions` and gate only in bundle code or hooks.** Rejected
+   for the tool-level case. A permission gate must intercept the runtime tool call
+   to reliably block a model-initiated action; an in-bundle check cannot, and it
+   loses the durable-pause semantics. (In-bundle hooks remain useful for
+   deterministic guardrails, but they are not the approval primitive.)
+4. **Hold pending state in memory on the live sandbox.** Rejected. An approval
+   that must survive hours-to-days and component restarts cannot live in a pod;
+   this forces the durable record plus suspend/resume.
+5. **Live-hibernate the sandbox for the duration of the pause.** Rejected.
+   ADR-0003 established that sandboxes are stateless: suspend deletes the pod and
+   resume rehydrates from history. The pause is a cold rehydrate, not a held
+   process.
+
+## Consequences
+
+- First production use of the suspend/resume path; its correctness (duplicate
+  side effects at the finish-race, ADR-0003) becomes load-bearing.
+- A frozen-contract change (`awaiting-approval`) that ripples through the
+  tri-language ACI regeneration and the worker lifecycle.
+- Composes with the durable workflow state store: an approval is durable
+  cross-turn state.
+- If the harness strategy adopts OpenCode, its native allow/ask/deny permission
+  gate (where `ask` pauses for human approval) may supersede the `canUseTool`
+  implementation; the policy-gate and durable-record halves remain regardless.
+  See the harness-strategy ADR.

--- a/docs/adr/0011-opencode-second-harness.md
+++ b/docs/adr/0011-opencode-second-harness.md
@@ -1,0 +1,95 @@
+# 11. OpenCode as the second harness behind the ACI
+
+Date: 2026-07-09
+Status: Proposed (acceptance gated on the steer spike below)
+
+## Context
+
+The ACI is the frozen, tri-language, session-scoped contract between the platform
+and whatever runs a bundle: stream NDJSON events, steer mid-run, interrupt
+(ADR-0005). It has exactly one implementation, the claude-agent-sdk runner. The
+second implementation is what proves the port and de-risks the on-prem
+harness-swap promise. We intend OpenCode (`sst/opencode`) to be that second
+harness: it is the direction the ecosystem is moving and it brings capabilities
+we would otherwise build ourselves.
+
+Investigation of OpenCode against the primitives AgentOS relies on found that it
+ships most of them as first-class configuration - but with two consequences that
+make this a genuine architectural fork, not a drop-in.
+
+## Decision
+
+Adopt **OpenCode as a second ACI harness, contingent on a steer spike**, and
+keep the claude-agent-sdk adapter as a fallback for steer-dependent agents until
+steer parity is proven.
+
+- **Gate:** before committing, spike `opencode serve` driven as an ACI streaming
+  server and determine whether mid-turn message injection (steer) is achievable
+  at a tool-loop boundary, or whether OpenCode can only offer
+  abort-and-resend-with-carried-context. This decides whether OpenCode is a
+  *full* ACI implementation or a *degraded-steer* one.
+- Build a **`bundle -> opencode.jsonc` translator** at deploy/runtime time. The
+  bundle stays the Claude Code plugin shape verbatim (ADR-0005, the distribution
+  wedge); OpenCode never sees the Claude manifest, only the translated config.
+- Where OpenCode provides a capability natively (MCP `{env:}` secrets, MCP OAuth,
+  allow/ask/deny approvals, id-addressable session resume), prefer it over a
+  bespoke platform build; the corresponding platform ADRs (per-agent secrets,
+  approval gates, durable multi-turn) narrow to the platform-side delivery only.
+
+## Evidence (docs review, opencode.ai/docs, 2026-07-09)
+
+- First-class and directly usable: native Skills (it even reads the
+  `.claude/skills/` path); stdio and remote MCP with `{env:VAR}` secret
+  interpolation and RFC 7591 dynamic client registration OAuth; a blocking
+  `tool.execute.before` hook; subagents; allow/ask/deny permissions where `ask`
+  pauses for human approval; id-addressable session persistence and resume; a
+  headless `opencode serve` HTTP server with an SSE event stream and a
+  `POST /session/:id/abort` interrupt; model-agnostic providers.
+- **Two gaps, both predicted by the second-harness analysis.** (1) OpenCode does
+  not load a Claude plugin bundle verbatim: `.claude-plugin/plugin.json` and
+  Claude's `.mcp.json` are ignored (MCP must live under OpenCode's own `mcp` key),
+  so a translator is required even though SKILL.md payloads port cleanly. (2)
+  Mid-run **steer** is not a shipped API primitive - OpenCode offers stream and
+  interrupt cleanly, but injecting a message into an in-flight turn exists only as
+  TUI message-queuing plus open feature work.
+
+## Alternatives considered and rejected
+
+1. **Stay single-harness on the claude-agent-sdk.** Rejected as the long-term
+   stance: it locks model and vendor choice and contradicts the model-agnostic,
+   opinionated-core / swappable-jobs commitment. Retained only as the fallback
+   adapter for steer-heavy agents.
+2. **Strands Agents SDK as the second harness** (the prior front-runner). Strong
+   stream/steer/interrupt fit and async throughout. Not chosen because OpenCode is
+   the ecosystem-standard target and brings the free MCP-OAuth, approvals, and
+   resume; Strands is the revisit candidate if OpenCode's steer gap proves fatal.
+3. **Google ADK.** Rejected: its request/response server has no steer or interrupt
+   endpoint, and the bidirectional `run_live` stack is voice/Live-API-tuned and
+   off the documented path for a text NDJSON contract.
+4. **Build our own harness.** Rejected: enormous, and it contradicts the
+   adopt-not-build boundary (ADR-0007). The ACI exists precisely so we adopt an
+   engine behind it.
+5. **Translate bundles to an OpenCode-native format at author time.** Rejected:
+   it breaks "the bundle is the Claude Code plugin shape verbatim" (ADR-0005). The
+   translation must be a deploy/runtime concern, invisible to the author, or the
+   distribution wedge is lost.
+6. **Accept degraded steer (abort-and-resend) unconditionally.** Deferred to the
+   spike, not accepted blind: the worker's finish-race kernel invariant is built
+   on steer-at-a-tool-boundary, so degraded steer may weaken a correctness
+   property. The spike decides whether that cost is acceptable or whether steer
+   parity must be driven upstream first.
+
+## Consequences
+
+- This decision gates the *implementation choices* of the per-agent-secrets and
+  approval-gate ADRs: several of their hardest parts arrive with the harness
+  rather than being built on the Claude SDK, so their build work should wait on
+  this fork.
+- The bundle translator, not the ACI server, is the bulk of the work (consistent
+  with the second-harness analysis).
+- Steer is the standing risk. The likely near-term shape is a dual-harness period:
+  OpenCode as the default, the claude-agent-sdk adapter retained for
+  steer-dependent agents until parity.
+- If the spike shows steer is unreachable and the degradation is unacceptable,
+  this ADR is superseded by one that either keeps a single harness or selects
+  Strands.


### PR DESCRIPTION
Records the agent-development architecture decisions from the recent exploration, and adds a heuristic for when a decision warrants an ADR versus a GitHub issue.

## AGENTS.md
Defines ADR vs. issue: an ADR is a cross-cutting decision that closes the door on alternatives (a contract, seam, substrate, or invariant), is expensive to reverse, and must record what we decided against and why. A feature, however large, is deletable and not architectural, so it is a GitHub issue. When in doubt, write the issue.

## ADRs (all Proposed; each records the alternatives considered and why they were rejected)
- **0009 Per-agent connector auth** - named per-agent secret refs delivered as environment for `.mcp.json` expansion, with a co-managed per-agent egress allowlist; OAuth deferred. The frozen ACI `credentials_ref` already anticipated per-tool secrets; this resolves it beyond the single model credential.
- **0010 Approval gates and human-in-the-loop** - one primitive with policy and permission gates; adds an `awaiting-approval` session status; a durable Approval record; first live use of the dormant suspend/resume path. Replaces the hardcoded `bypassPermissions`.
- **0011 OpenCode as the second harness behind the ACI** - Proposed, gated on a steer spike (mid-run injection is not a shipped OpenCode primitive), plus a `bundle -> opencode.jsonc` translator since OpenCode does not load a Claude plugin bundle verbatim.

0011 gates the implementation choices of 0009 and 0010: several of their hardest parts (MCP secrets/OAuth, approvals, resume) ship natively with OpenCode, so their build work should wait on that fork.

Context (not closed by this PR): #22 (approvals), #25 (second harness), #30 (bundle/authoring).