### PR TITLE
Backfill ADRs 0012-0017 for load-bearing architecture decisions

### DIFF
--- a/docs/adr/0012-substrate-and-channel-agnostic-core.md
+++ b/docs/adr/0012-substrate-and-channel-agnostic-core.md
@@ -1,0 +1,70 @@
+# 12. A substrate-agnostic worker and a channel-agnostic runner (the thin-shim thesis)
+
+Date: 2026-07-09
+Status: Accepted
+
+This is a retroactive record of a decision already built into main; the "what was
+built" is tracked in the shipped lanes, this ADR records the "why" and what it
+closes the door on.
+
+## Context
+
+The product has to run in three shapes from one codebase: a real Kubernetes
+cluster (production and leave-behind), a laptop with Docker and no cluster
+(developer middle mode), and an automated test with no Slack workspace at all.
+If any of the core logic (the concurrency kernel, routing, budgets, kill switch,
+resume path) learns which substrate it is on or which channel a message came
+from, those three shapes fork into three code paths, and the leave-behind /
+local-dev story dies quietly the first time a substrate-specific branch lands.
+
+## Decision
+
+The worker never learns its substrate and the runner never learns its channel.
+Two seams enforce this, both real code, not aspiration:
+
+- **Substrate seam.** The worker talks only to a `SandboxClient` Protocol
+  ([`apps/worker/src/agentos_worker/sandbox/k8s.py:50`](../../apps/worker/src/agentos_worker/sandbox/k8s.py)).
+  `KubernetesSandboxClient` (`k8s.py:101`) drives the agent-sandbox controller;
+  `DockerSandboxClient`
+  ([`sandbox/docker.py:93`](../../apps/worker/src/agentos_worker/sandbox/docker.py))
+  runs the identical runner image as a local container. Everything above the
+  protocol is byte-identical across modes.
+- **Channel seam.** The worker reaches Slack only through a base URL
+  (`SLACK_API_BASE_URL`,
+  [`config.py:146`](../../apps/worker/src/agentos_worker/config.py)). The CLI
+  stands up a local Slack Web API stub and mints the exact `QueuedSlackEvent`
+  wire payload onto the same `agentos:runs` stream
+  ([`cli/src/chat.rs:269`](../../cli/src/chat.rs)); the worker cannot tell the
+  stub from Slack.
+
+The single runner image, the ACI it speaks (ADR-0005), and the plugin bundle it
+loads are identical in every mode. Only the thing that starts the container, and
+the thing that delivered the message, differ, and neither is visible above the
+seam.
+
+## Alternatives considered
+
+- **Build for Kubernetes only.** Rejected: it forecloses the laptop middle mode
+  and forces a cluster into every small leave-behind. The Docker substrate is
+  what lets the whole product loop (real model call included) run on one machine.
+- **Managed cloud runtime (Bedrock AgentCore / Vertex / Foundry).** Rejected for
+  the interactive tier for the same reason ADR-0002 rejected it: cloud-locked
+  runtimes cannot leave behind on-prem, which is the product's differentiator.
+- **Let the kernel special-case the substrate or the channel** (a `if k8s:` fork,
+  or a direct Slack SDK call in the kernel). Rejected: this is the exact coupling
+  the thesis exists to prevent. Its failure mode is silent because tests running
+  in Docker mode still pass while production K8s behaviour diverges.
+
+## Consequences
+
+- Two substrate implementations and the CLI channel stub must stay behind their
+  respective seams; a substrate- or channel-specific branch above the seam is a
+  design error, not a shortcut.
+- Local middle mode and CLI-driven E2E are first-class verification surfaces, not
+  toys: the code they exercise is the code that runs in production.
+- Whether the substrate seam is a genuine swap axis or core-with-fallback is still
+  open (see [issue #86](https://github.com/curie-eng/agentos/issues/86)); this ADR
+  fixes the invariant (the core is blind to the substrate), not the number of
+  substrates we will ever ship.
+- This is the concrete instance of the swappable-jobs discipline recorded in
+  ADR-0016.

--- a/docs/adr/0013-concurrency-and-delivery-model.md
+++ b/docs/adr/0013-concurrency-and-delivery-model.md
@@ -1,0 +1,79 @@
+# 13. Concurrency and delivery: at-least-once streams with an idempotent, side-effect-aware kernel
+
+Date: 2026-07-09
+Status: Accepted
+
+Retroactive record of the worker's concurrency model, already built into main.
+The individual invariants each have an integration test under
+`apps/worker/tests/`; this ADR records why the model is shaped this way and what
+it forecloses.
+
+## Context
+
+The input side is unreliable in ways that matter for an agent that takes real
+actions: Slack redelivers events, a worker can crash mid-turn, a user sends a
+follow-up while a turn is still running, and a tool call may have already caused
+a side effect (a posted message, an external write) before it failed. A naive
+"read the queue, run the agent, retry on error" loop double-posts, double-acts,
+and replays ancient backlog after a restart. The concurrency model is the
+correctness core of the system.
+
+## Decision
+
+Transport is at-least-once and the kernel is made safe on top of it, rather than
+chasing exactly-once in the broker. Concretely:
+
+- **Transport: raw Valkey Streams with consumer groups** (`redis-py`,
+  `XADD` / `XREADGROUP` / `XAUTOCLAIM`), one group for interactive runs
+  (`agentos:runs`) and a **separate** group for evals (`agentos:evals`) so eval
+  load never starves interactive turns
+  ([`consumer.py:83`](../../apps/worker/src/agentos_worker/consumer.py),
+  [`eval/stream.py:216`](../../apps/worker/src/agentos_worker/eval/stream.py)).
+- **Dispatcher-side idempotency**: a `SET NX` on `dedupe:<event_id>` drops
+  redelivered Slack events before they enqueue
+  ([`apps/dispatcher/.../queue.py:73`](../../apps/dispatcher/src/agentos_dispatcher/queue.py)).
+- **One live session per thread**: a Valkey `SET NX PX` thread lock is the
+  routing CAS ([`threadlock.py:60`](../../apps/worker/src/agentos_worker/threadlock.py)).
+- **The finish race**: a follow-up during a live turn is a steer; if the turn
+  finished first the runner returns 409 and the kernel opens a fresh turn on the
+  same idle sandbox ([`kernel.py:402`](../../apps/worker/src/agentos_worker/kernel.py)).
+- **No auto-retry after a side effect**: if a prior attempt flagged a side
+  effect the kernel escalates to a human instead of retrying
+  ([`kernel.py:201`](../../apps/worker/src/agentos_worker/kernel.py)).
+- **Crash recovery without backlog replay**: pending entries are reclaimed with
+  `XAUTOCLAIM` ([`consumer.py:178`](../../apps/worker/src/agentos_worker/consumer.py))
+  and the runs group is created at `$` so a cold worker never replays old events.
+- **`kernel.py` is sacred**: changes require escalated adversarial review, and
+  the kernel never keyword-guesses intent.
+
+## Alternatives considered
+
+- **An exactly-once broker / message system.** Rejected: exactly-once delivery is
+  expensive and still would not make a side-effectful tool call idempotent, so we
+  would need the thread lock and the side-effect flag anyway. Putting the
+  correctness at the side-effect layer is both cheaper and actually sufficient.
+- **A job library such as BullMQ.** Considered (an early plan named it), and
+  rejected in favour of raw Valkey Streams: we need direct control over
+  consumer-group semantics, the create-at-`$` behaviour, and `XAUTOCLAIM` reclaim,
+  and the extra dependency bought nothing the primitive did not already give us.
+  The as-built queue is Valkey Streams via `redis-py`, not BullMQ.
+- **Auto-retry every failed turn.** Rejected: it double-fires any tool that
+  already caused a side effect. Escalation-instead-of-retry after a side-effect
+  flag is the deliberate opposite choice.
+- **A durable workflow engine (config-as-DAG) to get retries and state for
+  free.** Rejected per ADR-0007: building a generic orchestration engine is
+  commodity infra where we have no edge, and it would own the correctness we
+  instead keep in a small, testable kernel.
+
+## Consequences
+
+- The kernel invariants are load-bearing behaviour: a "simplification" of the
+  retry loop, the lock, or the finish race reintroduces duplicate side effects
+  that pass unit tests and only surface under concurrent production load.
+- Reclaim (ADR-0003's cold-rehydrate resume) rides on the same routing CAS, so
+  the resume path is where duplicate side effects are most likely to hide.
+- Shared stream-consumer helper extraction and promoting the turn payload into
+  `aci-protocol` are follow-ups
+  ([#9](https://github.com/curie-eng/agentos/issues/9),
+  [#7](https://github.com/curie-eng/agentos/issues/7)); they must preserve these
+  semantics, not just the surface API.

--- a/docs/adr/0014-git-push-is-the-deploy.md
+++ b/docs/adr/0014-git-push-is-the-deploy.md
@@ -1,0 +1,66 @@
+# 14. A git push is the deploy: immutable bundles, promote-not-rebuild, evals as a CI gate
+
+Date: 2026-07-09
+Status: Accepted
+
+Retroactive record of the git-flow deploy model already built into
+[`apps/api/src/agentos_api/gitflow.py`](../../apps/api/src/agentos_api/gitflow.py).
+
+## Context
+
+An agent is a versioned artifact (a Claude Code plugin bundle) that has to move
+from a developer's edit to a running bot with the same production discipline as
+code: reproducible, testable before promotion, and identical in dev and prod.
+The question was how a change becomes a deployment, and specifically what happens
+to the artifact between environments.
+
+## Decision
+
+A git push is the deploy, and the artifact built for dev is the exact artifact
+promoted to prod.
+
+- A push is HMAC-verified (`gitflow.py:35`,
+  [`routers/github.py:20`](../../apps/api/src/agentos_api/routers/github.py)).
+- A **dev-branch** push clones and archives the SHA, runs the single
+  `plugin_format.validate_bundle`, stores an **immutable versioned bundle**, and
+  creates a `Version` + dev `Deployment` (`gitflow.py:136`,
+  [`storage.py:22`](../../apps/api/src/agentos_api/storage.py)). It then fans out
+  the bundle's eval suite as a CI check and reports pass/fail back as a GitHub
+  commit status (`gitflow.py:186`,
+  [`routers/evals.py:15`](../../apps/api/src/agentos_api/routers/evals.py),
+  [`eval/stream.py:114`](../../apps/worker/src/agentos_worker/eval/stream.py)).
+- A **prod-branch** push does not rebuild. It finds the already-built `Version`
+  for that SHA and creates a prod `Deployment`, promoting the identical bytes
+  (`gitflow.py:172`).
+- The browser-authored path, `agentos local deploy`, and the webhook all
+  terminate at the same `Version` / `Deployment` tables and the same validator, so
+  there is one pipeline regardless of entry point.
+
+## Alternatives considered
+
+- **Rebuild the artifact on the prod push.** Rejected: a rebuild can differ from
+  what dev tested (dependency drift, a moved base image), which breaks the one
+  guarantee that makes the eval-as-CI gate meaningful, namely that prod runs the
+  bytes the evals passed against. Promote-not-rebuild is the deliberate choice.
+- **Mutable deployments / a moving `latest` bundle.** Rejected: a mutable bundle
+  can change under a running deployment, so a version is no longer a reproducible
+  fact. Immutability of the stored bundle is what lets a trace be tied back to an
+  exact version (the eval and observability moat).
+- **Evals as an optional or manual step.** Rejected: the production-discipline
+  layer is the product's value; making the eval run a gate on the dev push (a
+  commit status) is what turns "we have evals" into "a regression cannot silently
+  promote."
+- **A bespoke CD pipeline outside git.** Rejected: git branch to environment is
+  the model developers already have in their hands; a separate deploy tool is more
+  surface for no gain.
+
+## Consequences
+
+- Immutable-bundle storage and promote-not-rebuild are invariants: a contributor
+  who rebuilds on prod, or introduces an overwrite path for a stored bundle,
+  silently breaks dev/prod artifact identity.
+- The env-switcher and promote-to-prod UI, and freezing the eval-case format, ride
+  on this model ([#6](https://github.com/curie-eng/agentos/issues/6),
+  [#8](https://github.com/curie-eng/agentos/issues/8)).
+- The eval store itself is Langfuse (ADR-0004); this ADR is about the deploy flow
+  and the gate, not where scores live.

--- a/docs/adr/0015-credential-plane.md
+++ b/docs/adr/0015-credential-plane.md
@@ -1,0 +1,82 @@
+# 15. The credential plane: no broker, prefix-mapped, fail-loud and fail-closed
+
+Date: 2026-07-09
+Status: Accepted
+
+Retroactive record of how a model credential reaches the model, already built into
+[`runner/src/agentos_runner/sdk_auth.py`](../../runner/src/agentos_runner/sdk_auth.py).
+ADR-0005 anticipated this ("production runners need a proper API-key / Bedrock /
+Vertex path, ADR-worthy when that lane lands"); that lane has landed
+([#24](https://github.com/curie-eng/agentos/issues/24)).
+
+## Context
+
+The runner holds a customer's model credential, the install will be
+security-reviewed, and customers want to bring their own model (Anthropic direct,
+OpenRouter, a bundled local model). Two things had to be true at once: the secret
+must not sprawl across application processes, and a misconfigured or unusable
+credential must fail visibly rather than silently degrade.
+
+## Decision
+
+A credential flows from a Helm Secret to the model env variable with no
+application process brokering it: chart Secret -> worker env
+`AGENTOS_CREDENTIALS` -> injected into the claim boot env -> the runner maps it.
+The runner's mapping is prefix-based and fails loud on anything it cannot use
+(`sdk_auth.py:39`, `:51`):
+
+- `sk-ant-oat...` -> `CLAUDE_CODE_OAUTH_TOKEN` (checked first).
+- `sk-ant-...` -> `ANTHROPIC_API_KEY`.
+- `sk-or-...` (OpenRouter) -> the shared base-URL-override seam: base URL points at
+  OpenRouter's native Anthropic Messages endpoint and the key goes in the
+  `x-api-key` header, staying on the Anthropic wire format so prompt caching
+  survives.
+- bare `sk-...` -> raises `UnsupportedCredentialError` rather than forwarding a key
+  the SDK cannot use.
+
+The real model is the default. `AGENTOS_FAKE_MODEL` is a test-only knob; a missing
+credential fails **closed** rather than degrading to the fake model
+([`binding.py:137`](../../apps/worker/src/agentos_worker/binding.py),
+[`sandbox/docker.py:18`](../../apps/worker/src/agentos_worker/sandbox/docker.py),
+[`runner/__main__.py:62`](../../runner/src/agentos_runner/__main__.py)). An explicit
+SDK credential already in the env always wins, and the mapping is a no-op when
+`AGENTOS_CREDENTIALS` is unset.
+
+## Alternatives considered
+
+- **A credential broker / vault sidecar service.** Rejected: it adds a
+  secret-handling process to audit and a runtime dependency, for a problem the
+  chart Secret plus prefix-mapping already solves. Fewer processes touch the
+  secret, the better it reviews.
+- **Forward whatever credential is in the ambient environment (convenience
+  fallback).** Rejected, and this is not hypothetical: an ambient
+  `CLAUDE_CODE_OAUTH_TOKEN` shadowing `AGENTOS_CREDENTIALS` leaked into runners and
+  broke auth ([#106](https://github.com/curie-eng/agentos/issues/106), fixed in
+  [PR #109](https://github.com/curie-eng/agentos/pull/109)). Positive, by-name
+  credential selection is the deliberate guard.
+- **Default to the fake model when no credential is present.** Rejected: it turns
+  a misconfiguration into a silently-wrong answer. Fail-closed surfaces the problem
+  at deploy time.
+- **A separate harness per model provider for BYO.** Rejected: OpenRouter exposes a
+  native Anthropic Messages endpoint, so a base-URL override keeps one wire format
+  and preserves prompt caching, instead of swapping the harness
+  ([#24](https://github.com/curie-eng/agentos/issues/24); see PRs
+  [#94](https://github.com/curie-eng/agentos/pull/94),
+  [#98](https://github.com/curie-eng/agentos/pull/98),
+  [#105](https://github.com/curie-eng/agentos/pull/105)).
+
+## Consequences
+
+- The fail-loud / fail-closed posture is load-bearing security behaviour: a future
+  "just forward the key we have" or "fall back to fake" reopens the credential-leak
+  and silent-wrong-model failure classes this ADR closes.
+- The base-URL-override seam is the single extension point for any
+  Anthropic-compatible endpoint (OpenRouter today, a bundled local model via
+  `--local-model`); a new provider on the Anthropic wire format is config, not code.
+- Per-agent connector and MCP-server secrets are a separate credential plane,
+  recorded in ADR-0009; this ADR governs only the model credential the SDK reads.
+- Related hardening (default credentials shipping enabled, the ACI HTTP channel
+  having no auth) is tracked separately
+  ([#57](https://github.com/curie-eng/agentos/issues/57),
+  [#63](https://github.com/curie-eng/agentos/issues/63)) and does not change this
+  decision.

--- a/docs/adr/0016-swappable-jobs-around-an-opinionated-core.md
+++ b/docs/adr/0016-swappable-jobs-around-an-opinionated-core.md
@@ -1,0 +1,67 @@
+# 16. Swappable jobs around an opinionated core; the second implementation teaches the interface
+
+Date: 2026-07-09
+Status: Accepted
+
+Retroactive record of the design discipline described as-built in
+[`docs/architecture-vision.md`](../architecture-vision.md). This is the governing
+principle for every future "should we abstract X?" question, so it needs to be a
+decision on record, not just a doc.
+
+## Context
+
+AgentOS is an opinionated core (dispatcher, queue, worker kernel, sandbox
+substrate, runner behind the frozen ACI, the API's git-flow engine, the UI)
+surrounded by six jobs a production agent platform must do, each of which has one
+or more plausible vendors: observability, evals, blob storage, a relational
+store, a harness, a communication channel. The standing temptation on a system
+like this is to build a clean adapter interface for each job up front. A small
+team that does that spends its budget maintaining speculative abstraction layers
+whose shape is a guess about a second implementation that does not exist yet.
+
+## Decision
+
+Hexagonal in spirit, with discipline: **one implementation per port today**, and
+each port is defined by where the code already draws the line, not by a
+speculative interface layer. We do not write adapter frameworks
+(`StorageInterface`, `ChannelAdapter`, a pluggable channel registry) ahead of a
+real second implementation. A port is promoted from convention to a frozen
+contract only when a real swap demand arrives, the way the ACI protocol already
+was. Until then the boundary is held by convention plus review: the boundary
+files are known and small, cross-seam imports are flagged in review, and only the
+two contracts that genuinely must not drift (`aci-protocol`, `plugin-format`) are
+frozen in CI. The swap-readiness of each of the six jobs, and where each seam
+honestly is not clean yet, is catalogued in
+[`docs/architecture-vision.md`](../architecture-vision.md).
+
+## Alternatives considered
+
+- **Write the adapter interfaces now (a `StorageInterface`, a channel-adapter
+  framework, a generic eval-store interface).** Rejected: with one implementation,
+  the interface encodes guesses about the second implementation's needs and is
+  wrong in the ways that matter. The second implementation is what teaches the
+  interface; writing it first is negative work.
+- **Hard-couple the core to today's vendors (Langfuse, Slack, MinIO, Postgres) and
+  stop pretending they are swappable.** Rejected: it forecloses the leave-behind
+  portability story (a customer's managed Postgres, their S3, an air-gapped model)
+  that the product sells. The seams stay honest even with one adapter each.
+- **A generic plugin/registry framework for all six jobs.** Rejected as premature
+  abstraction: it is the commodity-orchestration trap ADR-0007 already declined,
+  applied to the seams instead of the engine.
+
+## Consequences
+
+- This is the meta-rule ADR-0012 (substrate/channel seams) is an instance of, and
+  the cousin of ADR-0007 (adopt-not-build): 0007 governs what we build versus
+  adopt, this governs how we seam what we built and when to harden a seam.
+- The open "is this seam a real swap axis" epics
+  ([#83](https://github.com/curie-eng/agentos/issues/83),
+  [#84](https://github.com/curie-eng/agentos/issues/84),
+  [#85](https://github.com/curie-eng/agentos/issues/85),
+  [#86](https://github.com/curie-eng/agentos/issues/86)) are answered by this
+  discipline: a seam gets promoted to a contract when a user needs the swap, not
+  before. Backfilling `INTERFACE.md` at each seam
+  ([#53](https://github.com/curie-eng/agentos/issues/53)) documents the black
+  lines without prematurely abstracting them.
+- A PR that adds a speculative abstraction layer ahead of a real second
+  implementation is violating this ADR, even when the code is clean.

--- a/docs/adr/0017-tri-language-contract-codegen.md
+++ b/docs/adr/0017-tri-language-contract-codegen.md
@@ -1,0 +1,57 @@
+# 17. Tri-language frozen contracts: Pydantic as source of truth, generate the rest, gate on drift
+
+Date: 2026-07-09
+Status: Accepted
+
+Retroactive record of the codegen mechanism behind the frozen contracts.
+ADR-0005 established that the ACI and plugin-format are frozen; this ADR records
+how that freeze is maintained across three languages and what it closes the door
+on. It is the narrowest of the backfill set; keep it if the codegen choice is
+worth its own record, otherwise it folds under ADR-0005.
+
+## Context
+
+`packages/aci-protocol` and `packages/plugin-format` are compiled against by the
+Python core, the Rust CLI, and the TypeScript UI. An unreviewed change to the
+contract in one language silently breaks the others unless something forces them
+to agree. The question was which language is authoritative and how the other two
+stay in lockstep.
+
+## Decision
+
+Python Pydantic models are the single source of truth. The committed JSON Schema
+and the generated TypeScript and Rust are derivatives, regenerated in CI and
+checked with `git diff --exit-code` so drift in any of the three languages fails
+the build. The compat gate regenerates schema and Rust in-process and fails on
+drift
+([`packages/aci-protocol/tests/test_schema_compat.py`](../../packages/aci-protocol/tests/test_schema_compat.py));
+the repo-root [`scripts/check-contracts.sh`](../../scripts/check-contracts.sh)
+runs the full regenerate-and-compile sweep; CI enforces it as the `contracts-ts`
+job ([`.github/workflows/ci.yaml`](../../.github/workflows/ci.yaml)).
+
+## Alternatives considered
+
+- **A protobuf / IDL as the source of truth.** Rejected: it adds a separate
+  toolchain and loses the Pydantic validation ergonomics the Python core already
+  depends on (the same models validate bundles and requests at runtime). Pydantic
+  is already load-bearing in the core, so making it authoritative costs nothing
+  extra.
+- **Hand-maintain the three language copies.** Rejected: it is exactly the
+  silent-cross-language-drift failure the freeze exists to prevent. Generation
+  plus a diff gate makes drift a build failure instead of a runtime surprise.
+- **Runtime schema validation only, no generated types.** Rejected: it gives up
+  the compile-time guarantee that the Rust CLI and TS UI agree with the Python
+  core before anything ships.
+- **Generate the Rust types from the JSON Schema with `typify`** instead of the
+  current hand-rolled emitter. Not chosen yet; it is an open refactor
+  ([#81](https://github.com/curie-eng/agentos/issues/81)) that would change the
+  emitter, not this decision (Pydantic stays the source of truth, the gate stays).
+
+## Consequences
+
+- Hand-editing the generated Rust or TypeScript, or switching the source-of-truth
+  language, breaks the guarantee silently and is a design error.
+- A task that needs either frozen package to change stops and escalates rather
+  than working around the gate, per ADR-0005.
+- The emitter implementation is free to change (see #81) as long as Pydantic
+  remains authoritative and the regenerate-and-diff gate remains the enforcement.


### PR DESCRIPTION
Backfills six ADRs for cross-cutting architecture decisions that were already built into main but had no decision record. Each states what was decided, the alternatives weighed, and why they were rejected, following the ADR-vs-issue heuristic: an ADR closes a door on other solutions and is hard to reverse; a feature (even a large one) gets an issue.

- **0012** Substrate- and channel-agnostic core (the thin-shim thesis)
- **0013** Concurrency and delivery model (at-least-once streams, idempotent side-effect-aware kernel)
- **0014** Git push is the deploy (immutable bundles, promote-not-rebuild, evals as a CI gate)
- **0015** The model credential plane (no broker, prefix-mapped, fail-loud/fail-closed)
- **0016** Swappable jobs around an opinionated core (the second implementation teaches the interface)
- **0017** Tri-language frozen-contract codegen (Pydantic source of truth, generate + gate on drift)

Docs-only. Numbered above the connector-auth / approval-gates / opencode ADRs (0009-0011) merged in parallel; 0015 cross-references 0009 to keep the model-credential and connector-secret planes distinct. Features that surfaced in the audit but are not architectural (behavior packs, the CLI surface, the UI wired/fixture split) were deliberately left as issues, not ADRs.