### PR TITLE
Apply the nav pack (hub button) on the render path

### DIFF
--- a/apps/worker/src/agentos_worker/behaviorpacks.py
+++ b/apps/worker/src/agentos_worker/behaviorpacks.py
@@ -28,13 +28,16 @@ the substrate; the kernel wiring that actually calls ``sample_tip`` /
 
 from __future__ import annotations
 
+import logging
 import re
 import unicodedata
 import zlib
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+logger = logging.getLogger(__name__)
 
 # Words that may trail a greeting without making it a real request: "hey there",
 # "morning team". A greeting followed only by filler is still a bare greeting;
@@ -152,10 +155,25 @@ class BehaviorPacks(BaseModel):
 
     @classmethod
     def from_config(cls, data: Mapping[str, Any] | None) -> BehaviorPacks:
-        """Parse the JSON stored on an agent row; ``None``/empty -> all-off."""
+        """Parse the JSON stored on an agent row into packs. TOTAL by contract:
+        never raises. ``None``/empty -> an all-off ``BehaviorPacks()``; and a
+        MALFORMED blob (not a mapping, or a nested field that fails validation)
+        ALSO falls back to all-off, with a warning so the bad blob stays
+        diagnosable. This mirrors the binding layer's defensive stance (a polite
+        drop, not a crash): a corrupt packs blob on an agent row must never brick
+        that agent's turns -- it just gets the platform default (packs off)."""
         if not data:
             return cls()
-        return cls.model_validate(data)
+        if not isinstance(data, Mapping):
+            logger.warning(
+                "behavior_packs is not a mapping (%r); defaulting to all-off", type(data)
+            )
+            return cls()
+        try:
+            return cls.model_validate(data)
+        except ValidationError as exc:
+            logger.warning("malformed behavior_packs; defaulting to all-off: %s", exc)
+            return cls()
 
 
 def _normalize(text: str) -> str:

--- a/apps/worker/src/agentos_worker/blocks.py
+++ b/apps/worker/src/agentos_worker/blocks.py
@@ -30,6 +30,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+from .behaviorpacks import BehaviorPacks, NavPack, ensure_hub_button
 from .mrkdwn import to_mrkdwn
 
 # Slack hard-caps a section's text at 3000 chars; stay under it with margin.
@@ -91,9 +92,15 @@ def _is_nav(label: str) -> bool:
     return label.lstrip()[:1] in ("←", "↑")
 
 
-def to_blocks(reply: Reply) -> list[dict[str, Any]]:
+def to_blocks(reply: Reply, nav: NavPack | None = None) -> list[dict[str, Any]]:
     """Render a ``Reply`` to a Block Kit blocks array. Order: header -> fields ->
-    body section(s) (chunked) -> buttons (nav-leftmost) -> footer."""
+    body section(s) (chunked) -> buttons (nav-leftmost) -> footer.
+
+    ``nav`` is the agent's no-dead-ends hub button: when present and enabled, the
+    hub button is appended to the reply's buttons (via ``ensure_hub_button``, the
+    platform-owned append policy) before the actions block is built. When ``nav``
+    is None or disabled the output is byte-identical to no-nav; ``ensure_hub_button``
+    also no-ops when a button already links to the hub."""
     blocks: list[dict[str, Any]] = []
     if reply.header:
         blocks.append({"type": "header", "text": {"type": "plain_text", "text": reply.header}})
@@ -106,8 +113,13 @@ def to_blocks(reply: Reply) -> list[dict[str, Any]]:
         )
     for piece in chunk(to_mrkdwn(reply.text)):
         blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": piece}})
-    if reply.buttons:
-        ordered = sorted(reply.buttons, key=lambda b: 0 if _is_nav(b[0]) else 1)
+    # ``reply.buttons`` are already (label, action_id) pairs, the same (label,
+    # command) shape ensure_hub_button operates on, so no conversion is needed.
+    buttons = (
+        reply.buttons if nav is None else ensure_hub_button(BehaviorPacks(nav=nav), reply.buttons)
+    )
+    if buttons:
+        ordered = sorted(buttons, key=lambda b: 0 if _is_nav(b[0]) else 1)
         blocks.append(
             {"type": "actions", "elements": [_button(label, aid) for label, aid in ordered]}
         )
@@ -150,17 +162,20 @@ def parse_reply(text: str) -> Reply | None:
     )
 
 
-def render(text: str) -> tuple[str, list[dict[str, Any]] | None]:
+def render(text: str, nav: NavPack | None = None) -> tuple[str, list[dict[str, Any]] | None]:
     """Map an outbound reply string to ``(text, blocks)`` for ``chat.update``.
 
     - A complete ``agentos-reply`` block -> (plain fallback text, blocks).
     - A half-streamed block (fence opened, not closed) -> (text before the fence,
       None), so streaming never shows raw JSON.
     - Anything else -> (mrkdwn text, None), the existing plain path.
+
+    ``nav`` (the agent's hub-button pack, threaded from the kernel) is applied to
+    a complete structured reply's buttons; None/disabled leaves output unchanged.
     """
     reply = parse_reply(text)
     if reply is not None:
-        return (to_mrkdwn(reply.text) or "(reply)", to_blocks(reply))
+        return (to_mrkdwn(reply.text) or "(reply)", to_blocks(reply, nav))
     open_at = text.find(_FENCE_OPEN)
     if open_at != -1:
         prefix = text[:open_at].strip()

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -43,8 +43,8 @@ from aci_protocol import (
 )
 from agentos_dispatcher.queue import QueuedSlackEvent
 
-from .behaviorpacks import sample_load, sample_tip
-from .binding import BindingResolver, ResolvedDeployment
+from .behaviorpacks import BehaviorPacks, NavPack, sample_load, sample_tip
+from .binding import BindingResolver
 from .config import WorkerConfig
 from .killswitch import KillSwitch
 from .markers import Markers
@@ -105,13 +105,26 @@ class _StreamAccumulator:
 class _ThrottledReply:
     """Coalesces chat.update edits while streaming; always flushes the final."""
 
-    def __init__(self, sink: SlackSink, *, channel: str, ts: str, min_interval_s: float) -> None:
+    def __init__(
+        self,
+        sink: SlackSink,
+        *,
+        channel: str,
+        ts: str,
+        min_interval_s: float,
+        nav: NavPack | None = None,
+    ) -> None:
         self._sink = sink
         self._channel = channel
         self._ts = ts
         self._min_interval_s = min_interval_s
         self._last = 0.0
         self._last_text: str | None = None
+        # The bound agent's hub-button pack, forwarded to the sink so a render of
+        # a COMPLETE structured reply can add the no-dead-ends hub button (in
+        # practice the final flush, which is the update that carries one). None
+        # when unbound/disabled.
+        self._nav = nav
 
     async def stream(self, text: str) -> None:
         if not text or text == self._last_text:
@@ -121,13 +134,15 @@ class _ThrottledReply:
             return
         self._last = now
         self._last_text = text
-        await self._sink.update(channel=self._channel, ts=self._ts, text=text)
+        await self._sink.update(channel=self._channel, ts=self._ts, text=text, nav=self._nav)
 
     async def finalize(self, text: str) -> None:
         if text == self._last_text:
             return
         self._last_text = text
-        await self._sink.update(channel=self._channel, ts=self._ts, text=text or "(no response)")
+        await self._sink.update(
+            channel=self._channel, ts=self._ts, text=text or "(no response)", nav=self._nav
+        )
 
 
 class Kernel:
@@ -213,6 +228,7 @@ class Kernel:
             # polite drop, not a crash.
             boot_env: dict[str, str] | None = None
             agent_id: uuid.UUID | None = None
+            nav: NavPack | None = None
             if self._binding is not None:
                 resolved = await self._binding.resolve(qevent.channel)
                 if resolved is None:
@@ -230,16 +246,21 @@ class Kernel:
                     return
                 agent_id = resolved.agent_id
                 boot_env = self._binding.boot_env(resolved, thread)
+                # Resolve the agent's packs once here (a pure parse, no I/O) and
+                # reuse: the nav pack is threaded to the final render, the same
+                # packs feed the shimmer below.
+                packs = self._binding.packs_for(resolved)
+                nav = packs.nav
                 # Personalize the shimmer: replace the dispatcher's generic status
                 # with this agent's sampled load line (+ tip). Best-effort and
                 # outside the concurrency-critical section, like the clear below.
                 if self._config.shimmer:
-                    await self._set_shimmer(qevent, resolved)
+                    await self._set_shimmer(qevent, packs)
 
             attempt = 0
             while True:
                 attempt += 1
-                outcome = await self._attempt(qevent, release_order, boot_env, agent_id)
+                outcome = await self._attempt(qevent, release_order, boot_env, agent_id, nav)
 
                 if outcome.terminal_ok:
                     await self._markers.mark_done(event_id)
@@ -338,12 +359,10 @@ class Kernel:
         )
         await self._markers.mark_done(qevent.slack_event_id)
 
-    async def _set_shimmer(self, qevent: QueuedSlackEvent, resolved: ResolvedDeployment) -> None:
+    async def _set_shimmer(self, qevent: QueuedSlackEvent, packs: BehaviorPacks) -> None:
         """Set the shimmer caption to this agent's sampled load line (+ tip),
         seeded by the thread ts. No-op when the agent enables neither pack, so the
         dispatcher's generic status stays. Best-effort (the sink swallows errors)."""
-        assert self._binding is not None
-        packs = self._binding.packs_for(resolved)
         load = sample_load(packs, qevent.thread_ts)
         tip = sample_tip(packs, qevent.thread_ts)
         if load and tip:
@@ -366,6 +385,7 @@ class Kernel:
         release_order: Callable[[], None],
         boot_env: dict[str, str] | None = None,
         agent_id: uuid.UUID | None = None,
+        nav: NavPack | None = None,
     ) -> TurnOutcome:
         thread = qevent.thread_ts
         event = self._to_event(qevent)
@@ -420,7 +440,7 @@ class Kernel:
                 and await self._killswitch.is_killed(agent_id)
             ):
                 await self.interrupt_thread(thread, f"agent {agent_id} killed by operator")
-            return await self._consume(qevent, route.turn)
+            return await self._consume(qevent, route.turn, nav)
         finally:
             self._unregister_run(agent_id, thread)
 
@@ -447,13 +467,16 @@ class Kernel:
         except SuspendedThreadError:
             return await asyncio.to_thread(self._substrate.resume, thread)
 
-    async def _consume(self, qevent: QueuedSlackEvent, turn: TurnStream) -> TurnOutcome:
+    async def _consume(
+        self, qevent: QueuedSlackEvent, turn: TurnStream, nav: NavPack | None = None
+    ) -> TurnOutcome:
         acc = _StreamAccumulator()
         reply = _ThrottledReply(
             self._sink,
             channel=qevent.channel,
             ts=qevent.placeholder_ts,
             min_interval_s=self._config.slack_edit_min_interval_s,
+            nav=nav,
         )
         try:
             # ``async with`` releases the aiohttp response on every exit path

--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -13,6 +13,7 @@ from typing import Protocol
 
 from slack_sdk.web.async_client import AsyncWebClient
 
+from .behaviorpacks import NavPack
 from .blocks import render
 
 logger = logging.getLogger(__name__)
@@ -21,7 +22,9 @@ logger = logging.getLogger(__name__)
 class SlackSink(Protocol):
     """Edit a message in place. The kernel throttles how often it calls this."""
 
-    async def update(self, *, channel: str, ts: str, text: str) -> None: ...
+    async def update(
+        self, *, channel: str, ts: str, text: str, nav: NavPack | None = None
+    ) -> None: ...
 
     async def set_status(self, *, channel: str, thread_ts: str, status: str) -> None:
         """Set the assistant-thread status (the "shimmer" caption) on the thread.
@@ -48,13 +51,17 @@ class AsyncSlackSink:
         else:
             self._client = AsyncWebClient(token=token)
 
-    async def update(self, *, channel: str, ts: str, text: str) -> None:
+    async def update(
+        self, *, channel: str, ts: str, text: str, nav: NavPack | None = None
+    ) -> None:
         # The runner emits Markdown; Slack renders mrkdwn. ``render`` converts to
         # mrkdwn and, if the reply carries a complete ``agentos-reply`` block,
         # returns Block Kit to render instead -- keeping this dialect/structure
         # knowledge at the real-Slack seam, out of the kernel. A half-streamed or
         # malformed block falls back to text, so partials never show raw JSON.
-        rendered_text, blocks = render(text)
+        # ``nav`` (the agent's hub-button pack, threaded from the kernel) appends
+        # the no-dead-ends hub button to a structured reply; None leaves it be.
+        rendered_text, blocks = render(text, nav)
         if blocks is not None:
             await self._client.chat_update(
                 channel=channel, ts=ts, text=rendered_text, blocks=blocks

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 import pytest
 import redis
 from aci_protocol import Final, OutboundEvent, SessionStatus
+from agentos_worker.behaviorpacks import NavPack
 from agentos_worker.config import WorkerConfig
 from agentos_worker.kernel import Kernel
 from agentos_worker.markers import Markers
@@ -99,11 +100,16 @@ class FakeSink(SlackSink):
 
     def __init__(self) -> None:
         self.updates: list[tuple[str, str, str]] = []
+        # The nav pack (if any) threaded to each update, parallel to ``updates``.
+        self.update_navs: list[NavPack | None] = []
         self.status_sets: list[tuple[str, str, str]] = []
         self.status_clears: list[tuple[str, str]] = []
 
-    async def update(self, *, channel: str, ts: str, text: str) -> None:
+    async def update(
+        self, *, channel: str, ts: str, text: str, nav: NavPack | None = None
+    ) -> None:
         self.updates.append((channel, ts, text))
+        self.update_navs.append(nav)
 
     async def set_status(self, *, channel: str, thread_ts: str, status: str) -> None:
         self.status_sets.append((channel, thread_ts, status))
@@ -114,6 +120,10 @@ class FakeSink(SlackSink):
     @property
     def last_text(self) -> str | None:
         return self.updates[-1][2] if self.updates else None
+
+    @property
+    def last_nav(self) -> NavPack | None:
+        return self.update_navs[-1] if self.update_navs else None
 
 
 # --- Fake Kubernetes client (sandboxes resolve to 127.0.0.1) ------------------

--- a/apps/worker/tests/kernel/test_binding_integration.py
+++ b/apps/worker/tests/kernel/test_binding_integration.py
@@ -246,3 +246,100 @@ def test_shimmer_off_never_sets_a_caption(make_harness) -> None:
             assert h.sink.status_sets == []
 
     asyncio.run(go())
+
+
+# -- nav pack reaches the final rendered reply --------------------------------
+# The kernel threads the bound agent's nav pack to the sink's ``update`` for the
+# final structured reply, so a bound agent whose nav pack is enabled gets the
+# no-dead-ends hub button on its rendered Block Kit. An agent with nav
+# disabled/absent gets none.
+
+# A structured reply with buttons, none of which links to the hub command.
+_REPLY_WITH_BUTTONS = (
+    "```agentos-reply\n"
+    '{"text": "here you go", "buttons": [["Details", "details"]]}\n'
+    "```"
+)
+
+
+def test_bound_agent_with_enabled_nav_gets_hub_button_on_final_reply(make_harness) -> None:
+    from agentos_worker.behaviorpacks import NavPack
+    from agentos_worker.blocks import render
+
+    async def go() -> None:
+        packs = {"nav": {"enabled": True, "hub_label": "Help", "hub_command": "help"}}
+        binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
+        async with make_harness(binding=binding) as h:
+            h.runner.default_script = [Final(text=_REPLY_WITH_BUTTONS, status=DONE)]
+            await h.kernel.process_event(_qevent("hi", channel="C-bound", thread="tNav"))
+
+            # The sink's final update was threaded the agent's enabled nav pack.
+            assert h.sink.last_nav == NavPack(
+                enabled=True, hub_label="Help", hub_command="help"
+            )
+            # ...and rendering that final reply with it surfaces the hub button.
+            assert h.sink.last_text is not None
+            _text, blocks = render(h.sink.last_text, nav=h.sink.last_nav)
+            assert blocks is not None
+            ids = [
+                e["action_id"]
+                for b in blocks
+                if b["type"] == "actions"
+                for e in b["elements"]
+            ]
+            assert "help" in ids
+
+    asyncio.run(go())
+
+
+def test_malformed_packs_blob_still_completes_the_turn(make_harness) -> None:
+    # Regression: a malformed behavior_packs blob must NOT brick the channel.
+    # from_config is total, so packs_for can't raise; process_event resolves an
+    # all-off default and the turn finishes normally (no poison-loop). shimmer is
+    # off (the default config), so this exercises the every-bound-turn path where
+    # packs_for now runs.
+    async def go() -> None:
+        # A nested field of the wrong type would raise pydantic.ValidationError
+        # if from_config were not defensive.
+        binding = StubBinding(
+            {"C-bound": _resolved_with_packs({"nav": {"enabled": "banana"}})}
+        )
+        async with make_harness(binding=binding) as h:  # shimmer defaults off
+            h.runner.default_script = [Final(text="answer", status=DONE)]
+            ev = _qevent("hi", channel="C-bound", thread="tBad")
+
+            # No exception escapes (a raise here would leave the event pending and
+            # crash-loop on reclaim).
+            await h.kernel.process_event(ev)
+
+            # The turn completed: a normal final update landed and the event is done.
+            assert h.runner.opened == ["hi"]
+            assert h.sink.last_text == "answer"
+            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+
+    asyncio.run(go())
+
+
+def test_bound_agent_without_nav_gets_no_hub_button(make_harness) -> None:
+    from agentos_worker.blocks import render
+
+    async def go() -> None:
+        binding = StubBinding({"C-bound": _resolved_with_packs({})})  # nav absent
+        async with make_harness(binding=binding) as h:
+            h.runner.default_script = [Final(text=_REPLY_WITH_BUTTONS, status=DONE)]
+            await h.kernel.process_event(_qevent("hi", channel="C-bound", thread="tNoNav"))
+
+            # No enabled nav reached the sink, so no hub button reaches the render.
+            assert not (h.sink.last_nav and h.sink.last_nav.enabled)
+            assert h.sink.last_text is not None
+            _text, blocks = render(h.sink.last_text, nav=h.sink.last_nav)
+            assert blocks is not None
+            ids = [
+                e["action_id"]
+                for b in blocks
+                if b["type"] == "actions"
+                for e in b["elements"]
+            ]
+            assert "help" not in ids
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_behaviorpacks.py
+++ b/apps/worker/tests/test_behaviorpacks.py
@@ -243,6 +243,22 @@ def test_from_config_roundtrip_and_none() -> None:
     assert match_greeting(parsed, "hi") == "yo"
 
 
+def test_from_config_malformed_nested_pack_falls_back_all_off() -> None:
+    # A nested field with the wrong type would raise pydantic.ValidationError;
+    # from_config must be TOTAL and fall back to an all-off BehaviorPacks() so a
+    # corrupt packs blob on an agent row can never brick that agent's turns.
+    packs = BehaviorPacks.from_config({"nav": {"enabled": "banana"}})
+    assert packs == BehaviorPacks()
+    assert packs.nav.enabled is False
+
+
+def test_from_config_non_dict_falls_back_all_off() -> None:
+    # A non-mapping blob (a decoded JSON array/scalar) also defaults to all-off,
+    # never raising.
+    for bad in (["nav"], "nav", 42):
+        assert BehaviorPacks.from_config(bad) == BehaviorPacks()  # type: ignore[arg-type]
+
+
 # -- nav pack (no-dead-ends hub button) ---------------------------------------
 
 _NAV = NavPack(enabled=True, hub_label="Help", hub_command="help")

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -2,7 +2,29 @@
 
 from __future__ import annotations
 
+from agentos_worker.behaviorpacks import NavPack
 from agentos_worker.blocks import Reply, chunk, parse_reply, render, to_blocks
+
+# An enabled nav pack, same shape as tests/test_behaviorpacks.py.
+_NAV = NavPack(enabled=True, hub_label="Help", hub_command="help")
+
+
+def _action_ids(blocks: list[dict]) -> list[str]:
+    return [
+        e["action_id"]
+        for b in blocks
+        if b["type"] == "actions"
+        for e in b["elements"]
+    ]
+
+
+def _action_labels(blocks: list[dict]) -> list[str]:
+    return [
+        e["text"]["text"]
+        for b in blocks
+        if b["type"] == "actions"
+        for e in b["elements"]
+    ]
 
 _BLOCK = """Here you go:
 
@@ -76,3 +98,44 @@ def test_render_plain_text_is_mrkdwn() -> None:
     text, blocks = render("**hi** [x](http://y)")
     assert blocks is None
     assert text == "*hi* <http://y|x>"
+
+
+# -- nav pack wiring into the render path -------------------------------------
+# Contract: to_blocks(reply, nav=None) / render(text, nav=None) gain an optional
+# nav: NavPack | None. When nav is enabled, the hub button is appended to the
+# actions block before it is emitted; when nav is None/disabled, output is
+# byte-identical to today (no hub button).
+
+
+def test_to_blocks_appends_hub_button_when_nav_enabled() -> None:
+    reply = Reply(text="x", buttons=[("Details", "details")])
+    blocks = to_blocks(reply, nav=_NAV)
+    assert "help" in _action_ids(blocks)  # the hub command reached the actions block
+    assert "← Help" in _action_labels(blocks)  # left-arrow: no back button present
+
+
+def test_to_blocks_nav_none_is_identical_to_no_nav() -> None:
+    reply = Reply(text="x", buttons=[("Details", "details")])
+    assert to_blocks(reply, nav=None) == to_blocks(reply)
+    assert "help" not in _action_ids(to_blocks(reply, nav=None))
+
+
+def test_to_blocks_disabled_nav_adds_no_hub_button() -> None:
+    disabled = NavPack(enabled=False, hub_label="Help", hub_command="help")
+    reply = Reply(text="x", buttons=[("Details", "details")])
+    assert to_blocks(reply, nav=disabled) == to_blocks(reply)
+    assert "help" not in _action_ids(to_blocks(reply, nav=disabled))
+
+
+def test_render_applies_nav_hub_button() -> None:
+    # _BLOCK already carries a "← Back" nav button, so the hub is above -> "↑".
+    _text, blocks = render(_BLOCK, nav=_NAV)
+    assert blocks is not None
+    assert "help" in _action_ids(blocks)
+    assert "↑ Help" in _action_labels(blocks)
+
+
+def test_render_without_nav_has_no_hub_button() -> None:
+    _text, blocks = render(_BLOCK)
+    assert blocks is not None
+    assert "help" not in _action_ids(blocks)


### PR DESCRIPTION
Ref CUR-1601. Wires the **nav behavior pack** into the live render path — its `ensure_hub_button` existed and was unit-tested but had **zero live callers**, so nav was declared but never applied.

## What
A bound agent whose nav pack is enabled now gets a no-dead-ends **hub button** appended to its structured (Block Kit) replies.

- **Render (`blocks.py`)** — `to_blocks(reply, nav=None)` / `render(text, nav=None)` gain an optional `NavPack`. When enabled, `reply.buttons` pass through `ensure_hub_button` (the platform-owned append/arrow/idempotency policy) before the actions block is emitted. `nav=None`/disabled → byte-identical output.
- **Sink (`slack_sink.py`)** — `AsyncSlackSink.update` and the `SlackSink` protocol forward `nav` to `render`.
- **Kernel (`kernel.py`)** — threads the bound agent's nav pack `process_event → _attempt → _consume → _ThrottledReply → sink.update`. Pure plumbing, no new control flow, nothing added to the concurrency-critical section. `packs_for` is now resolved once in `process_event` and reused for both nav and the shimmer caption.

## Kernel safety (F1 sacred — adversarially reviewed)
The plumbing was reviewed invariant-by-invariant (exactly-once delivery, lock ordering, kill gate, steer-vs-interrupt, Rule 3 — all preserved; nav is applied structurally, it never sniffs message text). The review caught one real regression from resolving `packs_for` unconditionally (it previously ran only when `shimmer` was on, which is off by default): a malformed `behavior_packs` blob would raise an uncaught `ValidationError` and poison the channel. Fixed at the parse boundary — **`BehaviorPacks.from_config` is now total** (malformed → all-off, logged), which also fixes a latent crash on the shimmer-on path. The kernel therefore needs no try/except.

## Tests
- `test_blocks.py` — hub button appears (with correct arrow) when nav enabled; identical output when None/disabled.
- `test_binding_integration.py` — a bound agent with an enabled nav pack gets the hub button on its final reply; without it, none; and a **malformed** packs blob with shimmer off still completes the turn (no poison-loop).
- `test_behaviorpacks.py` — `from_config` falls back to all-off on malformed / non-mapping input without raising.
- Full worker pack/kernel/blocks/slack_sink suites, `ruff`, and `mypy` all clean.

## Scope
Worker-only (`blocks.py`, `slack_sink.py`, `kernel.py`, `behaviorpacks.py` + tests). No API, migration, dispatcher, or frozen-contract change. This is deferred wiring from #92 (CUR-1596); the pack schema/model were already merged.