### PR TITLE
Route Langfuse admin password and project keys via secretKeyRef

### DIFF
--- a/charts/agentos/templates/NOTES.txt
+++ b/charts/agentos/templates/NOTES.txt
@@ -136,7 +136,8 @@ When exposed as NodePort (`agentos up` does this by default), Langfuse is reacha
   http://<any-node-ip>:{{ .Values.langfuse.web.service.nodePort }}
 The nodePort is pinned in values (langfuse.web.service.nodePort) so it survives a down/up cycle.
 {{- end }}
-  # Dev project keys (headless-bootstrapped): {{ .Values.langfuse.init.projectPublicKey }} / {{ .Values.langfuse.init.projectSecretKey }}
+  # Dev project public key (headless-bootstrapped): {{ .Values.langfuse.init.projectPublicKey }}
+  # The project secret key is stored in the {{ include "agentos.secretName" . }} Secret (key langfuseInitProjectSecretKey), not printed here.
 
 App services send OTLP traces to the collector, NOT directly to Langfuse:
   {{ include "agentos.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.grpcPort }} (gRPC) / :{{ .Values.otelCollector.service.httpPort }} (HTTP)

--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -76,7 +76,10 @@ spec:
             - name: LANGFUSE_PUBLIC_KEY
               value: {{ .Values.langfuse.init.projectPublicKey | quote }}
             - name: LANGFUSE_SECRET_KEY
-              value: {{ .Values.langfuse.init.projectSecretKey | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.langfuse.existingSecret | default (include "agentos.secretName" .) }}
+                  key: langfuseInitProjectSecretKey
             - name: S3_ENDPOINT_URL
               value: http://{{ include "agentos.minio.host" . }}:{{ .Values.minio.port }}
             - name: S3_ACCESS_KEY

--- a/charts/agentos/templates/langfuse.yaml
+++ b/charts/agentos/templates/langfuse.yaml
@@ -64,13 +64,19 @@ spec:
             - name: LANGFUSE_INIT_PROJECT_PUBLIC_KEY
               value: {{ .Values.langfuse.init.projectPublicKey | quote }}
             - name: LANGFUSE_INIT_PROJECT_SECRET_KEY
-              value: {{ .Values.langfuse.init.projectSecretKey | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.langfuse.existingSecret | default (include "agentos.secretName" .) }}
+                  key: langfuseInitProjectSecretKey
             - name: LANGFUSE_INIT_USER_EMAIL
               value: {{ .Values.langfuse.init.userEmail | quote }}
             - name: LANGFUSE_INIT_USER_NAME
               value: {{ .Values.langfuse.init.userName | quote }}
             - name: LANGFUSE_INIT_USER_PASSWORD
-              value: {{ .Values.langfuse.init.userPassword | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.langfuse.existingSecret | default (include "agentos.secretName" .) }}
+                  key: langfuseInitUserPassword
           ports:
             - name: http
               containerPort: 3000

--- a/charts/agentos/templates/secrets.yaml
+++ b/charts/agentos/templates/secrets.yaml
@@ -32,6 +32,9 @@ stringData:
   # Init project secret key, read by the model-pricing seed Job as basic-auth
   # password against the Langfuse public API.
   langfuseInitProjectSecretKey: {{ .Values.langfuse.init.projectSecretKey | quote }}
+  # Langfuse admin (init user) password, referenced by the Langfuse web
+  # deployment via secretKeyRef instead of a plaintext env value.
+  langfuseInitUserPassword: {{ .Values.langfuse.init.userPassword | quote }}
   # Full `Authorization` header value the OTel Collector sends to Langfuse
   # (derived from the Langfuse init keys unless otelCollector.otlpAuthHeader set).
   otlpAuthHeader: {{ include "agentos.otlpAuthHeader" . | quote }}

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -41,7 +41,8 @@ langfuse:
   nextauthUrl: http://localhost:23000
   # Dev-only secret material. Override in prod or set `existingSecret` to a
   # Secret carrying keys: langfuseEncryptionKey, langfuseSalt,
-  # langfuseNextauthSecret. ENCRYPTION_KEY must be 64 hex chars (openssl rand -hex 32).
+  # langfuseNextauthSecret, langfuseInitProjectSecretKey, langfuseInitUserPassword.
+  # ENCRYPTION_KEY must be 64 hex chars (openssl rand -hex 32).
   encryptionKey: "0000000000000000000000000000000000000000000000000000000000000000"
   salt: dev-salt-change-me
   nextauthSecret: dev-nextauth-secret-change-me


### PR DESCRIPTION
Renders the Langfuse admin password and project secret key from the chart Secret via `secretKeyRef` instead of plaintext pod-spec env, closing a High-severity exposure where any namespace user with `get pod`/`describe` (or a compromised sidecar) could read them from the pod spec.

**Changes**
- `langfuse.yaml`: `LANGFUSE_INIT_PROJECT_SECRET_KEY` and `LANGFUSE_INIT_USER_PASSWORD` now use `secretKeyRef`.
- `api.yaml`: `LANGFUSE_SECRET_KEY` now uses `secretKeyRef`.
- `secrets.yaml`: adds `langfuseInitUserPassword` (the admin password was not previously in the Secret; the project secret key already was).
- `NOTES.txt`: masks the printed secret key (public key retained).
- `values.yaml`: documents the two new keys a BYO `langfuse.existingSecret` must carry.

All three references mirror the existing `langfuse-model-pricing.yaml` pattern (`name: {{ .Values.langfuse.existingSecret | default (include "agentos.secretName" .) }}`).

**Verification:** `helm lint` clean; `helm template` on the Langfuse/API workloads shows only `secretKeyRef` for these vars, with `sk-lf-agentos-dev`/`agentos-dev-password` appearing only inside the `kind: Secret` stringData.

Closes #60