### PR TITLE
Validate commit sha and guard git archive against option injection

### DIFF
--- a/apps/api/src/agentos_api/gitflow.py
+++ b/apps/api/src/agentos_api/gitflow.py
@@ -11,6 +11,7 @@ GitHub API.
 import hashlib
 import hmac
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -26,6 +27,16 @@ from .schemas import WebhookResult
 from .storage import BundleStore
 
 _ZERO_SHA = "0" * 40
+# A full lowercase-hex git object id: SHA-1 (40) or SHA-256 (64).
+# Unanchored on purpose; paired with fullmatch below so a trailing newline
+# (which `$` would tolerate) is rejected.
+_SHA_RE = re.compile(r"[0-9a-f]{40}|[0-9a-f]{64}")
+
+
+def _is_valid_sha(sha: str) -> bool:
+    """True only for a full lowercase-hex SHA-1 or SHA-256 object id."""
+
+    return bool(_SHA_RE.fullmatch(sha))
 
 
 class GitFlowError(Exception):
@@ -67,6 +78,8 @@ def clone_and_archive(clone_url: str, sha: str, settings: Settings) -> bytes:
 
     if not clone_url.startswith(settings.git_allowed_schemes):
         raise GitFlowError(f"clone url scheme not allowed: {clone_url}")
+    if not _is_valid_sha(sha):
+        raise GitFlowError(f"invalid commit sha: {sha!r}")
 
     tmp = tempfile.mkdtemp(prefix="gitflow-")
     env = {
@@ -84,7 +97,7 @@ def clone_and_archive(clone_url: str, sha: str, settings: Settings) -> bytes:
                 timeout=120,
             )
             archived = subprocess.run(
-                ["git", "-C", tmp, "archive", "--format=tar", sha],
+                ["git", "-C", tmp, "archive", "--format=tar", "--", sha],
                 check=True,
                 capture_output=True,
                 env=env,
@@ -112,7 +125,7 @@ async def process_push(
     environment = environment_for_ref(ref if isinstance(ref, str) else None, settings)
     if environment is None:
         return WebhookResult(status="ignored")
-    if not isinstance(after, str) or after == _ZERO_SHA:
+    if not isinstance(after, str) or after == _ZERO_SHA or not _is_valid_sha(after):
         return WebhookResult(status="ignored")
     if not isinstance(repo, dict):
         return WebhookResult(status="ignored")

--- a/apps/api/tests/test_gitflow_unit.py
+++ b/apps/api/tests/test_gitflow_unit.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import hmac
+import subprocess
+from unittest import mock
 
 import pytest
 from agentos_api.config import Settings
@@ -14,6 +16,9 @@ from agentos_api.gitflow import (
 from agentos_api.models import Environment
 
 SECRET = "top-secret"
+_VALID_SHA1 = "a" * 40
+_VALID_SHA256 = "a" * 64
+_ALLOWED_URL = "file:///tmp/nonexistent-gitflow-repo"
 
 
 def _sign(body: bytes) -> str:
@@ -57,3 +62,63 @@ def test_clone_and_archive_refuses_disallowed_scheme() -> None:
     settings = Settings()
     with pytest.raises(GitFlowError):
         clone_and_archive("ext::sh -c whoami", "0" * 40, settings)
+
+
+@pytest.mark.parametrize(
+    "bad_sha",
+    [
+        "--foo",  # git-option injection via a leading dash
+        "--upload-pack=touch /tmp/pwned",  # a real option-injection payload
+        "-o",  # short option flag
+        "deadbeef",  # too short (8 hex chars, not 40/64)
+        "z" * 40,  # right length, non-hex chars
+        "A" * 40,  # uppercase hex is rejected (regex is lowercase only)
+        "a" * 39,  # one short of SHA-1
+        "a" * 41,  # one over SHA-1 (and not SHA-256)
+        "a" * 63,  # one short of SHA-256
+        "a" * 65,  # one over SHA-256
+        "a" * 40 + "\n",  # valid hex with a trailing newline ($ regex leak)
+        "a" * 40 + "\r",  # valid hex with a trailing carriage return
+        "a" * 40 + "\n--foo",  # embedded newline smuggling a git option
+        "",  # empty
+    ],
+)
+def test_clone_and_archive_rejects_invalid_sha_before_any_subprocess(
+    bad_sha: str,
+) -> None:
+    # An invalid ref must be refused by the format gate BEFORE git ever runs, so
+    # a leading-dash sha can never reach `git archive` as an injected option.
+    settings = Settings()
+    with mock.patch("agentos_api.gitflow.subprocess.run") as run:
+        with pytest.raises(GitFlowError):
+            clone_and_archive(_ALLOWED_URL, bad_sha, settings)
+    run.assert_not_called()
+
+
+def _completed(stdout: bytes = b"") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
+
+
+@pytest.mark.parametrize("good_sha", [_VALID_SHA1, _VALID_SHA256])
+def test_clone_and_archive_accepts_valid_hex_and_inserts_dash_dash(
+    good_sha: str,
+) -> None:
+    # A full lowercase-hex SHA-1 or SHA-256 passes the format gate, and the
+    # `git archive` argv must place a `--` separator immediately before the sha
+    # so a value can never be parsed as a git option.
+    settings = Settings()
+    with mock.patch("agentos_api.gitflow.subprocess.run") as run:
+        run.return_value = _completed(b"tar-bytes")
+        result = clone_and_archive(_ALLOWED_URL, good_sha, settings)
+
+    assert result == b"tar-bytes"
+
+    # Locate the `git archive` invocation among the subprocess calls.
+    archive_argv = next(
+        call.args[0]
+        for call in run.call_args_list
+        if "archive" in call.args[0]
+    )
+    assert "--" in archive_argv, archive_argv
+    dash_index = archive_argv.index("--")
+    assert archive_argv[dash_index + 1] == good_sha, archive_argv


### PR DESCRIPTION
Closes #65

The webhook-supplied push ref flowed into `git archive` positionally with no `--` separator and no format check, so a ref like `--foo` could inject `git archive` options (medium-severity option injection under a forgeable dev webhook HMAC).

## Changes
- Reject any ref that is not a full lowercase-hex SHA-1/SHA-256 object id (`re.fullmatch`, so trailing/embedded newlines are rejected too), **before any subprocess runs** -- enforced both at the webhook boundary (`process_push`) and inside `clone_and_archive`.
- Pass the sha after a `--` end-of-options separator in the `git archive` argv.

## Tests
Unit tests in `test_gitflow_unit.py` assert bad refs (leading-dash, wrong-length, non-hex, uppercase, trailing `\n`/`\r`, embedded `\n`) raise `GitFlowError` with `subprocess.run` never called, and that a valid hex sha passes with `--` placed immediately before the sha.

Note: an explicit host allowlist for `clone_url` (a separate SSRF surface the issue flagged as "consider") is intentionally left out of scope and worth a follow-up ticket.

Ref #65