### PR TITLE
Observability polish: unit rename, empty traces, log noise, OTLP warning

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -831,8 +831,8 @@
             "title": "Error Rate",
             "type": "number"
           },
-          "latency_p95_seconds": {
-            "title": "Latency P95 Seconds",
+          "latency_p95_ms": {
+            "title": "Latency P95 Ms",
             "type": "number"
           },
           "runs": {
@@ -852,7 +852,7 @@
           "start",
           "end",
           "runs",
-          "latency_p95_seconds",
+          "latency_p95_ms",
           "tokens",
           "cost_usd",
           "error_rate"

--- a/apps/api/src/agentos_api/metrics.py
+++ b/apps/api/src/agentos_api/metrics.py
@@ -32,7 +32,7 @@ def agent_trace_filter(agent_id: uuid.UUID | str) -> str:
 
     return f"agent-{agent_id}"
 
-SCALAR_METRICS = ("runs", "latency_p95_seconds", "tokens", "cost_usd")
+SCALAR_METRICS = ("runs", "latency_p95_ms", "tokens", "cost_usd")
 ALL_METRICS = (*SCALAR_METRICS, "error_rate")
 
 # metric -> (view, measure, aggregation, result-key, is_integer)
@@ -40,7 +40,7 @@ ALL_METRICS = (*SCALAR_METRICS, "error_rate")
 # (a run with many tool/generation spans would otherwise skew a span-weighted p95).
 _SPEC: dict[str, tuple[str, str, str, str, bool]] = {
     "runs": ("traces", "count", "count", "count_count", True),
-    "latency_p95_seconds": ("traces", "latency", "p95", "p95_latency", False),
+    "latency_p95_ms": ("traces", "latency", "p95", "p95_latency", False),
     "tokens": ("observations", "totalTokens", "sum", "sum_totalTokens", True),
     "cost_usd": ("observations", "totalCost", "sum", "sum_totalCost", False),
 }
@@ -149,7 +149,7 @@ async def summary(
         start=start,
         end=end,
         runs=int(scalars["runs"]),
-        latency_p95_seconds=scalars["latency_p95_seconds"],
+        latency_p95_ms=scalars["latency_p95_ms"],
         tokens=int(scalars["tokens"]),
         cost_usd=scalars["cost_usd"],
         error_rate=_error_rate(level_rows),

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -226,7 +226,7 @@ class MetricsSummary(BaseModel):
     start: str
     end: str
     runs: int
-    latency_p95_seconds: float
+    latency_p95_ms: float
     tokens: int
     cost_usd: float
     error_rate: float

--- a/apps/api/tests/test_metrics_unit.py
+++ b/apps/api/tests/test_metrics_unit.py
@@ -68,7 +68,7 @@ def test_scalar_query_maps_metric_to_view_and_measure() -> None:
 
 def test_latency_is_measured_per_run_on_the_traces_view() -> None:
     # p95 latency must be a per-run aggregate, not span-weighted (observations).
-    q = _scalar_query("latency_p95_seconds", "s", "e", None, None)
+    q = _scalar_query("latency_p95_ms", "s", "e", None, None)
     assert q["view"] == "traces"
     assert q["metrics"] == [{"measure": "latency", "aggregation": "p95"}]
 

--- a/apps/ui/e2e/cold-start-wired.spec.ts
+++ b/apps/ui/e2e/cold-start-wired.spec.ts
@@ -13,7 +13,7 @@ const SUMMARY = {
   start: "2026-06-28",
   end: "2026-07-05",
   runs: 0,
-  latency_p95_seconds: 0,
+  latency_p95_ms: 0,
   tokens: 0,
   cost_usd: 0,
   error_rate: 0,

--- a/apps/ui/e2e/delete-agent-wired.spec.ts
+++ b/apps/ui/e2e/delete-agent-wired.spec.ts
@@ -23,7 +23,7 @@ async function stubAgents(page: Page, deleteStatus: 204 | 409) {
     return route.fulfill(json(409, { detail: "agent has an active deployment; stop it before deleting" }));
   });
   await page.route("**/api/observability/metrics/summary*", (route) => route.fulfill(json(200, {
-    start: "s", end: "e", runs: 0, latency_p95_seconds: 0, tokens: 0, cost_usd: 0, error_rate: 0,
+    start: "s", end: "e", runs: 0, latency_p95_ms: 0, tokens: 0, cost_usd: 0, error_rate: 0,
   })));
   await page.route("**/api/langfuse/traces*", (route) => route.fulfill(json(200, [])));
 }

--- a/apps/ui/e2e/observability-wired.spec.ts
+++ b/apps/ui/e2e/observability-wired.spec.ts
@@ -10,7 +10,7 @@ const SUMMARY = {
   runs: 785,
   // Langfuse reports the latency measure in milliseconds (see lib/format.ts), so
   // 2100 here is 2.1s and must render as "2.10s".
-  latency_p95_seconds: 2100,
+  latency_p95_ms: 2100,
   tokens: 128000,
   cost_usd: 21.4,
   error_rate: 0.018,
@@ -19,7 +19,7 @@ const SUMMARY = {
 // Distinct last value per metric so a metric switch is observable in the caption.
 const LAST_VALUE: Record<string, number> = {
   runs: 122,
-  latency_p95_seconds: 3400,
+  latency_p95_ms: 3400,
   tokens: 44000,
   cost_usd: 7.25,
   error_rate: 0.06,

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -193,14 +193,14 @@ export async function getTrace(traceId: string): Promise<TraceTree> {
 
 // ---- observability (OB1): Langfuse-backed metrics + runner-pod log proxy ----
 
-export type MetricKey = "runs" | "latency_p95_seconds" | "tokens" | "cost_usd" | "error_rate";
+export type MetricKey = "runs" | "latency_p95_ms" | "tokens" | "cost_usd" | "error_rate";
 export type Granularity = "hour" | "day" | "week";
 
 export interface MetricsSummary {
   start: string;
   end: string;
   runs: number;
-  latency_p95_seconds: number;
+  latency_p95_ms: number;
   tokens: number;
   cost_usd: number;
   error_rate: number;

--- a/apps/ui/src/lib/format.ts
+++ b/apps/ui/src/lib/format.ts
@@ -1,5 +1,5 @@
 // The OB1 metrics API sources latency from Langfuse's metrics `latency` measure,
-// which is reported in MILLISECONDS despite the `latency_p95_seconds` field name
+// which is reported in MILLISECONDS, now reflected in the `latency_p95_ms` field name
 // (the Langfuse trace object's own `latency` is seconds, but the aggregate
 // metrics measure is ms). Formatting that value directly as seconds overstated
 // latency by 1000x. Convert here, in one place, so every display reads honest

--- a/apps/ui/src/views/obs/RealMetrics.tsx
+++ b/apps/ui/src/views/obs/RealMetrics.tsx
@@ -9,7 +9,7 @@ import type { MetricsSummary, MetricKey, Granularity, MetricFilter } from "../..
 // The five metrics the OB1 API exposes (Langfuse-backed; no Prometheus).
 const METRICS: { key: MetricKey; label: string; unit: string }[] = [
   { key: "runs", label: "Runs", unit: "" },
-  { key: "latency_p95_seconds", label: "Latency p95", unit: "s" },
+  { key: "latency_p95_ms", label: "Latency p95", unit: "ms" },
   { key: "tokens", label: "Tokens", unit: "" },
   { key: "cost_usd", label: "Cost", unit: "$" },
   { key: "error_rate", label: "Error rate", unit: "%" },
@@ -20,7 +20,7 @@ function fmt(key: MetricKey, v: number): string {
   switch (key) {
     case "runs":
       return String(Math.round(v));
-    case "latency_p95_seconds":
+    case "latency_p95_ms":
       return formatLatency(v);
     case "tokens":
       return v >= 1000 ? (v / 1000).toFixed(1) + "k" : String(Math.round(v));

--- a/apps/ui/src/views/wired/WiredOverview.tsx
+++ b/apps/ui/src/views/wired/WiredOverview.tsx
@@ -111,7 +111,7 @@ function LiveOverview({ agents }: { agents: AgentOut[] }) {
   const stats: [string, string][] = [
     ["Agents", String(scoped.length)],
     ["Runs (7d)", metric((d) => String(d.runs))],
-    ["Latency p95", metric((d) => formatLatency(d.latency_p95_seconds))],
+    ["Latency p95", metric((d) => formatLatency(d.latency_p95_ms))],
     ["Cost (7d)", metric((d) => "$" + d.cost_usd.toFixed(2))],
   ];
   const recent = traces.data ?? [];

--- a/apps/worker/src/agentos_worker/consumer.py
+++ b/apps/worker/src/agentos_worker/consumer.py
@@ -108,12 +108,18 @@ class Consumer:
                     count=self._config.read_count,
                     block=self._config.read_block_ms,
                 )
-            except (RedisTimeoutError, RedisConnectionError) as exc:
-                # The blocking read timed out or the connection blipped (real
-                # pod-to-pod RTT, a Valkey failover). Both are transient: log and
-                # retry rather than letting the exception kill the read loop (and
-                # with it the whole worker). A short pause avoids a hot spin if
-                # Valkey is briefly unreachable; redis-py reconnects on the retry.
+            except RedisTimeoutError as exc:
+                # A blocking-read timeout is the routine idle case (no entries
+                # arrived within read_block_ms plus the socket timeout margin), not
+                # a fault -- log at DEBUG so an idle worker doesn't flood WARNING.
+                # Still back off + retry rather than letting it kill the read loop.
+                logger.debug("stream read timed out (idle); retrying: %s", exc)
+                await self._sleep_or_stop(_READ_ERROR_BACKOFF_S)
+                continue
+            except RedisConnectionError as exc:
+                # A real connection fault (a Valkey failover, pod-to-pod blip):
+                # transient but worth a WARNING. Back off and retry; redis-py
+                # reconnects on the next attempt.
                 logger.warning("stream read failed transiently; retrying: %s", exc)
                 await self._sleep_or_stop(_READ_ERROR_BACKOFF_S)
                 continue

--- a/apps/worker/src/agentos_worker/consumer.py
+++ b/apps/worker/src/agentos_worker/consumer.py
@@ -21,18 +21,10 @@ from typing import cast
 
 from agentos_dispatcher.queue import QueuedSlackEvent
 from redis.asyncio import Redis
-from redis.exceptions import (
-    ConnectionError as RedisConnectionError,
-)
-from redis.exceptions import (
-    ResponseError,
-)
-from redis.exceptions import (
-    TimeoutError as RedisTimeoutError,
-)
 
 from .config import WorkerConfig
 from .kernel import Kernel
+from .stream_consumer import ReadLoopSpec, StreamConsumer, StreamEntry
 
 logger = logging.getLogger(__name__)
 
@@ -40,11 +32,8 @@ logger = logging.getLogger(__name__)
 # error, so a briefly-unreachable Valkey does not spin the read loop hot.
 _READ_ERROR_BACKOFF_S = 0.5
 
-# One stream entry as redis returns it with decode_responses=True.
-StreamEntry = tuple[str, dict[str, str]]
 
-
-class Consumer:
+class Consumer(StreamConsumer):
     """Runs the read loop and the periodic reclaim/reap maintenance loop."""
 
     def __init__(
@@ -55,10 +44,9 @@ class Consumer:
         config: WorkerConfig,
         max_concurrency: int = 16,
     ) -> None:
-        self._redis = redis
+        super().__init__(redis)
         self._kernel = kernel
         self._config = config
-        self._stop = asyncio.Event()
         self._sem = asyncio.Semaphore(max_concurrency)
         self._inflight: set[asyncio.Task[None]] = set()
         # Entry ids currently being handled by THIS consumer. XAUTOCLAIM would
@@ -79,16 +67,9 @@ class Consumer:
         off the pending list, not the group's start id). An existing group is
         left untouched.
         """
-        try:
-            await self._redis.xgroup_create(
-                self._config.stream, self._config.consumer_group, id="$", mkstream=True
-            )
-        except ResponseError as exc:
-            if "BUSYGROUP" not in str(exc):
-                raise
-
-    def request_stop(self) -> None:
-        self._stop.set()
+        await self._ensure_group(
+            self._config.stream, self._config.consumer_group, start_id="$"
+        )
 
     async def run(self) -> None:
         await self.ensure_group()
@@ -99,36 +80,20 @@ class Consumer:
     # -- read loop ------------------------------------------------------------
 
     async def _read_loop(self) -> None:
-        while not self._stop.is_set():
-            try:
-                resp = await self._redis.xreadgroup(
-                    self._config.consumer_group,
-                    self._config.consumer_name,
-                    {self._config.stream: ">"},
-                    count=self._config.read_count,
-                    block=self._config.read_block_ms,
-                )
-            except RedisTimeoutError as exc:
-                # A blocking-read timeout is the routine idle case (no entries
-                # arrived within read_block_ms plus the socket timeout margin), not
-                # a fault -- log at DEBUG so an idle worker doesn't flood WARNING.
-                # Still back off + retry rather than letting it kill the read loop.
-                logger.debug("stream read timed out (idle); retrying: %s", exc)
-                await self._sleep_or_stop(_READ_ERROR_BACKOFF_S)
-                continue
-            except RedisConnectionError as exc:
-                # A real connection fault (a Valkey failover, pod-to-pod blip):
-                # transient but worth a WARNING. Back off and retry; redis-py
-                # reconnects on the next attempt.
-                logger.warning("stream read failed transiently; retrying: %s", exc)
-                await self._sleep_or_stop(_READ_ERROR_BACKOFF_S)
-                continue
-            if not resp:
-                continue
-            streams = cast("list[tuple[str, list[StreamEntry]]]", resp)
-            for _stream, entries in streams:
-                for entry_id, fields in entries:
-                    await self._dispatch(entry_id, fields)
+        await self._consume(
+            ReadLoopSpec(
+                stream=self._config.stream,
+                group=self._config.consumer_group,
+                consumer=self._config.consumer_name,
+                count=self._config.read_count,
+                block_ms=self._config.read_block_ms,
+                backoff_s=_READ_ERROR_BACKOFF_S,
+                timeout_msg="stream read timed out (idle); retrying: %s",
+                connection_msg="stream read failed transiently; retrying: %s",
+                logger=logger,
+            ),
+            self._dispatch,
+        )
 
     async def _dispatch(self, entry_id: str, fields: dict[str, str]) -> None:
         if entry_id in self._inflight_ids:
@@ -163,7 +128,7 @@ class Consumer:
             self._sem.release()
 
     async def _ack(self, entry_id: str) -> None:
-        await self._redis.xack(self._config.stream, self._config.consumer_group, entry_id)
+        await self._xack(self._config.stream, self._config.consumer_group, entry_id)
 
     # -- maintenance loop -----------------------------------------------------
 
@@ -199,9 +164,3 @@ class Consumer:
             if cursor in ("0-0", "0"):
                 break
         return reclaimed
-
-    async def _sleep_or_stop(self, seconds: float) -> None:
-        try:
-            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
-        except TimeoutError:
-            pass

--- a/apps/worker/src/agentos_worker/eval/recorder.py
+++ b/apps/worker/src/agentos_worker/eval/recorder.py
@@ -46,6 +46,10 @@ class LangfuseEvalRecorder:
 
     async def record(self, run: EvalRunResult) -> list[str]:
         """Ingest one trace + score per case. Returns the created trace ids."""
+        if not run.results:
+            # No cases: don't POST a hollow ingestion batch (an empty trace shell
+            # in Langfuse). Nothing to record, so return before touching the API.
+            return []
         now = _now_iso()
         batch: list[dict[str, Any]] = []
         trace_ids: list[str] = []

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -226,9 +226,17 @@ class EvalStreamConsumer:
                     count=1,
                     block=self._config.read_block_ms,
                 )
-            except (RedisTimeoutError, RedisConnectionError) as exc:
+            except RedisTimeoutError as exc:
                 # Same transient-transport guard as the runs consumer: a blocking
-                # read timeout or connection blip must not kill the eval loop.
+                # read timeout is the routine idle case, not a fault -- log at
+                # DEBUG so an idle eval worker doesn't flood WARNING. Still back
+                # off + retry rather than letting it kill the eval loop.
+                logger.debug("eval stream read timed out (idle); retrying: %s", exc)
+                await self._sleep_or_stop(_EVAL_READ_ERROR_BACKOFF_S)
+                continue
+            except RedisConnectionError as exc:
+                # A real connection blip (Valkey failover): transient but worth a
+                # WARNING. Back off and retry.
                 logger.warning("eval stream read failed transiently; retrying: %s", exc)
                 await self._sleep_or_stop(_EVAL_READ_ERROR_BACKOFF_S)
                 continue

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -37,15 +37,6 @@ from aci_protocol import Budget
 from plugin_format import safe_extract
 from pydantic import BaseModel
 from redis.asyncio import Redis
-from redis.exceptions import (
-    ConnectionError as RedisConnectionError,
-)
-from redis.exceptions import (
-    ResponseError,
-)
-from redis.exceptions import (
-    TimeoutError as RedisTimeoutError,
-)
 
 from ..binding import (
     BUDGET_ENV,
@@ -58,6 +49,7 @@ from ..bundle_store import BundleStore
 from ..config import WorkerConfig
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
+from ..stream_consumer import ReadLoopSpec, StreamConsumer, StreamEntry
 from .models import EvalRunResult, EvalSuite
 from .recorder import LangfuseEvalRecorder
 from .run import run_eval_suite
@@ -68,7 +60,6 @@ logger = logging.getLogger(__name__)
 _EVAL_READ_ERROR_BACKOFF_S = 0.5
 
 STREAM_PAYLOAD_FIELD = "payload"
-StreamEntry = tuple[str, dict[str, str]]
 
 
 class EvalWorkItem(BaseModel):
@@ -158,7 +149,7 @@ def load_suite_from_bundle(data: bytes, suite_name: str) -> EvalSuite | None:
     return EvalSuite(name=suite_name, cases=loaded.cases)
 
 
-class EvalStreamConsumer:
+class EvalStreamConsumer(StreamConsumer):
     """Reads agentos:evals, runs each suite, records, reports, then acks."""
 
     def __init__(
@@ -172,14 +163,13 @@ class EvalStreamConsumer:
         recorder: LangfuseEvalRecorder,
         repo_lookup: Any,
     ) -> None:
-        self._redis = redis
+        super().__init__(redis)
         self._config = config
         self._bundles = bundle_store
         self._substrate = substrate
         self._reporter = reporter
         self._recorder = recorder
         self._repo_lookup = repo_lookup
-        self._stop = asyncio.Event()
         # Entry ids this consumer is handling right now. XAUTOCLAIM would
         # otherwise reclaim our own still-pending (long-running) eval and
         # re-run it in parallel; skipping these ids prevents that self-reclaim.
@@ -192,60 +182,35 @@ class EvalStreamConsumer:
         # dropping items produced while the worker was down would silently skip
         # required checks, violating the "an eval is never lost" guarantee this
         # consumer is built around. So a fresh group SHOULD pick up the backlog.
-        try:
-            await self._redis.xgroup_create(
-                self._config.eval_stream,
-                self._config.eval_consumer_group,
-                id="0",
-                mkstream=True,
-            )
-        except ResponseError as exc:
-            if "BUSYGROUP" not in str(exc):
-                raise
-
-    def request_stop(self) -> None:
-        self._stop.set()
+        await self._ensure_group(
+            self._config.eval_stream, self._config.eval_consumer_group, start_id="0"
+        )
 
     async def run(self) -> None:
         await self.ensure_group()
         await asyncio.gather(self._read_loop(), self._reclaim_loop())
 
     async def _read_loop(self) -> None:
-        while not self._stop.is_set():
-            # count=1 is load-bearing, not a tunable: this consumer handles an
-            # entry inline (evals are heavy and run sequentially), and only the
-            # entry inside _handle is tracked as in-flight. Claiming a batch would
-            # leave the un-handled tail claimed-but-untracked, where the reclaim
-            # loop could re-run one before the read loop reaches it (a duplicate
-            # report). Peer replicas in the group provide the parallelism instead.
-            try:
-                resp = await self._redis.xreadgroup(
-                    self._config.eval_consumer_group,
-                    self._config.eval_consumer_name,
-                    {self._config.eval_stream: ">"},
-                    count=1,
-                    block=self._config.read_block_ms,
-                )
-            except RedisTimeoutError as exc:
-                # Same transient-transport guard as the runs consumer: a blocking
-                # read timeout is the routine idle case, not a fault -- log at
-                # DEBUG so an idle eval worker doesn't flood WARNING. Still back
-                # off + retry rather than letting it kill the eval loop.
-                logger.debug("eval stream read timed out (idle); retrying: %s", exc)
-                await self._sleep_or_stop(_EVAL_READ_ERROR_BACKOFF_S)
-                continue
-            except RedisConnectionError as exc:
-                # A real connection blip (Valkey failover): transient but worth a
-                # WARNING. Back off and retry.
-                logger.warning("eval stream read failed transiently; retrying: %s", exc)
-                await self._sleep_or_stop(_EVAL_READ_ERROR_BACKOFF_S)
-                continue
-            if not resp:
-                continue
-            streams = cast("list[tuple[str, list[StreamEntry]]]", resp)
-            for _stream, entries in streams:
-                for entry_id, fields in entries:
-                    await self._handle(entry_id, fields)
+        # count=1 is load-bearing, not a tunable: this consumer handles an entry
+        # inline (evals are heavy and run sequentially), and only the entry inside
+        # _handle is tracked as in-flight. Claiming a batch would leave the
+        # un-handled tail claimed-but-untracked, where the reclaim loop could
+        # re-run one before the read loop reaches it (a duplicate report). Peer
+        # replicas in the group provide the parallelism instead.
+        await self._consume(
+            ReadLoopSpec(
+                stream=self._config.eval_stream,
+                group=self._config.eval_consumer_group,
+                consumer=self._config.eval_consumer_name,
+                count=1,
+                block_ms=self._config.read_block_ms,
+                backoff_s=_EVAL_READ_ERROR_BACKOFF_S,
+                timeout_msg="eval stream read timed out (idle); retrying: %s",
+                connection_msg="eval stream read failed transiently; retrying: %s",
+                logger=logger,
+            ),
+            self._handle,
+        )
 
     async def _reclaim_loop(self) -> None:
         """Periodically reclaim entries a dead consumer left pending and re-run
@@ -303,12 +268,6 @@ class EvalStreamConsumer:
             await self._ack(entry_id)
         finally:
             self._inflight_ids.discard(entry_id)
-
-    async def _sleep_or_stop(self, seconds: float) -> None:
-        try:
-            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
-        except TimeoutError:
-            pass
 
     async def _run_and_report(self, item: EvalWorkItem) -> EvalRunResult:
         repo = await self._repo_lookup.repo_full_name(item.agent_id)
@@ -390,6 +349,6 @@ class EvalStreamConsumer:
         )
 
     async def _ack(self, entry_id: str) -> None:
-        await self._redis.xack(
+        await self._xack(
             self._config.eval_stream, self._config.eval_consumer_group, entry_id
         )

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -41,6 +41,8 @@ from .sandbox import (
 from .slack_sink import AsyncSlackSink
 from .threadlock import ThreadLock
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class Runtime:
@@ -109,6 +111,11 @@ def _sandbox_client(
                 "before starting the worker, set AGENTOS_MODEL_BASE_URL to a local "
                 "endpoint for local-model mode, or set AGENTOS_FAKE_MODEL=1 for an "
                 "offline/test run."
+            )
+        if not env.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+            logger.warning(
+                "Docker substrate selected but OTEL_EXPORTER_OTLP_ENDPOINT is "
+                "unset; runner traces will not be exported"
             )
         return DockerSandboxClient(
             image=env.get("AGENTOS_RUNNER_IMAGE", "agentos-runner"),

--- a/apps/worker/src/agentos_worker/stream_consumer.py
+++ b/apps/worker/src/agentos_worker/stream_consumer.py
@@ -1,0 +1,130 @@
+"""Shared Valkey consumer-group read-loop mechanics.
+
+The runs consumer (``consumer.py``) and the eval consumer (``eval/stream.py``)
+both drive the same Valkey ``XREADGROUP`` loop: ensure the group exists, do a
+blocking group read, skip an empty/timeout response, survive a transient
+transport fault (a blocking-read ``TimeoutError`` is the routine idle case ->
+DEBUG; a ``ConnectionError`` is a real fault -> WARNING), back off and retry, and
+ack a handled entry. That shared plumbing lives here once; each consumer keeps
+its own stream/group/consumer names, backoff constant, log-message prefixes, and
+per-message business logic and passes them in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import cast
+
+from redis.asyncio import Redis
+from redis.exceptions import (
+    ConnectionError as RedisConnectionError,
+)
+from redis.exceptions import (
+    ResponseError,
+)
+from redis.exceptions import (
+    TimeoutError as RedisTimeoutError,
+)
+
+# One stream entry as redis returns it with decode_responses=True.
+StreamEntry = tuple[str, dict[str, str]]
+
+# An async per-message handler: (entry_id, fields) -> None.
+EntryHandler = Callable[[str, dict[str, str]], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ReadLoopSpec:
+    """The per-consumer knobs the shared read loop needs. Everything here is
+    deliberately passed in (not hard-coded) so each consumer's stream, group,
+    backoff, and log output stay exactly what they were before the extraction."""
+
+    stream: str
+    group: str
+    consumer: str
+    count: int
+    block_ms: int
+    backoff_s: float
+    # Log messages kept per-consumer so log output is byte-identical; each takes
+    # a single ``%s`` for the exception. The logger is the owning module's logger
+    # so records carry that module's name (tests assert on it).
+    timeout_msg: str
+    connection_msg: str
+    logger: logging.Logger
+
+
+class StreamConsumer:
+    """Base for a Valkey consumer-group reader.
+
+    Owns the transport-level plumbing (group create, blocking read loop with the
+    Timeout->DEBUG / Connection->WARNING split and backoff, ack, stop-aware
+    sleep). Subclasses supply their stream config via a :class:`ReadLoopSpec`,
+    their per-message handler, and their own maintenance/reclaim loops and
+    business logic.
+    """
+
+    def __init__(self, redis: Redis) -> None:
+        self._redis = redis
+        self._stop = asyncio.Event()
+
+    def request_stop(self) -> None:
+        self._stop.set()
+
+    async def _ensure_group(self, stream: str, group: str, *, start_id: str) -> None:
+        """Create the consumer group (and the stream) if it does not exist.
+
+        ``start_id`` is the group's read start position and is per-consumer (see
+        each subclass's ``ensure_group`` for why it picks ``$`` vs ``0``). An
+        existing group is left untouched.
+        """
+        try:
+            await self._redis.xgroup_create(stream, group, id=start_id, mkstream=True)
+        except ResponseError as exc:
+            if "BUSYGROUP" not in str(exc):
+                raise
+
+    async def _consume(self, spec: ReadLoopSpec, handler: EntryHandler) -> None:
+        """Blocking-read loop: read the group, dispatch each entry to ``handler``,
+        and survive transient transport faults until stop is requested."""
+        while not self._stop.is_set():
+            try:
+                resp = await self._redis.xreadgroup(
+                    spec.group,
+                    spec.consumer,
+                    {spec.stream: ">"},
+                    count=spec.count,
+                    block=spec.block_ms,
+                )
+            except RedisTimeoutError as exc:
+                # A blocking-read timeout is the routine idle case (no entries
+                # arrived within block_ms plus the socket timeout margin), not a
+                # fault -- log at DEBUG so an idle worker doesn't flood WARNING.
+                # Still back off + retry rather than letting it kill the loop.
+                spec.logger.debug(spec.timeout_msg, exc)
+                await self._sleep_or_stop(spec.backoff_s)
+                continue
+            except RedisConnectionError as exc:
+                # A real connection fault (a Valkey failover, pod-to-pod blip):
+                # transient but worth a WARNING. Back off and retry; redis-py
+                # reconnects on the next attempt.
+                spec.logger.warning(spec.connection_msg, exc)
+                await self._sleep_or_stop(spec.backoff_s)
+                continue
+            if not resp:
+                continue
+            streams = cast("list[tuple[str, list[StreamEntry]]]", resp)
+            for _stream, entries in streams:
+                for entry_id, fields in entries:
+                    await handler(entry_id, fields)
+
+    async def _sleep_or_stop(self, seconds: float) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
+        except TimeoutError:
+            pass
+
+    async def _xack(self, stream: str, group: str, entry_id: str) -> None:
+        await self._redis.xack(stream, group, entry_id)

--- a/apps/worker/tests/eval/test_recorder.py
+++ b/apps/worker/tests/eval/test_recorder.py
@@ -45,6 +45,31 @@ async def _score_for_trace(client: httpx.AsyncClient, trace_id: str) -> float | 
     return None
 
 
+def test_empty_run_skips_the_ingestion_post() -> None:
+    # A run with no case results must not POST a hollow ingestion batch; it
+    # returns [] before touching the network.
+    async def go() -> None:
+        posts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            posts.append(request)
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            recorder = LangfuseEvalRecorder(
+                base_url="http://langfuse.invalid",
+                public_key="pk",
+                secret_key="sk",
+                client=client,
+            )
+            run = EvalRunResult(version="v-empty", suite="empty-suite", results=[])
+            assert await recorder.record(run) == []
+        assert posts == []  # no /api/public/ingestion call was made
+
+    asyncio.run(go())
+
+
 def test_records_per_case_results_and_reads_them_back() -> None:
     async def go() -> None:
         async with httpx.AsyncClient(timeout=30.0) as client:

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import time
 import uuid
@@ -215,6 +216,58 @@ async def _drain_one(consumer: EvalStreamConsumer, reports: list[dict[str, Any]]
     finally:
         consumer.request_stop()
         await task
+
+
+def test_eval_read_loop_demotes_idle_timeout_to_debug(make_eval_harness, bundles, caplog) -> None:
+    """Mirror of the runs consumer: a blocking-read TimeoutError (routine idle) is
+    logged at DEBUG, a ConnectionError (real fault) at WARNING; both back off and
+    keep the eval loop alive."""
+    store, _upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (_base_url, _fake, _client):
+            token = uuid.uuid4().hex[:8]
+            cfg = _cfg(f"test:evals:{token}", f"g-{token}")
+            client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+            reports: list[dict[str, Any]] = []
+            async with httpx.AsyncClient(timeout=30.0) as lf_client:
+                consumer = _build_consumer(
+                    redis_client=client,
+                    cfg=cfg,
+                    bundle_store=store,
+                    substrate=_UnusedSubstrate(),
+                    reports=reports,
+                    lf_client=lf_client,
+                )
+                await consumer.ensure_group()
+
+                calls = {"n": 0}
+
+                async def flaky(*args: object, **kwargs: object) -> object:
+                    calls["n"] += 1
+                    if calls["n"] == 1:
+                        raise redis.exceptions.TimeoutError("idle eval read timeout")
+                    if calls["n"] == 2:
+                        raise redis.exceptions.ConnectionError("eval connection blip")
+                    consumer.request_stop()  # nothing queued; stop after both faults
+                    return []
+
+                consumer._redis.xreadgroup = flaky  # type: ignore[method-assign,assignment]
+
+                with caplog.at_level(logging.DEBUG, logger="agentos_worker.eval.stream"):
+                    await consumer.run()
+
+                assert calls["n"] >= 3  # retried past both injected faults
+                recs = [r for r in caplog.records if r.name == "agentos_worker.eval.stream"]
+                timeout_recs = [r for r in recs if "idle eval read timeout" in r.getMessage()]
+                conn_recs = [r for r in recs if "eval connection blip" in r.getMessage()]
+                assert timeout_recs and all(r.levelno == logging.DEBUG for r in timeout_recs)
+                assert conn_recs and all(r.levelno == logging.WARNING for r in conn_recs)
+
+            await client.delete(cfg.eval_stream)
+            await client.aclose()
+
+    asyncio.run(go())
 
 
 def test_seam_full_consume_eval_report_cycle(make_eval_harness, bundles) -> None:

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -5,6 +5,7 @@ against the real Valkey stream + consumer group.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 import uuid
 from collections.abc import Callable
@@ -149,15 +150,18 @@ def test_ensure_group_does_not_replay_preexisting_backlog(make_harness) -> None:
     asyncio.run(go())
 
 
-def test_read_loop_survives_transient_redis_timeout(make_harness) -> None:
+def test_read_loop_survives_transient_redis_timeout(make_harness, caplog) -> None:
     async def go() -> None:
         async with make_harness() as h:
             consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
             await consumer.ensure_group()
 
             # The first blocking read raises a transient redis TimeoutError (the
-            # real pod-to-pod RTT hazard). The loop must survive it and process
-            # the next read; an unguarded read would kill the worker.
+            # routine idle case) and the second a ConnectionError (a real fault).
+            # The loop must survive both and process the next read; an unguarded
+            # read would kill the worker. The two are logged at different levels:
+            # an idle timeout is DEBUG (not log-worthy every idle interval), a
+            # connection blip stays WARNING.
             real = h.async_redis.xreadgroup
             calls = {"n": 0}
 
@@ -165,6 +169,8 @@ def test_read_loop_survives_transient_redis_timeout(make_harness) -> None:
                 calls["n"] += 1
                 if calls["n"] == 1:
                     raise redis.exceptions.TimeoutError("simulated blocking-read timeout")
+                if calls["n"] == 2:
+                    raise redis.exceptions.ConnectionError("simulated connection blip")
                 return await real(*args, **kwargs)
 
             consumer._redis.xreadgroup = flaky  # type: ignore[method-assign,assignment]
@@ -173,13 +179,20 @@ def test_read_loop_survives_transient_redis_timeout(make_harness) -> None:
             qe = _qevent("hello", thread="tt1", event_id="t1")
             await h.async_redis.xadd(h.config.stream, qe.to_stream_fields())
 
-            task = asyncio.create_task(consumer.run())
-            await _wait_until(lambda: h.sink.last_text == "answer")
-            consumer.request_stop()
-            await task
+            with caplog.at_level(logging.DEBUG, logger="agentos_worker.consumer"):
+                task = asyncio.create_task(consumer.run())
+                await _wait_until(lambda: h.sink.last_text == "answer")
+                consumer.request_stop()
+                await task
 
-            assert calls["n"] >= 2  # it retried after the injected timeout
+            assert calls["n"] >= 3  # it retried after both injected faults
             assert h.runner.opened == ["hello"]
+
+            recs = [r for r in caplog.records if r.name == "agentos_worker.consumer"]
+            timeout_recs = [r for r in recs if "simulated blocking-read timeout" in r.getMessage()]
+            conn_recs = [r for r in recs if "simulated connection blip" in r.getMessage()]
+            assert timeout_recs and all(r.levelno == logging.DEBUG for r in timeout_recs)
+            assert conn_recs and all(r.levelno == logging.WARNING for r in conn_recs)
 
     asyncio.run(go())
 

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -7,6 +7,8 @@ AGENTOS_FAKE_MODEL must fail loudly instead of silently degrading to a fake.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from agentos_worker.config import WorkerConfig
 from agentos_worker.run import _sandbox_client, _substrate_config
@@ -81,3 +83,35 @@ def test_docker_with_explicit_fake_model_builds_docker_client() -> None:
         WorkerConfig(fake_model=True), {"AGENTOS_SANDBOX_SUBSTRATE": "docker"}, _SUB
     )
     assert isinstance(client, DockerSandboxClient)
+
+
+def test_docker_without_otlp_endpoint_warns(caplog) -> None:
+    # Docker substrate exports runner traces via OTLP; without an endpoint the
+    # traces silently go nowhere, so the boot must warn (not fail).
+    with caplog.at_level(logging.WARNING, logger="agentos_worker.run"):
+        client = _sandbox_client(
+            WorkerConfig(fake_model=True), {"AGENTOS_SANDBOX_SUBSTRATE": "docker"}, _SUB
+        )
+    assert isinstance(client, DockerSandboxClient)
+    warnings = [
+        r for r in caplog.records
+        if r.name == "agentos_worker.run" and "OTEL_EXPORTER_OTLP_ENDPOINT" in r.getMessage()
+    ]
+    assert warnings and all(r.levelno == logging.WARNING for r in warnings)
+
+
+def test_docker_with_otlp_endpoint_does_not_warn(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="agentos_worker.run"):
+        client = _sandbox_client(
+            WorkerConfig(fake_model=True),
+            {
+                "AGENTOS_SANDBOX_SUBSTRATE": "docker",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector:4318",
+            },
+            _SUB,
+        )
+    assert isinstance(client, DockerSandboxClient)
+    assert not [
+        r for r in caplog.records
+        if r.name == "agentos_worker.run" and "OTEL_EXPORTER_OTLP_ENDPOINT" in r.getMessage()
+    ]


### PR DESCRIPTION
Closes #17 — the batch of 4 independent observability fixes. Disjoint files; no sacred-kernel change.

1. **`latency_p95_seconds` → `latency_p95_ms`.** The field carries milliseconds, so the old name was a 1000x footgun. Renamed honestly across `schemas.py`/`metrics.py` (incl. the metric identifier used as the series request param + echoed value — request/response stay aligned; the upstream Langfuse `p95_latency` result-key is untouched), the regenerated `openapi.json` (drift test passes), and the UI (`client.ts`, `RealMetrics`, `WiredOverview`, `format.ts`, e2e fixtures). `grep` confirms no stale references remain.
2. **Empty-trace UX.** `LangfuseEvalRecorder.record()` returns early (no ingestion POST) when a run has zero results, instead of writing an observation-less trace shell for a 0/0 replay.
3. **Idle log noise.** The blocking `XREADGROUP` timeout logged a WARNING every poll cycle on both the main and eval consumers at idle. Split so a routine `TimeoutError` logs DEBUG while a real `ConnectionError` stays WARNING; both still back off and retry.
4. **Missing-OTLP boot warning.** The worker now warns at boot when the Docker substrate is selected but `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, so a silent no-telemetry config is caught early.

## Tests
A test pins each fix: metrics-unit + openapi-drift (rename), a recorder test asserting zero POSTs on an empty run, `caplog` tests asserting Timeout→DEBUG / Connection→WARNING on both consumers, and `_sandbox_client` warns/doesn't-warn tests. `ruff` + `mypy` clean; UI `typecheck`/`lint`/`test` clean.

_Note: 5 pre-existing integration tests fail in a stackless env (httpx.ConnectError to Langfuse/eval-runner) — unrelated to this diff, confirmed against base._