### PR TITLE
Backfill INTERFACE.md at every swappable seam

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ git history (`git log -- docs/`).
 - [`architecture-vision.md`](architecture-vision.md): the forward-looking
   "swappable jobs around an opinionated core" framing, covering where each
   adopted component's swap seam lives.
+- [`interfaces.md`](interfaces.md): the swappable-seam catalog (INTERFACE.md per
+  black line) with the swap-readiness grade table.
 - [`operations.md`](operations.md): running a cluster install, plus
   operator-facing findings from early installs.
 - [`slack-local-runbook.md`](slack-local-runbook.md): connect your own Slack

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,54 @@
+# AgentOS Interface Catalog (Swappable Seams)
+
+These files document the "strong black lines" that already exist in the code — the
+seams where one curated default component can be swapped without rewriting the system.
+The governing restraint is
+[**"the second implementation teaches the interface"**](architecture-vision.md): we do not
+write speculative adapter layers ahead of a real second implementation. Each `INTERFACE.md`
+is documentation of where the code already draws the line, not a new abstraction.
+
+## The seams
+
+| Seam | Kind | Impls | Grade | Epic(s) | INTERFACE.md |
+|---|---|---|---|---|---|
+| Substrate / SandboxClient | CLEAN | 2 (k8s, docker) | not separately graded | #86, #44 | [interfaces/substrate/INTERFACE.md](interfaces/substrate/INTERFACE.md) |
+| Harness in-proc / ModelSession | CLEAN | 1 + fake | A- | (folds into #25) | [interfaces/harness-modelsession/INTERFACE.md](interfaces/harness-modelsession/INTERFACE.md) |
+| ACI producer (frozen protocol) | CLEAN, frozen | 1 + reference | A- | #25, #47 | [interfaces/aci-producer/INTERFACE.md](interfaces/aci-producer/INTERFACE.md) |
+| Channel / ingress (Slack) | SOFT | 1 | C | #7, #19, #27, #38 | [interfaces/channel-ingress/INTERFACE.md](interfaces/channel-ingress/INTERFACE.md) |
+| Model provider / credentials | SOFT | 1 (Anthropic) | not separately graded | #24, #46 | [interfaces/model-provider/INTERFACE.md](interfaces/model-provider/INTERFACE.md) |
+| Telemetry / OTEL | SOFT | 1 | B+ | #47 | [interfaces/telemetry-otel/INTERFACE.md](interfaces/telemetry-otel/INTERFACE.md) |
+| Evals (case + scorer) | SOFT | 1 grader family | B | #8, #26 | [interfaces/evals/INTERFACE.md](interfaces/evals/INTERFACE.md) |
+| Blob storage (S3/MinIO) | SOFT | 2 concretes | B+ | #83 | [interfaces/blob-storage/INTERFACE.md](interfaces/blob-storage/INTERFACE.md) |
+| Relational DB (Postgres) | SOFT | 1 | A- | #84 | [interfaces/relational-db/INTERFACE.md](interfaces/relational-db/INTERFACE.md) |
+| Queue / stream (Valkey) | SOFT | 1 (redis-py) | not separately graded | #85, #7 | [interfaces/queue-stream/INTERFACE.md](interfaces/queue-stream/INTERFACE.md) |
+| Bundle format | CLEAN, frozen | 1 | not separately graded | #30 | [interfaces/bundle-format/INTERFACE.md](interfaces/bundle-format/INTERFACE.md) |
+| Approval / authorizer | NONE | 0 | not separately graded | #22 | [interfaces/approval/INTERFACE.md](interfaces/approval/INTERFACE.md) |
+| Workflow state store | NONE | 0 (concrete AffinityStore) | not separately graded | #23 | [interfaces/workflow-state/INTERFACE.md](interfaces/workflow-state/INTERFACE.md) |
+| Memory | NONE (field only) | 0 loaders | not separately graded | #28 | [interfaces/memory/INTERFACE.md](interfaces/memory/INTERFACE.md) |
+| Triggers | SOFT | 2 hardcoded (Slack, GH push) | not separately graded | #29 | [interfaces/triggers/INTERFACE.md](interfaces/triggers/INTERFACE.md) |
+
+## Kind legend
+
+- **CLEAN** — a real `Protocol` / typed port class draws the line in code.
+- **SOFT** — the swap happens through env vars, a URL/endpoint, a key prefix, or a wire
+  payload; there is no code interface, and that is a deliberate decision, not an omission.
+- **NONE** — the seam is not built yet; the file records the intended line and the placement
+  constraint a future implementation must honor.
+
+Seams not in the six-job Swap-readiness grade table below (substrate, model provider, queue,
+bundle format, approval, workflow-state, memory, triggers) are **not separately graded**.
+
+## Swap-readiness grade
+
+Reproduced verbatim from the "Swap readiness" section of
+[architecture-vision.md](architecture-vision.md). Only the six production-platform jobs are
+graded here.
+
+| Job | Port contract | Current adapter | Grade | Cheapest next step |
+|---|---|---|---|---|
+| Harness / runtime | Frozen ACI protocol (`packages/aci-protocol`), tri-language, CI-guarded | claude-agent-sdk runner | A-: strongest seam in the system; docked for the plugin-format entanglement and SDK-shaped resume | Write the "implement an ACI server" guide from the conformance suite so the port is documented, not just enforced |
+| Observability | OTLP to collector (write), API DTOs (read) | Langfuse behind `langfuse.py` | B+: write side clean but for one vendor span attribute; read side isolated in one module | Rename `langfuse.trace.name` to a neutral attribute mapped in the collector; rename the `/langfuse/*` API routes |
+| Evals | Our stream schema + `EvalMatrix` DTO; store behind recorder | Langfuse traces + `eval_pass` scores | B: schema is ours, but the case format is duplicated and the tag convention is unfrozen | Converge the two `cases.json` definitions into one frozen schema ([issue #8](https://github.com/curie-eng/agentos/issues/8)) |
+| Blob storage | S3 protocol (boto3 + mc, path-style, endpoint-configurable) | MinIO | B+: config-only within S3-compatible stores; three hand-aligned client sites; no interface for non-S3 | None needed until a non-S3 demand exists; document the three client sites as one seam |
+| Relational DB | SQLAlchemy 2.0 + alembic | Postgres | A-: managed-Postgres swap is a DSN change; two Postgres-isms in models | Leave as is; note the `postgresql.UUID` and schema-scoped enum as the two things a non-Postgres target would touch |
+| Communication | `QueuedSlackEvent` + `SlackSink` | Slack (Bolt + chat.update) | C: Slack-shaped names and edit-in-place semantics in the core's contract; service swappable (CLI stub), protocol not | Promote the queue payload into `aci-protocol` with channel-neutral field names in the same change |

--- a/docs/interfaces/aci-producer/INTERFACE.md
+++ b/docs/interfaces/aci-producer/INTERFACE.md
@@ -1,0 +1,53 @@
+# INTERFACE: ACI producer (frozen protocol)
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 + reference &nbsp;·&nbsp; **Swap-readiness grade:** A-
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+The frozen, cross-process ACI (Agent Container Interface) protocol — the strongest seam in the
+system. It makes the whole **harness** swappable: anything inside the sandbox that speaks this
+wire contract (session setup env + NDJSON event union + steer/interrupt endpoints) can replace the
+default claude-agent-sdk runner without the worker, CLI, or UI changing. What stays opinionated
+core is the protocol itself: the event shapes, the `AGENTOS_*` env contract, and the strict
+`version` gate. A second harness produces the same bytes; it does not get to redefine them.
+
+## Current contract
+
+A second implementation is an **ACI server** — an HTTP process that accepts the three endpoints
+(`docs/diagrams/aci.md:20`): `POST /v1/event` opens a turn, `POST /v1/steer` injects into the
+live turn (409 if none running), `POST /v1/interrupt` hard-stops it. It streams the outbound
+NDJSON discriminated union `OutboundEvent` (`packages/aci-protocol/src/aci_protocol/events.py:119`):
+`TextDelta` (`text_delta`, :76), `ToolNote` (`tool_note`, :83), `Final` (`final` + `status`, :91),
+`ErrorEvent` (`error` + `classification`, :99), `SideEffectFlag` (`side_effect_flag`, :107). Every
+outbound event carries `version` equal to `PROTOCOL_VERSION` and inbound frames are the
+`InboundMessage` union `Event | Interrupt` on the `kind` tag
+(`packages/aci-protocol/src/aci_protocol/events.py:64`, `:43`, `:55`). Setup is read from the
+environment via `SessionConfig.from_env` (`packages/aci-protocol/src/aci_protocol/session.py:96`),
+honoring the `AGENTOS_*` mapping in `to_env` (`:72`). Conformance is proven by
+`run_conformance(<your producer>)`, which must return `passed=True`.
+
+## Implementations today
+
+One producer (the runner, `runner/src/agentos_runner/adapter.py`, a `ModelSession` wrapping
+`ClaudeSDKClient`) plus the in-library `reference_producer` used by the conformance suite. The
+contract is tri-language: Pydantic source of truth, committed JSON Schema in
+`packages/aci-protocol/schema/`, and generated TS/Rust in `packages/aci-protocol/generated/`,
+CI-guarded by `packages/aci-protocol/tests/test_schema_compat.py`.
+
+## Known leakage
+
+Plugin-format entanglement: the ACI server must interpret Claude Code plugin bundles mounted at
+`AGENTOS_PLUGIN_DIR` (see the [bundle-format seam](../bundle-format/INTERFACE.md)), so a genuinely
+foreign harness inherits that shape too — the A- is docked for exactly this and for the
+SDK-shaped resume. Otherwise the line is clean and frozen: unknown wire versions raise
+`ProtocolVersionError`, and `extra="forbid"` rejects stray keys at construction.
+
+## Cross-links
+
+- **Epic(s):** [#25](https://github.com/curie-eng/agentos/issues/25) — write the "implement an ACI server" guide from the conformance suite so the port is documented, not just enforced
+- **Epic(s):** [#47](https://github.com/curie-eng/agentos/issues/47) — telemetry as part of the ACI (OTEL carried in `SessionConfig`)
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 1 (Harness / runtime), grade A-
+- **ADR(s):** [ADR-0005](../../adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md) — claude-agent-sdk adapter behind a frozen ACI session contract

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -1,0 +1,60 @@
+# INTERFACE: Approval / authorizer
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** NONE &nbsp;·&nbsp; **Implementations today:** 0 &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+The black line is an **Authorizer** port: a server-side decision, at approval-resolution
+time, of whether a given actor is allowed to resolve a given pending approval — plus the
+`awaiting-approval` lifecycle state that lets a session durably pause on that decision. What
+stays opinionated core is *where* the decision is enforced (server-side, at resolution) and
+that gates are policy-triggered, never phase-hardcoded by the platform. What becomes
+swappable is the authorizer *implementation* (channel-membership first, then user-group,
+explicit user-list, platform-RBAC) behind that one server-side check.
+
+## Current contract
+
+This seam does **not exist in code yet**; the contract below is the *intended* line from
+[ADR-0010](../../adr/0010-approval-gates-and-human-in-the-loop.md) and epic
+[#22](https://github.com/curie-eng/agentos/issues/22), stated so a future implementation
+builds to it. What exists today is only the negative space it must fill:
+
+- **The hardcoded posture the gate replaces.** The runner today builds session options with
+  `permission_mode="bypassPermissions"` (`runner/src/agentos_runner/adapter.py:82`) and has
+  no tool-permission callback. A permission gate must introduce a `canUseTool` callback that
+  replaces this hardcoded bypass, intercepting a model-initiated tool call so it can block
+  pending an approval.
+- **The frozen status enum the gate extends.** `SessionStatus` (`packages/aci-protocol/src/aci_protocol/events.py:28`)
+  today has exactly three values — `DONE = "done"`, `IDLE_AWAITING_INPUT = "idle-awaiting-input"`,
+  `CLASSIFIED_FAILURE = "classified-failure"` (lines 35–37). The intended contract adds a
+  fourth, `awaiting-approval`, as a backward-compatible frozen-contract change regenerated
+  across all three language targets (Pydantic source, JSON Schema, TypeScript, Rust).
+- **The durable record + resolve-once semantics.** A durable `Approval` record (Postgres)
+  with compare-and-set claim semantics is the intended backing store, so losers of the claim
+  race are told it was already resolved. The authorizer check runs server-side at resolution
+  time; self-approval is blocked.
+
+## Implementations today
+
+**None.** Zero authorizer implementations, no durable `Approval` record, no `awaiting-approval`
+status, and no `canUseTool` gate. The seam lands with epic #22. The suspend/resume path it
+relies on (ADR-0003) is built but dormant; an approval is its first intended production use.
+
+## Known leakage
+
+Nothing to leak yet — the file records a placement constraint, not existing code. The single
+constraint a future implementation must honor: the authorizer is **enforced server-side at
+resolution time**, not inside the sandbox or runner. The runtime `canUseTool` gate blocks the
+*tool call*, but the authorization decision (who may resolve a pending approval) must live on
+the server that owns the durable `Approval` record, so it cannot be spoofed from inside the
+agent's box. Policy gate points ship versioned in the bundle; route bindings (which channel,
+who may approve) are per-agent deployment config.
+
+## Cross-links
+
+- **Epic(s):** [#22](https://github.com/curie-eng/agentos/issues/22) — approval gates and human-in-the-loop; adds the durable record, `awaiting-approval` status, `canUseTool` gate, and the authorizer interface.
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — not one of the six graded jobs; a cross-cutting core lifecycle change, not separately graded.
+- **ADR(s):** [ADR-0010](../../adr/0010-approval-gates-and-human-in-the-loop.md) — Approval gates and human-in-the-loop (Proposed); grounds this intended line. Composes with [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) (stateless-first suspend/resume, the pause mechanism).

--- a/docs/interfaces/blob-storage/INTERFACE.md
+++ b/docs/interfaces/blob-storage/INTERFACE.md
@@ -1,0 +1,54 @@
+# INTERFACE: Blob storage (S3/MinIO)
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 &nbsp;·&nbsp; **Swap-readiness grade:** B+
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+Immutable plugin bundles are addressed by a deterministic `(agent, version)` key in
+an S3-compatible object store. The swappable thing is the **backend behind the S3
+wire protocol** (MinIO today, AWS S3 or any path-style S3 API tomorrow). What stays
+opinionated core is the write-once/no-mutation key discipline and the bundle bytes
+themselves. This is a deliberately un-abstracted seam: **the S3 protocol IS the port**
+— there is no `StorageInterface` class, and one is extracted only when a non-S3
+backend actually demands it (per the vision doc's "second implementation teaches the
+interface" restraint).
+
+## Current contract
+
+A second implementation must speak the boto3 S3 API with **path-style addressing**,
+configured entirely through env/settings — no code changes:
+
+- **Env/settings** (`apps/api/src/agentos_api/config.py:36-40`): `s3_endpoint_url`,
+  `s3_access_key`, `s3_secret_key`, `s3_region`, `bundle_bucket` (env vars
+  `S3_ENDPOINT_URL`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_REGION`, `BUNDLE_BUCKET`).
+- **Client construction** (`apps/api/src/agentos_api/storage.py:25-32`): `boto3.client("s3", endpoint_url=..., config=BotoConfig(s3={"addressing_style": "path"}))`.
+- **Operations used** (`storage.py:39-66`): `head_bucket`, `create_bucket`,
+  `head_object`, `put_object` (with `Body`, `ContentType`), `get_object` (reads
+  `obj["Body"].read()`). The backend must support exactly these five calls, path-style.
+
+## Implementations today
+
+Two concrete client sites plus a third in the chart:
+
+- **API writer** — `apps/api/src/agentos_api/storage.py:22` (`BundleStore`, async-offloaded boto3 write path).
+- **Worker reader** — `apps/worker/src/agentos_worker/bundle_store.py:37` (`BundleStore`, read-only `get`, path-style, "same construction the API's write path uses").
+- **Chart bundle-fetch init** — `charts/agentos/templates/agent-sandbox.yaml:110-111` uses the `mc` CLI (`mc alias set` / `mc cp`) rather than boto3, a third dialect of the same S3 protocol.
+
+## Known leakage
+
+The seam bleeds through **three hand-aligned client sites** that must agree on the
+same endpoint/credentials/bucket by convention, not by a shared interface: the API's
+boto3 writer, the worker's boto3 reader, and the chart's `mc`-based init container.
+The worker's docstring even notes it mirrors the API "so the env names line up." A
+switch to a fundamentally different backend (e.g. GCS-native rather than its S3
+compatibility layer) would touch all three independently — that is the cost of not
+abstracting, and the trigger that would justify extracting a real port.
+
+## Cross-links
+
+- **Epic(s):** #83 — vision epic for the blob-storage seam (extract a port only when a non-S3 backend lands).
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 4 (Blob storage), grade B+
+- **ADR(s):** [ADR-0007](../../adr/0007-adopt-not-build-boundaries.md) — Adopt-not-build boundaries (MinIO adopted, AGPLv3, "offer BYO-S3")

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -1,0 +1,49 @@
+# INTERFACE: Bundle format
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+The frozen bundle/plugin manifest format: the **Claude Code plugin shape verbatim**, a deliberate
+distribution wedge. What is swappable is the harness that consumes a bundle; what stays fixed is
+the shape a bundle must have to be accepted. The package does not invent format extensions —
+compatibility with real Claude Code bundles is the whole point, so the models are lenient
+(`extra="allow"`) rather than strict, and any bundle written for Claude Code validates unchanged.
+
+## Current contract
+
+`validate_bundle(path) -> ValidationResult` is the single entry point every deploy path calls
+(`packages/plugin-format/src/plugin_format/validate.py:55`). It returns path-qualified issues
+(codes like `manifest.missing`, `manifest.name_invalid`, `mcp.server_incomplete`) instead of
+raising. The shapes it checks (`packages/plugin-format/src/plugin_format/models.py`):
+`PluginManifest` (`.claude-plugin/plugin.json`, `:35`) with `name` required and optional
+`version`, `description`, `author`, `commands`, `agents`, `hooks` (`:55`), `mcpServers` (`:56`);
+`SkillFrontmatter` (`skills/**/SKILL.md`, `:59`) with `name`/`description` required and
+`allowed_tools` aliased to the verbatim `allowed-tools` key (`:71`); `McpServer`/`McpConfig`
+(`.mcp.json`, `:74`, `:94`) where the validator enforces each server define `command` (stdio) or
+`url` (remote). A second consumer must accept exactly these shapes.
+
+## Implementations today
+
+One: the `plugin_format` package. Like `aci-protocol` it is tri-language and frozen — Pydantic
+source of truth, committed JSON Schema, generated types — CI-guarded by
+`packages/plugin-format/tests/test_schema_compat.py`. Unlike `aci-protocol` it carries no
+`PROTOCOL_VERSION`; the format is pinned to the Claude Code shape and the models are lenient by
+design so future Claude Code keys still validate.
+
+## Known leakage
+
+By intent, the entire format is Claude-Code-shaped — that is the wedge, not a leak. The one live
+gap is the `hooks` field: it is modeled and preserved (`models.py:55`) but currently dead (no
+runner consumption). Epic #30 defines the meaning, validation contract, and runner consumption of
+`hooks` alongside new approval/trigger declarations, so the field's presence in the frozen shape is
+a placeholder the second consumer must not repurpose.
+
+## Cross-links
+
+- **Epic(s):** [#30](https://github.com/curie-eng/agentos/issues/30) — document the dead `hooks` field and new approval/trigger declarations: each field's meaning, validation contract, and runner consumption
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — the plugin format is the distribution wedge; not one of the six swap-readiness Jobs
+- **ADR(s):** [ADR-0005](../../adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md) — freezes `plugin-format` (with `aci-protocol`) as an interface built first

--- a/docs/interfaces/channel-ingress/INTERFACE.md
+++ b/docs/interfaces/channel-ingress/INTERFACE.md
@@ -1,0 +1,67 @@
+# INTERFACE: Channel / ingress (Slack)
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** C
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+The line that makes the communication channel swappable is the pair of contracts at
+the two ends of the run: the ingress payload the dispatcher enqueues
+(`QueuedSlackEvent`) and the egress port the kernel writes replies through
+(`SlackSink`). Everything between them — routing, concurrency, sandboxing — is
+opinionated core and channel-agnostic. This is the least-clean of the AgentOS seams:
+both ends are Slack-shaped by name and by semantics, so a second channel does not
+drop in behind a stable interface today. One implementation today; the port is the
+wire + Protocol contract, not a channel-neutral code interface — extracted only when a
+second channel demands it ("the second implementation teaches the interface").
+
+## Current contract
+
+A second channel must produce the ingress payload and satisfy the egress Protocol:
+
+- **Ingress** — `QueuedSlackEvent` (`apps/dispatcher/src/agentos_dispatcher/queue.py:34`),
+  a Pydantic model with Slack-named fields: `slack_event_id` (idempotency key,
+  line 48), `thread_ts` (conversation key, line 49), `channel` (line 50), `user`,
+  `text`, and `placeholder_ts` (the pre-posted reply the worker edits in place,
+  line 53). It serializes to a single Stream field via `to_stream_fields`
+  (`queue.py:56`), keyed by `STREAM_PAYLOAD_FIELD = "payload"` (`queue.py:31`).
+- **Egress** — the `SlackSink` Protocol (`apps/worker/src/agentos_worker/slack_sink.py:21`),
+  whose core method is `async def update(self, *, channel: str, ts: str, text: str)`
+  (`slack_sink.py:24`) — an edit-in-place on Slack's `chat.update`, plus best-effort
+  `set_status`/`clear_status`. The mrkdwn dialect is confined behind the sink in
+  `to_mrkdwn` (`apps/worker/src/agentos_worker/mrkdwn.py:45`).
+- **Binding** — a channel resolves to a deployment by `agents.slack_channel`
+  equality in `BindingResolver.resolve` (`apps/worker/src/agentos_worker/binding.py:94`).
+
+## Implementations today
+
+One: Slack. Ingress is `apps/dispatcher` (Bolt / Socket Mode); egress is
+`AsyncSlackSink` (`slack_sink.py:37`) on the Slack Web API. The swap proof that the
+protocol (not just the service) is the seam: the Rust CLI mints the exact
+`QueuedSlackEvent` wire payload — `struct QueuedSlackEvent` with the same seven fields
+(`cli/src/queue.rs:35`) — and drives the whole deployed system with zero Slack contact
+via `agentos local message` / `cluster message` (`cli/src/chat.rs`, `cli/src/message.rs`).
+
+## Known leakage
+
+The line leaks the vendor through the core contract in three ways. (1) The ingress
+field names are Slack's: `slack_event_id`, `thread_ts`, `placeholder_ts`. (2) The
+egress semantics are edit-a-placeholder — `update(channel, ts, text)` on `chat.update`,
+not post-a-message — so any channel without in-place edit must emulate it. (3) The
+reply base URL is worker-global: `WorkerConfig.slack_api_base_url`
+(`apps/worker/src/agentos_worker/config.py:40`), fed to `AsyncSlackSink(base_url=...)`
+(`slack_sink.py:45`), so two ingress paths cannot coexist on one deployment until
+replies route per turn. The restraint is deliberate: no multi-channel adapter framework
+is built (#27) — the channel-neutral rename comes with the second real channel.
+
+## Cross-links
+
+- **Epic(s):** #7 — promote the queue payload into `packages/aci-protocol` with
+  channel-neutral field names
+- **Epic(s):** #19 — per-turn reply routing (the reply base URL is worker-global today)
+- **Epic(s):** #27 — deliberately defers a pluggable multi-channel framework
+- **Epic(s):** #38 — channel-seam hardening / follow-up
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 6 (Communication channel), grade C
+- **ADR(s):** none directly on this seam

--- a/docs/interfaces/evals/INTERFACE.md
+++ b/docs/interfaces/evals/INTERFACE.md
@@ -1,0 +1,32 @@
+# INTERFACE: Evals (case + scorer)
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 grader family &nbsp;·&nbsp; **Swap-readiness grade:** B
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+The eval seam is defined by two wire contracts, not a code interface: the `agentos:evals` Valkey stream schema (request in) and the `EvalMatrix` DTO the API reads back (results out). The scorer/grader slots in *above* the port (a case names a grader; the runner applies it), and the result store (Langfuse) sits *behind* the recorder. Swapping either the grader family or the store means honoring the same stream payload and the same version/suite-tagged trace+score shape; the stream, the recorder's tag convention, and the matrix DTO are the opinionated core.
+
+## Current contract
+
+Request side — one stream field `payload` (`STREAM_PAYLOAD_FIELD`, `apps/worker/src/agentos_worker/eval/stream.py:72`) holding an `EvalWorkItem` JSON (`stream.py:76`): `agent_id`, `version_id`, `sha`, `suite`, `bundle_ref`, `target_url`, `requested_at`. Consumer group `agentos-eval-workers` reads it (`stream.py:6`, `stream.py:181`).
+
+Case + grader models — `EvalCase` is `{id, input, grader}` (`eval/models.py:53`); `Grader` is `{kind: GraderKind, expected, case_sensitive}` (`models.py:26`) where `GraderKind` is the enum-dispatched family `EXACT | CONTAINS | REGEX` (`models.py:18`), applied by `Grader.grade(output)` (`models.py:39`). This is the single "grader family" — deny-by-default, string-shaped only; an LLM-judge grader is explicitly a later addition (`models.py:27`).
+
+Result side — `LangfuseEvalRecorder.record()` (`eval/recorder.py:47`) posts, per case, a trace tagged `["eval", f"version:{run.version}", f"suite:{run.suite}"]` (`recorder.py:82`) plus an `eval_pass` numeric score `1.0/0.0` (`SCORE_NAME`, `recorder.py:25`; `_score_event`, `recorder.py:96`). The read path is `GET /matrix` returning `EvalMatrix`, querying traces by those tags (`apps/api/src/agentos_api/routers/evals.py:16`; `list_traces_by_tags(["eval", f"suite:{suite}"])` at `evals.py:23`).
+
+## Implementations today
+
+One grader family (the three deterministic `GraderKind` variants) and one store (Langfuse, via `LangfuseEvalRecorder`). No second scorer or second store adapter exists.
+
+## Known leakage
+
+Two seams bleed through. First, the eval-case format is duplicated across independent readers with *divergent* schemas: the CLI at `cli/src/evals.rs:16` reads `evals/cases.json` as `{name, input, expect_contains}` (a `Vec<String>`; doc at `evals.rs:3`), while the worker's `load_suite_from_bundle` (`stream.py:143`) reads the same `evals/cases.json` path but validates it as an `EvalSuite` of `{id, input, grader{...}}` (`models.py:63`). The two are hand-maintained and not the same shape. Second, the `version:`/`suite:` trace-tag convention is an unfrozen string contract hand-aligned between the recorder (`recorder.py:82`) and the matrix reader (`evals.py:23`) — a rename on one side silently breaks the grid.
+
+## Cross-links
+
+- **Epic(s):** #8 — converge and freeze the duplicated `cases.json` case format into one schema; #26 — scorer swappability (grader family beyond the deterministic three)
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 3 (Evals), grade B
+- **ADR(s):** [ADR-0004](../../adr/0004-langfuse-observability-and-eval-backbone.md) — Langfuse as the single observability + eval backbone

--- a/docs/interfaces/harness-modelsession/INTERFACE.md
+++ b/docs/interfaces/harness-modelsession/INTERFACE.md
@@ -1,0 +1,70 @@
+# INTERFACE: Harness in-process (`ModelSession`)
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 + fake &nbsp;·&nbsp; **Swap-readiness grade:** A- (the harness / ACI seam)
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+Inside the runner the model harness is reached through one in-process port: the
+`ModelSession` Protocol. Everything above it (ACI translation, budget, side-effect
+flagging, NDJSON, the HTTP layer) is written against the Protocol, so the concrete
+`claude-agent-sdk` driver is the only SDK-coupled code. What stays opinionated core
+is the frozen ACI wire contract the runner serves; the port is how a harness plugs
+into that runner. Steer and interrupt are first-class Protocol operations, not
+emulated.
+
+## Current contract
+
+A second harness must supply an object satisfying `ModelSession`
+(`runner/src/agentos_runner/adapter.py:24`), a five-method `Protocol`:
+
+- `async def connect(self) -> None` (`adapter.py:27`) — start/attach the harness,
+  rehydrating if a resume ref is configured.
+- `async def query(self, text: str) -> None` (`adapter.py:31`) — push a user message;
+  a `query` issued while a turn is live is the mid-run **steer**.
+- `def receive_turn(self) -> AsyncIterator[Any]` (`adapter.py:35`) — yield the harness
+  messages for the current turn, ending at its terminal result.
+- `async def interrupt(self) -> None` (`adapter.py:39`) — native hard stop at the next
+  safe boundary.
+- `async def close(self) -> None` (`adapter.py:43`) — tear down.
+
+The messages a `receive_turn` iterator yields must be mappable by
+`translate_message` (`runner/src/agentos_runner/translate.py:55`) into the ACI
+outbound union (`TextDelta` / `ToolNote` / `SideEffectFlag` / `ErrorEvent` /
+`Final`). Session options are assembled by `build_options`
+(`adapter.py:48`), which pins `permission_mode="bypassPermissions"`
+(`adapter.py:82`).
+
+## Implementations today
+
+Two, both in `runner/src/agentos_runner/`:
+
+- **Real:** `ClaudeAgentSession` (`adapter.py:87`), wrapping `ClaudeSDKClient` in
+  streaming-input mode; `receive_turn` delegates to `self._client.receive_response()`
+  (`adapter.py:100`) and `interrupt` to `self._client.interrupt()` (`adapter.py:103`).
+- **Fake:** `FakeModelSession` (`runner/src/agentos_runner/fake.py:52`), a scripted
+  replayer that constructs real SDK message dataclasses. It is the reusable acceptance
+  harness: `conformance_producer` (`runner/src/agentos_runner/conformance.py:33`) drives
+  a real `SessionRunner` over the fake (`conformance.py:24`), so the ACI conformance gate
+  validates the actual translation/final plumbing, not a canned stream.
+
+## Known leakage
+
+The port is CLEAN as a code interface but leaks harness shape in two places, both
+called out in vision-doc Job 1:
+
+- **SDK-shaped resume.** `AGENTOS_HISTORY_REF` is read verbatim into `history_ref`
+  (`runner/src/agentos_runner/config.py:64`) and passed as the SDK `resume` session id
+  by `build_options` (`adapter.py:64`, `:80`). A harness without an equivalent
+  resume/session-store concept must build its own history store.
+- **Plugin-format entanglement.** `packages/plugin-format` is the Claude Code plugin
+  shape verbatim, so a non-Claude harness must interpret Claude Code plugin bundles or
+  translate them; "implement the ACI server" understates that work.
+
+## Cross-links
+
+- **Epic(s):** — no standalone epic; folds into #25 (ACI producer / second-harness work).
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 1 (Harness / runtime), grade A-.
+- **ADR(s):** [ADR-0005](../../adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md) — claude-agent-sdk adapter behind a frozen ACI session contract; [ADR-0011](../../adr/0011-opencode-second-harness.md) — OpenCode as the second harness behind the ACI.

--- a/docs/interfaces/memory/INTERFACE.md
+++ b/docs/interfaces/memory/INTERFACE.md
@@ -1,0 +1,48 @@
+# INTERFACE: Memory
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** NONE &nbsp;·&nbsp; **Implementations today:** 0 loaders &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+There is no black line yet — memory is a **field only**. `SessionConfig` carries an optional
+`memory_ref` (`packages/aci-protocol/src/aci_protocol/session.py:68`) mapped to the
+`AGENTOS_MEMORY_REF` env var (`:85` in `to_env`, `:115` in `from_env`; documented as "optional;
+S3 path / API URL" in the README contract table). The reference is plumbed end-to-end through the
+session contract but **never dereferenced**: there are zero memory loaders in the codebase today.
+The port (load / append / consolidate) is unbuilt on purpose — "the second implementation teaches
+the interface," and there is no first loader to teach it yet.
+
+## Current contract
+
+The only committed surface is the optional string field:
+
+```python
+memory_ref: str | None = None   # session.py:68
+```
+
+and its env round-trip (`session.py:85`, `:115`). Nothing reads it. A future implementation must
+define the port — sketched by epic #28 as `load(memory_ref) -> records`,
+`append(record + provenance)`, `consolidate` — along with how `AGENTOS_MEMORY_REF` resolves (S3
+path vs API URL) and the shape of a provenance record. None of that exists in code on this branch.
+
+## Implementations today
+
+Zero. `memory_ref` is carried by `SessionConfig` and forwarded into the sandbox environment; no
+producer or consumer dereferences it.
+
+## Known leakage
+
+Not applicable — nothing is built to leak. The load-bearing constraint the future implementation
+must honor: **memory lives OUTSIDE the sandbox.** Per ADR-0003 (stateless-first; session state is
+externalized and a resumed thread rehydrates from history, never from a surviving in-RAM process),
+the memory store must be an external, rehydratable resource resolved from `memory_ref`, not
+in-pod state — an emptyDir-scratch or in-process cache would be lost on every suspend/resume.
+
+## Cross-links
+
+- **Epic(s):** [#28](https://github.com/curie-eng/agentos/issues/28) — define the memory port (`load` / `append` / `consolidate`), `AGENTOS_MEMORY_REF` resolution, and the provenance record shape
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — memory is not one of the six swap-readiness Jobs; not separately graded
+- **ADR(s):** [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) — stateless-first; rehydrate on resume; externalize session state

--- a/docs/interfaces/model-provider/INTERFACE.md
+++ b/docs/interfaces/model-provider/INTERFACE.md
@@ -1,0 +1,60 @@
+# INTERFACE: Model provider / credentials
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 (Anthropic) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+The model provider is swapped through config, not code: a base-URL override plus a
+credential whose prefix routes it onto the right SDK auth env, targeting any
+Anthropic-compatible endpoint. There is no provider interface to implement — a
+config author fills in a base URL, a credential, and a model id, and the runner maps
+them onto the variables the bundled Claude CLI authenticates from. What stays core is
+the Anthropic wire format (kept even for OpenRouter, so prompt caching survives).
+
+## Current contract
+
+Resolution lives in `runner/src/agentos_runner/sdk_auth.py`. A provider is defined by
+three things:
+
+- **Credential**, delivered as `AGENTOS_CREDENTIALS` (`sdk_auth.py:31`).
+  `resolve_model_credential` (`sdk_auth.py:82`) routes it by prefix
+  (`sdk_auth.py:94`): `sk-ant-oat...` → `CLAUDE_CODE_OAUTH_TOKEN`; other `sk-ant-...`
+  → `ANTHROPIC_API_KEY`; `sk-or-...` (OpenRouter) → base-URL override; a bare `sk-...`
+  raises `UnsupportedCredentialError` (`sdk_auth.py:47`, `:116`). An SDK credential
+  already in the env wins (`sdk_auth.py:89`).
+- **Base URL**, `ANTHROPIC_BASE_URL` (`sdk_auth.py:34`). `resolve_base_url_override`
+  (`sdk_auth.py:51`) builds the override env when set, and `resolve_sdk_env`
+  (`sdk_auth.py:124`) is the entry point that decides override-vs-plain.
+- **Model id**, `AGENTOS_MODEL`, read by `RunnerConfig.from_env`
+  (`runner/src/agentos_runner/config.py:62`).
+
+The override deliberately blanks `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_AUTH_TOKEN`
+to `""` (`sdk_auth.py:76`) so an inherited token cannot take precedence or leak to a
+third-party endpoint.
+
+## Implementations today
+
+One: Anthropic (direct API key or Claude Code OAuth token). OpenRouter is the
+intended reference second provider and is already wired as a prefix branch
+(`sdk_auth.py:100`): it reuses the shared base-URL-override seam, points at
+`OPENROUTER_BASE_URL = "https://openrouter.ai/api"` (`sdk_auth.py:36`), and puts the
+real key in `ANTHROPIC_API_KEY` (the `x-api-key` header OpenRouter reads).
+
+## Known leakage
+
+The gotcha the seam encodes rather than a bleed-through: base-URL override mode must
+carry a **non-empty** placeholder key, `NO_OP_API_KEY = "not-needed"`
+(`sdk_auth.py:44`). The bundled Claude CLI treats an empty `ANTHROPIC_API_KEY` as
+"not logged in" and refuses to dial the overridden endpoint (empirically verified
+2026-07-07, `sdk_auth.py:58`), so an empty string is not viable — a deliberately
+non-`sk-` placeholder passes the auth gate without being mistakable for a credential.
+The credential value is never logged.
+
+## Cross-links
+
+- **Epic(s):** #24 — bring your own model (OpenRouter + native Anthropic-format endpoints), the seam's forward work; #46 (closed) — the Ollama local-model demo mode, which also exercises this base-URL-override + credential path.
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — core config seam, not one of the six swappable jobs.
+- **ADR(s):** [ADR-0009](../../adr/0009-per-agent-connector-auth.md) — per-agent secrets and connector credentials (the model credential is the one credential the platform resolves today, via prefix mapping in `sdk_auth.py`).

--- a/docs/interfaces/queue-stream/INTERFACE.md
+++ b/docs/interfaces/queue-stream/INTERFACE.md
@@ -1,0 +1,65 @@
+# INTERFACE: Queue / stream (Valkey)
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 (redis-py) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+The seam is the Valkey Stream wire contract between the dispatcher (producer) and the
+worker (consumer): a named stream carrying a frozen one-field payload, spoken over the
+redis-py client. This is mostly opinionated **core** — the routing, consumer-group
+concurrency, dedupe, and reclaim rules are AgentOS's own and not meant to be swapped —
+with a soft swap only at the broker level: any redis-compatible Stream backend (Valkey,
+Redis, a managed equivalent) is a URL change. A non-redis broker (Kafka, SQS) would
+touch the wire and is a rewrite, not a config swap. One implementation today; the port
+is the stream key + payload shape + redis-py Stream verbs, not a code interface.
+
+## Current contract
+
+A second broker must honor the stream key, the payload encoding, and the Stream verbs:
+
+- **Stream key** — `"agentos:runs"`, defaulted identically on both ends:
+  `DispatcherConfig.stream` (`apps/dispatcher/src/agentos_dispatcher/config.py:47`,
+  env `AGENTOS_STREAM`) and `WorkerConfig.stream`
+  (`apps/worker/src/agentos_worker/config.py:72`).
+- **Payload encoding** — one Stream field, `STREAM_PAYLOAD_FIELD = "payload"`
+  (`queue.py:31`), holding `model_dump_json()`. Produced by `enqueue` via
+  `redis_client.xadd(config.stream, fields)`
+  (`apps/dispatcher/src/agentos_dispatcher/queue.py:82`) and reconstructed by
+  `QueuedSlackEvent.from_stream_fields` (`queue.py:60`).
+- **Consumer verbs** — the worker reads with `xreadgroup` over a consumer group
+  (`apps/worker/src/agentos_worker/consumer.py:104`), rebuilds the model at
+  `consumer.py:143`, and acknowledges with `xack` (`consumer.py:160`). The group is
+  `"agentos-workers"` (`WorkerConfig.consumer_group`, `config.py:73`).
+
+Idempotency lives beside the stream, not in it: `claim_event` does a
+`SET <dedupe_key> 1 NX EX <ttl>` before `XADD` (`queue.py:66`).
+
+## Implementations today
+
+One, redis-py against Valkey. The dispatcher `XADD`s (`queue.py:82`); the worker runs
+a consumer group with `XREADGROUP`/`XACK` and crash-recovery `XAUTOCLAIM`
+(`apps/worker/src/agentos_worker/consumer.py`). A second, sibling stream
+`"agentos:evals"` uses the same one-field `payload` convention
+(`apps/worker/src/agentos_worker/eval/stream.py`), reinforcing the wire shape as the
+real contract.
+
+## Known leakage
+
+The payload carried on this stream is `QueuedSlackEvent` — Slack-shaped by name
+(`slack_event_id`, `thread_ts`, `placeholder_ts`). That vendor leakage is not the queue
+seam's own; it belongs to the [channel / ingress seam](../channel-ingress/INTERFACE.md),
+and #7 promotes the payload into `packages/aci-protocol` with channel-neutral names,
+cleaning both seams at once. The queue seam's own constraint is narrower: the contract
+assumes redis Stream semantics (ordered entries, consumer groups, pending-entry
+reclaim), so a swap that stays redis-compatible is a URL change while a non-redis broker
+rewrites the wire and the consumer verbs.
+
+## Cross-links
+
+- **Epic(s):** #85 — vision: make the broker itself swappable behind the stream contract
+- **Epic(s):** #7 — payload promotion into `packages/aci-protocol` (overlaps the channel seam)
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — opinionated core (`agentos:runs` stream), not one of the six swap jobs
+- **ADR(s):** none directly on this seam

--- a/docs/interfaces/relational-db/INTERFACE.md
+++ b/docs/interfaces/relational-db/INTERFACE.md
@@ -1,0 +1,54 @@
+# INTERFACE: Relational DB (Postgres)
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** A-
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+App state (agents, versions, deployments) lives in a Postgres database, reached
+through SQLAlchemy 2.0 (async) with Alembic migrations. The swappable thing is the
+**Postgres instance behind the DSN** — compose Postgres, RDS, Cloud SQL, any managed
+Postgres — while the SQL/ORM layer and the `agentos` schema stay opinionated core.
+This is a deliberately un-abstracted seam: a managed-Postgres swap is a **DSN change**
+(`DATABASE_URL`), not a code change. There is no repository/DAL port; SQLAlchemy 2.0 +
+Alembic *is* the contract, extracted into something narrower only if a non-Postgres
+store is ever demanded.
+
+## Current contract
+
+A second implementation must be a Postgres speaking the async `asyncpg` dialect and
+honoring the models/migrations verbatim:
+
+- **DSN + schema** (`apps/api/src/agentos_api/db.py:21,29`): `SCHEMA = get_settings().db_schema` (default `"agentos"`, `config.py:21`); the engine is built from `database_url` (env `DATABASE_URL`, `config.py:18`) via `create_async_engine(..., pool_pre_ping=True)`.
+- **Schema-scoped metadata** (`db.py:24-25`): `Base.metadata = MetaData(schema=SCHEMA)` — every table is qualified into the `agentos` schema.
+- **Models** (`apps/api/src/agentos_api/models.py`): `Agent` (`agents`, line 25), `AgentVersion` (`agent_versions`, line 58), `Deployment` (`deployments`, line 79), plus the `Environment` StrEnum (`models.py:20`).
+- **Migrations**: 5 Alembic revisions in `apps/api/alembic/versions/` (`0001_initial` → `0005_behavior_packs`); the target DB must apply this chain.
+
+## Implementations today
+
+One: the compose/dev Postgres, reached through the single SQLAlchemy async engine in
+`apps/api/src/agentos_api/db.py:28-33`. Tests point the same engine at the compose
+Postgres by overriding `database_url` (per the module docstring).
+
+## Known leakage
+
+Two Postgres-isms make the "just change the DSN" story leak for a non-Postgres store:
+
+1. **`postgresql.UUID` column type** — `models.py:14` imports `UUID` from
+   `sqlalchemy.dialects.postgresql`, used as `UUID(as_uuid=True)` on every primary
+   and foreign key (e.g. `models.py:29, 62, 82`). This is a dialect-specific type.
+2. **Schema-qualified tables + a schema-scoped native enum** — foreign keys are
+   written as `f"{SCHEMA}.agents.id"` (`models.py:65, 88-89`) and the `environment`
+   column is a native Postgres `Enum(Environment, name="environment", schema=SCHEMA)`
+   (`models.py:91-92`), which materializes as a `CREATE TYPE` in the `agentos` schema.
+
+Both are cheap within the Postgres family (the A- grade) but would need rework for a
+different RDBMS — the marker that a real port should be extracted first.
+
+## Cross-links
+
+- **Epic(s):** #84 — vision epic for the relational-DB seam (keep the swap a DSN change; extract a port only for a non-Postgres store).
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 5 (Relational database), grade A-
+- **ADR(s):** [ADR-0007](../../adr/0007-adopt-not-build-boundaries.md) — Adopt-not-build boundaries ("vanilla Postgres" adopted for app state)

--- a/docs/interfaces/substrate/INTERFACE.md
+++ b/docs/interfaces/substrate/INTERFACE.md
@@ -1,0 +1,40 @@
+# INTERFACE: Substrate / SandboxClient
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 2 (Kubernetes, Docker) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded (core substrate)
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+The substrate is where a conversation thread claims, dials, suspends, and reaps an isolated runner runtime. `SandboxSubstrate` composes the port; everything Kubernetes-shaped (or Docker-shaped) lives behind the `SandboxClient` `Protocol`. The kernel talks in `thread_key` and receives a `SandboxHandle` with a dial target — it never touches a cluster or a container runtime directly. The swap axis is which runtime backs a claim (k8s CRDs vs local Docker containers); the routing, affinity, and rehydrate logic above the line stay opinionated core.
+
+## Current contract
+
+A second implementation must satisfy the `SandboxClient` `Protocol` at `apps/worker/src/agentos_worker/sandbox/k8s.py:50`, six methods:
+
+- `create_claim(name, *, pool, env=None, labels=None) -> None` (`k8s.py:53`)
+- `get_claim(name) -> ClaimView | None` (`k8s.py:62`)
+- `delete_claim(name) -> None` (`k8s.py:64`)
+- `list_claims(*, label_selector) -> list[ClaimView]` (`k8s.py:66`)
+- `get_sandbox(name) -> SandboxView | None` (`k8s.py:68`)
+- `set_sandbox_mode(name, mode: OperatingMode) -> None` (`k8s.py:70`)
+
+The exchanged value types are `ClaimView` (`sandbox/types.py:110`: `name`, `ready`, `sandbox_name`, `labels`) and `SandboxView` (`sandbox/types.py:120`: `name`, `ready`, `service_fqdn`, `operating_mode`, `port`). `operating_mode` must report `"Running"` for a claim to be handed back (`substrate.py:75`), and `OperatingMode` is `Literal["Running", "Suspended"]` (`k8s.py:30`). The selector reads `AGENTOS_SANDBOX_SUBSTRATE` (default `"kubernetes"`, else `"docker"`) in `_sandbox_client()` at `apps/worker/src/agentos_worker/run.py:81` (branch at `run.py:98`).
+
+## Implementations today
+
+Two, both under `apps/worker/src/agentos_worker/sandbox/`:
+
+- `KubernetesSandboxClient` (`k8s.py:101`) — drives agent-sandbox CRDs (`Sandbox` in `agents.x-k8s.io`, `SandboxClaim` in `extensions.agents.x-k8s.io`) via `CustomObjectsApi`.
+- `DockerSandboxClient` (`docker.py:94`) — boots runner containers on the local Docker daemon for middle mode (a laptop, no cluster).
+
+## Known leakage
+
+The `SandboxView.port` field (`types.py:134`) exists only because the Docker path publishes each runner on its own loopback host port, while the Kubernetes path uses one fleet-wide `runner_port`; `None` means "fall back to `SubstrateConfig.runner_port`". Credential handling also differs across the line: the k8s client strips `AGENTOS_CREDENTIALS` from per-claim env so it is never persisted in plaintext on the claim (`k8s.py:47`, `k8s.py:139`), relying on the chart Secret's `secretKeyRef`; the Docker client has no Secret and forwards it directly. These are runtime-shaped asymmetries the `Protocol` does not fully hide.
+
+## Cross-links
+
+- **Epic(s):** #86 — substrate vision (pluggable runtimes beyond agent-sandbox); #44 — substrate hardening
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — core substrate, not separately graded
+- **ADR(s):** [ADR-0002](../../adr/0002-kubernetes-agent-sandbox-as-runtime-substrate.md) — Kubernetes Agent Sandbox as the interactive runtime substrate; [ADR-0008](../../adr/0008-multi-tenancy.md) — multi-tenancy: hard-siloed compute (namespace-per-tenant) rides this seam

--- a/docs/interfaces/telemetry-otel/INTERFACE.md
+++ b/docs/interfaces/telemetry-otel/INTERFACE.md
@@ -1,0 +1,56 @@
+# INTERFACE: Telemetry / OTEL
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** B+
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+On the write side, observability is swapped at the OTLP wire, not in code: the runner
+exports `gen_ai.*` spans over OTLP-HTTP to a collector, and the collector is the only
+component that authenticates and forwards to a backend. Services never speak the
+backend directly. Swapping the trace store means repointing one collector exporter
+block, not touching the runner. The opinionated core is the span tree shape
+(`agent.run` → `llm.generation` → `execute_tool`) and the `gen_ai` semantic-convention
+attributes on it.
+
+## Current contract
+
+A second backend must ingest the OTLP-HTTP export produced in
+`runner/src/agentos_runner/otel.py`:
+
+- `build_tracer_provider` (`otel.py:36`) returns a `TracerProvider` wired with an
+  argument-free `OTLPSpanExporter()` over a `SimpleSpanProcessor` (`otel.py:62`), or
+  `None` when unconfigured (`otel.py:48`, so offline runs neither export nor fail).
+- Endpoint/headers come from the standard `OTEL_EXPORTER_OTLP_*` env vars, read by the
+  opentelemetry SDK itself (`otel.py:59`); `SessionConfig.otel` is the typed view of
+  the same vars.
+- `RunTracer.run_span` (`otel.py:80`) opens the root `agent.run` (`SpanKind.SERVER`,
+  `otel.py:98`) and a child `llm.generation` span. `_GenerationSpan.record_model`
+  stamps `gen_ai.request.model` (`otel.py:141`), `record_usage` stamps
+  `gen_ai.usage.input_tokens` / `output_tokens` (`otel.py:153`), and `tool_span` emits
+  an `execute_tool` child carrying `gen_ai.tool.name` and `gen_ai.operation.name`
+  (`otel.py:159`).
+
+## Implementations today
+
+One: Langfuse, reached through the OTel Collector (which authenticates and forwards,
+since Langfuse OTLP ingest is HTTP-only). The runner does not know it is Langfuse — it
+only knows OTLP. The read side (trace list, tree reconstruction) is a separate adapter
+in the API and out of scope for this write-side seam.
+
+## Known leakage
+
+The write path is clean but for one vendor attribute: the root span carries
+`langfuse.trace.name` (`otel.py:99`), a Langfuse-named attribute on an otherwise
+neutral OTLP path. `run_span` similarly stamps `langfuse.session.id` (`otel.py:101`)
+and `langfuse.user.id` (`otel.py:103`) so Langfuse maps them to its Sessions/Users
+features. A clean seam would emit a neutral attribute the collector maps to the
+vendor name; today the vendor name is set at the source.
+
+## Cross-links
+
+- **Epic(s):** #47 — extends the observability / telemetry write path.
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 2 (Observability / OTel store), grade B+.
+- **ADR(s):** [ADR-0004](../../adr/0004-langfuse-observability-and-eval-backbone.md) — Langfuse as the single observability + eval backbone (OTLP over HTTP/protobuf to the collector).

--- a/docs/interfaces/triggers/INTERFACE.md
+++ b/docs/interfaces/triggers/INTERFACE.md
@@ -1,0 +1,57 @@
+# INTERFACE: Triggers
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+A "trigger" is the thing that wakes an agent: an inbound event that gets turned into a
+run. Today there are **two hardcoded triggers** wired directly into their respective
+ingress handlers, with **no shared `Trigger`/`EventSource` port** between them. There
+is no swappable line here yet — each trigger is bespoke code. The open architectural
+question (Epic #29) is whether "trigger" is even a real seam, or whether new triggers
+are just new *event types* handled inside the existing Slack-dispatcher and
+API-webhook ingresses. This file records the current state honestly; it does not
+assert a port that does not exist.
+
+## Current contract
+
+There is no cross-trigger contract to satisfy — a new trigger today means adding
+another hardcoded handler. The two that exist:
+
+- **Slack mention** — `apps/dispatcher/src/agentos_dispatcher/handlers.py:196`:
+  `@app.event("app_mention")` on the Slack Bolt app, which calls `process_event(...)`
+  to enqueue a run. (An adjacent `@app.event("message")` DM handler sits at
+  `handlers.py:208`, gated to `channel_type == "im"`.)
+- **GitHub push** — `apps/api/src/agentos_api/routers/github.py:20-21`:
+  `@router.post("/webhook")` verifies the HMAC signature, then branches on
+  `x_github_event`; a `"push"` event (`github.py:38`) is handed to `process_push(...)`,
+  everything else is `"ignored"`.
+
+The two share no abstraction: one is a Slack Bolt event listener, the other a FastAPI
+route with GitHub HMAC auth. They converge only downstream (both end up enqueuing work).
+
+## Implementations today
+
+Two, both hardcoded, in two different processes:
+
+1. Slack `app_mention` in the dispatcher (`handlers.py:196`).
+2. GitHub `push` webhook in the API (`routers/github.py:20`).
+
+## Known leakage
+
+The whole seam is "leakage" in the sense that nothing is abstracted yet. Each trigger
+carries its source's shape end to end: Slack triggers are Bolt-event-shaped and
+authed by the Slack app token; the GitHub trigger is HMAC-signature-shaped and lives
+"outside the X-API-Key dependency" (`github.py` docstring). A future `Trigger` port —
+if Epic #29 concludes one is warranted — must reconcile these two auth models and
+payload shapes into a common event contract, and would live alongside the ingress
+handlers rather than replacing the transport-specific receivers.
+
+## Cross-links
+
+- **Epic(s):** #29 — triggers: decide whether "trigger" is a real seam (extract an `EventSource` port) or just new event types on the existing ingresses.
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — not one of the six swappable jobs; not separately graded.
+- **ADR(s):** none yet — no accepted ADR governs the trigger seam.

--- a/docs/interfaces/workflow-state/INTERFACE.md
+++ b/docs/interfaces/workflow-state/INTERFACE.md
@@ -1,0 +1,38 @@
+# INTERFACE: Workflow state store
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** NONE &nbsp;·&nbsp; **Implementations today:** 0 abstracted (a concrete `AffinityStore` exists) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+There is no workflow-state port yet — only a concrete, single-purpose route store. Today's `AffinityStore` records exactly one thing: the `thread_key -> sandbox route` binding on Valkey, with atomic acquire and TTL expiry. A general workflow state store (durable get / compare-and-swap put / list / delete / append for agent run state, checkpoints, and history) is unbuilt. The intended line, when extracted, is a small typed port the kernel writes state through, with Valkey (or Postgres) behind it — but per "the second implementation teaches the interface," the port lands only when a real second consumer demands it.
+
+## Current contract
+
+No port class exists. The concrete `AffinityStore` at `apps/worker/src/agentos_worker/sandbox/affinity.py:31` is what exists today, and its methods are the closest thing to a state contract:
+
+- `get(thread_key) -> RouteRecord | None` (`affinity.py:42`)
+- `put_if_absent(thread_key, record, ttl_seconds) -> bool` — atomic acquire, the CAS-shaped primitive (`affinity.py:49`, `SET ... nx=True`)
+- `replace(thread_key, record, ttl_seconds) -> None` (`affinity.py:59`)
+- `touch(thread_key, ttl_seconds) -> bool` (`affinity.py:64`)
+- `delete_if_claim(thread_key, claim_name) -> bool` — guarded delete via a Lua `_DELETE_IF_CLAIM` script (`affinity.py:69`, script at `affinity.py:18`)
+- `live_claim_names(...) -> set[str]` (`affinity.py:74`)
+- `mark_suspended(thread_key, history_ref, ttl_seconds) -> RouteRecord` (`affinity.py:96`)
+
+The stored value is a `RouteRecord` (`sandbox/types.py:54`) JSON-serialized. This is route affinity, not general workflow state — the get/put-CAS/list/delete/append surface epic #23 specifies does not exist here.
+
+## Implementations today
+
+Zero abstracted implementations. One concrete class, `AffinityStore` (`affinity.py:31`), bound directly to `redis.Redis` and to the sandbox-routing use case.
+
+## Known leakage
+
+The port does not exist yet, so there is nothing to leak through — but the placement constraint the future store must honor is already visible: it is stateless-first. Per ADR-0003, a suspend/resume is a cold pod restart (the live process never survives), so resume rehydrates from a caller-supplied `history_ref` injected as `AGENTOS_HISTORY_REF` rather than assuming any in-process or cache warmth (`sandbox/substrate.py:99`–`139`). A future workflow-state port must not assume process affinity or cache continuity across a suspend; state that must survive has to be written durably, keyed by thread/session, and rehydratable from cold.
+
+## Cross-links
+
+- **Epic(s):** #23 — full workflow state store API spec (get / put-CAS / list / delete / append); the extracted port lands with this epic, and its interface AC is the gold standard for this seam
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — not one of the six graded jobs
+- **ADR(s):** [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) — stateless-first sessions; rehydrate on resume; no cross-hibernation cache assumption


### PR DESCRIPTION
Backfills a short `INTERFACE.md` for each of AgentOS's 15 swappable seams (the "strong black lines"), documenting the *existing* contract: what is swappable vs opinionated core, the current contract with `file:line`, implementations today, and known leakage. Adds `docs/interfaces.md` as the top-level index linking all 15 files and reproducing the swap-readiness grade table from `architecture-vision.md`, plus a discoverability pointer in `docs/README.md`.

**Documentation only** — no adapter/abstraction code, per the "the second implementation teaches the interface" restraint in `docs/architecture-vision.md`.

### Placement decision (worth a look)
Files are centralized under `docs/interfaces/<slug>/INTERFACE.md` rather than scattered at each seam's code directory, because several seams genuinely share one directory (runner backs harness + model-provider + telemetry; `apps/api` backs blob + relational-db + triggers; `sandbox` backs substrate + workflow-state; `aci-protocol` backs ACI + memory; `dispatcher` backs channel + queue) — a literal one-`INTERFACE.md`-per-code-dir mapping would collide. Each file's **Current contract** section cites the exact code `file:line` so the black line stays locatable, and the index makes the whole seam map discoverable from one place. Happy to relocate any subset into code dirs if you'd prefer them co-located.

### Seams covered
substrate, harness/ModelSession, ACI producer, channel/ingress, model provider, telemetry/OTEL, evals, blob storage, relational DB, queue/stream, bundle format, approval, workflow state, memory, triggers.

Seams whose interface doc ships with their own epic (#24, #46, #28, #29, #19, #30) are still covered here to establish the template + index; those epics can refine their seam's file in place.

Closes #53