### PR TITLE
Scope the pod-log observability endpoint to the runner namespace

### DIFF
--- a/apps/api/src/agentos_api/routers/observability.py
+++ b/apps/api/src/agentos_api/routers/observability.py
@@ -86,10 +86,36 @@ async def runner_logs(
     namespace: str,
     pod: str,
     reader: PodLogReaderDep,
+    lister: PodListerDep,
     container: str | None = None,
     tail_lines: int | None = None,
     previous: bool = False,
 ) -> PodLogs:
+    settings = get_settings()
+    if namespace != settings.runner_namespace:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            f"logs are only available for the runner namespace "
+            f"{settings.runner_namespace!r}",
+        )
+    try:
+        runner_pods = await run_in_threadpool(
+            lister.list_runner_pods,
+            settings.runner_namespace,
+            settings.runner_pod_label_selector,
+        )
+    except NoClusterConfigured as exc:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)
+        ) from exc
+    except PodLogError as exc:
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, str(exc)) from exc
+    if pod not in runner_pods:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            f"{pod!r} is not a runner pod in namespace "
+            f"{settings.runner_namespace!r}",
+        )
     try:
         logs = await run_in_threadpool(
             reader.read, namespace, pod, container, tail_lines, previous

--- a/apps/api/tests/test_runner_logs.py
+++ b/apps/api/tests/test_runner_logs.py
@@ -1,16 +1,21 @@
-"""Runner-logs proxy: no-cluster degradation, success, and error mapping.
+"""Runner-logs proxy: namespace/pod scoping, no-cluster degradation, error mapping.
 
-The K8s access is injected, so success and error paths are exercised with a fake
-reader; the default app (no cluster configured) proves the 503 degradation.
+The log endpoint is scoped to the configured runner namespace + runner-pod label
+selector (issue #64): an out-of-scope namespace or a pod that is not a genuine
+runner pod is rejected with 403 *before* the pod-log reader is ever invoked. The
+K8s access is injected (both the pod lister and the log reader), so the scoping
+gate, success, and error paths are all exercised with fakes; the default app (no
+cluster configured) proves the 503 degradation.
 """
 
 import logging
 from typing import Any
 
 import pytest
-from agentos_api.deps import get_pod_log_reader
+from agentos_api.deps import get_pod_lister, get_pod_log_reader
 from agentos_api.k8s import (
     LazyPodLogReader,
+    NullPodLister,
     NullPodLogReader,
     PodLogError,
     PodLogReader,
@@ -19,7 +24,9 @@ from agentos_api.k8s import (
 from agentos_api.main import create_app
 from fastapi.testclient import TestClient
 
-URL = "/observability/runners/preview-pr-1/runner-abc/logs"
+# runner-abc lives in the configured runner namespace ("agentos"); the old URL
+# used "preview-pr-1", which is now out of scope and would be a 403.
+URL = "/observability/runners/agentos/runner-abc/logs"
 
 
 class FakeReader:
@@ -34,7 +41,17 @@ class FakeReader:
         return f"logs for {namespace}/{pod}"
 
 
-class NotFoundReader:
+class SpyReader:
+    """Records every .read() call so tests can assert it is NEVER reached on 403.
+
+    Optionally raises a configured error to exercise the 404/502 mappings once
+    execution legitimately reaches the reader (a valid runner pod).
+    """
+
+    def __init__(self, *, raises: Exception | None = None) -> None:
+        self.calls: list[tuple[str, str, str | None, int | None, bool]] = []
+        self._raises = raises
+
     def read(
         self,
         namespace: str,
@@ -43,48 +60,128 @@ class NotFoundReader:
         tail_lines: int | None,
         previous: bool,
     ) -> str:
-        raise PodLogError("pod not found", status=404)
+        self.calls.append((namespace, pod, container, tail_lines, previous))
+        if self._raises is not None:
+            raise self._raises
+        return f"logs for {namespace}/{pod}"
 
 
-def _client_with(reader: object) -> TestClient:
+class FakeLister:
+    """Returns a configurable set of runner-pod names; records list calls.
+
+    Membership of the requested pod in this list is what the endpoint checks to
+    decide whether the pod is a genuine runner pod.
+    """
+
+    def __init__(
+        self, pods: list[str], *, raises: Exception | None = None
+    ) -> None:
+        self._pods = pods
+        self._raises = raises
+        self.calls: list[tuple[str, str]] = []
+
+    def list_runner_pods(self, namespace: str, label_selector: str) -> list[str]:
+        self.calls.append((namespace, label_selector))
+        if self._raises is not None:
+            raise self._raises
+        return list(self._pods)
+
+
+def _client_with(reader: object, lister: object) -> TestClient:
     app = create_app()
     app.dependency_overrides[get_pod_log_reader] = lambda: reader
+    app.dependency_overrides[get_pod_lister] = lambda: lister
     return TestClient(app)
 
 
-def test_no_cluster_configured_degrades_to_503(auth_headers: dict[str, str]) -> None:
-    # With no cluster the reader is a NullPodLogReader, which the endpoint turns
-    # into a 503-with-reason rather than crashing.
-    with _client_with(NullPodLogReader()) as client:
+def test_non_runner_namespace_returns_403(auth_headers: dict[str, str]) -> None:
+    # A lister that WOULD return the requested pod, proving the namespace gate
+    # short-circuits *before* any cluster call (no list, no read).
+    reader = SpyReader()
+    lister = FakeLister(["some-pod"])
+    with _client_with(reader, lister) as client:
+        resp = client.get(
+            "/observability/runners/kube-system/some-pod/logs",
+            headers=auth_headers,
+        )
+    assert resp.status_code == 403
+    assert reader.calls == []  # the log reader must not run for an out-of-scope ns
+    assert lister.calls == []  # the check is cheap: it precedes any cluster call
+
+
+def test_pod_not_carrying_runner_selector_returns_403(
+    auth_headers: dict[str, str],
+) -> None:
+    # In-scope namespace, but the pod is not among the genuine runner pods.
+    reader = SpyReader()
+    lister = FakeLister(["runner-xyz", "runner-def"])  # excludes runner-abc
+    with _client_with(reader, lister) as client:
+        resp = client.get(URL, headers=auth_headers)
+    assert resp.status_code == 403
+    assert reader.calls == []  # rejected before ever reading logs
+    assert lister.calls  # membership was verified against the runner-pod list
+
+
+def test_returns_logs_for_valid_runner_pod(auth_headers: dict[str, str]) -> None:
+    # In-scope namespace and the pod IS a genuine runner pod -> logs are served.
+    reader = SpyReader()
+    lister = FakeLister(["runner-abc", "runner-old"])  # includes runner-abc
+    with _client_with(reader, lister) as client:
+        resp = client.get(URL, headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["namespace"] == "agentos"
+    assert body["pod"] == "runner-abc"
+    assert body["container"] is None
+    assert body["logs"] == "logs for agentos/runner-abc"
+    assert lister.calls  # membership verified first
+    assert reader.calls  # then the reader was invoked
+
+
+def test_no_cluster_configured_degrades_to_503(
+    auth_headers: dict[str, str],
+) -> None:
+    # With no cluster the lister raises NoClusterConfigured, which the endpoint
+    # turns into a 503-with-reason rather than crashing; the reader never runs.
+    reader = SpyReader()
+    with _client_with(reader, NullPodLister()) as client:
         resp = client.get(URL, headers=auth_headers)
     assert resp.status_code == 503
     assert "no kubernetes cluster" in resp.json()["detail"]
+    assert reader.calls == []
+
+
+def test_pod_not_found_maps_to_404(auth_headers: dict[str, str]) -> None:
+    # A valid runner pod whose logs the cluster reports as gone -> 404.
+    reader = SpyReader(raises=PodLogError("pod not found", status=404))
+    lister = FakeLister(["runner-abc"])
+    with _client_with(reader, lister) as client:
+        resp = client.get(URL, headers=auth_headers)
+    assert resp.status_code == 404
+    assert reader.calls  # execution reached the reader (pod was a valid runner)
+
+
+def test_other_cluster_error_maps_to_502(auth_headers: dict[str, str]) -> None:
+    # A valid runner pod but a non-404 cluster error -> 502.
+    reader = SpyReader(raises=PodLogError("boom", status=500))
+    lister = FakeLister(["runner-abc"])
+    with _client_with(reader, lister) as client:
+        resp = client.get(URL, headers=auth_headers)
+    assert resp.status_code == 502
+    assert reader.calls
+
+
+def test_runner_logs_require_api_key(client: Any) -> None:
+    assert client.get(URL).status_code == 401
+
+
+# --- k8s.py internals (do not hit the endpoint) ---------------------------
 
 
 def test_build_reader_degrades_to_null_when_config_unloadable() -> None:
     # An explicit but unloadable kubeconfig path degrades to the null reader.
     reader = build_pod_log_reader("/nonexistent/kubeconfig-path.yaml")
     assert isinstance(reader, NullPodLogReader)
-
-
-def test_returns_logs_from_the_reader(auth_headers: dict[str, str]) -> None:
-    with _client_with(FakeReader()) as client:
-        resp = client.get(URL, headers=auth_headers)
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["namespace"] == "preview-pr-1"
-    assert body["pod"] == "runner-abc"
-    assert body["logs"] == "logs for preview-pr-1/runner-abc"
-
-
-def test_pod_not_found_maps_to_404(auth_headers: dict[str, str]) -> None:
-    with _client_with(NotFoundReader()) as client:
-        resp = client.get(URL, headers=auth_headers)
-    assert resp.status_code == 404
-
-
-def test_runner_logs_require_api_key(client: Any) -> None:
-    assert client.get(URL).status_code == 401
 
 
 def test_lazy_reader_defers_resolution_until_first_read() -> None:


### PR DESCRIPTION
Closes #64

## Problem
The runner-logs proxy `GET /observability/runners/{namespace}/{pod}/logs` took `namespace` + `pod` straight from the path and passed them to the log reader, so any API-key holder could read logs of arbitrary pods in any namespace the API ServiceAccount could reach (secrets frequently leak into logs). The sibling pod-*list* endpoint was already scoped to the runner namespace + selector; the *logs* endpoint ignored them.

## Fix
Scope the logs endpoint the same way the list endpoint is:
- **403 unless `namespace == settings.runner_namespace`**, checked before any cluster call (the reader and lister are never touched for an out-of-scope namespace).
- **Verify the pod is a genuine runner pod** by listing runner pods via the existing `PodLister` (`runner_namespace` + `runner_pod_label_selector`) and checking membership; 403 otherwise, before any log read.
- Reuse the list path's no-cluster (503) / cluster-error (502) mapping; the existing reader 503/404/502 contract is preserved.

The fix lives entirely in the router by reusing the already-injected, already-RBAC'd `PodLister` (`list` on pods is granted); no `k8s.py`, config, schema, or RBAC change.

## RBAC note
The API SA `Role` in `charts/agentos/templates/api-rbac.yaml` is already a namespaced `Role` (not a `ClusterRole`) bound in the release namespace, so the SA is already physically unable to read `pods/log` outside it. If an operator ever sets `runner_namespace` to a namespace different from the Helm release namespace, the app gate would pass but RBAC would deny the read (fails closed, never open) -- worth keeping the two aligned.

## Tests
Test-first: `apps/api/tests/test_runner_logs.py` now asserts 403 for a non-runner namespace and for a pod absent from the runner-pod list (each proving the reader is never invoked), 200 only for an in-scope, verified runner pod, and preserves the 503/404/502 mappings. Full `apps/api` suite: 120 passed.