### PR TITLE
Add default-deny data-tier NetworkPolicy rail

### DIFF
--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -233,11 +233,12 @@ comfortable headroom for integration and soak testing.
 
 ## Security rails
 
-The four security-boundary rails ship **on by default** (ADR-0006). They attach to the
-agent-sandbox runner surface, so their NetworkPolicy / RBAC / probe resources
+The security-boundary rails ship **on by default** (ADR-0006). The runner-surface
+rails attach to the agent-sandbox, so their NetworkPolicy / RBAC / probe resources
 render only when `agentSandbox.deploy: true` (there are no runner pods to protect
 otherwise). With the sandbox off, the rendered manifests are byte-identical to a
-chart without the security rails.
+chart without those rails. The data-tier ingress rail is independent of the
+sandbox and renders whenever an in-chart store is deployed.
 
 | Rail | What ships | Values |
 |---|---|---|
@@ -245,6 +246,7 @@ chart without the security rails.
 | 2. Per-agent secret isolation | Least-privilege runner ServiceAccount (no secret get/list, token not mounted). The per-agent `resourceNames`-scoped Role is bound by the control plane per agent. | `agentSandbox.runner.serviceAccount.*` |
 | 3. Non-root / read-only rootfs | Pod + container securityContext on the runner: `runAsNonRoot`, uid 1000, `readOnlyRootFilesystem`, drop ALL caps, no privilege escalation, RuntimeDefault seccomp, plus writable emptyDir scratch (`/tmp`, `/home/runner`) and `HOME`. | `agentSandbox.runner.hardening.*` |
 | 4. gVisor kernel isolation | `runtimeClassName` on runner pods, driven by the `security.gvisor.mode` tri-state (`auto`/`require`/`off`) + a preflight that fails the install if the RuntimeClass is missing or downgraded, firing in `require` (always) and in `auto` for real-model runs + an optional RuntimeClass object. | `security.gvisor.*`, `security.gvisorPreflight.*` |
+| 5. Data-tier ingress isolation | Per deployed store (Postgres, MinIO, ClickHouse, Valkey): a default-deny-ingress NetworkPolicy plus a scoped-allow that permits ingress on the store's ports ONLY from this release's app pods (`name`+`instance` label). Blocks any co-tenant pod from opening `Postgres:5432` etc. | `security.dataTierNetworkPolicy.*` |
 
 **Fail-closed egress.** `security.networkPolicy.allowedEgress` is EMPTY by
 default: a fresh install denies all egress except DNS until the operator declares
@@ -264,6 +266,17 @@ sealed default denies. `--allow-web-egress 0.0.0.0/0` opens the open internet
 (still minus the `169.254.169.254` metadata endpoint the chart carves out of
 `0.0.0.0/0`); narrow the CIDR to a specific provider for a tighter posture. Omit
 the flag and the install stays fully sealed.
+
+**Data-tier ingress isolation.** The backing stores hold every credential and all
+trace/app data, so `security.dataTierNetworkPolicy.enabled` (default `true`)
+wraps each DEPLOYED in-chart store in a default-deny-ingress NetworkPolicy plus a
+scoped-allow that only admits this release's own app pods (matched by
+`app.kubernetes.io/name` + `app.kubernetes.io/instance`) on the store's ports.
+Without it, any pod in a NetworkPolicy-enforcing cluster could open `Postgres:5432`
+and exfiltrate. BYO stores (`<store>.deploy: false`) are external and get no
+policy. Claim 5 of the security probe verifies it empirically (an app-labeled pod
+reaches each store while a non-app-labeled pod is blocked), which also catches a
+non-enforcing CNI.
 
 **gVisor needs runsc on the node**, and `security.gvisor.mode` is a tri-state
 (default `auto`):
@@ -292,7 +305,7 @@ RuntimeClass object (the node must still provide the runtime).
 
 ```bash
 helm test <release> -n <ns>
-kubectl logs -n <ns> job/<release>-security-probe            # claims 1, 2, 4
+kubectl logs -n <ns> job/<release>-security-probe            # claims 1, 2, 4, 5
 kubectl logs -n <ns> <release>-security-probe-hardening      # claim 3
 ```
 

--- a/charts/agentos/templates/security-datatier-networkpolicy.yaml
+++ b/charts/agentos/templates/security-datatier-networkpolicy.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.security.dataTierNetworkPolicy.enabled }}
+{{/*
+Rail: default-deny ingress + scoped-allow around the data tier (Postgres, MinIO,
+ClickHouse, Valkey).
+
+The backing stores hold every credential and all trace/app data. Without an
+ingress restriction, any co-tenant pod in a NetworkPolicy-enforcing cluster can
+open Postgres:5432 (or MinIO:9000, ClickHouse:8123, Valkey:6379) and read or
+exfiltrate the whole store. This rail selects each DEPLOYED in-chart store's pods
+by their component selector labels and, per store, emits two policies that
+compose into: (a) a default-deny that blocks ALL ingress by construction, and
+(b) a narrow allow that re-permits ingress ONLY from pods carrying THIS release's
+`app.kubernetes.io/name` + `app.kubernetes.io/instance` labels (the release's own
+app components: api, worker, dispatcher, langfuse, ui, runner sandboxes, jobs),
+on the store's ports. NetworkPolicy allows are additive, so the pair means:
+release app pods reach the store, everything else is denied. Same-namespace only
+(no namespaceSelector) so two AgentOS releases sharing a namespace do not
+cross-reach each other's stores.
+
+BYO stores (`<store>.deploy: false`) are external hosts outside the cluster, so
+they get no policy here -- secure them at their own network boundary.
+
+A customer CNI that does not enforce NetworkPolicy turns all of this into a
+silent false-pass; the security probe's Claim 5 (data-tier ingress isolation)
+exists to catch exactly that.
+*/}}
+{{/* Data-tier store catalog. Ports are the pods' fixed container ports (NOT the
+     configurable service .port), since a NetworkPolicy matches the destination
+     container port. Keep this store set + representative ports in sync with the
+     $dt probe-target list in security-probe.yaml (Claim 5). */}}
+{{- $stores := list
+    (dict "component" "postgres"   "deploy" .Values.postgres.deploy   "ports" (list 5432))
+    (dict "component" "minio"      "deploy" .Values.minio.deploy      "ports" (list 9000 9001))
+    (dict "component" "clickhouse" "deploy" .Values.clickhouse.deploy "ports" (list 8123 9000))
+    (dict "component" "valkey"     "deploy" .Values.valkey.deploy     "ports" (list 6379))
+-}}
+{{- range $s := $stores }}
+{{- if $s.deploy }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "agentos.fullname" $ }}-{{ $s.component }}-default-deny-ingress
+  labels:
+    {{- include "agentos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $s.component }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "agentos.selectorLabels" (dict "root" $ "component" $s.component) | nindent 6 }}
+  policyTypes: [Ingress]
+  # No ingress rules == deny all ingress for the selected store pods.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "agentos.fullname" $ }}-{{ $s.component }}-allow-app-ingress
+  labels:
+    {{- include "agentos.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $s.component }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "agentos.selectorLabels" (dict "root" $ "component" $s.component) | nindent 6 }}
+  policyTypes: [Ingress]
+  # Allow ingress ONLY from THIS release's app pods (name + instance), same
+  # namespace. No namespaceSelector: co-namespace releases stay isolated.
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "agentos.name" $ }}
+              app.kubernetes.io/instance: {{ $.Release.Name }}
+      ports:
+        {{- range $p := $s.ports }}
+        - { protocol: TCP, port: {{ $p }} }
+        {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/agentos/templates/security-probe.yaml
+++ b/charts/agentos/templates/security-probe.yaml
@@ -2,7 +2,7 @@
 {{- $h := .Values.agentSandbox.runner.hardening }}
 {{/*
 The PT-3 security-boundary probe suite, re-run against the chart's rendered
-defaults as a `helm test`. Four claims:
+defaults as a `helm test`. Five claims:
 
   1. default-deny egress + metadata endpoint blocked, WITH a before/after control
      that proves the CNI actually enforces (not a silent false-pass).
@@ -10,8 +10,10 @@ defaults as a `helm test`. Four claims:
   3. runner containers are non-root with a read-only rootfs.
   4. gVisor RuntimeClass enforced (reported testable / not-testable honestly;
      enforcement itself is asserted by the preflight-gvisor hook).
+  5. data-tier ingress isolation: a release-app-labeled pod reaches each deployed
+     store's port while a non-app-labeled pod is blocked (the data-tier rail).
 
-Claim 3 is a self-contained hardened Pod (the pod IS the test). Claims 1, 2, 4
+Claim 3 is a self-contained hardened Pod (the pod IS the test). Claims 1, 2, 4, 5
 run from a kubectl-driven orchestrator with a scoped ServiceAccount.
 */}}
 apiVersion: v1
@@ -141,7 +143,22 @@ spec:
         {{- toYaml .Values.security.probe.resources | nindent 8 }}
 {{- end }}
 ---
-{{/* Claims 1, 2, 4: kubectl-driven orchestrator (alpine/k8s ships kubectl). */}}
+{{/* Claims 1, 2, 4, 5: kubectl-driven orchestrator (alpine/k8s ships kubectl).
+     $dt is the space-separated host:port list of stores Claim 5 probes (one
+     representative data port each). Keep this store set + ports in sync with the
+     $stores catalog in security-datatier-networkpolicy.yaml -- each port here
+     must be in that store's allow-list or Claim 5 red-fails a correct rail.
+     Claim 5 only asserts the data-tier boundary when the rail that creates it is
+     enabled AND the store is in-chart-deployed; BYO stores are external and
+     excluded. Both a disabled rail and all-BYO stores yield an empty list =>
+     Claim 5 skips. */}}
+{{- $dt := list -}}
+{{- if .Values.security.dataTierNetworkPolicy.enabled -}}
+{{- if .Values.postgres.deploy }}{{- $dt = append $dt (printf "%s:5432" (include "agentos.postgres.host" .)) -}}{{- end }}
+{{- if .Values.minio.deploy }}{{- $dt = append $dt (printf "%s:9000" (include "agentos.minio.host" .)) -}}{{- end }}
+{{- if .Values.clickhouse.deploy }}{{- $dt = append $dt (printf "%s:8123" (include "agentos.clickhouse.host" .)) -}}{{- end }}
+{{- if .Values.valkey.deploy }}{{- $dt = append $dt (printf "%s:6379" (include "agentos.valkey.host" .)) -}}{{- end }}
+{{- end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -191,6 +208,20 @@ spec:
               value: "app.kubernetes.io/name={{ include "agentos.name" . }},app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=runner-sandbox,agentos.io/egress-probe={{ .Release.Name }}"
             - name: PROBE_UNIQUE_VAL
               value: {{ .Release.Name | quote }}
+            # Claim 5: data-tier ingress isolation. Deployed-store host:port list
+            # (empty => skip). Two probe pods: the ALLOWED one carries this
+            # release's app labels (rail SHOULD permit it), the DENIED one carries
+            # only a probe label with NO app labels (rail SHOULD block it).
+            - name: DATATIER_TARGETS
+              value: {{ join " " $dt | quote }}
+            - name: DT_ALLOWED_POD
+              value: {{ include "agentos.fullname" . }}-dt-probe-allowed
+            - name: DT_DENIED_POD
+              value: {{ include "agentos.fullname" . }}-dt-probe-denied
+            - name: DT_ALLOWED_LABELS
+              value: "app.kubernetes.io/name={{ include "agentos.name" . }},app.kubernetes.io/instance={{ .Release.Name }},agentos.io/datatier-probe=allowed"
+            - name: DT_DENIED_LABELS
+              value: "agentos.io/datatier-probe=denied"
           command:
             - /bin/bash
             - -c
@@ -199,6 +230,7 @@ spec:
               fail=0
               cleanup() {
                 kubectl delete pod "$EGRESS_POD" sp-gvisor-check -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
+                kubectl delete pod "$DT_ALLOWED_POD" "$DT_DENIED_POD" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
                 kubectl delete networkpolicy "$ALLOW_ALL_NP" "$BROAD_ALLOW_NP" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
                 kubectl delete secret sp-agent-a-creds sp-agent-b-creds -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
                 kubectl delete serviceaccount sp-agent-a -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
@@ -208,7 +240,7 @@ spec:
               trap cleanup EXIT
 
               echo "###############################################"
-              echo "# AgentOS A2 security probe (claims 1, 2, 4)"
+              echo "# AgentOS A2 security probe (claims 1, 2, 4, 5)"
               echo "###############################################"
 
               # ================= Claim 1: egress + metadata (before/after) ==========
@@ -357,6 +389,48 @@ spec:
                     echo "  to runc?). kernel=${gkernel}"
                     fail=1
                   fi
+                fi
+              fi
+
+              # ================= Claim 5: data-tier ingress isolation ===============
+              # Prove the data-tier rail: a pod carrying THIS release's app labels
+              # can reach each deployed store's port (positive control), while a pod
+              # with no app labels is blocked (the isolation the rail enforces).
+              echo ""
+              echo "== Claim 5: data-tier ingress isolation (default-deny + scoped-allow) =="
+              if [ -z "$DATATIER_TARGETS" ]; then
+                echo "SKIP: data-tier NetworkPolicy rail disabled or no in-chart store deployed"
+              else
+                kubectl run "$DT_ALLOWED_POD" -n "$NS" --image="$NETSHOOT" --restart=Never \
+                  --labels="$DT_ALLOWED_LABELS" --command -- sleep 3600 >/dev/null
+                kubectl run "$DT_DENIED_POD" -n "$NS" --image="$NETSHOOT" --restart=Never \
+                  --labels="$DT_DENIED_LABELS" --command -- sleep 3600 >/dev/null
+                kubectl wait --for=condition=Ready "pod/$DT_ALLOWED_POD" -n "$NS" --timeout=120s >/dev/null
+                kubectl wait --for=condition=Ready "pod/$DT_DENIED_POD" -n "$NS" --timeout=120s >/dev/null
+
+                dt_reach() { # $1=pod $2=host $3=port -> prints reachable|blocked
+                  rc=$(kubectl exec -n "$NS" "$1" -- sh -c "nc -z -w5 $2 $3 >/dev/null 2>&1; echo rc=\$?" 2>/dev/null | sed -n 's/.*rc=//p')
+                  [ "$rc" = 0 ] && echo reachable || echo blocked
+                }
+
+                dt_fail=0
+                for target in $DATATIER_TARGETS; do
+                  host=${target%:*}
+                  port=${target##*:}
+                  allowed=$(dt_reach "$DT_ALLOWED_POD" "$host" "$port")
+                  denied=$(dt_reach "$DT_DENIED_POD" "$host" "$port")
+                  echo "${target} allowed->${allowed} denied->${denied}"
+                  if [ "$allowed" != reachable ] || [ "$denied" != blocked ]; then
+                    echo "RESULT: FAIL - ${target}: allowed=${allowed} (want reachable) denied=${denied} (want blocked)"
+                    echo "        (allowed=blocked => rail misconfigured; denied=reachable => isolation breach"
+                    echo "         OR a non-enforcing CNI silently no-oping the policy.)"
+                    dt_fail=1
+                    fail=1
+                  fi
+                done
+                kubectl delete pod "$DT_ALLOWED_POD" "$DT_DENIED_POD" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
+                if [ "$dt_fail" = 0 ]; then
+                  echo "RESULT: PASS - release app pods reach the data tier; non-app pods are blocked."
                 fi
               fi
 

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -601,6 +601,15 @@ security:
     # worker dials the claimed sandbox, so ingress is allowed from the release
     # namespace only. Egress policies do not affect ingress; this adds the lock.
     lockIngress: true
+  # Rail: default-deny ingress + scoped-allow around the data tier (Postgres,
+  # MinIO, ClickHouse, Valkey). The backing stores hold every credential and all
+  # trace/app data; by default any pod in a NetworkPolicy-enforcing cluster can
+  # open Postgres:5432 and exfiltrate. This restricts ingress to each deployed
+  # store's ports to THIS release's app pods only (by name+instance label).
+  # Same fail-closed, default-on posture as the runner rail. Lower priority on a
+  # single-tenant single-node dev cluster; matters for the shared/production path.
+  dataTierNetworkPolicy:
+    enabled: true
   # Rail 4: gVisor (runsc) kernel isolation for runner sandbox pods.
   gvisor:
     # Tri-state, default `auto`:


### PR DESCRIPTION
## What

Adds a default-deny ingress + scoped-allow NetworkPolicy around the data tier (Postgres, MinIO, ClickHouse, Valkey). Previously only runner-sandbox pods had NetworkPolicies, so any co-tenant pod in a NetworkPolicy-enforcing cluster could open Postgres:5432 and exfiltrate every credential and all trace/app data.

- **New `templates/security-datatier-networkpolicy.yaml`** — per deployed store, a `<store>-default-deny-ingress` plus a `<store>-allow-app-ingress` that admits only this release's app pods (matched by `app.kubernetes.io/name`+`instance`, same namespace) on the store's container ports (postgres 5432; minio 9000/9001; clickhouse 8123/9000; valkey 6379). Gated on each store's `deploy` flag, so BYO/external stores are left to the operator.
- **New `security.dataTierNetworkPolicy.enabled` flag (default true)** — mirrors the runner rail's fail-closed, default-on posture.
- **Security probe Claim 5** — an allowed pod (release app labels) and a denied pod (no app labels) empirically prove a pod outside the release app label set cannot reach the store ports. Skips cleanly when the rail is disabled or all stores are BYO.
- **README** — documents the rail.

## Verification

- `helm lint` clean.
- `helm template` renders 8 NetworkPolicy objects (2 per deployed store); toggle-off (`enabled=false`) renders none; BYO (`<store>.deploy=false`) drops that store's policies and its probe target.
- All 8 objects validated server-side (`kubectl apply --dry-run=server`).

## Notes for review

- **Same-namespace label scoping is an inherent NetworkPolicy property** — the allow selector trusts the release's `name`+`instance` labels; a co-tenant that could set those labels is out of NetworkPolicy's threat model (documented in the template).
- **Availability consideration for shared/prod:** default-deny ingress will also block any external metrics scraper hitting the store pods directly. No in-chart scraper does this today; confirm the monitoring path before a shared/production rollout.
- **Claim 5 gives a real signal only on a NetworkPolicy-enforcing CNI.** The existing `preflights.networkPolicyProbe` already guards general CNI enforcement; the local k3s/flannel dev cluster does not enforce NetworkPolicy, so full `helm test` E2E should run on an enforcing CNI.

Closes #69