### PR TITLE
Add liveness probes to long-running workloads

### DIFF
--- a/apps/dispatcher/Dockerfile
+++ b/apps/dispatcher/Dockerfile
@@ -6,7 +6,8 @@
 #   docker build -f apps/dispatcher/Dockerfile -t agentos-dispatcher .
 #
 # Socket Mode means no inbound HTTP: the process dials Slack out, so there is no
-# server port. The chart uses a process-liveness probe, not an HTTP probe.
+# server port. The chart uses a heartbeat-file exec liveness probe (a daemon
+# thread touches a file the probe checks for freshness), not an HTTP probe.
 FROM python:3.13-slim AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app

--- a/apps/dispatcher/src/agentos_dispatcher/config.py
+++ b/apps/dispatcher/src/agentos_dispatcher/config.py
@@ -23,6 +23,8 @@ Env mapping:
     AGENTOS_BACKOFF_INITIAL_SECONDS -> backoff_initial_seconds
     AGENTOS_BACKOFF_MAX_SECONDS     -> backoff_max_seconds
     AGENTOS_BACKOFF_MULTIPLIER      -> backoff_multiplier
+    AGENTOS_HEARTBEAT_FILE             -> heartbeat_file
+    AGENTOS_HEARTBEAT_INTERVAL_SECONDS -> heartbeat_interval_s
 """
 
 from typing import Annotated
@@ -134,6 +136,16 @@ class DispatcherConfig(BaseSettings):
     )
     backoff_multiplier: float = Field(
         default=2.0, gt=1, validation_alias="AGENTOS_BACKOFF_MULTIPLIER"
+    )
+
+    # A daemon thread touches heartbeat_file every heartbeat_interval_s so an exec
+    # liveness probe can restart the pod if the process fully wedges.
+    heartbeat_file: str = Field(
+        default="/tmp/agentos-dispatcher.heartbeat",
+        validation_alias="AGENTOS_HEARTBEAT_FILE",
+    )
+    heartbeat_interval_s: float = Field(
+        default=10.0, validation_alias="AGENTOS_HEARTBEAT_INTERVAL_SECONDS"
     )
 
     def dedupe_key(self, slack_event_id: str) -> str:

--- a/apps/dispatcher/src/agentos_dispatcher/heartbeat.py
+++ b/apps/dispatcher/src/agentos_dispatcher/heartbeat.py
@@ -1,0 +1,43 @@
+"""Process-liveness heartbeat: a daemon thread that touches a file on a cadence.
+
+The dispatcher runs Socket Mode, which dials Slack out and keeps no inbound HTTP
+port, so a kubelet cannot health-check it over the network. Instead a daemon
+thread touches a file every ``interval_s`` seconds and an exec liveness probe
+checks that file's freshness; if the mtime goes stale the pod is restarted.
+
+Scope, honestly stated: this proves only that the Python interpreter is still
+scheduling threads, i.e. the process is not fully wedged (a total deadlock or a
+GIL hang would stop the touches and the probe would fire). It is a process-level
+liveness signal. It does NOT, by itself, detect a Socket Mode connection that is
+silently dead while the process otherwise runs and keeps touching the file. A
+connection-aware health signal would be a separate mechanism.
+"""
+
+import logging
+import threading
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+
+def start_heartbeat(path: str, interval_s: float) -> threading.Event:
+    """Start a daemon thread that touches ``path`` now and every ``interval_s``.
+
+    Returns a ``threading.Event``; set it to stop the thread promptly. The thread
+    is a daemon, so it will not block process exit if the caller forgets to stop
+    it.
+    """
+    stop = threading.Event()
+
+    def _run() -> None:
+        while True:
+            try:
+                Path(path).touch()
+            except OSError as exc:
+                _logger.warning("heartbeat touch failed for %s: %s", path, exc)
+            if stop.wait(timeout=interval_s):
+                break
+
+    thread = threading.Thread(target=_run, name="dispatcher-heartbeat", daemon=True)
+    thread.start()
+    return stop

--- a/apps/dispatcher/src/agentos_dispatcher/run.py
+++ b/apps/dispatcher/src/agentos_dispatcher/run.py
@@ -11,6 +11,7 @@ import signal
 
 from .app import SocketModeConnection, build_app, build_redis, build_web_client
 from .config import DispatcherConfig
+from .heartbeat import start_heartbeat
 from .supervisor import BackoffPolicy, Supervisor
 
 
@@ -37,16 +38,21 @@ def main() -> None:
     config = DispatcherConfig()
 
     supervisor = build_supervisor(config, logger=logger)
+    hb_stop = start_heartbeat(config.heartbeat_file, config.heartbeat_interval_s)
 
     def _handle_signal(signum: int, _frame: object) -> None:
         logger.info("received signal %s, shutting down", signum)
+        hb_stop.set()
         supervisor.request_stop()
 
     signal.signal(signal.SIGINT, _handle_signal)
     signal.signal(signal.SIGTERM, _handle_signal)
 
     logger.info("dispatcher starting")
-    supervisor.run()
+    try:
+        supervisor.run()
+    finally:
+        hb_stop.set()
     logger.info("dispatcher stopped")
 
 

--- a/apps/dispatcher/tests/test_heartbeat.py
+++ b/apps/dispatcher/tests/test_heartbeat.py
@@ -1,0 +1,71 @@
+"""Heartbeat liveness for the dispatcher (issue #71).
+
+The dispatcher runs its Socket Mode loop on a background thread, so its
+heartbeat is a plain daemon thread that touches a file every interval. A probe
+reads the file's mtime; if the thread dies or wedges, the mtime goes stale.
+These tests drive the real thread against a real file (tmp_path) with a tiny
+interval, using the polling helper style of test_supervisor.py.
+"""
+
+import threading
+import time
+
+import pytest
+from agentos_dispatcher.config import DispatcherConfig
+from agentos_dispatcher.heartbeat import start_heartbeat
+
+
+def _wait_for(predicate, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_start_heartbeat_touches_file_then_stops_on_event(tmp_path) -> None:
+    path = tmp_path / "dispatcher.heartbeat"
+
+    stop = start_heartbeat(str(path), 0.02)
+    assert isinstance(stop, threading.Event)
+    try:
+        # Touched immediately (well within a second at a 0.02s interval).
+        assert _wait_for(path.exists, timeout=1.0)
+        assert abs(path.stat().st_mtime - time.time()) < 1.0
+
+        # It keeps touching: the mtime advances across intervals.
+        first = path.stat().st_mtime_ns
+        assert _wait_for(lambda: path.stat().st_mtime_ns > first, timeout=1.0)
+    finally:
+        stop.set()
+
+    # After stop, touching ceases: the mtime freezes.
+    time.sleep(0.1)
+    frozen = path.stat().st_mtime_ns
+    time.sleep(0.1)
+    assert path.stat().st_mtime_ns == frozen
+
+
+def test_dispatcher_config_heartbeat_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AGENTOS_HEARTBEAT_FILE", raising=False)
+    monkeypatch.delenv("AGENTOS_HEARTBEAT_INTERVAL_SECONDS", raising=False)
+
+    cfg = DispatcherConfig()
+
+    assert cfg.heartbeat_file == "/tmp/agentos-dispatcher.heartbeat"
+    assert cfg.heartbeat_interval_s == 10.0
+
+
+def test_dispatcher_config_reads_heartbeat_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTOS_HEARTBEAT_FILE", "/var/run/agentos/dp.hb")
+    monkeypatch.setenv("AGENTOS_HEARTBEAT_INTERVAL_SECONDS", "3.5")
+
+    cfg = DispatcherConfig()
+
+    assert cfg.heartbeat_file == "/var/run/agentos/dp.hb"
+    assert cfg.heartbeat_interval_s == 3.5

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -225,6 +225,16 @@ class WorkerConfig(BaseSettings):
     langfuse_public_key: str = "pk-lf-agentos-dev"
     langfuse_secret_key: str = "sk-lf-agentos-dev"
 
+    # The worker's asyncio loop touches heartbeat_file every heartbeat_interval_s
+    # so an exec liveness probe can restart a pod whose event loop has wedged.
+    heartbeat_file: str = Field(
+        default="/tmp/agentos-worker.heartbeat",
+        validation_alias="AGENTOS_HEARTBEAT_FILE",
+    )
+    heartbeat_interval_s: float = Field(
+        default=10.0, validation_alias="AGENTOS_HEARTBEAT_INTERVAL_SECONDS"
+    )
+
     key_prefix: str = "agentos:worker"
 
     @property

--- a/apps/worker/src/agentos_worker/heartbeat.py
+++ b/apps/worker/src/agentos_worker/heartbeat.py
@@ -1,0 +1,38 @@
+"""Liveness heartbeat: a file the event loop touches so a wedge is observable.
+
+The worker's health is not "the process is alive" but "the asyncio event loop is
+still turning". A pod whose loop is wedged (a blocking call, a deadlock) keeps its
+process up and passes a naive TCP/process probe while doing no work. This task
+runs on the same event loop as the consumers and touches a file each interval; a
+wedged loop cannot run it, so the file's mtime goes stale and a k8s exec liveness
+probe checking that staleness can restart the pod.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+async def run_heartbeat(path: str, interval_s: float, stop: asyncio.Event) -> None:
+    """Touch ``path`` on entry and every ``interval_s`` seconds until ``stop`` is set.
+
+    Mirrors the consumer's sleep-or-stop pattern so shutdown does not wait out a
+    full interval: the wait wakes early when ``stop`` is set.
+
+    A liveness helper must never crash the process it monitors, so a failed
+    ``touch`` (transient /tmp issue, permissions, full disk) is logged and the
+    loop continues; once the condition clears the file updates again.
+    """
+    while not stop.is_set():
+        try:
+            Path(path).touch()
+        except OSError:
+            logger.warning("heartbeat touch failed for %s", path, exc_info=True)
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=interval_s)
+        except TimeoutError:
+            pass

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -26,6 +26,7 @@ from .bundle_store import BundleStore
 from .config import WorkerConfig
 from .consumer import Consumer
 from .eval import EvalReporter, EvalStreamConsumer, LangfuseEvalRecorder
+from .heartbeat import run_heartbeat
 from .kernel import Kernel
 from .killswitch import KillSwitch
 from .markers import Markers
@@ -227,10 +228,15 @@ async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
 
     loop = asyncio.get_running_loop()
 
+    # Liveness heartbeat runs on this same event loop, so a wedged loop stops
+    # touching the file and the k8s exec probe restarts the pod (issue #71).
+    hb_stop = asyncio.Event()
+
     def _stop() -> None:
         rt.consumer.request_stop()
         rt.killswitch.request_stop()
         rt.eval_consumer.request_stop()
+        hb_stop.set()
 
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, _stop)
@@ -238,7 +244,10 @@ async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
     logging.getLogger("agentos_worker").info("worker starting")
     try:
         await asyncio.gather(
-            rt.consumer.run(), rt.killswitch.run(), rt.eval_consumer.run()
+            rt.consumer.run(),
+            rt.killswitch.run(),
+            rt.eval_consumer.run(),
+            run_heartbeat(config.heartbeat_file, config.heartbeat_interval_s, hb_stop),
         )
     finally:
         await rt.runner.close()

--- a/apps/worker/tests/test_heartbeat.py
+++ b/apps/worker/tests/test_heartbeat.py
@@ -1,0 +1,108 @@
+"""Heartbeat liveness for the worker (issue #71).
+
+``run_heartbeat`` touches a file on the worker's own asyncio loop so a liveness
+probe can detect a wedged event loop: if the loop stalls, the mtime stops
+advancing. These tests drive the real coroutine against a real file (tmp_path)
+with a tiny interval, matching the repo's asyncio.run test style
+(apps/worker/tests/kernel/test_consumer.py).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from agentos_worker.config import WorkerConfig
+from agentos_worker.heartbeat import run_heartbeat
+
+
+def test_run_heartbeat_touches_file_and_exits_promptly_on_stop(tmp_path) -> None:
+    path = tmp_path / "worker.heartbeat"
+
+    async def go() -> None:
+        stop = asyncio.Event()
+        task = asyncio.create_task(run_heartbeat(str(path), 0.01, stop))
+        try:
+            # The first touch happens immediately on start.
+            deadline = time.monotonic() + 1.0
+            while not path.exists() and time.monotonic() < deadline:
+                await asyncio.sleep(0.01)
+            assert path.exists()
+            # The mtime is fresh, not a stale file left from a prior run.
+            assert abs(path.stat().st_mtime - time.time()) < 1.0
+
+            # Setting stop makes it exit well within one interval, not a full one.
+            stop.set()
+            await asyncio.wait_for(task, timeout=1.0)
+        finally:
+            stop.set()
+            task.cancel()
+
+    asyncio.run(go())
+
+
+def test_run_heartbeat_touches_repeatedly(tmp_path) -> None:
+    path = tmp_path / "worker.heartbeat"
+
+    async def go() -> None:
+        stop = asyncio.Event()
+        task = asyncio.create_task(run_heartbeat(str(path), 0.02, stop))
+        try:
+            deadline = time.monotonic() + 1.0
+            while not path.exists() and time.monotonic() < deadline:
+                await asyncio.sleep(0.01)
+            assert path.exists()
+
+            first = path.stat().st_mtime_ns
+            # Sleep across several intervals so a subsequent touch must land.
+            await asyncio.sleep(0.1)
+            second = path.stat().st_mtime_ns
+            assert second > first
+        finally:
+            stop.set()
+            await asyncio.wait_for(task, timeout=1.0)
+
+    asyncio.run(go())
+
+
+def test_run_heartbeat_survives_touch_failure_and_exits_on_stop() -> None:
+    # Parent directory does not exist, so touch() raises FileNotFoundError.
+    # The loop must swallow it (never propagate) and still exit on stop.
+    path = "/nonexistent-dir-xyz/hb"
+
+    async def go() -> None:
+        stop = asyncio.Event()
+        task = asyncio.create_task(run_heartbeat(path, 0.01, stop))
+        try:
+            # Let the loop turn a few times through the failing touch.
+            await asyncio.sleep(0.05)
+            assert not task.done()  # the guard swallowed the error, loop alive
+            stop.set()
+            # Exits promptly despite every touch failing.
+            await asyncio.wait_for(task, timeout=1.0)
+        finally:
+            stop.set()
+            task.cancel()
+
+    asyncio.run(go())
+
+
+def test_worker_config_heartbeat_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENTOS_HEARTBEAT_FILE", raising=False)
+    monkeypatch.delenv("AGENTOS_HEARTBEAT_INTERVAL_SECONDS", raising=False)
+
+    cfg = WorkerConfig()
+
+    assert cfg.heartbeat_file == "/tmp/agentos-worker.heartbeat"
+    assert cfg.heartbeat_interval_s == 10.0
+
+
+def test_worker_config_reads_heartbeat_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOS_HEARTBEAT_FILE", "/var/run/agentos/wk.hb")
+    monkeypatch.setenv("AGENTOS_HEARTBEAT_INTERVAL_SECONDS", "2.5")
+
+    cfg = WorkerConfig()
+
+    assert cfg.heartbeat_file == "/var/run/agentos/wk.hb"
+    assert cfg.heartbeat_interval_s == 2.5

--- a/charts/agentos/templates/_helpers.tpl
+++ b/charts/agentos/templates/_helpers.tpl
@@ -129,6 +129,41 @@ app.kubernetes.io/component: {{ .component }}
       key: valkeyPassword
 {{- end -}}
 
+{{/* Heartbeat exec probes for the worker and dispatcher. Neither has an HTTP
+     port, so an exec probe checks AGENTOS_HEARTBEAT_FILE freshness (< 30s)
+     instead of hitting a port. Each Deployment sets its own heartbeat path via
+     that env var, so the probe body is path-agnostic and both callers share
+     identical timings -- the helper therefore takes no params. Include with
+     `nindent 10` so the probe keys land at the container's 10-space column. */}}
+{{- define "agentos.heartbeatProbes" -}}
+readinessProbe:
+  exec:
+    command:
+      - python
+      - -c
+      - |
+        import os, sys, time
+        p = os.environ["AGENTOS_HEARTBEAT_FILE"]
+        sys.exit(0 if os.path.exists(p) and time.time() - os.path.getmtime(p) < 30 else 1)
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+livenessProbe:
+  exec:
+    command:
+      - python
+      - -c
+      - |
+        import os, sys, time
+        p = os.environ["AGENTOS_HEARTBEAT_FILE"]
+        sys.exit(0 if os.path.exists(p) and time.time() - os.path.getmtime(p) < 30 else 1)
+  initialDelaySeconds: 30
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 4
+{{- end }}
+
 {{/* ---- Langfuse shared environment (mirrors compose.dev.yaml's
         x-langfuse-env anchor). Rendered into both web and worker. ---- */}}
 {{- define "agentos.langfuse.env" -}}

--- a/charts/agentos/templates/clickhouse.yaml
+++ b/charts/agentos/templates/clickhouse.yaml
@@ -68,6 +68,14 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.clickhouse.resources | nindent 12 }}
           volumeMounts:

--- a/charts/agentos/templates/dispatcher.yaml
+++ b/charts/agentos/templates/dispatcher.yaml
@@ -50,6 +50,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentos.secretName" . }}
                   key: slackSigningSecret
+            # Heartbeat file a background daemon thread in the dispatcher touches
+            # each tick; the exec probes below read this same path so template and
+            # app cannot drift.
+            - name: AGENTOS_HEARTBEAT_FILE
+              value: /tmp/agentos-dispatcher.heartbeat
+          # No HTTP port on the dispatcher (Slack Socket Mode is outbound-only),
+          # so an exec probe checks a heartbeat file a background daemon thread
+          # touches each tick. The dispatcher blocks the main thread in
+          # supervisor.run(), so a wedged/hung process stops touching the file ->
+          # it goes stale -> the probe fails -> restart.
+          {{- include "agentos.heartbeatProbes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.dispatcher.resources | nindent 12 }}
 {{- end }}

--- a/charts/agentos/templates/inference.yaml
+++ b/charts/agentos/templates/inference.yaml
@@ -92,6 +92,13 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 12
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.inference.port }}
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.inference.resources | nindent 12 }}
           volumeMounts:

--- a/charts/agentos/templates/minio.yaml
+++ b/charts/agentos/templates/minio.yaml
@@ -67,6 +67,14 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.minio.resources | nindent 12 }}
           volumeMounts:

--- a/charts/agentos/templates/otel-collector.yaml
+++ b/charts/agentos/templates/otel-collector.yaml
@@ -27,7 +27,11 @@ data:
           Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
       debug:
         verbosity: normal
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
     service:
+      extensions: [health_check]
       telemetry:
         metrics:
           level: none
@@ -93,6 +97,24 @@ spec:
               containerPort: 4317
             - name: otlp-http
               containerPort: 4318
+            - name: health
+              containerPort: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.otelCollector.resources | nindent 12 }}
           volumeMounts:

--- a/charts/agentos/templates/ui.yaml
+++ b/charts/agentos/templates/ui.yaml
@@ -62,6 +62,14 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
 {{- end }}

--- a/charts/agentos/templates/valkey.yaml
+++ b/charts/agentos/templates/valkey.yaml
@@ -63,6 +63,13 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 5
             failureThreshold: 10
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "valkey-cli -a \"$VALKEY_PASSWORD\" ping | grep -q PONG"]
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.valkey.resources | nindent 12 }}
           volumeMounts:

--- a/charts/agentos/templates/worker.yaml
+++ b/charts/agentos/templates/worker.yaml
@@ -94,6 +94,11 @@ spec:
               value: {{ $warmPool | quote }}
             - name: AGENTOS_RUNNER_PORT
               value: {{ .Values.agentSandbox.runner.port | quote }}
+            # Heartbeat file the worker's asyncio loop touches each tick; the
+            # exec probes below read this same path so template and app cannot
+            # drift.
+            - name: AGENTOS_HEARTBEAT_FILE
+              value: /tmp/agentos-worker.heartbeat
             # How long claim() waits for a cold sandbox to become ready before it
             # gives up. Must stay below the worker's per-thread lock TTL (120s).
             - name: AGENTOS_CLAIM_TIMEOUT_SECONDS
@@ -122,6 +127,10 @@ spec:
             {{- with .Values.worker.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          # No HTTP port on the worker, so an exec probe checks a heartbeat file
+          # the asyncio event loop touches each tick. A wedged loop stops
+          # touching it -> the file goes stale -> the probe fails -> restart.
+          {{- include "agentos.heartbeatProbes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
 {{- end }}


### PR DESCRIPTION
Closes #71

Every long-running Deployment/StatefulSet now has both a readiness and a liveness probe.

## Worker & dispatcher (no HTTP port)
Both touch a heartbeat file that an `exec` probe checks for freshness (`AGENTOS_HEARTBEAT_FILE`, stale threshold 30s vs a 10s touch interval):
- **Worker**: a coroutine on the asyncio event loop touches the file. A wedged loop (the exact failure mode in the issue) can't schedule the touch, so the file goes stale and the pod restarts. The touch is guarded (`except OSError`, logged) so a transient filesystem error can never propagate through `asyncio.gather` and crash the worker.
- **Dispatcher**: a daemon thread touches the file. This is a process-level liveness signal (detects a fully-wedged/hung process); Socket Mode blocks the main thread, so it does not, by itself, detect a silently-dead connection. Documented honestly in the module.

The shared readiness+liveness block lives in an `agentos.heartbeatProbes` chart helper (mirrors the existing `agentos.env.*` helpers).

## Other workloads
- **otel-collector**: adds the `health_check` extension (:13133) + HTTP readiness/liveness.
- **clickhouse / valkey / minio / ui / inference**: had readiness only; each gains a matching liveness probe (`/ping`, `valkey-cli ping`, `/minio/health/live`, `/`, tcpSocket).

`inference` (a first-party ollama server, `deploy: false` by default) was included via the "every persistent-process workload" success criterion; out of scope by design: `runner-prewarm` (a `sleep infinity` image-pin DaemonSet), `agent-sandbox-controller` (vendored), and `langfuse-worker` (third-party).

## Validation
- New unit tests for both heartbeat modules (touch/stop behavior, crash-guard, config env parsing).
- `helm lint` + `helm template` render clean; a per-workload audit confirms readiness+liveness on every in-scope workload.
- Consolidation refactor verified byte-identical rendered output.