### PR TITLE
Extract a shared Valkey stream-consumer helper

### DIFF
--- a/apps/worker/src/agentos_worker/consumer.py
+++ b/apps/worker/src/agentos_worker/consumer.py
@@ -21,18 +21,10 @@ from typing import cast
 
 from agentos_dispatcher.queue import QueuedSlackEvent
 from redis.asyncio import Redis
-from redis.exceptions import (
-    ConnectionError as RedisConnectionError,
-)
-from redis.exceptions import (
-    ResponseError,
-)
-from redis.exceptions import (
-    TimeoutError as RedisTimeoutError,
-)
 
 from .config import WorkerConfig
 from .kernel import Kernel
+from .stream_consumer import ReadLoopSpec, StreamConsumer, StreamEntry
 
 logger = logging.getLogger(__name__)
 
@@ -40,11 +32,8 @@ logger = logging.getLogger(__name__)
 # error, so a briefly-unreachable Valkey does not spin the read loop hot.
 _READ_ERROR_BACKOFF_S = 0.5
 
-# One stream entry as redis returns it with decode_responses=True.
-StreamEntry = tuple[str, dict[str, str]]
 
-
-class Consumer:
+class Consumer(StreamConsumer):
     """Runs the read loop and the periodic reclaim/reap maintenance loop."""
 
     def __init__(
@@ -55,10 +44,9 @@ class Consumer:
         config: WorkerConfig,
         max_concurrency: int = 16,
     ) -> None:
-        self._redis = redis
+        super().__init__(redis)
         self._kernel = kernel
         self._config = config
-        self._stop = asyncio.Event()
         self._sem = asyncio.Semaphore(max_concurrency)
         self._inflight: set[asyncio.Task[None]] = set()
         # Entry ids currently being handled by THIS consumer. XAUTOCLAIM would
@@ -79,16 +67,9 @@ class Consumer:
         off the pending list, not the group's start id). An existing group is
         left untouched.
         """
-        try:
-            await self._redis.xgroup_create(
-                self._config.stream, self._config.consumer_group, id="$", mkstream=True
-            )
-        except ResponseError as exc:
-            if "BUSYGROUP" not in str(exc):
-                raise
-
-    def request_stop(self) -> None:
-        self._stop.set()
+        await self._ensure_group(
+            self._config.stream, self._config.consumer_group, start_id="$"
+        )
 
     async def run(self) -> None:
         await self.ensure_group()
@@ -99,36 +80,20 @@ class Consumer:
     # -- read loop ------------------------------------------------------------
 
     async def _read_loop(self) -> None:
-        while not self._stop.is_set():
-            try:
-                resp = await self._redis.xreadgroup(
-                    self._config.consumer_group,
-                    self._config.consumer_name,
-                    {self._config.stream: ">"},
-                    count=self._config.read_count,
-                    block=self._config.read_block_ms,
-                )
-            except RedisTimeoutError as exc:
-                # A blocking-read timeout is the routine idle case (no entries
-                # arrived within read_block_ms plus the socket timeout margin), not
-                # a fault -- log at DEBUG so an idle worker doesn't flood WARNING.
-                # Still back off + retry rather than letting it kill the read loop.
-                logger.debug("stream read timed out (idle); retrying: %s", exc)
-                await self._sleep_or_stop(_READ_ERROR_BACKOFF_S)
-                continue
-            except RedisConnectionError as exc:
-                # A real connection fault (a Valkey failover, pod-to-pod blip):
-                # transient but worth a WARNING. Back off and retry; redis-py
-                # reconnects on the next attempt.
-                logger.warning("stream read failed transiently; retrying: %s", exc)
-                await self._sleep_or_stop(_READ_ERROR_BACKOFF_S)
-                continue
-            if not resp:
-                continue
-            streams = cast("list[tuple[str, list[StreamEntry]]]", resp)
-            for _stream, entries in streams:
-                for entry_id, fields in entries:
-                    await self._dispatch(entry_id, fields)
+        await self._consume(
+            ReadLoopSpec(
+                stream=self._config.stream,
+                group=self._config.consumer_group,
+                consumer=self._config.consumer_name,
+                count=self._config.read_count,
+                block_ms=self._config.read_block_ms,
+                backoff_s=_READ_ERROR_BACKOFF_S,
+                timeout_msg="stream read timed out (idle); retrying: %s",
+                connection_msg="stream read failed transiently; retrying: %s",
+                logger=logger,
+            ),
+            self._dispatch,
+        )
 
     async def _dispatch(self, entry_id: str, fields: dict[str, str]) -> None:
         if entry_id in self._inflight_ids:
@@ -163,7 +128,7 @@ class Consumer:
             self._sem.release()
 
     async def _ack(self, entry_id: str) -> None:
-        await self._redis.xack(self._config.stream, self._config.consumer_group, entry_id)
+        await self._xack(self._config.stream, self._config.consumer_group, entry_id)
 
     # -- maintenance loop -----------------------------------------------------
 
@@ -199,9 +164,3 @@ class Consumer:
             if cursor in ("0-0", "0"):
                 break
         return reclaimed
-
-    async def _sleep_or_stop(self, seconds: float) -> None:
-        try:
-            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
-        except TimeoutError:
-            pass

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -39,15 +39,6 @@ import httpx
 from aci_protocol import Budget
 from pydantic import BaseModel
 from redis.asyncio import Redis
-from redis.exceptions import (
-    ConnectionError as RedisConnectionError,
-)
-from redis.exceptions import (
-    ResponseError,
-)
-from redis.exceptions import (
-    TimeoutError as RedisTimeoutError,
-)
 
 from ..binding import (
     BUDGET_ENV,
@@ -60,6 +51,7 @@ from ..bundle_store import BundleStore
 from ..config import WorkerConfig
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
+from ..stream_consumer import ReadLoopSpec, StreamConsumer, StreamEntry
 from .models import EvalRunResult, EvalSuite
 from .recorder import LangfuseEvalRecorder
 from .run import run_eval_suite
@@ -70,7 +62,6 @@ logger = logging.getLogger(__name__)
 _EVAL_READ_ERROR_BACKOFF_S = 0.5
 
 STREAM_PAYLOAD_FIELD = "payload"
-StreamEntry = tuple[str, dict[str, str]]
 
 
 class EvalWorkItem(BaseModel):
@@ -178,7 +169,7 @@ def _safe_extract(data: bytes, dest: Path) -> None:
     raise ValueError("bundle is not a recognized zip or tar archive")
 
 
-class EvalStreamConsumer:
+class EvalStreamConsumer(StreamConsumer):
     """Reads agentos:evals, runs each suite, records, reports, then acks."""
 
     def __init__(
@@ -192,14 +183,13 @@ class EvalStreamConsumer:
         recorder: LangfuseEvalRecorder,
         repo_lookup: Any,
     ) -> None:
-        self._redis = redis
+        super().__init__(redis)
         self._config = config
         self._bundles = bundle_store
         self._substrate = substrate
         self._reporter = reporter
         self._recorder = recorder
         self._repo_lookup = repo_lookup
-        self._stop = asyncio.Event()
         # Entry ids this consumer is handling right now. XAUTOCLAIM would
         # otherwise reclaim our own still-pending (long-running) eval and
         # re-run it in parallel; skipping these ids prevents that self-reclaim.
@@ -212,60 +202,35 @@ class EvalStreamConsumer:
         # dropping items produced while the worker was down would silently skip
         # required checks, violating the "an eval is never lost" guarantee this
         # consumer is built around. So a fresh group SHOULD pick up the backlog.
-        try:
-            await self._redis.xgroup_create(
-                self._config.eval_stream,
-                self._config.eval_consumer_group,
-                id="0",
-                mkstream=True,
-            )
-        except ResponseError as exc:
-            if "BUSYGROUP" not in str(exc):
-                raise
-
-    def request_stop(self) -> None:
-        self._stop.set()
+        await self._ensure_group(
+            self._config.eval_stream, self._config.eval_consumer_group, start_id="0"
+        )
 
     async def run(self) -> None:
         await self.ensure_group()
         await asyncio.gather(self._read_loop(), self._reclaim_loop())
 
     async def _read_loop(self) -> None:
-        while not self._stop.is_set():
-            # count=1 is load-bearing, not a tunable: this consumer handles an
-            # entry inline (evals are heavy and run sequentially), and only the
-            # entry inside _handle is tracked as in-flight. Claiming a batch would
-            # leave the un-handled tail claimed-but-untracked, where the reclaim
-            # loop could re-run one before the read loop reaches it (a duplicate
-            # report). Peer replicas in the group provide the parallelism instead.
-            try:
-                resp = await self._redis.xreadgroup(
-                    self._config.eval_consumer_group,
-                    self._config.eval_consumer_name,
-                    {self._config.eval_stream: ">"},
-                    count=1,
-                    block=self._config.read_block_ms,
-                )
-            except RedisTimeoutError as exc:
-                # Same transient-transport guard as the runs consumer: a blocking
-                # read timeout is the routine idle case, not a fault -- log at
-                # DEBUG so an idle eval worker doesn't flood WARNING. Still back
-                # off + retry rather than letting it kill the eval loop.
-                logger.debug("eval stream read timed out (idle); retrying: %s", exc)
-                await self._sleep_or_stop(_EVAL_READ_ERROR_BACKOFF_S)
-                continue
-            except RedisConnectionError as exc:
-                # A real connection blip (Valkey failover): transient but worth a
-                # WARNING. Back off and retry.
-                logger.warning("eval stream read failed transiently; retrying: %s", exc)
-                await self._sleep_or_stop(_EVAL_READ_ERROR_BACKOFF_S)
-                continue
-            if not resp:
-                continue
-            streams = cast("list[tuple[str, list[StreamEntry]]]", resp)
-            for _stream, entries in streams:
-                for entry_id, fields in entries:
-                    await self._handle(entry_id, fields)
+        # count=1 is load-bearing, not a tunable: this consumer handles an entry
+        # inline (evals are heavy and run sequentially), and only the entry inside
+        # _handle is tracked as in-flight. Claiming a batch would leave the
+        # un-handled tail claimed-but-untracked, where the reclaim loop could
+        # re-run one before the read loop reaches it (a duplicate report). Peer
+        # replicas in the group provide the parallelism instead.
+        await self._consume(
+            ReadLoopSpec(
+                stream=self._config.eval_stream,
+                group=self._config.eval_consumer_group,
+                consumer=self._config.eval_consumer_name,
+                count=1,
+                block_ms=self._config.read_block_ms,
+                backoff_s=_EVAL_READ_ERROR_BACKOFF_S,
+                timeout_msg="eval stream read timed out (idle); retrying: %s",
+                connection_msg="eval stream read failed transiently; retrying: %s",
+                logger=logger,
+            ),
+            self._handle,
+        )
 
     async def _reclaim_loop(self) -> None:
         """Periodically reclaim entries a dead consumer left pending and re-run
@@ -323,12 +288,6 @@ class EvalStreamConsumer:
             await self._ack(entry_id)
         finally:
             self._inflight_ids.discard(entry_id)
-
-    async def _sleep_or_stop(self, seconds: float) -> None:
-        try:
-            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
-        except TimeoutError:
-            pass
 
     async def _run_and_report(self, item: EvalWorkItem) -> EvalRunResult:
         repo = await self._repo_lookup.repo_full_name(item.agent_id)
@@ -410,6 +369,6 @@ class EvalStreamConsumer:
         )
 
     async def _ack(self, entry_id: str) -> None:
-        await self._redis.xack(
+        await self._xack(
             self._config.eval_stream, self._config.eval_consumer_group, entry_id
         )

--- a/apps/worker/src/agentos_worker/stream_consumer.py
+++ b/apps/worker/src/agentos_worker/stream_consumer.py
@@ -1,0 +1,130 @@
+"""Shared Valkey consumer-group read-loop mechanics.
+
+The runs consumer (``consumer.py``) and the eval consumer (``eval/stream.py``)
+both drive the same Valkey ``XREADGROUP`` loop: ensure the group exists, do a
+blocking group read, skip an empty/timeout response, survive a transient
+transport fault (a blocking-read ``TimeoutError`` is the routine idle case ->
+DEBUG; a ``ConnectionError`` is a real fault -> WARNING), back off and retry, and
+ack a handled entry. That shared plumbing lives here once; each consumer keeps
+its own stream/group/consumer names, backoff constant, log-message prefixes, and
+per-message business logic and passes them in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import cast
+
+from redis.asyncio import Redis
+from redis.exceptions import (
+    ConnectionError as RedisConnectionError,
+)
+from redis.exceptions import (
+    ResponseError,
+)
+from redis.exceptions import (
+    TimeoutError as RedisTimeoutError,
+)
+
+# One stream entry as redis returns it with decode_responses=True.
+StreamEntry = tuple[str, dict[str, str]]
+
+# An async per-message handler: (entry_id, fields) -> None.
+EntryHandler = Callable[[str, dict[str, str]], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ReadLoopSpec:
+    """The per-consumer knobs the shared read loop needs. Everything here is
+    deliberately passed in (not hard-coded) so each consumer's stream, group,
+    backoff, and log output stay exactly what they were before the extraction."""
+
+    stream: str
+    group: str
+    consumer: str
+    count: int
+    block_ms: int
+    backoff_s: float
+    # Log messages kept per-consumer so log output is byte-identical; each takes
+    # a single ``%s`` for the exception. The logger is the owning module's logger
+    # so records carry that module's name (tests assert on it).
+    timeout_msg: str
+    connection_msg: str
+    logger: logging.Logger
+
+
+class StreamConsumer:
+    """Base for a Valkey consumer-group reader.
+
+    Owns the transport-level plumbing (group create, blocking read loop with the
+    Timeout->DEBUG / Connection->WARNING split and backoff, ack, stop-aware
+    sleep). Subclasses supply their stream config via a :class:`ReadLoopSpec`,
+    their per-message handler, and their own maintenance/reclaim loops and
+    business logic.
+    """
+
+    def __init__(self, redis: Redis) -> None:
+        self._redis = redis
+        self._stop = asyncio.Event()
+
+    def request_stop(self) -> None:
+        self._stop.set()
+
+    async def _ensure_group(self, stream: str, group: str, *, start_id: str) -> None:
+        """Create the consumer group (and the stream) if it does not exist.
+
+        ``start_id`` is the group's read start position and is per-consumer (see
+        each subclass's ``ensure_group`` for why it picks ``$`` vs ``0``). An
+        existing group is left untouched.
+        """
+        try:
+            await self._redis.xgroup_create(stream, group, id=start_id, mkstream=True)
+        except ResponseError as exc:
+            if "BUSYGROUP" not in str(exc):
+                raise
+
+    async def _consume(self, spec: ReadLoopSpec, handler: EntryHandler) -> None:
+        """Blocking-read loop: read the group, dispatch each entry to ``handler``,
+        and survive transient transport faults until stop is requested."""
+        while not self._stop.is_set():
+            try:
+                resp = await self._redis.xreadgroup(
+                    spec.group,
+                    spec.consumer,
+                    {spec.stream: ">"},
+                    count=spec.count,
+                    block=spec.block_ms,
+                )
+            except RedisTimeoutError as exc:
+                # A blocking-read timeout is the routine idle case (no entries
+                # arrived within block_ms plus the socket timeout margin), not a
+                # fault -- log at DEBUG so an idle worker doesn't flood WARNING.
+                # Still back off + retry rather than letting it kill the loop.
+                spec.logger.debug(spec.timeout_msg, exc)
+                await self._sleep_or_stop(spec.backoff_s)
+                continue
+            except RedisConnectionError as exc:
+                # A real connection fault (a Valkey failover, pod-to-pod blip):
+                # transient but worth a WARNING. Back off and retry; redis-py
+                # reconnects on the next attempt.
+                spec.logger.warning(spec.connection_msg, exc)
+                await self._sleep_or_stop(spec.backoff_s)
+                continue
+            if not resp:
+                continue
+            streams = cast("list[tuple[str, list[StreamEntry]]]", resp)
+            for _stream, entries in streams:
+                for entry_id, fields in entries:
+                    await handler(entry_id, fields)
+
+    async def _sleep_or_stop(self, seconds: float) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
+        except TimeoutError:
+            pass
+
+    async def _xack(self, stream: str, group: str, entry_id: str) -> None:
+        await self._redis.xack(stream, group, entry_id)


### PR DESCRIPTION
Closes #9. **Stacked on #171** (the #17 observability branch) because both touch `consumer.py`/`eval/stream.py`'s read loop — basing here lets the extracted helper capture #17's already-fixed log-level split in one place instead of conflicting. Retarget to `main` once #171 merges. (Review the refactor-only diff against `arao/17-obs-polish`.)

## What
The runs consumer (`consumer.py`) and the eval consumer (`eval/stream.py`) duplicated the Valkey `XREADGROUP` / consumer-group read loop. Extracted a shared `StreamConsumer` base class + a frozen `ReadLoopSpec` (stream/group/consumer names, count, block_ms, backoff, the two log strings, and the owning module's logger). Both consumers now subclass it.

## Behavior-preserving
The base owns only transport plumbing that was already identical between the two: group-ensure (BUSYGROUP swallow), the blocking read + empty-read `continue`, the `TimeoutError`→DEBUG / `ConnectionError`→WARNING split with backoff+retry, and ack. Everything race-sensitive stays on each subclass:
- Runs: `_dispatch` (semaphore backpressure → `create_task` fire-and-forget), `_handle` (ack-after-success, poison-ack on parse fail, no-ack-on-raise), `_maintenance_loop`/`_reclaim_once`.
- Eval: `count=1` and `start_id="0"` preserved; handler still awaited inline (sequential).

Each consumer logs through its **own** module logger, so log output (incl. logger name) is byte-identical — the #17 log-level tests pass unchanged.

## Sacred-module review
`apps/worker/CLAUDE.md` lists `consumer.py` as sacred. This sanctioned refactor got the required adversarial pass (spec-vs-impl + side-effects-detective): dispatch concurrency, ack timing, reclaim path, shutdown, and exception surface were each confirmed **identical** old-vs-new. No kernel/threadlock/markers change.

## Tests
Behavior-preserving refactor — the existing runs + eval consumer suites (incl. #17's Timeout→DEBUG / Connection→WARNING assertions on both) pass unchanged. `ruff` + `mypy` clean. (5 pre-existing integration failures need MinIO/Langfuse; unrelated, verified on base.)