### PR TITLE
Convert dispatcher + worker config to pydantic-settings

### DIFF
--- a/apps/dispatcher/CLAUDE.md
+++ b/apps/dispatcher/CLAUDE.md
@@ -35,7 +35,7 @@ summary.
 
 ## Config surface
 
-`DispatcherConfig.from_env(os.environ)` parses `SLACK_APP_TOKEN`,
+`DispatcherConfig()` (a `pydantic_settings.BaseSettings`) reads `SLACK_APP_TOKEN`,
 `SLACK_BOT_TOKEN`, `VALKEY_*`, `AGENTOS_STREAM` (must match the worker's
 stream name), `AGENTOS_DEDUPE_PREFIX`/`_TTL_SECONDS`, `AGENTOS_PLACEHOLDER_TEXT`,
 and the backoff tunables. Full table in `apps/dispatcher/README.md`.

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -57,7 +57,7 @@ connection and exits the loop without reconnecting. The Socket Mode adapter
 
 ## Config surface (env vars)
 
-Parsed by `DispatcherConfig.from_env(os.environ)`.
+Read from the environment by `DispatcherConfig()` (a `pydantic_settings.BaseSettings`).
 
 | env var | default | meaning |
 |---|---|---|

--- a/apps/dispatcher/pyproject.toml
+++ b/apps/dispatcher/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "slack-bolt>=1.21",
     "redis>=5.2",
     "pydantic>=2.10",
+    "pydantic-settings>=2.7",
 ]
 
 [build-system]

--- a/apps/dispatcher/src/agentos_dispatcher/config.py
+++ b/apps/dispatcher/src/agentos_dispatcher/config.py
@@ -1,9 +1,10 @@
-"""Typed configuration for the dispatcher, parsed from the process environment.
+"""Typed configuration for the dispatcher, read from the process environment.
 
 The dispatcher needs two Slack tokens (an app-level token for Socket Mode and a
 bot token for Web API calls), a Valkey connection, and the stream/dedupe/backoff
-knobs. ``DispatcherConfig.from_env`` is the single sanctioned parser; it mirrors
-the env-var handling style of ``aci_protocol.session.SessionConfig``.
+knobs. ``DispatcherConfig`` is a ``pydantic_settings.BaseSettings`` (the house
+pattern, see ``apps/api``): construct it with no arguments and it reads the
+environment on init, falling back to the defaults below for anything absent.
 
 Env mapping:
     SLACK_APP_TOKEN            -> slack_app_token   (xapp-..., Socket Mode)
@@ -24,16 +25,79 @@ Env mapping:
     AGENTOS_BACKOFF_MULTIPLIER      -> backoff_multiplier
 """
 
-from collections.abc import Mapping
-from typing import Any
+from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BeforeValidator, Field
+from pydantic.fields import FieldInfo
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings.sources import (
+    EnvSettingsSource,
+    PydanticBaseSettingsSource,
+)
 
 
-class DispatcherConfig(BaseModel):
+class _AliasOnlyEnvSource(EnvSettingsSource):
+    """Env source that reads an aliased field ONLY from its ``validation_alias``.
+
+    ``populate_by_name=True`` is set so tests can construct the config with
+    field-name kwargs. But in pydantic-settings that same flag makes the default
+    env source append the bare uppercased field name as a fallback env key for
+    every aliased field -- so ``stream`` (alias ``AGENTOS_STREAM``) would also
+    silently read a stray ``STREAM``. That breaks the behavior-preserving
+    contract of the refactor. We drop the field-name fallback for aliased
+    fields; non-aliased fields keep reading their plain uppercased name, and
+    kwarg population is untouched (it runs through the init source, not here).
+    """
+
+    def _extract_field_info(
+        self, field: FieldInfo, field_name: str
+    ) -> list[tuple[str, str, bool]]:
+        infos = super()._extract_field_info(field, field_name)
+        if field.validation_alias is not None:
+            infos = [info for info in infos if info[0] != field_name]
+        return infos
+
+
+def _parse_bool(value: object) -> bool:
+    """Parse the truthy env-string set the dispatcher has always accepted.
+
+    A real bool passes through (so kwarg construction in tests is unchanged); any
+    other string is truthy only when it is one of the accepted tokens, matching
+    the previous hand-rolled ``_set_bool``.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
+Bool = Annotated[bool, BeforeValidator(_parse_bool)]
+
+
+class DispatcherConfig(BaseSettings):
     """Everything the dispatcher needs to run, in one typed object."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = SettingsConfigDict(
+        frozen=True, populate_by_name=True, extra="ignore"
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Swap the env source so aliased fields read only their alias."""
+        return (
+            init_settings,
+            _AliasOnlyEnvSource(settings_cls),
+            dotenv_settings,
+            file_secret_settings,
+        )
 
     slack_app_token: str = ""
     slack_bot_token: str = ""
@@ -44,71 +108,34 @@ class DispatcherConfig(BaseModel):
     valkey_password: str = ""
     valkey_db: int = 0
 
-    stream: str = "agentos:runs"
-    dedupe_prefix: str = "agentos:dedupe:"
-    dedupe_ttl_seconds: int = 3600
+    stream: str = Field(default="agentos:runs", validation_alias="AGENTOS_STREAM")
+    dedupe_prefix: str = Field(
+        default="agentos:dedupe:", validation_alias="AGENTOS_DEDUPE_PREFIX"
+    )
+    dedupe_ttl_seconds: int = Field(
+        default=3600, validation_alias="AGENTOS_DEDUPE_TTL_SECONDS"
+    )
 
-    placeholder_text: str = "On it. Working on your request."
+    placeholder_text: str = Field(
+        default="On it. Working on your request.",
+        validation_alias="AGENTOS_PLACEHOLDER_TEXT",
+    )
     # When true, also set a Slack assistant-thread status (the native "shimmer"
     # on the app name) to placeholder_text while a turn runs. The worker clears it
     # when the turn ends. Off by default; requires the app's assistant feature +
     # assistant:write scope (see slack-app-manifest.yaml).
-    shimmer: bool = False
+    shimmer: Bool = Field(default=False, validation_alias="AGENTOS_SHIMMER")
 
-    backoff_initial_seconds: float = Field(default=1.0, gt=0)
-    backoff_max_seconds: float = Field(default=30.0, gt=0)
-    backoff_multiplier: float = Field(default=2.0, gt=1)
+    backoff_initial_seconds: float = Field(
+        default=1.0, gt=0, validation_alias="AGENTOS_BACKOFF_INITIAL_SECONDS"
+    )
+    backoff_max_seconds: float = Field(
+        default=30.0, gt=0, validation_alias="AGENTOS_BACKOFF_MAX_SECONDS"
+    )
+    backoff_multiplier: float = Field(
+        default=2.0, gt=1, validation_alias="AGENTOS_BACKOFF_MULTIPLIER"
+    )
 
     def dedupe_key(self, slack_event_id: str) -> str:
         """The Valkey key that guards a single Slack event id against retries."""
         return f"{self.dedupe_prefix}{slack_event_id}"
-
-    @classmethod
-    def from_env(cls, env: Mapping[str, str]) -> "DispatcherConfig":
-        """Build a config from a process-environment mapping, using defaults for
-        anything absent."""
-        values: dict[str, Any] = {}
-        _set_str(values, "slack_app_token", env, "SLACK_APP_TOKEN")
-        _set_str(values, "slack_bot_token", env, "SLACK_BOT_TOKEN")
-        _set_str(values, "slack_signing_secret", env, "SLACK_SIGNING_SECRET")
-        _set_str(values, "valkey_host", env, "VALKEY_HOST")
-        _set_int(values, "valkey_port", env, "VALKEY_PORT")
-        _set_str(values, "valkey_password", env, "VALKEY_PASSWORD")
-        _set_int(values, "valkey_db", env, "VALKEY_DB")
-        _set_str(values, "stream", env, "AGENTOS_STREAM")
-        _set_str(values, "dedupe_prefix", env, "AGENTOS_DEDUPE_PREFIX")
-        _set_int(values, "dedupe_ttl_seconds", env, "AGENTOS_DEDUPE_TTL_SECONDS")
-        _set_str(values, "placeholder_text", env, "AGENTOS_PLACEHOLDER_TEXT")
-        _set_bool(values, "shimmer", env, "AGENTOS_SHIMMER")
-        _set_float(values, "backoff_initial_seconds", env, "AGENTOS_BACKOFF_INITIAL_SECONDS")
-        _set_float(values, "backoff_max_seconds", env, "AGENTOS_BACKOFF_MAX_SECONDS")
-        _set_float(values, "backoff_multiplier", env, "AGENTOS_BACKOFF_MULTIPLIER")
-        return cls(**values)
-
-
-def _set_str(
-    values: dict[str, Any], key: str, env: Mapping[str, str], var: str
-) -> None:
-    if var in env:
-        values[key] = env[var]
-
-
-def _set_int(
-    values: dict[str, Any], key: str, env: Mapping[str, str], var: str
-) -> None:
-    if var in env:
-        values[key] = int(env[var])
-
-
-def _set_float(
-    values: dict[str, Any], key: str, env: Mapping[str, str], var: str
-) -> None:
-    if var in env:
-        values[key] = float(env[var])
-
-
-def _set_bool(
-    values: dict[str, Any], key: str, env: Mapping[str, str], var: str
-) -> None:
-    if var in env:
-        values[key] = env[var].strip().lower() in ("1", "true", "yes", "on")

--- a/apps/dispatcher/src/agentos_dispatcher/run.py
+++ b/apps/dispatcher/src/agentos_dispatcher/run.py
@@ -7,9 +7,7 @@ and hands a Socket Mode connection factory to the supervisor. Run it with
 """
 
 import logging
-import os
 import signal
-from collections.abc import Mapping
 
 from .app import SocketModeConnection, build_app, build_redis, build_web_client
 from .config import DispatcherConfig
@@ -33,10 +31,10 @@ def build_supervisor(config: DispatcherConfig, *, logger: logging.Logger) -> Sup
     return Supervisor(connect, backoff=backoff, logger=logger)
 
 
-def main(env: Mapping[str, str] | None = None) -> None:
+def main() -> None:
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger("agentos_dispatcher")
-    config = DispatcherConfig.from_env(env if env is not None else os.environ)
+    config = DispatcherConfig()
 
     supervisor = build_supervisor(config, logger=logger)
 

--- a/apps/dispatcher/tests/test_config.py
+++ b/apps/dispatcher/tests/test_config.py
@@ -14,6 +14,55 @@ import pytest
 from agentos_dispatcher.config import DispatcherConfig
 
 
+def _clear_all_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Delete every env var the config could read, for a clean-env baseline.
+
+    ``BaseSettings`` reads the environment for every field, so the compose-stack
+    Valkey vars (``VALKEY_HOST`` ...) may be set ambiently; strip them all so the
+    defaults assertions see only the code defaults.
+    """
+    for name, field in DispatcherConfig.model_fields.items():
+        alias = field.validation_alias
+        key = alias if isinstance(alias, str) else name.upper()
+        monkeypatch.delenv(key, raising=False)
+
+
+# Every env var the OLD hand-rolled ``DispatcherConfig.from_env`` (on
+# ``origin/main``) read, paired with a distinct sentinel and its expected
+# coerced value. Names are the exact old ones -- the override test proves no
+# name drifted and no read was dropped.
+_DISPATCHER_OVERRIDES: dict[str, tuple[str, str, object]] = {
+    # env var name -> (field name, raw env value, expected coerced value)
+    "SLACK_APP_TOKEN": ("slack_app_token", "xapp-sentinel", "xapp-sentinel"),
+    "SLACK_BOT_TOKEN": ("slack_bot_token", "xoxb-sentinel", "xoxb-sentinel"),
+    "SLACK_SIGNING_SECRET": (
+        "slack_signing_secret",
+        "sign-sentinel",
+        "sign-sentinel",
+    ),
+    "VALKEY_HOST": ("valkey_host", "valkey.host.example", "valkey.host.example"),
+    "VALKEY_PORT": ("valkey_port", "6380", 6380),
+    "VALKEY_PASSWORD": ("valkey_password", "vk-pass", "vk-pass"),
+    "VALKEY_DB": ("valkey_db", "7", 7),
+    "AGENTOS_STREAM": ("stream", "sentinel:runs", "sentinel:runs"),
+    "AGENTOS_DEDUPE_PREFIX": (
+        "dedupe_prefix",
+        "sentinel:dedupe:",
+        "sentinel:dedupe:",
+    ),
+    "AGENTOS_DEDUPE_TTL_SECONDS": ("dedupe_ttl_seconds", "7200", 7200),
+    "AGENTOS_PLACEHOLDER_TEXT": (
+        "placeholder_text",
+        "Sentinel placeholder.",
+        "Sentinel placeholder.",
+    ),
+    "AGENTOS_SHIMMER": ("shimmer", "true", True),
+    "AGENTOS_BACKOFF_INITIAL_SECONDS": ("backoff_initial_seconds", "2.5", 2.5),
+    "AGENTOS_BACKOFF_MAX_SECONDS": ("backoff_max_seconds", "45.5", 45.5),
+    "AGENTOS_BACKOFF_MULTIPLIER": ("backoff_multiplier", "3.5", 3.5),
+}
+
+
 def test_aliased_field_ignores_bare_field_name_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -55,3 +104,96 @@ def test_non_aliased_field_still_reads_plain_env(
     monkeypatch.setenv("VALKEY_HOST", "valkey.internal")
 
     assert DispatcherConfig().valkey_host == "valkey.internal"
+
+
+# --- Env-var parity vs the pre-pydantic from_env (review #178) ---------------
+
+
+def test_defaults_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clean env: every field must equal the exact default the old from_env produced.
+
+    Every field is enumerated; a drifted default is a silent prod break.
+    """
+    _clear_all_config_env(monkeypatch)
+
+    config = DispatcherConfig()
+
+    assert config.slack_app_token == ""
+    assert config.slack_bot_token == ""
+    assert config.slack_signing_secret == ""
+    assert config.valkey_host == "localhost"
+    assert config.valkey_port == 6379
+    assert config.valkey_password == ""
+    assert config.valkey_db == 0
+    assert config.stream == "agentos:runs"
+    assert config.dedupe_prefix == "agentos:dedupe:"
+    assert config.dedupe_ttl_seconds == 3600
+    assert config.placeholder_text == "On it. Working on your request."
+    assert config.shimmer is False
+    assert config.backoff_initial_seconds == 1.0
+    assert config.backoff_max_seconds == 30.0
+    assert config.backoff_multiplier == 2.0
+
+
+def test_overrides_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every env var the old from_env read, set under its EXACT old name, must be
+    read into the right field with the right coercion.
+
+    Proves no env-var name drifted and no read was dropped.
+    """
+    _clear_all_config_env(monkeypatch)
+    for env_var, (_field, raw, _expected) in _DISPATCHER_OVERRIDES.items():
+        monkeypatch.setenv(env_var, raw)
+
+    config = DispatcherConfig()
+
+    for env_var, (field, _raw, expected) in _DISPATCHER_OVERRIDES.items():
+        actual = getattr(config, field)
+        assert actual == expected, f"{env_var} -> {field}: {actual!r} != {expected!r}"
+        assert type(actual) is type(expected), (
+            f"{env_var} -> {field}: type {type(actual)} != {type(expected)}"
+        )
+
+
+# --- Per-service bool divergence (review #178) -------------------------------
+#
+# The old dispatcher ``_set_bool`` accepted ("1", "true", "yes", "on") as truthy
+# -- it DOES treat "on" as truthy, unlike the worker's ``_b``. These lock that.
+
+
+@pytest.mark.parametrize(
+    "token", ["1", "true", "yes", "on", "ON", "On", " on ", "TRUE"]
+)
+def test_bool_dispatcher_truthy_tokens_including_on(
+    monkeypatch: pytest.MonkeyPatch, token: str
+) -> None:
+    """The dispatcher truthy set includes "on" (case/space-insensitive)."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_SHIMMER", token)
+
+    assert DispatcherConfig().shimmer is True
+
+
+@pytest.mark.parametrize("token", ["0", "no", "off", "", "maybe"])
+def test_bool_dispatcher_falsy_tokens(
+    monkeypatch: pytest.MonkeyPatch, token: str
+) -> None:
+    """Falsy tokens ("off" included) parse to False."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_SHIMMER", token)
+
+    assert DispatcherConfig().shimmer is False
+
+
+def test_bool_on_divergence_between_services(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AGENTOS_SHIMMER=on: dispatcher True, worker False -- the documented per-service split."""
+    from agentos_worker.config import WorkerConfig
+
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.delenv("AGENTOS_SHIMMER", raising=False)
+    monkeypatch.setenv("AGENTOS_SHIMMER", "on")
+
+    assert DispatcherConfig().shimmer is True
+    assert WorkerConfig().shimmer is False

--- a/apps/dispatcher/tests/test_config.py
+++ b/apps/dispatcher/tests/test_config.py
@@ -1,0 +1,57 @@
+"""Regression tests for DispatcherConfig env-source resolution.
+
+``populate_by_name=True`` lets tests construct the config with field-name
+kwargs, but it must NOT make the env source read the bare uppercased field name
+as a fallback for a field that carries a ``validation_alias``. An aliased field
+must read only its ``AGENTOS_*`` alias; a stray generic env var (``STREAM``,
+``SHIMMER``, ...) in the pod env must be ignored, as it was before the
+BaseSettings refactor.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentos_dispatcher.config import DispatcherConfig
+
+
+def test_aliased_field_ignores_bare_field_name_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stray bare-name env var must not leak into an aliased field."""
+    monkeypatch.setenv("STREAM", "stray:stream")
+
+    config = DispatcherConfig()
+
+    assert config.stream == "agentos:runs"  # the default, not "stray:stream"
+
+
+def test_aliased_field_reads_its_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The intended AGENTOS_* alias is still read from the env."""
+    monkeypatch.setenv("AGENTOS_STREAM", "intended:stream")
+
+    assert DispatcherConfig().stream == "intended:stream"
+
+
+def test_alias_wins_over_bare_field_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With both set, only the alias is read and the bare name is ignored."""
+    monkeypatch.setenv("STREAM", "stray:stream")
+    monkeypatch.setenv("AGENTOS_STREAM", "intended:stream")
+
+    assert DispatcherConfig().stream == "intended:stream"
+
+
+def test_field_name_kwargs_still_populate() -> None:
+    """populate_by_name construction (used by tests) is unchanged."""
+    config = DispatcherConfig(stream="s", shimmer=True)
+
+    assert config.stream == "s"
+    assert config.shimmer is True
+
+
+def test_non_aliased_field_still_reads_plain_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fields without an alias keep reading their uppercased field name."""
+    monkeypatch.setenv("VALKEY_HOST", "valkey.internal")
+
+    assert DispatcherConfig().valkey_host == "valkey.internal"

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -121,7 +121,7 @@ Runtime rules (each has a provoking integration test in `tests/eval/test_stream.
   and acked (a poison-pill drop). A failing eval case is a failed COUNT in the report,
   not a consumer crash.
 
-Config surface (added to `WorkerConfig.from_env`): `AGENTOS_EVAL_STREAM` /
+Config surface (read by `WorkerConfig`): `AGENTOS_EVAL_STREAM` /
 `AGENTOS_EVAL_CONSUMER_GROUP`; MinIO/S3 `S3_ENDPOINT_URL` / `S3_ACCESS_KEY` /
 `S3_SECRET_KEY` / `S3_REGION` / `BUNDLE_BUCKET` (mirroring the API's env names); the
 platform API `AGENTOS_API_BASE_URL` / `AGENTOS_API_KEY` for `POST /evals/report`; and
@@ -179,7 +179,7 @@ Rules (detailed-architecture 2b), each with an integration test that provokes it
   `XAUTOCLAIM` reclaims entries a dead consumer took but never acked and
   reprocesses them; the markers make that safe.
 
-Config surface (`WorkerConfig.from_env`): `VALKEY_*`, `SLACK_BOT_TOKEN`,
+Config surface (`WorkerConfig`): `VALKEY_*`, `SLACK_BOT_TOKEN`,
 `AGENTOS_STREAM` / `AGENTOS_CONSUMER_GROUP` / `AGENTOS_CONSUMER_NAME`,
 `AGENTOS_MAX_ATTEMPTS`, plus `AGENTOS_NAMESPACE` / `AGENTOS_WARM_POOL` /
 `AGENTOS_RUNNER_PORT` for the substrate. Run with `python -m agentos_worker`.

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -5,6 +5,7 @@ description = "AgentOS worker: concurrency kernel (routing, finish-race CAS, ste
 requires-python = ">=3.13"
 dependencies = [
     "redis>=5.2",
+    "pydantic-settings>=2.7",
     "kubernetes>=31.0",
     "aci-protocol",
     "agentos-dispatcher",

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -1,30 +1,101 @@
-"""Typed configuration for the worker kernel, parsed from the environment.
+"""Typed configuration for the worker kernel, read from the environment.
 
 The kernel needs a Valkey connection (the stream it consumes plus its locks and
 markers), a Slack bot token (to edit the placeholder in place), the stream and
 consumer-group identity, and the tunables for retry, per-thread locking, and
 crash-recovery reclaim. Substrate wiring (namespace, warm pool, runner port)
 lives in ``SubstrateConfig`` and is assembled separately by the entrypoint.
+
+``WorkerConfig`` is a ``pydantic_settings.BaseSettings`` (the house pattern, see
+``apps/api``): construct it with no arguments and it reads the environment on
+init, falling back to the defaults below for anything absent. The AGENTOS_-prefixed
+knobs map through per-field ``validation_alias``; the rest read the uppercased
+field name (VALKEY_HOST, DATABASE_URL, S3_ENDPOINT_URL, LANGFUSE_HOST, ...).
 """
 
 from __future__ import annotations
 
 import os
 import socket
-from collections.abc import Mapping
-from typing import Any
+from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BeforeValidator, Field
+from pydantic.fields import FieldInfo
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings.sources import (
+    EnvSettingsSource,
+    PydanticBaseSettingsSource,
+)
+
+
+class _AliasOnlyEnvSource(EnvSettingsSource):
+    """Env source that reads an aliased field ONLY from its ``validation_alias``.
+
+    ``populate_by_name=True`` is set so tests can construct the config with
+    field-name kwargs (``WorkerConfig(fake_model=True)``). But in
+    pydantic-settings that same flag makes the default env source append the
+    bare uppercased field name as a fallback env key for every aliased field --
+    so ``api_key`` (alias ``AGENTOS_API_KEY``) would also silently read a stray
+    ``API_KEY``. That breaks the behavior-preserving contract of the refactor.
+    We drop the field-name fallback for aliased fields; non-aliased fields keep
+    reading their plain uppercased name, and kwarg population is untouched
+    (it runs through the init source, not here).
+    """
+
+    def _extract_field_info(
+        self, field: FieldInfo, field_name: str
+    ) -> list[tuple[str, str, bool]]:
+        infos = super()._extract_field_info(field, field_name)
+        if field.validation_alias is not None:
+            infos = [info for info in infos if info[0] != field_name]
+        return infos
 
 
 def _default_consumer_name() -> str:
     return f"{socket.gethostname()}-{os.getpid()}"
 
 
-class WorkerConfig(BaseModel):
+def _parse_bool(value: object) -> bool:
+    """Parse the truthy env-string set the worker has always accepted.
+
+    A real bool passes through (so kwarg construction in tests is unchanged); any
+    other string is truthy only when it is one of the accepted tokens, matching
+    the previous hand-rolled ``_b`` (note: the worker does not treat "on" as
+    truthy, unlike the dispatcher).
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes")
+    return bool(value)
+
+
+Bool = Annotated[bool, BeforeValidator(_parse_bool)]
+
+
+class WorkerConfig(BaseSettings):
     """Everything the kernel needs, in one typed object."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = SettingsConfigDict(
+        frozen=True, populate_by_name=True, extra="ignore"
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Swap the env source so aliased fields read only their alias."""
+        return (
+            init_settings,
+            _AliasOnlyEnvSource(settings_cls),
+            dotenv_settings,
+            file_secret_settings,
+        )
 
     # Valkey
     valkey_host: str = "localhost"
@@ -47,7 +118,9 @@ class WorkerConfig(BaseModel):
     # Deployment-to-runtime binding. The plugin dir is the local path the runner
     # reads; sandbox provisioning fetches AGENTOS_BUNDLE_REF into it. Platform
     # default budget applies when an agent's budget columns are NULL.
-    bundle_plugin_dir: str = "/bundles/current"
+    bundle_plugin_dir: str = Field(
+        default="/bundles/current", validation_alias="AGENTOS_PLUGIN_DIR"
+    )
     default_max_usd_per_day: float = 10.0
     default_max_output_tokens_per_run: int = 100000
 
@@ -56,22 +129,27 @@ class WorkerConfig(BaseModel):
     # call, no credential needed) -- the middle-mode default on a laptop.
     # credentials is the opaque AGENTOS_CREDENTIALS the runner forwards to the
     # model call; it is never logged and never required when fake_model is on.
-    fake_model: bool = False
-    credentials: str = ""
+    fake_model: Bool = Field(default=False, validation_alias="AGENTOS_FAKE_MODEL")
+    credentials: str = Field(default="", validation_alias="AGENTOS_CREDENTIALS")
     # Local model demo path: the worker can point the runner at an
     # Anthropic-compatible local endpoint without changing the fake-model default.
-    model_base_url: str = ""
-    model: str = ""
+    model_base_url: str = Field(default="", validation_alias="AGENTOS_MODEL_BASE_URL")
+    model: str = Field(default="", validation_alias="AGENTOS_MODEL")
 
     # When true, clear the Slack assistant-thread status (the "shimmer" the
     # dispatcher set) once a turn ends -- editing the placeholder does not
     # auto-clear it. Off by default; pairs with the dispatcher's AGENTOS_SHIMMER.
-    shimmer: bool = False
+    shimmer: Bool = Field(default=False, validation_alias="AGENTOS_SHIMMER")
 
     # Stream / consumer group (must match the dispatcher's AGENTOS_STREAM)
-    stream: str = "agentos:runs"
-    consumer_group: str = "agentos-workers"
-    consumer_name: str = Field(default_factory=_default_consumer_name)
+    stream: str = Field(default="agentos:runs", validation_alias="AGENTOS_STREAM")
+    consumer_group: str = Field(
+        default="agentos-workers", validation_alias="AGENTOS_CONSUMER_GROUP"
+    )
+    consumer_name: str = Field(
+        default_factory=_default_consumer_name,
+        validation_alias="AGENTOS_CONSUMER_NAME",
+    )
 
     # Read loop
     read_count: int = 16
@@ -88,7 +166,7 @@ class WorkerConfig(BaseModel):
     lock_poll_interval_s: float = 0.02
 
     # Retry (flag-clean failures only; see the no-retry-after-side-effects rule)
-    max_attempts: int = 3
+    max_attempts: int = Field(default=3, validation_alias="AGENTOS_MAX_ATTEMPTS")
     retry_backoff_base_s: float = Field(default=1.0, gt=0)
     retry_backoff_max_s: float = Field(default=20.0, gt=0)
 
@@ -113,8 +191,12 @@ class WorkerConfig(BaseModel):
 
     # Eval stream (F3): a separate consumer group on agentos:evals runs eval
     # suites and reports results to the platform API and Langfuse.
-    eval_stream: str = "agentos:evals"
-    eval_consumer_group: str = "agentos-eval-workers"
+    eval_stream: str = Field(
+        default="agentos:evals", validation_alias="AGENTOS_EVAL_STREAM"
+    )
+    eval_consumer_group: str = Field(
+        default="agentos-eval-workers", validation_alias="AGENTOS_EVAL_CONSUMER_GROUP"
+    )
     eval_consumer_name: str = Field(default_factory=_default_consumer_name)
     # MinIO / S3 for plugin bundles (mirrors the API's env names). The consumer
     # fetches a version's bundle by bundle_ref and loads its evals/ suite.
@@ -125,8 +207,10 @@ class WorkerConfig(BaseModel):
     bundle_bucket: str = "agentos-bundles"
     # Platform API for POST /evals/report. Defaults match the API's dev stack
     # (README serves it on :8000; its shared dev key is agentos-dev-key).
-    api_base_url: str = "http://localhost:8000"
-    api_key: str = "agentos-dev-key"
+    api_base_url: str = Field(
+        default="http://localhost:8000", validation_alias="AGENTOS_API_BASE_URL"
+    )
+    api_key: str = Field(default="agentos-dev-key", validation_alias="AGENTOS_API_KEY")
     report_max_attempts: int = 3
     report_backoff_base_s: float = Field(default=0.5, gt=0)
     # Langfuse for recording eval scores (the matrix reads them back by version).
@@ -160,53 +244,3 @@ class WorkerConfig(BaseModel):
 
     def lock_key(self, thread_key: str) -> str:
         return f"{self.key_prefix}:lock:{thread_key}"
-
-    @classmethod
-    def from_env(cls, env: Mapping[str, str]) -> WorkerConfig:
-        values: dict[str, Any] = {}
-        _s(values, "valkey_host", env, "VALKEY_HOST")
-        _i(values, "valkey_port", env, "VALKEY_PORT")
-        _s(values, "valkey_password", env, "VALKEY_PASSWORD")
-        _i(values, "valkey_db", env, "VALKEY_DB")
-        _s(values, "slack_bot_token", env, "SLACK_BOT_TOKEN")
-        _s(values, "slack_api_base_url", env, "SLACK_API_BASE_URL")
-        _s(values, "database_url", env, "DATABASE_URL")
-        _s(values, "db_schema", env, "DB_SCHEMA")
-        _s(values, "bundle_plugin_dir", env, "AGENTOS_PLUGIN_DIR")
-        _b(values, "fake_model", env, "AGENTOS_FAKE_MODEL")
-        _b(values, "shimmer", env, "AGENTOS_SHIMMER")
-        _s(values, "credentials", env, "AGENTOS_CREDENTIALS")
-        _s(values, "model_base_url", env, "AGENTOS_MODEL_BASE_URL")
-        _s(values, "model", env, "AGENTOS_MODEL")
-        _s(values, "eval_stream", env, "AGENTOS_EVAL_STREAM")
-        _s(values, "eval_consumer_group", env, "AGENTOS_EVAL_CONSUMER_GROUP")
-        _s(values, "s3_endpoint_url", env, "S3_ENDPOINT_URL")
-        _s(values, "s3_access_key", env, "S3_ACCESS_KEY")
-        _s(values, "s3_secret_key", env, "S3_SECRET_KEY")
-        _s(values, "s3_region", env, "S3_REGION")
-        _s(values, "bundle_bucket", env, "BUNDLE_BUCKET")
-        _s(values, "api_base_url", env, "AGENTOS_API_BASE_URL")
-        _s(values, "api_key", env, "AGENTOS_API_KEY")
-        _s(values, "langfuse_host", env, "LANGFUSE_HOST")
-        _s(values, "langfuse_public_key", env, "LANGFUSE_PUBLIC_KEY")
-        _s(values, "langfuse_secret_key", env, "LANGFUSE_SECRET_KEY")
-        _s(values, "stream", env, "AGENTOS_STREAM")
-        _s(values, "consumer_group", env, "AGENTOS_CONSUMER_GROUP")
-        _s(values, "consumer_name", env, "AGENTOS_CONSUMER_NAME")
-        _i(values, "max_attempts", env, "AGENTOS_MAX_ATTEMPTS")
-        return cls(**values)
-
-
-def _s(values: dict[str, Any], key: str, env: Mapping[str, str], var: str) -> None:
-    if var in env:
-        values[key] = env[var]
-
-
-def _i(values: dict[str, Any], key: str, env: Mapping[str, str], var: str) -> None:
-    if var in env:
-        values[key] = int(env[var])
-
-
-def _b(values: dict[str, Any], key: str, env: Mapping[str, str], var: str) -> None:
-    if var in env:
-        values[key] = env[var].strip().lower() in ("1", "true", "yes")

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -245,7 +245,7 @@ async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
 def main(env: Mapping[str, str] | None = None) -> None:
     logging.basicConfig(level=logging.INFO)
     resolved = env if env is not None else os.environ
-    config = WorkerConfig.from_env(resolved)
+    config = WorkerConfig()
     asyncio.run(_run(config, resolved))
 
 

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
 from agentos_worker.binding import (
     BASE_URL_ENV,
     CREDENTIALS_ENV,
@@ -100,10 +101,10 @@ def test_apply_model_env_omits_base_url_and_model_by_default() -> None:
     assert model_env not in env
 
 
-def test_worker_config_reads_local_model_env() -> None:
-    config = WorkerConfig.from_env(
-        {"AGENTOS_MODEL_BASE_URL": "http://x:1", "AGENTOS_MODEL": "qwen3:4b"}
-    )
+def test_worker_config_reads_local_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOS_MODEL_BASE_URL", "http://x:1")
+    monkeypatch.setenv("AGENTOS_MODEL", "qwen3:4b")
+    config = WorkerConfig()
 
     assert config.model_base_url == "http://x:1"
     assert config.model == "qwen3:4b"

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -1,0 +1,70 @@
+"""Regression tests for WorkerConfig env-source resolution.
+
+``populate_by_name=True`` lets tests construct the config with field-name
+kwargs, but it must NOT make the env source read the bare uppercased field name
+as a fallback for a field that carries a ``validation_alias``. An aliased field
+must read only its ``AGENTOS_*`` alias; a stray generic env var (``API_KEY``,
+``CREDENTIALS``, ...) in the pod env must be ignored, as it was before the
+BaseSettings refactor.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentos_worker.config import WorkerConfig
+
+
+def test_aliased_field_ignores_bare_field_name_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stray bare-name env var must not leak into an aliased field."""
+    monkeypatch.setenv("API_KEY", "stray")
+    monkeypatch.setenv("CREDENTIALS", "stray-creds")
+
+    config = WorkerConfig()
+
+    assert config.api_key == "agentos-dev-key"  # the default, not "stray"
+    assert config.credentials == ""  # the default, not "stray-creds"
+
+
+def test_aliased_field_reads_its_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The intended AGENTOS_* alias is still read from the env."""
+    monkeypatch.setenv("AGENTOS_API_KEY", "intended")
+    monkeypatch.setenv("AGENTOS_CREDENTIALS", "intended-creds")
+
+    config = WorkerConfig()
+
+    assert config.api_key == "intended"
+    assert config.credentials == "intended-creds"
+
+
+def test_alias_wins_over_bare_field_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With both set, only the alias is read and the bare name is ignored."""
+    monkeypatch.setenv("API_KEY", "stray")
+    monkeypatch.setenv("AGENTOS_API_KEY", "intended")
+
+    assert WorkerConfig().api_key == "intended"
+
+
+def test_field_name_kwargs_still_populate() -> None:
+    """populate_by_name construction (used by tests) is unchanged."""
+    config = WorkerConfig(fake_model=True, api_key="x", credentials="c")
+
+    assert config.fake_model is True
+    assert config.api_key == "x"
+    assert config.credentials == "c"
+
+
+def test_non_aliased_field_still_reads_plain_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fields without an alias keep reading their uppercased field name."""
+    monkeypatch.setenv("VALKEY_HOST", "valkey.internal")
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql+asyncpg://u:p@db:5432/agentos"
+    )
+
+    config = WorkerConfig()
+
+    assert config.valkey_host == "valkey.internal"
+    assert config.database_url == "postgresql+asyncpg://u:p@db:5432/agentos"

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -10,8 +10,93 @@ BaseSettings refactor.
 
 from __future__ import annotations
 
+import os
+import socket
+
 import pytest
 from agentos_worker.config import WorkerConfig
+
+
+def _clear_all_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Delete every env var the config could read, for a clean-env baseline.
+
+    ``BaseSettings`` reads the process environment for every field (aliased
+    fields via their ``validation_alias``, the rest via the uppercased field
+    name). The kernel suite runs against real Valkey/Postgres, so vars like
+    ``VALKEY_HOST``/``DATABASE_URL`` may be set in the ambient env; strip them
+    all so the defaults assertions below see only the code defaults.
+    """
+    for name, field in WorkerConfig.model_fields.items():
+        alias = field.validation_alias
+        key = alias if isinstance(alias, str) else name.upper()
+        monkeypatch.delenv(key, raising=False)
+
+
+# Every env var the OLD hand-rolled ``WorkerConfig.from_env`` read (on
+# ``origin/main``), paired with a distinct sentinel and the value the field
+# should hold after coercion. This is the parity oracle: the names are the exact
+# old ones, so the override test proves no name drifted and no var was dropped.
+_WORKER_OVERRIDES: dict[str, tuple[str, str, object]] = {
+    # env var name -> (field name, raw env value, expected coerced value)
+    "VALKEY_HOST": ("valkey_host", "valkey.host.example", "valkey.host.example"),
+    "VALKEY_PORT": ("valkey_port", "6380", 6380),
+    "VALKEY_PASSWORD": ("valkey_password", "vk-pass", "vk-pass"),
+    "VALKEY_DB": ("valkey_db", "7", 7),
+    "SLACK_BOT_TOKEN": ("slack_bot_token", "xoxb-sentinel", "xoxb-sentinel"),
+    "SLACK_API_BASE_URL": (
+        "slack_api_base_url",
+        "http://slack.stub:9",
+        "http://slack.stub:9",
+    ),
+    "DATABASE_URL": (
+        "database_url",
+        "postgresql+asyncpg://u:p@db:5432/x",
+        "postgresql+asyncpg://u:p@db:5432/x",
+    ),
+    "DB_SCHEMA": ("db_schema", "myschema", "myschema"),
+    "AGENTOS_PLUGIN_DIR": ("bundle_plugin_dir", "/custom/bundles", "/custom/bundles"),
+    "AGENTOS_FAKE_MODEL": ("fake_model", "true", True),
+    "AGENTOS_SHIMMER": ("shimmer", "yes", True),
+    "AGENTOS_CREDENTIALS": ("credentials", "cred-sentinel", "cred-sentinel"),
+    "AGENTOS_MODEL_BASE_URL": (
+        "model_base_url",
+        "http://model.local:1",
+        "http://model.local:1",
+    ),
+    "AGENTOS_MODEL": ("model", "claude-sentinel", "claude-sentinel"),
+    "AGENTOS_EVAL_STREAM": ("eval_stream", "sentinel:evals", "sentinel:evals"),
+    "AGENTOS_EVAL_CONSUMER_GROUP": (
+        "eval_consumer_group",
+        "sentinel-eval-workers",
+        "sentinel-eval-workers",
+    ),
+    "S3_ENDPOINT_URL": ("s3_endpoint_url", "http://s3.local:2", "http://s3.local:2"),
+    "S3_ACCESS_KEY": ("s3_access_key", "ak-sentinel", "ak-sentinel"),
+    "S3_SECRET_KEY": ("s3_secret_key", "sk-sentinel", "sk-sentinel"),
+    "S3_REGION": ("s3_region", "eu-west-9", "eu-west-9"),
+    "BUNDLE_BUCKET": ("bundle_bucket", "sentinel-bundles", "sentinel-bundles"),
+    "AGENTOS_API_BASE_URL": (
+        "api_base_url",
+        "http://api.local:3",
+        "http://api.local:3",
+    ),
+    "AGENTOS_API_KEY": ("api_key", "key-sentinel", "key-sentinel"),
+    "LANGFUSE_HOST": ("langfuse_host", "http://lf.local:4", "http://lf.local:4"),
+    "LANGFUSE_PUBLIC_KEY": ("langfuse_public_key", "pk-sentinel", "pk-sentinel"),
+    "LANGFUSE_SECRET_KEY": ("langfuse_secret_key", "sk-lf-sentinel", "sk-lf-sentinel"),
+    "AGENTOS_STREAM": ("stream", "sentinel:runs", "sentinel:runs"),
+    "AGENTOS_CONSUMER_GROUP": (
+        "consumer_group",
+        "sentinel-workers",
+        "sentinel-workers",
+    ),
+    "AGENTOS_CONSUMER_NAME": (
+        "consumer_name",
+        "sentinel-consumer",
+        "sentinel-consumer",
+    ),
+    "AGENTOS_MAX_ATTEMPTS": ("max_attempts", "9", 9),
+}
 
 
 def test_aliased_field_ignores_bare_field_name_env(
@@ -68,3 +153,152 @@ def test_non_aliased_field_still_reads_plain_env(
 
     assert config.valkey_host == "valkey.internal"
     assert config.database_url == "postgresql+asyncpg://u:p@db:5432/agentos"
+
+
+# --- Env-var parity vs the pre-pydantic from_env (review #178) ---------------
+
+
+def test_defaults_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clean env: every field must equal the exact default the old from_env produced.
+
+    Comprehensive check -- every field is enumerated. Config drift on a default
+    is a silent prod break, so this locks each default to the value the
+    hand-rolled ``WorkerConfig.from_env`` (on ``origin/main``) resolved to.
+    """
+    _clear_all_config_env(monkeypatch)
+
+    config = WorkerConfig()
+
+    # Valkey
+    assert config.valkey_host == "localhost"
+    assert config.valkey_port == 6379
+    assert config.valkey_password == ""
+    assert config.valkey_db == 0
+    # Slack
+    assert config.slack_bot_token == ""
+    assert config.slack_api_base_url == ""
+    # Postgres
+    assert (
+        config.database_url
+        == "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres"
+    )
+    assert config.db_schema == "agentos"
+    # Deployment-to-runtime binding
+    assert config.bundle_plugin_dir == "/bundles/current"
+    assert config.default_max_usd_per_day == 10.0
+    assert config.default_max_output_tokens_per_run == 100000
+    # Runner model + credentials
+    assert config.fake_model is False
+    assert config.credentials == ""
+    assert config.model_base_url == ""
+    assert config.model == ""
+    # Shimmer
+    assert config.shimmer is False
+    # Stream / consumer group
+    assert config.stream == "agentos:runs"
+    assert config.consumer_group == "agentos-workers"
+    # Read loop
+    assert config.read_count == 16
+    assert config.read_block_ms == 5000
+    # Per-thread lock
+    assert config.lock_ttl_ms == 120000
+    assert config.lock_acquire_timeout_s == 45.0
+    assert config.lock_poll_interval_s == 0.02
+    # Retry
+    assert config.max_attempts == 3
+    assert config.retry_backoff_base_s == 1.0
+    assert config.retry_backoff_max_s == 20.0
+    # Markers
+    assert config.idempotency_ttl_s == 86400
+    # Crash recovery
+    assert config.reclaim_min_idle_ms == 900000
+    assert config.reclaim_interval_s == 30.0
+    # Slack edit throttle
+    assert config.slack_edit_min_interval_s == 0.7
+    # Runner HTTP timeouts
+    assert config.runner_connect_timeout_s == 10.0
+    assert config.runner_total_timeout_s == 600.0
+    # Eval stream
+    assert config.eval_stream == "agentos:evals"
+    assert config.eval_consumer_group == "agentos-eval-workers"
+    # MinIO / S3
+    assert config.s3_endpoint_url == "http://localhost:29000"
+    assert config.s3_access_key == "minio"
+    assert config.s3_secret_key == "miniosecret"
+    assert config.s3_region == "us-east-1"
+    assert config.bundle_bucket == "agentos-bundles"
+    # Platform API
+    assert config.api_base_url == "http://localhost:8000"
+    assert config.api_key == "agentos-dev-key"
+    assert config.report_max_attempts == 3
+    assert config.report_backoff_base_s == 0.5
+    # Langfuse
+    assert config.langfuse_host == "http://localhost:23000"
+    assert config.langfuse_public_key == "pk-lf-agentos-dev"
+    assert config.langfuse_secret_key == "sk-lf-agentos-dev"
+    # Key prefix
+    assert config.key_prefix == "agentos:worker"
+
+    # Factory-defaulted names have no static default: the old from_env produced
+    # ``f"{hostname}-{pid}"`` via ``_default_consumer_name``. Assert that shape.
+    expected_consumer = f"{socket.gethostname()}-{os.getpid()}"
+    assert config.consumer_name == expected_consumer
+    assert config.eval_consumer_name == expected_consumer
+
+
+def test_overrides_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every env var the old from_env read, set to a sentinel under its EXACT old
+    name, must be read into the right field with the right coercion.
+
+    Proves no env-var name drifted in the BaseSettings port and no read was
+    dropped.
+    """
+    _clear_all_config_env(monkeypatch)
+    for env_var, (_field, raw, _expected) in _WORKER_OVERRIDES.items():
+        monkeypatch.setenv(env_var, raw)
+
+    config = WorkerConfig()
+
+    for env_var, (field, _raw, expected) in _WORKER_OVERRIDES.items():
+        actual = getattr(config, field)
+        assert actual == expected, f"{env_var} -> {field}: {actual!r} != {expected!r}"
+        # Coercion parity: ints/bools must be the coerced type, not a raw str.
+        assert type(actual) is type(expected), (
+            f"{env_var} -> {field}: type {type(actual)} != {type(expected)}"
+        )
+
+
+# --- Per-service bool divergence (review #178) -------------------------------
+#
+# The old worker ``_b`` accepted only ("1", "true", "yes") as truthy -- notably
+# NOT "on", unlike the dispatcher's ``_set_bool``. These lock that divergence.
+
+
+@pytest.mark.parametrize("token", ["1", "true", "yes", "TRUE", "Yes", " yes "])
+def test_bool_shared_truthy_tokens(
+    monkeypatch: pytest.MonkeyPatch, token: str
+) -> None:
+    """The truthy set shared with the dispatcher parses to True (case/space-insensitive)."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_SHIMMER", token)
+    monkeypatch.setenv("AGENTOS_FAKE_MODEL", token)
+
+    config = WorkerConfig()
+
+    assert config.shimmer is True
+    assert config.fake_model is True
+
+
+@pytest.mark.parametrize("token", ["on", "ON", "0", "no", "off", "", "maybe"])
+def test_bool_worker_rejects_on_and_falsy_tokens(
+    monkeypatch: pytest.MonkeyPatch, token: str
+) -> None:
+    """The worker does NOT treat "on" as truthy (the dispatcher does); falsy tokens are False."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_SHIMMER", token)
+    monkeypatch.setenv("AGENTOS_FAKE_MODEL", token)
+
+    config = WorkerConfig()
+
+    assert config.shimmer is False
+    assert config.fake_model is False

--- a/apps/worker/tests/test_slack_sink.py
+++ b/apps/worker/tests/test_slack_sink.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 from agentos_worker.config import WorkerConfig
 from agentos_worker.slack_sink import AsyncSlackSink
 
@@ -18,10 +19,13 @@ def test_unset_base_url_uses_the_sdk_default() -> None:
     assert sink._client.base_url == "https://slack.com/api/"
 
 
-def test_config_reads_slack_api_base_url_from_env() -> None:
-    assert WorkerConfig.from_env({}).slack_api_base_url == ""
-    cfg = WorkerConfig.from_env({"SLACK_API_BASE_URL": "http://localhost:9999"})
-    assert cfg.slack_api_base_url == "http://localhost:9999"
+def test_config_reads_slack_api_base_url_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SLACK_API_BASE_URL", raising=False)
+    assert WorkerConfig().slack_api_base_url == ""
+    monkeypatch.setenv("SLACK_API_BASE_URL", "http://localhost:9999")
+    assert WorkerConfig().slack_api_base_url == "http://localhost:9999"
 
 
 def test_update_converts_markdown_to_mrkdwn() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -76,6 +76,7 @@ version = "0.0.0"
 source = { editable = "apps/dispatcher" }
 dependencies = [
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "redis" },
     { name = "slack-bolt" },
 ]
@@ -83,6 +84,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.10" },
+    { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "redis", specifier = ">=5.2" },
     { name = "slack-bolt", specifier = ">=1.21" },
 ]
@@ -124,6 +126,7 @@ dependencies = [
     { name = "boto3" },
     { name = "httpx" },
     { name = "kubernetes" },
+    { name = "pydantic-settings" },
     { name = "redis" },
     { name = "slack-sdk" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -138,6 +141,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.35" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "kubernetes", specifier = ">=31.0" },
+    { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "redis", specifier = ">=5.2" },
     { name = "slack-sdk", specifier = ">=3.43" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },


### PR DESCRIPTION
Closes #74. The dispatcher and worker hand-rolled env→typed-config (`_set_*`/`_s`/`_i`/`_b` + manual `from_env`) where `apps/api` already uses `pydantic-settings`. Both are now `BaseSettings` subclasses with the helpers removed.

## Behavior-preserving
- **Every env var name + default unchanged.** Plain-name fields (`VALKEY_*`, `DATABASE_URL`, `S3_*`, `SLACK_*`, `LANGFUSE_*`) via case-insensitive name matching; `AGENTOS_*` fields via explicit `validation_alias`. Reconstructed the old `from_env` mapping and confirmed no rename/drop/default-change.
- **Bool parsing replicated exactly, per service** (dispatcher truthy set includes `on`; worker does not) via a `BeforeValidator`, with real-bool kwargs still passing through.
- Numeric `Field(gt=…)` constraints, the `consumer_name` default factory, and the `valkey_socket_timeout_s` derived invariant preserved.

## One subtlety handled
`populate_by_name=True` is needed for field-name kwarg construction in tests — but in pydantic-settings it also makes the env source read the bare uppercased field name as a fallback for aliased fields (so `API_KEY`/`CREDENTIALS`/`MODEL` would newly be read). Closed that with a small `_AliasOnlyEnvSource(EnvSettingsSource)` (via `settings_customise_sources`) that drops the field-name key for aliased fields while leaving kwarg population intact. Regression tests assert a stray `API_KEY`/`CREDENTIALS`/`STREAM` is ignored while the `AGENTOS_*` alias is read.

## Scope
Only dispatcher + worker config (+ their `run.py` call sites and config tests). `packages/aci-protocol/…/session.py` and `runner/…/config.py` deliberately left as-is. No sacred-kernel change.

## Tests
New `apps/worker/tests/test_config.py` + `apps/dispatcher/tests/test_config.py` (alias-only env behavior, kwarg construction, plain-name fields). Existing config/socket-timeout tests pass. `ruff` + `mypy` clean. (10 pre-existing infra failures — unmigrated DB / no API on :8000 — unrelated, verified on base.)