### PR TITLE
Runner: fast-fail on a rejected model credential

### DIFF
--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -242,8 +242,13 @@ class SessionRunner:
             if _is_auth_rejection(message):
                 # A rejected model credential is terminal: stop the live session
                 # so the SDK/CLI does not keep retrying with backoff to the wall,
-                # then surface a distinct, immediate classified failure.
-                await self._session.interrupt()
+                # then surface a distinct, immediate classified failure. Suppress
+                # a failing interrupt (a wedged transport -- the very state a bad
+                # credential can cause) so it cannot propagate to the generic
+                # retryable ``runner-error`` handler and defeat the fast-fail; the
+                # terminal ``model-credential-rejected`` error is emitted regardless.
+                with contextlib.suppress(Exception):
+                    await self._session.interrupt()
                 for line in self._auth_halt_lines():
                     yield line
                 return

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -34,7 +34,7 @@ from aci_protocol import (
     ToolNote,
     to_ndjson_line,
 )
-from claude_agent_sdk import ResultMessage
+from claude_agent_sdk import AssistantMessage, ResultMessage
 
 from .adapter import ModelSession
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
@@ -45,6 +45,30 @@ from .translate import TurnState, translate_message
 logger = logging.getLogger(__name__)
 
 SessionFactory = Callable[[], ModelSession]
+
+# The SDK surfaces a provider auth rejection (HTTP 401/403 -- e.g. a placeholder,
+# revoked, or wrong model key) as an ``AssistantMessage.error`` of this code
+# (see ``claude_agent_sdk.types.AssistantMessageError``). Unlike a 5xx or a rate
+# limit, a rejected credential is terminal and NON-retryable: retrying it only
+# burns wall time (the SDK/CLI otherwise backs off and re-attempts until a ~2min
+# timeout, surfacing as a generic hang). The runner fails the turn fast on this
+# signal instead of streaming a non-terminal error and continuing to drive the
+# session.
+_AUTH_REJECTION_SDK_CODE = "authentication_failed"
+
+# Classification carried on the fast-fail error event so consumers (F1's retry
+# rules) can tell a rejected credential from a transient failure and NOT retry
+# it -- distinct from both a budget halt and a generic runner error.
+AUTH_REJECTED_CLASSIFICATION = "model-credential-rejected"
+
+
+def _is_auth_rejection(message: object) -> bool:
+    """True when an SDK message reports a provider credential rejection (401/403)."""
+
+    return (
+        isinstance(message, AssistantMessage)
+        and getattr(message, "error", None) == _AUTH_REJECTION_SDK_CODE
+    )
 
 
 class SessionRunner:
@@ -215,6 +239,14 @@ class SessionRunner:
         assert self._session is not None
         await self._session.query(event.text)
         async for message in self._session.receive_turn():
+            if _is_auth_rejection(message):
+                # A rejected model credential is terminal: stop the live session
+                # so the SDK/CLI does not keep retrying with backoff to the wall,
+                # then surface a distinct, immediate classified failure.
+                await self._session.interrupt()
+                for line in self._auth_halt_lines():
+                    yield line
+                return
             usage = getattr(message, "usage", None)
             # The terminal result carries the authoritative turn total; streaming
             # assistant messages carry per-message output. Fold them differently
@@ -287,6 +319,35 @@ class SessionRunner:
             to_ndjson_line(
                 Final(
                     text="run halted: output token budget exceeded",
+                    status=SessionStatus.CLASSIFIED_FAILURE,
+                )
+            ),
+        ]
+
+    def _auth_halt_lines(self) -> list[str]:
+        """The error+final pair emitted when the provider rejects the credential.
+
+        Distinct from a budget halt and a generic runner error so downstream
+        retry rules do NOT retry a rejected credential (retrying only burns the
+        wall). The message names ``AGENTOS_CREDENTIALS`` since that is the ACI
+        reference the operator must fix; it carries no credential value.
+        """
+
+        logger.error(
+            "auth failure session=%s: model credential rejected by provider", self._session_id
+        )
+        self._turn_open = False
+        self._status = SessionStatus.CLASSIFIED_FAILURE
+        return [
+            to_ndjson_line(
+                ErrorEvent(
+                    message="model credential rejected by provider (check AGENTOS_CREDENTIALS)",
+                    classification=AUTH_REJECTED_CLASSIFICATION,
+                )
+            ),
+            to_ndjson_line(
+                Final(
+                    text="run failed: model credential rejected by provider",
                     status=SessionStatus.CLASSIFIED_FAILURE,
                 )
             ),

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -188,6 +188,65 @@ def test_sdk_exception_logs_turn_failure(caplog) -> None:
     assert any("authentication_failed" in message for message in messages)
 
 
+def test_auth_rejection_fails_fast_not_retried(caplog) -> None:
+    # A rejected model credential (provider 401/403 -> AssistantMessage.error
+    # "authentication_failed") must surface a DISTINCT, immediate classified
+    # failure -- not a generic error streamed while the SDK/CLI retries with
+    # backoff to the ~2min wall. The script places messages AFTER the auth error
+    # that must never be consumed (proving the turn aborted at the rejection and
+    # did not keep driving the session).
+    sentinel = "SHOULD-NOT-APPEAR-AFTER-AUTH-FAIL"
+    script = [
+        AssistantMessage(content=[], model="m", error="authentication_failed"),
+        AssistantMessage(content=[TextBlock(text=sentinel)], model="m"),
+        ResultMessage(
+            subtype="success", duration_ms=1, duration_api_ms=1,
+            is_error=False, num_turns=1, session_id="s", result=sentinel,
+        ),
+    ]
+    runner, fake = _runner(lambda: script)
+
+    with caplog.at_level(logging.ERROR, logger="agentos_runner.session"):
+        events = _drain(runner, Event(type="message", text="go", user="U", ts="1"))
+
+    # Distinct, terminal, credential-rejected classification (not "runner-error",
+    # not "budget-exceeded", not the raw SDK "authentication_failed").
+    assert [e.type for e in events] == ["error", "final"]
+    assert events[0].classification == "model-credential-rejected"
+    assert "AGENTOS_CREDENTIALS" in events[0].message
+    assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
+    assert runner.status == SessionStatus.CLASSIFIED_FAILURE
+    # Fast-fail: aborted at the rejection, never consuming later messages, and
+    # interrupted the live session so the CLI stops retrying.
+    assert all(sentinel not in getattr(e, "text", "") for e in events)
+    assert fake.interrupts >= 1
+    assert any(
+        record.levelno == logging.ERROR and "auth failure" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_transient_model_error_is_not_fast_failed() -> None:
+    # A transient AssistantMessage.error (e.g. a hard rate-limit) is NOT a
+    # credential rejection: it must flow through translation unchanged and reach
+    # the model's own terminal result, so genuine retry/backoff is preserved.
+    script = [
+        AssistantMessage(content=[], model="m", error="rate_limit"),
+        ResultMessage(
+            subtype="success", duration_ms=1, duration_api_ms=1,
+            is_error=False, num_turns=1, session_id="s", result="recovered",
+        ),
+    ]
+    runner, fake = _runner(lambda: script)
+    events = _drain(runner, Event(type="message", text="go", user="U", ts="1"))
+
+    classifications = [getattr(e, "classification", None) for e in events]
+    assert "model-credential-rejected" not in classifications
+    assert "rate_limit" in classifications  # translated, non-terminal
+    assert events[-1].status == SessionStatus.DONE  # reached the model's result
+    assert fake.interrupts == 0  # not aborted
+
+
 def test_budget_halt_logged(caplog) -> None:
     script = [
         AssistantMessage(

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -226,6 +226,40 @@ def test_auth_rejection_fails_fast_not_retried(caplog) -> None:
     )
 
 
+def test_auth_fast_fail_survives_a_wedged_interrupt(caplog) -> None:
+    # Hardening for the fast-fail: if interrupt() itself RAISES (a wedged
+    # transport -- the very state a bad credential can cause), the exception must
+    # NOT propagate to the generic *retryable* runner-error handler. The turn must
+    # still surface the terminal model-credential-rejected classification so the
+    # auth failure is never retried back into the ~2min hang.
+    class WedgedInterruptSession(FakeModelSession):
+        async def interrupt(self) -> None:
+            self.interrupts += 1
+            raise RuntimeError("transport wedged")
+
+    script = [AssistantMessage(content=[], model="m", error="authentication_failed")]
+    fake = WedgedInterruptSession(lambda: script)
+    runner = SessionRunner(
+        session_factory=lambda: fake,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+    )
+
+    with caplog.at_level(logging.ERROR, logger="agentos_runner.session"):
+        events = _drain(runner, Event(type="message", text="go", user="U", ts="1"))
+
+    # Still the terminal credential-rejected classification -- NOT the retryable
+    # generic "runner-error", even though interrupt() raised.
+    assert [e.type for e in events] == ["error", "final"]
+    assert events[0].classification == "model-credential-rejected"
+    assert "runner-error" not in [getattr(e, "classification", None) for e in events]
+    assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
+    assert runner.status == SessionStatus.CLASSIFIED_FAILURE
+    assert fake.interrupts >= 1  # the interrupt was attempted (and swallowed)
+
+
 def test_transient_model_error_is_not_fast_failed() -> None:
     # A transient AssistantMessage.error (e.g. a hard rate-limit) is NOT a
     # credential rejection: it must flow through translation unchanged and reach


### PR DESCRIPTION
Closes #121. A bad/placeholder model credential made a turn hang ~2 min then time out with no clear error — a top onboarding footgun (a runbook `sk-or-...` placeholder pasted verbatim). Root cause: the provider returns 401, and the SDK/CLI retries with backoff to the wall while the runner waited for a terminal result.

## Fix (runner only)
A provider auth rejection surfaces via the SDK as `AssistantMessage.error == "authentication_failed"` (not a Python exception). At the top of `_drive_turn`'s receive loop, detect it, `interrupt()` the session to stop the retry loop, and emit a **distinct terminal** `ErrorEvent(classification="model-credential-rejected")` + `Final(CLASSIFIED_FAILURE)` with a clear `"model credential rejected by provider (check AGENTOS_CREDENTIALS)"` message.

- **Non-retryable downstream:** the worker's `RETRYABLE_CLASSIFICATIONS` (`rate-limit`, `runner-error`) excludes `model-credential-rejected`, so it escalates to a human instead of retrying — no more ~2 min hang.
- **Transient errors unchanged:** `rate_limit`/`server_error` and raised `ClaudeSDKError`/`ProcessError` keep their existing (retryable) paths — the fast-fail is auth-only.
- **Not billed, no leak:** returns before budget accounting; the message/log carry only a hint, never the credential value.

## Scope
Only `runner/src/agentos_runner/session.py` (+ tests). The optional CLI credential-shape validation is out of scope (Rust lane). No sacred-kernel change.

## Tests
`test_auth_rejection_fails_fast_not_retried` (auth message → exactly `[error, final]`, `model-credential-rejected`, session interrupted, later messages never consumed) and `test_transient_model_error_is_not_fast_failed` (rate_limit flows through, `interrupts == 0`). `runner/tests` green; `ruff` + `mypy` clean.