### PR TITLE
Reject zip symlink entries on bundle extraction; dedupe the worker extractor

### DIFF
--- a/apps/api/src/agentos_api/bundles.py
+++ b/apps/api/src/agentos_api/bundles.py
@@ -7,10 +7,12 @@ router; this module is pure intake logic.
 """
 
 import io
+import stat
 import tarfile
 import tempfile
 import zipfile
 from pathlib import Path
+from typing import Literal
 
 from plugin_format import ValidationResult, validate_bundle
 
@@ -48,18 +50,27 @@ def extract(data: bytes, extension: str, dest: Path) -> None:
 
     if extension == ".zip":
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
-            for name in zf.namelist():
+            # zip has no built-in equivalent of tar's filter="data", so guard
+            # traversal and symlink entries by hand: a symlink like
+            # `x -> ../../etc/passwd` passes a name-only `..` check yet escapes
+            # `dest` when followed (the tar path below is covered by filter="data").
+            for info in zf.infolist():
+                name = info.filename
                 if Path(name).is_absolute() or ".." in Path(name).parts:
                     raise UnsupportedArchive(f"unsafe path in archive: {name}")
+                if stat.S_ISLNK(info.external_attr >> 16):
+                    raise UnsupportedArchive(f"symlink entry not allowed in archive: {name}")
             zf.extractall(dest)
-    elif extension == ".tar.gz":
-        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
-            # filter="data" (py3.12+) blocks absolute paths, traversal, and
-            # special files.
+        return
+    mode: Literal["r:gz", "r:"] = "r:gz" if extension == ".tar.gz" else "r:"
+    with tarfile.open(fileobj=io.BytesIO(data), mode=mode) as tf:
+        try:
+            # filter="data" (py3.12+) blocks absolute paths, traversal, symlinks,
+            # and special files; surface a rejection as UnsupportedArchive so the
+            # upload route answers 4xx rather than 500.
             tf.extractall(dest, filter="data")
-    else:
-        with tarfile.open(fileobj=io.BytesIO(data), mode="r:") as tf:
-            tf.extractall(dest, filter="data")
+        except tarfile.FilterError as exc:
+            raise UnsupportedArchive(f"unsafe entry in archive: {exc}") from exc
 
 
 # Where the frozen validator looks for the manifest; used here only to locate

--- a/apps/api/tests/test_bundles.py
+++ b/apps/api/tests/test_bundles.py
@@ -6,6 +6,7 @@ Postgres from the compose stack (per B2 constraints).
 
 import hashlib
 import io
+import os
 import tarfile
 import zipfile
 from pathlib import Path
@@ -44,6 +45,41 @@ def _zip(files: dict[str, str]) -> bytes:
     with zipfile.ZipFile(buf, "w") as zf:
         for rel, content in files.items():
             zf.writestr(rel, content)
+    return buf.getvalue()
+
+
+def _dir_with_symlink(tmp_path: Path) -> Path:
+    """A working tree a plugin author might archive: a real manifest plus a
+    symlink whose name is innocent (no ``..``) but which escapes the bundle."""
+    outside = tmp_path / "outside_secret.txt"
+    outside.write_text("credentials that must not leak")
+    work = tmp_path / "work"
+    (work / ".claude-plugin").mkdir(parents=True)
+    (work / ".claude-plugin" / "plugin.json").write_text(MANIFEST)
+    os.symlink(outside, work / "config.json")
+    return work
+
+
+def _zip_from_dir(root: Path) -> bytes:
+    """Zip a tree the way ``zip --symlinks`` does: a real symlink is stored as a
+    symlink entry (unix mode in external_attr), not its target's bytes."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for path in sorted(root.rglob("*")):
+            rel = path.relative_to(root).as_posix()
+            if path.is_symlink():
+                info = zipfile.ZipInfo(rel)
+                info.external_attr = os.lstat(path).st_mode << 16
+                zf.writestr(info, os.readlink(path))
+            elif path.is_file():
+                zf.write(path, rel)
+    return buf.getvalue()
+
+
+def _tar_gz_from_dir(root: Path) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        tf.add(root, arcname=".", recursive=True)
     return buf.getvalue()
 
 
@@ -100,6 +136,32 @@ def test_non_archive_is_rejected(tmp_path: Path) -> None:
     except bundles.UnsupportedArchive:
         return
     raise AssertionError("expected UnsupportedArchive")
+
+
+def test_zip_bundle_with_a_symlink_is_rejected(tmp_path: Path) -> None:
+    # Real scenario: a bundle is zipped from a tree containing a symlink pointing
+    # outside itself. The link name is innocent (no `..`), so a name-only guard
+    # passes it, yet extracting it would materialize a link that reads a file
+    # outside the bundle. Build the zip from an actual on-disk symlink.
+    data = _zip_from_dir(_dir_with_symlink(tmp_path))
+    try:
+        bundles.extract(data, ".zip", tmp_path / "out")
+    except bundles.UnsupportedArchive as exc:
+        assert "symlink" in str(exc)
+        return
+    raise AssertionError("expected UnsupportedArchive for a symlinked bundle")
+
+
+def test_tar_bundle_with_a_symlink_is_rejected(tmp_path: Path) -> None:
+    # Same real scenario via tar.gz: tarfile filter="data" rejects the symlink
+    # member; extract surfaces it as UnsupportedArchive (a clean 4xx), not a 500.
+    data = _tar_gz_from_dir(_dir_with_symlink(tmp_path))
+    try:
+        bundles.extract(data, ".tar.gz", tmp_path / "out")
+    except bundles.UnsupportedArchive as exc:
+        assert "unsafe entry" in str(exc)
+        return
+    raise AssertionError("expected UnsupportedArchive for a symlinked tar bundle")
 
 
 # --- full round trip against real MinIO + Postgres -----------------------

--- a/apps/worker/src/agentos_worker/bundle_store.py
+++ b/apps/worker/src/agentos_worker/bundle_store.py
@@ -16,6 +16,7 @@ the plugin root the runner sees matches the root the API validated on upload.
 from __future__ import annotations
 
 import io
+import stat
 import tarfile
 import zipfile
 from pathlib import Path
@@ -71,23 +72,45 @@ def _bundle_root(extracted: Path) -> Path:
     return extracted
 
 
-def _safe_extract(data: bytes, dest: Path) -> None:
-    """Extract a zip or tar(.gz) archive into ``dest``, refusing path traversal."""
+def safe_extract(data: bytes, dest: Path) -> None:
+    """Extract a zip or tar(.gz) archive into ``dest``, refusing unsafe entries.
+
+    Unsafe means anything that could write or point outside ``dest``: absolute
+    paths, ``..`` traversal, and symlink entries. The tar path delegates to
+    ``tarfile``'s ``filter="data"`` (py3.12+), which already rejects all three.
+    The zip path has no equivalent built-in, so it is checked here: ``zipfile``
+    would otherwise recreate a symlink entry verbatim, and a symlink such as
+    ``config -> ../../etc/passwd`` passes a name-only ``..`` check yet escapes
+    the extraction dir when followed. This is the single archive extractor for
+    the worker; ``eval.stream`` imports it rather than duplicating the logic.
+    """
     if zipfile.is_zipfile(io.BytesIO(data)):
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
-            for name in zf.namelist():
+            for info in zf.infolist():
+                name = info.filename
                 if Path(name).is_absolute() or ".." in Path(name).parts:
                     raise ValueError(f"unsafe path in bundle: {name}")
+                if stat.S_ISLNK(info.external_attr >> 16):
+                    raise ValueError(f"symlink entry not allowed in bundle: {name}")
             zf.extractall(dest)
         return
+    open_error: tarfile.TarError | None = None
     for mode in ("r:gz", "r:"):
         try:
-            with tarfile.open(fileobj=io.BytesIO(data), mode=mode) as tf:
-                tf.extractall(dest, filter="data")
-            return
-        except tarfile.TarError:
+            tf = tarfile.open(fileobj=io.BytesIO(data), mode=mode)
+        except tarfile.TarError as exc:
+            open_error = exc  # wrong compression for this mode; try the next
             continue
-    raise ValueError("bundle is not a recognized zip or tar archive")
+        with tf:
+            try:
+                tf.extractall(dest, filter="data")
+            except tarfile.FilterError as exc:
+                # filter="data" rejects symlinks, absolute paths, traversal, and
+                # special files. Surface it as an unsafe-entry error instead of
+                # letting it fall through and be misreported as "unrecognized".
+                raise ValueError(f"unsafe entry in bundle: {exc}") from exc
+        return
+    raise ValueError("bundle is not a recognized zip or tar archive") from open_error
 
 
 def extract_bundle(data: bytes, dest: Path) -> Path:
@@ -97,5 +120,5 @@ def extract_bundle(data: bytes, dest: Path) -> Path:
     wrapper subdir when the manifest sits one level down -- the same root the
     API validated, so the runner reads the plugin from the expected layout.
     """
-    _safe_extract(data, dest)
+    safe_extract(data, dest)
     return _bundle_root(dest)

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -26,12 +26,9 @@ acked, not a crash; a failing eval case is a failed count in the report.
 from __future__ import annotations
 
 import asyncio
-import io
 import logging
-import tarfile
 import tempfile
 import uuid
-import zipfile
 from pathlib import Path
 from typing import Any, cast
 
@@ -56,7 +53,7 @@ from ..binding import (
     SESSION_ID_ENV,
     apply_model_env,
 )
-from ..bundle_store import BundleStore
+from ..bundle_store import BundleStore, safe_extract
 from ..config import WorkerConfig
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
@@ -147,7 +144,7 @@ def load_suite_from_bundle(data: bytes, suite_name: str) -> EvalSuite | None:
     try:
         with tempfile.TemporaryDirectory() as tmp:
             dest = Path(tmp)
-            _safe_extract(data, dest)
+            safe_extract(data, dest)
             cases = next(
                 (p for p in dest.rglob("cases.json") if p.parent.name == "evals"), None
             )
@@ -158,24 +155,6 @@ def load_suite_from_bundle(data: bytes, suite_name: str) -> EvalSuite | None:
         logger.exception("could not load eval suite from bundle")
         return None
     return EvalSuite(name=suite_name, cases=loaded.cases)
-
-
-def _safe_extract(data: bytes, dest: Path) -> None:
-    if zipfile.is_zipfile(io.BytesIO(data)):
-        with zipfile.ZipFile(io.BytesIO(data)) as zf:
-            for name in zf.namelist():
-                if Path(name).is_absolute() or ".." in Path(name).parts:
-                    raise ValueError(f"unsafe path in bundle: {name}")
-            zf.extractall(dest)
-        return
-    for mode in ("r:gz", "r:"):
-        try:
-            with tarfile.open(fileobj=io.BytesIO(data), mode=mode) as tf:
-                tf.extractall(dest, filter="data")
-            return
-        except tarfile.TarError:
-            continue
-    raise ValueError("bundle is not a recognized zip or tar archive")
 
 
 class EvalStreamConsumer:

--- a/apps/worker/tests/test_bundle_store.py
+++ b/apps/worker/tests/test_bundle_store.py
@@ -1,0 +1,101 @@
+"""safe_extract: the single worker archive extractor rejects unsafe bundles.
+
+Pure unit tests (no MinIO / stack), but built from the *real* situation rather
+than hand-crafted attribute bits: a plugin author zips or tars a working tree
+that happens to contain a symlink pointing outside the bundle (a careless
+``ln -s``, a checked-in link, or a deliberate escape). The link's name is
+innocent (no ``..``), so a name-only guard would pass it, yet extracting it would
+place a link that reads a file outside the bundle root. We build the archives the
+way a real symlink-aware archiver does -- from actual on-disk symlinks -- and
+assert extraction refuses them while a normal bundle of the same shape extracts.
+``eval.stream`` imports this same ``safe_extract`` (no second copy).
+"""
+
+import io
+import os
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from agentos_worker.bundle_store import extract_bundle, safe_extract
+
+
+def _zip_from_dir(root: Path) -> bytes:
+    """Zip a tree the way ``zip --symlinks`` does: a real symlink is stored as a
+    symlink entry (its unix mode in ``external_attr``), not its target's bytes."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for path in sorted(root.rglob("*")):
+            rel = path.relative_to(root).as_posix()
+            if path.is_symlink():
+                info = zipfile.ZipInfo(rel)
+                info.external_attr = os.lstat(path).st_mode << 16
+                zf.writestr(info, os.readlink(path))
+            elif path.is_file():
+                zf.write(path, rel)
+    return buf.getvalue()
+
+
+def _tar_gz_from_dir(root: Path) -> bytes:
+    """tar a tree; ``tarfile`` stores a real on-disk symlink as a symlink member."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        tf.add(root, arcname=".", recursive=True)
+    return buf.getvalue()
+
+
+def _bundle_tree_with_symlink(tmp_path: Path) -> Path:
+    """A working tree a plugin author might archive: a real manifest plus a
+    symlink whose name is innocent but which points outside the bundle."""
+    outside = tmp_path / "outside_secret.txt"
+    outside.write_text("credentials that must not leak")
+    work = tmp_path / "work"
+    (work / ".claude-plugin").mkdir(parents=True)
+    (work / ".claude-plugin" / "plugin.json").write_text('{"name": "x", "version": "0.1.0"}')
+    os.symlink(outside, work / "config.json")  # innocent name, escapes the tree
+    return work
+
+
+def test_zip_bundle_carrying_a_symlink_is_rejected(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    with pytest.raises(ValueError, match="symlink"):
+        safe_extract(_zip_from_dir(_bundle_tree_with_symlink(tmp_path)), out)
+    # Nothing was materialized at the innocent link name, so the outside file is
+    # not reachable through the extracted bundle.
+    assert not (out / "config.json").exists()
+
+
+def test_tar_bundle_carrying_a_symlink_is_rejected(tmp_path: Path) -> None:
+    # The tar path relies on tarfile filter="data"; the extractor surfaces its
+    # rejection as an unsafe-entry error rather than "unrecognized archive".
+    with pytest.raises(ValueError, match="unsafe entry"):
+        safe_extract(_tar_gz_from_dir(_bundle_tree_with_symlink(tmp_path)), tmp_path / "out")
+
+
+def test_normal_bundle_extracts(tmp_path: Path) -> None:
+    # Same shape without the escape: a real config file (not a symlink) extracts.
+    work = tmp_path / "work"
+    (work / ".claude-plugin").mkdir(parents=True)
+    (work / ".claude-plugin" / "plugin.json").write_text('{"name": "x", "version": "0.1.0"}')
+    (work / "config.json").write_text("{}")
+    out = tmp_path / "out"
+    safe_extract(_zip_from_dir(work), out)
+    assert (out / "config.json").read_text() == "{}"
+    assert (out / ".claude-plugin" / "plugin.json").is_file()
+
+
+def test_extract_bundle_rejects_a_symlink_bundle(tmp_path: Path) -> None:
+    # extract_bundle (the Docker-substrate entrypoint) delegates to the one
+    # safe_extract, so the guard applies to the runtime path too.
+    with pytest.raises(ValueError):
+        extract_bundle(_zip_from_dir(_bundle_tree_with_symlink(tmp_path)), tmp_path / "out")
+
+
+def test_zip_traversal_is_rejected(tmp_path: Path) -> None:
+    # A `..` entry is the other escape shape; keep the name-guard covered too.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("../escape.txt", "x")
+    with pytest.raises(ValueError, match="unsafe path"):
+        safe_extract(buf.getvalue(), tmp_path / "out")


### PR DESCRIPTION
Closes #73

## What
- **Security:** reject zip **symlink** entries on extraction, in both the API upload path (`bundles.extract`) and the worker extractor. A symlink entry like `config -> ../../etc/passwd` passed the name-only `..` check but escaped the extraction dir when followed. The tar path was already safe via `tarfile` `filter="data"`.
- **Dedupe:** collapse the two byte-identical worker copies into one — `eval.stream` now imports `safe_extract` from `bundle_store` (zero-dep, both inside `agentos_worker`).

## Validation
ruff + mypy clean; new unit tests for symlink/`..` rejection and normal extraction on both paths; full `test_bundles.py` (incl. real MinIO/Postgres round-trip) green.

## Scope note for reviewer
The gap is closed in all three original sites and the two worker copies are now one. The issue's literal "exactly one `safe_extract` in the repo" is **not** fully met: the API keeps its own `extract` (different signature, part of `extract_and_validate`), so the traversal-guard `grep` now returns 2 hits (API + worker), down from 3. Fully unifying API + worker needs a shared home; the issue suggests `plugin-format`, which is a **frozen contract** package — flagging that relocation as a follow-up decision rather than touching a frozen package here.