### PR TITLE
UI: surface the serving sandbox + jump to its logs from a trace (part of #16)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1005,6 +1005,17 @@
       "TraceTree": {
         "description": "A trace plus its reconstructed observation tree.",
         "properties": {
+          "sandbox_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sandbox Id"
+          },
           "trace": {
             "additionalProperties": true,
             "title": "Trace",

--- a/apps/api/src/agentos_api/langfuse.py
+++ b/apps/api/src/agentos_api/langfuse.py
@@ -42,6 +42,57 @@ def matching_traces(
     return out[:limit]
 
 
+# The OTel resource attribute the runner stamps (runner/otel.py) so a trace is
+# attributable to the concrete sandbox that served it.
+_SANDBOX_ATTR = "agentos.sandbox_id"
+
+
+def _probe_sandbox_attr(bag: Any) -> str | None:
+    """Return a non-empty `agentos.sandbox_id` from one attribute bag, or None.
+
+    Checks the bag itself plus the common keys Langfuse uses to carry OTel
+    resource/metadata attributes (``metadata`` / ``resourceAttributes`` /
+    ``resource``, each optionally wrapping an ``attributes`` sub-dict). The bare
+    ``sandbox_id`` key is accepted too. Non-string / empty values are ignored.
+    """
+
+    if not isinstance(bag, dict):
+        return None
+    candidates: list[dict[str, Any]] = [bag]
+    for nest in ("metadata", "resourceAttributes", "resource"):
+        nested = bag.get(nest)
+        if isinstance(nested, dict):
+            candidates.append(nested)
+            inner = nested.get("attributes")
+            if isinstance(inner, dict):
+                candidates.append(inner)
+    for cand in candidates:
+        hit = cand.get(_SANDBOX_ATTR) or cand.get("sandbox_id")
+        if isinstance(hit, str) and hit.strip():
+            return hit
+    return None
+
+
+def hoist_sandbox_id(
+    trace: dict[str, Any], observations: list[dict[str, Any]]
+) -> str | None:
+    """Lift the runner's sandbox id out of a trace, or None when absent.
+
+    Checks, in order, the trace-level resource/metadata attributes then the
+    first observation's resource attributes, so the id resolves regardless of
+    whether Langfuse surfaces the OTel resource attr on the trace or only on an
+    observation. Only a present, non-empty attribute is returned -- no value is
+    invented.
+    """
+
+    hit = _probe_sandbox_attr(trace)
+    if hit:
+        return hit
+    if observations:
+        return _probe_sandbox_attr(observations[0])
+    return None
+
+
 def build_tree(observations: list[dict[str, Any]]) -> list[ObservationNode]:
     """Reconstruct the nested observation tree from a flat observation list.
 

--- a/apps/api/src/agentos_api/routers/runs.py
+++ b/apps/api/src/agentos_api/routers/runs.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..auth import require_api_key
 from ..deps import LangfuseDep
-from ..langfuse import build_tree
+from ..langfuse import build_tree, hoist_sandbox_id
 from ..metrics import agent_trace_filter
 from ..schemas import TraceTree
 
@@ -33,4 +33,8 @@ async def get_trace(trace_id: str, lf: LangfuseDep) -> TraceTree:
             status.HTTP_404_NOT_FOUND, "trace has no observations yet"
         )
     trace = await lf.get_trace(trace_id)
-    return TraceTree(trace=trace, tree=build_tree(observations))
+    return TraceTree(
+        trace=trace,
+        tree=build_tree(observations),
+        sandbox_id=hoist_sandbox_id(trace, observations),
+    )

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -215,6 +215,9 @@ class TraceTree(BaseModel):
 
     trace: dict[str, Any]
     tree: list[ObservationNode]
+    # The runner's sandbox id (agentos.sandbox_id), hoisted out of the trace/
+    # observation resource attributes; None when the trace predates the attr.
+    sandbox_id: str | None = None
 
 
 class MetricsSummary(BaseModel):

--- a/apps/api/tests/test_runs_proxy.py
+++ b/apps/api/tests/test_runs_proxy.py
@@ -58,6 +58,36 @@ def test_get_trace_returns_reconstructed_tree(
     assert body["tree"][0]["children"][0]["type"] == "GENERATION"
 
 
+def test_get_trace_surfaces_sandbox_id_from_observation(
+    auth_headers: dict[str, str],
+) -> None:
+    # The endpoint hoists agentos.sandbox_id onto the typed TraceTree field even
+    # when Langfuse carries it only on an observation (not the trace).
+    observations = [
+        {
+            "id": "r",
+            "type": "SPAN",
+            "name": "agent.run",
+            "startTime": "1",
+            "metadata": {"agentos.sandbox_id": "sbx-proxy"},
+        },
+    ]
+    with _app_with(observations) as client:
+        resp = client.get("/langfuse/traces/abc", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["sandbox_id"] == "sbx-proxy"
+
+
+def test_get_trace_sandbox_id_null_when_absent(
+    auth_headers: dict[str, str],
+) -> None:
+    observations = [{"id": "r", "type": "SPAN", "name": "agent.run", "startTime": "1"}]
+    with _app_with(observations) as client:
+        resp = client.get("/langfuse/traces/abc", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["sandbox_id"] is None
+
+
 def test_get_trace_404_when_no_observations(
     auth_headers: dict[str, str],
 ) -> None:

--- a/apps/api/tests/test_sandbox_hoist.py
+++ b/apps/api/tests/test_sandbox_hoist.py
@@ -1,0 +1,65 @@
+"""Unit tests for hoisting the runner's sandbox id out of a Langfuse trace.
+
+The runner stamps `agentos.sandbox_id` as an OTel resource attribute
+(runner/otel.py). Where Langfuse surfaces that attribute -- on the trace's
+resource/metadata or only on the observations -- is cluster/Langfuse-defined, so
+the hoist probes both. These tests fake both payload shapes; the real
+propagation is exercised only against a live Langfuse (see
+test_langfuse_integration.py).
+"""
+
+from typing import Any
+
+from agentos_api.langfuse import hoist_sandbox_id
+
+
+def test_hoist_from_trace_metadata() -> None:
+    trace = {"id": "t1", "metadata": {"agentos.sandbox_id": "runner-deal-desk-abc"}}
+    assert hoist_sandbox_id(trace, []) == "runner-deal-desk-abc"
+
+
+def test_hoist_from_trace_resource_attributes() -> None:
+    # Nested under resourceAttributes.attributes, the shape an OTel resource
+    # export can take once Langfuse maps it onto the trace.
+    trace = {
+        "id": "t1",
+        "resourceAttributes": {"attributes": {"agentos.sandbox_id": "sbx-9"}},
+    }
+    assert hoist_sandbox_id(trace, []) == "sbx-9"
+
+
+def test_hoist_from_first_observation_when_trace_lacks_it() -> None:
+    # Langfuse may surface the resource attr only on the observations; the hoist
+    # falls back to the first observation's resource attributes.
+    trace = {"id": "t1", "metadata": {"other": "x"}}
+    observations: list[dict[str, Any]] = [
+        {
+            "id": "root",
+            "type": "SPAN",
+            "resourceAttributes": {"agentos.sandbox_id": "sbx-obs"},
+        },
+        {"id": "child", "type": "SPAN"},
+    ]
+    assert hoist_sandbox_id(trace, observations) == "sbx-obs"
+
+
+def test_hoist_prefers_trace_over_observation() -> None:
+    trace = {"id": "t1", "metadata": {"agentos.sandbox_id": "sbx-trace"}}
+    observations = [{"id": "root", "metadata": {"agentos.sandbox_id": "sbx-obs"}}]
+    assert hoist_sandbox_id(trace, observations) == "sbx-trace"
+
+
+def test_hoist_accepts_bare_sandbox_id_key() -> None:
+    trace = {"id": "t1", "metadata": {"sandbox_id": "sbx-bare"}}
+    assert hoist_sandbox_id(trace, []) == "sbx-bare"
+
+
+def test_hoist_returns_none_when_absent() -> None:
+    trace = {"id": "t1", "metadata": {"other": "x"}}
+    observations = [{"id": "root", "type": "SPAN"}]
+    assert hoist_sandbox_id(trace, observations) is None
+
+
+def test_hoist_ignores_empty_value() -> None:
+    trace = {"id": "t1", "metadata": {"agentos.sandbox_id": ""}}
+    assert hoist_sandbox_id(trace, []) is None

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -52,6 +52,9 @@ export interface ObservationNode {
 export interface TraceTree {
   trace: Record<string, unknown>;
   tree: ObservationNode[];
+  // The serving sandbox id (agentos.sandbox_id), hoisted server-side from the
+  // trace/observation resource attributes; null when the trace predates it.
+  sandbox_id: string | null;
 }
 
 // A raw Langfuse trace row (opaque; we read a few well-known fields defensively).

--- a/apps/ui/src/state/reducer.test.ts
+++ b/apps/ui/src/state/reducer.test.ts
@@ -90,6 +90,22 @@ describe("reducer state machine", () => {
     expect(s.traceOpen).toBeNull();
   });
 
+  it("openLogs jumps to the logs tab preselected to the serving sandbox", () => {
+    const s = reducer(at(3), { type: "openLogs", sandboxId: "sbx-42" });
+    expect(s.nav).toBe("observability");
+    expect(s.obsTab).toBe("logs");
+    expect(s.logsPod).toBe("sbx-42");
+    expect(s.traceOpen).toBeNull();
+  });
+
+  it("a manual tab switch or nav clears the sandbox-logs prefill", () => {
+    let s = reducer(at(3), { type: "openLogs", sandboxId: "sbx-42" });
+    s = reducer(s, { type: "setObsTab", tab: "traces" });
+    expect(s.logsPod).toBeNull();
+    s = reducer(reducer(at(3), { type: "openLogs", sandboxId: "sbx-9" }), { type: "go", nav: "agents" });
+    expect(s.logsPod).toBeNull();
+  });
+
   it("changing tab or nav clears the agent trace filter", () => {
     let s = reducer(at(3), { type: "viewTraces", agentId: "agent-123" });
     s = reducer(s, { type: "setObsTab", tab: "metrics" });

--- a/apps/ui/src/state/store.tsx
+++ b/apps/ui/src/state/store.tsx
@@ -36,6 +36,7 @@ export function initialState(level: FixtureLevel): AppState {
     agentDetail: null,
     traceOpen: null,
     tracesAgentId: null,
+    logsPod: null,
     promoteForm: false,
     defaultModel: "claude-sonnet-5",
     driftHover: null,
@@ -58,6 +59,7 @@ function levelReset(s: AppState, level: FixtureLevel): AppState {
     matrixRun: false,
     traceOpen: null,
     tracesAgentId: null,
+    logsPod: null,
     obsTab: "traces",
     promoteForm: false,
     agentDeployed: level >= 3,
@@ -73,7 +75,7 @@ export function reducer(s: AppState, a: Action): AppState {
     case "setLevel":
       return levelReset(s, a.level);
     case "go":
-      return { ...s, nav: a.nav, agentDetail: null, traceOpen: null, tracesAgentId: null };
+      return { ...s, nav: a.nav, agentDetail: null, traceOpen: null, tracesAgentId: null, logsPod: null };
     case "openModal":
       return { ...s, modal: a.modal };
     case "closeModal":
@@ -83,7 +85,9 @@ export function reducer(s: AppState, a: Action): AppState {
     case "setEnv":
       return { ...s, env: a.env };
     case "setObsTab":
-      return { ...s, obsTab: a.tab, traceOpen: null, tracesAgentId: null };
+      // A manual tab switch clears any sandbox-logs prefill (openLogs sets the
+      // tab directly, so its prefill survives; a subsequent user click drops it).
+      return { ...s, obsTab: a.tab, traceOpen: null, tracesAgentId: null, logsPod: null };
     case "viewTraces":
       // Jump to the Traces tab pre-filtered to one agent (wired mode). The
       // fixture Traces list ignores the filter; the wired list applies it.
@@ -103,6 +107,19 @@ export function reducer(s: AppState, a: Action): AppState {
       return { ...s, traceOpen: a.id };
     case "closeTrace":
       return { ...s, traceOpen: null, promoteForm: false };
+    case "openLogs":
+      // Jump from a trace's detail into the Logs tab preselected to the serving
+      // sandbox. The sandbox id doubles as the pod-name prefill (RealLogs notes
+      // the sandbox_id<->pod-name assumption).
+      return {
+        ...s,
+        nav: "observability",
+        obsTab: "logs",
+        traceOpen: null,
+        agentDetail: null,
+        tracesAgentId: null,
+        logsPod: a.sandboxId,
+      };
     case "openAgentDetail":
       return { ...s, agentDetail: a.id };
     case "closeAgentDetail":

--- a/apps/ui/src/state/types.ts
+++ b/apps/ui/src/state/types.ts
@@ -50,6 +50,9 @@ export interface AppState {
   // When set (wired mode), the Traces list opens pre-filtered to this agent id;
   // null means all agents. Set by an agent card's "View traces" action.
   tracesAgentId: string | null;
+  // When set, the Logs tab opens preselected to this runner pod / sandbox id.
+  // Set by the trace detail's "View sandbox logs" action; null otherwise.
+  logsPod: string | null;
   promoteForm: boolean;
   defaultModel: string;
   driftHover: string | null;
@@ -73,6 +76,7 @@ export type Action =
   | { type: "setMetricRange"; range: MetricRange }
   | { type: "openTrace"; id: string }
   | { type: "closeTrace" }
+  | { type: "openLogs"; sandboxId: string }
   | { type: "openAgentDetail"; id: string }
   | { type: "closeAgentDetail" }
   | { type: "deployStart" }

--- a/apps/ui/src/views/obs/RealLogs.tsx
+++ b/apps/ui/src/views/obs/RealLogs.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { C } from "../../tokens";
 import { Button, Dot } from "../../primitives";
+import { useStore } from "../../state/store";
 import { getRunnerLogs, listRunnerPods, ApiError, type PodLogs } from "../../api/client";
 
 type Result =
@@ -68,14 +69,20 @@ function resultFromError(e: unknown): Result {
 // distinct cluster states are designed (503 no cluster, 404 pod not found, 502
 // other). On the dev box (no cluster) the 503 degraded state is expected.
 export function RealLogs() {
+  // When the trace detail's "View sandbox logs" set a prefill, preselect it. The
+  // sandbox_id doubles as the pod name: docker names the container after the
+  // sandbox, and on k8s the sandbox pod name is ASSUMED equal (to be confirmed on
+  // the cluster). Absent that identity, the prefill is a best-effort preselect.
+  const { state } = useStore();
+  const prefill = state.logsPod;
   const [namespace, setNamespace] = useState("agentos");
   const [pods, setPods] = useState<Pods>({ kind: "loading" });
-  const [selected, setSelected] = useState<string>(ALL);
+  const [selected, setSelected] = useState<string>(prefill ?? ALL);
   const [result, setResult] = useState<Result>({ kind: "idle" });
 
-  const loadPods = useCallback(async (ns: string) => {
+  const loadPods = useCallback(async (ns: string, keep: string = ALL) => {
     setPods({ kind: "loading" });
-    setSelected(ALL);
+    setSelected(keep);
     setResult({ kind: "idle" });
     try {
       const data = await listRunnerPods(ns.trim() || undefined);
@@ -89,9 +96,11 @@ export function RealLogs() {
     }
   }, []);
 
+  // Load pods on mount and whenever a new sandbox prefill arrives, keeping the
+  // prefilled pod selected across the reload (a namespace change resets to ALL).
   useEffect(() => {
-    void loadPods("agentos");
-  }, [loadPods]);
+    void loadPods("agentos", prefill ?? ALL);
+  }, [loadPods, prefill]);
 
   // Aggregate logs across every listed pod, one labeled block per pod. A single
   // pod short-circuits to the plain per-pod result so its distinct error states
@@ -143,7 +152,12 @@ export function RealLogs() {
     await fetchAll(ns, list);
   };
 
-  const podOptions = pods.kind === "ok" ? pods.pods : [];
+  const fetchedPods = pods.kind === "ok" ? pods.pods : [];
+  // Keep the selected pod in the dropdown even when the fetched list doesn't
+  // include it (a prefilled sandbox id, or a dev box with no cluster / empty
+  // list), so the <select> value always has a matching <option>.
+  const podOptions =
+    selected !== ALL && !fetchedPods.includes(selected) ? [selected, ...fetchedPods] : fetchedPods;
   const canFetch = pods.kind !== "loading";
 
   return (
@@ -167,7 +181,7 @@ export function RealLogs() {
           onChange={(e) => setSelected(e.target.value)}
           style={{ ...inputStyle, flex: 1, minWidth: 200 }}
         >
-          <option value={ALL}>{`All runner pods${podOptions.length ? ` (${podOptions.length})` : ""}`}</option>
+          <option value={ALL}>{`All runner pods${fetchedPods.length ? ` (${fetchedPods.length})` : ""}`}</option>
           {podOptions.map((p) => (
             <option key={p} value={p}>
               {p}

--- a/apps/ui/src/views/obs/RealTraces.tsx
+++ b/apps/ui/src/views/obs/RealTraces.tsx
@@ -167,15 +167,14 @@ function SpanRow({ node, depth }: { node: ObservationNode; depth: number }) {
   );
 }
 
-// Pull the runner's sandbox id from a trace's OTel resource/metadata, if present
-// (set by the runner as `agentos.sandbox_id`: the Docker container name locally,
-// the sandbox pod name on k8s). Returns null when absent, so the UI degrades
-// silently on traces emitted before the attribute existed.
-export function sandboxIdFromTrace(trace: RawTrace | null | undefined): string | null {
-  if (!trace || typeof trace !== "object") return null;
-  const candidates: unknown[] = [trace];
+// Probe one payload for the runner's OTel resource attribute (`agentos.sandbox_id`,
+// the Docker container name locally / the sandbox pod name on k8s). Checks the
+// object itself plus the keys Langfuse may nest resource/metadata attributes under.
+function probeSandboxAttr(source: unknown): string | null {
+  if (!source || typeof source !== "object") return null;
+  const candidates: unknown[] = [source];
   for (const key of ["metadata", "resourceAttributes", "resource"]) {
-    const v = (trace as Record<string, unknown>)[key];
+    const v = (source as Record<string, unknown>)[key];
     if (v && typeof v === "object") {
       candidates.push(v);
       const nested = (v as Record<string, unknown>).attributes;
@@ -190,12 +189,28 @@ export function sandboxIdFromTrace(trace: RawTrace | null | undefined): string |
   return null;
 }
 
+// Resolve the serving sandbox id. Prefers the API's typed field (TraceTree
+// `sandbox_id`, hoisted server-side from the trace/observation resource attrs);
+// falls back to probing the raw trace payload for older traces that predate the
+// hoist. Accepts either a full TraceTree or a bare trace dict (the probe path).
+// Returns null when absent, so the UI degrades silently.
+export function sandboxIdFromTrace(source: RawTrace | null | undefined): string | null {
+  if (!source || typeof source !== "object") return null;
+  const typed = (source as Record<string, unknown>)["sandbox_id"];
+  if (typeof typed === "string" && typed.trim() !== "") return typed;
+  const rec = source as Record<string, unknown>;
+  return probeSandboxAttr(rec) ?? probeSandboxAttr(rec["trace"]);
+}
+
 // Live trace drill-in: the reconstructed observation tree from the API proxy.
 export function RealTraceDetail() {
   const { state, dispatch } = useStore();
   const { data, loading, error, notFound } = useTrace(state.traceOpen);
   const traceName = data ? (str(data.trace as RawTrace, "name") ?? state.traceOpen) : state.traceOpen;
-  const sandboxId = sandboxIdFromTrace(data?.trace as RawTrace | undefined);
+  // Prefer the API's typed field; fall back to probing the raw trace payload.
+  const typedSandboxId =
+    typeof data?.sandbox_id === "string" && data.sandbox_id.trim() !== "" ? data.sandbox_id : null;
+  const sandboxId = typedSandboxId ?? sandboxIdFromTrace(data?.trace as RawTrace | undefined);
 
   return (
     <div>
@@ -231,6 +246,24 @@ export function RealTraceDetail() {
             >
               <Dot color={C.mutedStatus} size={6} />
               Served by sandbox <span style={{ color: C.text2 }}>{sandboxId}</span>
+              <button
+                type="button"
+                data-testid="view-sandbox-logs"
+                onClick={() => dispatch({ type: "openLogs", sandboxId })}
+                style={{
+                  marginLeft: 6,
+                  background: "transparent",
+                  border: "1px solid " + C.border,
+                  borderRadius: 20,
+                  padding: "2px 10px",
+                  color: C.link,
+                  fontFamily: C.mono,
+                  fontSize: 11.5,
+                  cursor: "pointer",
+                }}
+              >
+                View sandbox logs →
+              </button>
             </div>
           ) : null}
           <Card>

--- a/apps/ui/src/views/obs/sandbox-logs.test.tsx
+++ b/apps/ui/src/views/obs/sandbox-logs.test.tsx
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { RealTraceDetail } from "./RealTraces";
+import { RealLogs } from "./RealLogs";
+import { StoreProvider, useStore } from "../../state/store";
+import { getTrace, listRunnerPods, type TraceTree, type RunnerPods } from "../../api/client";
+
+// Mock only the data-layer calls; keep the real ApiError so RealLogs' error
+// branching (instanceof ApiError) is preserved.
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return { ...actual, getTrace: vi.fn(), listRunnerPods: vi.fn() };
+});
+
+const TRACE: TraceTree = {
+  trace: { id: "tr-1", name: "agentos-run:agent-x-thread-1" },
+  tree: [{ id: "root", type: "SPAN", name: "agent.run", model: null, startTime: "1", usageDetails: null, children: [] }],
+  sandbox_id: "sbx-42",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getTrace).mockResolvedValue(TRACE);
+  vi.mocked(listRunnerPods).mockResolvedValue({ namespace: "agentos", pods: ["pod-a"] } as RunnerPods);
+});
+
+function renderWired(ui: React.ReactNode) {
+  // RealTraceDetail consumes the react-query useTrace hook, so a QueryClientProvider
+  // is required (retry off so results resolve on the first response).
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <StoreProvider level={3}>{ui}</StoreProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// Surfaces the nav-relevant store state so a test can assert what openLogs did.
+function NavProbe() {
+  const { state } = useStore();
+  return <div data-testid="nav-probe">{`${state.nav}:${state.obsTab}:${state.logsPod ?? ""}`}</div>;
+}
+
+describe("RealTraceDetail — view sandbox logs (issue #16)", () => {
+  it("shows the control when a typed sandbox id is present and jumps to the logs tab prefilled", async () => {
+    const user = userEvent.setup();
+
+    function Harness() {
+      const { dispatch } = useStore();
+      useEffect(() => {
+        dispatch({ type: "openTrace", id: "tr-1" });
+      }, [dispatch]);
+      return (
+        <>
+          <RealTraceDetail />
+          <NavProbe />
+        </>
+      );
+    }
+
+    renderWired(<Harness />);
+
+    // The "Served by sandbox" row and the jump control appear once the trace loads.
+    expect(await screen.findByTestId("trace-sandbox")).toHaveTextContent("sbx-42");
+    const btn = await screen.findByTestId("view-sandbox-logs");
+
+    await user.click(btn);
+
+    // The store navigated to the Logs tab preselected to the serving sandbox.
+    await waitFor(() =>
+      expect(screen.getByTestId("nav-probe")).toHaveTextContent("observability:logs:sbx-42"),
+    );
+  });
+
+  it("does not render the control when no sandbox id is present", async () => {
+    vi.mocked(getTrace).mockResolvedValue({ ...TRACE, sandbox_id: null, trace: { id: "tr-1", name: "n" } });
+
+    function Harness() {
+      const { dispatch } = useStore();
+      useEffect(() => {
+        dispatch({ type: "openTrace", id: "tr-1" });
+      }, [dispatch]);
+      return <RealTraceDetail />;
+    }
+
+    renderWired(<Harness />);
+    // The span tree renders (trace loaded) but the sandbox control is absent.
+    expect(await screen.findByTestId("span-tree")).toBeInTheDocument();
+    expect(screen.queryByTestId("view-sandbox-logs")).toBeNull();
+  });
+});
+
+describe("RealLogs — sandbox prefill (issue #16)", () => {
+  it("preselects the prefilled sandbox id as the pod, even if not in the fetched list", async () => {
+    function Harness() {
+      const { dispatch } = useStore();
+      useEffect(() => {
+        dispatch({ type: "openLogs", sandboxId: "sbx-42" });
+      }, [dispatch]);
+      return <RealLogs />;
+    }
+
+    renderWired(<Harness />);
+
+    // The pod dropdown is preselected to the prefilled sandbox id, and it exists
+    // as an option even though the cluster only returned "pod-a".
+    const select = (await screen.findByTestId("logs-pod-select")) as HTMLSelectElement;
+    await waitFor(() => expect(select.value).toBe("sbx-42"));
+    expect(Array.from(select.options).map((o) => o.value)).toContain("sbx-42");
+  });
+});

--- a/apps/ui/src/views/obs/sandbox.test.ts
+++ b/apps/ui/src/views/obs/sandbox.test.ts
@@ -18,6 +18,20 @@ describe("sandboxIdFromTrace", () => {
     expect(sandboxIdFromTrace({ metadata: { sandbox_id: "sbx-bare" } })).toBe("sbx-bare");
   });
 
+  it("prefers a top-level typed sandbox_id (the API's hoisted field)", () => {
+    // A whole TraceTree can be passed: the typed field wins over a probe of the
+    // nested raw trace payload.
+    expect(
+      sandboxIdFromTrace({ sandbox_id: "sbx-typed", trace: { metadata: { "agentos.sandbox_id": "sbx-probed" } } }),
+    ).toBe("sbx-typed");
+  });
+
+  it("falls back to probing the nested trace when the typed field is absent", () => {
+    expect(sandboxIdFromTrace({ sandbox_id: null, trace: { metadata: { "agentos.sandbox_id": "sbx-probed" } } })).toBe(
+      "sbx-probed",
+    );
+  });
+
   it("returns null when absent or blank, so the UI degrades silently", () => {
     expect(sandboxIdFromTrace({ metadata: { other: "x" } })).toBeNull();
     expect(sandboxIdFromTrace({ metadata: { "agentos.sandbox_id": "" } })).toBeNull();


### PR DESCRIPTION
Part of #16 (sandbox visibility) — the **fully-testable slice**. Does not close #16.

Much of #16 was already merged (the pod-logs endpoint + k8s reader seam, the runner-pods list, the Logs tab, and a "Served by sandbox" row). This slice hardens the **identity** and closes the "**from that view**" gap.

## What
- **API:** hoist `agentos.sandbox_id` into a typed `TraceTree.sandbox_id`, lifting it from the trace-level resource/metadata attributes or (fallback) the first observation's attributes — so it resolves regardless of where Langfuse surfaces the OTel resource attr. `trace: dict` is untouched; `openapi.json` regenerated (drift test passes).
- **UI:** `RealTraceDetail` prefers the typed field (keeps the key-probe as a safety fallback) and adds a **"View sandbox logs"** control that opens the Logs tab prefilled to that sandbox via a new `openLogs` store action. `RealLogs` preselects the prefilled sandbox and injects it as a `<select>` option even if the fetched pod list lacks it. The `sandbox_id`↔pod-name identity is code-commented (docker: container name == sandbox name; k8s: assumed equal, to confirm on cluster).

## Tests
API hoist unit tests (trace-level, observation-fallback, precedence, bare key, absent, empty) + a proxy test surfacing the field; UI reducer tests (`openLogs` + prefill clearing) + a component test (button shown/hidden, `openLogs` nav, prefill option injection). API + UI suites green; `ruff`/`mypy`/`typecheck`/`lint` clean.

## Remaining for #16 (deliberately separate — need cluster/docker + an ADR)
1. **Docker log-reader parity** — the pod-logs endpoint proxies the k8s API only; local (`docker logs`) sandboxes 503 today. Needs a `DockerPodLogReader` in the API selected by substrate + an ADR (docker-in-the-API decision).
2. **Per-agent live-sandbox list** — the runner-pods endpoint is namespace-wide; per-agent filtering needs an agent-id label stamped on claims (worker + chart) and cluster verification.
3. **Cluster/Langfuse propagation** of the resource attr through the OTLP collector is verified only by the live `test_langfuse_integration.py` (can't run stackless); the added unit tests fake both payload shapes.