### PR TITLE
Observability polish: honest empty evals, quieter idle eval log, missing-OTLP warning

### DIFF
--- a/apps/worker/src/agentos_worker/eval/recorder.py
+++ b/apps/worker/src/agentos_worker/eval/recorder.py
@@ -46,6 +46,12 @@ class LangfuseEvalRecorder:
 
     async def record(self, run: EvalRunResult) -> list[str]:
         """Ingest one trace + score per case. Returns the created trace ids."""
+        if not run.results:
+            # A run with no case results (a 0/0 replay, an empty suite, or a
+            # failed-to-load bundle reported with results=[]) has nothing to
+            # observe. Posting it would create observation-less trace shells;
+            # keep the honest empty state and write nothing.
+            return []
         now = _now_iso()
         batch: list[dict[str, Any]] = []
         trace_ids: list[str] = []

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -246,9 +246,17 @@ class EvalStreamConsumer:
                     count=1,
                     block=self._config.read_block_ms,
                 )
-            except (RedisTimeoutError, RedisConnectionError) as exc:
-                # Same transient-transport guard as the runs consumer: a blocking
-                # read timeout or connection blip must not kill the eval loop.
+            except RedisTimeoutError:
+                # The routine case: the blocking read hit its block window with no
+                # eval entries. This fires every poll cycle on an idle worker, so
+                # log at DEBUG rather than flooding logs with WARNINGs.
+                logger.debug("eval stream read timed out (idle); retrying")
+                await self._sleep_or_stop(_EVAL_READ_ERROR_BACKOFF_S)
+                continue
+            except RedisConnectionError as exc:
+                # A real transport blip (Valkey failover, pod-to-pod drop): keep
+                # WARNING so genuine failures stay visible. It must still not kill
+                # the eval loop.
                 logger.warning("eval stream read failed transiently; retrying: %s", exc)
                 await self._sleep_or_stop(_EVAL_READ_ERROR_BACKOFF_S)
                 continue

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -41,6 +41,8 @@ from .sandbox import (
 from .slack_sink import AsyncSlackSink
 from .threadlock import ThreadLock
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class Runtime:
@@ -109,6 +111,16 @@ def _sandbox_client(
                 "before starting the worker, set AGENTOS_MODEL_BASE_URL to a local "
                 "endpoint for local-model mode, or set AGENTOS_FAKE_MODEL=1 for an "
                 "offline/test run."
+            )
+        if not env.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+            # A silent no-telemetry config is a common footgun in local middle
+            # mode: runs execute but no traces reach Langfuse. Warn at boot so it
+            # is caught early rather than debugged as "the Runs view is empty".
+            logger.warning(
+                "AGENTOS_SANDBOX_SUBSTRATE=docker but OTEL_EXPORTER_OTLP_ENDPOINT "
+                "is not set: runner containers will emit no traces. Set it (e.g. "
+                "http://otel-collector:4318, joined via AGENTOS_DOCKER_NETWORK) to "
+                "enable OTLP export."
             )
         return DockerSandboxClient(
             image=env.get("AGENTOS_RUNNER_IMAGE", "agentos-runner"),

--- a/apps/worker/tests/eval/test_recorder.py
+++ b/apps/worker/tests/eval/test_recorder.py
@@ -15,8 +15,14 @@ from typing import Any
 
 import httpx
 import pytest
-from agentos_worker.eval import EvalCaseResult, EvalRunResult, LangfuseEvalRecorder
+from agentos_worker.eval import (
+    EvalCaseResult,
+    EvalRunResult,
+    EvalSuite,
+    LangfuseEvalRecorder,
+)
 from agentos_worker.eval.recorder import SCORE_NAME
+from agentos_worker.eval.run import run_eval_suite
 
 _LF_HOST = os.environ.get("TEST_LANGFUSE_HOST", "http://localhost:23000")
 _LF_PK = os.environ.get("TEST_LANGFUSE_PUBLIC_KEY", "pk-lf-agentos-dev")
@@ -86,5 +92,39 @@ def test_records_per_case_results_and_reads_them_back() -> None:
             for trace in traces:
                 expected = 1.0 if (trace.get("metadata") or {}).get("passed") else 0.0
                 assert await _score_for_trace(client, trace["id"]) == expected
+
+    asyncio.run(go())
+
+
+def test_empty_suite_run_writes_no_langfuse_trace() -> None:
+    # Real scenario: a plugin ships an eval suite with no cases (or a 0/0
+    # replay). Running it must not write observation-less trace shells -- keep
+    # the honest empty state. Drive the real run_eval_suite entrypoint over an
+    # empty suite (0 cases => 0 runner calls => a real empty result) and assert
+    # nothing is ingested. Only Langfuse's HTTP is spied (the external-service
+    # rule); the eval run path itself is exercised for real.
+    async def go() -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(207, json={"errors": []})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            recorder = LangfuseEvalRecorder(
+                base_url="http://langfuse.invalid",
+                public_key="pk",
+                secret_key="sk",
+                client=client,
+            )
+            result = await run_eval_suite(
+                EvalSuite(name="empty", cases=[]),
+                base_url="http://runner.invalid",
+                version="v1",
+                recorder=recorder,
+            )
+
+        assert result.results == []
+        assert requests == []  # 0-case run -> no ingestion, no observation-less shell
 
     asyncio.run(go())

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -7,6 +7,8 @@ AGENTOS_FAKE_MODEL must fail loudly instead of silently degrading to a fake.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from agentos_worker.config import WorkerConfig
 from agentos_worker.run import _sandbox_client, _substrate_config
@@ -81,3 +83,26 @@ def test_docker_with_explicit_fake_model_builds_docker_client() -> None:
         WorkerConfig(fake_model=True), {"AGENTOS_SANDBOX_SUBSTRATE": "docker"}, _SUB
     )
     assert isinstance(client, DockerSandboxClient)
+
+
+def test_docker_without_otel_endpoint_warns(caplog: pytest.LogCaptureFixture) -> None:
+    # A Docker worker with no OTLP endpoint runs fine but emits no traces; the
+    # worker warns at boot so the silent no-telemetry config is caught early.
+    with caplog.at_level(logging.WARNING, logger="agentos_worker.run"):
+        _sandbox_client(
+            WorkerConfig(fake_model=True), {"AGENTOS_SANDBOX_SUBSTRATE": "docker"}, _SUB
+        )
+    assert any("OTEL_EXPORTER_OTLP_ENDPOINT" in r.message for r in caplog.records)
+
+
+def test_docker_with_otel_endpoint_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger="agentos_worker.run"):
+        _sandbox_client(
+            WorkerConfig(fake_model=True),
+            {
+                "AGENTOS_SANDBOX_SUBSTRATE": "docker",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector:4318",
+            },
+            _SUB,
+        )
+    assert not any("OTEL_EXPORTER_OTLP_ENDPOINT" in r.message for r in caplog.records)


### PR DESCRIPTION
Part of #17 (batch of small observability fixes). Three of the four items land here; two are deliberately deferred (below).

## Done here (worker lane)
- **Empty-trace shells:** `recorder.record()` short-circuits for a 0/0 run (empty suite, or a failed-to-load bundle reported with `results=[]`) instead of POSTing an observation-less batch — keep the honest empty state.
- **Idle-log noise (eval consumer):** split the eval read-loop `except` so a routine blocking-read timeout logs at DEBUG (it fires every poll cycle on an idle worker) while a real `RedisConnectionError` still logs WARNING.
- **Missing-OTLP boot warning:** the worker warns at boot when `AGENTOS_SANDBOX_SUBSTRATE=docker` and `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, so a silent no-telemetry config is caught early.

## Deferred, with reasons
- **`latency_p95_seconds` misnomer:** the honest fix (rename, or convert to seconds) also requires changing the UI consumer (`apps/ui/src/lib/format.ts`, `RealMetrics.tsx`), which is another lane's surface. Should land as one coordinated API+UI change, not a solo worker-lane push.
- **Idle-log noise on the *runs* consumer (`consumer.py`):** `consumer.py` is the sacred single-owner kernel module (`apps/worker/CLAUDE.md`). The same DEBUG/WARNING split belongs there, applied by that owner, not as a side effect of this ticket.

Leaving #17 open for those two.

## Validation
ruff + mypy clean; new unit tests for the empty-run skip (mock transport) and the OTLP boot warning (both present/absent). The `test_stream.py` failures are pre-existing on `main` (need Langfuse / a runner not booted here) and unchanged by this diff.