### PR TITLE
API: POST /evals/trigger — run a platform eval on demand

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -567,6 +567,103 @@
         "title": "EvalReportResult",
         "type": "object"
       },
+      "EvalTriggerRequest": {
+        "description": "Ask for an on-demand platform eval run for an agent (issue #10).\n\nEnqueues the same EvalJobRequest the git-push fan-out uses, minus the\npush-only gate. With no version_id the agent's active dev deployment is\nevaluated; suite falls back to Settings.eval_default_suite when omitted.",
+        "properties": {
+          "agent_id": {
+            "format": "uuid",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "suite": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suite"
+          },
+          "target_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Url"
+          },
+          "version_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version Id"
+          }
+        },
+        "required": [
+          "agent_id"
+        ],
+        "title": "EvalTriggerRequest",
+        "type": "object"
+      },
+      "EvalTriggerResult": {
+        "description": "The enqueued eval job's stream id plus the resolved job identity.",
+        "properties": {
+          "agent_id": {
+            "format": "uuid",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "bundle_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bundle Ref"
+          },
+          "sha": {
+            "title": "Sha",
+            "type": "string"
+          },
+          "stream_id": {
+            "title": "Stream Id",
+            "type": "string"
+          },
+          "suite": {
+            "title": "Suite",
+            "type": "string"
+          },
+          "version_id": {
+            "format": "uuid",
+            "title": "Version Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "stream_id",
+          "agent_id",
+          "version_id",
+          "sha",
+          "suite",
+          "bundle_ref"
+        ],
+        "title": "EvalTriggerResult",
+        "type": "object"
+      },
       "GreetingPackConfig": {
         "description": "The deterministic greeting short-circuit content for one agent.",
         "properties": {
@@ -2749,6 +2846,65 @@
           }
         },
         "summary": "Report Eval",
+        "tags": [
+          "evals"
+        ]
+      }
+    },
+    "/evals/trigger": {
+      "post": {
+        "operationId": "trigger_eval_evals_trigger_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvalTriggerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalTriggerResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Trigger Eval",
         "tags": [
           "evals"
         ]

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -212,6 +212,28 @@ async def create_deployment(
     )
 
 
+async def get_active_deployment(
+    session: AsyncSession, agent_id: uuid.UUID, environment: Environment
+) -> Deployment | None:
+    """The agent's current active deployment in an environment (most recent).
+
+    Git-flow appends a new active Deployment row per push without superseding
+    older ones, so "current" is the latest active row for the environment.
+    """
+
+    result: Deployment | None = await session.scalar(
+        select(Deployment)
+        .where(
+            Deployment.agent_id == agent_id,
+            Deployment.environment == environment,
+            Deployment.status == "active",
+        )
+        .order_by(Deployment.deployed_at.desc())
+        .limit(1)
+    )
+    return result
+
+
 async def list_deployments(
     session: AsyncSession, agent_id: uuid.UUID | None = None
 ) -> list[Deployment]:

--- a/apps/api/src/agentos_api/routers/evals.py
+++ b/apps/api/src/agentos_api/routers/evals.py
@@ -2,15 +2,91 @@
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from .. import crud
 from ..auth import require_api_key
-from ..deps import GitHubReporterDep, LangfuseDep
+from ..config import get_settings
+from ..deps import EvalQueueDep, GitHubReporterDep, LangfuseDep, SessionDep
+from ..evalqueue import EvalJobRequest, now_iso
 from ..evals import build_matrix
 from ..github_checks import GitHubReportError
-from ..schemas import EvalMatrix, EvalReport, EvalReportResult
+from ..models import Environment
+from ..schemas import (
+    EvalMatrix,
+    EvalReport,
+    EvalReportResult,
+    EvalTriggerRequest,
+    EvalTriggerResult,
+)
 
 router = APIRouter(
     prefix="/evals", tags=["evals"], dependencies=[Depends(require_api_key)]
 )
+
+
+@router.post("/trigger", response_model=EvalTriggerResult)
+async def trigger_eval(
+    body: EvalTriggerRequest, session: SessionDep, queue: EvalQueueDep
+) -> EvalTriggerResult:
+    # On-demand sibling of the git-push eval fan-out (gitflow.process_push):
+    # enqueue the SAME EvalJobRequest onto agentos:evals, minus the push-only
+    # gate. This does NOT parse the eval-case format (worker/CLI concern); it
+    # only resolves and emits agent_id/version_id/sha/suite/bundle_ref.
+    agent = await crud.get_agent(session, body.agent_id)
+    if agent is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+
+    if body.version_id is not None:
+        version = await crud.get_version(session, body.version_id)
+        if version is None or version.agent_id != agent.id:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, "version not found for this agent"
+            )
+        sha = version.commit_sha
+    else:
+        deployment = await crud.get_active_deployment(
+            session, agent.id, Environment.dev
+        )
+        if deployment is None:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND,
+                "agent has no active dev deployment to evaluate",
+            )
+        version = await crud.get_version(session, deployment.version_id)
+        if version is None:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, "deployed version not found"
+            )
+        sha = version.commit_sha or deployment.commit_sha
+
+    if sha is None:
+        # A version with no commit sha cannot be keyed in eval traces; this is a
+        # caller/data problem, surfaced as a clean 4xx rather than a 500 on the
+        # required-string EvalJobRequest.sha field.
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "resolved version has no commit sha; cannot run eval",
+        )
+
+    suite = body.suite or get_settings().eval_default_suite
+    stream_id = await queue.enqueue(
+        EvalJobRequest(
+            agent_id=agent.id,
+            version_id=version.id,
+            sha=sha,
+            suite=suite,
+            bundle_ref=version.bundle_ref,
+            target_url=body.target_url,
+            requested_at=now_iso(),
+        )
+    )
+    return EvalTriggerResult(
+        stream_id=stream_id,
+        agent_id=agent.id,
+        version_id=version.id,
+        sha=sha,
+        suite=suite,
+        bundle_ref=version.bundle_ref,
+    )
 
 
 @router.get("/matrix", response_model=EvalMatrix)

--- a/apps/api/src/agentos_api/routers/evals.py
+++ b/apps/api/src/agentos_api/routers/evals.py
@@ -67,6 +67,15 @@ async def trigger_eval(
             "resolved version has no commit sha; cannot run eval",
         )
 
+    if version.bundle_ref is None:
+        # The worker reads eval cases from the built bundle, so a version whose
+        # bundle was never built has nothing to evaluate. Reject up front rather
+        # than enqueuing an unrunnable job (mirrors the missing-sha guard above).
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"version {version.id} has no built bundle; nothing to evaluate",
+        )
+
     suite = body.suite or get_settings().eval_default_suite
     stream_id = await queue.enqueue(
         EvalJobRequest(

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -283,6 +283,31 @@ class EvalMatrix(BaseModel):
     rows: list[EvalMatrixRow]
 
 
+class EvalTriggerRequest(BaseModel):
+    """Ask for an on-demand platform eval run for an agent (issue #10).
+
+    Enqueues the same EvalJobRequest the git-push fan-out uses, minus the
+    push-only gate. With no version_id the agent's active dev deployment is
+    evaluated; suite falls back to Settings.eval_default_suite when omitted.
+    """
+
+    agent_id: uuid.UUID
+    version_id: uuid.UUID | None = None
+    suite: str | None = None
+    target_url: str | None = None
+
+
+class EvalTriggerResult(BaseModel):
+    """The enqueued eval job's stream id plus the resolved job identity."""
+
+    stream_id: str
+    agent_id: uuid.UUID
+    version_id: uuid.UUID
+    sha: str
+    suite: str
+    bundle_ref: str | None
+
+
 class EvalReport(BaseModel):
     """An eval run's rollup, reported so the API can post the PR check."""
 

--- a/apps/api/tests/test_evals_trigger_integration.py
+++ b/apps/api/tests/test_evals_trigger_integration.py
@@ -222,6 +222,39 @@ def test_trigger_explicit_version_id_is_used(
     assert body["bundle_ref"] == "b/2.tgz"
 
 
+def test_trigger_version_without_bundle_returns_400_and_does_not_enqueue(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, "trigger-no-bundle")
+    # The version has a commit sha but its bundle was never built; the worker
+    # reads eval cases from the bundle, so there is nothing to evaluate.
+    seeded = _seed(agent["id"], commit_sha="deadbeef", bundle_ref=None)
+
+    resp = client.post(
+        "/evals/trigger",
+        json={"agent_id": agent["id"], "version_id": seeded["version_id"]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400, resp.text
+    assert "no built bundle" in resp.json()["detail"]
+    assert _count_eval_entries_for_agent(agent["id"]) == 0
+
+
+def test_trigger_active_dev_deployment_without_bundle_returns_400(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Same guard on the active-dev-deployment resolution path (no version_id).
+    agent = _create_agent(client, auth_headers, "trigger-no-bundle-deploy")
+    _seed(agent["id"], commit_sha="deadbeef", bundle_ref=None)
+
+    resp = client.post(
+        "/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers
+    )
+    assert resp.status_code == 400, resp.text
+    assert "no built bundle" in resp.json()["detail"]
+    assert _count_eval_entries_for_agent(agent["id"]) == 0
+
+
 def test_trigger_unknown_version_for_agent_returns_404(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:

--- a/apps/api/tests/test_evals_trigger_integration.py
+++ b/apps/api/tests/test_evals_trigger_integration.py
@@ -1,0 +1,236 @@
+"""On-demand eval trigger endpoint (issue #10) against real Postgres + Valkey.
+
+Asserts POST /evals/trigger resolves an agent's active dev deployment (or an
+explicit version) and enqueues the SAME EvalJobRequest shape onto agentos:evals
+that the git-push fan-out uses -- minus the push-only gate. Mirrors
+test_evalqueue_integration's stream assertions and the router auth tests.
+"""
+
+import asyncio
+import json
+import uuid
+from typing import Any
+
+import redis
+from agentos_api import crud
+from agentos_api.config import get_settings
+from agentos_api.evalqueue import STREAM_PAYLOAD_FIELD, EvalJobRequest
+from agentos_api.models import Environment
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+REPO = "octo/trigger-10"
+
+
+def _create_agent(client: Any, auth_headers: dict[str, str], name: str) -> dict[str, Any]:
+    resp = client.post(
+        "/agents",
+        json={"name": name, "slack_channel": "#k", "repo_full_name": REPO},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _seed_version_and_dev_deployment(
+    agent_id: str,
+    *,
+    version_label: str,
+    commit_sha: str | None,
+    bundle_ref: str | None,
+    deploy: bool = True,
+) -> dict[str, str | None]:
+    """Insert a version (with commit_sha/bundle_ref) and, optionally, an active
+    dev deployment for it -- straight through the crud layer against the same
+    disposable DB the app is bound to (mirrors conftest._truncate)."""
+
+    engine = create_async_engine(get_settings().database_url)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with sessionmaker() as session:
+            version = await crud.create_version_row(
+                session,
+                uuid.UUID(agent_id),
+                version_label=version_label,
+                created_by="test",
+                commit_sha=commit_sha,
+                bundle_ref=bundle_ref,
+            )
+            version_id = str(version.id)
+            if deploy:
+                await crud.create_deployment_row(
+                    session,
+                    uuid.UUID(agent_id),
+                    version.id,
+                    Environment.dev,
+                    commit_sha=commit_sha,
+                )
+    finally:
+        await engine.dispose()
+    return {"version_id": version_id, "sha": commit_sha, "bundle_ref": bundle_ref}
+
+
+def _seed(
+    agent_id: str,
+    *,
+    version_label: str = "v1",
+    commit_sha: str | None = "cafef00d",
+    bundle_ref: str | None = "bundles/x/y.tar.gz",
+    deploy: bool = True,
+) -> dict[str, str | None]:
+    return asyncio.run(
+        _seed_version_and_dev_deployment(
+            agent_id,
+            version_label=version_label,
+            commit_sha=commit_sha,
+            bundle_ref=bundle_ref,
+            deploy=deploy,
+        )
+    )
+
+
+def _payload_for_stream_id(stream_id: str) -> dict[str, Any] | None:
+    sync = redis.from_url(get_settings().valkey_dsn())
+    try:
+        entries = sync.xrange("agentos:evals", min=stream_id, max=stream_id)
+        if not entries:
+            return None
+        _id, fields = entries[0]
+        return json.loads(fields[STREAM_PAYLOAD_FIELD.encode()])
+    finally:
+        sync.close()
+
+
+def _count_eval_entries_for_agent(agent_id: str) -> int:
+    sync = redis.from_url(get_settings().valkey_dsn())
+    try:
+        return sum(
+            1
+            for _id, fields in sync.xrevrange("agentos:evals", count=200)
+            if json.loads(fields[STREAM_PAYLOAD_FIELD.encode()]).get("agent_id")
+            == agent_id
+        )
+    finally:
+        sync.close()
+
+
+def test_trigger_enqueues_for_active_dev_deployment(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, "trigger-active")
+    seeded = _seed(agent["id"])
+
+    resp = client.post(
+        "/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["stream_id"]
+    assert body["version_id"] == seeded["version_id"]
+    assert body["sha"] == seeded["sha"]
+    assert body["suite"] == get_settings().eval_default_suite
+    assert body["bundle_ref"] == seeded["bundle_ref"]
+
+    # The decoded stream payload round-trips through EvalJobRequest with exactly
+    # the resolved fields (same wire contract as the git-push fan-out).
+    payload = _payload_for_stream_id(body["stream_id"])
+    assert payload is not None
+    req = EvalJobRequest.model_validate(payload)
+    assert str(req.agent_id) == agent["id"]
+    assert str(req.version_id) == seeded["version_id"]
+    assert req.sha == seeded["sha"]
+    assert req.suite == get_settings().eval_default_suite
+    assert req.bundle_ref == seeded["bundle_ref"]
+    assert req.target_url is None
+
+
+def test_trigger_requires_api_key(client: Any) -> None:
+    assert client.post("/evals/trigger", json={"agent_id": str(uuid.uuid4())}).status_code == 401
+
+
+def test_trigger_unknown_agent_returns_404_and_does_not_enqueue(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    missing = str(uuid.uuid4())
+    resp = client.post(
+        "/evals/trigger", json={"agent_id": missing}, headers=auth_headers
+    )
+    assert resp.status_code == 404, resp.text
+    assert _count_eval_entries_for_agent(missing) == 0
+
+
+def test_trigger_agent_without_active_dev_deployment_returns_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, "trigger-nodeploy")
+    # A version exists but was never deployed to dev.
+    _seed(agent["id"], deploy=False)
+    resp = client.post(
+        "/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers
+    )
+    assert resp.status_code == 404, resp.text
+    assert _count_eval_entries_for_agent(agent["id"]) == 0
+
+
+def test_trigger_suite_defaults_and_explicit(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, "trigger-suite")
+    _seed(agent["id"])
+
+    # Omitted -> eval_default_suite.
+    default_resp = client.post(
+        "/evals/trigger", json={"agent_id": agent["id"]}, headers=auth_headers
+    )
+    assert default_resp.status_code == 200, default_resp.text
+    assert default_resp.json()["suite"] == get_settings().eval_default_suite
+
+    # Explicit -> honored, and rides onto the stream.
+    explicit = client.post(
+        "/evals/trigger",
+        json={"agent_id": agent["id"], "suite": "regression"},
+        headers=auth_headers,
+    )
+    assert explicit.status_code == 200, explicit.text
+    assert explicit.json()["suite"] == "regression"
+    payload = _payload_for_stream_id(explicit.json()["stream_id"])
+    assert payload is not None and payload["suite"] == "regression"
+
+
+def test_trigger_explicit_version_id_is_used(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, "trigger-explicit-version")
+    # Active dev deployment points at v1; the caller asks for v2 explicitly.
+    _seed(agent["id"], version_label="v1", commit_sha="1111aaaa", bundle_ref="b/1.tgz")
+    v2 = _seed(
+        agent["id"],
+        version_label="v2",
+        commit_sha="2222bbbb",
+        bundle_ref="b/2.tgz",
+        deploy=False,
+    )
+
+    resp = client.post(
+        "/evals/trigger",
+        json={"agent_id": agent["id"], "version_id": v2["version_id"]},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["version_id"] == v2["version_id"]
+    assert body["sha"] == "2222bbbb"
+    assert body["bundle_ref"] == "b/2.tgz"
+
+
+def test_trigger_unknown_version_for_agent_returns_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers, "trigger-bad-version")
+    _seed(agent["id"])
+    resp = client.post(
+        "/evals/trigger",
+        json={"agent_id": agent["id"], "version_id": str(uuid.uuid4())},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404, resp.text
+    assert _count_eval_entries_for_agent(agent["id"]) == 0


### PR DESCRIPTION
Closes #10 (API-endpoint side). Platform eval fan-out was GitHub-push-triggered only; this adds an authenticated endpoint to trigger a run on demand.

## What
`POST /evals/trigger` (evals router, under the shared `require_api_key`). Body: `{ agent_id, version_id?, suite?, target_url? }`. It enqueues the **same `EvalJobRequest`** onto `agentos:evals` that `gitflow.process_push` uses — minus the push-only (`dev + bundle_built`) gate.

- **Resolution** (via crud, no hand-rolled SQL): explicit `version_id` is ownership-checked against the agent; otherwise the agent's **active dev deployment** → its version. `sha = version.commit_sha or deployment.commit_sha`; `suite` defaults to `eval_default_suite`.
- **Clean errors, no stray enqueue:** unknown agent → 404, no active dev deployment → 404, unknown/foreign version → 404, missing sha → 400. Enqueue happens only after resolution succeeds.
- Returns the stream id.

## Decoupled from #8
The endpoint never imports/parses the eval-**case** models (`EvalCase`/`EvalSuite`/`Grader`) — the worker reads cases from the bundle at run time. The trigger contract is `EvalJobRequest` (suite by name + bundle by ref), so #8's case-format work can't change this endpoint. (#10's stated "depends on #8" is product-value, not a code coupling.)

## Tests
`test_evals_trigger_integration.py` (7, against real Postgres+Valkey): payload round-trips through `EvalJobRequest`; requires api key; unknown agent / no dev deployment / unknown version → 404 + no enqueue; suite default vs explicit; explicit version resolves its sha/bundle_ref. `openapi.json` regenerated (drift test passes). `ruff` + `mypy` clean. Rebased onto current `main`.