### PR TITLE
CI: supply-chain hardening (least-privilege permissions, SHA-pin actions, pin npx generators)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   python:
     name: Python (ruff + mypy + pytest)
@@ -15,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: "3.13"
       - name: Sync workspace
@@ -114,13 +117,13 @@ jobs:
           node-version: "22"
       - name: Regenerate TypeScript from the committed schema and check for drift
         run: |
-          npx --yes json-schema-to-typescript@15 \
+          npx --yes json-schema-to-typescript@15.0.4 \
             packages/aci-protocol/schema/aci-protocol.schema.json \
             --unreachableDefinitions --no-additionalProperties=false \
             -o packages/aci-protocol/generated/ts/aci-protocol.ts
           git diff --exit-code -- packages/aci-protocol/generated/ts/aci-protocol.ts
       - name: tsc --noEmit on generated ACI types
-        run: npx --yes -p typescript@5 tsc --noEmit -p packages/aci-protocol/generated/ts/tsconfig.json
+        run: npx --yes -p typescript@5.9.3 tsc --noEmit -p packages/aci-protocol/generated/ts/tsconfig.json
 
   ui:
     name: UI (lint + vitest + build + Playwright)
@@ -133,7 +136,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
       - name: Install Node

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,16 +48,16 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/agentos-${{ matrix.name }}
           tags: |
@@ -66,7 +66,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -93,16 +93,16 @@ jobs:
             echo "v=latest" >> "$GITHUB_OUTPUT"
           fi
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/agentos-worker-local
           tags: |
@@ -111,7 +111,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: compose
           file: compose/worker-local.Dockerfile
@@ -181,7 +181,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
       - name: Pin chart image tags to the release version
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -229,7 +229,7 @@ jobs:
           path: dist
           merge-multiple: true
       - name: Create release with generated notes
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             dist/agentos-*


### PR DESCRIPTION
Hardens the CI/release supply chain per the issue's three gaps.

- **Least-privilege token**: adds top-level `permissions: contents: read` to `ci.yaml` (it previously inherited the default read-write `GITHUB_TOKEN`). `release.yaml` already scoped correctly and is unchanged.
- **SHA-pinned third-party actions** in both `ci.yaml` and `release.yaml` (astral-sh/setup-uv, pnpm/action-setup, docker/setup-buildx / login / metadata / build-push, azure/setup-helm, softprops/action-gh-release). Each pin carries a `# vX.Y.Z` comment in the Dependabot-readable format, so the `github-actions` ecosystem tracked in #13 keeps them current. First-party `actions/*` are left on major tags (out of scope for "third-party actions").
- **Pinned npx generators** in the contracts-ts job: `json-schema-to-typescript@15.0.4` and `typescript@5.9.3`, so CI no longer fetches latest-in-major at build time.

Every pinned SHA was verified to dereference to the commented release tag. `persist-credentials: false` and the existing `release.yaml` permissions are preserved.

Closes #72