### PR TITLE
Isolate the MinIO credential off the runner-visible bundle volume

### DIFF
--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -128,6 +128,12 @@ spec:
         # runner reads it as AGENTOS_PLUGIN_DIR.
         - name: bundles
           emptyDir: {}
+        # mc writes the MinIO credential in cleartext to its config dir. Keep
+        # that dir on an init-only volume the runner never mounts, so untrusted
+        # agent code cannot read the store credential off the shared bundles
+        # volume.
+        - name: mc-config
+          emptyDir: {}
         {{- end }}
         {{- if $runner.hardening.enabled }}
         {{- range $i, $p := $runner.hardening.writablePaths }}
@@ -160,7 +166,7 @@ spec:
                 echo "no AGENTOS_BUNDLE_REF; skipping bundle fetch"
                 exit 0
               fi
-              export MC_CONFIG_DIR={{ $bf.mountPath }}/.mc
+              export MC_CONFIG_DIR=/mc-config/.mc
               mc alias set src "$S3_ENDPOINT" "$S3_ACCESS_KEY" "$S3_SECRET_KEY"
               mc cp "src/${BUNDLE_BUCKET}/${REF}" {{ $bf.mountPath }}/.bundle-archive
               echo "fetched bundle '$REF' from ${BUNDLE_BUCKET}"
@@ -181,6 +187,8 @@ spec:
           volumeMounts:
             - name: bundles
               mountPath: {{ $bf.mountPath }}
+            - name: mc-config
+              mountPath: /mc-config
           resources:
             {{- toYaml $runner.resources | nindent 12 }}
         - name: bundle-extract


### PR DESCRIPTION
The `bundle-fetch` init container ran `mc alias set`, which writes the MinIO **root** credential in cleartext to `MC_CONFIG_DIR/config.json`. That dir was on the `bundles` emptyDir, which is also mounted into the runner container, so untrusted (prompt-injectable) agent code could read `/bundles/.mc/config.json`, extract the root credential, and read/tamper/wipe every agent's bundles.

Point `mc`'s config dir at a dedicated init-only `mc-config` emptyDir mounted **only** in `bundle-fetch`, so the credential file never lands on any runner-visible mount. Kept `mc alias set` (robust to arbitrary BYO passwords) rather than the URL-alias form.

**Verification** — `helm template` render shows the volume mounts:
- `bundle-fetch` → `bundles`, `mc-config`
- `bundle-extract` → `bundles`
- `runner` → `bundles`, `writable-*` (no `mc-config`)

Satisfies the success criterion: `find /bundles -name config.json` in the runner returns nothing, and no MinIO credential appears under any runner mount. `helm lint` clean.

Closes #56