### PR TITLE
K8s: gated PodDisruptionBudgets + parameterized store fsGroups (#79)

### DIFF
--- a/charts/agentos/Chart.yaml
+++ b/charts/agentos/Chart.yaml
@@ -14,6 +14,7 @@ kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: AgentOS
 home: https://github.com/curie-eng/agentos
+icon: https://raw.githubusercontent.com/curie-eng/agentos/main/apps/ui/public/favicon.svg
 sources:
   - https://github.com/curie-eng/agentos
 keywords:

--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -239,6 +239,40 @@ matches the planned resize: everything runs in 4 GB for
 chart/security verification, and a resize to >=8 vCPU / 16-20 GB gives
 comfortable headroom for integration and soak testing.
 
+## High availability and PodDisruptionBudgets
+
+Every backing store (Postgres, Valkey, ClickHouse, MinIO) ships as a
+single-replica StatefulSet -- correct for the single-node dev footprint, but it
+means a node drain evicts the store with no budget guarding it. Two levers move
+this toward production HA:
+
+- **Real HA is a BYO concern.** These in-chart stores are single-writer and do
+  not cluster. For genuine high availability, set `<store>.deploy: false` and
+  point the BYO `host`/`port`/`auth` block at a managed or replicated instance
+  (e.g. RDS/Aurora Postgres, a Valkey/Redis cluster, ClickHouse Cloud, real S3).
+- **Optional PodDisruptionBudgets.** Each store carries a
+  `<store>.podDisruptionBudget` block, OFF by default:
+
+  ```yaml
+  postgres:
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+  ```
+
+  When enabled, the chart renders a `policy/v1` PodDisruptionBudget selecting
+  that store's pods. **Caveat for single-replica stores:** a `minAvailable: 1`
+  budget on one replica allows zero voluntary disruptions, so a `kubectl drain`
+  of the node blocks until an operator intervenes. That is the point -- it stops
+  a routine drain from silently taking the datastore down -- but it requires you
+  to handle drains deliberately (scale up first, or delete the PDB for planned
+  maintenance). Enable it only once you run multiple replicas or explicitly want
+  drains gated.
+
+Production sizing (raise every `resources` block and persistence size, supply
+real secrets) is covered in **Production sizing** above; PDBs and BYO stores are
+the availability half of the same "not sized for prod out of the box" story.
+
 ## Security rails
 
 The security-boundary rails ship **on by default** (ADR-0006). The runner-surface
@@ -323,6 +357,29 @@ false-pass rather than trusted. Claim 4 reports honestly: if the gvisor
 runtimeclass is absent it is marked NOT-TESTABLE (per the security-boundary test plan, never faked), with
 enforcement asserted separately by the preflight and proven live in the security-boundary test plan
 (`uname` = `4.19.0-gvisor`).
+
+## Uninstalling and CRD lifecycle
+
+`helm uninstall <release> -n <ns>` removes everything the chart templated, but
+**not** the CRDs. The agent-sandbox CRDs (`sandboxes.agents.x-k8s.io` and the
+related types) are vendored under `charts/agentos/crds/`, which Helm installs
+before any template but never upgrades or deletes (this is Helm's documented
+`crds/` behavior, not a chart choice). A full teardown therefore needs a manual
+step:
+
+```bash
+helm uninstall <release> -n <ns>
+kubectl delete crd sandboxes.agents.x-k8s.io \
+  sandboxtemplates.extensions.agents.x-k8s.io \
+  sandboxwarmpools.extensions.agents.x-k8s.io \
+  sandboxclaims.extensions.agents.x-k8s.io
+```
+
+Only delete the CRDs if no other release on the cluster uses the agent-sandbox
+controller -- deleting a CRD deletes every custom resource of that kind
+cluster-wide. Likewise, upgrading the CRDs to a newer controller release is a
+manual `kubectl apply` of the new definitions; `helm upgrade` will not touch
+them.
 
 ## What the agent-sandbox subchart needs to know
 

--- a/charts/agentos/templates/clickhouse.yaml
+++ b/charts/agentos/templates/clickhouse.yaml
@@ -36,7 +36,7 @@ spec:
         {{- include "agentos.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: 101
+        fsGroup: {{ .Values.clickhouse.podSecurityContext.fsGroup }}
       {{- if not .Values.clickhouse.persistence.enabled }}
       volumes:
         - name: data

--- a/charts/agentos/templates/minio.yaml
+++ b/charts/agentos/templates/minio.yaml
@@ -35,7 +35,7 @@ spec:
         {{- include "agentos.selectorLabels" (dict "root" . "component" "minio") | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: 1000
+        fsGroup: {{ .Values.minio.podSecurityContext.fsGroup }}
       {{- if not .Values.minio.persistence.enabled }}
       volumes:
         - name: data

--- a/charts/agentos/templates/pdb.yaml
+++ b/charts/agentos/templates/pdb.yaml
@@ -1,0 +1,25 @@
+{{/*
+  Optional PodDisruptionBudgets for the single-replica stateful stores.
+  Off by default: a minAvailable:1 PDB on a replicas:1 store blocks voluntary
+  node drains (0 disruptions allowed), which is undesirable on a single-node
+  dev cluster. Enable per store (`<store>.podDisruptionBudget.enabled: true`)
+  once you have raised replicas or want drains to require operator
+  acknowledgement. See README "High availability and PodDisruptionBudgets".
+*/}}
+{{- range $store := (list "postgres" "valkey" "clickhouse" "minio") }}
+{{- $cfg := index $.Values $store }}
+{{- if and $cfg.deploy $cfg.podDisruptionBudget.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "agentos.fullname" $ }}-{{ $store }}
+  labels:
+    {{- include "agentos.labels" $ | nindent 4 }}
+spec:
+  minAvailable: {{ $cfg.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "agentos.selectorLabels" (dict "root" $ "component" $store) | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/agentos/templates/postgres.yaml
+++ b/charts/agentos/templates/postgres.yaml
@@ -33,7 +33,7 @@ spec:
         {{- include "agentos.selectorLabels" (dict "root" . "component" "postgres") | nindent 8 }}
     spec:
       securityContext:
-        fsGroup: 999
+        fsGroup: {{ .Values.postgres.podSecurityContext.fsGroup }}
       {{- if not .Values.postgres.persistence.enabled }}
       volumes:
         - name: data

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -148,6 +148,10 @@ postgres:
     password: postgres
     database: postgres
   existingSecret: ""
+  # fsGroup that owns the mounted data volume. Defaults to the postgres:16-alpine
+  # image's postgres user (999); parameterized for BYO images with a different UID.
+  podSecurityContext:
+    fsGroup: 999
   persistence:
     enabled: true
     size: 2Gi
@@ -166,6 +170,14 @@ postgres:
     allowPrivilegeEscalation: false
     seccompProfile:
       type: RuntimeDefault
+  # Optional PodDisruptionBudget for this single-replica store. OFF by default:
+  # a minAvailable:1 budget on one replica blocks voluntary node drains. Enable
+  # for prod HA after raising replicas or pointing at a managed/replicated
+  # instance via the BYO block. See README "High availability and
+  # PodDisruptionBudgets".
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
 
 # ---------------------------------------------------------------------------
 # Valkey (Redis-compatible). Langfuse cache/queue AND the dispatcher's Streams
@@ -192,6 +204,14 @@ valkey:
     allowPrivilegeEscalation: false
     seccompProfile:
       type: RuntimeDefault
+  # Optional PodDisruptionBudget for this single-replica store. OFF by default:
+  # a minAvailable:1 budget on one replica blocks voluntary node drains. Enable
+  # for prod HA after raising replicas or pointing at a managed/replicated
+  # instance via the BYO block. See README "High availability and
+  # PodDisruptionBudgets".
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
 
 # ---------------------------------------------------------------------------
 # ClickHouse. Langfuse's OLAP store for traces/observations/scores. The AVX
@@ -219,6 +239,10 @@ clickhouse:
     username: default
     password: clickhouse
   existingSecret: ""
+  # fsGroup that owns the mounted data volume. Defaults to the clickhouse-server
+  # image's clickhouse user (101); parameterized for BYO images with a different UID.
+  podSecurityContext:
+    fsGroup: 101
   clusterEnabled: false
   persistence:
     enabled: true
@@ -234,6 +258,14 @@ clickhouse:
     allowPrivilegeEscalation: false
     seccompProfile:
       type: RuntimeDefault
+  # Optional PodDisruptionBudget for this single-replica store. OFF by default:
+  # a minAvailable:1 budget on one replica blocks voluntary node drains. Enable
+  # for prod HA after raising replicas or pointing at a managed/replicated
+  # instance via the BYO block. See README "High availability and
+  # PodDisruptionBudgets".
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
 
 # ---------------------------------------------------------------------------
 # MinIO. Langfuse object storage (events, media, exports). BYO real S3 in prod:
@@ -251,6 +283,10 @@ minio:
     rootUser: minio
     rootPassword: miniosecret
   existingSecret: ""
+  # fsGroup that owns the mounted data volume. Defaults to the minio image's
+  # user (1000); parameterized for BYO images with a different UID.
+  podSecurityContext:
+    fsGroup: 1000
   persistence:
     enabled: true
     size: 3Gi
@@ -265,6 +301,14 @@ minio:
     allowPrivilegeEscalation: false
     seccompProfile:
       type: RuntimeDefault
+  # Optional PodDisruptionBudget for this single-replica store. OFF by default:
+  # a minAvailable:1 budget on one replica blocks voluntary node drains. Enable
+  # for prod HA after raising replicas or pointing at a managed/replicated
+  # instance via the BYO block. See README "High availability and
+  # PodDisruptionBudgets".
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
 
 # ---------------------------------------------------------------------------
 # Local inference endpoint for demo clusters. Opt in only: fake model stays the


### PR DESCRIPTION
Closes #79

Batch of low-severity K8s chart hygiene items from the controller-hardening review. Chart-only; **the default render is byte-identical to `main`** (every new value defaults to preserving current behavior).

## What changed
- **Optional gated PodDisruptionBudgets** (`templates/pdb.yaml`) for the four single-replica stateful stores (postgres, valkey, clickhouse, minio). `policy/v1`, rendered only when `<store>.deploy && <store>.podDisruptionBudget.enabled`; **OFF by default**. The BYO gate (`deploy`) prevents orphan PDBs selecting an absent StatefulSet.
- **HA sizing docs** (README "High availability and PodDisruptionBudgets"): real HA is a BYO-managed-store concern, plus the honest single-replica caveat — a `minAvailable: 1` budget on one replica allows zero voluntary disruptions and blocks `kubectl drain` until an operator intervenes (that is the point; enable deliberately).
- **Parameterized fsGroup UIDs** into `<store>.podSecurityContext.fsGroup` for postgres (999), clickhouse (101), minio (1000), per the chart's values-not-templates invariant, for BYO-image flexibility. Defaults equal the previously hardcoded UIDs.
- **Chart.yaml `icon`** added (clears the `helm lint` INFO).
- **CRD lifecycle** README section: surfaces for public users that `crds/` are never upgraded/deleted by Helm, with the manual `kubectl delete crd` teardown (CRD names verified against `crds/`).

## Verification
- `helm lint charts/agentos` clean (icon INFO gone).
- Default render (bare + `values-dev.yaml`) diffs empty against `origin/main`; renders zero PDBs.
- Enabling stores renders one correctly-selectored `policy/v1` PDB each; `deploy: false` + enabled renders none.
- Reviewed by code-reviewer, scope-creep, spec-vs-impl, and an SRE domain pass — all approve, no blocking findings.

## Deliberate scope calls
- **valkey fsGroup left hardcoded** — issue #79 names only postgres/clickhouse/minio for fsGroup; valkey is included in the PDB set ("the stateful stores"). Parameterizing valkey's fsGroup for consistency is a trivial follow-up if desired.
- **Chart `version` not bumped** — repo convention bumps chart version in dedicated release commits (version+appVersion together, tied to `v*` tags), and the chart installs from source rather than a published artifact. Left at `0.2.0`; happy to bump if you'd prefer.