### PR TITLE
Make gVisor auto mode fail closed for real-model installs

### DIFF
--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -57,7 +57,12 @@ Setting the two Slack tokens is what makes the dispatcher deploy. The runner
 NetworkPolicy is fail-closed (`security.networkPolicy.allowedEgress` is empty by
 default), so the `allowedEgress` flags are required to let real model calls reach
 the API -- here Anthropic's published range (`160.79.104.0/23`, TCP 443). Add
-further entries for any MCP endpoints the runner must reach.
+further entries for any MCP endpoints the runner must reach. Because this upgrade
+flips to a real model, under the default `security.gvisor.mode=auto` it now fails
+closed on a cluster without the `gvisor` RuntimeClass (runsc) -- install runsc +
+the containerd handler on every node first, or add `--set security.gvisor.mode=off`
+(or `-f charts/agentos/values-e2e-nogvisor.yaml`) to run real code without kernel
+isolation knowingly.
 
 **Cluster variants:**
 
@@ -65,9 +70,11 @@ further entries for any MCP endpoints the runner must reach.
   cluster): add `--set agentSandbox.controller.deploy=false`.
 - **No runsc and you want the no-gvisor shape to be explicit/deterministic**
   (skip the RuntimeClass lookup): `-f charts/agentos/values-e2e-nogvisor.yaml`.
-  Not required -- `auto` already handles a runsc-less cluster -- but it forces
-  isolation off without the lookup. To fail-hard instead when runsc is missing,
-  `--set security.gvisor.mode=require`.
+  `auto` handles a runsc-less cluster only for the fake-model default; a
+  real-model install (`fakeModel=false`) under `auto` now fails closed on a
+  runsc-less cluster, so on such a cluster use this overlay (or `--set
+  security.gvisor.mode=off`) to run real code without gVisor, or `--set
+  security.gvisor.mode=require` to fail-hard.
 - **Production sizing:** the default `resources`/persistence blocks are a modest
   single-node footprint (fits an 8-16 GB node). Raise them for real load.
 
@@ -237,7 +244,7 @@ chart without the security rails.
 | 1. Default-deny egress + metadata block | NetworkPolicies selecting `component: runner-sandbox`: default-deny egress, allow-DNS, an operator-declared egress allowlist, and (optional) ingress lock. Arbitrary internet AND `169.254.169.254` are denied by construction. | `security.networkPolicy.*` |
 | 2. Per-agent secret isolation | Least-privilege runner ServiceAccount (no secret get/list, token not mounted). The per-agent `resourceNames`-scoped Role is bound by the control plane per agent. | `agentSandbox.runner.serviceAccount.*` |
 | 3. Non-root / read-only rootfs | Pod + container securityContext on the runner: `runAsNonRoot`, uid 1000, `readOnlyRootFilesystem`, drop ALL caps, no privilege escalation, RuntimeDefault seccomp, plus writable emptyDir scratch (`/tmp`, `/home/runner`) and `HOME`. | `agentSandbox.runner.hardening.*` |
-| 4. gVisor kernel isolation | `runtimeClassName` on runner pods, driven by the `security.gvisor.mode` tri-state (`auto`/`require`/`off`) + a `require`-mode preflight that fails the install if the RuntimeClass is missing or downgraded + an optional RuntimeClass object. | `security.gvisor.*`, `security.gvisorPreflight.*` |
+| 4. gVisor kernel isolation | `runtimeClassName` on runner pods, driven by the `security.gvisor.mode` tri-state (`auto`/`require`/`off`) + a preflight that fails the install if the RuntimeClass is missing or downgraded, firing in `require` (always) and in `auto` for real-model runs + an optional RuntimeClass object. | `security.gvisor.*`, `security.gvisorPreflight.*` |
 
 **Fail-closed egress.** `security.networkPolicy.allowedEgress` is EMPTY by
 default: a fresh install denies all egress except DNS until the operator declares
@@ -265,7 +272,11 @@ the flag and the install stays fully sealed.
   RuntimeClass. Present -> runner pods use it. Absent -> pods run without it and
   `NOTES.txt` warns. Never blocks the install, so a bare install works on any
   cluster. (Helm's `lookup` returns empty under `helm template`/--dry-run, so a
-  templated render always shows the no-gvisor shape.)
+  templated render always shows the no-gvisor shape.) This never-blocks behavior
+  applies to the fake-model default only; enabling a real model
+  (`fakeModel=false` or `inference.deploy`) under `auto` renders the blocking
+  `preflight-gvisor` hook, so a runsc-less real-model install fails closed
+  instead of silently running on the host kernel.
 - **`require`** -- always stamp the RuntimeClass AND run the `preflight-gvisor`
   hook, which blocks the install with a clear remediation if the runtimeclass is
   missing or downgraded to runc. The fail-hard production posture.

--- a/charts/agentos/templates/NOTES.txt
+++ b/charts/agentos/templates/NOTES.txt
@@ -76,10 +76,12 @@ Kernel isolation (gVisor, security.gvisor.mode={{ $gvisorMode }}):
   - ACTIVE: runner pods run under RuntimeClass "{{ $gvisorClass }}".
 {{- else }}
   - !! WARNING: no "{{ .Values.security.gvisor.runtimeClassName }}" RuntimeClass was
-       found on this cluster, so runner pods run with NO kernel isolation. Install
-       runsc + the containerd handler on every node and re-run `helm upgrade`, or
-       set security.gvisor.mode=require to fail-hard on the next install, or =off to
-       acknowledge running without it.
+       found on this cluster, so runner pods run with NO kernel isolation. This is
+       allowed only because no untrusted real-model code runs here (fake model). Under
+       the default mode=auto, enabling a real model (agentSandbox.runner.fakeModel=false,
+       or local inference) will now FAIL the install closed unless runsc + the containerd
+       handler are installed on every node -- so install runsc and re-run `helm upgrade`,
+       or set security.gvisor.mode=off to run real code without isolation knowingly.
 {{- end }}
 {{- end }}
 {{- if not (include "agentos.dispatcher.enabled" .) }}

--- a/charts/agentos/templates/_helpers.tpl
+++ b/charts/agentos/templates/_helpers.tpl
@@ -250,6 +250,28 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 {{- end -}}
 
+{{/* ---- gVisor enforcement gate ----
+     agentos.gvisor.preflightRequired: non-empty ("true") when the blocking
+     gVisor enforcement preflight Job must render, else empty. It renders in
+     `require` (always) and in `auto` WHEN the runner runs a real (non-fake)
+     model -- i.e. untrusted agent code executes, so a missing/downgraded runsc
+     RuntimeClass must fail the install CLOSED instead of silently landing on
+     the host kernel. `auto` with the fake model (the bare-install default)
+     still degrades gracefully with only a NOTES warning; `off` never renders.
+     Real-model detection mirrors the AGENTOS_FAKE_MODEL gate in
+     agent-sandbox.yaml (fake is in effect only when runner.fakeModel AND NOT
+     inference.deploy), so real code runs when `(not fakeModel) OR inference.deploy`.
+     Also respects security.gvisorPreflight.enabled and agentSandbox.deploy. */}}
+{{- define "agentos.gvisor.preflightRequired" -}}
+{{- $mode := .Values.security.gvisor.mode | default "auto" -}}
+{{- $realModel := or (not .Values.agentSandbox.runner.fakeModel) .Values.inference.deploy -}}
+{{- if and .Values.agentSandbox.deploy .Values.security.gvisorPreflight.enabled -}}
+{{- if or (eq $mode "require") (and (eq $mode "auto") $realModel) -}}
+true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/* ---- Dispatcher gating ----
      The Slack dispatcher only deploys when it has both tokens; without them it
      would crash-loop the reconnect supervisor forever, so a token-less default

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -44,6 +44,10 @@ spec:
       # Kernel-isolation RuntimeClass from security.gvisor.mode. In `auto` this is
       # present only when the class was found by lookup at install time; under
       # `helm template`/--dry-run lookup is empty, so it renders the no-gvisor shape.
+      # In `auto` with a real (non-fake) model the install is guarded by the blocking
+      # gVisor preflight, so a runsc-less real-model install fails closed rather than
+      # silently rendering this no-gvisor shape; under `helm template`/--dry-run this
+      # still renders without runtimeClassName, but no real install proceeds unprotected.
       runtimeClassName: {{ $gvisorClass }}
       {{- end }}
       {{- if $runner.dnsPolicy }}

--- a/charts/agentos/templates/preflight-gvisor.yaml
+++ b/charts/agentos/templates/preflight-gvisor.yaml
@@ -1,8 +1,11 @@
 {{- $gvisorClass := include "agentos.gvisor.className" . }}
-{{- if and .Values.agentSandbox.deploy (eq (.Values.security.gvisor.mode | default "auto") "require") .Values.security.gvisorPreflight.enabled }}
+{{- if include "agentos.gvisor.preflightRequired" . }}
 {{/*
-Rail 4 preflight (security.gvisor.mode=require only): gVisor RuntimeClass is
-present AND enforced.
+Rail 4 preflight: gVisor RuntimeClass is present AND enforced. Renders for
+`require` (always) AND for `auto` when a real (non-fake) model runs -- i.e.
+untrusted agent code executes, so a missing/downgraded runsc must fail the
+install closed. Fake-model `auto` (the bare-install default) does NOT render
+this Job; it degrades to no-gvisor with a NOTES warning instead.
 
 A pre-install / pre-upgrade hook (also runnable via `helm test`) whose pod runs
 UNDER the runner's RuntimeClass. This makes the check RBAC-free and tests the
@@ -16,8 +19,9 @@ real property:
   - gVisor actually enforced -> `uname` reports a gVisor sentry kernel
     (e.g. 4.19.0-gvisor), distinct from the host, and the check passes.
 
-This fail-hard behavior is the `require` posture. `auto` never renders this Job
-(it degrades to no-gvisor with a NOTES warning instead); `off` disables the rail.
+This fail-hard behavior is the `require` posture and, for real-model runs, the
+`auto` posture too. Only fake-model `auto` skips this Job (degrading to
+no-gvisor with a NOTES warning); `off` disables the rail entirely.
 */}}
 apiVersion: batch/v1
 kind: Job
@@ -54,7 +58,7 @@ spec:
             - -c
             - |
               set -eu
-              echo "== AgentOS gVisor RuntimeClass preflight (mode=require) =="
+              echo "== AgentOS gVisor RuntimeClass preflight (mode={{ .Values.security.gvisor.mode | default "auto" }}) =="
               echo "requested RuntimeClass: {{ $gvisorClass }}"
               kernel=$(uname -a)
               echo "pod kernel: ${kernel}"
@@ -64,8 +68,10 @@ spec:
               fi
               echo "RESULT: FAIL - the pod scheduled but its kernel is NOT gVisor. The RuntimeClass"
               echo "        exists but is downgraded to runc, so runner pods would have no kernel"
-              echo "        isolation. Fix the containerd runsc handler on every node, or set"
-              echo "        security.gvisor.mode=auto (degrade gracefully) or off (disable knowingly)."
+              echo "        isolation. Fix the containerd runsc handler on every node, OR run the"
+              echo "        fake model (agentSandbox.runner.fakeModel=true, dev/offline) to degrade"
+              echo "        gracefully, OR set security.gvisor.mode=off to run real code without"
+              echo "        isolation knowingly."
               exit 1
           resources:
             {{- toYaml .Values.security.gvisorPreflight.resources | nindent 12 }}

--- a/charts/agentos/values-e2e-nogvisor.yaml
+++ b/charts/agentos/values-e2e-nogvisor.yaml
@@ -8,7 +8,10 @@
 # and the enforcement preflight never renders. Every OTHER security rail stays ON
 # (default-deny egress + metadata block, per-agent secret isolation, non-root /
 # read-only-rootfs). Use it for e2e/kind/scratch clusters where you want the
-# no-gvisor shape to be explicit and lookup-free.
+# no-gvisor shape to be explicit and lookup-free. Note that a real-model install
+# (agentSandbox.runner.fakeModel=false) under the default `auto` mode now fails
+# closed on a runsc-less cluster, so this overlay (mode=off) is the supported way
+# to run real code without gVisor knowingly.
 #
 #   helm install <release> charts/agentos -n <ns> --create-namespace \
 #     -f charts/agentos/values-e2e-nogvisor.yaml

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -606,9 +606,14 @@ security:
     #   auto    - at install/upgrade time the chart looks up the `runtimeClassName`
     #             RuntimeClass. If present, runner pods run under it; if absent,
     #             pods run with NO runtimeClassName (isolation OFF) and NOTES.txt
-    #             prints a prominent warning. Never blocks the install. NOTE: Helm's
-    #             `lookup` returns empty under `helm template`/--dry-run, so a
-    #             templated render always shows the no-gvisor shape.
+    #             prints a prominent warning. NOTE: Helm's `lookup` returns empty
+    #             under `helm template`/--dry-run, so a templated render always
+    #             shows the no-gvisor shape. This graceful degradation applies ONLY
+    #             to the fake-model/dev default; enabling a real model
+    #             (agentSandbox.runner.fakeModel=false or local inference.deploy)
+    #             makes `auto` render the blocking enforcement preflight, so a
+    #             runsc-less real-model install fails closed instead of silently
+    #             running on the host kernel.
     #   require - always stamp the runtimeClassName AND run the enforcement
     #             preflight as a blocking hook; a missing or downgraded runtime
     #             fails the install (the fail-hard, production posture).
@@ -626,8 +631,9 @@ security:
   # Enforcement preflight for `require` mode: verify the RuntimeClass EXISTS and is
   # actually ENFORCED (a pod under it reports a distinct gVisor kernel), so a
   # missing or silently-downgraded runtime fails the install with remediation
-  # instead of shipping runner pods with no kernel isolation. Only renders when
-  # security.gvisor.mode is `require` (auto degrades gracefully; off skips it).
+  # instead of shipping runner pods with no kernel isolation. Renders when
+  # security.gvisor.mode is `require`, OR mode is `auto` with a real (non-fake)
+  # model; fake-model `auto` degrades gracefully; `off` skips it.
   gvisorPreflight:
     enabled: true
     image: busybox:1.36


### PR DESCRIPTION
## Problem

The default `security.gvisor.mode=auto` looked up the `runsc` RuntimeClass and, when absent, silently ran runner pods on the **host kernel** with only a `NOTES.txt` warning. On the common cluster (kind / k3s / vanilla EKS / GKE / AKS ship no runsc), an operator connecting a real key ran untrusted agent code with node-level blast radius on a kernel CVE, contradicting the security-rails-on-by-default stance (ADR-0006).

## Fix

Render the existing blocking `preflight-gvisor` hook in `auto` mode **when a real (non-fake) model runs** -- `(not agentSandbox.runner.fakeModel) OR inference.deploy`, mirroring the `AGENTOS_FAKE_MODEL` gate in `agent-sandbox.yaml`. A runsc-less real-model install now fails closed at admission (the preflight pod is rejected because the RuntimeClass is absent) instead of degrading silently.

- **Fake-model `auto`** (the bare-install default) still degrades gracefully -- a bare `helm install` on a runsc-less cluster stays green.
- **`require`** and **`off`** are unchanged.
- **`values-e2e-nogvisor.yaml` (`mode=off`)** remains the explicit opt-out for running real code without kernel isolation knowingly.

New helper `agentos.gvisor.preflightRequired` gates the render; the preflight Job stamps a non-empty `runtimeClassName` so it genuinely tests isolation at admission.

## Render matrix (verified)

| mode | fakeModel | preflight renders |
|---|---|---|
| auto | true | no (degrades) |
| auto | false | **yes (fails closed)** |
| auto | true + inference.deploy | **yes** |
| require | either | yes (unchanged) |
| off | either | no (unchanged) |

`helm lint` clean; bare default, `values-dev`, and `values-e2e-nogvisor` overlays all render.

## Note

`auto`'s fail-closed respects `security.gvisorPreflight.enabled` (parity with `require`) -- setting that knob false is an explicit, named opt-out of the enforcement Job in all modes.

Closes #59