### PR TITLE
Scope agent-sandbox controller NetworkPolicy RBAC and harden its Deployment

### DIFF
--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -331,7 +331,28 @@ to install only the control plane + backing stores without the runner substrate.
   `agent-sandbox-system`, RBAC, webhook Service, and the Deployment running
   with `--extensions`). It is cluster-scoped; install it from exactly one
   release per cluster, or leave it false on clusters that already run
-  agent-sandbox.
+  agent-sandbox. **Cluster permissions (blast radius):** the controller's
+  ClusterRoles grant cluster-wide `create/delete/get/list/patch/update/watch`
+  on `pods`, `services`, and `persistentvolumeclaims` (it places sandbox pods
+  and their Services), full control of the `sandboxes` / `sandboxclaims` /
+  `sandboxtemplates` / `sandboxwarmpools` custom resources, `get/patch/update`
+  on those four CRDs by name, plus `leases` (leader-election) and `events`. Its NetworkPolicy permission has been
+  **de-scoped from cluster-wide to the release namespace only** (issue #66):
+  the vendored manifest drops the `networkpolicies` rule from its
+  `agent-sandbox-controller-extensions` ClusterRole, and a namespaced
+  `Role`/`RoleBinding` (`agent-sandbox-controller-networkpolicies`, rendered by
+  `templates/agent-sandbox.yaml`) re-grants it in `.Release.Namespace` only.
+  This confines the blast radius: a compromised controller (or a leaked SA
+  token) can no longer delete the fail-closed egress NetworkPolicy that IS
+  Rail 1's containment in any *other* namespace. It is not eliminated for this
+  release's own namespace, where the controller legitimately manages those
+  policies and so still holds delete on them. The Deployment is also hardened
+  with a non-root
+  (uid 65532) / read-only-rootfs / drop-ALL-caps / RuntimeDefault-seccomp
+  securityContext. On a shared multi-tenant cluster, prefer running the
+  controller from a dedicated platform release (or `controller.deploy: false`
+  with an externally-managed controller) given the residual cluster-wide
+  pod/service/PVC reach.
 - **Runner image**: the pool runs `agentos-runner`, defaulting to
   `ghcr.io/curie-eng/agentos-runner:latest` with `imagePullPolicy: IfNotPresent`
   (per-thread cold boots must not contain a pull; the `runner-prewarm` DaemonSet

--- a/charts/agentos/files/agent-sandbox/controller.yaml
+++ b/charts/agentos/files/agent-sandbox/controller.yaml
@@ -1,3 +1,13 @@
+# NOTE: This is the upstream kubernetes-sigs/agent-sandbox v0.5.0 controller
+# bundle, with two AgentOS security patches (issue #66):
+#   1. The cluster-wide `networkpolicies` rule has been REMOVED from the
+#      agent-sandbox-controller-extensions ClusterRole below. That permission is
+#      re-granted, scoped to the release namespace only, by a namespaced
+#      Role/RoleBinding in templates/agent-sandbox.yaml, so a compromised
+#      controller SA cannot delete the fail-closed egress policy (Rail 1) in
+#      any other namespace.
+#   2. The Deployment carries a non-root / read-only-rootfs securityContext.
+# Re-vendoring a newer upstream release must re-apply both patches.
 kind: Namespace
 apiVersion: v1
 metadata:
@@ -95,9 +105,21 @@ spec:
         app: agent-sandbox-controller
     spec:
       serviceAccountName: agent-sandbox-controller
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: agent-sandbox-controller
         image: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.5.0
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         args:
         - --leader-elect=true
         - --extensions
@@ -112,11 +134,15 @@ spec:
         - name: config-volume
           mountPath: /etc/sandbox-config
           readOnly: true
+        - name: tmp
+          mountPath: /tmp
       volumes:
       - name: config-volume
         configMap:
           name: agent-sandbox-config
           optional: true
+      - name: tmp
+        emptyDir: {}
 ---
 kind: Service
 apiVersion: v1
@@ -278,18 +304,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -4,9 +4,12 @@ the worker claims from, plus (optionally) the vendored upstream controller.
 
 - CRDs live in this chart's crds/ directory (Helm installs them before
   templates render, so the CRs below never race their own CRDs).
-- The controller bundle is the upstream v0.5.0 release manifests verbatim
+- The controller bundle is the upstream v0.5.0 release manifests
   (core manifest + extensions overlay: the Deployment runs with --extensions),
-  vendored under files/agent-sandbox/. Cluster-scoped, one per cluster.
+  vendored under files/agent-sandbox/ with two AgentOS security patches (#66:
+  the networkpolicies RBAC is de-scoped from cluster-wide to the release
+  namespace via the Role/RoleBinding below, and the Deployment carries a
+  hardened securityContext). Cluster-scoped, one per cluster.
 - The SandboxTemplate bakes the generic warm-pod env. Per-session env
   (AGENTOS_HISTORY_REF, AGENTOS_SESSION_ID) is injected per-claim by the
   substrate; envVarsInjectionPolicy Overrides makes that injection win.
@@ -15,6 +18,53 @@ the worker claims from, plus (optionally) the vendored upstream controller.
 */}}
 {{- if .Values.agentSandbox.controller.deploy }}
 {{ .Files.Get "files/agent-sandbox/controller.yaml" }}
+---
+{{/*
+Scoped replacement (#66) for the networkpolicies grant removed from the vendored
+controller's cluster-wide agent-sandbox-controller-extensions ClusterRole. The
+controller manages one NetworkPolicy per Sandbox, and this chart creates all
+Sandboxes in the release namespace (the worker's AGENTOS_NAMESPACE is
+.Release.Namespace), so a namespaced Role confines that power here: a compromised
+controller SA cannot delete the fail-closed egress policy (Rail 1) in any other
+namespace. Cross-namespace binding is intentional -- the SA lives in
+agent-sandbox-system, the NetworkPolicies it manages live in this namespace.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-sandbox-controller-networkpolicies
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-sandbox-controller-networkpolicies
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: agent-sandbox-controller
+  namespace: agent-sandbox-system
+roleRef:
+  kind: Role
+  name: agent-sandbox-controller-networkpolicies
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- if .Values.agentSandbox.deploy }}
 {{- $runner := .Values.agentSandbox.runner }}


### PR DESCRIPTION
Hardens the vendored `agent-sandbox` controller (upstream v0.5.0) against the escalation path in #66: a compromised controller (or leaked SA token) could delete the fail-closed egress NetworkPolicy that is Rail 1's containment, then exfiltrate from any sandbox.

## Changes
- **NetworkPolicy RBAC de-scoped to the release namespace.** Removed the cluster-wide `networkpolicies` rule from the `agent-sandbox-controller-extensions` ClusterRole and re-granted it via a namespaced `Role`/`RoleBinding` (`agent-sandbox-controller-networkpolicies`) in `.Release.Namespace` — the only namespace where this chart creates Sandboxes (worker `AGENTOS_NAMESPACE = .Release.Namespace`). The controller SA can no longer touch NetworkPolicies in any other namespace. Gated by `agentSandbox.controller.deploy`.
- **Hardened controller Deployment securityContext:** `runAsNonRoot` (uid 65532, the image's own nonroot user), `readOnlyRootFilesystem`, `drop: [ALL]` caps, no privilege escalation, `RuntimeDefault` seccomp, plus a writable `/tmp` emptyDir the controller needs for its webhook serving certs (`/tmp/k8s-webhook-server/serving-certs`).
- **README** now enumerates the controller's cluster permissions (blast radius) and documents the de-scope + hardening; the vendored manifest and template comment note the divergence from upstream v0.5.0.

## Verification (live k3s / k8scratch)
- `kubectl auth can-i delete networkpolicies` for the scoped SA: **yes** only in its own namespace; **no** in `default`, `agent-sandbox-system`, the live sandbox namespace, and cluster-wide.
- The controller boots under the new securityContext as uid 65532 with read-only rootfs, writing its webhook certs to the `/tmp` emptyDir — no read-only-filesystem error.
- `helm lint` clean; `helm template` renders with `controller.deploy` true (scoped RBAC present, no netpol rule in any ClusterRole) and false (both bundle and scoped RBAC suppressed).

Scope confined to the three files; the controller's other cluster grants (pods/services/PVC/CRs/leases/events) are unchanged and documented as residual blast radius, with a note preferring a dedicated platform release on shared clusters.

Closes #66