### PR TITLE
Wire greeting/help packs to short-circuit the model (ADR-0018)

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -43,7 +43,14 @@ from aci_protocol import (
 )
 from agentos_dispatcher.queue import QueuedSlackEvent
 
-from .behaviorpacks import BehaviorPacks, NavPack, sample_load, sample_tip
+from .behaviorpacks import (
+    BehaviorPacks,
+    NavPack,
+    match_greeting,
+    match_help,
+    sample_load,
+    sample_tip,
+)
 from .binding import BindingResolver
 from .config import WorkerConfig
 from .killswitch import KillSwitch
@@ -78,6 +85,10 @@ class _RouteResult:
     steered: bool
     handle: SandboxHandle | None = None
     turn: TurnStream | None = None
+    # An enabled greeting/help pack matched a provably-fresh thread (no existing
+    # route) under the route lock: the canned reply to deliver instead of
+    # claiming a sandbox or starting a model turn. None on every other path.
+    canned_reply: str | None = None
 
 
 @dataclass
@@ -229,6 +240,7 @@ class Kernel:
             boot_env: dict[str, str] | None = None
             agent_id: uuid.UUID | None = None
             nav: NavPack | None = None
+            packs: BehaviorPacks | None = None
             if self._binding is not None:
                 resolved = await self._binding.resolve(qevent.channel)
                 if resolved is None:
@@ -260,7 +272,9 @@ class Kernel:
             attempt = 0
             while True:
                 attempt += 1
-                outcome = await self._attempt(qevent, release_order, boot_env, agent_id, nav)
+                outcome = await self._attempt(
+                    qevent, release_order, boot_env, agent_id, nav, packs
+                )
 
                 if outcome.terminal_ok:
                     await self._markers.mark_done(event_id)
@@ -386,6 +400,7 @@ class Kernel:
         boot_env: dict[str, str] | None = None,
         agent_id: uuid.UUID | None = None,
         nav: NavPack | None = None,
+        packs: BehaviorPacks | None = None,
     ) -> TurnOutcome:
         thread = qevent.thread_ts
         event = self._to_event(qevent)
@@ -397,7 +412,7 @@ class Kernel:
         # streaming so a follow-up can steer.
         try:
             async with self._lock.hold(self._config.lock_key(thread)):
-                route = await self._route_and_start(thread, event, boot_env)
+                route = await self._route_and_start(thread, event, boot_env, packs)
         except (RunnerError, aiohttp.ClientError, TimeoutError, SandboxError) as exc:
             # The turn was never accepted (transient runner 5xx, runner not ready,
             # claim timeout). Convert to a retryable outcome so process_event backs
@@ -407,6 +422,18 @@ class Kernel:
             logger.warning("turn start failed for %s: %s", qevent.slack_event_id, exc)
             return TurnOutcome(terminal_ok=False, classification="runner-error")
         release_order()
+
+        if route.canned_reply is not None:
+            # An enabled greeting/help pack matched a provably-fresh thread under
+            # the route lock (ADR-0018). Deliver the canned reply onto the
+            # placeholder and return terminal-ok so process_event marks the event
+            # done. No run was registered, no sandbox claimed, no turn started.
+            await self._sink.update(
+                channel=qevent.channel,
+                ts=qevent.placeholder_ts,
+                text=route.canned_reply,
+            )
+            return TurnOutcome(terminal_ok=True)
 
         if route.steered:
             # Delivered into the thread's live turn; that turn streams the output
@@ -445,8 +472,25 @@ class Kernel:
             self._unregister_run(agent_id, thread)
 
     async def _route_and_start(
-        self, thread: str, event: Event, boot_env: dict[str, str] | None
+        self,
+        thread: str,
+        event: Event,
+        boot_env: dict[str, str] | None,
+        packs: BehaviorPacks | None = None,
     ) -> _RouteResult:
+        # Greeting/help pre-model short-circuit (ADR-0018): under the per-thread
+        # route lock, if an enabled greeting/help pack matches the message text AND
+        # the thread has no existing route, it is provably a NEW turn (it cannot be
+        # a steer -- rule 1 holds by construction, since the lookup and the routing
+        # both run under this same lock), so answer canned without claiming a
+        # sandbox or starting a model turn. Any existing route falls through to the
+        # normal claim -> steer/start_turn path below.
+        if packs is not None:
+            reply = match_greeting(packs, event.text) or match_help(packs, event.text)
+            if reply is not None:
+                existing = await asyncio.to_thread(self._substrate.lookup, thread)
+                if existing is None:
+                    return _RouteResult(steered=False, canned_reply=reply)
         # claim() adopts the thread's live sandbox and refreshes its route TTL
         # (so a busy thread past route_ttl is not reaped), or claims a warm one /
         # resumes a suspended one. On a fresh claim the boot env binds the agent's

--- a/apps/worker/tests/kernel/test_binding_integration.py
+++ b/apps/worker/tests/kernel/test_binding_integration.py
@@ -60,14 +60,16 @@ def _resolved(agent_id: uuid.UUID, *, bundle: str | None = "bundles/x.zip") -> R
     )
 
 
-def _qevent(text: str, *, channel: str, thread: str = "th-1") -> QueuedSlackEvent:
+def _qevent(
+    text: str, *, channel: str, thread: str = "th-1", placeholder: str = "p-1"
+) -> QueuedSlackEvent:
     return QueuedSlackEvent(
         slack_event_id=uuid.uuid4().hex,
         thread_ts=thread,
         channel=channel,
         user="U1",
         text=text,
-        placeholder_ts="p-1",
+        placeholder_ts=placeholder,
         received_at="2026-07-05T00:00:00+00:00",
     )
 
@@ -341,5 +343,163 @@ def test_bound_agent_without_nav_gets_no_hub_button(make_harness) -> None:
                 for e in b["elements"]
             ]
             assert "help" not in ids
+
+    asyncio.run(go())
+
+
+# -- greeting/help pre-model short-circuit (ADR-0018) --------------------------
+# The kernel wiring under test (in ``_route_and_start``, under the per-thread
+# lock, BEFORE claiming a sandbox): if an ENABLED greeting/help pack matches the
+# message text AND the thread is provably fresh (``substrate.lookup(thread) is
+# None`` -- no existing route), short-circuit -- deliver the canned reply onto the
+# placeholder, mark the event done, and DO NOT claim a sandbox or call start_turn.
+# A thread that already has a route is NEVER short-circuited (rule 1: it steers).
+#
+# Observables used here (mirroring the harness the other kernel tests use):
+#   * canned reply delivered   -> h.sink.last_text / h.sink.updates
+#   * event marked done        -> done_key exists in Valkey
+#   * start_turn NEVER called   -> h.runner.opened == []   (the fake runner records
+#                                   every /v1/event, which is start_turn, in .opened)
+#   * NO sandbox claimed        -> h.fake_k8s.claim_envs == []  (the real substrate
+#                                   creates a claim only via the fake K8s client,
+#                                   which records every create in .claim_envs)
+#   * steered (live thread)     -> h.runner.steers == [<follow-up text>]
+#
+# No additive harness change is needed: a FRESH thread has never been claimed, so
+# the real substrate's lookup() returns None on its own; a LIVE thread is set up
+# exactly as the existing steer test does (a first turn held active via runner.hold),
+# which leaves a route in Valkey so lookup() returns a handle.
+
+_GREET = "Hey! I'm your revenue assistant -- ask me anything."
+_HELP = "I can rank revenue leaks by $ impact and draft the outreach for you."
+
+
+def test_fresh_thread_greeting_short_circuits_no_sandbox_no_model(make_harness) -> None:
+    # THE HEADLINE COST WIN: a bare "hi" opening a fresh thread is answered from
+    # the placeholder with the agent's canned greeting -- no sandbox, no model.
+    async def go() -> None:
+        packs = {"greeting": {"enabled": True, "phrases": ["hi", "hello"], "reply": _GREET}}
+        binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
+        async with make_harness(binding=binding) as h:
+            # If the short-circuit did NOT fire, the runner would serve this and the
+            # turn would complete with "MODEL"; the assertions below would then fail
+            # on opened/last_text/claim_envs -- i.e. the feature is missing.
+            h.runner.default_script = [Final(text="MODEL", status=DONE)]
+            ev = _qevent("hi", channel="C-bound", thread="tGreet")
+
+            await h.kernel.process_event(ev)
+
+            # The canned greeting was delivered onto the placeholder...
+            assert h.sink.last_text == _GREET
+            assert any(ts == "p-1" and text == _GREET for _c, ts, text in h.sink.updates)
+            # ...the event is done...
+            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            # ...and NO model turn was started and NO sandbox was claimed.
+            assert h.runner.opened == []
+            assert h.fake_k8s.claim_envs == []
+
+    asyncio.run(go())
+
+
+def test_mid_live_thread_greeting_steers_and_is_not_short_circuited(make_harness) -> None:
+    # RULE 1 provoking test: a greeting arriving on a thread that ALREADY has a
+    # live turn must STEER into that turn -- the short-circuit must NOT swallow it
+    # (that would drop a steer to a live turn). A wiring that matches "hi" before
+    # the lookup-is-None gate (e.g. in process_event, as the doc first sketched)
+    # would deliver the canned greeting and drop the steer -> this test fails.
+    async def go() -> None:
+        packs = {"greeting": {"enabled": True, "phrases": ["hi", "hello"], "reply": _GREET}}
+        binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
+        async with make_harness(binding=binding) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+
+            # First turn opens and hangs active, leaving a live route on the thread.
+            e1 = _qevent("do the thing", channel="C-bound", thread="tLive", placeholder="ph-1")
+            t1 = asyncio.create_task(h.kernel.process_event(e1))
+            await _wait_until(lambda: h.runner.turn_active)
+
+            # Follow-up greeting on the SAME (now non-fresh) thread.
+            e2 = _qevent("hi", channel="C-bound", thread="tLive", placeholder="ph-2")
+            await h.kernel.process_event(e2)
+
+            # It steered into the live turn; no second turn was opened.
+            assert h.runner.steers == ["hi"]
+            assert h.runner.opened == ["do the thing"]
+            # The canned greeting was NEVER delivered (the short-circuit did not fire).
+            assert all(_GREET not in text for _c, _ts, text in h.sink.updates)
+            # The follow-up's placeholder was retired as a fold, not a canned reply.
+            folded = [u for u in h.sink.updates if u[1] == "ph-2"]
+            assert folded and "folded" in folded[-1][2].lower()
+
+            hold.set()
+            await t1
+
+    asyncio.run(go())
+
+
+def test_fresh_thread_help_short_circuits_no_sandbox_no_model(make_harness) -> None:
+    # The help half of the niceties battery: a bare "help" on a fresh thread is
+    # answered canned (greeting-then-help chain; greeting absent here, help fires).
+    async def go() -> None:
+        packs = {"help": {"enabled": True, "phrases": ["help", "what can you do"], "reply": _HELP}}
+        binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
+        async with make_harness(binding=binding) as h:
+            h.runner.default_script = [Final(text="MODEL", status=DONE)]
+            ev = _qevent("help", channel="C-bound", thread="tHelp")
+
+            await h.kernel.process_event(ev)
+
+            assert h.sink.last_text == _HELP
+            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert h.runner.opened == []
+            assert h.fake_k8s.claim_envs == []
+
+    asyncio.run(go())
+
+
+def test_fresh_thread_non_matching_message_runs_a_normal_turn(make_harness) -> None:
+    # The short-circuit fires ONLY on a match: a real request on a fresh thread,
+    # even with the greeting pack enabled, claims a sandbox and runs the model.
+    async def go() -> None:
+        packs = {"greeting": {"enabled": True, "phrases": ["hi", "hello"], "reply": _GREET}}
+        binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
+        async with make_harness(binding=binding) as h:
+            h.runner.default_script = [
+                TextDelta(text="Your pipeline "),
+                Final(text="Your pipeline is $2.1M.", status=DONE),
+            ]
+            ev = _qevent("what's my pipeline?", channel="C-bound", thread="tReal")
+
+            await h.kernel.process_event(ev)
+
+            # Normal path: model turn started, sandbox claimed, streamed reply.
+            assert h.runner.opened == ["what's my pipeline?"]
+            assert h.sink.last_text == "Your pipeline is $2.1M."
+            assert len(h.fake_k8s.claim_envs) == 1
+            assert h.sink.last_text != _GREET
+            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+
+    asyncio.run(go())
+
+
+def test_disabled_greeting_pack_never_short_circuits(make_harness) -> None:
+    # Opt-in: with the greeting pack DISABLED, even a bare "hi" runs a normal turn
+    # (match_greeting returns None for a disabled pack).
+    async def go() -> None:
+        packs = {"greeting": {"enabled": False, "phrases": ["hi", "hello"], "reply": _GREET}}
+        binding = StubBinding({"C-bound": _resolved_with_packs(packs)})
+        async with make_harness(binding=binding) as h:
+            h.runner.default_script = [Final(text="MODEL", status=DONE)]
+            ev = _qevent("hi", channel="C-bound", thread="tOff")
+
+            await h.kernel.process_event(ev)
+
+            assert h.runner.opened == ["hi"]
+            assert h.sink.last_text == "MODEL"
+            assert len(h.fake_k8s.claim_envs) == 1
+            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
 
     asyncio.run(go())

--- a/docs/adr/0018-greeting-help-pre-model-short-circuit.md
+++ b/docs/adr/0018-greeting-help-pre-model-short-circuit.md
@@ -1,0 +1,83 @@
+# 18. Greeting/help pre-model short-circuit in the kernel
+
+Date: 2026-07-09
+Status: Proposed
+
+## Context
+
+The behavior-packs substrate (ADR-adjacent work, CUR-1586) shipped opt-in,
+per-agent `greeting` and `help` packs: declarative phrase lists plus a canned
+reply. The pure matchers `match_greeting` / `match_help`
+(`apps/worker/src/agentos_worker/behaviorpacks.py`) are implemented and
+unit-tested but have **zero live callers** — the packs are configurable today but
+never fire. The intended payoff is a strict cost win: a bare "hi" or "help" is
+answered from the already-posted placeholder without claiming a sandbox or
+calling the model.
+
+Wiring this is not a normal feature: the only place it can fire is inside
+`Kernel.process_event` / `_attempt`, the F1 "sacred" concurrency kernel, which
+`apps/worker/CLAUDE.md` gates behind an adversarial review and single-owner rule.
+Two kernel invariants make the naive placement wrong:
+
+- **Rule 1 (one live session per thread).** A follow-up to a thread with a live
+  turn is a *steer*, never a new turn. `docs/behavior-packs.md` sketched the
+  short-circuit in `process_event` *before the retry loop* — but the
+  steer-vs-new-turn decision is only made later, inside `_attempt` under the
+  per-thread lock (`_route_and_start`). At that earlier point the kernel does not
+  yet know whether the event is a new turn or a steer, so matching "hi" there
+  would **drop a steer** to a live turn. The doc asserts a guarantee ("runs only
+  for a new turn") that its own placement does not provide.
+- **Rule 3 (the kernel never keyword-guesses intent).** Rule 3 forbids
+  text-sniffing to decide *steer vs. interrupt*. This short-circuit is a
+  different decision (answer a **new** turn canned vs. invoke the model), but it
+  still introduces text matching into the kernel, so it must be a deliberate,
+  narrowly-scoped exception rather than an ad-hoc keyword check.
+
+## Decision
+
+Wire the greeting/help short-circuit **inside the route critical section**, gated
+on the thread being provably fresh, so rule 1 holds by construction.
+
+- In `_route_and_start` (already running under the per-thread Valkey lock), BEFORE
+  claiming a sandbox: if the agent has an enabled greeting/help pack whose matcher
+  matches the message text **and** `substrate.lookup(thread) is None` (the thread
+  has no existing sandbox route), return a short-circuit result carrying the
+  canned reply — without claiming a sandbox or calling `start_turn`.
+- `_attempt` delivers the canned reply onto the existing placeholder and returns a
+  terminal-ok outcome; `process_event` marks the event done. No run is registered,
+  no sandbox claimed, no model turn started.
+- **`lookup(thread) is None` is the rule-1 guarantee.** A thread with *any* live
+  route (or a since-idle but still-claimed sandbox) is never short-circuited — it
+  falls through to the normal claim → steer/`start_turn` path. Because the check
+  and the routing both happen under the same lock, no live turn can appear between
+  the check and the decision. A steer therefore can never be swallowed by the
+  short-circuit.
+- The matchers are **opt-in, per-agent, declarative, deterministic, and
+  pre-model.** This is the scoped exception to rule 3's spirit: it is not the
+  kernel guessing steer-vs-interrupt intent from text; it is a configured,
+  data-driven reply the agent owner explicitly enabled.
+
+## Consequences / trade-offs
+
+- **Conservative on returning threads.** A greeting on a thread whose sandbox is
+  still claimed but idle (between turns) is *not* short-circuited — it routes
+  normally and hits the model. We trade that cost-optimization for rule-1
+  safety-by-construction. The dominant real case (a fresh "hi" opening a thread)
+  is fully optimized: no sandbox, no model.
+- **Saves both sandbox and model** on the fresh-thread path (better than the doc's
+  sketch, which — placed correctly — could at best skip the model after a claim).
+- Kernel diff stays small and is plumbing plus one guarded early return; it is
+  covered by a provoking integration test for the steer case (a mid-live-thread
+  "hi" must STEER, not be dropped) as `apps/worker/CLAUDE.md` requires, plus the
+  adversarial review.
+
+## Alternatives considered and rejected
+
+- **Doc's placement (in `process_event` before `_attempt`).** Simple, but not
+  rule-1-safe: it fires before steer-vs-new is decided and would drop steers.
+- **Short-circuit after `route.steered` is known, before `start_turn`.** Rule-1
+  safe, but the sandbox is already claimed by then, so it only saves the model
+  call, not the pod. The lock-guarded `lookup is None` check saves both.
+- **A cheap pre-lock `lookup` in `process_event`.** Loses the lock's atomicity —
+  a live turn could start between the lookup and the decision (TOCTOU), so a steer
+  could still be dropped. Rejected in favor of the in-lock check.


### PR DESCRIPTION
Ref CUR-1602. Wires the greeting/help behavior packs into the F1 kernel — their `match_greeting`/`match_help` existed and were unit-tested but had **zero live callers**, so the packs were configurable but never fired. **Stacked on #165 (nav)** — both resolve `packs` once in `process_event`; retarget to `main` once #165 merges. Review the greeting/help-only diff against `arao/nav-wire`.

## Design (ADR-0018, included in this PR)
The documented sketch placed the short-circuit before the retry loop — but the steer-vs-new-turn decision only happens later, so matching "hi" there would **drop a steer** to a live thread (rule 1). Instead, the short-circuit fires **inside `_route_and_start`, under the per-thread Valkey lock, before claiming a sandbox**, gated on `substrate.lookup(thread) is None`:
- **No existing route ⇒ provably a new turn** ⇒ reply with the canned text on the placeholder, mark done, **claim no sandbox and call no model**.
- **Any existing route ⇒ never short-circuited** ⇒ normal claim → steer/`start_turn`. Because the `lookup` and the routing decision share the same lock, no live turn can appear between them — **rule 1 holds by construction, a steer is never dropped.**

Rule 3 (kernel never keyword-guesses intent) is respected: the matchers are opt-in, per-agent, declarative pack data — the deliberate, ADR-sanctioned exception, and they never touch the steer/interrupt path.

## Safety
Adversarially reviewed (spec-vs-impl + side-effects) across TOCTOU, steer-drop, double-done, claim-leak, and the finish-race / racing-greetings cases — all safe. Delivery uses `sink.update` + `terminal_ok` (single `mark_done` in `process_event`); no run registered, no sandbox claimed, `release_order()` still called.

## Tests
`test_binding_integration.py`: fresh-thread greeting/help → canned reply, `runner.opened == []`, `fake_k8s.claim_envs == []`, done; **mid-live-thread "hi" → STEERS (`runner.steers == ["hi"]`), not dropped** (the mandated rule-1 provoking test); non-matching and disabled-pack → normal turn. Full kernel suite (43) green; `ruff` + `mypy` clean.