### PR TITLE
Block Kit status/links replies + no-edit streaming in the Slack sink

### DIFF
--- a/apps/worker/src/agentos_worker/blocks.py
+++ b/apps/worker/src/agentos_worker/blocks.py
@@ -43,14 +43,18 @@ _FENCE_OPEN = "```agentos-reply"
 @dataclass
 class Reply:
     """A formatted reply, independent of Block Kit. ``text`` is markdown (also
-    the plain-text fallback); ``header`` a header block; ``fields`` a two-column
-    section; ``buttons`` an actions block of ``(label, action_id)`` pairs;
-    ``footer`` a trailing context line."""
+    the plain-text fallback); ``status`` a leading context line (rendered
+    as-authored, like ``footer``); ``header`` a header block; ``fields`` a
+    two-column section; ``buttons`` an actions block of ``(label, action_id)``
+    pairs; ``links`` an actions block of ``(label, url)`` URL buttons; ``footer``
+    a trailing context line."""
 
     text: str = ""
+    status: str | None = None
     header: str | None = None
     fields: list[tuple[str, str]] = field(default_factory=list)
     buttons: list[tuple[str, str]] = field(default_factory=list)
+    links: list[tuple[str, str]] = field(default_factory=list)
     footer: str | None = None
 
 
@@ -79,12 +83,20 @@ def chunk(text: str, limit: int = _CHUNK_TARGET) -> list[str]:
     return out
 
 
+def _button_shell(label: str) -> dict[str, Any]:
+    """The shared button element; callers add either ``action_id`` (interactive,
+    dispatcher-handled) or ``url`` (a navigational link button)."""
+    return {"type": "button", "text": {"type": "plain_text", "text": label, "emoji": True}}
+
+
 def _button(label: str, action_id: str) -> dict[str, Any]:
-    return {
-        "type": "button",
-        "text": {"type": "plain_text", "text": label, "emoji": True},
-        "action_id": action_id,
-    }
+    return {**_button_shell(label), "action_id": action_id}
+
+
+def _context_block(text: str) -> dict[str, Any]:
+    """A context block (small greyed line) rendering ``text`` as-authored mrkdwn.
+    Used for the leading ``status`` line and the trailing ``footer``."""
+    return {"type": "context", "elements": [{"type": "mrkdwn", "text": text}]}
 
 
 def _is_nav(label: str) -> bool:
@@ -92,9 +104,24 @@ def _is_nav(label: str) -> bool:
     return label.lstrip()[:1] in ("←", "↑")
 
 
+def _is_http_url(url: str) -> bool:
+    """A link button's url must be an absolute http(s) URL; Slack rejects the
+    whole message otherwise. Anything else (empty, relative, other scheme) is
+    dropped so one bad link never breaks the reply."""
+    u = url.strip().lower()
+    return u.startswith("http://") or u.startswith("https://")
+
+
+def _link_button(label: str, url: str) -> dict[str, Any]:
+    """A URL button: interactive without the dispatcher (carries ``url``, no
+    ``action_id``)."""
+    return {**_button_shell(label), "url": url}
+
+
 def to_blocks(reply: Reply, nav: NavPack | None = None) -> list[dict[str, Any]]:
-    """Render a ``Reply`` to a Block Kit blocks array. Order: header -> fields ->
-    body section(s) (chunked) -> buttons (nav-leftmost) -> footer.
+    """Render a ``Reply`` to a Block Kit blocks array. Order: status (context) ->
+    header -> fields -> body section(s) (chunked) -> buttons (nav-leftmost) ->
+    links (URL buttons) -> footer.
 
     ``nav`` is the agent's no-dead-ends hub button: when present and enabled, the
     hub button is appended to the reply's buttons (via ``ensure_hub_button``, the
@@ -102,6 +129,8 @@ def to_blocks(reply: Reply, nav: NavPack | None = None) -> list[dict[str, Any]]:
     is None or disabled the output is byte-identical to no-nav; ``ensure_hub_button``
     also no-ops when a button already links to the hub."""
     blocks: list[dict[str, Any]] = []
+    if reply.status:
+        blocks.append(_context_block(reply.status))
     if reply.header:
         blocks.append({"type": "header", "text": {"type": "plain_text", "text": reply.header}})
     if reply.fields:
@@ -123,8 +152,16 @@ def to_blocks(reply: Reply, nav: NavPack | None = None) -> list[dict[str, Any]]:
         blocks.append(
             {"type": "actions", "elements": [_button(label, aid) for label, aid in ordered]}
         )
+    valid_links = [(label, url) for label, url in reply.links if _is_http_url(url)]
+    if valid_links:
+        blocks.append(
+            {
+                "type": "actions",
+                "elements": [_link_button(label, url) for label, url in valid_links],
+            }
+        )
     if reply.footer:
-        blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": reply.footer}]})
+        blocks.append(_context_block(reply.footer))
     return blocks
 
 
@@ -151,13 +188,16 @@ def parse_reply(text: str) -> Reply | None:
         return None
     if not isinstance(data, dict):
         return None
+    status = data.get("status")
     header = data.get("header")
     footer = data.get("footer")
     return Reply(
         text=str(data.get("text", "")),
+        status=str(status) if status is not None else None,
         header=str(header) if header is not None else None,
         fields=_pairs(data.get("fields")),
         buttons=_pairs(data.get("buttons")),
+        links=_pairs(data.get("links")),
         footer=str(footer) if footer is not None else None,
     )
 

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -141,6 +141,14 @@ class WorkerConfig(BaseSettings):
     # auto-clear it. Off by default; pairs with the dispatcher's AGENTOS_SHIMMER.
     shimmer: Bool = Field(default=False, validation_alias="AGENTOS_SHIMMER")
 
+    # When true, suppress intermediate placeholder edits while streaming so the
+    # placeholder gets exactly one chat.update (the final) -- rate-limit friendly
+    # and flicker-free; pair with the shimmer for liveness. Default false
+    # preserves live-edit streaming.
+    slack_no_edit_streaming: Bool = Field(
+        default=False, validation_alias="AGENTOS_SLACK_NO_EDIT_STREAMING"
+    )
+
     # Stream / consumer group (must match the dispatcher's AGENTOS_STREAM)
     stream: str = Field(default="agentos:runs", validation_alias="AGENTOS_STREAM")
     consumer_group: str = Field(

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -114,7 +114,9 @@ class _StreamAccumulator:
 
 
 class _ThrottledReply:
-    """Coalesces chat.update edits while streaming; always flushes the final."""
+    """Coalesces chat.update edits while streaming; always flushes the final. In
+    no-edit mode intermediate edits are suppressed entirely, so the placeholder
+    gets exactly one update (the final)."""
 
     def __init__(
         self,
@@ -124,11 +126,13 @@ class _ThrottledReply:
         ts: str,
         min_interval_s: float,
         nav: NavPack | None = None,
+        no_edit: bool = False,
     ) -> None:
         self._sink = sink
         self._channel = channel
         self._ts = ts
         self._min_interval_s = min_interval_s
+        self._no_edit = no_edit
         self._last = 0.0
         self._last_text: str | None = None
         # The bound agent's hub-button pack, forwarded to the sink so a render of
@@ -138,6 +142,8 @@ class _ThrottledReply:
         self._nav = nav
 
     async def stream(self, text: str) -> None:
+        if self._no_edit:
+            return
         if not text or text == self._last_text:
             return
         now = time.monotonic()
@@ -521,6 +527,7 @@ class Kernel:
             ts=qevent.placeholder_ts,
             min_interval_s=self._config.slack_edit_min_interval_s,
             nav=nav,
+            no_edit=self._config.slack_no_edit_streaming,
         )
         try:
             # ``async with`` releases the aiohttp response on every exit path

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -471,3 +471,42 @@ def test_kernel_delivers_claim_token_as_bearer_header(make_harness) -> None:
             await t1
 
     asyncio.run(go())
+
+
+# --- #31: no-edit streaming mode ----------------------------------------------
+
+_MULTI_DELTA = [
+    TextDelta(text="a"),
+    TextDelta(text="b"),
+    TextDelta(text="c"),
+    Final(text="abc final", status=DONE),
+]
+
+
+def test_no_edit_streaming_edits_placeholder_once(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(slack_no_edit_streaming=True) as h:
+            # Multiple TextDeltas stream, but in no-edit mode the placeholder is
+            # edited EXACTLY once -- the final. No intermediate chat.update calls.
+            h.runner.default_script = list(_MULTI_DELTA)
+            await h.kernel.process_event(_qevent("go"))
+
+            assert len(h.sink.updates) == 1
+            assert h.sink.last_text == "abc final"
+
+    asyncio.run(go())
+
+
+def test_default_streaming_edits_more_than_once(make_harness) -> None:
+    async def go() -> None:
+        # Deletion-test guard: with no-edit OFF (default; conftest sets
+        # slack_edit_min_interval_s=0.0) the SAME multi-delta script produces
+        # more than one edit, proving the flag actually changes behavior.
+        async with make_harness() as h:
+            h.runner.default_script = list(_MULTI_DELTA)
+            await h.kernel.process_event(_qevent("go"))
+
+            assert len(h.sink.updates) > 1
+            assert h.sink.last_text == "abc final"
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -139,3 +139,126 @@ def test_render_without_nav_has_no_hub_button() -> None:
     _text, blocks = render(_BLOCK)
     assert blocks is not None
     assert "help" not in _action_ids(blocks)
+
+
+# --- #31: status context + link buttons --------------------------------------
+
+
+def test_status_renders_as_first_context_block() -> None:
+    reply = Reply(text="body", status="Running the numbers")
+    blocks = to_blocks(reply)
+    first = blocks[0]
+    assert first["type"] == "context"
+    assert first["elements"] == [{"type": "mrkdwn", "text": "Running the numbers"}]
+
+
+def test_status_is_rendered_as_authored_not_mrkdwn_converted() -> None:
+    # Like footer, status is a context line rendered as-authored (no Markdown ->
+    # mrkdwn conversion); a Markdown link stays verbatim rather than <url|label>.
+    reply = Reply(text="body", status="**bold** [x](http://y)")
+    first = to_blocks(reply)[0]
+    assert first["type"] == "context"
+    assert first["elements"][0]["text"] == "**bold** [x](http://y)"
+
+
+def test_parse_reply_extracts_status() -> None:
+    reply = parse_reply('```agentos-reply\n{"status": "Working", "text": "b"}\n```')
+    assert reply is not None
+    assert reply.status == "Working"
+
+
+def test_parse_reply_status_is_none_without_the_key() -> None:
+    reply = parse_reply('```agentos-reply\n{"text": "b"}\n```')
+    assert reply is not None
+    assert reply.status is None
+
+
+def test_links_render_as_url_buttons() -> None:
+    reply = Reply(text="x", links=[("Docs", "https://x/y")])
+    actions = [b for b in to_blocks(reply) if b["type"] == "actions"]
+    assert len(actions) == 1
+    elements = actions[0]["elements"]
+    assert len(elements) == 1
+    el = elements[0]
+    assert el["url"] == "https://x/y"
+    assert el["text"]["text"] == "Docs"
+    assert "action_id" not in el  # a URL button is interactive without the dispatcher
+
+
+def test_links_with_invalid_url_are_dropped() -> None:
+    # Only the absolute http(s) link survives; empty / relative / non-URL are dropped
+    # so one malformed url never makes Slack reject the whole reply.
+    reply = Reply(
+        text="x",
+        links=[("Good", "https://ok.com"), ("Empty", ""), ("Rel", "/relative"), ("Bad", "None")],
+    )
+    actions = [b for b in to_blocks(reply) if b["type"] == "actions"]
+    assert len(actions) == 1
+    elements = actions[0]["elements"]
+    assert len(elements) == 1
+    assert elements[0]["url"] == "https://ok.com"
+    labels = [e["text"]["text"] for e in elements]
+    assert "Empty" not in labels
+    assert "Rel" not in labels
+    assert "Bad" not in labels
+
+
+def test_links_all_invalid_emits_no_actions_block() -> None:
+    # Every link url is invalid and there are no buttons: no actions block at all.
+    reply = Reply(text="x", links=[("Empty", ""), ("Rel", "/relative"), ("Bad", "None")])
+    assert not any(b["type"] == "actions" for b in to_blocks(reply))
+
+
+def test_parse_reply_extracts_links() -> None:
+    reply = parse_reply('```agentos-reply\n{"links": [["Docs", "https://x/y"]], "text": "b"}\n```')
+    assert reply is not None
+    assert reply.links == [("Docs", "https://x/y")]
+
+
+def test_parse_reply_drops_malformed_links() -> None:
+    reply = parse_reply(
+        '```agentos-reply\n'
+        '{"links": [["only-one"], ["a", "b", "c"], ["Docs", "https://x/y"]], "text": "b"}\n'
+        '```'
+    )
+    assert reply is not None
+    assert reply.links == [("Docs", "https://x/y")]  # 1-elem and 3-elem entries dropped
+
+
+def test_to_blocks_full_order_with_status_and_links() -> None:
+    reply = Reply(
+        text="body",
+        status="Working",
+        header="Title",
+        fields=[("A", "1")],
+        buttons=[("Go", "go")],
+        links=[("Docs", "https://x/y")],
+        footer="foot",
+    )
+    blocks = to_blocks(reply)
+    assert _types(blocks) == [
+        "context",  # status first
+        "header",
+        "section",  # fields
+        "section",  # body
+        "actions",  # buttons
+        "actions",  # links
+        "context",  # footer last
+    ]
+    actions = [b for b in blocks if b["type"] == "actions"]
+    # First actions block is buttons (action_id elements), second is links (url).
+    assert all("action_id" in e for e in actions[0]["elements"])
+    assert all("url" in e for e in actions[1]["elements"])
+    # status context is first, footer context is last.
+    assert blocks[0]["elements"][0]["text"] == "Working"
+    assert blocks[-1]["elements"][0]["text"] == "foot"
+
+
+def test_backward_compatible_without_status_or_links() -> None:
+    # Defaults (status None, links empty) add ZERO blocks: identical to today.
+    reply = Reply(header="H", text="body", footer="f")
+    blocks = to_blocks(reply)
+    assert _types(blocks) == ["header", "section", "context"]
+    # No status context leading, and no links actions block anywhere.
+    assert not any(b["type"] == "actions" for b in blocks)
+    assert blocks[0]["type"] == "header"  # header first, not a status context

--- a/apps/worker/tests/test_slack_sink.py
+++ b/apps/worker/tests/test_slack_sink.py
@@ -84,3 +84,44 @@ def test_clear_status_is_best_effort_on_error() -> None:
 
     # Must not raise -- clearing the shimmer can never fail a completed turn.
     asyncio.run(sink.clear_status(channel="C1", thread_ts="1.1"))
+
+
+# --- #31: no-edit streaming config + status/links pass-through ----------------
+
+
+def test_config_no_edit_streaming_defaults_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENTOS_SLACK_NO_EDIT_STREAMING", raising=False)
+    assert WorkerConfig().slack_no_edit_streaming is False
+
+
+def test_config_reads_no_edit_streaming_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENTOS_SLACK_NO_EDIT_STREAMING", "true")
+    assert WorkerConfig().slack_no_edit_streaming is True
+
+
+def test_update_renders_status_and_link_blocks_for_a_reply() -> None:
+    sink = AsyncSlackSink("xoxb-test")
+    captured: dict[str, object] = {}
+
+    async def _fake_chat_update(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    sink._client.chat_update = _fake_chat_update  # type: ignore[method-assign]
+
+    text = (
+        '```agentos-reply\n'
+        '{"status": "Working", "text": "body", "links": [["Docs", "https://x/y"]]}\n'
+        '```'
+    )
+    asyncio.run(sink.update(channel="C1", ts="1.1", text=text))
+
+    blocks = captured.get("blocks")
+    assert isinstance(blocks, list)
+    assert blocks[0]["type"] == "context"  # status context leads  # type: ignore[index]
+    link_actions = [
+        b
+        for b in blocks
+        if b["type"] == "actions" and any("url" in e for e in b["elements"])
+    ]
+    assert link_actions, "expected an actions block of URL link buttons"
+    assert link_actions[0]["elements"][0]["url"] == "https://x/y"


### PR DESCRIPTION
Closes #31

Extends the worker's Slack sink with richer structured replies and an optional no-edit streaming mode. Both stay confined to the sink; the mrkdwn/Block Kit dialect never leaks into the kernel.

## Richer Block Kit replies (over the `agentos-reply` convention)
- **status** — a leading context line (rendered as-authored, matching the `footer` precedent).
- **links** — an actions block of URL buttons that are interactive without the dispatcher (carry `url`, no `action_id`). Non-http(s) urls are dropped at render so one malformed link can't make Slack reject the whole reply.

## No-edit streaming mode
- `AGENTOS_SLACK_NO_EDIT_STREAMING` (default off). When on, the placeholder gets exactly **one** `chat.update` (the final) instead of a throttled series of intermediate edits — rate-limit friendly and flicker-free; pair with the shimmer for liveness. Implemented as a `no_edit` guard on the `_ThrottledReply` coalescer; `finalize` is unchanged, so the final is always delivered exactly once on every exit path.

## Review
Test-first (failing tests committed before impl). Reviewed by code-reviewer (APPROVE), spec-vs-impl (all AC met), scope-creep (0 findings), and side-effects-detective (mandatory for the sacred kernel touch — confirmed the single-final invariant holds and the kernel concurrency/routing/retry logic is untouched). `/simplify` consolidation applied (shared `_button_shell`/`_context_block` helpers), re-reviewed clean.

Note (pre-existing, out of scope): a malformed Block Kit reply raises `SlackApiError` in the sink, which `_consume` doesn't catch, so the consumer leaves the entry pending and retries — a poison-loop risk that predates this PR (applies to the existing `header`/`buttons` blocks path). The new `links` url guard narrows one easy trigger; hardening the sink/consumer against `SlackApiError` broadly is a separate follow-up.

Tests: `190 passed, 1 skipped` (worker suite); ruff + mypy clean.