### PR TITLE
Reduce sandbox cold-boot latency

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -149,6 +149,7 @@ the placeholder in place, and gets every failure mode right.
 XREADGROUP agentos:runs        Consumer (consumer group; XAUTOCLAIM reclaims a
    -> QueuedSlackEvent            dead consumer's pending entries after an idle
    -> Kernel.process_event        timeout, then reprocesses them idempotently)
+        -> SlackSink     chat.update placeholder to booting text (best effort)
         -> substrate.lookup/claim/resume   (sandbox substrate)
         -> RunnerClient  POST /v1/event | /v1/steer | /v1/interrupt   (runner)
         -> SlackSink     chat.update the placeholder as frames stream

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -149,6 +149,13 @@ class WorkerConfig(BaseSettings):
         default=False, validation_alias="AGENTOS_SLACK_NO_EDIT_STREAMING"
     )
 
+    # Shown by editing the dispatcher's placeholder to a "booting" state before the
+    # sandbox claim, so the cold-boot wait is not silent. Best-effort; overridable.
+    booting_text: str = Field(
+        default="Booting a runner for your request.",
+        validation_alias="AGENTOS_BOOTING_TEXT",
+    )
+
     # Stream / consumer group (must match the dispatcher's AGENTOS_STREAM)
     stream: str = Field(default="agentos:runs", validation_alias="AGENTOS_STREAM")
     consumer_group: str = Field(
@@ -166,9 +173,12 @@ class WorkerConfig(BaseSettings):
     # Per-thread lock (serializes the routing decision + turn opening across
     # workers so a thread never has two live sessions). The TTL must exceed the
     # worst-case critical section (a cold claim can take up to the substrate's
-    # claim_timeout, default 90s) so the lock never lapses mid-section and lets a
-    # second worker open a concurrent turn. 90s claim + slack/route overhead stays
-    # safely under this 120s TTL; if you raise claim_timeout keep it below this.
+    # claim_timeout, default 90s, now bounded end-to-end across the claim's bind
+    # and serviceFQDN phases by a single shared deadline in
+    # SandboxSubstrate._claim_fresh) so the lock never lapses mid-section and lets
+    # a second worker open a concurrent turn. 90s claim + slack/route overhead
+    # stays safely under this 120s TTL; if you raise claim_timeout keep it below
+    # this.
     lock_ttl_ms: int = 120000
     lock_acquire_timeout_s: float = 45.0
     lock_poll_interval_s: float = 0.02

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -409,6 +409,25 @@ class Kernel:
         packs: BehaviorPacks | None = None,
     ) -> TurnOutcome:
         thread = qevent.thread_ts
+
+        # Surface a booting state on the placeholder so the (up to claim_timeout)
+        # cold-boot wait is not silent. Best-effort and outside the per-thread lock:
+        # a Slack failure here must never fail the turn, and this must not lengthen
+        # the critical section. Fires once per attempt (retries re-affirm it).
+        # Suppressed under no-edit streaming: that mode's contract is exactly one
+        # chat.update (the final edit), so it opts out of the pre-boot edit too.
+        if not self._config.slack_no_edit_streaming:
+            try:
+                await self._sink.update(
+                    channel=qevent.channel,
+                    ts=qevent.placeholder_ts,
+                    text=self._config.booting_text,
+                )
+            except Exception:
+                logger.warning(
+                    "booting-state update failed for %s", qevent.slack_event_id
+                )
+
         event = self._to_event(qevent)
 
         # Critical section: decide steer-vs-new-turn and, if new, open the turn so

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -118,7 +118,7 @@ def _sandbox_client(
                 "Docker substrate selected but OTEL_EXPORTER_OTLP_ENDPOINT is "
                 "unset; runner traces will not be exported"
             )
-        return DockerSandboxClient(
+        client = DockerSandboxClient(
             image=env.get("AGENTOS_RUNNER_IMAGE", "agentos-runner"),
             bundle_store=BundleStore(config),
             network=env.get("AGENTOS_DOCKER_NETWORK") or None,
@@ -126,6 +126,10 @@ def _sandbox_client(
             default_plugin_dir=config.bundle_plugin_dir,
             environ=env,
         )
+        # Prewarm the runner image once at startup so the first claim window is
+        # not gated on a cold pull. Best-effort inside ensure_image.
+        client.ensure_image()
+        return client
     return KubernetesSandboxClient(sub_config.namespace)
 
 

--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -348,3 +348,25 @@ class DockerSandboxClient:
                 )
             return ""
         return proc.stdout
+
+    def ensure_image(self) -> None:
+        """Pre-pull the runner image if absent (IfNotPresent semantics).
+
+        Mirrors the K8s prewarm: run once at worker startup so the first claim
+        window never contains a cold image download. Best-effort -- a pull
+        failure (offline, registry down) warns and continues rather than
+        crashing the worker, and a truly-missing image still fails clearly
+        later at claim time.
+        """
+        try:
+            present = self._docker(["image", "inspect", self._image], check=False)
+            if present.strip():
+                return
+            self._docker(["pull", self._image])
+        except (DockerError, OSError):
+            # Log the image name only -- never the argv or stderr (house rule
+            # above: args may carry credentials).
+            logger.warning(
+                "runner image pre-pull failed for %s; first claim will pull implicitly",
+                self._image,
+            )

--- a/apps/worker/src/agentos_worker/sandbox/substrate.py
+++ b/apps/worker/src/agentos_worker/sandbox/substrate.py
@@ -195,9 +195,10 @@ class SandboxSubstrate:
             env=env,
             labels={THREAD_HASH_LABEL: thread_hash},
         )
+        deadline = time.monotonic() + config.claim_timeout_seconds
         try:
-            sandbox_name = self._await_bound(name)
-            bound = self._await_service_fqdn(sandbox_name)
+            sandbox_name = self._await_bound(name, deadline)
+            bound = self._await_service_fqdn(sandbox_name, deadline)
         except Exception:
             self._k8s.delete_claim(name)
             raise
@@ -241,8 +242,7 @@ class SandboxSubstrate:
         self._k8s.delete_claim(record.handle.claim_name)
         self._affinity.delete_if_claim(thread_key, record.handle.claim_name)
 
-    def _await_bound(self, claim_name: str) -> str:
-        deadline = time.monotonic() + self._config.claim_timeout_seconds
+    def _await_bound(self, claim_name: str, deadline: float) -> str:
         while time.monotonic() < deadline:
             claim = self._k8s.get_claim(claim_name)
             if claim is not None and claim.ready and claim.sandbox_name:
@@ -252,8 +252,7 @@ class SandboxSubstrate:
             f"claim {claim_name} not bound within {self._config.claim_timeout_seconds}s"
         )
 
-    def _await_service_fqdn(self, sandbox_name: str) -> SandboxView:
-        deadline = time.monotonic() + self._config.claim_timeout_seconds
+    def _await_service_fqdn(self, sandbox_name: str, deadline: float) -> SandboxView:
         while time.monotonic() < deadline:
             sandbox = self._k8s.get_sandbox(sandbox_name)
             if sandbox is not None and sandbox.service_fqdn:

--- a/apps/worker/src/agentos_worker/sandbox/types.py
+++ b/apps/worker/src/agentos_worker/sandbox/types.py
@@ -88,12 +88,15 @@ class SubstrateConfig:
     # Suspended routes wait longer: the thread may come back tomorrow.
     suspended_route_ttl_seconds: int = 86400
     # How long claim() waits for a claim to bind a ready sandbox before raising
-    # ClaimTimeoutError. A cold create (pod scheduling + bundle-fetch/extract init
-    # containers + runner boot + readiness) is ~30s on a small node and can run
-    # longer under load, so the default is 90s. This is the dominant term in the
-    # kernel's per-thread critical section: it MUST stay below the lock TTL
-    # (WorkerConfig.lock_ttl_ms, 120s) so the lock never lapses mid-claim and lets
-    # a second worker open a concurrent turn. Overridable via
+    # ClaimTimeoutError. This is a genuinely END-TO-END budget: a single shared
+    # deadline in SandboxSubstrate._claim_fresh spans BOTH the bind phase and the
+    # serviceFQDN phase, not one budget per phase, so the worst case is the
+    # configured value once rather than twice. A cold create (pod scheduling +
+    # bundle-fetch/extract init containers + runner boot + readiness) is ~30s on a
+    # small node and can run longer under load, so the default is 90s. This is the
+    # dominant term in the kernel's per-thread critical section: it MUST stay below
+    # the lock TTL (WorkerConfig.lock_ttl_ms, 120s) so the lock never lapses
+    # mid-claim and lets a second worker open a concurrent turn. Overridable via
     # AGENTOS_CLAIM_TIMEOUT_SECONDS; keep any override under the lock TTL too.
     claim_timeout_seconds: float = 90.0
     poll_interval_seconds: float = 0.05

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -19,7 +19,7 @@ from aci_protocol import (
     TextDelta,
 )
 from agentos_dispatcher.queue import QueuedSlackEvent
-from agentos_worker.behaviorpacks import BehaviorPacks
+from agentos_worker.behaviorpacks import BehaviorPacks, NavPack
 
 DONE = SessionStatus.DONE
 IDLE = SessionStatus.IDLE_AWAITING_INPUT
@@ -508,5 +508,69 @@ def test_default_streaming_edits_more_than_once(make_harness) -> None:
 
             assert len(h.sink.updates) > 1
             assert h.sink.last_text == "abc final"
+
+    asyncio.run(go())
+
+
+def test_booting_state_edits_placeholder_before_answer(make_harness) -> None:
+    # A fresh-claim turn edits the placeholder to the booting caption at the very
+    # start of the attempt, before the sandbox-claim wait, so the "booting a
+    # runner" state is visible ahead of the streamed answer on the same message.
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [
+                TextDelta(text="Hello "),
+                TextDelta(text="world"),
+                Final(text="Hello world", status=DONE),
+            ]
+            ev = _qevent("hi", thread="tBOOT", placeholder="ph-boot")
+            await h.kernel.process_event(ev)
+
+            booting = h.config.booting_text
+            on_ph = [
+                (i, u)
+                for i, u in enumerate(h.sink.updates)
+                if u[0] == ev.channel and u[1] == ev.placeholder_ts
+            ]
+            booting_idxs = [i for i, u in on_ph if u[2] == booting]
+            answer_idxs = [i for i, u in on_ph if u[2] != booting]
+            assert booting_idxs, "the booting caption was never edited onto the placeholder"
+            assert answer_idxs, "no streamed-answer update landed on the placeholder"
+            assert min(booting_idxs) < min(answer_idxs), (
+                "the booting caption must precede the first streamed-answer update"
+            )
+
+    asyncio.run(go())
+
+
+def test_booting_update_failure_never_fails_the_turn(make_harness) -> None:
+    # The booting edit is best-effort: if the Slack update for the booting caption
+    # raises, the turn still runs to its normal terminal answer. Inject a failure
+    # on the first booting-caption update and prove both that it fired and that the
+    # turn completed anyway.
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="all good", status=DONE)]
+
+            booting = h.config.booting_text
+            original_update = h.sink.update
+            fired = {"n": 0}
+
+            async def flaky_update(
+                *, channel: str, ts: str, text: str, nav: NavPack | None = None
+            ) -> None:
+                if text == booting and fired["n"] == 0:
+                    fired["n"] += 1
+                    raise RuntimeError("injected Slack failure on booting update")
+                await original_update(channel=channel, ts=ts, text=text, nav=nav)
+
+            h.sink.update = flaky_update  # type: ignore[method-assign]
+
+            ev = _qevent("hi", thread="tBOOTFAIL", placeholder="ph-boot-fail")
+            await h.kernel.process_event(ev)
+
+            assert fired["n"] > 0, "the booting update was never attempted"
+            assert h.sink.last_text == "all good"
+            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
 
     asyncio.run(go())

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -8,11 +8,12 @@ parsing (port + operating mode) are exercised for real.
 from __future__ import annotations
 
 import io
+import logging
 import tarfile
 from pathlib import Path
 
 from agentos_worker.bundle_store import extract_bundle
-from agentos_worker.sandbox.docker import DockerSandboxClient
+from agentos_worker.sandbox.docker import DockerError, DockerSandboxClient
 
 
 class _FakeBundleStore:
@@ -303,3 +304,79 @@ def test_extract_bundle_unwraps_single_wrapper_dir() -> None:
         root = extract_bundle(_plugin_tar_gz(wrapper=None), Path(tmp))
         assert root == Path(tmp)
         assert (root / ".claude-plugin" / "plugin.json").is_file()
+
+
+def test_ensure_image_pulls_when_absent() -> None:
+    # docker image inspect returns "" (with check=False) when the image is not
+    # cached locally, so ensure_image must pull it -- the IfNotPresent + prewarm.
+    client = _RecordingDocker(image="agentos-runner", bundle_store=_FakeBundleStore())
+    client.outputs = {}  # "image" inspect -> "" == absent
+    client.ensure_image()
+    assert ["image", "inspect", "agentos-runner"] in client.calls
+    assert ["pull", "agentos-runner"] in client.calls
+    inspect_at = client.calls.index(["image", "inspect", "agentos-runner"])
+    pull_at = client.calls.index(["pull", "agentos-runner"])
+    assert inspect_at < pull_at  # inspect first, then pull
+
+
+def test_ensure_image_skips_pull_when_present() -> None:
+    # A non-empty inspect means the image is already cached: no pull, so an
+    # offline run with the image present must not touch the network.
+    client = _RecordingDocker(image="agentos-runner", bundle_store=_FakeBundleStore())
+    client.outputs = {"image": '[{"Id":"sha256:cafef00d"}]'}
+    client.ensure_image()
+    assert ["image", "inspect", "agentos-runner"] in client.calls
+    assert all(argv[0] != "pull" for argv in client.calls)
+
+
+def test_ensure_image_is_best_effort_on_pull_failure(caplog) -> None:
+    # A pull failure (offline, registry down) must NOT crash worker startup: a
+    # truly-missing image still fails clearly later at claim time. The warning
+    # names only the image -- never the argv or the docker stderr.
+    class _PullFailsDocker(DockerSandboxClient):
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)  # type: ignore[arg-type]
+            self.calls: list[list[str]] = []
+
+        def _docker(self, args: list[str], *, check: bool = True) -> str:
+            self.calls.append(args)
+            if args[0] == "pull":
+                raise DockerError(
+                    "docker pull failed (1): SENTINEL_STDERR_LEAK"
+                )
+            return ""  # inspect: absent
+
+    client = _PullFailsDocker(image="agentos-runner", bundle_store=_FakeBundleStore())
+    with caplog.at_level(logging.WARNING, logger="agentos_worker.sandbox.docker"):
+        client.ensure_image()  # must return normally, no exception propagates
+    assert ["pull", "agentos-runner"] in client.calls
+    text = caplog.text
+    assert "agentos-runner" in text  # the warning names the image
+    assert "SENTINEL_STDERR_LEAK" not in text  # but never dumps the stderr
+
+
+def test_ensure_image_is_best_effort_when_docker_unavailable(caplog) -> None:
+    # A missing docker binary (or unreachable daemon) makes subprocess.run raise
+    # FileNotFoundError/OSError REGARDLESS of check=False, and that raise happens
+    # at the inspect step -- before any pull. That OSError must NOT crash worker
+    # startup: ensure_image is best-effort end to end, so the inspect call must be
+    # guarded too. The warning still names only the image, never the argv.
+    class _DockerUnavailable(DockerSandboxClient):
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)  # type: ignore[arg-type]
+            self.calls: list[list[str]] = []
+
+        def _docker(self, args: list[str], *, check: bool = True) -> str:
+            self.calls.append(args)
+            if args[:2] == ["image", "inspect"]:
+                # subprocess.run(["docker", ...]) raises this when the docker
+                # binary is absent, independent of check=False.
+                raise FileNotFoundError("docker")
+            return ""
+
+    client = _DockerUnavailable(image="agentos-runner", bundle_store=_FakeBundleStore())
+    with caplog.at_level(logging.WARNING, logger="agentos_worker.sandbox.docker"):
+        client.ensure_image()  # must return normally, no exception propagates
+    assert ["image", "inspect", "agentos-runner"] in client.calls
+    assert "agentos-runner" in caplog.text  # the warning names the image
+    assert "docker inspect" not in caplog.text  # but never dumps the argv

--- a/apps/worker/tests/sandbox/test_substrate.py
+++ b/apps/worker/tests/sandbox/test_substrate.py
@@ -4,17 +4,21 @@ the real cluster path is the e2e in test_e2e_k8scratch.py)."""
 
 from __future__ import annotations
 
+import time
+
 import pytest
 from agentos_worker.sandbox import (
     HISTORY_ENV,
     SESSION_ENV,
     AffinityStore,
     ClaimTimeoutError,
+    ClaimView,
     NoRouteError,
     RouteRecord,
     RouteState,
     SandboxHandle,
     SandboxSubstrate,
+    SandboxView,
     SubstrateConfig,
     SuspendedThreadError,
 )
@@ -219,6 +223,84 @@ def test_claim_race_never_adopts_dead_winner(
     assert handle.sandbox_name in fake_k8s.sandboxes
     assert "claim-dead" in fake_k8s.deleted
     assert substrate.lookup("T1") == handle
+
+
+class _SlowBindNoFqdnClient(FakeSandboxClient):
+    """A fake whose claim binds only after a wall-clock threshold and whose
+    bound sandbox never gets a serviceFQDN.
+
+    The bind readiness is TIME-based (measured against ``time.monotonic()``),
+    not iteration-count-based, so poll jitter cannot starve phase 1 -- the claim
+    reports ready once ``bind_after_seconds`` of real time has elapsed since the
+    first create_claim, regardless of how many polls happened. serviceFQDN is
+    always empty, so phase 2 (await_service_fqdn) can only ever time out.
+    """
+
+    bind_after_seconds: float = 1.2
+    _bind_deadline: float | None = None
+
+    def create_claim(self, name: str, **kwargs: object) -> None:
+        if self._bind_deadline is None:
+            self._bind_deadline = time.monotonic() + self.bind_after_seconds
+        super().create_claim(name, **kwargs)  # type: ignore[arg-type]
+
+    def get_claim(self, name: str) -> ClaimView | None:
+        claim = self.claims.get(name)
+        if claim is None:
+            return None
+        ready = self._bind_deadline is not None and time.monotonic() >= self._bind_deadline
+        return ClaimView(
+            name=claim.name,
+            ready=ready,
+            sandbox_name=claim.sandbox_name if ready else None,
+            labels=dict(claim.labels),
+        )
+
+    def get_sandbox(self, name: str) -> SandboxView | None:
+        view = super().get_sandbox(name)
+        if view is None:
+            return None
+        return SandboxView(
+            name=view.name,
+            ready=view.ready,
+            service_fqdn="",
+            operating_mode=view.operating_mode,
+        )
+
+
+def test_claim_budget_is_end_to_end_across_bind_and_fqdn(
+    affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    # The bind + FQDN phases must share ONE end-to-end deadline equal to
+    # claim_timeout_seconds (2.0s), not a fresh 2.0s each. Bind takes ~1.2s of
+    # wall clock, then FQDN never arrives. Under a shared budget the whole claim
+    # aborts at ~2.0s; under per-phase budgets it runs ~1.2 + 2.0 = ~3.2s.
+    # We assert < 2.6 (0.6s of slack over the 2.0 target) so CI jitter cannot
+    # flip a correctly-budgeted run, while ~3.2s of per-phase behavior stays red.
+    fake_k8s = _SlowBindNoFqdnClient()
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+
+    started = time.monotonic()
+    with pytest.raises(ClaimTimeoutError):
+        substrate.claim("T1")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2.6
+    # The unbound claim is not leaked despite the timeout.
+    assert fake_k8s.deleted == fake_k8s.created
+
+
+def test_claim_timeout_error_names_the_budget(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    fake_k8s.bind_ready = False
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+
+    with pytest.raises(ClaimTimeoutError) as excinfo:
+        substrate.claim("T1")
+    # The error message names the configured budget so the signature change
+    # (one shared deadline) does not silently drop the timeout value.
+    assert str(config.claim_timeout_seconds) in str(excinfo.value)
 
 
 def test_claim_on_suspended_route_refuses_to_fork(

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -16,6 +16,12 @@ from agentos_worker.sandbox import DockerSandboxClient, SubstrateConfig
 
 _SUB = SubstrateConfig(namespace="default", warm_pool="pool")
 
+# A non-secret placeholder credential. The docker fail-closed gate only checks
+# that a credential env var is PRESENT, so the value is irrelevant; keep it an
+# obvious placeholder behind a named constant so the secret scanner never
+# mistakes it for a real token.
+_FAKE_SDK_CRED = "oauth-PLACEHOLDER"
+
 
 def test_substrate_config_claim_timeout_defaults_to_90s() -> None:
     assert _substrate_config({}).claim_timeout_seconds == 90.0
@@ -49,18 +55,26 @@ def test_docker_without_credential_or_fake_fails_loudly() -> None:
     assert "AGENTOS_FAKE_MODEL" in msg
 
 
-def test_docker_with_sdk_credential_builds_docker_client() -> None:
+def test_docker_with_sdk_credential_builds_docker_client(monkeypatch) -> None:
+    # Keep hermetic: after Stream B, _sandbox_client prewarms the image via
+    # DockerSandboxClient.ensure_image; stub it so this test never shells docker.
+    monkeypatch.setattr(
+        DockerSandboxClient, "ensure_image", lambda self: None, raising=False
+    )
     client = _sandbox_client(
         WorkerConfig(),
-        {"AGENTOS_SANDBOX_SUBSTRATE": "docker", "CLAUDE_CODE_OAUTH_TOKEN": "oauth-PLACEHOLDER"},
+        {"AGENTOS_SANDBOX_SUBSTRATE": "docker", "CLAUDE_CODE_OAUTH_TOKEN": _FAKE_SDK_CRED},
         _SUB,
     )
     assert isinstance(client, DockerSandboxClient)
 
 
-def test_docker_with_agentos_credentials_reference_builds_docker_client() -> None:
+def test_docker_with_agentos_credentials_reference_builds_docker_client(monkeypatch) -> None:
     # AGENTOS_CREDENTIALS alone is a valid credential: forwarded by name and
     # mapped onto an SDK var by the runner, so the gate must accept it.
+    monkeypatch.setattr(
+        DockerSandboxClient, "ensure_image", lambda self: None, raising=False
+    )
     client = _sandbox_client(
         WorkerConfig(credentials="sk-ant-PLACEHOLDER"),
         {"AGENTOS_SANDBOX_SUBSTRATE": "docker"},
@@ -69,7 +83,10 @@ def test_docker_with_agentos_credentials_reference_builds_docker_client() -> Non
     assert isinstance(client, DockerSandboxClient)
 
 
-def test_docker_with_model_base_url_builds_docker_client_without_credential() -> None:
+def test_docker_with_model_base_url_builds_docker_client_without_credential(monkeypatch) -> None:
+    monkeypatch.setattr(
+        DockerSandboxClient, "ensure_image", lambda self: None, raising=False
+    )
     client = _sandbox_client(
         WorkerConfig(model_base_url="http://ollama:11434"),
         {"AGENTOS_SANDBOX_SUBSTRATE": "docker"},
@@ -78,7 +95,10 @@ def test_docker_with_model_base_url_builds_docker_client_without_credential() ->
     assert isinstance(client, DockerSandboxClient)
 
 
-def test_docker_with_explicit_fake_model_builds_docker_client() -> None:
+def test_docker_with_explicit_fake_model_builds_docker_client(monkeypatch) -> None:
+    monkeypatch.setattr(
+        DockerSandboxClient, "ensure_image", lambda self: None, raising=False
+    )
     client = _sandbox_client(
         WorkerConfig(fake_model=True), {"AGENTOS_SANDBOX_SUBSTRATE": "docker"}, _SUB
     )
@@ -115,3 +135,21 @@ def test_docker_with_otlp_endpoint_does_not_warn(caplog) -> None:
         r for r in caplog.records
         if r.name == "agentos_worker.run" and "OTEL_EXPORTER_OTLP_ENDPOINT" in r.getMessage()
     ]
+
+
+def test_sandbox_client_docker_prepulls_image(monkeypatch) -> None:
+    # _sandbox_client must prewarm the runner image exactly once at startup,
+    # inside the docker branch, so the first claim is not gated on a cold pull.
+    calls: list[object] = []
+    monkeypatch.setattr(
+        DockerSandboxClient,
+        "ensure_image",
+        lambda self: calls.append(self),
+        raising=False,
+    )
+    _sandbox_client(
+        WorkerConfig(),
+        {"AGENTOS_SANDBOX_SUBSTRATE": "docker", "CLAUDE_CODE_OAUTH_TOKEN": _FAKE_SDK_CRED},
+        _SUB,
+    )
+    assert len(calls) == 1


### PR DESCRIPTION
Closes #15.

Addresses the three cold-boot pain points from the issue. The Kubernetes runner-image prewarm half was already merged separately (the prewarm DaemonSet + `IfNotPresent` runner policy), so this PR delivers what remained: the bind-timeout tuning, the Docker-side pre-pull, and the booting-state feedback. Worker-only; no chart or dispatcher changes.

## Changes
- **Claim bind timeout is now one end-to-end budget.** `_await_bound` and `_await_service_fqdn` previously each computed their own `claim_timeout_seconds` deadline, so a cold claim could hold the kernel's per-thread critical section for up to 2x the timeout (180s at the 90s default) and exceed the 120s lock TTL. `_claim_fresh` now computes a single deadline shared by both phases, so the whole claim is genuinely bounded below the lock TTL. The 90s default is unchanged.
- **Docker substrate pre-pulls the runner image at startup.** `DockerSandboxClient.ensure_image()` does `docker image inspect` then `docker pull` only if absent (IfNotPresent), so the first claim window is not gated on a cold pull. Best-effort: a missing docker binary or unreachable registry warns and continues instead of crashing worker startup. Mirrors the merged K8s prewarm for local middle mode.
- **Booting-runner placeholder state.** The worker emits a best-effort `chat.update` to `booting_text` (default "Booting a runner for your request.", override `AGENTOS_BOOTING_TEXT`) before the sandbox claim, so the cold-boot wait is no longer silent. It sits outside the concurrency-critical section and can never fail the turn.

## Notes
- The end-to-end 90s cap intentionally converts the old "slow success up to 180s" into a hard bound. This is the correct invariant: the old per-phase budget could exceed the lock TTL and let a second worker open a concurrent turn. With the K8s image pull now out of the boot path (prewarm), measured cold create is ~30s, so 90s end-to-end retains ample headroom. Operators on genuinely slow clusters can raise `AGENTOS_CLAIM_TIMEOUT_SECONDS`, keeping it under the lock TTL.
- The `kernel.py` change was reviewed by spec-vs-impl + side-effects-detective per the sacred-module rule.