### PR TITLE
Bound the eval backlog: eval consumer group starts at a max-age cutoff

### DIFF
--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -198,6 +198,13 @@ class WorkerConfig(BaseSettings):
         default="agentos-eval-workers", validation_alias="AGENTOS_EVAL_CONSUMER_GROUP"
     )
     eval_consumer_name: str = Field(default_factory=_default_consumer_name)
+    # On first creation the eval group starts at (now - this window) rather than
+    # the stream head, so a backlog of ancient entries is not replayed en masse
+    # on boot. Recent entries (younger than the window) are still delivered, so a
+    # short outage never drops a live eval; only long-dead entries are skipped.
+    eval_stream_max_age_hours: int = Field(
+        default=24, validation_alias="AGENTOS_EVAL_STREAM_MAX_AGE_HOURS"
+    )
     # MinIO / S3 for plugin bundles (mirrors the API's env names). The consumer
     # fetches a version's bundle by bundle_ref and loads its evals/ suite.
     s3_endpoint_url: str = "http://localhost:29000"

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -29,6 +29,7 @@ import asyncio
 import logging
 import tempfile
 import uuid
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -176,14 +177,27 @@ class EvalStreamConsumer(StreamConsumer):
         self._inflight_ids: set[str] = set()
 
     async def ensure_group(self) -> None:
-        # Deliberately created at id 0 (unlike the runs consumer, which uses $ to
-        # avoid replaying a backlog of stale Slack mentions). An eval work item is
-        # a requested CI check on a specific PR SHA, not conversational noise:
-        # dropping items produced while the worker was down would silently skip
-        # required checks, violating the "an eval is never lost" guarantee this
-        # consumer is built around. So a fresh group SHOULD pick up the backlog.
+        # Create the group at a max-age cutoff rather than the stream head ("0").
+        # Reading from "0" replays the ENTIRE stream history the first time the
+        # group is created, so a stream that accumulated ancient entries (across
+        # deploys, weeks of PRs) storms them all into the worker at once on first
+        # boot. Starting at (now - eval_stream_max_age_hours) skips only long-dead
+        # entries while still delivering recent backlog: an eval younger than the
+        # window is never lost -- a short outage is covered -- but a week-old
+        # requeue is not replayed. Crash recovery is unaffected: the reclaim loop
+        # works off the pending list, not the group's start id. An existing group
+        # keeps its position, so this only bounds the very first creation.
+        cutoff_ms = int(
+            (
+                datetime.now(UTC)
+                - timedelta(hours=self._config.eval_stream_max_age_hours)
+            ).timestamp()
+            * 1000
+        )
         await self._ensure_group(
-            self._config.eval_stream, self._config.eval_consumer_group, start_id="0"
+            self._config.eval_stream,
+            self._config.eval_consumer_group,
+            start_id=str(cutoff_ms),
         )
 
     async def run(self) -> None:

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -20,7 +20,7 @@ import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import redis
@@ -639,3 +639,45 @@ async def _assert_langfuse_traces(
             break
         await asyncio.sleep(1)
     assert found == expected
+
+
+def test_worker_boot_after_an_outage_skips_stale_backlog_but_runs_recent() -> None:
+    # Real scenario: the worker was down for a while (a deploy, a weekend), so
+    # eval jobs queued ~2 days ago piled up on the stream alongside one queued
+    # ~10 minutes ago. When the worker boots and creates the group fresh, the
+    # stale backlog must not storm in, but the recent job must still run. Stream
+    # ids are millisecond timestamps, so the entries are placed at realistic
+    # wall-clock ages relative to now (default window is 24h).
+    async def go() -> None:
+        stream = f"agentos:evals:maxage:{uuid.uuid4().hex}"
+        group = f"grp-{uuid.uuid4().hex}"
+        cfg = _cfg(stream, group)  # default eval_stream_max_age_hours = 24
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+        consumer = EvalStreamConsumer(
+            redis=client,
+            config=cfg,
+            bundle_store=cast(Any, None),
+            substrate=cast(Any, None),
+            reporter=cast(Any, None),
+            recorder=cast(Any, None),
+            repo_lookup=cast(Any, None),
+        )
+        try:
+            now_ms = int(time.time() * 1000)
+            two_days_ago = now_ms - 48 * 3600 * 1000
+            ten_min_ago = now_ms - 10 * 60 * 1000
+            # Two stale jobs from ~2 days ago, then one queued ~10 minutes ago.
+            await client.xadd(stream, {"payload": "stale-1"}, id=f"{two_days_ago}-0")
+            await client.xadd(stream, {"payload": "stale-2"}, id=f"{two_days_ago + 1}-0")
+            recent_id = await client.xadd(stream, {"payload": "recent"}, id=f"{ten_min_ago}-0")
+
+            await consumer.ensure_group()  # created fresh at (now - 24h)
+
+            resp = await client.xreadgroup(group, "c1", {stream: ">"}, count=10)
+            delivered = [eid for _s, entries in (resp or []) for eid, _f in entries]
+            assert delivered == [recent_id], delivered
+        finally:
+            await client.delete(stream)
+            await client.aclose()
+
+    asyncio.run(go())


### PR DESCRIPTION
Scoped down (was "bundle file-tree + eval-backlog"). The **bundle file-tree** half is dropped — #140 (merged) already delivers the bundle tree UI-side over the existing `/files` endpoint, and #18 is closed. This PR is now just the remaining, still-unaddressed **eval-backlog** item.

## Problem
The eval consumer group is created at `id="0"`, which replays the **entire** stream history the first time the group is created — a boot-time storm once ancient entries accumulate on `agentos:evals`.

## Fix
Create the group at `(now - eval_stream_max_age_hours)` instead of the stream head — configurable via `AGENTOS_EVAL_STREAM_MAX_AGE_HOURS` (default 24h). Recent backlog is still delivered (a short outage never drops a live eval), but long-dead entries are skipped. Crash recovery is unaffected: the reclaim loop works off the pending list, not the group start id, and an existing group keeps its position — so this only bounds the very first creation.

## Validation
ruff + mypy clean; real-scenario test drives real Valkey — two jobs queued ~2 days ago plus one ~10 min ago; asserts the fresh group skips the stale pair and delivers only the recent one.