### PR TITLE
Authenticate the runner ACI HTTP channel with a per-sandbox bearer token

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -16,7 +16,10 @@ env built from the resolution: `AGENTOS_BUDGET` (the agent's
 `max_usd_per_day`/`max_output_tokens_per_run`, platform defaults when NULL),
 `AGENTOS_SESSION_ID`, `AGENTOS_AGENT_ID`, `AGENTOS_PLUGIN_DIR`, and
 `AGENTOS_BUNDLE_REF` (the MinIO key). An unmapped channel is a polite placeholder
-edit and drop, never a crash.
+edit and drop, never a crash. The claim env also carries a per-sandbox
+`AGENTOS_RUNNER_TOKEN` (minted with `secrets.token_urlsafe`) that the `RunnerClient`
+sends as an `Authorization: Bearer` header on every ACI call to that sandbox
+(issue #63).
 
 > Handoff: `AGENTOS_BUNDLE_REF` is a MinIO object key; the runner reads
 > `AGENTOS_PLUGIN_DIR` as a local mounted path and does not fetch. Fetching the

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -27,6 +27,7 @@ coupling the worker to a Slack token.
 from __future__ import annotations
 
 import json
+import secrets
 import uuid
 from typing import Any
 
@@ -50,6 +51,9 @@ FAKE_MODEL_ENV = "AGENTOS_FAKE_MODEL"
 CREDENTIALS_ENV = "AGENTOS_CREDENTIALS"
 BASE_URL_ENV = "ANTHROPIC_BASE_URL"
 MODEL_ENV = "AGENTOS_MODEL"
+# Per-claim bearer token the runner enforces on its ACI POST routes (issue #63).
+# Not a model credential, so apply_model_env never sees it; minted fresh per claim.
+RUNNER_TOKEN_ENV = "AGENTOS_RUNNER_TOKEN"
 
 _RESOLVE_SQL = """
 SELECT a.id AS agent_id,
@@ -147,6 +151,7 @@ class BindingResolver:
             SESSION_ID_ENV: f"agent-{resolved.agent_id}-thread-{thread_key}",
             AGENT_ID_ENV: str(resolved.agent_id),
             PLUGIN_DIR_ENV: self._config.bundle_plugin_dir,
+            RUNNER_TOKEN_ENV: secrets.token_urlsafe(32),
         }
         if resolved.bundle_ref is not None:
             env[BUNDLE_REF_ENV] = resolved.bundle_ref

--- a/apps/worker/src/agentos_worker/eval/run.py
+++ b/apps/worker/src/agentos_worker/eval/run.py
@@ -40,10 +40,13 @@ async def run_eval_suite(
     base_url: str,
     version: str,
     recorder: LangfuseEvalRecorder | None = None,
+    token: str | None = None,
 ) -> EvalRunResult:
     """Run a suite against a runner endpoint and, if configured, record it."""
     async with RunnerClient() as runner:
-        result = await EvalRunner(runner).run(suite, base_url=base_url, version=version)
+        result = await EvalRunner(runner).run(
+            suite, base_url=base_url, version=version, token=token
+        )
     if recorder is not None:
         await recorder.record(result)
     return result

--- a/apps/worker/src/agentos_worker/eval/runner.py
+++ b/apps/worker/src/agentos_worker/eval/runner.py
@@ -31,11 +31,15 @@ class EvalRunner:
     def __init__(self, runner: RunnerClient) -> None:
         self._runner = runner
 
-    async def run(self, suite: EvalSuite, *, base_url: str, version: str) -> EvalRunResult:
-        results = [await self._run_case(case, base_url) for case in suite.cases]
+    async def run(
+        self, suite: EvalSuite, *, base_url: str, version: str, token: str | None = None
+    ) -> EvalRunResult:
+        results = [await self._run_case(case, base_url, token) for case in suite.cases]
         return EvalRunResult(version=version, suite=suite.name, results=results)
 
-    async def _run_case(self, case: EvalCase, base_url: str) -> EvalCaseResult:
+    async def _run_case(
+        self, case: EvalCase, base_url: str, token: str | None = None
+    ) -> EvalCaseResult:
         start = time.monotonic()
         event = Event(type="eval_case", text=case.input, user="eval", ts="0")
         parts: list[str] = []
@@ -43,7 +47,7 @@ class EvalRunner:
         final_status: SessionStatus | None = None
         error_detail: str | None = None
         try:
-            turn = await self._runner.start_turn(base_url, event)
+            turn = await self._runner.start_turn(base_url, event, token=token)
             async with turn:
                 async for frame in turn:
                     if isinstance(frame, TextDelta):

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import secrets
 import tempfile
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -43,6 +44,7 @@ from ..binding import (
     BUDGET_ENV,
     BUNDLE_REF_ENV,
     PLUGIN_DIR_ENV,
+    RUNNER_TOKEN_ENV,
     SESSION_ID_ENV,
     apply_model_env,
 )
@@ -289,12 +291,16 @@ class EvalStreamConsumer(StreamConsumer):
         if suite is None:
             return await self._report_failed(item, repo, "unresolvable suite/bundle")
 
-        base_url, release_key = await self._acquire_target(item)
+        base_url, release_key, token = await self._acquire_target(item)
         if base_url is None:
             return await self._report_failed(item, repo, "runner provisioning failed")
         try:
             result = await run_eval_suite(
-                suite, base_url=base_url, version=item.sha, recorder=self._recorder
+                suite,
+                base_url=base_url,
+                version=item.sha,
+                recorder=self._recorder,
+                token=token,
             )
         finally:
             if release_key is not None:
@@ -313,9 +319,13 @@ class EvalStreamConsumer(StreamConsumer):
             return None
         return load_suite_from_bundle(data, item.suite)
 
-    async def _acquire_target(self, item: EvalWorkItem) -> tuple[str | None, str | None]:
+    async def _acquire_target(
+        self, item: EvalWorkItem
+    ) -> tuple[str | None, str | None, str | None]:
         if item.target_url is not None:
-            return item.target_url, None  # dev/test shortcut: eval a given runner
+            # dev/test shortcut: eval a given runner. Not a claim of ours, so no
+            # token -- the driver omits the header (only-when-configured).
+            return item.target_url, None, None
         release_key = f"eval-{uuid.uuid4().hex}"
         try:
             handle = await asyncio.to_thread(
@@ -323,8 +333,8 @@ class EvalStreamConsumer(StreamConsumer):
             )
         except SandboxError:
             logger.exception("could not provision a runner for eval %s", item.sha)
-            return None, None
-        return handle.base_url, release_key
+            return None, None, None
+        return handle.base_url, release_key, handle.token or None
 
     def _boot_env(self, item: EvalWorkItem) -> dict[str, str]:
         budget = Budget(
@@ -335,6 +345,7 @@ class EvalStreamConsumer(StreamConsumer):
             BUDGET_ENV: budget.model_dump_json(),
             SESSION_ID_ENV: f"eval-{item.version_id}",
             PLUGIN_DIR_ENV: self._config.bundle_plugin_dir,
+            RUNNER_TOKEN_ENV: secrets.token_urlsafe(32),
         }
         if item.bundle_ref is not None:
             env[BUNDLE_REF_ENV] = item.bundle_ref

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -333,7 +333,7 @@ class Kernel:
         handle = await asyncio.to_thread(self._substrate.lookup, thread_key)
         if handle is None:
             return False
-        await self._runner.interrupt(handle.base_url, reason)
+        await self._runner.interrupt(handle.base_url, reason, token=handle.token or None)
         return True
 
     def attach_killswitch(self, killswitch: KillSwitch) -> None:
@@ -498,9 +498,9 @@ class Kernel:
         # env is ignored. Then try to steer: a live turn takes the follow-up;
         # otherwise (fresh sandbox, or the finish-race 409) we open a new turn.
         handle = await self._claim_or_resume(thread, boot_env)
-        if await self._runner.steer(handle.base_url, event):
+        if await self._runner.steer(handle.base_url, event, token=handle.token or None):
             return _RouteResult(steered=True)
-        turn = await self._runner.start_turn(handle.base_url, event)
+        turn = await self._runner.start_turn(handle.base_url, event, token=handle.token or None)
         return _RouteResult(steered=False, handle=handle, turn=turn)
 
     async def _claim_or_resume(

--- a/apps/worker/src/agentos_worker/runner_client.py
+++ b/apps/worker/src/agentos_worker/runner_client.py
@@ -22,6 +22,18 @@ import aiohttp
 from aci_protocol import Event, Interrupt, OutboundEvent, parse_ndjson_line
 
 
+def _auth_headers(token: str | None) -> dict[str, str] | None:
+    """Per-call Authorization header for the per-sandbox runner token (issue #63).
+
+    The ClientSession is worker-wide and dials many base_urls, so the token is a
+    per-call header, never a session default -- a default would leak one sandbox's
+    token to every other. Returns None (no header) when the token is unset/empty.
+    """
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return None
+
+
 class RunnerError(Exception):
     """The runner returned an unexpected HTTP status or an unreadable stream."""
 
@@ -71,18 +83,24 @@ class RunnerClient:
             )
         )
 
-    async def start_turn(self, base_url: str, event: Event) -> TurnStream:
+    async def start_turn(
+        self, base_url: str, event: Event, token: str | None = None
+    ) -> TurnStream:
         """Open a turn. Returns once the runner has accepted it (turn active)."""
-        resp = await self._session.post(f"{base_url}/v1/event", json=event.model_dump())
+        resp = await self._session.post(
+            f"{base_url}/v1/event", json=event.model_dump(), headers=_auth_headers(token)
+        )
         if resp.status != 200:
             body = await resp.text()
             resp.release()
             raise RunnerError(f"/v1/event -> {resp.status}: {body}")
         return TurnStream(resp)
 
-    async def steer(self, base_url: str, event: Event) -> bool:
+    async def steer(self, base_url: str, event: Event, token: str | None = None) -> bool:
         """Inject a follow-up into the live turn. False on 409 (no active turn)."""
-        async with self._session.post(f"{base_url}/v1/steer", json=event.model_dump()) as resp:
+        async with self._session.post(
+            f"{base_url}/v1/steer", json=event.model_dump(), headers=_auth_headers(token)
+        ) as resp:
             if resp.status == 409:
                 return False
             if resp.status != 200:
@@ -90,10 +108,12 @@ class RunnerClient:
                 raise RunnerError(f"/v1/steer -> {resp.status}: {body}")
             return True
 
-    async def interrupt(self, base_url: str, reason: str) -> None:
+    async def interrupt(self, base_url: str, reason: str, token: str | None = None) -> None:
         """Hard-stop the live turn; its final is reclassified to idle."""
         frame = Interrupt(reason=reason)
-        async with self._session.post(f"{base_url}/v1/interrupt", json=frame.model_dump()) as resp:
+        async with self._session.post(
+            f"{base_url}/v1/interrupt", json=frame.model_dump(), headers=_auth_headers(token)
+        ) as resp:
             if resp.status not in (200, 409):
                 body = await resp.text()
                 raise RunnerError(f"/v1/interrupt -> {resp.status}: {body}")

--- a/apps/worker/src/agentos_worker/sandbox/substrate.py
+++ b/apps/worker/src/agentos_worker/sandbox/substrate.py
@@ -19,9 +19,11 @@ process or cache warmth. The runner accepts the ref as an SDK resume id
 
 from __future__ import annotations
 
+import secrets
 import time
 import uuid
 
+from ..binding import RUNNER_TOKEN_ENV
 from .affinity import AffinityStore
 from .k8s import (
     MANAGED_BY_LABEL,
@@ -124,7 +126,9 @@ class SandboxSubstrate:
         if record is None:
             raise NoRouteError(thread_key)
         old = record.handle
-        env = {SESSION_ENV: old.session_id}
+        # A resume creates a NEW claim; the old token died with the old claim, so
+        # mint a fresh one into the new claim env (issue #63).
+        env = {SESSION_ENV: old.session_id, RUNNER_TOKEN_ENV: secrets.token_urlsafe(32)}
         if old.history_ref is not None:
             env[HISTORY_ENV] = old.history_ref
 
@@ -207,6 +211,7 @@ class SandboxSubstrate:
             port=bound.port if bound.port is not None else config.runner_port,
             session_id=session_id or f"thread-{thread_hash}",
             history_ref=history_ref,
+            token=(env or {}).get(RUNNER_TOKEN_ENV, ""),
         )
         record = RouteRecord(handle=handle, state=state)
         for _ in range(3):

--- a/apps/worker/src/agentos_worker/sandbox/types.py
+++ b/apps/worker/src/agentos_worker/sandbox/types.py
@@ -39,6 +39,11 @@ class SandboxHandle:
     port: int
     session_id: str
     history_ref: str | None = None
+    # Per-claim bearer token the runner enforces on its ACI POST routes (issue
+    # #63). Defaulted so RouteRecord.from_json rehydrates legacy Valkey records
+    # (written before the token existed) with token == "" -- no header is sent
+    # for those and the pre-token runner enforces nothing, so they keep working.
+    token: str = ""
 
     @property
     def sandbox_id(self) -> str:

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -147,3 +147,39 @@ def test_eval_boot_env_carries_fake_and_credentials() -> None:
     env = consumer._boot_env(item)
     assert env[FAKE_MODEL_ENV] == "1"
     assert env[CREDENTIALS_ENV] == "cred-eval"
+
+
+# --- Per-sandbox runner token minting (issue #63) -----------------------------
+# The env-var name is the cross-package contract with the runner; asserted by its
+# literal string so this test file never depends on a constant that only exists
+# after the feature lands (which would break collection of the whole module).
+RUNNER_TOKEN_ENV = "AGENTOS_RUNNER_TOKEN"
+
+
+def test_binding_boot_env_mints_runner_token() -> None:
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig()  # type: ignore[attr-defined]
+
+    env = resolver.boot_env(_resolved(), "thread-1")
+    assert env.get(RUNNER_TOKEN_ENV), "boot_env must mint a non-empty runner token"
+
+
+def test_binding_boot_env_token_is_unique_per_claim() -> None:
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig()  # type: ignore[attr-defined]
+
+    first = resolver.boot_env(_resolved(), "thread-1")[RUNNER_TOKEN_ENV]
+    second = resolver.boot_env(_resolved(), "thread-1")[RUNNER_TOKEN_ENV]
+    assert first != second  # a fresh token is minted per claim
+
+
+def test_binding_boot_env_token_survives_credentials() -> None:
+    # Regression guard on the PR #109 apply_model_env credential pop: it strips
+    # ambient SDK creds when AGENTOS_CREDENTIALS is set, but must not eat the
+    # runner token (which is not a model credential).
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig(fake_model=True, credentials="cred-1")  # type: ignore[attr-defined]
+
+    env = resolver.boot_env(_resolved(), "thread-1")
+    assert env.get(RUNNER_TOKEN_ENV), "the runner token must survive credential selection"
+    assert env[CREDENTIALS_ENV] == "cred-1"

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -13,9 +13,11 @@ provisioned-runner end-to-end (no ``target_url``) that tears the sandbox down.
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 import logging
 import os
+import tarfile
 import time
 import uuid
 from collections.abc import Callable
@@ -37,6 +39,7 @@ from agentos_worker.eval import (
     GraderKind,
     LangfuseEvalRecorder,
 )
+from agentos_worker.eval.models import EvalRunResult
 from agentos_worker.sandbox import AffinityStore, SandboxSubstrate, SubstrateConfig
 from agentos_worker.sandbox.types import ClaimView, SandboxView
 from redis.asyncio import Redis as AsyncRedis
@@ -620,6 +623,120 @@ def test_pending_entry_from_a_dead_consumer_is_reclaimed(make_eval_harness, bund
             await client.aclose()
 
     asyncio.run(go())
+
+
+# --- Per-sandbox runner token threading (issue #63) ---------------------------
+# The env-var name is the cross-package contract with the runner; asserted by its
+# literal string so the module never depends on a constant that only exists after
+# the feature lands.
+RUNNER_TOKEN_ENV = "AGENTOS_RUNNER_TOKEN"
+
+
+def _suite_bundle(suite: EvalSuite) -> bytes:
+    """A minimal tar.gz carrying evals/cases.json, so the real
+    load_suite_from_bundle returns a real suite (the MinIO fetch is the only
+    faked boundary)."""
+    payload = suite.model_dump_json().encode("utf-8")
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo("evals/cases.json")
+        info.size = len(payload)
+        tf.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+class _FakeBundleStore:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def get(self, _ref: str) -> bytes:
+        return self._data
+
+
+@dataclass
+class _FakeHandle:
+    base_url: str
+    token: str
+
+
+class _TokenSubstrate:
+    """A substrate whose claim returns a handle carrying a known runner token."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+        self.released: list[str] = []
+
+    def claim(self, _key: str, *, env: dict[str, str] | None = None) -> _FakeHandle:
+        return _FakeHandle(base_url="http://sandbox.local:8080", token=self._token)
+
+    def release(self, key: str) -> None:
+        self.released.append(key)
+
+
+class _FakeReporter:
+    def __init__(self) -> None:
+        self.reports: list[Any] = []
+
+    async def report(self, report: Any) -> bool:
+        self.reports.append(report)
+        return True
+
+
+def test_eval_boot_env_mints_runner_token() -> None:
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(),
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.zip", target_url=None)
+    env = consumer._boot_env(item)
+    assert env.get(RUNNER_TOKEN_ENV), "_boot_env must mint a non-empty runner token"
+
+
+def test_eval_threads_claim_token_into_run_eval_suite(monkeypatch) -> None:
+    # The token surfaced from the provisioned handle must be threaded into the
+    # eval turn driver so a token-enforcing sandbox does not 401 the eval. The
+    # only faked boundary is the run_eval_suite seam (captured, not the code
+    # under test) and the MinIO bundle fetch.
+    from agentos_worker.eval import stream as stream_module
+
+    captured: dict[str, Any] = {}
+
+    async def _capture_run(
+        suite: EvalSuite, *, base_url: str, version: str, recorder: Any = None, token: Any = None
+    ) -> EvalRunResult:
+        captured["base_url"] = base_url
+        captured["token"] = token
+        return EvalRunResult(version=version, suite=suite.name, results=[])
+
+    monkeypatch.setattr(stream_module, "run_eval_suite", _capture_run)
+
+    suite = EvalSuite(
+        name="s",
+        cases=[EvalCase(id="1", input="q", grader=Grader(kind=CONTAINS, expected="a"))],
+    )
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(),
+        bundle_store=_FakeBundleStore(_suite_bundle(suite)),  # type: ignore[arg-type]
+        substrate=_TokenSubstrate("tok-eval-xyz"),  # type: ignore[arg-type]
+        reporter=_FakeReporter(),  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=_StubRepo(),
+    )
+    item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
+
+    async def go() -> None:
+        await consumer._run_and_report(item)
+
+    asyncio.run(go())
+
+    assert captured["base_url"] == "http://sandbox.local:8080"
+    assert captured["token"] == "tok-eval-xyz"
 
 
 async def _assert_langfuse_traces(

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -244,11 +244,20 @@ class FakeRunner:
         self.hold: object | None = None  # asyncio.Event when a turn should hang
         self.tail: list[OutboundEvent] = []
         self.event_fail_times: int = 0  # return 500 on the next N /v1/event calls
+        # Per-route captured request headers (the ACI auth Bearer check reads
+        # these): the most recent request's headers for each route, so a test can
+        # assert the worker delivered its per-sandbox token as Authorization.
+        self.event_headers: list[dict[str, str]] = []
+        self.steer_headers: list[dict[str, str]] = []
+        self.interrupt_headers: list[dict[str, str]] = []
+        self.status_headers: list[dict[str, str]] = []
 
-    async def _status(self, _request: web.Request) -> web.Response:
+    async def _status(self, request: web.Request) -> web.Response:
+        self.status_headers.append(dict(request.headers))
         return web.json_response({"status": "idle-awaiting-input", "turn_active": self.turn_active})
 
     async def _event(self, request: web.Request) -> web.StreamResponse:
+        self.event_headers.append(dict(request.headers))
         body = await request.json()
         self.opened.append(body["text"])
         if self.event_fail_times > 0:
@@ -269,6 +278,7 @@ class FakeRunner:
         return resp
 
     async def _steer(self, request: web.Request) -> web.Response:
+        self.steer_headers.append(dict(request.headers))
         body = await request.json()
         if not self.turn_active:
             return web.json_response({"error": "no active turn"}, status=409)
@@ -276,6 +286,7 @@ class FakeRunner:
         return web.json_response({"ok": True})
 
     async def _interrupt(self, request: web.Request) -> web.Response:
+        self.interrupt_headers.append(dict(request.headers))
         self.interrupts += 1
         if self.hold is not None:
             self.hold.set()  # type: ignore[attr-defined]

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -19,6 +19,7 @@ from aci_protocol import (
     TextDelta,
 )
 from agentos_dispatcher.queue import QueuedSlackEvent
+from agentos_worker.behaviorpacks import BehaviorPacks
 
 DONE = SessionStatus.DONE
 IDLE = SessionStatus.IDLE_AWAITING_INPUT
@@ -404,5 +405,69 @@ def test_order_lock_map_evicts_after_processing(make_harness) -> None:
             # Ref-counted eviction: no per-thread lock entry lingers once the last
             # holder releases (a regression would leak one entry per thread seen).
             assert h.kernel._order_locks == {}
+
+    asyncio.run(go())
+
+
+# --- Per-sandbox runner token delivery, end-to-end (issue #63) ----------------
+
+
+class _FakeResolved:
+    """The minimal resolved deployment the kernel reads (agent_id only; shimmer
+    off, so packs are never sampled)."""
+
+    def __init__(self, agent_id: uuid.UUID) -> None:
+        self.agent_id = agent_id
+
+
+class _TokenBinding:
+    """A binding whose boot_env injects a known runner token into the claim env,
+    so the test can assert the exact value the worker delivers as the Bearer
+    header. The claim-time minting itself is covered by the binding unit tests;
+    this proves the claim->handle->kernel->runner delivery path."""
+
+    def __init__(self, token: str, agent_id: uuid.UUID) -> None:
+        self._token = token
+        self._agent_id = agent_id
+
+    async def resolve(self, _channel: str) -> _FakeResolved:
+        return _FakeResolved(self._agent_id)
+
+    def boot_env(self, _resolved: object, _thread_key: str) -> dict[str, str]:
+        return {"AGENTOS_RUNNER_TOKEN": self._token}
+
+    def packs_for(self, _resolved: object) -> BehaviorPacks:
+        return BehaviorPacks()
+
+
+def test_kernel_delivers_claim_token_as_bearer_header(make_harness) -> None:
+    async def go() -> None:
+        binding = _TokenBinding("tok-24", uuid.uuid4())
+        async with make_harness(binding=binding) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="w")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+
+            e1 = _qevent("first", thread="tTok")
+            t1 = asyncio.create_task(h.kernel.process_event(e1))
+            await _wait_until(lambda: h.runner.turn_active)
+
+            # Event path: the opening /v1/event carried the claim-minted token.
+            assert h.runner.event_headers
+            assert h.runner.event_headers[-1].get("Authorization") == "Bearer tok-24"
+
+            # Steer path: a follow-up folded into the live turn carries it too.
+            await h.kernel.process_event(_qevent("second", thread="tTok"))
+            assert h.runner.steer_headers
+            assert h.runner.steer_headers[-1].get("Authorization") == "Bearer tok-24"
+
+            # Interrupt path: the explicit hard stop carries it as well.
+            await h.kernel.interrupt_thread("tTok", "user stop")
+            assert h.runner.interrupt_headers
+            assert h.runner.interrupt_headers[-1].get("Authorization") == "Bearer tok-24"
+
+            hold.set()
+            await t1
 
     asyncio.run(go())

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from aci_protocol import Event, Final, SessionStatus, TextDelta
 from agentos_worker.runner_client import RunnerClient
+from aiohttp import web
+from aiohttp.test_utils import TestServer
 
 DONE = SessionStatus.DONE
 
@@ -73,5 +75,94 @@ def test_turn_stream_released_when_consumer_raises(make_harness) -> None:
             finally:
                 hold.set()
                 await client.close()
+
+    asyncio.run(go())
+
+
+# --- Per-call Authorization header (issue #63) --------------------------------
+# Against a REAL local aiohttp server that records each request's headers, so the
+# assertion is on the actual bytes on the wire, not a mock of the client.
+
+
+class _HeaderRecordingRunner:
+    """Records the request headers seen on each ACI route."""
+
+    def __init__(self) -> None:
+        self.app = web.Application()
+        self.app.add_routes(
+            [
+                web.post("/v1/event", self._event),
+                web.post("/v1/steer", self._steer),
+                web.post("/v1/interrupt", self._interrupt),
+            ]
+        )
+        self.headers: dict[str, dict[str, str]] = {}
+
+    async def _event(self, request: web.Request) -> web.StreamResponse:
+        self.headers["event"] = dict(request.headers)
+        resp = web.StreamResponse(status=200, headers={"Content-Type": "application/x-ndjson"})
+        await resp.prepare(request)
+        await resp.write((Final(text="ok", status=DONE).model_dump_json() + "\n").encode("utf-8"))
+        await resp.write_eof()
+        return resp
+
+    async def _steer(self, request: web.Request) -> web.Response:
+        self.headers["steer"] = dict(request.headers)
+        return web.json_response({"ok": True})
+
+    async def _interrupt(self, request: web.Request) -> web.Response:
+        self.headers["interrupt"] = dict(request.headers)
+        return web.json_response({"ok": True})
+
+
+async def _drain(turn: Any) -> None:
+    async with turn:
+        async for _frame in turn:
+            pass
+
+
+def test_runner_client_sends_bearer_token_on_every_call() -> None:
+    async def go() -> None:
+        runner = _HeaderRecordingRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            turn = await client.start_turn(base_url, _event(), token="tok-1")
+            await _drain(turn)
+            await client.steer(base_url, _event(), token="tok-1")
+            await client.interrupt(base_url, "stop", token="tok-1")
+
+            assert runner.headers["event"].get("Authorization") == "Bearer tok-1"
+            assert runner.headers["steer"].get("Authorization") == "Bearer tok-1"
+            assert runner.headers["interrupt"].get("Authorization") == "Bearer tok-1"
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_runner_client_omits_authorization_without_token() -> None:
+    async def go() -> None:
+        for token in (None, ""):
+            runner = _HeaderRecordingRunner()
+            server = TestServer(runner.app)
+            await server.start_server()
+            base_url = f"http://127.0.0.1:{server.port}"
+            client = RunnerClient(total_timeout_s=30.0)
+            try:
+                turn = await client.start_turn(base_url, _event(), token=token)
+                await _drain(turn)
+                await client.steer(base_url, _event(), token=token)
+                await client.interrupt(base_url, "stop", token=token)
+
+                assert "Authorization" not in runner.headers["event"]
+                assert "Authorization" not in runner.headers["steer"]
+                assert "Authorization" not in runner.headers["interrupt"]
+            finally:
+                await client.close()
+                await server.close()
 
     asyncio.run(go())

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -255,6 +255,42 @@ def test_prepare_bundle_is_readable_by_nonroot_runner() -> None:
     assert nested_file.stat().st_mode & 0o004 == 0o004  # nested file: o+r
 
 
+def test_runner_token_forwarded_as_docker_env() -> None:
+    # The per-sandbox runner token rides the generic claim-env loop (it is not a
+    # worker-owned or credential var), so it must be emitted as -e KEY=value.
+    client = _RecordingDocker(image="agentos-runner", bundle_store=_FakeBundleStore())
+    client.create_claim(
+        "t1",
+        pool="pool",
+        env={"AGENTOS_BUDGET": "{}", "AGENTOS_RUNNER_TOKEN": "tok-25"},
+    )
+    envs = _flag_values(client.calls[0], "-e")
+    assert "AGENTOS_RUNNER_TOKEN=tok-25" in envs
+
+
+def test_runner_token_forwarded_even_when_credentials_selected() -> None:
+    # Credential selection (PR #109) forwards AGENTOS_CREDENTIALS by name and
+    # suppresses ambient SDK vars, but must not disturb the token, which travels
+    # in the claim env as an ordinary value.
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        environ={"AGENTOS_CREDENTIALS": "sk-PLACEHOLDER-byo"},
+    )
+    client.create_claim(
+        "t1",
+        pool="pool",
+        env={
+            "AGENTOS_CREDENTIALS": "sk-PLACEHOLDER-byo",
+            "AGENTOS_RUNNER_TOKEN": "tok-25b",
+        },
+    )
+    envs = _flag_values(client.calls[0], "-e")
+    assert "AGENTOS_RUNNER_TOKEN=tok-25b" in envs
+    assert "AGENTOS_CREDENTIALS" in envs  # still forwarded by name
+    assert "AGENTOS_CREDENTIALS=sk-PLACEHOLDER-byo" not in envs  # never as a value
+
+
 def test_extract_bundle_unwraps_single_wrapper_dir() -> None:
     import tempfile
 

--- a/apps/worker/tests/sandbox/test_k8s_claim.py
+++ b/apps/worker/tests/sandbox/test_k8s_claim.py
@@ -82,3 +82,22 @@ def test_credential_is_never_written_to_the_claim() -> None:
     assert all("super-secret-token" not in e.get("value", "") for e in entries)
     # The rest of the boot env is still written.
     assert {"name": "AGENTOS_BUDGET", "value": "{}"} in entries
+
+
+def test_runner_token_is_a_plaintext_env_entry_credential_excluded() -> None:
+    # The per-sandbox runner token intentionally rides the generic env loop as a
+    # plaintext {name, value} entry on the claim (there is no secretKeyRef path
+    # for it), while the model credential stays excluded.
+    api = _FakeApi()
+    _client(api).create_claim(
+        "claim-1",
+        pool="pool",
+        env={
+            "AGENTOS_BUDGET": "{}",
+            "AGENTOS_RUNNER_TOKEN": "tok-26",
+            "AGENTOS_CREDENTIALS": "super-secret-token",
+        },
+    )
+    entries = _env_entries(api)
+    assert {"name": "AGENTOS_RUNNER_TOKEN", "value": "tok-26"} in entries
+    assert all(e.get("name") != "AGENTOS_CREDENTIALS" for e in entries)

--- a/apps/worker/tests/sandbox/test_substrate.py
+++ b/apps/worker/tests/sandbox/test_substrate.py
@@ -232,3 +232,33 @@ def test_claim_on_suspended_route_refuses_to_fork(
         substrate.claim("T1")
     resumed = substrate.resume("T1")
     assert substrate.lookup("T1") == resumed
+
+
+# --- Per-sandbox runner token (issue #63) -------------------------------------
+# The env-var name is the cross-package contract with the runner; asserted by its
+# literal string.
+RUNNER_TOKEN_ENV = "AGENTOS_RUNNER_TOKEN"
+
+
+def test_resume_mints_fresh_runner_token(
+    substrate: SandboxSubstrate, fake_k8s: FakeSandboxClient
+) -> None:
+    # A resume creates a new claim; the old token died with the old claim, so the
+    # new claim env must carry a freshly minted, non-empty runner token.
+    substrate.claim("T1")
+    substrate.suspend("T1", history_ref="h-1")
+    resumed = substrate.resume("T1")
+
+    env = fake_k8s.claims[resumed.claim_name].env
+    assert env.get(RUNNER_TOKEN_ENV), "resume must mint a fresh runner token into the claim env"
+
+
+def test_claim_handle_carries_env_runner_token(
+    substrate: SandboxSubstrate, fake_k8s: FakeSandboxClient
+) -> None:
+    # The token in the claim env and the token on the returned handle must be the
+    # same value, so claim-time and call-time always agree.
+    handle = substrate.claim("T1", env={RUNNER_TOKEN_ENV: "tok-19"})
+
+    assert handle.token == "tok-19"
+    assert fake_k8s.claims[handle.claim_name].env[RUNNER_TOKEN_ENV] == "tok-19"

--- a/apps/worker/tests/sandbox/test_types.py
+++ b/apps/worker/tests/sandbox/test_types.py
@@ -1,0 +1,54 @@
+"""RouteRecord wire-format contract for the per-sandbox runner token (issue #63).
+
+The token is carried on the SandboxHandle from claim-time to call-time, and the
+affinity store serializes the handle to Valkey, so the token must survive the
+JSON round-trip. Upgrade safety: a route written by a pre-token worker has no
+``token`` key, and must rehydrate to ``token == ""`` (that sandbox's runner has
+no token configured, so the client sends no header and it keeps working).
+"""
+
+from __future__ import annotations
+
+import json
+
+from agentos_worker.sandbox.types import RouteRecord, SandboxHandle
+
+
+def _handle(**overrides: object) -> SandboxHandle:
+    base: dict[str, object] = {
+        "thread_key": "t",
+        "claim_name": "c",
+        "sandbox_name": "s",
+        "namespace": "n",
+        "service_fqdn": "s.n.svc.cluster.local",
+        "port": 8080,
+        "session_id": "sess",
+    }
+    base.update(overrides)
+    return SandboxHandle(**base)  # type: ignore[arg-type]
+
+
+def test_route_record_round_trips_token() -> None:
+    record = RouteRecord(handle=_handle(token="tok-20"))
+    restored = RouteRecord.from_json(record.to_json())
+
+    assert restored.handle.token == "tok-20"
+    assert restored.handle == record.handle
+
+
+def test_route_record_legacy_payload_without_token_defaults_empty() -> None:
+    # A route written before the token field existed: from_json must not crash and
+    # must default the token to "" (upgrade compatibility, the deploy-safety case).
+    legacy = {
+        "thread_key": "t",
+        "claim_name": "c",
+        "sandbox_name": "s",
+        "namespace": "n",
+        "service_fqdn": "s.n.svc.cluster.local",
+        "port": 8080,
+        "session_id": "sess",
+        "history_ref": None,
+        "state": "live",
+    }
+    record = RouteRecord.from_json(json.dumps(legacy))
+    assert record.handle.token == ""

--- a/runner/README.md
+++ b/runner/README.md
@@ -37,6 +37,15 @@ side-channel injections whose output surfaces on the open `/v1/event` stream (th
 proven steering pattern). The finish race (a steer arriving as a turn ends,
 409) is owned by the worker.
 
+The three POST routes (`/v1/event`, `/v1/steer`, `/v1/interrupt`) require an
+`Authorization: Bearer <token>` header matching `AGENTOS_RUNNER_TOKEN` when that
+env var is set, returning 401 otherwise; this is per-sandbox transport auth
+(defense-in-depth on the ACI ingress alongside the NetworkPolicy), not part of
+the frozen ACI wire contract. Enforcement is only-when-configured: with the var
+unset the app is pass-through (CLI, fake-model CI, and pre-token sandboxes stay
+unauthenticated). `GET /healthz` and `GET /status` are never gated (the chart
+readinessProbe hits `/healthz`).
+
 ## Environment
 
 ACI-frozen (`aci-protocol.SessionConfig`): `AGENTOS_PLUGIN_DIR`,
@@ -45,7 +54,9 @@ ACI-frozen (`aci-protocol.SessionConfig`): `AGENTOS_PLUGIN_DIR`,
 Runner-local: `AGENTOS_MODEL`, `AGENTOS_SYSTEM_PROMPT`, `AGENTOS_MAX_TURNS`,
 `AGENTOS_HISTORY_REF` (rehydrate; falls back to `AGENTOS_MEMORY_REF`),
 `AGENTOS_IDEMPOTENT_TOOLS` (override the read-only allowlist),
-`AGENTOS_RUNNER_PORT`, `AGENTOS_FAKE_MODEL` (offline smoke; no model call).
+`AGENTOS_RUNNER_PORT`, `AGENTOS_RUNNER_TOKEN` (per-sandbox bearer token gating the
+three ACI POST routes; enforced only when set), `AGENTOS_FAKE_MODEL` (offline
+smoke; no model call).
 
 ## Build and smoke
 

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -96,7 +96,7 @@ def main() -> None:
         config.port,
     )
     runner = build_runner(config, fake_model=fake_model, sdk_env=override)
-    app = create_app(runner)
+    app = create_app(runner, token=config.runner_token)
 
     async def _startup(_app: web.Application) -> None:
         try:

--- a/runner/src/agentos_runner/config.py
+++ b/runner/src/agentos_runner/config.py
@@ -25,6 +25,7 @@ class RunnerConfig:
     history_ref: str | None
     idempotent_tools: list[str] | None
     port: int
+    runner_token: str | None
 
     @property
     def ceiling(self) -> int:
@@ -65,4 +66,5 @@ class RunnerConfig:
             history_ref=env.get("AGENTOS_HISTORY_REF"),
             idempotent_tools=idempotent,
             port=int(env.get("AGENTOS_RUNNER_PORT", "8080")),
+            runner_token=env.get("AGENTOS_RUNNER_TOKEN") or None,
         )

--- a/runner/src/agentos_runner/server.py
+++ b/runner/src/agentos_runner/server.py
@@ -21,23 +21,73 @@ the open ``/v1/event`` stream, exactly as the PT-2 steering proof showed.
 
 from __future__ import annotations
 
+import hmac
 from typing import cast
 
 from aci_protocol import Event, Interrupt, parse_inbound
 from aiohttp import web
+from aiohttp.typedefs import Handler, Middleware
 
 from .session import SessionRunner
 
 _NDJSON = "application/x-ndjson"
 
+# The three ACI POST routes that drive a turn; gated when a token is configured.
+# /healthz and /status stay open so the chart readinessProbe (no auth header)
+# keeps working.
+_GATED_PATHS = frozenset({"/v1/event", "/v1/steer", "/v1/interrupt"})
+
 # Typed app key so aiohttp resolves the runner without the string-key warning.
 RUNNER: web.AppKey[SessionRunner] = web.AppKey("runner", SessionRunner)
 
 
-def create_app(runner: SessionRunner) -> web.Application:
-    """Build the aiohttp application bound to a started SessionRunner."""
+def _auth_middleware(token: str) -> Middleware:
+    """Require ``Authorization: Bearer <token>`` on the gated ACI POST routes.
 
-    app = web.Application()
+    Runs before body parsing so an authenticated call keeps the route's existing
+    400/409 semantics unchanged. The presented token is compared with the
+    configured one via ``hmac.compare_digest`` (no timing oracle).
+    """
+
+    # The configured token is invariant for the process, so encode it once here
+    # rather than on every gated request.
+    token_bytes = token.encode("utf-8")
+
+    @web.middleware
+    async def middleware(
+        request: web.Request, handler: Handler
+    ) -> web.StreamResponse:
+        if request.method == "POST" and request.path in _GATED_PATHS:
+            header = request.headers.get("Authorization", "")
+            scheme = "Bearer "
+            if not header.startswith(scheme):
+                return web.json_response(
+                    {"error": "missing bearer token"}, status=401
+                )
+            presented = header[len(scheme) :]
+            # Compare UTF-8 bytes: hmac.compare_digest raises TypeError on a
+            # non-ASCII str, which aiohttp would surface as a 500 instead of a
+            # 401. Bytes keep a crafted non-ASCII token a clean 401.
+            if not hmac.compare_digest(presented.encode("utf-8"), token_bytes):
+                return web.json_response({"error": "invalid token"}, status=401)
+        return await handler(request)
+
+    return middleware
+
+
+def create_app(runner: SessionRunner, token: str | None = None) -> web.Application:
+    """Build the aiohttp application bound to a started SessionRunner.
+
+    When ``token`` is set, the three ACI POST routes require a matching bearer
+    token; when it is ``None`` the app is a pass-through (CLI, fake-model CI, and
+    pre-token sandboxes stay unauthenticated).
+    """
+
+    # A falsy token (None or empty string) means no enforcement: an empty token
+    # would make ``Bearer `` with an empty value compare-equal, so treat it as
+    # pass-through rather than an unusable enforce-on state.
+    middlewares = [_auth_middleware(token)] if token else []
+    app = web.Application(middlewares=middlewares)
     app[RUNNER] = runner
     app.add_routes(
         [

--- a/runner/tests/test_config.py
+++ b/runner/tests/test_config.py
@@ -35,3 +35,19 @@ def test_explicit_history_ref_wins() -> None:
 def test_idempotent_tools_override_parsed() -> None:
     env = dict(_BASE, AGENTOS_IDEMPOTENT_TOOLS="Read, Custom , Grep")
     assert RunnerConfig.from_env(env).idempotent_tools == ["Read", "Custom", "Grep"]
+
+
+def test_runner_token_parsed_from_env() -> None:
+    env = dict(_BASE, AGENTOS_RUNNER_TOKEN="abc123")
+    assert RunnerConfig.from_env(env).runner_token == "abc123"
+
+
+def test_runner_token_absent_is_none() -> None:
+    assert RunnerConfig.from_env(dict(_BASE)).runner_token is None
+
+
+def test_runner_token_empty_string_is_none() -> None:
+    # An empty env value is treated as unset, so a stray empty var never turns on
+    # enforcement with an unusable token.
+    env = dict(_BASE, AGENTOS_RUNNER_TOKEN="")
+    assert RunnerConfig.from_env(env).runner_token is None

--- a/runner/tests/test_server.py
+++ b/runner/tests/test_server.py
@@ -88,3 +88,163 @@ def test_steer_takes_an_event_frame_and_conflicts_without_a_turn() -> None:
             assert bad.status == 400
 
     anyio.run(go)
+
+
+_TOKEN = "test-token-xyz"
+_AUTH = {"Authorization": f"Bearer {_TOKEN}"}
+_EVENT_FRAME = {"kind": "event", "type": "message", "text": "hi", "user": "U", "ts": "1"}
+
+
+def test_event_without_auth_header_is_401() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            resp = await client.post("/v1/event", json=_EVENT_FRAME)
+            assert resp.status == 401
+            assert "error" in await resp.json()
+
+    anyio.run(go)
+
+
+def test_event_with_wrong_token_is_401() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            resp = await client.post(
+                "/v1/event", json=_EVENT_FRAME, headers={"Authorization": "Bearer wrong"}
+            )
+            assert resp.status == 401
+
+    anyio.run(go)
+
+
+def test_event_with_malformed_header_is_401() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            # The raw token with no Bearer scheme is not a valid credential.
+            resp = await client.post(
+                "/v1/event", json=_EVENT_FRAME, headers={"Authorization": _TOKEN}
+            )
+            assert resp.status == 401
+
+    anyio.run(go)
+
+
+def test_event_with_correct_token_proceeds() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            resp = await client.post("/v1/event", json=_EVENT_FRAME, headers=_AUTH)
+            assert resp.status == 200
+            events = parse_ndjson(await resp.text())
+            assert events[-1].type == "final"
+            assert events[-1].status == SessionStatus.DONE
+
+    anyio.run(go)
+
+
+def test_steer_with_correct_token_and_no_turn_is_409_not_401() -> None:
+    runner, _ = _runner()
+    steer_frame = {"kind": "event", "type": "message", "text": "do X", "user": "U", "ts": "2"}
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            # Auth must not disturb the steer contract: a valid token with no live
+            # turn still returns 409, not 401.
+            resp = await client.post("/v1/steer", json=steer_frame, headers=_AUTH)
+            assert resp.status == 409
+
+    anyio.run(go)
+
+
+def test_interrupt_requires_auth_and_proceeds_with_token() -> None:
+    runner, fake = _runner()
+    interrupt_frame = {"kind": "interrupt", "reason": "stop"}
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            unauth = await client.post("/v1/interrupt", json=interrupt_frame)
+            assert unauth.status == 401
+
+            resp = await client.post("/v1/interrupt", json=interrupt_frame, headers=_AUTH)
+            assert resp.status == 200
+            assert (await resp.json())["ok"] is True
+            assert fake.interrupts >= 1
+
+    anyio.run(go)
+
+
+def test_steer_without_auth_header_is_401() -> None:
+    runner, _ = _runner()
+    steer_frame = {"kind": "event", "type": "message", "text": "do X", "user": "U", "ts": "2"}
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            resp = await client.post("/v1/steer", json=steer_frame)
+            assert resp.status == 401
+            assert "error" in await resp.json()
+
+    anyio.run(go)
+
+
+def test_empty_token_passes_through() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        # An empty token is a falsy token: create_app must not gate, so a
+        # header-less POST proceeds rather than 401-ing on an unusable token.
+        async with TestClient(TestServer(create_app(runner, token=""))) as client:
+            resp = await client.post("/v1/event", json=_EVENT_FRAME)
+            assert resp.status == 200
+
+    anyio.run(go)
+
+
+def test_healthz_never_gated() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            resp = await client.get("/healthz")
+            assert resp.status == 200
+
+    anyio.run(go)
+
+
+def test_status_never_gated() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            resp = await client.get("/status")
+            assert resp.status == 200
+
+    anyio.run(go)
+
+
+def test_no_token_configured_passes_through() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        # An app built with token=None does not gate: a header-less POST proceeds.
+        async with TestClient(TestServer(create_app(runner, token=None))) as client:
+            resp = await client.post("/v1/event", json=_EVENT_FRAME)
+            assert resp.status == 200
+
+    anyio.run(go)


### PR DESCRIPTION
## Problem

The runner's ACI HTTP routes `/v1/event`, `/v1/steer`, `/v1/interrupt` (`runner/src/agentos_runner/server.py`) had no auth: any workload able to reach a sandbox pod's `:8080` (a neighbor pod, a misconfigured ingress NetworkPolicy, a lateral-movement foothold) could drive, steer, interrupt, or budget-burn a live session with no credential. NetworkPolicy was the only control.

## Fix

Per-sandbox bearer token, defense-in-depth on the ACI ingress:

- **Worker** mints a fresh `secrets.token_urlsafe(32)` per claim into `AGENTOS_RUNNER_TOKEN` on every claim path (bound, eval, resume), carries it on `SandboxHandle`, and sends it as an `Authorization: Bearer` header on every ACI call to that sandbox (per-call, never a shared-session default, so one sandbox's token cannot leak to another).
- **Runner** reads `AGENTOS_RUNNER_TOKEN` (runner-local config, not the frozen `aci-protocol` contract) and, when set, returns **401** on the three POST routes unless the header matches (constant-time compare, bytes). `GET /healthz` and `/status` stay ungated (the chart readinessProbe hits `/healthz`).

**Success criterion met:** an unauthenticated `POST /v1/event` returns 401; only the worker, holding the per-claim token, can drive a turn.

**Only-when-configured:** with the var unset the runner is pass-through, so local `skill up`, fake-model CI, and pre-token sandboxes are unaffected, and a rolling upgrade is compatible in either image order (a new worker's header is ignored by an old runner; a new runner without the env does not enforce).

## Scope

- **In:** the bearer token (runner enforcement + worker mint/thread/send) and its tests.
- **Out (deliberate):** ingress NetworkPolicy is the other half of defense-in-depth and is tracked separately (#66, #69); it is not locally enforceable and not part of this PR's success criterion. The CLI Rust `skill up` path is untouched (localhost single-user, not the cluster neighbor-pod threat).

## Residuals (documented, accepted)

- On the k8s substrate the token rides the SandboxClaim CR as plaintext (like other claim env). Strictly better than today's no-token state under the stated threat model (a neighbor pod with no RBAC, not an actor with `get` on SandboxClaim CRs). A future secretKeyRef hardening can follow as its own issue.
- Docker substrate passes it via `-e` argv (localhost single-user; argv is never logged).

Tests: runner 401/passthrough/config tests, worker mint/handle/serialization/legacy-compat/header tests, and an end-to-end kernel test asserting the claim-minted token arrives as the Bearer header on event/steer/interrupt. Full suite green (`uv run pytest runner/tests apps/worker/tests`), ruff + mypy clean.

Closes #63