### PR TITLE
CLI: agent-lifecycle verbs (cluster kill / resume / budget / delete)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -17,10 +17,11 @@ disk and targets no environment.
 |---|---|---|---|---|---|
 | `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
 | `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
-| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `deploy` | Operate and drive a deployed cluster release. |
+| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `deploy` `kill` `resume` `budget` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
 
 The universal quartet `up`/`down`/`status`/`message` is on all three targets;
-`skill` adds `eval`, while `local` and `cluster` add `comms` plus `deploy`. The distinction
+`skill` adds `eval`, while `local` and `cluster` add `comms` plus `deploy`; `cluster`
+further adds the agent-lifecycle verbs `kill`/`resume`/`budget`/`delete`. The distinction
 that matters: `skill` is the **runner-only** loop, talking straight to a runner
 container's ACI HTTP surface with no platform in front; `local` and `cluster`
 put the **full platform** (queue, worker, sandbox) in front of the identical
@@ -83,6 +84,17 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `agentos cluster comms --slack` | Connect or disconnect a real Slack workspace with a thin `helm upgrade --reuse-values`; env-backed tokens are masked in dry-run output. |
 | `agentos cluster message "..."` | Drive the deployed release end to end with zero Slack: self plumbs kubectl port forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply. |
 | `agentos cluster deploy` | Package the bundle as tar.gz and push it to the platform API (`--api-url`, default `http://localhost:8000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
+| `agentos cluster kill <agent> --yes` | Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`). Destructive: refuses without `--yes`. |
+| `agentos cluster resume <agent>` | Resume a killed agent via the platform API (`POST /agents/{id}/resume`). |
+| `agentos cluster budget <agent> --limit <n>` | Set the agent's daily spend cap in USD via the platform API (`PUT /agents/{id}/budget`, `BudgetConfig.max_usd_per_day`); the per-run token cap is left at the platform default. |
+| `agentos cluster delete <agent> --yes` | Delete an agent via the platform API (`DELETE /agents/{id}`). Destructive and irreversible: refuses without `--yes`. |
+
+The four lifecycle verbs (`kill`, `resume`, `budget`, `delete`) act on a
+deployed release's agents through the same platform API as `cluster deploy`
+(`--api-url`, default `http://localhost:8000`; auth via `--api-key` or
+`AGENTOS_API_KEY`). They resolve `<agent>` (a name or id) to its API id with the
+same lookup `deploy` uses. Each takes `--dry-run` (prints the plan, makes no
+request); the destructive `kill`/`delete` also require `--yes`.
 
 ### Artifact resolution
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -6,7 +6,7 @@
 //! X-API-Key header.
 
 use anyhow::{bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 pub struct ApiClient {
@@ -57,6 +57,25 @@ pub struct Deployment {
     pub id: String,
     pub environment: String,
     pub status: String,
+}
+
+/// The agent kill-switch state (`KillState` in openapi.json): the response of
+/// `POST /agents/{id}/kill` and `POST /agents/{id}/resume`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct KillState {
+    pub killed: bool,
+}
+
+/// The per-agent budget (`BudgetConfig` in openapi.json): the request and
+/// response body of `PUT /agents/{id}/budget`. Both fields are optional; an
+/// omitted field means "platform default" server-side, so we only serialize the
+/// ones the caller set.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BudgetConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens_per_run: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_usd_per_day: Option<f64>,
 }
 
 /// The artifacts a deploy produces, for the summary printout.
@@ -293,5 +312,83 @@ impl ApiClient {
             deployment,
             channel,
         })
+    }
+
+    /// Resolve an agent identifier (its `name`, or its `id`) to the full record
+    /// by listing agents and matching -- the same name-based resolution the
+    /// deploy flow uses (`resolve_agent`), so the lifecycle verbs never grow a
+    /// second resolution path. Errors when nothing matches; never creates.
+    pub async fn find_agent(&self, identifier: &str) -> Result<Agent> {
+        self.list_agents()
+            .await?
+            .into_iter()
+            .find(|a| a.name == identifier || a.id == identifier)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no agent found matching {identifier:?} (by name or id); deploy it first with `agentos cluster deploy`"
+                )
+            })
+    }
+
+    /// Flip the agent kill switch on: `POST /agents/{id}/kill` (no request body).
+    pub async fn kill_agent(&self, agent_id: &str) -> Result<KillState> {
+        let resp = self
+            .http
+            .post(format!("{}/agents/{agent_id}/kill", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("POST /agents/{id}/kill")?;
+        Self::expect_ok(resp, "killing the agent")
+            .await?
+            .json()
+            .await
+            .context("decoding kill state")
+    }
+
+    /// Flip the agent kill switch off: `POST /agents/{id}/resume` (no request body).
+    pub async fn resume_agent(&self, agent_id: &str) -> Result<KillState> {
+        let resp = self
+            .http
+            .post(format!("{}/agents/{agent_id}/resume", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("POST /agents/{id}/resume")?;
+        Self::expect_ok(resp, "resuming the agent")
+            .await?
+            .json()
+            .await
+            .context("decoding kill state")
+    }
+
+    /// Set the agent budget: `PUT /agents/{id}/budget` with a `BudgetConfig` body.
+    pub async fn set_budget(&self, agent_id: &str, budget: &BudgetConfig) -> Result<BudgetConfig> {
+        let resp = self
+            .http
+            .put(format!("{}/agents/{agent_id}/budget", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .json(budget)
+            .send()
+            .await
+            .context("PUT /agents/{id}/budget")?;
+        Self::expect_ok(resp, "updating the budget")
+            .await?
+            .json()
+            .await
+            .context("decoding budget")
+    }
+
+    /// Delete the agent: `DELETE /agents/{id}` (204 No Content on success).
+    pub async fn delete_agent(&self, agent_id: &str) -> Result<()> {
+        let resp = self
+            .http
+            .delete(format!("{}/agents/{agent_id}", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("DELETE /agents/{id}")?;
+        Self::expect_ok(resp, "deleting the agent").await?;
+        Ok(())
     }
 }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -11,7 +11,7 @@ use agentos_aci_protocol::{Budget, EventType, OutboundEvent, SessionStatus};
 use anyhow::{bail, Context, Result};
 use clap::ValueEnum;
 
-use crate::api::{ApiClient, ChannelOutcome};
+use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
 use crate::bundle::pack_tar_gz;
 use crate::docker::{self, StartSpec};
 use crate::evals::{load_cases, turn_passes};
@@ -628,6 +628,169 @@ pub async fn deploy(opts: DeployOpts) -> Result<()> {
             outcome.deployment.id, outcome.deployment.environment, outcome.deployment.status
         ),
     );
+    Ok(())
+}
+
+/// Shared flags for the agent-lifecycle verbs (`cluster kill|resume|budget|delete`).
+/// Like `deploy`, these speak the committed platform-API contract through the
+/// existing `ApiClient` (no second HTTP client).
+pub struct AgentActionOpts {
+    pub api_url: String,
+    pub api_key: String,
+    /// Agent name or id to act on. Resolved to the API's `{agent_id}` via the
+    /// same name lookup `deploy` uses (`ApiClient::find_agent`).
+    pub agent: String,
+    pub dry_run: bool,
+}
+
+/// `agentos cluster kill <agent> --yes`: flip the agent kill switch on
+/// (`POST /agents/{id}/kill`). Destructive (it stops the agent's runs), so it
+/// refuses without `--yes`, mirroring `cluster down`. `--dry-run` prints the
+/// plan and makes no request.
+pub async fn kill(opts: AgentActionOpts, yes: bool) -> Result<()> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        ui.payload_plain(&format!(
+            "POST {}/agents/<id>/kill  (would resolve agent {:?} first)",
+            opts.api_url, opts.agent
+        ));
+        return Ok(());
+    }
+    if !yes {
+        bail!(
+            "`agentos cluster kill {}` stops the agent's runs; re-run with --yes to confirm",
+            opts.agent
+        );
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let agent = client.find_agent(&opts.agent).await?;
+    let cl = ui.checklist();
+    let step = cl.step(&format!("killing {}", agent.name));
+    let state = match client.kill_agent(&agent.id).await {
+        Ok(state) => {
+            step.done("killed");
+            state
+        }
+        Err(err) => {
+            step.fail("failed");
+            return Err(err);
+        }
+    };
+    ui.payload(&format!(
+        "agent {} killed (killed={})",
+        agent.name, state.killed
+    ));
+    ui.note("Run `agentos cluster resume <agent>` to bring it back.");
+    Ok(())
+}
+
+/// `agentos cluster resume <agent>`: flip the agent kill switch off
+/// (`POST /agents/{id}/resume`). Non-destructive, so no `--yes` gate.
+/// `--dry-run` prints the plan and makes no request.
+pub async fn resume(opts: AgentActionOpts) -> Result<()> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        ui.payload_plain(&format!(
+            "POST {}/agents/<id>/resume  (would resolve agent {:?} first)",
+            opts.api_url, opts.agent
+        ));
+        return Ok(());
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let agent = client.find_agent(&opts.agent).await?;
+    let cl = ui.checklist();
+    let step = cl.step(&format!("resuming {}", agent.name));
+    let state = match client.resume_agent(&agent.id).await {
+        Ok(state) => {
+            step.done("resumed");
+            state
+        }
+        Err(err) => {
+            step.fail("failed");
+            return Err(err);
+        }
+    };
+    ui.payload(&format!(
+        "agent {} resumed (killed={})",
+        agent.name, state.killed
+    ));
+    Ok(())
+}
+
+/// `agentos cluster budget <agent> --limit <n>`: set the agent budget
+/// (`PUT /agents/{id}/budget`). `--limit` sets the daily spend cap
+/// (`max_usd_per_day`, the primary `BudgetConfig` field the console surfaces as
+/// "Max $/day"); the per-run token cap is left at the platform default.
+/// `--dry-run` prints the plan and makes no request.
+pub async fn budget(opts: AgentActionOpts, limit: f64) -> Result<()> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        ui.payload_plain(&format!(
+            "PUT {}/agents/<id>/budget  {{\"max_usd_per_day\":{limit}}}  (would resolve agent {:?} first)",
+            opts.api_url, opts.agent
+        ));
+        return Ok(());
+    }
+    if !limit.is_finite() || limit <= 0.0 {
+        bail!("--limit must be a finite value greater than 0 (got {limit})");
+    }
+    let cfg = BudgetConfig {
+        max_output_tokens_per_run: None,
+        max_usd_per_day: Some(limit),
+    };
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let agent = client.find_agent(&opts.agent).await?;
+    let cl = ui.checklist();
+    let step = cl.step(&format!("setting budget for {}", agent.name));
+    let saved = match client.set_budget(&agent.id, &cfg).await {
+        Ok(saved) => {
+            step.done("updated");
+            saved
+        }
+        Err(err) => {
+            step.fail("failed");
+            return Err(err);
+        }
+    };
+    let usd = saved
+        .max_usd_per_day
+        .map(|v| format!("${v}/day"))
+        .unwrap_or_else(|| "platform default".to_string());
+    ui.payload(&format!("budget for {} set: max $/day {usd}", agent.name));
+    Ok(())
+}
+
+/// `agentos cluster delete <agent> --yes`: delete the agent
+/// (`DELETE /agents/{id}`). Destructive and irreversible, so it refuses without
+/// `--yes`, mirroring `cluster down`. `--dry-run` prints the plan and makes no
+/// request.
+pub async fn delete(opts: AgentActionOpts, yes: bool) -> Result<()> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        ui.payload_plain(&format!(
+            "DELETE {}/agents/<id>  (would resolve agent {:?} first)",
+            opts.api_url, opts.agent
+        ));
+        return Ok(());
+    }
+    if !yes {
+        bail!(
+            "`agentos cluster delete {}` permanently deletes the agent; re-run with --yes to confirm",
+            opts.agent
+        );
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let agent = client.find_agent(&opts.agent).await?;
+    let cl = ui.checklist();
+    let step = cl.step(&format!("deleting {}", agent.name));
+    match client.delete_agent(&agent.id).await {
+        Ok(()) => step.done("deleted"),
+        Err(err) => {
+            step.fail("failed");
+            return Err(err);
+        }
+    }
+    ui.payload(&format!("agent {} deleted", agent.name));
     Ok(())
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,9 @@
 use std::path::PathBuf;
 
 use agentos::artifacts;
-use agentos::commands::{self, DeployEnv, DeployOpts, SendType, StartOpts, DEFAULT_PORT};
+use agentos::commands::{
+    self, AgentActionOpts, DeployEnv, DeployOpts, SendType, StartOpts, DEFAULT_PORT,
+};
 use agentos::comms::{self, CommsOpts, LocalCommsOpts};
 use agentos::local::{self, LocalDownOpts, LocalOpts};
 use agentos::message::{self, MessageOpts};
@@ -514,6 +516,76 @@ enum ClusterAction {
         #[arg(long)]
         label: Option<String>,
     },
+    // Agent-lifecycle verbs (kill/resume/budget/delete) speak the platform API
+    // like `deploy` does. Design decision (#149): extend the existing `cluster`
+    // target rather than introduce a new top-level `agent` noun -- these act on a
+    // deployed release's agents, so they belong beside `cluster deploy`/`message`
+    // and reuse its `--api-url`/`--api-key` surface and agent resolution.
+    /// Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`).
+    Kill {
+        /// Agent name or id to kill.
+        agent: String,
+        /// Platform API base URL.
+        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
+        api_url: String,
+        /// Platform API key.
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        /// Confirm this destructive action (required; it stops the agent's runs).
+        #[arg(long)]
+        yes: bool,
+        /// Print what would be done and exit without making a request.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Resume a killed agent via the platform API (`POST /agents/{id}/resume`).
+    Resume {
+        /// Agent name or id to resume.
+        agent: String,
+        /// Platform API base URL.
+        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
+        api_url: String,
+        /// Platform API key.
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        /// Print what would be done and exit without making a request.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Set an agent's budget via the platform API (`PUT /agents/{id}/budget`).
+    Budget {
+        /// Agent name or id.
+        agent: String,
+        /// Daily spend cap in USD (BudgetConfig.max_usd_per_day). Must be > 0.
+        #[arg(long)]
+        limit: f64,
+        /// Platform API base URL.
+        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
+        api_url: String,
+        /// Platform API key.
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        /// Print what would be done and exit without making a request.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Delete an agent via the platform API (`DELETE /agents/{id}`).
+    Delete {
+        /// Agent name or id to delete.
+        agent: String,
+        /// Platform API base URL.
+        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
+        api_url: String,
+        /// Platform API key.
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        /// Confirm this destructive action (required; it permanently deletes the agent).
+        #[arg(long)]
+        yes: bool,
+        /// Print what would be done and exit without making a request.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 async fn resolve_compose_file(file: Option<String>, dry_run: bool) -> Result<String> {
@@ -950,6 +1022,74 @@ async fn main() -> Result<()> {
                 })
                 .await
             }
+            ClusterAction::Kill {
+                agent,
+                api_url,
+                api_key,
+                yes,
+                dry_run,
+            } => {
+                commands::kill(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
+                    yes,
+                )
+                .await
+            }
+            ClusterAction::Resume {
+                agent,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::resume(AgentActionOpts {
+                    api_url,
+                    api_key,
+                    agent,
+                    dry_run,
+                })
+                .await
+            }
+            ClusterAction::Budget {
+                agent,
+                limit,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::budget(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
+                    limit,
+                )
+                .await
+            }
+            ClusterAction::Delete {
+                agent,
+                api_url,
+                api_key,
+                yes,
+                dry_run,
+            } => {
+                commands::delete(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
+                    yes,
+                )
+                .await
+            }
         },
     }
 }
@@ -1064,6 +1204,95 @@ mod tests {
                 assert_eq!(app_token, "X");
             }
             _ => panic!("expected local comms command"),
+        }
+    }
+
+    #[test]
+    fn cluster_kill_parses_agent_and_yes() {
+        let cli = Cli::try_parse_from(["agentos", "cluster", "kill", "deal-desk", "--yes"])
+            .expect("cluster kill should parse");
+        match cli.command {
+            Command::Cluster {
+                action: ClusterAction::Kill { agent, yes, .. },
+            } => {
+                assert_eq!(agent, "deal-desk");
+                assert!(yes);
+            }
+            _ => panic!("expected cluster kill command"),
+        }
+    }
+
+    #[test]
+    fn cluster_kill_defaults_yes_and_dry_run_off() {
+        let cli = Cli::try_parse_from(["agentos", "cluster", "kill", "a"])
+            .expect("cluster kill without flags should parse");
+        match cli.command {
+            Command::Cluster {
+                action:
+                    ClusterAction::Kill {
+                        agent,
+                        yes,
+                        dry_run,
+                        ..
+                    },
+            } => {
+                assert_eq!(agent, "a");
+                assert!(!yes);
+                assert!(!dry_run);
+            }
+            _ => panic!("expected cluster kill command"),
+        }
+    }
+
+    #[test]
+    fn cluster_resume_parses_agent_and_dry_run() {
+        let cli = Cli::try_parse_from(["agentos", "cluster", "resume", "a", "--dry-run"])
+            .expect("cluster resume should parse");
+        match cli.command {
+            Command::Cluster {
+                action: ClusterAction::Resume { agent, dry_run, .. },
+            } => {
+                assert_eq!(agent, "a");
+                assert!(dry_run);
+            }
+            _ => panic!("expected cluster resume command"),
+        }
+    }
+
+    #[test]
+    fn cluster_budget_parses_agent_and_limit() {
+        let cli = Cli::try_parse_from(["agentos", "cluster", "budget", "a", "--limit", "12.5"])
+            .expect("cluster budget should parse");
+        match cli.command {
+            Command::Cluster {
+                action: ClusterAction::Budget { agent, limit, .. },
+            } => {
+                assert_eq!(agent, "a");
+                assert_eq!(limit, 12.5);
+            }
+            _ => panic!("expected cluster budget command"),
+        }
+    }
+
+    #[test]
+    fn cluster_budget_requires_limit() {
+        // `--limit` has no default, so omitting it is a parse error (not a silent
+        // zero-budget request).
+        assert!(Cli::try_parse_from(["agentos", "cluster", "budget", "a"]).is_err());
+    }
+
+    #[test]
+    fn cluster_delete_parses_agent_and_yes() {
+        let cli = Cli::try_parse_from(["agentos", "cluster", "delete", "a", "--yes"])
+            .expect("cluster delete should parse");
+        match cli.command {
+            Command::Cluster {
+                action: ClusterAction::Delete { agent, yes, .. },
+            } => {
+                assert_eq!(agent, "a");
+                assert!(yes);
+            }
+            _ => panic!("expected cluster delete command"),
         }
     }
 

--- a/cli/tests/api_lifecycle.rs
+++ b/cli/tests/api_lifecycle.rs
@@ -1,0 +1,226 @@
+//! Integration: the agent-lifecycle verbs (`cluster kill|resume|budget|delete`,
+//! #149) against the committed platform-API contract shapes (apps/api
+//! openapi.json), served by the wire-level test server. Covers both the
+//! `ApiClient` methods (correct HTTP method + path + body) and the command
+//! handlers (`--yes` gate on the destructive verbs, `--dry-run` makes no
+//! request).
+
+mod support;
+
+use agentos::api::{ApiClient, BudgetConfig};
+use agentos::commands::{self, AgentActionOpts};
+use support::{serve, Response};
+
+const AGENT_ID: &str = "11111111-1111-1111-1111-111111111111";
+
+/// A one-agent `GET /agents` list used by the handler-level resolution tests.
+fn agent_list() -> Response {
+    Response::json(
+        200,
+        &format!(
+            r##"[{{"id":"{AGENT_ID}","name":"deal-desk","slack_channel":"#x","created_at":"2026-07-05T00:00:00Z"}}]"##
+        ),
+    )
+}
+
+fn opts(base_url: &str, agent: &str, dry_run: bool) -> AgentActionOpts {
+    AgentActionOpts {
+        api_url: base_url.to_string(),
+        api_key: "k".to_string(),
+        agent: agent.to_string(),
+        dry_run,
+    }
+}
+
+// --- ApiClient methods: correct verb + path + body ------------------------
+
+#[tokio::test]
+async fn kill_agent_posts_to_kill_endpoint_with_empty_body() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("POST", p) if *p == format!("/agents/{AGENT_ID}/kill") => {
+            Response::json(200, r#"{"killed":true}"#)
+        }
+        other => panic!("unexpected request: {other:?}"),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    let state = client.kill_agent(AGENT_ID).await.unwrap();
+    assert!(state.killed);
+
+    let rec = server.recorded();
+    assert_eq!(rec.len(), 1);
+    assert_eq!(rec[0].method, "POST");
+    assert_eq!(rec[0].path, format!("/agents/{AGENT_ID}/kill"));
+    assert!(rec[0].body.is_empty(), "kill sends no body");
+    assert_eq!(rec[0].header("x-api-key"), Some("k"));
+}
+
+#[tokio::test]
+async fn resume_agent_posts_to_resume_endpoint() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("POST", p) if *p == format!("/agents/{AGENT_ID}/resume") => {
+            Response::json(200, r#"{"killed":false}"#)
+        }
+        other => panic!("unexpected request: {other:?}"),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    let state = client.resume_agent(AGENT_ID).await.unwrap();
+    assert!(!state.killed);
+
+    let rec = server.recorded();
+    assert_eq!(rec[0].method, "POST");
+    assert_eq!(rec[0].path, format!("/agents/{AGENT_ID}/resume"));
+}
+
+#[tokio::test]
+async fn set_budget_puts_the_limit_as_max_usd_per_day() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("PUT", p) if *p == format!("/agents/{AGENT_ID}/budget") => Response::json(
+            200,
+            r#"{"max_output_tokens_per_run":null,"max_usd_per_day":7.5}"#,
+        ),
+        other => panic!("unexpected request: {other:?}"),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    let cfg = BudgetConfig {
+        max_output_tokens_per_run: None,
+        max_usd_per_day: Some(7.5),
+    };
+    let saved = client.set_budget(AGENT_ID, &cfg).await.unwrap();
+    assert_eq!(saved.max_usd_per_day, Some(7.5));
+
+    let rec = server.recorded();
+    assert_eq!(rec[0].method, "PUT");
+    assert_eq!(rec[0].path, format!("/agents/{AGENT_ID}/budget"));
+    let body = String::from_utf8_lossy(&rec[0].body);
+    assert!(body.contains("\"max_usd_per_day\":7.5"), "body: {body}");
+    // The unset token cap is skipped, not sent as null, so the server keeps its
+    // platform default.
+    assert!(
+        !body.contains("max_output_tokens_per_run"),
+        "unset field must be omitted: {body}"
+    );
+}
+
+#[tokio::test]
+async fn delete_agent_issues_a_delete() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("DELETE", p) if *p == format!("/agents/{AGENT_ID}") => Response {
+            status: 204,
+            content_type: "application/json".into(),
+            body: Vec::new(),
+        },
+        other => panic!("unexpected request: {other:?}"),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    client.delete_agent(AGENT_ID).await.unwrap();
+
+    let rec = server.recorded();
+    assert_eq!(rec[0].method, "DELETE");
+    assert_eq!(rec[0].path, format!("/agents/{AGENT_ID}"));
+    assert_eq!(rec[0].header("x-api-key"), Some("k"));
+}
+
+#[tokio::test]
+async fn find_agent_errors_when_no_agent_matches() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => Response::json(200, "[]"),
+        other => panic!("unexpected request: {other:?}"),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    let err = client.find_agent("nope").await.unwrap_err();
+    assert!(err.to_string().contains("no agent found"), "{err}");
+}
+
+// --- Handlers: resolve-then-act, --yes gate, --dry-run --------------------
+
+#[tokio::test]
+async fn kill_handler_resolves_by_name_then_kills() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list(),
+        ("POST", p) if *p == format!("/agents/{AGENT_ID}/kill") => {
+            Response::json(200, r#"{"killed":true}"#)
+        }
+        other => panic!("unexpected request: {other:?}"),
+    });
+    commands::kill(opts(&server.base_url, "deal-desk", false), true)
+        .await
+        .unwrap();
+
+    let flow: Vec<(String, String)> = server
+        .recorded()
+        .iter()
+        .map(|r| (r.method.clone(), r.path.clone()))
+        .collect();
+    assert_eq!(
+        flow,
+        vec![
+            ("GET".to_string(), "/agents".to_string()),
+            ("POST".to_string(), format!("/agents/{AGENT_ID}/kill")),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn budget_handler_resolves_then_puts_the_limit() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list(),
+        ("PUT", p) if *p == format!("/agents/{AGENT_ID}/budget") => Response::json(
+            200,
+            r#"{"max_output_tokens_per_run":null,"max_usd_per_day":9.0}"#,
+        ),
+        other => panic!("unexpected request: {other:?}"),
+    });
+    commands::budget(opts(&server.base_url, "deal-desk", false), 9.0)
+        .await
+        .unwrap();
+
+    let rec = server.recorded();
+    assert_eq!(rec.len(), 2);
+    assert_eq!(rec[1].method, "PUT");
+    assert_eq!(rec[1].path, format!("/agents/{AGENT_ID}/budget"));
+    let body = String::from_utf8_lossy(&rec[1].body);
+    assert!(body.contains("\"max_usd_per_day\":9.0"), "body: {body}");
+}
+
+#[tokio::test]
+async fn kill_without_yes_refuses_and_makes_no_request() {
+    let server = serve(|req| panic!("no request expected, got {} {}", req.method, req.path));
+    let err = commands::kill(opts(&server.base_url, "deal-desk", false), false)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("--yes"), "{err}");
+    assert!(
+        server.recorded().is_empty(),
+        "a refused kill must make no request"
+    );
+}
+
+#[tokio::test]
+async fn delete_without_yes_refuses_and_makes_no_request() {
+    let server = serve(|req| panic!("no request expected, got {} {}", req.method, req.path));
+    let err = commands::delete(opts(&server.base_url, "deal-desk", false), false)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("--yes"), "{err}");
+    assert!(
+        server.recorded().is_empty(),
+        "a refused delete must make no request"
+    );
+}
+
+#[tokio::test]
+async fn dry_run_makes_no_request_for_any_verb() {
+    // Even a destructive verb under --dry-run (without --yes) touches nothing.
+    let server = serve(|req| panic!("dry-run must not request, got {} {}", req.method, req.path));
+    let base = &server.base_url;
+    commands::kill(opts(base, "a", true), false).await.unwrap();
+    commands::resume(opts(base, "a", true)).await.unwrap();
+    commands::budget(opts(base, "a", true), 5.0).await.unwrap();
+    commands::delete(opts(base, "a", true), false)
+        .await
+        .unwrap();
+    assert!(
+        server.recorded().is_empty(),
+        "no dry-run verb may make a request"
+    );
+}


### PR DESCRIPTION
Closes #149. Adds the four agent-lifecycle verbs that had no CLI equivalent, so the console/CLI parity goal is met for kill/resume/budget/delete.

## What
Under the existing **`cluster`** target (design choice: extend `cluster` rather than invent a new `agent` noun — these act on a deployed release's agents and reuse `cluster deploy`'s `--api-url`/`--api-key` surface + agent resolution):

| Verb | API |
|---|---|
| `cluster kill <agent>` | `POST /agents/{id}/kill` |
| `cluster resume <agent>` | `POST /agents/{id}/resume` |
| `cluster budget <agent> --limit <n>` | `PUT /agents/{id}/budget` (`max_usd_per_day`) |
| `cluster delete <agent> --yes` | `DELETE /agents/{id}` |

- Speaks only the committed `openapi.json` via the **existing** reqwest client (no second HTTP client, per `cli/CLAUDE.md`). `BudgetConfig`/`KillState` structs match the schema; unset budget fields are omitted (platform default).
- `<agent>` resolved by name **or** id via the same `list_agents` path `deploy` uses (never creates).
- Destructive `kill`/`delete` refuse without `--yes` (mirroring `down --yes`) and make **zero** requests when refused; all four support `--dry-run` (prints the plan, no request).
- `--limit` maps to the daily USD cap (`max_usd_per_day`), the console's primary budget field; validated finite & > 0.

## Tests
`cli/tests/api_lifecycle.rs` (10): method+path+body+`x-api-key` per verb, resolve-then-act ordering, `--yes` refusal → no request, `--dry-run` → no request; plus clap parse tests. `cargo test`/`clippy -D warnings`/`fmt --check` all clean.

## Scope / follow-ups
CLI-only (`main.rs`, `api.rs`, `commands.rs`, `README.md`, tests); no API/worker change. `command-manifest.json` and flipping the UI `noCliEquivalent` hints are **#145 follow-ups** (that ticket hasn't landed, so no manifest is created here).