### PR TITLE
Security scanning CI for the public repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot keeps the four dependency ecosystems in this repo current. Grouped
+# into one PR per ecosystem per week to keep the update volume reviewable.
+version: 2
+updates:
+  # GitHub Actions used across all workflow files (.github/workflows/).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # Rust crates. Both committed Cargo.lock files are tracked.
+  - package-ecosystem: cargo
+    directories:
+      - /cli
+      - /packages/aci-protocol/generated/rust
+    schedule:
+      interval: weekly
+    groups:
+      cargo:
+        patterns: ["*"]
+
+  # Python is managed with uv (uv.lock at the repo root); the `uv` ecosystem
+  # updates pyproject.toml and the lockfile together. This is the uv equivalent
+  # of the pip ecosystem named in the issue.
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python:
+        patterns: ["*"]
+
+  # The UI is a pnpm project; Dependabot's `npm` ecosystem handles pnpm lockfiles.
+  - package-ecosystem: npm
+    directory: /apps/ui
+    schedule:
+      interval: weekly
+    groups:
+      pnpm:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for CodeQL to upload results to the Security tab.
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Python and JavaScript/TypeScript are interpreted, so no build step
+          # is needed (build-mode: none). Rust is intentionally out of scope for
+          # this issue (Python + JavaScript only).
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -1,0 +1,56 @@
+name: Dependency Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Advisory databases change independently of the code, so re-run weekly to
+    # catch newly-published CVEs against dependencies that never changed.
+    - cron: "0 6 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      # Both committed Cargo.lock files are audited. cargo-audit reads the
+      # Cargo.lock in the working directory and fails the job on any advisory.
+      - name: Audit cli crate
+        working-directory: cli
+        run: cargo audit
+      - name: Audit generated ACI protocol crate
+        working-directory: packages/aci-protocol/generated/rust
+        run: cargo audit
+
+  python-audit:
+    name: pip-audit (uv workspace)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      # Export the fully-resolved third-party dependency set from the frozen
+      # lockfile. --no-emit-workspace drops the local workspace packages (they
+      # carry no advisories and pip-audit cannot resolve editable/local entries);
+      # --all-packages walks every workspace member so no member's deps are missed.
+      - name: Export locked requirements
+        run: |
+          uv export --frozen --all-packages --no-emit-workspace \
+            --format requirements-txt --output-file requirements-audit.txt
+      - name: pip-audit
+        run: uvx pip-audit --requirement requirements-audit.txt

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,38 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full-history sweep so a secret introduced (or surfaced by a future
+    # history rewrite) is caught even without a push.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks (full history)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          # fetch-depth: 0 pulls the entire history so `gitleaks detect` scans
+          # every commit, not just the tip. This doubles as the one-time
+          # full-history sweep the issue asks for (confirming the earlier history
+          # rewrite left no secrets behind) and re-runs it on every push/PR/cron.
+          fetch-depth: 0
+      # Run gitleaks from its official public image rather than the marketplace
+      # action: the action requires a paid GITLEAKS_LICENSE for organization
+      # accounts, while the CLI/image is MIT-licensed and free. `:latest` keeps
+      # the ruleset current, which is the desired behavior for a secret scanner.
+      - name: Run gitleaks
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/repo" \
+            ghcr.io/gitleaks/gitleaks:latest \
+            detect --source /repo --redact --verbose --exit-code 1

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,20 @@
+# Reviewed false positives from the full-history gitleaks sweep (issue #13).
+# Each entry is a commit:path:rule:line fingerprint. These are documentation
+# examples, code identifiers, and dev-default/dummy values -- NOT real secrets.
+# A genuine secret introduced later gets a different fingerprint and still fails
+# the gate. Re-verify before adding anything here.
+
+# TypeScript struct field names in the metrics table (`key:` is a field, not a
+# credential): apps/ui/src/views/obs/RealMetrics.tsx.
+eba9315b76cda2c258f3f7d2223dd5383f0e7fa4:apps/ui/src/views/obs/RealMetrics.tsx:generic-api-key:12
+b92e955c86e199c23c7ae47697e3949cb6b41a29:apps/ui/src/views/obs/RealMetrics.tsx:generic-api-key:11
+
+# Dummy placeholder Slack tokens in a Rust test (xapp-123456789 / xoxb-123456789).
+7a7d2bd42b286326c1ffd87fcf6b08d7af9e65e5:cli/src/comms.rs:generic-api-key:347
+
+# Documented dev-default Langfuse bootstrap keys (pk-lf-agentos-dev /
+# sk-lf-agentos-dev) shown in curl examples. These are fixed public dev defaults
+# baked into the headless bootstrap, not production credentials.
+be962e4a37f8644539244e2e872937f2fd8371a0:AGENTS.md:curl-auth-user:105
+7279a29e6fd7115bc002d3fed6e73d636e8912d7:AGENTS.md:curl-auth-user:105
+8d6184d608c0bf28e7323e65578bee1e5f077fb5:CLAUDE.md:curl-auth-user:75


### PR DESCRIPTION
Adds the security-hygiene CI a public repo needs, as new-file-only additions (no changes to the shared `ci.yaml` / `release.yaml`).

## What

- **Secret scanning** (`.github/workflows/gitleaks.yaml`): gitleaks on push/PR + weekly cron + manual dispatch. Checks out with `fetch-depth: 0` so `gitleaks detect` scans the **entire history** every run — this doubles as the full-history sweep confirming the earlier history rewrite left no secrets behind. Runs from the MIT-licensed public image (`ghcr.io/gitleaks/gitleaks`) rather than the marketplace action, which requires a paid `GITLEAKS_LICENSE` for organization accounts.
- **Dependency vulnerability gates** (`.github/workflows/dependency-audit.yaml`): `cargo audit` over both committed `Cargo.lock` crates (`cli`, `packages/aci-protocol/generated/rust`), and `pip-audit` over the uv-exported locked requirements (`uv export --frozen --all-packages --no-emit-workspace`). Also runs weekly so newly-published advisories against unchanged deps are still caught.
- **CodeQL SAST** (`.github/workflows/codeql.yaml`): Python and JavaScript/TypeScript, `build-mode: none`, results to the Security tab.
- **Dependabot** (`.github/dependabot.yml`): weekly updates for `github-actions`, `cargo` (both crate dirs), `uv`, and `npm` (pnpm) ecosystems, grouped one PR per ecosystem.

## Notable defaults chosen

- **`uv` ecosystem instead of `pip`**: the repo is uv-managed (`uv.lock`), so the `uv` Dependabot ecosystem (and `uv export` feeding pip-audit) is the correct equivalent of the issue's "pip" — the `pip` ecosystem would not update `uv.lock`.
- **`npm` ecosystem for pnpm**: Dependabot's `npm` ecosystem handles pnpm lockfiles.
- **Workflow named `gitleaks.yaml`, not `secret-scan.yaml`**: the repo `.gitignore` excludes `*secret*` paths, which would have silently dropped the file. Renamed rather than touch the shared `.gitignore`.

Validated locally: all YAML parses, `actionlint` clean, and the `uv export` command produces 1458 pinned third-party deps with no local/editable refs leaking into the audit input.

Closes #13