### PR TITLE
N1 soak: chart resilience under sustained load

### DIFF
--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -1,11 +1,123 @@
 # tests/soak
 
-This directory is reserved for the soak and chaos suite. The suite is not yet
-authored.
+The soak and chaos suite. It proves the definition-of-done under sustained load
+against a STANDING agentos cluster: concurrent threads plus a mid-thread batch
+job, a sandbox killed mid-run, and a resume-rehydrate under load, asserting no
+cross-talk between threads, no duplicate side effects, and a sandbox-affinity
+(prompt-cache warmth) proxy. It runs against a real cluster sized to the
+definition-of-done target and can run three consecutive times in one invocation.
 
-When written, it proves the definition-of-done under sustained load: concurrent
-threads plus a mid-thread batch job, a sandbox killed mid-run, and a
-resume-rehydrate, asserting no cross-talk between threads, no duplicate side
-effects, and sandbox-affined `cache_read_input_tokens > 0`. It runs against a
-real cluster sized to the full definition-of-done target and must pass three
-consecutive runs.
+The suite drives the worker's `SandboxSubstrate` plus Valkey plus `kubectl`
+directly, mirroring `apps/worker/tests/sandbox/test_e2e_k8scratch.py`. There is
+no REST thread or message API to drive; a turn is a `kubectl port-forward` to the
+sandbox pod followed by `POST /v1/event` (NDJSON frames ending in a `final`).
+
+## Opt-in gate
+
+The scenario never runs in default CI. It is gated on `AGENTOS_SOAK=1` and skips
+cleanly with no cluster. The pure-helper unit tests in `test_harness_unit.py`
+always run (offline, no cluster) and cover the deterministic harness logic.
+
+`tests/soak` is intentionally not in the pytest `testpaths`, so the scenario runs
+only when invoked by explicit path.
+
+## How to run
+
+Offline unit tests (no cluster, always green):
+
+```bash
+uv run pytest tests/soak/test_harness_unit.py -q
+```
+
+Full scenario, three consecutive runs, against a standing cluster and dev stack:
+
+```bash
+AGENTOS_SOAK=1 AGENTOS_SOAK_RUNS=3 uv run pytest tests/soak -q
+```
+
+Size the warm pool to at least `AGENTOS_SOAK_CONCURRENCY + AGENTOS_SOAK_BATCH`
+ready replicas (the `pool_ready` fixture blocks until the pool reports that many)
+so the concurrent claims and the batch burst never starve.
+
+## Environment knobs
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `AGENTOS_SOAK` | unset | Set to `1` to enable the scenario. Unset skips it. |
+| `AGENTOS_SOAK_CONCURRENCY` | `5` | Distinct concurrent Phase-A threads. |
+| `AGENTOS_SOAK_BATCH` | `3` | Concurrent Phase-B batch-burst threads. |
+| `AGENTOS_SOAK_RUNS` | `1` | Consecutive runs in one invocation (set `3` for the DoD). |
+| `AGENTOS_SANDBOX_E2E_NAMESPACE` | `agentos-g1` | Cluster namespace. |
+| `AGENTOS_SANDBOX_E2E_POOL` | `agentos-g1-runner-pool` | Warm pool name. |
+| `TEST_VALKEY_HOST` | `localhost` | Dev-stack Valkey host. |
+| `TEST_VALKEY_PORT` | `26379` | Dev-stack Valkey port. |
+| `TEST_VALKEY_PW` | `valkeypass` | Dev-stack Valkey password. |
+| `KUBECONFIG` | implicit | Points at the standing cluster. |
+| `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` | unset | Present enables live-cred content assertions and the cache-token probe. |
+
+Without a live credential the fake-model runner is in play: turns still stream a
+`final` frame and every structural assertion (isolation, affinity, pod UIDs,
+claim counts, injected history ref) holds, but reply-content assertions (marker
+echo, content-level no-cross-talk) are skipped because the fake model does not
+echo the prompt.
+
+## Phase map
+
+| Phase | What it exercises | Key assertions |
+|---|---|---|
+| A | Concurrent threads | Distinct threads bind distinct sandboxes (isolation); re-claim returns the same sandbox (affinity); with live creds each reply carries its own marker and no foreign marker (no content cross-talk). |
+| B | Mid-thread batch job | A batch burst runs while Phase-A threads are held; all batch turns reach `final` and Phase-A pod UIDs are unchanged (undisturbed under load). |
+| C | Sandbox killed mid-run | Unclean `kubectl delete pod`; re-claim yields a fresh pod (new UID) that answers `/healthz` and reaches `final`; exactly one live `SandboxClaim` survives for the thread hash (no orphan or duplicate). |
+| D | Resume-rehydrate under load | Suspend deletes the pod; resume creates a new claim whose pod carries `AGENTOS_HISTORY_REF`; concurrently loaded threads keep their pods. |
+| Cache warmth | Prompt-cache affinity proxy | A non-killed, non-suspended thread keeps the same pod UID across consecutive turns (`EVIDENCE same_pod_across_turns`). |
+
+## Documented assumptions and gaps
+
+1. **"Batch job" is interpreted as a concurrent burst under sustained load.** The
+   batch phase launches `AGENTOS_SOAK_BATCH` additional threads while the Phase-A
+   threads are still held claimed, and asserts the batch turns complete without
+   disturbing the held threads. An alternative reading of "batch job" is an eval
+   fan-out (an `XADD` to the `agentos:evals` stream consumed by a separate
+   consumer group). That path is not part of the sandbox substrate this suite
+   drives, so it is noted here as an alternative rather than exercised.
+
+2. **"No duplicate side effects" is asserted at the substrate level (one live
+   claim survives a kill), not as end-to-end side-effect idempotency.** The
+   semantic invariant, a failed run that emitted a side effect escalates to a
+   human instead of auto-retrying, is the kernel's rule (the fourth rule in
+   `apps/worker/CLAUDE.md`) and already has a provoking integration test in
+   `apps/worker/tests/kernel`. This suite drives the `SandboxSubstrate` seam
+   directly (mirroring `apps/worker/tests/sandbox/test_e2e_k8scratch.py`) and so
+   asserts the observable substrate-level proxy: after an unclean kill and
+   re-claim, exactly one live `SandboxClaim` remains for the thread hash (no
+   orphaned or duplicated claim). Re-driving turns through the kernel path (a
+   Valkey `agentos:runs` producer plus a fake Slack sink plus the in-cluster
+   consumer) to count actual side-effect executions is deliberately left out of
+   this footprint: it would duplicate the kernel suite's existing coverage and
+   pull the soak away from the substrate seam it is meant to stress. See the
+   follow-up below.
+
+3. **`cache_read_input_tokens` is not observable at the cluster level, so the
+   suite asserts pod-UID affinity as the cache-warmth proxy.** The runner's OTel
+   export (`runner/src/agentos_runner/otel.py`, `_GenerationSpan.record_usage`)
+   exports only `gen_ai.usage.input_tokens` and `output_tokens` and drops the
+   cache-token fields, so Langfuse never records `cache_read_input_tokens`. It is
+   asserted only at the SDK layer in `runner/tests/test_live.py`. The soak
+   therefore asserts the cluster-observable property that ENABLES cache reuse:
+   the same pod (same pod UID) serves consecutive turns on a thread (ADR-0003
+   "same pod across turns"). A single `xfail` probe (`test_cache_read_tokens_probe`)
+   attempts to read per-trace usage from Langfuse and would turn green if the
+   OTel export is later extended. Follow-up: extend `_GenerationSpan.record_usage`
+   to export `cache_read_input_tokens` / `cache_creation_input_tokens` so this
+   probe can become a real assertion.
+
+## Follow-ups noted (outside this footprint)
+
+- Extend `runner/src/agentos_runner/otel.py` to export the cache-token usage
+  fields (see gap 3 above); the `xfail` probe becomes a real assertion then.
+- Add an end-to-end side-effect-idempotency soak that drives turns through the
+  kernel path (a Valkey `agentos:runs` producer plus a fake Slack sink plus the
+  in-cluster consumer), kills a sandbox after a side-effecting tool call fires,
+  re-drives, and asserts the effect executed exactly once (see gap 2 above).
+- If an eval-fanout batch interpretation is wanted, add a phase that drives the
+  `agentos:evals` stream and its consumer group (see gap 1 above).

--- a/tests/soak/conftest.py
+++ b/tests/soak/conftest.py
@@ -1,0 +1,101 @@
+"""Fixtures and import wiring for the soak suite.
+
+The cluster-touching fixtures (``substrate``, ``pool_ready``) are only requested
+by the gated scenario in ``test_soak_resilience.py``; when ``AGENTOS_SOAK`` is
+unset that module skips at collection time via its own ``pytestmark`` and these
+fixtures never run, so the suite stays clean offline. The pure-helper unit tests
+request none of these fixtures and always run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+# importlib import mode does not add the test directory to sys.path, so make the
+# sibling ``harness`` module importable from every test module in this folder.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from harness import SoakConfig, kubectl  # noqa: E402
+
+# The scenario module carries the enforcing skip guard; this documents the same
+# opt-in gate at the package level (module markers on conftest do not propagate,
+# so the real guard lives in test_soak_resilience.py).
+pytestmark = pytest.mark.skipif(
+    os.environ.get("AGENTOS_SOAK") != "1",
+    reason="soak/chaos suite; set AGENTOS_SOAK=1 with a standing cluster + dev stack",
+)
+
+
+@pytest.fixture(scope="session")
+def cfg() -> SoakConfig:
+    return SoakConfig.from_env()
+
+
+@pytest.fixture(scope="session")
+def substrate(cfg: SoakConfig) -> Iterator[object]:
+    """A real substrate over the standing cluster and dev-stack Valkey.
+
+    Mirrors the sandbox e2e template's ``substrate`` fixture: real ``redis``
+    client, a soak-scoped key prefix, and teardown that scans and deletes the
+    prefix so a run leaves no route keys behind.
+    """
+
+    import redis
+    from agentos_worker.sandbox import (
+        AffinityStore,
+        KubernetesSandboxClient,
+        SandboxSubstrate,
+        SubstrateConfig,
+    )
+
+    client = redis.Redis(
+        host=cfg.valkey_host,
+        port=cfg.valkey_port,
+        password=cfg.valkey_password,
+    )
+    client.ping()
+    prefix = "soak:agentos:sandbox"
+    config = SubstrateConfig(
+        namespace=cfg.namespace,
+        warm_pool=cfg.pool,
+        claim_timeout_seconds=120.0,
+        poll_interval_seconds=0.05,
+        key_prefix=prefix,
+    )
+    yield SandboxSubstrate(
+        KubernetesSandboxClient(cfg.namespace),
+        AffinityStore(client, key_prefix=prefix),
+        config,
+    )
+    keys = list(client.scan_iter(match=f"{prefix}:*"))
+    if keys:
+        client.delete(*keys)
+    client.close()
+
+
+@pytest.fixture
+def pool_ready(cfg: SoakConfig) -> None:
+    """Block until the warm pool has enough ready replicas for the run.
+
+    The soak claims ``concurrency`` distinct threads plus a ``batch`` burst, so
+    the pool must be able to hand out that many sandboxes without starving.
+    """
+
+    wanted = cfg.concurrency + cfg.batch
+    deadline = time.monotonic() + 300.0
+    while time.monotonic() < deadline:
+        raw = kubectl(cfg, "get", "sandboxwarmpool", cfg.pool, "-o", "json")
+        status = json.loads(raw).get("status") or {}
+        if status.get("readyReplicas", 0) >= wanted:
+            return
+        time.sleep(2)
+    raise AssertionError(
+        f"warm pool {cfg.pool} never reached readyReplicas>={wanted}"
+    )

--- a/tests/soak/harness.py
+++ b/tests/soak/harness.py
@@ -1,0 +1,228 @@
+"""Reusable helpers for the soak and chaos scenario.
+
+Two layers live here:
+
+- **Pure helpers** (``thread_hash``, ``unique_marker``, ``final_frame``,
+  ``collected_text``, ``detect_cross_talk``) have no cluster or subprocess
+  dependency and are unit-tested offline in ``test_harness_unit.py``.
+- **Cluster helpers** (``kubectl``, ``pod_of_sandbox``, ``pod_uid``,
+  ``port_forward``, ``get_json``, ``post_event``, ``final_frame`` consumers,
+  ``live_sandboxclaims``) mirror ``apps/worker/tests/sandbox/test_e2e_k8scratch.py``
+  and only run when a real cluster is configured.
+
+The substrate seam is synchronous, so the scenario drives concurrency with a
+``ThreadPoolExecutor``; nothing here is async.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import urllib.request
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SoakConfig:
+    """Frozen knobs for one soak invocation, built from the environment.
+
+    The namespace, pool, and Valkey defaults match the sandbox e2e template so
+    the two suites can share a standing cluster and dev stack.
+    """
+
+    namespace: str
+    pool: str
+    valkey_host: str
+    valkey_port: int
+    valkey_password: str | None
+    concurrency: int
+    batch: int
+    runs: int
+    live_creds: bool
+
+    @classmethod
+    def from_env(cls) -> SoakConfig:
+        password = os.environ.get("TEST_VALKEY_PW", "valkeypass") or None
+        live = bool(
+            os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY")
+        )
+        return cls(
+            namespace=os.environ.get("AGENTOS_SANDBOX_E2E_NAMESPACE", "agentos-g1"),
+            pool=os.environ.get("AGENTOS_SANDBOX_E2E_POOL", "agentos-g1-runner-pool"),
+            valkey_host=os.environ.get("TEST_VALKEY_HOST", "localhost"),
+            valkey_port=int(os.environ.get("TEST_VALKEY_PORT", "26379")),
+            valkey_password=password,
+            concurrency=int(os.environ.get("AGENTOS_SOAK_CONCURRENCY", "5")),
+            batch=int(os.environ.get("AGENTOS_SOAK_BATCH", "3")),
+            runs=int(os.environ.get("AGENTOS_SOAK_RUNS", "1")),
+            live_creds=live,
+        )
+
+
+# -- pure helpers (offline-unit-testable) -----------------------------------
+
+
+def thread_hash(thread_key: str) -> str:
+    """The sha256[:10] thread hash the worker stamps on claim names and labels.
+
+    Mirrors ``SubstrateConfig.claim_name_for`` and the ``agentos.dev/thread-hash``
+    label so the soak can select a thread's cluster-side resources by label.
+    """
+
+    return hashlib.sha256(thread_key.encode("utf-8")).hexdigest()[:10]
+
+
+def unique_marker(prefix: str, seed: int) -> str:
+    """A deterministic-per-(prefix, seed), collision-resistant content token.
+
+    Deterministic so the offline unit tests can assert stability; unique across
+    seeds so distinct threads carry distinct markers. No wall-clock input.
+    """
+
+    digest = hashlib.sha256(f"{prefix}:{seed}".encode()).hexdigest()[:8]
+    return f"soakmark-{prefix}-{seed}-{digest}"
+
+
+def final_frame(frames: Sequence[dict[str, object]]) -> dict[str, object] | None:
+    """The last frame whose ``type`` is ``final``, or None if there is none."""
+
+    for frame in reversed(frames):
+        if frame.get("type") == "final":
+            return frame
+    return None
+
+
+def collected_text(frames: Sequence[dict[str, object]]) -> str:
+    """Concatenate the ``text`` field across every text-bearing frame.
+
+    ACI outbound frames (``text_delta``, ``tool_note``, ``final``) all carry a
+    ``text`` field; joining them yields the full assistant utterance for a turn.
+    """
+
+    parts: list[str] = []
+    for frame in frames:
+        value = frame.get("text")
+        if isinstance(value, str) and value:
+            parts.append(value)
+    return " ".join(parts)
+
+
+def detect_cross_talk(marker: str, other_markers: Sequence[str], text: str) -> bool:
+    """True if any foreign marker (a marker other than this thread's) is in ``text``.
+
+    A thread's own ``marker`` is expected in its reply; a foreign marker leaking
+    into this thread's reply is cross-talk between threads.
+    """
+
+    return any(other != marker and other in text for other in other_markers)
+
+
+# -- cluster helpers (require a configured cluster) --------------------------
+
+
+def kubectl(cfg: SoakConfig, *args: str) -> str:
+    """Run a namespaced ``kubectl`` command and return stdout."""
+
+    result = subprocess.run(
+        ["kubectl", "-n", cfg.namespace, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return result.stdout
+
+
+def pod_of_sandbox(cfg: SoakConfig, name: str) -> dict[str, object]:
+    """The pod object for a sandbox (pod name == sandbox name)."""
+
+    raw = kubectl(cfg, "get", "pod", name, "-o", "json")
+    return dict(json.loads(raw))
+
+
+def pod_uid(pod: dict[str, object]) -> str:
+    """The pod's ``metadata.uid`` (identity that changes on a rebuild)."""
+
+    metadata = pod["metadata"]
+    assert isinstance(metadata, dict)
+    uid = metadata["uid"]
+    assert isinstance(uid, str)
+    return uid
+
+
+@contextlib.contextmanager
+def port_forward(cfg: SoakConfig, pod: str, remote_port: int) -> Iterator[str]:
+    """Port-forward to a sandbox pod and yield the local base URL."""
+
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        local_port = probe.getsockname()[1]
+    proc = subprocess.Popen(
+        [
+            "kubectl",
+            "-n",
+            cfg.namespace,
+            "port-forward",
+            f"pod/{pod}",
+            f"{local_port}:{remote_port}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        assert proc.stdout is not None
+        line = proc.stdout.readline()
+        if "Forwarding from" not in line:
+            raise RuntimeError(f"port-forward failed: {line}")
+        yield f"http://127.0.0.1:{local_port}"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def get_json(base: str, path: str) -> dict[str, object]:
+    """GET ``{base}{path}`` and parse the JSON body."""
+
+    with urllib.request.urlopen(f"{base}{path}", timeout=10) as resp:
+        return dict(json.loads(resp.read()))
+
+
+def post_event(
+    base: str, text: str, *, user: str = "U-soak", ts: str = "1.0"
+) -> list[dict[str, object]]:
+    """POST an ACI ``message`` event and return the parsed NDJSON frames."""
+
+    body = json.dumps(
+        {"kind": "event", "type": "message", "text": text, "user": user, "ts": ts}
+    ).encode()
+    request = urllib.request.Request(
+        f"{base}/v1/event", data=body, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(request, timeout=90) as resp:
+        return [json.loads(line) for line in resp.read().splitlines() if line.strip()]
+
+
+def live_sandboxclaims(cfg: SoakConfig, thread_hash_value: str) -> list[dict[str, object]]:
+    """SandboxClaim objects tagged with the given thread hash label.
+
+    Used to assert exactly one live claim survives a chaos kill and re-claim
+    (no orphaned or duplicated claim for the thread).
+    """
+
+    raw = kubectl(
+        cfg,
+        "get",
+        "sandboxclaims",
+        "-l",
+        f"agentos.dev/thread-hash={thread_hash_value}",
+        "-o",
+        "json",
+    )
+    items = json.loads(raw).get("items", [])
+    return [dict(item) for item in items]

--- a/tests/soak/test_harness_unit.py
+++ b/tests/soak/test_harness_unit.py
@@ -1,0 +1,101 @@
+"""Offline unit tests for the pure soak helpers.
+
+These run with no cluster and no dev stack: they exercise only the pure
+functions in ``harness.py`` (``thread_hash``, ``unique_marker``, ``final_frame``,
+``collected_text``, ``detect_cross_talk``). They are deliberately not gated by
+``AGENTOS_SOAK`` so the harness logic stays covered in default CI paths when the
+suite is run by explicit path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from harness import (
+    collected_text,
+    detect_cross_talk,
+    final_frame,
+    thread_hash,
+    unique_marker,
+)
+
+
+def test_thread_hash_matches_sha256_prefix() -> None:
+    key = "soak-thread-42"
+    expected = hashlib.sha256(key.encode("utf-8")).hexdigest()[:10]
+    assert thread_hash(key) == expected
+    assert len(thread_hash(key)) == 10
+
+
+def test_thread_hash_distinct_keys_distinct_hashes() -> None:
+    assert thread_hash("soak-thread-1") != thread_hash("soak-thread-2")
+
+
+def test_unique_marker_is_deterministic_per_seed() -> None:
+    assert unique_marker("phase-a", 3) == unique_marker("phase-a", 3)
+
+
+def test_unique_marker_is_unique_across_seeds() -> None:
+    markers = {unique_marker("phase-a", seed) for seed in range(50)}
+    assert len(markers) == 50
+
+
+def test_unique_marker_format() -> None:
+    marker = unique_marker("phase-a", 7)
+    assert marker.startswith("soakmark-phase-a-7-")
+    assert " " not in marker
+
+
+def test_final_frame_picks_last_final() -> None:
+    frames: list[dict[str, object]] = [
+        {"type": "text_delta", "text": "thinking"},
+        {"type": "final", "text": "first final"},
+        {"type": "text_delta", "text": "more"},
+        {"type": "final", "text": "second final"},
+    ]
+    result = final_frame(frames)
+    assert result is not None
+    assert result["text"] == "second final"
+
+
+def test_final_frame_none_when_absent() -> None:
+    frames: list[dict[str, object]] = [{"type": "text_delta", "text": "no final here"}]
+    assert final_frame(frames) is None
+
+
+def test_collected_text_concatenates_text_fields() -> None:
+    frames: list[dict[str, object]] = [
+        {"type": "text_delta", "text": "hello"},
+        {"type": "tool_note", "text": "searching", "tool": "search"},
+        {"type": "final", "text": "world", "status": "done"},
+    ]
+    assert collected_text(frames) == "hello searching world"
+
+
+def test_collected_text_ignores_non_text_frames() -> None:
+    frames: list[dict[str, object]] = [
+        {"type": "final", "text": "only this", "status": "done"},
+        {"type": "side_effect_flag"},
+        {"type": "text_delta", "text": ""},
+    ]
+    assert collected_text(frames) == "only this"
+
+
+def test_detect_cross_talk_true_when_foreign_marker_present() -> None:
+    own = "soakmark-a-0-aaaa"
+    others = [own, "soakmark-b-1-bbbb"]
+    text = f"reply carrying {own} and leaked soakmark-b-1-bbbb"
+    assert detect_cross_talk(own, others, text) is True
+
+
+def test_detect_cross_talk_false_when_only_own_marker_present() -> None:
+    own = "soakmark-a-0-aaaa"
+    others = [own, "soakmark-b-1-bbbb"]
+    text = f"clean reply carrying only {own}"
+    assert detect_cross_talk(own, others, text) is False
+
+
+def test_detect_cross_talk_false_when_no_markers_present() -> None:
+    own = "soakmark-a-0-aaaa"
+    others = [own, "soakmark-b-1-bbbb"]
+    assert detect_cross_talk(own, others, "no markers at all") is False

--- a/tests/soak/test_soak_resilience.py
+++ b/tests/soak/test_soak_resilience.py
@@ -1,0 +1,332 @@
+"""The soak and chaos scenario against a standing agentos cluster.
+
+Gated behind ``AGENTOS_SOAK=1`` (plus a reachable cluster and the dev-stack
+Valkey). Parametrized over ``range(runs)`` so ``AGENTOS_SOAK_RUNS=3`` runs the
+whole scenario three consecutive times in one invocation, matching the
+definition-of-done "must pass three consecutive runs".
+
+Four phases share the module-scoped substrate and a set of held claims:
+
+- Phase A: concurrent threads are isolated (distinct sandboxes) and affined
+  (re-claim returns the same sandbox); with live creds, no content cross-talk.
+- Phase B: a mid-thread batch burst runs while Phase-A threads are held, and
+  leaves them undisturbed (same pod UIDs).
+- Phase C: a sandbox is killed mid-run (unclean pod delete); the thread
+  re-claims a fresh sandbox and exactly one live claim survives (no orphan or
+  duplicate side effect at the substrate level).
+- Phase D: one thread is suspended and resumed under sustained load on the
+  others; the resumed pod carries the injected history ref and the loaded
+  threads keep their pods.
+
+A cache-warmth proxy asserts pod-UID affinity across consecutive turns (the
+ADR-0003 "same pod across turns" property that enables prompt-cache reuse); see
+the README for why the direct ``cache_read_input_tokens`` signal is not
+cluster-observable today.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from harness import (
+    SoakConfig,
+    collected_text,
+    detect_cross_talk,
+    final_frame,
+    get_json,
+    kubectl,
+    live_sandboxclaims,
+    pod_of_sandbox,
+    pod_uid,
+    port_forward,
+    post_event,
+    thread_hash,
+    unique_marker,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("AGENTOS_SOAK") != "1",
+    reason="soak/chaos suite; set AGENTOS_SOAK=1 with a standing cluster + dev stack",
+)
+
+# Evaluated at import so the parametrization reflects AGENTOS_SOAK_RUNS. When the
+# suite is skipped (AGENTOS_SOAK unset) this still yields a single skipped param.
+_RUNS = SoakConfig.from_env().runs
+
+
+def _drive_turn(
+    cfg: SoakConfig,
+    sandbox_name: str,
+    port: int,
+    text: str,
+    *,
+    user: str,
+    ts: str,
+) -> list[dict[str, object]]:
+    """Port-forward to a sandbox, assert health, post one ACI turn, return frames."""
+
+    with port_forward(cfg, sandbox_name, port) as base:
+        assert get_json(base, "/healthz") == {"ok": True}
+        return post_event(base, text, user=user, ts=ts)
+
+
+def _assert_final(frames: Sequence[dict[str, object]]) -> None:
+    final = final_frame(frames)
+    types = [f.get("type") for f in frames]
+    assert final is not None, f"turn did not end in a final frame: {types}"
+
+
+def _wait_pod_gone(cfg: SoakConfig, sandbox_name: str, timeout: float = 90.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            pod_of_sandbox(cfg, sandbox_name)
+        except subprocess.CalledProcessError:
+            return
+        time.sleep(1)
+    raise AssertionError(f"pod {sandbox_name} was never deleted within {timeout}s")
+
+
+@pytest.mark.parametrize("run", range(_RUNS))
+def test_soak_resilience(run: int, substrate: object, cfg: SoakConfig, pool_ready: None) -> None:
+    from agentos_worker.sandbox import HISTORY_ENV, SandboxHandle, SandboxSubstrate
+
+    assert isinstance(substrate, SandboxSubstrate)
+    print(f"\nEVIDENCE soak_run={run} concurrency={cfg.concurrency} batch={cfg.batch}")
+
+    a_keys = [f"soak-a-{run}-{i}" for i in range(cfg.concurrency)]
+    batch_keys = [f"soak-batch-{run}-{j}" for j in range(cfg.batch)]
+    claimed: dict[str, SandboxHandle] = {}
+    markers: dict[str, str] = {}
+    uids: dict[str, str] = {}
+
+    try:
+        # -- Phase A: concurrent threads, isolation + affinity ----------------
+        def _claim(key: str) -> tuple[str, SandboxHandle]:
+            return key, substrate.claim(key)
+
+        with ThreadPoolExecutor(max_workers=cfg.concurrency) as pool:
+            for key, handle in pool.map(_claim, a_keys):
+                claimed[key] = handle
+        for idx, key in enumerate(a_keys):
+            markers[key] = unique_marker(f"a-r{run}", idx)
+
+        sandbox_names = {h.sandbox_name for h in claimed.values()}
+        assert len(sandbox_names) == cfg.concurrency, "distinct threads shared a sandbox"
+        print(f"EVIDENCE phase_a_distinct_sandboxes={len(sandbox_names)}")
+
+        def _turn(key: str) -> tuple[str, list[dict[str, object]]]:
+            handle = claimed[key]
+            text = f"Please remember this token exactly: {markers[key]}"
+            frames = _drive_turn(cfg, handle.sandbox_name, handle.port, text, user=key, ts="1.0")
+            return key, frames
+
+        replies: dict[str, list[dict[str, object]]] = {}
+        with ThreadPoolExecutor(max_workers=cfg.concurrency) as pool:
+            for key, frames in pool.map(_turn, a_keys):
+                _assert_final(frames)
+                replies[key] = frames
+
+        # Affinity: re-claim returns the same sandbox, and record pod UIDs.
+        for key in a_keys:
+            again = substrate.claim(key)
+            assert again.sandbox_name == claimed[key].sandbox_name, "affinity broke on re-claim"
+            uids[key] = pod_uid(pod_of_sandbox(cfg, claimed[key].sandbox_name))
+        print("EVIDENCE phase_a_affinity_stable=true")
+
+        # Content-level no-cross-talk only when a real model is behind the runner.
+        if cfg.live_creds:
+            all_markers = list(markers.values())
+            for key in a_keys:
+                text = collected_text(replies[key])
+                assert markers[key] in text, f"thread {key} reply dropped its own marker"
+                assert not detect_cross_talk(markers[key], all_markers, text), (
+                    f"thread {key} reply leaked a foreign marker"
+                )
+            print("EVIDENCE phase_a_no_content_cross_talk=true")
+
+        # -- Phase B: mid-thread batch burst under sustained hold -------------
+        # "batch job" is interpreted as a burst of concurrent threads launched
+        # while the Phase-A threads are still held claimed. (An alternative
+        # reading, an eval fan-out XADD to agentos:evals, is a separate consumer
+        # group not exercised by the sandbox substrate; see the README.)
+        def _batch_turn(key: str) -> tuple[str, list[dict[str, object]]]:
+            handle = substrate.claim(key)
+            claimed[key] = handle
+            frames = _drive_turn(
+                cfg, handle.sandbox_name, handle.port, "batch turn under load", user=key, ts="1.0"
+            )
+            return key, frames
+
+        with ThreadPoolExecutor(max_workers=max(cfg.batch, 1)) as pool:
+            for _key, frames in pool.map(_batch_turn, batch_keys):
+                _assert_final(frames)
+        print(f"EVIDENCE phase_b_batch_turns_final={cfg.batch}")
+
+        # Phase-A threads are undisturbed: same pod UIDs, follow-up lands same pod.
+        for key in a_keys:
+            assert pod_uid(pod_of_sandbox(cfg, claimed[key].sandbox_name)) == uids[key], (
+                f"batch burst disturbed Phase-A thread {key}"
+            )
+        probe = a_keys[0]
+        _, frames = _turn(probe)
+        _assert_final(frames)
+        assert pod_uid(pod_of_sandbox(cfg, claimed[probe].sandbox_name)) == uids[probe]
+        print("EVIDENCE phase_b_phase_a_undisturbed=true")
+
+        # -- Phase C: sandbox killed mid-run ---------------------------------
+        # The kernel's no-auto-retry-after-side-effects escalation is unit-tested
+        # in apps/worker/tests/kernel; here we assert the substrate-level proxy
+        # for "no duplicate side effect": exactly one live claim survives a kill.
+        victim = a_keys[-1]
+        victim_hash = thread_hash(victim)
+        victim_sandbox = claimed[victim].sandbox_name
+        old_uid = uids[victim]
+        kubectl(cfg, "delete", "pod", victim_sandbox, "--wait=false")
+        _wait_pod_gone(cfg, victim_sandbox)
+        print(f"EVIDENCE phase_c_killed_pod uid={old_uid}")
+
+        fresh = substrate.claim(victim)
+        claimed[victim] = fresh
+        new_uid = pod_uid(pod_of_sandbox(cfg, fresh.sandbox_name))
+        assert new_uid != old_uid, "re-claim returned the killed pod UID"
+        frames = _drive_turn(
+            cfg, fresh.sandbox_name, fresh.port, "back after a kill", user=victim, ts="2.0"
+        )
+        _assert_final(frames)
+        uids[victim] = new_uid
+
+        # Exactly one live claim for this thread (no orphan/duplicate). Allow a
+        # brief settle for the evicted claim's deletion to finalize.
+        deadline = time.monotonic() + 30
+        live_count = 0
+        while time.monotonic() < deadline:
+            live_count = len(live_sandboxclaims(cfg, victim_hash))
+            if live_count == 1:
+                break
+            time.sleep(2)
+        assert live_count == 1, f"expected exactly one live claim, saw {live_count}"
+        print("EVIDENCE phase_c_single_live_claim=true")
+
+        # -- Phase D: resume-rehydrate under sustained load -------------------
+        loaded = [k for k in a_keys if k != victim][: max(cfg.concurrency - 1, 1)]
+        target = loaded[0]
+        others = loaded[1:]
+        target_marker = markers[target]
+
+        def _sustained(key: str) -> str:
+            handle = claimed[key]
+            frames = _drive_turn(
+                cfg, handle.sandbox_name, handle.port, "sustained follow-up", user=key, ts="3.0"
+            )
+            _assert_final(frames)
+            return key
+
+        original_claim = claimed[target].claim_name
+        with ThreadPoolExecutor(max_workers=max(len(others), 1)) as pool:
+            load = pool.map(_sustained, others) if others else iter(())
+            substrate.suspend(target, history_ref=target_marker)
+            _wait_pod_gone(cfg, claimed[target].sandbox_name)
+            resumed = substrate.resume(target)
+            claimed[target] = resumed
+            list(load)
+
+        assert resumed.claim_name != original_claim, "resume reused the suspended claim"
+        resumed_pod = pod_of_sandbox(cfg, resumed.sandbox_name)
+        containers = resumed_pod["spec"]["containers"]  # type: ignore[index]
+        assert isinstance(containers, list)
+        env = {
+            e.get("name"): e.get("value")
+            for c in containers
+            for e in c.get("env", [])
+        }
+        assert env.get(HISTORY_ENV) == target_marker, "resumed pod missing injected history ref"
+        frames = _drive_turn(
+            cfg, resumed.sandbox_name, resumed.port, "resumed and rehydrated", user=target, ts="4.0"
+        )
+        _assert_final(frames)
+        for key in others:
+            assert pod_uid(pod_of_sandbox(cfg, claimed[key].sandbox_name)) == uids[key], (
+                f"suspend/resume disturbed concurrently loaded thread {key}"
+            )
+        print(f"EVIDENCE phase_d_resume_injected_history_ref pod={resumed.sandbox_name}")
+
+        # -- Cache-warmth proxy: same pod across consecutive turns ------------
+        stable = loaded[-1] if len(loaded) > 1 else target
+        first_uid = pod_uid(pod_of_sandbox(cfg, claimed[stable].sandbox_name))
+        frames = _drive_turn(
+            cfg, claimed[stable].sandbox_name, claimed[stable].port, "warmth turn one",
+            user=stable, ts="5.0",
+        )
+        _assert_final(frames)
+        frames = _drive_turn(
+            cfg, claimed[stable].sandbox_name, claimed[stable].port, "warmth turn two",
+            user=stable, ts="6.0",
+        )
+        _assert_final(frames)
+        second_uid = pod_uid(pod_of_sandbox(cfg, claimed[stable].sandbox_name))
+        assert second_uid == first_uid, "pod rebound between consecutive turns (cache lost)"
+        print(f"EVIDENCE same_pod_across_turns uid={first_uid}")
+
+    finally:
+        for key in list(claimed):
+            try:
+                substrate.release(key)
+            except Exception:
+                pass
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "otel.py does not export cache_read_input_tokens; "
+        "see runner/src/agentos_runner/otel.py -- tracked follow-up"
+    ),
+)
+@pytest.mark.skipif(
+    not (os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY")),
+    reason="cache-token probe needs live creds so a real model reports usage",
+)
+def test_cache_read_tokens_probe(cfg: SoakConfig) -> None:
+    """Probe: assert a per-trace ``cache_read_input_tokens`` is observable.
+
+    This lights up green only if the runner's OTel export is later extended to
+    carry the cache-token fields (today ``_GenerationSpan.record_usage`` drops
+    them, so Langfuse never sees them). Reading is via the Langfuse public API
+    using the dev-stack keys; if Langfuse is not reachable the probe skips.
+    """
+
+    host = os.environ.get("LANGFUSE_HOST", "http://localhost:23000")
+    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY", "pk-lf-agentos-dev")
+    secret_key = os.environ.get("LANGFUSE_SECRET_KEY", "sk-lf-agentos-dev")
+
+    import base64
+
+    token = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
+    request = urllib.request.Request(
+        f"{host}/api/public/observations?limit=50",
+        headers={"Authorization": f"Basic {token}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as resp:
+            import json
+
+            payload = json.loads(resp.read())
+    except (urllib.error.URLError, TimeoutError) as exc:
+        pytest.skip(f"Langfuse not reachable for the cache-token probe: {exc}")
+
+    observations = payload.get("data", [])
+    cache_reads = [
+        (o.get("usage") or {}).get("cache_read_input_tokens", 0) for o in observations
+    ]
+    assert any((count or 0) > 0 for count in cache_reads), (
+        "no observation reported cache_read_input_tokens > 0 "
+        "(otel.py drops the cache-token fields today)"
+    )


### PR DESCRIPTION
Authors the soak and chaos scenario at `tests/soak/` (previously only a README stub). It proves the sustained-load definition-of-done against a standing cluster.

## What it does
Drives the worker's `SandboxSubstrate` + Valkey + `kubectl` directly (mirroring `apps/worker/tests/sandbox/test_e2e_k8scratch.py`; there is no REST thread/message API). Four phases share a substrate and a set of held claims:

- **A: concurrent threads** bind distinct sandboxes (isolation) and re-claim to the same sandbox (affinity); with live creds each reply carries its own marker and no foreign marker (no content cross-talk).
- **B: mid-thread batch job** runs a concurrent burst while Phase-A threads are held, and asserts they are undisturbed (same pod UIDs).
- **C: sandbox killed mid-run** does an unclean pod delete; the re-claim yields a fresh pod (new UID) that serves a turn, and exactly one live `SandboxClaim` survives for the thread hash.
- **D: resume-rehydrate under sustained load** suspends and resumes one thread while others run turns; the resumed pod carries `AGENTOS_HISTORY_REF` and the loaded threads keep their pods.
- **Cache-warmth proxy** asserts pod-UID affinity across consecutive turns.

## Gating and runs
Opt-in via `AGENTOS_SOAK=1`; skips cleanly with no cluster. Parametrized over `AGENTOS_SOAK_RUNS` so `=3` runs the whole scenario three consecutive times in one invocation. Pure harness helpers have offline unit tests that always run.

## Documented decisions (in the README)
- "Batch job" is read as a concurrent burst under load; the eval-fanout reading is noted as an alternative.
- "No duplicate side effects" is asserted at the substrate level (one live claim survives a kill); the semantic no-retry-after-side-effect invariant is the kernel's rule and already has a provoking test in `apps/worker/tests/kernel`. An end-to-end kernel-path idempotency soak is logged as a follow-up.
- `cache_read_input_tokens` is not exported by `runner/src/agentos_runner/otel.py`, so the suite asserts pod-UID affinity as the cache-warmth proxy plus an `xfail` probe that lights up if the OTel export is later extended. Follow-up logged.

Scope is strictly `tests/soak/`; no app, CLI, chart, or config files touched.

## Verification
- `uv run ruff check tests/soak` clean
- `uv run pytest tests/soak/test_harness_unit.py -q` -> 12 passed
- `uv run pytest tests/soak -q` (no cluster) -> 12 passed, 2 skipped (cluster scenario + probe skip cleanly)

Closes #21