### PR TITLE
Fix metadata-endpoint egress carve-out (IPv6 ::/0 and broad non-/0 allows)

### DIFF
--- a/charts/agentos/templates/security-networkpolicy.yaml
+++ b/charts/agentos/templates/security-networkpolicy.yaml
@@ -1,3 +1,51 @@
+{{- /*
+Pack an IPv4 dotted-quad into a 32-bit integer, e.g. "169.254.169.254" ->
+2852039166. Used by agentos.metadataExcept to test CIDR containment.
+*/ -}}
+{{- define "agentos.ipv4ToInt" -}}
+{{- $o := splitList "." (trim .) -}}
+{{- add (mul (int64 (index $o 0)) 16777216) (mul (int64 (index $o 1)) 65536) (mul (int64 (index $o 2)) 256) (int64 (index $o 3)) -}}
+{{- end -}}
+{{- /*
+Given an allowedEgress CIDR string, return the metadata/link-local `except`
+entry that must be carved back out of it, or "" when the CIDR cannot reach the
+cloud metadata endpoint. NetworkPolicy allows are additive, so a broad allow
+(the realistic 0.0.0.0/0 model-API case, or a 0.0.0.0/1 + 128.0.0.0/1 split, or
+::/0) re-permits the metadata IP that rail 1 denies -- unless we except it.
+
+Kubernetes requires each `except` to be the same address family as `cidr` and a
+strict subset of it, so we (a) pick the family from the CIDR, (b) only emit when
+the CIDR actually contains the metadata address, and (c) size the IPv4 except to
+stay a STRICT subset (169.254.0.0/16 for prefix <16, the /32 host for 16..<32,
+and nothing for an exact /32 host allow, which is a deliberate operator choice).
+
+IPv4 containment is computed exactly (top `prefix` bits of 169.254.169.254 vs the
+network). IPv6 covers the realistic broad cases -- ::/0 and the AWS IMDS ULA
+prefix fd00:ec2::/nn -- and carves out fd00:ec2::254; full IPv6 range math is not
+attempted (documented assumption). Operators can always override with an explicit
+per-entry `except:` list, which wins over this auto carve-out.
+*/ -}}
+{{- define "agentos.metadataExcept" -}}
+{{- $parts := splitList "/" . -}}
+{{- $ip := index $parts 0 -}}
+{{- $prefix := index $parts 1 | int -}}
+{{- if contains ":" $ip -}}
+  {{- if or (eq $prefix 0) (and (hasPrefix "fd00:ec2:" $ip) (le $prefix 32)) -}}fd00:ec2::254/128{{- end -}}
+{{- else -}}
+  {{- $meta := include "agentos.ipv4ToInt" "169.254.169.254" | int64 -}}
+  {{- $net := include "agentos.ipv4ToInt" $ip | int64 -}}
+  {{- $block := int64 1 -}}
+  {{- range until (sub 32 $prefix | int) -}}{{- $block = mul $block 2 -}}{{- end -}}
+  {{- if eq (div $meta $block) (div $net $block) -}}
+    {{- /* Size the except to stay a STRICT subset of cidr (apiserver requires
+           exceptMaskLen > cidrMaskLen). prefix<16 -> the /16 link-local block;
+           16<=prefix<32 -> the /32 host; prefix==32 is the operator explicitly
+           allowing exactly the metadata host, so emit nothing (any except would
+           equal cidr and be rejected -- respect the deliberate allow). */ -}}
+    {{- if lt $prefix 16 -}}169.254.0.0/16{{- else if lt $prefix 32 -}}169.254.169.254/32{{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
 {{- if and .Values.agentSandbox.deploy .Values.security.networkPolicy.enabled }}
 {{- $np := .Values.security.networkPolicy }}
 {{/*
@@ -163,18 +211,22 @@ spec:
         - ipBlock:
             cidr: {{ .cidr }}
             {{- /* NetworkPolicy allows are additive, so a broad allow (the
-                   realistic 0.0.0.0/0 model-API case) would re-permit the cloud
-                   metadata endpoint that rail 1 blocks. Carve it back out with
-                   `except`. Kubernetes requires except to be a SUBSET of cidr,
-                   so we only auto-add it to the all-egress case; a narrower CIDR
-                   cannot contain 169.254.169.254 anyway. Operators can override
-                   with an explicit `except:` list per entry. */}}
+                   realistic 0.0.0.0/0 model-API case, a /1 split, or ::/0) would
+                   re-permit the cloud metadata endpoint that rail 1 blocks. Carve
+                   it back out with `except`. An explicit per-entry `except:` list
+                   wins; otherwise agentos.metadataExcept returns a same-family,
+                   subset-safe carve-out for ANY CIDR that contains the metadata
+                   address (not just exact /0), and "" for CIDRs that cannot reach
+                   it. See the helper for the containment/family rules. */}}
             {{- if .except }}
             except:
               {{- toYaml .except | nindent 14 }}
-            {{- else if or (eq .cidr "0.0.0.0/0") (eq .cidr "::/0") }}
+            {{- else }}
+            {{- $auto := include "agentos.metadataExcept" .cidr | trim }}
+            {{- if $auto }}
             except:
-              - 169.254.169.254/32
+              - {{ $auto }}
+            {{- end }}
             {{- end }}
       {{- with .ports }}
       ports:

--- a/charts/agentos/templates/security-probe.yaml
+++ b/charts/agentos/templates/security-probe.yaml
@@ -181,6 +181,8 @@ spec:
               value: {{ .Values.security.probe.busyboxImage | quote }}
             - name: ALLOW_ALL_NP
               value: {{ include "agentos.fullname" . }}-security-probe-allow-all
+            - name: BROAD_ALLOW_NP
+              value: {{ include "agentos.fullname" . }}-security-probe-broad-allow
             # The egress-probe carries this release's runner-sandbox labels (so the
             # chart's default-deny selects it) PLUS a unique per-release probe label.
             # The temporary allow-all selects ONLY the unique label, so it never
@@ -197,7 +199,7 @@ spec:
               fail=0
               cleanup() {
                 kubectl delete pod "$EGRESS_POD" sp-gvisor-check -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
-                kubectl delete networkpolicy "$ALLOW_ALL_NP" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
+                kubectl delete networkpolicy "$ALLOW_ALL_NP" "$BROAD_ALLOW_NP" -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
                 kubectl delete secret sp-agent-a-creds sp-agent-b-creds -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
                 kubectl delete serviceaccount sp-agent-a -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
                 kubectl delete role sp-agent-a -n "$NS" --ignore-not-found >/dev/null 2>&1 || true
@@ -257,6 +259,51 @@ spec:
               else
                 echo "RESULT: FAIL - before=${before} after=${after_ext} metadata=${after_meta} dns=${dns_ok}"
                 echo "        (a non-enforcing CNI shows before=after=reachable: silent false-pass.)"
+                fail=1
+              fi
+
+              # ---- Claim 1b: metadata blocked UNDER a broad (0.0.0.0/0) allowlist ----
+              # Phase 2 proves default-deny blocks metadata. This proves the additive
+              # carve-out: a broad allow (the realistic model-API 0.0.0.0/0 case) must
+              # reach the internet yet keep the metadata endpoint blocked via `except`.
+              # Mirrors exactly what the chart renders for allowedEgress:[{cidr:0.0.0.0/0}]
+              # (issue #70: a broad allow must not silently re-open IMDS).
+              echo ""
+              echo "== Claim 1b: metadata blocked under a broad 0.0.0.0/0 allowlist =="
+              kubectl run "$EGRESS_POD" -n "$NS" --image="$NETSHOOT" --restart=Never \
+                --labels="$PROBE_LABELS" \
+                --command -- sleep 3600 >/dev/null
+              kubectl wait --for=condition=Ready "pod/$EGRESS_POD" -n "$NS" --timeout=120s >/dev/null
+              cat <<EOF | kubectl apply -f - >/dev/null
+              apiVersion: networking.k8s.io/v1
+              kind: NetworkPolicy
+              metadata:
+                name: ${BROAD_ALLOW_NP}
+                namespace: ${NS}
+              spec:
+                podSelector:
+                  matchLabels:
+                    agentos.io/egress-probe: ${PROBE_UNIQUE_VAL}
+                policyTypes: [Egress]
+                egress:
+                  - to:
+                      - ipBlock:
+                          cidr: 0.0.0.0/0
+                          except:
+                            - 169.254.0.0/16
+              EOF
+              sleep 5
+              broad_ext=$(classify "$(probe_rc "https://${BLOCKED}/")")
+              broad_meta=$(classify "$(probe_rc "http://169.254.169.254/latest/meta-data/")")
+              echo "phase 3 (broad allow + except): ${BLOCKED} -> ${broad_ext}   metadata(169.254.169.254) -> ${broad_meta}"
+              kubectl delete networkpolicy "$BROAD_ALLOW_NP" -n "$NS" --ignore-not-found >/dev/null
+              kubectl delete pod "$EGRESS_POD" -n "$NS" --ignore-not-found >/dev/null
+              if [ "$broad_ext" = reachable ] && [ "$broad_meta" = blocked ]; then
+                echo "RESULT: PASS - a broad 0.0.0.0/0 allow reaches the internet but the metadata"
+                echo "        endpoint stays blocked (the except carve-out holds)."
+              else
+                echo "RESULT: FAIL - broad-allow ext=${broad_ext} metadata=${broad_meta}"
+                echo "        (metadata=reachable means a broad allow re-opened IMDS: #70 regression.)"
                 fail=1
               fi
 


### PR DESCRIPTION
The NetworkPolicy egress allowlist auto-adds an `except` so a broad allow does not re-open the cloud metadata endpoint (169.254.169.254 / fd00:ec2::254). The old logic was fragile:

- **IPv6 family mismatch:** `cidr: ::/0` appended an IPv4 `/32` except. Kubernetes requires each `except` to be the same family as, and a strict subset of, `cidr`, so the apiserver rejected the entire policy and nothing covered the real IPv6 IMDS address.
- **Only exact `/0`:** a broad-but-not-`/0` allow (e.g. the `0.0.0.0/1` + `128.0.0.0/1` split) got no carve-out, silently re-opening IMDS. The except also only covered the `/32` host, not the `169.254.0.0/16` link-local range.

## Change (scoped to two chart templates)

- `security-networkpolicy.yaml`: replace the exact-`/0` check with a `agentos.metadataExcept` helper that returns a **same-family, subset-safe** except for **any** CIDR that actually contains the metadata address (exact IPv4 32-bit containment arithmetic; IPv6 covers `::/0` and the `fd00:ec2::/nn` ULA prefix). IPv4 allows `<`/16 get `169.254.0.0/16`; `16..<32` get the `/32`; an exact `/32` host allow is a deliberate operator choice and is left untouched. Explicit per-entry `except:` still wins.
- `security-probe.yaml`: add probe Claim 1b applying the chart's rendered broad-`0.0.0.0/0` policy and asserting arbitrary egress is reachable while the metadata endpoint stays blocked.

## Verification

- `helm lint` clean; full chart + `values-dev` render OK.
- Rendered carve-outs across cases: `0.0.0.0/0`->`169.254.0.0/16`, `::/0`->`fd00:ec2::254/128`, `0.0.0.0/1`->none, `128.0.0.0/1`->`169.254.0.0/16`, `169.254.0.0/16`->`169.254.169.254/32`, `169.254.169.254/32`->none, `fd00:ec2::/32`->`fd00:ec2::254/128`, `fd00:ec2:1::/48`->none.
- `kubectl apply --dry-run=server` accepts every auto-generated except (the old `::/0` case was apiserver-rejected).
- Embedded probe NetworkPolicy parses as valid YAML.

**Assumption:** full IPv6 range arithmetic is not attempted; the realistic broad IPv6 cases (`::/0`, `fd00:ec2::/nn` with prefix <= 32) are handled explicitly and always render a valid, subset-safe except.

Closes #70