### PR TITLE
Thread ENVIRONMENT through the chart to the API container

### DIFF
--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -69,6 +69,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentos.secretName" . }}
                   key: githubWebhookSecret
+            - name: ENVIRONMENT
+              value: {{ .Values.api.environment | quote }}
             - name: ORG_NAME
               value: {{ .Values.api.orgName | quote }}
             - name: LANGFUSE_HOST

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -267,6 +267,13 @@ api:
     tag: latest
     pullPolicy: Always
   imagePullSecrets: []
+  # Deploy environment the API boots as (`dev` or `prod`), rendered as
+  # ENVIRONMENT on the api container. `prod` arms the API production boot gate,
+  # which refuses to start on the dev-default `apiKey`/`githubWebhookSecret`
+  # below -- so this backs up the render-time secret gate as defense in depth.
+  # Left at `dev` so a bare `helm install` and the dev overlays boot without
+  # real secrets; set to `prod` (with real secrets) for a production install.
+  environment: dev
   # Single shared API key the UI and CLI authenticate with. Dev default; override
   # (or point at an existingSecret) in any shared deployment.
   apiKey: agentos-dev-key


### PR DESCRIPTION
## What

Threads a deploy-environment value through the umbrella chart to the API container, so the API's production boot gate (#57) fires on chart-managed deploys, not only bare/compose runs.

- Add `api.environment` chart value (default `dev`) in `charts/agentos/values.yaml`.
- Render it as the `ENVIRONMENT` env var on the api Deployment in `charts/agentos/templates/api.yaml`, matching the surrounding `- name: / value:` formatting.

## Why

#57's API validator refuses to boot on the default `apiKey`/`githubWebhookSecret` when `ENVIRONMENT=production`, but the chart never set `ENVIRONMENT`, leaving that gate dormant in the Helm path. Wiring it through composes it with the render-time secret gate as defense in depth (notably backing up an operator who sets `allowDevDefaults=true`).

Default is `dev` so a bare `helm install` and the dev overlays boot without real secrets; set `api.environment=prod` (with real secrets) for a production install.

## Verify

```
helm lint charts/agentos                 # 0 charts failed
helm template charts/agentos             # -> ENVIRONMENT "dev" on the api container
helm template charts/agentos --set api.environment=prod   # -> ENVIRONMENT "prod"
```

Chart-only change; the API config consumer lands with #57.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)