### PR TITLE
Pin first-party images to an immutable chart-version tag (#62)

### DIFF
--- a/charts/agentos/templates/_helpers.tpl
+++ b/charts/agentos/templates/_helpers.tpl
@@ -307,6 +307,27 @@ true
 {{- end -}}
 {{- end -}}
 
+{{/* ---- First-party image reference ----
+     Render a fully-qualified image ref for a first-party (GHCR) workload,
+     preferring an immutable content digest over a mutable tag. Call with a dict:
+       repository  the image repo (e.g. ghcr.io/curie-eng/agentos-api)
+       tag         optional explicit tag; empty falls back to defaultTag
+       digest      optional "sha256:..." -- when set, wins and pins by digest
+       defaultTag  the fallback tag when `tag` is empty (pass .Chart.AppVersion)
+     - digest set -> "<repository>@sha256:..."  (fully immutable + verifiable)
+     - else       -> "<repository>:<tag|defaultTag>"
+     An empty tag defaulting to the chart appVersion is what makes a given chart
+     version render a deterministic image ref (same chart version -> same ref,
+     installable and rollback-able) without every install pinning a field.  */}}
+{{- define "agentos.image" -}}
+{{- $repo := required "image.repository is required" .repository -}}
+{{- if .digest -}}
+{{- printf "%s@%s" $repo .digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repo (.tag | default .defaultTag | default "latest") -}}
+{{- end -}}
+{{- end -}}
+
 {{/* ---- Dispatcher gating ----
      The Slack dispatcher only deploys when it has both tokens; without them it
      would crash-loop the reconnect supervisor forever, so a token-less default

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -238,7 +238,7 @@ spec:
       {{- end }}
       containers:
         - name: runner
-          image: "{{ $runner.image }}:{{ $runner.tag }}"
+          image: {{ include "agentos.image" (dict "repository" $runner.image "tag" $runner.tag "digest" $runner.digest "defaultTag" $.Chart.AppVersion) | quote }}
           imagePullPolicy: {{ $runner.imagePullPolicy }}
           {{- if $runner.hardening.enabled }}
           securityContext:

--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -46,7 +46,7 @@ spec:
       # on a fresh install (migration 0001 creates the `agentos` schema).
       initContainers:
         - name: migrate
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          image: {{ include "agentos.image" (dict "repository" .Values.api.image.repository "tag" .Values.api.image.tag "digest" .Values.api.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           command: ["alembic", "-c", "alembic.ini", "upgrade", "head"]
           env:
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          image: {{ include "agentos.image" (dict "repository" .Values.api.image.repository "tag" .Values.api.image.tag "digest" .Values.api.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           env:
             {{- include "agentos.env.postgres" . | nindent 12 }}

--- a/charts/agentos/templates/dispatcher.yaml
+++ b/charts/agentos/templates/dispatcher.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
         - name: dispatcher
-          image: "{{ .Values.dispatcher.image.repository }}:{{ .Values.dispatcher.image.tag }}"
+          image: {{ include "agentos.image" (dict "repository" .Values.dispatcher.image.repository "tag" .Values.dispatcher.image.tag "digest" .Values.dispatcher.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.dispatcher.image.pullPolicy }}
           env:
             {{- include "agentos.env.valkey" . | nindent 12 }}

--- a/charts/agentos/templates/runner-prewarm.yaml
+++ b/charts/agentos/templates/runner-prewarm.yaml
@@ -51,8 +51,10 @@ spec:
       {{- end }}
       containers:
         - name: prewarm
-          image: "{{ $runner.image }}:{{ $runner.tag }}"
-          # Always so the roll above fetches a fresh `latest`.
+          image: {{ include "agentos.image" (dict "repository" $runner.image "tag" $runner.tag "digest" $runner.digest "defaultTag" $.Chart.AppVersion) | quote }}
+          # Always so the roll above re-pulls the pinned ref (and picks up a
+          # moved tag on the rare cluster that still overrides tag back to a
+          # mutable one); on an immutable digest/version pin it is a no-op.
           imagePullPolicy: Always
           command: ["sleep", "infinity"]
           resources:

--- a/charts/agentos/templates/ui.yaml
+++ b/charts/agentos/templates/ui.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
         - name: ui
-          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          image: {{ include "agentos.image" (dict "repository" .Values.ui.image.repository "tag" .Values.ui.image.tag "digest" .Values.ui.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           env:
             # nginx reverse-proxies /api/ to this upstream (the /api prefix is

--- a/charts/agentos/templates/worker.yaml
+++ b/charts/agentos/templates/worker.yaml
@@ -76,7 +76,7 @@ spec:
       {{- end }}
       containers:
         - name: worker
-          image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
+          image: {{ include "agentos.image" (dict "repository" .Values.worker.image.repository "tag" .Values.worker.image.tag "digest" .Values.worker.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           env:
             {{- include "agentos.env.postgres" . | nindent 12 }}

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -251,9 +251,16 @@ otelCollector:
 #   - ui         static React SPA served by nginx, proxying /api to the API
 #
 # IMAGE DEFAULTS: every app image defaults to the GHCR package the Release
-# workflow publishes, pulled `Always` so a fresh install on a node that cached an
-# older `latest` digest never silently serves a stale image (pin an immutable tag
-# for production, where `Always` on a digest is a cheap no-op).
+# workflow publishes. The `tag` is left EMPTY so it resolves to the chart
+# `appVersion` (see Chart.yaml) -- an immutable, per-release version tag rather
+# than the mutable `latest`. That makes installs deterministic and rollback-able:
+# the same chart version always renders the same image ref (`helm template` shows
+# `...-api:<appVersion>`, not `:latest`). For the strongest guarantee set `digest`
+# to a `sha256:...` content digest instead (it wins over `tag` and pins by digest,
+# verifiable via `cosign verify-attestation` / `gh attestation verify`); the
+# Release workflow prints each published image's digest. `pullPolicy: Always` on
+# an immutable ref is a cheap no-op that still self-heals a node that cached a
+# same-named ref, so it is kept.
 # The repo and its packages are public, so NO imagePullSecret is needed by
 # default; the `imagePullSecrets` plumbing stays for private forks. For offline
 # dev/e2e use values-dev.yaml, which repoints each image at a locally-built,
@@ -264,7 +271,10 @@ api:
   replicas: 1
   image:
     repository: ghcr.io/curie-eng/agentos-api
-    tag: latest
+    # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.
+    tag: ""
+    # Optional "sha256:..." content digest; when set it wins over `tag`.
+    digest: ""
     pullPolicy: Always
   imagePullSecrets: []
   # Single shared API key the UI and CLI authenticate with. Dev default; override
@@ -292,7 +302,10 @@ dispatcher:
   replicas: 1
   image:
     repository: ghcr.io/curie-eng/agentos-dispatcher
-    tag: latest
+    # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.
+    tag: ""
+    # Optional "sha256:..." content digest; when set it wins over `tag`.
+    digest: ""
     pullPolicy: Always
   imagePullSecrets: []
   # Slack credentials. Socket Mode means the process dials out (no ingress), so
@@ -312,7 +325,10 @@ worker:
   replicas: 1
   image:
     repository: ghcr.io/curie-eng/agentos-worker
-    tag: latest
+    # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.
+    tag: ""
+    # Optional "sha256:..." content digest; when set it wins over `tag`.
+    digest: ""
     pullPolicy: Always
   imagePullSecrets: []
   # The worker drives the Kubernetes API to claim/manage agent-sandbox CRDs, so
@@ -350,7 +366,10 @@ ui:
   replicas: 1
   image:
     repository: ghcr.io/curie-eng/agentos-ui
-    tag: latest
+    # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.
+    tag: ""
+    # Optional "sha256:..." content digest; when set it wins over `tag`.
+    digest: ""
     pullPolicy: Always
   imagePullSecrets: []
   service:
@@ -441,7 +460,14 @@ agentSandbox:
     # offline dev/e2e (a locally-built, cluster-imported image) use values-dev,
     # which overrides this back to `agentos-runner` with imagePullPolicy Never.
     image: ghcr.io/curie-eng/agentos-runner
-    tag: latest
+    # Empty -> chart appVersion (immutable per-release tag, not mutable `latest`),
+    # so the prewarm cache and the per-thread IfNotPresent bind are the SAME
+    # pinned ref -- which also removes the `latest`-churn race behind the
+    # 2026-07-06 claim-timeout incident (an in-boot re-pull of a moved tag).
+    # Override to pin an explicit version, or set `digest` for a sha256 pin.
+    tag: ""
+    # Optional "sha256:..." content digest; when set it wins over `tag`.
+    digest: ""
     # IfNotPresent -- NOT Always, unlike the four Deployment-managed services.
     # A sandbox pod is cold-created per Slack thread, so `Always` would put a
     # (re-)pull of this ~380MB image inside the per-thread boot window; when


### PR DESCRIPTION
## What
Pins the five first-party GHCR images (api, dispatcher, worker, ui, runner) to an **immutable** reference instead of the mutable `tag: latest`, addressing the reproducibility / supply-chain half of #62.

- New `agentos.image` helper (`_helpers.tpl`): renders `<repo>@sha256:...` when an `image.digest` value is set, otherwise `<repo>:<tag|appVersion>`.
- All five workloads default `tag: ""`, which resolves to the chart **appVersion** (`0.2.0` today) — an immutable per-release tag. Optional `image.digest` (`sha256:...`) is wired on each for a stronger content-digest pin (verifiable via `cosign verify-attestation` / `gh attestation verify`).
- Both api container refs (init `migrate` + main), dispatcher, worker, ui, and the runner (in `agent-sandbox.yaml` + `runner-prewarm.yaml`) go through the helper.
- `values.yaml` image comment block and per-image comments updated.

## Deliberately unchanged
- **pullPolicy** stays as-is (services `Always`, runner `IfNotPresent` + prewarm). The runner posture is a load-bearing invariant in `charts/agentos/CLAUDE.md` (2026-07-06 claim-timeout incident); `Always` on an immutable ref is a cheap self-healing no-op. Pinning the runner's tag additionally removes the `latest`-churn race behind that incident.
- `values-dev.yaml` (local `:local` / `pullPolicy: Never`) is unaffected — it sets explicit tags that override the appVersion default.

## Verification
```
helm lint charts/agentos                 # 0 failed (default + values-dev)
helm template charts/agentos             # every workload -> ...-<name>:0.2.0
helm template ... --set api.image.digest=sha256:deadbeefcafe
                                         # -> ...agentos-api@sha256:deadbeefcafe
```
- Two identical renders of the same chart version produce identical image refs (determinism confirmed).
- Dev overlay renders `agentos-*:local` as before.

## Scope / out of scope
Issue #62 also asks for release-workflow **provenance / SBOM / cosign signing** (`.github/workflows/release.yaml`) — that is a separate CI concern and is **not** in this Helm-chart change, so this is `Ref #62`, not `Closes`. Probes (the liveness/readiness portion) were already added by #71 (PR #176) and are present on all long-running workloads — not touched here.

Ref #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)