### PR TITLE
Gate the Langfuse init bootstrap credentials (#198)

### DIFF
--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -195,6 +195,14 @@ Secrets: dev credentials live in `values.yaml` and are written to one
 `langfuse.existingSecret` (and each store's `existingSecret`) at your own
 Secrets. `langfuse.encryptionKey` must be 64 hex chars (`openssl rand -hex 32`).
 
+Guard against shipping those dev defaults to a shared/production cluster with
+`--set security.checkDefaultCredentials=true`: the chart then refuses to render
+while `langfuse.init.projectSecretKey` or `langfuse.init.userPassword` still
+carries its published dev default (a Langfuse admin-takeover risk on a reachable
+UI; the project key also feeds the OTel Collector auth header). Override those
+values or supply `langfuse.existingSecret` to clear the gate. It is off by
+default so the zero-secret bare install stays green.
+
 ## The two preflights
 
 Both run as Helm hooks (blocking a broken install) and are re-runnable via

--- a/charts/agentos/templates/_helpers.tpl
+++ b/charts/agentos/templates/_helpers.tpl
@@ -97,6 +97,34 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 {{- end -}}
 
+{{/* ---- Default-credential gate (issue #198) ----
+     When security.checkDefaultCredentials is on, refuse to render if a Langfuse
+     bootstrap identity still carries the published dev default from values.yaml.
+     Unlike the nine store/control-plane secrets, these init identities seed the
+     org/project on first boot (a different lifecycle), so #57 deliberately
+     excludes them from its render-time gate; this closes that gap. The published
+     admin password is a Langfuse admin-takeover risk on a reachable UI, and the
+     project secret key also feeds the OTel Collector auth header. The operator
+     clears the gate by overriding the value or supplying langfuse.existingSecret
+     (the #169 secretKeyRef escape carries both keys).
+
+     Off by default so the flagship zero-secret bare install stays green and the
+     dev/e2e overlays render unchanged; flip it on for a shared/production
+     cluster. #57 will fold the store/control-plane secrets into this same helper
+     (hence the general name) once its design pass lands. */}}
+{{- define "agentos.checkDefaultCredentials" -}}
+{{- if .Values.security.checkDefaultCredentials -}}
+{{- if not .Values.langfuse.existingSecret -}}
+{{- if eq .Values.langfuse.init.projectSecretKey "sk-lf-agentos-dev" -}}
+{{- fail "security.checkDefaultCredentials is on but langfuse.init.projectSecretKey is still the published dev default \"sk-lf-agentos-dev\". Override it (or set langfuse.existingSecret) before installing on a shared/production cluster -- this key also feeds the OTel Collector auth header." -}}
+{{- end -}}
+{{- if eq .Values.langfuse.init.userPassword "agentos-dev-password" -}}
+{{- fail "security.checkDefaultCredentials is on but langfuse.init.userPassword is still the published dev default \"agentos-dev-password\". Override it (or set langfuse.existingSecret) before installing on a shared/production cluster -- the published admin password allows Langfuse admin takeover on a reachable UI." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/* ---- Shared first-party-app environment fragments ---- */}}
 
 {{/* Postgres connection env for the app services. POSTGRES_PASSWORD comes from

--- a/charts/agentos/templates/secrets.yaml
+++ b/charts/agentos/templates/secrets.yaml
@@ -11,7 +11,12 @@ those (or supply an `existingSecret` per store) in any shared deployment.
 
 The plaintext values here are the dev defaults documented in values.yaml; they
 are NOT production material. `stringData` lets Kubernetes base64-encode them.
+
+Render-time gate: refuse to emit the published Langfuse bootstrap defaults when
+security.checkDefaultCredentials is on (issue #198). This Secret always renders,
+so the guard runs on every install/upgrade/template.
 */}}
+{{- include "agentos.checkDefaultCredentials" . }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -668,3 +668,15 @@ security:
     resources:
       requests: { cpu: 50m, memory: 64Mi }
       limits: { cpu: 250m, memory: 128Mi }
+  # Render-time credential gate (issue #198). When true, the chart refuses to
+  # render if a Langfuse bootstrap identity (langfuse.init.projectSecretKey /
+  # langfuse.init.userPassword) still carries the published dev default from this
+  # file -- the published admin password is a Langfuse admin-takeover risk on a
+  # reachable UI, and the project secret key also feeds the OTel Collector auth
+  # header. Clear the gate by overriding those values or supplying
+  # langfuse.existingSecret (the secretKeyRef escape, keys langfuseInitProjectSecretKey
+  # + langfuseInitUserPassword). Off by default so the flagship zero-secret bare
+  # install stays green and the dev/e2e overlays render unchanged; flip it on for a
+  # shared/production cluster. (#57 will extend this same gate to the nine
+  # store/control-plane secrets once its design pass lands.)
+  checkDefaultCredentials: false


### PR DESCRIPTION
## What

Adds a render-time gate that refuses the **published** Langfuse bootstrap defaults `langfuse.init.projectSecretKey` and `langfuse.init.userPassword`.

- New `security.checkDefaultCredentials` flag (default `false`).
- New `agentos.checkDefaultCredentials` helper, invoked from the always-rendered `secrets.yaml`. When the flag is on, the chart `fail`s while either init credential still carries its published dev default, unless the operator overrides the value or supplies `langfuse.existingSecret`.

## Why

`secrets.yaml` renders the init identities from their published dev defaults unconditionally. #169 (merged) routed them via `secretKeyRef` so they no longer land in the Deployment env, but nothing refuses the published values themselves. An operator who overrides the other secrets still boots authenticating to Langfuse with:

- a published **admin password** (`agentos-dev-password`) → Langfuse admin takeover on a reachable UI, and
- a published **project secret key** (`sk-lf-agentos-dev`) that also feeds the OTel Collector auth header.

This is the render-time gate #198 asks for. It is scoped to the two `langfuse.init.*` identities that #57 deliberately excluded from its store/control-plane gate; the helper is generally named so **#57 can fold its nine secrets into the same seam** once its design pass lands.

## Design notes

- **Off by default** so the flagship zero-secret bare `helm install` stays green (README "green with zero secrets") and the `values-dev` / `values-e2e-nogvisor` overlays render unchanged. Operators flip it on for shared/production clusters — matching how the README already frames prod overrides.
- Reuses #169's `langfuse.existingSecret` escape as the override path (that Secret carries both keys).
- Follows the chart's `security.*` flag idiom.

## Verification (`helm` v3.21.3)

- `helm lint charts/agentos` → 0 failed.
- Flag **off** (default): renders; `values-dev` + `values-e2e-nogvisor` overlays render.
- Flag **on** + published defaults: fails on `projectSecretKey`; with that overridden, fails on `userPassword`.
- Flag **on** + both overridden: renders. Flag **on** + `langfuse.existingSecret` set: renders.

Ref CUR-198

🤖 Generated with [Claude Code](https://claude.com/claude-code)