### PR TITLE
CI: build first-party images on PRs + CI hygiene

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Python (ruff + mypy + pytest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install uv
@@ -91,7 +91,7 @@ jobs:
       run:
         working-directory: cli
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Toolchain
@@ -114,7 +114,7 @@ jobs:
       - name: Release build
         run: cargo build --release --locked
       - name: Upload agentos binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: agentos-x86_64-linux-${{ github.sha }}
           path: cli/target/release/agentos
@@ -124,11 +124,11 @@ jobs:
     name: Contracts (generated TypeScript compiles)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
       - name: Regenerate TypeScript from the committed schema and check for drift
@@ -148,7 +148,7 @@ jobs:
       run:
         working-directory: apps/ui
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install pnpm
@@ -156,7 +156,7 @@ jobs:
         with:
           version: 9
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: "22"
           cache: pnpm
@@ -182,7 +182,7 @@ jobs:
     name: Compose (release stack validates)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Generate the release compose
@@ -247,7 +247,7 @@ jobs:
           - name: ui
             dockerfile: apps/ui/Dockerfile
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up Buildx
@@ -273,7 +273,7 @@ jobs:
     name: Build worker-local overlay image (no push)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Build the base worker image locally

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Supersede an in-flight run when a branch is pushed again so runs stop
+# stacking. Keyed per workflow+ref: each PR branch and main have independent
+# groups, and a new push to a branch cancels only that branch's older run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -14,13 +21,18 @@ jobs:
     name: Python (ruff + mypy + pytest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: "3.13"
+      # Fail fast if uv.lock has drifted from the pyproject.toml files (a
+      # dependency edit committed without re-locking). --check resolves and
+      # compares without writing, so it never mutates the checkout.
+      - name: Lockfile is up to date
+        run: uv lock --check
       - name: Sync workspace
         run: uv sync
       - name: Ruff
@@ -79,26 +91,30 @@ jobs:
       run:
         working-directory: cli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Toolchain
         run: rustup component add rustfmt clippy
       - name: Fmt
         run: cargo fmt --check
+      # --locked on every resolving cargo command asserts the committed
+      # Cargo.lock (both cli/ and the generated ACI crate) already satisfies its
+      # Cargo.toml -- cargo errors instead of silently updating the lock, which
+      # is the lockfile-freshness gate for Rust (mirrors uv lock --check above).
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --locked -- -D warnings
       - name: Test
-        run: cargo test
+        run: cargo test --locked
       - name: Generated ACI protocol crate compiles
         working-directory: packages/aci-protocol/generated/rust
-        run: cargo test
+        run: cargo test --locked
       # Continuously prove the release build (the artifact a cold user downloads)
       # and publish it as a sha-addressable workflow artifact every run.
       - name: Release build
-        run: cargo build --release
+        run: cargo build --release --locked
       - name: Upload agentos binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agentos-x86_64-linux-${{ github.sha }}
           path: cli/target/release/agentos
@@ -108,11 +124,11 @@ jobs:
     name: Contracts (generated TypeScript compiles)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
       - name: Regenerate TypeScript from the committed schema and check for drift
@@ -132,7 +148,7 @@ jobs:
       run:
         working-directory: apps/ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Install pnpm
@@ -140,7 +156,7 @@ jobs:
         with:
           version: 9
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: pnpm
@@ -166,7 +182,7 @@ jobs:
     name: Compose (release stack validates)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Generate the release compose
@@ -206,3 +222,61 @@ jobs:
         run: |
           count=$(docker compose -f compose.release.yaml --profile full config --services | wc -l)
           [ "$count" -eq 12 ] || { echo "full profile must render 12 services, got $count" >&2; exit 1; }
+
+  # Build the first-party images on every PR/push -- build only, never push --
+  # so a Dockerfile break is caught here instead of only at release time. This
+  # mirrors release.yaml's build step (same contexts, same pinned actions, same
+  # gha layer cache) minus the registry login and push. All five app images
+  # build from public bases (python/node/nginx), so no GHCR credentials are
+  # needed; the worker-local overlay is handled separately below.
+  images:
+    name: Build ${{ matrix.name }} image (no push)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: runner
+            dockerfile: runner/Dockerfile
+          - name: api
+            dockerfile: apps/api/Dockerfile
+          - name: dispatcher
+            dockerfile: apps/dispatcher/Dockerfile
+          - name: worker
+            dockerfile: apps/worker/Dockerfile
+          - name: ui
+            dockerfile: apps/ui/Dockerfile
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - name: Build (no push)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: false
+          load: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # The worker-local overlay is FROM the published agentos-worker image, so it
+  # cannot be built purely from the checkout. Build the base worker image
+  # locally first and tag it exactly as the overlay's FROM ref, then build the
+  # overlay against it. Plain `docker build` uses the default buildx builder
+  # (docker driver), whose FROM lookup consults the local image store -- so the
+  # overlay resolves the just-built base with no GHCR pull, no registry auth,
+  # and works on any branch (including forks). Build only, never pushed.
+  worker-local-image:
+    name: Build worker-local overlay image (no push)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Build the base worker image locally
+        run: docker build -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile .
+      - name: Build the worker-local overlay (no push)
+        run: docker build --build-arg BASE_TAG=ci-local -f compose/worker-local.Dockerfile compose

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,7 +39,7 @@ jobs:
           - language: javascript-typescript
             build-mode: none
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,6 +9,12 @@ on:
     - cron: "0 6 * * 3"
   workflow_dispatch:
 
+# Supersede an in-flight run when the same ref is pushed again so runs stop
+# stacking (scheduled/dispatch runs each key on their own ref).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -33,7 +39,7 @@ jobs:
           - language: javascript-typescript
             build-mode: none
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -11,6 +11,12 @@ on:
     - cron: "0 6 * * 2"
   workflow_dispatch:
 
+# Supersede an in-flight run when the same ref is pushed again so runs stop
+# stacking (scheduled/dispatch runs each key on their own ref).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -19,7 +25,7 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Install cargo-audit
@@ -37,7 +43,7 @@ jobs:
     name: pip-audit (uv workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Install uv

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -25,7 +25,7 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install cargo-audit
@@ -43,7 +43,7 @@ jobs:
     name: pip-audit (uv workspace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Install uv

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -11,6 +11,12 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+# Supersede an in-flight run when the same ref is pushed again so runs stop
+# stacking (scheduled/dispatch runs each key on their own ref).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -19,7 +25,7 @@ jobs:
     name: gitleaks (full history)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # fetch-depth: 0 pulls the entire history so `gitleaks detect` scans

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -25,7 +25,7 @@ jobs:
     name: gitleaks (full history)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           # fetch-depth: 0 pulls the entire history so `gitleaks detect` scans

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
             context: .
             dockerfile: apps/ui/Dockerfile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Buildx
@@ -81,7 +81,7 @@ jobs:
     needs: [images]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Compute base tag
@@ -140,7 +140,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Add target
@@ -166,7 +166,7 @@ jobs:
           mkdir -p dist
           cp "$bin" "dist/agentos-${{ matrix.target }}"
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agentos-${{ matrix.target }}
           path: dist/agentos-${{ matrix.target }}
@@ -177,7 +177,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Helm
@@ -202,13 +202,13 @@ jobs:
           mkdir -p dist
           python3 compose/generate_release_compose.py --version "${version}" > dist/compose.release.yaml
       - name: Upload chart artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agentos-chart
           path: dist/agentos-*.tgz
           if-no-files-found: error
       - name: Upload release compose artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agentos-compose
           path: dist/compose.release.yaml
@@ -223,7 +223,7 @@ jobs:
       contents: write
     steps:
       - name: Download built binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: agentos-*
           path: dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
             context: .
             dockerfile: apps/ui/Dockerfile
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up Buildx
@@ -81,7 +81,7 @@ jobs:
     needs: [images]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Compute base tag
@@ -140,7 +140,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Add target
@@ -166,7 +166,7 @@ jobs:
           mkdir -p dist
           cp "$bin" "dist/agentos-${{ matrix.target }}"
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: agentos-${{ matrix.target }}
           path: dist/agentos-${{ matrix.target }}
@@ -177,7 +177,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up Helm
@@ -202,13 +202,13 @@ jobs:
           mkdir -p dist
           python3 compose/generate_release_compose.py --version "${version}" > dist/compose.release.yaml
       - name: Upload chart artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: agentos-chart
           path: dist/agentos-*.tgz
           if-no-files-found: error
       - name: Upload release compose artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: agentos-compose
           path: dist/compose.release.yaml
@@ -223,7 +223,7 @@ jobs:
       contents: write
     steps:
       - name: Download built binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           pattern: agentos-*
           path: dist


### PR DESCRIPTION
Implements #14. Workflow/CI-only change.

## PR-time image builds (the core gap)
The five service images and `compose/worker-local.Dockerfile` previously built only in `release.yaml`, so a Dockerfile break surfaced only at release. This adds to `ci.yaml`:
- an `images` matrix job that builds all five first-party images (runner/api/dispatcher/worker/ui) **build-only, `push: false`**, reusing release's contexts, SHA-pinned docker actions, and gha layer cache. All five build from public bases (python/node/nginx), so no GHCR credentials are needed.
- a `worker-local-image` job that builds the base worker image locally, tags it as the overlay's `FROM` ref, then builds `worker-local.Dockerfile` against it — so the overlay validates with no GHCR pull, no registry auth, on any branch. Also `push: false`.

## CI hygiene
- **`concurrency: cancel-in-progress`** on `ci` and the three security workflows (codeql / dependency-audit / gitleaks), keyed per workflow+ref, so superseded runs stop stacking. `release.yaml` is intentionally left untouched.
- **Lockfile-freshness gates**: `uv lock --check` in the Python job; `--locked` on the resolving cargo commands (covers both `cli/` and the generated ACI crate). pnpm already uses `--frozen-lockfile`.
- **Off the deprecated Node 20 runtime**: bumped GitHub-authored actions to their current majors — `checkout` v7, `setup-node` v6, `upload-artifact` v7, `download-artifact` v8 — across all workflows. Verified none of the intervening breaking changes affect this repo's usage (fork-PR blocking only applies to `pull_request_target`/`workflow_run`; setup-node auto-cache is overridden by the explicit `cache: pnpm`; artifact direct-upload is opt-in). `codeql-action` stays `v3` (no newer major exists).

## Deferred
The musl fully-static CLI build (last checkbox) is explicitly conditional on glibc portability reports from users — none have arrived — so it is left out.

## Verification
- All workflows parse (`yaml.safe_load`).
- `actionlint` (via `rhysd/actionlint` image) passes clean, exit 0.
- `uv lock --check` and `cargo metadata --locked` (both crates) pass against the current tree, so the new freshness gates are green today.
- No existing job was weakened (`--locked` and the action bumps only strengthen).

Closes #14