### PR TITLE
K8s: container securityContext for first-party + backing-store workloads (#67)

### DIFF
--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -48,6 +48,10 @@ spec:
         - name: migrate
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          {{- with .Values.api.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ["alembic", "-c", "alembic.ini", "upgrade", "head"]
           env:
             {{- include "agentos.env.postgres" . | nindent 12 }}
@@ -56,6 +60,10 @@ spec:
         - name: api
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          {{- with .Values.api.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- include "agentos.env.postgres" . | nindent 12 }}
             {{- include "agentos.env.valkey" . | nindent 12 }}

--- a/charts/agentos/templates/clickhouse.yaml
+++ b/charts/agentos/templates/clickhouse.yaml
@@ -47,6 +47,10 @@ spec:
           # Pinned tag; the AVX preflight validates it against the node's CPU.
           image: "{{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- with .Values.clickhouse.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: CLICKHOUSE_USER
               value: {{ .Values.clickhouse.auth.username | quote }}

--- a/charts/agentos/templates/dispatcher.yaml
+++ b/charts/agentos/templates/dispatcher.yaml
@@ -33,6 +33,10 @@ spec:
         - name: dispatcher
           image: "{{ .Values.dispatcher.image.repository }}:{{ .Values.dispatcher.image.tag }}"
           imagePullPolicy: {{ .Values.dispatcher.image.pullPolicy }}
+          {{- with .Values.dispatcher.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- include "agentos.env.valkey" . | nindent 12 }}
             - name: SLACK_APP_TOKEN

--- a/charts/agentos/templates/langfuse.yaml
+++ b/charts/agentos/templates/langfuse.yaml
@@ -38,6 +38,10 @@ spec:
         - name: langfuse-web
           image: "{{ .Values.langfuse.image.web }}:{{ .Values.langfuse.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- with .Values.langfuse.web.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- include "agentos.langfuse.env" . | nindent 12 }}
             {{- if .Values.langfuse.web.nodeOptions }}
@@ -119,6 +123,10 @@ spec:
         - name: langfuse-worker
           image: "{{ .Values.langfuse.image.worker }}:{{ .Values.langfuse.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- with .Values.langfuse.worker.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- include "agentos.langfuse.env" . | nindent 12 }}
             {{- if .Values.langfuse.worker.nodeOptions }}

--- a/charts/agentos/templates/minio.yaml
+++ b/charts/agentos/templates/minio.yaml
@@ -45,6 +45,10 @@ spec:
         - name: minio
           image: {{ .Values.minio.image }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- with .Values.minio.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args: ["server", "/data", "--console-address", ":9001"]
           env:
             - name: MINIO_ROOT_USER

--- a/charts/agentos/templates/otel-collector.yaml
+++ b/charts/agentos/templates/otel-collector.yaml
@@ -85,6 +85,10 @@ spec:
         - name: otel-collector
           image: {{ .Values.otelCollector.image }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- with .Values.otelCollector.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args: ["--config=/etc/otel/collector-config.yaml"]
           env:
             - name: LANGFUSE_OTLP_AUTH_HEADER

--- a/charts/agentos/templates/postgres.yaml
+++ b/charts/agentos/templates/postgres.yaml
@@ -43,6 +43,10 @@ spec:
         - name: postgres
           image: {{ .Values.postgres.image }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- with .Values.postgres.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: POSTGRES_USER
               value: {{ .Values.postgres.auth.username | quote }}

--- a/charts/agentos/templates/ui.yaml
+++ b/charts/agentos/templates/ui.yaml
@@ -46,6 +46,10 @@ spec:
         - name: ui
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          {{- with .Values.ui.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             # nginx reverse-proxies /api/ to this upstream (the /api prefix is
             # stripped). Points at the in-chart API Service.

--- a/charts/agentos/templates/valkey.yaml
+++ b/charts/agentos/templates/valkey.yaml
@@ -43,6 +43,10 @@ spec:
         - name: valkey
           image: {{ .Values.valkey.image }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- with .Values.valkey.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c

--- a/charts/agentos/templates/worker.yaml
+++ b/charts/agentos/templates/worker.yaml
@@ -78,6 +78,10 @@ spec:
         - name: worker
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          {{- with .Values.worker.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- include "agentos.env.postgres" . | nindent 12 }}
             {{- include "agentos.env.valkey" . | nindent 12 }}

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -104,11 +104,34 @@ langfuse:
     resources:
       requests: { cpu: 150m, memory: 384Mi }
       limits: { cpu: "1", memory: 1536Mi }
+    # Container securityContext (issue #67). Restricted-PSS baseline: the Langfuse
+    # image runs as a non-root uid and needs no Linux capabilities, so all are
+    # dropped and privilege escalation is denied. readOnlyRootFilesystem stays
+    # false -- the Next.js server writes to its rootfs (.next cache, /tmp).
+    # To opt out, override the fields (e.g. runAsNonRoot: false for a fork whose
+    # image must run as root), or set the whole block to null to drop it.
+    containerSecurityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop: [ALL]
+      seccompProfile:
+        type: RuntimeDefault
   worker:
     nodeOptions: "--max-old-space-size=640"
     resources:
       requests: { cpu: 150m, memory: 384Mi }
       limits: { cpu: "1", memory: 1Gi }
+    # See langfuse.web.containerSecurityContext above.
+    containerSecurityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop: [ALL]
+      seccompProfile:
+        type: RuntimeDefault
 
 # ---------------------------------------------------------------------------
 # Postgres. Langfuse's transactional store AND the app-state DB (agents,
@@ -131,6 +154,18 @@ postgres:
   resources:
     requests: { cpu: 100m, memory: 128Mi }
     limits: { cpu: 500m, memory: 512Mi }
+  # Container securityContext (issue #67). The postgres image entrypoint starts
+  # as root to initialise/own PGDATA (chown, then gosu drop to the `postgres`
+  # user), so runAsNonRoot and capabilities.drop:[ALL] would break init and are
+  # deliberately NOT set here -- full restricted-PSS on this store needs a
+  # validated runAsUser + writable dirs on a real cluster (pod-level fsGroup is
+  # already set in the template). These two knobs are safe on a root entrypoint:
+  # they still deny privilege escalation and pin the RuntimeDefault seccomp
+  # profile. Override fields or set the whole block to null to opt out.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
 
 # ---------------------------------------------------------------------------
 # Valkey (Redis-compatible). Langfuse cache/queue AND the dispatcher's Streams
@@ -149,6 +184,14 @@ valkey:
   resources:
     requests: { cpu: 50m, memory: 64Mi }
     limits: { cpu: 250m, memory: 256Mi }
+  # Container securityContext (issue #67). Safe subset only -- the valkey-alpine
+  # entrypoint starts as root and drops to the `valkey` user (gosu), so
+  # runAsNonRoot / capabilities.drop are left unset. See
+  # postgres.containerSecurityContext for the full rationale.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
 
 # ---------------------------------------------------------------------------
 # ClickHouse. Langfuse's OLAP store for traces/observations/scores. The AVX
@@ -183,6 +226,14 @@ clickhouse:
   resources:
     requests: { cpu: 200m, memory: 512Mi }
     limits: { cpu: "2", memory: 1536Mi }
+  # Container securityContext (issue #67). Safe subset only -- the ClickHouse
+  # image entrypoint starts as root to own /var/lib/clickhouse and drops to the
+  # `clickhouse` user, so runAsNonRoot / capabilities.drop are left unset. See
+  # postgres.containerSecurityContext for the full rationale.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
 
 # ---------------------------------------------------------------------------
 # MinIO. Langfuse object storage (events, media, exports). BYO real S3 in prod:
@@ -206,6 +257,14 @@ minio:
   resources:
     requests: { cpu: 50m, memory: 128Mi }
     limits: { cpu: 500m, memory: 512Mi }
+  # Container securityContext (issue #67). Safe subset only -- the MinIO image
+  # defaults to running as root; forcing runAsNonRoot / capabilities.drop here
+  # without a validated uid + writable data dir on a real cluster risks breaking
+  # startup. See postgres.containerSecurityContext for the full rationale.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
 
 # ---------------------------------------------------------------------------
 # Local inference endpoint for demo clusters. Opt in only: fake model stays the
@@ -241,6 +300,19 @@ otelCollector:
   resources:
     requests: { cpu: 50m, memory: 64Mi }
     limits: { cpu: 250m, memory: 256Mi }
+  # Container securityContext (issue #67). Full restricted-PSS: the collector
+  # image runs as a non-root uid, needs no capabilities, and only reads a mounted
+  # (read-only) config while writing nothing to its rootfs -- so the root
+  # filesystem is read-only too. Override fields or set the whole block to null
+  # to opt out.
+  containerSecurityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
 
 # ---------------------------------------------------------------------------
 # First-party app services (A4). The control plane the runner fleet serves:
@@ -286,6 +358,20 @@ api:
   resources:
     requests: { cpu: 100m, memory: 256Mi }
     limits: { cpu: "1", memory: 512Mi }
+  # Container securityContext (issue #67). Restricted-PSS baseline: the image runs
+  # as non-root uid 1000 (see apps/api/Dockerfile) and needs no Linux
+  # capabilities. readOnlyRootFilesystem stays false -- the app writes to its
+  # rootfs (/tmp, $HOME); enable it only with matching writable emptyDir mounts.
+  # To opt out, override the fields (e.g. runAsNonRoot: false for a fork whose
+  # image must run as root), or set the whole block to null to drop it.
+  containerSecurityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
 
 dispatcher:
   deploy: true
@@ -306,6 +392,17 @@ dispatcher:
   resources:
     requests: { cpu: 50m, memory: 128Mi }
     limits: { cpu: 500m, memory: 256Mi }
+  # Container securityContext (issue #67). Image runs as non-root uid 1000 (see
+  # apps/dispatcher/Dockerfile). readOnlyRootFilesystem stays false -- the
+  # dispatcher writes a heartbeat file under /tmp. See api.containerSecurityContext.
+  containerSecurityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
 
 worker:
   deploy: true
@@ -344,6 +441,19 @@ worker:
   resources:
     requests: { cpu: 100m, memory: 192Mi }
     limits: { cpu: "1", memory: 512Mi }
+  # Container securityContext (issue #67). Image runs as non-root uid 1000 (see
+  # apps/worker/Dockerfile). This pod mounts a Kubernetes API token and drives
+  # the sandbox lifecycle, so the hardening matters most here. readOnlyRootFilesystem
+  # stays false -- the worker writes a heartbeat file under /tmp. See
+  # api.containerSecurityContext.
+  containerSecurityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
 
 ui:
   deploy: true
@@ -366,6 +476,20 @@ ui:
   resources:
     requests: { cpu: 25m, memory: 64Mi }
     limits: { cpu: 250m, memory: 128Mi }
+  # Container securityContext (issue #67). The UI is served by nginx-unprivileged,
+  # which already runs as non-root uid 101 and binds :8080 (no CAP_NET_BIND_SERVICE
+  # needed), so all capabilities are dropped. readOnlyRootFilesystem stays false --
+  # nginx writes to /var/cache/nginx, /var/run and /tmp; enable it only with
+  # matching writable emptyDir mounts. Override fields or set the whole block to
+  # null to opt out.
+  containerSecurityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
 
 # ---------------------------------------------------------------------------
 # Install-time preflights. Both are Helm hooks that block a broken install, and


### PR DESCRIPTION
## What

Adds a hardened, values-parameterized container `securityContext` to the workloads that lacked one. Before this, only the runner and security-probe (in `agent-sandbox.yaml` / `security-probe.yaml`) set container hardening; every other workload failed PSS *restricted* (datastores had pod-level `fsGroup` only).

Each workload gets a `containerSecurityContext` block in `values.yaml`, rendered with `{{- with }}` + `toYaml` so operators can opt out per component (override individual fields, e.g. `runAsNonRoot: false`, or set the whole block to `null`).

## Workloads changed

**Full restricted-PSS baseline** — `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`:

| Workload | readOnlyRootFilesystem | Why safe |
|---|---|---|
| api (+ migrate init) | false | image runs as uid 1000 (`apps/api/Dockerfile`); writes `/tmp`, `$HOME` |
| worker | false | uid 1000; mounts the K8s API token — the standout target in the issue; writes `/tmp` heartbeat |
| dispatcher | false | uid 1000; writes `/tmp` heartbeat |
| ui | false | nginx-unprivileged uid 101, binds :8080 (no `CAP_NET_BIND_SERVICE`); nginx writes cache/run dirs |
| otel-collector | **true** | non-root image; reads a RO ConfigMap, writes nothing to rootfs |
| langfuse-web | false | non-root node uid; Next.js writes `.next`/`/tmp` |
| langfuse-worker | false | non-root node uid |

`readOnlyRootFilesystem` is left `false` where the process writes to its rootfs — enabling it needs matching writable `emptyDir` mounts, deferred to avoid an unverifiable runtime break.

**Safe subset only** — `allowPrivilegeEscalation: false` + `seccompProfile: RuntimeDefault` (pod-level `fsGroup` unchanged):

- **postgres, valkey, clickhouse, minio** — these images' entrypoints start as **root** (chown the data dir, `gosu`-drop to the service user / initdb). Forcing `runAsNonRoot` or dropping `CAP_CHOWN` would break init, so those knobs are **intentionally left off** as documented per-store opt-ins needing real-cluster validation. This is the flagged exception per the issue's "some backing stores need a writable dir or a specific uid" caveat.

## Out of scope / flagged

- **Datastores' full restricted posture** (runAsNonRoot + drop-caps + RORFs) — needs a validated `runAsUser` + writable dirs tested on a cluster; can't be verified here without breaking risk.
- **`readOnlyRootFilesystem` on the app/langfuse/ui workloads** — needs writable `emptyDir` scratch mounts + verification.
- **inference (ollama)** and short-lived **hook Jobs** (minio-init, langfuse model-pricing) — not in the issue's workload list; left untouched.
- The **UNTRUSTED sandbox** is #68, deliberately not touched here.

## Verification

- `helm lint charts/agentos` → 0 failed
- `helm template charts/agentos` — clean with defaults, with the dispatcher enabled, and with `values-dev.yaml`
- Confirmed the intended `securityContext` renders on all 11 targeted workloads (incl. the api migrate init) and that a `null` override drops the block

Closes #67

Ref CUR-1603

🤖 Generated with [Claude Code](https://claude.com/claude-code)
