### PR TITLE
Security low-batch (#78): cleartext-http warning, secret env, probe RBAC, trace-id validation

### DIFF
--- a/apps/api/src/agentos_api/routers/runs.py
+++ b/apps/api/src/agentos_api/routers/runs.py
@@ -1,5 +1,7 @@
 """Langfuse read proxy powering the Runs view."""
 
+import re
+
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..auth import require_api_key
@@ -14,6 +16,11 @@ router = APIRouter(
     dependencies=[Depends(require_api_key)],
 )
 
+# Trace ids reach Langfuse's URL path (`/api/public/traces/{id}`), so restrict
+# them to the safe id charset (OTel hex, UUIDs, cuids) — no `/`, `.`, or `..`
+# that could traverse into other upstream paths.
+_TRACE_ID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,128}\Z")
+
 
 @router.get("/traces")
 async def list_traces(
@@ -27,6 +34,10 @@ async def list_traces(
 
 @router.get("/traces/{trace_id}", response_model=TraceTree)
 async def get_trace(trace_id: str, lf: LangfuseDep) -> TraceTree:
+    if not _TRACE_ID_RE.match(trace_id):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, "invalid trace id"
+        )
     observations = await lf.get_observations(trace_id)
     if not observations:
         raise HTTPException(

--- a/apps/api/tests/test_runs_proxy.py
+++ b/apps/api/tests/test_runs_proxy.py
@@ -96,6 +96,16 @@ def test_get_trace_404_when_no_observations(
     assert resp.status_code == 404
 
 
+def test_get_trace_rejects_malformed_trace_id(
+    auth_headers: dict[str, str],
+) -> None:
+    # A trace id carrying path metacharacters is refused before it can reach
+    # Langfuse's URL path (no `.`/`..`/`/` traversal into other upstream paths).
+    with _app_with([]) as client:
+        resp = client.get("/langfuse/traces/abc.def", headers=auth_headers)
+    assert resp.status_code == 400
+
+
 def test_proxy_requires_api_key() -> None:
     with _app_with([]) as client:
         resp = client.get("/langfuse/traces/abc")

--- a/charts/agentos/templates/security-probe.yaml
+++ b/charts/agentos/templates/security-probe.yaml
@@ -52,8 +52,12 @@ rules:
     resources: [pods/log]
     verbs: [get]
   - apiGroups: [""]
+    # The probe only create/deletes its own test secrets by name; the "can-i
+    # list secrets" isolation check runs under the agent token (a
+    # SelfSubjectAccessReview needs no list grant here). Do not add `list`:
+    # it would let this hook enumerate and read every secret in the namespace.
     resources: [secrets]
-    verbs: [create, delete, get, list]
+    verbs: [create, delete, get]
   - apiGroups: [""]
     resources: [serviceaccounts]
     verbs: [create, delete, get]

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -87,8 +87,48 @@ pub struct DeployOutcome {
     pub channel: ChannelOutcome,
 }
 
+/// Whether this endpoint would send the `X-API-Key` over cleartext HTTP to a
+/// non-loopback host (a forgotten `https://` that leaks the key on the wire).
+/// Local dev over `http://localhost` is expected and returns false.
+fn is_insecure_endpoint(base_url: &str) -> bool {
+    let lower = base_url.trim().to_ascii_lowercase();
+    if lower.starts_with("https://") {
+        return false;
+    }
+    let authority = lower
+        .strip_prefix("http://")
+        .unwrap_or(&lower)
+        .split('/')
+        .next()
+        .unwrap_or("");
+    // Strip the port, handling both `host:port` and `[::1]:port` IPv6 forms.
+    let host = if let Some(rest) = authority.strip_prefix('[') {
+        rest.split(']').next().unwrap_or("")
+    } else {
+        authority.split(':').next().unwrap_or("")
+    };
+    let is_loopback = host == "localhost"
+        || host.ends_with(".localhost")
+        || host.starts_with("127.")
+        || host == "::1"
+        || host == "0.0.0.0";
+    !is_loopback
+}
+
+/// Warn (to stderr) when the endpoint would leak the API key over cleartext
+/// HTTP. See [`is_insecure_endpoint`].
+fn warn_if_insecure(base_url: &str) {
+    if is_insecure_endpoint(base_url) {
+        eprintln!(
+            "warning: API endpoint '{base_url}' uses cleartext HTTP; the API key \
+             will be sent unencrypted. Use an https:// URL for non-local endpoints."
+        );
+    }
+}
+
 impl ApiClient {
     pub fn new(base_url: &str, api_key: &str) -> Result<Self> {
+        warn_if_insecure(base_url);
         let http = reqwest::Client::builder()
             .connect_timeout(std::time::Duration::from_secs(5))
             .build()
@@ -390,5 +430,41 @@ impl ApiClient {
             .context("DELETE /agents/{id}")?;
         Self::expect_ok(resp, "deleting the agent").await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_insecure_endpoint;
+
+    #[test]
+    fn https_is_always_secure() {
+        assert!(!is_insecure_endpoint("https://api.example.com"));
+        assert!(!is_insecure_endpoint("HTTPS://API.EXAMPLE.COM"));
+    }
+
+    #[test]
+    fn http_to_loopback_is_allowed() {
+        for url in [
+            "http://localhost:8000",
+            "http://localhost",
+            "http://127.0.0.1:8000",
+            "http://[::1]:8000",
+            "http://0.0.0.0:8000",
+            "http://api.localhost",
+        ] {
+            assert!(!is_insecure_endpoint(url), "expected {url} to be allowed");
+        }
+    }
+
+    #[test]
+    fn http_to_remote_host_is_insecure() {
+        for url in [
+            "http://api.example.com",
+            "http://api.example.com:8000/v1",
+            "http://10.0.0.5:8000",
+        ] {
+            assert!(is_insecure_endpoint(url), "expected {url} to warn");
+        }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -256,8 +256,15 @@ enum LocalAction {
         /// new message text.
         #[arg(long = "continue")]
         r#continue: bool,
-        /// Valkey password (compose default `valkeypass`).
-        #[arg(long, default_value = message::DEFAULT_VALKEY_PASSWORD)]
+        /// Valkey password (compose default `valkeypass`). Prefer the
+        /// AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the
+        /// command line, where it leaks via `ps` and shell history.
+        #[arg(
+            long,
+            env = "AGENTOS_VALKEY_PASSWORD",
+            hide_env_values = true,
+            default_value = message::DEFAULT_VALKEY_PASSWORD
+        )]
         valkey_password: String,
         /// Local mode only: platform API base URL for the channel lookup.
         #[arg(long)]
@@ -461,8 +468,15 @@ enum ClusterAction {
         /// Local port the Valkey port-forward binds.
         #[arg(long, default_value_t = message::DEFAULT_VALKEY_LOCAL_PORT)]
         valkey_local_port: u16,
-        /// Valkey password (chart default `valkeypass`).
-        #[arg(long, default_value = message::DEFAULT_VALKEY_PASSWORD)]
+        /// Valkey password (chart default `valkeypass`). Prefer the
+        /// AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the
+        /// command line, where it leaks via `ps` and shell history.
+        #[arg(
+            long,
+            env = "AGENTOS_VALKEY_PASSWORD",
+            hide_env_values = true,
+            default_value = message::DEFAULT_VALKEY_PASSWORD
+        )]
         valkey_password: String,
         /// Local port the API port-forward binds (default-channel lookup).
         #[arg(long, default_value_t = message::DEFAULT_API_LOCAL_PORT)]


### PR DESCRIPTION
## What

The four low-blast-radius items from #78, batched on one branch.

| # | Item | Fix | Files |
|---|------|-----|-------|
| 1 | CLI defaults API endpoint to `http://`, sending the API key cleartext if `https://` is forgotten | Warn on stderr when the endpoint is `http://` to a **non-loopback** host; `http://localhost` stays quiet. Pure `is_insecure_endpoint()` predicate + unit tests | `cli/src/api.rs` |
| 2 | Secrets accepted as literal CLI args leak via `ps`/history | `--valkey-password` now reads `AGENTOS_VALKEY_PASSWORD` (`hide_env_values`), so it need not sit on the command line; help steers to the env var. (`--api-key` already reads `AGENTOS_API_KEY`.) | `cli/src/main.rs` |
| 3 | security-probe hook Role has `list` on Secrets (can enumerate + read all namespace secrets) | Drop `list`. The probe only `create`/`delete`s its own test secrets by name; the "can-i list secrets" isolation check runs under the **agent** token (a SelfSubjectAccessReview needs no grant on the hook SA) | `charts/agentos/templates/security-probe.yaml` |
| 4 | Langfuse `trace_id` path param interpolated into the upstream URL (`..` traversal) | Validate the id charset (`[A-Za-z0-9_-]{1,128}`) at the `/langfuse/traces/{id}` router boundary → 400 on malformed | `apps/api/src/agentos_api/routers/runs.py` |

## Verification

- `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` — green (165 tests, incl. 3 new `is_insecure_endpoint` cases).
- `helm lint charts/agentos` clean; rendered probe secrets rule is now `[create, delete, get]`.
- `uv run ruff check` + `uv run mypy` clean; `pytest apps/api/tests/test_runs_proxy.py` green (9, incl. new malformed-id test).

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)