### PR TITLE
Auto-generate strong per-release chart secrets

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -82,6 +82,14 @@ jobs:
             | python3 -c "import sys, yaml; yaml.safe_dump_all(yaml.safe_load_all(sys.stdin), sys.stdout)" \
             | kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version "$KUBE_VERSION"
 
+      # Prove the credential Secret generates strong per-release values on the
+      # sealed path (issue #195) while the dev overlay keeps its deterministic
+      # published defaults. Runs the chart-owned assertion script.
+      - name: helm render assertions (credential generation)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/render-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -190,10 +190,27 @@ Toggles (all default `true`): `langfuse.deploy`, `postgres.deploy`,
 Flipping any to `false` removes its resources from the render; consumers
 (Langfuse env, the collector config) repoint at the BYO host automatically.
 
-Secrets: dev credentials live in `values.yaml` and are written to one
-`<release>-secrets` Secret. For production, override the values or point
-`langfuse.existingSecret` (and each store's `existingSecret`) at your own
-Secrets. `langfuse.encryptionKey` must be 64 hex chars (`openssl rand -hex 32`).
+Secrets: all credentials are written to one `<release>-secrets` Secret. A sealed
+`helm install` (the default) AUTO-GENERATES a strong random per release for the
+nine chart-owned credentials (the backing-store passwords, the Langfuse
+salt/encryptionKey/nextauthSecret, and the api/webhook keys) rather than shipping
+the published dev defaults. The generated values are persisted via a `lookup` of
+the release Secret, so `helm upgrade` re-uses them and never rotates a live store
+credential (the Bitnami lookup-persist convention). Set
+`security.allowDevDefaults: true` (values-dev.yaml, i.e. `agentos cluster up
+--dev`) to keep the deterministic published defaults for dev/CI. A per-store
+`existingSecret` and explicit `--set` overrides still win in every mode -- an
+override that differs from the published default beats the persisted value on
+install AND upgrade (matching Bitnami's provided-value-first precedence), so
+rotation/recovery works; point `langfuse.existingSecret` (and each store's
+`existingSecret`) at your own Secrets to bring your own. `langfuse.encryptionKey`
+must be 64 hex chars (`openssl rand -hex 32`).
+
+Caveat: generation relies on Helm `lookup`, which is empty under client-side
+rendering. Driving this chart via `helm template | kubectl apply` or ArgoCD's
+client-side Helm (no live API lookup) regenerates these values on every sync and
+would rotate live store credentials -- pin them via `--set`/`existingSecret` (or
+use the `helm install/upgrade` path / `agentos cluster up`) in that case.
 
 Guard against shipping those dev defaults to a shared/production cluster with
 `--set security.checkDefaultCredentials=true`: the chart then refuses to render

--- a/charts/agentos/ci/render-assertions.sh
+++ b/charts/agentos/ci/render-assertions.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #195 (auto-generate strong per-release chart
+# credentials). Proves three things about the chart's credential Secret:
+#
+#   1. A SEALED render (security.allowDevDefaults defaults false, `lookup` empty
+#      offline under `helm template`) GENERATES a strong random value for each of
+#      the nine chart-owned secret keys instead of shipping the published dev
+#      default. The generated langfuseEncryptionKey is 64 lowercase-hex chars.
+#   2. The DEV overlay (values-dev.yaml sets allowDevDefaults=true) keeps the
+#      deterministic published defaults, so the dev/e2e path renders unchanged.
+#   3. An explicit `--set` override that differs from the published default is
+#      honored on the sealed path (override wins over generation).
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly, naming the key.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# The nine chart-owned secret keys, each with its published dev default.
+KEYS=(
+  postgresPassword
+  valkeyPassword
+  clickhousePassword
+  minioRootPassword
+  langfuseSalt
+  langfuseEncryptionKey
+  langfuseNextauthSecret
+  apiKey
+  githubWebhookSecret
+)
+declare -A DEFAULTS=(
+  [postgresPassword]="postgres"
+  [valkeyPassword]="valkeypass"
+  [clickhousePassword]="clickhouse"
+  [minioRootPassword]="miniosecret"
+  [langfuseSalt]="dev-salt-change-me"
+  [langfuseEncryptionKey]="0000000000000000000000000000000000000000000000000000000000000000"
+  [langfuseNextauthSecret]="dev-nextauth-secret-change-me"
+  [apiKey]="agentos-dev-key"
+  [githubWebhookSecret]="dev-webhook-secret"
+)
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SEALED="$TMP/sealed.yaml"
+DEV="$TMP/dev.yaml"
+
+echo "=== Rendering sealed chart (allowDevDefaults default false) ==="
+helm template "$CHART" --show-only templates/secrets.yaml > "$SEALED"
+
+echo "=== Rendering dev overlay (allowDevDefaults=true) ==="
+helm template "$CHART" -f "$CHART/values-dev.yaml" --show-only templates/secrets.yaml > "$DEV"
+
+# Read one stringData key from a rendered Secret via PyYAML (robust vs grep/awk).
+read_key() {
+  # $1 = rendered secret YAML file, $2 = key
+  python3 -c '
+import sys, yaml
+path, key = sys.argv[1], sys.argv[2]
+doc = yaml.safe_load(open(path))
+sd = (doc or {}).get("stringData", {})
+if key not in sd:
+    sys.stderr.write("stringData is missing key %r\n" % key)
+    sys.exit(3)
+sys.stdout.write(str(sd[key]))
+' "$1" "$2"
+}
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+echo "=== Assertion 1: sealed render GENERATES (no published default) ==="
+for key in "${KEYS[@]}"; do
+  val="$(read_key "$SEALED" "$key")"
+  def="${DEFAULTS[$key]}"
+  if [[ "$val" == "$def" ]]; then
+    fail "sealed render still emits the published dev default for '$key' (value == '$def'); expected a generated value."
+  fi
+  echo "  ok: $key was generated (not the published default)"
+done
+
+echo "=== Assertion 2: sealed langfuseEncryptionKey is 64 lowercase-hex chars ==="
+enc="$(read_key "$SEALED" langfuseEncryptionKey)"
+if [[ ! "$enc" =~ ^[0-9a-f]{64}$ ]]; then
+  fail "sealed langfuseEncryptionKey must match ^[0-9a-f]{64}$; got '${enc}' (length ${#enc})."
+fi
+echo "  ok: langfuseEncryptionKey is 64 lowercase-hex chars"
+
+echo "=== Assertion 3: dev overlay keeps the deterministic published defaults ==="
+for key in "${KEYS[@]}"; do
+  val="$(read_key "$DEV" "$key")"
+  def="${DEFAULTS[$key]}"
+  if [[ "$val" != "$def" ]]; then
+    fail "dev overlay must keep the published default for '$key'; expected '$def', got '$val'."
+  fi
+  echo "  ok: $key == published default (deterministic dev path)"
+done
+
+echo "=== Assertion 4: explicit override wins on the sealed path ==="
+# On the sealed path (no allowDevDefaults, empty offline `lookup`), an operator
+# `--set` that differs from the published default must be honored verbatim rather
+# than generated -- this proves the override branch sits ahead of generation.
+OVERRIDE="$TMP/override.yaml"
+helm template "$CHART" --set api.apiKey=override-sentinel-xyz \
+  --show-only templates/secrets.yaml > "$OVERRIDE"
+got="$(read_key "$OVERRIDE" apiKey)"
+if [[ "$got" != "override-sentinel-xyz" ]]; then
+  fail "explicit --set api.apiKey override must be honored on the sealed path; expected 'override-sentinel-xyz', got '$got'."
+fi
+echo "  ok: explicit apiKey override honored (override wins over generation)"
+
+echo "=== Assertion 5: quoted \"false\" does NOT disable generation (fail closed) ==="
+# Go templates treat any non-empty string as truthy, so a quoted
+# `security.allowDevDefaults="false"` (easily produced by --set or values-file
+# quoting) must NOT read as truthy and ship the published dev default. Only the
+# literal `true` opts into defaults; every other value falls through to
+# generation. Assert both the bareword and the quoted-string spellings still
+# generate apiKey (not the published `agentos-dev-key`).
+for spelling in "security.allowDevDefaults=false" 'security.allowDevDefaults="false"'; do
+  FALSY="$TMP/falsy.yaml"
+  helm template "$CHART" --set "$spelling" \
+    --show-only templates/secrets.yaml > "$FALSY"
+  got="$(read_key "$FALSY" apiKey)"
+  if [[ "$got" == "agentos-dev-key" ]]; then
+    fail "allowDevDefaults '$spelling' must NOT ship the published default; apiKey generated expected, got 'agentos-dev-key' (fail-OPEN regression)."
+  fi
+  echo "  ok: --set $spelling still generates apiKey (fail closed)"
+done
+
+echo
+echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path."

--- a/charts/agentos/templates/_helpers.tpl
+++ b/charts/agentos/templates/_helpers.tpl
@@ -125,6 +125,66 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 {{- end -}}
 
+{{/* ---- Auto-generated per-release chart credential (issue #195) ----
+     Resolve one chart-owned secret value, generating a strong random per release
+     for a sealed install instead of shipping the published dev default. Call with
+     a dict: root (the top context), key (the stringData key, matching an existing
+     Secret's data), value (.Values.<path>), default (the published dev default),
+     hex (true for the 64-hex encryption key, else false).
+
+     The existing Secret's data is looked up ONCE by the caller (secrets.yaml) and
+     passed in as `.existingData` (an always-present dict, empty under `helm
+     template`/--dry-run/first install), so this helper does no per-key lookup.
+
+     Four branches, in PRECEDENCE order, and WHY this order is correct:
+       1. allowDevDefaults: the deterministic dev/CI escape hatch (values-dev.yaml
+          sets it true). Return the value verbatim so the dev/e2e path renders the
+          published defaults unchanged, byte-for-byte reproducible. Taking this
+          first also means `--dev` reverts to the defaults even if a random was
+          previously generated into the release Secret. Gate on positive equality
+          against the literal "true" (`eq (toString ...) "true"`), NOT plain
+          truthiness: Go templates treat any non-empty string as truthy, so a
+          quoted `--set security.allowDevDefaults="false"` would otherwise read as
+          truthy and ship the published default -- a fail-OPEN regression.
+       2. Explicit override: if the operator/CLI supplied a value that differs from
+          the published default (`ne value default`), it WINS -- even on `helm
+          upgrade`. This is operator intent (a rotation, a recovery, a `--set`, or
+          an `existingSecret`-equivalent value), so it must beat the persisted
+          value; matches Bitnami's `providedPasswordValue`-first precedence. It
+          MUST sit ahead of the persist branch or an explicit rotation on
+          upgrade would be silently ignored.
+       3. Persist existing: no override, so if a prior install already GENERATED
+          this key, re-use it. `helm upgrade` must NEVER rotate a live store
+          credential (Postgres would reject the new password against its persisted
+          data), so we return the stored value from `.existingData` when present.
+          Generated secrets always have value==published-default (nobody set them),
+          so they never take branch 2 and always land here on upgrade -- exactly
+          the "upgrade must not rotate" guarantee. `.existingData` is always a dict
+          (the caller applies `| default dict`), empty under `helm
+          template`/--dry-run and on first install, so a missing key falls through
+          to generation.
+       4. Generate: a first sealed install (value still equals the published
+          default, no prior Secret) gets a strong random. `randAlphaNum` is
+          crypto-backed (Sprig). hex=true hashes it to 64 lowercase-hex chars (the
+          encryption key format); otherwise a 32-char alphanumeric.
+
+     Net effect: an operator who forgets to re-pass `--set` on a later upgrade
+     safely reverts value to the default, which then reuses the persisted generated
+     value via branch 3 rather than rotating it. */}}
+{{- define "agentos.managedSecret" -}}
+{{- if eq (toString .root.Values.security.allowDevDefaults) "true" -}}{{/* string-coercion safety -- a quoted "false" must not read as truthy and silently ship a published default (fail closed to generation). */}}
+{{- .value -}}
+{{- else if ne (toString .value) (toString .default) -}}
+{{- .value -}}
+{{- else if hasKey .existingData .key -}}
+{{- index .existingData .key | b64dec -}}
+{{- else if .hex -}}
+{{- randAlphaNum 32 | sha256sum -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
+
 {{/* ---- Shared first-party-app environment fragments ---- */}}
 
 {{/* Postgres connection env for the app services. POSTGRES_PASSWORD comes from

--- a/charts/agentos/templates/secrets.yaml
+++ b/charts/agentos/templates/secrets.yaml
@@ -9,14 +9,23 @@ Secret unconditionally (they have no per-component existingSecret escape). So
 this object always renders, synthesized from the values defaults -- override
 those (or supply an `existingSecret` per store) in any shared deployment.
 
-The plaintext values here are the dev defaults documented in values.yaml; they
-are NOT production material. `stringData` lets Kubernetes base64-encode them.
+The nine chart-owned credentials (the backing-store passwords, the Langfuse
+salt/encryptionKey/nextauthSecret, and the api/webhook keys) are resolved through
+`agentos.managedSecret` (issue #195): a sealed install GENERATES a strong random
+per release and `helm upgrade` re-uses the persisted value (never rotates a live
+store credential). An explicit override (a `--set`/values value that differs from
+the published default) WINS in every mode, install and upgrade, so rotation and
+recovery work; `security.allowDevDefaults=true` (values-dev.yaml) instead keeps
+the deterministic published value. The remaining keys below
+carry the published dev defaults documented in values.yaml; they are NOT
+production material. `stringData` lets Kubernetes base64-encode them.
 
 Render-time gate: refuse to emit the published Langfuse bootstrap defaults when
 security.checkDefaultCredentials is on (issue #198). This Secret always renders,
 so the guard runs on every install/upgrade/template.
 */}}
 {{- include "agentos.checkDefaultCredentials" . }}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "agentos.secretName" .)).data | default dict -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -26,14 +35,14 @@ metadata:
 type: Opaque
 stringData:
   # Backing-store credentials (fallback when a store sets no existingSecret).
-  postgresPassword: {{ .Values.postgres.auth.password | quote }}
-  valkeyPassword: {{ .Values.valkey.password | quote }}
-  clickhousePassword: {{ .Values.clickhouse.auth.password | quote }}
-  minioRootPassword: {{ .Values.minio.auth.rootPassword | quote }}
+  postgresPassword: {{ include "agentos.managedSecret" (dict "root" . "key" "postgresPassword" "value" .Values.postgres.auth.password "default" "postgres" "hex" false "existingData" $existingSecret) | quote }}
+  valkeyPassword: {{ include "agentos.managedSecret" (dict "root" . "key" "valkeyPassword" "value" .Values.valkey.password "default" "valkeypass" "hex" false "existingData" $existingSecret) | quote }}
+  clickhousePassword: {{ include "agentos.managedSecret" (dict "root" . "key" "clickhousePassword" "value" .Values.clickhouse.auth.password "default" "clickhouse" "hex" false "existingData" $existingSecret) | quote }}
+  minioRootPassword: {{ include "agentos.managedSecret" (dict "root" . "key" "minioRootPassword" "value" .Values.minio.auth.rootPassword "default" "miniosecret" "hex" false "existingData" $existingSecret) | quote }}
   # Langfuse app secrets.
-  langfuseSalt: {{ .Values.langfuse.salt | quote }}
-  langfuseEncryptionKey: {{ .Values.langfuse.encryptionKey | quote }}
-  langfuseNextauthSecret: {{ .Values.langfuse.nextauthSecret | quote }}
+  langfuseSalt: {{ include "agentos.managedSecret" (dict "root" . "key" "langfuseSalt" "value" .Values.langfuse.salt "default" "dev-salt-change-me" "hex" false "existingData" $existingSecret) | quote }}
+  langfuseEncryptionKey: {{ include "agentos.managedSecret" (dict "root" . "key" "langfuseEncryptionKey" "value" .Values.langfuse.encryptionKey "default" "0000000000000000000000000000000000000000000000000000000000000000" "hex" true "existingData" $existingSecret) | quote }}
+  langfuseNextauthSecret: {{ include "agentos.managedSecret" (dict "root" . "key" "langfuseNextauthSecret" "value" .Values.langfuse.nextauthSecret "default" "dev-nextauth-secret-change-me" "hex" false "existingData" $existingSecret) | quote }}
   # Init project secret key, read by the model-pricing seed Job as basic-auth
   # password against the Langfuse public API.
   langfuseInitProjectSecretKey: {{ .Values.langfuse.init.projectSecretKey | quote }}
@@ -47,8 +56,8 @@ stringData:
   # a real-model deploy sets agentSandbox.runner.credentials).
   agentCredentials: {{ .Values.agentSandbox.runner.credentials | quote }}
   # First-party app credentials.
-  apiKey: {{ .Values.api.apiKey | quote }}
-  githubWebhookSecret: {{ .Values.api.githubWebhookSecret | quote }}
+  apiKey: {{ include "agentos.managedSecret" (dict "root" . "key" "apiKey" "value" .Values.api.apiKey "default" "agentos-dev-key" "hex" false "existingData" $existingSecret) | quote }}
+  githubWebhookSecret: {{ include "agentos.managedSecret" (dict "root" . "key" "githubWebhookSecret" "value" .Values.api.githubWebhookSecret "default" "dev-webhook-secret" "hex" false "existingData" $existingSecret) | quote }}
   slackAppToken: {{ .Values.dispatcher.slack.appToken | quote }}
   slackBotToken: {{ .Values.dispatcher.slack.botToken | quote }}
   slackSigningSecret: {{ .Values.dispatcher.slack.signingSecret | quote }}

--- a/charts/agentos/values-dev.yaml
+++ b/charts/agentos/values-dev.yaml
@@ -103,3 +103,8 @@ ui:
     repository: agentos-ui
     tag: local
     pullPolicy: Never
+
+security:
+  # Deterministic dev credentials: keep the published defaults from values.yaml
+  # instead of generating per-release randoms (mirrors compose.dev.yaml).
+  allowDevDefaults: true

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -881,3 +881,20 @@ security:
   # shared/production cluster. (#57 will extend this same gate to the nine
   # store/control-plane secrets once its design pass lands.)
   checkDefaultCredentials: false
+  # Auto-generate per-release chart credentials (issue #195). Default false: a
+  # no-override `helm install` GENERATES a strong random per release for the nine
+  # chart-owned credentials (postgres/valkey/clickhouse/minio passwords, the
+  # Langfuse salt/encryptionKey/nextauthSecret, and the api/webhook keys) instead
+  # of shipping the published dev defaults. Generated values are persisted via a
+  # `lookup` of the release Secret, so `helm upgrade` re-uses them and never
+  # rotates a live store credential. Set true (values-dev.yaml does) for a
+  # deterministic dev/CI render that keeps the published defaults byte-for-byte.
+  # A per-store `existingSecret` and explicit `--set` overrides still win in every
+  # mode -- an override that differs from the published default beats the persisted
+  # value on install AND upgrade, so rotation/recovery works.
+  # Caveat: generation relies on Helm `lookup`, which is empty under client-side
+  # rendering. Driving this chart via `helm template | kubectl apply` or ArgoCD's
+  # client-side Helm (no live API lookup) regenerates these values on every sync
+  # and would rotate live store credentials -- pin them via `--set`/`existingSecret`
+  # (or use the `helm install/upgrade` path / `agentos cluster up`) in that case.
+  allowDevDefaults: false

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -550,6 +550,13 @@ pub fn up_commands(o: &UpOpts) -> Vec<OpsCommand> {
         plain(&o.common.namespace),
         plain("--create-namespace"),
     ];
+    if o.dev {
+        // With #195 the sealed chart auto-generates strong per-release secrets
+        // by default. `--dev` must opt into the chart's deterministic published
+        // defaults so local/CI stacks stay reproducible and match compose.
+        args.push(plain("--set"));
+        args.push(plain("security.allowDevDefaults=true"));
+    }
     if !o.no_expose {
         args.push(plain("--set"));
         args.push(plain("ui.service.type=NodePort"));
@@ -1945,6 +1952,54 @@ mod tests {
             local_model: None,
         });
         assert!(!cmds[0].display().contains("secret values file"));
+    }
+
+    #[test]
+    fn up_dev_emits_allow_dev_defaults_flag() {
+        // Under --dev the operator opts into the deterministic published chart
+        // credentials, so `up` must pass security.allowDevDefaults=true through
+        // to helm (issue #195). Without it the sealed chart generates strong
+        // random values and the dev/e2e stack would not match compose.
+        let cmds = up_commands(&UpOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            secrets: vec![],
+            dev: true,
+            no_expose: true,
+            set: vec![],
+            allow_web_egress: vec![],
+            fake_model: false,
+            credentials: None,
+            local_model: None,
+        });
+        let line = cmds[0].display();
+        assert!(
+            line.contains("security.allowDevDefaults=true"),
+            "expected --dev to emit security.allowDevDefaults=true: {line}"
+        );
+    }
+
+    #[test]
+    fn up_without_dev_omits_allow_dev_defaults_flag() {
+        // The default (non-dev) path must NOT opt into the published defaults;
+        // the sealed chart generates strong per-release credentials there.
+        let cmds = up_commands(&UpOpts {
+            common: common(),
+            chart: "charts/agentos".into(),
+            secrets: vec![],
+            dev: false,
+            no_expose: true,
+            set: vec![],
+            allow_web_egress: vec![],
+            fake_model: false,
+            credentials: None,
+            local_model: None,
+        });
+        let line = cmds[0].display();
+        assert!(
+            !line.contains("security.allowDevDefaults"),
+            "non-dev up must not emit security.allowDevDefaults: {line}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #195

A no-override `helm install` now generates a unique strong random per release for the nine chart-owned credentials (postgres/valkey/clickhouse/minio passwords, Langfuse salt/encryptionKey/nextauthSecret, api.apiKey/githubWebhookSecret) instead of rendering the published dev defaults, and `helm upgrade` never rotates them (the Bitnami convention; issue #57's generate branch).

## How
New `agentos.managedSecret` helper resolves each credential in order:
1. `security.allowDevDefaults=true` -> the deterministic dev default (dev/CI escape hatch).
2. Explicit override (value differs from the published default) -> use it, so an operator `--set`/`existingSecret` still rotates/recovers a credential, even on upgrade.
3. Previously-generated value persists via a single `lookup` of the release Secret -> no rotation on upgrade.
4. Otherwise generate: `randAlphaNum 32`, or a 64-hex `sha256sum` for `langfuse.encryptionKey`.

## Notes
- `security.allowDevDefaults` defaults false; `values-dev.yaml` sets it true and `agentos cluster up --dev` passes `--set security.allowDevDefaults=true`, keeping the dev/CI path deterministic.
- The gate matches the literal string `"true"` (fail closed): a quoted `--set security.allowDevDefaults="false"` cannot read as truthy and ship a published default.
- The existing Secret is looked up once (hoisted), not per key.
- The #198 `checkDefaultCredentials` gate (Langfuse init identities) is untouched and still fires; generated values are non-default so it passes automatically.
- Caveat documented: generation relies on `lookup`, which is empty under client-side rendering (`helm template | apply`, ArgoCD Helm) -- pin values via `--set`/`existingSecret` there or they regenerate each sync.

## Verification
- `charts/agentos/ci/render-assertions.sh` (wired into helm-ci): sealed render generates all nine (encryptionKey 64-hex), dev overlay stays deterministic, explicit override wins, quoted-`"false"` gate stays fail-closed.
- CLI unit tests: `--dev` emits the flag, non-dev omits it.
- Live k8scratch: fresh install generated all nine; `helm upgrade` did not rotate any; `--set api.apiKey=...` override won over the persisted value while the other eight persisted; `allowDevDefaults=true` reverted to dev defaults.