### PR TITLE
K8s (#68): harden the sandbox bundle-fetch/extract init containers

### DIFF
--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -156,6 +156,20 @@ spec:
         - name: bundle-fetch
           image: {{ $bf.fetchImage }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- if $runner.hardening.enabled }}
+          # Same container-level lockdown as the runner: these init containers
+          # run an authenticated S3 fetch and archive extract of operator-supplied
+          # input in the untrusted pod, so they must not run looser than it. Every
+          # write targets a mounted emptyDir (the fetched archive to `bundles`, mc's
+          # config to the dedicated `mc-config` volume via MC_CONFIG_DIR), so a
+          # read-only rootfs is safe.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+          {{- end }}
           command:
             - /bin/sh
             - -c
@@ -194,6 +208,17 @@ spec:
         - name: bundle-extract
           image: {{ $bf.extractImage }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- if $runner.hardening.enabled }}
+          # Same container-level lockdown as the runner (see bundle-fetch): all
+          # writes target the mounted `bundles` volume, so a read-only rootfs is
+          # safe here too.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+          {{- end }}
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
## What

The untrusted runner pod's two init containers — `bundle-fetch` (mc) and `bundle-extract` (busybox) — ran with **only** the pod-level `securityContext` (`runAsNonRoot` + seccomp). At the container level they had default capabilities, a writable rootfs, and privilege escalation allowed — the loosest posture in the most sensitive pod, while performing an authenticated S3 fetch and an archive extract of **operator-supplied** input (path-traversal / zip-bomb surface) right next to the fully locked-down runner.

## Fix

Mirror the runner container's `securityContext` onto both init containers, gated by the same `agentSandbox.runner.hardening.enabled` flag:

```yaml
securityContext:
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  capabilities:
    drop: [ALL]
```

`readOnlyRootFilesystem` is safe here because every write already targets the mounted `bundles` emptyDir: mc's config dir is redirected via `MC_CONFIG_DIR=$mountPath/.mc`, the fetched archive lands at `$mountPath/.bundle-archive`, and extract stages/writes under `$mountPath`. Nothing writes to the container rootfs.

## Verification

- `helm lint charts/agentos` clean.
- `helm template --set agentSandbox.deploy=true` renders both init containers with the block above, identical to the runner container.
- ⚠️ **Not yet verified on a live cluster.** Per `charts/agentos/CLAUDE.md`, the final gate is `helm test` (the security-probe suite) / the e2e run confirming bundle fetch+extract still succeed under the read-only rootfs — I can't run a cluster from here. Worth a `helm test` pass before merge.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)