### PR TITLE
API: production boot gate refusing dev-default secrets (#57)

### DIFF
--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -7,11 +7,22 @@ environment variable for shared or production deployments.
 
 from functools import lru_cache
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Dev-only default secrets. The production boot gate refuses to start when any of
+# these is still in place under ENVIRONMENT=prod.
+_DEV_DEFAULT_API_KEY = "agentos-dev-key"
+_DEV_DEFAULT_WEBHOOK_SECRET = "dev-webhook-secret"
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    # Deploy environment the API boots as, "dev" or "prod" (the chart renders it
+    # from api.environment onto the ENVIRONMENT var). "prod" arms the production
+    # boot gate below, which refuses the dev-default secrets.
+    environment: str = "dev"
 
     # Postgres (async driver). Dedicated `agentos` schema keeps our tables clear
     # of Langfuse's own tables on the same database.
@@ -84,6 +95,26 @@ class Settings(BaseSettings):
         return (
             f"redis://:{self.valkey_password}@{self.valkey_host}:{self.valkey_port}/0"
         )
+
+    @model_validator(mode="after")
+    def _refuse_dev_defaults_in_prod(self) -> "Settings":
+        """Production boot gate (#57): with ENVIRONMENT=prod, refuse to start if a
+        shared secret is unset or still the shipped dev default, so a prod deploy
+        can never silently run on well-known credentials."""
+        if self.environment.strip().lower() != "prod":
+            return self
+        offenders = []
+        if self.api_key in ("", _DEV_DEFAULT_API_KEY):
+            offenders.append("API_KEY")
+        if self.github_webhook_secret in ("", _DEV_DEFAULT_WEBHOOK_SECRET):
+            offenders.append("GITHUB_WEBHOOK_SECRET")
+        if offenders:
+            raise ValueError(
+                "ENVIRONMENT=prod but these secrets are unset or still the dev "
+                f"default: {', '.join(offenders)}. Set real values before booting "
+                "in production."
+            )
+        return self
 
 
 @lru_cache

--- a/apps/api/tests/test_config_prod_gate.py
+++ b/apps/api/tests/test_config_prod_gate.py
@@ -1,0 +1,49 @@
+"""The production boot gate (#57): ENVIRONMENT=prod must refuse dev-default secrets."""
+
+import pytest
+from agentos_api.config import Settings
+from pydantic import ValidationError
+
+
+def _settings(**overrides: str) -> Settings:
+    # Ignore any ambient .env / process env so the test controls every field.
+    base = {
+        "environment": "prod",
+        "api_key": "a-real-key",
+        "github_webhook_secret": "a-real-secret",
+    }
+    base.update(overrides)
+    return Settings(_env_file=None, **base)
+
+
+def test_dev_environment_allows_defaults() -> None:
+    # The dev default construction (what every local run uses) must still work.
+    s = Settings(_env_file=None, environment="dev")
+    assert s.api_key == "agentos-dev-key"
+
+
+def test_prod_with_real_secrets_boots() -> None:
+    s = _settings()
+    assert s.environment == "prod"
+
+
+@pytest.mark.parametrize(
+    "overrides, offender",
+    [
+        ({"api_key": "agentos-dev-key"}, "API_KEY"),
+        ({"api_key": ""}, "API_KEY"),
+        ({"github_webhook_secret": "dev-webhook-secret"}, "GITHUB_WEBHOOK_SECRET"),
+        ({"github_webhook_secret": ""}, "GITHUB_WEBHOOK_SECRET"),
+    ],
+)
+def test_prod_refuses_dev_default_or_empty_secret(
+    overrides: dict[str, str], offender: str
+) -> None:
+    with pytest.raises(ValidationError) as exc:
+        _settings(**overrides)
+    assert offender in str(exc.value)
+
+
+def test_prod_is_case_insensitive() -> None:
+    with pytest.raises(ValidationError):
+        _settings(environment="PROD", api_key="agentos-dev-key")


### PR DESCRIPTION
## What

Implements the **API production boot gate** that the chart already advertises and wires but that was never built.

`charts/agentos/values.yaml:353` says `prod` *"arms the API production boot gate, which refuses to start on the dev-default `apiKey`/`githubWebhookSecret`"*, and #213 threaded `ENVIRONMENT` onto the api container — but nothing in the API read it, so a prod deploy would happily boot on `agentos-dev-key`.

## Fix

- Add an `environment` setting (reads the `ENVIRONMENT` var the chart renders from `api.environment`).
- Add a `model_validator(mode="after")` that, **only when `ENVIRONMENT=prod`**, fails `Settings` construction (hence app startup) if `api_key` or `github_webhook_secret` is empty or still the shipped dev default.
- Dev/local runs (`ENVIRONMENT` unset → `"dev"`) are unaffected.

## Verification

`uv run ruff check` + `uv run mypy` clean; new `apps/api/tests/test_config_prod_gate.py` (7 cases: dev allows defaults, prod+real boots, prod+default/empty for each secret refuses, case-insensitive) passes.

## Scope note

This closes the **API-side** half of #57 (the advertised boot gate). The remaining item on #57 — a raw `helm install` (bypassing `agentos cluster up`) still rendering dev defaults — is the chart-side `lookup`-persist work tracked in #195. So `Ref #57`, not `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)