### PR TITLE
worker: warn on multi-agent channel shadowing (#38); fix stale ARCHITECTURE link

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -325,7 +325,7 @@ The UI ships one build that runs in two worlds, selected by `?api=1` (query) or
 `VITE_WIRED=1` (build flag) ([`apps/ui/src/api/config.ts:20`](apps/ui/src/api/config.ts)).
 
 - **Wired (real API):** Agents/Fleet, Runs/Traces, Metrics, Logs, Cost, and create/deploy are backed by `apps/api`.
-- **Fixture (showroom):** an `acme-corp` demo dataset ([`apps/ui/src/fixtures/`](apps/ui/src/fixtures/)) plus a scripted CLI-terminal view ([`apps/ui/src/views/Terminal.tsx`](apps/ui/src/views/Terminal.tsx)) render a self-contained demo. Several wired views (Evals matrix, Versions, Usage, Settings) are still honest `ComingSoon` placeholders ([`apps/ui/src/views/wired/WiredStubs.tsx`](apps/ui/src/views/wired/WiredStubs.tsx)) so wired mode never leaks fixture data. The Memory tab is a permanent coming-soon empty-state ([`apps/ui/src/views/obs/MemoryStub.tsx`](apps/ui/src/views/obs/MemoryStub.tsx)) pending v1.1 memory generation.
+- **Fixture (showroom):** an `acme-corp` demo dataset ([`apps/ui/src/fixtures/`](apps/ui/src/fixtures/)) renders a self-contained demo. Several wired views (Evals matrix, Versions, Usage, Settings) are still honest `ComingSoon` placeholders ([`apps/ui/src/views/wired/WiredStubs.tsx`](apps/ui/src/views/wired/WiredStubs.tsx)) so wired mode never leaks fixture data. The Memory tab is a permanent coming-soon empty-state ([`apps/ui/src/views/obs/MemoryStub.tsx`](apps/ui/src/views/obs/MemoryStub.tsx)) pending v1.1 memory generation.
 
 Retiring the fixture/showroom surface in favor of the real API everywhere is a
 top near-term item; see [issue #4](https://github.com/curie-eng/agentos/issues/4).

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -27,6 +27,7 @@ coupling the worker to a Slack token.
 from __future__ import annotations
 
 import json
+import logging
 import secrets
 import uuid
 from typing import Any
@@ -38,6 +39,8 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from .behaviorpacks import BehaviorPacks
 from .config import WorkerConfig
+
+logger = logging.getLogger(__name__)
 
 # Env vars the worker injects into a bound sandbox claim. AGENTOS_BUNDLE_REF is
 # the MinIO object key sandbox provisioning fetches into AGENTOS_PLUGIN_DIR (a
@@ -68,7 +71,6 @@ JOIN {schema}.deployments d ON d.agent_id = a.id AND d.status = 'active'
 JOIN {schema}.agent_versions v ON v.id = d.version_id AND v.agent_id = a.id
 WHERE a.slack_channel = :channel
 ORDER BY (d.environment = 'prod') DESC, d.deployed_at DESC
-LIMIT 1
 """
 
 
@@ -98,10 +100,27 @@ class BindingResolver:
     async def resolve(self, channel: str) -> ResolvedDeployment | None:
         async with self._engine.connect() as conn:
             result = await conn.execute(self._sql, {"channel": channel})
-            row = result.mappings().first()
-        if row is None:
+            rows = result.mappings().all()
+        if not rows:
             return None
-        data = dict(row)
+        # The ORDER BY still picks one deterministic winner (prod-first, then most
+        # recent), but if more than one *agent* is bound to this channel the others
+        # silently never respond. Surface that instead of dropping them invisibly
+        # (#38). One agent with both a dev and a prod deployment active is two rows
+        # but one agent, so count distinct agents, not rows.
+        distinct_agents = {r["agent_id"] for r in rows}
+        if len(distinct_agents) > 1:
+            chosen = rows[0]["agent_id"]
+            shadowed = sorted(str(a) for a in distinct_agents if a != chosen)
+            logger.warning(
+                "channel %s has %d agents bound; routing to agent %s and shadowing "
+                "%s (only one agent per channel responds; see issue #38)",
+                channel,
+                len(distinct_agents),
+                chosen,
+                ", ".join(shadowed),
+            )
+        data = dict(rows[0])
         # asyncpg returns JSONB as a str for a raw-text SELECT (no column type to
         # trigger SQLAlchemy's json deserializer); decode it to the dict the model
         # expects. A dict (or None) passes through untouched.

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -177,6 +177,53 @@ def test_prod_deployment_wins_over_dev() -> None:
     asyncio.run(go())
 
 
+def test_multiple_agents_on_one_channel_warns_and_picks_one(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            try:
+                async with engine.connect():
+                    pass
+            except SQLAlchemyError as exc:
+                pytest.skip(f"Postgres not reachable: {exc}")
+
+            token = uuid.uuid4().hex[:8]
+            channel = f"C-{token}"
+            # Two distinct agents bound to the same channel, both active.
+            a_prod = await _seed_agent(
+                engine, channel=channel, name=f"agent-a-{token}", max_usd=None, max_tokens=None
+            )
+            a_dev = await _seed_agent(
+                engine, channel=channel, name=f"agent-b-{token}", max_usd=None, max_tokens=None
+            )
+            await _seed_deployment(
+                engine, agent_id=a_prod, environment="prod", bundle_ref="bundles/a.zip"
+            )
+            await _seed_deployment(
+                engine, agent_id=a_dev, environment="dev", bundle_ref="bundles/b.zip"
+            )
+
+            with caplog.at_level("WARNING"):
+                resolved = await _resolver(engine).resolve(channel)
+
+            # Deterministic winner (prod outranks dev) and a warning naming the
+            # shadowed agent, rather than a silent drop (#38).
+            assert resolved is not None
+            assert resolved.agent_id == a_prod
+            assert any(
+                "agents bound" in r.message and str(a_dev) in r.message
+                for r in caplog.records
+            )
+
+            await _cleanup(engine, [a_prod, a_dev])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
 def test_deployment_pointing_at_another_agents_version_does_not_resolve() -> None:
     async def go() -> None:
         engine = create_async_engine(_DB_URL)


### PR DESCRIPTION
Two small, independent sweep items.

## 1. Surface silent multi-agent channel shadowing (`Ref #38`)

`BindingResolver.resolve` picks one deployment per channel (prod-first, then most recent). When **more than one agent** is bound to the same Slack channel, the others silently never respond — they look deployed and healthy but are dead (the core hazard in #38).

The resolver now logs a `warning` naming the chosen agent and the shadowed ones. It counts **distinct agents**, not rows — one agent with both a dev and a prod deployment active is two rows but one agent, so that normal case does not warn. **Selection behavior is unchanged** (same `ORDER BY`, same winner); this only makes the silent case observable.

This deliberately does **not** decide the 1:1-vs-1:N cardinality policy (schema constraint / routing), which is the larger open design in #38 — hence `Ref`, not `Closes`.

## 2. Fix dangling `ARCHITECTURE.md` link

Section 8 linked `apps/ui/src/views/Terminal.tsx`, deleted in `b789b31` ("UI: delete the simulated CLI-terminal view"). Removed the clause.

## Verification

`uv run ruff check` clean; `uv run pytest apps/worker/tests/binding/test_resolver.py` → 7 passed (6 existing + a new case asserting two agents on one channel picks the prod winner **and** logs the shadow warning). Only doc + a worker log line otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)