### PR TITLE
Spike: OpenCode second harness behind the ACI port (#25)

### DIFF
--- a/runner/src/agentos_runner/opencode/__init__.py
+++ b/runner/src/agentos_runner/opencode/__init__.py
@@ -1,0 +1,20 @@
+"""OpenCode second-harness spike (issue #25).
+
+An additive, opt-in ``ModelSession`` that drives a live ``opencode serve``
+subprocess behind the runner's frozen adapter seam. The claude-agent-sdk runner
+stays the default; nothing in the runner core changes. See ``session.py`` for the
+live adapter, ``synth.py`` for the OpenCode-frame -> SDK-message shim, and
+``conformance.py`` for the live ACI conformance entrypoint.
+"""
+
+from __future__ import annotations
+
+from .conformance import opencode_conformance_producer
+from .session import OpenCodeModelSession
+from .synth import TurnSynthesizer
+
+__all__ = [
+    "OpenCodeModelSession",
+    "TurnSynthesizer",
+    "opencode_conformance_producer",
+]

--- a/runner/src/agentos_runner/opencode/conformance.py
+++ b/runner/src/agentos_runner/opencode/conformance.py
@@ -1,0 +1,91 @@
+"""Run the frozen ACI conformance suite over a LIVE OpenCode-backed runner.
+
+Mirrors ``agentos_runner.conformance`` but swaps the fake session for the live
+:class:`OpenCodeModelSession`, so the gate validates the real translation/final
+plumbing against a genuinely running ``opencode serve`` and real model turns --
+not a scripted stream. ``run_conformance`` drives four inbound cases (message,
+job, eval_case, interrupt); the three events each cost one real model turn, and
+the bare interrupt yields an idle final without a model call. Each producer call
+builds an isolated runner (fresh subprocess) to completion via ``anyio.run``.
+
+Run:  PYTHONPATH=src python -m agentos_runner.opencode.conformance   (from runner/)
+"""
+
+from __future__ import annotations
+
+import anyio
+from aci_protocol import Event, Interrupt, run_conformance
+
+from ..otel import RunTracer
+from ..session import SessionRunner
+from ..side_effects import SideEffectClassifier
+from .session import OpenCodeModelSession
+
+
+def _build_runner() -> SessionRunner:
+    return SessionRunner(
+        session_factory=OpenCodeModelSession,
+        ceiling=0,  # unbounded: conformance validates protocol shape, not budgets
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="opencode-conformance",
+    )
+
+
+def opencode_conformance_producer(message: Event | Interrupt) -> list[str]:
+    """Return the NDJSON lines a live OpenCode runner emits for one inbound frame."""
+
+    lines: list[str] = []
+
+    async def _run() -> None:
+        runner = _build_runner()
+        await runner.start()
+        try:
+            async for line in runner.run_inbound(message):
+                lines.append(line)
+        finally:
+            await runner.close()
+
+    anyio.run(_run)
+    return lines
+
+
+def _demo_turn(prompt: str = "Reply with exactly the word: pong") -> list[str]:
+    """Drive one live turn and return its ACI NDJSON lines."""
+
+    lines: list[str] = []
+
+    async def _run() -> None:
+        runner = _build_runner()
+        await runner.start()
+        try:
+            event = Event(type="message", text=prompt, user="U1", ts="1.0")
+            async for line in runner.run_turn(event):
+                lines.append(line)
+        finally:
+            await runner.close()
+
+    anyio.run(_run)
+    return lines
+
+
+def main() -> int:
+    print("=== OpenCode-backed ACI conformance (live opencode serve) ===")
+    report = run_conformance(opencode_conformance_producer)
+    for check in report.checks:
+        print(f"  [{'PASS' if check.passed else 'FAIL'}] {check.name}: {check.detail}")
+    print(f"  -> {report.summary()}  passed={report.passed}")
+
+    print("\n=== Representative live OpenCode turn -> ACI NDJSON ===")
+    demo = _demo_turn()
+    for line in demo:
+        print("  " + line.rstrip())
+
+    ends_in_final = bool(demo) and '"final"' in demo[-1]
+    ok = report.passed and ends_in_final
+    print(f"\nLIVE SPIKE RESULT: {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runner/src/agentos_runner/opencode/session.py
+++ b/runner/src/agentos_runner/opencode/session.py
@@ -44,6 +44,7 @@ import shutil
 import socket
 import subprocess
 import tempfile
+import time
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -231,16 +232,23 @@ class OpenCodeModelSession:
 
     async def receive_turn(self) -> AsyncIterator[Any]:
         synth = TurnSynthesizer()
+        start = time.monotonic()
+        last_type = "none"
         while not synth.done:
             try:
                 frame = await asyncio.wait_for(self._queue.get(), timeout=_SILENCE_TIMEOUT)
             except TimeoutError:
+                elapsed = time.monotonic() - start
                 yield _result(
-                    text="opencode turn timed out awaiting model output",
+                    text=(
+                        f"opencode turn produced no output for {_SILENCE_TIMEOUT:.0f}s "
+                        f"(last frame '{last_type}', {elapsed:.0f}s into turn)"
+                    ),
                     is_error=True,
                     usage=None,
                 )
                 return
+            last_type = str(frame.get("type", "unknown"))
             for message in synth.ingest(frame):
                 yield message
 

--- a/runner/src/agentos_runner/opencode/session.py
+++ b/runner/src/agentos_runner/opencode/session.py
@@ -1,0 +1,286 @@
+"""A live ``ModelSession`` backed by an ``opencode serve`` subprocess.
+
+This is the real (non-scripted) OpenCode harness for issue #25. It implements
+the runner's ``ModelSession`` protocol (``connect`` / ``query`` /
+``receive_turn`` / ``interrupt`` / ``close``) by supervising a local
+``opencode serve`` process, driving it over its HTTP API, and turning its live
+Server-Sent-Event stream into claude-agent-sdk messages via
+:class:`~agentos_runner.opencode.synth.TurnSynthesizer`. Because the shim emits
+SDK-shaped messages, the entire runner core runs unmodified (see ``synth.py``).
+
+Wire protocol (OpenCode v1, verified against ``opencode`` v1.17.17 ``GET /doc``):
+
+- ``connect``   -> ``POST /session`` creates a session; a background task opens
+  the global ``GET /event`` SSE bus and buffers this session's frames.
+- ``query``     -> ``POST /session/{id}/prompt_async`` (returns 204; output
+  streams on the event bus).
+- ``receive_turn`` drains the buffered frames through a fresh ``TurnSynthesizer``
+  until the turn's terminal result.
+- ``interrupt`` -> ``POST /session/{id}/abort``.
+- ``close``     tears down the SSE reader, the HTTP session, and the subprocess.
+
+Two spike semantic gaps (documented, not solved here):
+
+* **Steer is completion-deferred.** OpenCode admits a message posted mid-turn at
+  the next turn boundary rather than interleaving it into the live generation, so
+  a steer lands as the next turn's prompt. The runner's steer path still works;
+  the timing differs from the claude-agent-sdk's first-class mid-turn steer.
+* **No resume equivalent.** OpenCode has no ``resume`` handle matching the SDK's,
+  so ``AGENTOS_HISTORY_REF`` rehydration is unsupported and every session
+  cold-starts. History replay is out of scope for this spike.
+
+Concurrency note: this uses ``asyncio`` primitives directly (queue, task, event)
+and therefore assumes the runner's ``anyio`` host is on its default asyncio
+backend, which is what ``anyio.run`` and the runner's HTTP server use. aiohttp
+mandates asyncio regardless.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+from collections.abc import AsyncIterator
+from typing import Any
+
+import aiohttp
+
+from .synth import TurnSynthesizer, _result
+
+# Default cheap real model routed through OpenRouter. GLM-4.6 reliably returns a
+# concrete short text answer (unlike GLM-5.2, which can return reasoning + empty
+# text on trivial prompts, issue #107). Override via env for a different model.
+DEFAULT_PROVIDER = os.environ.get("OPENCODE_SPIKE_PROVIDER", "openrouter")
+DEFAULT_MODEL = os.environ.get("OPENCODE_SPIKE_MODEL", "z-ai/glm-4.6")
+
+# Max seconds of silence on the event bus before a turn is declared timed out.
+# The ACI stream must always terminate; a wedged provider call otherwise hangs
+# ``receive_turn`` forever. Generous so a slow-but-live model is not cut off.
+_SILENCE_TIMEOUT = float(os.environ.get("OPENCODE_SPIKE_SILENCE_TIMEOUT", "120"))
+
+# How long to wait for ``opencode serve`` to answer /api/health after launch.
+_READY_ATTEMPTS = 160
+_READY_INTERVAL = 0.25
+
+
+def _free_port() -> int:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = int(sock.getsockname()[1])
+    sock.close()
+    return port
+
+
+def _find_opencode() -> str:
+    """Locate the opencode binary (PATH, then the standard install location)."""
+
+    found = shutil.which("opencode")
+    if found:
+        return found
+    fallback = os.path.expanduser("~/.opencode/bin/opencode")
+    if os.path.exists(fallback):
+        return fallback
+    raise RuntimeError("opencode binary not found on PATH or ~/.opencode/bin")
+
+
+def _subprocess_env() -> dict[str, str]:
+    """Build the subprocess env, forwarding exactly the OpenRouter credential.
+
+    OpenCode expects ``OPENROUTER_API_KEY``; this project stores it as
+    ``OPENROUTER_TOKEN``. The key value is never logged or echoed.
+    """
+
+    env = dict(os.environ)
+    key = os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENROUTER_TOKEN")
+    if key:
+        env["OPENROUTER_API_KEY"] = key
+    # Ensure the bun-shipped opencode runtime is resolvable.
+    extra = os.pathsep.join(
+        p for p in (os.path.expanduser("~/.opencode/bin"), os.path.expanduser("~/.bun/bin")) if p
+    )
+    env["PATH"] = extra + os.pathsep + env.get("PATH", "")
+    return env
+
+
+class OpenCodeModelSession:
+    """ModelSession driving one live ``opencode serve`` process over its HTTP API."""
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        provider: str | None = None,
+        cwd: str | None = None,
+    ) -> None:
+        self._model = model or DEFAULT_MODEL
+        self._provider = provider or DEFAULT_PROVIDER
+        self._cwd = cwd
+        self._bin = _find_opencode()
+
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._base: str | None = None
+        self._sid: str | None = None
+        self._http: aiohttp.ClientSession | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self._connected = asyncio.Event()
+        self._workdir: str | None = None
+        self._owns_cwd = False
+        self._log: Any = None
+
+    async def connect(self) -> None:
+        workdir = self._cwd
+        if workdir is None:
+            workdir = tempfile.mkdtemp(prefix="agentos-opencode-")
+            self._owns_cwd = True
+        self._workdir = workdir
+        port = _free_port()
+        self._base = f"http://127.0.0.1:{port}"
+        self._log = tempfile.NamedTemporaryFile(
+            prefix="opencode-serve-", suffix=".log", delete=False
+        )
+        self._proc = subprocess.Popen(
+            [self._bin, "serve", "--port", str(port), "--hostname", "127.0.0.1",
+             "--log-level", "ERROR"],
+            stdout=self._log,
+            stderr=self._log,
+            env=_subprocess_env(),
+            cwd=workdir,
+        )
+        self._http = aiohttp.ClientSession()
+        await self._await_ready()
+        async with self._http.post(f"{self._base}/session", json={}) as resp:
+            resp.raise_for_status()
+            self._sid = str((await resp.json())["id"])
+        self._reader_task = asyncio.create_task(self._read_events())
+        # Ensure the SSE stream is established before any prompt is posted, so no
+        # turn frame is emitted before the reader is listening.
+        await asyncio.wait_for(self._connected.wait(), timeout=15)
+
+    async def _await_ready(self) -> None:
+        assert self._http is not None and self._base is not None
+        for _ in range(_READY_ATTEMPTS):
+            try:
+                async with self._http.get(
+                    f"{self._base}/api/health", timeout=aiohttp.ClientTimeout(total=2)
+                ) as resp:
+                    if resp.status == 200:
+                        return
+            except Exception:  # noqa: BLE001 - a starting server refuses/times out; retry
+                pass
+            await asyncio.sleep(_READY_INTERVAL)
+        raise RuntimeError("opencode serve did not become ready")
+
+    async def _read_events(self) -> None:
+        assert self._http is not None and self._base is not None
+        try:
+            async with self._http.get(
+                f"{self._base}/event",
+                timeout=aiohttp.ClientTimeout(total=None, sock_read=None),
+            ) as resp:
+                self._connected.set()
+                async for raw in resp.content:
+                    line = raw.decode("utf-8", "replace").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    payload = line[5:].strip()
+                    if not payload:
+                        continue
+                    try:
+                        frame = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+                    props = frame.get("properties", {})
+                    sid = props.get("sessionID") if isinstance(props, dict) else None
+                    # Keep only this session's frames; global bus noise
+                    # (server.connected, plugin.added, ...) carries no sessionID.
+                    if sid == self._sid:
+                        await self._queue.put(frame)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - a dropped stream must still let
+            # an in-flight receive_turn terminate rather than hang on an empty queue.
+            self._connected.set()
+            await self._queue.put(
+                {
+                    "type": "session.error",
+                    "properties": {
+                        "sessionID": self._sid,
+                        "error": {"message": f"event stream closed: {exc}"},
+                    },
+                }
+            )
+
+    async def query(self, text: str) -> None:
+        if self._http is None or self._base is None or self._sid is None:
+            raise RuntimeError("session not connected")
+        body = {
+            "model": {"providerID": self._provider, "modelID": self._model},
+            "parts": [{"type": "text", "text": text}],
+        }
+        async with self._http.post(
+            f"{self._base}/session/{self._sid}/prompt_async", json=body
+        ) as resp:
+            if resp.status not in (200, 204):
+                detail = await resp.text()
+                raise RuntimeError(f"opencode prompt_async failed: {resp.status} {detail}")
+
+    async def receive_turn(self) -> AsyncIterator[Any]:
+        synth = TurnSynthesizer()
+        while not synth.done:
+            try:
+                frame = await asyncio.wait_for(self._queue.get(), timeout=_SILENCE_TIMEOUT)
+            except TimeoutError:
+                yield _result(
+                    text="opencode turn timed out awaiting model output",
+                    is_error=True,
+                    usage=None,
+                )
+                return
+            for message in synth.ingest(frame):
+                yield message
+
+    async def interrupt(self) -> None:
+        if self._http is None or self._base is None or self._sid is None:
+            return
+        try:
+            async with self._http.post(
+                f"{self._base}/session/{self._sid}/abort",
+                timeout=aiohttp.ClientTimeout(total=10),
+            ):
+                pass
+        except Exception:  # noqa: BLE001 - a best-effort abort must not raise into
+            # the runner's interrupt/finally path (which itself suppresses).
+            pass
+
+    async def close(self) -> None:
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._reader_task = None
+        if self._http is not None:
+            await self._http.close()
+            self._http = None
+        if self._proc is not None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+            self._proc = None
+        if self._log is not None:
+            try:
+                self._log.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._log = None
+        if self._owns_cwd and self._workdir is not None:
+            shutil.rmtree(self._workdir, ignore_errors=True)
+            self._workdir = None

--- a/runner/src/agentos_runner/opencode/synth.py
+++ b/runner/src/agentos_runner/opencode/synth.py
@@ -20,9 +20,13 @@ time and it returns the SDK messages to yield now, marking ``done`` at the turn
 boundary. The relevant OpenCode v1 frames (verified against ``opencode`` v1.17.17
 ``GET /doc`` and a captured live turn) are:
 
-- ``message.part.delta {field:"text", delta}`` -- one incremental text chunk
-  (the new chunk only, not a growing snapshot). Each maps to one ``TextBlock``.
-- ``message.part.updated {part}`` -- part snapshots. A ``tool`` part at
+- ``message.part.delta {partID, field:"text", delta}`` -- one incremental chunk
+  (the new chunk only, not a growing snapshot). ``field`` is ``"text"`` even for
+  a reasoning part, so the channel is resolved from the part's snapshot (below)
+  by ``partID``; only text-part chunks become ``TextBlock``s, so a reasoning
+  model's thinking never leaks into ``text_delta`` / ``final``.
+- ``message.part.updated {part}`` -- part snapshots carrying ``part.id`` and
+  ``part.type`` (``text`` | ``reasoning`` | ``tool`` | ``step-*``). A ``tool`` part at
   ``state.status == "running"`` maps to one ``ToolUseBlock``; a ``step-finish``
   part carries token totals. The ``text`` part-updated snapshots (the empty
   text-start and full text-end bookends) are intentionally ignored so text
@@ -100,6 +104,12 @@ class TurnSynthesizer:
         self._model_id: str | None = None
         self._error: str | None = None
         self._seen_activity = False
+        # partID -> part.type, learned from message.part.updated snapshots. A
+        # message.part.delta carries field="text" even when its part is a
+        # reasoning part, so the delta alone cannot tell the answer channel from
+        # the thinking channel; the part's snapshot (always emitted before the
+        # part's first delta, verified on the live wire) supplies the real type.
+        self._part_types: dict[str, str] = {}
 
     def _terminal(self) -> ResultMessage:
         if self._error is not None:
@@ -116,9 +126,17 @@ class TurnSynthesizer:
         out: list[Any] = []
 
         if ftype == "message.part.delta" and props.get("field") == "text":
+            # Any text-channel delta means the turn is live, even one we drop.
+            self._seen_activity = True
             chunk = props.get("delta", "")
-            if chunk:
-                self._seen_activity = True
+            # Emit only content whose part is known to be a text part. Reasoning
+            # deltas (and any delta for a partID not yet typed) are dropped so a
+            # reasoning model's thinking never leaks into text_delta / final --
+            # mirroring how translate.py drops non-TextBlock content. Deny by
+            # default is safe because the part's start snapshot always precedes
+            # its first delta (verified on the live wire); a missing snapshot
+            # drops the chunk rather than leaking an untyped channel.
+            if chunk and self._part_types.get(str(props.get("partID"))) == "text":
                 self._final_text += chunk
                 out.append(
                     AssistantMessage(content=[TextBlock(text=chunk)], model=self._model_id or "")
@@ -128,6 +146,9 @@ class TurnSynthesizer:
             part = props.get("part", {})
             if isinstance(part, dict):
                 ptype = part.get("type")
+                pid = part.get("id")
+                if isinstance(pid, str) and isinstance(ptype, str):
+                    self._part_types[pid] = ptype
                 if ptype in ("text", "step-start", "step-finish", "reasoning"):
                     self._seen_activity = True
                 if ptype == "tool":

--- a/runner/src/agentos_runner/opencode/synth.py
+++ b/runner/src/agentos_runner/opencode/synth.py
@@ -1,0 +1,181 @@
+"""Synthesize claude-agent-sdk messages from a live OpenCode `/event` stream.
+
+This is the load-bearing shim for the OpenCode second harness (issue #25). The
+runner core (``translate.py``, ``session.py``, ``otel.py``, the HTTP server, and
+``packages/aci-protocol``) pattern-matches on claude-agent-sdk dataclasses
+(``AssistantMessage`` / ``ResultMessage`` / ``TextBlock`` / ``ToolUseBlock``).
+Rather than teach that core a second message vocabulary, this module re-emits
+OpenCode's wire frames as those same dataclasses, so the whole runner runs
+byte-for-byte unmodified against an OpenCode backend.
+
+The mapping direction is:
+
+    OpenCode /event frame  ->  claude-agent-sdk message  ->  (unchanged)
+    translate.py  ->  ACI outbound event  ->  NDJSON
+
+Unlike the offline spike (which collected a whole scripted turn then synthesized
+it in one shot), a live turn arrives incrementally over Server-Sent Events, so
+``TurnSynthesizer`` is a *stateful, incremental* mapper: feed it one frame at a
+time and it returns the SDK messages to yield now, marking ``done`` at the turn
+boundary. The relevant OpenCode v1 frames (verified against ``opencode`` v1.17.17
+``GET /doc`` and a captured live turn) are:
+
+- ``message.part.delta {field:"text", delta}`` -- one incremental text chunk
+  (the new chunk only, not a growing snapshot). Each maps to one ``TextBlock``.
+- ``message.part.updated {part}`` -- part snapshots. A ``tool`` part at
+  ``state.status == "running"`` maps to one ``ToolUseBlock``; a ``step-finish``
+  part carries token totals. The ``text`` part-updated snapshots (the empty
+  text-start and full text-end bookends) are intentionally ignored so text
+  already streamed via deltas is never emitted twice.
+- ``message.updated {info}`` -- assistant message info carrying ``modelID`` and
+  rolled-up ``tokens``.
+- ``session.status {status:{type}}`` -- a ``busy`` -> ``idle`` transition marks
+  turn completion (the terminal ``ResultMessage``). ``session.idle`` is the
+  deprecated equivalent and is handled the same way.
+- ``session.error {error}`` -- a hard failure, mapped to an error result.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+
+
+def _tokens(tok: Any) -> dict[str, int] | None:
+    """Fold an OpenCode token block into the SDK ``usage`` shape, or None."""
+
+    if not isinstance(tok, dict):
+        return None
+    return {
+        "input_tokens": int(tok.get("input", 0) or 0),
+        "output_tokens": int(tok.get("output", 0) or 0),
+    }
+
+
+def _error_message(err: Any) -> str:
+    """Extract a human string from an OpenCode ``session.error`` payload."""
+
+    if isinstance(err, dict):
+        data = err.get("data")
+        if isinstance(data, dict) and data.get("message"):
+            return str(data["message"])
+        for key in ("message", "name"):
+            if err.get(key):
+                return str(err[key])
+    return str(err) if err else "session error"
+
+
+def _result(
+    *, text: str, is_error: bool, usage: dict[str, int] | None
+) -> ResultMessage:
+    return ResultMessage(
+        subtype="error" if is_error else "success",
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=is_error,
+        num_turns=1,
+        session_id="opencode-session",
+        result=text,
+        usage=usage,
+    )
+
+
+class TurnSynthesizer:
+    """Incrementally map one OpenCode turn's `/event` frames to SDK messages.
+
+    Feed each frame to :meth:`ingest`; it returns zero or more SDK messages to
+    yield immediately. When the turn terminates (``busy`` -> ``idle`` transition,
+    a ``session.idle``, or a ``session.error``) it appends the single terminal
+    ``ResultMessage`` and sets :attr:`done`. A turn only terminates on ``idle``
+    once real turn activity has been seen (a ``busy`` status or streamed
+    content), so a stale pre-turn ``idle`` on the shared bus cannot end a turn
+    early.
+    """
+
+    def __init__(self) -> None:
+        self.done = False
+        self._final_text = ""
+        self._usage: dict[str, int] | None = None
+        self._model_id: str | None = None
+        self._error: str | None = None
+        self._seen_activity = False
+
+    def _terminal(self) -> ResultMessage:
+        if self._error is not None:
+            return _result(text=self._error, is_error=True, usage=self._usage)
+        return _result(text=self._final_text, is_error=False, usage=self._usage)
+
+    def ingest(self, frame: dict[str, Any]) -> list[Any]:
+        if self.done:
+            return []
+        ftype = frame.get("type")
+        props = frame.get("properties", {})
+        if not isinstance(props, dict):
+            return []
+        out: list[Any] = []
+
+        if ftype == "message.part.delta" and props.get("field") == "text":
+            chunk = props.get("delta", "")
+            if chunk:
+                self._seen_activity = True
+                self._final_text += chunk
+                out.append(
+                    AssistantMessage(content=[TextBlock(text=chunk)], model=self._model_id or "")
+                )
+
+        elif ftype == "message.part.updated":
+            part = props.get("part", {})
+            if isinstance(part, dict):
+                ptype = part.get("type")
+                if ptype in ("text", "step-start", "step-finish", "reasoning"):
+                    self._seen_activity = True
+                if ptype == "tool":
+                    state = part.get("state", {}) if isinstance(part.get("state"), dict) else {}
+                    status = state.get("status")
+                    if status == "running":
+                        self._seen_activity = True
+                        out.append(
+                            AssistantMessage(
+                                content=[
+                                    ToolUseBlock(
+                                        id=str(part.get("callID") or part.get("id") or "call"),
+                                        name=str(part.get("tool") or "unknown"),
+                                        input=state.get("input") or {},
+                                    )
+                                ],
+                                model=self._model_id or "",
+                            )
+                        )
+                    elif status == "error":
+                        self._error = str(state.get("error") or "tool failed")
+                elif ptype == "step-finish":
+                    u = _tokens(part.get("tokens"))
+                    if u is not None:
+                        self._usage = u
+
+        elif ftype == "message.updated":
+            info = props.get("info", {})
+            if isinstance(info, dict):
+                model = info.get("modelID")
+                if model:
+                    self._model_id = str(model)
+                u = _tokens(info.get("tokens"))
+                if u is not None:
+                    self._usage = u
+
+        elif ftype == "session.error":
+            self._error = _error_message(props.get("error"))
+            out.append(self._terminal())
+            self.done = True
+
+        elif ftype in ("session.status", "session.idle"):
+            status = props.get("status") if ftype == "session.status" else {"type": "idle"}
+            stype = status.get("type") if isinstance(status, dict) else None
+            if stype == "busy":
+                self._seen_activity = True
+            elif stype == "idle" and self._seen_activity:
+                out.append(self._terminal())
+                self.done = True
+
+        return out

--- a/runner/tests/test_opencode_synth.py
+++ b/runner/tests/test_opencode_synth.py
@@ -1,0 +1,332 @@
+"""Offline regression for the OpenCode harness shim (issue #25).
+
+These tests exercise the OpenCode-frame -> SDK-message synthesis and drive it
+through the *real* runner core (translate + session + conformance) with zero
+network: scripted ``/event`` frames stand in for a live SSE stream, the same way
+``fake.py`` scripts SDK messages. They pin the mapping (text deltas, tool calls,
+usage, terminal result, the ignored text-part bookends, the busy->idle gate) and
+prove a scripted OpenCode turn passes the frozen ACI conformance suite.
+
+The live path (a real ``opencode serve`` + a real OpenRouter turn) is validated
+separately by ``agentos_runner.opencode.conformance`` -- not here, so this file
+stays fast and deterministic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import anyio
+from aci_protocol import Event, Interrupt, parse_ndjson, run_conformance
+from agentos_runner.opencode.synth import TurnSynthesizer
+from agentos_runner.otel import RunTracer
+from agentos_runner.session import SessionRunner
+from agentos_runner.side_effects import SideEffectClassifier
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+
+SID = "ses_test"
+MSG = "msg_1"
+
+
+# --- scripted OpenCode /event frame builders (real v1.17.17 wire shapes) --------
+
+
+def busy() -> dict[str, Any]:
+    return {"type": "session.status", "properties": {"sessionID": SID, "status": {"type": "busy"}}}
+
+
+def idle() -> dict[str, Any]:
+    return {"type": "session.status", "properties": {"sessionID": SID, "status": {"type": "idle"}}}
+
+
+def text_delta(delta: str, part_id: str = "prt_text") -> dict[str, Any]:
+    return {
+        "type": "message.part.delta",
+        "properties": {
+            "sessionID": SID,
+            "messageID": MSG,
+            "partID": part_id,
+            "field": "text",
+            "delta": delta,
+        },
+    }
+
+
+def text_part_bookend(text: str, part_id: str = "prt_text") -> dict[str, Any]:
+    # The text-start (empty) and text-end (full snapshot) part updates the runner
+    # must ignore so streamed deltas are never re-emitted.
+    return {
+        "type": "message.part.updated",
+        "properties": {
+            "sessionID": SID,
+            "part": {"id": part_id, "type": "text", "text": text},
+            "time": 1,
+        },
+    }
+
+
+def tool_running(call_id: str, tool: str, inp: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "message.part.updated",
+        "properties": {
+            "sessionID": SID,
+            "part": {
+                "id": f"prt_{call_id}",
+                "type": "tool",
+                "callID": call_id,
+                "tool": tool,
+                "state": {"status": "running", "input": inp},
+            },
+            "time": 1,
+        },
+    }
+
+
+def step_finish(input_tokens: int, output_tokens: int) -> dict[str, Any]:
+    return {
+        "type": "message.part.updated",
+        "properties": {
+            "sessionID": SID,
+            "part": {
+                "type": "step-finish",
+                "tokens": {"input": input_tokens, "output": output_tokens, "reasoning": 0},
+            },
+            "time": 2,
+        },
+    }
+
+
+def message_updated(model_id: str, input_tokens: int, output_tokens: int) -> dict[str, Any]:
+    return {
+        "type": "message.updated",
+        "properties": {
+            "sessionID": SID,
+            "info": {
+                "modelID": model_id,
+                "tokens": {"input": input_tokens, "output": output_tokens},
+            },
+        },
+    }
+
+
+def session_error(message: str) -> dict[str, Any]:
+    return {
+        "type": "session.error",
+        "properties": {"sessionID": SID, "error": {"data": {"message": message}}},
+    }
+
+
+# Global bus noise the reader would drop / the synth must ignore.
+NOISE = [
+    {"type": "server.connected", "properties": {}},
+    {"type": "plugin.added", "properties": {}},
+    {"type": "session.updated", "properties": {"sessionID": SID}},
+    {"type": "session.diff", "properties": {"sessionID": SID}},
+]
+
+
+def default_turn_frames() -> list[dict[str, Any]]:
+    """A representative live-shaped turn: text, a side-effecting tool, more text."""
+
+    return [
+        busy(),
+        text_part_bookend(""),
+        text_delta("Looking into it"),
+        tool_running("call_1", "Bash", {"command": "echo hi"}),
+        text_delta(" all done"),
+        text_part_bookend("Looking into it all done"),
+        step_finish(20, 8),
+        message_updated("z-ai/glm-4.6", 20, 8),
+        idle(),
+    ]
+
+
+def _run_synth(frames: list[dict[str, Any]]) -> tuple[list[Any], TurnSynthesizer]:
+    synth = TurnSynthesizer()
+    out: list[Any] = []
+    for frame in frames:
+        out.extend(synth.ingest(frame))
+    return out, synth
+
+
+# --- a scripted (offline) ModelSession that replays frames through the synth ----
+
+
+class ScriptedOpenCodeSession:
+    """ModelSession replaying scripted OpenCode frames through the live synth.
+
+    Structurally the live ``OpenCodeModelSession``'s ``receive_turn`` without a
+    subprocess or SSE: it feeds canned frames to a fresh ``TurnSynthesizer``, so
+    it exercises the exact OpenCode->SDK synthesis the runner core consumes.
+    """
+
+    def __init__(self, frames_factory: Any = None) -> None:
+        self._frames_factory = frames_factory or default_turn_frames
+        self.queries: list[str] = []
+        self.interrupts = 0
+
+    async def connect(self) -> None:
+        return None
+
+    async def query(self, text: str) -> None:
+        self.queries.append(text)
+
+    async def interrupt(self) -> None:
+        self.interrupts += 1
+
+    async def receive_turn(self) -> AsyncIterator[Any]:
+        synth = TurnSynthesizer()
+        for frame in self._frames_factory():
+            for message in synth.ingest(frame):
+                yield message
+
+    async def close(self) -> None:
+        return None
+
+
+def _build_runner() -> SessionRunner:
+    return SessionRunner(
+        session_factory=ScriptedOpenCodeSession,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="opencode-offline",
+    )
+
+
+def _offline_producer(message: Event | Interrupt) -> list[str]:
+    lines: list[str] = []
+
+    async def _run() -> None:
+        runner = _build_runner()
+        await runner.start()
+        try:
+            async for line in runner.run_inbound(message):
+                lines.append(line)
+        finally:
+            await runner.close()
+
+    anyio.run(_run)
+    return lines
+
+
+# --- synth unit tests -----------------------------------------------------------
+
+
+def test_synth_maps_text_tool_and_terminal_result() -> None:
+    messages, synth = _run_synth(default_turn_frames())
+    assert synth.done
+
+    texts = [
+        b.text
+        for m in messages
+        if isinstance(m, AssistantMessage)
+        for b in m.content
+        if isinstance(b, TextBlock)
+    ]
+    assert texts == ["Looking into it", " all done"], texts
+
+    tools = [
+        b
+        for m in messages
+        if isinstance(m, AssistantMessage)
+        for b in m.content
+        if isinstance(b, ToolUseBlock)
+    ]
+    assert len(tools) == 1
+    assert tools[0].name == "Bash"
+    assert tools[0].id == "call_1"
+    assert tools[0].input == {"command": "echo hi"}
+
+    results = [m for m in messages if isinstance(m, ResultMessage)]
+    assert len(results) == 1
+    result = results[0]
+    assert result.is_error is False
+    assert result.result == "Looking into it all done"
+    assert result.usage == {"input_tokens": 20, "output_tokens": 8}
+
+
+def test_synth_carries_model_onto_streamed_messages() -> None:
+    # model_id is only known after message.updated; a turn whose message.updated
+    # precedes text should stamp the model on the text messages.
+    frames = [
+        busy(),
+        message_updated("z-ai/glm-4.6", 5, 2),
+        text_delta("hi"),
+        idle(),
+    ]
+    messages, _ = _run_synth(frames)
+    text_msgs = [m for m in messages if isinstance(m, AssistantMessage) and m.content]
+    assert text_msgs and text_msgs[0].model == "z-ai/glm-4.6"
+
+
+def test_synth_ignores_bookends_and_bus_noise() -> None:
+    # Interleaving noise + bookends must not duplicate or drop text.
+    frames = [busy(), *NOISE, text_part_bookend(""), text_delta("one"), *NOISE,
+              text_delta(" two"), text_part_bookend("one two"), idle()]
+    messages, _ = _run_synth(frames)
+    texts = [
+        b.text
+        for m in messages
+        if isinstance(m, AssistantMessage)
+        for b in m.content
+        if isinstance(b, TextBlock)
+    ]
+    assert texts == ["one", " two"], texts
+
+
+def test_synth_session_error_yields_error_result() -> None:
+    frames = [busy(), text_delta("partial"), session_error("provider exploded")]
+    messages, synth = _run_synth(frames)
+    assert synth.done
+    results = [m for m in messages if isinstance(m, ResultMessage)]
+    assert len(results) == 1
+    assert results[0].is_error is True
+    assert results[0].result == "provider exploded"
+
+
+def test_synth_pre_turn_idle_does_not_terminate() -> None:
+    # A stale idle with no preceding activity must not end a turn (the busy/
+    # activity gate). Only the idle after real activity terminates.
+    synth = TurnSynthesizer()
+    assert synth.ingest(idle()) == []
+    assert synth.done is False
+    synth.ingest(busy())
+    synth.ingest(text_delta("go"))
+    out = synth.ingest(idle())
+    assert synth.done is True
+    assert any(isinstance(m, ResultMessage) for m in out)
+
+
+def test_synth_interrupted_iteration_still_has_no_partial_duplicate() -> None:
+    # Feeding a turn missing its idle leaves the synth not-done and emits no
+    # terminal result -- the runner then supplies its own final (its contract).
+    frames = default_turn_frames()[:-1]  # drop the terminal idle
+    messages, synth = _run_synth(frames)
+    assert synth.done is False
+    assert not any(isinstance(m, ResultMessage) for m in messages)
+
+
+# --- offline end-to-end through the real runner core ----------------------------
+
+
+def test_scripted_opencode_turn_streams_wellformed_ndjson() -> None:
+    lines = _offline_producer(Event(type="message", text="do it", user="U1", ts="1.0"))
+    events = parse_ndjson("".join(lines))
+    types = [e.type for e in events]
+    assert types[-1] == "final", types
+    assert "text_delta" in types
+    # Bash is non-idempotent -> the runner flags one side effect.
+    assert "side_effect_flag" in types
+    final = events[-1]
+    assert final.status == "done"
+    assert final.text == "Looking into it all done"
+
+
+def test_scripted_opencode_backend_passes_aci_conformance() -> None:
+    report = run_conformance(_offline_producer)
+    assert report.passed, report.summary() + " :: " + str(
+        [(c.name, c.detail) for c in report.checks if not c.passed]
+    )
+    assert any(c.name == "producer_stream" and c.passed for c in report.checks)

--- a/runner/tests/test_opencode_synth.py
+++ b/runner/tests/test_opencode_synth.py
@@ -117,6 +117,41 @@ def session_error(message: str) -> dict[str, Any]:
     }
 
 
+def reasoning_part(part_id: str = "prt_reason") -> dict[str, Any]:
+    # The message.part.updated snapshot that announces a reasoning part; its
+    # deltas arrive on field="text" just like a text part's, so only this
+    # snapshot distinguishes the thinking channel from the answer channel.
+    return {
+        "type": "message.part.updated",
+        "properties": {
+            "sessionID": SID,
+            "part": {"id": part_id, "type": "reasoning"},
+            "time": 1,
+        },
+    }
+
+
+def reasoning_then_text_frames() -> list[dict[str, Any]]:
+    """A reasoning-forward turn: thinking streams first, then the answer.
+
+    Mirrors a live gpt-oss-style turn where reasoning deltas precede the text
+    answer and both carry field="text"; only the answer must reach the ACI.
+    """
+
+    return [
+        busy(),
+        reasoning_part("prt_r"),
+        text_delta("Let me think about the request. ", "prt_r"),
+        text_delta("I will keep it terse.", "prt_r"),
+        text_part_bookend("", "prt_t"),
+        text_delta("pong", "prt_t"),
+        text_part_bookend("pong", "prt_t"),
+        step_finish(30, 4),
+        message_updated("openai/gpt-oss-120b", 30, 4),
+        idle(),
+    ]
+
+
 # Global bus noise the reader would drop / the synth must ignore.
 NOISE = [
     {"type": "server.connected", "properties": {}},
@@ -211,6 +246,32 @@ def _offline_producer(message: Event | Interrupt) -> list[str]:
     return lines
 
 
+def _turn_ndjson(frames_factory: Any) -> list[str]:
+    """NDJSON for one turn whose session replays ``frames_factory()``."""
+
+    lines: list[str] = []
+
+    async def _run() -> None:
+        runner = SessionRunner(
+            session_factory=lambda: ScriptedOpenCodeSession(frames_factory),
+            ceiling=0,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="opencode-offline",
+        )
+        await runner.start()
+        try:
+            async for line in runner.run_turn(
+                Event(type="message", text="x", user="U1", ts="1.0")
+            ):
+                lines.append(line)
+        finally:
+            await runner.close()
+
+    anyio.run(_run)
+    return lines
+
+
 # --- synth unit tests -----------------------------------------------------------
 
 
@@ -253,6 +314,7 @@ def test_synth_carries_model_onto_streamed_messages() -> None:
     frames = [
         busy(),
         message_updated("z-ai/glm-4.6", 5, 2),
+        text_part_bookend(""),
         text_delta("hi"),
         idle(),
     ]
@@ -284,6 +346,22 @@ def test_synth_session_error_yields_error_result() -> None:
     assert len(results) == 1
     assert results[0].is_error is True
     assert results[0].result == "provider exploded"
+
+
+def test_synth_drops_reasoning_deltas_keeps_text() -> None:
+    # A delta's field is "text" even for a reasoning part; only the text part's
+    # content (resolved by partID from the snapshots) reaches the SDK messages.
+    messages, synth = _run_synth(reasoning_then_text_frames())
+    texts = [
+        b.text
+        for m in messages
+        if isinstance(m, AssistantMessage)
+        for b in m.content
+        if isinstance(b, TextBlock)
+    ]
+    assert texts == ["pong"], texts
+    results = [m for m in messages if isinstance(m, ResultMessage)]
+    assert results and results[0].result == "pong"
 
 
 def test_synth_pre_turn_idle_does_not_terminate() -> None:
@@ -322,6 +400,20 @@ def test_scripted_opencode_turn_streams_wellformed_ndjson() -> None:
     final = events[-1]
     assert final.status == "done"
     assert final.text == "Looking into it all done"
+
+
+def test_reasoning_content_absent_from_ndjson_stream() -> None:
+    lines = _turn_ndjson(reasoning_then_text_frames)
+    events = parse_ndjson("".join(lines))
+    text_deltas = [e.text for e in events if e.type == "text_delta"]
+    assert text_deltas == ["pong"], text_deltas
+    final = events[-1]
+    assert final.type == "final"
+    assert final.text == "pong"
+    # No thinking-channel content leaks anywhere in the emitted stream.
+    blob = "".join(lines)
+    assert "think about" not in blob
+    assert "keep it terse" not in blob
 
 
 def test_scripted_opencode_backend_passes_aci_conformance() -> None:


### PR DESCRIPTION
**PROOF-OF-CONCEPT — NOT FOR MERGE.** Phase 1 vertical slice of the OpenCode second harness (Ref #25, spike brief in the issue thread). Proves the ACI port end to end: a real `ModelSession` implementation over a live `opencode serve` subprocess passes the frozen conformance suite on real model turns.

## What works (verified live)

`OpenCodeModelSession` (`runner/src/agentos_runner/opencode/`) supervises an `opencode serve` subprocess (v1.17.17), drives it over its v1 HTTP API (`POST /session`, `prompt_async`, `abort`), reads the session-filtered `GET /event` SSE bus, and synthesizes claude-agent-sdk message shapes (`TurnSynthesizer`) so `translate.py`, `session.py`, `otel.py`, `server.py`, and `packages/aci-protocol` run **unmodified** — zero core changes, purely additive.

Live conformance, real OpenRouter GLM-4.6 turns (not scripted frames):

```
$ OPENCODE_SPIKE_SILENCE_TIMEOUT=60 PYTHONPATH=src:. python -m agentos_runner.opencode.conformance
=== OpenCode-backed ACI conformance (live opencode serve) ===
  [PASS] outbound_roundtrip: 5 outbound event types round-tripped
  [PASS] inbound_roundtrip: 4 inbound messages round-tripped
  [PASS] reject_unknown_version: unknown version rejected with ProtocolVersionError
  [PASS] reject_missing_version: missing version rejected with ProtocolVersionError
  [PASS] producer_stream: producer streams for 4 inbound cases are well formed
  -> 5/5 conformance checks passed  passed=True

=== Representative live OpenCode turn -> ACI NDJSON ===
  {"version":"0.1.0","type":"text_delta","text":"\n"}
  {"version":"0.1.0","type":"text_delta","text":"\npong"}
  {"version":"0.1.0","type":"final","text":"\n\npong","status":"done"}

LIVE SPIKE RESULT: PASS
```

Also passes live with `OPENCODE_SPIKE_MODEL=openai/gpt-oss-120b` (a reasoning-forward model), which caught a real mapping bug during the spike: OpenCode's `message.part.delta` carries `field:"text"` even for reasoning parts, so the synthesizer now tracks partID → part.type from the `message.part.updated` snapshots and drops reasoning-channel (and untyped) deltas — only text-part content reaches `text_delta`/`final`, matching how the Claude runner drops thinking blocks.

Offline regression (no network): `pytest runner/tests/ -q` → 101 passed, 3 skipped, including scripted-frame tests driving the synthesizer through the real `SessionRunner` (reasoning-leak case included). `ruff` + `mypy` clean.

## Two known semantic gaps (documented in the adapter, not solved)

1. **Steer is completion-deferred.** OpenCode accepts a message posted mid-turn but applies it at the next turn boundary rather than interleaving mid-generation. Coarser-grained than the SDK's mid-turn steer; compatible with the runner's steer contract.
2. **No `resume` equivalent.** `AGENTOS_HISTORY_REF` rehydration is unsupported; sessions cold-start. Phase 2 path is replay-on-boot (aligned with ADR-0003 stateless-first).

## Observed live behavior worth knowing

- On the vague conformance prompts ("nightly report", "case 7"), GLM-4.6/gpt-oss occasionally stall past the silence timeout; the adapter then emits a protocol-correct `error` + `final{classified-failure}` stream (which also exercises the error mapping live). Timeout is env-tunable (`OPENCODE_SPIKE_SILENCE_TIMEOUT`, default 120s); the error message includes elapsed time and last frame seen.
- Model auth is OpenRouter only (`OPENROUTER_TOKEN`/`OPENROUTER_API_KEY`), per the spike brief's auth constraint. Default model `z-ai/glm-4.6` (GLM-5.2 can return reasoning + empty text on trivial prompts, #107); override via `OPENCODE_SPIKE_PROVIDER`/`OPENCODE_SPIKE_MODEL`.

## Stubbed / deferred to Phase 2

- Plugin-format translator (skills remap, `.mcp.json` → `opencode.json`, commands/agents) — not started, per the phased brief.
- History replay-on-boot; `AGENTOS_CREDENTIALS` → OpenCode provider auth mapping; runner image packaging (Bun + opencode under the non-root/read-only rails); parity evals.
- The conformance entrypoint builds a fresh subprocess per producer call — fine for a conformance harness, but the production path must honor the one-long-lived-session-per-process invariant.

Ref #25 (non-closing — this is a spike, the epic stays open).
