### PR TITLE
Pin the queue payload wire shape with a cross-language golden fixture (#7)

### DIFF
--- a/apps/dispatcher/tests/test_queue.py
+++ b/apps/dispatcher/tests/test_queue.py
@@ -1,11 +1,22 @@
 """Queue seam + dedupe against real Valkey."""
 
+from pathlib import Path
+
 import redis
 from agentos_dispatcher.config import DispatcherConfig
 from agentos_dispatcher.queue import (
     QueuedSlackEvent,
     claim_event,
     enqueue,
+)
+
+# The committed wire golden the Rust CLI mirror (cli/src/queue.rs) round-trips too.
+_GOLDEN_FIXTURE = (
+    Path(__file__).resolve().parents[3]
+    / "packages"
+    / "aci-protocol"
+    / "schema"
+    / "queued-slack-event.fixture.json"
 )
 
 
@@ -27,6 +38,19 @@ def test_queued_event_stream_fields_roundtrip() -> None:
     # The worker (F1) consumes a single JSON payload field.
     assert set(fields) == {"payload"}
     assert QueuedSlackEvent.from_stream_fields(fields) == event
+
+
+def test_queued_event_matches_cross_language_golden() -> None:
+    # One committed wire fixture pins the QueuedSlackEvent bytes across the Python
+    # producer here and the hand-mirrored Rust struct in cli/src/queue.rs: both
+    # must deserialize it and re-serialize to identical bytes. Guards the frozen
+    # queue seam against silent field rename/reorder drift until the payload is
+    # promoted into aci-protocol (#7). This does not move the model — the
+    # dispatcher still owns QueuedSlackEvent.
+    raw = _GOLDEN_FIXTURE.read_text().strip()
+    event = QueuedSlackEvent.model_validate_json(raw)
+    assert event.slack_event_id == "Ev0GOLDEN0001"
+    assert event.model_dump_json() == raw
 
 
 def test_enqueue_writes_one_stream_entry_the_worker_can_read(

--- a/cli/src/queue.rs
+++ b/cli/src/queue.rs
@@ -281,6 +281,25 @@ mod tests {
     }
 
     #[test]
+    fn queued_event_matches_cross_language_golden() {
+        // The same committed wire fixture the Python producer (apps/dispatcher)
+        // round-trips: this hand-mirrored struct must deserialize it and
+        // re-serialize to identical bytes, catching seam drift between the two
+        // languages until the payload is promoted into aci-protocol (#7).
+        let raw =
+            include_str!("../../packages/aci-protocol/schema/queued-slack-event.fixture.json")
+                .trim_end();
+        let event: QueuedSlackEvent = serde_json::from_str(raw).expect("golden deserializes");
+        assert_eq!(event.slack_event_id, "Ev0GOLDEN0001");
+        assert_eq!(event.received_at, "2026-07-05T00:00:00+00:00");
+        assert_eq!(
+            event.payload_json().unwrap(),
+            raw,
+            "Rust wire bytes drifted from golden"
+        );
+    }
+
+    #[test]
     fn payload_json_carries_the_exact_seam_field_names() {
         let event = QueuedSlackEvent {
             slack_event_id: "EvSIM-x".into(),

--- a/packages/aci-protocol/schema/queued-slack-event.fixture.json
+++ b/packages/aci-protocol/schema/queued-slack-event.fixture.json
@@ -1,0 +1,1 @@
+{"slack_event_id":"Ev0GOLDEN0001","thread_ts":"1720000000.000100","channel":"C0GOLDENAAA","user":"U0GOLDENBBB","text":"hello from the golden fixture","placeholder_ts":"1720000000.000200","received_at":"2026-07-05T00:00:00+00:00"}


### PR DESCRIPTION
## What

`QueuedSlackEvent` is the frozen queue seam, hand-mirrored across two languages — the Python producer (`apps/dispatcher/src/agentos_dispatcher/queue.py`) and the Rust CLI mirror (`cli/src/queue.rs`). Until now nothing pinned the **wire bytes across both**: a field rename or reorder on one side would silently diverge (the exact drift risk #7 calls out), and the existing tests only checked each side in isolation.

## Fix — the "minimum fallback" from #7

One committed wire golden, `packages/aci-protocol/schema/queued-slack-event.fixture.json`, that **both** sides must round-trip to byte-identical output:
- Python: `QueuedSlackEvent.model_validate_json(fixture)` then `model_dump_json() == fixture`.
- Rust: `serde_json::from_str::<QueuedSlackEvent>(fixture)` then `payload_json() == fixture`.

Either side reordering/renaming a field now fails its test.

## Scope

This is deliberately **not** the full #7 promotion. It does **not** move the model into `aci-protocol` (the dispatcher still owns `QueuedSlackEvent` per its `CLAUDE.md`) and does **not** do the channel-neutral rename — those remain the larger open work. `Ref #7`, not `Closes`. (The fixture lives under `aci-protocol/schema/` as the neutral shared location and the model's eventual home.)

## Verification

- Rust: `cargo test queued_event_matches_cross_language_golden` → ok; `cargo fmt --check` + `cargo clippy -- -D warnings` clean.
- Python: `pytest apps/dispatcher/tests/test_queue.py -k golden` → 1 passed; `ruff` clean.

Both produce the identical compact byte string, confirming cross-language wire compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)