### PR TITLE
Clamp model-authored Block Kit to Slack limits and fall back to text-only

### DIFF
--- a/apps/worker/src/agentos_worker/blocks.py
+++ b/apps/worker/src/agentos_worker/blocks.py
@@ -36,6 +36,25 @@ from .mrkdwn import to_mrkdwn
 # Slack hard-caps a section's text at 3000 chars; stay under it with margin.
 _CHUNK_TARGET = 2900
 
+# Slack hard-caps on Block Kit output; exceed any and chat.update is rejected and
+# the whole reply is lost, so ``to_blocks`` clamps every one of these.
+_HEADER_MAX = 150  # header plain_text -> 150 chars
+_BUTTON_LABEL_MAX = 75  # button plain_text label -> 75 chars
+_ACTION_ID_MAX = 255  # action_id -> 255 chars
+_SECTION_FIELDS_MAX = 10  # a section's ``fields`` -> 10 entries
+_BLOCKS_MAX = 50  # blocks per message -> 50
+
+# Slack caps chat.update's ``text`` field at 40000 chars; stay under it with margin.
+_SLACK_TEXT_MAX = 39000
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Truncate display text so the result length is ``<= limit``, marking the cut
+    with an ellipsis. For header text and button labels (human-read, not opaque)."""
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
 _FENCE = re.compile(r"```agentos-reply\s*\n(.*?)\n```", re.DOTALL)
 _FENCE_OPEN = "```agentos-reply"
 
@@ -86,11 +105,16 @@ def chunk(text: str, limit: int = _CHUNK_TARGET) -> list[str]:
 def _button_shell(label: str) -> dict[str, Any]:
     """The shared button element; callers add either ``action_id`` (interactive,
     dispatcher-handled) or ``url`` (a navigational link button)."""
+    # Slack hard-caps a button label at 75 chars; clamp here so both interactive
+    # and URL link buttons stay under it.
+    label = _truncate(label, _BUTTON_LABEL_MAX)
     return {"type": "button", "text": {"type": "plain_text", "text": label, "emoji": True}}
 
 
 def _button(label: str, action_id: str) -> dict[str, Any]:
-    return {**_button_shell(label), "action_id": action_id}
+    # Slack hard-caps action_id at 255 chars; it is an opaque id, not display text,
+    # so truncate hard with no marker.
+    return {**_button_shell(label), "action_id": action_id[:_ACTION_ID_MAX]}
 
 
 def _context_block(text: str) -> dict[str, Any]:
@@ -132,12 +156,18 @@ def to_blocks(reply: Reply, nav: NavPack | None = None) -> list[dict[str, Any]]:
     if reply.status:
         blocks.append(_context_block(reply.status))
     if reply.header:
-        blocks.append({"type": "header", "text": {"type": "plain_text", "text": reply.header}})
+        # Slack hard-caps a header's plain_text at 150 chars.
+        header_text = _truncate(reply.header, _HEADER_MAX)
+        blocks.append({"type": "header", "text": {"type": "plain_text", "text": header_text}})
     if reply.fields:
+        # Slack hard-caps a section at 10 fields; keep the first 10, order preserved.
         blocks.append(
             {
                 "type": "section",
-                "fields": [{"type": "mrkdwn", "text": f"*{k}*\n{v}"} for k, v in reply.fields],
+                "fields": [
+                    {"type": "mrkdwn", "text": f"*{k}*\n{v}"}
+                    for k, v in reply.fields[:_SECTION_FIELDS_MAX]
+                ],
             }
         )
     for piece in chunk(to_mrkdwn(reply.text)):
@@ -162,7 +192,9 @@ def to_blocks(reply: Reply, nav: NavPack | None = None) -> list[dict[str, Any]]:
         )
     if reply.footer:
         blocks.append(_context_block(reply.footer))
-    return blocks
+    # Slack hard-caps a message at 50 blocks; drop the tail overflow last so the
+    # ordering/priority of the earlier blocks is preserved.
+    return blocks[:_BLOCKS_MAX]
 
 
 def _pairs(raw: Any) -> list[tuple[str, str]]:
@@ -215,7 +247,10 @@ def render(text: str, nav: NavPack | None = None) -> tuple[str, list[dict[str, A
     """
     reply = parse_reply(text)
     if reply is not None:
-        return (to_mrkdwn(reply.text) or "(reply)", to_blocks(reply, nav))
+        return (
+            _truncate(to_mrkdwn(reply.text) or "(reply)", _SLACK_TEXT_MAX),
+            to_blocks(reply, nav),
+        )
     open_at = text.find(_FENCE_OPEN)
     if open_at != -1:
         prefix = text[:open_at].strip()

--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Protocol
 
+from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
 from .behaviorpacks import NavPack
@@ -108,9 +109,18 @@ class AsyncSlackSink:
         client = self._client_for(endpoint)
         rendered_text, blocks = render(text, nav)
         if blocks is not None:
-            await client.chat_update(
-                channel=channel, ts=ts, text=rendered_text, blocks=blocks
-            )
+            # Slack rejects the whole message if a block exceeds a limit we did not
+            # clamp; fall back to a text-only update so the turn still completes and
+            # the stream entry is acked instead of re-enqueuing the paid model turn.
+            try:
+                await client.chat_update(
+                    channel=channel, ts=ts, text=rendered_text, blocks=blocks
+                )
+            except SlackApiError:
+                logger.warning(
+                    "chat_update with blocks rejected for %s; retrying text-only", ts
+                )
+                await client.chat_update(channel=channel, ts=ts, text=rendered_text)
         else:
             await client.chat_update(channel=channel, ts=ts, text=rendered_text)
 

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from agentos_worker.behaviorpacks import NavPack
 from agentos_worker.blocks import Reply, chunk, parse_reply, render, to_blocks
 
@@ -262,3 +264,56 @@ def test_backward_compatible_without_status_or_links() -> None:
     # No status context leading, and no links actions block anywhere.
     assert not any(b["type"] == "actions" for b in blocks)
     assert blocks[0]["type"] == "header"  # header first, not a status context
+
+
+# --- #228: clamp Block Kit output to Slack's hard limits ----------------------
+# Slack rejects the whole message (and the turn's reply is lost) if any block
+# exceeds its documented cap. to_blocks must clamp so the reply is always
+# deliverable, whatever the model authored. Tests assert the length/count
+# invariant only, leaving the exact truncation style to the implementer.
+
+
+def test_header_text_clamped_to_150() -> None:
+    reply = Reply(text="body", header="H" * 200)
+    header = next(b for b in to_blocks(reply) if b["type"] == "header")
+    assert len(header["text"]["text"]) <= 150
+
+
+def test_button_label_clamped_to_75() -> None:
+    reply = Reply(text="body", buttons=[("x" * 200, "y" * 400)])
+    actions = next(b for b in to_blocks(reply) if b["type"] == "actions")
+    element = actions["elements"][0]
+    assert len(element["text"]["text"]) <= 75
+
+
+def test_action_id_clamped_to_255() -> None:
+    reply = Reply(text="body", buttons=[("x" * 200, "y" * 400)])
+    actions = next(b for b in to_blocks(reply) if b["type"] == "actions")
+    element = actions["elements"][0]
+    assert len(element["action_id"]) <= 255
+
+
+def test_section_fields_capped_at_10() -> None:
+    reply = Reply(text="body", fields=[(f"k{i}", f"v{i}") for i in range(15)])
+    section = next(
+        b for b in to_blocks(reply) if b["type"] == "section" and "fields" in b
+    )
+    assert len(section["fields"]) == 10
+
+
+def test_total_blocks_capped_at_50() -> None:
+    # ~150000 non-newline chars chunk into ~52 sections (target ~2900); with a
+    # header on top that is well over Slack's 50-block ceiling.
+    reply = Reply(text="x" * 150_000, header="Title")
+    assert len(to_blocks(reply)) <= 50
+
+
+def test_render_bounds_fallback_text_for_oversized_body() -> None:
+    # A complete structured reply whose BODY is far over Slack's chat.update
+    # text cap (~40000). render must still return blocks (it is a complete
+    # reply) AND bound the accessibility/fallback text, or the text-only retry
+    # in AsyncSlackSink.update re-raises and re-opens the unbounded paid loop.
+    text = "```agentos-reply\n" + json.dumps({"header": "H", "text": "x" * 60000}) + "\n```"
+    rendered_text, blocks = render(text)
+    assert blocks is not None
+    assert len(rendered_text) <= 40000

--- a/apps/worker/tests/test_slack_sink.py
+++ b/apps/worker/tests/test_slack_sink.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
 from agentos_worker.config import WorkerConfig
 from agentos_worker.slack_sink import AsyncSlackSink
+from slack_sdk.errors import SlackApiError
 
 
 def test_base_url_override_passes_through() -> None:
@@ -161,3 +163,76 @@ def test_update_renders_status_and_link_blocks_for_a_reply() -> None:
     ]
     assert link_actions, "expected an actions block of URL link buttons"
     assert link_actions[0]["elements"][0]["url"] == "https://x/y"
+
+
+# --- #228: text-only fallback when a blocks update is rejected ----------------
+# If Slack rejects the with-blocks chat_update (SlackApiError, e.g. invalid_blocks),
+# the reply must still be delivered: retry text-only so the turn completes exactly
+# once and never re-enqueues.
+
+
+def test_update_falls_back_to_text_only_on_slack_api_error() -> None:
+    sink = AsyncSlackSink("xoxb-test")
+    calls: list[dict[str, object]] = []
+
+    async def _fake_chat_update(**kwargs: object) -> None:
+        calls.append(kwargs)
+        if "blocks" in kwargs:  # the first (with-blocks) call is rejected
+            raise SlackApiError(
+                "invalid_blocks", {"ok": False, "error": "invalid_blocks"}
+            )
+
+    sink._client_for(None).chat_update = _fake_chat_update  # type: ignore[method-assign]
+
+    text = '```agentos-reply\n{"header": "Hi", "text": "body"}\n```'
+    # Must not raise: the rejected blocks update falls back to a text-only update.
+    asyncio.run(sink.update(channel="C1", ts="1.1", text=text))
+
+    assert len(calls) == 2
+    second = calls[1]
+    assert "blocks" not in second  # the retry is text-only
+    assert second["text"] == "body"  # same accessibility fallback text
+
+
+def test_update_fallback_text_stays_within_slack_text_cap() -> None:
+    # Loop-closure: model Slack's real failure mode where chat.update rejects
+    # ANY call carrying blocks OR text longer than 40000 chars. A reply with a
+    # ~60000-char body must still complete: the with-blocks call is rejected,
+    # and the text-only retry must send bounded (<=40000) text so it succeeds
+    # instead of re-raising and re-opening the unbounded paid-retry loop.
+    sink = AsyncSlackSink("xoxb-test")
+    calls: list[dict[str, object]] = []
+
+    async def _fake_chat_update(**kwargs: object) -> None:
+        text = kwargs.get("text")
+        if "blocks" in kwargs or (isinstance(text, str) and len(text) > 40000):
+            raise SlackApiError("too_long", {"ok": False, "error": "msg_too_long"})
+        calls.append(kwargs)  # only a within-cap text-only call is recorded
+
+    sink._client_for(None).chat_update = _fake_chat_update  # type: ignore[method-assign]
+
+    text = "```agentos-reply\n" + json.dumps({"header": "H", "text": "x" * 60000}) + "\n```"
+    # Must not raise: the fallback text is bounded so the retry succeeds.
+    asyncio.run(sink.update(channel="C1", ts="1.1", text=text))
+
+    assert calls, "expected a successful text-only update"
+    final = calls[-1]
+    assert "blocks" not in final
+    assert isinstance(final["text"], str)
+    assert len(final["text"]) <= 40000
+
+
+def test_update_does_not_retry_when_blocks_update_succeeds() -> None:
+    sink = AsyncSlackSink("xoxb-test")
+    calls: list[dict[str, object]] = []
+
+    async def _fake_chat_update(**kwargs: object) -> None:
+        calls.append(kwargs)
+
+    sink._client_for(None).chat_update = _fake_chat_update  # type: ignore[method-assign]
+
+    text = '```agentos-reply\n{"header": "Hi", "text": "body"}\n```'
+    asyncio.run(sink.update(channel="C1", ts="1.1", text=text))
+
+    assert len(calls) == 1  # a spurious retry would make this 2
+    assert isinstance(calls[0].get("blocks"), list)


### PR DESCRIPTION
## Problem
`to_blocks` applied no Slack Block Kit limits, so ordinary model verbosity (a long header, a big field set, a huge body) made `chat.update` raise `SlackApiError`. That exception was unhandled: the stream entry stayed pending and `XAUTOCLAIM` re-ran the **full paid model turn** on every reclaim — an unbounded paid-retry loop from non-adversarial output, with the user stuck on the placeholder forever.

## Fix
- **Clamp in `to_blocks`** (`blocks.py`): header 150, button label 75 (both interactive and URL buttons), action_id 255, section fields 10, total blocks 50 — each to Slack's hard cap.
- **Bound the fallback text** at the `render` seam to Slack's ~40k text cap, so the text-only path can never itself exceed a limit and re-open the loop (caught in review: an oversized body would otherwise make the *retry* raise again).
- **Text-only fallback** (`slack_sink.py`): `AsyncSlackSink.update` catches `SlackApiError` on the with-blocks `chat.update` and retries text-only, so the turn completes exactly once and the entry is acked instead of re-enqueuing.

Tests: one length/count-invariant test per clamped limit, plus fallback tests (delivers exactly once on rejection; no spurious retry on success; fallback text stays within the text cap so an oversized body does not re-open the loop).

## Scope note (for review)
Fix-direction item 3 in the issue — a delivery-count dead-letter in the stream consumer — is a **deliberate follow-up**. It lives in `consumer.py`, which `apps/worker/CLAUDE.md` declares a single-owner **sacred module** requiring dedicated adversarial review, and the issue itself labels it a "Follow-up rail." The stated Acceptance (a limit-exceeding reply is delivered and the turn completes exactly once) is closed by the clamp + fallback here. The "does not re-enqueue" guarantee is covered at the sink seam (a limit-exceeding reply no longer raises out of `update()`); a direct consumer-level assertion belongs with the deferred dead-letter follow-up in the sacred module.

Closes #228