### PR TITLE
Forward exactly one model credential; none for fake/local runners

### DIFF
--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -45,7 +45,13 @@ import urllib.request
 from collections.abc import Mapping
 from pathlib import Path
 
-from ..binding import BUNDLE_REF_ENV, CREDENTIALS_ENV, PLUGIN_DIR_ENV
+from ..binding import (
+    BASE_URL_ENV,
+    BUNDLE_REF_ENV,
+    CREDENTIALS_ENV,
+    FAKE_MODEL_ENV,
+    PLUGIN_DIR_ENV,
+)
 from ..bundle_store import BundleStore, extract_bundle
 from .k8s import (
     MANAGED_BY_LABEL,
@@ -180,12 +186,26 @@ class DockerSandboxClient:
         # for the legacy real-Anthropic path. Selection keys on the worker environ (the
         # by-name forward reads the value from there); an empty AGENTOS_CREDENTIALS is
         # treated as unset.
-        if self._environ.get(CREDENTIALS_ENV):
-            args += ["-e", CREDENTIALS_ENV]
-        else:
-            for var in _SDK_PASSTHROUGH_ENV:
-                if var in self._environ:
-                    args += ["-e", var]
+        # Suppress credentials the runner does not need, so a real token never sits
+        # in a container that resolves none (recoverable via /proc/1/environ by a
+        # same-uid agent):
+        #   - fake-model run (AGENTOS_FAKE_MODEL): the runner authenticates nothing,
+        #     so forward no credential at all.
+        #   - base-URL-override / local run (ANTHROPIC_BASE_URL): drop only the
+        #     ambient SDK fallback -- a local endpoint needs no real Anthropic token.
+        #     An EXPLICIT AGENTOS_CREDENTIALS is still forwarded, because the runner
+        #     routes an sk-or- OpenRouter key into ANTHROPIC_API_KEY even with a
+        #     preset base URL (runner sdk_auth.resolve_sdk_env); suppressing it would
+        #     break BYO OpenRouter.
+        fake_model = FAKE_MODEL_ENV in env
+        base_url_override = BASE_URL_ENV in env
+        if not fake_model:
+            if self._environ.get(CREDENTIALS_ENV):
+                args += ["-e", CREDENTIALS_ENV]
+            elif not base_url_override:
+                for var in _SDK_PASSTHROUGH_ENV:
+                    if var in self._environ:
+                        args += ["-e", var]
         args.append(self._image)
 
         try:

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -207,6 +207,81 @@ def test_ambient_sdk_creds_forwarded_when_agentos_credentials_empty() -> None:
     assert all("PLACEHOLDER" not in a for a in argv)  # the value never leaks into argv
 
 
+# Placeholder ambient OAuth token (never real). Hoisted into a named constant so
+# the secrets-scan pre-commit hook does not false-positive on an inline
+# `"CLAUDE_CODE_OAUTH_TOKEN": "sk-..."` literal; the value is asserted absent from
+# the forwarded argv below.
+_AMBIENT_OAUTH = "sk-PLACEHOLDER-oauth"
+
+
+def test_no_credential_forwarded_under_fake_model() -> None:
+    # A fake-model run needs no model credential: neither the explicit BYO
+    # reference nor the ambient SDK token must ride into the untrusted runner.
+    # Gating keys on the boot env (AGENTOS_FAKE_MODEL present), not the worker
+    # environ, so even a fully-credentialed worker leaks nothing.
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        environ={
+            "CLAUDE_CODE_OAUTH_TOKEN": _AMBIENT_OAUTH,
+            "AGENTOS_CREDENTIALS": "sk-ant-PLACEHOLDER",
+        },
+    )
+    client.create_claim(
+        "t1", pool="pool", env={"AGENTOS_FAKE_MODEL": "1", "AGENTOS_BUDGET": "{}"}
+    )
+    envs = _flag_values(client.calls[0], "-e")
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in envs  # ambient SDK token not forwarded
+    assert "ANTHROPIC_API_KEY" not in envs
+    assert "AGENTOS_CREDENTIALS" not in envs  # BYO reference not forwarded either
+    assert all("PLACEHOLDER" not in a for a in client.calls[0])  # no value leaks
+
+
+def test_ambient_sdk_creds_not_forwarded_under_local_model() -> None:
+    # A local/base-URL-override run (ANTHROPIC_BASE_URL in the boot env) points the
+    # runner at a local endpoint that needs no Anthropic credential, so the ambient
+    # SDK token must not ride into that container.
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        environ={"CLAUDE_CODE_OAUTH_TOKEN": _AMBIENT_OAUTH},
+    )
+    client.create_claim(
+        "t1",
+        pool="pool",
+        env={"ANTHROPIC_BASE_URL": "http://ollama:11434", "AGENTOS_BUDGET": "{}"},
+    )
+    envs = _flag_values(client.calls[0], "-e")
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in envs  # ambient SDK token not forwarded
+    assert "ANTHROPIC_API_KEY" not in envs
+    assert all("PLACEHOLDER" not in a for a in client.calls[0])  # no value leaks
+
+
+def test_explicit_credential_forwarded_under_base_url_override() -> None:
+    # BYO OpenRouter with a preset base URL: the runner routes an sk-or- key into
+    # ANTHROPIC_API_KEY even when ANTHROPIC_BASE_URL is set (runner sdk_auth), so an
+    # EXPLICIT AGENTOS_CREDENTIALS must still be forwarded by name -- while the
+    # ambient SDK token still must not ride along.
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        environ={
+            "CLAUDE_CODE_OAUTH_TOKEN": _AMBIENT_OAUTH,
+            "AGENTOS_CREDENTIALS": "sk-or-PLACEHOLDER",
+        },
+    )
+    client.create_claim(
+        "t1",
+        pool="pool",
+        env={"ANTHROPIC_BASE_URL": "https://openrouter.ai/api", "AGENTOS_BUDGET": "{}"},
+    )
+    envs = _flag_values(client.calls[0], "-e")
+    assert "AGENTOS_CREDENTIALS" in envs  # BYO OpenRouter key still forwarded by name
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in envs  # ambient SDK token still suppressed
+    assert "ANTHROPIC_API_KEY" not in envs
+    assert all("PLACEHOLDER" not in a for a in client.calls[0])  # value never in argv
+
+
 def test_get_sandbox_reports_published_port_and_mode() -> None:
     client = _RecordingDocker(image="agentos-runner", bundle_store=_FakeBundleStore())
     client.outputs = {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -246,6 +246,27 @@ fn find_repo_root() -> Option<PathBuf> {
     }
 }
 
+/// Pick the model-credential env vars to forward into the runner container, BY
+/// NAME (docker reads their values from the caller's env; no secret is put in
+/// argv). Mirrors the worker docker substrate's positive single-credential
+/// selection (apps/worker/src/agentos_worker/sandbox/docker.py):
+/// - fake/local model (`suppress_credential`): forward NONE -- those runners
+///   resolve no Anthropic credential, and a real token must not sit in an
+///   untrusted, egress-rail-less container readable via /proc/1/environ.
+/// - an explicit non-empty AGENTOS_CREDENTIALS (`byo_credential`): the operator's
+///   chosen BYO credential, forwarded ALONE so an ambient SDK token can neither
+///   shadow it nor ride into the sandbox.
+/// - otherwise: the ambient SDK creds for the legacy real-Anthropic path.
+fn select_passthrough_env(suppress_credential: bool, byo_credential: Option<&str>) -> Vec<String> {
+    if suppress_credential {
+        return Vec::new();
+    }
+    match byo_credential {
+        Some(cred) if !cred.is_empty() => vec!["AGENTOS_CREDENTIALS".into()],
+        _ => vec!["CLAUDE_CODE_OAUTH_TOKEN".into(), "ANTHROPIC_API_KEY".into()],
+    }
+}
+
 pub async fn start(opts: StartOpts) -> Result<()> {
     let plugin_dir = opts
         .plugin_dir
@@ -321,21 +342,12 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         model = Some(local_model.clone());
     }
 
-    let mut passthrough_env: Vec<String> =
-        vec!["CLAUDE_CODE_OAUTH_TOKEN".into(), "ANTHROPIC_API_KEY".into()];
-    // Forward the opaque model credential the runner resolves in sdk_auth (OAuth
-    // token, Anthropic API key, or an OpenRouter sk-or- key routed to the
-    // OpenRouter Anthropic endpoint). Without this, `skill up` cannot drive a
-    // real OpenRouter/BYO model even though the runner supports it -- the key
-    // never reaches the container in the env slot resolve_model_credential reads.
-    //
-    // Skip it under --local-model: the runner prioritizes an sk-or- credential
-    // and would rewrite the local Ollama base URL to OpenRouter, silently
-    // sending a local-model run to the remote provider. Local model needs no
-    // credential, so an sk-or- key sitting in the caller's env must not leak in.
-    if opts.local_model.is_none() {
-        passthrough_env.push("AGENTOS_CREDENTIALS".into());
-    }
+    // Forward exactly one model credential (or none under fake/local) -- never
+    // the ambient SDK token alongside a chosen BYO credential. See
+    // select_passthrough_env.
+    let suppress_credential = opts.local_model.is_some() || opts.fake_model;
+    let byo_credential = std::env::var("AGENTOS_CREDENTIALS").ok();
+    let passthrough_env = select_passthrough_env(suppress_credential, byo_credential.as_deref());
 
     let spec = StartSpec {
         image: opts.image.clone(),
@@ -1005,7 +1017,7 @@ async fn git_short_sha(dir: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_cases_path, validate_slack_channel};
+    use super::{resolve_cases_path, select_passthrough_env, validate_slack_channel};
     use std::path::PathBuf;
 
     #[test]
@@ -1058,5 +1070,50 @@ mod tests {
     #[test]
     fn rejects_leading_whitespace_hash() {
         assert!(validate_slack_channel("  #testing").is_err());
+    }
+
+    #[test]
+    fn suppress_credential_forwards_nothing_even_with_byo() {
+        // A fake OR local model run needs no credential: forward none, even when
+        // an explicit BYO reference is present, so a real token never leaks into
+        // the untrusted runner.
+        assert_eq!(
+            select_passthrough_env(true, Some("sk-or-x")),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn explicit_byo_credential_forwarded_alone() {
+        // A non-empty BYO credential is forwarded alone -- the ambient SDK vars
+        // must not shadow the operator's chosen credential.
+        assert_eq!(
+            select_passthrough_env(false, Some("sk-or-x")),
+            vec!["AGENTOS_CREDENTIALS".to_string()]
+        );
+    }
+
+    #[test]
+    fn empty_byo_credential_falls_back_to_sdk_vars() {
+        // An empty AGENTOS_CREDENTIALS (a blank line in .env) is treated as unset,
+        // so the ambient SDK vars carry the legacy real-Anthropic credential.
+        assert_eq!(
+            select_passthrough_env(false, Some("")),
+            vec![
+                "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+                "ANTHROPIC_API_KEY".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn no_byo_credential_falls_back_to_sdk_vars() {
+        assert_eq!(
+            select_passthrough_env(false, None),
+            vec![
+                "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+                "ANTHROPIC_API_KEY".to_string()
+            ]
+        );
     }
 }

--- a/docs/interfaces/substrate/INTERFACE.md
+++ b/docs/interfaces/substrate/INTERFACE.md
@@ -31,7 +31,7 @@ Two, both under `apps/worker/src/agentos_worker/sandbox/`:
 
 ## Known leakage
 
-The `SandboxView.port` field (`types.py:134`) exists only because the Docker path publishes each runner on its own loopback host port, while the Kubernetes path uses one fleet-wide `runner_port`; `None` means "fall back to `SubstrateConfig.runner_port`". Credential handling also differs across the line: the k8s client strips `AGENTOS_CREDENTIALS` from per-claim env so it is never persisted in plaintext on the claim (`k8s.py:47`, `k8s.py:139`), relying on the chart Secret's `secretKeyRef`; the Docker client has no Secret and forwards it directly. These are runtime-shaped asymmetries the `Protocol` does not fully hide.
+The `SandboxView.port` field (`types.py:134`) exists only because the Docker path publishes each runner on its own loopback host port, while the Kubernetes path uses one fleet-wide `runner_port`; `None` means "fall back to `SubstrateConfig.runner_port`". Credential handling also differs across the line: the k8s client strips `AGENTOS_CREDENTIALS` from per-claim env so it is never persisted in plaintext on the claim (`k8s.py:47`, `k8s.py:139`), relying on the chart Secret's `secretKeyRef`; the Docker client has no Secret and forwards exactly one model credential by name -- an explicit AGENTOS_CREDENTIALS alone (never an ambient CLAUDE_CODE_OAUTH_TOKEN/ANTHROPIC_API_KEY that would shadow it), and none at all for a fake-model or local base-URL-override run that resolves none. These are runtime-shaped asymmetries the `Protocol` does not fully hide.
 
 ## Cross-links
 


### PR DESCRIPTION
## Problem
The worker docker substrate got positive single-credential selection in #109, but the CLI runner path never mirrored it, and neither layer suppressed credentials for fake/local-model runners. Result: an ambient `CLAUDE_CODE_OAUTH_TOKEN` shadowed an operator's chosen `AGENTOS_CREDENTIALS` (silent mis-billing of the wrong key), and a real token rode into fake/local containers that resolve none (recoverable via `/proc/1/environ` in a prompt-injectable, egress-rail-less runner).

## Fix
- **CLI** (`cli/src/commands.rs`): new pure `select_passthrough_env` helper mirrors the worker's positive single-credential selection — an explicit non-empty `AGENTOS_CREDENTIALS` is forwarded alone (ambient SDK vars can no longer shadow it); otherwise the ambient SDK vars carry the legacy real-Anthropic path; nothing is forwarded under `--local-model` or `--fake-model`.
- **Worker** (`apps/worker/.../sandbox/docker.py`): same fake/local suppression. A fake-model run forwards no credential; a base-URL-override run drops only the ambient SDK fallback but **still forwards an explicit `AGENTOS_CREDENTIALS`** — the runner routes an `sk-or-` OpenRouter key into `ANTHROPIC_API_KEY` even with a preset base URL (regression caught in cross-model review), so suppressing it would break BYO OpenRouter.
- Credentials are forwarded **by name only**; no value ever lands in the docker argv.

## Verification
Unit tests on both layers (CLI `select_passthrough_env` + worker `create_claim` argv); full suites green (Rust 232, Python 619); ruff/mypy/clippy/fmt clean. Live docker check confirmed: with all three creds in the parent env, the BYO argv forwards only `AGENTOS_CREDENTIALS` (ambient tokens `<UNSET>` in the container), and the fake/local argv leaves the container with no credentials.

Closes #229