### PR TITLE
Durable agent-scoped KV state store (first slice of #23)

### DIFF
--- a/apps/api/alembic/versions/0006_workflow_state.py
+++ b/apps/api/alembic/versions/0006_workflow_state.py
@@ -1,0 +1,50 @@
+"""add workflow_state_entries (durable agent-scoped KV store, #23)
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-07-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "agentos"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workflow_state_entries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("namespace", sa.String(), nullable=False),
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("value", postgresql.JSONB(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"
+        ),
+        # The composite unique constraint's index also serves lookups by
+        # agent_id and by (agent_id, namespace) prefix, so no extra index needed.
+        sa.UniqueConstraint(
+            "agent_id", "namespace", "key", name="uq_state_agent_ns_key"
+        ),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("workflow_state_entries", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1079,6 +1079,68 @@
         "title": "SettingsPackConfig",
         "type": "object"
       },
+      "StateEntryOut": {
+        "description": "A durable state entry as returned to the caller.",
+        "properties": {
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "namespace": {
+            "title": "Namespace",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "value": {
+            "additionalProperties": true,
+            "title": "Value",
+            "type": "object"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "namespace",
+          "key",
+          "value",
+          "version",
+          "updated_at"
+        ],
+        "title": "StateEntryOut",
+        "type": "object"
+      },
+      "StateEntryPut": {
+        "description": "Write a durable state entry (#23). ``expected_version`` opts into\ncompare-and-set: the write is rejected with 409 unless it matches the stored\nversion (omit it for a blind upsert).",
+        "properties": {
+          "expected_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Version"
+          },
+          "value": {
+            "additionalProperties": true,
+            "title": "Value",
+            "type": "object"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "StateEntryPut",
+        "type": "object"
+      },
       "TipsPackConfig": {
         "description": "Rotating capability tips for one agent (mirrors behaviorpacks.TipsPack).\nSeparate from LoadPackConfig: a load line is what the agent is doing now, a\ntip advertises what it can do.",
         "properties": {
@@ -2182,6 +2244,308 @@
         "summary": "Resume Agent",
         "tags": [
           "control"
+        ]
+      }
+    },
+    "/agents/{agent_id}/state/{namespace}": {
+      "get": {
+        "operationId": "list_state_agents__agent_id__state__namespace__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "title": "Namespace",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/StateEntryOut"
+                  },
+                  "title": "Response List State Agents  Agent Id  State  Namespace  Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List State",
+        "tags": [
+          "state"
+        ]
+      }
+    },
+    "/agents/{agent_id}/state/{namespace}/{key}": {
+      "delete": {
+        "operationId": "delete_state_agents__agent_id__state__namespace___key__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "title": "Namespace",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "title": "Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete State",
+        "tags": [
+          "state"
+        ]
+      },
+      "get": {
+        "operationId": "get_state_agents__agent_id__state__namespace___key__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "title": "Namespace",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "title": "Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StateEntryOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get State",
+        "tags": [
+          "state"
+        ]
+      },
+      "put": {
+        "operationId": "put_state_agents__agent_id__state__namespace___key__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "title": "Namespace",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "title": "Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StateEntryPut"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StateEntryOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put State",
+        "tags": [
+          "state"
         ]
       }
     },

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -28,6 +28,7 @@ from .routers import (
     github,
     observability,
     runs,
+    state,
 )
 from .storage import BundleStore
 
@@ -83,6 +84,7 @@ def create_app() -> FastAPI:
     app.include_router(control.router)
     app.include_router(evals.router)
     app.include_router(runs.router)
+    app.include_router(state.router)
     return app
 
 

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Enum, ForeignKey, func
+from sqlalchemy import Enum, ForeignKey, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -97,3 +97,38 @@ class Deployment(Base):
     commit_sha: Mapped[str | None] = mapped_column(default=None)
     status: Mapped[str] = mapped_column(server_default="active")
     deployed_at: Mapped[datetime] = mapped_column(server_default=func.now())
+
+
+class WorkflowStateEntry(Base):
+    """Durable, agent-scoped key/value state (#23, first slice).
+
+    Cross-turn business state (a pending-approvals map, a dedupe seen-set) has
+    nowhere durable to live today: sandboxes do not survive suspend, so agents
+    keep it in-process and lose it on restart. This is a small scoped store --
+    namespace + key per agent, an arbitrary-JSON value, and a monotonic
+    ``version`` for compare-and-set. Backed by Postgres JSONB (no new datastore).
+    Exposing it to bundle code via an auto-mounted MCP server is a later slice;
+    this lands the store and its HTTP API.
+    """
+
+    __tablename__ = "workflow_state_entries"
+    __table_args__ = (
+        UniqueConstraint("agent_id", "namespace", "key", name="uq_state_agent_ns_key"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE")
+    )
+    namespace: Mapped[str]
+    key: Mapped[str]
+    value: Mapped[dict[str, Any]] = mapped_column(JSONB)
+    # Monotonic per-entry counter for compare-and-set: a put may pass the version
+    # it last read, and the write is rejected if the stored version moved on.
+    version: Mapped[int] = mapped_column(default=1)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), onupdate=func.now()
+    )

--- a/apps/api/src/agentos_api/routers/state.py
+++ b/apps/api/src/agentos_api/routers/state.py
@@ -1,0 +1,112 @@
+"""Durable agent-scoped key/value state (#23, first slice).
+
+A small compare-and-set KV store: namespace + key per agent, an arbitrary-JSON
+value, Postgres JSONB backing. This is the API surface the approvals epic (#22)
+and other cross-turn workflow state will consume; exposing it to bundle code via
+an auto-mounted MCP server is a later slice.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud
+from ..auth import require_api_key
+from ..deps import SessionDep
+from ..models import WorkflowStateEntry
+from ..schemas import StateEntryOut, StateEntryPut
+
+router = APIRouter(
+    prefix="/agents", tags=["state"], dependencies=[Depends(require_api_key)]
+)
+
+
+async def _get_entry(
+    session: AsyncSession, agent_id: uuid.UUID, namespace: str, key: str
+) -> WorkflowStateEntry | None:
+    entry: WorkflowStateEntry | None = await session.scalar(
+        select(WorkflowStateEntry).where(
+            WorkflowStateEntry.agent_id == agent_id,
+            WorkflowStateEntry.namespace == namespace,
+            WorkflowStateEntry.key == key,
+        )
+    )
+    return entry
+
+
+@router.put("/{agent_id}/state/{namespace}/{key}", response_model=StateEntryOut)
+async def put_state(
+    agent_id: uuid.UUID,
+    namespace: str,
+    key: str,
+    data: StateEntryPut,
+    session: SessionDep,
+) -> StateEntryOut:
+    # Unknown agent is a 404 (the FK would also reject, but this is the clear
+    # signal). expected_version opts into compare-and-set.
+    if await crud.get_agent(session, agent_id) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+    entry = await _get_entry(session, agent_id, namespace, key)
+    if entry is None:
+        if data.expected_version is not None:
+            # A CAS put that expects a prior version cannot create the entry.
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "version mismatch: entry does not exist yet",
+            )
+        entry = WorkflowStateEntry(
+            agent_id=agent_id, namespace=namespace, key=key, value=data.value
+        )
+        session.add(entry)
+    else:
+        if data.expected_version is not None and data.expected_version != entry.version:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                f"version mismatch: expected {data.expected_version}, "
+                f"stored {entry.version}",
+            )
+        entry.value = data.value
+        entry.version += 1
+    await session.commit()
+    await session.refresh(entry)
+    return StateEntryOut.model_validate(entry)
+
+
+@router.get("/{agent_id}/state/{namespace}/{key}", response_model=StateEntryOut)
+async def get_state(
+    agent_id: uuid.UUID, namespace: str, key: str, session: SessionDep
+) -> StateEntryOut:
+    entry = await _get_entry(session, agent_id, namespace, key)
+    if entry is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "state entry not found")
+    return StateEntryOut.model_validate(entry)
+
+
+@router.get("/{agent_id}/state/{namespace}", response_model=list[StateEntryOut])
+async def list_state(
+    agent_id: uuid.UUID, namespace: str, session: SessionDep
+) -> list[StateEntryOut]:
+    entries = await session.scalars(
+        select(WorkflowStateEntry)
+        .where(
+            WorkflowStateEntry.agent_id == agent_id,
+            WorkflowStateEntry.namespace == namespace,
+        )
+        .order_by(WorkflowStateEntry.key)
+    )
+    return [StateEntryOut.model_validate(e) for e in entries]
+
+
+@router.delete(
+    "/{agent_id}/state/{namespace}/{key}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_state(
+    agent_id: uuid.UUID, namespace: str, key: str, session: SessionDep
+) -> Response:
+    entry = await _get_entry(session, agent_id, namespace, key)
+    if entry is not None:
+        await session.delete(entry)
+        await session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -351,3 +351,24 @@ class CostReport(BaseModel):
     end: str
     total_usd: float
     points: list[MetricPoint]
+
+
+class StateEntryPut(BaseModel):
+    """Write a durable state entry (#23). ``expected_version`` opts into
+    compare-and-set: the write is rejected with 409 unless it matches the stored
+    version (omit it for a blind upsert)."""
+
+    value: dict[str, Any]
+    expected_version: int | None = None
+
+
+class StateEntryOut(BaseModel):
+    """A durable state entry as returned to the caller."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    namespace: str
+    key: str
+    value: dict[str, Any]
+    version: int
+    updated_at: datetime

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -1,0 +1,98 @@
+"""Durable KV state store (#23): real Postgres round-trip + compare-and-set.
+
+Nothing mocked -- exercises the API against the compose Postgres (the
+disposable-DB conftest provisions and migrates a throwaway database per run).
+"""
+
+from typing import Any
+
+
+def _agent(client: Any, headers: dict[str, str]) -> str:
+    resp = client.post(
+        "/agents",
+        json={"name": "state-agent", "slack_channel": "#s"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    agent_id: str = resp.json()["id"]
+    return agent_id
+
+
+def test_put_get_list_delete_round_trip(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    base = f"/agents/{aid}/state/approvals"
+
+    # put (create) -> version 1
+    r = client.put(
+        f"{base}/thread-1", json={"value": {"status": "pending"}}, headers=auth_headers
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["value"] == {"status": "pending"}
+    assert r.json()["version"] == 1
+
+    # get returns what was written
+    got = client.get(f"{base}/thread-1", headers=auth_headers)
+    assert got.status_code == 200
+    assert got.json()["value"] == {"status": "pending"}
+
+    # put (update) -> version bumps to 2
+    r2 = client.put(
+        f"{base}/thread-1", json={"value": {"status": "approved"}}, headers=auth_headers
+    )
+    assert r2.json()["version"] == 2
+
+    # list by namespace returns both keys
+    client.put(
+        f"{base}/thread-2", json={"value": {"status": "pending"}}, headers=auth_headers
+    )
+    listed = client.get(base, headers=auth_headers).json()
+    assert {e["key"] for e in listed} == {"thread-1", "thread-2"}
+
+    # delete -> 204, then gone
+    d = client.delete(f"{base}/thread-1", headers=auth_headers)
+    assert d.status_code == 204
+    assert client.get(f"{base}/thread-1", headers=auth_headers).status_code == 404
+
+
+def test_compare_and_set_rejects_a_stale_version(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    url = f"/agents/{aid}/state/dedupe/seen"
+
+    v1 = client.put(url, json={"value": {"n": 1}}, headers=auth_headers).json()
+    assert v1["version"] == 1
+
+    # CAS with the current version succeeds and bumps to 2.
+    ok = client.put(
+        url, json={"value": {"n": 2}, "expected_version": 1}, headers=auth_headers
+    )
+    assert ok.status_code == 200
+    assert ok.json()["version"] == 2
+
+    # CAS with the now-stale version 1 is rejected, and the value is unchanged.
+    stale = client.put(
+        url, json={"value": {"n": 3}, "expected_version": 1}, headers=auth_headers
+    )
+    assert stale.status_code == 409, stale.text
+    assert client.get(url, headers=auth_headers).json()["value"] == {"n": 2}
+
+
+def test_put_unknown_agent_is_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    missing = "00000000-0000-0000-0000-000000000000"
+    r = client.put(
+        f"/agents/{missing}/state/ns/k", json={"value": {}}, headers=auth_headers
+    )
+    assert r.status_code == 404
+
+
+def test_get_missing_entry_is_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    r = client.get(f"/agents/{aid}/state/ns/nope", headers=auth_headers)
+    assert r.status_code == 404


### PR DESCRIPTION
Part of #23 (epic). First slice: the durable store + its HTTP API. Additive — a new table + router, no changes to existing behavior.

## Why
Cross-turn business state (a pending-approvals map, a dedupe seen-set, reconciliation records) has nowhere durable to live: sandboxes don't survive suspend, so agents keep it in-process and lose it on restart. This is the API surface the **approval-gates epic (#22)** and other workflow state will consume.

## What
- **`WorkflowStateEntry` model** (migration `0006`): Postgres JSONB `value`, agent-scoped `namespace` + `key` (unique per agent), a monotonic `version` for compare-and-set. No new datastore.
- **`routers/state.py`** under the shared API-key auth:
  - `PUT /agents/{id}/state/{ns}/{key}` — upsert; optional `expected_version` opts into CAS (→ **409** on mismatch)
  - `GET /agents/{id}/state/{ns}/{key}` — get (404 if missing)
  - `GET /agents/{id}/state/{ns}` — list a namespace
  - `DELETE /agents/{id}/state/{ns}/{key}` — 204
- OpenAPI regenerated.

## Validation
ruff + mypy clean; real-Postgres tests: put/get/list/delete round-trip and a CAS stale-version 409; existing `test_bundles` + OpenAPI-drift green (migration `0006` applies cleanly in the chain).

## Scope notes for review
- **Sequenced ahead of #22 on purpose** — the store's API is independent of approval *logic* (per the #23 description); approvals will consume this contract. Flagging in case you'd rather hold it until #22 lands.
- **Not in this slice:** the auto-mounted `agentos-state` MCP server that exposes this to bundle code, `append` for log-shaped values, and audit-log reads in the UI — all called out in #23 as separate slices.