### PR TITLE
Guard block-action handler against channel-less payloads

### DIFF
--- a/apps/dispatcher/src/agentos_dispatcher/handlers.py
+++ b/apps/dispatcher/src/agentos_dispatcher/handlers.py
@@ -146,6 +146,21 @@ def process_action(
     if not command:
         return None
 
+    # The catch-all matcher fires on *every* block action, including ones from an
+    # App Home tab or a modal, which carry no channel and no message. We can only
+    # turn a click into an in-thread reply when both are present. Bail here --
+    # before the idempotency claim -- so a channel-less click neither KeyErrors on
+    # body["channel"]["id"], nor burns the dedupe key (which would drop the Slack
+    # redelivery too), nor posts an un-threaded placeholder against a thread_ts of
+    # "" (a lock key shared across all such clicks in the kernel).
+    channel = (body.get("channel") or {}).get("id")
+    message = body.get("message") or {}
+    # Reply in the clicked message's thread (its thread_ts, or its own ts if root).
+    thread_ts = message.get("thread_ts") or message.get("ts")
+    if not channel or not thread_ts:
+        log.info("block action without channel/message, skipping")
+        return None
+
     # A click carries no Slack event_id, so synthesize a stable idempotency key
     # from the interaction; a re-delivered click cannot enqueue (or post a second
     # placeholder) twice, same as the event dedupe.
@@ -157,10 +172,6 @@ def process_action(
         log.info("duplicate block action %s, skipping", slack_event_id)
         return None
 
-    channel = body["channel"]["id"]
-    message = body.get("message") or {}
-    # Reply in the clicked message's thread (its thread_ts, or its own ts if root).
-    thread_ts = message.get("thread_ts") or message.get("ts") or ""
     user = (body.get("user") or {}).get("id", "")
 
     placeholder = web_client.chat_postMessage(

--- a/apps/dispatcher/tests/test_dispatch.py
+++ b/apps/dispatcher/tests/test_dispatch.py
@@ -290,6 +290,54 @@ def test_duplicate_click_enqueues_exactly_once(
     assert redis_client.xlen(config.stream) == 1
 
 
+def _home_tab_action_request(
+    envelope_id: str,
+    *,
+    action_id: str = "reports",
+    trigger_id: str | None = None,
+) -> SocketModeRequest:
+    """A block action from an App Home tab: container is a view, and the payload
+    carries no ``channel`` and no ``message`` (the shape that KeyErrored)."""
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "block_actions",
+            "trigger_id": trigger_id or f"trig-{envelope_id}",
+            "team": {"id": "T1"},
+            "user": {"id": "U123"},
+            "api_app_id": "A1",
+            "token": "verif",
+            "container": {"type": "view", "view_id": "V1"},
+            "view": {"id": "V1", "type": "home"},
+            "actions": [{"type": "button", "action_id": action_id, "action_ts": "1.5"}],
+        },
+    )
+
+
+def test_channel_less_action_is_skipped_without_burning_idempotency_key(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    app, web_client = _build(config, redis_client)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    # A Home-tab click (no channel, no message) must not KeyError, must not post a
+    # placeholder, and must not enqueue -- there is no thread to answer in.
+    handler.handle(sock, _home_tab_action_request("env-1", trigger_id="trig-home"))
+    _drain(app)
+
+    assert sock.acked_envelope_ids == ["env-1"]  # Bolt still acked the envelope
+    assert web_client.chat_postMessage.call_count == 0
+    assert redis_client.xlen(config.stream) == 0
+
+    # The idempotency key was NOT claimed: no dedupe key was written, so a Slack
+    # redelivery of this interaction is not silently dropped. (A burned key here
+    # would linger for the TTL and drop the redelivery.)
+    dedupe_key = f"{config.dedupe_prefix}action-trig-home"
+    assert redis_client.exists(dedupe_key) == 0
+
+
 def test_bot_authored_message_is_ignored(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:


### PR DESCRIPTION
## Problem

The catch-all `@app.action(re.compile(r".+"))` matcher in the dispatcher fires on **every** block action, including App Home tab and modal clicks that carry no `channel` and no `message`. `process_action` read `body["channel"]["id"]` and fell `thread_ts` back to `""`, so those payloads KeyErrored — and did so **after** the dedupe claim, burning the idempotency key and dropping the Slack redelivery too. The `thread_ts=""` fallback also handed the kernel a per-thread lock key shared across all such clicks.

Latent today (only in-message buttons render) but reachable the moment a Home tab or modal is added.

## Fix

Move the channel/message resolution above the idempotency claim and bail when either is absent. A channel-less click is now skipped cleanly: never KeyErrors, never consumes the dedupe key (so a redelivery isn't silently dropped), and never posts an un-threaded placeholder. The `or ""` fallback is removed so a message-less payload resolves to `None` and hits the bail.

Chose the "bail before claim" fix direction (the issue's primary) over scoping the matcher, keeping the catch-all matcher intact.

## Test

`test_channel_less_action_is_skipped_without_burning_idempotency_key` drives Bolt's real `SocketModeHandler.handle` with a Home-tab payload (no channel, no message) and asserts the envelope is acked but no placeholder is posted, nothing is enqueued, and the dedupe key was never written. Mutation-verified: removing the guard makes the test fail on the burned key. Full suite: 43 passed.

Closes #232