### PR TITLE
Validate Slack channel-ID shape on the agent API schema

### DIFF
--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -1,12 +1,40 @@
 """Pydantic v2 request/response models for the API surface."""
 
+import re
 import uuid
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .models import Environment
+
+# Slack channel IDs start with C (public/private channel), D (DM), or G (legacy
+# private group) followed by uppercase-alphanumeric chars. Allowlist-shaped on
+# purpose: unlike the CLI's blocklist (which only rejects a leading '#'), this
+# also rejects bare names ("general"), pasted URLs, and lowercase IDs -- none of
+# which the worker can route on.
+_SLACK_CHANNEL_ID = re.compile(r"^[CDG][A-Z0-9]{7,}$")
+
+
+def _validate_slack_channel_id(value: str | None) -> str | None:
+    """Enforce a Slack channel-ID shape on a binding. Slack events carry the
+    channel ID (e.g. C0123ABCD) and the worker routes on it, so a #name or
+    bare-name binding never receives messages. This is the authoritative gate
+    for every caller (UI, API, CLI); the CLI keeps a fast local check purely
+    for UX. Reused by AgentCreate and AgentUpdate so create and PATCH validate
+    identically; None (an omitted PATCH field) passes through as a no-op."""
+    if value is None:
+        return value
+    if not _SLACK_CHANNEL_ID.match(value):
+        raise ValueError(
+            f"slack channel {value!r} is not a Slack channel ID: real Slack "
+            "events carry the channel ID (e.g. C0123ABCD) and the worker "
+            "routes on it, so a #name or bare-name binding never receives "
+            "messages. Pass the channel ID instead -- find it in the channel's "
+            "About tab, or the channel URL (.../archives/C0123ABCD)."
+        )
+    return value
 
 
 class AppConfig(BaseModel):
@@ -98,12 +126,20 @@ class AgentCreate(BaseModel):
     repo_full_name: str | None = None
     behavior_packs: BehaviorPacksConfig | None = None
 
+    _check_slack_channel = field_validator("slack_channel")(
+        _validate_slack_channel_id
+    )
+
 
 class AgentUpdate(BaseModel):
     """Partial update of a mutable agent field. Only slack_channel is updatable
     (name and repo binding are identity); an omitted field is left unchanged."""
 
     slack_channel: str | None = None
+
+    _check_slack_channel = field_validator("slack_channel")(
+        _validate_slack_channel_id
+    )
 
 
 class AgentOut(BaseModel):

--- a/apps/api/tests/test_behavior_packs_integration.py
+++ b/apps/api/tests/test_behavior_packs_integration.py
@@ -10,7 +10,7 @@ from typing import Any
 def _create_agent(client: Any, auth_headers: dict[str, str], **body: Any) -> dict[str, Any]:
     resp = client.post(
         "/agents",
-        json={"name": "packs-bot", "slack_channel": "C-PACKS", **body},
+        json={"name": "packs-bot", "slack_channel": "C000PACKS1", **body},
         headers=auth_headers,
     )
     assert resp.status_code == 201, resp.text

--- a/apps/api/tests/test_bundles.py
+++ b/apps/api/tests/test_bundles.py
@@ -108,7 +108,7 @@ def test_non_archive_is_rejected(tmp_path: Path) -> None:
 def _create_version(client: Any, headers: dict[str, str]) -> tuple[str, str]:
     agent = client.post(
         "/agents",
-        json={"name": "bundle-agent", "slack_channel": "#b"},
+        json={"name": "bundle-agent", "slack_channel": "C000000B01"},
         headers=headers,
     ).json()
     version = client.post(

--- a/apps/api/tests/test_control_integration.py
+++ b/apps/api/tests/test_control_integration.py
@@ -28,7 +28,7 @@ def valkey() -> Iterator[redis.Redis]:
 def _make_agent(client: Any, headers: dict[str, str]) -> str:
     agent = client.post(
         "/agents",
-        json={"name": "kill-agent", "slack_channel": "#k"},
+        json={"name": "kill-agent", "slack_channel": "C000000K01"},
         headers=headers,
     ).json()
     return str(agent["id"])

--- a/apps/api/tests/test_crud.py
+++ b/apps/api/tests/test_crud.py
@@ -30,7 +30,7 @@ def test_full_round_trip(
     # create agent
     resp = client.post(
         "/agents",
-        json={"name": "triage-bot", "slack_channel": "#triage"},
+        json={"name": "triage-bot", "slack_channel": "C0TRIAGE01"},
         headers=auth_headers,
     )
     assert resp.status_code == 201, resp.text
@@ -72,7 +72,7 @@ def test_full_round_trip(
 
     got_agent = client.get(f"/agents/{agent_id}", headers=auth_headers)
     assert got_agent.status_code == 200
-    assert got_agent.json()["slack_channel"] == "#triage"
+    assert got_agent.json()["slack_channel"] == "C0TRIAGE01"
 
     listed_versions = client.get(
         f"/agents/{agent_id}/versions", headers=auth_headers
@@ -119,22 +119,22 @@ def test_patch_agent_moves_slack_channel(
     # of the existing agent (the audit MAJOR: the channel was silently ignored).
     agent = client.post(
         "/agents",
-        json={"name": "mover", "slack_channel": "#old"},
+        json={"name": "mover", "slack_channel": "C000000OLD"},
         headers=auth_headers,
     ).json()
     agent_id = agent["id"]
 
     resp = client.patch(
         f"/agents/{agent_id}",
-        json={"slack_channel": "#new"},
+        json={"slack_channel": "C000000NEW"},
         headers=auth_headers,
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["slack_channel"] == "#new"
+    assert resp.json()["slack_channel"] == "C000000NEW"
 
     # The change is persisted, not just echoed back.
     got = client.get(f"/agents/{agent_id}", headers=auth_headers).json()
-    assert got["slack_channel"] == "#new"
+    assert got["slack_channel"] == "C000000NEW"
 
 
 def test_patch_agent_omitted_field_is_noop(
@@ -142,14 +142,56 @@ def test_patch_agent_omitted_field_is_noop(
 ) -> None:
     agent = client.post(
         "/agents",
-        json={"name": "stable", "slack_channel": "#keep"},
+        json={"name": "stable", "slack_channel": "C0000KEEP1"},
         headers=auth_headers,
     ).json()
     resp = client.patch(
         f"/agents/{agent['id']}", json={}, headers=auth_headers
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["slack_channel"] == "#keep"
+    assert resp.json()["slack_channel"] == "C0000KEEP1"
+
+
+def test_create_agent_rejects_non_id_channel(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The API is the authoritative gate (the CLI check is UX-only): a #name
+    # binding never routes, so create must reject it with a 422, not persist a
+    # dead binding a non-CLI caller (the UI) could create.
+    resp = client.post(
+        "/agents",
+        json={"name": "bad-create", "slack_channel": "#general"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422, resp.text
+    assert "slack channel" in resp.text.lower()
+    # Nothing was persisted despite the rejected create.
+    assert [a["id"] for a in client.get("/agents", headers=auth_headers).json()] == []
+
+
+def test_patch_agent_rejects_non_id_channel(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # A redeploy that PATCHes a #name channel onto an existing agent must be
+    # rejected too, and must not clobber the agent's current (valid) channel.
+    agent = client.post(
+        "/agents",
+        json={"name": "patch-bad", "slack_channel": "C000GOOD01"},
+        headers=auth_headers,
+    ).json()
+    agent_id = agent["id"]
+
+    resp = client.patch(
+        f"/agents/{agent_id}",
+        json={"slack_channel": "general"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422, resp.text
+    assert "slack channel" in resp.text.lower()
+
+    # The rejected PATCH left the original channel intact.
+    got = client.get(f"/agents/{agent_id}", headers=auth_headers).json()
+    assert got["slack_channel"] == "C000GOOD01"
 
 
 def test_patch_missing_agent_returns_404(
@@ -158,7 +200,7 @@ def test_patch_missing_agent_returns_404(
     missing = "00000000-0000-0000-0000-000000000000"
     resp = client.patch(
         f"/agents/{missing}",
-        json={"slack_channel": "#x"},
+        json={"slack_channel": "C000000X01"},
         headers=auth_headers,
     )
     assert resp.status_code == 404
@@ -171,7 +213,7 @@ def test_delete_agent_removes_it_and_cascades_versions(
     # version rows go with it (FK cascade) rather than lingering as orphans.
     agent = client.post(
         "/agents",
-        json={"name": "disposable", "slack_channel": "#gone"},
+        json={"name": "disposable", "slack_channel": "C0000GONE1"},
         headers=auth_headers,
     ).json()
     agent_id = agent["id"]
@@ -210,7 +252,7 @@ def test_delete_agent_with_active_deployment_returns_409(
     # traffic; the endpoint refuses with 409 and leaves everything intact.
     agent = client.post(
         "/agents",
-        json={"name": "live-one", "slack_channel": "#live"},
+        json={"name": "live-one", "slack_channel": "C0000LIVE1"},
         headers=auth_headers,
     ).json()
     agent_id = agent["id"]

--- a/apps/api/tests/test_evalqueue_integration.py
+++ b/apps/api/tests/test_evalqueue_integration.py
@@ -151,7 +151,7 @@ def test_dev_push_fans_out_prod_push_does_not(
 ) -> None:
     agent = client.post(
         "/agents",
-        json={"name": "k1-fanout", "slack_channel": "#k", "repo_full_name": REPO},
+        json={"name": "k1-fanout", "slack_channel": "C000000K01", "repo_full_name": REPO},
         headers=auth_headers,
     ).json()
     clone_url, sha = _build_bare_repo(tmp_path)
@@ -186,7 +186,7 @@ def test_redelivered_dev_push_does_not_refan_out(
 ) -> None:
     agent = client.post(
         "/agents",
-        json={"name": "k1-redeliver", "slack_channel": "#k", "repo_full_name": REPO},
+        json={"name": "k1-redeliver", "slack_channel": "C000000K01", "repo_full_name": REPO},
         headers=auth_headers,
     ).json()
     clone_url, sha = _build_bare_repo(tmp_path)

--- a/apps/api/tests/test_evals_trigger_integration.py
+++ b/apps/api/tests/test_evals_trigger_integration.py
@@ -24,7 +24,7 @@ REPO = "octo/trigger-10"
 def _create_agent(client: Any, auth_headers: dict[str, str], name: str) -> dict[str, Any]:
     resp = client.post(
         "/agents",
-        json={"name": name, "slack_channel": "#k", "repo_full_name": REPO},
+        json={"name": name, "slack_channel": "C000000K01", "repo_full_name": REPO},
         headers=auth_headers,
     )
     assert resp.status_code == 201, resp.text

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -118,7 +118,7 @@ def _register_agent(client: Any, headers: dict[str, str]) -> str:
         "/agents",
         json={
             "name": "gitflow-agent",
-            "slack_channel": "#g",
+            "slack_channel": "C000000G01",
             "repo_full_name": REPO,
         },
         headers=headers,

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -10,7 +10,7 @@ from typing import Any
 def _agent(client: Any, headers: dict[str, str]) -> str:
     resp = client.post(
         "/agents",
-        json={"name": "state-agent", "slack_channel": "#s"},
+        json={"name": "state-agent", "slack_channel": "C000000S01"},
         headers=headers,
     )
     assert resp.status_code == 201, resp.text


### PR DESCRIPTION
## Problem

The `#name`-that-never-routes guard (#143) lived only in the CLI (`validate_slack_channel`). The API had no validator: `AgentCreate` and `AgentUpdate` typed `slack_channel` as a bare `str`, and the PATCH path persisted it unvalidated. Any non-CLI caller -- including the UI, the primary surface per ADR-0008 -- could persist a dead channel binding with no error. The CLI check is also blocklist-shaped (rejects only a leading `#`), missing bare names (`general`), pasted URLs, and lowercase IDs.

## Change

Add an allowlist Pydantic `field_validator` (`^[CDG][A-Z0-9]{7,}$`) shared by `AgentCreate` and `AgentUpdate`, so **create and PATCH reject a non-ID channel identically** with a clear 422. An omitted PATCH field (`None`) still passes through as a no-op, preserving the current channel. The CLI check stays as a fast local UX error.

Implemented as a `field_validator` (not `Field(pattern=...)`) so the error message can guide the caller and the committed OpenAPI schema is unchanged (no drift).

## Tests

- New `test_create_agent_rejects_non_id_channel` and `test_patch_agent_rejects_non_id_channel` (422 + clear message + no clobber/no persist).
- Existing tests that seeded `#name`/`C-PACKS` channels via the API are updated to real channel IDs -- those bindings could never have routed. Full `apps/api` suite: 119 passed; ruff + mypy clean.

Closes #231