### PR TITLE
Propose ADR-0020: inbound triggers as a new event kind (#29 design)

### DIFF
--- a/docs/adr/0020-inbound-triggers-as-a-new-event-kind.md
+++ b/docs/adr/0020-inbound-triggers-as-a-new-event-kind.md
@@ -1,0 +1,90 @@
+# 20. Inbound triggers as a new event kind, ingested by the API
+
+Date: 2026-07-10
+Status: Proposed
+
+Proposes how "triggers beyond chat" (issue
+[#29](https://github.com/curie-eng/agentos/issues/29)) enter the system: which
+service accepts a non-Slack trigger, and how a triggered turn produces output
+when there is no Slack placeholder to edit. This ADR is **Proposed**, not
+Accepted — it exists to get a decision from the worker/kernel owner before any
+code lands, because the mechanism touches the sacred kernel/dispatcher seam
+(`apps/worker/CLAUDE.md`) and the hand-mirrored queue payload
+(`docs/roadmap.md` §2).
+
+## Context
+
+Today the only way to start a turn is a Slack `app_mention`/DM: the dispatcher
+(Socket Mode, no inbound HTTP port) dedupes it, **posts a placeholder reply**,
+and `XADD`s a `QueuedSlackEvent` onto `agentos:runs`; the worker kernel later
+edits that placeholder in place as the reply streams. `QueuedSlackEvent`
+therefore carries a `placeholder_ts` the kernel assumes exists.
+
+#29 wants agents to also react to external events — the first slice being a
+generic HMAC-verified inbound webhook (`POST /hooks/{agent}/{hook}`) mapping a
+payload to a turn on the existing stream/kernel path ("no new execution
+machinery"). Two decisions block a working slice, and both cross into the
+single-owner kernel/dispatcher area, so they are recorded here rather than
+guessed in a PR:
+
+1. **Which service accepts the webhook?** The dispatcher is the conceptual
+   ingress, but it is Socket-Mode-only with no inbound HTTP server. The API
+   already owns HTTP ingress, already verifies an HMAC webhook (the GitHub
+   git-flow hook, `routers/github.py` `verify_signature`), and already produces
+   to a Valkey stream (`agentos:evals`).
+2. **How does a triggered turn produce output?** A webhook has no Slack
+   placeholder, but the kernel edits `placeholder_ts`. Either the ingress posts
+   a placeholder before enqueuing (keeps the kernel unchanged, but spreads Slack
+   knowledge/credentials into a second service), or the kernel learns a
+   "post-instead-of-edit" output path for placeholder-less events (a kernel
+   change).
+
+## Decision (proposed)
+
+1. **The API accepts inbound triggers.** Add `POST /hooks/{agent}/{hook}` to
+   `apps/api`, reusing the existing HMAC verification pattern (per-agent hook
+   secret, `x-agentos-signature-256` over the raw body, `hmac.compare_digest`)
+   and dedupe (`SET NX`) already proven on the GitHub webhook. The dispatcher
+   stays Slack-only. Rationale: reuse the API's HTTP + HMAC + Valkey wiring
+   instead of giving the Socket-Mode dispatcher a new inbound-server role.
+
+2. **A trigger is a new event *kind* with no placeholder; the kernel posts its
+   output.** Extend the queued-event contract with a `source`
+   (`slack` | `webhook` | `cron`) and make `placeholder_ts` optional. On a
+   placeholder-less event the kernel **posts** its reply to the event's
+   channel/thread rather than editing a pre-posted message. This keeps Slack
+   credentials in one place (the worker's existing `SlackSink`) and avoids the
+   API growing a Slack client. Per #29's semantics, a trigger targeting a thread
+   with a live interactive session waits for idle (jobs are outputs, not steering
+   inputs) — kernel behaviour that only its owner should implement.
+
+3. **Promote the queue payload out of its hand-mirrored form.** Adding `source`
+   is the moment to address the roadmap §2 debt: move the turn payload into a
+   shared, drift-gated contract (alongside `aci-protocol`) rather than mirroring
+   the new field by hand in the dispatcher (Python) and CLI (Rust).
+
+Decisions (2) and (3) are **kernel/contract changes owned by the worker
+single-owner** (Yichen); this ADR is the request to accept or amend the shape
+before that work starts. Decision (1) is API-lane and can proceed once the event
+shape in (2) is agreed.
+
+## Alternatives considered
+
+- **Webhook in the dispatcher.** Conceptually the ingress home, but it would add
+  an inbound HTTP server to a Socket-Mode process and still needs the same
+  event-shape decision. Rejected as a larger change for no contract benefit.
+- **API posts the placeholder, kernel unchanged.** Avoids a kernel change but
+  duplicates the dispatcher's placeholder+enqueue logic in the API and couples
+  the API to Slack credentials — spreading Slack knowledge across two services.
+  Rejected in favour of a single Slack-output owner (the worker).
+
+## Consequences
+
+- One HMAC-verified ingress pattern serves both GitHub git-flow and generic
+  triggers; cron (the other #29 trigger) reuses the same event kind with a
+  scheduler producing the event.
+- The kernel gains a placeholder-less output path, exercised by a provoking
+  test alongside its existing invariants.
+- The turn payload becomes a first-class contract, retiring a known drift risk.
+- Until this is Accepted and the kernel side lands, the webhook cannot complete a
+  turn end to end, so no partial webhook code should merge.

--- a/docs/adr/0079-inbound-triggers-as-a-new-event-kind.md
+++ b/docs/adr/0079-inbound-triggers-as-a-new-event-kind.md
@@ -1,4 +1,4 @@
-# 20. Inbound triggers as a new event kind, ingested by the API
+# 79. Inbound triggers as a new event kind, ingested by the API
 
 Date: 2026-07-10
 Status: Proposed

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,4 +107,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0076 | [A closed, versioned attribute schema for the runner's OTel span stream](0076-closed-typed-telemetry-attribute-schema.md) | Accepted |
 | 0077 | [Skill-tier durable approvals stay unavailable, reported not absent](0077-skill-tier-durable-approvals-stay-unavailable.md) | Accepted |
 | 0078 | [Route message-driven approval cards through the connected Slack transport](0078-approval-cards-over-connected-transport.md) | Accepted |
+| 0079 | [Inbound triggers as a new event kind, ingested by the API](0079-inbound-triggers-as-a-new-event-kind.md) | Proposed |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Design proposal for #29 (triggers beyond chat), as a **Proposed** ADR rather than code.

## Why an ADR, not an implementation PR
#29's minimal webhook slice can't complete a turn end-to-end without two decisions that land in the **single-owner kernel/dispatcher seam** (`apps/worker/CLAUDE.md`):
1. **Which service accepts a non-Slack trigger** — dispatcher (Socket-Mode, no inbound port) vs API (already does HTTP + HMAC + Valkey).
2. **How a triggered turn produces output** with no Slack `placeholder_ts` to edit — ingress posts a placeholder, or the kernel learns a "post-instead-of-edit" path.

Guessing these in code would likely be reworked/closed (as some of my earlier PRs were). The repo's own rule is "write an ADR for the decision before/alongside the work," so this tees up the call for @yichenzhang-curietech (kernel) and @TheConnMan without touching any sacred code.

## What it proposes (see the ADR for rationale + alternatives)
1. **API accepts inbound triggers** — `POST /hooks/{agent}/{hook}`, reusing the GitHub-webhook HMAC pattern + dedupe; dispatcher stays Slack-only.
2. **A trigger is a new event *kind*** with an optional `placeholder_ts` + a `source` discriminator; the **kernel posts** its reply (rather than editing a placeholder), keeping Slack output in one owner. Trigger-vs-live-session idle semantics stay kernel-owned.
3. **Promote the queue payload** into a drift-gated shared contract (roadmap §2 debt) when `source` is added.

Decisions (2)/(3) are worker-owned contract changes — this PR is the request to **accept or amend the event shape** before implementation. Decision (1) is API-lane and can proceed once (2) is agreed.

Refs #29. Docs-only; no code paths change.