### PR TITLE
BYO model: values-gated LiteLLM sidecar in the chart (#253)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -90,6 +90,14 @@ jobs:
           set -euo pipefail
           bash charts/agentos/ci/render-assertions.sh
 
+      # Prove the BYO-model LiteLLM sidecar (issue #253) is off by default,
+      # renders fully when its values flag is enabled, and yields to local
+      # inference. Runs the chart-owned assertion script.
+      - name: helm render assertions (litellm sidecar)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/litellm-sidecar-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/agentos/ci/litellm-sidecar-assertions.sh
+++ b/charts/agentos/ci/litellm-sidecar-assertions.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #253 (BYO model: values-gated LiteLLM
+# Anthropic-format sidecar in the chart). Proves:
+#
+#   1. DEFAULT render (agentSandbox.runner.liteLLM.enabled defaults false): the
+#      sidecar container, its config volume, and the localhost ANTHROPIC_BASE_URL
+#      override are ALL absent from the rendered SandboxTemplate.
+#   2. ENABLED render (liteLLM.enabled=true + a configExistingSecret): the
+#      `litellm` sidecar container renders, mounts the operator Secret at
+#      /etc/litellm/config.yaml, and the runner's ANTHROPIC_BASE_URL is repointed
+#      at http://localhost:<port>.
+#   3. PRECEDENCE: with local inference.deploy=true the sidecar's localhost
+#      ANTHROPIC_BASE_URL override does NOT render (the in-cluster inference
+#      endpoint path wins), matching the values-doc contract.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+TPL=templates/agent-sandbox.yaml
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+render() {
+  # $@ = extra --set flags. agentSandbox.deploy is on by default in values.yaml.
+  helm template rel "$CHART" --show-only "$TPL" "$@"
+}
+
+echo "=== Assertion 1: DEFAULT render omits the sidecar ==="
+DEFAULT="$TMP/default.yaml"
+render > "$DEFAULT"
+if grep -qE '^\s*-?\s*name: litellm' "$DEFAULT"; then
+  fail "default render must NOT contain a litellm sidecar/volume; found one (sidecar rendered while disabled)."
+fi
+if grep -q "localhost:" "$DEFAULT"; then
+  fail "default render must NOT repoint ANTHROPIC_BASE_URL at localhost."
+fi
+echo "  ok: no litellm sidecar, no localhost base-url override by default"
+
+echo "=== Assertion 2: ENABLED render adds the sidecar + repoints the runner ==="
+ENABLED="$TMP/enabled.yaml"
+render \
+  --set agentSandbox.runner.liteLLM.enabled=true \
+  --set agentSandbox.runner.liteLLM.configExistingSecret=my-litellm-cfg \
+  --set agentSandbox.runner.liteLLM.port=4000 > "$ENABLED"
+
+grep -qE '^\s*- name: litellm$' "$ENABLED" \
+  || fail "enabled render must contain a container named 'litellm'."
+grep -q 'secretName: "my-litellm-cfg"' "$ENABLED" \
+  || fail "enabled render must mount the operator config Secret (my-litellm-cfg)."
+grep -q 'mountPath: /etc/litellm' "$ENABLED" \
+  || fail "enabled render must mount the config at /etc/litellm."
+grep -q 'value: http://localhost:4000' "$ENABLED" \
+  || fail "enabled render must repoint ANTHROPIC_BASE_URL at http://localhost:4000."
+echo "  ok: sidecar container, config Secret mount, and localhost base-url all present"
+
+echo "=== Assertion 3: local inference wins over the sidecar base-url override ==="
+INFER="$TMP/infer.yaml"
+render \
+  --set agentSandbox.runner.liteLLM.enabled=true \
+  --set agentSandbox.runner.liteLLM.configExistingSecret=my-litellm-cfg \
+  --set inference.deploy=true > "$INFER"
+if grep -q 'value: http://localhost:' "$INFER"; then
+  fail "with inference.deploy=true the sidecar localhost ANTHROPIC_BASE_URL must NOT render (inference path wins)."
+fi
+echo "  ok: inference.deploy=true suppresses the localhost base-url override"
+
+echo
+echo "PASS: LiteLLM sidecar is off by default, renders fully when enabled, and yields to local inference."

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -121,8 +121,21 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       {{- end }}
-      {{- if or $bf.enabled $runner.hardening.enabled }}
+      {{- if or $bf.enabled $runner.hardening.enabled $runner.liteLLM.enabled }}
       volumes:
+        {{- if $runner.liteLLM.enabled }}
+        # LiteLLM proxy config (model_list + router/fallback), mounted read-only
+        # into the sidecar. Sourced from the operator-provided Secret so provider
+        # keys referenced by the config are never inlined into a manifest.
+        - name: litellm-config
+          secret:
+            secretName: {{ $runner.liteLLM.configExistingSecret | quote }}
+            # Map the config key onto the fixed filename the sidecar reads,
+            # regardless of how the operator named it in the Secret.
+            items:
+              - key: {{ $runner.liteLLM.configKey | quote }}
+                path: config.yaml
+        {{- end }}
         {{- if $bf.enabled }}
         # Shared bundle volume: the init pair populates <mountPath>/current, the
         # runner reads it as AGENTOS_PLUGIN_DIR.
@@ -270,6 +283,44 @@ spec:
             {{- toYaml $runner.resources | nindent 12 }}
       {{- end }}
       containers:
+        {{- if $runner.liteLLM.enabled }}
+        # BYO model (#24): LiteLLM Anthropic-format proxy sidecar. Off by default;
+        # enabled only for genuine multi-model routing/fallback. Serves the
+        # Anthropic API shape on localhost:<port>, which the runner targets via
+        # ANTHROPIC_BASE_URL above. Config (model_list, router/fallback) comes from
+        # the operator-provided Secret; provider keys come from liteLLM.extraEnv.
+        - name: litellm
+          image: {{ $runner.liteLLM.image | quote }}
+          imagePullPolicy: {{ $runner.liteLLM.imagePullPolicy }}
+          {{- if $runner.hardening.enabled }}
+          # Same container-level lockdown as the runner: the proxy only reads its
+          # mounted config and talks upstream, so a read-only rootfs is safe.
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+          {{- end }}
+          args:
+            - --config
+            - /etc/litellm/config.yaml
+            - --port
+            - {{ $runner.liteLLM.port | quote }}
+          ports:
+            - name: litellm
+              containerPort: {{ $runner.liteLLM.port }}
+          {{- with $runner.liteLLM.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: litellm-config
+              mountPath: /etc/litellm
+              readOnly: true
+          resources:
+            {{- toYaml $runner.liteLLM.resources | nindent 12 }}
+        {{- end }}
         - name: runner
           image: {{ include "agentos.image" (dict "repository" $runner.image "tag" $runner.tag "digest" $runner.digest "defaultTag" $.Chart.AppVersion) | quote }}
           imagePullPolicy: {{ $runner.imagePullPolicy }}
@@ -308,6 +359,13 @@ spec:
             # non-zero.
             - name: AGENTOS_MODEL
               value: {{ $runner.model | quote }}
+            {{- end }}
+            {{- if and $runner.liteLLM.enabled (not .Values.inference.deploy) }}
+            # BYO model (#24): route through the in-pod LiteLLM sidecar, which
+            # serves the Anthropic API shape on localhost. Multi-model routing /
+            # fallback lives in the sidecar's config; the runner just points at it.
+            - name: ANTHROPIC_BASE_URL
+              value: http://localhost:{{ $runner.liteLLM.port }}
             {{- end }}
             {{- if $runner.credentials }}
             # Warm-pod fallback credential; the worker's per-claim Overrides

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -707,6 +707,37 @@ agentSandbox:
     envVarsInjectionPolicy: Overrides
     # Extra env for the runner container, list of {name, value}.
     extraEnv: []
+    # --- BYO model: LiteLLM Anthropic-format sidecar (part of #24) ---
+    # Off by default. Enable ONLY for genuine multi-model routing/fallback: a
+    # LiteLLM proxy runs as a sidecar in the sandbox pod, serving the Anthropic
+    # API shape on localhost, and the runner's ANTHROPIC_BASE_URL is repointed at
+    # it (http://localhost:<port>). For a single model per agent prefer the
+    # OpenRouter / provider-native path (leave this off and set runner.model +
+    # runner.credentials, or a per-agent credential) -- a sidecar per sandbox pod
+    # is pure overhead when no routing is needed. Ignored while local
+    # inference.deploy is on (that path already binds ANTHROPIC_BASE_URL to the
+    # in-cluster Ollama endpoint).
+    liteLLM:
+      enabled: false
+      image: ghcr.io/berriai/litellm:main-stable
+      imagePullPolicy: IfNotPresent
+      # Port the proxy listens on inside the pod; the runner reaches it over
+      # localhost, so it is never exposed as a Service.
+      port: 4000
+      # Name of a pre-created Secret (or ConfigMap-shaped Secret) holding the
+      # LiteLLM config.yaml -- the model_list and router/fallback settings. It is
+      # mounted read-only at /etc/litellm/config.yaml and passed to the proxy via
+      # --config. REQUIRED when enabled; provider API keys the config references
+      # are supplied through extraEnv (secretKeyRef), never inlined here.
+      configExistingSecret: ""
+      # Key within that Secret that carries the config file body.
+      configKey: config.yaml
+      # Extra env for the sidecar, list of {name, value} (or full env entries with
+      # valueFrom.secretKeyRef for provider credentials, e.g. OPENAI_API_KEY).
+      extraEnv: []
+      resources:
+        requests: { cpu: 50m, memory: 128Mi }
+        limits: { cpu: "1", memory: 512Mi }
     # --- Bundle-fetch provisioning ---
     # AGENTOS_BUNDLE_REF is a MinIO object key the substrate injects per-claim
     # (bound sandboxes carry it; warm/unbound pods do not). Before the runner


### PR DESCRIPTION
## What

Adds an off-by-default LiteLLM Anthropic-format sidecar to the runner SandboxTemplate, per #253 (part of the #24 BYO-model epic).

- New `agentSandbox.runner.liteLLM` values block (camelCase, toggle idiom): `enabled` (default `false`), `image`, `imagePullPolicy`, `port`, `configExistingSecret`, `configKey`, `extraEnv`, `resources`.
- When `enabled=true`: a `litellm` sidecar container runs in the sandbox pod serving the Anthropic API shape on `localhost:<port>`; the runner's `ANTHROPIC_BASE_URL` is repointed at it. Config (model_list + router/fallback) is mounted read-only from an operator-provided Secret so provider keys are never inlined into a manifest. Inherits the runner's container hardening when enabled.
- Precedence: local `inference.deploy=true` still wins over the sidecar's localhost override.
- Guidance in values.yaml steers operators to OpenRouter / provider-native paths for single-model agents; the sidecar is only for genuine multi-model routing/fallback.

## Acceptance

Enabling the flag deploys the sidecar; disabled by default it is absent from the rendered manifests. ✅

## Verify

- `helm lint charts/agentos` — clean.
- `charts/agentos/ci/litellm-sidecar-assertions.sh` — new chart-owned render-assertion script (default omits sidecar; enabled renders container + Secret mount + localhost base-url; inference precedence). Wired into `helm-ci.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #253