### PR TITLE
Second harness: "implement an ACI server" guide from the conformance suite (#256)

### DIFF
--- a/docs/interfaces/aci-producer/INTERFACE.md
+++ b/docs/interfaces/aci-producer/INTERFACE.md
@@ -47,6 +47,7 @@ SDK-shaped resume. Otherwise the line is clean and frozen: unknown wire versions
 
 ## Cross-links
 
+- **Guide:** [implementing-an-aci-server.md](./implementing-an-aci-server.md) — stand up a conformant second ACI server, driven from the conformance suite (#256).
 - **Epic(s):** [#25](https://github.com/curie-eng/agentos/issues/25) — write the "implement an ACI server" guide from the conformance suite so the port is documented, not just enforced
 - **Epic(s):** [#47](https://github.com/curie-eng/agentos/issues/47) — telemetry as part of the ACI (OTEL carried in `SessionConfig`)
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 1 (Harness / runtime), grade A-

--- a/docs/interfaces/aci-producer/implementing-an-aci-server.md
+++ b/docs/interfaces/aci-producer/implementing-an-aci-server.md
@@ -1,0 +1,222 @@
+# Guide: implementing an ACI server
+
+> Part of the #25 epic (a second harness behind the ACI protocol). Companion to
+> [INTERFACE.md](./INTERFACE.md) (the frozen protocol) and driven by the
+> conformance suite in `packages/aci-protocol/src/aci_protocol/conformance.py`.
+
+The ACI (Agent Container Interface) is the seam that makes the **harness**
+swappable: anything inside the sandbox that speaks the ACI wire contract can
+replace the default claude-agent-sdk runner without the worker, CLI, or UI
+changing. This guide shows how to stand up a second, conformant ACI server from
+scratch, using the conformance suite as your specification and acceptance test —
+you should not need to read the reference runner's internals.
+
+The frozen contract lives in `packages/aci-protocol`; import its Pydantic models
+rather than re-deriving the wire shapes. The models are the single source of
+truth (the committed JSON Schema and generated Rust/TS are derived from them).
+
+## What "an ACI server" is
+
+An ACI server is an **HTTP process** inside the sandbox that exposes three POST
+routes and streams NDJSON back:
+
+| Route | Purpose |
+| --- | --- |
+| `POST /v1/event` | Open a turn. Body is an inbound `event` frame; the response streams outbound NDJSON, ending in a `final` event. |
+| `POST /v1/steer` | Inject a follow-up `event` into the live turn; return `409` when no turn is active (the caller then falls back to a fresh `/v1/event`). |
+| `POST /v1/interrupt` | Hard-stop the live turn. Body is an `interrupt` frame; the open turn's `final` is reclassified to idle. |
+
+Plus two unauthenticated GETs the platform relies on: `GET /healthz` (liveness)
+and `GET /status` (session status + readiness). The chart's readiness probe hits
+`/healthz` with no auth header, so keep those two open even when the POST routes
+are token-gated.
+
+Session setup is **not** on the wire — it comes from the environment. Read it once
+at startup with `SessionConfig.from_env()` (the `AGENTOS_*` mapping: `plugin_dir`,
+`session_id`, `sandbox_id`, `budget`, optional `memory_ref`, `credentials_ref`,
+`otel`).
+
+## The wire contract in one screen
+
+Import everything from `aci_protocol`; do not hand-roll JSON.
+
+**Inbound** — a discriminated union on `kind` (`parse_inbound` decodes it):
+
+- `Event` = `{kind: "event", type: "message"|"job"|"eval_case", text, user, ts}`
+- `Interrupt` = `{kind: "interrupt", reason}`
+
+**Outbound** — a discriminated union on `type`, each carrying `version`
+(`to_ndjson_line` encodes, `parse_ndjson_line` decodes one line):
+
+- `TextDelta` → `text_delta` `{version, text}`
+- `ToolNote` → `tool_note` `{version, text, tool?}`
+- `Final` → `final` `{version, text, status}` where `status ∈ {done,
+  idle-awaiting-input, classified-failure}`
+- `ErrorEvent` → `error` `{version, message, classification?}`
+- `SideEffectFlag` → `side_effect_flag` `{version, tool?, detail?}`
+
+**Version gate (strict).** Every outbound event's `version` must equal
+`PROTOCOL_VERSION` (currently `0.1.0`). The decoder raises `ProtocolVersionError`
+on a missing or mismatched version — this is deliberate and is one of the
+conformance checks. Because the models set `version` as a `const` literal, you get
+this for free by constructing the models rather than emitting raw dicts.
+
+## Step 1 — model your turn as a producer
+
+Before writing any HTTP, capture your harness's core behavior as a **`Producer`**:
+a plain function mapping one inbound frame to the NDJSON lines your server would
+emit for it. This is exactly what the conformance suite validates, and it lets you
+reach `passed=True` before you have a socket open.
+
+```python
+from collections.abc import Iterable
+
+from aci_protocol import (
+    Event, Interrupt, Final, TextDelta, ToolNote, SideEffectFlag,
+    SessionStatus, to_ndjson_line,
+)
+
+def my_producer(message: Event | Interrupt) -> Iterable[str]:
+    # Interrupt: end the turn as idle-awaiting-input.
+    if isinstance(message, Interrupt):
+        return [to_ndjson_line(Final(text="interrupted",
+                                     status=SessionStatus.IDLE_AWAITING_INPUT))]
+
+    # Event: do your harness's real work here (call your model, run tools),
+    # emitting events as you go. Every stream MUST end in a Final.
+    lines = [to_ndjson_line(TextDelta(text="working..."))]
+    # ... your model/tool loop appends ToolNote / TextDelta / SideEffectFlag ...
+    lines.append(to_ndjson_line(Final(text="all done", status=SessionStatus.DONE)))
+    return lines
+```
+
+Note what you did **not** do: no version strings, no JSON assembly, no field
+names. Constructing the frozen models and calling `to_ndjson_line` guarantees the
+version gate and the exact wire shape.
+
+## Step 2 — run the conformance suite against your producer
+
+`run_conformance` is your acceptance test. Pass your producer; it returns a
+`ConformanceReport` (it never raises — every failure is a failing `CheckResult`).
+
+```python
+from aci_protocol import run_conformance
+from my_harness import my_producer
+
+report = run_conformance(my_producer)
+assert report.passed, report.summary()
+```
+
+The suite runs five checks (the last only when you pass a producer):
+
+| Check | What it proves |
+| --- | --- |
+| `outbound_roundtrip` | Every outbound event type survives encode→decode (library-level; always runs). |
+| `inbound_roundtrip` | Every inbound frame survives encode→decode (always runs). |
+| `reject_unknown_version` | A `9.9.9` line is rejected with `ProtocolVersionError`. |
+| `reject_missing_version` | A version-less line is rejected. |
+| `producer_stream` | **Your** producer emits a well-formed stream for every inbound case. |
+
+`producer_stream` is where your implementation is judged. It exercises **all four
+inbound cases** — `event:message`, `event:job`, `event:eval_case`, and
+`interrupt` — and for each requires:
+
+1. the producer emits **at least one** event (no empty stream);
+2. the stream **ends in a `final`** event;
+3. **every** event carries `version == PROTOCOL_VERSION`.
+
+A harness that handles ordinary messages but drops `interrupt` or a batch `job`
+will fail here — that is the point. A concrete failing example: a producer that
+emits only a `text_delta` and no `final` fails `producer_stream` with a detail
+naming the missing `final`.
+
+## Step 3 — wrap the producer in the three HTTP routes
+
+Once the producer is conformant, the server is thin: parse the body with
+`parse_inbound`, reject the wrong frame type, and stream the producer's lines.
+Sketch (framework-agnostic; the reference uses aiohttp):
+
+```python
+# POST /v1/event
+frame = parse_inbound(await request.json())      # -> Event | Interrupt
+if not isinstance(frame, Event):
+    return json_response({"error": "use /v1/interrupt for interrupts"}, status=400)
+# stream NDJSON, content-type application/x-ndjson
+for line in my_producer(frame):
+    await response.write(line.encode("utf-8"))
+```
+
+Route contract to honor:
+
+- **`/v1/event`**: body must be an `event` frame (400 otherwise). Response
+  `Content-Type: application/x-ndjson`, streamed, ending in `final`.
+- **`/v1/steer`**: body is an `event` frame injected into the live turn; its output
+  surfaces on the open `/v1/event` stream. Return **409** when no turn is active.
+- **`/v1/interrupt`**: body is an `interrupt` frame; hard-stop the live turn and
+  let its `final` reclassify to `idle-awaiting-input`.
+- **`/healthz`**, **`/status`**: always-open GETs; `/status` returns
+  `{status, ready, turn_active}`.
+- **Auth (optional):** when a bearer token is configured, require
+  `Authorization: Bearer <token>` on the three POST routes only, compared with a
+  constant-time check; leave the GETs open for the probe.
+
+Map any decode/validation error on a POST body to a **400** so a malformed frame
+is a clean client error, not a 500.
+
+## Step 4 — read session setup from the environment
+
+At process start, build your config from env and honor it:
+
+```python
+from aci_protocol import SessionConfig
+
+cfg = SessionConfig.from_env()   # AGENTOS_PLUGIN_DIR, AGENTOS_SESSION_ID, ...
+# cfg.plugin_dir: mount point of the Claude Code plugin bundle to load
+# cfg.budget:     Budget{max_output_tokens_per_run, task_budget_hint?, max_usd_per_day}
+# cfg.otel:       optional OTLP endpoint/headers/protocol
+```
+
+Your server must interpret the plugin bundle mounted at `AGENTOS_PLUGIN_DIR` (the
+Claude Code plugin shape — see the
+[bundle-format seam](../bundle-format/INTERFACE.md)). This is the one documented
+entanglement: a foreign harness still has to load that bundle shape.
+
+## Step 5 — wire it as a test gate (recommended)
+
+Make conformance a permanent gate, exactly as the protocol package and the runner
+do. The runner builds its producer by driving the real session to completion and
+collecting the NDJSON it emits (`runner/src/agentos_runner/conformance.py`); your
+producer can do the same over your implementation:
+
+```python
+def test_my_harness_is_conformant() -> None:
+    report = run_conformance(my_producer)
+    assert report.passed, report.summary()
+```
+
+If your producer needs to run an async turn to completion (most real harnesses
+do), collect the stream inside the sync `Producer` boundary — e.g. with
+`anyio.run` — the way the reference runner's `conformance_producer` does; the
+suite only needs the finished list of lines.
+
+## Acceptance checklist
+
+You have a conformant ACI server when:
+
+- [ ] `run_conformance(my_producer).passed` is `True` (all five checks).
+- [ ] The producer ends every stream in a `final` and handles `interrupt` and
+      `job`/`eval_case`, not just `message`.
+- [ ] All outbound events are built from `aci_protocol` models (version gate free).
+- [ ] `POST /v1/event` streams `application/x-ndjson`; `/v1/steer` returns 409 with
+      no live turn; `/v1/interrupt` reclassifies to idle.
+- [ ] `GET /healthz` and `GET /status` are open and unauthenticated.
+- [ ] `SessionConfig.from_env()` is honored and the `AGENTOS_PLUGIN_DIR` bundle is
+      loaded.
+
+## Cross-links
+
+- [INTERFACE.md](./INTERFACE.md) — the frozen ACI protocol and its swap-readiness grade.
+- `packages/aci-protocol/README.md` — the full contract surface and decisions.
+- `packages/aci-protocol/src/aci_protocol/conformance.py` — the suite this guide is driven from.
+- `packages/aci-protocol/src/aci_protocol/reference.py` — a minimal conformant `reference_producer` to copy from.
+- `runner/src/agentos_runner/conformance.py` — the reference producer built over a real session (the pattern for Step 5).


### PR DESCRIPTION
## What

Doc-only. Adds the "implement an ACI server" guide, driven from the existing conformance suite so the frozen port (`packages/aci-protocol`) is documented, not just enforced. Per #256 (part of #25).

`docs/interfaces/aci-producer/implementing-an-aci-server.md` walks a developer end to end:
- what an ACI server is (three POST routes + `/healthz`//`status`, NDJSON streaming, env-based setup);
- the wire contract in one screen (inbound/outbound discriminated unions + the strict `version` gate), all via `aci_protocol` models so the version gate comes for free;
- model your turn as a `Producer`, then use `run_conformance(producer)` as the acceptance test;
- the five checks and exactly what `producer_stream` demands (non-empty, ends in `final`, all four inbound cases incl. `interrupt`/`job`, version match);
- wrap the producer in the HTTP routes (400 on bad frame, 409 on steer with no live turn, optional bearer auth on POSTs only);
- `SessionConfig.from_env()` + the `AGENTOS_PLUGIN_DIR` bundle entanglement;
- wire conformance as a permanent test gate (the `runner/src/agentos_runner/conformance.py` pattern);
- an acceptance checklist.

Grounded in `packages/aci-protocol` (README, `conformance.py`, `reference.py`) and the runner's conformance producer. The guide's sample producer was run through `run_conformance` and passes 5/5. Linked from the aci-producer INTERFACE. No code.

## Acceptance

A developer can follow the guide + conformance suite to stand up a stub server without reading the reference runner's internals. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #256