### PR TITLE
Blessed in-bundle stdio MCP engine template + docs (#274)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ export CLAUDE_CODE_OAUTH_TOKEN=...
 
 A committed first-party example lives at `examples/weather/`. `cd examples/weather && agentos skill up` runs it from a clean clone. `agentos init` scaffolds this same weather template, so every fresh bundle starts as a runnable web-search skill to learn from and edit.
 
+For the "engine as an in-bundle stdio MCP server" shape — a bundle that ships
+its own tools as a stdio subprocess the harness spawns, which a hosted harness
+cannot do — see the template at [`examples/text-stats-engine/`](examples/text-stats-engine/README.md).
+
 For a fully offline round-trip (no credential, scripted replies), add
 `--fake-model` to `agentos skill up` — an explicit test-only mode that never reaches
 the Anthropic API.

--- a/examples/tests/test_text_stats_engine.py
+++ b/examples/tests/test_text_stats_engine.py
@@ -1,0 +1,76 @@
+"""The text-stats-engine template validates and its in-bundle engine runs.
+
+Guards the blessed "engine as an in-bundle stdio MCP server" template (#274):
+the bundle stays byte-compatible with ``plugin_format.validate_bundle`` and the
+engine speaks the MCP stdio transport end-to-end without a model or the network.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from plugin_format import validate_bundle
+
+BUNDLE = Path(__file__).resolve().parents[1] / "text-stats-engine"
+
+
+def test_template_bundle_validates() -> None:
+    result = validate_bundle(BUNDLE)
+    assert result.valid, result.errors
+    assert result.errors == []
+
+
+def _drive(*requests: dict) -> list[dict]:
+    payload = "".join(json.dumps(r) + "\n" for r in requests)
+    proc = subprocess.run(
+        [sys.executable, "scripts/engine_server.py"],
+        cwd=BUNDLE,
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    return [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+
+
+def test_engine_handshake_and_tools_list() -> None:
+    responses = _drive(
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+    )
+    assert responses[0]["result"]["serverInfo"]["name"] == "text-stats-engine"
+    tool_names = {t["name"] for t in responses[1]["result"]["tools"]}
+    assert tool_names == {"word_count", "char_count", "reading_time_minutes"}
+
+
+def test_engine_tool_call_returns_result() -> None:
+    (response,) = _drive(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "word_count", "arguments": {"text": "one two three"}},
+        }
+    )
+    assert response["result"]["content"][0]["text"] == "3"
+    assert response["result"]["isError"] is False
+
+
+def test_engine_notification_gets_no_reply() -> None:
+    # Notifications carry no id and must produce no response line.
+    responses = _drive({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    assert responses == []
+
+
+def test_engine_unknown_tool_is_an_error() -> None:
+    (response,) = _drive(
+        {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {"name": "nope", "arguments": {}},
+        }
+    )
+    assert response["error"]["code"] == -32602

--- a/examples/text-stats-engine/.claude-plugin/plugin.json
+++ b/examples/text-stats-engine/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "text-stats-engine",
+  "version": "0.1.0",
+  "description": "Template bundle: an engine packaged as an in-bundle stdio MCP server.",
+  "author": { "name": "CurieTech" },
+  "keywords": ["template", "mcp", "stdio", "engine"],
+  "mcpServers": ".mcp.json"
+}

--- a/examples/text-stats-engine/.gitignore
+++ b/examples/text-stats-engine/.gitignore
@@ -1,0 +1,1 @@
+.agentos/

--- a/examples/text-stats-engine/.mcp.json
+++ b/examples/text-stats-engine/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "text-stats-engine": {
+      "command": "python3",
+      "args": ["scripts/engine_server.py"]
+    }
+  }
+}

--- a/examples/text-stats-engine/README.md
+++ b/examples/text-stats-engine/README.md
@@ -1,0 +1,83 @@
+# text-stats-engine — engine as an in-bundle stdio MCP server
+
+A blessed template bundle for the **"engine as an in-bundle stdio MCP server"**
+shape (#274). The bundle's tools live *inside the bundle* and are spawned as a
+stdio subprocess by the harness — no network service, no hosted sidecar, nothing
+to provision. A hosted harness that can only reach remote MCP URLs cannot do
+this; running the engine in-process next to the agent is the differentiator this
+template paves.
+
+## What's here
+
+```
+text-stats-engine/
+  .claude-plugin/plugin.json   manifest; points mcpServers at .mcp.json
+  .mcp.json                    declares the stdio server (command + args)
+  scripts/engine_server.py     the engine: a stdlib-only stdio MCP server
+  skills/text-stats/SKILL.md   a skill that drives the engine's tools
+```
+
+The engine (`scripts/engine_server.py`) speaks the MCP **stdio transport**:
+newline-delimited JSON-RPC 2.0 on stdin/stdout. It is deliberately
+dependency-free (Python stdlib only) so it runs end-to-end from a clean clone
+with no install step. It implements `initialize`, `tools/list`, and `tools/call`
+for a tiny deterministic text-statistics engine (`word_count`, `char_count`,
+`reading_time_minutes`).
+
+The `.mcp.json` declaration is what makes it "in-bundle": the `command` +
+`args` point at a script *inside the bundle*, resolved relative to the bundle
+root, so the harness spawns it as a child process. This validates against
+`plugin_format.validate_bundle` unchanged — the format already accepts stdio MCP
+servers (the `McpServer` model), which is exactly the surface this template
+exploits.
+
+## Run it end-to-end
+
+Drive the engine directly (no model, no network) to see the transport work:
+
+```bash
+cd examples/text-stats-engine
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"word_count","arguments":{"text":"one two three"}}}' \
+  | python3 scripts/engine_server.py
+```
+
+You will see three JSON-RPC responses: the handshake, the tool catalog, and
+`3` (the word count). Under a real agent, `agentos skill up` spawns the same
+server from the `.mcp.json` declaration and the `text-stats` skill calls its
+tools.
+
+## When to use this shape vs. a CLI subprocess
+
+Both shapes run engine code you ship inside the bundle. They differ in how the
+agent talks to it.
+
+**Use an in-bundle stdio MCP server (this template) when:**
+
+- The engine exposes **discrete, callable tools** the model chooses among
+  mid-turn — `tools/list` advertises them and the model calls them by name with
+  typed arguments (the `inputSchema`).
+- You want **structured request/response** with argument validation, multiple
+  round-trips within one turn, and per-tool results, rather than one opaque
+  invocation.
+- You want the engine to be a **long-lived process** for the session (spawned
+  once, many calls) instead of re-exec'd per call.
+- You want it to work on a substrate that cannot host a network MCP endpoint —
+  the whole point of the differentiator.
+
+**Use a CLI subprocess (e.g. a `scripts/` command the skill shells out to via
+`Bash`) when:**
+
+- The work is a **one-shot command** — run it, read stdout, done — with no need
+  for a tool catalog or a persistent session.
+- The engine is an **existing binary or script** you do not want to wrap in an
+  MCP server (a Makefile target, a linter, a codegen step).
+- The model does not need to *choose* among tools; the skill already knows the
+  exact command to run.
+
+Rule of thumb: reach for the stdio MCP engine when the model needs to **pick and
+call typed tools**; reach for a CLI subprocess when the skill needs to **run one
+known command**. The CLI-subprocess shape keeps working exactly as before; this
+template adds the MCP-engine option alongside it.

--- a/examples/text-stats-engine/scripts/engine_server.py
+++ b/examples/text-stats-engine/scripts/engine_server.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""In-bundle stdio MCP server: the "engine" this template ships.
+
+This is the blessed "engine as an in-bundle stdio MCP server" shape (#274). The
+engine's tools live *inside the bundle* and are spawned as a stdio subprocess by
+the harness via the ``.mcp.json`` declaration — no network service, no hosted
+sidecar, nothing to provision. A hosted harness that can only reach remote MCP
+URLs cannot do this; running the engine in-process next to the agent is the
+differentiator this template paves.
+
+Transport: the MCP stdio transport — newline-delimited JSON-RPC 2.0 on stdin /
+stdout (one message per line). Deliberately dependency-free (Python stdlib only)
+so the template runs end-to-end from a clean clone with no install step.
+
+Implements just enough of MCP to be a real, drivable server:
+    initialize        -> protocol handshake
+    tools/list        -> advertise this engine's tools
+    tools/call        -> run a tool and return its result
+
+The tools are a tiny deterministic "text statistics" engine so the template is
+verifiable without a model or the network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+PROTOCOL_VERSION = "2025-06-18"
+SERVER_NAME = "text-stats-engine"
+SERVER_VERSION = "0.1.0"
+
+# Tool catalog advertised via tools/list. Each entry carries the JSON Schema the
+# MCP client uses to validate arguments before calling.
+TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "word_count",
+        "description": "Count the words in a piece of text.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "char_count",
+        "description": "Count the characters in a piece of text.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {"type": "string"},
+                "include_whitespace": {"type": "boolean", "default": True},
+            },
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "reading_time_minutes",
+        "description": "Estimate reading time in minutes at 200 words per minute.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"text": {"type": "string"}},
+            "required": ["text"],
+        },
+    },
+]
+
+
+def _run_tool(name: str, arguments: dict[str, Any]) -> str:
+    text = str(arguments.get("text", ""))
+    if name == "word_count":
+        return str(len(text.split()))
+    if name == "char_count":
+        if arguments.get("include_whitespace", True):
+            return str(len(text))
+        return str(len("".join(text.split())))
+    if name == "reading_time_minutes":
+        words = len(text.split())
+        # Round up to a whole minute; empty text reads in 0 minutes.
+        return str(-(-words // 200)) if words else "0"
+    raise KeyError(name)
+
+
+def _handle(request: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a JSON-RPC response, or None for a notification (no reply)."""
+
+    method = request.get("method")
+    req_id = request.get("id")
+
+    # Notifications (e.g. notifications/initialized) carry no id and get no reply.
+    if req_id is None:
+        return None
+
+    if method == "initialize":
+        result = {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+        }
+    elif method == "tools/list":
+        result = {"tools": TOOLS}
+    elif method == "tools/call":
+        params = request.get("params") or {}
+        name = params.get("name", "")
+        arguments = params.get("arguments") or {}
+        try:
+            output = _run_tool(name, arguments)
+        except KeyError:
+            return _error(req_id, -32602, f"unknown tool: {name!r}")
+        result = {"content": [{"type": "text", "text": output}], "isError": False}
+    else:
+        return _error(req_id, -32601, f"method not found: {method!r}")
+
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _error(req_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+def main() -> None:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        response = _handle(request)
+        if response is not None:
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/text-stats-engine/skills/text-stats/SKILL.md
+++ b/examples/text-stats-engine/skills/text-stats/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: text-stats
+description: Compute word count, character count, or reading time for a piece of text using the in-bundle text-stats engine. Invoke whenever the user asks how long a passage is, how many words or characters it has, or how long it takes to read.
+allowed-tools:
+  - text-stats-engine
+---
+
+# Text statistics
+
+## When to run
+The user asks how many words or characters a passage has, or how long it takes
+to read.
+
+## How to answer
+1. Take the text the user provided (or asks about).
+2. Call the in-bundle engine's tool for the metric requested:
+   - `word_count` for a word total.
+   - `char_count` for a character total (pass `include_whitespace: false` to
+     exclude spaces).
+   - `reading_time_minutes` for an estimated read time at 200 wpm.
+3. Report the number plainly, naming the metric and the text it applies to.
+
+## Notes
+The engine runs as an in-bundle stdio MCP server (`scripts/engine_server.py`,
+declared in `.mcp.json`). The harness spawns it as a subprocess; there is no
+network service and nothing to provision. See this bundle's README for when to
+prefer this shape over a CLI subprocess.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ testpaths = [
     "apps/worker/tests",
     "runner/tests",
     "compose/tests",
+    "examples/tests",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## What

Adds the blessed **"engine as an in-bundle stdio MCP server"** template bundle plus docs (part of #30). The plugin format already validates stdio MCP servers (the `McpServer` model) — something a hosted harness cannot run — and this template paves that differentiator.

`examples/text-stats-engine/`:
- `scripts/engine_server.py` — a stdlib-only stdio MCP server (newline-delimited JSON-RPC 2.0): `initialize`, `tools/list`, `tools/call` over a small deterministic text-statistics engine. No deps, no network, runs from a clean clone.
- `.mcp.json` — declares the engine as an in-bundle stdio server (`command` + `args` resolved relative to the bundle root).
- `skills/text-stats/SKILL.md` — a skill that drives the engine's tools.
- `README.md` — explains the shape and **when to use it vs. a CLI subprocess** (typed tool selection mid-turn vs. one known one-shot command). The CLI-subprocess shape keeps working.

## Verification

- `plugin_format.validate_bundle('examples/text-stats-engine')` → `valid: True`, no errors/warnings (byte-compatible with the frozen format).
- Engine driven end-to-end via stdin/stdout: handshake, tool catalog, and tool results all correct.
- New tests under `examples/tests/` (registered in workspace `testpaths`): bundle validates, handshake + tools/list, tool call result, notification produces no reply, unknown tool errors. `uv run pytest examples/tests` → 5 passed. `ruff check examples/` clean.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)