### PR TITLE
CliHint primitive: glyph morphs to copy button (#277)

### DIFF
--- a/apps/ui/src/primitives/CliHint.test.tsx
+++ b/apps/ui/src/primitives/CliHint.test.tsx
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CliHint } from "./CliHint";
+import { StoreProvider, useStore } from "../state/store";
+
+// Surfaces the store's toast so a copy can be asserted without styling internals.
+function ToastProbe() {
+  const { state } = useStore();
+  return <span data-testid="toast">{state.toast ?? ""}</span>;
+}
+
+function renderHint(props: { command: string; label?: string }) {
+  return render(
+    <StoreProvider>
+      <CliHint {...props} />
+      <ToastProbe />
+    </StoreProvider>,
+  );
+}
+
+const writeText = vi.fn(() => Promise.resolve());
+
+function setClipboard(value: unknown) {
+  Object.defineProperty(navigator, "clipboard", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+beforeEach(() => {
+  writeText.mockClear();
+  setClipboard({ writeText });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("CliHint", () => {
+  it("renders the resting >_ glyph", () => {
+    renderHint({ command: "agentos skill up" });
+    expect(screen.getByRole("button")).toHaveTextContent(">_");
+  });
+
+  it("previews the exact command in a tooltip and aria-label", () => {
+    renderHint({ command: "agentos skill up" });
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveAttribute("title", "$ agentos skill up");
+    expect(btn).toHaveAccessibleName("Copy command: agentos skill up");
+  });
+
+  it("morphs to the copy glyph on hover and back on leave", async () => {
+    const user = userEvent.setup();
+    renderHint({ command: "agentos skill up" });
+    const btn = screen.getByRole("button");
+    await user.hover(btn);
+    expect(btn).toHaveTextContent("⧉");
+    await user.unhover(btn);
+    expect(btn).toHaveTextContent(">_");
+  });
+
+  it("morphs on keyboard focus and back on blur", async () => {
+    const user = userEvent.setup();
+    renderHint({ command: "agentos skill up" });
+    const btn = screen.getByRole("button");
+    await user.tab();
+    expect(btn).toHaveFocus();
+    expect(btn).toHaveTextContent("⧉");
+    await user.tab();
+    expect(btn).toHaveTextContent(">_");
+  });
+
+  it("copies on click: writes the command, toasts, and flips to ✓", async () => {
+    const user = userEvent.setup();
+    setClipboard({ writeText }); // after setup(), which installs its own stub
+    renderHint({ command: "agentos skill up" });
+    const btn = screen.getByRole("button");
+    await user.click(btn);
+    expect(writeText).toHaveBeenCalledWith("agentos skill up");
+    expect(screen.getByTestId("toast")).toHaveTextContent("Copied");
+    expect(btn).toHaveAttribute("data-copied", "true");
+    expect(btn).toHaveTextContent("✓");
+    // The ✓ resets after the timeout.
+    await waitFor(() => expect(btn).toHaveAttribute("data-copied", "false"), {
+      timeout: 2500,
+    });
+  });
+
+  it("copies via keyboard (Enter) for accessibility", async () => {
+    const user = userEvent.setup();
+    setClipboard({ writeText }); // after setup(), which installs its own stub
+    renderHint({ command: "agentos skill up" });
+    const btn = screen.getByRole("button");
+    btn.focus();
+    await user.keyboard("{Enter}");
+    expect(writeText).toHaveBeenCalledWith("agentos skill up");
+  });
+
+  it("renders an optional label", () => {
+    renderHint({ command: "agentos skill up", label: "Run it" });
+    expect(screen.getByRole("button")).toHaveTextContent("Run it");
+  });
+
+  it("still toasts when the clipboard API is unavailable", async () => {
+    const user = userEvent.setup();
+    setClipboard(undefined); // after setup(), which installs its own stub
+    renderHint({ command: "agentos skill up" });
+    await user.click(screen.getByRole("button"));
+    expect(writeText).not.toHaveBeenCalled();
+    expect(screen.getByTestId("toast")).toHaveTextContent("Copied");
+  });
+});

--- a/apps/ui/src/primitives/CliHint.tsx
+++ b/apps/ui/src/primitives/CliHint.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { C } from "../tokens";
+import { useStore } from "../state/store";
+
+// CliHint: a resting `>_` glyph that morphs in place into a copy button on
+// hover / keyboard-focus (cross-fades to `⧉`, accent color), previews the exact
+// command in a tooltip, and copies on a single click (glyph flips to a green
+// `✓` and fires the "Copied" toast). Composes the same clipboard + toast
+// affordance as CopyButton, in a self-contained inline control.
+//
+// Keyboard-accessible (it is a real <button>, so Enter/Space activate it); on
+// touch, a tap copies directly (there is no hover step to gate on). The
+// morph is driven by hover/focus state and a transient "copied" flag, all
+// CSS transitions so it degrades gracefully.
+
+const COPIED_RESET_MS = 1200;
+
+export function CliHint({ command, label }: { command: string; label?: string }) {
+  const { dispatch } = useStore();
+  const [active, setActive] = useState(false); // hover or keyboard focus
+  const [copied, setCopied] = useState(false);
+
+  function copy() {
+    if (navigator.clipboard) {
+      void navigator.clipboard.writeText(command).catch(() => {});
+    }
+    dispatch({ type: "toast", message: "Copied" });
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), COPIED_RESET_MS);
+  }
+
+  // Resting `>_`; morphs to `⧉` on hover/focus; flips to `✓` right after copy.
+  const glyph = copied ? "✓" : active ? "⧉" : ">_";
+  const glyphColor = copied ? C.brand : active ? C.link : C.muted;
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      onMouseEnter={() => setActive(true)}
+      onMouseLeave={() => setActive(false)}
+      onFocus={() => setActive(true)}
+      onBlur={() => setActive(false)}
+      title={`$ ${command}`}
+      aria-label={`Copy command: ${command}`}
+      data-copied={copied ? "true" : "false"}
+      style={{
+        background: "transparent",
+        border: "none",
+        color: glyphColor,
+        cursor: "pointer",
+        fontFamily: C.mono,
+        fontSize: 12,
+        padding: "2px 4px",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 5,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          color: glyphColor,
+          width: "1.4em",
+          textAlign: "center",
+          transition: "color .15s ease",
+        }}
+      >
+        {glyph}
+      </span>
+      {label ? <span>{label}</span> : null}
+    </button>
+  );
+}

--- a/apps/ui/src/primitives/index.ts
+++ b/apps/ui/src/primitives/index.ts
@@ -4,6 +4,7 @@ export { Chip } from "./Chip";
 export { Button, type ButtonVariant } from "./Button";
 export { Card } from "./Card";
 export { CopyButton } from "./CopyButton";
+export { CliHint } from "./CliHint";
 export { SectionTitle } from "./SectionTitle";
 export { EmptyState } from "./EmptyState";
 export { Notice } from "./Notice";


### PR DESCRIPTION
## What

New React primitive `apps/ui/src/primitives/CliHint.tsx` (part of #145, console/CLI parity). Composes the same clipboard + `Toast` affordance as `CopyButton`:

- Resting `>_` glyph that **morphs in place** into a copy glyph (`⧉`, accent/link color) on hover or keyboard focus.
- Previews the exact command as `$ <command>` in a `title` tooltip.
- Single click copies: writes to clipboard (best-effort), fires the "Copied" toast, and the glyph flips to a green `✓` (resets after a short delay).
- Keyboard-accessible (native `<button>`, so Enter/Space activate) and touch-friendly (a tap copies directly, no hover gate).

Self-contained — no manifest dependency yet (that's #278). Exported from `primitives/index.ts`.

## Verification

- `pnpm test` → 96 passed (16 files), including the new `CliHint.test.tsx` (resting glyph, hover/focus morph + blur reset, tooltip + aria-label preview, click copy, keyboard Enter copy, optional label, clipboard-unavailable still toasts).
- `pnpm lint` (zero warnings) and `pnpm typecheck` clean.

Note: the coverage gate script `scripts/check_coverage.py` referenced in the task does not exist in this repo (no coverage tooling is installed here), so it could not be run. The unit test exercises every branch of the new file (all three glyph/color states, label present/absent, clipboard present/absent, and each hover/focus/click/keyboard handler).

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)