### PR TITLE
Durable state store: append + size caps (#248)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1079,6 +1079,19 @@
         "title": "SettingsPackConfig",
         "type": "object"
       },
+      "StateAppendIn": {
+        "description": "Append ``item`` to a log-shaped (JSON array) state entry (#248). If the\nentry does not exist it is created as a single-element array; if it exists\nits value must already be an array, else the append is rejected.",
+        "properties": {
+          "item": {
+            "title": "Item"
+          }
+        },
+        "required": [
+          "item"
+        ],
+        "title": "StateAppendIn",
+        "type": "object"
+      },
       "StateEntryOut": {
         "description": "A durable state entry as returned to the caller.",
         "properties": {
@@ -1096,9 +1109,7 @@
             "type": "string"
           },
           "value": {
-            "additionalProperties": true,
-            "title": "Value",
-            "type": "object"
+            "title": "Value"
           },
           "version": {
             "title": "Version",
@@ -1116,7 +1127,7 @@
         "type": "object"
       },
       "StateEntryPut": {
-        "description": "Write a durable state entry (#23). ``expected_version`` opts into\ncompare-and-set: the write is rejected with 409 unless it matches the stored\nversion (omit it for a blind upsert).",
+        "description": "Write a durable state entry (#23). ``expected_version`` opts into\ncompare-and-set: the write is rejected with 409 unless it matches the stored\nversion (omit it for a blind upsert). ``value`` is any JSON value (object,\narray, or scalar); an array value is what ``append`` grows.",
         "properties": {
           "expected_version": {
             "anyOf": [
@@ -1130,9 +1141,7 @@
             "title": "Expected Version"
           },
           "value": {
-            "additionalProperties": true,
-            "title": "Value",
-            "type": "object"
+            "title": "Value"
           }
         },
         "required": [
@@ -2544,6 +2553,94 @@
           }
         },
         "summary": "Put State",
+        "tags": [
+          "state"
+        ]
+      }
+    },
+    "/agents/{agent_id}/state/{namespace}/{key}/append": {
+      "post": {
+        "description": "Append an item to a log-shaped (JSON array) entry (#248).\n\nCreates the entry as a single-element array if absent; otherwise the stored\nvalue must already be an array, else the append is a 409. Subject to the\nsame per-value and per-namespace size caps as a put.",
+        "operationId": "append_state_agents__agent_id__state__namespace___key__append_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "title": "Namespace",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "title": "Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StateAppendIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StateEntryOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Append State",
         "tags": [
           "state"
         ]

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -82,6 +82,11 @@ class Settings(BaseSettings):
     # available the logs endpoint degrades to 503 rather than crashing.
     kube_config_path: str | None = None
     metrics_default_window_hours: int = 168  # 7 days
+    # Durable state store size caps (#248). A hard non-goal of the store is that
+    # it never becomes a database product, so a single value and a whole
+    # namespace are both bounded. Sizes are the serialized-JSON byte length.
+    state_max_value_bytes: int = 64 * 1024  # 64 KiB per value
+    state_max_namespace_bytes: int = 1024 * 1024  # 1 MiB per (agent, namespace)
     # The namespace the runner sandboxes run in, and the label selector that
     # identifies them (the chart labels sandbox pods
     # app.kubernetes.io/component=runner-sandbox). Used by the pod-list endpoint

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -124,7 +124,9 @@ class WorkflowStateEntry(Base):
     )
     namespace: Mapped[str]
     key: Mapped[str]
-    value: Mapped[dict[str, Any]] = mapped_column(JSONB)
+    # Any JSON value: an object (a pending-approvals map), an array (a log
+    # grown by append, #248), or a scalar. JSONB stores all of them.
+    value: Mapped[Any] = mapped_column(JSONB)
     # Monotonic per-entry counter for compare-and-set: a put may pass the version
     # it last read, and the write is rejected if the stored version moved on.
     version: Mapped[int] = mapped_column(default=1)

--- a/apps/api/src/agentos_api/routers/state.py
+++ b/apps/api/src/agentos_api/routers/state.py
@@ -1,12 +1,18 @@
-"""Durable agent-scoped key/value state (#23, first slice).
+"""Durable agent-scoped key/value state (#23, #248).
 
-A small compare-and-set KV store: namespace + key per agent, an arbitrary-JSON
-value, Postgres JSONB backing. This is the API surface the approvals epic (#22)
-and other cross-turn workflow state will consume; exposing it to bundle code via
-an auto-mounted MCP server is a later slice.
+A small compare-and-set KV/document store: namespace + key per agent, an
+arbitrary-JSON value, Postgres JSONB backing. Operations: get / put-with-CAS /
+list / delete / append. Two hard non-goals keep this from becoming a database
+product: there is no query language (get-by-key + list-by-namespace only), and
+both a single value and a whole namespace are size-capped (#248). This is the
+API surface the approvals epic (#22) and other cross-turn workflow state
+consume; exposing it to bundle code via an auto-mounted MCP server is a later
+slice.
 """
 
+import json
 import uuid
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import select
@@ -14,13 +20,56 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud
 from ..auth import require_api_key
+from ..config import get_settings
 from ..deps import SessionDep
 from ..models import WorkflowStateEntry
-from ..schemas import StateEntryOut, StateEntryPut
+from ..schemas import StateAppendIn, StateEntryOut, StateEntryPut
 
 router = APIRouter(
     prefix="/agents", tags=["state"], dependencies=[Depends(require_api_key)]
 )
+
+
+def _json_size(value: Any) -> int:
+    """Serialized-JSON byte length, the unit both size caps are measured in."""
+    return len(json.dumps(value, separators=(",", ":")).encode("utf-8"))
+
+
+async def _enforce_caps(
+    session: AsyncSession,
+    agent_id: uuid.UUID,
+    namespace: str,
+    key: str,
+    value: Any,
+) -> None:
+    """Reject a write that breaks the per-value or per-namespace size cap (#248).
+
+    The namespace total counts the incoming value plus every *other* key already
+    in the namespace (the key being written replaces its own prior size).
+    """
+    settings = get_settings()
+    value_bytes = _json_size(value)
+    if value_bytes > settings.state_max_value_bytes:
+        raise HTTPException(
+            413,
+            f"value is {value_bytes} bytes, over the "
+            f"{settings.state_max_value_bytes}-byte per-value cap",
+        )
+
+    others = await session.scalars(
+        select(WorkflowStateEntry.value).where(
+            WorkflowStateEntry.agent_id == agent_id,
+            WorkflowStateEntry.namespace == namespace,
+            WorkflowStateEntry.key != key,
+        )
+    )
+    namespace_bytes = value_bytes + sum(_json_size(v) for v in others)
+    if namespace_bytes > settings.state_max_namespace_bytes:
+        raise HTTPException(
+            413,
+            f"namespace {namespace!r} would be {namespace_bytes} bytes, over the "
+            f"{settings.state_max_namespace_bytes}-byte per-namespace cap",
+        )
 
 
 async def _get_entry(
@@ -48,6 +97,7 @@ async def put_state(
     # signal). expected_version opts into compare-and-set.
     if await crud.get_agent(session, agent_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+    await _enforce_caps(session, agent_id, namespace, key, data.value)
     entry = await _get_entry(session, agent_id, namespace, key)
     if entry is None:
         if data.expected_version is not None:
@@ -68,6 +118,47 @@ async def put_state(
                 f"stored {entry.version}",
             )
         entry.value = data.value
+        entry.version += 1
+    await session.commit()
+    await session.refresh(entry)
+    return StateEntryOut.model_validate(entry)
+
+
+@router.post(
+    "/{agent_id}/state/{namespace}/{key}/append", response_model=StateEntryOut
+)
+async def append_state(
+    agent_id: uuid.UUID,
+    namespace: str,
+    key: str,
+    data: StateAppendIn,
+    session: SessionDep,
+) -> StateEntryOut:
+    """Append an item to a log-shaped (JSON array) entry (#248).
+
+    Creates the entry as a single-element array if absent; otherwise the stored
+    value must already be an array, else the append is a 409. Subject to the
+    same per-value and per-namespace size caps as a put.
+    """
+    if await crud.get_agent(session, agent_id) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+    entry = await _get_entry(session, agent_id, namespace, key)
+    if entry is None:
+        new_value = [data.item]
+        await _enforce_caps(session, agent_id, namespace, key, new_value)
+        entry = WorkflowStateEntry(
+            agent_id=agent_id, namespace=namespace, key=key, value=new_value
+        )
+        session.add(entry)
+    else:
+        if not isinstance(entry.value, list):
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "cannot append: stored value is not a JSON array",
+            )
+        new_value = [*entry.value, data.item]
+        await _enforce_caps(session, agent_id, namespace, key, new_value)
+        entry.value = new_value
         entry.version += 1
     await session.commit()
     await session.refresh(entry)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -356,10 +356,19 @@ class CostReport(BaseModel):
 class StateEntryPut(BaseModel):
     """Write a durable state entry (#23). ``expected_version`` opts into
     compare-and-set: the write is rejected with 409 unless it matches the stored
-    version (omit it for a blind upsert)."""
+    version (omit it for a blind upsert). ``value`` is any JSON value (object,
+    array, or scalar); an array value is what ``append`` grows."""
 
-    value: dict[str, Any]
+    value: Any
     expected_version: int | None = None
+
+
+class StateAppendIn(BaseModel):
+    """Append ``item`` to a log-shaped (JSON array) state entry (#248). If the
+    entry does not exist it is created as a single-element array; if it exists
+    its value must already be an array, else the append is rejected."""
+
+    item: Any
 
 
 class StateEntryOut(BaseModel):
@@ -369,6 +378,6 @@ class StateEntryOut(BaseModel):
 
     namespace: str
     key: str
-    value: dict[str, Any]
+    value: Any
     version: int
     updated_at: datetime

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -96,3 +96,103 @@ def test_get_missing_entry_is_404(
     aid = _agent(client, auth_headers)
     r = client.get(f"/agents/{aid}/state/ns/nope", headers=auth_headers)
     assert r.status_code == 404
+
+
+def test_concurrent_cas_one_writer_wins_loser_sees_compare_failure(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The AC's core scenario: two writers both read the same version, both try a
+    # compare-and-set write; exactly one wins and the loser gets the 409.
+    aid = _agent(client, auth_headers)
+    url = f"/agents/{aid}/state/counter/n"
+
+    seed = client.put(url, json={"value": {"n": 0}}, headers=auth_headers).json()
+    read_version = seed["version"]  # both writers observe this version
+
+    winner = client.put(
+        url,
+        json={"value": {"n": 1}, "expected_version": read_version},
+        headers=auth_headers,
+    )
+    loser = client.put(
+        url,
+        json={"value": {"n": 2}, "expected_version": read_version},
+        headers=auth_headers,
+    )
+
+    assert winner.status_code == 200, winner.text
+    assert loser.status_code == 409, loser.text
+    # The winner's write stands; the loser's did not clobber it.
+    assert client.get(url, headers=auth_headers).json()["value"] == {"n": 1}
+
+
+def test_append_grows_a_log_shaped_entry(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    url = f"/agents/{aid}/state/audit/log/append"
+
+    # First append creates the entry as a single-element array (version 1).
+    r1 = client.post(url, json={"item": {"event": "created"}}, headers=auth_headers)
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["value"] == [{"event": "created"}]
+    assert r1.json()["version"] == 1
+
+    # Second append extends the array and bumps the version.
+    r2 = client.post(url, json={"item": {"event": "approved"}}, headers=auth_headers)
+    assert r2.json()["value"] == [{"event": "created"}, {"event": "approved"}]
+    assert r2.json()["version"] == 2
+
+
+def test_append_onto_a_non_array_value_is_409(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    base = f"/agents/{aid}/state/audit"
+    client.put(f"{base}/obj", json={"value": {"not": "a list"}}, headers=auth_headers)
+
+    r = client.post(f"{base}/obj/append", json={"item": 1}, headers=auth_headers)
+    assert r.status_code == 409, r.text
+
+
+def test_value_over_the_per_value_cap_is_rejected(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    from agentos_api.config import get_settings
+
+    aid = _agent(client, auth_headers)
+    # Shrink the per-value cap for this test. get_settings() is lru_cached, so it
+    # returns a singleton we mutate and reset via cache_clear() in the finally.
+    get_settings().state_max_value_bytes = 50
+    try:
+        oversized = {"blob": "x" * 200}
+        r = client.put(
+            f"/agents/{aid}/state/big/v", json={"value": oversized}, headers=auth_headers
+        )
+        assert r.status_code == 413, r.text
+        # A small value under the cap still writes.
+        ok = client.put(
+            f"/agents/{aid}/state/big/v", json={"value": {"n": 1}}, headers=auth_headers
+        )
+        assert ok.status_code == 200
+    finally:
+        get_settings.cache_clear()
+
+
+def test_namespace_over_the_per_namespace_cap_is_rejected(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    from agentos_api.config import get_settings
+
+    aid = _agent(client, auth_headers)
+    base = f"/agents/{aid}/state/capped"
+    get_settings().state_max_namespace_bytes = 100
+    try:
+        # First key fits (~58 bytes serialized).
+        a = client.put(f"{base}/a", json={"value": {"s": "x" * 50}}, headers=auth_headers)
+        assert a.status_code == 200, a.text
+        # Second key pushes the namespace total (~116 bytes) over the 100 cap.
+        b = client.put(f"{base}/b", json={"value": {"s": "x" * 50}}, headers=auth_headers)
+        assert b.status_code == 413, b.text
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
## What

Completes the scoped KV/document store's AC for #248 (part of epic #23). The store's first slice — get / put-with-CAS / list / delete on a Postgres JSONB table (`workflow_state_entries`, migration 0006) — landed via #239. This PR adds the two pieces that slice deferred:

- **`append`** — `POST /agents/{id}/state/{namespace}/{key}/append` grows a log-shaped (JSON array) entry: creates it as a single-element array if absent, extends it otherwise (409 if the stored value is not an array), and bumps the version.
- **Size caps** — a per-value cap and a per-namespace cap, measured in serialized-JSON bytes and configurable via `Settings` (`state_max_value_bytes`, `state_max_namespace_bytes`). Enforced on both put and append; over-cap writes return **413**. This is the hard non-goal that keeps the store from becoming a database product.
- Broadened the stored value from object-only to any JSON value (object / array / scalar) so `append` can target arrays. JSONB already stores all of them.

## Verification

`uv run pytest apps/api/tests/test_state.py` → 9 passed (against the conftest's **disposable scratch DB**, never the shared compose Postgres). New tests:
- concurrent CAS round-trip: two writers read one version, one wins, the loser sees the 409 compare failure (the AC's core scenario);
- append round-trip; append-onto-non-array → 409;
- per-value cap → 413; per-namespace cap → 413.

`ruff` clean, `mypy src` clean (32 files), openapi drift test passes (regenerated `openapi.json`).

## Note on scope

The task brief assumed the JSONB table + migration did not exist yet; they were merged the same day via #239. Rather than duplicate a parallel store (against repo convention), this extends the existing one. **No new migration** is included because the append/caps work is app-layer only — the value column is already JSONB and holds arbitrary JSON without a DDL change. This remains the foundation for #249/#250, which are not touched here.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)