### PR TITLE
Provider-native /anthropic endpoints: Zhipu, Moonshot, DeepSeek (#252)

### DIFF
--- a/docs/interfaces/model-provider/INTERFACE.md
+++ b/docs/interfaces/model-provider/INTERFACE.md
@@ -1,7 +1,7 @@
 # INTERFACE: Model provider / credentials
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 (Anthropic) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 prefix-routed (Anthropic, OpenRouter) + base-URL-selected provider-native endpoints (Zhipu, Moonshot, DeepSeek, Ollama) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -25,9 +25,10 @@ three things:
   → `ANTHROPIC_API_KEY`; `sk-or-...` (OpenRouter) → base-URL override; a bare `sk-...`
   raises `UnsupportedCredentialError` (`sdk_auth.py:47`, `:116`). An SDK credential
   already in the env wins (`sdk_auth.py:89`).
-- **Base URL**, `ANTHROPIC_BASE_URL` (`sdk_auth.py:34`). `resolve_base_url_override`
-  (`sdk_auth.py:51`) builds the override env when set, and `resolve_sdk_env`
-  (`sdk_auth.py:124`) is the entry point that decides override-vs-plain.
+- **Base URL**, `ANTHROPIC_BASE_URL`, or its `AGENTOS_`-namespaced alias
+  `AGENTOS_MODEL_BASE_URL` (the raw var wins when both are set).
+  `resolve_base_url_override` builds the override env when either is set, and
+  `resolve_sdk_env` is the entry point that decides override-vs-plain.
 - **Model id**, `AGENTOS_MODEL`, read by `RunnerConfig.from_env`
   (`runner/src/agentos_runner/config.py:62`).
 
@@ -37,11 +38,32 @@ third-party endpoint.
 
 ## Implementations today
 
-One: Anthropic (direct API key or Claude Code OAuth token). OpenRouter is the
-intended reference second provider and is already wired as a prefix branch
-(`sdk_auth.py:100`): it reuses the shared base-URL-override seam, points at
-`OPENROUTER_BASE_URL = "https://openrouter.ai/api"` (`sdk_auth.py:36`), and puts the
-real key in `ANTHROPIC_API_KEY` (the `x-api-key` header OpenRouter reads).
+**Anthropic** (direct API key or Claude Code OAuth token) — the plain path, no
+base URL. **OpenRouter** — the one prefix-routed alternative: an `sk-or-`
+credential auto-selects `OPENROUTER_BASE_URL = "https://openrouter.ai/api"` and
+puts the real key in `ANTHROPIC_API_KEY` (the `x-api-key` header OpenRouter
+reads).
+
+**Provider-native `/anthropic` endpoints** — Zhipu (GLM), Moonshot (Kimi),
+DeepSeek, and local Ollama are selected by **base URL**, not key prefix. Moonshot
+and DeepSeek use OpenAI-style `sk-` keys and Zhipu uses a non-`sk-` key, so no key
+prefix distinguishes them; the config author instead points the base URL at the
+provider's `/anthropic` endpoint and supplies the provider key in
+`AGENTOS_CREDENTIALS`. In base-URL-override mode a supplied provider credential is
+forwarded into `ANTHROPIC_API_KEY` (`x-api-key`), overriding the `NO_OP_API_KEY`
+placeholder; a Claude Code OAuth token (`sk-ant-oat`) is never forwarded and stays
+blanked (hermetic). Canonical base URLs are in `PROVIDER_BASE_URLS`:
+
+| Provider | `AGENTOS_MODEL_BASE_URL` | Key shape | Candidate models |
+| --- | --- | --- | --- |
+| Zhipu (GLM) | `https://api.z.ai/api/anthropic` | `id.secret` (non-`sk-`) | GLM 5.x |
+| Moonshot (Kimi) | `https://api.moonshot.ai/anthropic` | `sk-...` | Kimi K2.x |
+| DeepSeek | `https://api.deepseek.com/anthropic` | `sk-...` | DeepSeek V4 |
+
+Each keeps the Anthropic wire format (the SDK appends `/v1/messages`), so the
+provider's automatic prefix caching applies — a single-model agent needs no
+gateway. A minimal config: `AGENTOS_MODEL_BASE_URL=https://api.deepseek.com/anthropic`,
+`AGENTOS_CREDENTIALS=<deepseek key>`, `AGENTOS_MODEL=deepseek-...`.
 
 ## Known leakage
 

--- a/runner/src/agentos_runner/sdk_auth.py
+++ b/runner/src/agentos_runner/sdk_auth.py
@@ -16,10 +16,21 @@ prefix, so the more specific OAuth prefix is checked first):
 - ``sk-or-...`` (OpenRouter) is routed through the base-URL-override seam:
   base URL -> OpenRouter's Anthropic endpoint, key -> ``ANTHROPIC_API_KEY``
   (the ``x-api-key`` header OpenRouter reads), and ``ANTHROPIC_AUTH_TOKEN``
-  left blank. A bare ``sk-...`` OpenAI-style key is still rejected loudly.
-  Other providers are post-MVP.
+  left blank. A bare ``sk-...`` OpenAI-style key is still rejected loudly on the
+  direct-Anthropic path (no base URL set).
 - Anything else is treated as a Claude Code OAuth token ->
   ``CLAUDE_CODE_OAUTH_TOKEN``.
+
+Provider-native Anthropic-compatible endpoints (Zhipu/GLM, Moonshot/Kimi,
+DeepSeek, ...) share OpenAI's ``sk-`` key shape or use a non-``sk-`` key, so a
+key prefix cannot select them unambiguously. They are instead selected by base
+URL: the config author points ``AGENTOS_MODEL_BASE_URL`` (or the raw SDK var
+``ANTHROPIC_BASE_URL``) at the provider's ``/anthropic`` endpoint and supplies
+the provider key in ``AGENTOS_CREDENTIALS``. In that base-URL-override mode the
+provider key is forwarded into ``ANTHROPIC_API_KEY`` (the ``x-api-key`` header
+these endpoints read). Canonical base URLs live in ``PROVIDER_BASE_URLS``. A
+Claude Code OAuth token (``sk-ant-oat``) is never forwarded to a third-party
+endpoint -- override mode keeps it blanked (hermetic).
 
 The credential value (and its length) is never logged or echoed.
 """
@@ -33,7 +44,33 @@ OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
 API_KEY_ENV = "ANTHROPIC_API_KEY"
 BASE_URL_ENV = "ANTHROPIC_BASE_URL"
 AUTH_TOKEN_ENV = "ANTHROPIC_AUTH_TOKEN"
+# AGENTOS_-namespaced alias for the base-URL override seam, mapped onto the raw
+# SDK var (BASE_URL_ENV). It lets a config author stay in the AGENTOS_* config
+# namespace (like AGENTOS_MODEL / AGENTOS_CREDENTIALS) instead of setting the
+# SDK's own ANTHROPIC_BASE_URL directly. The raw var wins when both are set.
+MODEL_BASE_URL_ENV = "AGENTOS_MODEL_BASE_URL"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api"
+
+# A Claude Code OAuth token shares the sk-ant- prefix with an API key; this more
+# specific prefix distinguishes it and marks it as non-forwardable to any
+# third-party endpoint.
+OAUTH_TOKEN_PREFIX = "sk-ant-oat"
+
+# Canonical provider-native Anthropic-compatible base URLs (the SDK appends
+# /v1/messages). These keep the Anthropic wire format -- and therefore provider
+# automatic prefix caching -- rather than the OpenAI chat-completions shape.
+# Selected by base URL (see module docstring), not by key prefix. OpenRouter is
+# the one prefix-routed provider (sk-or-) and is included here for reference.
+ZHIPU_BASE_URL = "https://api.z.ai/api/anthropic"
+MOONSHOT_BASE_URL = "https://api.moonshot.ai/anthropic"
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/anthropic"
+PROVIDER_BASE_URLS: dict[str, str] = {
+    "zhipu": ZHIPU_BASE_URL,
+    "moonshot": MOONSHOT_BASE_URL,
+    "deepseek": DEEPSEEK_BASE_URL,
+    "openrouter": OPENROUTER_BASE_URL,
+}
+
 _SDK_CREDENTIAL_ENV = (OAUTH_TOKEN_ENV, API_KEY_ENV)
 
 # Non-empty no-op placeholder API key used in base-URL override mode. It is
@@ -68,7 +105,7 @@ def resolve_base_url_override(env: MutableMapping[str, str]) -> dict[str, str] |
     endpoint, keeping override mode hermetic. The base URL is not a secret, but
     this module keeps the same no echo discipline it uses for credentials.
     """
-    base_url = env.get(BASE_URL_ENV)
+    base_url = env.get(BASE_URL_ENV) or env.get(MODEL_BASE_URL_ENV)
     if not base_url:
         return None
     return {
@@ -77,6 +114,20 @@ def resolve_base_url_override(env: MutableMapping[str, str]) -> dict[str, str] |
         OAUTH_TOKEN_ENV: "",
         AUTH_TOKEN_ENV: "",
     }
+
+
+def _is_forwardable_provider_credential(credential: str) -> bool:
+    """Whether a credential may be forwarded to a base-URL-overridden endpoint.
+
+    In base-URL-override mode the operator has deliberately pointed the runner at
+    a provider-native Anthropic-compatible endpoint (Zhipu/Moonshot/DeepSeek,
+    etc.) and supplied that provider's key; it is sent as the ``x-api-key``
+    header. A Claude Code OAuth token (``sk-ant-oat``) is the one thing never
+    forwarded to a third-party endpoint, so it stays blanked (hermetic).
+    """
+    if not credential:
+        return False
+    return not credential.startswith(OAUTH_TOKEN_PREFIX)
 
 
 def resolve_model_credential(env: MutableMapping[str, str]) -> None:
@@ -137,6 +188,14 @@ def resolve_sdk_env(env: MutableMapping[str, str]) -> dict[str, str] | None:
     if not credential.startswith("sk-or-"):
         override = resolve_base_url_override(env)
         if override is not None:
+            # Provider-native Anthropic-compatible endpoints (Zhipu/GLM,
+            # Moonshot/Kimi, DeepSeek, ...) are selected by base URL and
+            # authenticate with their own key sent as x-api-key. Forward a
+            # supplied provider credential into ANTHROPIC_API_KEY, overriding the
+            # NO_OP placeholder. A missing credential (e.g. local Ollama) keeps
+            # the placeholder; an Anthropic OAuth token stays blanked (hermetic).
+            if _is_forwardable_provider_credential(credential):
+                override[API_KEY_ENV] = credential
             return override
     resolve_model_credential(env)
     return None

--- a/runner/tests/test_sdk_auth.py
+++ b/runner/tests/test_sdk_auth.py
@@ -11,9 +11,14 @@ from agentos_runner.sdk_auth import (
     AUTH_TOKEN_ENV,
     BASE_URL_ENV,
     CREDENTIALS_ENV,
+    DEEPSEEK_BASE_URL,
+    MODEL_BASE_URL_ENV,
+    MOONSHOT_BASE_URL,
     NO_OP_API_KEY,
     OAUTH_TOKEN_ENV,
     OPENROUTER_BASE_URL,
+    PROVIDER_BASE_URLS,
+    ZHIPU_BASE_URL,
     UnsupportedCredentialError,
     resolve_model_credential,
     resolve_sdk_env,
@@ -163,3 +168,90 @@ def test_resolve_sdk_env_openrouter_with_preset_base_url_sets_api_key() -> None:
     assert resolve_sdk_env(env) is None
     assert env[API_KEY_ENV] == "sk-or-PLACEHOLDER"
     assert env[AUTH_TOKEN_ENV] == ""
+
+
+# --- Provider-native Anthropic-compatible endpoints (#252): Zhipu / Moonshot /
+# DeepSeek. Selected by base URL; the provider key is forwarded as x-api-key.
+
+
+def test_provider_base_urls_stay_on_anthropic_format() -> None:
+    # The canonical endpoints keep the Anthropic wire format (SDK appends
+    # /v1/messages) so provider automatic prefix caching survives.
+    assert PROVIDER_BASE_URLS["zhipu"] == ZHIPU_BASE_URL == "https://api.z.ai/api/anthropic"
+    assert PROVIDER_BASE_URLS["moonshot"] == MOONSHOT_BASE_URL
+    assert PROVIDER_BASE_URLS["deepseek"] == DEEPSEEK_BASE_URL
+    assert PROVIDER_BASE_URLS["openrouter"] == OPENROUTER_BASE_URL
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [ZHIPU_BASE_URL, MOONSHOT_BASE_URL, DEEPSEEK_BASE_URL],
+)
+def test_provider_native_key_forwarded_as_x_api_key(base_url: str) -> None:
+    # Moonshot / DeepSeek use OpenAI-style sk- keys; Zhipu uses a non-sk key.
+    # With the provider base URL set, the key must be forwarded to
+    # ANTHROPIC_API_KEY (x-api-key), overriding the NO_OP placeholder -- not
+    # rejected and not dropped.
+    env = {BASE_URL_ENV: base_url, CREDENTIALS_ENV: "sk-PROVIDER-PLACEHOLDER"}
+    override = resolve_sdk_env(env)
+
+    assert override is not None
+    assert override[BASE_URL_ENV] == base_url
+    assert override[API_KEY_ENV] == "sk-PROVIDER-PLACEHOLDER"
+    # Inherited OAuth / Bearer tokens stay blanked so they cannot leak to the
+    # third-party endpoint.
+    assert override[OAUTH_TOKEN_ENV] == ""
+    assert override[AUTH_TOKEN_ENV] == ""
+
+
+def test_zhipu_non_sk_key_forwarded() -> None:
+    # Zhipu keys are id.secret shaped (no sk- prefix); still forwarded.
+    env = {BASE_URL_ENV: ZHIPU_BASE_URL, CREDENTIALS_ENV: "zhipu-id.PLACEHOLDER"}
+    override = resolve_sdk_env(env)
+    assert override is not None
+    assert override[API_KEY_ENV] == "zhipu-id.PLACEHOLDER"
+
+
+def test_model_base_url_alias_selects_override() -> None:
+    # AGENTOS_MODEL_BASE_URL (AGENTOS_-namespaced alias) drives the same seam.
+    env = {MODEL_BASE_URL_ENV: DEEPSEEK_BASE_URL, CREDENTIALS_ENV: "sk-DEEPSEEK-PLACEHOLDER"}
+    override = resolve_sdk_env(env)
+    assert override is not None
+    assert override[BASE_URL_ENV] == DEEPSEEK_BASE_URL
+    assert override[API_KEY_ENV] == "sk-DEEPSEEK-PLACEHOLDER"
+
+
+def test_raw_base_url_wins_over_alias() -> None:
+    env = {
+        BASE_URL_ENV: MOONSHOT_BASE_URL,
+        MODEL_BASE_URL_ENV: DEEPSEEK_BASE_URL,
+        CREDENTIALS_ENV: "sk-PLACEHOLDER",
+    }
+    override = resolve_sdk_env(env)
+    assert override is not None
+    assert override[BASE_URL_ENV] == MOONSHOT_BASE_URL
+
+
+def test_oauth_token_not_forwarded_to_provider_endpoint() -> None:
+    # A Claude Code OAuth token must never be forwarded to a third-party
+    # endpoint; the placeholder stays and the token is blanked (hermetic).
+    env = {BASE_URL_ENV: ZHIPU_BASE_URL, CREDENTIALS_ENV: "sk-ant-oatPLACEHOLDER"}
+    override = resolve_sdk_env(env)
+    assert override is not None
+    assert override[API_KEY_ENV] == NO_OP_API_KEY
+    assert override[OAUTH_TOKEN_ENV] == ""
+
+
+def test_ollama_without_credential_keeps_placeholder() -> None:
+    # No credential (local Ollama): the NO_OP placeholder is retained.
+    env = {BASE_URL_ENV: "http://ollama:11434"}
+    override = resolve_sdk_env(env)
+    assert override is not None
+    assert override[API_KEY_ENV] == NO_OP_API_KEY
+
+
+def test_bare_sk_still_rejected_without_base_url() -> None:
+    # The direct-Anthropic path (no base URL) still rejects a bare sk- key: there
+    # is no provider endpoint to forward it to.
+    with pytest.raises(UnsupportedCredentialError):
+        resolve_sdk_env({CREDENTIALS_ENV: "sk-PLACEHOLDER"})


### PR DESCRIPTION
## What

Extends the model-provider seam (`runner/src/agentos_runner/sdk_auth.py`) so a single-model agent can target a provider-native Anthropic-compatible `/anthropic` endpoint with no gateway, keeping the Anthropic wire format (so provider automatic prefix caching applies).

## Why by base URL, not key prefix

- **Moonshot (Kimi)** and **DeepSeek** issue OpenAI-style `sk-` keys; **Zhipu (GLM)** uses a non-`sk-` `id.secret` key. None has a distinctive prefix that unambiguously selects the provider, so they are selected by **base URL** via the existing override seam (OpenRouter remains the one prefix-routed provider).

## Changes

- In base-URL-override mode, a supplied `AGENTOS_CREDENTIALS` is now forwarded into `ANTHROPIC_API_KEY` (`x-api-key`) instead of being dropped for the `NO_OP` placeholder. A Claude Code OAuth token (`sk-ant-oat`) is never forwarded to a third-party endpoint (hermetic); a missing credential (local Ollama) keeps the placeholder.
- Adds `AGENTOS_MODEL_BASE_URL` as an `AGENTOS_`-namespaced alias for `ANTHROPIC_BASE_URL` (raw var wins when both set).
- Adds canonical `PROVIDER_BASE_URLS` constants (Zhipu/Moonshot/DeepSeek/OpenRouter).
- Bare `sk-` keys are still rejected loudly on the direct-Anthropic path (no base URL).
- 10 new unit tests in `runner/tests/test_sdk_auth.py`; `docs/interfaces/model-provider/INTERFACE.md` updated.

Part of #24.

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)