### PR TITLE
agentos schema -> command-manifest.json + CI drift gate (#276)

### DIFF
--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1,0 +1,1563 @@
+{
+  "about": "AgentOS CLI: run a plugin locally, no Slack workspace needed",
+  "args": [
+    {
+      "global": true,
+      "help": "Show verbose plumbing (helm/kubectl/rollout/port-forward)",
+      "id": "debug",
+      "long": "debug",
+      "positional": false,
+      "possible_values": [
+        "true",
+        "false"
+      ],
+      "required": false
+    },
+    {
+      "global": true,
+      "help": "Payload only; suppress progress and diagnostics",
+      "id": "quiet",
+      "long": "quiet",
+      "positional": false,
+      "possible_values": [
+        "true",
+        "false"
+      ],
+      "required": false,
+      "short": "q"
+    },
+    {
+      "default_values": [
+        "auto"
+      ],
+      "global": true,
+      "help": "Colorize output",
+      "id": "color",
+      "long": "color",
+      "positional": false,
+      "possible_values": [
+        "auto",
+        "always",
+        "never"
+      ],
+      "required": false
+    }
+  ],
+  "hidden": false,
+  "name": "agentos",
+  "subcommands": [
+    {
+      "about": "Scaffold a new plugin bundle (Claude Code plugin shape)",
+      "args": [
+        {
+          "global": false,
+          "help": "Kebab-case plugin name (e.g. deal-desk)",
+          "id": "name",
+          "positional": true,
+          "required": true
+        },
+        {
+          "global": false,
+          "help": "Target directory; defaults to ./<name>",
+          "id": "dir",
+          "long": "dir",
+          "positional": false,
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "name": "init"
+    },
+    {
+      "about": "Work with a local runner session for a plugin bundle",
+      "hidden": false,
+      "name": "skill",
+      "subcommands": [
+        {
+          "about": "Boot a local runner container for the bundle and print the env summary",
+          "args": [
+            {
+              "default_values": [
+                "."
+              ],
+              "global": false,
+              "help": "Plugin bundle directory",
+              "id": "plugin_dir",
+              "long": "plugin-dir",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Runner image. Default: version-pinned `ghcr.io/curie-eng/agentos-runner:<version>` on release builds; local `agentos-runner` on dev builds. Pass to override",
+              "id": "image",
+              "long": "image",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "7245"
+              ],
+              "global": false,
+              "help": "Host port for the local bot",
+              "id": "port",
+              "long": "port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-runner-local"
+              ],
+              "global": false,
+              "help": "Container name",
+              "id": "name",
+              "long": "name",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Use the runner's scripted fake model (offline; no credential)",
+              "id": "fake_model",
+              "long": "fake-model",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Docker network to join (e.g. agentos_default for the dev stack)",
+              "id": "network",
+              "long": "network",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "OTLP endpoint for traces (e.g. http://otel-collector:4318)",
+              "id": "otel_endpoint",
+              "long": "otel-endpoint",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "{\"max_output_tokens_per_run\":100000,\"max_usd_per_day\":5.0}"
+              ],
+              "global": false,
+              "help": "ACI budget JSON for the session",
+              "id": "budget",
+              "long": "budget",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Model id, forwarded as AGENTOS_MODEL. Omit for the SDK default. Setting it makes token usage attributable in Langfuse traces",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Run the named model through local Ollama",
+              "id": "local_model",
+              "long": "local-model",
+              "num_args": {
+                "max": 1,
+                "min": 0
+              },
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "up"
+        },
+        {
+          "about": "Stop and remove the local runner container",
+          "hidden": false,
+          "name": "down"
+        },
+        {
+          "about": "Show the local runner's session status",
+          "args": [
+            {
+              "global": false,
+              "help": "Runner base URL (defaults to the started runner, then localhost)",
+              "id": "url",
+              "long": "url",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "status"
+        },
+        {
+          "about": "Send a synthetic event to the local runner and stream the reply",
+          "args": [
+            {
+              "global": false,
+              "help": "The message text",
+              "id": "text",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "U-local"
+              ],
+              "global": false,
+              "help": "Synthetic Slack user id",
+              "id": "user",
+              "long": "user",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "message"
+              ],
+              "global": false,
+              "help": "ACI event type",
+              "id": "event_type",
+              "long": "event-type",
+              "positional": false,
+              "possible_values": [
+                "message",
+                "job",
+                "eval-case"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Runner base URL (defaults to the started runner, then localhost)",
+              "id": "url",
+              "long": "url",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "message"
+        },
+        {
+          "about": "Run the bundle's eval cases through the local runner",
+          "args": [
+            {
+              "global": false,
+              "help": "Eval case file (default: evals/cases.json here, then the running bundle's)",
+              "id": "cases",
+              "long": "cases",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Runner base URL (defaults to the started runner, then localhost)",
+              "id": "url",
+              "long": "url",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "eval"
+        }
+      ]
+    },
+    {
+      "about": "Work with the local compose stack and local platform API",
+      "hidden": false,
+      "name": "local",
+      "subcommands": [
+        {
+          "about": "Bring the dev stack up (`core` with `--minimal`, else `full`) and print URLs. Add `--slack` for the optional dispatcher",
+          "args": [
+            {
+              "global": false,
+              "help": "Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Print the docker compose command and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Bring up only the 7 core services (skip Langfuse/ClickHouse/OTel/UI)",
+              "id": "minimal",
+              "long": "minimal",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Run the named model through local Ollama",
+              "id": "local_model",
+              "long": "local-model",
+              "num_args": {
+                "max": 1,
+                "min": 0
+              },
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Also start the optional Slack dispatcher (adds --profile slack)",
+              "id": "slack",
+              "long": "slack",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "up"
+        },
+        {
+          "about": "Stop the dev stack (docker compose down), keeping volumes",
+          "args": [
+            {
+              "global": false,
+              "help": "Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Also destroy volumes (adds -v). Prompts for confirmation unless --yes",
+              "id": "wipe",
+              "long": "wipe",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Skip the --wipe confirmation prompt",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the docker compose command and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "down"
+        },
+        {
+          "about": "Show the dev stack's service status (docker compose ps)",
+          "args": [
+            {
+              "global": false,
+              "help": "Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Print the docker compose command and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "status"
+        },
+        {
+          "about": "Connect or disconnect the local compose stack from a real Slack workspace",
+          "args": [
+            {
+              "global": false,
+              "help": "Chat surface to configure. Required until the CLI grows more than one comms target",
+              "id": "slack",
+              "long": "slack",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear Slack from the local stack instead of connecting it",
+              "id": "disconnect",
+              "long": "disconnect",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                ""
+              ],
+              "env": "SLACK_APP_TOKEN",
+              "global": false,
+              "help": "Slack app token. Defaults from SLACK_APP_TOKEN",
+              "id": "app_token",
+              "long": "app-token",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                ""
+              ],
+              "env": "SLACK_BOT_TOKEN",
+              "global": false,
+              "help": "Slack bot token. Defaults from SLACK_BOT_TOKEN",
+              "id": "bot_token",
+              "long": "bot-token",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Print the docker compose command(s) that would run and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "comms"
+        },
+        {
+          "about": "Drive the local compose stack end to end with zero Slack contact",
+          "args": [
+            {
+              "global": false,
+              "help": "The user message text",
+              "id": "text",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Slack channel id to send as; must match the target agent's slack_channel. Omit to use the sole deployed agent's channel (errors if zero or multiple agents are deployed)",
+              "id": "channel",
+              "long": "channel",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Existing thread ts to continue a conversation; omit to start a new thread. Pair with --channel to keep multi-turn context",
+              "id": "thread",
+              "long": "thread",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Reuse the last turn's context (channel, thread, transport) recorded in .agentos/last-turn.json in the working directory; type only the new message text",
+              "id": "continue",
+              "long": "continue",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                "valkeypass"
+              ],
+              "env": "AGENTOS_VALKEY_PASSWORD",
+              "global": false,
+              "help": "Valkey password (compose default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
+              "id": "valkey_password",
+              "long": "valkey-password",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Local mode only: platform API base URL for the channel lookup",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key for the default-channel lookup",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "U-agentos-message"
+              ],
+              "global": false,
+              "help": "Synthetic Slack user id for the enqueued event",
+              "id": "user",
+              "long": "user",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos:runs"
+              ],
+              "env": "AGENTOS_STREAM",
+              "global": false,
+              "help": "Stream the dispatcher enqueues onto",
+              "id": "stream",
+              "long": "stream",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "How long to wait for the worker's reply before printing diagnostics. Default: 300 seconds",
+              "id": "timeout_secs",
+              "long": "timeout-secs",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the queue and stub plan that a real run would produce, and exit",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "message"
+        },
+        {
+          "about": "Push the bundle to the local platform API and deploy it",
+          "args": [
+            {
+              "default_values": [
+                "."
+              ],
+              "global": false,
+              "help": "Plugin bundle directory",
+              "id": "plugin_dir",
+              "long": "plugin-dir",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Slack channel to bind the agent to. On first create it defaults to #local-dev; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
+              "id": "slack_channel",
+              "long": "slack-channel",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "dev"
+              ],
+              "global": false,
+              "help": "Target environment",
+              "id": "env",
+              "long": "env",
+              "positional": false,
+              "possible_values": [
+                "dev",
+                "prod"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Version label; defaults to <manifest version>-<unix time>",
+              "id": "label",
+              "long": "label",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "deploy"
+        }
+      ]
+    },
+    {
+      "about": "Work with the deployed cluster release and platform API",
+      "hidden": false,
+      "name": "cluster",
+      "subcommands": [
+        {
+          "about": "Install or upgrade the AgentOS release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) to install with the real model and egress opened to the provider; without it the install is sealed (fake model, canned replies) and re-running with the env var set goes live",
+          "args": [
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Helm chart. Default: the version-pinned chart release asset on release builds; local `charts/agentos` on dev builds. Pass a path or ref to override",
+              "id": "chart",
+              "long": "chart",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Keep the UI and Langfuse services ClusterIP instead of NodePort",
+              "id": "no_expose",
+              "long": "no-expose",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Force the sealed fake-model install even when AGENTOS_MODEL_CREDENTIALS is set (dev/CI escape hatch); suppresses the fake-model warning",
+              "id": "fake_model",
+              "long": "fake-model",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Run the named model through the chart inference deployment",
+              "id": "local_model",
+              "long": "local-model",
+              "num_args": {
+                "max": 1,
+                "min": 0
+              },
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Open runner egress to a declared destination for skill web access, repeatable CIDR, TCP 443. Additive to the model egress; omit to stay fully sealed",
+              "id": "allow_web_egress",
+              "long": "allow-web-egress",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Extra `--set KEY=VAL` passed through to helm verbatim (repeatable)",
+              "id": "set",
+              "long": "set",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Install with the chart's built-in dev-default secrets instead of generating strong per-release randoms. Deterministic, for local dev and CI only -- these defaults are published in the public repo",
+              "id": "dev",
+              "long": "dev",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the helm command that would run and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "up"
+        },
+        {
+          "about": "Uninstall the release and sweep its runtime namespaces (helm uninstall + kubectl delete namespace). The agents.x-k8s.io CRDs are left in place",
+          "args": [
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Skip the interactive confirmation prompt",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the commands that would run and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "down"
+        },
+        {
+          "about": "Report release health and access URLs (read-only: helm status + kubectl)",
+          "args": [
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the read-only commands that would run and exit",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "status"
+        },
+        {
+          "about": "Connect or disconnect the cluster release from a real Slack workspace",
+          "args": [
+            {
+              "global": false,
+              "help": "Chat surface to configure. Required until the CLI grows more than one comms target",
+              "id": "slack",
+              "long": "slack",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear the Slack tokens from the release instead of setting them",
+              "id": "disconnect",
+              "long": "disconnect",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                ""
+              ],
+              "env": "SLACK_APP_TOKEN",
+              "global": false,
+              "help": "Slack app token. Defaults from SLACK_APP_TOKEN",
+              "id": "app_token",
+              "long": "app-token",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                ""
+              ],
+              "env": "SLACK_BOT_TOKEN",
+              "global": false,
+              "help": "Slack bot token. Defaults from SLACK_BOT_TOKEN",
+              "id": "bot_token",
+              "long": "bot-token",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Helm chart. Default: the version-pinned chart release asset on release builds; local `charts/agentos` on dev builds. Pass a path or ref to override",
+              "id": "chart",
+              "long": "chart",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the helm command that would run and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "comms"
+        },
+        {
+          "about": "Drive the deployed Kubernetes release end to end with zero Slack contact",
+          "args": [
+            {
+              "global": false,
+              "help": "The user message text",
+              "id": "text",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Slack channel id to send as; must match the target agent's slack_channel. Omit to use the sole deployed agent's channel (errors if zero or multiple agents are deployed)",
+              "id": "channel",
+              "long": "channel",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Existing thread ts to continue a conversation; omit to start a new thread. Pair with --channel to keep multi-turn context",
+              "id": "thread",
+              "long": "thread",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Reuse the last turn's context (channel, thread, transport) recorded in .agentos/last-turn.json in the working directory; type only the new message text",
+              "id": "continue",
+              "long": "continue",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Helm chart. Default: the version-pinned chart release asset on release builds; local `charts/agentos` on dev builds. Pass a path or ref to override",
+              "id": "chart",
+              "long": "chart",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Host the in-cluster worker uses to reach the stub. Omit to auto-detect the local IP the kernel would use to reach the cluster",
+              "id": "listen_host",
+              "long": "listen-host",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "8155"
+              ],
+              "global": false,
+              "help": "Port the stub binds (0.0.0.0); the worker posts here",
+              "id": "listen_port",
+              "long": "listen-port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "56381"
+              ],
+              "global": false,
+              "help": "Local port the Valkey port-forward binds",
+              "id": "valkey_local_port",
+              "long": "valkey-local-port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "valkeypass"
+              ],
+              "env": "AGENTOS_VALKEY_PASSWORD",
+              "global": false,
+              "help": "Valkey password (chart default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
+              "id": "valkey_password",
+              "long": "valkey-password",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "8123"
+              ],
+              "global": false,
+              "help": "Local port the API port-forward binds (default-channel lookup)",
+              "id": "api_local_port",
+              "long": "api-local-port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key for the default-channel lookup",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "U-agentos-message"
+              ],
+              "global": false,
+              "help": "Synthetic Slack user id for the enqueued event",
+              "id": "user",
+              "long": "user",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos:runs"
+              ],
+              "env": "AGENTOS_STREAM",
+              "global": false,
+              "help": "Stream the dispatcher enqueues onto",
+              "id": "stream",
+              "long": "stream",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "How long to wait for the worker's reply before printing diagnostics. Defaults high because the worker kernel can retry a run up to 3 times with a 90s sandbox-claim timeout each (worst case near 270s of claim waits alone), so a shorter ceiling can time out while it is still working. Default: 300 seconds",
+              "id": "timeout_secs",
+              "long": "timeout-secs",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Skip pointing the worker at the stub. Wiring is on by default (helm upgrade + rollout wait); with --no-wire the command refuses to run unless the worker is already wired, printing the exact command to run",
+              "id": "no_wire",
+              "long": "no-wire",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Wire even when the release is connected to a real Slack workspace (a dispatcher deployment exists). Without this the wiring is refused, since the stub would hijack that workspace's replies cluster-wide",
+              "id": "force_wire",
+              "long": "force-wire",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the kubectl/helm commands, stub URL, and enqueue description that a real run would produce, and exit without executing anything",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "message"
+        },
+        {
+          "about": "Push the bundle to the platform API and deploy it",
+          "args": [
+            {
+              "default_values": [
+                "."
+              ],
+              "global": false,
+              "help": "Plugin bundle directory",
+              "id": "plugin_dir",
+              "long": "plugin-dir",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Slack channel to bind the agent to. On first create it defaults to #local-dev; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
+              "id": "slack_channel",
+              "long": "slack-channel",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "dev"
+              ],
+              "global": false,
+              "help": "Target environment",
+              "id": "env",
+              "long": "env",
+              "positional": false,
+              "possible_values": [
+                "dev",
+                "prod"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Version label; defaults to <manifest version>-<unix time>",
+              "id": "label",
+              "long": "label",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "deploy"
+        },
+        {
+          "about": "Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id to kill",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm this destructive action (required; it stops the agent's runs)",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "kill"
+        },
+        {
+          "about": "Resume a killed agent via the platform API (`POST /agents/{id}/resume`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id to resume",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "resume"
+        },
+        {
+          "about": "Set an agent's budget via the platform API (`PUT /agents/{id}/budget`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Daily spend cap in USD (BudgetConfig.max_usd_per_day). Must be > 0",
+              "id": "limit",
+              "long": "limit",
+              "positional": false,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "budget"
+        },
+        {
+          "about": "Delete an agent via the platform API (`DELETE /agents/{id}`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id to delete",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "help": "Platform API base URL",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm this destructive action (required; it permanently deletes the agent)",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "delete"
+        }
+      ]
+    },
+    {
+      "about": "Build the runner image locally from `runner/Dockerfile` (source checkout only)",
+      "args": [
+        {
+          "default_values": [
+            "agentos-runner"
+          ],
+          "global": false,
+          "help": "Image tag to build",
+          "id": "tag",
+          "long": "tag",
+          "positional": false,
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "long_about": "Build the runner image locally from `runner/Dockerfile` (source checkout only).\n\nRuns `docker build -f runner/Dockerfile -t <tag> .` from the repo root. A release binary pulls the pinned runner image from GHCR automatically and never needs this; it errors clearly if Docker is missing or there is no repo checkout.",
+      "name": "build"
+    },
+    {
+      "about": "Bootstrap a dev checkout: install deps and build, start nothing (source checkout only)",
+      "hidden": false,
+      "long_about": "Bootstrap a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo build` in `cli`, then builds the runner image. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
+      "name": "install"
+    },
+    {
+      "about": "Run a repo dev script (contracts, chart-check, e2e) -- source checkout only",
+      "hidden": false,
+      "long_about": "Run a repo dev script (contracts, chart-check, e2e) -- source checkout only.\n\nThin wrappers over the repo's dev scripts so contributors get a unified `agentos <command>` surface; the scripts stay the implementation. A release binary has no scripts and errors clearly.",
+      "name": "dev",
+      "subcommands": [
+        {
+          "about": "Check the frozen contracts (`bash scripts/check-contracts.sh`)",
+          "hidden": false,
+          "name": "contracts"
+        },
+        {
+          "about": "Render-assert the Helm chart (`bash charts/agentos/ci/render-assertions.sh`)",
+          "hidden": false,
+          "name": "chart-check"
+        },
+        {
+          "about": "Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`)",
+          "hidden": false,
+          "name": "e2e"
+        }
+      ]
+    },
+    {
+      "about": "Print the machine-readable command manifest (JSON) to stdout",
+      "hidden": true,
+      "long_about": "Print the machine-readable command manifest (JSON) to stdout.\n\nHidden, developer-facing: regenerates `cli/command-manifest.json`, which a CI drift gate keeps in lockstep with the CLI grammar. Also reachable as `dump-commands`.",
+      "name": "schema"
+    }
+  ]
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -21,6 +21,7 @@ pub mod render;
 pub mod retired;
 pub mod runner;
 pub mod scaffold;
+pub mod schema;
 pub mod state;
 pub mod ui;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -107,6 +107,13 @@ enum Command {
         #[command(subcommand)]
         action: DevAction,
     },
+    /// Print the machine-readable command manifest (JSON) to stdout.
+    ///
+    /// Hidden, developer-facing: regenerates `cli/command-manifest.json`, which
+    /// a CI drift gate keeps in lockstep with the CLI grammar. Also reachable as
+    /// `dump-commands`.
+    #[command(hide = true, alias = "dump-commands")]
+    Schema,
 }
 
 #[derive(Subcommand)]
@@ -1162,6 +1169,11 @@ async fn main() -> Result<()> {
                 .await
             }
         },
+        Command::Schema => {
+            use clap::CommandFactory;
+            print!("{}", agentos::schema::manifest_json(&Cli::command()));
+            Ok(())
+        }
     }
 }
 

--- a/cli/src/schema.rs
+++ b/cli/src/schema.rs
@@ -1,0 +1,191 @@
+//! A machine-readable snapshot of the CLI grammar.
+//!
+//! [`manifest`] walks a built `clap::Command` tree and emits structured JSON:
+//! every target/verb, its args and flags, their env vars, defaults, and help
+//! text. The `agentos schema` (hidden) subcommand prints [`manifest_json`] to
+//! stdout; the checked-in `cli/command-manifest.json` is that output, and
+//! `cli/tests/command_surface.rs` regenerates it and fails on drift -- the same
+//! generated-artifact-plus-CI-gate discipline the repo applies to
+//! `packages/aci-protocol` and `packages/plugin-format`.
+//!
+//! It reads the clap grammar reflectively (never a hand-maintained copy), so any
+//! new command, flag, default, or help string shows up in the manifest the
+//! moment the grammar changes -- and the drift gate then requires the committed
+//! file to be regenerated in the same PR.
+
+use clap::builder::StyledStr;
+use serde_json::{json, Map, Value};
+
+/// Build the full command manifest as a JSON value rooted at the top-level
+/// command.
+pub fn manifest(command: &clap::Command) -> Value {
+    command_to_value(command)
+}
+
+/// Pretty-printed manifest JSON with a trailing newline (so the checked-in file
+/// is POSIX-clean and matches `println!`-style regeneration).
+pub fn manifest_json(command: &clap::Command) -> String {
+    let mut out = serde_json::to_string_pretty(&manifest(command))
+        .expect("manifest is plain JSON and always serializes");
+    out.push('\n');
+    out
+}
+
+fn styled_to_string(value: Option<&StyledStr>) -> Option<String> {
+    value.map(std::string::ToString::to_string)
+}
+
+fn command_to_value(command: &clap::Command) -> Value {
+    let mut obj = Map::new();
+    obj.insert("name".into(), json!(command.get_name()));
+    if let Some(about) = styled_to_string(command.get_about()) {
+        obj.insert("about".into(), json!(about));
+    }
+    if let Some(long_about) = styled_to_string(command.get_long_about()) {
+        obj.insert("long_about".into(), json!(long_about));
+    }
+    obj.insert("hidden".into(), json!(command.is_hide_set()));
+
+    let aliases: Vec<String> = command.get_visible_aliases().map(str::to_string).collect();
+    if !aliases.is_empty() {
+        obj.insert("aliases".into(), json!(aliases));
+    }
+
+    // Declaration order is stable across builds, so the manifest is
+    // deterministic and diffs cleanly.
+    let args: Vec<Value> = command.get_arguments().map(arg_to_value).collect();
+    if !args.is_empty() {
+        obj.insert("args".into(), Value::Array(args));
+    }
+
+    let subcommands: Vec<Value> = command.get_subcommands().map(command_to_value).collect();
+    if !subcommands.is_empty() {
+        obj.insert("subcommands".into(), Value::Array(subcommands));
+    }
+
+    Value::Object(obj)
+}
+
+fn arg_to_value(arg: &clap::Arg) -> Value {
+    let mut obj = Map::new();
+    obj.insert("id".into(), json!(arg.get_id().as_str()));
+
+    if let Some(help) = styled_to_string(arg.get_help()) {
+        obj.insert("help".into(), json!(help));
+    }
+    if let Some(long) = arg.get_long() {
+        obj.insert("long".into(), json!(long));
+    }
+    if let Some(short) = arg.get_short() {
+        obj.insert("short".into(), json!(short.to_string()));
+    }
+    if let Some(env) = arg.get_env() {
+        obj.insert("env".into(), json!(env.to_string_lossy()));
+    }
+
+    obj.insert("positional".into(), json!(arg.is_positional()));
+    obj.insert("required".into(), json!(arg.is_required_set()));
+    obj.insert("global".into(), json!(arg.is_global_set()));
+
+    let defaults: Vec<String> = arg
+        .get_default_values()
+        .iter()
+        .map(|v| v.to_string_lossy().into_owned())
+        .collect();
+    if !defaults.is_empty() {
+        obj.insert("default_values".into(), json!(defaults));
+    }
+
+    let possible: Vec<String> = arg
+        .get_possible_values()
+        .iter()
+        .map(|pv| pv.get_name().to_string())
+        .collect();
+    if !possible.is_empty() {
+        obj.insert("possible_values".into(), json!(possible));
+    }
+
+    if let Some(range) = arg.get_num_args() {
+        obj.insert(
+            "num_args".into(),
+            json!({
+                "min": range.min_values(),
+                "max": range.max_values(),
+            }),
+        );
+    }
+
+    Value::Object(obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{Arg, ArgAction, Command};
+
+    fn sample() -> Command {
+        Command::new("demo")
+            .about("Demo CLI")
+            .arg(
+                Arg::new("verbose")
+                    .long("verbose")
+                    .short('v')
+                    .action(ArgAction::SetTrue)
+                    .global(true)
+                    .help("Chatter"),
+            )
+            .subcommand(
+                Command::new("run").about("Run it").arg(
+                    Arg::new("port")
+                        .long("port")
+                        .env("DEMO_PORT")
+                        .default_value("8080")
+                        .help("Port"),
+                ),
+            )
+            .subcommand(Command::new("hidden-one").hide(true))
+    }
+
+    #[test]
+    fn manifest_captures_names_help_and_nesting() {
+        let value = manifest(&sample());
+        assert_eq!(value["name"], "demo");
+        assert_eq!(value["about"], "Demo CLI");
+
+        let subs = value["subcommands"].as_array().expect("subcommands");
+        let run = subs.iter().find(|c| c["name"] == "run").expect("run");
+        let args = run["args"].as_array().expect("run args");
+        let port = args.iter().find(|a| a["id"] == "port").expect("port arg");
+        assert_eq!(port["long"], "port");
+        assert_eq!(port["env"], "DEMO_PORT");
+        assert_eq!(port["default_values"][0], "8080");
+        assert_eq!(port["help"], "Port");
+    }
+
+    #[test]
+    fn manifest_records_hidden_and_global_flags() {
+        let value = manifest(&sample());
+        let subs = value["subcommands"].as_array().unwrap();
+        let hidden = subs
+            .iter()
+            .find(|c| c["name"] == "hidden-one")
+            .expect("hidden-one");
+        assert_eq!(hidden["hidden"], true);
+
+        let verbose = value["args"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|a| a["id"] == "verbose")
+            .expect("verbose");
+        assert_eq!(verbose["global"], true);
+        assert_eq!(verbose["short"], "v");
+    }
+
+    #[test]
+    fn manifest_json_is_pretty_and_newline_terminated() {
+        let text = manifest_json(&sample());
+        assert!(text.ends_with("}\n"));
+        assert!(text.contains("\n  \"name\""));
+    }
+}

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -136,6 +136,50 @@ fn process_help_top_level_lists_new_surface_and_hides_retired_verbs() {
     }
 }
 
+/// The checked-in manifest must equal what `agentos schema` emits from the live
+/// clap grammar. This is the generated-artifact + CI drift gate (mirroring the
+/// schema-export discipline for `packages/aci-protocol` / `packages/plugin-format`):
+/// any grammar change (new command, flag, default, env var, help text) must be
+/// accompanied by a regenerated `cli/command-manifest.json` in the same PR.
+#[test]
+fn command_manifest_matches_committed_artifact() {
+    let output = Command::new(bin())
+        .arg("schema")
+        .output()
+        .expect("run agentos schema");
+    assert!(
+        output.status.success(),
+        "agentos schema failed\n{}",
+        output_text(&output)
+    );
+    let generated = String::from_utf8(output.stdout).expect("manifest is utf-8");
+
+    let manifest_path = concat!(env!("CARGO_MANIFEST_DIR"), "/command-manifest.json");
+    let committed =
+        std::fs::read_to_string(manifest_path).expect("cli/command-manifest.json is committed");
+
+    assert_eq!(
+        generated, committed,
+        "cli/command-manifest.json is stale; regenerate with \
+         `cargo run -- schema > cli/command-manifest.json`"
+    );
+}
+
+/// `dump-commands` is the documented alias for the hidden `schema` verb.
+#[test]
+fn dump_commands_alias_emits_same_manifest() {
+    let schema = Command::new(bin())
+        .arg("schema")
+        .output()
+        .expect("run agentos schema");
+    let alias = Command::new(bin())
+        .arg("dump-commands")
+        .output()
+        .expect("run agentos dump-commands");
+    assert!(schema.status.success() && alias.status.success());
+    assert_eq!(schema.stdout, alias.stdout);
+}
+
 fn to_argv(parts: &[&str]) -> Vec<String> {
     parts.iter().map(|part| (*part).to_string()).collect()
 }


### PR DESCRIPTION
## What

Adds a machine-readable CLI manifest as a **generated artifact with a CI drift gate**, mirroring the schema-export discipline the repo applies to `packages/aci-protocol` and `packages/plugin-format`.

- New hidden `agentos schema` subcommand (alias `dump-commands`) walks `Cli::command()` via `clap::CommandFactory` and prints structured JSON to stdout: every target/verb, its args and flags, env vars, defaults, `possible_values`, `num_args`, and help text.
- `src/schema.rs` holds the reflective walker (unit-tested against a synthetic clap grammar).
- Committed output: `cli/command-manifest.json`.
- `cli/tests/command_surface.rs` regenerates the manifest from the built binary and asserts byte-equality with the committed file, failing on drift. A second test asserts the `dump-commands` alias emits the identical manifest.

Regenerate after any grammar change:
```
cargo run -- schema > cli/command-manifest.json
```

## Verification

`cargo test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` all pass.

Foundation stone for the console/CLI parity epic (#145). Does not implement #278–280.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)