### PR TITLE
Promote a trace to an anonymized eval case (one click) (#259)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -424,6 +424,29 @@
         "title": "Environment",
         "type": "string"
       },
+      "EvalCaseOut": {
+        "description": "An eval case conforming to the frozen eval-case format (#8, ADR-0019):\nan input prompt plus the grader that judges the answer. Emitted by the\npromote-a-trace-to-an-eval-case endpoint (#259).",
+        "properties": {
+          "grader": {
+            "$ref": "#/components/schemas/GraderOut"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "input": {
+            "title": "Input",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "input",
+          "grader"
+        ],
+        "title": "EvalCaseOut",
+        "type": "object"
+      },
       "EvalCell": {
         "description": "One cell of the eval matrix: a case's result on a version.",
         "properties": {
@@ -662,6 +685,35 @@
           "bundle_ref"
         ],
         "title": "EvalTriggerResult",
+        "type": "object"
+      },
+      "GraderOut": {
+        "description": "A deterministic grader, mirroring the frozen eval-case Grader shape\n(`apps/worker/schema/eval-cases.schema.json`). Do not let this drift from the\nworker's `Grader` model.",
+        "properties": {
+          "case_sensitive": {
+            "default": false,
+            "title": "Case Sensitive",
+            "type": "boolean"
+          },
+          "expected": {
+            "title": "Expected",
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "exact",
+              "contains",
+              "regex"
+            ],
+            "title": "Kind",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "expected"
+        ],
+        "title": "GraderOut",
         "type": "object"
       },
       "GreetingPackConfig": {
@@ -3502,6 +3554,65 @@
           }
         },
         "summary": "Get Trace",
+        "tags": [
+          "langfuse"
+        ]
+      }
+    },
+    "/langfuse/traces/{trace_id}/eval-case": {
+      "post": {
+        "description": "Promote a real trace into an anonymized, runnable eval case (#259).\n\nReads the trace + its observations, extracts the conversation input/output,\nanonymizes them (emails, Slack ids, phone numbers, credential-shaped tokens),\nand emits an EvalCase conforming to the frozen eval-case format. 404s when the\ntrace has no observations yet, matching the read path.",
+        "operationId": "promote_trace_to_eval_case_langfuse_traces__trace_id__eval_case_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "trace_id",
+            "required": true,
+            "schema": {
+              "title": "Trace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalCaseOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Promote Trace To Eval Case",
         "tags": [
           "langfuse"
         ]

--- a/apps/api/src/agentos_api/evalcase.py
+++ b/apps/api/src/agentos_api/evalcase.py
@@ -1,0 +1,139 @@
+"""Promote a Langfuse trace into an anonymized eval case (#259).
+
+One click in the Runs view turns a real conversation into a runnable eval case
+conforming to the frozen eval-case format (ADR-0019,
+``apps/worker/schema/eval-cases.schema.json``): ``{id, input, grader}`` with a
+deterministic ``{kind, expected, case_sensitive}`` grader. The models here are a
+deliberate API-side mirror of the worker's frozen ``EvalCase``/``Grader`` shape
+(the API never imports the worker package); the shape must not drift from that
+schema.
+
+Anonymization is the load-bearing part: the promoted case is derived from a real
+Slack conversation, so emails, Slack ids, phone numbers, and credential-shaped
+tokens are redacted out of both the input prompt and the expected output before
+the case is emitted. The redaction is intentionally conservative -- it never
+invents content, only masks recognizable identifiers with a stable placeholder.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from .schemas import EvalCaseOut, GraderOut
+
+# The expected-output snippet is capped so a promoted grader keys off a salient
+# line rather than an entire multi-paragraph answer (which would rarely match on
+# re-run). The human refines it after promotion; this is a runnable starting
+# point, not a final assertion.
+_EXPECTED_MAX_LEN = 200
+
+# Redaction patterns, applied in order. Emails and tokens are matched before the
+# generic phone/number patterns so a digit-bearing email or key is masked whole
+# rather than partially. Each maps a recognizable identifier to a stable
+# placeholder so the anonymized text stays readable.
+_REDACTIONS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"), "<email>"),
+    # Slack-ish OAuth / bot tokens and API keys (xoxb-, sk-ant-, sk-...).
+    (re.compile(r"\b(?:xox[bpasr]|sk(?:-[A-Za-z]+)?)-[A-Za-z0-9-]{6,}\b"), "<token>"),
+    # Slack object ids: users U/W, channels C/G, DMs D. Uppercase alnum, >=8.
+    (re.compile(r"\b[UWCGD][A-Z0-9]{7,}\b"), "<slack-id>"),
+    # Phone numbers: an optional +, then 9+ digits possibly split by -, space, ().
+    (re.compile(r"\+?\d(?:[\d\s().-]{7,})\d"), "<phone>"),
+]
+
+
+def redact(text: str) -> str:
+    """Mask recognizable PII / secrets in ``text`` with stable placeholders."""
+    for pattern, placeholder in _REDACTIONS:
+        text = pattern.sub(placeholder, text)
+    return text
+
+
+def _coerce_text(value: Any) -> str:
+    """Flatten a Langfuse input/output payload into a single text string.
+
+    Handles the common shapes: a bare string; a chat-style list of
+    ``{"role", "content"}`` messages (the last user message for an input, the
+    last message for an output); a ``{"content": ...}`` dict; else a compact JSON
+    dump so nothing is silently dropped.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        # Prefer the last message that carries text content.
+        for msg in reversed(value):
+            if isinstance(msg, dict) and msg.get("content"):
+                return _coerce_text(msg["content"])
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, dict):
+        for key in ("content", "text", "output", "input", "value"):
+            if value.get(key):
+                return _coerce_text(value[key])
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def _last_user_input(value: Any) -> str:
+    """The last user-authored message from a chat-style input, else all of it."""
+    if isinstance(value, list):
+        for msg in reversed(value):
+            if isinstance(msg, dict) and msg.get("role") == "user" and msg.get("content"):
+                return _coerce_text(msg["content"])
+    return _coerce_text(value)
+
+
+def extract_io(
+    trace: dict[str, Any], observations: list[dict[str, Any]]
+) -> tuple[str, str]:
+    """Best-effort (input, output) text for a trace.
+
+    Prefers the trace-level ``input``/``output`` fields; falls back to the first
+    observation carrying an input (the prompt) and the last carrying an output
+    (the answer) when the trace itself does not surface them.
+    """
+    input_text = _last_user_input(trace.get("input"))
+    output_text = _coerce_text(trace.get("output"))
+
+    if not input_text:
+        for obs in observations:
+            if isinstance(obs, dict) and obs.get("input"):
+                input_text = _last_user_input(obs["input"])
+                break
+    if not output_text:
+        for obs in reversed(observations):
+            if isinstance(obs, dict) and obs.get("output"):
+                output_text = _coerce_text(obs["output"])
+                break
+    return input_text, output_text
+
+
+def _expected_snippet(output: str) -> str:
+    """A salient, capped snippet of the (already-redacted) output for the grader.
+
+    The first non-empty line, trimmed to the length cap. Empty when there is no
+    output -- a ``contains`` grader on ``""`` trivially passes, which keeps the
+    case runnable while signalling the human to fill in a real assertion.
+    """
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped[:_EXPECTED_MAX_LEN]
+    return output.strip()[:_EXPECTED_MAX_LEN]
+
+
+def trace_to_eval_case(
+    trace_id: str, trace: dict[str, Any], observations: list[dict[str, Any]]
+) -> EvalCaseOut:
+    """Build an anonymized, runnable eval case from a trace and its observations."""
+    raw_input, raw_output = extract_io(trace, observations)
+    anon_input = redact(raw_input).strip()
+    anon_output = redact(raw_output)
+    return EvalCaseOut(
+        id=f"promoted-{trace_id}",
+        input=anon_input,
+        grader=GraderOut(kind="contains", expected=_expected_snippet(anon_output)),
+    )

--- a/apps/api/src/agentos_api/routers/runs.py
+++ b/apps/api/src/agentos_api/routers/runs.py
@@ -6,9 +6,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..auth import require_api_key
 from ..deps import LangfuseDep
+from ..evalcase import trace_to_eval_case
 from ..langfuse import build_tree, hoist_sandbox_id
 from ..metrics import agent_trace_filter
-from ..schemas import TraceTree
+from ..schemas import EvalCaseOut, TraceTree
 
 router = APIRouter(
     prefix="/langfuse",
@@ -49,3 +50,23 @@ async def get_trace(trace_id: str, lf: LangfuseDep) -> TraceTree:
         tree=build_tree(observations),
         sandbox_id=hoist_sandbox_id(trace, observations),
     )
+
+
+@router.post("/traces/{trace_id}/eval-case", response_model=EvalCaseOut)
+async def promote_trace_to_eval_case(trace_id: str, lf: LangfuseDep) -> EvalCaseOut:
+    """Promote a real trace into an anonymized, runnable eval case (#259).
+
+    Reads the trace + its observations, extracts the conversation input/output,
+    anonymizes them (emails, Slack ids, phone numbers, credential-shaped tokens),
+    and emits an EvalCase conforming to the frozen eval-case format. 404s when the
+    trace has no observations yet, matching the read path.
+    """
+    if not _TRACE_ID_RE.match(trace_id):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid trace id")
+    observations = await lf.get_observations(trace_id)
+    if not observations:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, "trace has no observations yet"
+        )
+    trace = await lf.get_trace(trace_id)
+    return trace_to_eval_case(trace_id, trace, observations)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -117,6 +117,26 @@ class AgentOut(BaseModel):
     created_at: datetime
 
 
+class GraderOut(BaseModel):
+    """A deterministic grader, mirroring the frozen eval-case Grader shape
+    (`apps/worker/schema/eval-cases.schema.json`). Do not let this drift from the
+    worker's `Grader` model."""
+
+    kind: Literal["exact", "contains", "regex"]
+    expected: str
+    case_sensitive: bool = False
+
+
+class EvalCaseOut(BaseModel):
+    """An eval case conforming to the frozen eval-case format (#8, ADR-0019):
+    an input prompt plus the grader that judges the answer. Emitted by the
+    promote-a-trace-to-an-eval-case endpoint (#259)."""
+
+    id: str
+    input: str
+    grader: GraderOut
+
+
 class VersionCreate(BaseModel):
     version_label: str
     bundle_ref: str | None = None

--- a/apps/api/tests/test_promote_eval_case.py
+++ b/apps/api/tests/test_promote_eval_case.py
@@ -1,0 +1,149 @@
+"""Promote-a-trace-to-an-eval-case endpoint (#259).
+
+Only the external Langfuse read is faked (permitted); the extraction,
+anonymization, and FastAPI wiring run for real. Also unit-tests the pure
+anonymization/extraction helpers.
+"""
+
+from typing import Any
+
+import pytest
+from agentos_api.deps import get_langfuse
+from agentos_api.evalcase import extract_io, redact, trace_to_eval_case
+from agentos_api.main import create_app
+from fastapi.testclient import TestClient
+
+
+class FakeLangfuse:
+    def __init__(
+        self, observations: list[dict[str, Any]], trace: dict[str, Any] | None = None
+    ) -> None:
+        self._observations = observations
+        self._trace = trace or {"id": "t", "name": "demo"}
+
+    async def get_observations(self, trace_id: str) -> list[dict[str, Any]]:
+        return self._observations
+
+    async def get_trace(self, trace_id: str) -> dict[str, Any]:
+        return {**self._trace, "id": trace_id}
+
+
+def _app_with(
+    observations: list[dict[str, Any]], trace: dict[str, Any] | None = None
+) -> TestClient:
+    app = create_app()
+    app.dependency_overrides[get_langfuse] = lambda: FakeLangfuse(observations, trace)
+    return TestClient(app)
+
+
+# --- Endpoint --------------------------------------------------------------
+
+
+def test_promote_emits_runnable_anonymized_case(auth_headers: dict[str, str]) -> None:
+    trace = {
+        "name": "agentos-run:agent-x",
+        "input": [{"role": "user", "content": "Email me at jane.doe@acme.com about U012ABCDEF"}],
+        "output": "Sure, I sent the summary to your address.\nMore detail below.",
+    }
+    with _app_with([{"id": "r", "type": "SPAN"}], trace) as client:
+        resp = client.post("/langfuse/traces/abc/eval-case", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    case = resp.json()
+
+    # Conforms to the frozen eval-case shape.
+    assert case["id"] == "promoted-abc"
+    assert set(case["grader"]) == {"kind", "expected", "case_sensitive"}
+    assert case["grader"]["kind"] == "contains"
+
+    # Anonymized: the email and Slack id never reach the emitted case.
+    assert "jane.doe@acme.com" not in case["input"]
+    assert "U012ABCDEF" not in case["input"]
+    assert "<email>" in case["input"]
+    assert "<slack-id>" in case["input"]
+
+    # Expected keys off the first salient (redacted) output line, capped.
+    assert case["grader"]["expected"] == "Sure, I sent the summary to your address."
+
+
+def test_promote_falls_back_to_observation_io(auth_headers: dict[str, str]) -> None:
+    # The trace has no top-level input/output; the endpoint pulls them from the
+    # observations (first input, last output).
+    observations = [
+        {"id": "a", "type": "GENERATION", "input": "What is the refund policy?"},
+        {"id": "b", "type": "GENERATION", "output": "Refunds are issued within 30 days."},
+    ]
+    with _app_with(observations, {"name": "run"}) as client:
+        resp = client.post("/langfuse/traces/xyz/eval-case", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    case = resp.json()
+    assert case["input"] == "What is the refund policy?"
+    assert case["grader"]["expected"] == "Refunds are issued within 30 days."
+
+
+def test_promote_404_when_no_observations(auth_headers: dict[str, str]) -> None:
+    with _app_with([]) as client:
+        resp = client.post("/langfuse/traces/abc/eval-case", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_promote_rejects_malformed_trace_id(auth_headers: dict[str, str]) -> None:
+    with _app_with([{"id": "r"}]) as client:
+        resp = client.post("/langfuse/traces/abc.def/eval-case", headers=auth_headers)
+    assert resp.status_code == 400
+
+
+def test_promote_requires_api_key() -> None:
+    with _app_with([{"id": "r"}]) as client:
+        resp = client.post("/langfuse/traces/abc/eval-case")
+    assert resp.status_code == 401
+
+
+# --- Pure helpers ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,needle,absent",
+    [
+        ("ping a@b.com", "<email>", "a@b.com"),
+        ("user U01ABCDEFG here", "<slack-id>", "U01ABCDEFG"),
+        ("call +1 (415) 555-1234 now", "<phone>", "555-1234"),
+        ("token xoxb-123456-abcdef leaked", "<token>", "xoxb-123456-abcdef"),
+        ("key sk-ant-abc123def456 used", "<token>", "sk-ant-abc123def456"),
+    ],
+)
+def test_redact_masks_identifiers(raw: str, needle: str, absent: str) -> None:
+    out = redact(raw)
+    assert needle in out
+    assert absent not in out
+
+
+def test_redact_leaves_plain_text_untouched() -> None:
+    text = "What is the weather in San Francisco today?"
+    assert redact(text) == text
+
+
+def test_extract_io_prefers_trace_level_fields() -> None:
+    trace = {"input": "hello", "output": "world"}
+    assert extract_io(trace, []) == ("hello", "world")
+
+
+def test_extract_io_picks_last_user_message() -> None:
+    trace = {
+        "input": [
+            {"role": "system", "content": "be nice"},
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "second"},
+        ],
+        "output": "ok",
+    }
+    got_input, _ = extract_io(trace, [])
+    assert got_input == "second"
+
+
+def test_trace_to_eval_case_empty_output_is_still_runnable() -> None:
+    case = trace_to_eval_case("t1", {"input": "hi", "output": ""}, [{"id": "r"}])
+    assert case.input == "hi"
+    # No output -> a trivially-passing contains-"" grader keeps the case runnable.
+    assert case.grader.expected == ""
+    assert case.grader.kind == "contains"

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -60,6 +60,19 @@ export interface TraceTree {
 // A raw Langfuse trace row (opaque; we read a few well-known fields defensively).
 export type RawTrace = Record<string, unknown>;
 
+// An eval case in the frozen eval-case format (#8/#259): an input prompt plus a
+// deterministic grader. Returned by promoteTraceToEvalCase.
+export interface GraderOut {
+  kind: "exact" | "contains" | "regex";
+  expected: string;
+  case_sensitive: boolean;
+}
+export interface EvalCaseOut {
+  id: string;
+  input: string;
+  grader: GraderOut;
+}
+
 /** Thrown when the bundle validator rejects the archive (HTTP 422). */
 export class BundleValidationError extends Error {
   issues: BundleIssue[];
@@ -189,6 +202,16 @@ export async function getTrace(traceId: string): Promise<TraceTree> {
     headers: headers(),
   });
   return jsonOrThrow<TraceTree>(resp);
+}
+
+// Promote a trace into an anonymized, runnable eval case (#259). The API reads
+// the trace, scrubs PII, and returns a case in the frozen eval-case format.
+export async function promoteTraceToEvalCase(traceId: string): Promise<EvalCaseOut> {
+  const resp = await fetch(url(`/langfuse/traces/${encodeURIComponent(traceId)}/eval-case`), {
+    method: "POST",
+    headers: headers(),
+  });
+  return jsonOrThrow<EvalCaseOut>(resp);
 }
 
 // ---- observability (OB1): Langfuse-backed metrics + runner-pod log proxy ----

--- a/apps/ui/src/state/store.tsx
+++ b/apps/ui/src/state/store.tsx
@@ -44,6 +44,7 @@ export function initialState(level: FixtureLevel): AppState {
     showSuccess: false,
     deployIssues: null,
     deployError: null,
+    promotedEvalCases: [],
   };
 }
 
@@ -82,6 +83,15 @@ export function reducer(s: AppState, a: Action): AppState {
       return { ...s, modal: null, pluginUploaded: false, deployIssues: null, deployError: null };
     case "toast":
       return { ...s, toast: a.message };
+    case "addPromotedEvalCase":
+      // Newest first; dedupe by id so re-promoting the same trace replaces it.
+      return {
+        ...s,
+        promotedEvalCases: [
+          a.evalCase,
+          ...s.promotedEvalCases.filter((c) => c.id !== a.evalCase.id),
+        ],
+      };
     case "setEnv":
       return { ...s, env: a.env };
     case "setObsTab":

--- a/apps/ui/src/state/types.ts
+++ b/apps/ui/src/state/types.ts
@@ -61,6 +61,16 @@ export interface AppState {
   // Wired-deploy feedback surfaced in the create-agent modal.
   deployIssues: DeployIssue[] | null;
   deployError: string | null;
+  // Eval cases promoted from real traces (#259), newest first. Anonymized by the
+  // API before they land here.
+  promotedEvalCases: PromotedEvalCase[];
+}
+
+// An anonymized eval case promoted from a trace (mirrors the API EvalCaseOut).
+export interface PromotedEvalCase {
+  id: string;
+  input: string;
+  grader: { kind: "exact" | "contains" | "regex"; expected: string; case_sensitive: boolean };
 }
 
 export type Action =
@@ -90,6 +100,7 @@ export type Action =
   | { type: "installPlugin" }
   | { type: "promoteFormOpen" }
   | { type: "promoteEval" }
+  | { type: "addPromotedEvalCase"; evalCase: PromotedEvalCase }
   | { type: "runMatrix" }
   | { type: "reconfigureMatrix" }
   | { type: "revealToken"; value: boolean }

--- a/apps/ui/src/views/obs/RealTraces.tsx
+++ b/apps/ui/src/views/obs/RealTraces.tsx
@@ -1,8 +1,10 @@
+import { useState } from "react";
 import { C } from "../../tokens";
 import { Card, Chip, Dot, EmptyState, Notice } from "../../primitives";
 import { hoverBg } from "../../lib/style";
 import { useStore } from "../../state/store";
 import { useTraces, useTrace } from "../../api/hooks";
+import { promoteTraceToEvalCase } from "../../api/client";
 import type { RawTrace, ObservationNode } from "../../api/client";
 
 function str(o: RawTrace, key: string): string | null {
@@ -206,7 +208,24 @@ export function sandboxIdFromTrace(source: RawTrace | null | undefined): string 
 export function RealTraceDetail() {
   const { state, dispatch } = useStore();
   const { data, loading, error, notFound } = useTrace(state.traceOpen);
+  const [promoting, setPromoting] = useState(false);
+  const [promoteError, setPromoteError] = useState<string | null>(null);
   const traceName = data ? (str(data.trace as RawTrace, "name") ?? state.traceOpen) : state.traceOpen;
+
+  const promote = async () => {
+    if (!state.traceOpen || promoting) return;
+    setPromoting(true);
+    setPromoteError(null);
+    try {
+      const evalCase = await promoteTraceToEvalCase(state.traceOpen);
+      dispatch({ type: "addPromotedEvalCase", evalCase });
+      dispatch({ type: "toast", message: `Promoted to eval case ${evalCase.id} (anonymized)` });
+    } catch (e) {
+      setPromoteError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoting(false);
+    }
+  };
   // Prefer the API's typed field; fall back to probing the raw trace payload.
   const typedSandboxId =
     typeof data?.sandbox_id === "string" && data.sandbox_id.trim() !== "" ? data.sandbox_id : null;
@@ -238,7 +257,35 @@ export function RealTraceDetail() {
               live
             </Chip>
             <span style={{ marginLeft: "auto", fontSize: 12.5, color: C.muted, fontFamily: C.mono }}>{state.traceOpen}</span>
+            <button
+              type="button"
+              data-testid="promote-eval-case"
+              onClick={() => void promote()}
+              disabled={promoting}
+              title="Turn this conversation into an anonymized eval case"
+              style={{
+                background: "transparent",
+                border: "1px solid " + C.border,
+                borderRadius: 20,
+                padding: "3px 12px",
+                color: C.link,
+                fontFamily: C.mono,
+                fontSize: 11.5,
+                cursor: promoting ? "default" : "pointer",
+                opacity: promoting ? 0.6 : 1,
+              }}
+            >
+              {promoting ? "Promoting…" : "Promote to eval case"}
+            </button>
           </div>
+          {promoteError ? (
+            <div
+              data-testid="promote-error"
+              style={{ fontSize: 12, color: C.destructive, fontFamily: C.mono, marginBottom: 16 }}
+            >
+              Could not promote: {promoteError}
+            </div>
+          ) : null}
           {sandboxId ? (
             <div
               data-testid="trace-sandbox"

--- a/apps/ui/src/views/obs/promote-eval-case.test.tsx
+++ b/apps/ui/src/views/obs/promote-eval-case.test.tsx
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { RealTraceDetail } from "./RealTraces";
+import { StoreProvider, useStore } from "../../state/store";
+import { getTrace, promoteTraceToEvalCase, type TraceTree, type EvalCaseOut } from "../../api/client";
+
+// Mock only the data-layer calls; keep the real store + component wiring.
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return { ...actual, getTrace: vi.fn(), promoteTraceToEvalCase: vi.fn() };
+});
+
+const TRACE: TraceTree = {
+  trace: { id: "tr-1", name: "agentos-run:agent-x-thread-1" },
+  tree: [{ id: "root", type: "SPAN", name: "agent.run", model: null, startTime: "1", usageDetails: null, children: [] }],
+  sandbox_id: null,
+};
+
+const CASE: EvalCaseOut = {
+  id: "promoted-tr-1",
+  input: "What is the refund policy?",
+  grader: { kind: "contains", expected: "30 days", case_sensitive: false },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getTrace).mockResolvedValue(TRACE);
+  vi.mocked(promoteTraceToEvalCase).mockResolvedValue(CASE);
+});
+
+function renderWired(ui: React.ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <StoreProvider level={3}>{ui}</StoreProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// Surfaces the promoted-eval-case count + latest toast so the test can assert the
+// case landed in the store.
+function StoreProbe() {
+  const { state } = useStore();
+  return (
+    <div data-testid="store-probe">{`${state.promotedEvalCases.length}:${state.promotedEvalCases[0]?.id ?? ""}:${state.toast ?? ""}`}</div>
+  );
+}
+
+function Harness() {
+  const { dispatch } = useStore();
+  useEffect(() => {
+    dispatch({ type: "openTrace", id: "tr-1" });
+  }, [dispatch]);
+  return (
+    <>
+      <RealTraceDetail />
+      <StoreProbe />
+    </>
+  );
+}
+
+describe("RealTraceDetail — promote to eval case (#259)", () => {
+  it("promotes the open trace and stores the anonymized case", async () => {
+    const user = userEvent.setup();
+    renderWired(<Harness />);
+
+    const btn = await screen.findByTestId("promote-eval-case");
+    await user.click(btn);
+
+    await waitFor(() => expect(promoteTraceToEvalCase).toHaveBeenCalledWith("tr-1"));
+    // The returned case lands in the store (newest first) and a toast fires.
+    await waitFor(() =>
+      expect(screen.getByTestId("store-probe")).toHaveTextContent("1:promoted-tr-1:"),
+    );
+    expect(screen.getByTestId("store-probe")).toHaveTextContent("Promoted to eval case promoted-tr-1");
+  });
+
+  it("surfaces an error and does not store a case when promotion fails", async () => {
+    vi.mocked(promoteTraceToEvalCase).mockRejectedValue(new Error("boom"));
+    const user = userEvent.setup();
+    renderWired(<Harness />);
+
+    const btn = await screen.findByTestId("promote-eval-case");
+    await user.click(btn);
+
+    expect(await screen.findByTestId("promote-error")).toHaveTextContent("boom");
+    expect(screen.getByTestId("store-probe")).toHaveTextContent("0::");
+  });
+});


### PR DESCRIPTION
## What

Adds a one-click path from a real conversation in the Runs/observability view to a runnable, **anonymized** eval case in the frozen eval-case format (ADR-0019). The frozen schema is not touched.

### API (`apps/api`)
- New endpoint `POST /langfuse/traces/{trace_id}/eval-case` (`routers/runs.py`): reuses the same trace-id validation and 404-when-no-observations behavior as the read path, then emits an `EvalCase`.
- `evalcase.py` holds the pure logic: `extract_io` (trace-level input/output, falling back to first/last observation), `redact` (masks emails, Slack ids, phone numbers, and `xoxb-`/`sk-…` credential-shaped tokens with stable placeholders), and `trace_to_eval_case` (builds `{id, input, grader{kind:"contains", expected}}`, keying `expected` off the first salient redacted output line, capped).
- `schemas.py` gains `GraderOut`/`EvalCaseOut`, a deliberate API-side mirror of the worker's frozen `Grader`/`EvalCase` (the API never imports the worker package).

### UI (`apps/ui`)
- `promoteTraceToEvalCase` client call + `EvalCaseOut` type.
- A "Promote to eval case" action on the trace detail (`RealTraces.tsx`) that calls the API, stores the anonymized case (`state.promotedEvalCases`, newest-first, dedup by id) via a new `addPromotedEvalCase` action, and toasts; errors surface inline.

## Tests
- Endpoint + helper unit tests with a faked Langfuse read (mirrors `test_runs_proxy.py`): anonymization end-to-end, observation fallback, 404/400/401, and pure `redact`/`extract_io` cases.
- UI test: promote stores the case + toasts; failure surfaces an error and stores nothing.
- `openapi.json` regenerated (drift test green); `pnpm test`/`lint`/`typecheck` green.

Part of #26. Depends on the frozen eval-case format (#8).

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)