### PR TITLE
dx: one-command smoke test + surface the e2e path in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,33 @@ channel binding, and troubleshooting) see
 
 ## Quickstart
 
+### See it work (60-second smoke test)
+
+One command builds the runner image and round-trips a real turn through a runner
+container — no Slack, no cluster, no credential:
+
+```bash
+./scripts/smoke.sh
+```
+
+Green output means the ACI loop works end to end (init → runner → message →
+streamed reply → evals). To drive the **full** dispatcher → queue → worker →
+reply path locally, use the local loop (the *One-command middle mode* block
+below):
+
+```bash
+agentos local up                                     # stores + API + worker (fake model)
+agentos local deploy --plugin-dir ./my-agent --api-url http://localhost:28000
+agentos local message "what changed in the last deploy?"   # worker answers; reply streamed back
+```
+
+For a real model reply, export a credential first (`CLAUDE_CODE_OAUTH_TOKEN`,
+`ANTHROPIC_API_KEY`, `AGENTOS_CREDENTIALS`, or an `sk-or-…` OpenRouter key), as in
+the CLI walkthrough below. The rest of this section is the detailed,
+component-by-component setup.
+
+---
+
 Operators should start from a binary downloaded from
 [GitHub Releases](https://github.com/curie-eng/agentos/releases):
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# One-command end-to-end smoke test.
+#
+# Builds the runner image, then round-trips a synthetic turn through a REAL
+# runner container (fake model, zero Slack, zero cluster, zero credential) via
+# cli/scripts/e2e.sh: init a bundle, boot the runner, send a message, stream the
+# NDJSON reply, run the eval cases, tear down. Green output = the ACI loop works.
+#
+# For the full dispatcher -> queue -> worker -> reply path, use the local loop
+# instead (README "See it work"): agentos local up -> local deploy -> local message.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "==> Building the runner image (agentos-runner)..."
+docker build -f runner/Dockerfile -t agentos-runner .
+
+echo "==> Running the end-to-end round-trip (cli/scripts/e2e.sh)..."
+bash cli/scripts/e2e.sh
+
+echo "==> Smoke test passed."


### PR DESCRIPTION
## Why

Verifying the system works end to end was hard to find: the runner-image build was buried in a parenthetical in the Quickstart, and `cli/scripts/e2e.sh` (the offline round-trip that actually exercises the ACI loop) wasn't mentioned in the README at all.

## What

- **`scripts/smoke.sh`** — one command that builds the runner image and runs `cli/scripts/e2e.sh` (init a bundle → boot a real runner container, fake model → send a message → stream the NDJSON reply → run evals → tear down). No Slack, no cluster, no credential.
  ```bash
  ./scripts/smoke.sh
  ```
- **README "See it work (60-second smoke test)"** callout at the top of the Quickstart, pointing to `scripts/smoke.sh` and to the full local loop (`agentos local up` → `local deploy` → `local message`) for the dispatcher→queue→worker→reply path, plus how to get a real-model reply.

Docs + a wrapper script only — no code changes. `bash -n scripts/smoke.sh` clean; the two commands it wraps are the repo's existing, documented e2e entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)