### PR TITLE
cli: 'agentos build' + 'agentos e2e' (dev flows as commands, not scripts)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -33,6 +33,12 @@ That is the full loop. `agentos skill up` starts the runner container,
 `agentos skill down` stops it. Edit `skills/weather-bot/SKILL.md` in the bundle
 and re-run steps 2 and 3 to see your change answer.
 
+Want the whole offline round-trip in one command? `agentos e2e` scaffolds a
+throwaway bundle, runs `skill up --fake-model` -> `skill message` ->
+`skill eval` -> `skill down`, and cleans up after itself — the scripted
+equivalent as a first-class command. It only needs the runner image present
+(the same one `skill up` uses); it never builds an image.
+
 ## Level up: a real model
 
 The fake model returns scripted replies. To get a genuine answer, bring your own

--- a/cli/README.md
+++ b/cli/README.md
@@ -312,9 +312,25 @@ agentos e2e
 
 It scaffolds a throwaway bundle, runs `skill up --fake-model` -> `skill message`
 -> `skill eval` -> `skill down`, and cleans up on exit. Requires an
-`agentos-runner` image to be present (`docker build -f runner/Dockerfile -t
-agentos-runner .` from the repo root for dev; a release binary pulls its pinned
-GHCR ref on first run). It never runs `docker build`.
+`agentos-runner` image to be present: build it with **`agentos build`** (the
+one-command `docker build -f runner/Dockerfile -t agentos-runner .` from the repo
+root) for dev; a release binary pulls its pinned GHCR ref on first run. `e2e`
+itself never builds -- so `agentos build && agentos e2e` is the full from-scratch
+smoke test.
+
+## `agentos build`
+
+Build the runner image locally from `runner/Dockerfile`:
+
+```bash
+agentos build            # docker build -f runner/Dockerfile -t agentos-runner .
+agentos build --tag my-runner:dev
+```
+
+Run it from an agentos source checkout (it walks up to the repo root to find
+`runner/Dockerfile`). It prints a clear error if Docker is not installed or if
+there is no checkout -- a release binary pulls the pinned runner image from GHCR
+automatically and never needs to build.
 
 The scripted E2E (`cli/scripts/e2e.sh`) does the same round-trip and adds an
 optional deploy leg against a locally-run apps/api; it can later become a thin

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,9 @@ Slack involved.
 Every environment command takes a **target noun** in the middle: `skill`,
 `local`, or `cluster`. Pick the lightest one that answers your question.
 `agentos init` is the exception, a top-level verb that scaffolds a bundle on
-disk and targets no environment.
+disk and targets no environment. `agentos e2e` is a second top-level verb: it
+runs the whole offline `skill` round-trip (scaffold -> up -> message -> eval ->
+down) as one command.
 
 | Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
 |---|---|---|---|---|---|
@@ -32,6 +34,7 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 | Command | What it does |
 |---|---|
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed. |
+| `agentos e2e` | Run the offline end-to-end round-trip in one command: scaffold a throwaway bundle in a temp dir, `skill up --fake-model`, send a message, run the eval cases, then tear the container and temp dir down (even on failure; `--keep` leaves them for debugging). The native equivalent of `cli/scripts/e2e.sh` — it reuses the same handlers rather than shelling out. Assumes the runner image exists (`--image`, default the same one `skill up` uses); it never runs `docker build`. `--port` overrides the host port. |
 
 ## `skill` target: runner-only, fully offline
 
@@ -300,8 +303,22 @@ original turn used a non-default value.
 cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test
 ```
 
-The scripted E2E (real runner container, fake model, offline) plus an optional
-deploy leg against a locally-run apps/api:
+The offline end-to-end round-trip (real runner container, fake model) is a
+first-class command:
+
+```bash
+agentos e2e
+```
+
+It scaffolds a throwaway bundle, runs `skill up --fake-model` -> `skill message`
+-> `skill eval` -> `skill down`, and cleans up on exit. Requires an
+`agentos-runner` image to be present (`docker build -f runner/Dockerfile -t
+agentos-runner .` from the repo root for dev; a release binary pulls its pinned
+GHCR ref on first run). It never runs `docker build`.
+
+The scripted E2E (`cli/scripts/e2e.sh`) does the same round-trip and adds an
+optional deploy leg against a locally-run apps/api; it can later become a thin
+`agentos e2e` wrapper:
 
 ```bash
 bash cli/scripts/e2e.sh
@@ -310,6 +327,3 @@ AGENTOS_E2E_NETWORK=agentos_default \
 AGENTOS_E2E_OTEL=http://otel-collector:4318 \
 AGENTOS_E2E_API_URL=http://localhost:8000 bash cli/scripts/e2e.sh
 ```
-
-Requires an `agentos-runner` image (`docker build -f runner/Dockerfile -t
-agentos-runner .` from the repo root).

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -569,6 +569,63 @@ pub struct E2eOpts {
     pub keep: bool,
 }
 
+/// `agentos build`: build the runner image locally from the repo's Dockerfile.
+/// The one-command equivalent of `docker build -f runner/Dockerfile -t <tag> .`
+/// run from the repo root, so `agentos build && agentos e2e` is the full
+/// from-scratch smoke test. Errors clearly when Docker is missing or when run
+/// outside a source checkout (a release binary pulls the image from GHCR).
+pub async fn build(tag: &str) -> Result<()> {
+    let ui = crate::ui::ui();
+    if !on_path("docker") {
+        bail!(
+            "Docker is not installed or not on PATH. Install Docker \
+             (https://docs.docker.com/get-docker/) and retry."
+        );
+    }
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `agentos build` \
+         from an agentos repo checkout -- a release binary pulls the runner image from GHCR \
+         automatically and never needs to build.",
+    )?;
+    ui.note(&format!(
+        "=== docker build -f runner/Dockerfile -t {tag} . (in {}) ===",
+        root.display()
+    ));
+    // Inherit stdio so the build log streams to the terminal like a hand-run build.
+    let status = tokio::process::Command::new("docker")
+        .args(["build", "-f", "runner/Dockerfile", "-t", tag, "."])
+        .current_dir(&root)
+        .status()
+        .await
+        .context("failed to invoke docker")?;
+    if !status.success() {
+        bail!("docker build failed ({status})");
+    }
+    ui.success(&format!("built runner image '{tag}'"));
+    Ok(())
+}
+
+/// Whether `bin` resolves on PATH.
+fn on_path(bin: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).any(|dir| dir.join(bin).is_file()))
+        .unwrap_or(false)
+}
+
+/// Walk up from the current directory to the repo root: the nearest ancestor
+/// that contains `runner/Dockerfile`.
+fn find_repo_root() -> Option<PathBuf> {
+    let mut dir = std::env::current_dir().ok()?;
+    loop {
+        if dir.join("runner/Dockerfile").is_file() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
 /// `agentos e2e`: the scripted offline round-trip (`cli/scripts/e2e.sh`) as a
 /// first-class command. Scaffolds a throwaway bundle in a temp dir, boots a
 /// runner with the fake model, sends a message, runs the eval cases, and tears

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -530,6 +530,157 @@ pub fn resolve_cases_path(
     )
 }
 
+/// Container name for the offline `agentos e2e` round-trip. Distinct from the
+/// `skill up` default so an e2e run never collides with a hand-started dev
+/// runner.
+pub const E2E_CONTAINER: &str = "agentos-e2e-runner";
+
+/// Eval cases for the offline `e2e` round-trip, matched to the runner's fake
+/// model (`fake.py`): the scripted turn's FINAL text is "all done", so every
+/// grader here must be satisfied by that string. Byte-mirrors the suite
+/// `cli/scripts/e2e.sh` writes, so the two stay behaviorally identical.
+const E2E_CASES: &str = r#"{
+  "name": "e2e",
+  "cases": [
+    {
+      "id": "finishes-the-turn",
+      "input": "wrap it up",
+      "grader": { "kind": "contains", "expected": "all done", "case_sensitive": false }
+    },
+    {
+      "id": "reports-done",
+      "input": "what is the status?",
+      "grader": { "kind": "contains", "expected": "done", "case_sensitive": false }
+    }
+  ]
+}
+"#;
+
+/// Options for `agentos e2e`, mirroring its clap flags.
+pub struct E2eOpts {
+    /// Runner image ref, already resolved (release-pinned or local dev tag) the
+    /// same way `skill up` resolves it. The command assumes this image exists:
+    /// build it for dev with `docker build -f runner/Dockerfile -t agentos-runner .`;
+    /// a release binary pulls its pinned ref from GHCR on first run.
+    pub image: String,
+    pub port: u16,
+    /// Skip teardown (leave the container and temp bundle in place) for
+    /// debugging a failed round-trip.
+    pub keep: bool,
+}
+
+/// `agentos e2e`: the scripted offline round-trip (`cli/scripts/e2e.sh`) as a
+/// first-class command. Scaffolds a throwaway bundle in a temp dir, boots a
+/// runner with the fake model, sends a message, runs the eval cases, and tears
+/// the container and temp dir down on exit (even on failure) unless `--keep`.
+///
+/// It reuses the same handlers the individual subcommands call
+/// (`scaffold`/`start`/`send`/`eval`/`stop`) rather than shelling out to the
+/// `agentos` binary, and never builds an image: the runner image must already be
+/// present (see `E2eOpts::image`).
+pub async fn e2e(opts: E2eOpts) -> Result<()> {
+    let ui = crate::ui::ui();
+    let name = "deal-desk";
+
+    let workdir = make_e2e_workdir()?;
+    let bundle = workdir.join(name);
+    let original_cwd = std::env::current_dir()?;
+
+    // The round-trip runs from inside the bundle dir so the reused handlers
+    // resolve `.agentos/runner.json` and the eval cases exactly as they do for
+    // a hand-run `skill *` session. Restored before teardown removes the dir.
+    let result = e2e_round_trip(&opts, &bundle, name).await;
+
+    // Teardown always runs (the point of an e2e is not to leak a container),
+    // unless --keep asks to leave it for inspection.
+    if opts.keep {
+        ui.note(&format!(
+            "--keep set: left container '{E2E_CONTAINER}' and bundle {} in place; \
+             tear down with 'docker rm -f {E2E_CONTAINER}' and 'rm -rf {}'",
+            bundle.display(),
+            workdir.display(),
+        ));
+    } else {
+        ui.note("=== agentos skill down (teardown) ===");
+        // stop() reads state from the cwd's .agentos/runner.json.
+        let _ = std::env::set_current_dir(&bundle);
+        if let Err(err) = stop().await {
+            ui.warn(&format!("teardown: could not stop runner cleanly: {err}"));
+            // Best-effort direct removal so a failed stop still frees the name.
+            let _ = docker::remove_container(E2E_CONTAINER).await;
+        }
+        let _ = std::env::set_current_dir(&original_cwd);
+        if let Err(err) = std::fs::remove_dir_all(&workdir) {
+            ui.warn(&format!(
+                "teardown: could not remove temp dir {}: {err}",
+                workdir.display()
+            ));
+        }
+    }
+
+    if result.is_ok() {
+        ui.success("e2e round-trip passed");
+    }
+    result
+}
+
+/// The five-step round-trip, factored out so `e2e` can always run teardown
+/// around it. Chdirs into the scaffolded bundle; the caller restores the cwd.
+async fn e2e_round_trip(opts: &E2eOpts, bundle: &Path, name: &str) -> Result<()> {
+    let ui = crate::ui::ui();
+
+    ui.note("=== agentos init (scaffold bundle in temp dir) ===");
+    scaffold(bundle, name)?;
+    // Swap the scaffold's weather eval seed for the fake-model round-trip cases.
+    std::fs::write(bundle.join("evals/e2e-cases.json"), E2E_CASES)
+        .with_context(|| format!("writing e2e eval cases under {}", bundle.display()))?;
+    std::env::set_current_dir(bundle)
+        .with_context(|| format!("entering bundle dir {}", bundle.display()))?;
+
+    ui.note("=== agentos skill up (fake model, offline) ===");
+    start(StartOpts {
+        plugin_dir: PathBuf::from("."),
+        image: opts.image.clone(),
+        port: opts.port,
+        name: E2E_CONTAINER.to_string(),
+        fake_model: true,
+        network: None,
+        otel_endpoint: None,
+        budget: DEFAULT_BUDGET.to_string(),
+        model: None,
+        local_model: None,
+    })
+    .await?;
+
+    ui.note("=== agentos skill status ===");
+    status(None).await?;
+
+    ui.note("=== agentos skill message (synthetic event, streamed NDJSON reply) ===");
+    send(
+        "@agentos can we approve the Meridian deal at 18% discount?",
+        "U-local",
+        EventType::Message,
+        None,
+    )
+    .await?;
+
+    ui.note("=== agentos skill eval ===");
+    eval(Some(PathBuf::from("evals/e2e-cases.json")), None).await?;
+
+    Ok(())
+}
+
+/// A fresh, uniquely-named temp dir for one e2e run. Avoids the `tempfile` crate
+/// (dev-only here) so the binary keeps its dependency set; cleanup is the
+/// caller's `remove_dir_all`.
+fn make_e2e_workdir() -> Result<PathBuf> {
+    let dir =
+        std::env::temp_dir().join(format!("agentos-e2e-{}-{}", std::process::id(), unix_now()));
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("creating temp workdir {}", dir.display()))?;
+    Ok(dir)
+}
+
 pub struct DeployOpts {
     pub plugin_dir: PathBuf,
     pub api_url: String,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,6 +79,17 @@ enum Command {
         #[command(subcommand)]
         action: ClusterAction,
     },
+    /// Build the runner image locally from `runner/Dockerfile` (source checkout only).
+    ///
+    /// Runs `docker build -f runner/Dockerfile -t <tag> .` from the repo root, so
+    /// `agentos build && agentos e2e` is the full from-scratch smoke test. A release
+    /// binary pulls the pinned runner image from GHCR automatically and never needs
+    /// this; it errors clearly if Docker is missing or there is no repo checkout.
+    Build {
+        /// Image tag to build.
+        #[arg(long, default_value = "agentos-runner")]
+        tag: String,
+    },
     /// Run the offline end-to-end round-trip natively (scripts -> `agentos <command>`).
     ///
     /// Scaffolds a throwaway bundle in a temp dir, boots a local runner with the
@@ -1136,6 +1147,7 @@ async fn main() -> Result<()> {
                 .await
             }
         },
+        Command::Build { tag } => commands::build(&tag).await,
         Command::E2e { image, port, keep } => {
             let image = artifacts::resolve_image(
                 image.as_deref(),
@@ -1155,6 +1167,21 @@ mod tests {
     #[test]
     fn clap_surface_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn build_defaults_tag_and_accepts_override() {
+        let cli = Cli::try_parse_from(["agentos", "build"]).expect("build should parse");
+        match cli.command {
+            Command::Build { tag } => assert_eq!(tag, "agentos-runner"),
+            _ => panic!("expected build command"),
+        }
+        let cli = Cli::try_parse_from(["agentos", "build", "--tag", "my-runner:dev"])
+            .expect("build --tag should parse");
+        match cli.command {
+            Command::Build { tag } => assert_eq!(tag, "my-runner:dev"),
+            _ => panic!("expected build command"),
+        }
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 use agentos::artifacts;
 use agentos::commands::{
-    self, AgentActionOpts, DeployEnv, DeployOpts, SendType, StartOpts, DEFAULT_PORT,
+    self, AgentActionOpts, DeployEnv, DeployOpts, E2eOpts, SendType, StartOpts, DEFAULT_PORT,
 };
 use agentos::comms::{self, CommsOpts, LocalCommsOpts};
 use agentos::local::{self, LocalDownOpts, LocalOpts};
@@ -78,6 +78,27 @@ enum Command {
     Cluster {
         #[command(subcommand)]
         action: ClusterAction,
+    },
+    /// Run the offline end-to-end round-trip natively (scripts -> `agentos <command>`).
+    ///
+    /// Scaffolds a throwaway bundle in a temp dir, boots a local runner with the
+    /// fake model, sends a message, runs the eval cases, and tears the container
+    /// and temp dir down on exit. The one-command equivalent of the scripted
+    /// `skill up --fake-model` -> `skill message` -> `skill eval` -> `skill down`
+    /// (`cli/scripts/e2e.sh`). Fully offline: it assumes the runner image already
+    /// exists (build it for dev with `docker build -f runner/Dockerfile -t
+    /// agentos-runner .`; a release binary pulls its pinned ref from GHCR on
+    /// first run) and never runs `docker build`.
+    E2e {
+        /// Runner image. Default: version-pinned `ghcr.io/curie-eng/agentos-runner:<version>` on release builds; local `agentos-runner` on dev builds. Pass to override.
+        #[arg(long)]
+        image: Option<String>,
+        /// Host port for the local runner.
+        #[arg(long, default_value_t = DEFAULT_PORT)]
+        port: u16,
+        /// Skip teardown; leave the container and temp bundle in place for debugging.
+        #[arg(long)]
+        keep: bool,
     },
 }
 
@@ -1115,6 +1136,14 @@ async fn main() -> Result<()> {
                 .await
             }
         },
+        Command::E2e { image, port, keep } => {
+            let image = artifacts::resolve_image(
+                image.as_deref(),
+                artifacts::Channel::current(),
+                artifacts::version(),
+            );
+            commands::e2e(E2eOpts { image, port, keep }).await
+        }
     }
 }
 
@@ -1317,6 +1346,41 @@ mod tests {
                 assert!(yes);
             }
             _ => panic!("expected cluster delete command"),
+        }
+    }
+
+    #[test]
+    fn e2e_parses_image_port_and_keep() {
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "e2e",
+            "--image",
+            "local-runner",
+            "--port",
+            "9000",
+            "--keep",
+        ])
+        .expect("e2e flags should parse");
+        match cli.command {
+            Command::E2e { image, port, keep } => {
+                assert_eq!(image.as_deref(), Some("local-runner"));
+                assert_eq!(port, 9000);
+                assert!(keep);
+            }
+            _ => panic!("expected e2e command"),
+        }
+    }
+
+    #[test]
+    fn e2e_defaults_image_none_port_and_keep_off() {
+        let cli = Cli::try_parse_from(["agentos", "e2e"]).expect("bare e2e should parse");
+        match cli.command {
+            Command::E2e { image, port, keep } => {
+                assert_eq!(image, None);
+                assert_eq!(port, DEFAULT_PORT);
+                assert!(!keep);
+            }
+            _ => panic!("expected e2e command"),
         }
     }
 


### PR DESCRIPTION
## Why

Dev flows in this CLI are `agentos <command>`, not loose shell scripts. The offline end-to-end smoke test still lived as `cli/scripts/e2e.sh`, invoked by hand. This promotes it to a first-class subcommand: the whole runner-only, fully-offline round-trip is now `agentos e2e`.

## What

Adds a top-level `E2e` command (a peer of `init`/`skill`/`local`/`cluster`) whose handler runs the same round-trip `e2e.sh` does today, but **natively by reusing the existing handlers** (`scaffold`/`start`/`send`/`eval`/`stop`) rather than shelling out to the `agentos` binary:

1. Scaffold a throwaway `deal-desk` bundle into a temp dir.
2. `skill up --fake-model` on it (fully offline).
3. Send a message and stream the NDJSON reply.
4. Run the fake-model eval cases (final text `"all done"`, byte-mirroring the suite `e2e.sh` writes).
5. `skill down` + remove the temp dir on exit — even on failure — unless `--keep`.

Flags: `--image <ref>` (defaults to the same image `skill up` resolves via `artifacts::resolve_image`), `--port` (default `7245`), and `--keep` (skip teardown for debugging). Clear step headers are printed like the script.

### Constraints honored

- **Never runs `docker build`.** The command assumes the runner image already exists — built for dev with `docker build -f runner/Dockerfile -t agentos-runner .`, or pulled from GHCR on first run for a release binary, matching `skill up`'s image resolution exactly.
- No changes to the worker kernel or any frozen contract.
- `cli/scripts/e2e.sh` is untouched and CI is unchanged; the docs note it can later become a thin `agentos e2e` wrapper.

### Docs

Updated `cli/README.md` (top-level verb table + the Verify section) and `QUICKSTART.md` to present `agentos e2e` as the one-command offline round-trip.

## Note on teardown

Teardown runs around the round-trip via a captured `Result`, so the common failures (missing image, unhealthy runner, connection refused) clean up the container and temp dir. The two reused handlers that call `std::process::exit(1)` internally (a classified-failure reply, a failing eval case) will skip Rust cleanup — but the fake model always yields `"all done"`, so the offline path never hits them; a genuinely broken runner leaving the container is effectively `--keep` for inspection.

## Verify

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass (added two arg-parse tests mirroring the existing `main.rs` parse tests). `cargo build` + `agentos e2e --help` wires up correctly.

A full `agentos e2e` run needs the `agentos-runner` image, which is **not present** in this environment (and building it is out of scope here), so I verified build + `--help` + graceful-failure teardown (no leftover container or temp dir when the image is absent) rather than a green round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)