### PR TITLE
cli: unify dev flows under agentos (build, install, dev <contracts|chart-check|e2e>)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,23 @@
 See [AGENTS.md](AGENTS.md) - the agent instructions for this repo live there.
 
+## One entry point: `agentos <command>`
+
+Dev and operator flows go through the `agentos` CLI, not loose shell scripts or
+bare tool invocations. When you would otherwise add a `./scripts/foo.sh`, tell
+someone to run a raw `docker`/`helm`/`uv`/`pnpm` command, or document a
+multi-step setup, add or extend an `agentos` subcommand instead — a single,
+discoverable surface beats a scatter of scripts. The script or tool call can
+stay the *implementation*; it just isn't the interface.
+
+- Building the runner image → `agentos build` (not a copy-pasted `docker build -f runner/Dockerfile ...`).
+- First-run dev bootstrap → `agentos install`.
+- Contributor/CI scripts (contract codegen, chart render-asserts, the e2e round-trip) → `agentos dev <...>`. The `dev` namespace fences off commands that need a **source checkout + dev toolchains**; they error clearly when run from a released binary.
+- Operator/product commands stay top-level: `init`, `build`, `skill`, `local`, `cluster`.
+
+New tooling ships as an `agentos` subcommand (add the clap surface in
+`cli/src/main.rs`, the handler in `cli/src/commands.rs`); a new loose script in
+`scripts/` should be the exception with a reason, not the default.
+
 ## Architecture Decision Records (ADRs)
 
 `docs/adr/` is the system of record for architecture decisions. Each ADR captures

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,6 +32,7 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 | Command | What it does |
 |---|---|
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed. |
+| `agentos build` | Build the runner image locally: `docker build -f runner/Dockerfile -t agentos-runner .` from the repo root (found by walking up to `runner/Dockerfile`). `--tag` overrides the tag. Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
 
 ## `skill` target: runner-only, fully offline
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,6 +34,37 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed. |
 | `agentos build` | Build the runner image locally: `docker build -f runner/Dockerfile -t agentos-runner .` from the repo root (found by walking up to `runner/Dockerfile`). `--tag` overrides the tag. Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
 
+## `agentos install`
+
+Contributor bootstrap for a fresh source checkout: install dependencies and
+build, but **start nothing**. Run it once after cloning; then `agentos local up`
+brings the stack up. From the repo root (found by walking up to
+`runner/Dockerfile`) it runs, in order and each idempotent, streaming output:
+
+1. Copy `.env.example` to `.env` if `.env` is missing (otherwise left untouched).
+2. `uv sync` at the repo root (needs `uv`).
+3. `pnpm install` in `apps/ui` (needs `pnpm`).
+4. `cargo build` in `cli` (needs `cargo`).
+5. Build the runner image via `agentos build` (needs `docker`).
+
+Each required tool is checked first; a missing one prints a pointer (e.g. `uv is
+not installed - https://docs.astral.sh/uv/`) and stops. Run outside a source
+checkout it errors clearly -- a release binary has nothing to install.
+
+## `agentos dev`
+
+Thin wrappers over the repo's dev scripts, so contributors get one unified
+`agentos <command>` surface while the scripts stay the implementation. Each finds
+the repo root, confirms the script exists, shells `bash <script>` from the root,
+streams its output, and propagates its exit code. Run outside a source checkout
+they error clearly -- a release binary has no dev scripts.
+
+| Command | What it does |
+|---|---|
+| `agentos dev contracts` | `bash scripts/check-contracts.sh` -- check the frozen contracts. |
+| `agentos dev chart-check` | `bash charts/agentos/ci/render-assertions.sh` -- render-assert the Helm chart. |
+| `agentos dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
+
 ## `skill` target: runner-only, fully offline
 
 Boots just the runner container on the host Docker daemon and speaks its ACI

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -87,6 +87,62 @@ pub fn init(name: &str, dir: Option<PathBuf>) -> Result<()> {
     Ok(())
 }
 
+/// `agentos build`: build the runner image locally from the repo's Dockerfile.
+/// The one-command equivalent of `docker build -f runner/Dockerfile -t <tag> .`
+/// run from the repo root. Errors clearly when Docker is missing or when run
+/// outside a source checkout (a release binary pulls the image from GHCR).
+pub async fn build(tag: &str) -> Result<()> {
+    let ui = crate::ui::ui();
+    if !on_path("docker") {
+        bail!(
+            "Docker is not installed or not on PATH. Install Docker \
+             (https://docs.docker.com/get-docker/) and retry."
+        );
+    }
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `agentos build` \
+         from an agentos repo checkout -- a release binary pulls the runner image from GHCR \
+         automatically and never needs to build.",
+    )?;
+    ui.note(&format!(
+        "=== docker build -f runner/Dockerfile -t {tag} . (in {}) ===",
+        root.display()
+    ));
+    // Inherit stdio so the build log streams to the terminal like a hand-run build.
+    let status = tokio::process::Command::new("docker")
+        .args(["build", "-f", "runner/Dockerfile", "-t", tag, "."])
+        .current_dir(&root)
+        .status()
+        .await
+        .context("failed to invoke docker")?;
+    if !status.success() {
+        bail!("docker build failed ({status})");
+    }
+    ui.success(&format!("built runner image '{tag}'"));
+    Ok(())
+}
+
+/// Whether `bin` resolves on PATH.
+fn on_path(bin: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).any(|dir| dir.join(bin).is_file()))
+        .unwrap_or(false)
+}
+
+/// Walk up from the current directory to the repo root: the nearest ancestor
+/// that contains `runner/Dockerfile`.
+fn find_repo_root() -> Option<PathBuf> {
+    let mut dir = std::env::current_dir().ok()?;
+    loop {
+        if dir.join("runner/Dockerfile").is_file() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
 pub async fn start(opts: StartOpts) -> Result<()> {
     let plugin_dir = opts
         .plugin_dir

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -122,6 +122,109 @@ pub async fn build(tag: &str) -> Result<()> {
     Ok(())
 }
 
+/// `agentos install`: from-a-checkout dev bootstrap -- install deps and build
+/// the runner image, but start nothing. Each step is idempotent and streams its
+/// output; a missing tool prints a friendly pointer and stops. A release binary
+/// has no source tree to install, so this errors clearly outside a checkout.
+pub async fn install() -> Result<()> {
+    let ui = crate::ui::ui();
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `agentos install` \
+         from an agentos source checkout -- a release binary has nothing to install.",
+    )?;
+
+    // 1. Seed .env from .env.example (idempotent: skip if .env already exists).
+    let env_path = root.join(".env");
+    let env_example = root.join(".env.example");
+    if env_path.exists() {
+        ui.note("=== .env already exists; leaving it untouched ===");
+    } else if env_example.exists() {
+        ui.note("=== cp .env.example .env ===");
+        std::fs::copy(&env_example, &env_path).context("failed to copy .env.example to .env")?;
+    } else {
+        ui.note("=== no .env.example to seed .env from; skipping ===");
+    }
+
+    // 2. uv sync (repo root).
+    require_tool("uv", "uv is not installed - https://docs.astral.sh/uv/")?;
+    run_step(&root, "uv", &["sync"], "uv sync").await?;
+
+    // 3. pnpm install in apps/ui.
+    require_tool(
+        "pnpm",
+        "pnpm is not installed - https://pnpm.io/installation",
+    )?;
+    run_step(
+        &root.join("apps/ui"),
+        "pnpm",
+        &["install"],
+        "pnpm install (apps/ui)",
+    )
+    .await?;
+
+    // 4. cargo build in cli.
+    require_tool("cargo", "cargo is not installed - https://rustup.rs/")?;
+    run_step(&root.join("cli"), "cargo", &["build"], "cargo build (cli)").await?;
+
+    // 5. Build the runner image via the existing `build` handler.
+    build("agentos-runner").await?;
+
+    ui.success("Setup complete. Start the stack with: agentos local up");
+    Ok(())
+}
+
+/// `agentos dev <script>`: run a repo dev script by relative path. Thin wrapper
+/// -- finds the repo root, confirms the script exists, shells `bash <script>`
+/// from the root, streams its output, and propagates its exit code. A release
+/// binary has no scripts, so this errors clearly outside a checkout.
+pub async fn dev_script(rel_path: &str) -> Result<()> {
+    let ui = crate::ui::ui();
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `agentos dev` \
+         from an agentos source checkout -- a release binary has no dev scripts.",
+    )?;
+    let script = root.join(rel_path);
+    if !script.is_file() {
+        bail!("script not found: {}", script.display());
+    }
+    ui.note(&format!("=== bash {rel_path} (in {}) ===", root.display()));
+    let status = tokio::process::Command::new("bash")
+        .arg(rel_path)
+        .current_dir(&root)
+        .status()
+        .await
+        .context("failed to invoke bash")?;
+    if !status.success() {
+        bail!("{rel_path} failed ({status})");
+    }
+    Ok(())
+}
+
+/// Bail with a friendly pointer when a required tool is not on PATH.
+fn require_tool(bin: &str, hint: &str) -> Result<()> {
+    if on_path(bin) {
+        Ok(())
+    } else {
+        bail!("{hint}")
+    }
+}
+
+/// Run one install step in `dir`, streaming its output and failing on nonzero.
+async fn run_step(dir: &Path, bin: &str, args: &[&str], label: &str) -> Result<()> {
+    let ui = crate::ui::ui();
+    ui.note(&format!("=== {label} (in {}) ===", dir.display()));
+    let status = tokio::process::Command::new(bin)
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .await
+        .with_context(|| format!("failed to invoke {bin}"))?;
+    if !status.success() {
+        bail!("{label} failed ({status})");
+    }
+    Ok(())
+}
+
 /// Whether `bin` resolves on PATH.
 fn on_path(bin: &str) -> bool {
     std::env::var_os("PATH")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,6 +79,17 @@ enum Command {
         #[command(subcommand)]
         action: ClusterAction,
     },
+    /// Build the runner image locally from `runner/Dockerfile` (source checkout only).
+    ///
+    /// Runs `docker build -f runner/Dockerfile -t <tag> .` from the repo root. A
+    /// release binary pulls the pinned runner image from GHCR automatically and
+    /// never needs this; it errors clearly if Docker is missing or there is no
+    /// repo checkout.
+    Build {
+        /// Image tag to build.
+        #[arg(long, default_value = "agentos-runner")]
+        tag: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -648,6 +659,7 @@ async fn main() -> Result<()> {
     ui::init(Ui::from_process(cli.color, cli.debug, cli.quiet));
     match cli.command {
         Command::Init { name, dir } => commands::init(&name, dir),
+        Command::Build { tag } => commands::build(&tag).await,
         Command::Skill { action } => match action {
             SkillAction::Up {
                 plugin_dir,
@@ -1126,6 +1138,21 @@ mod tests {
     #[test]
     fn clap_surface_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn build_defaults_tag_and_accepts_override() {
+        let cli = Cli::try_parse_from(["agentos", "build"]).expect("build should parse");
+        match cli.command {
+            Command::Build { tag } => assert_eq!(tag, "agentos-runner"),
+            _ => panic!("expected build command"),
+        }
+        let cli = Cli::try_parse_from(["agentos", "build", "--tag", "my-runner:dev"])
+            .expect("build --tag should parse");
+        match cli.command {
+            Command::Build { tag } => assert_eq!(tag, "my-runner:dev"),
+            _ => panic!("expected build command"),
+        }
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -90,6 +90,33 @@ enum Command {
         #[arg(long, default_value = "agentos-runner")]
         tag: String,
     },
+    /// Bootstrap a dev checkout: install deps and build, start nothing (source checkout only).
+    ///
+    /// From the repo root, runs (each idempotent, streaming output): copy
+    /// `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in
+    /// `apps/ui`, `cargo build` in `cli`, then builds the runner image. A
+    /// release binary has no source tree to install and errors clearly; a
+    /// missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.
+    Install,
+    /// Run a repo dev script (contracts, chart-check, e2e) -- source checkout only.
+    ///
+    /// Thin wrappers over the repo's dev scripts so contributors get a unified
+    /// `agentos <command>` surface; the scripts stay the implementation. A
+    /// release binary has no scripts and errors clearly.
+    Dev {
+        #[command(subcommand)]
+        action: DevAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum DevAction {
+    /// Check the frozen contracts (`bash scripts/check-contracts.sh`).
+    Contracts,
+    /// Render-assert the Helm chart (`bash charts/agentos/ci/render-assertions.sh`).
+    ChartCheck,
+    /// Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`).
+    E2e,
 }
 
 #[derive(Subcommand)]
@@ -660,6 +687,14 @@ async fn main() -> Result<()> {
     match cli.command {
         Command::Init { name, dir } => commands::init(&name, dir),
         Command::Build { tag } => commands::build(&tag).await,
+        Command::Install => commands::install().await,
+        Command::Dev { action } => match action {
+            DevAction::Contracts => commands::dev_script("scripts/check-contracts.sh").await,
+            DevAction::ChartCheck => {
+                commands::dev_script("charts/agentos/ci/render-assertions.sh").await
+            }
+            DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
+        },
         Command::Skill { action } => match action {
             SkillAction::Up {
                 plugin_dir,
@@ -1153,6 +1188,39 @@ mod tests {
             Command::Build { tag } => assert_eq!(tag, "my-runner:dev"),
             _ => panic!("expected build command"),
         }
+    }
+
+    #[test]
+    fn install_parses() {
+        let cli = Cli::try_parse_from(["agentos", "install"]).expect("install should parse");
+        assert!(matches!(cli.command, Command::Install));
+    }
+
+    #[test]
+    fn dev_subcommands_parse() {
+        let cli = Cli::try_parse_from(["agentos", "dev", "contracts"])
+            .expect("dev contracts should parse");
+        assert!(matches!(
+            cli.command,
+            Command::Dev {
+                action: DevAction::Contracts
+            }
+        ));
+        let cli = Cli::try_parse_from(["agentos", "dev", "chart-check"])
+            .expect("dev chart-check should parse");
+        assert!(matches!(
+            cli.command,
+            Command::Dev {
+                action: DevAction::ChartCheck
+            }
+        ));
+        let cli = Cli::try_parse_from(["agentos", "dev", "e2e"]).expect("dev e2e should parse");
+        assert!(matches!(
+            cli.command,
+            Command::Dev {
+                action: DevAction::E2e
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Unifies the contributor dev flows under the `agentos` CLI so they're first-class subcommands, not loose scripts. Builds on the two reusable helpers in `cli/src/commands.rs` (`find_repo_root()`, `on_path()`), reused by all three commands.

## `agentos build`
Build the runner image locally: `docker build -f runner/Dockerfile -t <tag> .` from the repo root. `--tag` overrides. Clear error if Docker is missing or run outside a source checkout (a release binary pulls the pinned image from GHCR).

## `agentos install`
From-a-checkout dev bootstrap: install deps and build, **start nothing**. From the repo root, in order and each idempotent, streaming output:
1. Copy `.env.example` to `.env` if `.env` is missing.
2. `uv sync` (repo root) — needs `uv`.
3. `pnpm install` in `apps/ui` — needs `pnpm`.
4. `cargo build` in `cli` — needs `cargo`.
5. Build the runner image via the existing `build()` handler — needs `docker`.

Each required tool is checked first; a missing one prints a pointer (e.g. `uv is not installed - https://docs.astral.sh/uv/`) and stops. Outside a checkout it errors clearly. Ends with a next-step hint: `Start the stack with: agentos local up`.

## `agentos dev <subcommand>`
Thin wrappers over the repo's dev scripts (scripts stay the implementation); each finds the repo root, confirms the script exists, shells `bash <script>` from the root, streams output, and propagates the exit code:
- `agentos dev contracts` → `bash scripts/check-contracts.sh`
- `agentos dev chart-check` → `bash charts/agentos/ci/render-assertions.sh`
- `agentos dev e2e` → `bash cli/scripts/e2e.sh`

## Notes
- main.rs owns the clap surface; handlers live in commands.rs, matching the `build` command's structure. Doc comments note these are source-checkout (contributor) commands; a release binary errors clearly. No worker kernel or frozen contract touched.
- Parse unit tests for `install` and each `dev` subcommand; `cli/README.md` gains `## agentos install` and `## agentos dev` sections.
- Verified: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
