### PR TITLE
Promote queue turn payload into aci-protocol with channel-neutral naming

### DIFF
--- a/apps/dispatcher/src/agentos_dispatcher/__init__.py
+++ b/apps/dispatcher/src/agentos_dispatcher/__init__.py
@@ -1,9 +1,10 @@
 """AgentOS dispatcher (Slack Bolt, Socket Mode).
 
 Acks Slack events fast, posts an in-thread placeholder, and enqueues a normalized
-job onto a Valkey Stream keyed by the Slack event id (idempotent), under
-reconnect supervision. ``QueuedSlackEvent`` is the queue seam the worker (F1)
-consumes.
+job onto a Valkey Stream keyed by the delivery's event id (idempotent), under
+reconnect supervision. The queue payload is ``aci_protocol.QueuedTurn`` (issue
+#7); this package owns its Valkey Stream transport (the ``payload`` encoding and
+dedupe) plus the Slack ingress.
 """
 
 from .app import (
@@ -16,9 +17,10 @@ from .config import DispatcherConfig
 from .handlers import is_actionable, process_event, register_handlers
 from .queue import (
     STREAM_PAYLOAD_FIELD,
-    QueuedSlackEvent,
     claim_event,
     enqueue,
+    from_stream_fields,
+    to_stream_fields,
 )
 from .supervisor import BackoffPolicy, Connection, Supervisor
 
@@ -29,7 +31,6 @@ __all__ = [
     "BackoffPolicy",
     "Connection",
     "DispatcherConfig",
-    "QueuedSlackEvent",
     "SocketModeConnection",
     "Supervisor",
     "__version__",
@@ -38,7 +39,9 @@ __all__ = [
     "build_web_client",
     "claim_event",
     "enqueue",
+    "from_stream_fields",
     "is_actionable",
     "process_event",
     "register_handlers",
+    "to_stream_fields",
 ]

--- a/apps/dispatcher/src/agentos_dispatcher/handlers.py
+++ b/apps/dispatcher/src/agentos_dispatcher/handlers.py
@@ -22,11 +22,12 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from aci_protocol import QueuedTurn, ReplyHandle
 from slack_bolt import App
 from slack_sdk.web import WebClient
 
 from .config import DispatcherConfig
-from .queue import QueuedSlackEvent, claim_event, enqueue
+from .queue import claim_event, enqueue
 
 if TYPE_CHECKING:
     from redis import Redis
@@ -99,13 +100,12 @@ def process_event(
         except Exception as exc:  # noqa: BLE001 -- shimmer is best-effort, never fatal
             log.debug("assistant setStatus skipped for %s: %s", slack_event_id, exc)
 
-    queued = QueuedSlackEvent(
-        slack_event_id=slack_event_id,
-        thread_ts=thread_ts,
-        channel=channel,
-        user=event.get("user", ""),
+    queued = QueuedTurn(
+        event_id=slack_event_id,
+        conversation_id=thread_ts,
+        author=event.get("user", ""),
         text=event.get("text", ""),
-        placeholder_ts=placeholder_ts,
+        reply_handle=ReplyHandle(channel=channel, placeholder=placeholder_ts),
         received_at=clock(),
     )
     stream_id = enqueue(redis_client, config, queued)
@@ -131,7 +131,7 @@ def process_action(
     logger: logging.Logger | None = None,
 ) -> str | None:
     """Normalize a Block Kit button click into a turn: dedupe, post an in-thread
-    placeholder, and enqueue a ``QueuedSlackEvent`` whose text is the button's
+    placeholder, and enqueue a ``QueuedTurn`` whose text is the button's
     command. The worker answers it exactly as if the user had typed that command.
 
     Same four steps as ``process_event`` (ack is Bolt's, before this runs); no
@@ -168,13 +168,12 @@ def process_action(
         thread_ts=thread_ts,
         text=config.placeholder_text,
     )
-    queued = QueuedSlackEvent(
-        slack_event_id=slack_event_id,
-        thread_ts=thread_ts,
-        channel=channel,
-        user=user,
+    queued = QueuedTurn(
+        event_id=slack_event_id,
+        conversation_id=thread_ts,
+        author=user,
         text=command,
-        placeholder_ts=placeholder["ts"],
+        reply_handle=ReplyHandle(channel=channel, placeholder=placeholder["ts"]),
         received_at=clock(),
     )
     stream_id = enqueue(redis_client, config, queued)

--- a/apps/dispatcher/src/agentos_dispatcher/queue.py
+++ b/apps/dispatcher/src/agentos_dispatcher/queue.py
@@ -1,10 +1,12 @@
 """The queue seam between the dispatcher and the worker (F1).
 
-``QueuedSlackEvent`` is the normalized job the dispatcher enqueues onto the
-Valkey Stream and the worker consumes. It is defined here, inside the dispatcher,
-because the dispatcher is the producer and therefore owns the shape; F1 imports
-or mirrors this model. If it later deserves promotion into a shared package, the
-orchestrator makes that call (dispatcher does not touch ``packages/``).
+``QueuedTurn`` (from ``aci_protocol``) is the normalized job the dispatcher
+enqueues onto the Valkey Stream and the worker consumes. The model was promoted
+into the frozen ACI package (issue #7) so the contract is shared across three
+languages and guarded by the schema-compat gate rather than hand-mirrored. This
+module owns only the Valkey Stream *transport* of that model (a transport detail
+that stays out of the frozen package): the single-``payload`` wire encoding plus
+the dedupe guard.
 
 Wire encoding: a Stream entry carries the model as a single ``payload`` field
 holding ``model_dump_json()``. A one-field JSON blob keeps the seam explicit and
@@ -12,16 +14,17 @@ versionable (add fields without reshaping the Stream schema) and lets the worker
 reconstruct the model with ``from_stream_fields``.
 
 Dedupe (idempotency, detailed-architecture 2b rule 5): the idempotency key is the
-Slack event id. A retried Slack delivery must not enqueue twice. We guard with a
-Valkey ``SET <dedupe_key> 1 NX EX <ttl>`` before enqueuing: the first delivery
-claims the key and enqueues; a retry finds the key present and is dropped. This is
-chosen over stream-side dedupe because it is O(1), TTL-bounded (no unbounded
-dedupe set to prune), and does not require scanning the Stream.
+delivery's ``event_id`` (the Slack event id for the Slack adapter). A retried
+delivery must not enqueue twice. We guard with a Valkey ``SET <dedupe_key> 1 NX
+EX <ttl>`` before enqueuing: the first delivery claims the key and enqueues; a
+retry finds the key present and is dropped. This is chosen over stream-side
+dedupe because it is O(1), TTL-bounded (no unbounded dedupe set to prune), and
+does not require scanning the Stream.
 """
 
 from typing import TYPE_CHECKING, Any, cast
 
-from pydantic import BaseModel
+from aci_protocol import QueuedTurn
 
 from .config import DispatcherConfig
 
@@ -31,39 +34,17 @@ if TYPE_CHECKING:
 STREAM_PAYLOAD_FIELD = "payload"
 
 
-class QueuedSlackEvent(BaseModel):
-    """A normalized Slack event ready for the worker to route and run.
-
-    Fields:
-        slack_event_id: Slack's per-delivery event id; the idempotency key.
-        thread_ts: the canonical thread key (the root message ts of the thread).
-        channel: Slack channel id the message arrived in.
-        user: Slack user id that authored the message.
-        text: the message text.
-        placeholder_ts: ts of the placeholder reply the dispatcher already posted;
-            the worker edits this message in place with the real response.
-        received_at: ISO-8601 UTC timestamp of when the dispatcher received it.
-    """
-
-    slack_event_id: str
-    thread_ts: str
-    channel: str
-    user: str
-    text: str
-    placeholder_ts: str
-    received_at: str
-
-    def to_stream_fields(self) -> dict[str, str]:
-        """Render to the flat field map an ``XADD`` takes."""
-        return {STREAM_PAYLOAD_FIELD: self.model_dump_json()}
-
-    @classmethod
-    def from_stream_fields(cls, fields: dict[str, str]) -> "QueuedSlackEvent":
-        """Reconstruct from a Stream entry's field map (the worker's entry point)."""
-        return cls.model_validate_json(fields[STREAM_PAYLOAD_FIELD])
+def to_stream_fields(turn: QueuedTurn) -> dict[str, str]:
+    """Render a turn to the flat field map an ``XADD`` takes (one ``payload``)."""
+    return {STREAM_PAYLOAD_FIELD: turn.model_dump_json()}
 
 
-def claim_event(redis_client: "Redis", config: "DispatcherConfig", slack_event_id: str) -> bool:
+def from_stream_fields(fields: dict[str, str]) -> QueuedTurn:
+    """Reconstruct a turn from a Stream entry's field map (the worker's entry point)."""
+    return QueuedTurn.model_validate_json(fields[STREAM_PAYLOAD_FIELD])
+
+
+def claim_event(redis_client: "Redis", config: "DispatcherConfig", event_id: str) -> bool:
     """Claim a Slack event id for processing, returning True on the first claim.
 
     Uses ``SET NX EX`` so exactly one delivery of a given event id wins; retries
@@ -71,7 +52,7 @@ def claim_event(redis_client: "Redis", config: "DispatcherConfig", slack_event_i
     to drop.
     """
     claimed = redis_client.set(
-        config.dedupe_key(slack_event_id),
+        config.dedupe_key(event_id),
         "1",
         nx=True,
         ex=config.dedupe_ttl_seconds,
@@ -79,11 +60,11 @@ def claim_event(redis_client: "Redis", config: "DispatcherConfig", slack_event_i
     return bool(claimed)
 
 
-def enqueue(redis_client: "Redis", config: "DispatcherConfig", event: QueuedSlackEvent) -> str:
-    """Append the normalized event to the Valkey Stream, returning its Stream id."""
+def enqueue(redis_client: "Redis", config: "DispatcherConfig", turn: QueuedTurn) -> str:
+    """Append the normalized turn to the Valkey Stream, returning its Stream id."""
     # redis-py types the fields param as an invariant dict of a broad key/value
     # union, so a plain dict[str, str] does not match; cast to satisfy the stub.
-    fields = cast("dict[Any, Any]", event.to_stream_fields())
+    fields = cast("dict[Any, Any]", to_stream_fields(turn))
     stream_id = redis_client.xadd(config.stream, fields)
     return _as_str(stream_id)
 

--- a/apps/dispatcher/tests/test_dispatch.py
+++ b/apps/dispatcher/tests/test_dispatch.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 import redis
 from agentos_dispatcher.app import build_app
 from agentos_dispatcher.config import DispatcherConfig
-from agentos_dispatcher.queue import QueuedSlackEvent
+from agentos_dispatcher.queue import from_stream_fields
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_bolt.authorization import AuthorizeResult
@@ -142,13 +142,13 @@ def test_envelope_acked_placeholder_posted_and_enqueued(
     # 3) Exactly one job was enqueued, carrying the placeholder ts for the worker.
     assert redis_client.xlen(config.stream) == 1
     _, fields = redis_client.xrange(config.stream)[0]
-    queued = QueuedSlackEvent.from_stream_fields(fields)
-    assert queued.slack_event_id == "Ev-100"
-    assert queued.channel == "C123"
-    assert queued.user == "U123"
+    queued = from_stream_fields(fields)
+    assert queued.event_id == "Ev-100"
+    assert queued.reply_handle.channel == "C123"
+    assert queued.author == "U123"
     assert queued.text == "hi there"
-    assert queued.thread_ts == "1700.0001"
-    assert queued.placeholder_ts == BOT_TS
+    assert queued.conversation_id == "1700.0001"
+    assert queued.reply_handle.placeholder == BOT_TS
 
 
 def test_shimmer_sets_assistant_status_after_placeholder(
@@ -252,12 +252,12 @@ def test_button_click_enqueues_a_turn(
     )
     assert redis_client.xlen(config.stream) == 1
     _, fields = redis_client.xrange(config.stream)[0]
-    queued = QueuedSlackEvent.from_stream_fields(fields)
+    queued = from_stream_fields(fields)
     assert queued.text == "reports"
-    assert queued.channel == "C123"
-    assert queued.thread_ts == "1700.0001"
-    assert queued.placeholder_ts == BOT_TS
-    assert queued.slack_event_id == "action-trig-env-1"
+    assert queued.reply_handle.channel == "C123"
+    assert queued.conversation_id == "1700.0001"
+    assert queued.reply_handle.placeholder == BOT_TS
+    assert queued.event_id == "action-trig-env-1"
 
 
 def test_button_click_prefers_value_over_action_id(
@@ -271,7 +271,7 @@ def test_button_click_prefers_value_over_action_id(
     _drain(app)
 
     _, fields = redis_client.xrange(config.stream)[0]
-    assert QueuedSlackEvent.from_stream_fields(fields).text == "show top 5"
+    assert from_stream_fields(fields).text == "show top 5"
 
 
 def test_duplicate_click_enqueues_exactly_once(

--- a/apps/dispatcher/tests/test_queue.py
+++ b/apps/dispatcher/tests/test_queue.py
@@ -3,53 +3,53 @@
 from pathlib import Path
 
 import redis
+from aci_protocol import QueuedTurn, ReplyHandle
 from agentos_dispatcher.config import DispatcherConfig
 from agentos_dispatcher.queue import (
-    QueuedSlackEvent,
     claim_event,
     enqueue,
+    from_stream_fields,
+    to_stream_fields,
 )
 
-# The committed wire golden the Rust CLI mirror (cli/src/queue.rs) round-trips too.
+# The committed wire golden the Rust CLI consumer (cli/src/queue.rs) round-trips too.
 _GOLDEN_FIXTURE = (
     Path(__file__).resolve().parents[3]
     / "packages"
     / "aci-protocol"
     / "schema"
-    / "queued-slack-event.fixture.json"
+    / "queued-turn.fixture.json"
 )
 
 
-def _event(event_id: str = "Ev1") -> QueuedSlackEvent:
-    return QueuedSlackEvent(
-        slack_event_id=event_id,
-        thread_ts="123.45",
-        channel="C1",
-        user="U1",
+def _event(event_id: str = "Ev1") -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id,
+        conversation_id="123.45",
+        author="U1",
         text="hello",
-        placeholder_ts="999.00",
+        reply_handle=ReplyHandle(channel="C1", placeholder="999.00"),
         received_at="2026-07-05T00:00:00+00:00",
     )
 
 
-def test_queued_event_stream_fields_roundtrip() -> None:
+def test_queued_turn_stream_fields_roundtrip() -> None:
     event = _event()
-    fields = event.to_stream_fields()
+    fields = to_stream_fields(event)
     # The worker (F1) consumes a single JSON payload field.
     assert set(fields) == {"payload"}
-    assert QueuedSlackEvent.from_stream_fields(fields) == event
+    assert from_stream_fields(fields) == event
 
 
-def test_queued_event_matches_cross_language_golden() -> None:
-    # One committed wire fixture pins the QueuedSlackEvent bytes across the Python
-    # producer here and the hand-mirrored Rust struct in cli/src/queue.rs: both
-    # must deserialize it and re-serialize to identical bytes. Guards the frozen
-    # queue seam against silent field rename/reorder drift until the payload is
-    # promoted into aci-protocol (#7). This does not move the model — the
-    # dispatcher still owns QueuedSlackEvent.
+def test_queued_turn_matches_cross_language_golden() -> None:
+    # One committed wire fixture pins the QueuedTurn bytes across the Python
+    # producer here and the Rust consumer in cli/src/queue.rs: both must
+    # deserialize it and re-serialize to identical bytes. Guards the frozen queue
+    # payload against silent field rename/reorder drift. The model itself now
+    # lives in packages/aci-protocol (#7); this test pins its wire bytes.
     raw = _GOLDEN_FIXTURE.read_text().strip()
-    event = QueuedSlackEvent.model_validate_json(raw)
-    assert event.slack_event_id == "Ev0GOLDEN0001"
+    event = QueuedTurn.model_validate_json(raw)
+    assert event.event_id == "Ev0GOLDEN0001"
     assert event.model_dump_json() == raw
 
 
@@ -64,7 +64,7 @@ def test_enqueue_writes_one_stream_entry_the_worker_can_read(
     entry_id, fields = entries[0]
     assert entry_id == stream_id
     # Round-trips through the wire back into the model the worker reconstructs.
-    assert QueuedSlackEvent.from_stream_fields(fields) == event
+    assert from_stream_fields(fields) == event
 
 
 def test_claim_event_is_first_writer_wins(

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -15,10 +15,11 @@ Per-channel dev/prod bot-identity routing (the dispatcher carrying which bot was
 addressed) is a J1/dispatcher refinement noted for later.
 
 Contract (cross-lane, load-bearing): agents.slack_channel MUST store the Slack
-channel ID (e.g. ``C0123ABCD``), because the dispatcher enqueues
-``QueuedSlackEvent.channel`` as the Slack event's channel id, and this resolver
-matches on equality. If the create-agent API/UI stores a channel NAME (``#triage``)
-instead, every real mention resolves to None and is dropped. Storing the id at
+channel ID (e.g. ``C0123ABCD``), because the dispatcher enqueues the Slack
+channel id as ``QueuedTurn.reply_handle.channel``, the kernel passes that value
+into ``resolve()``, and this resolver matches on equality. If the create-agent
+API/UI stores a channel NAME (``#triage``) instead, every real mention resolves
+to None and is dropped. Storing the id at
 agent creation (or translating name->id there) is the API/UI's responsibility;
 this resolver deliberately does not call the Slack API to translate, to avoid
 coupling the worker to a Slack token.

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -271,11 +271,11 @@ class WorkerConfig(BaseSettings):
         """
         return self.read_block_ms / 1000 + 5.0
 
-    def done_key(self, slack_event_id: str) -> str:
-        return f"{self.key_prefix}:done:{slack_event_id}"
+    def done_key(self, event_id: str) -> str:
+        return f"{self.key_prefix}:done:{event_id}"
 
-    def side_effect_key(self, slack_event_id: str) -> str:
-        return f"{self.key_prefix}:sidefx:{slack_event_id}"
+    def side_effect_key(self, event_id: str) -> str:
+        return f"{self.key_prefix}:sidefx:{event_id}"
 
     def lock_key(self, thread_key: str) -> str:
         return f"{self.key_prefix}:lock:{thread_key}"

--- a/apps/worker/src/agentos_worker/consumer.py
+++ b/apps/worker/src/agentos_worker/consumer.py
@@ -19,7 +19,7 @@ import asyncio
 import logging
 from typing import cast
 
-from agentos_dispatcher.queue import QueuedSlackEvent
+from agentos_dispatcher.queue import from_stream_fields
 from redis.asyncio import Redis
 
 from .config import WorkerConfig
@@ -111,7 +111,7 @@ class Consumer(StreamConsumer):
     async def _handle(self, entry_id: str, fields: dict[str, str]) -> None:
         try:
             try:
-                qevent = QueuedSlackEvent.from_stream_fields(fields)
+                qevent = from_stream_fields(fields)
             except Exception:
                 logger.exception("unparseable stream entry %s; acking as poison", entry_id)
                 await self._ack(entry_id)

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -36,12 +36,12 @@ from aci_protocol import (
     Event,
     Final,
     OutboundEvent,
+    QueuedTurn,
     SessionStatus,
     SideEffectFlag,
     TextDelta,
     ToolNote,
 )
-from agentos_dispatcher.queue import QueuedSlackEvent
 
 from .behaviorpacks import (
     BehaviorPacks,
@@ -199,14 +199,14 @@ class Kernel:
         # because it is released before the stream is consumed.
         self._order_locks: dict[str, _LockEntry] = {}
 
-    async def process_event(self, qevent: QueuedSlackEvent) -> None:
+    async def process_event(self, qevent: QueuedTurn) -> None:
         """Handle one queued Slack event to a terminal state (success or escalate).
 
         Returns normally once the event is terminally handled; the consumer then
         acks it. Raising leaves the entry pending for crash-recovery reclaim.
         """
-        event_id = qevent.slack_event_id
-        thread = qevent.thread_ts
+        event_id = qevent.event_id
+        thread = qevent.conversation_id
 
         # Acquire the per-thread order lock BEFORE any await, so concurrent
         # same-thread events queue in task-arrival order (asyncio.Lock is FIFO and
@@ -248,7 +248,7 @@ class Kernel:
             nav: NavPack | None = None
             packs: BehaviorPacks | None = None
             if self._binding is not None:
-                resolved = await self._binding.resolve(qevent.channel)
+                resolved = await self._binding.resolve(qevent.reply_handle.channel)
                 if resolved is None:
                     await self._drop_with_message(
                         qevent, "No agent is configured for this channel yet."
@@ -314,7 +314,7 @@ class Kernel:
             # is safe outside the concurrency-critical section above.
             if self._config.shimmer:
                 await self._sink.clear_status(
-                    channel=qevent.channel, thread_ts=qevent.thread_ts
+                    channel=qevent.reply_handle.channel, thread_ts=qevent.conversation_id
                 )
 
     def _acquire_order_entry(self, thread: str) -> _LockEntry:
@@ -371,20 +371,20 @@ class Kernel:
             if not threads:
                 del self._active_by_agent[agent_id]
 
-    async def _drop_with_message(self, qevent: QueuedSlackEvent, message: str) -> None:
+    async def _drop_with_message(self, qevent: QueuedTurn, message: str) -> None:
         """Edit the placeholder with a reason and mark the event done (a polite
         drop for an unmapped channel or a paused agent, never a crash)."""
         await self._sink.update(
-            channel=qevent.channel, ts=qevent.placeholder_ts, text=message
+            channel=qevent.reply_handle.channel, ts=qevent.reply_handle.placeholder, text=message
         )
-        await self._markers.mark_done(qevent.slack_event_id)
+        await self._markers.mark_done(qevent.event_id)
 
-    async def _set_shimmer(self, qevent: QueuedSlackEvent, packs: BehaviorPacks) -> None:
+    async def _set_shimmer(self, qevent: QueuedTurn, packs: BehaviorPacks) -> None:
         """Set the shimmer caption to this agent's sampled load line (+ tip),
         seeded by the thread ts. No-op when the agent enables neither pack, so the
         dispatcher's generic status stays. Best-effort (the sink swallows errors)."""
-        load = sample_load(packs, qevent.thread_ts)
-        tip = sample_tip(packs, qevent.thread_ts)
+        load = sample_load(packs, qevent.conversation_id)
+        tip = sample_tip(packs, qevent.conversation_id)
         if load and tip:
             caption = f"{load}\n\nTip: {tip}"
         elif load:
@@ -394,21 +394,21 @@ class Kernel:
         else:
             return
         await self._sink.set_status(
-            channel=qevent.channel, thread_ts=qevent.thread_ts, status=caption
+            channel=qevent.reply_handle.channel, thread_ts=qevent.conversation_id, status=caption
         )
 
     # -- internals ------------------------------------------------------------
 
     async def _attempt(
         self,
-        qevent: QueuedSlackEvent,
+        qevent: QueuedTurn,
         release_order: Callable[[], None],
         boot_env: dict[str, str] | None = None,
         agent_id: uuid.UUID | None = None,
         nav: NavPack | None = None,
         packs: BehaviorPacks | None = None,
     ) -> TurnOutcome:
-        thread = qevent.thread_ts
+        thread = qevent.conversation_id
 
         # Surface a booting state on the placeholder so the (up to claim_timeout)
         # cold-boot wait is not silent. Best-effort and outside the per-thread lock:
@@ -419,13 +419,13 @@ class Kernel:
         if not self._config.slack_no_edit_streaming:
             try:
                 await self._sink.update(
-                    channel=qevent.channel,
-                    ts=qevent.placeholder_ts,
+                    channel=qevent.reply_handle.channel,
+                    ts=qevent.reply_handle.placeholder,
                     text=self._config.booting_text,
                 )
             except Exception:
                 logger.warning(
-                    "booting-state update failed for %s", qevent.slack_event_id
+                    "booting-state update failed for %s", qevent.event_id
                 )
 
         event = self._to_event(qevent)
@@ -444,7 +444,7 @@ class Kernel:
             # off and retries within max_attempts, instead of letting the entry
             # escape to the consumer and sit pending for the whole reclaim window.
             release_order()
-            logger.warning("turn start failed for %s: %s", qevent.slack_event_id, exc)
+            logger.warning("turn start failed for %s: %s", qevent.event_id, exc)
             return TurnOutcome(terminal_ok=False, classification="runner-error")
         release_order()
 
@@ -454,8 +454,8 @@ class Kernel:
             # placeholder and return terminal-ok so process_event marks the event
             # done. No run was registered, no sandbox claimed, no turn started.
             await self._sink.update(
-                channel=qevent.channel,
-                ts=qevent.placeholder_ts,
+                channel=qevent.reply_handle.channel,
+                ts=qevent.reply_handle.placeholder,
                 text=route.canned_reply,
             )
             return TurnOutcome(terminal_ok=True)
@@ -472,8 +472,8 @@ class Kernel:
             # the accepted MVP semantic; durable per-steer replay is a deliberate
             # follow-up, flagged to the orchestrator rather than silently assumed.
             await self._sink.update(
-                channel=qevent.channel,
-                ts=qevent.placeholder_ts,
+                channel=qevent.reply_handle.channel,
+                ts=qevent.reply_handle.placeholder,
                 text="Folded into the in-progress reply above.",
             )
             return TurnOutcome(terminal_ok=True, steered=True)
@@ -537,13 +537,13 @@ class Kernel:
             return await asyncio.to_thread(self._substrate.resume, thread)
 
     async def _consume(
-        self, qevent: QueuedSlackEvent, turn: TurnStream, nav: NavPack | None = None
+        self, qevent: QueuedTurn, turn: TurnStream, nav: NavPack | None = None
     ) -> TurnOutcome:
         acc = _StreamAccumulator()
         reply = _ThrottledReply(
             self._sink,
-            channel=qevent.channel,
-            ts=qevent.placeholder_ts,
+            channel=qevent.reply_handle.channel,
+            ts=qevent.reply_handle.placeholder,
             min_interval_s=self._config.slack_edit_min_interval_s,
             nav=nav,
             no_edit=self._config.slack_no_edit_streaming,
@@ -554,10 +554,10 @@ class Kernel:
             # the connection is never leaked.
             async with turn:
                 async for frame in turn:
-                    await self._apply_frame(frame, acc, reply, qevent.slack_event_id)
+                    await self._apply_frame(frame, acc, reply, qevent.event_id)
         except (aiohttp.ClientError, TimeoutError) as exc:
             # Stream dropped mid-run (sandbox killed, network fault). No final.
-            logger.warning("turn stream dropped for %s: %s", qevent.slack_event_id, exc)
+            logger.warning("turn stream dropped for %s: %s", qevent.event_id, exc)
             return TurnOutcome(
                 terminal_ok=False,
                 saw_side_effect=acc.saw_side_effect,
@@ -609,14 +609,23 @@ class Kernel:
             status=acc.status,
         )
 
-    async def _escalate(self, qevent: QueuedSlackEvent, message: str) -> None:
-        logger.warning("escalating event %s: %s", qevent.slack_event_id, message)
-        await self._sink.update(channel=qevent.channel, ts=qevent.placeholder_ts, text=message)
+    async def _escalate(self, qevent: QueuedTurn, message: str) -> None:
+        logger.warning("escalating event %s: %s", qevent.event_id, message)
+        await self._sink.update(
+            channel=qevent.reply_handle.channel,
+            ts=qevent.reply_handle.placeholder,
+            text=message,
+        )
 
     def _backoff(self, attempt: int) -> float:
         raw: float = self._config.retry_backoff_base_s * (2 ** (attempt - 1))
         return min(self._config.retry_backoff_max_s, raw)
 
     @staticmethod
-    def _to_event(qevent: QueuedSlackEvent) -> Event:
-        return Event(type="message", text=qevent.text, user=qevent.user, ts=qevent.thread_ts)
+    def _to_event(qevent: QueuedTurn) -> Event:
+        return Event(
+            type="message",
+            text=qevent.text,
+            user=qevent.author,
+            ts=qevent.conversation_id,
+        )

--- a/apps/worker/tests/kernel/test_binding_integration.py
+++ b/apps/worker/tests/kernel/test_binding_integration.py
@@ -10,8 +10,7 @@ import time
 import uuid
 from collections.abc import Callable
 
-from aci_protocol import Final, SessionStatus, TextDelta
-from agentos_dispatcher.queue import QueuedSlackEvent
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from agentos_worker.behaviorpacks import BehaviorPacks
 from agentos_worker.binding import (
     AGENT_ID_ENV,
@@ -62,14 +61,13 @@ def _resolved(agent_id: uuid.UUID, *, bundle: str | None = "bundles/x.zip") -> R
 
 def _qevent(
     text: str, *, channel: str, thread: str = "th-1", placeholder: str = "p-1"
-) -> QueuedSlackEvent:
-    return QueuedSlackEvent(
-        slack_event_id=uuid.uuid4().hex,
-        thread_ts=thread,
-        channel=channel,
-        user="U1",
+) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U1",
         text=text,
-        placeholder_ts=placeholder,
+        reply_handle=ReplyHandle(channel=channel, placeholder=placeholder),
         received_at="2026-07-05T00:00:00+00:00",
     )
 
@@ -92,7 +90,7 @@ def test_unmapped_channel_is_a_polite_drop(make_harness) -> None:
 
             assert h.runner.opened == []  # no turn ever opened
             assert h.sink.last_text is not None and "no agent" in h.sink.last_text.lower()
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
 
@@ -317,7 +315,7 @@ def test_malformed_packs_blob_still_completes_the_turn(make_harness) -> None:
             # The turn completed: a normal final update landed and the event is done.
             assert h.runner.opened == ["hi"]
             assert h.sink.last_text == "answer"
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
 
@@ -393,7 +391,7 @@ def test_fresh_thread_greeting_short_circuits_no_sandbox_no_model(make_harness) 
             assert h.sink.last_text == _GREET
             assert any(ts == "p-1" and text == _GREET for _c, ts, text in h.sink.updates)
             # ...the event is done...
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
             # ...and NO model turn was started and NO sandbox was claimed.
             assert h.runner.opened == []
             assert h.fake_k8s.claim_envs == []
@@ -453,7 +451,7 @@ def test_fresh_thread_help_short_circuits_no_sandbox_no_model(make_harness) -> N
             await h.kernel.process_event(ev)
 
             assert h.sink.last_text == _HELP
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
             assert h.runner.opened == []
             assert h.fake_k8s.claim_envs == []
 
@@ -480,7 +478,7 @@ def test_fresh_thread_non_matching_message_runs_a_normal_turn(make_harness) -> N
             assert h.sink.last_text == "Your pipeline is $2.1M."
             assert len(h.fake_k8s.claim_envs) == 1
             assert h.sink.last_text != _GREET
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
 
@@ -500,6 +498,6 @@ def test_disabled_greeting_pack_never_short_circuits(make_harness) -> None:
             assert h.runner.opened == ["hi"]
             assert h.sink.last_text == "MODEL"
             assert len(h.fake_k8s.claim_envs) == 1
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -11,21 +11,20 @@ import uuid
 from collections.abc import Callable
 
 import redis.exceptions
-from aci_protocol import Final, SessionStatus, TextDelta
-from agentos_dispatcher.queue import QueuedSlackEvent
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+from agentos_dispatcher.queue import to_stream_fields
 from agentos_worker.consumer import Consumer
 
 DONE = SessionStatus.DONE
 
 
-def _qevent(text: str, *, thread: str = "th-1", event_id: str | None = None) -> QueuedSlackEvent:
-    return QueuedSlackEvent(
-        slack_event_id=event_id or uuid.uuid4().hex,
-        thread_ts=thread,
-        channel="C1",
-        user="U1",
+def _qevent(text: str, *, thread: str = "th-1", event_id: str | None = None) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id or uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U1",
         text=text,
-        placeholder_ts="p-1",
+        reply_handle=ReplyHandle(channel="C1", placeholder="p-1"),
         received_at="2026-07-05T00:00:00+00:00",
     )
 
@@ -47,7 +46,7 @@ def test_consumes_stream_entry_end_to_end_and_acks(make_harness) -> None:
             await consumer.ensure_group()
 
             qe = _qevent("hello", thread="tc1", event_id="c1")
-            await h.async_redis.xadd(h.config.stream, qe.to_stream_fields())
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
 
             task = asyncio.create_task(consumer.run())
             await _wait_until(lambda: h.sink.last_text == "answer")
@@ -74,7 +73,7 @@ def test_reclaim_skips_this_consumers_own_inflight_entry(make_harness) -> None:
             await consumer.ensure_group()
 
             qe = _qevent("hello", thread="ti1", event_id="i1")
-            await h.async_redis.xadd(h.config.stream, qe.to_stream_fields())
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
             task = asyncio.create_task(consumer.run())
             await _wait_until(lambda: h.runner.turn_active)
 
@@ -106,11 +105,11 @@ def test_dispatch_applies_backpressure_at_capacity(make_harness) -> None:
             )
             await consumer.ensure_group()
 
-            first = _qevent("a", thread="ta", event_id="a").to_stream_fields()
+            first = to_stream_fields(_qevent("a", thread="ta", event_id="a"))
             await consumer._dispatch("1-0", first)
             await _wait_until(lambda: h.runner.turn_active)  # slot taken, turn hanging
 
-            second_fields = _qevent("b", thread="tb", event_id="b").to_stream_fields()
+            second_fields = to_stream_fields(_qevent("b", thread="tb", event_id="b"))
             second = asyncio.create_task(consumer._dispatch("2-0", second_fields))
             await asyncio.sleep(0.1)
             assert not second.done()  # blocked: capacity is full
@@ -129,14 +128,14 @@ def test_ensure_group_does_not_replay_preexisting_backlog(make_harness) -> None:
             # persistent Valkey carrying a backlog from a prior deploy). Creating
             # the group at "$" must skip it; creating at "0" would storm it.
             stale = _qevent("stale", thread="tb1", event_id="b1")
-            await h.async_redis.xadd(h.config.stream, stale.to_stream_fields())
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(stale))
 
             consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
             await consumer.ensure_group()
 
             # An entry produced AFTER the group exists must still be delivered.
             fresh = _qevent("fresh", thread="tb2", event_id="b2")
-            await h.async_redis.xadd(h.config.stream, fresh.to_stream_fields())
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(fresh))
             h.runner.default_script = [Final(text="answer", status=DONE)]
 
             task = asyncio.create_task(consumer.run())
@@ -177,7 +176,7 @@ def test_read_loop_survives_transient_redis_timeout(make_harness, caplog) -> Non
 
             h.runner.default_script = [Final(text="answer", status=DONE)]
             qe = _qevent("hello", thread="tt1", event_id="t1")
-            await h.async_redis.xadd(h.config.stream, qe.to_stream_fields())
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
 
             with caplog.at_level(logging.DEBUG, logger="agentos_worker.consumer"):
                 task = asyncio.create_task(consumer.run())
@@ -205,7 +204,7 @@ def test_reclaims_and_reprocesses_a_dead_consumers_pending_entry(make_harness) -
             await consumer.ensure_group()
 
             qe = _qevent("orphan", thread="tr1", event_id="r1")
-            await h.async_redis.xadd(h.config.stream, qe.to_stream_fields())
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
 
             # A different (now "dead") consumer takes delivery but never acks,
             # leaving the entry pending — the crash mid-run case.

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -14,11 +14,12 @@ from collections.abc import Callable
 from aci_protocol import (
     ErrorEvent,
     Final,
+    QueuedTurn,
+    ReplyHandle,
     SessionStatus,
     SideEffectFlag,
     TextDelta,
 )
-from agentos_dispatcher.queue import QueuedSlackEvent
 from agentos_worker.behaviorpacks import BehaviorPacks, NavPack
 
 DONE = SessionStatus.DONE
@@ -32,14 +33,13 @@ def _qevent(
     thread: str = "th-1",
     event_id: str | None = None,
     placeholder: str = "p-1",
-) -> QueuedSlackEvent:
-    return QueuedSlackEvent(
-        slack_event_id=event_id or uuid.uuid4().hex,
-        thread_ts=thread,
-        channel="C1",
-        user="U1",
+) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id or uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U1",
         text=text,
-        placeholder_ts=placeholder,
+        reply_handle=ReplyHandle(channel="C1", placeholder=placeholder),
         received_at="2026-07-05T00:00:00+00:00",
     )
 
@@ -66,7 +66,7 @@ def test_new_turn_streams_to_slack_and_acks(make_harness) -> None:
 
             assert h.runner.opened == ["hi"]
             assert h.sink.last_text == "Hello world"
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
 
@@ -169,8 +169,8 @@ def test_side_effect_failure_escalates_without_retry(make_harness) -> None:
 
             assert h.runner.opened == ["do it"]  # exactly one attempt, no retry
             assert h.sink.last_text is not None and "human" in h.sink.last_text.lower()
-            assert await h.async_redis.exists(h.config.side_effect_key(ev.slack_event_id))
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.side_effect_key(ev.event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
 
@@ -311,13 +311,13 @@ def test_prior_side_effect_marker_escalates_without_running(make_harness) -> Non
             # A prior attempt executed a side effect then the worker crashed: the
             # marker is set but the event never reached done. It must escalate,
             # never re-run the non-idempotent action.
-            await h.async_redis.set(h.config.side_effect_key(ev.slack_event_id), "1")
+            await h.async_redis.set(h.config.side_effect_key(ev.event_id), "1")
 
             await h.kernel.process_event(ev)
 
             assert h.runner.opened == []  # no turn was ever opened
             assert h.sink.last_text is not None and "human" in h.sink.last_text.lower()
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
 
@@ -530,7 +530,7 @@ def test_booting_state_edits_placeholder_before_answer(make_harness) -> None:
             on_ph = [
                 (i, u)
                 for i, u in enumerate(h.sink.updates)
-                if u[0] == ev.channel and u[1] == ev.placeholder_ts
+                if u[0] == ev.reply_handle.channel and u[1] == ev.reply_handle.placeholder
             ]
             booting_idxs = [i for i, u in on_ph if u[2] == booting]
             answer_idxs = [i for i, u in on_ph if u[2] != booting]
@@ -571,6 +571,6 @@ def test_booting_update_failure_never_fails_the_turn(make_harness) -> None:
 
             assert fired["n"] > 0, "the booting update was never attempted"
             assert h.sink.last_text == "all good"
-            assert await h.async_redis.exists(h.config.done_key(ev.slack_event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -22,15 +22,16 @@ release with `up`, `status`, `down`, `comms`, `message`, and `deploy`. Full comm
   client in this binary; do not add a second one for a specific endpoint.
   Keep `reqwest`'s feature set minimal (`json`, `stream`, `multipart`) --
   adding a feature should come with a reason in the PR, not just convenience.
-- **The queue seam is mirrored, not imported, across languages.** The CLI
-  never talks to the dispatcher's Valkey Stream directly -- `agentos skill message`
-  talks straight to a local runner container's ACI HTTP surface
-  (`/v1/event`, `/v1/steer`, `/v1/interrupt`), bypassing the
+- **The queue payload is the frozen `QueuedTurn` contract, not a hand-mirror.**
+  `agentos skill message` talks straight to a local runner container's ACI HTTP
+  surface (`/v1/event`, `/v1/steer`, `/v1/interrupt`), bypassing the
   dispatcher/worker entirely by design (that is the point: zero Slack, zero
-  cluster). If a future task wires the CLI to the real dispatcher/worker
-  queue seam (the future dispatcher or worker queue surface), mirror the
-  `QueuedSlackEvent` shape rather than importing Python types into Rust --
-  keep the contract-mirroring discipline explicit at the boundary.
+  cluster). The `local message` / `cluster message` drivers do enqueue onto the
+  real Valkey Stream, and the payload they mint is `agentos_aci_protocol::QueuedTurn`
+  (promoted into `packages/aci-protocol` by issue #7) consumed from the generated
+  crate -- never redefine it locally in `cli/src`. `cli/src/queue.rs` owns only the
+  Valkey Stream transport of that type (the single-`payload` encoding, the
+  `EvSIM-` synthetic ids, the XADD and the ack-based completion signal).
 - **`agentos init` scaffolds the plugin-format shape verbatim.** The
   generated bundle (`.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`,
   `.mcp.json`) must stay byte-compatible with what `plugin_format.validate_bundle`

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -2,7 +2,7 @@
 //! Slack at all. Used by the `local message` and `cluster message` verbs.
 //!
 //! The CLI *is* the Slack service. It stands up a minimal Slack Web API stub on
-//! a local port, XADDs the exact `QueuedSlackEvent` the dispatcher would produce
+//! a local port, XADDs the exact `QueuedTurn` the dispatcher would produce
 //! onto the real Valkey stream (synthetic, internally-consistent ids since the
 //! CLI itself is the endpoint that receives them back), then waits for the
 //! worker to consume and finalize the turn. The caller prints the placeholder's

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -5,7 +5,7 @@
 //! workspace can exercise the entire deployed machinery (Valkey queue -> worker
 //! -> claimed sandbox -> the real skill -> the reply) without any Slack access,
 //! tokens, or workspace. It is the retained chat helper engine, backed by a
-//! local Slack Web API stub plus the frozen `QueuedSlackEvent` enqueue and the
+//! local Slack Web API stub plus the frozen `QueuedTurn` enqueue and the
 //! ack-based completion signal, with Kubernetes-aware auto-plumbing bolted on
 //! top:
 //!
@@ -38,7 +38,7 @@ use crate::chat::{
     await_reply, continue_hint_line, continue_hint_long_line, resolve_targets, Outcome, SlackStub,
 };
 use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
-use crate::queue::{self, connect, diagnostics, xadd, QueuedSlackEvent};
+use crate::queue::{self, connect, diagnostics, synthetic_turn, xadd};
 use crate::state::{save_turn, TurnContext, TurnVerb};
 
 pub const DEFAULT_STREAM: &str = queue::DEFAULT_STREAM;
@@ -385,7 +385,7 @@ pub fn dry_run_lines(opts: &MessageOpts, advertise_host: &str) -> Vec<String> {
         .clone()
         .unwrap_or_else(|| "<the sole deployed agent's slack_channel>".to_string());
     lines.push(format!(
-        "enqueue a synthetic QueuedSlackEvent for channel {channel} on stream {}",
+        "enqueue a synthetic QueuedTurn for channel {channel} on stream {}",
         opts.stream
     ));
     lines
@@ -581,7 +581,7 @@ async fn wire_worker(opts: &MessageOpts, url: &str) -> Result<()> {
 /// The cluster path's self-plumbing (kubectl port-forwards, the wiring helm
 /// upgrade, the dispatcher guard) is all cluster-specific, so local mode keeps
 /// only the shared engine: bind the same Slack stub, enqueue the same
-/// `QueuedSlackEvent`, wait on the same XACK signal. The compose worker is
+/// `QueuedTurn`, wait on the same XACK signal. The compose worker is
 /// already running and already pointed at this stub (its `SLACK_API_BASE_URL` is
 /// fixed to `http://localhost:{DEFAULT_LOCAL_STUB_PORT}/api/`), so there is
 /// nothing to wire.
@@ -603,7 +603,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             )),
         }
         ui.payload_plain(&format!(
-            "enqueue a synthetic QueuedSlackEvent on stream {}",
+            "enqueue a synthetic QueuedTurn on stream {}",
             opts.stream
         ));
         return Ok(());
@@ -638,7 +638,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
 
     let (channel, thread_ts, placeholder_ts) =
         resolve_targets(Some(&channel), opts.thread.as_deref());
-    let event = QueuedSlackEvent::synthetic(
+    let event = synthetic_turn(
         &channel,
         &opts.user,
         &opts.text,
@@ -648,7 +648,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     let stream_id = xadd(&mut conn, &opts.stream, &event).await?;
     ui.note(&format!(
         "enqueued {} on {} as {stream_id}",
-        event.slack_event_id, opts.stream
+        event.event_id, opts.stream
     ));
     ui.note(&format!(
         "waiting up to {}s for the worker to finalize the turn...",
@@ -788,7 +788,7 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     let mut conn = connect(&valkey_url).await?;
     let (channel, thread_ts, placeholder_ts) =
         resolve_targets(Some(&channel), opts.thread.as_deref());
-    let event = QueuedSlackEvent::synthetic(
+    let event = synthetic_turn(
         &channel,
         &opts.user,
         &opts.text,
@@ -798,7 +798,7 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     let stream_id = xadd(&mut conn, &opts.stream, &event).await?;
     ui.note(&format!(
         "enqueued {} on {} as {stream_id}",
-        event.slack_event_id, opts.stream
+        event.event_id, opts.stream
     ));
     ui.note(&format!(
         "waiting up to {}s for the worker to finalize the turn...",

--- a/cli/src/queue.rs
+++ b/cli/src/queue.rs
@@ -1,18 +1,19 @@
 //! Shared machinery for the Slack-facing drivers (`chat` and `message`).
 //!
-//! Both mint the exact `QueuedSlackEvent` the dispatcher would produce, `XADD`
-//! it onto the real Valkey stream, and (on timeout) print the same stream
-//! diagnostics. The queue seam is frozen: one `payload` field holding the JSON
-//! of a `QueuedSlackEvent` whose fields mirror
-//! `apps/dispatcher/src/agentos_dispatcher/queue.py` exactly.
+//! Both mint the exact `QueuedTurn` the dispatcher would produce, `XADD` it onto
+//! the real Valkey stream, and (on timeout) print the same stream diagnostics.
+//! The queue seam is the frozen `QueuedTurn` contract promoted into
+//! `packages/aci-protocol` (issue #7): the CLI uses the generated
+//! `agentos_aci_protocol` types directly rather than hand-mirroring them. The
+//! wire form is one `payload` field holding this model's JSON.
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use agentos_aci_protocol::{QueuedTurn, ReplyHandle};
 use anyhow::{Context, Result};
 use redis::aio::MultiplexedConnection;
 use redis::streams::{StreamInfoGroupsReply, StreamPendingCountReply, StreamPendingReply};
 use redis::AsyncCommands;
-use serde::{Deserialize, Serialize};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -28,47 +29,33 @@ pub const WORKER_GROUP: &str = "agentos-workers";
 const EVENT_ID_PREFIX: &str = "EvSIM-";
 const STREAM_PAYLOAD_FIELD: &str = "payload";
 
-/// The normalized job the dispatcher enqueues and the worker consumes.
-///
-/// Field names and types are the frozen queue seam
-/// (`dispatcher.queue.QueuedSlackEvent`); the wire form is a single `payload`
-/// field holding this struct as JSON.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct QueuedSlackEvent {
-    pub slack_event_id: String,
-    pub thread_ts: String,
-    pub channel: String,
-    pub user: String,
-    pub text: String,
-    pub placeholder_ts: String,
-    pub received_at: String,
+/// Build a synthetic turn: a fresh `EvSIM-` id and the current UTC time, with the
+/// given conversation/reply coordinates. Maps the Slack-facing drivers' inputs
+/// onto the channel-neutral `QueuedTurn` (channel + placeholder live in the
+/// `reply_handle`).
+pub fn synthetic_turn(
+    channel: impl Into<String>,
+    author: impl Into<String>,
+    text: impl Into<String>,
+    conversation_id: impl Into<String>,
+    placeholder: impl Into<String>,
+) -> QueuedTurn {
+    QueuedTurn {
+        event_id: new_event_id(),
+        conversation_id: conversation_id.into(),
+        author: author.into(),
+        text: text.into(),
+        reply_handle: ReplyHandle {
+            channel: channel.into(),
+            placeholder: placeholder.into(),
+        },
+        received_at: now_rfc3339(),
+    }
 }
 
-impl QueuedSlackEvent {
-    /// Build a synthetic event: a fresh `EvSIM-` id and the current UTC time,
-    /// with the given Slack timestamps.
-    pub fn synthetic(
-        channel: impl Into<String>,
-        user: impl Into<String>,
-        text: impl Into<String>,
-        thread_ts: impl Into<String>,
-        placeholder_ts: impl Into<String>,
-    ) -> Self {
-        Self {
-            slack_event_id: new_event_id(),
-            thread_ts: thread_ts.into(),
-            channel: channel.into(),
-            user: user.into(),
-            text: text.into(),
-            placeholder_ts: placeholder_ts.into(),
-            received_at: now_rfc3339(),
-        }
-    }
-
-    /// The JSON blob stored under the stream's single `payload` field.
-    pub fn payload_json(&self) -> Result<String> {
-        serde_json::to_string(self).context("serializing the queued event")
-    }
+/// The JSON blob stored under the stream's single `payload` field.
+pub fn payload_json(turn: &QueuedTurn) -> Result<String> {
+    serde_json::to_string(turn).context("serializing the queued turn")
 }
 
 /// A synthetic Slack event id with the `EvSIM-` prefix and a random suffix.
@@ -113,9 +100,9 @@ pub async fn connect(url: &str) -> Result<MultiplexedConnection> {
 pub async fn xadd(
     conn: &mut MultiplexedConnection,
     stream: &str,
-    event: &QueuedSlackEvent,
+    turn: &QueuedTurn,
 ) -> Result<String> {
-    let payload = event.payload_json()?;
+    let payload = payload_json(turn)?;
     let stream_id: String = redis::cmd("XADD")
         .arg(stream)
         .arg("*")
@@ -281,19 +268,18 @@ mod tests {
     }
 
     #[test]
-    fn queued_event_matches_cross_language_golden() {
+    fn queued_turn_matches_cross_language_golden() {
         // The same committed wire fixture the Python producer (apps/dispatcher)
-        // round-trips: this hand-mirrored struct must deserialize it and
-        // re-serialize to identical bytes, catching seam drift between the two
-        // languages until the payload is promoted into aci-protocol (#7).
+        // round-trips: the generated QueuedTurn must deserialize it and
+        // re-serialize to identical bytes. This pins the frozen QueuedTurn seam
+        // across the Python producer and this Rust consumer (issue #7).
         let raw =
-            include_str!("../../packages/aci-protocol/schema/queued-slack-event.fixture.json")
-                .trim_end();
-        let event: QueuedSlackEvent = serde_json::from_str(raw).expect("golden deserializes");
-        assert_eq!(event.slack_event_id, "Ev0GOLDEN0001");
-        assert_eq!(event.received_at, "2026-07-05T00:00:00+00:00");
+            include_str!("../../packages/aci-protocol/schema/queued-turn.fixture.json").trim_end();
+        let turn: QueuedTurn = serde_json::from_str(raw).expect("golden deserializes");
+        assert_eq!(turn.event_id, "Ev0GOLDEN0001");
+        assert_eq!(turn.received_at, "2026-07-05T00:00:00+00:00");
         assert_eq!(
-            event.payload_json().unwrap(),
+            payload_json(&turn).unwrap(),
             raw,
             "Rust wire bytes drifted from golden"
         );
@@ -301,16 +287,14 @@ mod tests {
 
     #[test]
     fn payload_json_carries_the_exact_seam_field_names() {
-        let event = QueuedSlackEvent {
-            slack_event_id: "EvSIM-x".into(),
-            thread_ts: "1720000000.000100".into(),
-            channel: "C-SIM-x".into(),
-            user: "U-agentos-chat".into(),
-            text: "hello".into(),
-            placeholder_ts: "1720000000.000200".into(),
-            received_at: "2026-07-05T00:00:00Z".into(),
-        };
-        let json = event.payload_json().unwrap();
+        let turn = synthetic_turn(
+            "C-SIM-x",
+            "U-agentos-chat",
+            "hello",
+            "1720000000.000100",
+            "1720000000.000200",
+        );
+        let json = payload_json(&turn).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
         let object = value.as_object().unwrap();
 
@@ -319,17 +303,18 @@ mod tests {
         assert_eq!(
             keys,
             vec![
-                "channel",
-                "placeholder_ts",
+                "author",
+                "conversation_id",
+                "event_id",
                 "received_at",
-                "slack_event_id",
+                "reply_handle",
                 "text",
-                "thread_ts",
-                "user",
             ]
         );
-        assert_eq!(object["slack_event_id"], "EvSIM-x");
-        assert_eq!(object["placeholder_ts"], "1720000000.000200");
+        // channel and placeholder are nested in the channel-neutral reply_handle.
+        assert_eq!(object["reply_handle"]["channel"], "C-SIM-x");
+        assert_eq!(object["reply_handle"]["placeholder"], "1720000000.000200");
+        assert_eq!(object["conversation_id"], "1720000000.000100");
     }
 
     #[test]

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -10,7 +10,8 @@
 use std::time::Duration;
 
 use agentos::chat::{resolve_targets, SlackStub};
-use agentos::queue::{diagnostics, entry_acked, xadd, QueuedSlackEvent, WORKER_GROUP};
+use agentos::queue::{diagnostics, entry_acked, synthetic_turn, xadd, WORKER_GROUP};
+use agentos_aci_protocol::QueuedTurn;
 
 const DEFAULT_VALKEY_URL: &str = "redis://:valkeypass@localhost:26379";
 
@@ -54,7 +55,7 @@ async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
     };
     let stream = unique_stream();
 
-    let event = QueuedSlackEvent::synthetic(
+    let event = synthetic_turn(
         "C-SIM-x",
         "U-agentos-chat",
         "hello world",
@@ -90,7 +91,7 @@ async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
 
     // The payload JSON round-trips into the same event with the exact
     // dispatcher-side field names.
-    let decoded: QueuedSlackEvent = serde_json::from_str(&fields[0].1).unwrap();
+    let decoded: QueuedTurn = serde_json::from_str(&fields[0].1).unwrap();
     assert_eq!(decoded, event);
 
     let value: serde_json::Value = serde_json::from_str(&fields[0].1).unwrap();
@@ -104,17 +105,16 @@ async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
     assert_eq!(
         keys,
         vec![
-            "channel",
-            "placeholder_ts",
+            "author",
+            "conversation_id",
+            "event_id",
             "received_at",
-            "slack_event_id",
+            "reply_handle",
             "text",
-            "thread_ts",
-            "user",
         ]
     );
     assert!(
-        decoded.slack_event_id.starts_with("EvSIM-"),
+        decoded.event_id.starts_with("EvSIM-"),
         "synthetic id keeps its collision-proof prefix on the wire"
     );
 }
@@ -139,7 +139,7 @@ async fn explicit_channel_and_thread_land_verbatim_on_the_wire() {
         "explicit thread becomes thread_ts"
     );
 
-    let event = QueuedSlackEvent::synthetic(
+    let event = synthetic_turn(
         &channel,
         "U-agentos-chat",
         "hi",
@@ -163,13 +163,13 @@ async fn explicit_channel_and_thread_land_verbatim_on_the_wire() {
 
     assert!(!stream_id.is_empty(), "XADD returned an id");
     assert_eq!(entries.len(), 1, "exactly one entry enqueued");
-    let decoded: QueuedSlackEvent = serde_json::from_str(&entries[0].1[0].1).unwrap();
+    let decoded: QueuedTurn = serde_json::from_str(&entries[0].1[0].1).unwrap();
     assert_eq!(
-        decoded.channel, "CSIM12345",
+        decoded.reply_handle.channel, "CSIM12345",
         "the XADD'd payload keeps the exact channel the worker binds on"
     );
     assert_eq!(
-        decoded.thread_ts, "1720000000.000100",
+        decoded.conversation_id, "1720000000.000100",
         "the XADD'd payload keeps the exact thread_ts"
     );
 }
@@ -194,7 +194,7 @@ async fn absent_channel_and_thread_fall_back_to_synthetic() {
     assert!(secs.parse::<u64>().is_ok(), "secs numeric: {thread_ts}");
     assert_eq!(micros.len(), 6, "micros width: {thread_ts}");
 
-    let event = QueuedSlackEvent::synthetic(
+    let event = synthetic_turn(
         &channel,
         "U-agentos-chat",
         "hi",
@@ -218,14 +218,14 @@ async fn absent_channel_and_thread_fall_back_to_synthetic() {
 
     assert!(!stream_id.is_empty(), "XADD returned an id");
     assert_eq!(entries.len(), 1, "exactly one entry enqueued");
-    let decoded: QueuedSlackEvent = serde_json::from_str(&entries[0].1[0].1).unwrap();
+    let decoded: QueuedTurn = serde_json::from_str(&entries[0].1[0].1).unwrap();
     assert!(
-        decoded.channel.starts_with("C-SIM-"),
+        decoded.reply_handle.channel.starts_with("C-SIM-"),
         "synthetic channel on the wire: {}",
-        decoded.channel
+        decoded.reply_handle.channel
     );
     assert_eq!(
-        decoded.thread_ts, thread_ts,
+        decoded.conversation_id, thread_ts,
         "synthetic thread_ts round-trips onto the stream"
     );
 }
@@ -241,7 +241,7 @@ async fn diagnostics_reports_stream_length_and_consumer_group_state() {
     };
     let stream = unique_stream();
 
-    let event = QueuedSlackEvent::synthetic("C-SIM-x", "U-agentos-chat", "hi", "1.1", "1.2");
+    let event = synthetic_turn("C-SIM-x", "U-agentos-chat", "hi", "1.1", "1.2");
     let stream_id = xadd(&mut conn, &stream, &event).await.unwrap();
 
     // The worker's group name; create it at 0 so it sees the existing entry.
@@ -285,7 +285,7 @@ async fn entry_acked_tracks_the_worker_consuming_and_acking() {
         return;
     };
     let stream = unique_stream();
-    let event = QueuedSlackEvent::synthetic("C-SIM-x", "U-agentos-chat", "hi", "1.1", "1.2");
+    let event = synthetic_turn("C-SIM-x", "U-agentos-chat", "hi", "1.1", "1.2");
     let stream_id = xadd(&mut conn, &stream, &event).await.unwrap();
 
     // No group yet: not acked.

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -77,6 +77,24 @@ pub struct SessionConfig {
     pub otel: OtelConfig,
 }
 
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplyHandle {
+    pub channel: String,
+    pub placeholder: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QueuedTurn {
+    pub event_id: String,
+    pub conversation_id: String,
+    pub author: String,
+    pub text: String,
+    pub reply_handle: ReplyHandle,
+    pub received_at: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", deny_unknown_fields)]
 pub enum InboundMessage {

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -53,6 +53,13 @@ export type Detail = string | null;
 export type Tool1 = string | null;
 export type Type5 = "side_effect_flag";
 export type Version4 = "0.1.0";
+export type Author = string;
+export type ConversationId = string;
+export type EventId = string;
+export type ReceivedAt = string;
+export type Channel = string;
+export type Placeholder = string;
+export type Text4 = string;
 export type CredentialsRef = string | null;
 export type MemoryRef = string | null;
 export type PluginDir = string;
@@ -185,6 +192,42 @@ export interface SideEffectFlag {
   tool?: Tool1;
   type: Type5;
   version: Version4;
+}
+/**
+ * A normalized inbound turn ready for the worker to route and run.
+ *
+ * The channel-neutral promotion of the dispatcher's former ``QueuedSlackEvent``.
+ * The Valkey Stream carries this model as a single ``payload`` JSON field; the
+ * stream-encoding helpers live with the producer (the dispatcher), not on this
+ * frozen model, so the contract stays transport-agnostic.
+ *
+ * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * via the `definition` "QueuedTurn".
+ */
+export interface QueuedTurn {
+  author: Author;
+  conversation_id: ConversationId;
+  event_id: EventId;
+  received_at: ReceivedAt;
+  reply_handle: ReplyHandle;
+  text: Text4;
+}
+/**
+ * Channel-neutral coordinates for where a turn's reply is delivered.
+ *
+ * The reply model is edit-in-place: the ingress adapter pre-posts a placeholder
+ * message and the worker edits it as the answer streams. For the Slack adapter
+ * today, ``channel`` is the Slack channel id (also the key the deployment
+ * binding matches an agent on) and ``placeholder`` is the ts of the pre-posted
+ * placeholder message. Issue #19 extends this with a per-turn reply endpoint so
+ * two ingress paths can coexist on one worker.
+ *
+ * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * via the `definition` "ReplyHandle".
+ */
+export interface ReplyHandle {
+  channel: Channel;
+  placeholder: Placeholder;
 }
 /**
  * The typed session setup contract.

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -256,6 +256,65 @@
       ],
       "title": "OutboundEvent"
     },
+    "QueuedTurn": {
+      "additionalProperties": false,
+      "description": "A normalized inbound turn ready for the worker to route and run.\n\nThe channel-neutral promotion of the dispatcher's former ``QueuedSlackEvent``.\nThe Valkey Stream carries this model as a single ``payload`` JSON field; the\nstream-encoding helpers live with the producer (the dispatcher), not on this\nfrozen model, so the contract stays transport-agnostic.",
+      "properties": {
+        "author": {
+          "title": "Author",
+          "type": "string"
+        },
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        },
+        "event_id": {
+          "title": "Event Id",
+          "type": "string"
+        },
+        "received_at": {
+          "title": "Received At",
+          "type": "string"
+        },
+        "reply_handle": {
+          "$ref": "#/$defs/ReplyHandle"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "author",
+        "conversation_id",
+        "event_id",
+        "received_at",
+        "reply_handle",
+        "text"
+      ],
+      "title": "QueuedTurn",
+      "type": "object"
+    },
+    "ReplyHandle": {
+      "additionalProperties": false,
+      "description": "Channel-neutral coordinates for where a turn's reply is delivered.\n\nThe reply model is edit-in-place: the ingress adapter pre-posts a placeholder\nmessage and the worker edits it as the answer streams. For the Slack adapter\ntoday, ``channel`` is the Slack channel id (also the key the deployment\nbinding matches an agent on) and ``placeholder`` is the ts of the pre-posted\nplaceholder message. Issue #19 extends this with a per-turn reply endpoint so\ntwo ingress paths can coexist on one worker.",
+      "properties": {
+        "channel": {
+          "title": "Channel",
+          "type": "string"
+        },
+        "placeholder": {
+          "title": "Placeholder",
+          "type": "string"
+        }
+      },
+      "required": [
+        "channel",
+        "placeholder"
+      ],
+      "title": "ReplyHandle",
+      "type": "object"
+    },
     "SessionConfig": {
       "additionalProperties": false,
       "description": "The typed session setup contract.\n\n``credentials_ref`` is a reference to injected secrets (AGENTOS_CREDENTIALS);\nsection 0 describes these as per-tool secrets via K8s Secret refs, so the\ncontract carries the reference, not the secret material itself.",

--- a/packages/aci-protocol/schema/queued-slack-event.fixture.json
+++ b/packages/aci-protocol/schema/queued-slack-event.fixture.json
@@ -1,1 +1,0 @@
-{"slack_event_id":"Ev0GOLDEN0001","thread_ts":"1720000000.000100","channel":"C0GOLDENAAA","user":"U0GOLDENBBB","text":"hello from the golden fixture","placeholder_ts":"1720000000.000200","received_at":"2026-07-05T00:00:00+00:00"}

--- a/packages/aci-protocol/schema/queued-turn.fixture.json
+++ b/packages/aci-protocol/schema/queued-turn.fixture.json
@@ -1,0 +1,1 @@
+{"event_id":"Ev0GOLDEN0001","conversation_id":"1720000000.000100","author":"U0GOLDENBBB","text":"hello from the golden fixture","reply_handle":{"channel":"C0GOLDENAAA","placeholder":"1720000000.000200"},"received_at":"2026-07-05T00:00:00+00:00"}

--- a/packages/aci-protocol/src/aci_protocol/__init__.py
+++ b/packages/aci-protocol/src/aci_protocol/__init__.py
@@ -34,6 +34,7 @@ from .ndjson import (
 )
 from .reference import reference_producer
 from .session import Budget, OtelConfig, SessionConfig
+from .turn import QueuedTurn, ReplyHandle
 from .version import PROTOCOL_VERSION
 
 __version__ = "0.0.0"
@@ -45,6 +46,9 @@ __all__ = [
     "SessionConfig",
     "Budget",
     "OtelConfig",
+    # queue turn payload (the ingress job the worker consumes)
+    "QueuedTurn",
+    "ReplyHandle",
     # inbound
     "Event",
     "Interrupt",

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -28,6 +28,7 @@ from .events import (
     ToolNote,
 )
 from .session import Budget, OtelConfig, SessionConfig
+from .turn import QueuedTurn, ReplyHandle
 from .version import PROTOCOL_VERSION
 
 _NONE = type(None)
@@ -269,6 +270,8 @@ def render_rust() -> str:
         _struct(Budget),
         _struct(OtelConfig),
         _struct(SessionConfig),
+        _struct(ReplyHandle),
+        _struct(QueuedTurn),
         _tagged_enum("InboundMessage", "kind", (Event, Interrupt)),
         _tagged_enum(
             "OutboundEvent",

--- a/packages/aci-protocol/src/aci_protocol/schema_export.py
+++ b/packages/aci-protocol/src/aci_protocol/schema_export.py
@@ -27,6 +27,7 @@ from .events import (
 from .events import InboundMessage as InboundMessageUnion
 from .events import OutboundEvent as OutboundEventUnion
 from .session import Budget, OtelConfig, SessionConfig
+from .turn import QueuedTurn, ReplyHandle
 from .version import PROTOCOL_VERSION
 
 
@@ -55,6 +56,8 @@ _MODELS = (
     Final,
     ErrorEvent,
     SideEffectFlag,
+    ReplyHandle,
+    QueuedTurn,
 )
 
 SCHEMA_ID = "https://curie.tech/agentos/aci-protocol.schema.json"

--- a/packages/aci-protocol/src/aci_protocol/turn.py
+++ b/packages/aci-protocol/src/aci_protocol/turn.py
@@ -1,0 +1,66 @@
+"""The queued turn payload: the normalized inbound job an ingress adapter
+enqueues and the worker consumes.
+
+This is the channel-neutral promotion of the dispatcher's former
+``QueuedSlackEvent`` (issue #7). It lives here, in the frozen ACI package, so the
+contract is shared across all three languages (Pydantic source of truth, with
+generated TypeScript and Rust derived from the committed JSON Schema) and guarded
+by the schema-compat gate, rather than hand-mirrored between the Python producer
+and the Rust CLI.
+
+The field names are channel-agnostic so a second ingress adapter (not just Slack)
+can produce and route the same payload:
+
+    event_id        idempotency key for the delivery
+    conversation_id the conversation/thread key routing keeps one live session per
+    author          who authored the message
+    text            the message text
+    reply_handle    where the reply is delivered (see ``ReplyHandle``)
+    received_at     ISO-8601 UTC timestamp of when the adapter received it
+
+For the Slack adapter today, ``event_id`` is the Slack event id, ``conversation_id``
+is the thread ts, ``author`` is the Slack user id, and ``reply_handle`` carries the
+Slack channel plus the placeholder message ts. The Valkey Stream wire encoding (a
+single ``payload`` field holding this model's JSON) is a transport detail and
+stays outside this package, in the dispatcher's queue module.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+_STRICT = ConfigDict(extra="forbid")
+
+
+class ReplyHandle(BaseModel):
+    """Channel-neutral coordinates for where a turn's reply is delivered.
+
+    The reply model is edit-in-place: the ingress adapter pre-posts a placeholder
+    message and the worker edits it as the answer streams. For the Slack adapter
+    today, ``channel`` is the Slack channel id (also the key the deployment
+    binding matches an agent on) and ``placeholder`` is the ts of the pre-posted
+    placeholder message. Issue #19 extends this with a per-turn reply endpoint so
+    two ingress paths can coexist on one worker.
+    """
+
+    model_config = _STRICT
+
+    channel: str
+    placeholder: str
+
+
+class QueuedTurn(BaseModel):
+    """A normalized inbound turn ready for the worker to route and run.
+
+    The channel-neutral promotion of the dispatcher's former ``QueuedSlackEvent``.
+    The Valkey Stream carries this model as a single ``payload`` JSON field; the
+    stream-encoding helpers live with the producer (the dispatcher), not on this
+    frozen model, so the contract stays transport-agnostic.
+    """
+
+    model_config = _STRICT
+
+    event_id: str
+    conversation_id: str
+    author: str
+    text: str
+    reply_handle: ReplyHandle
+    received_at: str


### PR DESCRIPTION
Closes #7.

Promotes the dispatcher/CLI queue payload into `packages/aci-protocol` as the frozen tri-language `QueuedTurn` contract, and renames its fields to be channel-agnostic. Doing the promotion and the rename in one motion turns two roadmap debts (per `docs/architecture-vision.md` job 6) into one change, and is the prerequisite for the reply half (#19) and any second channel adapter.

## What changed

**Frozen contract (`packages/aci-protocol`)**
- New `QueuedTurn` + nested `ReplyHandle` models (Pydantic source of truth), wired into `schema_export` and `rust_export`. Regenerated the committed JSON Schema, Rust crate, and TypeScript. `scripts/check-contracts.sh` and the schema-compat pytest gate now guard the payload across all three languages, replacing the previous hand-mirrored Python/Rust structs plus a single golden-fixture test.
- Channel-neutral fields: `event_id`, `conversation_id`, `author`, `text`, `reply_handle`, `received_at`. `reply_handle` nests `{channel, placeholder}` (the Slack channel id the deployment binding matches on, and the placeholder message the worker edits in place).

**Dependents swept**
- Dispatcher: `queue.py` now owns only the Valkey Stream transport (the single-`payload` encoding and the dedupe guard) and exposes `to_stream_fields`/`from_stream_fields`; `handlers.py` maps the Slack event onto `QueuedTurn`.
- Worker: `consumer.py`, `kernel.py`, and the channel `binding.py` read the neutral fields. The `kernel.py` change is a mechanical field rename with no control-flow change.
- CLI: `cli/src/queue.rs` consumes the generated `agentos_aci_protocol::QueuedTurn` instead of a hand-mirrored struct; `chat.rs`/`message.rs` and the CLI `CLAUDE.md` seam note updated.
- Renamed the cross-language golden fixture to `queued-turn.fixture.json`; updated the Python and Rust round-trip tests.

## Design decisions (flagged for review)
- **`reply_handle` shape.** It carries today's Slack reply coordinates (`channel` + `placeholder`) under channel-neutral names. #19 will extend it with a per-turn reply endpoint so two ingress paths can coexist; I deliberately did not build a channel-adapter framework ahead of that second real need (per `architecture-vision.md`).
- **`PROTOCOL_VERSION` not bumped.** No existing ACI session/event shape changed; `QueuedTurn` is an additive new model and carries no `version` field (matching the former `QueuedSlackEvent`). The compat gate, not a version bump, is the safety net here. Happy to bump if a reviewer prefers.
- The `kernel.py` edit is a pure field rename, but it is still the sacred module: it warrants the spec-vs-impl + side-effects adversarial review per `apps/worker/CLAUDE.md`.

## Verification
- `uv run ruff check .` and `uv run mypy` clean.
- `pytest`: aci-protocol (26), dispatcher + worker kernel (92), full worker suite (269 passed, 1 skipped), all against real Valkey/Postgres from `compose.dev.yaml`. Whole-repo collection (634 tests) imports cleanly.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, and `cargo test` all pass, including the 7 real-Valkey `chat_enqueue` tests asserting the exact channel-neutral wire shape.
- `scripts/check-contracts.sh` passes (regenerate + compile Rust/TS + no drift).
- Cross-language wire bytes are pinned by `queued-turn.fixture.json`, round-tripped by both the Python producer and the Rust consumer.

Note: the full `agentos local up` live message loop was not exercised because the local product images are amd64-only (fails on this Apple Silicon host); the producer wire shape and the worker routing path are covered by the real-Valkey integration tests above instead.