### PR TITLE
Fix model-integration test fixtures to use valid Slack channel IDs

### DIFF
--- a/apps/api/tests/test_agent_model_integration.py
+++ b/apps/api/tests/test_agent_model_integration.py
@@ -13,7 +13,7 @@ def _create_agent(
 ) -> dict[str, Any]:
     resp = client.post(
         "/agents",
-        json={"name": "model-bot", "slack_channel": "C-MODEL", **body},
+        json={"name": "model-bot", "slack_channel": "CMODEL001", **body},
         headers=auth_headers,
     )
     assert resp.status_code == 201, resp.text
@@ -62,10 +62,10 @@ def test_patch_without_model_leaves_it_unchanged(
     # A PATCH touching only slack_channel must not clear the model.
     resp = client.patch(
         f"/agents/{agent['id']}",
-        json={"slack_channel": "C-MOVED"},
+        json={"slack_channel": "CMOVED001"},
         headers=auth_headers,
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["slack_channel"] == "C-MOVED"
+    assert body["slack_channel"] == "CMOVED001"
     assert body["model"] == "deepseek-v4"


### PR DESCRIPTION
## Problem
The Python suite fails on `main`: `apps/api/tests/test_agent_model_integration.py` (4 tests) returns 422 instead of 201.

Two features that merged independently collide:
- **#231** added a Slack channel-ID validator on the agent schema (`^[CDG][A-Z0-9]{7,}$`).
- **#254** (per-agent model selection) added these tests, whose fixtures POST `slack_channel: "C-MODEL"` / `"C-MOVED"` — both rejected by that regex (dash, too short).

Neither PR could see the other's change, so the break only appeared once both were on `main`. It currently blocks every open PR's CI.

## Fix
Swap the fixtures to valid IDs (`CMODEL001` / `CMOVED001`) that satisfy the validator. Pure test-data change; assertion intent is unchanged.

## Verification
`uv run pytest apps/api/tests/test_agent_model_integration.py -q` -> `4 passed`.