### PR TITLE
Runner-owned TurnEvent message model behind ModelSession (#307)

### DIFF
--- a/docs/interfaces/harness-modelsession/INTERFACE.md
+++ b/docs/interfaces/harness-modelsession/INTERFACE.md
@@ -9,8 +9,9 @@
 
 Inside the runner the model harness is reached through one in-process port: the
 `ModelSession` Protocol. Everything above it (ACI translation, budget, side-effect
-flagging, NDJSON, the HTTP layer) is written against the Protocol, so the concrete
-`claude-agent-sdk` driver is the only SDK-coupled code. What stays opinionated core
+flagging, NDJSON, the HTTP layer) is written against the runner-owned `TurnEvent`
+union, so the `claude-agent-sdk` types survive in exactly one place: inside
+`adapter.map_sdk_message`, the SDK->TurnEvent mapping. What stays opinionated core
 is the frozen ACI wire contract the runner serves; the port is how a harness plugs
 into that runner. Steer and interrupt are first-class Protocol operations, not
 emulated.
@@ -18,46 +19,55 @@ emulated.
 ## Current contract
 
 A second harness must supply an object satisfying `ModelSession`
-(`runner/src/agentos_runner/adapter.py:24`), a five-method `Protocol`:
+(`runner/src/agentos_runner/adapter.py:37`), a five-method `Protocol`:
 
-- `async def connect(self) -> None` (`adapter.py:27`) — start/attach the harness,
+- `async def connect(self) -> None` (`adapter.py:40`) — start/attach the harness,
   rehydrating if a resume ref is configured.
-- `async def query(self, text: str) -> None` (`adapter.py:31`) — push a user message;
+- `async def query(self, text: str) -> None` (`adapter.py:44`) — push a user message;
   a `query` issued while a turn is live is the mid-run **steer**.
-- `def receive_turn(self) -> AsyncIterator[Any]` (`adapter.py:35`) — yield the harness
-  messages for the current turn, ending at its terminal result.
-- `async def interrupt(self) -> None` (`adapter.py:39`) — native hard stop at the next
+- `def receive_turn(self) -> AsyncIterator[TurnEvent]` (`adapter.py:48`) — yield the
+  runner `TurnEvent`s for the current turn, ending at its terminal result.
+- `async def interrupt(self) -> None` (`adapter.py:52`) — native hard stop at the next
   safe boundary.
-- `async def close(self) -> None` (`adapter.py:43`) — tear down.
+- `async def close(self) -> None` (`adapter.py:56`) — tear down.
 
-The messages a `receive_turn` iterator yields must be mappable by
-`translate_message` (`runner/src/agentos_runner/translate.py:55`) into the ACI
-outbound union (`TextDelta` / `ToolNote` / `SideEffectFlag` / `ErrorEvent` /
-`Final`). Session options are assembled by `build_options`
-(`adapter.py:48`), which pins `permission_mode="bypassPermissions"`
-(`adapter.py:82`).
+A `receive_turn` iterator now yields the runner-owned `TurnEvent` union
+(`AssistantText | ToolCall | RateLimit | TurnResult`,
+`runner/src/agentos_runner/events.py:64`), which `translate_event`
+(`runner/src/agentos_runner/translate.py:49`) maps into the ACI outbound union
+(`TextDelta` / `ToolNote` / `SideEffectFlag` / `ErrorEvent` / `Final`). A second
+harness emits `TurnEvent`s directly; only the Claude adapter maps the SDK's own
+message types onto the union, in `map_sdk_message` (`adapter.py:61`), the sole
+surviving SDK-coupled mapping. Session options are assembled by `build_options`
+(`adapter.py:130`), which pins `permission_mode="bypassPermissions"`
+(`adapter.py:164`).
 
 ## Implementations today
 
 Two, both in `runner/src/agentos_runner/`:
 
-- **Real:** `ClaudeAgentSession` (`adapter.py:87`), wrapping `ClaudeSDKClient` in
-  streaming-input mode; `receive_turn` delegates to `self._client.receive_response()`
-  (`adapter.py:100`) and `interrupt` to `self._client.interrupt()` (`adapter.py:103`).
-- **Fake:** `FakeModelSession` (`runner/src/agentos_runner/fake.py:52`), a scripted
-  replayer that constructs real SDK message dataclasses. It is the reusable acceptance
-  harness: `conformance_producer` (`runner/src/agentos_runner/conformance.py:33`) drives
+- **Real:** `ClaudeAgentSession` (`adapter.py:169`), wrapping `ClaudeSDKClient` in
+  streaming-input mode; `receive_turn` wraps `self._client.receive_response()` and maps
+  each SDK message through `map_sdk_message` (`adapter.py:182`), and `interrupt`
+  delegates to `self._client.interrupt()` (`adapter.py:188`).
+- **Fake:** `FakeModelSession` (`runner/src/agentos_runner/fake.py:30`), a scripted
+  replayer that emits runner `TurnEvent`s directly (`fake.py:65`). It is the reusable
+  acceptance harness: `conformance_producer` (`runner/src/agentos_runner/conformance.py:33`) drives
   a real `SessionRunner` over the fake (`conformance.py:24`), so the ACI conformance gate
   validates the actual translation/final plumbing, not a canned stream.
 
 ## Known leakage
 
 The port is CLEAN as a code interface but leaks harness shape in two places, both
-called out in vision-doc Job 1:
+called out in vision-doc Job 1. A third leak — the message vocabulary itself — was
+**closed by #307**: a non-Claude harness previously had to forge `claude-agent-sdk`
+message dataclasses (the OpenCode spike synthesized dummy `ResultMessage` fields) to
+feed the runner core; harnesses now emit the runner-owned `TurnEvent` union directly,
+so that forging is gone.
 
 - **SDK-shaped resume.** `AGENTOS_HISTORY_REF` is read verbatim into `history_ref`
-  (`runner/src/agentos_runner/config.py:64`) and passed as the SDK `resume` session id
-  by `build_options` (`adapter.py:64`, `:80`). A harness without an equivalent
+  (`runner/src/agentos_runner/config.py:66`) and passed as the SDK `resume` session id
+  by `build_options` (`adapter.py:130`, `:162`). A harness without an equivalent
   resume/session-store concept must build its own history store.
 - **Plugin-format entanglement.** `packages/plugin-format` is the Claude Code plugin
   shape verbatim, so a non-Claude harness must interpret Claude Code plugin bundles or

--- a/runner/src/agentos_runner/__init__.py
+++ b/runner/src/agentos_runner/__init__.py
@@ -9,10 +9,11 @@ flags non-idempotent tool calls, loads a validated plugin bundle, exports gen_ai
 OTel spans to the collector, and rehydrates from a history ref on start.
 """
 
-from .adapter import ClaudeAgentSession, ModelSession, build_options
+from .adapter import ClaudeAgentSession, ModelSession, build_options, map_sdk_message
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .config import RunnerConfig
 from .conformance import conformance_producer
+from .events import AssistantText, RateLimit, ToolCall, TurnEvent, TurnResult
 from .fake import FakeModelSession
 from .otel import RunTracer, build_tracer_provider
 from .plugin import PluginBundleError, load_plugins
@@ -25,7 +26,13 @@ __version__ = "0.0.0"
 __all__ = [
     "ModelSession",
     "ClaudeAgentSession",
+    "map_sdk_message",
     "build_options",
+    "AssistantText",
+    "ToolCall",
+    "RateLimit",
+    "TurnResult",
+    "TurnEvent",
     "BudgetTracker",
     "BUDGET_CLASSIFICATION",
     "RunnerConfig",

--- a/runner/src/agentos_runner/adapter.py
+++ b/runner/src/agentos_runner/adapter.py
@@ -15,10 +15,23 @@ this boundary and nothing above it is. ``aci-protocol`` is never mocked.
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import AsyncIterator
-from typing import Any, Protocol
+from typing import Protocol
 
-from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, SdkPluginConfig, TaskBudget
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    RateLimitEvent,
+    ResultMessage,
+    SdkPluginConfig,
+    TaskBudget,
+    TextBlock,
+    ToolUseBlock,
+)
+
+from .events import AssistantText, RateLimit, ToolCall, TurnEvent, TurnResult
 
 
 class ModelSession(Protocol):
@@ -32,8 +45,8 @@ class ModelSession(Protocol):
         """Push a user message into the session (initial turn or mid-run steer)."""
         ...
 
-    def receive_turn(self) -> AsyncIterator[Any]:
-        """Yield SDK messages for the current turn, ending at its terminal result."""
+    def receive_turn(self) -> AsyncIterator[TurnEvent]:
+        """Yield TurnEvents for the current turn, ending at its terminal result."""
         ...
 
     async def interrupt(self) -> None:
@@ -43,6 +56,75 @@ class ModelSession(Protocol):
     async def close(self) -> None:
         """Tear down the session."""
         ...
+
+
+def map_sdk_message(message: object) -> list[TurnEvent]:
+    """Map one claude-agent-sdk message to the runner TurnEvents it produces.
+
+    This is the ONE place claude-agent-sdk dataclasses survive in the runner: the
+    SDK boundary maps into the runner-owned ``TurnEvent`` union so everything above
+    it (translate, session) never imports the SDK.
+    """
+
+    if isinstance(message, AssistantMessage):
+        return _map_assistant(message)
+    if isinstance(message, ResultMessage):
+        return [
+            TurnResult(
+                text=message.result or "",
+                is_error=message.is_error,
+                subtype=message.subtype or "",
+                usage=message.usage,
+            )
+        ]
+    if isinstance(message, RateLimitEvent):
+        return [RateLimit(rejected=message.rate_limit_info.status == "rejected")]
+    # UserMessage, SystemMessage, and StreamEvent carry no outbound-visible
+    # content in the v0.1 contract; they are intentionally dropped.
+    return []
+
+
+def _map_assistant(message: AssistantMessage) -> list[TurnEvent]:
+    model = message.model or None
+    events: list[TurnEvent] = []
+
+    # A provider auth rejection arrives as an AssistantMessage.error with (often)
+    # empty content. Prepend it as a leading AssistantText carrier so the error
+    # precedes any text and survives content-less messages (the fast-fail case).
+    if message.error:
+        events.append(AssistantText(text="", model=model, error=message.error))
+
+    for block in message.content:
+        if isinstance(block, TextBlock):
+            if block.text:
+                events.append(AssistantText(text=block.text, model=model))
+        elif isinstance(block, ToolUseBlock):
+            events.append(ToolCall(name=block.name, id=block.id, model=model))
+        # ThinkingBlock and any other block type are dropped: this is where a
+        # reasoning model's thinking is discarded so it never reaches the ACI.
+
+    # Home ``usage`` onto exactly one event so the budget increments once per
+    # source message (session._drive_turn folds usage per event). Home it onto the
+    # LAST mapped event, not the first: session._drive_turn folds usage per event
+    # in order and halts the turn the instant the ceiling trips, so if a source
+    # message's usage exceeds the budget the halt must fire only AFTER every event
+    # that message produced. Homing to the first event would halt right after the
+    # leading text and drop a later side-effecting ToolCall -- and with it the
+    # required ``side_effect_flag`` -- letting a run whose mutating tool already
+    # ran be auto-retried. Homing to the last event preserves the pre-refactor
+    # guarantee that the whole message was translated as one unit before any
+    # same-message budget halt. If the message has no content/error events, a
+    # single carrier event delivers the usage.
+    if message.usage:
+        if events:
+            last = events[-1]
+            # Content events are only ever AssistantText/ToolCall (both carry a
+            # ``usage`` field); the narrowing keeps ``dataclasses.replace`` typed.
+            if isinstance(last, (AssistantText, ToolCall)):
+                events[-1] = dataclasses.replace(last, usage=message.usage)
+        else:
+            events.append(AssistantText(text="", model=model, usage=message.usage))
+    return events
 
 
 def build_options(
@@ -97,8 +179,10 @@ class ClaudeAgentSession:
     async def query(self, text: str) -> None:
         await self._client.query(text)
 
-    def receive_turn(self) -> AsyncIterator[Any]:
-        return self._client.receive_response()
+    async def receive_turn(self) -> AsyncIterator[TurnEvent]:
+        async for message in self._client.receive_response():
+            for event in map_sdk_message(message):
+                yield event
 
     async def interrupt(self) -> None:
         await self._client.interrupt()

--- a/runner/src/agentos_runner/events.py
+++ b/runner/src/agentos_runner/events.py
@@ -1,0 +1,64 @@
+"""The runner-owned TurnEvent union: the vocabulary the runner core consumes.
+
+``translate.py`` and ``session.py`` pattern-match on these frozen dataclasses
+instead of the claude-agent-sdk message types, so the runner core never imports
+``claude_agent_sdk``. Producers map onto this union at their own seam: the SDK
+adapter (``adapter.map_sdk_message``), the fake session, and the OpenCode synth.
+
+``usage`` stays a plain ``Mapping[str, int] | None`` -- the same dict shape the
+SDK and OpenCode already produce -- so ``budget.py`` and ``otel.py`` consume it
+unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AssistantText:
+    """A chunk of assistant answer text, plus optional turn metadata.
+
+    ``model`` backfills the OTel generation model (first non-empty wins, idempotent);
+    ``usage`` is the source message's output-token report, folded into the budget
+    exactly once per source message (homed to one event by the adapter);
+    ``error`` is a provider/assistant-level error code (e.g. ``authentication_failed``
+    or a hard rate limit) surfaced WITHOUT terminating the turn.
+    """
+
+    text: str = ""
+    model: str | None = None
+    usage: Mapping[str, int] | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """A tool invocation the assistant requested this turn."""
+
+    name: str
+    # Carried for a future history/resume consumer; no runtime reader yet.
+    id: str = ""
+    model: str | None = None
+    usage: Mapping[str, int] | None = None
+
+
+@dataclass(frozen=True)
+class RateLimit:
+    """A provider rate-limit signal; only a hard rejection is an ACI error."""
+
+    rejected: bool = False
+
+
+@dataclass(frozen=True)
+class TurnResult:
+    """The terminal result of a turn (authoritative text + usage)."""
+
+    text: str = ""
+    is_error: bool = False
+    subtype: str = ""
+    usage: Mapping[str, int] | None = None
+
+
+TurnEvent = AssistantText | ToolCall | RateLimit | TurnResult

--- a/runner/src/agentos_runner/fake.py
+++ b/runner/src/agentos_runner/fake.py
@@ -1,58 +1,36 @@
 """A scripted ModelSession for tests and the conformance suite.
 
-The fake is the mock at the adapter seam: it constructs real claude-agent-sdk
-message dataclasses with canned content, so everything above it (translation,
-budget, side-effect flagging, status, NDJSON, the HTTP layer) runs unmodified and
-un-mocked while the model (the only external dependency) is replaced. It never
-spawns the CLI or touches the network. ``aci-protocol`` is never mocked.
+The fake is the mock at the adapter seam: it emits runner ``TurnEvent``s with
+canned content, so everything above it (translation, budget, side-effect
+flagging, status, NDJSON, the HTTP layer) runs unmodified and un-mocked while the
+model (the only external dependency) is replaced. It never spawns the CLI or
+touches the network. ``aci-protocol`` is never mocked.
 """
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Callable
-from typing import Any
 
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
-
-
-def _assistant(*blocks: Any, usage: dict[str, Any] | None = None) -> AssistantMessage:
-    return AssistantMessage(content=list(blocks), model="fake-model", usage=usage)
+from .events import AssistantText, ToolCall, TurnEvent, TurnResult
 
 
-def _result(
-    *,
-    text: str = "",
-    is_error: bool = False,
-    subtype: str = "success",
-    usage: dict[str, Any] | None = None,
-) -> ResultMessage:
-    return ResultMessage(
-        subtype=subtype,
-        duration_ms=1,
-        duration_api_ms=1,
-        is_error=is_error,
-        num_turns=1,
-        session_id="fake-session",
-        result=text,
-        usage=usage,
-    )
-
-
-def default_turn() -> list[Any]:
+def default_turn() -> list[TurnEvent]:
     """A representative successful turn: text, a side-effecting tool, then done."""
 
     return [
-        _assistant(TextBlock(text="Looking into it")),
-        _assistant(ToolUseBlock(id="t1", name="Bash", input={"command": "echo hi"})),
-        _assistant(TextBlock(text="all done"), usage={"input_tokens": 20, "output_tokens": 8}),
-        _result(text="all done", usage={"input_tokens": 20, "output_tokens": 8}),
+        AssistantText(text="Looking into it", model="fake-model"),
+        ToolCall(name="Bash", id="t1", model="fake-model"),
+        AssistantText(
+            text="all done", model="fake-model", usage={"input_tokens": 20, "output_tokens": 8}
+        ),
+        TurnResult(text="all done", usage={"input_tokens": 20, "output_tokens": 8}),
     ]
 
 
 class FakeModelSession:
-    """A ModelSession that replays a fixed script of SDK messages per turn.
+    """A ModelSession that replays a fixed script of TurnEvents per turn.
 
-    ``script_factory`` returns the messages for the next ``receive_turn``, so a
+    ``script_factory`` returns the events for the next ``receive_turn``, so a
     test can vary the script across turns. ``interrupt`` truncates the current
     turn's replay at the next boundary (``truncate_on_interrupt=True``, the
     default), emulating an SDK interrupt that aborts the iterator before a result;
@@ -62,7 +40,7 @@ class FakeModelSession:
 
     def __init__(
         self,
-        script_factory: Callable[[], list[Any]] | None = None,
+        script_factory: Callable[[], list[TurnEvent]] | None = None,
         *,
         truncate_on_interrupt: bool = True,
     ) -> None:
@@ -84,11 +62,11 @@ class FakeModelSession:
         self.interrupts += 1
         self._interrupted = True
 
-    async def receive_turn(self) -> AsyncIterator[Any]:
-        for message in self._script_factory():
+    async def receive_turn(self) -> AsyncIterator[TurnEvent]:
+        for event in self._script_factory():
             if self._interrupted and self._truncate_on_interrupt:
                 return
-            yield message
+            yield event
 
     async def close(self) -> None:
         self.connected = False

--- a/runner/src/agentos_runner/opencode/synth.py
+++ b/runner/src/agentos_runner/opencode/synth.py
@@ -1,22 +1,21 @@
-"""Synthesize claude-agent-sdk messages from a live OpenCode `/event` stream.
+"""Synthesize runner TurnEvents from a live OpenCode `/event` stream.
 
 This is the load-bearing shim for the OpenCode second harness (issue #25). The
 runner core (``translate.py``, ``session.py``, ``otel.py``, the HTTP server, and
-``packages/aci-protocol``) pattern-matches on claude-agent-sdk dataclasses
-(``AssistantMessage`` / ``ResultMessage`` / ``TextBlock`` / ``ToolUseBlock``).
-Rather than teach that core a second message vocabulary, this module re-emits
-OpenCode's wire frames as those same dataclasses, so the whole runner runs
-byte-for-byte unmodified against an OpenCode backend.
+``packages/aci-protocol``) pattern-matches on the runner-owned ``TurnEvent`` union
+(``AssistantText`` / ``ToolCall`` / ``TurnResult``). This module re-emits
+OpenCode's wire frames as those TurnEvents, so the whole runner runs unmodified
+against an OpenCode backend.
 
 The mapping direction is:
 
-    OpenCode /event frame  ->  claude-agent-sdk message  ->  (unchanged)
+    OpenCode /event frame  ->  runner TurnEvent  ->  (unchanged)
     translate.py  ->  ACI outbound event  ->  NDJSON
 
 Unlike the offline spike (which collected a whole scripted turn then synthesized
 it in one shot), a live turn arrives incrementally over Server-Sent Events, so
 ``TurnSynthesizer`` is a *stateful, incremental* mapper: feed it one frame at a
-time and it returns the SDK messages to yield now, marking ``done`` at the turn
+time and it returns the TurnEvents to yield now, marking ``done`` at the turn
 boundary. The relevant OpenCode v1 frames (verified against ``opencode`` v1.17.17
 ``GET /doc`` and a captured live turn) are:
 
@@ -34,7 +33,7 @@ boundary. The relevant OpenCode v1 frames (verified against ``opencode`` v1.17.1
 - ``message.updated {info}`` -- assistant message info carrying ``modelID`` and
   rolled-up ``tokens``.
 - ``session.status {status:{type}}`` -- a ``busy`` -> ``idle`` transition marks
-  turn completion (the terminal ``ResultMessage``). ``session.idle`` is the
+  turn completion (the terminal ``TurnResult``). ``session.idle`` is the
   deprecated equivalent and is handled the same way.
 - ``session.error {error}`` -- a hard failure, mapped to an error result.
 """
@@ -43,7 +42,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+from ..events import AssistantText, ToolCall, TurnResult
 
 
 def _tokens(tok: Any) -> dict[str, int] | None:
@@ -72,15 +71,11 @@ def _error_message(err: Any) -> str:
 
 def _result(
     *, text: str, is_error: bool, usage: dict[str, int] | None
-) -> ResultMessage:
-    return ResultMessage(
-        subtype="error" if is_error else "success",
-        duration_ms=1,
-        duration_api_ms=1,
+) -> TurnResult:
+    return TurnResult(
+        text=text,
         is_error=is_error,
-        num_turns=1,
-        session_id="opencode-session",
-        result=text,
+        subtype="error" if is_error else "success",
         usage=usage,
     )
 
@@ -111,7 +106,7 @@ class TurnSynthesizer:
         # part's first delta, verified on the live wire) supplies the real type.
         self._part_types: dict[str, str] = {}
 
-    def _terminal(self) -> ResultMessage:
+    def _terminal(self) -> TurnResult:
         if self._error is not None:
             return _result(text=self._error, is_error=True, usage=self._usage)
         return _result(text=self._final_text, is_error=False, usage=self._usage)
@@ -138,9 +133,7 @@ class TurnSynthesizer:
             # drops the chunk rather than leaking an untyped channel.
             if chunk and self._part_types.get(str(props.get("partID"))) == "text":
                 self._final_text += chunk
-                out.append(
-                    AssistantMessage(content=[TextBlock(text=chunk)], model=self._model_id or "")
-                )
+                out.append(AssistantText(text=chunk, model=self._model_id or ""))
 
         elif ftype == "message.part.updated":
             part = props.get("part", {})
@@ -157,14 +150,9 @@ class TurnSynthesizer:
                     if status == "running":
                         self._seen_activity = True
                         out.append(
-                            AssistantMessage(
-                                content=[
-                                    ToolUseBlock(
-                                        id=str(part.get("callID") or part.get("id") or "call"),
-                                        name=str(part.get("tool") or "unknown"),
-                                        input=state.get("input") or {},
-                                    )
-                                ],
+                            ToolCall(
+                                name=str(part.get("tool") or "unknown"),
+                                id=str(part.get("callID") or part.get("id") or "call"),
                                 model=self._model_id or "",
                             )
                         )

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -34,26 +34,26 @@ from aci_protocol import (
     ToolNote,
     to_ndjson_line,
 )
-from claude_agent_sdk import AssistantMessage, ResultMessage
 
 from .adapter import ModelSession
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
+from .events import AssistantText, TurnResult
 from .otel import RunTracer, _GenerationSpan
 from .side_effects import SideEffectClassifier
-from .translate import TurnState, translate_message
+from .translate import TurnState, translate_event
 
 logger = logging.getLogger(__name__)
 
 SessionFactory = Callable[[], ModelSession]
 
 # The SDK surfaces a provider auth rejection (HTTP 401/403 -- e.g. a placeholder,
-# revoked, or wrong model key) as an ``AssistantMessage.error`` of this code
-# (see ``claude_agent_sdk.types.AssistantMessageError``). Unlike a 5xx or a rate
-# limit, a rejected credential is terminal and NON-retryable: retrying it only
-# burns wall time (the SDK/CLI otherwise backs off and re-attempts until a ~2min
-# timeout, surfacing as a generic hang). The runner fails the turn fast on this
-# signal instead of streaming a non-terminal error and continuing to drive the
-# session.
+# revoked, or wrong model key) as an ``AssistantMessage.error``, which the adapter
+# maps to an ``AssistantText.error`` of this code (see
+# ``claude_agent_sdk.types.AssistantMessageError``). Unlike a 5xx or a rate limit,
+# a rejected credential is terminal and NON-retryable: retrying it only burns wall
+# time (the SDK/CLI otherwise backs off and re-attempts until a ~2min timeout,
+# surfacing as a generic hang). The runner fails the turn fast on this signal
+# instead of streaming a non-terminal error and continuing to drive the session.
 _AUTH_REJECTION_SDK_CODE = "authentication_failed"
 
 # Classification carried on the fast-fail error event so consumers (F1's retry
@@ -62,13 +62,10 @@ _AUTH_REJECTION_SDK_CODE = "authentication_failed"
 AUTH_REJECTED_CLASSIFICATION = "model-credential-rejected"
 
 
-def _is_auth_rejection(message: object) -> bool:
-    """True when an SDK message reports a provider credential rejection (401/403)."""
+def _is_auth_rejection(event: object) -> bool:
+    """True when a TurnEvent reports a provider credential rejection (401/403)."""
 
-    return (
-        isinstance(message, AssistantMessage)
-        and getattr(message, "error", None) == _AUTH_REJECTION_SDK_CODE
-    )
+    return isinstance(event, AssistantText) and event.error == _AUTH_REJECTION_SDK_CODE
 
 
 class SessionRunner:
@@ -238,8 +235,8 @@ class SessionRunner:
 
         assert self._session is not None
         await self._session.query(event.text)
-        async for message in self._session.receive_turn():
-            if _is_auth_rejection(message):
+        async for turn_event in self._session.receive_turn():
+            if _is_auth_rejection(turn_event):
                 # A rejected model credential is terminal: stop the live session
                 # so the SDK/CLI does not keep retrying with backoff to the wall,
                 # then surface a distinct, immediate classified failure. Suppress
@@ -252,16 +249,16 @@ class SessionRunner:
                 for line in self._auth_halt_lines():
                     yield line
                 return
-            usage = getattr(message, "usage", None)
+            usage = getattr(turn_event, "usage", None)
             # The terminal result carries the authoritative turn total; streaming
-            # assistant messages carry per-message output. Fold them differently
-            # so the same tokens are not counted twice (see BudgetTracker).
-            if isinstance(message, ResultMessage):
+            # assistant events carry per-event output. Fold them differently so
+            # the same tokens are not counted twice (see BudgetTracker).
+            if isinstance(turn_event, TurnResult):
                 tracker.set_total(usage)
             else:
                 tracker.add_increment(usage)
             budget_hit = tracker.exceeded
-            events = translate_message(message, state, self._classifier, gen)
+            events = translate_event(turn_event, state, self._classifier, gen)
 
             for outbound in events:
                 if isinstance(outbound, ToolNote):

--- a/runner/src/agentos_runner/translate.py
+++ b/runner/src/agentos_runner/translate.py
@@ -1,11 +1,11 @@
-"""Translate claude-agent-sdk messages into ACI outbound events.
+"""Translate runner TurnEvents into ACI outbound events.
 
-This is the pure mapping at the heart of the runner: it turns each SDK message
-(assistant text, tool calls, terminal result, rate-limit signal) into zero or
-more ACI outbound events (text_delta / tool_note / side_effect_flag / error /
-final). It is stateful only through ``TurnState`` (side-effect dedup, carried
-error classification) and side-effect free otherwise, so it is unit-testable
-without a session, a network, or the HTTP layer.
+This is the pure mapping at the heart of the runner: it turns each runner
+``TurnEvent`` (assistant text, tool calls, terminal result, rate-limit signal)
+into zero or more ACI outbound events (text_delta / tool_note / side_effect_flag
+/ error / final). It is stateful only through ``TurnState`` (side-effect dedup,
+carried error classification) and side-effect free otherwise, so it is
+unit-testable without a session, a network, or the HTTP layer.
 
 Budget and interrupt outcomes are *not* decided here: this layer reports the
 model's own terminal status (done vs classified-failure), and the session applies
@@ -26,14 +26,8 @@ from aci_protocol import (
     TextDelta,
     ToolNote,
 )
-from claude_agent_sdk import (
-    AssistantMessage,
-    RateLimitEvent,
-    ResultMessage,
-    TextBlock,
-    ToolUseBlock,
-)
 
+from .events import AssistantText, RateLimit, ToolCall, TurnResult
 from .otel import _GenerationSpan
 from .side_effects import SideEffectClassifier
 
@@ -45,96 +39,103 @@ class TurnState:
     side_effect_emitted: bool = False
     error_classification: str | None = None
     # Assistant text streamed during the turn, accumulated so a DONE result with
-    # an empty ``result`` can still deliver the model's answer. Reasoning models
-    # routed through OpenRouter (e.g. z-ai/glm-5.2) emit the answer as a TextBlock
-    # but their empty-signature thinking block trips the SDK's result extraction,
-    # leaving ``ResultMessage.result`` empty (issue #107).
+    # an empty ``text`` can still deliver the model's answer. Reasoning models
+    # routed through OpenRouter (e.g. z-ai/glm-5.2) emit the answer as an
+    # AssistantText but their empty-signature thinking block trips the SDK's
+    # result extraction, leaving the terminal TurnResult text empty (issue #107).
     assistant_text: str = ""
 
 
-def translate_message(
-    message: object,
+def translate_event(
+    event: object,
     state: TurnState,
     classifier: SideEffectClassifier,
     gen: _GenerationSpan | None,
 ) -> list[OutboundEvent]:
-    """Map one SDK message to the ACI outbound events it produces."""
+    """Map one runner TurnEvent to the ACI outbound events it produces."""
 
-    if isinstance(message, AssistantMessage):
-        return _translate_assistant(message, state, classifier, gen)
-    if isinstance(message, ResultMessage):
-        return _translate_result(message, state, gen)
-    if isinstance(message, RateLimitEvent):
-        # status is one of allowed / allowed_warning / rejected; only a hard
-        # rejection is an ACI error. The warning states are advisory (the model
-        # is still allowed to continue) and must not inject a failure event into
-        # an otherwise-successful run.
-        if message.rate_limit_info.status == "rejected":
+    if isinstance(event, AssistantText):
+        return _translate_assistant_text(event, state, gen)
+    if isinstance(event, ToolCall):
+        return _translate_tool_call(event, state, classifier, gen)
+    if isinstance(event, RateLimit):
+        # Only a hard rejection is an ACI error. A non-rejecting rate-limit signal
+        # is advisory (the model is still allowed to continue) and must not inject
+        # a failure event into an otherwise-successful run.
+        if event.rejected:
             state.error_classification = "rate-limit"
             return [ErrorEvent(message="model rate limit reached", classification="rate-limit")]
         return []
-    # UserMessage, SystemMessage, and StreamEvent carry no outbound-visible
-    # content in the v0.1 contract; they are intentionally dropped.
+    if isinstance(event, TurnResult):
+        return _translate_result(event, state, gen)
     return []
 
 
-def _translate_assistant(
-    message: AssistantMessage,
+def _translate_assistant_text(
+    event: AssistantText,
+    state: TurnState,
+    gen: _GenerationSpan | None,
+) -> list[OutboundEvent]:
+    events: list[OutboundEvent] = []
+
+    # Backfill the generation model from the event's own report when AGENTOS_MODEL
+    # was unset at span open (record_model no-ops once a model is already stamped).
+    if gen is not None:
+        gen.record_model(event.model)
+
+    if event.error:
+        state.error_classification = event.error
+        events.append(
+            ErrorEvent(message=f"model error: {event.error}", classification=event.error)
+        )
+
+    if event.text:
+        state.assistant_text += event.text
+        events.append(TextDelta(text=event.text))
+    return events
+
+
+def _translate_tool_call(
+    event: ToolCall,
     state: TurnState,
     classifier: SideEffectClassifier,
     gen: _GenerationSpan | None,
 ) -> list[OutboundEvent]:
     events: list[OutboundEvent] = []
 
-    # Backfill the generation model from the SDK's own report when AGENTOS_MODEL
-    # was unset at span open (record_model no-ops once a model is already stamped).
     if gen is not None:
-        gen.record_model(getattr(message, "model", None))
+        gen.record_model(event.model)
 
-    error = getattr(message, "error", None)
-    if error:
-        state.error_classification = error
-        events.append(ErrorEvent(message=f"model error: {error}", classification=error))
-
-    for block in message.content:
-        if isinstance(block, TextBlock):
-            if block.text:
-                state.assistant_text += block.text
-                events.append(TextDelta(text=block.text))
-        elif isinstance(block, ToolUseBlock):
-            events.append(ToolNote(text=f"running tool {block.name}", tool=block.name))
-            if gen is not None:
-                gen.tool_span(block.name)
-            if classifier.is_side_effecting(block.name) and not state.side_effect_emitted:
-                events.append(
-                    SideEffectFlag(tool=block.name, detail="non-idempotent tool executed")
-                )
-                state.side_effect_emitted = True
+    events.append(ToolNote(text=f"running tool {event.name}", tool=event.name))
+    if gen is not None:
+        gen.tool_span(event.name)
+    if classifier.is_side_effecting(event.name) and not state.side_effect_emitted:
+        events.append(SideEffectFlag(tool=event.name, detail="non-idempotent tool executed"))
+        state.side_effect_emitted = True
     return events
 
 
 def _translate_result(
-    message: ResultMessage,
+    event: TurnResult,
     state: TurnState,
     gen: _GenerationSpan | None,
 ) -> list[OutboundEvent]:
     if gen is not None:
-        gen.record_usage(message.usage)
+        gen.record_usage(event.usage)
 
-    subtype = message.subtype or ""
-    if message.is_error or subtype.startswith("error"):
-        text = message.result or "run failed"
+    if event.is_error or event.subtype.startswith("error"):
+        text = event.text or "run failed"
         events: list[OutboundEvent] = []
         if state.error_classification is None:
             events.append(
-                ErrorEvent(message=text, classification=subtype or "server-error")
+                ErrorEvent(message=text, classification=event.subtype or "server-error")
             )
         events.append(Final(text=text, status=SessionStatus.CLASSIFIED_FAILURE))
         return events
 
-    # The SDK's ``result`` is authoritative when present. When it is empty on an
+    # The result's ``text`` is authoritative when present. When it is empty on an
     # otherwise-successful turn, fall back to the assistant text streamed this turn
     # so a reasoning model whose result-extraction returned empty (issue #107)
-    # still delivers its answer. Provider-agnostic: it only fires when result is
+    # still delivers its answer. Provider-agnostic: it only fires when text is
     # empty, so non-reasoning models and the fake-model path are unaffected.
-    return [Final(text=message.result or state.assistant_text, status=SessionStatus.DONE)]
+    return [Final(text=event.text or state.assistant_text, status=SessionStatus.DONE)]

--- a/runner/tests/test_adapter.py
+++ b/runner/tests/test_adapter.py
@@ -1,0 +1,173 @@
+"""map_sdk_message: the claude-agent-sdk -> TurnEvent adapter seam.
+
+This is the ONE place claude-agent-sdk dataclasses survive in the runner. Every
+assertion here pins the shape ``map_sdk_message`` produces so ``translate.py`` and
+``session.py`` can consume the runner-owned ``TurnEvent`` union and never import
+the SDK. Importing the SDK types in this file is therefore correct -- it is the
+adapter's own contract under test.
+"""
+
+from agentos_runner.adapter import map_sdk_message
+from agentos_runner.events import AssistantText, RateLimit, ToolCall, TurnResult
+from claude_agent_sdk import (
+    AssistantMessage,
+    RateLimitEvent,
+    ResultMessage,
+    TextBlock,
+    ThinkingBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+from claude_agent_sdk.types import RateLimitInfo
+
+
+def _result(
+    *,
+    subtype: str = "success",
+    is_error: bool = False,
+    result: str = "",
+    usage: dict | None = None,
+) -> ResultMessage:
+    return ResultMessage(
+        subtype=subtype,
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=is_error,
+        num_turns=1,
+        session_id="s",
+        result=result,
+        usage=usage,
+    )
+
+
+def test_text_block_maps_to_assistant_text() -> None:
+    events = map_sdk_message(AssistantMessage(content=[TextBlock(text="hi")], model="m"))
+    assert events == [AssistantText(text="hi", model="m")]
+
+
+def test_tool_use_blocks_map_to_tool_calls_in_order() -> None:
+    events = map_sdk_message(
+        AssistantMessage(
+            content=[
+                ToolUseBlock(id="1", name="Bash", input={}),
+                ToolUseBlock(id="2", name="Write", input={}),
+            ],
+            model="m",
+        )
+    )
+    assert all(isinstance(e, ToolCall) for e in events)
+    assert [(e.name, e.id, e.model) for e in events] == [
+        ("Bash", "1", "m"),
+        ("Write", "2", "m"),
+    ]
+
+
+def test_empty_content_error_survives_as_leading_carrier() -> None:
+    # A provider auth rejection arrives as an AssistantMessage.error with EMPTY
+    # content. The error must survive as a leading AssistantText carrier so the
+    # session's fast-fail sees it (the auth-rejection case).
+    events = map_sdk_message(
+        AssistantMessage(content=[], model="m", error="authentication_failed")
+    )
+    assert events == [AssistantText(text="", error="authentication_failed", model="m")]
+
+
+def test_error_prepended_before_content() -> None:
+    # When a message carries BOTH an error and non-empty text, the error must be
+    # emitted as a leading empty-text carrier BEFORE the text event, so the
+    # downstream ACI stream surfaces the error before the text delta. Ordering is
+    # load-bearing: a consumer fast-failing on the error must see it first.
+    events = map_sdk_message(
+        AssistantMessage(content=[TextBlock(text="hi")], model="m", error="rate_limit")
+    )
+    assert events == [
+        AssistantText(text="", model="m", error="rate_limit"),
+        AssistantText(text="hi", model="m"),
+    ]
+
+
+def test_usage_homed_to_exactly_one_event_no_double_count() -> None:
+    # Load-bearing correctness property: a single source AssistantMessage carrying
+    # usage must fold that usage into the budget exactly once, so the adapter homes
+    # it onto exactly one event. If every mapped event carried the usage, the
+    # budget would double-count (8 + 8 = 16) and could trip the ceiling early.
+    events = map_sdk_message(
+        AssistantMessage(
+            content=[TextBlock(text="a"), ToolUseBlock(id="1", name="Read", input={})],
+            model="m",
+            usage={"output_tokens": 8},
+        )
+    )
+    total = sum((e.usage or {}).get("output_tokens", 0) for e in events)
+    assert total == 8
+
+
+def test_usage_homed_to_last_event() -> None:
+    # Usage homes onto the LAST mapped event, not the first. session._drive_turn
+    # folds usage per event in order and halts the turn the instant the ceiling
+    # trips; homing to the last event guarantees a same-message budget halt fires
+    # only AFTER a later side-effecting ToolCall (and its required side_effect_flag)
+    # has been emitted, preserving the no-retry-after-side-effects guarantee. Bash
+    # is side-effecting, so the last event here is the ToolCall.
+    events = map_sdk_message(
+        AssistantMessage(
+            content=[TextBlock(text="a"), ToolUseBlock(id="1", name="Bash", input={})],
+            model="m",
+            usage={"output_tokens": 8},
+        )
+    )
+    assert events[-1].usage == {"output_tokens": 8}
+    assert events[0].usage is None
+
+
+def test_reasoning_block_dropped() -> None:
+    # ThinkingBlock content is dropped at the adapter so a reasoning model's
+    # thinking never reaches the ACI (mirrors how the answer-only channel works).
+    events = map_sdk_message(
+        AssistantMessage(
+            content=[
+                TextBlock(text="answer"),
+                ThinkingBlock(thinking="secret plan", signature=""),
+            ],
+            model="m",
+        )
+    )
+    assert events == [AssistantText(text="answer", model="m")]
+    assert all("secret plan" not in getattr(e, "text", "") for e in events)
+
+
+def test_result_success_maps_to_turn_result() -> None:
+    events = map_sdk_message(_result(result="done", usage={"output_tokens": 5}))
+    assert events == [
+        TurnResult(text="done", is_error=False, subtype="success", usage={"output_tokens": 5})
+    ]
+
+
+def test_result_error_carries_subtype_and_is_error() -> None:
+    events = map_sdk_message(
+        _result(subtype="error_during_execution", is_error=True, result="boom")
+    )
+    assert len(events) == 1
+    result = events[0]
+    assert isinstance(result, TurnResult)
+    assert result.is_error is True
+    assert result.subtype == "error_during_execution"
+    assert result.text == "boom"
+
+
+def test_rate_limit_rejected_maps_to_rate_limit_event() -> None:
+    events = map_sdk_message(
+        RateLimitEvent(rate_limit_info=RateLimitInfo(status="rejected"), uuid="u", session_id="s")
+    )
+    assert events == [RateLimit(rejected=True)]
+
+
+def test_rate_limit_allowed_maps_to_non_rejected() -> None:
+    events = map_sdk_message(
+        RateLimitEvent(rate_limit_info=RateLimitInfo(status="allowed"), uuid="u", session_id="s")
+    )
+    assert events == [RateLimit(rejected=False)]
+
+
+def test_user_message_maps_to_nothing() -> None:
+    assert map_sdk_message(UserMessage(content="hello")) == []

--- a/runner/tests/test_budget.py
+++ b/runner/tests/test_budget.py
@@ -4,9 +4,9 @@ import anyio
 from aci_protocol import Event, SessionStatus, parse_ndjson
 from agentos_runner import BudgetTracker, RunTracer, SideEffectClassifier
 from agentos_runner.budget import BUDGET_CLASSIFICATION
+from agentos_runner.events import AssistantText, ToolCall, TurnResult
 from agentos_runner.fake import FakeModelSession
 from agentos_runner.session import SessionRunner
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
 
 def test_tracker_sums_per_message_output() -> None:
@@ -78,15 +78,8 @@ def _runner(script, ceiling: int) -> tuple[SessionRunner, FakeModelSession]:
 
 def test_budget_halt_on_assistant_usage() -> None:
     script = [
-        AssistantMessage(
-            content=[TextBlock(text="thinking hard")],
-            model="fake",
-            usage={"output_tokens": 500},
-        ),
-        ResultMessage(
-            subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
-            num_turns=1, session_id="s", result="done", usage={"output_tokens": 500},
-        ),
+        AssistantText(text="thinking hard", model="fake", usage={"output_tokens": 500}),
+        TurnResult(text="done", usage={"output_tokens": 500}),
     ]
     runner, fake = _runner(script, ceiling=10)
     events = _run(runner, _event())
@@ -102,11 +95,8 @@ def test_budget_halt_on_assistant_usage() -> None:
 
 def test_budget_halt_when_usage_only_on_result() -> None:
     script = [
-        AssistantMessage(content=[TextBlock(text="quick")], model="fake"),
-        ResultMessage(
-            subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
-            num_turns=1, session_id="s", result="done", usage={"output_tokens": 999},
-        ),
+        AssistantText(text="quick", model="fake"),
+        TurnResult(text="done", usage={"output_tokens": 999}),
     ]
     runner, _ = _runner(script, ceiling=10)
     events = _run(runner, _event())
@@ -118,17 +108,40 @@ def test_budget_halt_when_usage_only_on_result() -> None:
     assert any(e.type == "error" and e.classification == BUDGET_CLASSIFICATION for e in events)
 
 
+def test_side_effect_flag_survives_budget_halt() -> None:
+    # A side-effecting ToolCall whose usage trips the ceiling must still emit its
+    # side_effect_flag BEFORE the budget halt, so the worker's
+    # no-retry-after-side-effects rule sees that a mutating tool already ran. This
+    # is the exact TurnEvent sequence the fixed adapter homes usage-to-last onto:
+    # the text event carries no usage, the ToolCall carries the budget-tripping
+    # usage, so the halt fires only after the ToolCall has been translated.
+    script = [
+        AssistantText(text="a", model="m"),
+        ToolCall(name="Bash", id="1", model="m", usage={"output_tokens": 500}),
+        TurnResult(text="done", usage={"output_tokens": 500}),
+    ]
+    runner, _ = _runner(script, ceiling=10)
+    events = _run(runner, _event())
+
+    types = [e.type for e in events]
+    assert "side_effect_flag" in types
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.CLASSIFIED_FAILURE
+    # The side_effect_flag is emitted before the terminal final -- the tool's
+    # mutation is visible to the retry rules ahead of the halt.
+    assert types.index("side_effect_flag") < types.index("final")
+    assert any(
+        e.type == "error" and e.classification == BUDGET_CLASSIFICATION for e in events
+    )
+
+
 def test_no_false_halt_from_terminal_double_report() -> None:
     # Same 80 tokens reported on the assistant message and the terminal result
     # must not sum to 160 and trip a 100 ceiling.
     script = [
-        AssistantMessage(
-            content=[TextBlock(text="hi")], model="fake", usage={"output_tokens": 80}
-        ),
-        ResultMessage(
-            subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
-            num_turns=1, session_id="s", result="hi", usage={"output_tokens": 80},
-        ),
+        AssistantText(text="hi", model="fake", usage={"output_tokens": 80}),
+        TurnResult(text="hi", usage={"output_tokens": 80}),
     ]
     runner, _ = _runner(script, ceiling=100)
     events = _run(runner, _event())
@@ -138,11 +151,8 @@ def test_no_false_halt_from_terminal_double_report() -> None:
 
 def test_under_budget_completes_done() -> None:
     script = [
-        AssistantMessage(content=[TextBlock(text="hello")], model="fake"),
-        ResultMessage(
-            subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
-            num_turns=1, session_id="s", result="hello", usage={"output_tokens": 5},
-        ),
+        AssistantText(text="hello", model="fake"),
+        TurnResult(text="hello", usage={"output_tokens": 5}),
     ]
     runner, _ = _runner(script, ceiling=1000)
     events = _run(runner, _event())

--- a/runner/tests/test_opencode_synth.py
+++ b/runner/tests/test_opencode_synth.py
@@ -1,9 +1,9 @@
 """Offline regression for the OpenCode harness shim (issue #25).
 
-These tests exercise the OpenCode-frame -> SDK-message synthesis and drive it
+These tests exercise the OpenCode-frame -> TurnEvent synthesis and drive it
 through the *real* runner core (translate + session + conformance) with zero
 network: scripted ``/event`` frames stand in for a live SSE stream, the same way
-``fake.py`` scripts SDK messages. They pin the mapping (text deltas, tool calls,
+``fake.py`` scripts TurnEvents. They pin the mapping (text deltas, tool calls,
 usage, terminal result, the ignored text-part bookends, the busy->idle gate) and
 prove a scripted OpenCode turn passes the frozen ACI conformance suite.
 
@@ -19,11 +19,11 @@ from typing import Any
 
 import anyio
 from aci_protocol import Event, Interrupt, parse_ndjson, run_conformance
+from agentos_runner.events import AssistantText, ToolCall, TurnResult
 from agentos_runner.opencode.synth import TurnSynthesizer
 from agentos_runner.otel import RunTracer
 from agentos_runner.session import SessionRunner
 from agentos_runner.side_effects import SideEffectClassifier
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
 
 SID = "ses_test"
 MSG = "msg_1"
@@ -279,32 +279,21 @@ def test_synth_maps_text_tool_and_terminal_result() -> None:
     messages, synth = _run_synth(default_turn_frames())
     assert synth.done
 
-    texts = [
-        b.text
-        for m in messages
-        if isinstance(m, AssistantMessage)
-        for b in m.content
-        if isinstance(b, TextBlock)
-    ]
+    texts = [m.text for m in messages if isinstance(m, AssistantText)]
     assert texts == ["Looking into it", " all done"], texts
 
-    tools = [
-        b
-        for m in messages
-        if isinstance(m, AssistantMessage)
-        for b in m.content
-        if isinstance(b, ToolUseBlock)
-    ]
+    tools = [m for m in messages if isinstance(m, ToolCall)]
     assert len(tools) == 1
+    # ToolCall in the union carries the tool name and id (what the runner uses to
+    # note and side-effect-flag the call); the raw tool input is not part of it.
     assert tools[0].name == "Bash"
     assert tools[0].id == "call_1"
-    assert tools[0].input == {"command": "echo hi"}
 
-    results = [m for m in messages if isinstance(m, ResultMessage)]
+    results = [m for m in messages if isinstance(m, TurnResult)]
     assert len(results) == 1
     result = results[0]
     assert result.is_error is False
-    assert result.result == "Looking into it all done"
+    assert result.text == "Looking into it all done"
     assert result.usage == {"input_tokens": 20, "output_tokens": 8}
 
 
@@ -319,7 +308,7 @@ def test_synth_carries_model_onto_streamed_messages() -> None:
         idle(),
     ]
     messages, _ = _run_synth(frames)
-    text_msgs = [m for m in messages if isinstance(m, AssistantMessage) and m.content]
+    text_msgs = [m for m in messages if isinstance(m, AssistantText) and m.text]
     assert text_msgs and text_msgs[0].model == "z-ai/glm-4.6"
 
 
@@ -328,13 +317,7 @@ def test_synth_ignores_bookends_and_bus_noise() -> None:
     frames = [busy(), *NOISE, text_part_bookend(""), text_delta("one"), *NOISE,
               text_delta(" two"), text_part_bookend("one two"), idle()]
     messages, _ = _run_synth(frames)
-    texts = [
-        b.text
-        for m in messages
-        if isinstance(m, AssistantMessage)
-        for b in m.content
-        if isinstance(b, TextBlock)
-    ]
+    texts = [m.text for m in messages if isinstance(m, AssistantText)]
     assert texts == ["one", " two"], texts
 
 
@@ -342,26 +325,20 @@ def test_synth_session_error_yields_error_result() -> None:
     frames = [busy(), text_delta("partial"), session_error("provider exploded")]
     messages, synth = _run_synth(frames)
     assert synth.done
-    results = [m for m in messages if isinstance(m, ResultMessage)]
+    results = [m for m in messages if isinstance(m, TurnResult)]
     assert len(results) == 1
     assert results[0].is_error is True
-    assert results[0].result == "provider exploded"
+    assert results[0].text == "provider exploded"
 
 
 def test_synth_drops_reasoning_deltas_keeps_text() -> None:
     # A delta's field is "text" even for a reasoning part; only the text part's
-    # content (resolved by partID from the snapshots) reaches the SDK messages.
+    # content (resolved by partID from the snapshots) reaches the TurnEvents.
     messages, synth = _run_synth(reasoning_then_text_frames())
-    texts = [
-        b.text
-        for m in messages
-        if isinstance(m, AssistantMessage)
-        for b in m.content
-        if isinstance(b, TextBlock)
-    ]
+    texts = [m.text for m in messages if isinstance(m, AssistantText)]
     assert texts == ["pong"], texts
-    results = [m for m in messages if isinstance(m, ResultMessage)]
-    assert results and results[0].result == "pong"
+    results = [m for m in messages if isinstance(m, TurnResult)]
+    assert results and results[0].text == "pong"
 
 
 def test_synth_pre_turn_idle_does_not_terminate() -> None:
@@ -374,7 +351,7 @@ def test_synth_pre_turn_idle_does_not_terminate() -> None:
     synth.ingest(text_delta("go"))
     out = synth.ingest(idle())
     assert synth.done is True
-    assert any(isinstance(m, ResultMessage) for m in out)
+    assert any(isinstance(m, TurnResult) for m in out)
 
 
 def test_synth_interrupted_iteration_still_has_no_partial_duplicate() -> None:
@@ -383,7 +360,7 @@ def test_synth_interrupted_iteration_still_has_no_partial_duplicate() -> None:
     frames = default_turn_frames()[:-1]  # drop the terminal idle
     messages, synth = _run_synth(frames)
     assert synth.done is False
-    assert not any(isinstance(m, ResultMessage) for m in messages)
+    assert not any(isinstance(m, TurnResult) for m in messages)
 
 
 # --- offline end-to-end through the real runner core ----------------------------

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -5,9 +5,9 @@ import logging
 import anyio
 from aci_protocol import Event, Interrupt, SessionStatus, parse_ndjson
 from agentos_runner import RunTracer, SideEffectClassifier, build_options
+from agentos_runner.events import AssistantText, TurnResult
 from agentos_runner.fake import FakeModelSession, default_turn
 from agentos_runner.session import SessionRunner
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
 
 def _runner(
@@ -99,11 +99,8 @@ def test_interrupt_reclassifies_error_result_to_idle() -> None:
     # result after the interrupt. An intentional stop must read as idle, not a
     # classified failure.
     script = [
-        AssistantMessage(content=[TextBlock(text="working")], model="m"),
-        ResultMessage(
-            subtype="error_during_execution", duration_ms=1, duration_api_ms=1,
-            is_error=True, num_turns=1, session_id="s", result="aborted",
-        ),
+        AssistantText(text="working", model="m"),
+        TurnResult(text="aborted", is_error=True, subtype="error_during_execution"),
     ]
     fake = FakeModelSession(lambda: script, truncate_on_interrupt=False)
     runner = SessionRunner(
@@ -197,12 +194,9 @@ def test_auth_rejection_fails_fast_not_retried(caplog) -> None:
     # did not keep driving the session).
     sentinel = "SHOULD-NOT-APPEAR-AFTER-AUTH-FAIL"
     script = [
-        AssistantMessage(content=[], model="m", error="authentication_failed"),
-        AssistantMessage(content=[TextBlock(text=sentinel)], model="m"),
-        ResultMessage(
-            subtype="success", duration_ms=1, duration_api_ms=1,
-            is_error=False, num_turns=1, session_id="s", result=sentinel,
-        ),
+        AssistantText(text="", model="m", error="authentication_failed"),
+        AssistantText(text=sentinel, model="m"),
+        TurnResult(text=sentinel),
     ]
     runner, fake = _runner(lambda: script)
 
@@ -237,7 +231,7 @@ def test_auth_fast_fail_survives_a_wedged_interrupt(caplog) -> None:
             self.interrupts += 1
             raise RuntimeError("transport wedged")
 
-    script = [AssistantMessage(content=[], model="m", error="authentication_failed")]
+    script = [AssistantText(text="", model="m", error="authentication_failed")]
     fake = WedgedInterruptSession(lambda: script)
     runner = SessionRunner(
         session_factory=lambda: fake,
@@ -265,11 +259,8 @@ def test_transient_model_error_is_not_fast_failed() -> None:
     # credential rejection: it must flow through translation unchanged and reach
     # the model's own terminal result, so genuine retry/backoff is preserved.
     script = [
-        AssistantMessage(content=[], model="m", error="rate_limit"),
-        ResultMessage(
-            subtype="success", duration_ms=1, duration_api_ms=1,
-            is_error=False, num_turns=1, session_id="s", result="recovered",
-        ),
+        AssistantText(text="", model="m", error="rate_limit"),
+        TurnResult(text="recovered"),
     ]
     runner, fake = _runner(lambda: script)
     events = _drain(runner, Event(type="message", text="go", user="U", ts="1"))
@@ -283,21 +274,8 @@ def test_transient_model_error_is_not_fast_failed() -> None:
 
 def test_budget_halt_logged(caplog) -> None:
     script = [
-        AssistantMessage(
-            content=[TextBlock(text="thinking hard")],
-            model="fake",
-            usage={"output_tokens": 500},
-        ),
-        ResultMessage(
-            subtype="success",
-            duration_ms=1,
-            duration_api_ms=1,
-            is_error=False,
-            num_turns=1,
-            session_id="s",
-            result="done",
-            usage={"output_tokens": 500},
-        ),
+        AssistantText(text="thinking hard", model="fake", usage={"output_tokens": 500}),
+        TurnResult(text="done", usage={"output_tokens": 500}),
     ]
     runner, _ = _runner(lambda: script, ceiling=10)
 
@@ -319,11 +297,8 @@ def test_error_result_body_not_logged(caplog) -> None:
     # branch.
     sentinel = "SENTINEL-RESULT-BODY-7c2e"
     script = [
-        AssistantMessage(content=[TextBlock(text="working")], model="m"),
-        ResultMessage(
-            subtype="error_during_execution", duration_ms=1, duration_api_ms=1,
-            is_error=True, num_turns=1, session_id="s", result=sentinel,
-        ),
+        AssistantText(text="working", model="m"),
+        TurnResult(text=sentinel, is_error=True, subtype="error_during_execution"),
     ]
     runner, _ = _runner(lambda: script)
 

--- a/runner/tests/test_translate.py
+++ b/runner/tests/test_translate.py
@@ -1,40 +1,28 @@
-"""SDK-message to ACI-outbound-event translation."""
+"""TurnEvent to ACI-outbound-event translation."""
 
 from aci_protocol import SessionStatus
 from agentos_runner import SideEffectClassifier
-from agentos_runner.translate import TurnState, translate_message
-from claude_agent_sdk import (
-    AssistantMessage,
-    RateLimitEvent,
-    ResultMessage,
-    TextBlock,
-    ThinkingBlock,
-    ToolUseBlock,
-)
-from claude_agent_sdk.types import RateLimitInfo
+from agentos_runner.events import AssistantText, RateLimit, ToolCall, TurnResult
+from agentos_runner.translate import TurnState, translate_event
 
 
-def _translate(message: object, state: TurnState | None = None) -> list:
-    return translate_message(message, state or TurnState(), SideEffectClassifier(), None)
+def _translate(event: object, state: TurnState | None = None) -> list:
+    return translate_event(event, state or TurnState(), SideEffectClassifier(), None)
 
 
 def test_text_block_becomes_text_delta() -> None:
-    msg = AssistantMessage(content=[TextBlock(text="hi there")], model="m")
-    events = _translate(msg)
+    events = _translate(AssistantText(text="hi there"))
     assert [e.type for e in events] == ["text_delta"]
     assert events[0].text == "hi there"
 
 
 def test_tool_use_emits_note_and_side_effect_once() -> None:
+    # Two tool calls share a TurnState across events: the side-effect dedup lives
+    # in the state, so a second side-effecting tool in the same run adds a note
+    # but no second flag.
     state = TurnState()
-    msg = AssistantMessage(
-        content=[
-            ToolUseBlock(id="1", name="Bash", input={}),
-            ToolUseBlock(id="2", name="Write", input={}),
-        ],
-        model="m",
-    )
-    events = _translate(msg, state)
+    events = _translate(ToolCall(name="Bash", id="1"), state)
+    events += _translate(ToolCall(name="Write", id="2"), state)
     types = [e.type for e in events]
     # Two tool notes, but the side-effect flag fires once per run (dedup).
     assert types.count("tool_note") == 2
@@ -43,17 +31,12 @@ def test_tool_use_emits_note_and_side_effect_once() -> None:
 
 
 def test_read_only_tool_notes_without_flag() -> None:
-    msg = AssistantMessage(content=[ToolUseBlock(id="1", name="Read", input={})], model="m")
-    events = _translate(msg)
+    events = _translate(ToolCall(name="Read", id="1"))
     assert [e.type for e in events] == ["tool_note"]
 
 
 def test_result_success_is_final_done() -> None:
-    msg = ResultMessage(
-        subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
-        num_turns=1, session_id="s", result="answer",
-    )
-    events = _translate(msg)
+    events = _translate(TurnResult(text="answer"))
     assert [e.type for e in events] == ["final"]
     assert events[0].status == SessionStatus.DONE
     assert events[0].text == "answer"
@@ -61,70 +44,48 @@ def test_result_success_is_final_done() -> None:
 
 def test_reasoning_model_empty_result_falls_back_to_assistant_text() -> None:
     # A reasoning model routed through OpenRouter (e.g. z-ai/glm-5.2) streams the
-    # answer as a TextBlock but the terminal ResultMessage reports success with an
+    # answer as assistant text but the terminal TurnResult reports success with an
     # EMPTY result (the empty-signature thinking block trips result extraction).
-    # The delivered Final must carry the assistant text, not "".
+    # The delivered Final must carry the accumulated assistant text, not "".
     state = TurnState()
-    assistant = AssistantMessage(
-        content=[
-            TextBlock(text="The sky is blue on a clear day."),
-            ThinkingBlock(thinking="the user asked...", signature=""),
-        ],
-        model="z-ai/glm-5.2",
-    )
-    _translate(assistant, state)  # accumulates text into state
-    result = ResultMessage(
-        subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
-        num_turns=1, session_id="s", result="",
-    )
-    events = _translate(result, state)
+    _translate(AssistantText(text="The sky is blue on a clear day."), state)  # accumulates
+    events = _translate(TurnResult(text=""), state)
     assert [e.type for e in events] == ["final"]
     assert events[0].status == SessionStatus.DONE
     assert events[0].text == "The sky is blue on a clear day."
 
 
 def test_result_with_own_text_ignores_accumulated_fallback() -> None:
-    # When the ResultMessage carries its own result, it wins over accumulated text
+    # When the TurnResult carries its own text, it wins over accumulated text
     # (non-reasoning models are unaffected by the empty-result fallback).
     state = TurnState()
-    _translate(AssistantMessage(content=[TextBlock(text="streamed")], model="m"), state)
-    result = ResultMessage(
-        subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
-        num_turns=1, session_id="s", result="authoritative",
-    )
-    events = _translate(result, state)
+    _translate(AssistantText(text="streamed"), state)
+    events = _translate(TurnResult(text="authoritative"), state)
     assert [e.type for e in events] == ["final"]
     assert events[0].text == "authoritative"
 
 
 def test_result_error_is_error_then_classified_final() -> None:
-    msg = ResultMessage(
-        subtype="error_during_execution", duration_ms=1, duration_api_ms=1, is_error=True,
-        num_turns=1, session_id="s", result="boom",
+    events = _translate(
+        TurnResult(text="boom", is_error=True, subtype="error_during_execution")
     )
-    events = _translate(msg)
     assert [e.type for e in events] == ["error", "final"]
     assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
 
 
 def test_assistant_error_field_emits_error_event() -> None:
-    msg = AssistantMessage(content=[], model="m", error="rate_limit")
-    events = _translate(msg)
+    events = _translate(AssistantText(text="", error="rate_limit"))
     assert [e.type for e in events] == ["error"]
     assert events[0].classification == "rate_limit"
 
 
 def test_rate_limit_rejected_maps_to_error() -> None:
-    info = RateLimitInfo(status="rejected")
-    events = _translate(RateLimitEvent(rate_limit_info=info, uuid="u", session_id="s"))
+    events = _translate(RateLimit(rejected=True))
     assert [e.type for e in events] == ["error"]
     assert events[0].classification == "rate-limit"
 
 
 def test_rate_limit_warning_is_dropped() -> None:
-    # allowed / allowed_warning are advisory; the run is still allowed to
+    # A non-rejecting rate-limit signal is advisory; the run is still allowed to
     # continue, so no failure event is injected.
-    for status in ("allowed", "allowed_warning"):
-        info = RateLimitInfo(status=status)
-        events = _translate(RateLimitEvent(rate_limit_info=info, uuid="u", session_id="s"))
-        assert events == []
+    assert _translate(RateLimit(rejected=False)) == []


### PR DESCRIPTION
Stacked on #226 (do not merge until the stack merges). Ref #307.

## What

Replaces the claude-agent-sdk message dataclasses that the runner core pattern-matched on with a runner-owned `TurnEvent` union (`AssistantText | ToolCall | RateLimit | TurnResult`). The Claude adapter maps SDK -> TurnEvent in `map_sdk_message` (the sole surviving SDK boundary); the fake and OpenCode producers emit `TurnEvent`s directly, and the shared translation/budget/error logic stays single-sourced. This is the one seam extraction from #25's audit that shrinks per-harness work rather than relocating it.

## Acceptance criteria

- `ModelSession.receive_turn` yields `TurnEvent`; no `claude_agent_sdk` imports remain in `translate.py`, `session.py`, or the OpenCode adapter (`opencode/synth.py`). `adapter.py` keeps them for the SDK mapping only.
- Frozen `run_conformance` stays green for the fake and OpenCode sessions; no `aci-protocol` / `plugin-format` change. Live OpenCode conformance re-verified 5/5 against a real `opencode serve` + OpenRouter turn.
- OpenCode synth emits `TurnEvent` directly; the dummy `ResultMessage` fields are deleted.
- OTel span inputs (model id, usage tokens, tool name) unchanged (`test_otel.py` untouched).

## Notes

- `usage` stays a plain dict so `budget.py`/`otel.py` are untouched. The adapter homes a source message's `usage` onto the **last** mapped event so a same-message budget halt still emits a trailing side-effecting tool's `side_effect_flag` (preserving the worker's no-retry-after-side-effects safety) -- caught by the cross-model review pass.
- `docs/interfaces/harness-modelsession/INTERFACE.md` updated; the SDK-message-vocabulary leak is now closed.