### PR TITLE
Declare read-only tool sets per harness adapter

### DIFF
--- a/runner/CLAUDE.md
+++ b/runner/CLAUDE.md
@@ -24,11 +24,13 @@ Docker via `agentos skill up`. Full behavior spec in `runner/README.md`.
   end-to-end budget wiring through the API and UI Cost view is separate,
   not-yet-built work; do not assume this runner-local enforcement is the
   whole budget story.
-- **`side_effect_flag` uses a deny-by-default, read-only allowlist**
-  (`side_effects.py`). A new tool defaults to "not idempotent" until
-  explicitly allowlisted -- never flip the default to allow-by-default, since
-  the worker's no-retry-after-side-effects rule depends on this flag being
-  conservative.
+- **`side_effect_flag` uses a deny-by-default, read-only allowlist**, now
+  declared per harness adapter (`CLAUDE_READONLY_TOOLS` in `adapter.py`,
+  `OPENCODE_READONLY_TOOLS` in `opencode/session.py`) while the classifier in
+  `side_effects.py` stays deny-by-default and harness-agnostic. A new tool
+  defaults to "not idempotent" until explicitly allowlisted -- never flip the
+  default to allow-by-default, since the worker's no-retry-after-side-effects
+  rule depends on this flag being conservative.
 - **Rehydration on start is stateless-first** (ADR-0003): the runner
   rehydrates from `AGENTOS_HISTORY_REF` (falling back to `AGENTOS_MEMORY_REF`)
   on boot rather than assuming any surviving in-process state. Never write a

--- a/runner/src/agentos_runner/__init__.py
+++ b/runner/src/agentos_runner/__init__.py
@@ -9,7 +9,13 @@ flags non-idempotent tool calls, loads a validated plugin bundle, exports gen_ai
 OTel spans to the collector, and rehydrates from a history ref on start.
 """
 
-from .adapter import ClaudeAgentSession, ModelSession, build_options, map_sdk_message
+from .adapter import (
+    CLAUDE_READONLY_TOOLS,
+    ClaudeAgentSession,
+    ModelSession,
+    build_options,
+    map_sdk_message,
+)
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .config import RunnerConfig
 from .conformance import conformance_producer
@@ -19,7 +25,7 @@ from .otel import RunTracer, build_tracer_provider
 from .plugin import PluginBundleError, load_plugins
 from .server import create_app
 from .session import SessionRunner
-from .side_effects import DEFAULT_IDEMPOTENT_TOOLS, SideEffectClassifier
+from .side_effects import SideEffectClassifier
 
 __version__ = "0.0.0"
 
@@ -45,5 +51,5 @@ __all__ = [
     "create_app",
     "SessionRunner",
     "SideEffectClassifier",
-    "DEFAULT_IDEMPOTENT_TOOLS",
+    "CLAUDE_READONLY_TOOLS",
 ]

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -14,7 +14,12 @@ import sys
 
 from aiohttp import web
 
-from .adapter import ClaudeAgentSession, ModelSession, build_options
+from .adapter import (
+    CLAUDE_READONLY_TOOLS,
+    ClaudeAgentSession,
+    ModelSession,
+    build_options,
+)
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .otel import RunTracer, build_tracer_provider
@@ -66,7 +71,14 @@ def build_runner(
         session_factory=factory,
         ceiling=config.ceiling,
         tracer=RunTracer(provider),
-        classifier=SideEffectClassifier(config.idempotent_tools),
+        classifier=SideEffectClassifier(
+            # ``is not None`` (not ``or``): an env of ``","`` parses to ``[]``,
+            # which denies every tool, and that operator-set edge must be honored
+            # rather than falling back to the harness declaration.
+            config.idempotent_tools
+            if config.idempotent_tools is not None
+            else CLAUDE_READONLY_TOOLS
+        ),
         trace_name=f"agentos-run:{config.session.session_id}",
         session_id=config.session.session_id,
         model=config.model,

--- a/runner/src/agentos_runner/adapter.py
+++ b/runner/src/agentos_runner/adapter.py
@@ -33,6 +33,22 @@ from claude_agent_sdk import (
 
 from .events import AssistantText, RateLimit, ToolCall, TurnEvent, TurnResult
 
+# Built-in Claude Code tools that only read state, declared here as this harness's
+# read-only set for the deny-by-default side-effect classifier (side_effects.py).
+# Names match the claude-agent-sdk's tool identifiers.
+CLAUDE_READONLY_TOOLS: frozenset[str] = frozenset(
+    {
+        "Read",
+        "Glob",
+        "Grep",
+        "LS",
+        "NotebookRead",
+        "WebFetch",
+        "WebSearch",
+        "TodoRead",
+    }
+)
+
 
 class ModelSession(Protocol):
     """One long-lived model session the runner drives turn by turn."""

--- a/runner/src/agentos_runner/conformance.py
+++ b/runner/src/agentos_runner/conformance.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable
 import anyio
 from aci_protocol import Event, Interrupt
 
+from .adapter import CLAUDE_READONLY_TOOLS
 from .fake import FakeModelSession
 from .otel import RunTracer
 from .session import SessionRunner
@@ -25,7 +26,7 @@ def _build_runner() -> SessionRunner:
         session_factory=FakeModelSession,
         ceiling=0,  # unbounded: conformance validates protocol shape, not budgets
         tracer=RunTracer(None),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="conformance",
     )
 

--- a/runner/src/agentos_runner/opencode/__init__.py
+++ b/runner/src/agentos_runner/opencode/__init__.py
@@ -10,11 +10,12 @@ live adapter, ``synth.py`` for the OpenCode-frame -> SDK-message shim, and
 from __future__ import annotations
 
 from .conformance import opencode_conformance_producer
-from .session import OpenCodeModelSession
+from .session import OPENCODE_READONLY_TOOLS, OpenCodeModelSession
 from .synth import TurnSynthesizer
 
 __all__ = [
     "OpenCodeModelSession",
+    "OPENCODE_READONLY_TOOLS",
     "TurnSynthesizer",
     "opencode_conformance_producer",
 ]

--- a/runner/src/agentos_runner/opencode/conformance.py
+++ b/runner/src/agentos_runner/opencode/conformance.py
@@ -19,7 +19,7 @@ from aci_protocol import Event, Interrupt, run_conformance
 from ..otel import RunTracer
 from ..session import SessionRunner
 from ..side_effects import SideEffectClassifier
-from .session import OpenCodeModelSession
+from .session import OPENCODE_READONLY_TOOLS, OpenCodeModelSession
 
 
 def _build_runner() -> SessionRunner:
@@ -27,7 +27,7 @@ def _build_runner() -> SessionRunner:
         session_factory=OpenCodeModelSession,
         ceiling=0,  # unbounded: conformance validates protocol shape, not budgets
         tracer=RunTracer(None),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(OPENCODE_READONLY_TOOLS),
         trace_name="opencode-conformance",
     )
 

--- a/runner/src/agentos_runner/opencode/session.py
+++ b/runner/src/agentos_runner/opencode/session.py
@@ -52,6 +52,19 @@ import aiohttp
 
 from .synth import TurnSynthesizer, _result
 
+# OpenCode's lowercase read-only built-ins, declared here as this harness's
+# read-only set for the deny-by-default side-effect classifier (side_effects.py).
+# The tool surface was enumerated live against opencode 1.17.17 (GET
+# /experimental/tool): bash, read, glob, grep, edit, write, task, webfetch,
+# todowrite, skill, plus the question/invalid pseudo-tools. Of those, only read,
+# grep, glob, webfetch, and skill are pure reads (skill loads a skill's
+# instructions into the conversation, an idempotent read). bash/edit/write/task/
+# todowrite are deliberately NOT listed, and question is excluded as interactive
+# rather than a pure read. Deny-by-default covers anything uncertain or unknown.
+OPENCODE_READONLY_TOOLS: frozenset[str] = frozenset(
+    {"read", "grep", "glob", "webfetch", "skill"}
+)
+
 # Default cheap real model routed through OpenRouter. GLM-4.6 reliably returns a
 # concrete short text answer (unlike GLM-5.2, which can return reasoning + empty
 # text on trivial prompts, issue #107). Override via env for a different model.

--- a/runner/src/agentos_runner/side_effects.py
+++ b/runner/src/agentos_runner/side_effects.py
@@ -6,43 +6,31 @@ human instead of retrying, because at-least-once delivery plus a mutating tool
 means a blind retry risks a duplicate real-world action.
 
 Design choice (documented for F1/K1): a **read-only allowlist**, deny-by-default.
-A small set of known read-only Claude Code tools is treated as idempotent; every
-other tool the harness executes is treated as potentially side-effecting and
-flags the run. This fails safe: a new or unknown tool escalates rather than
-being silently retried. The alternative, an explicit non-idempotent denylist,
-fails open (a new mutating tool would be missed) and was rejected for that
-reason. The allowlist is overridable via ``AGENTOS_IDEMPOTENT_TOOLS`` (a comma
-separated list that replaces the default) so an operator can widen it per plugin
-without a code change.
+A set of known read-only tools is treated as idempotent; every other tool the
+harness executes is treated as potentially side-effecting and flags the run.
+This fails safe: a new or unknown tool escalates rather than being silently
+retried. The alternative, an explicit non-idempotent denylist, fails open (a new
+mutating tool would be missed) and was rejected for that reason.
+
+The read-only set is **declared per harness adapter**, because each harness names
+its built-in tools differently (Claude Code uses PascalCase, OpenCode uses
+lowercase ids), so a single hardcoded set would misclassify one harness's tools
+as side-effecting. See ``CLAUDE_READONLY_TOOLS`` in ``adapter.py`` and
+``OPENCODE_READONLY_TOOLS`` in ``opencode/session.py``; the classifier itself is
+harness-agnostic and just takes the declared set. The declaration is overridable
+via ``AGENTOS_IDEMPOTENT_TOOLS`` (a comma separated list that replaces the
+harness declaration) so an operator can widen it per plugin without a code
+change.
 """
 
 from collections.abc import Iterable
-
-# Built-in Claude Code tools that only read state. Names match the SDK's tool
-# identifiers. Anything not listed here is treated as side-effecting.
-DEFAULT_IDEMPOTENT_TOOLS: frozenset[str] = frozenset(
-    {
-        "Read",
-        "Glob",
-        "Grep",
-        "LS",
-        "NotebookRead",
-        "WebFetch",
-        "WebSearch",
-        "TodoRead",
-    }
-)
 
 
 class SideEffectClassifier:
     """Decide whether a tool name denotes a non-idempotent (side-effecting) call."""
 
-    def __init__(self, idempotent_tools: Iterable[str] | None = None) -> None:
-        self._idempotent = (
-            frozenset(idempotent_tools)
-            if idempotent_tools is not None
-            else DEFAULT_IDEMPOTENT_TOOLS
-        )
+    def __init__(self, idempotent_tools: Iterable[str]) -> None:
+        self._idempotent = frozenset(idempotent_tools)
 
     def is_side_effecting(self, tool_name: str) -> bool:
         """True if executing ``tool_name`` may cause a non-idempotent side effect."""

--- a/runner/tests/test_budget.py
+++ b/runner/tests/test_budget.py
@@ -2,7 +2,12 @@
 
 import anyio
 from aci_protocol import Event, SessionStatus, parse_ndjson
-from agentos_runner import BudgetTracker, RunTracer, SideEffectClassifier
+from agentos_runner import (
+    CLAUDE_READONLY_TOOLS,
+    BudgetTracker,
+    RunTracer,
+    SideEffectClassifier,
+)
 from agentos_runner.budget import BUDGET_CLASSIFICATION
 from agentos_runner.events import AssistantText, ToolCall, TurnResult
 from agentos_runner.fake import FakeModelSession
@@ -70,7 +75,7 @@ def _runner(script, ceiling: int) -> tuple[SessionRunner, FakeModelSession]:
         session_factory=lambda: fake,
         ceiling=ceiling,
         tracer=RunTracer(None),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="t",
     )
     return runner, fake

--- a/runner/tests/test_config.py
+++ b/runner/tests/test_config.py
@@ -37,6 +37,14 @@ def test_idempotent_tools_override_parsed() -> None:
     assert RunnerConfig.from_env(env).idempotent_tools == ["Read", "Custom", "Grep"]
 
 
+def test_idempotent_tools_empty_override_is_empty_list_not_none() -> None:
+    # ``AGENTOS_IDEMPOTENT_TOOLS=","`` parses to ``[]`` (an empty allowlist), not
+    # None. ``__main__.py`` distinguishes the two with ``is not None`` so an empty
+    # operator override reaches the classifier and denies every tool.
+    env = dict(_BASE, AGENTOS_IDEMPOTENT_TOOLS=",")
+    assert RunnerConfig.from_env(env).idempotent_tools == []
+
+
 def test_runner_token_parsed_from_env() -> None:
     env = dict(_BASE, AGENTOS_RUNNER_TOKEN="abc123")
     assert RunnerConfig.from_env(env).runner_token == "abc123"

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -14,7 +14,12 @@ import os
 import anyio
 import pytest
 from aci_protocol import Event, SessionStatus, parse_ndjson
-from agentos_runner import RunTracer, SideEffectClassifier, build_options
+from agentos_runner import (
+    CLAUDE_READONLY_TOOLS,
+    RunTracer,
+    SideEffectClassifier,
+    build_options,
+)
 from agentos_runner.adapter import ClaudeAgentSession
 from agentos_runner.session import SessionRunner
 
@@ -36,7 +41,7 @@ def test_live_runner_answers_trivial_message() -> None:
         session_factory=lambda: ClaudeAgentSession(options),
         ceiling=0,
         tracer=RunTracer(None),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="live-smoke",
     )
 

--- a/runner/tests/test_opencode_synth.py
+++ b/runner/tests/test_opencode_synth.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import anyio
 from aci_protocol import Event, Interrupt, parse_ndjson, run_conformance
+from agentos_runner import CLAUDE_READONLY_TOOLS
 from agentos_runner.events import AssistantText, ToolCall, TurnResult
 from agentos_runner.opencode.synth import TurnSynthesizer
 from agentos_runner.otel import RunTracer
@@ -225,7 +226,7 @@ def _build_runner() -> SessionRunner:
         session_factory=ScriptedOpenCodeSession,
         ceiling=0,
         tracer=RunTracer(None),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="opencode-offline",
     )
 
@@ -256,7 +257,7 @@ def _turn_ndjson(frames_factory: Any) -> list[str]:
             session_factory=lambda: ScriptedOpenCodeSession(frames_factory),
             ceiling=0,
             tracer=RunTracer(None),
-            classifier=SideEffectClassifier(),
+            classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
             trace_name="opencode-offline",
         )
         await runner.start()

--- a/runner/tests/test_otel.py
+++ b/runner/tests/test_otel.py
@@ -2,7 +2,12 @@
 
 import anyio
 from aci_protocol import Event, OtelConfig
-from agentos_runner import RunTracer, SideEffectClassifier, build_tracer_provider
+from agentos_runner import (
+    CLAUDE_READONLY_TOOLS,
+    RunTracer,
+    SideEffectClassifier,
+    build_tracer_provider,
+)
 from agentos_runner.fake import FakeModelSession
 from agentos_runner.session import SessionRunner
 from opentelemetry.sdk.trace import TracerProvider
@@ -19,7 +24,7 @@ def test_run_emits_agent_generation_and_tool_spans() -> None:
         session_factory=FakeModelSession,  # default_turn: text + Bash tool + result usage
         ceiling=0,
         tracer=RunTracer(provider),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="agentos-run:test",
         model="fake-model",
     )
@@ -54,7 +59,7 @@ def test_generation_model_backfilled_from_sdk_when_unconfigured() -> None:
         session_factory=FakeModelSession,
         ceiling=0,
         tracer=RunTracer(provider),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="agentos-run:test",
         model=None,
     )
@@ -85,7 +90,7 @@ def test_run_stamps_langfuse_session_and_user_ids() -> None:
         session_factory=FakeModelSession,
         ceiling=0,
         tracer=RunTracer(provider),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="agentos-run:test",
         session_id="agent-abc-thread-123",
         model="fake-model",
@@ -114,7 +119,7 @@ def test_run_omits_langfuse_user_id_when_event_user_empty() -> None:
         session_factory=FakeModelSession,
         ceiling=0,
         tracer=RunTracer(provider),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="agentos-run:test",
         session_id="agent-abc-thread-123",
         model="fake-model",

--- a/runner/tests/test_server.py
+++ b/runner/tests/test_server.py
@@ -2,7 +2,12 @@
 
 import anyio
 from aci_protocol import SessionStatus, parse_ndjson
-from agentos_runner import RunTracer, SideEffectClassifier, create_app
+from agentos_runner import (
+    CLAUDE_READONLY_TOOLS,
+    RunTracer,
+    SideEffectClassifier,
+    create_app,
+)
 from agentos_runner.fake import FakeModelSession
 from agentos_runner.session import SessionRunner
 from aiohttp.test_utils import TestClient, TestServer
@@ -14,7 +19,7 @@ def _runner() -> tuple[SessionRunner, FakeModelSession]:
         session_factory=lambda: fake,
         ceiling=0,
         tracer=RunTracer(None),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="t",
     )
     return runner, fake

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -4,7 +4,12 @@ import logging
 
 import anyio
 from aci_protocol import Event, Interrupt, SessionStatus, parse_ndjson
-from agentos_runner import RunTracer, SideEffectClassifier, build_options
+from agentos_runner import (
+    CLAUDE_READONLY_TOOLS,
+    RunTracer,
+    SideEffectClassifier,
+    build_options,
+)
 from agentos_runner.events import AssistantText, TurnResult
 from agentos_runner.fake import FakeModelSession, default_turn
 from agentos_runner.session import SessionRunner
@@ -18,7 +23,7 @@ def _runner(
         session_factory=lambda: fake,
         ceiling=ceiling,
         tracer=RunTracer(None),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="t",
     )
     return runner, fake
@@ -105,7 +110,7 @@ def test_interrupt_reclassifies_error_result_to_idle() -> None:
     fake = FakeModelSession(lambda: script, truncate_on_interrupt=False)
     runner = SessionRunner(
         session_factory=lambda: fake, ceiling=0, tracer=RunTracer(None),
-        classifier=SideEffectClassifier(), trace_name="t",
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS), trace_name="t",
     )
 
     lines: list[str] = []
@@ -139,7 +144,7 @@ def test_sdk_exception_still_terminates_in_final() -> None:
 
     runner = SessionRunner(
         session_factory=RaisingSession, ceiling=0, tracer=RunTracer(None),
-        classifier=SideEffectClassifier(), trace_name="t",
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS), trace_name="t",
     )
     events = _drain(runner, Event(type="message", text="go", user="U", ts="1"))
     assert [e.type for e in events] == ["error", "final"]
@@ -167,7 +172,7 @@ def test_sdk_exception_logs_turn_failure(caplog) -> None:
         session_factory=RaisingSession,
         ceiling=0,
         tracer=RunTracer(None),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="t",
     )
     with caplog.at_level(logging.ERROR, logger="agentos_runner.session"):
@@ -237,7 +242,7 @@ def test_auth_fast_fail_survives_a_wedged_interrupt(caplog) -> None:
         session_factory=lambda: fake,
         ceiling=0,
         tracer=RunTracer(None),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
         trace_name="t",
     )
 

--- a/runner/tests/test_side_effects.py
+++ b/runner/tests/test_side_effects.py
@@ -1,16 +1,22 @@
-"""The side-effect classifier: read-only allowlist, deny-by-default."""
+"""The side-effect classifier: read-only allowlist, deny-by-default.
 
-from agentos_runner import DEFAULT_IDEMPOTENT_TOOLS, SideEffectClassifier
+The read-only set is declared per harness adapter, so the classifier is always
+constructed with an explicit tool set: ``CLAUDE_READONLY_TOOLS`` for the
+claude-agent-sdk path, ``OPENCODE_READONLY_TOOLS`` for the OpenCode path.
+"""
+
+from agentos_runner import CLAUDE_READONLY_TOOLS, SideEffectClassifier
+from agentos_runner.opencode import OPENCODE_READONLY_TOOLS
 
 
 def test_read_only_tools_are_idempotent() -> None:
-    classifier = SideEffectClassifier()
-    for tool in DEFAULT_IDEMPOTENT_TOOLS:
+    classifier = SideEffectClassifier(CLAUDE_READONLY_TOOLS)
+    for tool in CLAUDE_READONLY_TOOLS:
         assert not classifier.is_side_effecting(tool)
 
 
 def test_mutating_and_unknown_tools_flag() -> None:
-    classifier = SideEffectClassifier()
+    classifier = SideEffectClassifier(CLAUDE_READONLY_TOOLS)
     # Known mutating tools and any unknown/new tool are treated as side-effecting.
     for tool in ("Bash", "Write", "Edit", "SomeBrandNewTool"):
         assert classifier.is_side_effecting(tool)
@@ -19,5 +25,39 @@ def test_mutating_and_unknown_tools_flag() -> None:
 def test_override_replaces_the_allowlist() -> None:
     classifier = SideEffectClassifier(["Bash"])
     assert not classifier.is_side_effecting("Bash")
-    # An override replaces (does not extend) the default set.
+    # An override replaces (does not extend) the declared set.
+    assert classifier.is_side_effecting("Read")
+
+
+def test_claude_declaration_does_not_absorb_opencode_names() -> None:
+    # The Claude declaration is PascalCase; OpenCode's lowercase read-only names
+    # are NOT in it, so classifying an OpenCode call against the Claude set flags.
+    classifier = SideEffectClassifier(CLAUDE_READONLY_TOOLS)
+    assert classifier.is_side_effecting("read")
+
+
+def test_opencode_read_only_tools_are_idempotent() -> None:
+    # Regression (issue #308): OpenCode's lowercase read-only built-ins (verified
+    # against opencode 1.17.17) must not be misclassified as side-effecting when
+    # the OpenCode declaration is used.
+    classifier = SideEffectClassifier(OPENCODE_READONLY_TOOLS)
+    for tool in ("read", "grep", "glob", "webfetch", "skill"):
+        assert not classifier.is_side_effecting(tool)
+
+
+def test_opencode_mutating_and_unknown_tools_flag() -> None:
+    classifier = SideEffectClassifier(OPENCODE_READONLY_TOOLS)
+    # ``bash`` is deliberately NOT allowlisted; deny-by-default covers unknowns.
+    # ``todoread`` and ``list`` are not real opencode 1.17.17 builtins; keeping
+    # them out of the allowlist keeps a fail-open regression from returning.
+    for tool in ("bash", "write", "SomeBrandNewTool", "todoread", "list"):
+        assert classifier.is_side_effecting(tool)
+
+
+def test_empty_override_denies_everything() -> None:
+    # An operator env of ``AGENTOS_IDEMPOTENT_TOOLS=","`` parses to ``[]`` (not
+    # None), and ``__main__.py`` uses ``is not None`` (not ``or``) so that ``[]``
+    # reaches the classifier and denies every tool. An empty allowlist must flag
+    # even a canonical read.
+    classifier = SideEffectClassifier([])
     assert classifier.is_side_effecting("Read")

--- a/runner/tests/test_translate.py
+++ b/runner/tests/test_translate.py
@@ -1,13 +1,16 @@
 """TurnEvent to ACI-outbound-event translation."""
 
 from aci_protocol import SessionStatus
-from agentos_runner import SideEffectClassifier
+from agentos_runner import CLAUDE_READONLY_TOOLS, SideEffectClassifier
 from agentos_runner.events import AssistantText, RateLimit, ToolCall, TurnResult
+from agentos_runner.opencode import OPENCODE_READONLY_TOOLS
 from agentos_runner.translate import TurnState, translate_event
 
 
 def _translate(event: object, state: TurnState | None = None) -> list:
-    return translate_event(event, state or TurnState(), SideEffectClassifier(), None)
+    return translate_event(
+        event, state or TurnState(), SideEffectClassifier(CLAUDE_READONLY_TOOLS), None
+    )
 
 
 def test_text_block_becomes_text_delta() -> None:
@@ -33,6 +36,28 @@ def test_tool_use_emits_note_and_side_effect_once() -> None:
 def test_read_only_tool_notes_without_flag() -> None:
     events = _translate(ToolCall(name="Read", id="1"))
     assert [e.type for e in events] == ["tool_note"]
+
+
+def test_opencode_read_only_tool_notes_without_flag() -> None:
+    # Regression (issue #308): an OpenCode ``read`` classified against the OpenCode
+    # declaration is a plain tool note with NO side-effect flag.
+    events = translate_event(
+        ToolCall(name="read", id="t1", model=None),
+        TurnState(),
+        SideEffectClassifier(OPENCODE_READONLY_TOOLS),
+        None,
+    )
+    assert [e.type for e in events] == ["tool_note"]
+
+
+def test_opencode_unknown_tool_emits_side_effect_flag() -> None:
+    events = translate_event(
+        ToolCall(name="SomeBrandNewTool", id="t1", model=None),
+        TurnState(),
+        SideEffectClassifier(OPENCODE_READONLY_TOOLS),
+        None,
+    )
+    assert "side_effect_flag" in [e.type for e in events]
 
 
 def test_result_success_is_final_done() -> None:


### PR DESCRIPTION
Stacked on #315 (the TurnEvent branch); do not merge independently, per epic #25 and ADR-0009.

The side-effect classifier's idempotent-tool allowlist hardcoded Claude Code's PascalCase tool names, so OpenCode's lowercase tools (read, webfetch, ...) misclassified as side-effecting and wrongly suppressed the worker's auto-retry.

- Each harness adapter now declares its read-only tool set: the Claude adapter declares `CLAUDE_READONLY_TOOLS` (the existing PascalCase set, byte-for-byte) and the OpenCode adapter declares `OPENCODE_READONLY_TOOLS` (read, grep, glob, webfetch, skill - verified against the live opencode 1.17.17 tool surface via `GET /experimental/tool`; the initially drafted todoread/list entries were dropped as nonexistent-and-fail-open, and skill added as a confirmed read-only builtin).
- `SideEffectClassifier` requires an explicit tool set; deny-by-default for unknown tools is unchanged.
- `AGENTOS_IDEMPOTENT_TOOLS` still replaces the harness declaration, including the empty-override edge (`","` parses to `[]` and denies every tool), now covered by tests.
- Regression tests at both the classifier and translate layers: an OpenCode read-only tool emits no `side_effect_flag`; unknown tools still do.

Ref #308