### PR TITLE
Put plugin-bundle ingestion behind a BundleInstaller port

### DIFF
--- a/runner/src/agentos_runner/__init__.py
+++ b/runner/src/agentos_runner/__init__.py
@@ -22,7 +22,7 @@ from .conformance import conformance_producer
 from .events import AssistantText, RateLimit, ToolCall, TurnEvent, TurnResult
 from .fake import FakeModelSession
 from .otel import RunTracer, build_tracer_provider
-from .plugin import PluginBundleError, load_plugins
+from .plugin import BundleInstaller, ClaudeBundleInstaller, PluginBundleError, load_plugins
 from .server import create_app
 from .session import SessionRunner
 from .side_effects import SideEffectClassifier
@@ -47,6 +47,8 @@ __all__ = [
     "RunTracer",
     "build_tracer_provider",
     "PluginBundleError",
+    "BundleInstaller",
+    "ClaudeBundleInstaller",
     "load_plugins",
     "create_app",
     "SessionRunner",

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -23,7 +23,7 @@ from .adapter import (
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .otel import RunTracer, build_tracer_provider
-from .plugin import load_plugins
+from .plugin import ClaudeBundleInstaller
 from .sdk_auth import UnsupportedCredentialError, resolve_sdk_env
 from .server import create_app
 from .session import SessionRunner
@@ -49,7 +49,7 @@ def build_runner(
     def factory() -> ModelSession:
         if fake_model:
             return FakeModelSession()
-        plugins = load_plugins(config.session.plugin_dir)
+        plugins = ClaudeBundleInstaller().install(config.session.plugin_dir)
         options = build_options(
             plugins=plugins,
             model=config.model,

--- a/runner/src/agentos_runner/opencode/__init__.py
+++ b/runner/src/agentos_runner/opencode/__init__.py
@@ -10,12 +10,14 @@ live adapter, ``synth.py`` for the OpenCode-frame -> SDK-message shim, and
 from __future__ import annotations
 
 from .conformance import opencode_conformance_producer
+from .installer import OpenCodeBundleInstaller
 from .session import OPENCODE_READONLY_TOOLS, OpenCodeModelSession
 from .synth import TurnSynthesizer
 
 __all__ = [
     "OpenCodeModelSession",
     "OPENCODE_READONLY_TOOLS",
+    "OpenCodeBundleInstaller",
     "TurnSynthesizer",
     "opencode_conformance_producer",
 ]

--- a/runner/src/agentos_runner/opencode/conformance.py
+++ b/runner/src/agentos_runner/opencode/conformance.py
@@ -19,10 +19,14 @@ from aci_protocol import Event, Interrupt, run_conformance
 from ..otel import RunTracer
 from ..session import SessionRunner
 from ..side_effects import SideEffectClassifier
+from .installer import OpenCodeBundleInstaller
 from .session import OPENCODE_READONLY_TOOLS, OpenCodeModelSession
 
 
 def _build_runner() -> SessionRunner:
+    # The conformance session is deliberately bundle-less: the stub installer
+    # makes that an explicit decision at the port rather than an accident (#310).
+    OpenCodeBundleInstaller().install(None)
     return SessionRunner(
         session_factory=OpenCodeModelSession,
         ceiling=0,  # unbounded: conformance validates protocol shape, not budgets

--- a/runner/src/agentos_runner/opencode/installer.py
+++ b/runner/src/agentos_runner/opencode/installer.py
@@ -1,0 +1,37 @@
+"""The OpenCode harness :class:`BundleInstaller`: an explicit, documented no-op.
+
+The OpenCode spike has no bundle-to-config compiler yet, so its session runs from
+a bare temp dir with no plugin bundle. This stub exists so that bundle-less
+behavior is an explicit decision made at the ``BundleInstaller`` port
+(Decision 3 of the harness-neutral runner seams ADR, PR #306) rather than an
+accident of the spike never wiring a bundle in: the
+installer always contributes an empty (``None``) OpenCode session config, and
+warns when a bundle is configured so an operator is not silently surprised that
+their bundle was ignored. The real bundle-to-OpenCode-config compiler is issue
+#310.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class OpenCodeBundleInstaller:
+    """Return the OpenCode harness's empty session config; today always ``None``.
+
+    A truthy ``plugin_dir`` is honored as a no-op with a warning: the OpenCode
+    harness does not yet support bundles, so the session runs bundle-less until
+    the compiler (issue #310) lands.
+    """
+
+    def install(self, plugin_dir: str | None) -> None:
+        if plugin_dir:
+            logger.warning(
+                "plugin bundle configured at %s but the OpenCode harness does not "
+                "yet support bundles; the session runs bundle-less (compiler is "
+                "issue #310)",
+                plugin_dir,
+            )
+        return None

--- a/runner/src/agentos_runner/plugin.py
+++ b/runner/src/agentos_runner/plugin.py
@@ -7,16 +7,44 @@ valid bundle into the ``ClaudeAgentOptions.plugins`` shape (a local plugin
 config). An invalid bundle is a hard configuration error surfaced at startup, not
 a silent skip: a runner that booted with a broken bundle would answer with the
 wrong (empty) capability set.
+
+Bundle ingestion sits behind the :class:`BundleInstaller` port so a non-Claude
+harness can interpret the same validated bundle into its own session config
+(Decision 3 of the harness-neutral runner seams ADR, PR #306). The Claude
+implementation
+(:class:`ClaudeBundleInstaller`) is the passthrough that hands the bundle straight
+to the SDK; the OpenCode harness supplies its own installer (see
+``opencode/installer.py``). The port's output type is generic because each
+harness contributes a different native config shape.
 """
 
 from pathlib import Path
+from typing import Protocol, TypeVar, runtime_checkable
 
 from claude_agent_sdk import SdkPluginConfig
 from plugin_format import validate_bundle
 
+T_co = TypeVar("T_co", covariant=True)
+
 
 class PluginBundleError(RuntimeError):
     """Raised when the mounted plugin bundle fails validation."""
+
+
+@runtime_checkable
+class BundleInstaller(Protocol[T_co]):
+    """Ingest a validated plugin bundle into a harness-native session config.
+
+    The single seam where a harness turns the mounted bundle at ``plugin_dir``
+    into its own session-config contribution: validate the bundle and return this
+    harness's native config, raise :class:`PluginBundleError` on an invalid
+    bundle, and treat a ``None`` or absent dir as "no bundle configured" by
+    returning the harness's empty configuration. ``T_co`` is the harness-native
+    config type (a Claude plugin-config list, ``None`` for the OpenCode stub, and
+    so on), so the contract is one shape while the payload stays per harness.
+    """
+
+    def install(self, plugin_dir: str | None) -> T_co: ...
 
 
 def load_plugins(plugin_dir: str | None) -> list[SdkPluginConfig]:
@@ -37,3 +65,17 @@ def load_plugins(plugin_dir: str | None) -> list[SdkPluginConfig]:
         raise PluginBundleError(f"invalid plugin bundle at {root}: {detail}")
 
     return [SdkPluginConfig(type="local", path=str(root))]
+
+
+class ClaudeBundleInstaller:
+    """The Claude harness :class:`BundleInstaller`: the passthrough.
+
+    Hands the validated bundle straight to the SDK unchanged, which is exactly
+    ``load_plugins`` -- the installer delegates to it so the passthrough stays the
+    single source of the Claude ingestion behavior. Named by Decision 3 of the
+    harness-neutral runner seams ADR (PR #306) as the current passthrough seam
+    that a non-Claude harness replaces.
+    """
+
+    def install(self, plugin_dir: str | None) -> list[SdkPluginConfig]:
+        return load_plugins(plugin_dir)

--- a/runner/tests/test_opencode_installer.py
+++ b/runner/tests/test_opencode_installer.py
@@ -1,0 +1,29 @@
+"""The OpenCode stub bundle installer: an explicit, documented no-op (issue #309)."""
+
+import logging
+
+from agentos_runner.opencode import OpenCodeBundleInstaller
+from agentos_runner.plugin import BundleInstaller
+
+_INSTALLER_LOGGER = "agentos_runner.opencode.installer"
+
+
+def test_no_dir_returns_none_without_warning(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        assert OpenCodeBundleInstaller().install(None) is None
+    assert caplog.records == []
+
+
+def test_configured_bundle_returns_none_and_warns(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        assert OpenCodeBundleInstaller().install("/some/bundle") is None
+    messages = [record.getMessage() for record in caplog.records]
+    assert len(messages) == 1
+    warning = messages[0]
+    assert "/some/bundle" in warning
+    assert "bundle-less" in warning
+    assert "#310" in warning
+
+
+def test_opencode_installer_satisfies_bundle_installer_port() -> None:
+    assert isinstance(OpenCodeBundleInstaller(), BundleInstaller)

--- a/runner/tests/test_plugin.py
+++ b/runner/tests/test_plugin.py
@@ -3,7 +3,12 @@
 from pathlib import Path
 
 import pytest
-from agentos_runner import PluginBundleError, load_plugins
+from agentos_runner import (
+    BundleInstaller,
+    ClaudeBundleInstaller,
+    PluginBundleError,
+    load_plugins,
+)
 
 _FIXTURES = Path(__file__).resolve().parents[2] / "packages/plugin-format/tests/fixtures"
 
@@ -23,3 +28,24 @@ def test_invalid_bundle_raises() -> None:
     bundle = _FIXTURES / "bad_manifest_name"
     with pytest.raises(PluginBundleError):
         load_plugins(str(bundle))
+
+
+def test_claude_installer_passthrough_matches_load_plugins() -> None:
+    bundle = _FIXTURES / "valid_bundle"
+    installer = ClaudeBundleInstaller()
+    assert installer.install(str(bundle)) == load_plugins(str(bundle))
+    assert installer.install(str(bundle)) == [{"type": "local", "path": str(bundle)}]
+
+
+def test_claude_installer_no_dir_is_empty() -> None:
+    assert ClaudeBundleInstaller().install(None) == []
+
+
+def test_claude_installer_invalid_bundle_raises() -> None:
+    bundle = _FIXTURES / "bad_manifest_name"
+    with pytest.raises(PluginBundleError):
+        ClaudeBundleInstaller().install(str(bundle))
+
+
+def test_claude_installer_satisfies_bundle_installer_port() -> None:
+    assert isinstance(ClaudeBundleInstaller(), BundleInstaller)


### PR DESCRIPTION
Stacked on #316 (the tool-sets branch); do not merge independently, per epic #25 and the harness-neutral runner seams ADR (PR #306).

plugin.py handed the validated bundle straight to the SDK as SdkPluginConfig, leaving no seam where a non-Claude harness can interpret the bundle (the OpenCode spike runs bundle-less from a bare temp dir by accident rather than decision).

- `BundleInstaller` port (generic, runtime-checkable protocol): validated bundle in, harness-native session config out. Raises `PluginBundleError` on an invalid bundle; None dir yields the harness's empty config.
- `ClaudeBundleInstaller` is the passthrough, delegating to the unchanged `load_plugins`; the production factory now installs through it. Runner behavior and conformance unchanged.
- `OpenCodeBundleInstaller` is an explicit documented no-op that warns when a bundle is configured, making the spike's bundle-less behavior a decision at the port. The real bundle-to-opencode-config compiler is #310, which will also bind the installer result into the session factory (Codex review note).
- No plugin-format change.

Ref #309