### PR TITLE
Compile plugin bundles into OpenCode session workdirs

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -58,6 +58,20 @@ Runner-local: `AGENTOS_MODEL`, `AGENTOS_SYSTEM_PROMPT`, `AGENTOS_MAX_TURNS`,
 three ACI POST routes; enforced only when set), `AGENTOS_FAKE_MODEL` (offline
 smoke; no model call).
 
+## OpenCode harness bundle fidelity
+
+The optional OpenCode second harness (issue #25) does not consume a Claude plugin
+bundle directly; `opencode/installer.py` compiles the validated bundle into an
+OpenCode session workdir (`opencode.json` MCP config, `.claude/skills/`,
+`.opencode/commands/`, `.opencode/agents/`). That compilation is copy-verbatim
+where OpenCode's leniency permits and a field remap only where the formats
+differ, so a few Claude-only elements are lost in translation (skill
+`allowed-tools`, command/agent `model` aliases, agent `tools` lists, `scripts/`,
+manifest hooks, non-`${CLAUDE_PLUGIN_ROOT}` `${VAR}` references, the http/sse
+transport distinction). The **canonical per-element fidelity record** lives in the
+`opencode/installer.py` module docstring; each loss also surfaces at runtime as a
+`logger.warning` on `agentos_runner.opencode.installer`.
+
 ## Build and smoke
 
 The image compiles against the frozen workspace packages, so build from the repo

--- a/runner/src/agentos_runner/opencode/__init__.py
+++ b/runner/src/agentos_runner/opencode/__init__.py
@@ -10,13 +10,14 @@ live adapter, ``synth.py`` for the OpenCode-frame -> SDK-message shim, and
 from __future__ import annotations
 
 from .conformance import opencode_conformance_producer
-from .installer import OpenCodeBundleInstaller
+from .installer import CompiledOpenCodeBundle, OpenCodeBundleInstaller
 from .session import OPENCODE_READONLY_TOOLS, OpenCodeModelSession
 from .synth import TurnSynthesizer
 
 __all__ = [
     "OpenCodeModelSession",
     "OPENCODE_READONLY_TOOLS",
+    "CompiledOpenCodeBundle",
     "OpenCodeBundleInstaller",
     "TurnSynthesizer",
     "opencode_conformance_producer",

--- a/runner/src/agentos_runner/opencode/conformance.py
+++ b/runner/src/agentos_runner/opencode/conformance.py
@@ -13,6 +13,11 @@ Run:  PYTHONPATH=src python -m agentos_runner.opencode.conformance   (from runne
 
 from __future__ import annotations
 
+import atexit
+import json
+import os
+import tempfile
+
 import anyio
 from aci_protocol import Event, Interrupt, run_conformance
 
@@ -22,13 +27,83 @@ from ..side_effects import SideEffectClassifier
 from .installer import OpenCodeBundleInstaller
 from .session import OPENCODE_READONLY_TOOLS, OpenCodeModelSession
 
+_DEFAULT_DEMO_PROMPT = "Reply with exactly the word: pong"
 
-def _build_runner() -> SessionRunner:
-    # The conformance session is deliberately bundle-less: the stub installer
-    # makes that an explicit decision at the port rather than an accident (#310).
-    OpenCodeBundleInstaller().install(None)
+# When a bundle is installed, the representative turn must exercise it end to end:
+# load a skill via the skill tool and call the bundled MCP tool, proving the
+# compiled config reached OpenCode (issue #310 live round-trip proof).
+_BUNDLE_DEMO_PROMPT = (
+    "First use the skill tool to load the 'roundtrip-greeter' skill and follow "
+    "its instruction, then call the 'agentos_probe' MCP tool and include its "
+    "output verbatim in your reply."
+)
+
+# Expected proof values from runner/tests/fixtures/opencode_live_bundle.
+_BUNDLE_SKILL_TOKEN = "AGENTOS-ROUNDTRIP"
+_BUNDLE_MCP_NONCE = "NONCE-7f3a9c"
+
+_CONFORMANCE_WORKDIR: tempfile.TemporaryDirectory[str] | None = None
+
+
+def _conformance_workdir_root() -> str:
+    """Return the shared root for compiled bundles in this process."""
+
+    global _CONFORMANCE_WORKDIR
+    if _CONFORMANCE_WORKDIR is None:
+        _CONFORMANCE_WORKDIR = tempfile.TemporaryDirectory(
+            prefix="agentos-opencode-conformance-"
+        )
+        atexit.register(_CONFORMANCE_WORKDIR.cleanup)
+    return _CONFORMANCE_WORKDIR.name
+
+
+def _bundle_demo_failures(lines: list[str]) -> list[str]:
+    """Return missing proof from a bundle demo turn."""
+
+    parsed: list[object] = []
+    for line in lines:
+        try:
+            parsed.append(json.loads(line))
+        except json.JSONDecodeError:
+            parsed.append(None)
+
+    failures: list[str] = []
+    terminal = parsed[-1] if parsed else None
+    if (
+        not isinstance(terminal, dict)
+        or terminal.get("type") != "final"
+        or terminal.get("status") != "done"
+    ):
+        failures.append("no final/done")
+    else:
+        text = terminal.get("text")
+        final_text = text if isinstance(text, str) else ""
+        if _BUNDLE_SKILL_TOKEN not in final_text:
+            failures.append("missing skill token")
+        if _BUNDLE_MCP_NONCE not in final_text:
+            failures.append("missing nonce")
+
+    has_skill_note = any(
+        isinstance(event, dict)
+        and event.get("type") == "tool_note"
+        and event.get("tool") == "skill"
+        for event in parsed
+    )
+    if not has_skill_note:
+        failures.append("no skill tool_note")
+    return failures
+
+
+def _build_runner(plugin_dir: str | None) -> SessionRunner:
+    # Compile the bundle (if any) and bind the materialized workdir as the
+    # session's cwd -- this is where OpenCode discovers the compiled config.
+    # A bundle-less call yields cwd=None (the session mkdtemps its own workdir).
+    compiled = OpenCodeBundleInstaller(
+        workdir_root=_conformance_workdir_root()
+    ).install(plugin_dir)
+    cwd = compiled.workdir if compiled else None
     return SessionRunner(
-        session_factory=OpenCodeModelSession,
+        session_factory=lambda: OpenCodeModelSession(cwd=cwd),
         ceiling=0,  # unbounded: conformance validates protocol shape, not budgets
         tracer=RunTracer(None),
         classifier=SideEffectClassifier(OPENCODE_READONLY_TOOLS),
@@ -42,7 +117,7 @@ def opencode_conformance_producer(message: Event | Interrupt) -> list[str]:
     lines: list[str] = []
 
     async def _run() -> None:
-        runner = _build_runner()
+        runner = _build_runner(os.environ.get("AGENTOS_PLUGIN_DIR"))
         await runner.start()
         try:
             async for line in runner.run_inbound(message):
@@ -54,13 +129,13 @@ def opencode_conformance_producer(message: Event | Interrupt) -> list[str]:
     return lines
 
 
-def _demo_turn(prompt: str = "Reply with exactly the word: pong") -> list[str]:
+def _demo_turn(prompt: str) -> list[str]:
     """Drive one live turn and return its ACI NDJSON lines."""
 
     lines: list[str] = []
 
     async def _run() -> None:
-        runner = _build_runner()
+        runner = _build_runner(os.environ.get("AGENTOS_PLUGIN_DIR"))
         await runner.start()
         try:
             event = Event(type="message", text=prompt, user="U1", ts="1.0")
@@ -74,19 +149,28 @@ def _demo_turn(prompt: str = "Reply with exactly the word: pong") -> list[str]:
 
 
 def main() -> int:
+    plugin_dir = os.environ.get("AGENTOS_PLUGIN_DIR")
     print("=== OpenCode-backed ACI conformance (live opencode serve) ===")
+    if plugin_dir:
+        print(f"  (bundle installed from AGENTOS_PLUGIN_DIR={plugin_dir})")
     report = run_conformance(opencode_conformance_producer)
     for check in report.checks:
         print(f"  [{'PASS' if check.passed else 'FAIL'}] {check.name}: {check.detail}")
     print(f"  -> {report.summary()}  passed={report.passed}")
 
     print("\n=== Representative live OpenCode turn -> ACI NDJSON ===")
-    demo = _demo_turn()
+    demo = _demo_turn(_BUNDLE_DEMO_PROMPT if plugin_dir else _DEFAULT_DEMO_PROMPT)
     for line in demo:
         print("  " + line.rstrip())
 
-    ends_in_final = bool(demo) and '"final"' in demo[-1]
-    ok = report.passed and ends_in_final
+    if plugin_dir:
+        bundle_failures = _bundle_demo_failures(demo)
+        for failure in bundle_failures:
+            print(f"  [FAIL] bundle demo: {failure}")
+        ok = report.passed and not bundle_failures
+    else:
+        ends_in_final = bool(demo) and '"final"' in demo[-1]
+        ok = report.passed and ends_in_final
     print(f"\nLIVE SPIKE RESULT: {'PASS' if ok else 'FAIL'}")
     return 0 if ok else 1
 

--- a/runner/src/agentos_runner/opencode/installer.py
+++ b/runner/src/agentos_runner/opencode/installer.py
@@ -1,37 +1,517 @@
-"""The OpenCode harness :class:`BundleInstaller`: an explicit, documented no-op.
+"""The OpenCode bundle compiler: validated plugin bundle -> OpenCode session workdir.
 
-The OpenCode spike has no bundle-to-config compiler yet, so its session runs from
-a bare temp dir with no plugin bundle. This stub exists so that bundle-less
-behavior is an explicit decision made at the ``BundleInstaller`` port
-(Decision 3 of the harness-neutral runner seams ADR, PR #306) rather than an
-accident of the spike never wiring a bundle in: the
-installer always contributes an empty (``None``) OpenCode session config, and
-warns when a bundle is configured so an operator is not silently surprised that
-their bundle was ignored. The real bundle-to-OpenCode-config compiler is issue
-#310.
+``OpenCodeBundleInstaller`` is the OpenCode harness's :class:`BundleInstaller`
+(Decision 3 of the harness-neutral runner seams ADR, PR #306; issue #310). It
+validates a mounted Claude Code plugin bundle with the frozen
+``plugin_format.validate_bundle`` and *materializes* a temporary OpenCode session
+workdir that ``OpenCodeModelSession`` runs ``opencode serve`` in. OpenCode
+discovers all four config surfaces natively from that cwd:
+
+* ``opencode.json``            -- MCP servers under the ``mcp`` key
+* ``.claude/skills/<name>/``   -- skills (copied byte-identical)
+* ``.opencode/commands/*.md``  -- slash commands
+* ``.opencode/agents/*.md``    -- subagents
+
+A ``None``/empty ``plugin_dir`` returns ``None`` (no bundle configured, no
+filesystem effect); an invalid bundle raises :class:`PluginBundleError` with the
+aggregated validation issues, exactly as ``load_plugins`` does for the Claude
+harness -- a broken bundle fails runner startup visibly rather than running
+capability-less.
+
+Fidelity record (AC2)
+=====================
+
+Compilation copies verbatim wherever OpenCode's leniency permits and transforms
+only where the two formats' shapes genuinely differ. Every loss below is also
+emitted at runtime as a ``logger.warning`` on ``agentos_runner.opencode.installer``
+so an operator sees exactly what degraded; warnings never fail the install.
+
+* **Skills** copy byte-identical into ``.claude/skills/``. OpenCode ignores
+  unknown skill frontmatter, so a skill's ``allowed-tools`` restriction is
+  **lost** (per-skill tool limits are not enforced; warned per skill). OpenCode
+  discovers a skill only when its frontmatter ``name`` is kebab-case
+  (``^[a-z0-9]+(-[a-z0-9]+)*$``); a validator-passing but non-kebab name is
+  copied yet **silently undiscovered** by OpenCode (warned). A ``SKILL.md``
+  nested deeper than ``skills/<name>/SKILL.md`` is copied but **not discovered**
+  by OpenCode (warned). Symlinks inside ``skills/`` -- and a symlinked or
+  out-of-root ``skills/`` directory itself -- are **skipped** with a warning
+  (never followed) so an out-of-bundle target cannot leak host/container content
+  into the model-readable workdir.
+* **MCP servers** (from root ``.mcp.json`` and/or the manifest ``mcpServers``
+  field, inline object or path string) remap into ``opencode.json``. A stdio
+  ``{command, args, env}`` becomes ``{type: "local", command: [command, *args],
+  environment: env, cwd: <bundle dir>}``. A remote ``{type: "http"|"sse", url,
+  headers}`` becomes ``{type: "remote", url, headers}`` -- Claude's ``http`` vs
+  ``sse`` transport distinction **collapses to** ``remote`` (SSE-transport
+  servers are untested under OpenCode). ``${CLAUDE_PLUGIN_ROOT}`` anywhere in a
+  command/args/env/url/headers value expands to the absolute bundle path (the one
+  substitution knowable at compile time). Any other ``${VAR}`` **passes through
+  verbatim** and unexpanded -- secret delivery is ADR-0009's seam, out of scope
+  here (warned per occurrence). On a duplicate server name across declaration
+  forms the **root ``.mcp.json`` entry wins** (warned).
+* **Commands** copy into ``.opencode/commands/<name>.md`` with the shared
+  ``$ARGUMENTS`` body intact. Sources come from the conventional ``commands/``
+  directory and any manifest ``commands`` pointer (a file, or a directory whose
+  ``*.md`` are collected). A manifest-declared path that resolves outside the
+  bundle root, is a symlink, or matches nothing is **skipped** with a warning
+  (same guards apply to ``agents``). A Claude ``model`` alias in the frontmatter
+  will not resolve in OpenCode, so ``model`` is **stripped** (warned); other
+  Claude-only frontmatter (``allowed-tools``, ``argument-hint``,
+  ``disable-model-invocation``) is harmlessly ignored by OpenCode and kept.
+* **Agents** copy into ``.opencode/agents/<name>.md`` with ``description`` (and
+  everything else) kept but ``model`` and ``tools`` **stripped**: Claude model
+  aliases do not resolve and the ``tools`` list names PascalCase Claude tools
+  meaningless to OpenCode (OpenCode restricts via ``permission`` config instead;
+  that restriction is **not** reconstructed here). Warned.
+* **scripts/** and manifest **hooks** are **unsupported**: bundle scripts have no
+  OpenCode target and Claude hook events have no OpenCode equivalent in this
+  compiler (OpenCode's hook system is JS-native). Nothing is materialized for
+  either; each is warned when present.
+* **plugin.json metadata** (version/description/author/homepage/keywords) is
+  **dropped** -- it has no OpenCode session surface; only ``name`` is used, for
+  log context.
+
+See ``runner/README.md`` for the operator-facing pointer to this record.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import re
+import shutil
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from plugin_format import McpConfig, McpServer, PluginManifest
+
+from ..plugin import PluginBundleError, ensure_valid_bundle
 
 logger = logging.getLogger(__name__)
 
+_OPENCODE_SCHEMA = "https://opencode.ai/config.json"
+_PLUGIN_ROOT_VAR = "CLAUDE_PLUGIN_ROOT"
+_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
 
-class OpenCodeBundleInstaller:
-    """Return the OpenCode harness's empty session config; today always ``None``.
 
-    A truthy ``plugin_dir`` is honored as a no-op with a warning: the OpenCode
-    harness does not yet support bundles, so the session runs bundle-less until
-    the compiler (issue #310) lands.
+@dataclass(frozen=True)
+class CompiledOpenCodeBundle:
+    """A materialized OpenCode session workdir.
+
+    ``workdir`` is passed straight to ``OpenCodeModelSession(cwd=...)``; the
+    frozen dataclass (not a bare ``str``) leaves room for #311 to add fields
+    without changing the ``BundleInstaller`` port signature.
     """
 
-    def install(self, plugin_dir: str | None) -> None:
-        if plugin_dir:
+    workdir: str
+
+
+class OpenCodeBundleInstaller:
+    """Compile a validated plugin bundle into an OpenCode session workdir."""
+
+    def __init__(self, workdir_root: str | None = None) -> None:
+        self._workdir_root = workdir_root
+
+    def install(self, plugin_dir: str | None) -> CompiledOpenCodeBundle | None:
+        if not plugin_dir:
+            return None
+
+        root = Path(plugin_dir).resolve()
+        ensure_valid_bundle(root)
+
+        plugin_root = str(root)
+        manifest = _load_manifest(root)
+        workdir = Path(
+            tempfile.mkdtemp(prefix="agentos-opencode-bundle-", dir=self._workdir_root)
+        )
+
+        _compile_skills(root, workdir)
+        _compile_commands(root, manifest, workdir)
+        _compile_agents(root, manifest, workdir)
+        mcp = _compile_mcp(root, manifest, plugin_root)
+        _warn_unsupported(root, manifest)
+
+        config: dict[str, Any] = {"$schema": _OPENCODE_SCHEMA}
+        if mcp:
+            config["mcp"] = mcp
+        (workdir / "opencode.json").write_text(
+            json.dumps(config, indent=2) + "\n", encoding="utf-8"
+        )
+        logger.info("compiled OpenCode bundle %r into %s", manifest.name, workdir)
+        return CompiledOpenCodeBundle(workdir=str(workdir))
+
+
+def _load_manifest(root: Path) -> PluginManifest:
+    for loc in _MANIFEST_LOCATIONS:
+        path = root / loc
+        if path.is_file():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return PluginManifest.model_validate(data)
+    # Unreachable after a passing validate_bundle (manifest presence is checked
+    # there); defensive so a caller cannot proceed without a manifest.
+    raise PluginBundleError(f"no manifest found in validated bundle at {root}")
+
+
+# -- skills -----------------------------------------------------------------
+
+
+def _compile_skills(root: Path, workdir: Path) -> None:
+    skills_dir = root / "skills"
+    if not _walkable_top_dir(root, skills_dir, "skills"):
+        return
+    _copy_skill_tree(skills_dir, workdir / ".claude" / "skills", skills_dir)
+
+
+def _copy_skill_tree(src: Path, dest: Path, skills_root: Path) -> None:
+    """Copy ``src`` into ``dest`` byte-identical, skipping symlinks with a warning.
+
+    Symlinks are checked at every level and never followed, so a symlinked
+    directory cannot smuggle out-of-bundle content into the session workdir. A
+    ``SKILL.md`` nested deeper than ``skills/<name>/SKILL.md`` is copied but
+    warned (OpenCode will not discover it).
+    """
+
+    for entry in sorted(src.iterdir()):
+        if entry.is_symlink():
             logger.warning(
-                "plugin bundle configured at %s but the OpenCode harness does not "
-                "yet support bundles; the session runs bundle-less (compiler is "
-                "issue #310)",
-                plugin_dir,
+                "skipping symlink %s under skills/: symlinks are not copied into "
+                "the OpenCode session workdir (an out-of-bundle target would leak "
+                "host content the model could read)",
+                entry.name,
             )
+            continue
+        target = dest / entry.name
+        if entry.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            _copy_skill_tree(entry, target, skills_root)
+        elif entry.is_file():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(entry, target)
+            if entry.name == "SKILL.md":
+                rel = entry.relative_to(skills_root)
+                if len(rel.parts) > 2:
+                    logger.warning(
+                        "skill file %s is nested deeper than skills/<name>/SKILL.md; "
+                        "it is copied but OpenCode discovers skills only at "
+                        "skills/<name>/SKILL.md, so this one stays undiscovered",
+                        rel.as_posix(),
+                    )
+                _warn_skill_frontmatter(entry)
+
+
+def _warn_skill_frontmatter(skill_file: Path) -> None:
+    frontmatter = _parse_frontmatter(skill_file.read_text(encoding="utf-8"))
+    if frontmatter is None:
+        return
+    name = frontmatter.get("name")
+    if "allowed-tools" in frontmatter or "allowed_tools" in frontmatter:
+        logger.warning(
+            "skill %r declares 'allowed-tools'; OpenCode ignores unknown skill "
+            "frontmatter, so its per-skill tool restriction is lost",
+            name,
+        )
+    if isinstance(name, str) and not _KEBAB_RE.match(name):
+        logger.warning(
+            "skill name %r is not kebab-case (^[a-z0-9]+(-[a-z0-9]+)*$); OpenCode "
+            "will silently not discover it",
+            name,
+        )
+
+
+# -- commands & agents ------------------------------------------------------
+
+
+def _compile_commands(root: Path, manifest: PluginManifest, workdir: Path) -> None:
+    for src in _collect_markdown(root, "commands", manifest.commands):
+        _emit_markdown(src, workdir / ".opencode" / "commands", {"model"}, "command")
+
+
+def _compile_agents(root: Path, manifest: PluginManifest, workdir: Path) -> None:
+    for src in _collect_markdown(root, "agents", manifest.agents):
+        _emit_markdown(src, workdir / ".opencode" / "agents", {"model", "tools"}, "agent")
+
+
+def _collect_markdown(
+    root: Path, dirname: str, declared: str | list[str] | None
+) -> list[Path]:
+    """Collect markdown sources: conventional dir first, then manifest paths.
+
+    Keyed by output filename so a later declaration of the same basename wins
+    (warned); insertion order is preserved for a deterministic compile.
+    """
+
+    collected: dict[str, Path] = {}
+
+    def add(path: Path) -> None:
+        if path.name in collected:
+            logger.warning(
+                "%s %r declared more than once; the last declaration wins",
+                dirname[:-1],
+                path.name,
+            )
+        collected[path.name] = path
+
+    conventional = root / dirname
+    if _walkable_top_dir(root, conventional, dirname):
+        _add_markdown_from_dir(conventional, dirname, add)
+
+    declared_paths = [declared] if isinstance(declared, str) else (declared or [])
+    for rel in declared_paths:
+        _collect_declared_markdown(root, dirname, rel, add)
+
+    return list(collected.values())
+
+
+def _collect_declared_markdown(
+    root: Path, dirname: str, rel: str, add: Callable[[Path], None]
+) -> None:
+    """Collect markdown from a manifest-declared ``commands``/``agents`` path.
+
+    The path is bundle-supplied, so it is contained to the resolved bundle root
+    before anything is read (see :func:`_contained_declared_path`). A contained
+    directory contributes its ``*.md`` (same per-entry symlink guard); a path
+    matching nothing is skipped with a warning.
+    """
+
+    path = _contained_declared_path(root, rel, dirname)
+    if path is None:
+        return
+    if path.is_file():
+        add(path)
+    elif path.is_dir():
+        _add_markdown_from_dir(path, rel, add)
+    else:
+        logger.warning(
+            "%s path %r declared in the manifest matches no file or directory; "
+            "nothing is materialized for it",
+            dirname,
+            rel,
+        )
+
+
+def _emit_markdown(src: Path, dest_dir: Path, strip: set[str], kind: str) -> None:
+    text = src.read_text(encoding="utf-8")
+    frontmatter = _parse_frontmatter(text)
+    if frontmatter is None:
+        out = text
+    else:
+        dropped = [key for key in strip if key in frontmatter]
+        kept = {key: value for key, value in frontmatter.items() if key not in strip}
+        body = text.split("---", 2)[2]
+        out = _render_markdown(kept, body)
+        for key in dropped:
+            logger.warning(
+                "%s %r: dropped frontmatter key %r (its Claude value does not "
+                "resolve in OpenCode)",
+                kind,
+                src.name,
+                key,
+            )
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / src.name).write_text(out, encoding="utf-8")
+
+
+def _render_markdown(frontmatter: dict[str, Any], body: str) -> str:
+    block = yaml.safe_dump(frontmatter, sort_keys=False) if frontmatter else ""
+    return f"---\n{block}---{body}"
+
+
+# -- MCP --------------------------------------------------------------------
+
+
+def _compile_mcp(
+    root: Path, manifest: PluginManifest, plugin_root: str
+) -> dict[str, Any]:
+    servers: dict[str, McpServer] = {}
+    declared_file: Path | None = None
+
+    declared = manifest.mcpServers
+    if isinstance(declared, dict):
+        servers.update(_parse_mcp_object(declared))
+    elif isinstance(declared, str):
+        declared_path = _contained_declared_path(root, declared, "mcpServers")
+        if declared_path is not None and declared_path.is_file():
+            servers.update(_parse_mcp_file(declared_path))
+            declared_file = declared_path.resolve()
+
+    root_mcp = root / ".mcp.json"
+    if root_mcp.is_file() and root_mcp.resolve() != declared_file:
+        for name, server in _parse_mcp_file(root_mcp).items():
+            if name in servers:
+                logger.warning(
+                    "MCP server %r is declared in both the manifest and root "
+                    ".mcp.json; the root .mcp.json entry wins",
+                    name,
+                )
+            servers[name] = server  # root .mcp.json wins the collision
+
+    return {name: _remap_server(server, plugin_root) for name, server in servers.items()}
+
+
+def _parse_mcp_object(obj: object) -> dict[str, McpServer]:
+    # Accept both a full config object and a bare servers map (the inline
+    # manifest form), mirroring validate.py's _validate_mcp_object.
+    payload = obj if isinstance(obj, dict) and "mcpServers" in obj else {"mcpServers": obj}
+    return McpConfig.model_validate(payload).mcpServers
+
+
+def _parse_mcp_file(path: Path) -> dict[str, McpServer]:
+    return _parse_mcp_object(json.loads(path.read_text(encoding="utf-8")))
+
+
+def _remap_server(server: McpServer, plugin_root: str) -> dict[str, Any]:
+    if server.command is not None:
+        command = [_expand(server.command, plugin_root)]
+        command.extend(_expand(arg, plugin_root) for arg in server.args or [])
+        local: dict[str, Any] = {"type": "local", "command": command}
+        if server.env is not None:
+            local["environment"] = {
+                key: _expand(value, plugin_root) for key, value in server.env.items()
+            }
+        # Pin the stdio server's cwd to the bundle dir so relative paths behave
+        # as they did under Claude's plugin-root semantics (plan 8.4).
+        local["cwd"] = plugin_root
+        return local
+
+    remote: dict[str, Any] = {"type": "remote", "url": _expand(server.url or "", plugin_root)}
+    if server.headers is not None:
+        remote["headers"] = {
+            key: _expand(value, plugin_root) for key, value in server.headers.items()
+        }
+    return remote
+
+
+def _expand(value: str, plugin_root: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        var = match.group(1)
+        if var == _PLUGIN_ROOT_VAR:
+            return plugin_root
+        logger.warning(
+            "MCP config references ${%s}; only ${CLAUDE_PLUGIN_ROOT} expands at "
+            "compile time, so this passes through verbatim (secret delivery is "
+            "ADR-0009, out of scope for the compiler)",
+            var,
+        )
+        return match.group(0)
+
+    return _VAR_RE.sub(_replace, value)
+
+
+# -- unsupported surfaces ---------------------------------------------------
+
+
+def _warn_unsupported(root: Path, manifest: PluginManifest) -> None:
+    if (root / "scripts").exists():
+        logger.warning(
+            "bundle declares scripts/ but OpenCode has no target for bundle "
+            "scripts; nothing is materialized for them"
+        )
+    if manifest.hooks is not None:
+        logger.warning(
+            "bundle manifest declares hooks but OpenCode's plugin/hook system is "
+            "JS-native; no hooks are translated"
+        )
+
+
+# -- shared helpers ---------------------------------------------------------
+
+
+def _within_root(root: Path, candidate: Path) -> bool:
+    """Whether ``candidate`` resolves to a path inside the resolved bundle root.
+
+    ``root`` is already resolved at :meth:`OpenCodeBundleInstaller.install`.
+    Resolving the candidate collapses ``..`` traversal, absolute replacement
+    (``root / "/abs"`` == ``/abs``), and symlink targets, so a bundle-supplied
+    path pointing anywhere outside the bundle is caught here before it is read.
+    """
+
+    return candidate.resolve().is_relative_to(root)
+
+
+def _contained_declared_path(root: Path, rel: str, label: str) -> Path | None:
+    """Resolve a manifest-declared ``rel`` within ``root`` or warn and skip.
+
+    The shared containment gate for every manifest pointer (``commands``,
+    ``agents``, ``mcpServers``): a path resolving outside the resolved bundle
+    root, or a symlink, is rejected with a warning naming ``rel`` and ``None`` is
+    returned so the caller materializes nothing. Returns the joined path when it
+    is contained, leaving file-vs-dir dispatch to the caller.
+    """
+
+    path = root / rel
+    if not _within_root(root, path):
+        logger.warning(
+            "%s path %r declared in the manifest resolves outside the bundle root; "
+            "skipping it (a manifest must not pull files in from outside the bundle)",
+            label,
+            rel,
+        )
         return None
+    if path.is_symlink():
+        logger.warning(
+            "%s path %r declared in the manifest is a symlink; skipping it "
+            "(symlinks are never followed into the OpenCode session workdir)",
+            label,
+            rel,
+        )
+        return None
+    return path
+
+
+def _add_markdown_from_dir(
+    directory: Path, label: str, add: Callable[[Path], None]
+) -> None:
+    """Add every direct ``*.md`` under ``directory``, skipping symlinks with a warning.
+
+    ``label`` names the source (the conventional dirname or the declared rel) so
+    the per-entry symlink warning points at what the operator actually wrote.
+    """
+
+    for md in sorted(directory.glob("*.md")):
+        if md.is_symlink():
+            logger.warning("skipping symlink %s under %s/", md.name, label)
+            continue
+        add(md)
+
+
+def _walkable_top_dir(root: Path, path: Path, label: str) -> bool:
+    """Whether a conventional top-level dir is safe to iterate.
+
+    ``is_dir()`` follows symlinks, so a bundle shipping ``skills``/``commands``/
+    ``agents`` as a symlink (or a path escaping the root) would have its target's
+    real children iterated and the per-entry guards never fire. Skip such a dir
+    with a warning; return ``False`` (no warning) when the path simply is not a
+    directory.
+    """
+
+    if not path.exists():
+        return False
+    if path.is_symlink() or not _within_root(root, path):
+        logger.warning(
+            "skipping top-level %s/: it is a symlink or resolves outside the bundle "
+            "root, so its contents are not materialized into the OpenCode session "
+            "workdir (an out-of-bundle target would leak host content the model "
+            "could read)",
+            label,
+        )
+        return False
+    return path.is_dir()
+
+
+def _parse_frontmatter(text: str) -> dict[str, Any] | None:
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        loaded = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    return loaded if isinstance(loaded, dict) else None

--- a/runner/src/agentos_runner/plugin.py
+++ b/runner/src/agentos_runner/plugin.py
@@ -31,6 +31,22 @@ class PluginBundleError(RuntimeError):
     """Raised when the mounted plugin bundle fails validation."""
 
 
+def ensure_valid_bundle(root: Path) -> None:
+    """Validate the bundle at ``root`` or raise with the aggregated issues.
+
+    The shared fail-loud gate every harness installer runs before ingesting a
+    bundle: a broken bundle is a hard startup error, not a silent skip. Both the
+    Claude passthrough (``load_plugins``) and the OpenCode compiler
+    (``opencode/installer.py``) call this so the rejection message stays
+    identical across harnesses.
+    """
+
+    result = validate_bundle(root)
+    if not result.valid:
+        detail = "; ".join(f"[{i.code}] {i.location}: {i.message}" for i in result.errors)
+        raise PluginBundleError(f"invalid plugin bundle at {root}: {detail}")
+
+
 @runtime_checkable
 class BundleInstaller(Protocol[T_co]):
     """Ingest a validated plugin bundle into a harness-native session config.
@@ -59,10 +75,7 @@ def load_plugins(plugin_dir: str | None) -> list[SdkPluginConfig]:
         return []
 
     root = Path(plugin_dir)
-    result = validate_bundle(root)
-    if not result.valid:
-        detail = "; ".join(f"[{i.code}] {i.location}: {i.message}" for i in result.errors)
-        raise PluginBundleError(f"invalid plugin bundle at {root}: {detail}")
+    ensure_valid_bundle(root)
 
     return [SdkPluginConfig(type="local", path=str(root))]
 

--- a/runner/tests/fixtures/opencode_live_bundle/.claude-plugin/plugin.json
+++ b/runner/tests/fixtures/opencode_live_bundle/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "opencode-live-bundle",
+  "version": "0.1.0",
+  "description": "A live round-trip bundle: one skill, one command, one stdio MCP probe server. Used by the OpenCode compiler unit tests and the live proof.",
+  "author": { "name": "CurieTech" },
+  "keywords": ["fixture", "opencode", "roundtrip"],
+  "mcpServers": ".mcp.json"
+}

--- a/runner/tests/fixtures/opencode_live_bundle/.mcp.json
+++ b/runner/tests/fixtures/opencode_live_bundle/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "probe": {
+      "command": "python3",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp/mcp_probe_server.py"],
+      "env": { "PROBE_MODE": "1" }
+    }
+  }
+}

--- a/runner/tests/fixtures/opencode_live_bundle/commands/ping.md
+++ b/runner/tests/fixtures/opencode_live_bundle/commands/ping.md
@@ -1,0 +1,6 @@
+---
+description: A trivial ping command that asks the model to reply with pong.
+model: sonnet
+---
+
+Reply with exactly the word: pong

--- a/runner/tests/fixtures/opencode_live_bundle/mcp/mcp_probe_server.py
+++ b/runner/tests/fixtures/opencode_live_bundle/mcp/mcp_probe_server.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Minimal stdlib-only MCP server over stdio for the opencode_live_bundle fixture.
+
+Speaks JSON-RPC 2.0 (newline-delimited) implementing just enough of the Model
+Context Protocol (2024-11-05) to advertise and serve one tool, ``agentos_probe``,
+which returns a fixed nonce. A live turn that surfaces the nonce proves the MCP
+server the compiled OpenCode config points at actually executed end to end.
+
+No third-party dependencies: this is fixture content the bundle's .mcp.json
+points at, driven as ``python3 mcp/mcp_probe_server.py``.
+"""
+
+import json
+import sys
+
+PROTOCOL_VERSION = "2024-11-05"
+NONCE = "NONCE-7f3a9c"
+
+TOOLS = [
+    {
+        "name": "agentos_probe",
+        "description": "Return a fixed probe nonce proving the MCP server executed.",
+        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+    }
+]
+
+
+def _send(message):
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def _respond(msg_id, result):
+    _send({"jsonrpc": "2.0", "id": msg_id, "result": result})
+
+
+def _error(msg_id, code, message):
+    _send({"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}})
+
+
+def _handle(request):
+    method = request.get("method")
+    msg_id = request.get("id")
+    if method == "initialize":
+        _respond(
+            msg_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "agentos-probe", "version": "0.1.0"},
+            },
+        )
+    elif method == "notifications/initialized":
+        return  # notification: no response
+    elif method == "tools/list":
+        _respond(msg_id, {"tools": TOOLS})
+    elif method == "tools/call":
+        params = request.get("params") or {}
+        if params.get("name") == "agentos_probe":
+            _respond(
+                msg_id,
+                {"content": [{"type": "text", "text": NONCE}], "isError": False},
+            )
+        else:
+            _error(msg_id, -32602, f"unknown tool: {params.get('name')}")
+    elif msg_id is not None:
+        _error(msg_id, -32601, f"method not found: {method}")
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        _handle(request)
+
+
+if __name__ == "__main__":
+    main()

--- a/runner/tests/fixtures/opencode_live_bundle/skills/roundtrip-greeter/SKILL.md
+++ b/runner/tests/fixtures/opencode_live_bundle/skills/roundtrip-greeter/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: roundtrip-greeter
+description: Greets the user and proves the skill was loaded by emitting a fixed round-trip token.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Roundtrip Greeter
+
+When following this skill, greet the user and include the literal token
+`AGENTOS-ROUNDTRIP` verbatim in your reply. The token proves this skill's
+instructions were loaded and followed.

--- a/runner/tests/test_opencode_installer.py
+++ b/runner/tests/test_opencode_installer.py
@@ -1,29 +1,552 @@
-"""The OpenCode stub bundle installer: an explicit, documented no-op (issue #309)."""
+"""The OpenCode bundle compiler: validated plugin bundle -> OpenCode session workdir.
 
+Pins the #310 compiler contract (plan sections 4-8): ``install()`` validates a
+bundle then materializes a temp workdir carrying ``opencode.json`` (MCP), copied
+skills under ``.claude/skills/``, and commands/agents under ``.opencode/``. Every
+test asserts compiled *content* (bytes, parsed JSON, warning text), never mere
+file existence. No mocks -- the compiler is pure filesystem + JSON.
+
+The import of ``CompiledOpenCodeBundle`` fails until the compiler is written; that
+collection error is the intended pre-implementation state.
+"""
+
+import json
 import logging
+from pathlib import Path
+from typing import cast
 
-from agentos_runner.opencode import OpenCodeBundleInstaller
-from agentos_runner.plugin import BundleInstaller
+import pytest
+import yaml
+from agentos_runner.opencode import CompiledOpenCodeBundle, OpenCodeBundleInstaller
+from agentos_runner.opencode.conformance import (
+    _BUNDLE_MCP_NONCE,
+    _BUNDLE_SKILL_TOKEN,
+    _build_runner,
+    _bundle_demo_failures,
+)
+from agentos_runner.opencode.session import OpenCodeModelSession
+from agentos_runner.plugin import BundleInstaller, PluginBundleError
 
 _INSTALLER_LOGGER = "agentos_runner.opencode.installer"
 
+_HERE = Path(__file__).resolve().parent
+_LIVE_BUNDLE = _HERE / "fixtures" / "opencode_live_bundle"
+_PLUGIN_FORMAT_FIXTURES = _HERE.parents[1] / "packages/plugin-format/tests/fixtures"
 
-def test_no_dir_returns_none_without_warning(caplog) -> None:
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_manifest(root: Path, name: str = "synthetic-bundle", **extra: object) -> None:
+    manifest: dict[str, object] = {"name": name}
+    manifest.update(extra)
+    _write(root / ".claude-plugin" / "plugin.json", json.dumps(manifest))
+
+
+def _relfiles(workdir: str) -> set[str]:
+    base = Path(workdir)
+    return {p.relative_to(base).as_posix() for p in base.rglob("*") if p.is_file()}
+
+
+def _frontmatter(text: str) -> dict:
+    assert text.startswith("---"), "compiled markdown should retain a frontmatter block"
+    _, block, _body = text.split("---", 2)
+    loaded = yaml.safe_load(block)
+    return loaded or {}
+
+
+def _opencode_config(workdir: str) -> dict:
+    return json.loads((Path(workdir) / "opencode.json").read_text(encoding="utf-8"))
+
+
+def _messages(caplog) -> str:
+    return " ".join(record.getMessage() for record in caplog.records)
+
+
+# 1 -------------------------------------------------------------------------
+def test_install_none_returns_none_without_effect(tmp_path, caplog) -> None:
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
     with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
-        assert OpenCodeBundleInstaller().install(None) is None
+        assert installer.install(None) is None
+        assert installer.install("") is None
     assert caplog.records == []
+    assert list(tmp_path.iterdir()) == []  # no filesystem effect for a bundle-less install
 
 
-def test_configured_bundle_returns_none_and_warns(caplog) -> None:
-    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
-        assert OpenCodeBundleInstaller().install("/some/bundle") is None
-    messages = [record.getMessage() for record in caplog.records]
-    assert len(messages) == 1
-    warning = messages[0]
-    assert "/some/bundle" in warning
-    assert "bundle-less" in warning
-    assert "#310" in warning
-
-
-def test_opencode_installer_satisfies_bundle_installer_port() -> None:
+# 2 -------------------------------------------------------------------------
+def test_installer_satisfies_bundle_installer_port() -> None:
     assert isinstance(OpenCodeBundleInstaller(), BundleInstaller)
+
+
+# 3 -------------------------------------------------------------------------
+def test_invalid_bundle_raises_naming_issue(tmp_path) -> None:
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    bad = _PLUGIN_FORMAT_FIXTURES / "bad_manifest_name"
+    with pytest.raises(PluginBundleError) as exc:
+        installer.install(str(bad))
+    # Parity with load_plugins: the aggregated validation issue code surfaces.
+    assert "manifest.name_invalid" in str(exc.value)
+    assert list(tmp_path.iterdir()) == []  # a rejected bundle materializes nothing
+
+
+# 4 -------------------------------------------------------------------------
+def test_full_fixture_compile_materializes_expected_workdir(tmp_path) -> None:
+    bundle = str(_LIVE_BUNDLE)
+    compiled = OpenCodeBundleInstaller(workdir_root=str(tmp_path)).install(bundle)
+    assert isinstance(compiled, CompiledOpenCodeBundle)
+    workdir = Path(compiled.workdir)
+
+    # Exactly these files land; mcp/ probe server is referenced in place, never copied.
+    assert _relfiles(compiled.workdir) == {
+        "opencode.json",
+        ".claude/skills/roundtrip-greeter/SKILL.md",
+        ".opencode/commands/ping.md",
+    }
+
+    # Skill copies byte-identical.
+    source = (_LIVE_BUNDLE / "skills/roundtrip-greeter/SKILL.md").read_bytes()
+    assert (workdir / ".claude/skills/roundtrip-greeter/SKILL.md").read_bytes() == source
+
+    config = _opencode_config(compiled.workdir)
+    assert config["$schema"] == "https://opencode.ai/config.json"
+    probe = config["mcp"]["probe"]
+    assert probe["type"] == "local"
+    # ${CLAUDE_PLUGIN_ROOT} expands to the absolute bundle path; command becomes an array.
+    assert probe["command"] == ["python3", f"{bundle}/mcp/mcp_probe_server.py"]
+    assert probe["environment"] == {"PROBE_MODE": "1"}
+    # stdio server cwd pinned to the bundle dir so relative paths behave (plan 8.4).
+    assert probe["cwd"] == bundle
+
+
+# 5 -------------------------------------------------------------------------
+def test_remote_server_remap(tmp_path) -> None:
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="remote-bundle", mcpServers=".mcp.json")
+    _write(
+        bundle / ".mcp.json",
+        json.dumps(
+            {
+                "mcpServers": {
+                    "remote-api": {
+                        "type": "http",
+                        "url": "https://mcp.example.com/v1",
+                        "headers": {"X-Api-Style": "static"},
+                    }
+                }
+            }
+        ),
+    )
+    compiled = OpenCodeBundleInstaller(workdir_root=str(tmp_path)).install(str(bundle))
+    remote = _opencode_config(compiled.workdir)["mcp"]["remote-api"]
+    assert remote["type"] == "remote"  # http/sse transport distinction collapses to remote
+    assert remote["url"] == "https://mcp.example.com/v1"
+    assert remote["headers"] == {"X-Api-Style": "static"}
+
+
+# 6 -------------------------------------------------------------------------
+def test_skill_copy_fidelity_and_warnings(tmp_path, caplog) -> None:
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(_LIVE_BUNDLE))
+
+    source = (_LIVE_BUNDLE / "skills/roundtrip-greeter/SKILL.md").read_bytes()
+    dest = (Path(compiled.workdir) / ".claude/skills/roundtrip-greeter/SKILL.md").read_bytes()
+    assert dest == source  # verbatim copy including the ignored allowed-tools key
+
+    warned = _messages(caplog)
+    assert "allowed-tools" in warned
+    assert "roundtrip-greeter" in warned  # the fidelity warning names the affected skill
+
+    # A frontmatter name that passes the lenient validator but violates OpenCode's
+    # kebab pattern is copied but warned (OpenCode would silently not discover it).
+    caplog.clear()
+    kebab = tmp_path / "kebab"
+    _write_manifest(kebab, name="kebab-bundle")
+    _write(
+        kebab / "skills" / "greeter" / "SKILL.md",
+        "---\nname: Greeter_Caps\ndescription: Not kebab-case.\n---\n\nHello.\n",
+    )
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        installer.install(str(kebab))
+    assert "Greeter_Caps" in _messages(caplog)
+
+
+# 7 -------------------------------------------------------------------------
+def test_mcp_inline_dict_and_path_pointer_forms(tmp_path) -> None:
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+
+    # Inline-object manifest mcpServers form.
+    inline = tmp_path / "inline"
+    _write_manifest(
+        inline,
+        name="inline-bundle",
+        mcpServers={"inline-srv": {"command": "python3", "args": ["-m", "srv"]}},
+    )
+    inline_mcp = _opencode_config(installer.install(str(inline)).workdir)["mcp"]
+    assert inline_mcp["inline-srv"]["type"] == "local"
+    assert inline_mcp["inline-srv"]["command"] == ["python3", "-m", "srv"]
+
+    # Path-pointer manifest form (valid_bundle points mcpServers at ".mcp.json"):
+    # each server appears exactly once, not duplicated by re-reading root .mcp.json.
+    valid = _PLUGIN_FORMAT_FIXTURES / "valid_bundle"
+    valid_mcp = _opencode_config(installer.install(str(valid)).workdir)["mcp"]
+    assert set(valid_mcp) == {"local-tools", "remote-api"}
+    assert valid_mcp["local-tools"]["command"] == ["python", "-m", "demo_tools"]
+    assert valid_mcp["local-tools"]["environment"] == {"DEMO_MODE": "1"}
+    assert valid_mcp["remote-api"]["type"] == "remote"
+
+
+# 8 -------------------------------------------------------------------------
+def test_duplicate_server_name_root_wins_and_warns(tmp_path, caplog) -> None:
+    bundle = tmp_path / "bundle"
+    _write_manifest(
+        bundle,
+        name="dup-bundle",
+        mcpServers={"dup": {"command": "python3", "args": ["manifest_version.py"]}},
+    )
+    _write(
+        bundle / ".mcp.json",
+        json.dumps({"mcpServers": {"dup": {"command": "python3", "args": ["root_version.py"]}}}),
+    )
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+    dup = _opencode_config(compiled.workdir)["mcp"]["dup"]
+    assert dup["command"] == ["python3", "root_version.py"]  # root .mcp.json wins the collision
+    assert "dup" in _messages(caplog)
+
+
+# 9 -------------------------------------------------------------------------
+def test_command_and_agent_frontmatter_stripping(tmp_path, caplog) -> None:
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="cmd-agent-bundle")
+    _write(
+        bundle / "commands" / "deploy.md",
+        "---\ndescription: Deploy the thing.\nmodel: sonnet\nargument-hint: <env>\n---\n\n"
+        "Deploy to $ARGUMENTS now.\n",
+    )
+    _write(
+        bundle / "agents" / "helper.md",
+        "---\nname: helper\ndescription: A helper agent.\nmodel: opus\n"
+        "tools:\n  - Bash\n  - Read\n---\n\nYou are a helper.\n",
+    )
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+    workdir = Path(compiled.workdir)
+
+    command_text = (workdir / ".opencode/commands/deploy.md").read_text(encoding="utf-8")
+    command_fm = _frontmatter(command_text)
+    assert "model" not in command_fm  # Claude model alias stripped (won't resolve in OpenCode)
+    assert command_fm["description"] == "Deploy the thing."
+    assert "Deploy to $ARGUMENTS now." in command_text  # body preserved intact
+
+    agent_text = (workdir / ".opencode/agents/helper.md").read_text(encoding="utf-8")
+    agent_fm = _frontmatter(agent_text)
+    assert "model" not in agent_fm
+    assert "tools" not in agent_fm  # Claude PascalCase tool list dropped
+    assert agent_fm["description"] == "A helper agent."
+    assert "You are a helper." in agent_text
+
+    assert "model" in _messages(caplog).lower()
+
+
+# 10 ------------------------------------------------------------------------
+def test_scripts_and_hooks_warn_and_materialize_nothing(tmp_path, caplog) -> None:
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="scripts-hooks-bundle", hooks={"PreToolUse": [{"matcher": "*"}]})
+    _write(bundle / "scripts" / "setup.sh", "#!/bin/bash\necho hi\n")
+    _write(
+        bundle / "skills" / "s" / "SKILL.md",
+        "---\nname: s\ndescription: A minimal skill so the bundle carries content.\n---\n\nBody.\n",
+    )
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+    workdir = Path(compiled.workdir)
+
+    files = _relfiles(compiled.workdir)
+    assert not any("setup.sh" in f for f in files)  # scripts unsupported, not copied
+    assert not (workdir / "scripts").exists()
+    assert not any("hook" in f.lower() for f in files)  # hooks unsupported, not materialized
+
+    warned = _messages(caplog).lower()
+    assert "scripts" in warned
+    assert "hook" in warned
+
+
+# 11 ------------------------------------------------------------------------
+def test_non_plugin_root_var_passes_through_and_warns(tmp_path, caplog) -> None:
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="var-bundle", mcpServers=".mcp.json")
+    _write(
+        bundle / ".mcp.json",
+        json.dumps(
+            {
+                "mcpServers": {
+                    "envy": {
+                        "command": "python3",
+                        "args": ["-m", "srv"],
+                        "env": {"UPSTREAM_TOKEN": "${MY_UPSTREAM_VAR}"},
+                    }
+                }
+            }
+        ),
+    )
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+    environment = _opencode_config(compiled.workdir)["mcp"]["envy"]["environment"]
+    # A ${VAR} other than CLAUDE_PLUGIN_ROOT is left verbatim (ADR-0009 owns delivery).
+    assert environment == {"UPSTREAM_TOKEN": "${MY_UPSTREAM_VAR}"}
+    assert "MY_UPSTREAM_VAR" in _messages(caplog)
+
+
+# 12 ------------------------------------------------------------------------
+def test_skills_only_bundle_omits_mcp_key(tmp_path) -> None:
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="skills-only-bundle")
+    _write(
+        bundle / "skills" / "solo" / "SKILL.md",
+        "---\nname: solo\ndescription: The only skill; no MCP anywhere.\n---\n\nBody.\n",
+    )
+    compiled = OpenCodeBundleInstaller(workdir_root=str(tmp_path)).install(str(bundle))
+    workdir = Path(compiled.workdir)
+    config = _opencode_config(compiled.workdir)
+    assert "mcp" not in config  # pinned choice: the mcp key is ABSENT, not an empty object
+    assert config["$schema"] == "https://opencode.ai/config.json"
+    assert (workdir / ".claude/skills/solo/SKILL.md").is_file()
+
+
+# 13 ------------------------------------------------------------------------
+def test_symlink_in_skills_skipped_and_warns(tmp_path, caplog) -> None:
+    outside = tmp_path / "outside_target.txt"
+    outside.write_text("LEAKED-HOST-CONTENT", encoding="utf-8")
+
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="symlink-bundle")
+    skill_dir = bundle / "skills" / "realskill"
+    _write(
+        skill_dir / "SKILL.md",
+        "---\nname: realskill\ndescription: A real skill next to a symlink.\n---\n\nBody.\n",
+    )
+    (skill_dir / "leak.txt").symlink_to(outside)
+
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+    workdir = Path(compiled.workdir)
+
+    assert (workdir / ".claude/skills/realskill/SKILL.md").is_file()
+    assert not (workdir / ".claude/skills/realskill/leak.txt").exists()  # symlink skipped
+    for materialized in workdir.rglob("*"):
+        if materialized.is_file():
+            body = materialized.read_text(encoding="utf-8", errors="ignore")
+            assert "LEAKED-HOST-CONTENT" not in body  # smuggled content never lands
+
+    warned = _messages(caplog)
+    assert "leak.txt" in warned or "symlink" in warned.lower()
+
+
+# 14 ------------------------------------------------------------------------
+def test_build_runner_binds_compiled_workdir_as_session_cwd() -> None:
+    # Wiring: _build_runner compiles the bundle and binds the compiled workdir as
+    # the session factory's cwd. Reading the private _cwd avoids widening session.py
+    # public surface purely for a test.
+    runner = _build_runner(str(_LIVE_BUNDLE))
+    session = runner._factory()
+    assert session._cwd is not None
+    assert (Path(session._cwd) / "opencode.json").is_file()
+
+    bundleless = _build_runner(None)
+    assert bundleless._factory()._cwd is None
+
+
+def test_build_runner_reuses_one_conformance_workdir_root() -> None:
+    first_session = cast(OpenCodeModelSession, _build_runner(str(_LIVE_BUNDLE))._factory())
+    second_session = cast(OpenCodeModelSession, _build_runner(str(_LIVE_BUNDLE))._factory())
+    first = first_session._cwd
+    second = second_session._cwd
+
+    assert first is not None
+    assert second is not None
+    assert Path(first).parent == Path(second).parent
+    assert Path(first).parent.name.startswith("agentos-opencode-conformance-")
+
+
+def test_bundle_demo_gate_requires_live_skill_and_mcp_proof() -> None:
+    valid = [
+        json.dumps({"type": "text_delta", "text": "working"}),
+        json.dumps({"type": "tool_note", "text": "loaded", "tool": "skill"}),
+        json.dumps(
+            {
+                "type": "final",
+                "text": f"{_BUNDLE_SKILL_TOKEN} {_BUNDLE_MCP_NONCE}",
+                "status": "done",
+            }
+        )
+        + "  ",
+    ]
+
+    assert _bundle_demo_failures(valid) == []
+    assert _bundle_demo_failures([*valid, "not json"]) == ["no final/done"]
+
+    wrong_tool = valid.copy()
+    wrong_tool[1] = json.dumps({"type": "tool_note", "text": "loaded", "tool": "read"})
+    assert _bundle_demo_failures(wrong_tool) == ["no skill tool_note"]
+
+    missing_proof = valid.copy()
+    missing_proof[-1] = json.dumps({"type": "final", "text": "other", "status": "done"})
+    assert _bundle_demo_failures(missing_proof) == ["missing skill token", "missing nonce"]
+
+
+# 15 ------------------------------------------------------------------------
+def test_absolute_manifest_command_path_skipped_and_warns(tmp_path, caplog) -> None:
+    # A manifest command pointer that is an absolute path replaces the join root
+    # entirely (``root / "/abs"`` == ``/abs``); it must never be read.
+    outside = tmp_path / "outside_abs.md"
+    outside.write_text(
+        "---\ndescription: Off-bundle command.\n---\n\nLEAKED-ABS-COMMAND\n",
+        encoding="utf-8",
+    )
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="abs-cmd-bundle", commands=str(outside))
+    _write(
+        bundle / "skills" / "s" / "SKILL.md",
+        "---\nname: s\ndescription: Content so the bundle is non-empty.\n---\n\nBody.\n",
+    )
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+
+    files = _relfiles(compiled.workdir)
+    assert not any(f.startswith(".opencode/commands/") for f in files)  # nothing materialized
+    for rel in files:
+        body = (Path(compiled.workdir) / rel).read_text(encoding="utf-8", errors="ignore")
+        assert "LEAKED-ABS-COMMAND" not in body  # off-bundle content never lands
+    warned = _messages(caplog)
+    assert str(outside) in warned  # the warning names the declared path
+
+
+# 16 ------------------------------------------------------------------------
+def test_parent_traversal_manifest_agent_path_skipped_and_warns(tmp_path, caplog) -> None:
+    outside = tmp_path / "outside.md"
+    outside.write_text(
+        "---\ndescription: Off-bundle agent.\n---\n\nLEAKED-TRAVERSAL-AGENT\n",
+        encoding="utf-8",
+    )
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="traversal-agent-bundle", agents="../outside.md")
+    _write(
+        bundle / "skills" / "s" / "SKILL.md",
+        "---\nname: s\ndescription: Content so the bundle is non-empty.\n---\n\nBody.\n",
+    )
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+
+    files = _relfiles(compiled.workdir)
+    assert not any(f.startswith(".opencode/agents/") for f in files)  # traversal skipped
+    for rel in files:
+        body = (Path(compiled.workdir) / rel).read_text(encoding="utf-8", errors="ignore")
+        assert "LEAKED-TRAVERSAL-AGENT" not in body
+    assert "../outside.md" in _messages(caplog)
+
+
+# 17 ------------------------------------------------------------------------
+def test_symlinked_top_level_skills_dir_skipped_and_warns(tmp_path, caplog) -> None:
+    # ``is_dir()`` follows a symlink, so a symlinked skills/ would iterate the
+    # target's real children and bypass the per-entry guard. The top-level dir
+    # must be rejected before it is walked.
+    external = tmp_path / "external_skills"
+    _write(
+        external / "sneaky" / "SKILL.md",
+        "---\nname: sneaky\ndescription: Off-bundle skill.\n---\n\nLEAKED-SYMLINK-SKILL\n",
+    )
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="symlink-skills-bundle")
+    _write(
+        bundle / "commands" / "ok.md",
+        "---\ndescription: A real in-bundle command.\n---\n\nRun $ARGUMENTS.\n",
+    )
+    (bundle / "skills").symlink_to(external, target_is_directory=True)
+
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+
+    files = _relfiles(compiled.workdir)
+    assert not any(".claude/skills" in f for f in files)  # symlinked skills/ not walked
+    assert ".opencode/commands/ok.md" in files  # the real in-bundle content still compiles
+    for rel in files:
+        body = (Path(compiled.workdir) / rel).read_text(encoding="utf-8", errors="ignore")
+        assert "LEAKED-SYMLINK-SKILL" not in body
+    assert "skills" in _messages(caplog).lower()
+
+
+# 18 ------------------------------------------------------------------------
+def test_mcp_pointer_escaping_root_skipped_and_warns(tmp_path, caplog) -> None:
+    outside_mcp = tmp_path / "outside_mcp.json"
+    outside_mcp.write_text(
+        json.dumps({"mcpServers": {"escapee": {"command": "python3", "args": ["x.py"]}}}),
+        encoding="utf-8",
+    )
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="escape-mcp-bundle", mcpServers="../outside_mcp.json")
+    _write(
+        bundle / "skills" / "s" / "SKILL.md",
+        "---\nname: s\ndescription: Content so the bundle is non-empty.\n---\n\nBody.\n",
+    )
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+
+    config = _opencode_config(compiled.workdir)
+    assert "mcp" not in config  # no server pulled in from outside the bundle root
+    assert "../outside_mcp.json" in _messages(caplog)
+
+
+# 19 ------------------------------------------------------------------------
+def test_directory_form_manifest_command_pointer_collects_md(tmp_path, caplog) -> None:
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="dir-cmd-bundle", commands="extra_cmds")
+    _write(
+        bundle / "extra_cmds" / "alpha.md",
+        "---\ndescription: Alpha command.\n---\n\nAlpha runs $ARGUMENTS.\n",
+    )
+    _write(
+        bundle / "extra_cmds" / "beta.md",
+        "---\ndescription: Beta command.\n---\n\nBeta runs $ARGUMENTS.\n",
+    )
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+    workdir = Path(compiled.workdir)
+
+    files = _relfiles(compiled.workdir)
+    assert ".opencode/commands/alpha.md" in files
+    assert ".opencode/commands/beta.md" in files
+    alpha = (workdir / ".opencode/commands/alpha.md").read_text(encoding="utf-8")
+    assert "Alpha runs $ARGUMENTS." in alpha  # directory-form *.md content materializes
+
+
+# 20 ------------------------------------------------------------------------
+def test_deep_nested_skill_md_copied_with_warning(tmp_path, caplog) -> None:
+    bundle = tmp_path / "bundle"
+    _write_manifest(bundle, name="deep-skill-bundle")
+    _write(
+        bundle / "skills" / "mygroup" / "nested" / "SKILL.md",
+        "---\nname: deep-skill\ndescription: Nested deeper than convention.\n---\n\nBody.\n",
+    )
+    installer = OpenCodeBundleInstaller(workdir_root=str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger=_INSTALLER_LOGGER):
+        compiled = installer.install(str(bundle))
+    workdir = Path(compiled.workdir)
+
+    # Copied byte-identical despite the non-canonical depth.
+    assert (workdir / ".claude/skills/mygroup/nested/SKILL.md").is_file()
+    warned = _messages(caplog)
+    assert "mygroup/nested/SKILL.md" in warned
+    assert "nested deeper" in warned.lower()


### PR DESCRIPTION
Stacked on #317 (the BundleInstaller port branch); do not merge independently, per epic #25 and the harness-neutral runner seams ADR (PR #306).

Implements the OpenCode `BundleInstaller`: a validated AgentOS plugin bundle compiles into an OpenCode session workdir that `OpenCodeModelSession` consumes via its existing `cwd` seam, so a real agent (skills + MCP servers + commands) runs under the second harness.

- `opencode.json` carries the remapped MCP servers (stdio `command`+`args` become a command array with `environment` and a bundle-dir `cwd`; `http`/`sse` collapse to `remote`); `${CLAUDE_PLUGIN_ROOT}` expands to the absolute bundle path, which is what makes bundle-shipped stdio servers reachable. Skills copy byte-identical to `.claude/skills/`; commands and agents land under `.opencode/` with Claude-only frontmatter (`model`, agent `tools`) stripped.
- Bundle-declared paths are contained to the bundle root: escaping or symlinked manifest pointers and top-level dirs are skipped with warnings instead of pulling external readable files into the model-visible workdir (found by the security pass; pinned by content-asserting tests).
- Fidelity losses are documented per element in the installer module docstring (referenced from `runner/README.md`) and each surfaces as a compile-time warning: `allowed-tools` dropped, `scripts/` and manifest hooks unsupported, non-`CLAUDE_PLUGIN_ROOT` `${VAR}` passthrough, http/sse transport collapse, command/agent frontmatter drops, plugin.json metadata unused.
- The conformance entrypoint binds the compiled workdir into the session factory (closing the #317 review note about the discarded installer result), asserts the live demo outcomes machine-checkably (done-final with skill token + MCP nonce + a `skill` tool_note, nonzero exit on any miss), and compiles under one exit-cleaned temp root.
- 22 offline tests cover every remap and containment vector; the fixture bundle includes a self-contained stdlib stdio MCP probe server so the live proof is hermetic on the MCP side.

Notes for the reviewer:

- A cross-model review claimed `.claude/skills/` is not discovered by OpenCode 1.17.17 from the session cwd; the live proof below refutes this for the pinned version (the skill token only exists inside the compiled workdir's SKILL.md).
- The manifest string-pointer MCP form silently fails under Claude Code's `--plugin-dir` but works under this compiler, a small fidelity gain over the first harness.
- Two remaining duplications against the frozen `plugin-format` package (MCP payload normalization, frontmatter parsing) are deliberate: promoting shared helpers there is a contract change that needs its own reviewed PR per `packages/CLAUDE.md`.

## Live round-trip proof

```
set -a && source agentos/.env && set +a
AGENTOS_PLUGIN_DIR="$PWD/runner/tests/fixtures/opencode_live_bundle" \
OPENCODE_SPIKE_SILENCE_TIMEOUT=90 uv run python -m agentos_runner.opencode.conformance
```

Conformance with the bundle installed: `5/5 conformance checks passed  passed=True`.

Demo turn (openrouter / z-ai/glm-4.6), terminal NDJSON:

```
{"version":"0.1.0","type":"tool_note","text":"running tool skill","tool":"skill"}
{"version":"0.1.0","type":"tool_note","text":"running tool probe_agentos_probe","tool":"probe_agentos_probe"}
{"version":"0.1.0","type":"side_effect_flag","tool":"probe_agentos_probe","detail":"non-idempotent tool executed"}
{"version":"0.1.0","type":"final","text":"\n\n\nHello! I've loaded the roundtrip-greeter skill as instructed. The token that proves this skill's instructions were loaded and followed is: `AGENTOS-ROUNDTRIP`\n\n\nThe probe returned: NONCE-7f3a9c","status":"done"}

LIVE SPIKE RESULT: PASS
```

The nonce can only originate from the probe MCP server executing over stdio via the compiled `opencode.json`, and the skill token only from the compiled workdir's SKILL.md: both halves of the round-trip are real. The `side_effect_flag` on the MCP tool is the deny-by-default classifier working as intended (MCP tools are not in `OPENCODE_READONLY_TOOLS`). The gate now asserts all of this itself and exits nonzero on any miss.

Offline gates: `uv run pytest -q` 672 passed / 4 skipped; `uv run ruff check .` clean; `uv run mypy` clean.

Ref #310
