### PR TITLE
Bring the OpenCode session up to the shared config contract

### DIFF
--- a/docs/interfaces/model-provider/INTERFACE.md
+++ b/docs/interfaces/model-provider/INTERFACE.md
@@ -1,6 +1,6 @@
 # INTERFACE: Model provider / credentials
 
-> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> Part of the AgentOS swappable seam catalog. See the [seam index](../../interfaces.md).
 > **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 (Anthropic) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
@@ -9,7 +9,7 @@
 
 The model provider is swapped through config, not code: a base-URL override plus a
 credential whose prefix routes it onto the right SDK auth env, targeting any
-Anthropic-compatible endpoint. There is no provider interface to implement — a
+Anthropic-compatible endpoint. There is no provider interface to implement. A
 config author fills in a base URL, a credential, and a model id, and the runner maps
 them onto the variables the bundled Claude CLI authenticates from. What stays core is
 the Anthropic wire format (kept even for OpenRouter, so prompt caching survives).
@@ -20,41 +20,67 @@ Resolution lives in `runner/src/agentos_runner/sdk_auth.py`. A provider is defin
 three things:
 
 - **Credential**, delivered as `AGENTOS_CREDENTIALS` (`sdk_auth.py:31`).
-  `resolve_model_credential` (`sdk_auth.py:82`) routes it by prefix
-  (`sdk_auth.py:94`): `sk-ant-oat...` → `CLAUDE_CODE_OAUTH_TOKEN`; other `sk-ant-...`
+  `resolve_model_credential` (`sdk_auth.py:99`) routes it by prefix
+  (`sdk_auth.py:55`): `sk-ant-oat...` → `CLAUDE_CODE_OAUTH_TOKEN`; other `sk-ant-...`
   → `ANTHROPIC_API_KEY`; `sk-or-...` (OpenRouter) → base-URL override; a bare `sk-...`
-  raises `UnsupportedCredentialError` (`sdk_auth.py:47`, `:116`). An SDK credential
-  already in the env wins (`sdk_auth.py:89`).
+  raises `UnsupportedCredentialError` (`sdk_auth.py:51`, `:134`). An SDK credential
+  already in the env wins (`sdk_auth.py:106`).
 - **Base URL**, `ANTHROPIC_BASE_URL` (`sdk_auth.py:34`). `resolve_base_url_override`
-  (`sdk_auth.py:51`) builds the override env when set, and `resolve_sdk_env`
-  (`sdk_auth.py:124`) is the entry point that decides override-vs-plain.
+  (`sdk_auth.py:68`) builds the override env when set, and `resolve_sdk_env`
+  (`sdk_auth.py:142`) is the entry point that decides override-vs-plain.
 - **Model id**, `AGENTOS_MODEL`, read by `RunnerConfig.from_env`
   (`runner/src/agentos_runner/config.py:62`).
 
 The override deliberately blanks `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_AUTH_TOKEN`
-to `""` (`sdk_auth.py:76`) so an inherited token cannot take precedence or leak to a
+to `""` (`sdk_auth.py:94`, `:95`) so an inherited token cannot take precedence or leak to a
 third-party endpoint.
 
 ## Implementations today
 
 One: Anthropic (direct API key or Claude Code OAuth token). OpenRouter is the
 intended reference second provider and is already wired as a prefix branch
-(`sdk_auth.py:100`): it reuses the shared base-URL-override seam, points at
+(`sdk_auth.py:118`): it reuses the shared base-URL-override seam, points at
 `OPENROUTER_BASE_URL = "https://openrouter.ai/api"` (`sdk_auth.py:36`), and puts the
 real key in `ANTHROPIC_API_KEY` (the `x-api-key` header OpenRouter reads).
+
+## OpenCode harness fidelity
+
+The OpenCode harness uses its own binder over the shared credential classifier.
+A credential with the `sk` plus `-or-` prefix has class `openrouter` and maps to
+exactly `OPENROUTER_API_KEY`. OAuth tokens, Anthropic API keys, unrecognized `sk`
+credentials, and opaque credentials are rejected loudly. The rejection identifies
+`AGENTOS_CREDENTIALS` and the credential class without exposing the value.
+
+Before starting OpenCode, the subprocess builder removes known OpenRouter,
+Anthropic, Claude OAuth, AgentOS credential, and inline OpenCode config variables
+from the inherited environment. It then injects only the selected binder output.
+This sanitize then select rule prevents ambient credentials from shadowing the
+session credential or leaking to a different provider.
+
+`AGENTOS_SYSTEM_PROMPT` and `AGENTOS_MAX_TURNS` reach OpenCode through inline
+`agent.build` configuration. Claude `max_turns` aborts the run at the limit.
+OpenCode `steps` uses the same numeric bound but forces a final text only response,
+so the termination shape differs. OpenCode has no native equivalent for the
+Claude SDK daily USD limit, so `max_usd_per_day` is not mapped and there is no USD
+cap in this harness.
+
+The runner still enforces `max_output_tokens_per_run` when OpenCode reports token
+totals during a turn. If OpenCode reports no tokens, the tracker remains at zero
+and cannot halt the turn. This is an explicit consequence of missing provider
+usage data, not an unmetered estimate.
 
 ## Known leakage
 
 The gotcha the seam encodes rather than a bleed-through: base-URL override mode must
 carry a **non-empty** placeholder key, `NO_OP_API_KEY = "not-needed"`
-(`sdk_auth.py:44`). The bundled Claude CLI treats an empty `ANTHROPIC_API_KEY` as
+(`sdk_auth.py:48`). The bundled Claude CLI treats an empty `ANTHROPIC_API_KEY` as
 "not logged in" and refuses to dial the overridden endpoint (empirically verified
-2026-07-07, `sdk_auth.py:58`), so an empty string is not viable — a deliberately
+2026-07-07, `sdk_auth.py:75`), so an empty string is not viable. A deliberately
 non-`sk-` placeholder passes the auth gate without being mistakable for a credential.
 The credential value is never logged.
 
 ## Cross-links
 
-- **Epic(s):** #24 — bring your own model (OpenRouter + native Anthropic-format endpoints), the seam's forward work; #46 (closed) — the Ollama local-model demo mode, which also exercises this base-URL-override + credential path.
-- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — core config seam, not one of the six swappable jobs.
-- **ADR(s):** [ADR-0009](../../adr/0009-per-agent-connector-auth.md) — per-agent secrets and connector credentials (the model credential is the one credential the platform resolves today, via prefix mapping in `sdk_auth.py`).
+- **Epic(s):** #24 covers bring your own model through OpenRouter and native Anthropic format endpoints. The seam's forward work also includes #46, the closed Ollama local model demo mode, which exercises the same base URL override and credential path.
+- **Vision doc:** [architecture-vision.md](../../architecture-vision.md) defines this as a core config seam, not one of the six swappable jobs.
+- **ADR(s):** [ADR-0009](../../adr/0009-per-agent-connector-auth.md) covers per agent secrets and connector credentials. The model credential is the one credential the platform resolves today through prefix mapping in `sdk_auth.py`.

--- a/runner/src/agentos_runner/config.py
+++ b/runner/src/agentos_runner/config.py
@@ -15,6 +15,11 @@ from dataclasses import dataclass
 
 from aci_protocol import SessionConfig
 
+# Shared default turn cap read by both the runner env parse (RunnerConfig.from_env)
+# and the OpenCode conformance harness, so both paths cap identically when
+# AGENTOS_MAX_TURNS is unset.
+DEFAULT_MAX_TURNS = 20
+
 
 @dataclass(frozen=True)
 class RunnerConfig:
@@ -62,7 +67,7 @@ class RunnerConfig:
             session=session,
             model=env.get("AGENTOS_MODEL"),
             system_prompt=env.get("AGENTOS_SYSTEM_PROMPT"),
-            max_turns=int(env.get("AGENTOS_MAX_TURNS", "20")),
+            max_turns=int(env.get("AGENTOS_MAX_TURNS", str(DEFAULT_MAX_TURNS))),
             history_ref=env.get("AGENTOS_HISTORY_REF"),
             idempotent_tools=idempotent,
             port=int(env.get("AGENTOS_RUNNER_PORT", "8080")),

--- a/runner/src/agentos_runner/opencode/auth.py
+++ b/runner/src/agentos_runner/opencode/auth.py
@@ -1,0 +1,35 @@
+"""Bind shared credential classes to the OpenCode harness environment.
+
+Credential classification belongs to the harness neutral runner seam established
+by ADR 0009 and PR 306. This module is the per harness binder: it consumes the
+shared ``classify_credential`` result and selects only the environment variable
+that OpenCode supports. Unsupported classes fail before a model session starts so
+credentials are never silently dropped.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ..sdk_auth import (
+    CREDENTIALS_ENV,
+    UnsupportedCredentialError,
+    classify_credential,
+)
+
+OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
+
+
+def resolve_opencode_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Resolve ``AGENTOS_CREDENTIALS`` into the OpenCode process environment."""
+    credential = env.get(CREDENTIALS_ENV)
+    if not credential:
+        return {}
+
+    credential_class = classify_credential(credential)
+    if credential_class == "openrouter":
+        return {OPENROUTER_API_KEY_ENV: credential}
+
+    raise UnsupportedCredentialError(
+        f"AGENTOS_CREDENTIALS has unsupported class {credential_class} for OpenCode"
+    )

--- a/runner/src/agentos_runner/opencode/conformance.py
+++ b/runner/src/agentos_runner/opencode/conformance.py
@@ -8,7 +8,10 @@ job, eval_case, interrupt); the three events each cost one real model turn, and
 the bare interrupt yields an idle final without a model call. Each producer call
 builds an isolated runner (fresh subprocess) to completion via ``anyio.run``.
 
-Run:  PYTHONPATH=src python -m agentos_runner.opencode.conformance   (from runner/)
+Run from ``runner/`` with the model credential selected explicitly:
+
+``AGENTOS_CREDENTIALS="$OPENROUTER_API_KEY" PYTHONPATH=src python -m
+agentos_runner.opencode.conformance``
 """
 
 from __future__ import annotations
@@ -19,11 +22,13 @@ import os
 import tempfile
 
 import anyio
-from aci_protocol import Event, Interrupt, run_conformance
+from aci_protocol import Budget, Event, Interrupt, run_conformance
 
+from ..config import DEFAULT_MAX_TURNS
 from ..otel import RunTracer
 from ..session import SessionRunner
 from ..side_effects import SideEffectClassifier
+from .auth import resolve_opencode_env
 from .installer import OpenCodeBundleInstaller
 from .session import OPENCODE_READONLY_TOOLS, OpenCodeModelSession
 
@@ -95,6 +100,18 @@ def _bundle_demo_failures(lines: list[str]) -> list[str]:
 
 
 def _build_runner(plugin_dir: str | None) -> SessionRunner:
+    credential_env = resolve_opencode_env(os.environ)
+    system_prompt = os.environ.get("AGENTOS_SYSTEM_PROMPT")
+    # DEFAULT_MAX_TURNS mirrors RunnerConfig.from_env so the OpenCode path caps
+    # turns identically to the Claude path when AGENTOS_MAX_TURNS is unset.
+    max_turns = int(os.environ.get("AGENTOS_MAX_TURNS", str(DEFAULT_MAX_TURNS)))
+    budget_raw = os.environ.get("AGENTOS_BUDGET")
+    ceiling = (
+        Budget.model_validate_json(budget_raw).max_output_tokens_per_run
+        if budget_raw
+        else 0
+    )
+
     # Compile the bundle (if any) and bind the materialized workdir as the
     # session's cwd -- this is where OpenCode discovers the compiled config.
     # A bundle-less call yields cwd=None (the session mkdtemps its own workdir).
@@ -103,8 +120,13 @@ def _build_runner(plugin_dir: str | None) -> SessionRunner:
     ).install(plugin_dir)
     cwd = compiled.workdir if compiled else None
     return SessionRunner(
-        session_factory=lambda: OpenCodeModelSession(cwd=cwd),
-        ceiling=0,  # unbounded: conformance validates protocol shape, not budgets
+        session_factory=lambda: OpenCodeModelSession(
+            cwd=cwd,
+            credential_env=credential_env,
+            system_prompt=system_prompt,
+            max_turns=max_turns,
+        ),
+        ceiling=ceiling,
         tracer=RunTracer(None),
         classifier=SideEffectClassifier(OPENCODE_READONLY_TOOLS),
         trace_name="opencode-conformance",

--- a/runner/src/agentos_runner/opencode/session.py
+++ b/runner/src/agentos_runner/opencode/session.py
@@ -19,7 +19,7 @@ Wire protocol (OpenCode v1, verified against ``opencode`` v1.17.17 ``GET /doc``)
 - ``interrupt`` -> ``POST /session/{id}/abort``.
 - ``close``     tears down the SSE reader, the HTTP session, and the subprocess.
 
-Two spike semantic gaps (documented, not solved here):
+Two remaining spike semantic gaps are documented here:
 
 * **Steer is completion-deferred.** OpenCode admits a message posted mid-turn at
   the next turn boundary rather than interleaving it into the live generation, so
@@ -28,6 +28,10 @@ Two spike semantic gaps (documented, not solved here):
 * **No resume equivalent.** OpenCode has no ``resume`` handle matching the SDK's,
   so ``AGENTOS_HISTORY_REF`` rehydration is unsupported and every session
   cold-starts. History replay is out of scope for this spike.
+
+Fidelity note: Claude ``max_turns`` aborts a run when the bound is reached.
+OpenCode ``steps`` uses the same bound but forces a final text only response.
+The termination shape therefore differs even though the iteration limit matches.
 
 Concurrency note: this uses ``asyncio`` primitives directly (queue, task, event)
 and therefore assumes the runner's ``anyio`` host is on its default asyncio
@@ -39,6 +43,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import shutil
 import socket
@@ -50,7 +55,16 @@ from typing import Any
 
 import aiohttp
 
+from ..sdk_auth import (
+    API_KEY_ENV,
+    AUTH_TOKEN_ENV,
+    CREDENTIALS_ENV,
+    OAUTH_TOKEN_ENV,
+)
+from .auth import OPENROUTER_API_KEY_ENV
 from .synth import TurnSynthesizer, _result
+
+_logger = logging.getLogger(__name__)
 
 # OpenCode's lowercase read-only built-ins, declared here as this harness's
 # read-only set for the deny-by-default side-effect classifier (side_effects.py).
@@ -80,6 +94,29 @@ _SILENCE_TIMEOUT = float(os.environ.get("OPENCODE_SPIKE_SILENCE_TIMEOUT", "120")
 _READY_ATTEMPTS = 160
 _READY_INTERVAL = 0.25
 
+# The single OpenCode agent name both config carrier and prompt body must name.
+# ``build_config_content`` nests the system prompt and step cap under
+# ``agent.<name>``, but the prompt API's default agent is NOT this one -- so
+# ``build_prompt_body`` must name the same agent or the turn runs a different
+# agent that never sees that config (neither system prompt nor turn cap applies).
+# Verified live against opencode v1.17.17 (GET /agent plus a live turn whose reply
+# lacked the config-injected proof token, 2026-07-11). Keep the two uses coupled
+# through this constant.
+_OPENCODE_AGENT = "build"
+
+_LEGACY_OPENROUTER_ENV = "OPENROUTER_" + "TOKEN"
+_SANITIZED_ENV_NAMES = frozenset(
+    {
+        OPENROUTER_API_KEY_ENV,
+        _LEGACY_OPENROUTER_ENV,
+        API_KEY_ENV,
+        AUTH_TOKEN_ENV,
+        OAUTH_TOKEN_ENV,
+        CREDENTIALS_ENV,
+        "OPENCODE_CONFIG_CONTENT",
+    }
+)
+
 
 def _free_port() -> int:
     sock = socket.socket()
@@ -101,23 +138,68 @@ def _find_opencode() -> str:
     raise RuntimeError("opencode binary not found on PATH or ~/.opencode/bin")
 
 
-def _subprocess_env() -> dict[str, str]:
-    """Build the subprocess env, forwarding exactly the OpenRouter credential.
+def build_subprocess_env(
+    base_env: dict[str, str],
+    credential_env: dict[str, str] | None,
+    config_content: str | None,
+) -> dict[str, str]:
+    """Return the sanitized environment for ``opencode serve``."""
 
-    OpenCode expects ``OPENROUTER_API_KEY``; this project stores it as
-    ``OPENROUTER_TOKEN``. The key value is never logged or echoed.
-    """
+    env = {
+        key: value
+        for key, value in base_env.items()
+        if key not in _SANITIZED_ENV_NAMES
+    }
+    if credential_env:
+        env.update(credential_env)
 
-    env = dict(os.environ)
-    key = os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENROUTER_TOKEN")
-    if key:
-        env["OPENROUTER_API_KEY"] = key
-    # Ensure the bun-shipped opencode runtime is resolvable.
+    # Ensure the bun shipped opencode runtime is resolvable.
     extra = os.pathsep.join(
-        p for p in (os.path.expanduser("~/.opencode/bin"), os.path.expanduser("~/.bun/bin")) if p
+        p
+        for p in (
+            os.path.expanduser("~/.opencode/bin"),
+            os.path.expanduser("~/.bun/bin"),
+        )
+        if p
     )
     env["PATH"] = extra + os.pathsep + env.get("PATH", "")
+    if config_content:
+        env["OPENCODE_CONFIG_CONTENT"] = config_content
     return env
+
+
+def build_prompt_body(provider: str, model: str, text: str) -> dict[str, Any]:
+    """Return the ``POST /session/{id}/prompt_async`` body for one turn.
+
+    The ``"agent"`` field is load-bearing and must name the same agent the config
+    carrier targets (see ``_OPENCODE_AGENT``).
+    """
+
+    return {
+        "agent": _OPENCODE_AGENT,
+        "model": {"providerID": provider, "modelID": model},
+        "parts": [{"type": "text", "text": text}],
+    }
+
+
+def build_config_content(
+    system_prompt: str | None, max_turns: int | None
+) -> str | None:
+    """Return inline OpenCode config for the supplied session settings."""
+
+    build: dict[str, str | int] = {}
+    if system_prompt:
+        build["prompt"] = system_prompt
+    if max_turns is not None:
+        if max_turns > 0:
+            build["steps"] = max_turns
+        else:
+            _logger.warning(
+                "OpenCode steps must be positive; omitting max_turns=%s", max_turns
+            )
+    if not build:
+        return None
+    return json.dumps({"agent": {_OPENCODE_AGENT: build}})
 
 
 class OpenCodeModelSession:
@@ -129,10 +211,16 @@ class OpenCodeModelSession:
         model: str | None = None,
         provider: str | None = None,
         cwd: str | None = None,
+        credential_env: dict[str, str] | None = None,
+        system_prompt: str | None = None,
+        max_turns: int | None = None,
     ) -> None:
         self._model = model or DEFAULT_MODEL
         self._provider = provider or DEFAULT_PROVIDER
         self._cwd = cwd
+        self._credential_env = credential_env
+        self._system_prompt = system_prompt
+        self._max_turns = max_turns
         self._bin = _find_opencode()
 
         self._proc: subprocess.Popen[bytes] | None = None
@@ -158,11 +246,23 @@ class OpenCodeModelSession:
             prefix="opencode-serve-", suffix=".log", delete=False
         )
         self._proc = subprocess.Popen(
-            [self._bin, "serve", "--port", str(port), "--hostname", "127.0.0.1",
-             "--log-level", "ERROR"],
+            [
+                self._bin,
+                "serve",
+                "--port",
+                str(port),
+                "--hostname",
+                "127.0.0.1",
+                "--log-level",
+                "ERROR",
+            ],
             stdout=self._log,
             stderr=self._log,
-            env=_subprocess_env(),
+            env=build_subprocess_env(
+                dict(os.environ),
+                self._credential_env,
+                build_config_content(self._system_prompt, self._max_turns),
+            ),
             cwd=workdir,
         )
         self._http = aiohttp.ClientSession()
@@ -232,10 +332,7 @@ class OpenCodeModelSession:
     async def query(self, text: str) -> None:
         if self._http is None or self._base is None or self._sid is None:
             raise RuntimeError("session not connected")
-        body = {
-            "model": {"providerID": self._provider, "modelID": self._model},
-            "parts": [{"type": "text", "text": text}],
-        }
+        body = build_prompt_body(self._provider, self._model, text)
         async with self._http.post(
             f"{self._base}/session/{self._sid}/prompt_async", json=body
         ) as resp:

--- a/runner/src/agentos_runner/opencode/synth.py
+++ b/runner/src/agentos_runner/opencode/synth.py
@@ -27,11 +27,24 @@ boundary. The relevant OpenCode v1 frames (verified against ``opencode`` v1.17.1
 - ``message.part.updated {part}`` -- part snapshots carrying ``part.id`` and
   ``part.type`` (``text`` | ``reasoning`` | ``tool`` | ``step-*``). A ``tool`` part at
   ``state.status == "running"`` maps to one ``ToolUseBlock``; a ``step-finish``
-  part carries token totals. The ``text`` part-updated snapshots (the empty
-  text-start and full text-end bookends) are intentionally ignored so text
-  already streamed via deltas is never emitted twice.
+  part carries that **step's** token block. The ``text`` part-updated snapshots
+  (the empty text-start and full text-end bookends) are intentionally ignored so
+  text already streamed via deltas is never emitted twice.
 - ``message.updated {info}`` -- assistant message info carrying ``modelID`` and
-  rolled-up ``tokens``.
+  the latest step's ``tokens``.
+
+Token accounting is **per step, not cumulative** (verified against a live
+``opencode`` 1.17.17 multi-step turn): each ``step-finish`` part and each
+``message.updated`` reports the output tokens of *that step only* and resets on
+the next step, while ``session.updated`` carries the session-cumulative total
+that spans turns. So a turn's true output total is the *sum* of its per-step
+maxima, not a single running max over the reports. ``TurnSynthesizer`` therefore
+accumulates one monotonic max per step (keyed by the ``step-finish`` part id,
+which is genuinely per-step; ``message.updated``'s id is the turn-constant
+message id and is only a fallback when no ``step-finish`` carries tokens) and
+sums them. Folding those reports into one max instead undercounts a multi-step
+turn (a budget ceiling between one step's tokens and the turn total would never
+trip), which is the bug this module previously had.
 - ``session.status {status:{type}}`` -- a ``busy`` -> ``idle`` transition marks
   turn completion (the terminal ``TurnResult``). ``session.idle`` is the
   deprecated equivalent and is handled the same way.
@@ -95,10 +108,27 @@ class TurnSynthesizer:
     def __init__(self) -> None:
         self.done = False
         self._final_text = ""
-        self._usage: dict[str, int] | None = None
         self._model_id: str | None = None
         self._error: str | None = None
         self._seen_activity = False
+        # Per-step output-token accounting. OpenCode reports output tokens PER
+        # STEP -- each step-finish part and each message.updated carries only
+        # that step's tokens and resets on the next step -- so the turn total is
+        # the SUM of per-step maxima, not one running max over the reports.
+        # ``_step_output`` keys the max seen per step-finish part id (a step's
+        # block can still stream upward within one id, so keep the max);
+        # ``_msg_output_max`` is the fallback total used only when no step-finish
+        # part carries tokens (message.updated's id is the turn-constant message
+        # id, so summing it alongside the step parts would double-count the same
+        # per-step reports). ``_last_input`` is the most recent block's input
+        # count, kept so the terminal result carries the real input alongside the
+        # summed output. ``_emitted_output_total`` is the running total already
+        # emitted as mid-turn deltas, so each carrier is the positive rise (never
+        # negative, never double-counted).
+        self._step_output: dict[str, int] = {}
+        self._msg_output_max = 0
+        self._last_input: int | None = None
+        self._emitted_output_total = 0
         # partID -> part.type, learned from message.part.updated snapshots. A
         # message.part.delta carries field="text" even when its part is a
         # reasoning part, so the delta alone cannot tell the answer channel from
@@ -106,10 +136,52 @@ class TurnSynthesizer:
         # part's first delta, verified on the live wire) supplies the real type.
         self._part_types: dict[str, str] = {}
 
+    def _running_output_total(self) -> int:
+        """The turn's output total so far: the sum of per-step maxima.
+
+        Falls back to the max output seen on ``message.updated`` only when no
+        ``step-finish`` part carried tokens, so a turn whose only usage source is
+        ``message.updated`` still reports something rather than nothing.
+        """
+
+        if self._step_output:
+            return sum(self._step_output.values())
+        return self._msg_output_max
+
+    def _terminal_usage(self) -> dict[str, int] | None:
+        """The terminal token block: last-seen input, summed per-step output."""
+
+        if self._last_input is None:
+            return None
+        return {
+            "input_tokens": self._last_input,
+            "output_tokens": self._running_output_total(),
+        }
+
     def _terminal(self) -> TurnResult:
+        usage = self._terminal_usage()
         if self._error is not None:
-            return _result(text=self._error, is_error=True, usage=self._usage)
-        return _result(text=self._final_text, is_error=False, usage=self._usage)
+            return _result(text=self._error, is_error=True, usage=usage)
+        return _result(text=self._final_text, is_error=False, usage=usage)
+
+    def _usage_carrier(self) -> AssistantText | None:
+        """Emit the positive rise in the running turn total, or None if flat.
+
+        Called after a per-step max is updated; the carrier delta is the amount
+        the summed turn total rose since the last carrier, so the runner folds
+        each step's tokens into the budget exactly once and never negatively.
+        """
+
+        total = self._running_output_total()
+        if total <= self._emitted_output_total:
+            return None
+        delta = total - self._emitted_output_total
+        self._emitted_output_total = total
+        return AssistantText(
+            text="",
+            model=self._model_id or "",
+            usage={"output_tokens": delta},
+        )
 
     def ingest(self, frame: dict[str, Any]) -> list[Any]:
         if self.done:
@@ -159,9 +231,19 @@ class TurnSynthesizer:
                     elif status == "error":
                         self._error = str(state.get("error") or "tool failed")
                 elif ptype == "step-finish":
-                    u = _tokens(part.get("tokens"))
-                    if u is not None:
-                        self._usage = u
+                    block = _tokens(part.get("tokens"))
+                    if block is not None:
+                        # Key this step's output by its part id (per-step on the
+                        # wire); a missing id collapses to one bucket. A step's
+                        # block can stream upward within the id, so keep the max.
+                        key = pid if isinstance(pid, str) and pid else "__step__"
+                        self._step_output[key] = max(
+                            self._step_output.get(key, 0), block["output_tokens"]
+                        )
+                        self._last_input = block["input_tokens"]
+                        carrier = self._usage_carrier()
+                        if carrier is not None:
+                            out.append(carrier)
 
         elif ftype == "message.updated":
             info = props.get("info", {})
@@ -169,9 +251,22 @@ class TurnSynthesizer:
                 model = info.get("modelID")
                 if model:
                     self._model_id = str(model)
-                u = _tokens(info.get("tokens"))
-                if u is not None:
-                    self._usage = u
+                block = _tokens(info.get("tokens"))
+                if block is not None:
+                    # message.updated reports the same per-step output as the
+                    # step-finish part but under a turn-constant message id, so
+                    # it cannot be a per-step key without double-counting. Track
+                    # its max as a fallback total, and only let it drive the
+                    # last-seen block and mid-turn carrier when no step-finish
+                    # part has supplied tokens.
+                    self._msg_output_max = max(
+                        self._msg_output_max, block["output_tokens"]
+                    )
+                    if not self._step_output:
+                        self._last_input = block["input_tokens"]
+                        carrier = self._usage_carrier()
+                        if carrier is not None:
+                            out.append(carrier)
 
         elif ftype == "session.error":
             self._error = _error_message(props.get("error"))

--- a/runner/src/agentos_runner/sdk_auth.py
+++ b/runner/src/agentos_runner/sdk_auth.py
@@ -35,6 +35,10 @@ BASE_URL_ENV = "ANTHROPIC_BASE_URL"
 AUTH_TOKEN_ENV = "ANTHROPIC_AUTH_TOKEN"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api"
 _SDK_CREDENTIAL_ENV = (OAUTH_TOKEN_ENV, API_KEY_ENV)
+_SK_PREFIX = "sk" + "-"
+_OAUTH_PREFIX = _SK_PREFIX + "ant-oat"
+_ANTHROPIC_PREFIX = _SK_PREFIX + "ant-"
+_OPENROUTER_PREFIX = _SK_PREFIX + "or-"
 
 # Non-empty no-op placeholder API key used in base-URL override mode. It is
 # deliberately not sk-... shaped so it can never be mistaken for a real
@@ -46,6 +50,19 @@ NO_OP_API_KEY = "not-needed"
 
 class UnsupportedCredentialError(RuntimeError):
     """``AGENTOS_CREDENTIALS`` is a recognizably non-Anthropic credential."""
+
+
+def classify_credential(credential: str) -> str:
+    """Classify a model credential without binding it to a harness."""
+    if credential.startswith(_OAUTH_PREFIX):
+        return "oauth-token"
+    if credential.startswith(_ANTHROPIC_PREFIX):
+        return "anthropic-api-key"
+    if credential.startswith(_OPENROUTER_PREFIX):
+        return "openrouter"
+    if credential.startswith(_SK_PREFIX):
+        return "unsupported-sk"
+    return "opaque"
 
 
 def resolve_base_url_override(env: MutableMapping[str, str]) -> dict[str, str] | None:
@@ -91,13 +108,14 @@ def resolve_model_credential(env: MutableMapping[str, str]) -> None:
     credential = env.get(CREDENTIALS_ENV)
     if not credential:
         return
-    if credential.startswith("sk-ant-oat"):
+    credential_class = classify_credential(credential)
+    if credential_class == "oauth-token":
         # Claude Code OAuth tokens share the sk-ant- prefix with API keys, so
         # this more specific check must come first.
         env[OAUTH_TOKEN_ENV] = credential
-    elif credential.startswith("sk-ant-"):
+    elif credential_class == "anthropic-api-key":
         env[API_KEY_ENV] = credential
-    elif credential.startswith("sk-or-"):
+    elif credential_class == "openrouter":
         # OpenRouter: reuse the shared base-URL-override seam to target OpenRouter's
         # native Anthropic Messages endpoint (the SDK appends /v1/messages). The real
         # key goes in ANTHROPIC_API_KEY (sent as the x-api-key header, which is what
@@ -110,7 +128,7 @@ def resolve_model_credential(env: MutableMapping[str, str]) -> None:
         assert override is not None  # base URL was just set
         env.update(override)
         env[API_KEY_ENV] = credential  # real key -> x-api-key (what OpenRouter reads)
-    elif credential.startswith("sk-"):
+    elif credential_class == "unsupported-sk":
         # OpenAI-style ("sk-...") and similar. Fail loudly rather than
         # forwarding a key the Anthropic SDK cannot use.
         raise UnsupportedCredentialError(
@@ -134,7 +152,7 @@ def resolve_sdk_env(env: MutableMapping[str, str]) -> dict[str, str] | None:
     override mode), or ``None`` when resolution mutated ``env`` in place.
     """
     credential = env.get(CREDENTIALS_ENV, "")
-    if not credential.startswith("sk-or-"):
+    if classify_credential(credential) != "openrouter":
         override = resolve_base_url_override(env)
         if override is not None:
             return override

--- a/runner/tests/test_opencode_auth.py
+++ b/runner/tests/test_opencode_auth.py
@@ -1,0 +1,61 @@
+"""OpenCode credential binder (issue #311 AC1).
+
+``resolve_opencode_env`` maps an ``AGENTOS_CREDENTIALS`` reference onto the env
+OpenCode reads. Only an OpenRouter (``sk-or-``) credential is supported; every
+other class is rejected loudly (never silently dropped) with a message that names
+``AGENTOS_CREDENTIALS`` and never echoes the credential value.
+
+All credential values are obviously-fake and split across a ``+`` so no real
+token shape appears as a single literal.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentos_runner.opencode.auth import resolve_opencode_env
+from agentos_runner.sdk_auth import CREDENTIALS_ENV, UnsupportedCredentialError
+
+OPENROUTER_API_KEY_ENV = "OPENROUTER_API_KEY"
+
+FAKE_OPENROUTER_KEY = "sk-or-" + "v1-FAKE-abc"
+FAKE_OAUTH_TOKEN = "sk-ant-oat" + "01-FAKE"
+FAKE_ANTHROPIC_KEY = "sk-ant-" + "api03-FAKE"
+FAKE_UNSUPPORTED_SK = "sk-" + "proj-FAKE"
+FAKE_OPAQUE = "opaque-" + "FAKE-token"
+
+
+def test_openrouter_credential_maps_to_openrouter_api_key_only() -> None:
+    out = resolve_opencode_env({CREDENTIALS_ENV: FAKE_OPENROUTER_KEY})
+    # Exactly the one bound var -- nothing else.
+    assert out == {OPENROUTER_API_KEY_ENV: FAKE_OPENROUTER_KEY}
+
+
+@pytest.mark.parametrize(
+    "credential",
+    [FAKE_OAUTH_TOKEN, FAKE_ANTHROPIC_KEY, FAKE_UNSUPPORTED_SK, FAKE_OPAQUE],
+)
+def test_non_openrouter_classes_rejected_loudly(credential: str) -> None:
+    with pytest.raises(UnsupportedCredentialError) as exc:
+        resolve_opencode_env({CREDENTIALS_ENV: credential})
+    message = str(exc.value)
+    # Names the ACI reference the operator must fix ...
+    assert "AGENTOS_CREDENTIALS" in message
+    # ... and never echoes the credential value (no-echo discipline).
+    assert credential not in message
+
+
+def test_rejection_never_silently_drops_the_credential() -> None:
+    # An unsupported credential must raise, not return an empty/partial env that
+    # would let the session fall through to no-credential (silent drop).
+    with pytest.raises(UnsupportedCredentialError):
+        resolve_opencode_env({CREDENTIALS_ENV: FAKE_ANTHROPIC_KEY})
+
+
+def test_unset_credentials_is_empty_noop() -> None:
+    assert resolve_opencode_env({}) == {}
+
+
+def test_empty_credentials_is_empty_noop() -> None:
+    # Matches the Claude binder's empty-string no-op contract; never injects an
+    # empty OPENROUTER_API_KEY.
+    assert resolve_opencode_env({CREDENTIALS_ENV: ""}) == {}

--- a/runner/tests/test_opencode_installer.py
+++ b/runner/tests/test_opencode_installer.py
@@ -364,6 +364,19 @@ def test_build_runner_binds_compiled_workdir_as_session_cwd() -> None:
     assert bundleless._factory()._cwd is None
 
 
+def test_build_runner_defaults_max_turns_to_20_like_claude_path(monkeypatch) -> None:
+    # Parity: with AGENTOS_MAX_TURNS unset the OpenCode conformance runner must
+    # bind the same default turn cap (20) that RunnerConfig.from_env applies to
+    # the Claude path, not an unbounded None.
+    monkeypatch.delenv("AGENTOS_MAX_TURNS", raising=False)
+    session = cast(OpenCodeModelSession, _build_runner(None)._factory())
+    assert session._max_turns == 20
+
+    monkeypatch.setenv("AGENTOS_MAX_TURNS", "5")
+    capped = cast(OpenCodeModelSession, _build_runner(None)._factory())
+    assert capped._max_turns == 5
+
+
 def test_build_runner_reuses_one_conformance_workdir_root() -> None:
     first_session = cast(OpenCodeModelSession, _build_runner(str(_LIVE_BUNDLE))._factory())
     second_session = cast(OpenCodeModelSession, _build_runner(str(_LIVE_BUNDLE))._factory())

--- a/runner/tests/test_opencode_session.py
+++ b/runner/tests/test_opencode_session.py
@@ -1,0 +1,193 @@
+"""Pure builders for the OpenCode subprocess env + inline config (issue #311).
+
+Two module-level helpers the plan extracts from ``OpenCodeModelSession`` so they
+are testable without spawning ``opencode serve`` (a live server is driver-only --
+sub-agent sandboxes kill it):
+
+- ``build_subprocess_env(base_env, credential_env, config_content)`` sanitizes
+  inherited credential vars, injects exactly the bound credential, augments PATH,
+  and sets ``OPENCODE_CONFIG_CONTENT`` only when there is content.
+- ``build_config_content(system_prompt, max_turns)`` serializes the
+  ``agent.build`` prompt/steps carrier, or ``None`` when nothing is set.
+
+AC3 lives here too: ambient ``OPENROUTER_*`` must never reach the subprocess
+without an explicit binding (the deleted spike fallback).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+
+import pytest
+from agentos_runner.opencode.session import (
+    build_config_content,
+    build_prompt_body,
+    build_subprocess_env,
+)
+
+FAKE_OPENROUTER_KEY = "sk-or-" + "v1-FAKE-key"
+
+# Every credential var the builder must strip from an inherited environment.
+CREDENTIAL_VARS = [
+    "OPENROUTER_API_KEY",
+    "OPENROUTER_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "AGENTOS_CREDENTIALS",
+    "OPENCODE_CONFIG_CONTENT",
+]
+
+
+def _polluted_base() -> dict[str, str]:
+    """A base env carrying ambient values for every credential var, plus HOME/PATH."""
+
+    base = {"HOME": "/home/runner", "PATH": "/usr/bin"}
+    for var in CREDENTIAL_VARS:
+        base[var] = "AMBIENT-" + var
+    return base
+
+
+# --- subprocess env: sanitize + inject ------------------------------------------
+
+
+def test_env_builder_strips_every_ambient_credential_var() -> None:
+    out = build_subprocess_env(_polluted_base(), None, None)
+    for var in CREDENTIAL_VARS:
+        assert var not in out, var
+
+
+def test_env_builder_injects_only_the_bound_credential() -> None:
+    out = build_subprocess_env(
+        _polluted_base(), {"OPENROUTER_API_KEY": FAKE_OPENROUTER_KEY}, None
+    )
+    assert out["OPENROUTER_API_KEY"] == FAKE_OPENROUTER_KEY
+    # No other credential var leaks from the ambient base.
+    for var in CREDENTIAL_VARS:
+        if var == "OPENROUTER_API_KEY":
+            continue
+        assert var not in out, var
+
+
+def test_env_builder_passes_through_unrelated_vars() -> None:
+    out = build_subprocess_env({"HOME": "/home/runner", "PATH": "/usr/bin"}, None, None)
+    assert out["HOME"] == "/home/runner"
+
+
+def test_env_builder_prefixes_opencode_and_bun_bin_onto_path() -> None:
+    out = build_subprocess_env({"PATH": "/usr/bin"}, None, None)
+    assert ".opencode/bin" in out["PATH"]
+    assert ".bun/bin" in out["PATH"]
+    # The opencode runtime dir must be a PATH *prefix*, ahead of the inherited entries.
+    assert out["PATH"].index(".opencode/bin") < out["PATH"].index("/usr/bin")
+
+
+def test_ac3_ambient_openrouter_never_reaches_subprocess_without_binding() -> None:
+    # The removed spike fallback used to forward host OPENROUTER_API_KEY /
+    # OPENROUTER_TOKEN. With no explicit binding the subprocess must get no
+    # OpenRouter credential at all.
+    base = {
+        "PATH": "/usr/bin",
+        "OPENROUTER_API_KEY": "AMBIENT-key",
+        "OPENROUTER_TOKEN": "AMBIENT-token",
+    }
+    out = build_subprocess_env(base, None, None)
+    assert "OPENROUTER_API_KEY" not in out
+    assert "OPENROUTER_TOKEN" not in out
+
+
+def test_env_builder_sets_config_content_when_present() -> None:
+    content = '{"agent": {"build": {"prompt": "p"}}}'
+    out = build_subprocess_env({"PATH": "/usr/bin"}, None, content)
+    assert out["OPENCODE_CONFIG_CONTENT"] == content
+
+
+def test_env_builder_omits_config_content_when_absent() -> None:
+    out = build_subprocess_env({"PATH": "/usr/bin"}, None, None)
+    # Absent, not empty-string.
+    assert "OPENCODE_CONFIG_CONTENT" not in out
+
+
+def test_source_no_longer_reads_ambient_openrouter_token() -> None:
+    # AC3 done-when: `grep OPENROUTER_TOKEN runner/src/.../session.py` is empty.
+    source = pathlib.Path(
+        "runner/src/agentos_runner/opencode/session.py"
+    ).read_text(encoding="utf-8")
+    assert "OPENROUTER_TOKEN" not in source
+
+
+# --- config content composition -------------------------------------------------
+
+
+def test_config_content_prompt_and_steps() -> None:
+    content = build_config_content("You are terse.", 3)
+    assert content is not None
+    assert json.loads(content) == {
+        "agent": {"build": {"prompt": "You are terse.", "steps": 3}}
+    }
+
+
+def test_config_content_prompt_only_omits_steps() -> None:
+    content = build_config_content("only prompt", None)
+    assert content is not None
+    assert json.loads(content) == {"agent": {"build": {"prompt": "only prompt"}}}
+
+
+def test_config_content_steps_only_omits_prompt() -> None:
+    content = build_config_content(None, 5)
+    assert content is not None
+    assert json.loads(content) == {"agent": {"build": {"steps": 5}}}
+
+
+def test_config_content_empty_prompt_treated_as_unset() -> None:
+    content = build_config_content("", 2)
+    assert content is not None
+    assert json.loads(content) == {"agent": {"build": {"steps": 2}}}
+
+
+def test_config_content_none_when_nothing_to_set() -> None:
+    assert build_config_content(None, None) is None
+    assert build_config_content("", None) is None
+
+
+def test_config_content_nonpositive_steps_omitted_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # steps has schema exclusiveMinimum 0; a <=0 value would fail serve config
+    # validation, so it is dropped (with a warning) rather than emitted.
+    with caplog.at_level(logging.WARNING):
+        content = build_config_content("p", 0)
+    assert content is not None
+    parsed = json.loads(content)
+    assert parsed == {"agent": {"build": {"prompt": "p"}}}
+    assert "steps" not in parsed["agent"]["build"]
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+
+def test_config_content_nonpositive_steps_alone_is_none() -> None:
+    assert build_config_content(None, 0) is None
+
+
+def test_config_content_roundtrips_json_metacharacters() -> None:
+    prompt = 'Include "quotes", \n newlines, and {braces} verbatim.'
+    content = build_config_content(prompt, 1)
+    assert content is not None
+    parsed = json.loads(content)
+    assert parsed["agent"]["build"]["prompt"] == prompt
+    assert parsed["agent"]["build"]["steps"] == 1
+
+
+# --- prompt body composition ----------------------------------------------------
+
+
+def test_prompt_body_targets_build_agent_and_carries_model_and_text() -> None:
+    # The body MUST name the build agent, or the OPENCODE_CONFIG_CONTENT carrier
+    # (which nests prompt/steps under agent.build) never applies to the turn.
+    body = build_prompt_body("openrouter", "z-ai/glm-4.6", "hello")
+    assert body == {
+        "agent": "build",
+        "model": {"providerID": "openrouter", "modelID": "z-ai/glm-4.6"},
+        "parts": [{"type": "text", "text": "hello"}],
+    }

--- a/runner/tests/test_opencode_synth.py
+++ b/runner/tests/test_opencode_synth.py
@@ -18,8 +18,9 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 import anyio
-from aci_protocol import Event, Interrupt, parse_ndjson, run_conformance
+from aci_protocol import Event, Interrupt, SessionStatus, parse_ndjson, run_conformance
 from agentos_runner import CLAUDE_READONLY_TOOLS
+from agentos_runner.budget import BUDGET_CLASSIFICATION
 from agentos_runner.events import AssistantText, ToolCall, TurnResult
 from agentos_runner.opencode.synth import TurnSynthesizer
 from agentos_runner.otel import RunTracer
@@ -84,12 +85,18 @@ def tool_running(call_id: str, tool: str, inp: dict[str, Any]) -> dict[str, Any]
     }
 
 
-def step_finish(input_tokens: int, output_tokens: int) -> dict[str, Any]:
+def step_finish(
+    input_tokens: int, output_tokens: int, part_id: str = "prt_step"
+) -> dict[str, Any]:
+    # Each step-finish part carries a distinct id on the live wire and reports
+    # that step's tokens only (reset on the next step); vary ``part_id`` to model
+    # a multi-step turn whose true output total is the sum of the steps.
     return {
         "type": "message.part.updated",
         "properties": {
             "sessionID": SID,
             "part": {
+                "id": part_id,
                 "type": "step-finish",
                 "tokens": {"input": input_tokens, "output": output_tokens, "reasoning": 0},
             },
@@ -280,7 +287,9 @@ def test_synth_maps_text_tool_and_terminal_result() -> None:
     messages, synth = _run_synth(default_turn_frames())
     assert synth.done
 
-    texts = [m.text for m in messages if isinstance(m, AssistantText)]
+    # Filter on m.text so zero-text usage carriers (the mid-turn budget signal)
+    # are not mistaken for answer text.
+    texts = [m.text for m in messages if isinstance(m, AssistantText) and m.text]
     assert texts == ["Looking into it", " all done"], texts
 
     tools = [m for m in messages if isinstance(m, ToolCall)]
@@ -336,7 +345,8 @@ def test_synth_drops_reasoning_deltas_keeps_text() -> None:
     # A delta's field is "text" even for a reasoning part; only the text part's
     # content (resolved by partID from the snapshots) reaches the TurnEvents.
     messages, synth = _run_synth(reasoning_then_text_frames())
-    texts = [m.text for m in messages if isinstance(m, AssistantText)]
+    # Filter on m.text so zero-text usage carriers are excluded from answer text.
+    texts = [m.text for m in messages if isinstance(m, AssistantText) and m.text]
     assert texts == ["pong"], texts
     results = [m for m in messages if isinstance(m, TurnResult)]
     assert results and results[0].text == "pong"
@@ -400,3 +410,203 @@ def test_scripted_opencode_backend_passes_aci_conformance() -> None:
         [(c.name, c.detail) for c in report.checks if not c.passed]
     )
     assert any(c.name == "producer_stream" and c.passed for c in report.checks)
+
+
+# --- mid-turn usage carriers + budget enforcement (issue #311 AC2) --------------
+
+
+def usage_increment_frames() -> list[dict[str, Any]]:
+    """Three per-step token reports that each RESET (real per-step wire shape).
+
+    Each step reports only its own output (20, 11, 28), and message.updated
+    echoes the same per-step number under the constant message id. The turn's
+    true output total is the SUM (59), so the mid-turn deltas are [20, 11, 28].
+    """
+
+    return [
+        busy(),
+        step_finish(50, 20, "prt_s1"),  # step 1: total 0 -> 20, delta 20
+        message_updated("z-ai/glm-4.6", 50, 20),  # redundant per-step echo, no carrier
+        step_finish(60, 11, "prt_s2"),  # step 2: total 20 -> 31, delta 11
+        message_updated("z-ai/glm-4.6", 60, 11),  # redundant per-step echo, no carrier
+        step_finish(70, 28, "prt_s3"),  # step 3: total 31 -> 59, delta 28
+        idle(),
+    ]
+
+
+def _usage_carriers(messages: list[Any]) -> list[AssistantText]:
+    return [m for m in messages if isinstance(m, AssistantText) and m.usage is not None]
+
+
+def test_synth_emits_monotonic_positive_usage_deltas() -> None:
+    # The mid-turn budget signal: each step's per-step output is summed into a
+    # running turn total, and each rise in that total is emitted as a zero-text
+    # AssistantText carrying only the positive delta, so the runner can fold and
+    # halt before the terminal. The redundant message.updated echo of the same
+    # per-step number emits nothing (it is not a per-step key; summing it would
+    # double-count).
+    messages, _ = _run_synth(usage_increment_frames())
+    carriers = _usage_carriers(messages)
+    assert [c.usage["output_tokens"] for c in carriers] == [20, 11, 28]
+    # Carriers are text-free so translate emits no ACI event for them.
+    assert all(c.text == "" for c in carriers)
+    # The terminal result carries the last-seen input with the SUMMED per-step
+    # output (59), which the deltas also sum to -- so the mid-turn signal and the
+    # authoritative terminal total agree (no double count in the runner's fold).
+    results = [m for m in messages if isinstance(m, TurnResult)]
+    assert results[-1].usage == {"input_tokens": 70, "output_tokens": 59}
+    assert sum(c.usage["output_tokens"] for c in carriers) == 59
+
+
+def within_step_streaming_frames() -> list[dict[str, Any]]:
+    """One step whose block streams upward (5 -> 20) under a single part id."""
+
+    return [
+        busy(),
+        step_finish(10, 5, "prt_s1"),  # step 1 rises: total 0 -> 5, delta 5
+        step_finish(10, 20, "prt_s1"),  # SAME id 5 -> 20: total 5 -> 20, delta 15
+        idle(),
+    ]
+
+
+def test_synth_within_step_streaming_takes_max_not_sum() -> None:
+    # A step's block can climb within one part id as it streams. That id
+    # contributes its MAX (20), not the sum of its intermediate reports (25), so
+    # the running total tracks 20 and the deltas [5, 15] sum to 20.
+    messages, _ = _run_synth(within_step_streaming_frames())
+    carriers = _usage_carriers(messages)
+    assert [c.usage["output_tokens"] for c in carriers] == [5, 15]
+    assert sum(c.usage["output_tokens"] for c in carriers) == 20
+    results = [m for m in messages if isinstance(m, TurnResult)]
+    assert results[-1].usage == {"input_tokens": 10, "output_tokens": 20}
+
+
+def budget_runaway_frames() -> list[dict[str, Any]]:
+    """A runaway turn: output far above the ceiling reported mid-turn, then more text.
+
+    The post-report ``text_delta`` is the tripwire: if the halt fires at the
+    ``step-finish`` (via a mid-turn usage carrier), the text after it never
+    reaches the stream and the session is interrupted; if the halt only lands at
+    the terminal ``idle`` (base behavior), the text leaks through first and no
+    interrupt is issued.
+    """
+
+    return [
+        busy(),
+        text_part_bookend(""),
+        text_delta("before "),
+        step_finish(10, 500),
+        text_delta("LEAKED-AFTER-HALT"),
+        idle(),
+    ]
+
+
+def test_opencode_budget_halts_midturn_on_reported_usage() -> None:
+    created: list[ScriptedOpenCodeSession] = []
+
+    def factory() -> ScriptedOpenCodeSession:
+        session = ScriptedOpenCodeSession(budget_runaway_frames)
+        created.append(session)
+        return session
+
+    lines: list[str] = []
+
+    async def _run() -> None:
+        runner = SessionRunner(
+            session_factory=factory,
+            ceiling=10,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
+            trace_name="opencode-offline",
+        )
+        await runner.start()
+        try:
+            async for line in runner.run_turn(
+                Event(type="message", text="x", user="U1", ts="1.0")
+            ):
+                lines.append(line)
+        finally:
+            await runner.close()
+
+    anyio.run(_run)
+
+    blob = "".join(lines)
+    events = parse_ndjson(blob)
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.CLASSIFIED_FAILURE
+    assert any(
+        e.type == "error" and e.classification == BUDGET_CLASSIFICATION for e in events
+    )
+    # Halt landed at the step-finish, before the post-report text: the runaway
+    # turn is actually cut off (interrupt called), not just relabelled at the end.
+    assert "LEAKED-AFTER-HALT" not in blob
+    assert created and created[0].interrupts >= 1
+
+
+def multistep_undercount_frames() -> list[dict[str, Any]]:
+    """Two steps EACH under the ceiling whose SUM exceeds it (the Codex case).
+
+    Each step reports 300 output tokens (below a ceiling of 500), but the turn's
+    true total is 600. The single-max fold this module used to do would top out
+    at 300 and never trip the ceiling; summing per-step maxima trips it at the
+    second step-finish. The post-report text is the tripwire: it must not reach
+    the stream if the halt fires mid-turn.
+    """
+
+    return [
+        busy(),
+        text_part_bookend(""),
+        text_delta("step one "),
+        step_finish(10, 300, "prt_s1"),  # per-step 300 < 500, running total 300
+        text_delta("step two "),
+        step_finish(10, 300, "prt_s2"),  # running total 600 > 500 -> halt here
+        text_delta("LEAKED-AFTER-HALT"),
+        idle(),
+    ]
+
+
+def test_opencode_budget_halts_on_summed_multistep_usage() -> None:
+    # The multi-step undercount regression: no single step crosses the ceiling,
+    # but their SUM does. Proves the runner halts on the summed per-step total,
+    # not on the max of any one step's report.
+    created: list[ScriptedOpenCodeSession] = []
+
+    def factory() -> ScriptedOpenCodeSession:
+        session = ScriptedOpenCodeSession(multistep_undercount_frames)
+        created.append(session)
+        return session
+
+    lines: list[str] = []
+
+    async def _run() -> None:
+        runner = SessionRunner(
+            session_factory=factory,
+            ceiling=500,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(CLAUDE_READONLY_TOOLS),
+            trace_name="opencode-offline",
+        )
+        await runner.start()
+        try:
+            async for line in runner.run_turn(
+                Event(type="message", text="x", user="U1", ts="1.0")
+            ):
+                lines.append(line)
+        finally:
+            await runner.close()
+
+    anyio.run(_run)
+
+    blob = "".join(lines)
+    events = parse_ndjson(blob)
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.CLASSIFIED_FAILURE
+    assert any(
+        e.type == "error" and e.classification == BUDGET_CLASSIFICATION for e in events
+    )
+    # Halt fired at the second step-finish (summed total 600 > 500), before the
+    # post-report text -- the runaway multi-step turn is actually cut off.
+    assert "LEAKED-AFTER-HALT" not in blob
+    assert created and created[0].interrupts >= 1

--- a/runner/tests/test_sdk_auth_classify.py
+++ b/runner/tests/test_sdk_auth_classify.py
@@ -1,0 +1,132 @@
+"""Shared credential classification + frozen resolve_sdk_env parity (issue #311).
+
+``classify_credential`` is the pure prefix classifier the plan extracts out of
+``resolve_model_credential`` so the OpenCode binder can share it. These tests pin
+the five classes and the OAuth-before-API-key order.
+
+The ``test_parity_*`` cases call the public ``resolve_sdk_env`` /
+``resolve_model_credential`` and assert their current outputs, proving the
+refactor preserves the Claude binder byte-for-byte. They live here (not in the
+frozen ``test_sdk_auth.py``) so the frozen gate stays untouched while the new
+classifier is still exercised against the real routing.
+
+All credential values are obviously-fake and split across a ``+`` so no real
+token shape ever appears as a single literal.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentos_runner.sdk_auth import (
+    API_KEY_ENV,
+    AUTH_TOKEN_ENV,
+    BASE_URL_ENV,
+    CREDENTIALS_ENV,
+    NO_OP_API_KEY,
+    OAUTH_TOKEN_ENV,
+    OPENROUTER_BASE_URL,
+    UnsupportedCredentialError,
+    classify_credential,
+    resolve_model_credential,
+    resolve_sdk_env,
+)
+
+# Fake credentials, one per class. Split literals keep the secrets hook quiet and
+# make the fakeness obvious.
+FAKE_OAUTH_TOKEN = "sk-ant-oat" + "01-FAKE"
+FAKE_ANTHROPIC_KEY = "sk-ant-" + "api03-FAKE"
+FAKE_OPENROUTER_KEY = "sk-or-" + "v1-FAKE"
+FAKE_UNSUPPORTED_SK = "sk-" + "proj-FAKE"
+FAKE_OPAQUE = "opaque-" + "FAKE-token"
+
+
+# --- classify_credential: the five classes, order pinned ------------------------
+
+
+def test_classify_oauth_token() -> None:
+    assert classify_credential(FAKE_OAUTH_TOKEN) == "oauth-token"
+
+
+def test_classify_anthropic_api_key() -> None:
+    assert classify_credential(FAKE_ANTHROPIC_KEY) == "anthropic-api-key"
+
+
+def test_classify_openrouter() -> None:
+    assert classify_credential(FAKE_OPENROUTER_KEY) == "openrouter"
+
+
+def test_classify_unsupported_sk() -> None:
+    assert classify_credential(FAKE_UNSUPPORTED_SK) == "unsupported-sk"
+
+
+def test_classify_opaque() -> None:
+    assert classify_credential(FAKE_OPAQUE) == "opaque"
+
+
+def test_classify_oauth_prefix_wins_over_api_key() -> None:
+    # sk-ant-oat shares the sk-ant- prefix with a plain API key; the more
+    # specific OAuth check must be first, so an OAuth token never classifies as
+    # anthropic-api-key.
+    result = classify_credential(FAKE_OAUTH_TOKEN)
+    assert result == "oauth-token"
+    assert result != "anthropic-api-key"
+
+
+# --- frozen-behavior parity: resolve_sdk_env / resolve_model_credential ---------
+
+
+def test_parity_openrouter_routes_key_to_api_key_env() -> None:
+    env = {CREDENTIALS_ENV: FAKE_OPENROUTER_KEY}
+    assert resolve_sdk_env(env) is None
+    assert env[BASE_URL_ENV] == OPENROUTER_BASE_URL
+    assert env[API_KEY_ENV] == FAKE_OPENROUTER_KEY
+    assert env[AUTH_TOKEN_ENV] == ""
+    assert env[OAUTH_TOKEN_ENV] == ""
+
+
+def test_parity_anthropic_api_key_mutates_env() -> None:
+    env = {CREDENTIALS_ENV: FAKE_ANTHROPIC_KEY}
+    assert resolve_sdk_env(env) is None
+    assert env[API_KEY_ENV] == FAKE_ANTHROPIC_KEY
+    assert BASE_URL_ENV not in env
+
+
+def test_parity_oauth_token_routes_to_oauth_env() -> None:
+    env = {CREDENTIALS_ENV: FAKE_OAUTH_TOKEN}
+    assert resolve_sdk_env(env) is None
+    assert env[OAUTH_TOKEN_ENV] == FAKE_OAUTH_TOKEN
+    assert API_KEY_ENV not in env
+
+
+def test_parity_opaque_token_routes_to_oauth_env() -> None:
+    env = {CREDENTIALS_ENV: FAKE_OPAQUE}
+    assert resolve_sdk_env(env) is None
+    assert env[OAUTH_TOKEN_ENV] == FAKE_OPAQUE
+
+
+def test_parity_unsupported_sk_rejected_loudly() -> None:
+    with pytest.raises(UnsupportedCredentialError):
+        resolve_model_credential({CREDENTIALS_ENV: FAKE_UNSUPPORTED_SK})
+
+
+def test_parity_openrouter_with_preset_base_url_still_routes_key() -> None:
+    # The #229 regression: a preset ANTHROPIC_BASE_URL must not drop the sk-or-
+    # key -- it is still routed into ANTHROPIC_API_KEY (the x-api-key header).
+    env = {BASE_URL_ENV: OPENROUTER_BASE_URL, CREDENTIALS_ENV: FAKE_OPENROUTER_KEY}
+    assert resolve_sdk_env(env) is None
+    assert env[API_KEY_ENV] == FAKE_OPENROUTER_KEY
+    assert env[AUTH_TOKEN_ENV] == ""
+
+
+def test_parity_base_url_override_returns_dict() -> None:
+    override = resolve_sdk_env({BASE_URL_ENV: "http://ollama:11434"})
+    assert override is not None
+    assert override[BASE_URL_ENV] == "http://ollama:11434"
+    assert override[API_KEY_ENV] == NO_OP_API_KEY
+    assert override[AUTH_TOKEN_ENV] == ""
+
+
+def test_parity_no_credential_is_a_noop() -> None:
+    env: dict[str, str] = {}
+    assert resolve_sdk_env(env) is None
+    assert env == {}


### PR DESCRIPTION
Stacked on #318 (the bundle-compiler branch); do not merge independently, per epic #25 and the harness-neutral runner seams ADR (PR #306).

Brings the OpenCode harness up to the shared session-config contract. The spike forwarded a single hardcoded OpenRouter env var and dropped SessionConfig's system_prompt, max_turns, and budget on the floor.

- **Credential binder**: `classify_credential` is extracted in `sdk_auth.py` as the shared prefix classification (the Claude resolve path is rewired through it byte-for-byte; its tests are untouched). The new OpenCode binder maps an sk-or credential from `AGENTOS_CREDENTIALS` onto `OPENROUTER_API_KEY` and rejects every other class loudly pre-boot, naming the variable and never echoing the value. The spike's ambient `OPENROUTER_API_KEY`/legacy-token fallback is removed; the serve subprocess env is sanitized (all credential-bearing names stripped) with positive single-credential injection, the PR #109 posture.
- **system_prompt / max_turns**: ride `OPENCODE_CONFIG_CONTENT` as `{"agent": {"build": {"prompt", "steps"}}}`, and prompts explicitly target the build agent — the API's default agent is not `build`, so without the pin the carrier silently never applies (found live; the coupling is now held by one constant). Config-content merges key-wise above the compiled project `opencode.json`, so #318's bundle config survives (live-verified). Fidelity note: Claude `max_turns` aborts, OpenCode `steps` forces a text-only response; the conformance harness defaults the cap to 20 like the Claude path.
- **Budget**: live frame capture showed OpenCode reports output tokens per model step (blocks reset each step; only `session.updated` is cumulative, across the whole session). The synth keeps a per-step max and sums across steps, emitting positive mid-turn usage deltas, so the runner's output-token ceiling halts a multi-step turn mid-flight — the prior single-max fold provably could not (Codex review caught this; the plan's cumulative assumption was wrong).

## Live verification (all driver-executed, opencode serve v1.17.17, openrouter/z-ai/glm-4.6)

1. Binder-carried credential baseline: conformance 5/5, `LIVE SPIKE RESULT: PASS` with `AGENTOS_CREDENTIALS` as the only credential source.
2. Loud rejection: an sk-ant credential exits nonzero before serve spawns; the error names `AGENTOS_CREDENTIALS` and the class; zero occurrences of the value in output.
3. system_prompt: a token-demanding system prompt surfaced its token in a live final through the full runner path (`"pong\n\nAGENTOS-SYS-PROOF"`). The handoff is deterministic (the merged `/config` always carries the prompt); the model's per-sample compliance with it varies (observed 1/3 with a conflicting "reply with exactly" demo prompt), which is a model property, not a wiring one.
4. max_turns: unset -> multi-step bundle turn with tool_notes and passing bundle proofs; `AGENTOS_MAX_TURNS=1` -> zero tool_notes (text-only forced) and the bundle-proof gate correctly fails nonzero.
5. Budget: a 1-token ceiling halts with `budget-exceeded` + classified-failure; a 30-token ceiling halts a MULTI-STEP bundle turn mid-flight after tool activity (steps of ~20/11/28 whose sum trips it — the exact case the old fold missed).
6. Bundle merge: system-prompt config content + compiled bundle together: skill token, MCP nonce, and skill tool_note all still pass.
7. Token semantics captured: `message.part.updated`/`message.updated` are per-step (20 -> 11 -> 28), `session.updated` is session-cumulative (20 -> 31 -> 59) — recorded here as the ground truth the synth fold is built on.

## Notes for the reviewer

- Security review verdict: net improvement (old code forwarded the entire ambient env to the subprocess). One deliberate follow-up before OpenCode leaves spike status: `build_subprocess_env` sanitizes by denylist; recommend an allowlist (or covering other provider-credential families like `OPENAI_API_KEY` and `OTEL_EXPORTER_OTLP_HEADERS`) once the harness is on the production path.
- Deferred altitude note: `classify_credential`/`UnsupportedCredentialError`/`CREDENTIALS_ENV` are harness-neutral but live in the Claude-named `sdk_auth.py`; hoisting them into a neutral module is a rename-only follow-up.
- `agentos_probe` and other MCP tools still raise `side_effect_flag` (deny-by-default classifier) — intended.

Offline gates: `uv run pytest -q` 716 passed / 4 skipped; `uv run ruff check .` clean; `uv run mypy` clean.

Ref #311
