### PR TITLE
Package the OpenCode runner image under the security rails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,6 +238,8 @@ jobs:
         include:
           - name: runner
             dockerfile: runner/Dockerfile
+          - name: runner-opencode
+            dockerfile: runner/Dockerfile.opencode
           - name: api
             dockerfile: apps/api/Dockerfile
           - name: dispatcher

--- a/runner/CLAUDE.md
+++ b/runner/CLAUDE.md
@@ -49,11 +49,15 @@ Docker via `agentos skill up`. Full behavior spec in `runner/README.md`.
   `runAsNonRoot`, a read-only rootfs, and writable-emptyDir scratch only at
   `/tmp` and `/home/runner`. Do not add a code path that writes anywhere
   else in the container filesystem.
+- **Harness selection is image-level** (ADR-0009). The OpenCode variant uses
+  `runner/Dockerfile.opencode`; the Claude image remains the default. Do not add
+  runtime harness selection to either entrypoint.
 
 ## Verify
 
 ```bash
 docker build -f runner/Dockerfile -t agentos-runner .   # from repo root; compiles against the frozen workspace packages
+docker build -f runner/Dockerfile.opencode -t agentos-runner-opencode .
 uv run pytest runner/tests -q                            # unit + integration + conformance
 uv run ruff check runner/ && uv run mypy
 ```

--- a/runner/Dockerfile.opencode
+++ b/runner/Dockerfile.opencode
@@ -1,0 +1,73 @@
+# AgentOS OpenCode runner image.
+#
+# Build from the repository root:
+#
+#   docker build -f runner/Dockerfile.opencode -t agentos-runner-opencode .
+#
+# OpenCode is a Bun compiled single binary that requires glibc. Keep this image
+# on Bookworm or another glibc base. Do not switch it to Alpine or musl.
+FROM python:3.13-slim-bookworm
+
+ARG TARGETARCH
+ARG OPENCODE_SHA256_X64=3957e8b9b80867633daf82cba43f17980c8daf71d4d265a40313fb21d5d58fac
+ARG OPENCODE_SHA256_ARM64=5a03cf2abc71cef8c57cd03add3ff55a0c1d6e0d4af4b825efdc503cfce23ab3
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && apt-get install -y --no-install-recommends --only-upgrade curl ca-certificates \
+    && case "$TARGETARCH" in \
+        amd64) OCARCH=x64; OCSHA256="$OPENCODE_SHA256_X64" ;; \
+        arm64) OCARCH=arm64; OCSHA256="$OPENCODE_SHA256_ARM64" ;; \
+        *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && archive=/tmp/opencode.tar.gz \
+    && curl -fsSL \
+        "https://github.com/sst/opencode/releases/download/v1.17.17/opencode-linux-${OCARCH}.tar.gz" \
+        -o "$archive" \
+    && echo "${OCSHA256}  ${archive}" | sha256sum -c - \
+    && tar -xzf "$archive" -C /usr/local/bin opencode \
+    && chmod 755 /usr/local/bin/opencode \
+    && rm -f "$archive" \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the frozen workspace packages and the runner from the repository root.
+COPY packages/aci-protocol ./packages/aci-protocol
+COPY packages/plugin-format ./packages/plugin-format
+COPY runner ./runner
+
+# Use one venv. Install local packages by path first, then the runner without
+# dependencies, then the exact third party versions tested in the root uv.lock.
+# claude-agent-sdk is import only in this image: plugin.py imports
+# SdkPluginConfig at module load and opencode/installer.py imports plugin.py.
+# This entrypoint never spawns the Claude CLI.
+RUN python3 -m venv /app/.venv \
+    && /app/.venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /app/.venv/bin/pip install --no-cache-dir ./packages/aci-protocol ./packages/plugin-format \
+    && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner \
+    && /app/.venv/bin/pip install --no-cache-dir \
+        "claude-agent-sdk==0.2.115" \
+        "aiohttp==3.14.1" \
+        "opentelemetry-sdk==1.43.0" \
+        "opentelemetry-exporter-otlp-proto-http==1.43.0" \
+        "anyio==4.14.1" \
+        "pyyaml==6.0.3"
+
+# uid and gid 1000 match the chart security context. Runtime state stays under
+# the writable /home/runner mount, while temporary session files use /tmp.
+RUN groupadd --gid 1000 runner \
+    && useradd --uid 1000 --gid 1000 --home-dir /home/runner --create-home --shell /usr/sbin/nologin runner \
+    && chown -R 1000:1000 /home/runner
+
+ENV HOME=/home/runner
+ENV XDG_DATA_HOME=/home/runner/.local/share
+ENV XDG_STATE_HOME=/home/runner/.local/state
+ENV XDG_CACHE_HOME=/home/runner/.cache
+ENV XDG_CONFIG_HOME=/home/runner/.config
+ENV PATH="/app/.venv/bin:$PATH"
+ENV AGENTOS_RUNNER_PORT=8080
+EXPOSE 8080
+
+USER 1000:1000
+CMD ["python", "-m", "agentos_runner.opencode"]

--- a/runner/README.md
+++ b/runner/README.md
@@ -90,6 +90,49 @@ curl -sN -X POST http://localhost:18080/v1/event -H 'Content-Type: application/j
   -d '{"kind":"event","type":"message","text":"hi","user":"U","ts":"1.0"}'
 ```
 
+### OpenCode image variant
+
+Build the separate OpenCode runner image from the repository root:
+
+```bash
+docker build -f runner/Dockerfile.opencode -t agentos-runner-opencode .
+```
+
+Run the offline fake smoke under the same filesystem and user rails as the
+chart. This path does not require an OpenCode binary call or model credential:
+
+```bash
+docker run -d --name opencode-runner-smoke \
+  --read-only --tmpfs /tmp --tmpfs /home/runner:uid=1000,gid=1000 \
+  --user 1000:1000 --cap-drop ALL \
+  -e AGENTOS_FAKE_MODEL=1 -e AGENTOS_PLUGIN_DIR=/unused \
+  -e AGENTOS_SESSION_ID=smoke -e AGENTOS_SANDBOX_ID=sbx \
+  -e 'AGENTOS_BUDGET={"max_output_tokens_per_run":100000,"max_usd_per_day":5.0}' \
+  -p 18080:8080 agentos-runner-opencode
+curl -s http://localhost:18080/healthz
+curl -sN -X POST http://localhost:18080/v1/event \
+  -H 'Content-Type: application/json' \
+  -d '{"kind":"event","type":"message","text":"hi","user":"U","ts":"1.0"}'
+docker rm -f opencode-runner-smoke
+```
+
+Run live conformance inside the container with an OpenRouter credential:
+
+```bash
+docker run --rm --read-only --tmpfs /tmp --tmpfs /home/runner:uid=1000,gid=1000 \
+  --user 1000:1000 --cap-drop ALL \
+  -e AGENTOS_CREDENTIALS="$OPENROUTER_API_KEY" \
+  agentos-runner-opencode python -m agentos_runner.opencode.conformance
+```
+
+This image intentionally has no Node runtime. Node based stdio MCP servers in
+plugin bundles cannot run in this variant; Python based servers can. Under this
+image, `AGENTOS_MODEL` is passed verbatim as the OpenRouter modelID. Operators
+must override the chart default `claude-sonnet-5`, or turns fail at the provider.
+An `AGENTOS_HISTORY_REF` causes startup to fail because OpenCode has no resume
+support. A positive daily USD cap logs a startup warning because OpenCode cannot
+enforce that cap natively; the per run output token ceiling remains enforced.
+
 ## Verify (from repo root)
 
 ```bash

--- a/runner/src/agentos_runner/opencode/__main__.py
+++ b/runner/src/agentos_runner/opencode/__main__.py
@@ -1,0 +1,131 @@
+"""OpenCode runner entrypoint: build the session and serve the ACI.
+
+Reads the ACI ``AGENTOS_*`` / ``OTEL_EXPORTER_OTLP_*`` env into a RunnerConfig,
+wires the real OpenCode session (validated plugin bundle, budget, OTel), and
+serves the HTTP channel. The session is started in ``on_startup`` so a plugin or
+connect failure fails the process visibly rather than after the port is up.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+from aiohttp import web
+
+from ..config import RunnerConfig
+from ..fake import FakeModelSession
+from ..otel import RunTracer, build_tracer_provider
+from ..sdk_auth import UnsupportedCredentialError
+from ..server import create_app
+from ..session import SessionRunner
+from ..side_effects import SideEffectClassifier
+from .auth import resolve_opencode_env
+from .installer import OpenCodeBundleInstaller
+from .session import OPENCODE_READONLY_TOOLS, OpenCodeModelSession
+
+logger = logging.getLogger(__name__)
+
+
+def build_runner(
+    config: RunnerConfig,
+    *,
+    fake_model: bool = False,
+    credential_env: dict[str, str] | None = None,
+) -> SessionRunner:
+    """Wire a SessionRunner backed by a real OpenCode session."""
+
+    def factory() -> FakeModelSession | OpenCodeModelSession:
+        if fake_model:
+            return FakeModelSession()
+        compiled = OpenCodeBundleInstaller().install(config.session.plugin_dir)
+        cwd = compiled.workdir if compiled else None
+        return OpenCodeModelSession(
+            cwd=cwd,
+            credential_env=credential_env,
+            system_prompt=config.system_prompt,
+            max_turns=config.max_turns,
+            model=config.model,
+        )
+
+    provider = build_tracer_provider(
+        config.session.otel,
+        config.session.session_id,
+        config.session.sandbox_id,
+    )
+    return SessionRunner(
+        session_factory=factory,
+        ceiling=config.ceiling,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(
+            config.idempotent_tools
+            if config.idempotent_tools is not None
+            else OPENCODE_READONLY_TOOLS
+        ),
+        trace_name=f"agentos-run:{config.session.session_id}",
+        session_id=config.session.session_id,
+        model=config.model,
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    fake_model = os.environ.get("AGENTOS_FAKE_MODEL", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    logger.info("OpenCode runner starting fake_model=%s", fake_model)
+    config = RunnerConfig.from_env(os.environ)
+
+    credential_env = None
+    if not fake_model:
+        if config.history_ref:
+            raise RuntimeError(
+                "OpenCode harness does not support AGENTOS_HISTORY_REF rehydration; "
+                "refusing to silently cold-start"
+            )
+        try:
+            credential_env = resolve_opencode_env(os.environ)
+        except UnsupportedCredentialError as exc:
+            logger.error("credential resolution failed: %s", exc)
+            raise
+
+    if config.max_usd_per_day > 0:
+        logger.warning(
+            "daily USD cap has no native OpenCode enforcement; "
+            "the per-run output-token ceiling remains enforced"
+        )
+
+    logger.info(
+        "OpenCode runner configured session=%s model=%s port=%d",
+        config.session.session_id,
+        config.model,
+        config.port,
+    )
+    runner = build_runner(
+        config,
+        fake_model=fake_model,
+        credential_env=credential_env,
+    )
+    app = create_app(runner, token=config.runner_token)
+
+    async def _startup(_app: web.Application) -> None:
+        try:
+            await runner.start()
+        except Exception as exc:
+            logger.error(
+                "session start failed error_class=%s: %s",
+                type(exc).__name__,
+                exc,
+            )
+            raise
+        logger.info("session started session=%s", config.session.session_id)
+
+    app.on_startup.append(_startup)
+    web.run_app(app, host="0.0.0.0", port=config.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/runner/tests/test_opencode_main.py
+++ b/runner/tests/test_opencode_main.py
@@ -1,0 +1,399 @@
+"""Offline unit tests for the OpenCode runner server entrypoint (issue #312).
+
+Pins the wiring contract of ``agentos_runner.opencode.__main__`` -- the mirror of
+``agentos_runner.__main__`` that composes the OpenCode harness instead of the
+claude-agent-sdk one. Everything here is offline: the CI anchor (the fake
+round-trip) must pass on a machine with no ``opencode`` binary, proven by
+monkeypatching ``_find_opencode`` to raise and showing it is never consulted.
+
+House rules honored: the only mocks are monkeypatches of env / module-namespace
+collaborators (``_find_opencode``, ``OpenCodeModelSession``, ``SideEffectClassifier``,
+``create_app``, ``web.run_app``); credential-shaped literals are hoisted to named
+constants built by concatenation so the secrets hook never trips on a quoted
+``sk-`` string.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import agentos_runner.opencode.__main__ as oc_main
+import agentos_runner.opencode.session as oc_session
+import anyio
+import pytest
+from aci_protocol import Event, SessionStatus, parse_ndjson
+from agentos_runner import (
+    BUDGET_CLASSIFICATION,
+    PluginBundleError,
+    SideEffectClassifier,
+)
+from agentos_runner.config import RunnerConfig
+from agentos_runner.fake import FakeModelSession
+from agentos_runner.opencode import OPENCODE_READONLY_TOOLS
+from agentos_runner.opencode.__main__ import build_runner, main
+from agentos_runner.sdk_auth import UnsupportedCredentialError
+
+_HERE = Path(__file__).parent
+_LIVE_BUNDLE = _HERE / "fixtures" / "opencode_live_bundle"
+
+# The frozen ACI env shape, mirroring runner/tests/test_config.py's _BASE.
+_BASE = {
+    "AGENTOS_PLUGIN_DIR": "/bundle",
+    "AGENTOS_SESSION_ID": "sess-1",
+    "AGENTOS_SANDBOX_ID": "sbx-1",
+    "AGENTOS_BUDGET": '{"max_output_tokens_per_run": 1000, "max_usd_per_day": 5.0}',
+}
+
+# Runner-local vars set per-test on top of _BASE; delenv'd in _set_env so a stray
+# ambient value never contaminates a main() test.
+_OPTIONAL_VARS = (
+    "AGENTOS_FAKE_MODEL",
+    "AGENTOS_HISTORY_REF",
+    "AGENTOS_CREDENTIALS",
+    "AGENTOS_IDEMPOTENT_TOOLS",
+    "AGENTOS_RUNNER_TOKEN",
+    "AGENTOS_MODEL",
+    "AGENTOS_SYSTEM_PROMPT",
+    "AGENTOS_MAX_TURNS",
+)
+
+# A per-sandbox bearer token (not a model credential): a plain identifier.
+_RUNNER_TOKEN = "test-token-" + "xyz"
+
+# Credential-shaped literals, concatenated so the secrets hook sees identifiers,
+# not quoted ``sk-`` strings. The unsupported one classifies as an Anthropic API
+# key, which OpenCode's binder rejects; the OpenRouter dict is passed straight
+# through as ``credential_env`` (never re-classified by build_runner).
+_UNSUPPORTED_CRED = "sk-" + "ant-" + "a" * 24
+_OPENROUTER_ENV = {"OPENROUTER_API_KEY": "sk-" + "or-" + "v1-" + "z" * 24}
+
+
+def _config(**overrides: str) -> RunnerConfig:
+    return RunnerConfig.from_env(dict(_BASE, **overrides))
+
+
+def _event() -> Event:
+    return Event(type="message", text="hi", user="U1", ts="1.0")
+
+
+def _drive_turn(runner: object) -> list:
+    """Start a runner, drive one turn, and return the parsed ACI events."""
+
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()  # type: ignore[attr-defined]
+        async for line in runner.run_turn(_event()):  # type: ignore[attr-defined]
+            lines.append(line)
+
+    anyio.run(go)
+    return parse_ndjson("".join(lines))
+
+
+def _raise_find_opencode(*_args: object, **_kwargs: object) -> str:
+    raise AssertionError("opencode binary must not be looked up on this path")
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
+    """Install a clean ACI env into os.environ for a main() test."""
+
+    for key, value in _BASE.items():
+        monkeypatch.setenv(key, value)
+    for key in _OPTIONAL_VARS:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in overrides.items():
+        monkeypatch.setenv(key, value)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Fake round-trip -- the CI anchor: passes with no opencode binary present.
+# --------------------------------------------------------------------------- #
+
+
+def test_fake_round_trip_needs_no_opencode_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The fake factory must never touch _find_opencode; raise from it to prove the
+    # offline path is a true no-op that a binary-less CI machine can run.
+    monkeypatch.setattr(oc_session, "_find_opencode", _raise_find_opencode)
+    runner = build_runner(_config(), fake_model=True)
+    events = _drive_turn(runner)
+    assert events[-1].type == "final"
+    assert events[-1].status == SessionStatus.DONE
+
+
+# --------------------------------------------------------------------------- #
+# 2. Classifier declaration -- OpenCode read-only set, is-not-None override edge.
+# --------------------------------------------------------------------------- #
+
+
+def _capture_classifier(monkeypatch: pytest.MonkeyPatch) -> dict:
+    captured: dict[str, object] = {}
+    real = oc_main.SideEffectClassifier
+
+    def _cap(tools: object) -> SideEffectClassifier:
+        captured["tools"] = tools
+        instance = real(tools)
+        captured["instance"] = instance
+        return instance
+
+    monkeypatch.setattr(oc_main, "SideEffectClassifier", _cap)
+    return captured
+
+
+def test_default_classifier_declares_opencode_readonly_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture_classifier(monkeypatch)
+    build_runner(_config(), fake_model=True)
+    # The default allowlist must be OpenCode's lowercase set, not the Claude one.
+    assert captured["tools"] == OPENCODE_READONLY_TOOLS
+    classifier = captured["instance"]
+    assert not classifier.is_side_effecting("read")  # type: ignore[attr-defined]
+    assert classifier.is_side_effecting("write")  # type: ignore[attr-defined]
+
+
+def test_empty_idempotent_override_denies_every_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # AGENTOS_IDEMPOTENT_TOOLS="," parses to [] (an empty allowlist). The
+    # entrypoint must guard with ``is not None`` (not ``or``) so [] reaches the
+    # classifier and denies everything, rather than falling back to the OpenCode
+    # declaration.
+    captured = _capture_classifier(monkeypatch)
+    build_runner(_config(AGENTOS_IDEMPOTENT_TOOLS=","), fake_model=True)
+    assert captured["tools"] == []
+    assert captured["instance"].is_side_effecting("read")  # type: ignore[attr-defined]
+
+
+def test_explicit_idempotent_override_replaces_the_declaration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture_classifier(monkeypatch)
+    build_runner(_config(AGENTOS_IDEMPOTENT_TOOLS="Read, Custom"), fake_model=True)
+    assert captured["tools"] == ["Read", "Custom"]
+
+
+# --------------------------------------------------------------------------- #
+# 3. Session wiring -- compiled cwd, prompt/turns/model from config, credentials.
+# --------------------------------------------------------------------------- #
+
+
+def _capture_session(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    calls: list[dict] = []
+
+    class _CapturingSession(FakeModelSession):
+        def __init__(self, **kwargs: object) -> None:
+            calls.append(kwargs)
+            super().__init__()
+
+    monkeypatch.setattr(oc_main, "OpenCodeModelSession", _CapturingSession)
+    return calls
+
+
+def _start_and_close(runner: object) -> None:
+    async def go() -> None:
+        await runner.start()  # type: ignore[attr-defined]
+        await runner.close()  # type: ignore[attr-defined]
+
+    anyio.run(go)
+
+
+def test_session_wiring_binds_compiled_cwd_and_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_session(monkeypatch)
+    config = _config(
+        AGENTOS_PLUGIN_DIR=str(_LIVE_BUNDLE),
+        AGENTOS_SYSTEM_PROMPT="be terse",
+        AGENTOS_MAX_TURNS="7",
+        AGENTOS_MODEL="z-ai/glm-4.6",
+    )
+    runner = build_runner(config, fake_model=False, credential_env=dict(_OPENROUTER_ENV))
+    _start_and_close(runner)
+
+    assert len(calls) == 1
+    kwargs = calls[0]
+    # The compiled bundle workdir is bound as the session cwd -- an existing dir
+    # holding opencode.json (where OpenCode discovers the compiled config).
+    cwd = kwargs["cwd"]
+    assert cwd is not None
+    assert (Path(cwd) / "opencode.json").is_file()
+    assert kwargs["system_prompt"] == "be terse"
+    assert kwargs["max_turns"] == 7
+    assert kwargs["model"] == "z-ai/glm-4.6"
+    assert kwargs["credential_env"] == _OPENROUTER_ENV
+
+
+def test_session_wiring_bundleless_passes_cwd_none_and_default_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _capture_session(monkeypatch)
+    # An empty plugin dir compiles to no bundle -> cwd None (the session mkdtemps
+    # its own workdir); an unset AGENTOS_MODEL passes model=None (the session's
+    # own default applies).
+    config = _config(AGENTOS_PLUGIN_DIR="")
+    runner = build_runner(config, fake_model=False, credential_env={})
+    _start_and_close(runner)
+
+    assert len(calls) == 1
+    assert calls[0]["cwd"] is None
+    assert calls[0]["model"] is None
+
+
+# --------------------------------------------------------------------------- #
+# 4. Fail-loud in main() -- before the port is up.
+# --------------------------------------------------------------------------- #
+
+
+def _stub_serve(monkeypatch: pytest.MonkeyPatch) -> list:
+    served: list = []
+    monkeypatch.setattr(oc_main.web, "run_app", lambda app, **_k: served.append(app))
+    return served
+
+
+def test_main_history_ref_refuses_to_cold_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # OpenCode has no resume; a set AGENTOS_HISTORY_REF must fail loud at startup
+    # rather than silently cold-starting a session the worker asked to rehydrate.
+    _set_env(monkeypatch, AGENTOS_HISTORY_REF="s3://hist")
+    served = _stub_serve(monkeypatch)
+    with pytest.raises(RuntimeError) as excinfo:
+        main()
+    # Not the UnsupportedCredentialError subclass -- the plain history refusal.
+    assert excinfo.type is RuntimeError
+    assert "history" in str(excinfo.value).lower()
+    assert not served
+
+
+def test_main_unsupported_credential_raises_before_serving(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_env(monkeypatch, AGENTOS_CREDENTIALS=_UNSUPPORTED_CRED)
+    served = _stub_serve(monkeypatch)
+    with pytest.raises(UnsupportedCredentialError):
+        main()
+    assert not served
+
+
+def test_main_fake_mode_ignores_history_ref_and_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The fake path resolves no credential and rehydrates nothing, so neither an
+    # unsupported credential nor a history ref stops an offline fake boot.
+    _set_env(
+        monkeypatch,
+        AGENTOS_FAKE_MODEL="1",
+        AGENTOS_HISTORY_REF="s3://hist",
+        AGENTOS_CREDENTIALS=_UNSUPPORTED_CRED,
+    )
+    monkeypatch.setattr(oc_session, "_find_opencode", _raise_find_opencode)
+    served = _stub_serve(monkeypatch)
+    main()
+    assert len(served) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 4b. The runner token is passed through to the ACI app (regression: #63).
+# --------------------------------------------------------------------------- #
+
+
+def test_main_passes_runner_token_to_create_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #63: the ACI HTTP channel must never ship unauthenticated. The entrypoint
+    # reuses create_app, so it must forward config.runner_token; dropping it
+    # silently reopens the unauthenticated hole.
+    _set_env(monkeypatch, AGENTOS_FAKE_MODEL="1", AGENTOS_RUNNER_TOKEN=_RUNNER_TOKEN)
+    captured: dict[str, object] = {}
+    real_create_app = oc_main.create_app
+
+    def _cap(runner: object, token: str | None = None) -> object:
+        captured["token"] = token
+        return real_create_app(runner, token=token)
+
+    monkeypatch.setattr(oc_main, "create_app", _cap)
+    served = _stub_serve(monkeypatch)
+    main()
+    assert captured["token"] == _RUNNER_TOKEN
+    assert len(served) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 5. Budget ceiling flows from AGENTOS_BUDGET.max_output_tokens_per_run.
+# --------------------------------------------------------------------------- #
+
+
+def test_budget_ceiling_flows_from_env_and_halts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(oc_session, "_find_opencode", _raise_find_opencode)
+    # A ceiling of 1 is exceeded by the fake turn's 8 output tokens, so the run
+    # halts with a classified-failure final carrying the budget classification.
+    config = _config(
+        AGENTOS_BUDGET='{"max_output_tokens_per_run": 1, "max_usd_per_day": 5.0}'
+    )
+    runner = build_runner(config, fake_model=True)
+    events = _drive_turn(runner)
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.CLASSIFIED_FAILURE
+    assert any(
+        e.type == "error" and e.classification == BUDGET_CLASSIFICATION for e in events
+    )
+
+
+def test_budget_headroom_completes_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oc_session, "_find_opencode", _raise_find_opencode)
+    config = _config(
+        AGENTOS_BUDGET='{"max_output_tokens_per_run": 1000, "max_usd_per_day": 5.0}'
+    )
+    runner = build_runner(config, fake_model=True)
+    events = _drive_turn(runner)
+    assert events[-1].type == "final"
+    assert events[-1].status == SessionStatus.DONE
+
+
+# --------------------------------------------------------------------------- #
+# 6. A daily-USD cap warns (OpenCode has no native enforcement of it).
+# --------------------------------------------------------------------------- #
+
+
+def test_main_warns_on_usd_cap_without_native_enforcement(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # _BASE carries max_usd_per_day=5.0. The Claude path hands the daily USD cap
+    # to the SDK; OpenCode cannot enforce it, so the entrypoint must warn rather
+    # than silently pretend the cap is honored (only the per-run token ceiling is).
+    _set_env(monkeypatch)
+    served = _stub_serve(monkeypatch)
+    with caplog.at_level(logging.WARNING):
+        main()
+    assert any("usd" in record.getMessage().lower() for record in caplog.records)
+    assert len(served) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Invalid bundle fails closed at start -- before any capability-less boot.
+# --------------------------------------------------------------------------- #
+
+
+def test_invalid_bundle_raises_plugin_bundle_error_on_start(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # ensure_valid_bundle rejects a manifest-less dir; that PluginBundleError must
+    # propagate out of session start (never a capability-less boot), and it fires
+    # before the binary is ever needed.
+    monkeypatch.setattr(oc_session, "_find_opencode", _raise_find_opencode)
+    bad_bundle = tmp_path / "bundle"
+    bad_bundle.mkdir()
+    (bad_bundle / "random.txt").write_text("not a bundle", encoding="utf-8")
+    runner = build_runner(_config(AGENTOS_PLUGIN_DIR=str(bad_bundle)), fake_model=False)
+
+    async def go() -> None:
+        await runner.start()
+
+    with pytest.raises(PluginBundleError):
+        anyio.run(go)


### PR DESCRIPTION
Ships a second runner image variant (`runner/Dockerfile.opencode` + `python -m agentos_runner.opencode`) that packages the pinned opencode v1.17.17 binary and holds the chart's security rails on a real cluster. Harness selection stays image-level (ADR-0009); the Claude image, its entrypoint, and all chart values are untouched.

Part of #25. Stacked on `task/311-opencode-session-config-parity` (draft; do not merge ahead of the stack).

## Verification

### AC3 — Claude image + chart values unchanged
`git diff origin/task/311...HEAD --name-only` touches exactly six files; a scoped diff over `runner/Dockerfile`, `runner/src/agentos_runner/__main__.py`, and `charts/` is empty. Full suite green: **730 passed / 4 skipped**, `ruff` clean, `mypy` clean (108 files).

### AC2 — frozen ACI env contract + in-container conformance
Offline fake smoke under the emulated rails (`--read-only --tmpfs /tmp --tmpfs /home/runner:uid=1000,gid=1000 --user 1000:1000 --cap-drop ALL`) — NDJSON ends in a `final`/`done`, no write errors under the read-only rootfs:
```
POST /v1/event {"kind":"event","type":"message","text":"hi",...}
{"type":"text_delta","text":"Looking into it"}
{"type":"tool_note","text":"running tool Bash","tool":"Bash"}
{"type":"side_effect_flag","tool":"Bash","detail":"non-idempotent tool executed"}
{"type":"final","text":"all done","status":"done"}
```
Credentialed conformance inside the image (OpenRouter key, same rails):
```
docker run --rm --read-only --tmpfs /tmp --tmpfs /home/runner:uid=1000,gid=1000 \
  --user 1000:1000 --cap-drop ALL -e AGENTOS_CREDENTIALS=<sk-or-...> \
  agentos-runner-opencode:312 python -m agentos_runner.opencode.conformance
  -> 5/5 conformance checks passed  passed=True
  Representative live turn: {"type":"final","text":"\n\npong","status":"done"}
  LIVE SPIKE RESULT: PASS   (exit 0)
```

### AC1 — runs under the chart securityContext on a real cluster (k8scratch)
The variant image was imported to the node (`k3s ctr images import`) and run from the **real rendered SandboxTemplate podTemplate** (`charts/agentos/templates/agent-sandbox.yaml`: pod-level `runAsNonRoot`/`runAsUser`/`runAsGroup`/`fsGroup` 1000 + `seccompProfile: RuntimeDefault` at :117-121; container-level `allowPrivilegeEscalation: false` / `readOnlyRootFilesystem: true` / `drop: [ALL]` at :253-257). Pod `Running` + `/healthz` ready with `image: agentos-runner-opencode:312`.

Rails proof via `kubectl exec` (kubelet-enforced):
```
id -u                       -> 1000
touch /usr/local/bin/x      -> Read-only file system (rc=1)   # RO rootfs negative control
touch /app/x                -> Read-only file system (rc=1)
touch /tmp/x                -> OK                              # writable-mount positive control
touch /home/runner/x        -> OK
ls /home/runner/.local/share/opencode  -> exists              # OpenCode state lands in the writable emptyDir
logs | grep sk-or-/OPENROUTER  -> (empty)                     # no credential leak
```
Live turn through the deployed pod (real OpenRouter glm-4.6):
```
POST /v1/event "What is 12 * 12? Reply with just the number."
{"type":"text_delta","text":"\n144"}
{"type":"final","text":"\n\n144","status":"done"}
```
Memory footprint during the turn: **496Mi** against the runner's 768Mi limit (no OOM).

Fail-loud negative control — `AGENTOS_CREDENTIALS=sk-ant-...` (unsupported for OpenCode):
```
exitCode=1 reason=Error
ERROR: credential resolution failed: AGENTOS_CREDENTIALS has unsupported class anthropic-api-key for OpenCode
agentos_runner.sdk_auth.UnsupportedCredentialError: ... unsupported class anthropic-api-key for OpenCode
(no "Running on http" line -> died before the port bound)
```

## Review

Four heterogeneous reviewers + a cross-model Codex pass against the frozen diff:
- **code-reviewer:** APPROVE, clean (verified both opencode v1.17.17 sha256s byte-exact against the live GitHub release assets).
- **scope-creep-reviewer:** PASS, 0 creep hunks — every hunk traces to an AC.
- **spec-vs-impl-reviewer:** all three ACs met (live proofs above).
- **security-reviewer:** PASS, hardening sound (non-root, RO-rootfs-clean, sha256-pinned with hard-fail, reproducible == uv.lock, no baked secret, fail-loud before port bind, #63 bearer gate preserved, no credential leak).
- **Codex (cross-model):** caught that the documented `docker run` commands mounted `/home/runner` root-owned, so a reader running the live conformance verbatim would hit `EACCES` on `/home/runner/.local` — **fixed** (both commands now use `--tmpfs /home/runner:uid=1000,gid=1000`).

## Notes / scope limits
- `AGENTOS_PLUGIN_DIR` pointing at a non-existent dir (the warm-pool `/unused` sentinel) fails `ensure_valid_bundle` on **both** the Claude and OpenCode images identically (verified) — the fail-closed bundle contract, not a regression. A real deployment binds a valid bundle or an empty plugin dir; the cluster proof above booted bundle-less and the bundle path is covered by the in-container conformance (live bundle mounted).
- k8scratch has no NetworkPolicy controller, so the egress rails are render-verified only; the securityContext rails above are kubelet-enforced and are the real cluster proof.
- `claude-agent-sdk==0.2.115` is present but import-only (no Node, no Claude CLI spawned in this image).
- `curl`/`ca-certificates` remain in the runtime image (same posture as the Claude image; mitigated by drop-ALL + RO rootfs + fail-closed egress).

## Deferred follow-ups (to file)
- Publish `agentos-runner-opencode` from `release.yaml` (this PR is build-only CI; "builds from the repo" is satisfied by the ci.yaml matrix gate — touching the release pipeline in an unmerged stack is out of scope).
- Pre-existing `runner/Dockerfile` `claude-agent-sdk` pin drift (0.2.110 vs uv.lock 0.2.115) — one-line follow-up that touches the Claude image (AC3).

Ref #312
