### PR TITLE
Agent-driven discoverability: llms.txt + parity-pain README (#327)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@ message is answered by a versioned plugin running in an isolated Kubernetes
 sandbox, traced through Langfuse and steerable mid-turn; a git push deploys that
 plugin under a bot identity via the API's git-flow engine. Relay is the project
 codename; `agentos` is the product-surface name (bot handle, CLI binary). Read
-`ARCHITECTURE.md` before touching a cross-component seam.
+`ARCHITECTURE.md` before touching a cross-component seam. If you are a coding
+agent orienting in this repo, [`llms.txt`](llms.txt) is the curated machine map
+of these docs, organized around the parity ladder.
 
 ## Directory map
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,17 @@ hold new features against.
 "agentos" is the product-surface name — the CLI binary, the bot handle, the
 console. Both names refer to the same system.
 
-## What it does
+## What does AgentOS do?
+
+Your agent worked on your laptop and then broke once it was deployed. AgentOS is
+a harness that runs the **same immutable bundle** and the **same
+`evals/cases.json`** identically across three targets (`skill` in-process,
+`local` via docker compose, `cluster` on Kubernetes), so a tier-to-tier
+divergence surfaces as the harness catching a real environment bug before
+production, not a silent regression after it. A coding agent can already write a
+`skill.md`; what it cannot guarantee alone is that the skill behaves the same
+deployed as it did locally. That guarantee is the harness's job: the local loop
+is the production loop.
 
 A Slack `@mention` (or DM) is answered by a versioned plugin running in an
 isolated Kubernetes sandbox, with the run traced end to end and steerable
@@ -66,7 +76,9 @@ journeys filed as `epic`-labeled issues.
 Every CLI command that touches an environment takes a **target noun** in the
 middle: `skill`, `local`, or `cluster`. Pick the lightest one that answers your
 question. (`agentos init` is the exception: it scaffolds a bundle on disk and
-targets no environment.)
+targets no environment.) The point of the three targets is that the identical
+bundle and the identical `evals/cases.json` run across all of them, so promoting
+`skill` to `local` to `cluster` is a parity ladder, not three separate setups.
 
 | Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
 |---|---|---|---|---|---|
@@ -104,8 +116,8 @@ export `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) and set
 **`cluster` (deployed Helm release).** `agentos cluster up` installs the platform
 on Kubernetes and `agentos cluster message "..."` drives the deployed release end
 to end with no Slack. See
-[Operating a cluster install](#operating-a-cluster-install) and
-[`docs/operations.md`](docs/operations.md).
+[How do I run my agent on a Kubernetes cluster?](#how-do-i-run-my-agent-on-a-kubernetes-cluster)
+and [`docs/operations.md`](docs/operations.md).
 
 **Real Slack (production).** With a workspace connected, `@mention` the bot in a
 channel or DM it: the dispatcher acks, posts a placeholder, and the worker routes
@@ -150,7 +162,7 @@ channel binding, and troubleshooting) see
 - **Rust toolchain** (stable, edition 2021, with `rustfmt` and `clippy`): for
   the CLI. Skip if you use a prebuilt CLI binary from Releases.
 - **kubectl + helm**: only for the cluster-install path (see
-  [Operating a cluster install](#operating-a-cluster-install)).
+  [How do I run my agent on a Kubernetes cluster?](#how-do-i-run-my-agent-on-a-kubernetes-cluster)).
 
 ## Quickstart
 
@@ -338,7 +350,7 @@ Each package documents its own deeper verify commands and gotchas in its own
 README (linked above) and its own scoped `CLAUDE.md` — this quickstart is
 enough to see the pieces move; it is not a substitute for those.
 
-## Dev workflow
+## How do I develop and verify a change?
 
 - **Python packages** are one `uv` workspace (root `pyproject.toml`); ruff,
   mypy, and pytest run across all members from the repo root (see step 3
@@ -352,7 +364,7 @@ enough to see the pieces move; it is not a substitute for those.
   gate every cross-language lane; changing either requires regenerating the
   committed schema/TS/Rust artifacts and is enforced by a CI compat test.
 
-## Operating a cluster install
+## How do I run my agent on a Kubernetes cluster?
 
 The same `agentos` binary installs and runs the platform on a Kubernetes
 cluster, wrapping the umbrella Helm chart the way `linkerd` or `cilium` wrap
@@ -376,7 +388,7 @@ Use `--chart <path>` when developing the chart locally. The short version:
 Full runbook (the credential model, the Slack-connect command, and the
 zero-Slack `message` flow) is in [`docs/operations.md`](docs/operations.md).
 
-## Where to go next
+## Where do I go next?
 
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) — the component diagram, the
   message-flow and deploy-flow sequence diagrams, and the built/in-progress

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,35 @@
+# AgentOS
+
+> A harness that runs the same immutable bundle and the same evals across three targets (skill, local, cluster), so an agent that worked locally does not silently break once deployed. Its CLI's primary user is a coding agent driven by a developer, not a human at a prompt.
+
+The point of the three targets (`skill` in-process, `local` via docker compose, `cluster` on Kubernetes) is running the SAME bundle and the SAME `evals/cases.json` across all of them. A tier-to-tier eval divergence is the harness catching a real environment bug, not the skill's logic being wrong. Writing a `skill.md` is something an agent can already do; guaranteeing it behaves the same deployed as it did locally is the harness's job.
+
+## Start here
+
+- [QUICKSTART.md](QUICKSTART.md): first agent reply in about a minute, the fastest path in.
+- [README.md](README.md): what AgentOS is, how to run it, and the target-by-target CLI walkthroughs.
+- [docs/vision.md](docs/vision.md): the north star, who it is for, and the parity thesis new features are held against.
+
+## The parity ladder (skill -> local -> cluster)
+
+- [README.md#which-target-do-i-want](README.md#which-target-do-i-want): the target table, which of skill/local/cluster answers your question.
+- [cli/README.md](cli/README.md): the full `agentos` command reference across all three targets.
+- [docs/operations.md](docs/operations.md): the cluster runbook (credential model, Slack connect, zero-Slack message flow).
+
+## Architecture
+
+- [ARCHITECTURE.md](ARCHITECTURE.md): the component map, message-flow and deploy-flow sequence diagrams, and the built vs deferred split.
+- [docs/adr/](docs/adr/): the load-bearing architecture decisions, each with the live-cluster evidence behind it.
+- [AGENTS.md](AGENTS.md): the operative rules for working in this repo (verify commands, dev stack, frozen-contract escalation).
+
+## Examples
+
+- [examples/weather/](examples/weather/): the first-party example bundle, a runnable web-search skill that `agentos init` scaffolds.
+- [examples/text-stats-engine/README.md](examples/text-stats-engine/README.md): a bundle that ships its own tools as an in-bundle stdio MCP server, a shape a hosted harness cannot do.
+
+## Optional
+
+- [SECURITY.md](SECURITY.md): the security posture and reporting process.
+- [docs/behavior-packs.md](docs/behavior-packs.md): reusable behavior packs for bundles.
+- [docs/onboarding.md](docs/onboarding.md): the end-to-end onboarding walkthrough.
+- [docs/slack-local-runbook.md](docs/slack-local-runbook.md): exercising real Slack routing against the local compose stack.


### PR DESCRIPTION
Implements [ADR-0021](docs/adr/0021-agentos-is-a-harness-for-coding-agents.md): position AgentOS for discovery by a *coding agent* on the parity pain ("my agent worked locally but broke deployed"), and make the repo immediately usable once an agent reaches the docs.

## What changed
- **`llms.txt`** (new, root): a curated doc map following the llms.txt spec (H1 + blockquote summary + H2 link-list sections), organized around the parity ladder (`skill` -> `local` -> `cluster`). Every one of its 15 links resolves to a real file.
- **`README.md`**: leads with the parity-pain framing (worked locally, broke once deployed; the local loop is the production loop) and reframes the journey/action headings as the first-person questions a coding agent issues ("What does AgentOS do?", "How do I develop and verify a change?", "How do I run my agent on a Kubernetes cluster?", "Where do I go next?"). Pure-reference headings left declarative per ADR-0021's warning against gimmicky restate-the-obvious phrasing.
- **`AGENTS.md`**: one sentence pointing a coding agent at `llms.txt` as the curated machine map.

## AC status
- [x] **AC1** `llms.txt` + root `AGENTS.md` exist and validate as well-formed (link resolution + anchor integrity + llms.txt structure verified).
- [x] **AC2** README headings match agent-query phrasing on the parity pain.
- [ ] **AC3** Registry / awesome-list submission opened. **Left for a human to open** (see below) — submitting a PR to a third-party list under your identity is an outward-facing action I don't auto-execute. This PR therefore uses `Ref #327`, not a closing keyword, so merging does not prematurely close the issue.

## Anchor safety
`#which-target-do-i-want` and `#quickstart` heading texts are unchanged (linked cross-file from `QUICKSTART.md` and `docs/operations.md`). The renamed cluster heading's two internal README links were updated; a repo-wide grep confirms no stale anchor references.

## AC3: ready-to-open registry submission
Suggested target: **[awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code)** (AgentOS ships Claude Code plugin-format bundles and is a harness for coding agents, the strongest-fit list). Proposed entry:

> **[AgentOS](https://github.com/curie-eng/agentos)** - Open-source, self-hostable harness for shipping Claude Code plugins as production agents. Runs the same immutable bundle and the same eval suite across local, docker compose, and Kubernetes, so an agent that works locally does not silently break once deployed.

To open it: fork the list, add the line under the fitting category, and `gh pr create` against that repo. Say the word and I can prepare the exact fork+edit+PR commands (still for you to run under your GitHub identity).

Ref #327