### PR TITLE
Add `agentos guide`: a self-contained primer for coding agents

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -32,6 +32,7 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 | Command | What it does |
 |---|---|
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed. |
+| `agentos guide` | Print a self-contained primer (ADR-0021) for a coding agent driving the harness: the parity ladder, when/which decision logic, the landmines, and verify-first, to stdout. `--json` emits the same content as a structured variant (data on stdout). |
 | `agentos build` | Build the runner image locally: `docker build -f runner/Dockerfile -t agentos-runner .` from the repo root (found by walking up to `runner/Dockerfile`). `--tag` overrides the tag. Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
 
 ## `agentos install`

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1534,6 +1534,26 @@
       "hidden": true,
       "long_about": "Print the machine-readable command manifest (JSON) to stdout.\n\nHidden, developer-facing: regenerates `cli/command-manifest.json`, which a CI drift gate keeps in lockstep with the CLI grammar. Also reachable as `dump-commands`.",
       "name": "schema"
+    },
+    {
+      "about": "Print a self-contained primer for a coding agent driving the harness (ADR-0021)",
+      "args": [
+        {
+          "global": false,
+          "help": "Emit the primer as structured JSON (stdout=data, human text=stderr)",
+          "id": "json",
+          "long": "json",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "long_about": "Print a self-contained primer for a coding agent driving the harness (ADR-0021).\n\nOrdered by what the agent needs first (roughly 100 lines), carrying only non-discoverable knowledge: the parity ladder, when/which decision logic, the landmines, and verify-first. Human-readable Markdown by default; `--json` emits a structured variant (data on stdout, human text on stderr).",
+      "name": "guide"
     }
   ]
 }

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -1,0 +1,282 @@
+//! `agentos guide`: the self-describing harness primer (ADR-0021, issue #322).
+//!
+//! Emits a compact, self-contained "how to drive this harness" document for a
+//! coding agent, modeled on `SKILL.md`: ordered by what the agent needs first,
+//! roughly 100 lines, carrying only non-discoverable knowledge -- the parity
+//! ladder, the when/which decision logic, the landmines, and verify-first. It
+//! deliberately omits a directory tour the agent could derive itself (ADR-0021
+//! decision 2: restate-the-obvious guidance measurably hurts).
+//!
+//! One data model ([`primer`]) is the single source of truth; the Markdown
+//! default and the `--json` structured variant both render from it, so a command
+//! printed by one is byte-identical in the other and the drift test in
+//! `cli/tests/guide.rs` can validate the printed commands against the CLI's own
+//! `agentos schema` manifest. Every printed `agentos ...` invocation is a real
+//! command path -- prose refers to the product as "AgentOS".
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::ui;
+
+/// The whole primer as data. Serialized directly for `--json`; rendered to
+/// Markdown for the default. Fields are ordered as the agent reads them.
+#[derive(Serialize)]
+pub struct Primer {
+    pub harness: &'static str,
+    pub summary: &'static str,
+    pub verify_first: VerifyFirst,
+    pub parity_ladder: Vec<Rung>,
+    pub decision_logic: Vec<Decision>,
+    pub landmines: Vec<Landmine>,
+    pub recovery: Vec<Recovery>,
+}
+
+#[derive(Serialize)]
+pub struct VerifyFirst {
+    pub why: &'static str,
+    pub commands: Vec<&'static str>,
+}
+
+/// One rung of the parity ladder: a real, runnable command and why to run it.
+#[derive(Serialize)]
+pub struct Rung {
+    pub tier: &'static str,
+    pub command: &'static str,
+    pub purpose: &'static str,
+}
+
+#[derive(Serialize)]
+pub struct Decision {
+    pub question: &'static str,
+    pub answer: &'static str,
+}
+
+#[derive(Serialize)]
+pub struct Landmine {
+    pub title: &'static str,
+    pub detail: &'static str,
+}
+
+#[derive(Serialize)]
+pub struct Recovery {
+    pub symptom: &'static str,
+    pub fix: &'static str,
+}
+
+/// The authored primer. Content lives here so Markdown and JSON never diverge.
+pub fn primer() -> Primer {
+    Primer {
+        harness: "agentos",
+        summary: "AgentOS is a harness: it guarantees that a bundle behaving in a local chat \
+                  behaves identically as a deployed local process and again on Kubernetes. You \
+                  author the skill; the harness owns deployment parity.",
+        verify_first: VerifyFirst {
+            why: "Your training data is stale. Confirm a command exists before you run it -- \
+                  never invoke one you have not seen in the manifest or --help.",
+            commands: vec!["agentos schema", "agentos skill --help"],
+        },
+        parity_ladder: vec![
+            Rung {
+                tier: "init",
+                command: "agentos init deal-desk",
+                purpose: "Scaffold a bundle (Claude Code plugin shape) with an evals/cases.json seed.",
+            },
+            Rung {
+                tier: "skill",
+                command: "agentos skill up --fake-model",
+                purpose: "Boot the runner alone, offline, no credential -- the fastest authoring loop.",
+            },
+            Rung {
+                tier: "skill",
+                command: "agentos skill eval",
+                purpose: "Run evals/cases.json in-process. This is the promotion gate; it must be green.",
+            },
+            Rung {
+                tier: "skill",
+                command: "agentos skill message \"hello\"",
+                purpose: "Drive one synthetic turn and stream the reply.",
+            },
+            Rung {
+                tier: "skill",
+                command: "agentos skill down",
+                purpose: "Stop and remove the runner.",
+            },
+            Rung {
+                tier: "local",
+                command: "agentos local up",
+                purpose: "Bring up the full platform via compose (queue, worker, sandbox), still zero Slack.",
+            },
+            Rung {
+                tier: "local",
+                command: "agentos local deploy",
+                purpose: "Push the identical bundle to the local platform API.",
+            },
+            Rung {
+                tier: "local",
+                command: "agentos local message \"hello\"",
+                purpose: "Drive the real product loop end to end -- the path a Slack mention would take.",
+            },
+            Rung {
+                tier: "cluster",
+                command: "agentos cluster up",
+                purpose: "Install the release on Kubernetes via Helm.",
+            },
+            Rung {
+                tier: "cluster",
+                command: "agentos cluster deploy",
+                purpose: "Ship the same bundle to the cluster.",
+            },
+            Rung {
+                tier: "cluster",
+                command: "agentos cluster message \"hello\"",
+                purpose: "Drive the same loop on the cluster.",
+            },
+        ],
+        decision_logic: vec![
+            Decision {
+                question: "skill vs local vs cluster",
+                answer: "skill is the runner only (offline, no platform, no Slack) -- the tightest \
+                         loop. local puts the full platform in front of the identical runner via \
+                         compose. cluster is the same on Kubernetes. Pick the lightest tier that \
+                         answers your question; promote only to reproduce a divergence.",
+            },
+            Decision {
+                question: "skill vs MCP server",
+                answer: "A skill is a prompt+tools capability inside the bundle; an MCP server is an \
+                         external tool surface the skill calls. Add a skill for behavior the agent \
+                         performs; add an MCP server to give it a new tool.",
+            },
+            Decision {
+                question: "how an eval gates promotion",
+                answer: "evals/cases.json is the contract. `agentos skill eval` must be green before \
+                         you deploy; merging to main promotes to prod (git flow is the deploy model). \
+                         Never promote a bundle whose evals are red.",
+            },
+        ],
+        landmines: vec![
+            Landmine {
+                title: "Skill frontmatter uses `allowed-tools`, not `tools`",
+                detail: "The wrong key parses but silently grants no tools.",
+            },
+            Landmine {
+                title: "MCP servers must be inline objects in .mcp.json",
+                detail: "A string-pointer declaration silently fails to load; use the bare inline object form.",
+            },
+            Landmine {
+                title: "In-cluster sandboxes need dnsPolicy ClusterFirst",
+                detail: "Otherwise the bound bundle fetch cannot resolve the in-cluster object store.",
+            },
+            Landmine {
+                title: "secretKeyRef env vars resolve once, at pod start",
+                detail: "A connect that rotates a secret must also roll the pod; `agentos cluster comms` does this for you.",
+            },
+            Landmine {
+                title: "An empty-string API key is not \"unset\"",
+                detail: "It trips the CLI auth gate. Omit the flag or env entirely to fall back, rather than passing an empty value.",
+            },
+        ],
+        recovery: vec![
+            Recovery {
+                symptom: "\"platform API ... unreachable\" on a local deploy or message",
+                fix: "The stack is down. Run `agentos local up`, then retry.",
+            },
+            Recovery {
+                symptom: "authentication_failed from a live model",
+                fix: "A real credential is empty or being overridden. Unset the empty one; set AGENTOS_MODEL_CREDENTIALS for `agentos cluster up`.",
+            },
+            Recovery {
+                symptom: "\"(no response)\" or an empty reply",
+                fix: "You are on the fake model (--fake-model, or a sealed install). Provide a credential to go live.",
+            },
+            Recovery {
+                symptom: "a command \"does not exist\"",
+                fix: "You trusted training over the manifest. Re-run `agentos schema` and use the confirmed spelling.",
+            },
+        ],
+    }
+}
+
+fn tier_caption(tier: &'static str) -> &'static str {
+    match tier {
+        "init" => "0. Scaffold a bundle (Claude Code plugin shape + evals/cases.json seed)",
+        "skill" => "1. skill tier: the runner alone, offline, fake model -- the fastest loop",
+        "local" => "2. local tier: the same bundle through the full platform (compose), zero Slack",
+        "cluster" => "3. cluster tier: the same bundle on Kubernetes (a Helm release)",
+        other => other,
+    }
+}
+
+/// Render the primer as Markdown. Every `agentos ...` token printed here is a
+/// real command; the drift test enforces that against the live manifest.
+fn render_markdown(p: &Primer) -> String {
+    let mut s = String::new();
+    s.push_str("# AgentOS harness primer\n\n");
+    s.push_str(p.summary);
+    s.push_str(
+        "\n\nYou are a coding agent driving this harness. This primer carries only what you \
+         cannot derive from the command tree or your training data. Read it before you \
+         start.\n\n",
+    );
+
+    s.push_str("## Verify-first (before every command)\n\n");
+    s.push_str(p.verify_first.why);
+    s.push_str("\n\n");
+    for c in &p.verify_first.commands {
+        s.push_str(&format!("    {c}\n"));
+    }
+    s.push('\n');
+
+    s.push_str("## The parity ladder (the core loop)\n\n");
+    s.push_str(
+        "One immutable bundle and one evals/cases.json, run at three tiers. Climb only as far \
+         as you need. A tier-to-tier divergence is the harness catching a real environment \
+         bug, not your skill's logic.\n\n",
+    );
+    let mut last_tier = "";
+    for r in &p.parity_ladder {
+        if r.tier != last_tier {
+            s.push_str(&format!("    # {}\n", tier_caption(r.tier)));
+            last_tier = r.tier;
+        }
+        s.push_str(&format!("    {}\n", r.command));
+        s.push_str(&format!("    #   {}\n", r.purpose));
+    }
+    s.push('\n');
+    s.push_str(
+        "The eval file never changes across tiers. If `skill eval` is green but a deployed \
+         message misbehaves, the bundle is fine and the environment is not -- that gap is the \
+         signal the harness exists to surface.\n\n",
+    );
+
+    s.push_str("## When / which\n\n");
+    for d in &p.decision_logic {
+        s.push_str(&format!("- **{}**\n  {}\n\n", d.question, d.answer));
+    }
+
+    s.push_str("## Landmines (non-discoverable)\n\n");
+    for l in &p.landmines {
+        s.push_str(&format!("- **{}**\n  {}\n\n", l.title, l.detail));
+    }
+
+    s.push_str("## Error -> recovery\n\n");
+    for r in &p.recovery {
+        s.push_str(&format!("- **{}**\n  {}\n\n", r.symptom, r.fix));
+    }
+
+    s.push_str("When anything is uncertain, confirm it against `agentos schema` before you act.\n");
+    s
+}
+
+/// `agentos guide`: print the primer. Markdown to stdout by default; `--json`
+/// prints the structured variant to stdout (any human text would go to stderr).
+pub fn run(json: bool) -> Result<()> {
+    let p = primer();
+    let ui = ui::ui();
+    if json {
+        ui.payload_plain(&serde_json::to_string_pretty(&p)?);
+    } else {
+        ui.payload_plain(&render_markdown(&p));
+    }
+    Ok(())
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -12,6 +12,7 @@ pub mod commands;
 pub mod comms;
 pub mod docker;
 pub mod evals;
+pub mod guide;
 pub mod local;
 pub mod message;
 pub mod ndjson;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,6 +114,17 @@ enum Command {
     /// `dump-commands`.
     #[command(hide = true, alias = "dump-commands")]
     Schema,
+    /// Print a self-contained primer for a coding agent driving the harness (ADR-0021).
+    ///
+    /// Ordered by what the agent needs first (roughly 100 lines), carrying only
+    /// non-discoverable knowledge: the parity ladder, when/which decision logic,
+    /// the landmines, and verify-first. Human-readable Markdown by default;
+    /// `--json` emits a structured variant (data on stdout, human text on stderr).
+    Guide {
+        /// Emit the primer as structured JSON (stdout=data, human text=stderr).
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1166,6 +1177,7 @@ async fn main() -> Result<()> {
             print!("{}", agentos::schema::manifest_json(&Cli::command()));
             Ok(())
         }
+        Command::Guide { json } => agentos::guide::run(json),
     }
 }
 

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -1,0 +1,253 @@
+//! `agentos guide` (#322 / ADR-0021): the self-describing harness primer.
+//!
+//! These tests pin the acceptance criteria: the primer prints to stdout, `--json`
+//! emits a structured variant with the data on stdout (human text goes to stderr),
+//! the primer is self-contained and roughly 100 lines, and -- the drift guard --
+//! every `agentos ...` command the primer prints resolves to a real command in
+//! the CLI's own machine-readable manifest (`agentos schema`). The test reads the
+//! grammar from that manifest, so it tracks the CLI surface automatically and
+//! fails the build if the primer ever references a command that does not exist.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentos")
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(bin())
+        .args(args)
+        .output()
+        .expect("run agentos")
+}
+
+fn out_str(o: &Output) -> String {
+    String::from_utf8(o.stdout.clone()).expect("stdout utf-8")
+}
+
+fn err_str(o: &Output) -> String {
+    String::from_utf8(o.stderr.clone()).expect("stderr utf-8")
+}
+
+/// The CLI's real command surface, read from `agentos schema` (the #145/#278
+/// manifest): a map from a parent command path ("" == root) to the set of its
+/// direct subcommand names. This is the ground truth the primer is validated
+/// against, so the test tracks the grammar automatically.
+struct Surface {
+    children: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl Surface {
+    fn load() -> Surface {
+        let out = run(&["schema"]);
+        assert!(
+            out.status.success(),
+            "agentos schema failed:\n{}",
+            err_str(&out)
+        );
+        let root: Value = serde_json::from_str(&out_str(&out)).expect("manifest is json");
+        let mut children = BTreeMap::new();
+        walk(&root, String::new(), &mut children);
+        Surface { children }
+    }
+
+    /// Resolve a printed `agentos ...` invocation to its subcommand path.
+    /// `Ok(Some(path))` when it resolves, `Ok(None)` when the line carries no
+    /// invocation, `Err(reason)` when a bare token that should name a subcommand
+    /// does not exist in the grammar (the drift/typo this guard exists to catch).
+    fn resolve(&self, line: &str) -> Result<Option<String>, String> {
+        let idx = match line.find("agentos ") {
+            Some(i) => i,
+            None => return Ok(None),
+        };
+        let rest = &line[idx + "agentos ".len()..];
+        let empty = BTreeSet::new();
+        let mut path = String::new();
+        let mut matched = 0usize;
+        for raw in rest.split_whitespace() {
+            let tok =
+                raw.trim_matches(|c| c == '`' || c == '"' || c == '.' || c == ',' || c == ')');
+            if tok.is_empty() {
+                break;
+            }
+            if tok.starts_with('-') {
+                break; // flags: the command path is complete
+            }
+            let here = self.children.get(&path).unwrap_or(&empty);
+            if here.contains(tok) {
+                path = if path.is_empty() {
+                    tok.to_string()
+                } else {
+                    format!("{path} {tok}")
+                };
+                matched += 1;
+            } else if here.is_empty() {
+                break; // leaf reached: this token is a positional value
+            } else {
+                return Err(format!(
+                    "`agentos {path} {tok}` -- `{tok}` is not a real subcommand"
+                ));
+            }
+        }
+        if matched == 0 {
+            return Err(format!("`agentos {rest}` names no real command"));
+        }
+        Ok(Some(path))
+    }
+}
+
+fn walk(node: &Value, prefix: String, out: &mut BTreeMap<String, BTreeSet<String>>) {
+    let mut names = BTreeSet::new();
+    if let Some(subs) = node.get("subcommands").and_then(|s| s.as_array()) {
+        for sub in subs {
+            let name = sub
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or_default()
+                .to_string();
+            names.insert(name.clone());
+            let child_prefix = if prefix.is_empty() {
+                name.clone()
+            } else {
+                format!("{prefix} {name}")
+            };
+            walk(sub, child_prefix, out);
+        }
+    }
+    out.insert(prefix, names);
+}
+
+#[test]
+fn guide_prints_primer_to_stdout() {
+    let out = run(&["guide"]);
+    assert!(
+        out.status.success(),
+        "agentos guide failed:\n{}",
+        err_str(&out)
+    );
+    let text = out_str(&out);
+    assert!(!text.trim().is_empty(), "primer stdout was empty");
+    // Self-contained: it covers all three tiers, the eval gate, the parity
+    // concept, and at least one non-discoverable landmine.
+    for needle in [
+        "skill",
+        "local",
+        "cluster",
+        "eval",
+        "parity",
+        "allowed-tools",
+    ] {
+        assert!(text.contains(needle), "primer missing `{needle}`\n{text}");
+    }
+    // "Roughly 100 lines": a real primer, neither a stub nor a sprawling manual.
+    let lines = text.lines().count();
+    assert!(
+        (60..=160).contains(&lines),
+        "primer is {lines} lines, expected roughly 100"
+    );
+}
+
+#[test]
+fn guide_json_emits_pure_structured_data_on_stdout() {
+    let out = run(&["guide", "--json"]);
+    assert!(
+        out.status.success(),
+        "agentos guide --json failed:\n{}",
+        err_str(&out)
+    );
+    // stdout is exclusively the data payload: it parses as one JSON value with no
+    // human prose bleeding in (that belongs on stderr, per ADR-0021 decision 1).
+    let v: Value = serde_json::from_str(&out_str(&out)).expect("stdout is pure json");
+    assert!(
+        v.get("parity_ladder")
+            .and_then(|l| l.as_array())
+            .is_some_and(|a| !a.is_empty()),
+        "json missing a non-empty parity_ladder"
+    );
+    assert!(
+        v.get("landmines")
+            .and_then(|l| l.as_array())
+            .is_some_and(|a| !a.is_empty()),
+        "json missing a non-empty landmines list"
+    );
+    assert!(
+        v.get("verify_first")
+            .and_then(|vf| vf.get("commands"))
+            .and_then(|c| c.as_array())
+            .is_some_and(|a| !a.is_empty()),
+        "json missing verify_first.commands"
+    );
+}
+
+#[test]
+fn guide_is_registered_in_the_manifest() {
+    let surface = Surface::load();
+    assert!(
+        surface
+            .children
+            .get("")
+            .is_some_and(|top| top.contains("guide")),
+        "`guide` is not a real subcommand in the CLI manifest surface"
+    );
+}
+
+#[test]
+fn every_command_the_primer_prints_exists_in_the_cli_surface() {
+    // AC #4: the primer must not drift from the grammar. Validate both the
+    // Markdown default and the --json commands against the live manifest.
+    let surface = Surface::load();
+
+    let md = out_str(&run(&["guide"]));
+    let mut resolved = Vec::new();
+    for line in md.lines() {
+        match surface.resolve(line) {
+            Ok(Some(path)) => resolved.push(path),
+            Ok(None) => {}
+            Err(e) => panic!("primer prints a command not in the CLI surface: {e}"),
+        }
+    }
+    // The primer genuinely walks the parity ladder (not a contentless doc that
+    // trips no commands): the core rungs must be present.
+    for expected in ["init", "skill up", "skill eval", "local up", "cluster up"] {
+        assert!(
+            resolved.iter().any(|p| p == expected),
+            "primer never prints `agentos {expected}`; resolved={resolved:?}"
+        );
+    }
+
+    // The --json parity ladder draws from the same source of truth: every command
+    // it lists resolves against the grammar and appears verbatim in the Markdown.
+    let json: Value =
+        serde_json::from_str(&out_str(&run(&["guide", "--json"]))).expect("guide --json is json");
+    let ladder = json["parity_ladder"]
+        .as_array()
+        .expect("parity_ladder is an array");
+    for rung in ladder {
+        let cmd = rung["command"].as_str().expect("rung command is a string");
+        assert!(
+            cmd.starts_with("agentos "),
+            "rung command `{cmd}` is not an agentos invocation"
+        );
+        match surface.resolve(cmd) {
+            Ok(Some(_)) => {}
+            other => panic!("json rung `{cmd}` does not resolve to a real command: {other:?}"),
+        }
+        assert!(
+            md.contains(cmd),
+            "json rung `{cmd}` is absent from the Markdown primer (source-of-truth drift)"
+        );
+    }
+    for cmd in json["verify_first"]["commands"]
+        .as_array()
+        .expect("verify_first.commands is an array")
+    {
+        let cmd = cmd.as_str().expect("command is a string");
+        assert!(
+            matches!(surface.resolve(cmd), Ok(Some(_))),
+            "verify_first command `{cmd}` does not resolve to a real command"
+        );
+    }
+}


### PR DESCRIPTION
Implements [ADR-0021](docs/adr/0021-agentos-is-a-harness-for-coding-agents.md) (self-describing harness): `agentos guide` emits a compact (~90-line) primer teaching a coding agent how to drive the AgentOS harness, corrected at runtime on every invocation rather than relying on stale training knowledge.

The primer carries only non-discoverable knowledge:
- **Parity ladder** as real, runnable commands (`init` -> `skill up`/`eval` -> `local up`/`deploy`/`message` -> `cluster up`/`deploy`/`message`), with `skill eval` as the promotion gate and a plain statement that a tier-to-tier divergence is the harness catching an environment bug. `eval` exists only under `skill` today, so local/cluster parity is demonstrated via `deploy`+`message` rather than an invented `local eval`/`cluster eval`.
- **When/which decision logic** (skill vs local vs cluster; skill vs MCP server; how an eval gates promotion).
- **Landmines** (`allowed-tools` not `tools`; MCP string-pointer form silently fails; sandbox DNS `ClusterFirst`; `secretKeyRef` needs a pod rollout on connect; empty-string API key trips the auth gate).
- **Verify-first**: confirm commands against `agentos schema` before running.
- **Error -> recovery** table.

Markdown to stdout by default; `--json` emits a structured variant (data on stdout, diagnostics on stderr). A single `Primer` data model is the source of truth for both outputs, and a drift test resolves every command the primer prints against the live `agentos schema` manifest so the primer cannot drift from the CLI grammar.

Closes #322