### PR TITLE
Agent-facing CLI output contract: --json, semantic exit codes, non-interactive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,12 @@ just that unit tests pass.
   behavior (values, state transitions, emitted events, trace contents). Avoid
   hollow "does it render / does an element exist" checks and any AI-vision or
   screenshot-polling assertions -- they mask weak architecture and rot fast.
+- **New/changed CLI commands follow the agent-facing contract (ADR-0021):**
+  structured `--json` output for read/report commands (JSON to stdout, human/log
+  to stderr), semantic exit codes (0 success / 1 failure / 2 usage / 3 transient),
+  non-interactive (a `--yes`/`--force` path, never blocking on stdin), and errors
+  as `{"error","fix"}` recovery instructions. Exit-code scheme: see
+  `cli/README.md`.
 
 ## Playwright: two modes
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.4.3",
  "indicatif",
+ "jsonschema",
  "redis",
  "regex",
  "reqwest",
@@ -45,6 +46,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +67,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -133,6 +154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,16 +214,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -343,6 +397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,10 +420,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -394,6 +469,17 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -429,12 +515,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -512,6 +625,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -519,9 +646,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -781,6 +919,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +977,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -821,6 +1010,12 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mime"
@@ -860,10 +1055,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -878,10 +1151,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -992,6 +1294,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1043,6 +1351,52 @@ dependencies = [
  "tokio-util",
  "url",
  "xxhash-rust",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -1195,6 +1549,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -1581,6 +1941,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +2006,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +2041,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1840,6 +2237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +2285,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -56,3 +56,10 @@ tokio = { version = "1", features = [
 
 [dev-dependencies]
 tempfile = "3"
+# JSON Schema validation for the agent-facing --json contract gate (ADR-0021).
+# Default features pull reqwest + a second TLS stack for remote $ref resolution
+# we never use; the committed schemas are self-contained, so keep it lean.
+jsonschema = { version = "0.47", default-features = false }
+# The frozen ACI types are a normal dependency of the lib, but integration test
+# crates need them by name to build a SessionStatus for the status_json contract.
+agentos-aci-protocol = { path = "../packages/aci-protocol/generated/rust" }

--- a/cli/README.md
+++ b/cli/README.md
@@ -327,6 +327,39 @@ does not replay `--stream`, `--listen-port`, `--valkey-local-port`,
 `--api-local-port`, or `--user`, so pass any of those again explicitly if the
 original turn used a non-default value.
 
+## Agent-facing output contract
+
+The CLI's primary consumer is a coding agent (ADR-0021), so its output and
+control flow are machine-first.
+
+**`--json`** (global) switches the read/report commands `agentos skill status`
+and `agentos skill eval` to a single machine-readable JSON object on **stdout**;
+all human and log text (progress, notes, warnings) goes to **stderr**, so a
+plain `... --json | jq` yields clean data. On failure under `--json`, the error
+is emitted to stdout as `{"error": "<message>", "fix": "<hint>"|null}` instead of
+a prose message, so an agent can recover without parsing prose. `NO_COLOR`,
+`CLICOLOR`, and `--color=never` are honored on every command.
+
+**Semantic exit codes** let an agent branch on *why* a command failed without
+parsing output:
+
+| Code | Class     | Meaning                                                                 |
+|------|-----------|-------------------------------------------------------------------------|
+| 0    | success   | The command did what was asked.                                         |
+| 1    | failure   | A genuine runtime failure (well-formed request, operation did not succeed). Do not retry blindly. |
+| 2    | usage     | A deterministic input error (missing `--yes`, a malformed flag/value, no bundle). Retrying the same argv fails identically -- fix the input. |
+| 3    | transient | A retryable condition (the endpoint was unreachable or timed out). The same argv may succeed once the dependency is up. |
+
+**Non-interactive by default.** Every mutating command has a non-interactive
+path (`--yes` on `cluster down`/`kill`/`delete` and `local down --wipe`); none
+block on stdin. A confirmation prompt that would otherwise read stdin refuses
+with a usage error (exit 2) when the session is not a terminal, rather than
+hanging.
+
+(`agentos local status` and `agentos cluster status` proxy raw
+`docker compose`/`helm`/`kubectl` output and do not yet support `--json`; use
+`agentos skill status` for a machine-readable runner status today.)
+
 ## Verify
 
 ```bash

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1549,22 +1549,8 @@
     },
     {
       "about": "Print a self-contained primer for a coding agent driving the harness (ADR-0021)",
-      "args": [
-        {
-          "global": false,
-          "help": "Emit the primer as structured JSON (stdout=data, human text=stderr)",
-          "id": "json",
-          "long": "json",
-          "positional": false,
-          "possible_values": [
-            "true",
-            "false"
-          ],
-          "required": false
-        }
-      ],
       "hidden": false,
-      "long_about": "Print a self-contained primer for a coding agent driving the harness (ADR-0021).\n\nOrdered by what the agent needs first (roughly 100 lines), carrying only non-discoverable knowledge: the parity ladder, when/which decision logic, the landmines, and verify-first. Human-readable Markdown by default; `--json` emits a structured variant (data on stdout, human text on stderr).",
+      "long_about": "Print a self-contained primer for a coding agent driving the harness (ADR-0021).\n\nOrdered by what the agent needs first (roughly 100 lines), carrying only non-discoverable knowledge: the parity ladder, when/which decision logic, the landmines, and verify-first. Human-readable Markdown by default; The global `--json` emits a structured variant (data on stdout, human text on stderr).",
       "name": "guide"
     }
   ]

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -41,6 +41,18 @@
         "never"
       ],
       "required": false
+    },
+    {
+      "global": true,
+      "help": "Machine-readable JSON to stdout; human/log text to stderr",
+      "id": "json",
+      "long": "json",
+      "positional": false,
+      "possible_values": [
+        "true",
+        "false"
+      ],
+      "required": false
     }
   ],
   "hidden": false,

--- a/cli/schema/error.schema.json
+++ b/cli/schema/error.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "agentos --json error",
+  "description": "The agent-facing error payload emitted to stdout when a command fails under --json: the rendered error message plus an optional actionable fix hint (null when none applies).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["error", "fix"],
+  "properties": {
+    "error": {
+      "type": "string"
+    },
+    "fix": {
+      "type": ["string", "null"]
+    }
+  }
+}

--- a/cli/schema/eval.schema.json
+++ b/cli/schema/eval.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "agentos skill eval --json",
+  "description": "The agent-facing payload of `agentos skill eval --json`: the pass/fail roll-up plus one row per eval case.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["total", "passed", "failed", "cases"],
+  "properties": {
+    "total": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "passed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "passed", "seconds"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "passed": {
+            "type": "boolean"
+          },
+          "seconds": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/cli/schema/status.schema.json
+++ b/cli/schema/status.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "agentos skill status --json",
+  "description": "The agent-facing payload of `agentos skill status --json`: the runner base URL plus the serialized ACI SessionStatus. The wrapper keys are what the CLI owns and are locked; the inner `session` is a frozen ACI contract elsewhere, so it is left unconstrained here rather than mirrored field-by-field.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["url", "session"],
+  "properties": {
+    "url": {
+      "type": "string"
+    },
+    "session": {}
+  }
+}

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -277,22 +277,30 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     let (plugin_name, manifest_version) = read_manifest(&plugin_dir)?;
 
     if opts.local_model.is_some() && opts.fake_model {
-        bail!("--local-model cannot be combined with --fake-model");
+        return Err(crate::exit::usage(
+            "--local-model cannot be combined with --fake-model",
+        ));
     }
     if opts.local_model.is_some() && opts.model.is_some() {
-        bail!("--local-model cannot be combined with --model");
+        return Err(crate::exit::usage(
+            "--local-model cannot be combined with --model",
+        ));
     }
 
     if state::load(&plugin_dir)?.is_some() {
-        bail!(
+        return Err(crate::exit::usage(format!(
             "a local runner is already recorded in {}/.agentos/runner.json; run 'agentos skill down' there first",
             plugin_dir.display()
-        );
+        )));
     }
 
     // Parse (not just forward) the budget so a typo fails here, not in-container.
-    let _: Budget = serde_json::from_str(&opts.budget)
-        .with_context(|| format!("--budget is not a valid ACI budget: {}", opts.budget))?;
+    let _: Budget = serde_json::from_str(&opts.budget).map_err(|e| {
+        crate::exit::usage(format!(
+            "--budget is not a valid ACI budget: {}: {e}",
+            opts.budget
+        ))
+    })?;
 
     let session_id = format!("local-{}", unix_now());
     let mut network = opts.network.clone();
@@ -515,11 +523,44 @@ pub async fn stop() -> Result<()> {
     Ok(())
 }
 
+/// The `agentos skill status --json` payload: the runner base URL plus the
+/// serialized session status. Generic over the status shape so it serves both
+/// the frozen `SessionStatus` (contract test) and the runner's raw `/status`
+/// body (the live call site), which are both left unconstrained by
+/// `cli/schema/status.schema.json`. Pure so it stays contract-testable.
+pub fn status_json<T: serde::Serialize>(url: &str, status: &T) -> serde_json::Value {
+    serde_json::json!({ "url": url, "session": status })
+}
+
+/// The `agentos skill eval --json` payload: the pass/fail roll-up plus one row
+/// per case. Pure so it stays unit/contract-testable against
+/// `cli/schema/eval.schema.json`.
+pub fn eval_json(
+    results: &[(String, bool, f64)],
+    passed: usize,
+    total: usize,
+) -> serde_json::Value {
+    let cases: Vec<serde_json::Value> = results
+        .iter()
+        .map(|(id, ok, seconds)| serde_json::json!({ "id": id, "passed": ok, "seconds": seconds }))
+        .collect();
+    serde_json::json!({
+        "total": total,
+        "passed": passed,
+        "failed": total - passed,
+        "cases": cases,
+    })
+}
+
 pub async fn status(url: Option<String>) -> Result<()> {
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
     let status = client.status().await?;
     let ui = crate::ui::ui();
+    if ui.json() {
+        ui.emit_json(&status_json(&url, &status));
+        return Ok(());
+    }
     ui.note(&format!("runner {url}"));
     ui.payload_plain(&serde_json::to_string_pretty(&status)?);
     Ok(())
@@ -645,6 +686,16 @@ pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()
     }
     bar.finish();
 
+    // Under --json the whole roll-up is one machine payload on stdout; the human
+    // table + verdict lines are suppressed so they cannot corrupt it.
+    if ui.json() {
+        ui.emit_json(&eval_json(&results, passed, total));
+        if passed < total {
+            std::process::exit(crate::exit::ExitClass::Failure.code());
+        }
+        return Ok(());
+    }
+
     // The result table is payload -> stdout; the roll-up verdict is a
     // diagnostic -> stderr.
     let rows: Vec<Vec<String>> = results
@@ -668,7 +719,7 @@ pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()
         ));
     }
     if passed < total {
-        std::process::exit(1);
+        std::process::exit(crate::exit::ExitClass::Failure.code());
     }
     Ok(())
 }
@@ -695,10 +746,12 @@ pub fn resolve_cases_path(
             return Ok(in_bundle);
         }
     }
-    bail!(
+    Err(crate::exit::CliError::usage(format!(
         "no eval cases found: looked for {} and the running bundle's evals/cases.json; pass --cases",
         local.display()
-    )
+    ))
+    .with_fix("pass --cases")
+    .into())
 }
 
 pub struct DeployOpts {
@@ -716,18 +769,6 @@ pub struct DeployOpts {
     /// `agentos local up` for local). Naming the fix turns a raw
     /// "Connection refused" into something the operator can act on.
     pub connect_hint: String,
-}
-
-/// True when the error chain contains a reqwest connect/timeout failure --
-/// i.e. the platform API was unreachable rather than returning an error
-/// status. Lets deploy() swap the raw "Connection refused (os error 111)"
-/// for an actionable remediation.
-fn is_api_unreachable(err: &anyhow::Error) -> bool {
-    err.chain().any(|cause| {
-        cause
-            .downcast_ref::<reqwest::Error>()
-            .is_some_and(|e| e.is_connect() || e.is_timeout())
-    })
 }
 
 pub async fn deploy(opts: DeployOpts) -> Result<()> {
@@ -773,7 +814,7 @@ pub async fn deploy(opts: DeployOpts) -> Result<()> {
         }
         Err(err) => {
             step.fail("failed");
-            if is_api_unreachable(&err) {
+            if crate::exit::is_transient_reqwest(&err) {
                 return Err(err.context(opts.connect_hint));
             }
             return Err(err);
@@ -848,10 +889,12 @@ pub async fn kill(opts: AgentActionOpts, yes: bool) -> Result<()> {
         return Ok(());
     }
     if !yes {
-        bail!(
+        return Err(crate::exit::CliError::usage(format!(
             "`agentos cluster kill {}` stops the agent's runs; re-run with --yes to confirm",
             opts.agent
-        );
+        ))
+        .with_fix("re-run with --yes")
+        .into());
     }
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     let agent = client.find_agent(&opts.agent).await?;
@@ -923,7 +966,9 @@ pub async fn budget(opts: AgentActionOpts, limit: f64) -> Result<()> {
         return Ok(());
     }
     if !limit.is_finite() || limit <= 0.0 {
-        bail!("--limit must be a finite value greater than 0 (got {limit})");
+        return Err(crate::exit::usage(format!(
+            "--limit must be a finite value greater than 0 (got {limit})"
+        )));
     }
     let cfg = BudgetConfig {
         max_output_tokens_per_run: None,
@@ -965,10 +1010,12 @@ pub async fn delete(opts: AgentActionOpts, yes: bool) -> Result<()> {
         return Ok(());
     }
     if !yes {
-        bail!(
+        return Err(crate::exit::CliError::usage(format!(
             "`agentos cluster delete {}` permanently deletes the agent; re-run with --yes to confirm",
             opts.agent
-        );
+        ))
+        .with_fix("re-run with --yes")
+        .into());
     }
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     let agent = client.find_agent(&opts.agent).await?;
@@ -993,12 +1040,12 @@ pub async fn delete(opts: AgentActionOpts, yes: bool) -> Result<()> {
 /// front instead.
 fn validate_slack_channel(channel: &str) -> Result<()> {
     if channel.trim_start().starts_with('#') {
-        bail!(
+        return Err(crate::exit::usage(format!(
             "slack channel {channel:?} is a name, not an ID: real Slack events carry the \
              channel ID (e.g. C0123ABCD) and the worker routes on it, so a #name binding \
              never receives messages. Pass the channel ID instead -- find it in the \
              channel's About tab, or the channel URL (.../archives/C0123ABCD)."
-        );
+        )));
     }
     Ok(())
 }

--- a/cli/src/exit.rs
+++ b/cli/src/exit.rs
@@ -1,0 +1,143 @@
+//! Semantic exit codes and error classification for the agent-facing CLI
+//! contract (ADR-0021 decision 1).
+//!
+//! An agent driving `agentos` needs to branch on *why* a command failed without
+//! parsing prose. The scheme is four stable exit classes:
+//!
+//! - `0` Success: the command did what was asked.
+//! - `1` Failure: a genuine runtime failure (the request was well-formed but the
+//!   operation did not succeed).
+//! - `2` Usage: a deterministic input error (a missing `--yes`, a malformed
+//!   flag) -- retrying the same argv will fail identically, so fix the input.
+//! - `3` Transient: a retryable condition (the endpoint was unreachable or timed
+//!   out) -- the same argv may succeed once the dependency is up.
+//!
+//! A command tags an input error by returning [`usage`] (or building a
+//! [`CliError`] directly); an unreachable dependency is detected structurally by
+//! walking the error chain for a `reqwest` connect/timeout error. Everything
+//! else is [`ExitClass::Failure`]. [`classify`] returns the class plus an
+//! optional one-line fix hint, and [`error_json`] renders the whole thing as the
+//! `--json` error payload.
+
+/// The four semantic exit classes. The `#[repr(i32)]` values are the process
+/// exit codes and are a stable contract agents branch on.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(i32)]
+pub enum ExitClass {
+    Success = 0,
+    Failure = 1,
+    Usage = 2,
+    Transient = 3,
+}
+
+impl ExitClass {
+    /// The process exit code for this class.
+    pub fn code(self) -> i32 {
+        self as i32
+    }
+}
+
+/// A tagged CLI error: a message, an optional actionable fix hint, and the exit
+/// class it maps to. Carried through `anyhow`'s chain so [`classify`] can recover
+/// the class even when the error was wrapped in later context.
+#[derive(Debug)]
+pub struct CliError {
+    pub message: String,
+    pub fix: Option<String>,
+    pub class: ExitClass,
+}
+
+impl CliError {
+    /// A deterministic input error (exit 2).
+    pub fn usage(msg: impl Into<String>) -> Self {
+        CliError {
+            message: msg.into(),
+            fix: None,
+            class: ExitClass::Usage,
+        }
+    }
+
+    /// A retryable condition (exit 3).
+    pub fn transient(msg: impl Into<String>) -> Self {
+        CliError {
+            message: msg.into(),
+            fix: None,
+            class: ExitClass::Transient,
+        }
+    }
+
+    /// Attach an actionable fix hint (surfaced in the `--json` payload).
+    pub fn with_fix(mut self, fix: impl Into<String>) -> Self {
+        self.fix = Some(fix.into());
+        self
+    }
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Render the message only; the fix travels through `classify`, not the
+        // Display surface, so a wrapping `err.to_string()` stays clean.
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for CliError {}
+
+/// Build a usage error (exit 2) as an `anyhow::Error` ready to `return Err(..)`.
+pub fn usage(msg: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::from(CliError::usage(msg))
+}
+
+/// Build a transient error (exit 3) as an `anyhow::Error` ready to `return Err(..)`.
+pub fn transient(msg: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::from(CliError::transient(msg))
+}
+
+/// Classify an error into its exit class plus an optional fix hint. Walks the
+/// `anyhow` chain so a tagged [`CliError`] is found even under context layers; a
+/// `reqwest` connect/timeout failure anywhere in the chain maps to
+/// [`ExitClass::Transient`] with a retry hint; everything else is
+/// [`ExitClass::Failure`] with no fix.
+pub fn classify(err: &anyhow::Error) -> (ExitClass, Option<String>) {
+    for cause in err.chain() {
+        if let Some(cli) = cause.downcast_ref::<CliError>() {
+            // A transient error is retryable by definition, so it always carries
+            // a retry hint even when the caller did not attach a specific one.
+            let fix = cli
+                .fix
+                .clone()
+                .or_else(|| (cli.class == ExitClass::Transient).then(|| RETRY_HINT.to_string()));
+            return (cli.class, fix);
+        }
+    }
+    if is_transient_reqwest(err) {
+        return (ExitClass::Transient, Some(RETRY_HINT.to_string()));
+    }
+    (ExitClass::Failure, None)
+}
+
+/// True when the error chain contains a `reqwest` connect/timeout failure --
+/// i.e. a dependency (runner, platform API) was unreachable rather than
+/// returning an error status. The single definition of "unreachable" shared by
+/// [`classify`]'s Transient rule and command-level remediation hints, so the
+/// two never diverge on what counts as retryable.
+pub fn is_transient_reqwest(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<reqwest::Error>()
+            .is_some_and(|e| e.is_connect() || e.is_timeout())
+    })
+}
+
+/// The default one-line retry hint for a transient (retryable) failure.
+const RETRY_HINT: &str = "the endpoint was unreachable; retry once it is up";
+
+/// The `--json` error payload: `{"error": <message>, "fix": <hint or null>}`.
+/// `error` is the top-level rendered error; `fix` comes from [`classify`].
+pub fn error_json(err: &anyhow::Error) -> serde_json::Value {
+    let (_class, fix) = classify(err);
+    serde_json::json!({
+        "error": format!("{err:#}"),
+        "fix": fix,
+    })
+}

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -275,13 +275,14 @@ pub fn primer_markdown() -> String {
     render_markdown(&primer())
 }
 
-/// `agentos guide`: print the primer. Markdown to stdout by default; `--json`
-/// prints the structured variant to stdout (any human text would go to stderr).
-pub fn run(json: bool) -> Result<()> {
+/// `agentos guide`: print the primer. Markdown to stdout by default; the global
+/// `--json` flag prints the structured variant to stdout via the shared
+/// machine-output path (any human text would go to stderr).
+pub fn run() -> Result<()> {
     let p = primer();
     let ui = ui::ui();
-    if json {
-        ui.payload_plain(&serde_json::to_string_pretty(&p)?);
+    if ui.json() {
+        ui.emit_json(&serde_json::to_value(&p)?);
     } else {
         ui.payload_plain(&render_markdown(&p));
     }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -12,6 +12,7 @@ pub mod commands;
 pub mod comms;
 pub mod docker;
 pub mod evals;
+pub mod exit;
 pub mod guide;
 pub mod local;
 pub mod message;

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -241,7 +241,16 @@ pub async fn down(o: LocalDownOpts) -> Result<()> {
 
 /// Read a y/N confirmation from stderr/stdin before `--wipe` destroys volumes.
 fn confirm_wipe(file: &str) -> Result<bool> {
-    use std::io::Write;
+    use std::io::{IsTerminal, Write};
+    // An agent (or any piped stdin) can never answer this prompt; refuse instead
+    // of blocking on a read that will never complete. `--yes` is the non-interactive path.
+    if !std::io::stdin().is_terminal() {
+        return Err(crate::exit::CliError::usage(
+            "refusing to prompt for confirmation in a non-interactive session; re-run with --yes to proceed",
+        )
+        .with_fix("pass --yes")
+        .into());
+    }
     eprint!(
         "This destroys all volumes for the '{file}' dev stack (Postgres, ClickHouse, MinIO, Valkey data). Continue? [y/N] "
     );

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -52,6 +52,13 @@ struct Cli {
         help = "Colorize output"
     )]
     color: ColorFlag,
+    /// Machine-readable JSON to stdout; human/log text to stderr.
+    #[arg(
+        long,
+        global = true,
+        help = "Machine-readable JSON to stdout; human/log text to stderr"
+    )]
+    json: bool,
 }
 
 #[derive(Subcommand)]
@@ -683,16 +690,34 @@ async fn materialize_artifact(
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     if let Some(hint) = agentos::retired_hint(&args) {
         eprintln!("{hint}");
-        std::process::exit(2);
+        std::process::exit(agentos::exit::ExitClass::Usage.code());
     }
 
     let cli = Cli::parse();
-    ui::init(Ui::from_process(cli.color, cli.debug, cli.quiet));
-    match cli.command {
+    ui::init(Ui::from_process(cli.color, cli.debug, cli.quiet, cli.json));
+    // main never returns Err (which would give anyhow's default exit 1 and skip
+    // classification). Run the command, then map any error to a semantic exit
+    // code: the JSON payload goes to stdout under --json, else the human error
+    // to stderr (matching anyhow's default), and the class picks the exit code.
+    if let Err(err) = run(cli.command).await {
+        let (class, _fix) = agentos::exit::classify(&err);
+        if ui::ui().json() {
+            ui::ui().emit_json(&agentos::exit::error_json(&err));
+        } else {
+            eprintln!("Error: {err:#}");
+        }
+        std::process::exit(class.code());
+    }
+}
+
+/// Dispatch one parsed command. Returns the command's `Result`; `main`
+/// classifies any error into a semantic exit code (see `agentos::exit`).
+async fn run(command: Command) -> Result<()> {
+    match command {
         Command::Init { name, dir } => commands::init(&name, dir),
         Command::Build { tag } => commands::build(&tag).await,
         Command::Install => commands::install().await,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -126,12 +126,9 @@ enum Command {
     /// Ordered by what the agent needs first (roughly 100 lines), carrying only
     /// non-discoverable knowledge: the parity ladder, when/which decision logic,
     /// the landmines, and verify-first. Human-readable Markdown by default;
-    /// `--json` emits a structured variant (data on stdout, human text on stderr).
-    Guide {
-        /// Emit the primer as structured JSON (stdout=data, human text=stderr).
-        #[arg(long)]
-        json: bool,
-    },
+    /// The global `--json` emits a structured variant (data on stdout, human
+    /// text on stderr).
+    Guide,
 }
 
 #[derive(Subcommand)]
@@ -1202,7 +1199,7 @@ async fn run(command: Command) -> Result<()> {
             print!("{}", agentos::schema::manifest_json(&Cli::command()));
             Ok(())
         }
-        Command::Guide { json } => agentos::guide::run(json),
+        Command::Guide => agentos::guide::run(),
     }
 }
 

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -488,7 +488,9 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             ui.note("stream diagnostics:");
             let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
             ui.note(&diag);
-            std::process::exit(1);
+            // A timeout is retryable (the worker may still be working, or a
+            // transient stall), so it maps to the transient exit code, not failure.
+            std::process::exit(crate::exit::ExitClass::Transient.code());
         }
     }
 }
@@ -627,7 +629,9 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
             ui.note("stream diagnostics:");
             let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
             ui.note(&diag);
-            std::process::exit(1);
+            // A timeout is retryable (the worker may still be working, or a
+            // transient stall), so it maps to the transient exit code, not failure.
+            std::process::exit(crate::exit::ExitClass::Transient.code());
         }
     }
 }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1022,7 +1022,16 @@ pub async fn down(opts: DownOpts) -> Result<()> {
 
 /// Read a y/N confirmation from stderr/stdin for `down` when `--yes` is absent.
 fn confirm(o: &CommonOpts) -> Result<bool> {
-    use std::io::Write;
+    use std::io::{IsTerminal, Write};
+    // An agent (or any piped stdin) can never answer this prompt; refuse instead
+    // of blocking on a read that will never complete. `--yes` is the non-interactive path.
+    if !std::io::stdin().is_terminal() {
+        return Err(crate::exit::CliError::usage(
+            "refusing to prompt for confirmation in a non-interactive session; re-run with --yes to proceed",
+        )
+        .with_fix("pass --yes")
+        .into());
+    }
     eprint!(
         "This uninstalls release '{}' and deletes namespaces '{}' and 'agent-sandbox-system'. Continue? [y/N] ",
         o.release, o.namespace

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -93,6 +93,7 @@ pub struct Ui {
     debug: bool,
     quiet: bool,
     interactive: bool,
+    json: bool,
 }
 
 /// Resolve whether a given stream should embed ANSI, honoring the `--color`
@@ -123,11 +124,13 @@ impl Ui {
     /// resolved per stream: stdout (payload) and stderr (diagnostics) each
     /// follow their own tty state, so redirecting one never taints the other.
     /// Interactivity (spinners and redraws) is independent of color: on only
-    /// for a non-CI, non-dumb terminal. Unicode mirrors the locale.
-    pub fn resolve(color: ColorFlag, debug: bool, quiet: bool, env: &UiEnv) -> Ui {
+    /// for a non-CI, non-dumb terminal. Unicode mirrors the locale. Under
+    /// `--json` the run is never interactive: a spinner on stderr is fine, but
+    /// the machine payload owns stdout and must not share it with progress redraws.
+    pub fn resolve(color: ColorFlag, debug: bool, quiet: bool, json: bool, env: &UiEnv) -> Ui {
         let color_stdout = want_color(color, env, env.stdout_tty);
         let color_stderr = want_color(color, env, env.stderr_tty);
-        let interactive = env.stderr_tty && !env.ci && !env.term_dumb;
+        let interactive = env.stderr_tty && !env.ci && !env.term_dumb && !json;
         Ui {
             color_stdout,
             color_stderr,
@@ -136,11 +139,12 @@ impl Ui {
             debug,
             quiet,
             interactive,
+            json,
         }
     }
 
     /// Snapshot the real process environment and resolve. Non-pure wrapper.
-    pub fn from_process(color: ColorFlag, debug: bool, quiet: bool) -> Ui {
+    pub fn from_process(color: ColorFlag, debug: bool, quiet: bool, json: bool) -> Ui {
         let env = UiEnv {
             no_color: std::env::var_os("NO_COLOR")
                 .map(|v| !v.is_empty())
@@ -156,7 +160,21 @@ impl Ui {
             utf8: detect_utf8(),
             truecolor: anstyle_query::truecolor(),
         };
-        Ui::resolve(color, debug, quiet, &env)
+        Ui::resolve(color, debug, quiet, json, &env)
+    }
+
+    /// Whether `--json` is in effect: the human stdout emitters are suppressed so
+    /// they cannot corrupt the single-line machine payload.
+    pub fn json(&self) -> bool {
+        self.json
+    }
+
+    /// Write one compact JSON line (plus a trailing newline) to stdout. No color;
+    /// the payload is machine-consumed.
+    pub fn emit_json(&self, value: &serde_json::Value) {
+        if let Ok(line) = serde_json::to_string(value) {
+            let _ = writeln!(anstream::stdout(), "{line}");
+        }
     }
 
     // -- styling helpers ---------------------------------------------------
@@ -330,6 +348,9 @@ impl Ui {
 
     /// A bright bold-white payload line on stdout.
     pub fn payload(&self, line: &str) {
+        if self.json {
+            return;
+        }
         let _ = writeln!(
             anstream::stdout(),
             "{}",
@@ -339,11 +360,17 @@ impl Ui {
 
     /// An unstyled payload line on stdout (raw data).
     pub fn payload_plain(&self, line: &str) {
+        if self.json {
+            return;
+        }
         let _ = writeln!(anstream::stdout(), "{line}");
     }
 
     /// Write raw streamed tokens to stdout with no newline, flushing.
     pub fn print_tokens(&self, s: &str) {
+        if self.json {
+            return;
+        }
         let mut out = anstream::stdout();
         let _ = write!(out, "{s}");
         let _ = out.flush();
@@ -352,6 +379,9 @@ impl Ui {
     /// Write agent answer text to stdout in the bright payload color (non-bold),
     /// no trailing newline, flushed. Used for streamed tokens and returned replies.
     pub fn answer(&self, s: &str) {
+        if self.json {
+            return;
+        }
         let styled = self.paint_out(self.answer_style(), s);
         let mut out = anstream::stdout();
         let _ = write!(out, "{styled}");
@@ -361,6 +391,9 @@ impl Ui {
     /// A key/value line on stdout: dim padded key, then value. The caller
     /// pre-styles the value (e.g. via `url`) when it is a URL or id.
     pub fn kv(&self, key: &str, val: &str) {
+        if self.json {
+            return;
+        }
         let key_styled = self.paint_out(self.dim(), &format!("{key:<12}"));
         let _ = writeln!(anstream::stdout(), "{key_styled}  {val}");
     }
@@ -450,7 +483,7 @@ pub fn init(ui: Ui) {
 /// The process-global `Ui`. Falls back to a safe auto default (for tests and
 /// any pre-init caller).
 pub fn ui() -> &'static Ui {
-    UI.get_or_init(|| Ui::from_process(ColorFlag::Auto, false, false))
+    UI.get_or_init(|| Ui::from_process(ColorFlag::Auto, false, false, false))
 }
 
 // ---------------------------------------------------------------------------
@@ -680,7 +713,7 @@ mod tests {
             no_color: true,
             ..base_env()
         };
-        assert!(Ui::resolve(ColorFlag::Always, false, false, &env).color_stderr);
+        assert!(Ui::resolve(ColorFlag::Always, false, false, false, &env).color_stderr);
     }
 
     #[test]
@@ -690,7 +723,7 @@ mod tests {
             stderr_tty: true,
             ..base_env()
         };
-        assert!(!Ui::resolve(ColorFlag::Never, false, false, &env).color_stderr);
+        assert!(!Ui::resolve(ColorFlag::Never, false, false, false, &env).color_stderr);
     }
 
     #[test]
@@ -700,8 +733,8 @@ mod tests {
             ..base_env()
         };
         let off = base_env();
-        assert!(Ui::resolve(ColorFlag::Auto, false, false, &on).color_stderr);
-        assert!(!Ui::resolve(ColorFlag::Auto, false, false, &off).color_stderr);
+        assert!(Ui::resolve(ColorFlag::Auto, false, false, false, &on).color_stderr);
+        assert!(!Ui::resolve(ColorFlag::Auto, false, false, false, &off).color_stderr);
     }
 
     #[test]
@@ -711,7 +744,7 @@ mod tests {
             clicolor_force: true,
             ..base_env()
         };
-        assert!(Ui::resolve(ColorFlag::Auto, false, false, &env).color_stderr);
+        assert!(Ui::resolve(ColorFlag::Auto, false, false, false, &env).color_stderr);
     }
 
     #[test]
@@ -721,7 +754,7 @@ mod tests {
             stderr_tty: true,
             ..base_env()
         };
-        let ui = Ui::resolve(ColorFlag::Auto, false, false, &env);
+        let ui = Ui::resolve(ColorFlag::Auto, false, false, false, &env);
         assert!(ui.color_stderr, "color follows tty under CI+Auto");
         assert!(!ui.interactive, "CI is never interactive");
     }
@@ -733,7 +766,7 @@ mod tests {
             stderr_tty: true,
             ..base_env()
         };
-        let ui = Ui::resolve(ColorFlag::Auto, false, false, &env);
+        let ui = Ui::resolve(ColorFlag::Auto, false, false, false, &env);
         assert!(!ui.color_stderr);
         assert!(!ui.interactive);
     }
@@ -745,7 +778,7 @@ mod tests {
             stdout_tty: false,
             ..base_env()
         };
-        let ui = Ui::resolve(ColorFlag::Auto, false, false, &env);
+        let ui = Ui::resolve(ColorFlag::Auto, false, false, false, &env);
         assert!(
             ui.color_stderr,
             "diagnostics on a terminal stderr are colored"
@@ -760,8 +793,8 @@ mod tests {
             utf8: false,
             ..base_env()
         };
-        assert!(Ui::resolve(ColorFlag::Auto, false, false, &utf8).unicode);
-        assert!(!Ui::resolve(ColorFlag::Auto, false, false, &ascii).unicode);
+        assert!(Ui::resolve(ColorFlag::Auto, false, false, false, &utf8).unicode);
+        assert!(!Ui::resolve(ColorFlag::Auto, false, false, false, &ascii).unicode);
     }
 
     #[test]
@@ -773,7 +806,7 @@ mod tests {
             truecolor: false,
             ..base_env()
         };
-        let ui = Ui::resolve(ColorFlag::Always, false, false, &tc_off);
+        let ui = Ui::resolve(ColorFlag::Always, false, false, false, &tc_off);
         let s = ui.paint_err(ui.green(), "x");
         assert!(
             s.contains("\x1b[32m") || s.contains("[32m"),
@@ -789,7 +822,7 @@ mod tests {
             truecolor: true,
             ..base_env()
         };
-        let ui2 = Ui::resolve(ColorFlag::Always, false, false, &tc_on);
+        let ui2 = Ui::resolve(ColorFlag::Always, false, false, false, &tc_on);
         assert!(
             ui2.paint_err(ui2.green(), "x").contains("38;2"),
             "truecolor path emits 24-bit"

--- a/cli/tests/exit_codes.rs
+++ b/cli/tests/exit_codes.rs
@@ -1,0 +1,64 @@
+//! Unit-level coverage for the semantic exit-code + error-classification
+//! contract (ADR-0021 decision 1, AC 2 and AC 4). These reference the
+//! yet-to-exist `agentos::exit` module, so the file will not compile until the
+//! implementer adds it; that red state is the contract handoff.
+
+use agentos::exit::{self, CliError, ExitClass};
+
+#[test]
+fn exit_class_codes_are_stable() {
+    assert_eq!(ExitClass::Success.code(), 0);
+    assert_eq!(ExitClass::Failure.code(), 1);
+    assert_eq!(ExitClass::Usage.code(), 2);
+    assert_eq!(ExitClass::Transient.code(), 3);
+}
+
+#[test]
+fn classify_usage_error_is_usage_class() {
+    let err = exit::usage("bad");
+    let (class, _fix) = exit::classify(&err);
+    assert_eq!(class, ExitClass::Usage);
+}
+
+#[test]
+fn classify_transient_error_is_transient_with_fix() {
+    let err = exit::transient("net");
+    let (class, fix) = exit::classify(&err);
+    assert_eq!(class, ExitClass::Transient);
+    assert!(fix.is_some(), "transient errors carry a retry hint");
+}
+
+#[test]
+fn classify_plain_anyhow_is_failure_with_no_fix() {
+    let err = anyhow::anyhow!("boom");
+    let (class, fix) = exit::classify(&err);
+    assert_eq!(class, ExitClass::Failure);
+    assert_eq!(fix, None);
+}
+
+#[test]
+fn classify_finds_clierror_through_context_wrapping() {
+    // A tagged CliError buried under an anyhow context layer must still be
+    // discovered by walking the error chain: class + fix survive wrapping.
+    let base: anyhow::Error = CliError::usage("nope").with_fix("do X").into();
+    let wrapped = base.context("outer");
+    let (class, fix) = exit::classify(&wrapped);
+    assert_eq!(class, ExitClass::Usage);
+    assert_eq!(fix.as_deref(), Some("do X"));
+}
+
+#[test]
+fn error_json_carries_message_and_fix() {
+    let err: anyhow::Error = CliError::usage("nope").with_fix("do X").into();
+    let value = exit::error_json(&err);
+    assert_eq!(value["error"], "nope");
+    assert_eq!(value["fix"], "do X");
+}
+
+#[test]
+fn error_json_fix_is_null_for_plain_error() {
+    let err = anyhow::anyhow!("kaboom");
+    let value = exit::error_json(&err);
+    assert_eq!(value["error"], "kaboom");
+    assert!(value["fix"].is_null());
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1,0 +1,77 @@
+//! Integration: the agent-facing `--json` outputs must validate against the
+//! committed JSON Schemas (ADR-0021 decision 1, AC 1 and AC 4). The schema
+//! files under `cli/schema/` and the `status_json`/`eval_json` builders do not
+//! exist yet, so this file will not compile / the schema loads fail at red; the
+//! implementer creates the schemas alongside the `--json` wiring.
+
+use agentos::commands::{eval_json, status_json};
+use agentos::exit;
+use agentos_aci_protocol::SessionStatus;
+
+fn load_schema(name: &str) -> serde_json::Value {
+    let path = format!("{}/schema/{}", env!("CARGO_MANIFEST_DIR"), name);
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("committed schema {path} must exist: {e}"));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("schema {path} must be valid JSON: {e}"))
+}
+
+fn validator(schema: &serde_json::Value) -> jsonschema::Validator {
+    jsonschema::validator_for(schema).expect("schema compiles to a validator")
+}
+
+#[test]
+fn status_json_validates_against_status_schema() {
+    let schema = load_schema("status.schema.json");
+    let value = status_json("http://127.0.0.1:8787", &SessionStatus::Done);
+    let v = validator(&schema);
+    assert!(
+        v.is_valid(&value),
+        "status_json output must validate against status.schema.json: {value}"
+    );
+}
+
+#[test]
+fn eval_json_validates_against_eval_schema() {
+    let schema = load_schema("eval.schema.json");
+    // Two cases, one pass one fail: (id, passed, seconds) rows plus the roll-up.
+    let results = vec![
+        ("case-pass".to_string(), true, 1.5_f64),
+        ("case-fail".to_string(), false, 0.25_f64),
+    ];
+    let value = eval_json(&results, 1, 2);
+    let v = validator(&schema);
+    assert!(
+        v.is_valid(&value),
+        "eval_json output must validate against eval.schema.json: {value}"
+    );
+}
+
+#[test]
+fn error_json_validates_against_error_schema() {
+    let schema = load_schema("error.schema.json");
+    let err = exit::usage("x").context("y");
+    let value = exit::error_json(&err);
+    let v = validator(&schema);
+    assert!(
+        v.is_valid(&value),
+        "error_json output must validate against error.schema.json: {value}"
+    );
+}
+
+#[test]
+fn eval_schema_gate_has_teeth() {
+    // negative control: proves the schema gate discriminates
+    let schema = load_schema("eval.schema.json");
+    let results = vec![("only".to_string(), true, 1.0_f64)];
+    let mut value = eval_json(&results, 1, 1);
+    // Strip a required top-level key; a schema with real teeth must now reject.
+    value
+        .as_object_mut()
+        .expect("eval_json returns a JSON object")
+        .remove("total");
+    let v = validator(&schema);
+    assert!(
+        !v.is_valid(&value),
+        "eval schema must reject an object missing the required `total` key"
+    );
+}

--- a/cli/tests/non_interactive.rs
+++ b/cli/tests/non_interactive.rs
@@ -1,0 +1,101 @@
+//! Integration: the non-interactive audit + `--json` global flag + semantic
+//! exit codes (ADR-0021 decision 1, AC 1, AC 2, AC 3). Every mutating command
+//! exposes `--yes`; `--json` parses globally and on the agent-facing read
+//! verbs; and error exits carry the right semantic code. The exit-code checks
+//! are hermetic (no server, no network topology assumptions beyond a closed
+//! local port).
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentos")
+}
+
+fn help(args: &[&str]) -> (bool, String) {
+    let output = Command::new(bin())
+        .args(args)
+        .arg("--help")
+        .output()
+        .expect("run agentos --help");
+    let text = String::from_utf8_lossy(&output.stdout).into_owned()
+        + &String::from_utf8_lossy(&output.stderr);
+    (output.status.success(), text)
+}
+
+#[test]
+fn mutating_commands_expose_yes_flag() {
+    // AC3: every mutating command has a non-interactive `--yes` path so an agent
+    // never has to answer a stdin prompt to complete a destructive action.
+    let cases: &[&[&str]] = &[
+        &["local", "down"],
+        &["cluster", "down"],
+        &["cluster", "kill"],
+        &["cluster", "delete"],
+    ];
+    for args in cases.iter().copied() {
+        let (ok, text) = help(args);
+        assert!(ok, "help for {args:?} should succeed:\n{text}");
+        assert!(
+            text.contains("--yes"),
+            "{args:?} --help must list a --yes flag:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn json_global_flag_parses_on_skill_status_and_eval() {
+    // AC1: `--json` is a global flag; it must parse on the agent-facing read
+    // verbs. Fails until `--json` is added to the top-level Cli.
+    for args in [["skill", "status", "--json"], ["skill", "eval", "--json"]] {
+        let (ok, text) = help(&args);
+        assert!(
+            ok,
+            "`agentos {} --help` must exit 0 (global --json):\n{text}",
+            args.join(" ")
+        );
+    }
+}
+
+#[test]
+fn json_global_flag_parses_before_subcommand() {
+    // The global flag must also parse ahead of the subcommand path.
+    let (ok, text) = help(&["--json", "skill", "status"]);
+    assert!(
+        ok,
+        "`agentos --json skill status --help` must exit 0:\n{text}"
+    );
+}
+
+#[test]
+fn skill_status_connection_refused_exits_transient() {
+    // Hermetic: port 1 is reserved/closed, so the runner status call fails with
+    // a connect error -> transient class -> exit 3 (safe to retry). RED until
+    // the transient classification + main wiring lands (today: exit 1).
+    let output = Command::new(bin())
+        .args(["skill", "status", "--url", "http://127.0.0.1:1"])
+        .output()
+        .expect("run agentos skill status");
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "connection refused must map to the transient exit code (3)\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn cluster_kill_without_yes_exits_usage() {
+    // Hermetic: the missing-`--yes` guard fires before any network call, so no
+    // server is needed. RED until usage classification lands (today: exit 1
+    // via a plain anyhow bail).
+    let output = Command::new(bin())
+        .args(["cluster", "kill", "someagent"])
+        .output()
+        .expect("run agentos cluster kill");
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "missing --yes must map to the usage exit code (2)\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
Implements [ADR-0021](docs/adr/0021-agentos-is-a-harness-for-coding-agents.md) decision 1 (agent-facing substrate is the default): the CLI's primary consumer is a coding agent, so its output and control flow are machine-first.

## What
- **`--json`** (global) switches the read/report verbs `skill status` and `skill eval` to a single JSON object on **stdout**, with all human/log text on **stderr** (human stdout emitters are suppressed under `--json`, so `... --json | jq` stays clean).
- **Semantic exit codes** an agent branches on: `0` success, `1` failure, `2` usage/input-error (do-not-retry, clap-compatible), `3` transient (safe-to-retry; a reqwest connect/timeout anywhere in the error chain classifies transient).
- **Non-interactive:** every mutating command already has `--yes`; the stdin confirm prompts now refuse with a usage error on a non-TTY instead of blocking.
- **Errors as recovery instructions:** under `--json` a failure emits `{"error","fix"}` to stdout, no traceback.
- Committed JSON schemas under `cli/schema/` gate output drift via a hermetic contract test (with a negative control proving the gate discriminates). The gate runs in the existing `cargo test --locked` CI job.
- Exit-code scheme + `--json` contract documented in `cli/README.md` and the repo `AGENTS.md` review checklist.

## Scope note
`--json` covers the two commands the CLI itself formats and an agent branches on (`skill status`, `skill eval`). `local status`/`cluster status` proxy raw helm/kubectl/compose text and are deferred (noted in the README).

## Verification
`cargo fmt --check`, `cargo clippy --locked -- -D warnings`, `cargo test --locked` (260 tests) all green. Hands-on E2E confirmed: transient+`--json` -> clean JSON on stdout / stderr empty / exit 3; missing-`--yes`+`--json` -> `{"...","fix":"re-run with --yes"}` exit 2; eval-no-cases -> `fix:"pass --cases"` exit 2; non-`--json` errors go to stderr.

Closes #323