### PR TITLE
Add non-interactive spec-file scaffold to `agentos init`

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -40,7 +40,20 @@ release with `up`, `status`, `down`, `comms`, `message`, and `deploy`. Full comm
   root `AGENTS.md` and a `.claude/skills/using-agentos/SKILL.md` harness primer
   (body rendered from `guide::primer_markdown()`) alongside the bundle; both
   live outside the `plugin_format`-validated `skills/` tree, so they do not
-  affect validation.
+  affect validation. The non-interactive spec-file path
+  (`agentos init --from-spec <path>`, `scaffold::scaffold_from_spec`) produces the
+  SAME plugin-format-verbatim shape and carries the same byte-compat obligation:
+  its `SKILL.md` frontmatter uses `allowed-tools` (never `tools`) and its
+  `.mcp.json` servers each define `command` or `url` (as strings). The spec's
+  `evals` reuse the frozen `evals::EvalCase` type directly (not a hand-mirror), so a
+  spec-authored eval suite cannot drift from the shape `skill eval` loads. Because
+  the spec's `evals` ARE the frozen eval-case shape reused verbatim, unknown keys
+  inside an eval case are ignored exactly as the platform's worker `EvalSuite`
+  ignores them (pydantic default `extra="ignore"`, `ConfigDict(frozen=True)`) --
+  this is intentional PARITY with the platform grader, not an oversight, so do NOT
+  add `deny_unknown_fields` to the eval structs (it would make `skill eval` stricter
+  than the platform and break parity). The spec's OWN top-level fields stay strict
+  (`deny_unknown_fields` on `AgentSpec`/`SkillSpec`).
 - **The `evals/cases.json` seed and `skill eval` loader hand-mirror the frozen
   eval-case schema.** The `agentos init` seed (`scaffold::eval_cases`) and the
   `skill eval` loader (`evals::EvalSuite`/`load_suite`) mirror the frozen

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,8 +32,50 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 | Command | What it does |
 |---|---|
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed, a root `AGENTS.md`, and an installable `.claude/skills/using-agentos/SKILL.md` harness primer. |
+| `agentos init --from-spec <path>` | Scaffold **non-interactively** from an agent-authored spec file (JSON). The bundle name comes from the spec, not a positional argument. A coding agent interviews the human, writes the spec, then this command lays down the same plugin-format shape deterministically -- zero prompts. See the spec shape below. |
 | `agentos guide` | Print a self-contained primer (ADR-0021) for a coding agent driving the harness: the parity ladder, when/which decision logic, the landmines, and verify-first, to stdout. `--json` emits the same content as a structured variant (data on stdout). |
 | `agentos build` | Build the runner image locally: `docker build -f runner/Dockerfile -t agentos-runner .` from the repo root (found by walking up to `runner/Dockerfile`). `--tag` overrides the tag. Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
+
+### `init --from-spec` spec shape
+
+The spec is a JSON object an agent writes after interviewing the human. `name`
+is the kebab-case bundle name; every `skills[].name` is kebab-case and unique;
+`connectors` (optional) is the raw `.mcp.json` `mcpServers` map (each server must
+define `command` or `url` as a string); `evals` reuses the frozen eval-case shape
+so the scaffolded `evals/cases.json` loads unchanged through `agentos skill eval`.
+An unknown TOP-LEVEL field is a hard error, so an authoring typo fails loud, but
+unknown keys INSIDE an eval case are ignored exactly as the platform's worker
+`EvalSuite` ignores them (pydantic `extra="ignore"`), which is intentional parity
+with the platform grader, not an oversight.
+
+```json
+{
+  "name": "deal-desk",
+  "description": "Prices and reviews deal desk requests.",
+  "skills": [
+    {
+      "name": "deal-desk",
+      "description": "Invoke when a rep submits a pricing exception request.",
+      "allowed_tools": ["WebSearch", "WebFetch"],
+      "instructions": "Price the exception against the guardrails, then summarize the decision.\n"
+    }
+  ],
+  "connectors": {
+    "crm": { "command": "crm-mcp", "args": ["--stdio"] }
+  },
+  "evals": [
+    {
+      "id": "prices-a-deal",
+      "input": "Quote 20% off for Acme",
+      "grader": { "kind": "contains", "expected": "approved", "case_sensitive": false }
+    }
+  ]
+}
+```
+
+```bash
+agentos init --from-spec agent-spec.json   # bundle name (deal-desk) comes from the spec
+```
 
 ## `agentos install`
 

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -63,16 +63,24 @@
       "args": [
         {
           "global": false,
-          "help": "Kebab-case plugin name (e.g. deal-desk)",
+          "help": "Kebab-case plugin name (e.g. deal-desk). Omit when using --from-spec",
           "id": "name",
           "positional": true,
-          "required": true
+          "required": false
         },
         {
           "global": false,
           "help": "Target directory; defaults to ./<name>",
           "id": "dir",
           "long": "dir",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Scaffold non-interactively from an agent-authored spec file (JSON). The bundle name comes from the spec",
+          "id": "from_spec",
+          "long": "from-spec",
           "positional": false,
           "required": false
         }

--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -39,8 +39,33 @@ cleanup() {
 trap cleanup EXIT
 
 echo
-echo "=== agentos init ==="
-"$BIN" init deal-desk --dir "$WORKDIR/deal-desk"
+echo "=== agentos init --from-spec (non-interactive, agent-authored spec) ==="
+# AC #2: a coding agent writes a spec, the CLI scaffolds a runnable bundle from
+# it with zero prompts, and the spec-scaffolded evals/cases.json greens on the
+# eval path. The single grader is `contains "all done"` so it passes under the
+# offline fake model (fake.py's final frame text is "all done").
+cat > "$WORKDIR/agent-spec.json" <<'EOF'
+{
+  "name": "deal-desk",
+  "description": "Prices and reviews deal desk requests.",
+  "skills": [
+    {
+      "name": "deal-desk",
+      "description": "Invoke when a rep submits a pricing exception request.",
+      "allowed_tools": ["WebSearch", "WebFetch"],
+      "instructions": "Price the exception against the guardrails, then summarize the decision.\n"
+    }
+  ],
+  "evals": [
+    {
+      "id": "finishes-the-turn",
+      "input": "wrap it up",
+      "grader": { "kind": "contains", "expected": "all done", "case_sensitive": false }
+    }
+  ]
+}
+EOF
+"$BIN" init --from-spec "$WORKDIR/agent-spec.json" --dir "$WORKDIR/deal-desk"
 
 cd "$WORKDIR/deal-desk"
 
@@ -87,7 +112,13 @@ echo "=== agentos skill message (synthetic event, streamed NDJSON reply) ==="
 "$BIN" skill message "@agentos can we approve the Meridian deal at 18% discount?"
 
 echo
-echo "=== agentos skill eval ==="
+echo "=== agentos skill eval (spec-scaffolded evals/cases.json) ==="
+# No --cases: exercise the evals/cases.json the --from-spec scaffold wrote,
+# proving spec -> bundle -> skill eval passes end to end offline (AC #2).
+"$BIN" skill eval
+
+echo
+echo "=== agentos skill eval (explicit cases file) ==="
 "$BIN" skill eval --cases evals/e2e-cases.json
 
 if [[ -n "${AGENTOS_E2E_API_URL:-}" ]]; then

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -17,7 +17,7 @@ use crate::docker::{self, StartSpec};
 use crate::evals::{load_suite, turn_passes};
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
-use crate::scaffold::{read_manifest, scaffold};
+use crate::scaffold::{read_manifest, scaffold, scaffold_from_spec};
 use crate::state::{self, RunnerState};
 
 pub const DEFAULT_PORT: u16 = 7245; // the design canon's local bot port
@@ -72,19 +72,67 @@ pub struct StartOpts {
     pub local_model: Option<String>,
 }
 
-pub fn init(name: &str, dir: Option<PathBuf>) -> Result<()> {
-    let dir = dir.unwrap_or_else(|| PathBuf::from(name));
-    let created = scaffold(&dir, name)?;
+pub fn init(name: Option<String>, dir: Option<PathBuf>, from_spec: Option<PathBuf>) -> Result<()> {
     let ui = crate::ui::ui();
-    ui.success(&format!(
-        "initialized plugin bundle '{name}' in {}",
-        dir.display()
-    ));
+
+    // Spec-file path (ADR-0021 decision 5): fully non-interactive. The bundle
+    // name comes from the spec, never a prompt.
+    if let Some(spec_path) = from_spec {
+        let body = std::fs::read_to_string(&spec_path)
+            .with_context(|| format!("reading spec file {}", spec_path.display()))?;
+        let spec = crate::spec::parse(&body)?;
+        // A positional name is allowed only if it matches the spec's name; a
+        // mismatch is an authoring error, not a silent override.
+        if let Some(positional) = &name {
+            if positional != &spec.name {
+                bail!(
+                    "positional name {:?} does not match the spec name {:?}; \
+                     the bundle name comes from the spec -- omit the name or make them match",
+                    positional,
+                    spec.name
+                );
+            }
+        }
+        let dir = dir.unwrap_or_else(|| PathBuf::from(&spec.name));
+        let created = scaffold_from_spec(&dir, &spec)?;
+        report_scaffold(
+            ui,
+            format!(
+                "initialized plugin bundle '{}' in {} (from spec {})",
+                spec.name,
+                dir.display(),
+                spec_path.display()
+            ),
+            created,
+            &dir,
+        );
+        return Ok(());
+    }
+
+    let name = match name {
+        Some(name) => name,
+        None => bail!("provide a plugin NAME or --from-spec <path>"),
+    };
+    let dir = dir.unwrap_or_else(|| PathBuf::from(&name));
+    let created = scaffold(&dir, &name)?;
+    report_scaffold(
+        ui,
+        format!("initialized plugin bundle '{name}' in {}", dir.display()),
+        created,
+        &dir,
+    );
+    Ok(())
+}
+
+/// Report a freshly scaffolded bundle: the success line, one `created` note per
+/// written path, and the `Next:` hint. Shared by both `init` branches so the
+/// only per-branch difference is the success message text.
+fn report_scaffold(ui: &crate::ui::Ui, success_msg: String, created: Vec<PathBuf>, dir: &Path) {
+    ui.success(&success_msg);
     for path in created {
         ui.note(&format!("created {}", path.display()));
     }
     ui.note(&format!("Next: cd {} && agentos skill up", dir.display()));
-    Ok(())
 }
 
 /// `agentos build`: build the runner image locally from the repo's Dockerfile.

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -14,10 +14,14 @@ use std::path::Path;
 use agentos_aci_protocol::{OutboundEvent, SessionStatus};
 use anyhow::{anyhow, bail, Context, Result};
 use regex::RegexBuilder;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// How a case's expected value is compared against the agent's answer.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+// `Serialize` is derived alongside `Deserialize` so the spec scaffold path
+// (`spec.rs`) can re-emit an assembled suite into `evals/cases.json`; the
+// `rename_all = "lowercase"` round-trips both ways so the written kind is the
+// same lowercase token `load_suite` reads back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum GraderKind {
     Exact,
@@ -26,7 +30,7 @@ pub enum GraderKind {
 }
 
 /// A single deterministic grader mirroring the worker's `Grader`.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Grader {
     pub kind: GraderKind,
     pub expected: String,
@@ -65,7 +69,7 @@ impl Grader {
 }
 
 /// One eval: an input prompt and the grader that judges the answer.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EvalCase {
     pub id: String,
     pub input: String,
@@ -73,10 +77,37 @@ pub struct EvalCase {
 }
 
 /// A named set of eval cases run together against one plugin version.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EvalSuite {
     pub name: String,
     pub cases: Vec<EvalCase>,
+}
+
+/// Validate an assembled suite: reject an empty case list and eagerly compile
+/// every regex grader so a bad pattern fails now, not mid-run. Factored out of
+/// `load_suite` so the spec scaffold path (`spec.rs`) enforces the identical
+/// eval-case discipline against a suite it built in memory rather than read from
+/// disk -- one rule, two entry points, no drift.
+pub fn validate_suite(name: &str, cases: &[EvalCase]) -> Result<()> {
+    if cases.is_empty() {
+        bail!("suite {:?} contains no eval cases", name);
+    }
+    for case in cases {
+        if case.grader.kind == GraderKind::Regex {
+            RegexBuilder::new(&case.grader.expected)
+                .build()
+                .map_err(|err| {
+                    anyhow!(
+                        "case {:?} has an invalid regex grader {:?}: {err}. The local CLI compiles \
+                         patterns with the Rust `regex` crate, a portable subset with no lookaround \
+                         or backreferences; the pattern may still be valid on the platform.",
+                        case.id,
+                        case.grader.expected
+                    )
+                })?;
+        }
+    }
+    Ok(())
 }
 
 /// Parse the suite object at `path`. Rejects an empty `cases` list, eagerly
@@ -99,24 +130,7 @@ pub fn load_suite(path: &Path) -> Result<EvalSuite> {
     }
     let suite: EvalSuite = serde_json::from_value(value)
         .with_context(|| format!("{} is not a valid eval suite", path.display()))?;
-    if suite.cases.is_empty() {
-        bail!("{} contains no eval cases", path.display());
-    }
-    for case in &suite.cases {
-        if case.grader.kind == GraderKind::Regex {
-            RegexBuilder::new(&case.grader.expected)
-                .build()
-                .map_err(|err| {
-                    anyhow!(
-                        "case {:?} has an invalid regex grader {:?}: {err}. The local CLI compiles \
-                         patterns with the Rust `regex` crate, a portable subset with no lookaround \
-                         or backreferences; the pattern may still be valid on the platform.",
-                        case.id,
-                        case.grader.expected
-                    )
-                })?;
-        }
-    }
+    validate_suite(&suite.name, &suite.cases)?;
     Ok(suite)
 }
 

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -148,6 +148,13 @@ pub fn primer() -> Primer {
                          performs; add an MCP server to give it a new tool.",
             },
             Decision {
+                question: "authoring a bundle: interview, not prompts",
+                answer: "init never prompts interactively. To author a new bundle, interview the \
+                         human, write an agent-spec.json (name, description, skills, connectors, \
+                         evals), then run `agentos init --from-spec agent-spec.json` -- the CLI \
+                         scaffolds the bundle deterministically from that spec.",
+            },
+            Decision {
                 question: "how an eval gates promotion",
                 answer: "evals/cases.json is the contract. `agentos skill eval` must be green before \
                          you deploy; merging to main promotes to prod (git flow is the deploy model). \

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -24,6 +24,7 @@ pub mod retired;
 pub mod runner;
 pub mod scaffold;
 pub mod schema;
+pub mod spec;
 pub mod state;
 pub mod ui;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,11 +65,14 @@ struct Cli {
 enum Command {
     /// Scaffold a new plugin bundle (Claude Code plugin shape).
     Init {
-        /// Kebab-case plugin name (e.g. deal-desk).
-        name: String,
+        /// Kebab-case plugin name (e.g. deal-desk). Omit when using --from-spec.
+        name: Option<String>,
         /// Target directory; defaults to ./<name>.
         #[arg(long)]
         dir: Option<PathBuf>,
+        /// Scaffold non-interactively from an agent-authored spec file (JSON). The bundle name comes from the spec.
+        #[arg(long, value_name = "PATH")]
+        from_spec: Option<PathBuf>,
     },
     /// Work with a local runner session for a plugin bundle.
     Skill {
@@ -715,7 +718,11 @@ async fn main() {
 /// classifies any error into a semantic exit code (see `agentos::exit`).
 async fn run(command: Command) -> Result<()> {
     match command {
-        Command::Init { name, dir } => commands::init(&name, dir),
+        Command::Init {
+            name,
+            dir,
+            from_spec,
+        } => commands::init(name, dir, from_spec),
         Command::Build { tag } => commands::build(&tag).await,
         Command::Install => commands::install().await,
         Command::Dev { action } => match action {

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -15,6 +15,10 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
+use serde_json::Value;
+
+use crate::evals::EvalSuite;
+use crate::spec::{AgentSpec, SkillSpec};
 
 /// Kebab-case check mirroring plugin_format's `^[a-z0-9]+(-[a-z0-9]+)*$`.
 pub fn valid_name(name: &str) -> bool {
@@ -111,8 +115,15 @@ pub fn scaffold(dir: &Path, name: &str) -> Result<Vec<PathBuf>> {
         ),
     ];
 
-    // Refuse if ANY target (or a stray manifest) already exists: init must
-    // never truncate a file the user already has (e.g. a real .mcp.json).
+    write_bundle(dir, files)
+}
+
+/// Write a bundle's files with the shared collision-refusal discipline: refuse
+/// if ANY target (or a stray root `plugin.json`) already exists, leaving every
+/// existing file untouched and creating nothing on collision. Both the weather
+/// scaffold and the spec scaffold funnel through here so the "never truncate a
+/// file the user already has" guarantee is identical for both paths.
+fn write_bundle(dir: &Path, files: Vec<(PathBuf, String)>) -> Result<Vec<PathBuf>> {
     let mut collisions: Vec<PathBuf> = files
         .iter()
         .map(|(path, _)| path.clone())
@@ -138,6 +149,89 @@ pub fn scaffold(dir: &Path, name: &str) -> Result<Vec<PathBuf>> {
         created.push(path);
     }
     Ok(created)
+}
+
+/// Render one skill's `SKILL.md`: YAML frontmatter (name, description, and
+/// `allowed-tools` only when non-empty) then the instructions body.
+///
+/// The frontmatter is rendered without a YAML crate. `name` is kebab-case
+/// (validated in `spec.rs`), so a bare scalar is always safe. `description` and
+/// each `allowed-tools` value are ARBITRARY agent-authored text, so they are
+/// emitted as JSON-encoded strings: a serde_json string is a valid YAML
+/// double-quoted scalar (YAML double-quoted supports the same `\n \t \" \\
+/// \uXXXX` escapes serde_json emits), so the round-trip is exact. A bare scalar
+/// here would corrupt or invalidate the frontmatter `plugin_format.validate_bundle`
+/// parses with `yaml.safe_load` -- a colon-space breaks parsing, a leading ` #`
+/// silently truncates as a comment, leading `"[{&*@` etc. error the scanner.
+fn render_skill_md(skill: &SkillSpec) -> String {
+    let mut s = String::new();
+    s.push_str("---\n");
+    s.push_str(&format!("name: {}\n", skill.name));
+    s.push_str(&format!(
+        "description: {}\n",
+        serde_json::to_string(&skill.description).expect("string serializes")
+    ));
+    // Omit the key entirely when empty: the wrong shape (an empty list) reads as
+    // "no tools" but is noise; a real Claude Code bundle just leaves it out.
+    if !skill.allowed_tools.is_empty() {
+        s.push_str("allowed-tools:\n");
+        for tool in &skill.allowed_tools {
+            s.push_str(&format!(
+                "  - {}\n",
+                serde_json::to_string(tool).expect("string serializes")
+            ));
+        }
+    }
+    s.push_str("---\n\n");
+    // Normalize to a single trailing newline regardless of how the author ended
+    // the body, so the file always ends with exactly one.
+    s.push_str(skill.instructions.trim_end_matches('\n'));
+    s.push('\n');
+    s
+}
+
+/// Scaffold a bundle deterministically from an agent-authored spec. The spec is
+/// already validated by `spec::parse`; this only lays down files, funneling
+/// through `write_bundle` for the identical collision refusal as `scaffold`.
+pub fn scaffold_from_spec(dir: &Path, spec: &AgentSpec) -> Result<Vec<PathBuf>> {
+    let manifest = serde_json::to_string_pretty(&serde_json::json!({
+        "name": spec.name,
+        "description": spec.description,
+        "version": "0.1.0",
+    }))
+    .expect("spec manifest serializes");
+
+    // `.mcp.json` carries the connectors verbatim under `mcpServers`; an empty
+    // map yields `{"mcpServers": {}}`, matching the weather scaffold's seed.
+    let mut mcp_root = serde_json::Map::new();
+    mcp_root.insert(
+        "mcpServers".to_string(),
+        Value::Object(spec.connectors.clone()),
+    );
+    let mcp = serde_json::to_string_pretty(&Value::Object(mcp_root)).expect("mcp serializes");
+    let mcp = format!("{mcp}\n");
+
+    // Assemble the suite and emit it, reusing the frozen `EvalSuite` Serialize so
+    // the written `evals/cases.json` loads unchanged through `load_suite`.
+    let suite = EvalSuite {
+        name: spec.name.clone(),
+        cases: spec.evals.clone(),
+    };
+    let cases = serde_json::to_string_pretty(&suite).expect("suite serializes");
+
+    let mut files: Vec<(PathBuf, String)> =
+        vec![(dir.join(".claude-plugin/plugin.json"), manifest)];
+    for skill in &spec.skills {
+        files.push((
+            dir.join(format!("skills/{}/SKILL.md", skill.name)),
+            render_skill_md(skill),
+        ));
+    }
+    files.push((dir.join(".mcp.json"), mcp));
+    files.push((dir.join("evals/cases.json"), cases));
+    files.push((dir.join(".gitignore"), GITIGNORE.to_string()));
+
+    write_bundle(dir, files)
 }
 
 /// Read the plugin name and version from a bundle's manifest.

--- a/cli/src/spec.rs
+++ b/cli/src/spec.rs
@@ -1,0 +1,118 @@
+//! `agentos init --from-spec`: the agent-authored spec model + strict parse.
+//!
+//! A coding agent interviews the human and writes a JSON spec; the CLI scaffolds
+//! a runnable bundle from it with zero interactive prompts (ADR-0021 decision 5).
+//! Both structs use `deny_unknown_fields` so an authoring typo (e.g. `skils`)
+//! fails loud rather than silently dropping the intended field -- the verify-first
+//! ethos applied to the spec itself. The `evals` field reuses the frozen
+//! `crate::evals::EvalCase` type directly, so a spec's eval shape is locked to the
+//! same contract `agentos skill eval` loads and cannot drift.
+
+use anyhow::{anyhow, bail, Result};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use crate::evals::{validate_suite, EvalCase};
+use crate::scaffold::valid_name;
+
+/// One skill an agent describes: it becomes a `skills/<name>/SKILL.md`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SkillSpec {
+    pub name: String,
+    pub description: String,
+    /// Verbatim Claude Code `allowed-tools` values; empty omits the key entirely.
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    pub instructions: String,
+}
+
+/// The whole bundle an agent describes. `connectors` is the raw `.mcp.json`
+/// `mcpServers` map (server name -> server object) and is written through
+/// verbatim after validation.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AgentSpec {
+    pub name: String,
+    pub description: String,
+    pub skills: Vec<SkillSpec>,
+    #[serde(default)]
+    pub connectors: Map<String, Value>,
+    pub evals: Vec<EvalCase>,
+}
+
+/// Deserialize the spec JSON (strict) then validate it. Returns actionable
+/// errors that name the offending value so an agent can self-correct.
+pub fn parse(json: &str) -> Result<AgentSpec> {
+    // Inline serde's message (not just wrap it) so `deny_unknown_fields` errors
+    // that name the offending field -- e.g. "unknown field `skils`" -- survive an
+    // anyhow `.to_string()`, which only renders the outermost context otherwise.
+    let spec: AgentSpec = serde_json::from_str(json)
+        .map_err(|err| anyhow!("spec is not a valid agent spec (JSON): {err}"))?;
+    validate(&spec)?;
+    Ok(spec)
+}
+
+fn validate(spec: &AgentSpec) -> Result<()> {
+    if !valid_name(&spec.name) {
+        bail!(
+            "spec name {:?} must be kebab-case (lowercase letters, digits, hyphens)",
+            spec.name
+        );
+    }
+    if spec.skills.is_empty() {
+        bail!("spec must define at least one skill");
+    }
+
+    // Skill names must be valid kebab and unique: they collide on the same
+    // `skills/<name>/SKILL.md` path otherwise, which we refuse before any write.
+    let mut seen = std::collections::HashSet::new();
+    for skill in &spec.skills {
+        if !valid_name(&skill.name) {
+            bail!(
+                "spec skill name {:?} must be kebab-case (lowercase letters, digits, hyphens)",
+                skill.name
+            );
+        }
+        if !seen.insert(skill.name.as_str()) {
+            bail!(
+                "spec has two skills named {:?}; skill names must be unique",
+                skill.name
+            );
+        }
+    }
+
+    if spec.evals.is_empty() {
+        bail!("spec must define at least one eval case");
+    }
+
+    // Mirror plugin_format `_validate_mcp_object`: a connector object is only
+    // usable if it defines `command` (stdio) or `url` (remote); reject anything
+    // else rather than scaffold a broken `.mcp.json`. When a field is present it
+    // must be a STRING: the frozen `McpServer` types `command`/`url` as `str`, so
+    // a non-string here (e.g. `{"command": 42}`) would pass this gate but make
+    // `validate_bundle` reject the emitted `.mcp.json` -- catch it now with a
+    // message that names the offending field.
+    for (name, value) in &spec.connectors {
+        let obj = value.as_object();
+        for key in ["command", "url"] {
+            if let Some(field) = obj.and_then(|o| o.get(key)) {
+                if !field.is_null() && !field.is_string() {
+                    bail!("connector {name:?} field '{key}' must be a string");
+                }
+            }
+        }
+        let defines = |key: &str| obj.and_then(|o| o.get(key)).is_some_and(|v| v.is_string());
+        if !(defines("command") || defines("url")) {
+            bail!("connector {name:?} must define either 'command' (stdio) or 'url' (remote)");
+        }
+    }
+
+    // Reuse the frozen suite-level discipline (empty-cases + regex compile) so a
+    // spec's evals are held to the exact contract `agentos skill eval` enforces.
+    // Borrow the spec's own name/evals directly rather than cloning them into a
+    // throwaway suite purely to validate.
+    validate_suite(&spec.name, &spec.evals)?;
+
+    Ok(())
+}

--- a/cli/tests/spec_scaffold.rs
+++ b/cli/tests/spec_scaffold.rs
@@ -1,0 +1,600 @@
+//! Integration tests for issue #325: `agentos init --from-spec <PATH>`.
+//!
+//! These pin the acceptance criteria for scaffolding a Claude Code plugin
+//! bundle NON-INTERACTIVELY from an agent-authored spec file, and for the
+//! scaffolded `evals/cases.json` being loadable by the SAME loader that
+//! `agentos skill eval` uses (`agentos::evals::load_suite`). The parity
+//! guarantee is the whole point: a spec authored by an agent must produce a
+//! bundle whose eval suite the platform eval path accepts unchanged.
+//!
+//! Written test-first: the `agentos::spec` module, `scaffold_from_spec`, and
+//! the `--from-spec` clap flag do not exist yet, so this file fails to compile
+//! and/or fails at runtime until the implementer builds the feature.
+//!
+//! Note on the fixtures: `instructions` bodies keep their markdown headings off
+//! the opening JSON quote (a leading sentence first) so the raw-string literals
+//! never contain a `"#` sequence that would prematurely close an `r#"..."#`
+//! delimiter. The `\n` escapes are literal in the raw string and parse to real
+//! newlines via serde_json, which is what an authored markdown body would carry.
+
+use std::path::Path;
+use std::process::Command;
+
+use agentos::evals::{load_suite, GraderKind};
+use agentos::scaffold::{read_manifest, scaffold_from_spec};
+use agentos::spec::parse;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentos")
+}
+
+fn output_text(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+/// A valid two-skill spec with one connector and one eval. The single eval
+/// grader is `{kind: contains, expected: "all done"}` deliberately: that is the
+/// fake-model-compatible grader that makes the offline `skill eval` parity demo
+/// pass, so a spec authored this way scaffolds a suite that greens without a
+/// real model.
+fn valid_spec_json() -> &'static str {
+    r#"{
+      "name": "deal-desk",
+      "description": "Prices and reviews deal desk requests.",
+      "skills": [
+        {
+          "name": "deal-desk",
+          "description": "Invoke when a rep submits a pricing exception request.",
+          "allowed_tools": ["WebSearch", "WebFetch"],
+          "instructions": "Deal desk skill body.\n\n## When to run\nA rep asks for a pricing exception.\n"
+        },
+        {
+          "name": "renewal-review",
+          "description": "Invoke when a renewal needs a discount review.",
+          "instructions": "Renewal review skill body.\n\n## When to run\nA renewal needs review.\n"
+        }
+      ],
+      "connectors": {
+        "crm": { "command": "crm-mcp", "args": ["--stdio"] }
+      },
+      "evals": [
+        { "id": "prices-a-deal", "input": "Quote 20% off for Acme", "grader": { "kind": "contains", "expected": "all done", "case_sensitive": false } }
+      ]
+    }"#
+}
+
+/// Write `body` to `<dir>/spec.json` and return the path.
+fn write_spec(dir: &Path, body: &str) -> std::path::PathBuf {
+    let path = dir.join("spec.json");
+    std::fs::write(&path, body).expect("write spec fixture");
+    path
+}
+
+// --- library-level scaffold behavior --------------------------------------
+
+/// The happy path: a valid spec scaffolds every bundle artifact with the
+/// content the spec dictates. Deleting the impl (returning no files) or writing
+/// the wrong name/description makes concrete file-content assertions fail.
+#[test]
+fn scaffolds_the_full_bundle_from_a_valid_spec() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(valid_spec_json()).expect("valid spec parses");
+    let created = scaffold_from_spec(&out, &spec).expect("scaffold succeeds");
+    assert!(!created.is_empty(), "scaffold should report created files");
+
+    // 1. Manifest: name + version from the spec, description carried through.
+    let (name, version) = read_manifest(&out).unwrap();
+    assert_eq!(name, "deal-desk", "manifest name comes from spec.name");
+    assert_eq!(version, "0.1.0", "scaffold pins version 0.1.0");
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.join(".claude-plugin/plugin.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        manifest["description"],
+        "Prices and reviews deal desk requests."
+    );
+
+    // 5. .gitignore ignores local workstation state.
+    let gitignore = std::fs::read_to_string(out.join(".gitignore")).unwrap();
+    assert!(gitignore.contains(".agentos/"), "{gitignore}");
+}
+
+/// Every skill in a multi-skill spec becomes its own SKILL.md carrying that
+/// skill's name, description, allowed-tools (only when present), and body.
+#[test]
+fn writes_one_skill_md_per_skill_with_frontmatter_and_body() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(valid_spec_json()).unwrap();
+    scaffold_from_spec(&out, &spec).unwrap();
+
+    // Skill one: has allowed_tools -> allowed-tools YAML block with each tool.
+    // description and each tool are emitted as quoted YAML scalars (arbitrary
+    // agent-authored text must be a quoted scalar or it corrupts/invalidates the
+    // frontmatter `plugin_format.validate_bundle` parses with `yaml.safe_load`).
+    let deal = std::fs::read_to_string(out.join("skills/deal-desk/SKILL.md")).unwrap();
+    assert!(deal.starts_with("---\nname: deal-desk\n"), "{deal}");
+    assert!(
+        deal.contains("description: \"Invoke when a rep submits a pricing exception request.\""),
+        "{deal}"
+    );
+    assert!(deal.contains("allowed-tools:"), "{deal}");
+    assert!(deal.contains("  - \"WebSearch\""), "{deal}");
+    assert!(deal.contains("  - \"WebFetch\""), "{deal}");
+    // Instructions body lands after the frontmatter.
+    assert!(deal.contains("Deal desk skill body."), "{deal}");
+    assert!(
+        deal.contains("A rep asks for a pricing exception."),
+        "{deal}"
+    );
+
+    // Skill two: no allowed_tools -> the allowed-tools key is omitted entirely.
+    let renewal = std::fs::read_to_string(out.join("skills/renewal-review/SKILL.md")).unwrap();
+    assert!(
+        renewal.starts_with("---\nname: renewal-review\n"),
+        "{renewal}"
+    );
+    assert!(
+        renewal.contains("description: \"Invoke when a renewal needs a discount review.\""),
+        "{renewal}"
+    );
+    assert!(
+        !renewal.contains("allowed-tools:"),
+        "empty allowed_tools must omit the key entirely\n{renewal}"
+    );
+    assert!(renewal.contains("Renewal review skill body."), "{renewal}");
+}
+
+/// Regression: a description containing a colon-space (`Deal desk: pricing
+/// exceptions`) is a bare YAML scalar corruptor -- `yaml.safe_load` raises
+/// `mapping values are not allowed here` and rejects the bundle. The rendered
+/// frontmatter must quote it so the exact quoted line is present.
+#[test]
+fn description_with_a_colon_is_rendered_as_a_quoted_scalar() {
+    let body = r#"{
+      "name": "colon-desc",
+      "description": "Bundle desc.",
+      "skills": [
+        { "name": "solo", "description": "Deal desk: pricing exceptions", "instructions": "Body.\n" }
+      ],
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "contains", "expected": "all done" } }
+      ]
+    }"#;
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(body).unwrap();
+    scaffold_from_spec(&out, &spec).unwrap();
+
+    let solo = std::fs::read_to_string(out.join("skills/solo/SKILL.md")).unwrap();
+    assert!(
+        solo.contains("description: \"Deal desk: pricing exceptions\""),
+        "colon-space description must be a quoted scalar\n{solo}"
+    );
+}
+
+/// Regression: a description containing ` #` (`Reviews deals #1 priority`) is
+/// treated as a comment by `yaml.safe_load` and silently TRUNCATES the value.
+/// Quoting keeps the ` #` inside the string.
+#[test]
+fn description_with_a_hash_is_rendered_as_a_quoted_scalar() {
+    let body = r#"{
+      "name": "hash-desc",
+      "description": "Bundle desc.",
+      "skills": [
+        { "name": "solo", "description": "Reviews deals #1 priority", "instructions": "Body.\n" }
+      ],
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "contains", "expected": "all done" } }
+      ]
+    }"#;
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(body).unwrap();
+    scaffold_from_spec(&out, &spec).unwrap();
+
+    let solo = std::fs::read_to_string(out.join("skills/solo/SKILL.md")).unwrap();
+    assert!(
+        solo.contains("description: \"Reviews deals #1 priority\""),
+        "` #` description must be quoted so it is not read as a YAML comment\n{solo}"
+    );
+}
+
+/// A connector in the spec becomes a `.mcp.json` `mcpServers` entry verbatim.
+#[test]
+fn writes_mcp_json_with_the_spec_connectors() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(valid_spec_json()).unwrap();
+    scaffold_from_spec(&out, &spec).unwrap();
+
+    let mcp: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join(".mcp.json")).unwrap()).unwrap();
+    assert!(mcp["mcpServers"].is_object(), "{mcp}");
+    assert_eq!(mcp["mcpServers"]["crm"]["command"], "crm-mcp", "{mcp}");
+}
+
+/// A spec with no connectors still writes a valid `.mcp.json` with an empty
+/// `mcpServers` object (the default), not a missing file.
+#[test]
+fn writes_empty_mcp_servers_when_no_connectors() {
+    let body = r#"{
+      "name": "no-conn",
+      "description": "No connectors here.",
+      "skills": [
+        { "name": "solo", "description": "Do the thing.", "instructions": "Solo body.\n" }
+      ],
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "contains", "expected": "all done" } }
+      ]
+    }"#;
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(body).unwrap();
+    scaffold_from_spec(&out, &spec).unwrap();
+
+    let mcp: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(out.join(".mcp.json")).unwrap()).unwrap();
+    assert!(mcp["mcpServers"].is_object(), "{mcp}");
+    assert_eq!(
+        mcp["mcpServers"].as_object().unwrap().len(),
+        0,
+        "no connectors must yield an empty mcpServers object\n{mcp}"
+    );
+}
+
+/// The scaffolded `evals/cases.json` is the suite object and is loadable by the
+/// SAME loader `agentos skill eval` uses. This is the parity guarantee: the
+/// eval suite an agent-authored spec produces must load unchanged on the eval
+/// path. Deleting the eval-writing impl breaks `load_suite`.
+#[test]
+fn scaffolded_evals_load_through_the_skill_eval_loader() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(valid_spec_json()).unwrap();
+    scaffold_from_spec(&out, &spec).unwrap();
+
+    let suite = load_suite(&out.join("evals/cases.json")).expect("suite loads");
+    assert_eq!(suite.name, "deal-desk", "suite name is the spec name");
+    assert_eq!(suite.cases.len(), 1, "one eval in the spec -> one case");
+    let case = &suite.cases[0];
+    assert_eq!(case.id, "prices-a-deal");
+    assert_eq!(case.grader.kind, GraderKind::Contains);
+    assert_eq!(case.grader.expected, "all done");
+}
+
+// --- validation / error behavior ------------------------------------------
+
+/// A spec `name` that is not kebab-case is rejected, and the message names the
+/// offending value so the author can fix it.
+#[test]
+fn rejects_a_non_kebab_spec_name() {
+    let body = valid_spec_json().replace("\"name\": \"deal-desk\"", "\"name\": \"Deal_Desk\"");
+    let err = parse(&body)
+        .expect_err("bad spec name must error")
+        .to_string();
+    assert!(
+        err.contains("Deal_Desk"),
+        "message must name the value: {err}"
+    );
+}
+
+/// A skill `name` that is not kebab-case is rejected with an actionable message.
+#[test]
+fn rejects_a_non_kebab_skill_name() {
+    let body = valid_spec_json().replace(
+        "\"name\": \"renewal-review\"",
+        "\"name\": \"Renewal_Review\"",
+    );
+    let err = parse(&body)
+        .expect_err("bad skill name must error")
+        .to_string();
+    assert!(
+        err.contains("Renewal_Review"),
+        "message must name the value: {err}"
+    );
+}
+
+/// Two skills sharing a name is an authoring error (they collide on the same
+/// `skills/<name>/SKILL.md` path), rejected before any disk write.
+#[test]
+fn rejects_duplicate_skill_names() {
+    let body = r#"{
+      "name": "dupe",
+      "description": "Two skills, one name.",
+      "skills": [
+        { "name": "same", "description": "First.", "instructions": "A body.\n" },
+        { "name": "same", "description": "Second.", "instructions": "B body.\n" }
+      ],
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "contains", "expected": "all done" } }
+      ]
+    }"#;
+    let err = parse(body)
+        .expect_err("duplicate skill names must error")
+        .to_string();
+    assert!(
+        err.contains("same"),
+        "message must name the duplicate: {err}"
+    );
+}
+
+/// A spec must declare at least one skill.
+#[test]
+fn rejects_an_empty_skills_array() {
+    let body = r#"{
+      "name": "empty-skills",
+      "description": "No skills.",
+      "skills": [],
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "contains", "expected": "all done" } }
+      ]
+    }"#;
+    let err = parse(body)
+        .expect_err("empty skills must error")
+        .to_string();
+    assert!(
+        err.to_lowercase().contains("skill"),
+        "message must mention skills: {err}"
+    );
+}
+
+/// A spec must declare at least one eval (mirrors `load_suite`'s empty-cases
+/// rejection: an empty suite is not runnable).
+#[test]
+fn rejects_an_empty_evals_array() {
+    let body = r#"{
+      "name": "empty-evals",
+      "description": "No evals.",
+      "skills": [
+        { "name": "solo", "description": "Do it.", "instructions": "Solo body.\n" }
+      ],
+      "evals": []
+    }"#;
+    let err = parse(body).expect_err("empty evals must error").to_string();
+    assert!(
+        err.to_lowercase().contains("eval"),
+        "message must mention evals: {err}"
+    );
+}
+
+/// A connector server object with neither `command` nor `url` is unusable and
+/// must be rejected rather than scaffolded into a broken `.mcp.json`.
+#[test]
+fn rejects_a_connector_without_command_or_url() {
+    let body = r#"{
+      "name": "bad-conn",
+      "description": "Broken connector.",
+      "skills": [
+        { "name": "solo", "description": "Do it.", "instructions": "Solo body.\n" }
+      ],
+      "connectors": {
+        "crm": { "args": ["--stdio"] }
+      },
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "contains", "expected": "all done" } }
+      ]
+    }"#;
+    let err = parse(body)
+        .expect_err("connector without command/url must error")
+        .to_string();
+    assert!(
+        err.contains("command") || err.contains("url") || err.contains("crm"),
+        "message must explain the missing command/url: {err}"
+    );
+}
+
+/// A connector whose `command` is present but not a STRING (`{"command": 42}`)
+/// is rejected: the frozen `McpServer` types `command`/`url` as `str`, so a
+/// non-string would pass a mere presence check but make `validate_bundle` reject
+/// the emitted `.mcp.json`. The message must name the connector and the field.
+#[test]
+fn rejects_a_connector_with_a_non_string_command() {
+    let body = r#"{
+      "name": "typed-conn",
+      "description": "Wrong-typed connector.",
+      "skills": [
+        { "name": "solo", "description": "Do it.", "instructions": "Solo body.\n" }
+      ],
+      "connectors": {
+        "crm": { "command": 42 }
+      },
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "contains", "expected": "all done" } }
+      ]
+    }"#;
+    let err = parse(body)
+        .expect_err("non-string command must error")
+        .to_string();
+    assert!(
+        err.contains("crm") && err.contains("command") && err.contains("string"),
+        "message must name the connector and the wrong-typed field: {err}"
+    );
+}
+
+/// An unknown top-level field (a typo like `skils`) is rejected via
+/// `deny_unknown_fields`, so a mistyped spec fails loudly instead of silently
+/// dropping the intended field. This is the intended strict-parse design.
+#[test]
+fn rejects_an_unknown_top_level_field() {
+    let body = r#"{
+      "name": "typo",
+      "description": "Typo'd key.",
+      "skils": [
+        { "name": "solo", "description": "Do it.", "instructions": "Solo body.\n" }
+      ],
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "contains", "expected": "all done" } }
+      ]
+    }"#;
+    let err = parse(body)
+        .expect_err("unknown field must error")
+        .to_string();
+    assert!(
+        err.contains("skils"),
+        "message must name the unknown field: {err}"
+    );
+}
+
+/// An eval carrying an invalid regex grader is rejected at parse/scaffold time,
+/// reusing the `load_suite` regex-at-load discipline (a bad pattern fails now,
+/// not mid-run).
+#[test]
+fn rejects_an_invalid_regex_grader_in_a_spec_eval() {
+    let body = r#"{
+      "name": "bad-regex",
+      "description": "Invalid regex grader.",
+      "skills": [
+        { "name": "solo", "description": "Do it.", "instructions": "Solo body.\n" }
+      ],
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "regex", "expected": "(unclosed" } }
+      ]
+    }"#;
+    // Either parse or scaffold must reject it; assert the combined pipeline errors.
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let result = parse(body).and_then(|spec| scaffold_from_spec(&out, &spec).map(|_| ()));
+    let err = result
+        .expect_err("invalid regex grader must error")
+        .to_string();
+    assert!(
+        err.contains("(unclosed") || err.to_lowercase().contains("regex"),
+        "message must name the bad pattern: {err}"
+    );
+}
+
+// --- collision refusal (mirrors existing scaffold discipline) --------------
+
+/// Scaffolding twice into the same dir refuses the second time rather than
+/// truncating the first bundle.
+#[test]
+fn refuses_to_scaffold_twice_into_the_same_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(valid_spec_json()).unwrap();
+    scaffold_from_spec(&out, &spec).unwrap();
+    assert!(
+        scaffold_from_spec(&out, &spec).is_err(),
+        "second scaffold into the same dir must refuse"
+    );
+}
+
+/// If a single target file already exists, scaffold refuses, leaves that file
+/// untouched, and does not create the manifest. Mirrors the existing
+/// `refuses_to_truncate_any_existing_target_even_without_a_manifest` test.
+#[test]
+fn refuses_to_truncate_an_existing_target_and_writes_no_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    std::fs::create_dir_all(&out).unwrap();
+    let existing = r#"{"mcpServers":{"important":{"command":"x"}}}"#;
+    std::fs::write(out.join(".mcp.json"), existing).unwrap();
+
+    let spec = parse(valid_spec_json()).unwrap();
+    let err = scaffold_from_spec(&out, &spec).unwrap_err().to_string();
+    assert!(err.contains(".mcp.json"), "{err}");
+    assert_eq!(
+        std::fs::read_to_string(out.join(".mcp.json")).unwrap(),
+        existing,
+        "existing file must be untouched"
+    );
+    assert!(
+        !out.join(".claude-plugin/plugin.json").exists(),
+        "no manifest may be written when a target collides"
+    );
+}
+
+// --- CLI surface through the agentos binary --------------------------------
+
+/// `agentos init --from-spec <valid>` is fully non-interactive (no stdin),
+/// exits 0, and produces a bundle whose manifest name is the SPEC's name (not
+/// any positional argument -- none is passed).
+#[test]
+fn cli_init_from_spec_scaffolds_non_interactively() {
+    let dir = tempfile::tempdir().unwrap();
+    let spec_path = write_spec(dir.path(), valid_spec_json());
+    let out = dir.path().join("bundle");
+
+    let output = Command::new(bin())
+        .arg("init")
+        .arg("--from-spec")
+        .arg(&spec_path)
+        .arg("--dir")
+        .arg(&out)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run agentos init --from-spec");
+
+    assert!(
+        output.status.success(),
+        "expected success\n{}",
+        output_text(&output)
+    );
+    let (name, _version) = read_manifest(&out).expect("manifest written");
+    assert_eq!(
+        name, "deal-desk",
+        "bundle name is the spec name, not a positional"
+    );
+}
+
+/// `agentos init --from-spec <invalid>` exits non-zero and names the problem.
+#[test]
+fn cli_init_from_spec_rejects_an_invalid_spec() {
+    let dir = tempfile::tempdir().unwrap();
+    // Non-kebab name is a deterministic input error.
+    let body = valid_spec_json().replace("\"name\": \"deal-desk\"", "\"name\": \"Deal_Desk\"");
+    let spec_path = write_spec(dir.path(), &body);
+    let out = dir.path().join("bundle");
+
+    let output = Command::new(bin())
+        .arg("init")
+        .arg("--from-spec")
+        .arg(&spec_path)
+        .arg("--dir")
+        .arg(&out)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run agentos init --from-spec");
+
+    assert!(
+        !output.status.success(),
+        "expected failure for an invalid spec\n{}",
+        output_text(&output)
+    );
+    assert!(
+        output_text(&output).contains("Deal_Desk"),
+        "message must name the offending value\n{}",
+        output_text(&output)
+    );
+}
+
+/// `agentos init` with NEITHER a positional name NOR `--from-spec` exits
+/// non-zero and tells the user to pass a name or `--from-spec`.
+#[test]
+fn cli_init_without_name_or_spec_errors_with_guidance() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+
+    let output = Command::new(bin())
+        .arg("init")
+        .arg("--dir")
+        .arg(&out)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run agentos init with no name");
+
+    assert!(
+        !output.status.success(),
+        "expected failure when neither name nor --from-spec is given\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output).to_lowercase();
+    assert!(
+        text.contains("name") && text.contains("from-spec"),
+        "message must point at name or --from-spec\n{}",
+        output_text(&output)
+    );
+}


### PR DESCRIPTION
Implements [ADR-0021](docs/adr/0021-agentos-is-a-harness-for-coding-agents.md) decision 5: the "interview to scaffold an agent" is agent-conducted; the CLI stays non-interactive and deterministic. A coding agent interviews the human, writes a JSON spec (name, skills, connectors, starter evals), and `agentos init --from-spec <path>` scaffolds a runnable Claude Code plugin bundle from it with zero prompts.

## What
- New `spec` module: strict (`deny_unknown_fields`) `AgentSpec`/`SkillSpec` parse + validation (kebab names, unique skills, connector `command`/`url` typed as strings, regex-grader compile). The spec's `evals` reuse the frozen `EvalCase` type, so a spec's eval shape cannot drift from what `agentos skill eval` loads.
- `scaffold_from_spec` emits the same plugin-format-verbatim bundle as the weather scaffold (shared `write_bundle` collision-refusal). SKILL.md frontmatter renders arbitrary agent-authored strings as JSON-encoded YAML scalars, so a description containing `:` or `#` stays byte-compatible with `plugin_format.validate_bundle`.
- `init` gains `--from-spec`; the positional name becomes optional (it comes from the spec). The `agentos guide` primer and `cli/README.md` document the interview-to-spec flow. `cli/command-manifest.json` regenerated for the new grammar.

## Acceptance criteria
- A coding agent can write a spec and get a runnable bundle with zero interactive prompts. Verified live: `init --from-spec` (stdin closed) then `skill up --fake-model` then `skill eval` = 1/1 passed, exit 0.
- The scaffolded bundle passes `agentos skill eval`, and the frozen `plugin_format.validate_bundle` returns valid on a spec-scaffolded bundle (including a description with `:`/`#`).

Closes #325