### PR TITLE
agentos init ships an Agent Skill + AGENTS.md (and scaffolds the real bundle)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -14,9 +14,10 @@ the runner container on your host Docker daemon, talking straight to the agent.
 ## Your first agent reply
 
 ```bash
-# 1. Scaffold a bundle. This creates a runnable weather skill you can edit later.
-agentos init weather-bot
-cd weather-bot
+# 1. Scaffold a bundle. This creates a starter skill named for your agent, plus
+#    an AGENTS.md and a using-agentos harness-primer skill, that you edit next.
+agentos init my-agent
+cd my-agent
 
 # 2. Boot the runner with the built-in fake model (offline, instant, no key).
 agentos skill up --fake-model
@@ -30,7 +31,7 @@ agentos skill down
 
 That is the full loop. `agentos skill up` starts the runner container,
 `agentos skill message` sends a synthetic event and streams the reply, and
-`agentos skill down` stops it. Edit `skills/weather-bot/SKILL.md` in the bundle
+`agentos skill down` stops it. Edit `skills/my-agent/SKILL.md` in the bundle
 and re-run steps 2 and 3 to see your change answer.
 
 ## Level up: a real model

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ export CLAUDE_CODE_OAUTH_TOKEN=...
 ../target/release/agentos skill eval
 ```
 
-A committed first-party example lives at `examples/weather/`. `cd examples/weather && agentos skill up` runs it from a clean clone. `agentos init` scaffolds this same weather template, so every fresh bundle starts as a runnable web-search skill to learn from and edit.
+A committed first-party example lives at `examples/weather/`. `cd examples/weather && agentos skill up` runs it from a clean clone. `agentos init` scaffolds a generic starter skill named for your agent (plus a root `AGENTS.md` and an installable `.claude/skills/using-agentos/SKILL.md` harness primer) that you edit to build your own agent; see `examples/weather/` for a runnable example to learn from.
 
 For the "engine as an in-bundle stdio MCP server" shape — a bundle that ships
 its own tools as a stdio subprocess the harness spawns, which a hosted harness

--- a/apps/worker/schema/eval-cases.example.json
+++ b/apps/worker/schema/eval-cases.example.json
@@ -3,11 +3,11 @@
     {
       "grader": {
         "case_sensitive": false,
-        "expected": "weather",
+        "expected": "",
         "kind": "contains"
       },
-      "id": "example-answers",
-      "input": "What's the weather in San Francisco?"
+      "id": "example-smoke",
+      "input": "In one short sentence, introduce yourself as the example agent."
     }
   ],
   "name": "example"

--- a/apps/worker/src/agentos_worker/eval/runner.py
+++ b/apps/worker/src/agentos_worker/eval/runner.py
@@ -78,6 +78,18 @@ class EvalRunner:
                 latency_ms=_elapsed_ms(start),
                 error=error_detail or "runner reported a classified failure",
             )
+        # Grade only a completed turn. A turn that ends idle-awaiting-input, or
+        # never produced a Final at all, is not a passing answer even if its text
+        # matches the grader -- this mirrors the CLI's ``turn_passes`` Done-gate
+        # so the platform promotion gate keeps skill/local/cluster parity.
+        if final_status is not SessionStatus.DONE:
+            return EvalCaseResult(
+                case_id=case.id,
+                passed=False,
+                output=output,
+                latency_ms=_elapsed_ms(start),
+                error=f"turn did not complete (status={final_status})",
+            )
         return EvalCaseResult(
             case_id=case.id,
             passed=case.grader.grade(output),

--- a/apps/worker/tests/eval/conftest.py
+++ b/apps/worker/tests/eval/conftest.py
@@ -66,6 +66,9 @@ class FakeEvalRunner:
         # Inputs whose turn ends with a classified-failure final (budget/model
         # error) while still carrying text in responses[input].
         self.classified_failure_inputs: set[str] = set()
+        # Inputs whose turn ends idle-awaiting-input (an incomplete turn) while
+        # still carrying text in responses[input].
+        self.idle_inputs: set[str] = set()
         self.default_output = ""
         self.seen: list[dict[str, str]] = []
 
@@ -79,11 +82,12 @@ class FakeEvalRunner:
         if text in self.fail_inputs:
             return web.json_response({"error": "boom"}, status=500)
         output = self.responses.get(text, self.default_output)
-        status = (
-            SessionStatus.CLASSIFIED_FAILURE
-            if text in self.classified_failure_inputs
-            else SessionStatus.DONE
-        )
+        if text in self.classified_failure_inputs:
+            status = SessionStatus.CLASSIFIED_FAILURE
+        elif text in self.idle_inputs:
+            status = SessionStatus.IDLE_AWAITING_INPUT
+        else:
+            status = SessionStatus.DONE
         resp = web.StreamResponse(status=200, headers={"Content-Type": "application/x-ndjson"})
         await resp.prepare(request)
         frame = Final(text=output, status=status)

--- a/apps/worker/tests/eval/test_models.py
+++ b/apps/worker/tests/eval/test_models.py
@@ -88,15 +88,17 @@ def test_valid_regex_grader_constructs_and_grades() -> None:
 
 def test_committed_fixture_parses_and_grades(eval_cases_example_path: Path) -> None:
     """The committed cross-language fixture loads as an EvalSuite and its single
-    contains grader passes on matching text and fails otherwise (proving the
-    scaffold output is platform-loadable, the latent bug in issue #8)."""
+    smoke grader (contains "") grades any completed turn's text True, proving the
+    scaffold output is platform-loadable (the latent bug in issue #8)."""
     suite = EvalSuite.model_validate_json(
         eval_cases_example_path.read_text(encoding="utf-8")
     )
     assert len(suite.cases) == 1
     grader = suite.cases[0].grader
-    assert grader.grade("it's sunny weather today") is True
-    assert grader.grade("no match here") is False
+    assert grader.kind == GraderKind.CONTAINS
+    assert grader.expected == ""
+    assert grader.grade("anything at all") is True
+    assert grader.grade("") is True
 
 
 def test_old_array_form_is_rejected() -> None:

--- a/apps/worker/tests/eval/test_runner.py
+++ b/apps/worker/tests/eval/test_runner.py
@@ -84,6 +84,29 @@ def test_classified_failure_final_fails_even_if_text_matches(make_eval_harness) 
     asyncio.run(go())
 
 
+def test_idle_awaiting_input_final_fails_even_if_text_matches(make_eval_harness) -> None:
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            # The turn ends idle-awaiting-input (an incomplete turn), yet its text
+            # contains the expected string. Grading only a Done turn, the case must
+            # still FAIL -- an incomplete turn can never turn a promotion gate green,
+            # matching the CLI's Done-gate.
+            fake.responses = {"q": "the answer is 4"}
+            fake.idle_inputs = {"q"}
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(client).run(suite, base_url=base_url, version="v1")
+
+            case = result.results[0]
+            assert case.passed is False
+            assert case.error is not None  # the incomplete-turn reason is recorded
+            assert result.summary() == "0/1 passed"
+
+    asyncio.run(go())
+
+
 def test_all_passed_suite(make_eval_harness) -> None:
     async def go() -> None:
         async with make_eval_harness() as (base_url, fake, client):

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -807,7 +807,7 @@ def test_committed_fixture_loads_from_bundle_with_name_override(
 ) -> None:
     """A tar bundle carrying the committed cross-language fixture bytes at
     evals/cases.json loads through load_suite_from_bundle: the payload suite-name
-    override wins over the file's name, and the case grades weather text True.
+    override wins over the file's name, and the smoke grader grades any text True.
     Proves the scaffold output is platform-loadable (the latent bug in issue #8).
     """
     fixture_bytes = eval_cases_example_path.read_bytes()
@@ -824,4 +824,4 @@ def test_committed_fixture_loads_from_bundle_with_name_override(
     assert suite is not None
     assert suite.name == "override-suite-name"  # payload override at stream.py:160
     assert len(suite.cases) == 1
-    assert suite.cases[0].grader.grade("it's sunny weather today") is True
+    assert suite.cases[0].grader.grade("literally anything") is True

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -36,7 +36,11 @@ release with `up`, `status`, `down`, `comms`, `message`, and `deploy`. Full comm
   generated bundle (`.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`,
   `.mcp.json`) must stay byte-compatible with what `plugin_format.validate_bundle`
   accepts -- if `packages/plugin-format` changes, this scaffold needs
-  updating in the same reviewed change, not independently.
+  updating in the same reviewed change, not independently. `init` also drops a
+  root `AGENTS.md` and a `.claude/skills/using-agentos/SKILL.md` harness primer
+  (body rendered from `guide::primer_markdown()`) alongside the bundle; both
+  live outside the `plugin_format`-validated `skills/` tree, so they do not
+  affect validation.
 - **The `evals/cases.json` seed and `skill eval` loader hand-mirror the frozen
   eval-case schema.** The `agentos init` seed (`scaffold::eval_cases`) and the
   `skill eval` loader (`evals::EvalSuite`/`load_suite`) mirror the frozen

--- a/cli/README.md
+++ b/cli/README.md
@@ -31,7 +31,7 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 
 | Command | What it does |
 |---|---|
-| `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed. |
+| `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed, a root `AGENTS.md`, and an installable `.claude/skills/using-agentos/SKILL.md` harness primer. |
 | `agentos guide` | Print a self-contained primer (ADR-0021) for a coding agent driving the harness: the parity ladder, when/which decision logic, the landmines, and verify-first, to stdout. `--json` emits the same content as a structured variant (data on stdout). |
 | `agentos build` | Build the runner image locally: `docker build -f runner/Dockerfile -t agentos-runner .` from the repo root (found by walking up to `runner/Dockerfile`). `--tag` overrides the tag. Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
 

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -268,6 +268,13 @@ fn render_markdown(p: &Primer) -> String {
     s
 }
 
+/// The primer rendered to Markdown. One seam for callers that need the same
+/// authored body the `agentos guide` default prints -- the scaffold's harness
+/// skill renders from this so the two can never diverge (D2 anti-drift).
+pub fn primer_markdown() -> String {
+    render_markdown(&primer())
+}
+
 /// `agentos guide`: print the primer. Markdown to stdout by default; `--json`
 /// prints the structured variant to stdout (any human text would go to stderr).
 pub fn run(json: bool) -> Result<()> {

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -1,11 +1,16 @@
 //! `agentos init`: scaffold a Claude Code plugin bundle.
 //!
-//! The layout matches the frozen `plugin-format` package: a manifest at
-//! `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md` with YAML
-//! frontmatter, a root `.mcp.json`, plus a CLI-local `evals/cases.json` seed
-//! (a suite object `{name, cases: [{id, input, grader}]}`, hand-mirroring the
-//! frozen eval-case schema) for `agentos skill eval`. Names are kebab-case per
-//! the validator.
+//! Seven files. The deployed bundle shape matches the frozen `plugin-format`
+//! package: a manifest at `.claude-plugin/plugin.json`, a genericized starter
+//! `skills/<name>/SKILL.md` with YAML frontmatter, a root `.mcp.json`, plus a
+//! CLI-local `evals/cases.json` seed (a suite object
+//! `{name, cases: [{id, input, grader}]}`, hand-mirroring the frozen eval-case
+//! schema) for `agentos skill eval` -- a single smoke case that passes on any
+//! completed turn. Two more files teach the developer's coding agent how to
+//! drive the harness: a root `AGENTS.md` (the cross-agent auto-scanned standard)
+//! and an installable primer skill at `.claude/skills/using-agentos/SKILL.md`
+//! whose body is rendered from `guide::primer_markdown()` so it can never drift
+//! from `agentos guide`. Names are kebab-case per the validator.
 
 use std::path::{Path, PathBuf};
 
@@ -31,28 +36,57 @@ fn manifest(name: &str) -> String {
     .expect("static manifest serializes")
 }
 
+/// The genericized starter skill for `<name>`: a believable, editable
+/// placeholder scoped to the bundle name (no weather demo). Keeps the
+/// correct-by-example `allowed-tools` key and the when/how/rules section shape
+/// a real skill uses.
 fn skill_md(name: &str) -> String {
     format!(
-        "---\nname: {name}\ndescription: Look up a location's weather forecast using a live web search. Invoke whenever the user asks about the weather, whether to expect rain, temperature, or what to wear or plan for outdoor activities.\nallowed-tools:\n  - WebSearch\n  - WebFetch\n---\n\n# Weather\n\n## When to run\nThe user asks about the weather, a forecast, temperature, rain or snow chances, or whether a day suits an outdoor plan.\n\n## How to answer\n1. Determine the location and day. If the user named them, use them. If not, ask one short question instead of guessing.\n2. Run a web search for the forecast, e.g. `<city> weather forecast <day>`. Prefer a national weather service or a major forecast provider.\n3. Report, in two or three sentences: expected high and low, sky conditions, and precipitation chance. Include the location and day so there is no ambiguity.\n4. Name the source of the forecast at the end.\n\n## Hard rules\n\n- Never invent a forecast. If the search returns nothing usable, say so and name what you tried.\n- Temperatures in Fahrenheit first, Celsius in parentheses.\n- Keep the reply short enough to read in Slack without expanding.\n"
+        "---\nname: {name}\ndescription: Starter skill for the {name} agent. Replace this description with when the agent should invoke this skill -- it is the routing signal.\nallowed-tools:\n  - WebSearch\n  - WebFetch\n---\n\n# {name}\n\nThis is the starter skill scaffolded by `agentos init`. Replace each section\nbelow with your agent's real behavior; keep the section shape.\n\n## When to run\nDescribe the requests this skill should handle.\n\n## How to answer\n1. Numbered, concrete steps the agent follows.\n2. Prefer verifiable sources and tools over recall.\n\n## Hard rules\n- Never invent an answer. If you cannot find one, say so and name what you tried.\n- Keep replies short enough to read in Slack without expanding.\n"
     )
 }
 
+/// The `evals/cases.json` seed: a single smoke case named for `<name>`. The
+/// `contains ""` grader passes on any completed (`Done`) turn, so the scaffold
+/// is green out of the box under both `--fake-model` and a real credential --
+/// a status gate the author replaces with real graders first.
 fn eval_cases(name: &str) -> String {
     serde_json::to_string_pretty(&serde_json::json!({
         "name": name,
         "cases": [
             {
-                "id": format!("{name}-answers"),
-                "input": "What's the weather in San Francisco?",
+                "id": format!("{name}-smoke"),
+                "input": format!("In one short sentence, introduce yourself as the {name} agent."),
                 "grader": {
                     "kind": "contains",
-                    "expected": "weather",
+                    "expected": "",
                     "case_sensitive": false,
                 },
             }
         ],
     }))
     .expect("static eval cases serialize")
+}
+
+/// The root `AGENTS.md`: the cross-agent auto-scanned standard carrying the
+/// non-discoverable operating rules (the authoring loop, eval-as-promotion-gate,
+/// verify-first, the top landmines) and a pointer to `agentos guide` for the
+/// full primer.
+fn agents_md(name: &str) -> String {
+    format!(
+        "# Agent instructions: {name}\n\nThis is an AgentOS bundle (a Claude Code plugin shape). The full harness\nprimer is one command away and is the source of truth:\n\n    agentos guide\n\n## The loop\n\n1. `agentos skill up --fake-model` -- boot the runner offline, no credential.\n2. Edit `skills/{name}/SKILL.md` (behavior) and `evals/cases.json` (the contract).\n3. `agentos skill eval` -- must be green before any deploy. Merging to main promotes.\n4. `agentos skill down` when finished.\n\n## Rules\n\n- Verify before running: `agentos schema` lists every real command; never\n  invoke one you have not confirmed.\n- The eval file is the promotion gate and never changes across tiers\n  (skill/local/cluster). Never deploy on red.\n- Landmines: run `agentos guide` (or read\n  `.claude/skills/using-agentos/SKILL.md`) for the full, current list. The most\n  common: skill frontmatter uses `allowed-tools`, not `tools` (the wrong key\n  parses but silently grants no tools).\n- The scaffolded eval is a smoke test (passes on any completed turn).\n  Replace it with real graders as the first authoring step.\n"
+    )
+}
+
+/// The installable harness primer skill at `.claude/skills/using-agentos/`,
+/// auto-discovered by Claude Code as a PROJECT skill. Frontmatter (guidance-only,
+/// so no `allowed-tools`) followed by the guide body VERBATIM from
+/// `crate::guide::primer_markdown()` -- one source of truth, drift-gated.
+fn using_agentos_skill() -> String {
+    format!(
+        "---\nname: using-agentos\ndescription: How to drive the AgentOS harness -- the parity ladder, tier decision logic, landmines, and recovery steps. Invoke when running agentos commands, authoring or evaluating a bundle, or debugging a divergence between skill, local, and cluster tiers.\n---\n\n{}",
+        crate::guide::primer_markdown()
+    )
 }
 
 const MCP_JSON: &str = "{\n  \"mcpServers\": {}\n}\n";
@@ -70,6 +104,11 @@ pub fn scaffold(dir: &Path, name: &str) -> Result<Vec<PathBuf>> {
         (dir.join(".mcp.json"), MCP_JSON.to_string()),
         (dir.join("evals/cases.json"), eval_cases(name)),
         (dir.join(".gitignore"), GITIGNORE.to_string()),
+        (dir.join("AGENTS.md"), agents_md(name)),
+        (
+            dir.join(".claude/skills/using-agentos/SKILL.md"),
+            using_agentos_skill(),
+        ),
     ];
 
     // Refuse if ANY target (or a stray manifest) already exists: init must
@@ -143,7 +182,7 @@ mod tests {
     fn scaffolds_the_frozen_bundle_shape() {
         let dir = tempfile::tempdir().unwrap();
         let created = scaffold(dir.path(), "deal-desk").unwrap();
-        assert_eq!(created.len(), 5);
+        assert_eq!(created.len(), 7);
 
         let manifest: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(dir.path().join(".claude-plugin/plugin.json")).unwrap(),
@@ -151,21 +190,29 @@ mod tests {
         .unwrap();
         assert_eq!(manifest["name"], "deal-desk");
 
+        // Genericized starter skill for <name>: no weather anywhere.
         let skill = std::fs::read_to_string(dir.path().join("skills/deal-desk/SKILL.md")).unwrap();
         assert!(skill.starts_with("---\nname: deal-desk\n"));
-        assert!(skill.contains("description: Look up a location's weather forecast"));
+        let description_line = skill
+            .lines()
+            .find(|l| l.starts_with("description:"))
+            .expect("skill has a description line");
+        assert!(
+            description_line.contains("deal-desk"),
+            "description mentions the name: {description_line}"
+        );
         assert!(skill.contains("allowed-tools:"));
-        assert!(skill.contains("- WebSearch"));
-        assert!(skill.contains("- WebFetch"));
-        assert!(skill.contains("# Weather"));
-        assert!(skill.contains("## How to answer"));
-        assert!(skill.contains("Never invent a forecast"));
+        assert!(
+            !skill.contains("weather") && !skill.contains("Weather"),
+            "starter skill must be genericized, not weather"
+        );
 
         let mcp: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap())
                 .unwrap();
         assert!(mcp["mcpServers"].is_object());
 
+        // Single smoke case named for <name>: contains "" (status-gated pass).
         let cases: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(dir.path().join("evals/cases.json")).unwrap(),
         )
@@ -173,15 +220,60 @@ mod tests {
         assert_eq!(cases["name"], "deal-desk");
         let case_list = cases["cases"].as_array().unwrap();
         assert_eq!(case_list.len(), 1);
-        assert_eq!(case_list[0]["id"], "deal-desk-answers");
-        assert!(case_list[0]["input"].as_str().unwrap().contains("weather"));
+        assert_eq!(case_list[0]["id"], "deal-desk-smoke");
         assert_eq!(case_list[0]["grader"]["kind"], "contains");
-        assert_eq!(case_list[0]["grader"]["expected"], "weather");
+        assert_eq!(case_list[0]["grader"]["expected"], "");
+        assert_eq!(case_list[0]["grader"]["case_sensitive"], false);
+
+        // AGENTS.md teaches the developer's coding agent the harness.
+        let agents = std::fs::read_to_string(dir.path().join("AGENTS.md")).unwrap();
+        assert!(agents.contains("agentos guide"));
+        assert!(agents.contains("agentos skill eval"));
+        assert!(agents.contains("allowed-tools"));
+
+        // The installable harness primer skill, discovered by Claude Code.
+        let harness_skill =
+            std::fs::read_to_string(dir.path().join(".claude/skills/using-agentos/SKILL.md"))
+                .unwrap();
+        assert!(harness_skill.starts_with("---\nname: using-agentos\n"));
+        let harness_description = harness_skill
+            .lines()
+            .find(|l| l.starts_with("description:"))
+            .expect("harness skill has a description line");
+        assert!(
+            !harness_description
+                .trim_start_matches("description:")
+                .trim()
+                .is_empty(),
+            "harness skill description is non-empty"
+        );
+        assert!(harness_skill.contains("# AgentOS harness primer"));
+        assert!(harness_skill.contains("agentos schema"));
 
         assert_eq!(
             read_manifest(dir.path()).unwrap(),
             ("deal-desk".to_string(), "0.1.0".to_string())
         );
+    }
+
+    #[test]
+    fn harness_skill_body_equals_the_guide() {
+        // Anti-drift (D2): the scaffolded harness skill body is rendered from
+        // `guide::primer_markdown()`, never re-authored, so the guide and the
+        // scaffolded skill can never diverge. The body after the frontmatter's
+        // closing `---\n` (plus its blank line) must equal the guide verbatim.
+        let dir = tempfile::tempdir().unwrap();
+        scaffold(dir.path(), "deal-desk").unwrap();
+        let content =
+            std::fs::read_to_string(dir.path().join(".claude/skills/using-agentos/SKILL.md"))
+                .unwrap();
+        let body = content
+            .splitn(3, "---\n")
+            .nth(2)
+            .expect("frontmatter-delimited body")
+            .strip_prefix('\n')
+            .expect("blank line after the closing frontmatter fence");
+        assert_eq!(body, crate::guide::primer_markdown());
     }
 
     #[test]
@@ -212,6 +304,22 @@ mod tests {
         assert!(err.to_string().contains(".mcp.json"), "{err}");
         assert_eq!(
             std::fs::read_to_string(dir.path().join(".mcp.json")).unwrap(),
+            existing,
+            "existing file must be untouched"
+        );
+        assert!(!dir.path().join(".claude-plugin/plugin.json").exists());
+    }
+
+    #[test]
+    fn refuses_to_overwrite_an_existing_agents_md() {
+        let dir = tempfile::tempdir().unwrap();
+        let existing = "# My own agent notes\nDo not clobber me.\n";
+        std::fs::write(dir.path().join("AGENTS.md"), existing).unwrap();
+
+        let err = scaffold(dir.path(), "deal-desk").unwrap_err();
+        assert!(err.to_string().contains("AGENTS.md"), "{err}");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("AGENTS.md")).unwrap(),
             existing,
             "existing file must be untouched"
         );

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -67,9 +67,12 @@ agentos skill message "hello"
 agentos skill down
 ```
 
-`agentos init` scaffolds a runnable weather example plugin bundle: a Claude Code
-plugin with `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`,
-and an `evals/cases.json` seed. `--fake-model` gives scripted replies with no
+`agentos init` scaffolds a generic starter bundle: a Claude Code plugin
+(`.claude-plugin/plugin.json`, a starter `skills/<name>/SKILL.md`, `.mcp.json`,
+and an `evals/cases.json` smoke seed) plus a root `AGENTS.md` and
+`.claude/skills/using-agentos/SKILL.md`, the harness primer. The scaffolded eval
+is a smoke test that passes out of the box; replace it with real graders as you
+build. `--fake-model` gives scripted replies with no
 Anthropic key, so this proves the loop offline. Drop `--fake-model` and export a
 credential, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, or
 `AGENTOS_CREDENTIALS`, for a real model.


### PR DESCRIPTION
Implements [ADR-0021](docs/adr/0021-agentos-is-a-harness-for-coding-agents.md) decision 2: `agentos init` makes the harness self-describing in the target repo.

## What
- `agentos init <name>` now drops, alongside the bundle files:
  - a root **`AGENTS.md`** (the cross-agent standard Codex/Cursor/Claude Code all scan) with the authoring loop, verify-first, the eval-as-promotion-gate, and a pointer to `agentos guide`;
  - an installable **`.claude/skills/using-agentos/SKILL.md`** harness primer, auto-discovered by Claude Code as a project skill, whose body is rendered from the same `guide::primer()` as `agentos guide` (via a new `primer_markdown()` seam) and is drift-gated against it.
- The starter `skills/<name>/SKILL.md` and `evals/cases.json` are **named for `<name>`** instead of a hardcoded weather demo. The scaffolded eval is a `contains ""` smoke grader: green out of the box under both `--fake-model` and a real model, meant to be replaced with real graders as the first authoring step. `examples/weather/` remains the runnable first-party example, untouched.
- The frozen cross-language fixture `apps/worker/schema/eval-cases.example.json` moves in lockstep with the scaffold seed (byte-match test enforces it); QUICKSTART / onboarding / cli docs drop the weather-scaffold claim.

## Placement decision (please sanity-check)
The harness skill goes under `.claude/skills/` (not the deployed `skills/` bundle dir) so it teaches the developer's coding agent without becoming deployed agent behavior; `AGENTS.md` at root is the auto-scanned cross-agent surface. This satisfies ADR-0021's "auto-discover through the standards they already scan" better than a bare root `SKILL.md` (which Claude Code does not scan).

## Related fix (Codex review caught it)
The smoke grader exposed a pre-existing CLI/platform parity asymmetry: the platform worker eval (`EvalRunner._run_case`) graded any non-`CLASSIFIED_FAILURE` turn, so an incomplete turn (`idle-awaiting-input`, or no final) could falsely pass under `contains ""`. It now requires `SessionStatus.DONE` before grading, mirroring the CLI `turn_passes`, so skill/local/cluster agree. Regression test added.

## Note
`pack_tar_gz` excludes only `.agentos/`/`.git/`, so `AGENTS.md` and `.claude/skills/using-agentos/SKILL.md` are tarred into deploy uploads. Harmless (validate ignores them; the runner loads skills only from `skills/`); leaving a deploy-packaging change out of scope.

Verified end to end: `agentos init` -> `plugin_format.validate_bundle` valid=True (0 errors) -> `agentos skill up --fake-model` -> `agentos skill eval` prints `1/1 passed`.

Closes #324