### PR TITLE
Add the primer before-after eval harness and its pilot delta

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -65,6 +65,7 @@ they error clearly -- a release binary has no dev scripts.
 | `agentos dev contracts` | `bash scripts/check-contracts.sh` -- check the frozen contracts. |
 | `agentos dev chart-check` | `bash charts/agentos/ci/render-assertions.sh` -- render-assert the Helm chart. |
 | `agentos dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
+| `agentos dev harness-eval` | `bash cli/scripts/harness-eval.sh` -- the primer before-after harness smoke (deterministic fake driver, no token spend). |
 
 ## `skill` target: runner-only, fully offline
 

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1526,6 +1526,11 @@
           "about": "Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`)",
           "hidden": false,
           "name": "e2e"
+        },
+        {
+          "about": "Run the primer before-after harness smoke (`bash cli/scripts/harness-eval.sh`)",
+          "hidden": false,
+          "name": "harness-eval"
         }
       ]
     },

--- a/cli/scripts/harness-eval.sh
+++ b/cli/scripts/harness-eval.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Run the primer before-after harness smoke: the deterministic fake-driver
+# run that proves the harness wiring works without spending model tokens.
+# The real before-after benchmark is `uv run python -m harness_eval run
+# --driver claude` (see the harness-eval package).
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+uv run python -m harness_eval run --driver fake

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -135,6 +135,8 @@ enum DevAction {
     ChartCheck,
     /// Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`).
     E2e,
+    /// Run the primer before-after harness smoke (`bash cli/scripts/harness-eval.sh`).
+    HarnessEval,
 }
 
 #[derive(Subcommand)]
@@ -702,6 +704,7 @@ async fn main() -> Result<()> {
                 commands::dev_script("charts/agentos/ci/render-assertions.sh").await
             }
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
+            DevAction::HarnessEval => commands::dev_script("cli/scripts/harness-eval.sh").await,
         },
         Command::Skill { action } => match action {
             SkillAction::Up {
@@ -1235,6 +1238,14 @@ mod tests {
             cli.command,
             Command::Dev {
                 action: DevAction::E2e
+            }
+        ));
+        let cli = Cli::try_parse_from(["agentos", "dev", "harness-eval"])
+            .expect("dev harness-eval should parse");
+        assert!(matches!(
+            cli.command,
+            Command::Dev {
+                action: DevAction::HarnessEval
             }
         ));
     }

--- a/docs/harness-eval-delta.md
+++ b/docs/harness-eval-delta.md
@@ -1,0 +1,112 @@
+# Primer before/after eval delta
+
+## What this measures
+
+This is the recorded result of the primer before/after harness: how a coding
+agent's success on realistic AgentOS work changes when the AgentOS primer
+(`agentos guide`) is placed in its context. The method:
+
+- **The harness.** Every task runs under two conditions, baseline (no primer) and
+  with primer, and a deterministic scorer grades the workspace the agent produced.
+  See [`harness-eval/README.md`](../harness-eval/README.md) for the harness, the
+  task set, and the scorers.
+- **The task set.** Four realistic tasks, one per scorer category: author a Claude
+  skill, register an MCP server, write an eval gate, and fix an empty API key.
+  Each keys on one primer-taught landmine.
+- **Deterministic scoring.** Each scorer inspects the produced files and returns
+  pass or fail with no LLM judge, so a given workspace always scores the same way.
+- **The two conditions.** The baseline sends the task prompt alone; the with-primer
+  condition prepends the `agentos guide` output as an instruction preamble.
+- **Isolation.** Each run isolates the agent from host configuration (strict MCP
+  config, and settings sources limited to project and local, excluding the host
+  user config), so the baseline is a true control with no ambient AgentOS
+  knowledge; token counts include cache-read and cache-creation input tokens,
+  which dominate, hence the large absolute values.
+
+This work is the citation asset called for in
+[ADR-0021](adr/0021-agentos-is-a-harness-for-coding-agents.md): publishing the
+harness's own before/after eval delta as proof of the primer's value.
+
+## Result
+
+**Headline:** on this isolated pilot run, accuracy dropped from 75.0% baseline to
+50.0% with the primer (n=1 per cell), and the primer raised mean token use per
+task by about 124702 tokens; both conditions ran with zero errors.
+
+Run details: a single trial per task-condition (n=1 per cell), 4 tasks x 2
+conditions = 8 real `claude -p` runs, executed locally via the isolated
+`ClaudeCodeDriver` on 2026-07-11 using the Claude Code default model. Primer text
+came from `agentos guide`.
+
+| Metric | Baseline | With primer | Delta |
+| --- | --- | --- | --- |
+| Accuracy | 75.0% (3/4) | 50.0% (2/4) | -25.0 points |
+| Total tokens | 833093 | 1331901 | +498808 |
+| Mean tokens/task | 208273.25 | 332975.25 | +124702.0 |
+| Errors | 0 | 0 | +0.00 error rate |
+
+Per task:
+
+| Task | Category | Baseline | Baseline tokens | With primer | With-primer tokens |
+| --- | --- | --- | --- | --- | --- |
+| Author a Claude skill | `build-skill` | pass | 173407 | pass | 144801 |
+| Register an MCP server | `add-mcp-server` | fail | 207658 | fail | 217448 |
+| Write an eval gate | `write-eval-gate` | pass | 243001 | fail | 715774 |
+| Fix an empty API key | `fix-empty-api-key` | pass | 209027 | pass | 253878 |
+
+Notes on the tasks that did not pass:
+
+- **`add-mcp-server` (fail in both arms).** Both the baseline and the with-primer
+  run left `.mcp.json` with no `mcpServers` entry, so the primer did not flip this
+  task under isolation.
+- **`write-eval-gate` (pass to fail).** The baseline wrote a valid
+  `{"cases": [{... "grader": ...}]}`. The with-primer run wrote a top-level JSON
+  array with no `cases` key and no grader, which the scorer correctly failed,
+  while burning far more tokens.
+
+## Reading the result
+
+This is an **n=1 pilot**. Its value is that it proves the harness runs end to end
+against a real coding agent and produces the three metrics (accuracy, mean tokens,
+error rate) plus the before/after delta. It is **not** a proof of the primer's
+value.
+
+On this isolated single sample the primer did not help: net accuracy went down 25
+points. That drop is driven by the with-primer `write-eval-gate` run choosing a
+non-conforming schema (a top-level array instead of a `cases` object), which
+regressed a task the baseline had passed; `add-mcp-server` failed in both arms.
+Token cost rose sharply with the primer in context.
+
+A single trial per cell cannot separate the primer's effect from ordinary
+run-to-run variance in a non-deterministic agent. A real delta needs many trials
+per cell across multiple models, so the pass/fail and token figures average out; a
+nominal single-sample regression like this one is exactly the noise that warning
+guards against. This run is the reproducible starting point for that larger
+measurement, not the published headline. Multi-sample, variance-aware evals are
+tracked separately in issue #332.
+
+## Reproduce this
+
+```bash
+uv run python -m harness_eval run --driver claude --format json --out harness-eval-result.json
+```
+
+This requires `agentos` and `claude` on `PATH` and a working model credential, and
+it spends tokens (8 real agent runs). The numbers will differ run to run because
+the agent is non-deterministic; treat any single run as one noisy sample.
+
+## Publishable summary
+
+> AgentOS ships a reproducible harness that measures how a coding agent's success
+> on realistic AgentOS tasks changes with and without the AgentOS primer
+> (`agentos guide`) in context, scoring each run deterministically against the
+> specific landmine it targets, with every run isolated from host configuration so
+> the baseline is a true no-knowledge control. In a first isolated n=1 pilot the
+> primer did not help: net accuracy went down 25 points, driven by one task
+> regressing on a non-conforming schema choice, and token cost rose sharply. That
+> single trial is a proof the measurement works end to end, not a headline number:
+> a meaningful before/after delta requires many trials per cell across models. The
+> harness and its methodology are the deliverable; the headline numbers await a
+> larger run.
+>
+> `Primer before-after: accuracy 75.0% -> 50.0% (-25.0 points), mean tokens +124702.0, error rate +0.00.`

--- a/harness-eval/README.md
+++ b/harness-eval/README.md
@@ -1,0 +1,113 @@
+# harness-eval
+
+A reproducible harness that measures a coding agent's task success on realistic
+AgentOS work **with** versus **without** the AgentOS primer (`agentos guide`) in
+context. Each task runs under two conditions (baseline and with primer), a
+deterministic scorer grades the workspace the agent produced, and the harness
+rolls the outcomes up into three metrics (accuracy, mean tokens, error rate) plus
+the before/after delta between them. This is the measurement half of
+[ADR-0021](../docs/adr/0021-agentos-is-a-harness-for-coding-agents.md): that ADR
+commits to the primer as the harness's own citation asset, and publishing the
+before/after eval delta is the consequence implemented under
+[issue #326](https://github.com/curie-eng/agentos/issues/326). The primer text
+being measured is emitted by `agentos guide` (issue #322).
+
+## The task set
+
+Four tasks, one per scorer category. Each is a concrete instruction a coding
+agent would act on inside a scaffolded bundle, and each keys on one primer-taught
+landmine that an unprimed agent tends to get wrong.
+
+| Task | Category | What the agent is asked to do | Primer landmine |
+| --- | --- | --- | --- |
+| Author a Claude skill | `build-skill` | Add a `skills/summarize/SKILL.md` with YAML frontmatter (name, description, a tool restriction to Read and Bash) and a short body, following the Claude Code plugin skill format. | The tool restriction key is `allowed-tools`, not `tools`. |
+| Register an MCP server | `add-mcp-server` | Register the `fetch` MCP server (runs via `uvx mcp-server-fetch`) under `mcpServers` in the bundle's `.mcp.json`, using the Claude Code `.mcp.json` format. | An `mcpServers` entry is an inline object with `command`/`args`, not a string pointer. |
+| Write an eval gate | `write-eval-gate` | Add an eval suite at `evals/cases.json` with at least one case (id, input prompt, grader) that checks the agent can add two numbers. | Every eval case must name a grader; graders are deny-by-default. |
+| Fix an empty API key | `fix-empty-api-key` | The bundle's `.env` sets `ANTHROPIC_API_KEY` to an empty string, silently breaking the CLI auth gate. Fix it so no residual empty assignment remains. | An empty `ANTHROPIC_API_KEY` assignment breaks auth; remove it or set a real value. |
+
+## Scoring
+
+Every scorer is **deterministic**: it inspects the files the agent produced in
+the workspace and returns pass or fail with no LLM judge involved, so a given
+workspace always scores the same way and results are reproducible. Each scorer
+grades exactly the landmine its task keys on:
+
+- **`build-skill`** passes when a `skills/**/SKILL.md` declares `allowed-tools` in
+  its frontmatter. A file using `tools` instead fails.
+- **`add-mcp-server`** passes when `.mcp.json` has at least one `mcpServers` entry
+  that is an inline object carrying a `command`. String-pointer entries fail.
+- **`write-eval-gate`** passes when `evals/cases.json` is a JSON object with a
+  non-empty `cases` list and every case names a `grader`. A missing `cases` key,
+  an empty list, or any case without a grader fails.
+- **`fix-empty-api-key`** passes when no residual empty `ANTHROPIC_API_KEY=`
+  assignment remains in `.env` (a removed assignment or a non-empty value both
+  pass); an assignment left empty fails.
+
+The scorer registry is **deny-by-default**: `score_run` looks the scorer up by
+`task.category`, and a category with no registered scorer raises rather than
+silently passing. Categories and scorers are bijective (every task has a scorer,
+every scorer has a task).
+
+Three metrics roll up across the task set, per condition:
+
+- **accuracy** = passed / total tasks.
+- **mean tokens** = total tokens / total tasks (input plus output).
+- **error rate** = total agent errors / total tasks.
+
+The reported **delta** is always `with_primer` minus `baseline`, so a positive
+accuracy delta and a negative token or error delta read as the primer helping.
+
+## How the real driver seeds a task
+
+The `claude` driver builds each task's starting state from a real bundle rather
+than a hand-written fixture. It runs `agentos init <task-id>` to scaffold a real
+bundle, then **neutralizes** the parts the default scaffold already satisfies so
+the scorer measures only the agent's own change:
+
+- `build-skill`: remove the scaffold's default `skills/` directory.
+- `write-eval-gate`: overwrite `evals/cases.json` with an empty `{"cases": []}`.
+- `add-mcp-server`: ensure `.mcp.json` exists with an empty `mcpServers` map.
+- `fix-empty-api-key`: seed `.env` with `ANTHROPIC_API_KEY=""`.
+
+Each task therefore starts in a state the scorer fails, and the only way to a pass
+is the agent making the intended change.
+
+## Running it
+
+### Deterministic smoke (no token spend)
+
+The `fake` driver replays canned pass/fail workspaces over the real task catalog
+with no subprocess and no token spend, so the smoke is fully deterministic and
+always shows a positive primer lift. Use it in CI and for local sanity checks:
+
+```bash
+agentos dev harness-eval
+# equivalently, from the package:
+uv run python -m harness_eval run --driver fake
+```
+
+### Real before/after benchmark
+
+The `claude` driver fetches the live primer via `agentos guide`, seeds each task
+from a real bundle, and drives a real `claude -p` run per task-condition. It
+requires both `agentos` and `claude` on `PATH` and a working model credential,
+and it spends tokens:
+
+```bash
+uv run python -m harness_eval run --driver claude [--model <id>] [--format json] [--out <path>]
+```
+
+`--format json` emits the full `DeltaReport` (both rollups plus every per-run
+score); the default `md` format renders the headline deltas and a per-task
+pass/fail table. `--out` writes the rendered report to a file instead of stdout.
+
+## Reproducibility and limits
+
+The deterministic scorers and the fixed task set make the **structure** of the
+result reproducible: the same workspace always scores the same way, and the metric
+definitions never move. The **agent** under test is non-deterministic, so the
+absolute numbers (pass/fail on any single task, token counts) vary from run to
+run, and a single trial per cell is a noisy sample. A meaningful primer delta
+needs many trials per cell across models. See
+[`docs/harness-eval-delta.md`](../docs/harness-eval-delta.md) for the recorded
+pilot result and an honest reading of what it does and does not show.

--- a/harness-eval/pyproject.toml
+++ b/harness-eval/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "harness-eval"
+version = "0.0.0"
+description = "AgentOS primer before-after harness: measures coding-agent task success with vs without the agentos guide primer"
+requires-python = ">=3.13"
+dependencies = [
+    "pydantic>=2",
+    "pyyaml>=6",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/harness_eval"]

--- a/harness-eval/src/harness_eval/__init__.py
+++ b/harness-eval/src/harness_eval/__init__.py
@@ -1,0 +1,7 @@
+"""Primer before-after harness for AgentOS.
+
+Measures a coding agent's task-success WITH vs WITHOUT the AgentOS primer
+(``agentos guide``). Each realistic task runs under two conditions, is scored
+deterministically against the produced workspace, and rolls up into an
+accuracy/token/error-rate delta report.
+"""

--- a/harness-eval/src/harness_eval/__main__.py
+++ b/harness-eval/src/harness_eval/__main__.py
@@ -1,0 +1,127 @@
+"""CLI: run the primer before-after harness and print the delta report.
+
+The ``fake`` driver replays a deterministic canned run set over the real task
+catalog (no subprocess, no token spend) so the smoke always shows a positive
+primer lift. The ``claude`` driver fetches the real primer and drives a live
+coding agent for dogfooding.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+
+from .driver import AgentRunSpec, ClaudeCodeDriver, FakeDriver
+from .harness import run_harness
+from .models import Condition, DeltaReport
+from .primer import fetch_primer
+from .report import render_markdown, render_summary
+from .tasks import TASKS
+
+# Canned fixtures per category: the workspace relpath plus its passing and
+# failing contents. One table keyed by category, so the pass/fail workspaces
+# cannot drift out of step.
+_FIXTURES: dict[str, tuple[str, str, str]] = {
+    "build-skill": (
+        "skills/summarize/SKILL.md",
+        (
+            "---\nname: summarize\ndescription: Summarize text.\n"
+            "allowed-tools:\n  - Read\n  - Bash\n---\n# Summarize\n\nBody.\n"
+        ),
+        (
+            "---\nname: summarize\ndescription: Summarize text.\n"
+            "tools:\n  - Read\n  - Bash\n---\n# Summarize\n\nBody.\n"
+        ),
+    ),
+    "add-mcp-server": (
+        ".mcp.json",
+        '{"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}}}',
+        '{"mcpServers": {"fetch": "mcp-server-fetch"}}',
+    ),
+    "write-eval-gate": (
+        "evals/cases.json",
+        (
+            '{"cases": [{"id": "c1", "input": "2+2", '
+            '"grader": {"kind": "contains", "expected": "4"}}]}'
+        ),
+        '{"cases": []}',
+    ),
+    "fix-empty-api-key": (
+        ".env",
+        "OTHER=1\nMODEL=claude\n",
+        'ANTHROPIC_API_KEY=""\nOTHER=1\n',
+    ),
+}
+# Baseline passes only the back half of the catalog; the primer passes all.
+_BASELINE_PASSES = {"write-eval-gate", "fix-empty-api-key"}
+
+
+def _canned_runs() -> dict[tuple[str, Condition], AgentRunSpec]:
+    runs: dict[tuple[str, Condition], AgentRunSpec] = {}
+    for task in TASKS:
+        relpath, pass_content, fail_content = _FIXTURES[task.category]
+        pass_files = {relpath: pass_content}
+        fail_files = {relpath: fail_content}
+        baseline_ok = task.category in _BASELINE_PASSES
+        runs[(task.id, Condition.BASELINE)] = AgentRunSpec(
+            files=pass_files if baseline_ok else fail_files,
+            transcript="baseline run",
+            input_tokens=180,
+            output_tokens=90,
+            errors=0 if baseline_ok else 2,
+        )
+        runs[(task.id, Condition.WITH_PRIMER)] = AgentRunSpec(
+            files=pass_files,
+            transcript="with-primer run",
+            input_tokens=90,
+            output_tokens=40,
+            errors=0,
+        )
+    return runs
+
+
+def _run_fake() -> DeltaReport:
+    base_dir = Path(tempfile.mkdtemp(prefix="harness-eval-fake-"))
+    driver = FakeDriver(_canned_runs(), base_dir=base_dir)
+    return run_harness(TASKS, driver, primer="(fake primer)")
+
+
+def _run_claude(model: str | None) -> DeltaReport:
+    primer = fetch_primer()
+    driver = ClaudeCodeDriver(model=model)
+    return run_harness(TASKS, driver, primer=primer)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="harness_eval")
+    sub = parser.add_subparsers(dest="command", required=True)
+    run = sub.add_parser("run", help="run the primer before-after harness")
+    run.add_argument("--driver", choices=["fake", "claude"], default="fake")
+    run.add_argument("--format", choices=["md", "json", "summary"], default="md")
+    run.add_argument("--out", type=Path, default=None)
+    run.add_argument("--model", default=None)
+    args = parser.parse_args(argv)
+
+    if args.driver == "claude":
+        report = _run_claude(args.model)
+    else:
+        report = _run_fake()
+
+    if args.format == "json":
+        rendered = report.model_dump_json()
+    elif args.format == "summary":
+        rendered = render_summary(report)
+    else:
+        rendered = render_markdown(report, TASKS)
+
+    if args.out is not None:
+        args.out.write_text(rendered)
+    else:
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness-eval/src/harness_eval/driver.py
+++ b/harness-eval/src/harness_eval/driver.py
@@ -1,0 +1,236 @@
+"""Agent drivers: the seam that actually runs a task under a condition.
+
+``FakeDriver`` replays canned workspaces for deterministic tests and the CLI
+smoke. ``ClaudeCodeDriver`` drives a real coding agent against a freshly seeded
+bundle for dogfooding; it is never exercised by the unit tests and degrades to
+zeros rather than raising on a malformed agent response.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field
+
+from .models import AgentRun, Condition, HarnessTask
+from .primer import primer_prompt_prefix
+
+
+class AgentDriver(Protocol):
+    """Runs one task under one condition and returns the produced run."""
+
+    def run(
+        self, task: HarnessTask, condition: Condition, primer: str | None
+    ) -> AgentRun: ...
+
+
+class AgentRunSpec(BaseModel):
+    """A canned agent run: the files it produced plus its token/error counts."""
+
+    files: dict[str, str] = Field(default_factory=dict)
+    transcript: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    errors: int = 0
+
+
+class FakeDriver:
+    """Replay ``AgentRunSpec`` fixtures keyed by ``(task_id, condition)``.
+
+    Every call materializes a fresh unique workspace under ``base_dir`` and
+    records ``(task, condition, primer)`` in ``calls`` so tests can assert the
+    primer is forwarded only on the WITH_PRIMER condition.
+    """
+
+    def __init__(
+        self,
+        runs: dict[tuple[str, Condition], AgentRunSpec],
+        base_dir: Path,
+    ) -> None:
+        self.runs = runs
+        self.base_dir = base_dir
+        self.calls: list[tuple[HarnessTask, Condition, str | None]] = []
+        self._counter = itertools.count()
+
+    def run(
+        self, task: HarnessTask, condition: Condition, primer: str | None
+    ) -> AgentRun:
+        self.calls.append((task, condition, primer))
+        spec = self.runs[(task.id, condition)]
+        workspace = self.base_dir / f"{task.id}-{condition.value}-{next(self._counter)}"
+        workspace.mkdir(parents=True, exist_ok=True)
+        for rel, content in spec.files.items():
+            target = workspace / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content)
+        return AgentRun(
+            task_id=task.id,
+            condition=condition,
+            workspace=workspace,
+            transcript=spec.transcript,
+            input_tokens=spec.input_tokens,
+            output_tokens=spec.output_tokens,
+            errors=spec.errors,
+        )
+
+
+class ClaudeCodeDriver:
+    """Drive a real coding agent against a freshly seeded AgentOS bundle."""
+
+    def __init__(
+        self,
+        agentos_bin: str = "agentos",
+        claude_bin: str = "claude",
+        model: str | None = None,
+        base_dir: Path | None = None,
+    ) -> None:
+        self.agentos_bin = agentos_bin
+        self.claude_bin = claude_bin
+        self.model = model
+        self.base_dir = base_dir
+        self._counter = itertools.count()
+
+    def run(
+        self, task: HarnessTask, condition: Condition, primer: str | None
+    ) -> AgentRun:
+        workspace = self._seed_bundle(task)
+        prompt = task.prompt
+        if condition is Condition.WITH_PRIMER and primer:
+            prompt = primer_prompt_prefix(primer) + "\n\n" + task.prompt
+        # Isolate the run from host config so the baseline is a true control:
+        # no host MCP servers (strict + empty config) and no user setting source
+        # (excludes the host global CLAUDE.md, memory, and skills). Only the
+        # injected prompt then differs between the two conditions.
+        cmd = [
+            self.claude_bin,
+            "-p",
+            prompt,
+            "--output-format",
+            "json",
+            "--permission-mode",
+            "acceptEdits",
+            "--allowedTools",
+            "Edit,Write,Read,Bash",
+            "--strict-mcp-config",
+            "--mcp-config",
+            '{"mcpServers": {}}',
+            "--setting-sources",
+            "project,local",
+        ]
+        if self.model:
+            cmd += ["--model", self.model]
+        transcript, input_tokens, output_tokens, errors = self._invoke(cmd, workspace)
+        return AgentRun(
+            task_id=task.id,
+            condition=condition,
+            workspace=workspace,
+            transcript=transcript,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            errors=errors,
+        )
+
+    def _seed_bundle(self, task: HarnessTask) -> Path:
+        """Seed a bundle and neutralize it to a per-task failing start state.
+
+        Runs ``agentos init`` under a unique parent, resolves the produced
+        bundle, then strips whatever the default scaffold pre-satisfies so the
+        scorer measures only the agent's change.
+        """
+        root = self.base_dir if self.base_dir is not None else Path(tempfile.mkdtemp())
+        root.mkdir(parents=True, exist_ok=True)
+        parent = root / f"{task.id}-{next(self._counter)}"
+        parent.mkdir(parents=True, exist_ok=True)
+        try:
+            subprocess.run(
+                [self.agentos_bin, "init", task.id],
+                cwd=parent,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError):
+            pass
+        candidate = parent / task.id
+        if candidate.is_dir():
+            bundle = candidate
+        else:
+            bundle = parent
+            bundle.mkdir(parents=True, exist_ok=True)
+            (bundle / ".mcp.json").write_text('{"mcpServers": {}}\n')
+        self._neutralize(bundle, task)
+        return bundle
+
+    @staticmethod
+    def _neutralize(bundle: Path, task: HarnessTask) -> None:
+        """Erase any default scaffold that pre-satisfies the task's scorer."""
+        if task.category == "build-skill":
+            skills = bundle / "skills"
+            if skills.exists():
+                shutil.rmtree(skills)
+        elif task.category == "write-eval-gate":
+            cases = bundle / "evals" / "cases.json"
+            cases.parent.mkdir(parents=True, exist_ok=True)
+            cases.write_text('{"cases": []}\n')
+        elif task.category == "add-mcp-server":
+            mcp = bundle / ".mcp.json"
+            mcp.write_text('{"mcpServers": {}}\n')
+        elif task.category == "fix-empty-api-key":
+            (bundle / ".env").write_text('ANTHROPIC_API_KEY=""\n')
+
+    def _invoke(self, cmd: list[str], workspace: Path) -> tuple[str, int, int, int]:
+        """Run the agent and best-effort extract transcript/tokens/errors."""
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+                timeout=1800,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError):
+            # Missing binary, timeout, or other launch failure: a real error, not
+            # a zero-error fail. subprocess.TimeoutExpired is a SubprocessError.
+            return "", 0, 0, 1
+        transcript, input_tokens, output_tokens, errors = self._parse_output(result.stdout)
+        # A non-zero exit is an error even when stdout still parsed.
+        if result.returncode != 0:
+            errors = max(errors, 1)
+        return transcript, input_tokens, output_tokens, errors
+
+    @staticmethod
+    def _parse_output(stdout: str) -> tuple[str, int, int, int]:
+        try:
+            payload: Any = json.loads(stdout)
+        except (json.JSONDecodeError, ValueError):
+            return stdout, 0, 0, 0
+        if not isinstance(payload, dict):
+            return stdout, 0, 0, 0
+        transcript = str(payload.get("result", ""))
+        usage = payload.get("usage")
+        input_tokens = 0
+        output_tokens = 0
+        if isinstance(usage, dict):
+            # Cache tokens are additive with the base input count; omitting them
+            # undercounts and can bias the two conditions differently.
+            input_tokens = (
+                _as_int(usage.get("input_tokens"))
+                + _as_int(usage.get("cache_creation_input_tokens"))
+                + _as_int(usage.get("cache_read_input_tokens"))
+            )
+            output_tokens = _as_int(usage.get("output_tokens"))
+        errors = 1 if payload.get("is_error") else 0
+        return transcript, input_tokens, output_tokens, errors
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0

--- a/harness-eval/src/harness_eval/harness.py
+++ b/harness-eval/src/harness_eval/harness.py
@@ -1,0 +1,79 @@
+"""The harness loop: run every task under every condition, score, roll up.
+
+Drives the injected ``driver`` across the given conditions, scores each run
+through the injected ``scorer``, accumulates per-condition rollups, and returns
+the paired ``DeltaReport``. The primer is forwarded only on the WITH_PRIMER
+condition; the baseline condition always gets ``None``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from .driver import AgentDriver
+from .models import (
+    AgentRun,
+    Condition,
+    ConditionRollup,
+    DeltaReport,
+    HarnessTask,
+    TaskScore,
+)
+from .scoring import score_run
+
+
+class _Accumulator:
+    """Mutable running totals for one condition."""
+
+    def __init__(self, condition: Condition) -> None:
+        self.condition = condition
+        self.total = 0
+        self.passed = 0
+        self.total_tokens = 0
+        self.total_errors = 0
+
+    def add(self, score: TaskScore) -> None:
+        self.total += 1
+        if score.success:
+            self.passed += 1
+        self.total_tokens += score.total_tokens
+        self.total_errors += score.errors
+
+    def rollup(self) -> ConditionRollup:
+        return ConditionRollup(
+            condition=self.condition,
+            total=self.total,
+            passed=self.passed,
+            total_tokens=self.total_tokens,
+            total_errors=self.total_errors,
+        )
+
+
+def run_harness(
+    tasks: Sequence[HarnessTask],
+    driver: AgentDriver,
+    *,
+    conditions: Sequence[Condition] = (Condition.BASELINE, Condition.WITH_PRIMER),
+    primer: str | None = None,
+    scorer: Callable[[HarnessTask, AgentRun], TaskScore] = score_run,
+) -> DeltaReport:
+    """Run the full task-by-condition matrix and return the delta report."""
+    if not {Condition.BASELINE, Condition.WITH_PRIMER}.issubset(conditions):
+        raise ValueError(
+            "run_harness requires both the baseline and with-primer conditions "
+            "to compute a delta report"
+        )
+    accumulators = {condition: _Accumulator(condition) for condition in conditions}
+    scores: list[TaskScore] = []
+
+    for task in tasks:
+        for condition in conditions:
+            forwarded = primer if condition is Condition.WITH_PRIMER else None
+            run = driver.run(task, condition, forwarded)
+            score = scorer(task, run)
+            scores.append(score)
+            accumulators[condition].add(score)
+
+    baseline = accumulators[Condition.BASELINE].rollup()
+    with_primer = accumulators[Condition.WITH_PRIMER].rollup()
+    return DeltaReport(baseline=baseline, with_primer=with_primer, scores=scores)

--- a/harness-eval/src/harness_eval/models.py
+++ b/harness-eval/src/harness_eval/models.py
@@ -1,0 +1,119 @@
+"""Domain models for the primer before-after harness.
+
+Frozen configs plus derived rollups. A ``ConditionRollup`` accumulates one
+condition's outcomes (baseline or with-primer); a ``DeltaReport`` pairs the two
+and exposes the before-after deltas. All rate properties zero-guard an empty
+rollup back to ``0.0`` so an unrun condition never divides by zero.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Condition(StrEnum):
+    """The two conditions each task runs under."""
+
+    BASELINE = "baseline"
+    WITH_PRIMER = "with_primer"
+
+
+class HarnessTask(BaseModel):
+    """One realistic AgentOS task the agent is asked to perform.
+
+    ``landmine`` names the primer-taught gotcha the task keys on (the thing an
+    unprimed agent tends to get wrong).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    title: str
+    category: str
+    prompt: str
+    landmine: str
+
+
+class AgentRun(BaseModel):
+    """The result of running one task under one condition.
+
+    ``workspace`` is the directory the agent produced; the scorer grades it.
+    """
+
+    task_id: str
+    condition: Condition
+    workspace: Path
+    transcript: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    errors: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+class TaskScore(BaseModel):
+    """The graded outcome of a single ``AgentRun``."""
+
+    task_id: str
+    condition: Condition
+    success: bool
+    detail: str
+    total_tokens: int
+    errors: int
+
+
+class ConditionRollup(BaseModel):
+    """Accumulated outcomes for one condition across every task."""
+
+    condition: Condition
+    total: int
+    passed: int
+    total_tokens: int
+    total_errors: int
+
+    @property
+    def accuracy(self) -> float:
+        if self.total == 0:
+            return 0.0
+        return self.passed / self.total
+
+    @property
+    def mean_tokens(self) -> float:
+        if self.total == 0:
+            return 0.0
+        return self.total_tokens / self.total
+
+    @property
+    def error_rate(self) -> float:
+        if self.total == 0:
+            return 0.0
+        return self.total_errors / self.total
+
+
+class DeltaReport(BaseModel):
+    """The two condition rollups plus every per-run score, with the deltas.
+
+    Each delta is ``with_primer - baseline`` so a positive accuracy delta and a
+    negative token/error delta read as the primer helping.
+    """
+
+    baseline: ConditionRollup
+    with_primer: ConditionRollup
+    scores: list[TaskScore]
+
+    @property
+    def accuracy_delta(self) -> float:
+        return self.with_primer.accuracy - self.baseline.accuracy
+
+    @property
+    def token_delta(self) -> float:
+        return self.with_primer.mean_tokens - self.baseline.mean_tokens
+
+    @property
+    def error_rate_delta(self) -> float:
+        return self.with_primer.error_rate - self.baseline.error_rate

--- a/harness-eval/src/harness_eval/primer.py
+++ b/harness-eval/src/harness_eval/primer.py
@@ -1,0 +1,49 @@
+"""Fetch the AgentOS primer (``agentos guide``) and wrap it as a prompt preamble.
+
+``subprocess`` is referenced at module scope so tests can monkeypatch
+``harness_eval.primer.subprocess.run`` without a real ``agentos`` binary.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+
+class PrimerUnavailable(Exception):
+    """Raised when the ``agentos guide`` primer cannot be fetched."""
+
+
+def fetch_primer(agentos_bin: str = "agentos") -> str:
+    """Return the stdout of ``<agentos_bin> guide``.
+
+    Raises ``PrimerUnavailable`` on a non-zero exit, a missing binary, or a
+    timeout so a hung ``agentos guide`` cannot hang the whole run.
+    """
+    try:
+        result = subprocess.run(
+            [agentos_bin, "guide"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except FileNotFoundError as exc:
+        raise PrimerUnavailable(f"{agentos_bin} not found") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise PrimerUnavailable(f"{agentos_bin} guide timed out") from exc
+    if result.returncode != 0:
+        raise PrimerUnavailable(
+            f"{agentos_bin} guide exited {result.returncode}: {result.stderr}"
+        )
+    return result.stdout
+
+
+def primer_prompt_prefix(primer_text: str) -> str:
+    """Wrap the primer as an instruction preamble embedding it verbatim."""
+    return (
+        "You are working inside an AgentOS bundle. Read the project primer below "
+        "before you act, and follow its conventions exactly.\n\n"
+        "--- BEGIN AGENTOS PRIMER ---\n"
+        f"{primer_text}\n"
+        "--- END AGENTOS PRIMER ---\n\n"
+        "Now complete the following task:"
+    )

--- a/harness-eval/src/harness_eval/report.py
+++ b/harness-eval/src/harness_eval/report.py
@@ -1,0 +1,65 @@
+"""Render a ``DeltaReport`` as markdown (full doc) or a compact summary block."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from .models import Condition, DeltaReport, HarnessTask
+
+
+def _pct(fraction: float) -> str:
+    return f"{fraction * 100:.1f}%"
+
+
+def _points(fraction: float) -> str:
+    sign = "+" if fraction >= 0 else ""
+    return f"{sign}{fraction * 100:.1f}"
+
+
+def render_markdown(report: DeltaReport, tasks: Sequence[HarnessTask]) -> str:
+    """Full repo-doc body: headline deltas plus a per-task pass/fail table."""
+    outcomes: dict[tuple[str, Condition], bool] = {
+        (score.task_id, score.condition): score.success for score in report.scores
+    }
+
+    def cell(task_id: str, condition: Condition) -> str:
+        result = outcomes.get((task_id, condition))
+        if result is None:
+            return "n/a"
+        return "pass" if result else "fail"
+
+    lines = [
+        "# Primer before-after harness",
+        "",
+        "## Headline",
+        "",
+        f"- Baseline accuracy: {_pct(report.baseline.accuracy)}",
+        f"- With-primer accuracy: {_pct(report.with_primer.accuracy)}",
+        f"- Accuracy delta: {_points(report.accuracy_delta)} points",
+        f"- Mean-token delta: {report.token_delta:+.1f}",
+        f"- Error-rate delta: {report.error_rate_delta:+.2f}",
+        "",
+        "## Per-task results",
+        "",
+        "| Task | Category | Baseline | With primer |",
+        "| --- | --- | --- | --- |",
+    ]
+    for task in tasks:
+        lines.append(
+            f"| {task.title} | {task.category} "
+            f"| {cell(task.id, Condition.BASELINE)} "
+            f"| {cell(task.id, Condition.WITH_PRIMER)} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_summary(report: DeltaReport) -> str:
+    """Compact publishable block with the before/after headline accuracy."""
+    return (
+        f"Primer before-after: accuracy {_pct(report.baseline.accuracy)} -> "
+        f"{_pct(report.with_primer.accuracy)} "
+        f"({_points(report.accuracy_delta)} points), "
+        f"mean tokens {report.token_delta:+.1f}, "
+        f"error rate {report.error_rate_delta:+.2f}."
+    )

--- a/harness-eval/src/harness_eval/scoring.py
+++ b/harness-eval/src/harness_eval/scoring.py
@@ -1,0 +1,141 @@
+"""Deterministic scorers, one per task category.
+
+Each scorer grades a produced workspace against the primer landmine for its
+category and returns ``(passed, detail)``. ``score_run`` looks the scorer up by
+``task.category`` and wraps the outcome in a ``TaskScore`` carrying the run's
+token and error counts. An unknown category raises ``KeyError`` by design: a
+category with no scorer must never silently pass.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .models import AgentRun, HarnessTask, TaskScore
+
+Scorer = Callable[[Path, str], tuple[bool, str]]
+
+
+def _skill_frontmatter(text: str) -> dict[str, Any] | None:
+    """Parse the leading ``---`` YAML frontmatter block of a SKILL.md."""
+    stripped = text.lstrip()
+    if not stripped.startswith("---"):
+        return None
+    parts = stripped.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        loaded = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def score_build_skill(workspace: Path, _transcript: str) -> tuple[bool, str]:
+    """Pass when a SKILL.md restricts tools via ``allowed-tools`` (not ``tools``)."""
+    skills = list(workspace.glob("skills/**/SKILL.md"))
+    if not skills:
+        return False, "no skills/**/SKILL.md found"
+    for skill in skills:
+        frontmatter = _skill_frontmatter(skill.read_text())
+        if frontmatter is None:
+            continue
+        if "allowed-tools" in frontmatter:
+            return True, f"{skill.name} uses allowed-tools"
+        if "tools" in frontmatter:
+            return False, f"{skill.name} uses tools, not allowed-tools"
+    return False, "no SKILL.md declares allowed-tools"
+
+
+def score_add_mcp_server(workspace: Path, _transcript: str) -> tuple[bool, str]:
+    """Pass when .mcp.json has a server as an inline object with a command."""
+    path = workspace / ".mcp.json"
+    if not path.is_file():
+        return False, "no .mcp.json found"
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        return False, f".mcp.json is not valid JSON: {exc}"
+    servers = data.get("mcpServers") if isinstance(data, dict) else None
+    if not isinstance(servers, dict) or not servers:
+        return False, ".mcp.json has no mcpServers"
+    for name, entry in servers.items():
+        if isinstance(entry, dict) and "command" in entry:
+            return True, f"server {name} is an inline object with a command"
+    return False, "mcpServers entries are string pointers, not inline objects"
+
+
+def score_write_eval_gate(workspace: Path, _transcript: str) -> tuple[bool, str]:
+    """Pass when evals/cases.json is non-empty and every case names a grader.
+
+    A ``grader`` that is present but unusable (null or an empty object) must
+    fail: a case that names no real grader cannot gate anything.
+    """
+    path = workspace / "evals" / "cases.json"
+    if not path.is_file():
+        return False, "no evals/cases.json found"
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        return False, f"cases.json is not valid JSON: {exc}"
+    cases = data.get("cases") if isinstance(data, dict) else None
+    if not isinstance(cases, list) or not cases:
+        return False, "cases.json has no cases"
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict) or "grader" not in case:
+            return False, f"case {index} has no grader"
+        grader = case["grader"]
+        if not isinstance(grader, dict) or not grader:
+            return False, f"case {index} has an empty grader"
+    return True, f"{len(cases)} cases, each with a grader"
+
+
+def score_fix_empty_api_key(workspace: Path, _transcript: str) -> tuple[bool, str]:
+    """Pass when no residual empty ANTHROPIC_API_KEY assignment remains in .env.
+
+    Every ``ANTHROPIC_API_KEY=`` line is inspected: a single empty assignment
+    fails even when another line assigns a real value, because the later empty
+    line wins and re-breaks the key.
+    """
+    path = workspace / ".env"
+    if not path.is_file():
+        return True, "no .env file, nothing left empty"
+    found = False
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("ANTHROPIC_API_KEY="):
+            continue
+        found = True
+        value = stripped.split("=", 1)[1].strip()
+        if not (value and value.strip("\"'")):
+            return False, "ANTHROPIC_API_KEY is still assigned an empty value"
+    if found:
+        return True, "ANTHROPIC_API_KEY has a non-empty value"
+    return True, "ANTHROPIC_API_KEY assignment removed"
+
+
+SCORERS: dict[str, Scorer] = {
+    "build-skill": score_build_skill,
+    "add-mcp-server": score_add_mcp_server,
+    "write-eval-gate": score_write_eval_gate,
+    "fix-empty-api-key": score_fix_empty_api_key,
+}
+
+
+def score_run(task: HarnessTask, run: AgentRun) -> TaskScore:
+    """Score a run by dispatching on ``task.category`` (KeyError if unknown)."""
+    scorer = SCORERS[task.category]
+    passed, detail = scorer(run.workspace, run.transcript)
+    return TaskScore(
+        task_id=run.task_id,
+        condition=run.condition,
+        success=passed,
+        detail=detail,
+        total_tokens=run.total_tokens,
+        errors=run.errors,
+    )

--- a/harness-eval/src/harness_eval/tasks.py
+++ b/harness-eval/src/harness_eval/tasks.py
@@ -1,0 +1,59 @@
+"""The task catalog: one realistic AgentOS task per scorer category.
+
+Categories are bijective with ``scoring.SCORERS`` (every scorer has a task and
+every task category has a scorer). Each prompt is a concrete instruction a
+coding agent would act on inside a scaffolded bundle, and ``landmine`` names the
+primer-taught gotcha the task is designed to expose.
+"""
+
+from __future__ import annotations
+
+from .models import HarnessTask
+
+TASKS: list[HarnessTask] = [
+    HarnessTask(
+        id="build-skill",
+        title="Author a Claude skill",
+        category="build-skill",
+        prompt=(
+            "Add a skill named summarize under skills/summarize/SKILL.md. It should "
+            "have YAML frontmatter with a name, a description, and a restriction to "
+            "the Read and Bash tools, then a short body describing what the skill "
+            "does. Follow the Claude Code plugin skill format exactly."
+        ),
+        landmine="the tool restriction key is allowed-tools, not tools",
+    ),
+    HarnessTask(
+        id="add-mcp-server",
+        title="Register an MCP server",
+        category="add-mcp-server",
+        prompt=(
+            "Register the fetch MCP server in this bundle's .mcp.json so the agent "
+            "can fetch URLs. The server runs via uvx mcp-server-fetch. Wire it up "
+            "under mcpServers using the Claude Code .mcp.json format."
+        ),
+        landmine="an mcpServers entry is an inline object with command/args, not a string pointer",
+    ),
+    HarnessTask(
+        id="write-eval-gate",
+        title="Write an eval gate",
+        category="write-eval-gate",
+        prompt=(
+            "Add an eval suite at evals/cases.json with at least one case that "
+            "checks the agent can add two numbers. Each case needs an id, an input "
+            "prompt, and a grader that decides pass or fail from the answer."
+        ),
+        landmine="every eval case must name a grader; graders are deny-by-default",
+    ),
+    HarnessTask(
+        id="fix-empty-api-key",
+        title="Fix an empty API key",
+        category="fix-empty-api-key",
+        prompt=(
+            "The .env in this bundle sets ANTHROPIC_API_KEY to an empty string, "
+            "which silently breaks the CLI auth gate. Fix it so there is no "
+            "residual empty ANTHROPIC_API_KEY assignment left behind."
+        ),
+        landmine="an empty ANTHROPIC_API_KEY assignment breaks auth; remove it or set a real value",
+    ),
+]

--- a/harness-eval/tests/conftest.py
+++ b/harness-eval/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Shared fixtures for the harness-eval test suite.
+
+Deliberately imports nothing from ``harness_eval``: the package source does not
+exist yet, so keeping this module import-clean lets each test file fail on its
+own missing-import line instead of aborting collection for the whole suite.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+import pytest
+
+WorkspaceFactory = Callable[[Mapping[str, str] | None], Path]
+
+
+@pytest.fixture
+def workspace_factory(tmp_path: Path) -> WorkspaceFactory:
+    """Return a builder that materializes a fresh workspace dir from a
+    ``{relpath: content}`` mapping and hands back its path.
+
+    Each call gets a distinct directory under ``tmp_path`` so a single test can
+    build several independent workspaces (e.g. a PASS and a FAIL case)."""
+
+    counter = itertools.count()
+
+    def make(files: Mapping[str, str] | None = None) -> Path:
+        ws = tmp_path / f"ws-{next(counter)}"
+        ws.mkdir(parents=True, exist_ok=True)
+        for rel, content in (files or {}).items():
+            target = ws / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content)
+        return ws
+
+    return make

--- a/harness-eval/tests/test_harness.py
+++ b/harness-eval/tests/test_harness.py
@@ -1,0 +1,151 @@
+"""FakeDriver behavior and the run_harness delta pipeline.
+
+The key test builds a driver where WITH_PRIMER runs pass and BASELINE runs fail
+across several tasks (mixed tokens/errors), runs the harness end-to-end through
+the real ``score_run``, and asserts the hand-computed rollups and deltas. Two
+further tests prove the scorer seam is honored and that ``primer`` is forwarded
+only on the WITH_PRIMER condition."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from harness_eval.driver import AgentRunSpec, FakeDriver
+from harness_eval.harness import run_harness
+from harness_eval.models import AgentRun, Condition, HarnessTask, TaskScore
+
+_SKILL_GOOD = """---
+name: my-skill
+description: Does a thing.
+allowed-tools:
+  - Read
+---
+# My Skill
+"""
+
+_SKILL_WRONG_KEY = """---
+name: my-skill
+description: Does a thing.
+tools:
+  - Read
+---
+# My Skill
+"""
+
+
+def _skill_task(task_id: str) -> HarnessTask:
+    return HarnessTask(
+        id=task_id,
+        title=f"Build {task_id}",
+        category="build-skill",
+        prompt="Author a skill.",
+        landmine="allowed-tools not tools",
+    )
+
+
+def test_fake_driver_writes_workspace_and_returns_run(tmp_path: Path) -> None:
+    task = _skill_task("t1")
+    spec = AgentRunSpec(
+        files={"skills/my-skill/SKILL.md": _SKILL_GOOD},
+        transcript="did it",
+        input_tokens=40,
+        output_tokens=10,
+        errors=1,
+    )
+    driver = FakeDriver({(task.id, Condition.WITH_PRIMER): spec}, base_dir=tmp_path)
+
+    run = driver.run(task, Condition.WITH_PRIMER, primer="PRIMER")
+
+    assert run.workspace.is_dir()
+    assert (run.workspace / "skills/my-skill/SKILL.md").read_text() == _SKILL_GOOD
+    assert run.transcript == "did it"
+    assert run.input_tokens == 40
+    assert run.output_tokens == 10
+    assert run.total_tokens == 50
+    assert run.errors == 1
+    assert run.condition == Condition.WITH_PRIMER
+
+
+def test_run_harness_delta_math(tmp_path: Path) -> None:
+    tasks = [_skill_task("t1"), _skill_task("t2"), _skill_task("t3")]
+
+    # BASELINE fails (wrong key), WITH_PRIMER passes. Mixed tokens/errors.
+    fail = {"skills/my-skill/SKILL.md": _SKILL_WRONG_KEY}
+    good = {"skills/my-skill/SKILL.md": _SKILL_GOOD}
+    b = Condition.BASELINE
+    p = Condition.WITH_PRIMER
+    runs = {
+        ("t1", b): AgentRunSpec(files=fail, input_tokens=100, output_tokens=50, errors=2),
+        ("t2", b): AgentRunSpec(files=fail, input_tokens=200, output_tokens=100, errors=1),
+        ("t3", b): AgentRunSpec(files=fail, input_tokens=120, output_tokens=80, errors=3),
+        ("t1", p): AgentRunSpec(files=good, input_tokens=40, output_tokens=10, errors=0),
+        ("t2", p): AgentRunSpec(files=good, input_tokens=60, output_tokens=20, errors=0),
+        ("t3", p): AgentRunSpec(files=good, input_tokens=50, output_tokens=30, errors=1),
+    }
+    driver = FakeDriver(runs, base_dir=tmp_path)
+
+    report = run_harness(tasks, driver, primer="PRIMER-TEXT")
+
+    # Accuracy: all baseline fail, all primer pass.
+    assert report.baseline.accuracy == 0.0
+    assert report.with_primer.accuracy == 1.0
+    assert report.accuracy_delta == 1.0
+
+    # Tokens: baseline totals 150+300+200 = 650 (mean 650/3);
+    # primer totals 50+80+80 = 210 (mean 70).
+    assert report.baseline.mean_tokens == 650 / 3
+    assert report.with_primer.mean_tokens == 70.0
+    assert report.token_delta == 70.0 - 650 / 3
+
+    # Errors: baseline 2+1+3 = 6 (rate 2.0); primer 0+0+1 = 1 (rate 1/3).
+    assert report.baseline.error_rate == 2.0
+    assert report.with_primer.error_rate == 1 / 3
+    assert report.error_rate_delta == 1 / 3 - 2.0
+
+    # Every run produced a TaskScore.
+    assert len(report.scores) == 6
+    assert all(isinstance(s, TaskScore) for s in report.scores)
+
+
+def test_run_harness_honors_custom_scorer(tmp_path: Path) -> None:
+    tasks = [_skill_task("t1"), _skill_task("t2")]
+    # Workspaces would FAIL score_build_skill, but the custom scorer forces PASS,
+    # proving run_harness routes scoring through the injected callable.
+    fail = {"skills/my-skill/SKILL.md": _SKILL_WRONG_KEY}
+    runs = {
+        ("t1", Condition.BASELINE): AgentRunSpec(files=fail),
+        ("t2", Condition.BASELINE): AgentRunSpec(files=fail),
+        ("t1", Condition.WITH_PRIMER): AgentRunSpec(files=fail),
+        ("t2", Condition.WITH_PRIMER): AgentRunSpec(files=fail),
+    }
+    driver = FakeDriver(runs, base_dir=tmp_path)
+
+    def always_pass(task: HarnessTask, run: AgentRun) -> TaskScore:
+        return TaskScore(
+            task_id=task.id,
+            condition=run.condition,
+            success=True,
+            detail="forced",
+            total_tokens=run.total_tokens,
+            errors=run.errors,
+        )
+
+    report = run_harness(tasks, driver, scorer=always_pass)
+    assert len(report.scores) == 4
+    assert all(s.success for s in report.scores)
+
+
+def test_run_harness_forwards_primer_only_with_primer(tmp_path: Path) -> None:
+    tasks = [_skill_task("t1")]
+    good = {"skills/my-skill/SKILL.md": _SKILL_GOOD}
+    runs = {
+        ("t1", Condition.BASELINE): AgentRunSpec(files=good),
+        ("t1", Condition.WITH_PRIMER): AgentRunSpec(files=good),
+    }
+    driver = FakeDriver(runs, base_dir=tmp_path)
+
+    run_harness(tasks, driver, primer="THE-PRIMER")
+
+    seen = {condition: passed_primer for (_task, condition, passed_primer) in driver.calls}
+    assert seen[Condition.BASELINE] is None
+    assert seen[Condition.WITH_PRIMER] == "THE-PRIMER"

--- a/harness-eval/tests/test_main.py
+++ b/harness-eval/tests/test_main.py
@@ -1,0 +1,32 @@
+"""Lock the fake-driver CLI smoke contract.
+
+Drives the ``__main__`` entry point through the fake driver and JSON format,
+capturing stdout, and asserts the rebuilt ``DeltaReport`` shows a positive
+primer lift. Deterministic: no subprocess, no network, no token spend.
+"""
+
+from __future__ import annotations
+
+import harness_eval.__main__ as main_mod
+import pytest
+from harness_eval.models import DeltaReport
+
+
+def test_main_fake_json_reports_positive_lift(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main_mod.main(["run", "--driver", "fake", "--format", "json"])
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    report = DeltaReport.model_validate_json(captured.out)
+
+    assert report.accuracy_delta > 0
+
+
+def test_main_fake_summary_prints_headline(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main_mod.main(["run", "--driver", "fake", "--format", "summary"])
+    assert exit_code == 0
+
+    out = capsys.readouterr().out
+    assert "accuracy" in out
+    assert "50.0%" in out
+    assert "100.0%" in out

--- a/harness-eval/tests/test_models.py
+++ b/harness-eval/tests/test_models.py
@@ -1,0 +1,118 @@
+"""Domain-model tests: enum values, pydantic validation, derived properties,
+the ``total == 0`` zero-guards, and delta-math signs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from harness_eval.models import (
+    AgentRun,
+    Condition,
+    ConditionRollup,
+    DeltaReport,
+    HarnessTask,
+    TaskScore,
+)
+from pydantic import ValidationError
+
+
+def test_condition_members() -> None:
+    assert Condition.BASELINE.value == "baseline"
+    assert Condition.WITH_PRIMER.value == "with_primer"
+    # StrEnum: members compare equal to their string value.
+    assert Condition.BASELINE == "baseline"
+
+
+def test_harness_task_is_frozen() -> None:
+    task = HarnessTask(
+        id="t1",
+        title="Build a skill",
+        category="build-skill",
+        prompt="Author a skill.",
+        landmine="allowed-tools not tools",
+    )
+    with pytest.raises(ValidationError):
+        task.title = "changed"  # type: ignore[misc]
+
+
+def test_harness_task_requires_all_fields() -> None:
+    with pytest.raises(ValidationError):
+        HarnessTask(id="t1")  # type: ignore[call-arg]
+
+
+def test_agent_run_total_tokens(tmp_path: Path) -> None:
+    run = AgentRun(
+        task_id="t1",
+        condition=Condition.BASELINE,
+        workspace=tmp_path,
+        transcript="hello",
+        input_tokens=120,
+        output_tokens=30,
+        errors=2,
+    )
+    assert run.total_tokens == 150
+
+
+def test_task_score_carries_fields(tmp_path: Path) -> None:
+    score = TaskScore(
+        task_id="t1",
+        condition=Condition.WITH_PRIMER,
+        success=True,
+        detail="skill built with allowed-tools",
+        total_tokens=90,
+        errors=0,
+    )
+    assert score.success is True
+    assert score.total_tokens == 90
+
+
+def test_condition_rollup_properties() -> None:
+    rollup = ConditionRollup(
+        condition=Condition.BASELINE,
+        total=4,
+        passed=1,
+        total_tokens=800,
+        total_errors=6,
+    )
+    assert rollup.accuracy == pytest.approx(0.25)
+    assert rollup.mean_tokens == pytest.approx(200.0)
+    assert rollup.error_rate == pytest.approx(1.5)
+
+
+def test_condition_rollup_zero_guard() -> None:
+    rollup = ConditionRollup(
+        condition=Condition.WITH_PRIMER,
+        total=0,
+        passed=0,
+        total_tokens=0,
+        total_errors=0,
+    )
+    assert rollup.accuracy == 0.0
+    assert rollup.mean_tokens == 0.0
+    assert rollup.error_rate == 0.0
+
+
+def test_delta_report_math_signs() -> None:
+    baseline = ConditionRollup(
+        condition=Condition.BASELINE,
+        total=4,
+        passed=1,
+        total_tokens=800,
+        total_errors=8,
+    )
+    with_primer = ConditionRollup(
+        condition=Condition.WITH_PRIMER,
+        total=4,
+        passed=3,
+        total_tokens=400,
+        total_errors=2,
+    )
+    report = DeltaReport(baseline=baseline, with_primer=with_primer, scores=[])
+
+    # accuracy: 0.75 - 0.25 => positive
+    assert report.accuracy_delta == pytest.approx(0.5)
+    # mean tokens: 100 - 200 => negative (primer cheaper)
+    assert report.token_delta == pytest.approx(-100.0)
+    # error rate: 0.5 - 2.0 => negative (primer fewer errors)
+    assert report.error_rate_delta == pytest.approx(-1.5)

--- a/harness-eval/tests/test_primer.py
+++ b/harness-eval/tests/test_primer.py
@@ -1,0 +1,62 @@
+"""Primer fetch/prefix tests. ``subprocess.run`` is monkeypatched to a fake; no
+real ``agentos`` binary is invoked."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+from typing import Any
+
+import harness_eval.primer as primer
+import pytest
+from harness_eval.primer import PrimerUnavailable, fetch_primer, primer_prompt_prefix
+
+_GUIDE_TEXT = "# AgentOS primer\nRun `agentos init` first. Use allowed-tools, not tools.\n"
+
+
+def _fake_run_factory(returncode: int, stdout: str):  # type: ignore[no-untyped-def]
+    def _fake_run(
+        cmd: Sequence[str], *args: Any, **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=list(cmd), returncode=returncode, stdout=stdout, stderr=""
+        )
+
+    return _fake_run
+
+
+def test_fetch_primer_returns_stdout_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(primer.subprocess, "run", _fake_run_factory(0, _GUIDE_TEXT))
+    assert fetch_primer("agentos") == _GUIDE_TEXT
+
+
+def test_fetch_primer_raises_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(primer.subprocess, "run", _fake_run_factory(1, ""))
+    with pytest.raises(PrimerUnavailable):
+        fetch_primer("agentos")
+
+
+def test_fetch_primer_raises_on_missing_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("agentos not found")
+
+    monkeypatch.setattr(primer.subprocess, "run", _boom)
+    with pytest.raises(PrimerUnavailable):
+        fetch_primer("agentos")
+
+
+def test_fetch_primer_raises_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd="agentos guide", timeout=60)
+
+    monkeypatch.setattr(primer.subprocess, "run", _boom)
+    with pytest.raises(PrimerUnavailable):
+        fetch_primer("agentos")
+
+
+def test_primer_prompt_prefix_wraps_primer_text() -> None:
+    prefix = primer_prompt_prefix(_GUIDE_TEXT)
+    # Behavioral, not format-brittle: the primer body is embedded verbatim and
+    # some framing surrounds it (the returned text is longer than the input).
+    assert _GUIDE_TEXT in prefix
+    assert len(prefix) > len(_GUIDE_TEXT)

--- a/harness-eval/tests/test_report.py
+++ b/harness-eval/tests/test_report.py
@@ -1,0 +1,75 @@
+"""Report rendering: assertions target substance (task titles, accuracy numbers,
+the delta) rather than exact markdown formatting."""
+
+from __future__ import annotations
+
+from harness_eval.models import (
+    Condition,
+    ConditionRollup,
+    DeltaReport,
+    HarnessTask,
+    TaskScore,
+)
+from harness_eval.report import render_markdown, render_summary
+
+_TASKS = [
+    HarnessTask(
+        id="t1",
+        title="Author a Claude skill",
+        category="build-skill",
+        prompt="p",
+        landmine="l",
+    ),
+    HarnessTask(
+        id="t2",
+        title="Register an MCP server",
+        category="add-mcp-server",
+        prompt="p",
+        landmine="l",
+    ),
+]
+
+
+def _report() -> DeltaReport:
+    baseline = ConditionRollup(
+        condition=Condition.BASELINE,
+        total=4,
+        passed=1,  # 25%
+        total_tokens=800,
+        total_errors=8,
+    )
+    with_primer = ConditionRollup(
+        condition=Condition.WITH_PRIMER,
+        total=4,
+        passed=3,  # 75%
+        total_tokens=400,
+        total_errors=2,
+    )
+    scores = [
+        TaskScore(
+            task_id="t1",
+            condition=Condition.WITH_PRIMER,
+            success=True,
+            detail="ok",
+            total_tokens=100,
+            errors=0,
+        ),
+    ]
+    return DeltaReport(baseline=baseline, with_primer=with_primer, scores=scores)
+
+
+def test_render_markdown_includes_titles_and_numbers() -> None:
+    body = render_markdown(_report(), _TASKS)
+    for task in _TASKS:
+        assert task.title in body
+    # Both condition accuracies and the +50-point delta appear in some form
+    # ("25%"/"0.25", "75%"/"0.75", "50%"/"0.50").
+    assert "25" in body
+    assert "75" in body
+    assert "50" in body
+
+
+def test_render_summary_includes_before_and_after_accuracy() -> None:
+    summary = render_summary(_report())
+    assert "25" in summary
+    assert "75" in summary

--- a/harness-eval/tests/test_scoring.py
+++ b/harness-eval/tests/test_scoring.py
@@ -1,0 +1,282 @@
+"""Scorer semantics: one PASS and one FAIL per scorer, the SCORERS registry,
+and ``score_run`` mapping (including the unknown-category error)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from harness_eval.models import AgentRun, Condition, HarnessTask
+from harness_eval.scoring import (
+    SCORERS,
+    score_add_mcp_server,
+    score_build_skill,
+    score_fix_empty_api_key,
+    score_run,
+    score_write_eval_gate,
+)
+
+# The ``workspace_factory`` fixture is provided by conftest.py; this alias just
+# names its shape for readable signatures (mapping of relpath -> content).
+WorkspaceFactory = Callable[..., Path]
+
+# --- SKILL.md contents (the primer landmine: allowed-tools, not tools) --------
+
+_SKILL_GOOD = """---
+name: my-skill
+description: Does a thing.
+allowed-tools:
+  - Read
+  - Bash
+---
+# My Skill
+
+Body text.
+"""
+
+_SKILL_WRONG_KEY = """---
+name: my-skill
+description: Does a thing.
+tools:
+  - Read
+  - Bash
+---
+# My Skill
+
+Body text.
+"""
+
+# Frontmatter that is well delimited but not valid YAML (a bare unclosed
+# bracket makes ``yaml.safe_load`` raise ``yaml.YAMLError``).
+_SKILL_MALFORMED_YAML = """---
+name: my-skill
+allowed-tools: [Read, Bash
+---
+# My Skill
+
+Body text.
+"""
+
+
+def test_score_build_skill_pass(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({"skills/my-skill/SKILL.md": _SKILL_GOOD})
+    passed, _detail = score_build_skill(ws, "")
+    assert passed is True
+
+
+def test_score_build_skill_fail_wrong_key(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({"skills/my-skill/SKILL.md": _SKILL_WRONG_KEY})
+    passed, _detail = score_build_skill(ws, "")
+    assert passed is False
+
+
+def test_score_build_skill_fail_missing(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({})
+    passed, _detail = score_build_skill(ws, "")
+    assert passed is False
+
+
+def test_score_build_skill_malformed_yaml_no_raise(
+    workspace_factory: WorkspaceFactory,
+) -> None:
+    ws = workspace_factory({"skills/my-skill/SKILL.md": _SKILL_MALFORMED_YAML})
+    passed, _detail = score_build_skill(ws, "")
+    assert passed is False
+
+
+# --- .mcp.json ----------------------------------------------------------------
+
+_MCP_INLINE = '{"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}}}'
+_MCP_POINTER = '{"mcpServers": {"fetch": "mcp-server-fetch"}}'
+
+
+def test_score_add_mcp_server_pass(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({".mcp.json": _MCP_INLINE})
+    passed, _detail = score_add_mcp_server(ws, "")
+    assert passed is True
+
+
+def test_score_add_mcp_server_fail_pointer(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({".mcp.json": _MCP_POINTER})
+    passed, _detail = score_add_mcp_server(ws, "")
+    assert passed is False
+
+
+def test_score_add_mcp_server_fail_absent(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({})
+    passed, _detail = score_add_mcp_server(ws, "")
+    assert passed is False
+
+
+# --- evals/cases.json ---------------------------------------------------------
+
+_CASES_GOOD = (
+    '{"cases": [{"id": "c1", "input": "2+2", '
+    '"grader": {"kind": "contains", "expected": "4"}}]}'
+)
+_CASES_NO_GRADER = '{"cases": [{"id": "c1", "input": "2+2"}]}'
+_CASES_EMPTY = '{"cases": []}'
+_CASES_NULL_GRADER = '{"cases": [{"id": "c1", "input": "2+2", "grader": null}]}'
+_CASES_EMPTY_GRADER = '{"cases": [{"id": "c1", "input": "2+2", "grader": {}}]}'
+
+
+def test_score_write_eval_gate_pass(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({"evals/cases.json": _CASES_GOOD})
+    passed, _detail = score_write_eval_gate(ws, "")
+    assert passed is True
+
+
+def test_score_write_eval_gate_fail_missing_grader(
+    workspace_factory: WorkspaceFactory,
+) -> None:
+    ws = workspace_factory({"evals/cases.json": _CASES_NO_GRADER})
+    passed, _detail = score_write_eval_gate(ws, "")
+    assert passed is False
+
+
+def test_score_write_eval_gate_fail_empty(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({"evals/cases.json": _CASES_EMPTY})
+    passed, _detail = score_write_eval_gate(ws, "")
+    assert passed is False
+
+
+def test_score_write_eval_gate_fail_null_grader(
+    workspace_factory: WorkspaceFactory,
+) -> None:
+    ws = workspace_factory({"evals/cases.json": _CASES_NULL_GRADER})
+    passed, _detail = score_write_eval_gate(ws, "")
+    assert passed is False
+
+
+def test_score_write_eval_gate_fail_empty_grader(
+    workspace_factory: WorkspaceFactory,
+) -> None:
+    ws = workspace_factory({"evals/cases.json": _CASES_EMPTY_GRADER})
+    passed, _detail = score_write_eval_gate(ws, "")
+    assert passed is False
+
+
+# --- .env empty-API-key fix ---------------------------------------------------
+
+_ENV_FIXED_REMOVED = "OTHER=1\nMODEL=claude\n"
+_ENV_FIXED_NONEMPTY = 'ANTHROPIC_API_KEY="sk-real"\nOTHER=1\n'
+_ENV_STILL_EMPTY_QUOTED = 'ANTHROPIC_API_KEY=""\nOTHER=1\n'
+_ENV_STILL_EMPTY_BARE = "ANTHROPIC_API_KEY=\nOTHER=1\n"
+# A good key line that a later line re-assigns to empty: the residual wins.
+_ENV_GOOD_THEN_EMPTY = 'ANTHROPIC_API_KEY="sk-real"\nOTHER=1\nANTHROPIC_API_KEY=""\n'
+
+
+def test_score_fix_empty_api_key_pass_removed(
+    workspace_factory: WorkspaceFactory,
+) -> None:
+    ws = workspace_factory({".env": _ENV_FIXED_REMOVED})
+    passed, _detail = score_fix_empty_api_key(ws, "")
+    assert passed is True
+
+
+def test_score_fix_empty_api_key_pass_nonempty(
+    workspace_factory: WorkspaceFactory,
+) -> None:
+    ws = workspace_factory({".env": _ENV_FIXED_NONEMPTY})
+    passed, _detail = score_fix_empty_api_key(ws, "")
+    assert passed is True
+
+
+def test_score_fix_empty_api_key_fail_quoted_empty(
+    workspace_factory: WorkspaceFactory,
+) -> None:
+    ws = workspace_factory({".env": _ENV_STILL_EMPTY_QUOTED})
+    passed, _detail = score_fix_empty_api_key(ws, "")
+    assert passed is False
+
+
+def test_score_fix_empty_api_key_fail_bare_empty(
+    workspace_factory: WorkspaceFactory,
+) -> None:
+    ws = workspace_factory({".env": _ENV_STILL_EMPTY_BARE})
+    passed, _detail = score_fix_empty_api_key(ws, "")
+    assert passed is False
+
+
+def test_score_fix_empty_api_key_fail_good_then_empty(
+    workspace_factory: WorkspaceFactory,
+) -> None:
+    ws = workspace_factory({".env": _ENV_GOOD_THEN_EMPTY})
+    passed, _detail = score_fix_empty_api_key(ws, "")
+    assert passed is False
+
+
+# --- SCORERS registry + score_run ---------------------------------------------
+
+
+def test_scorers_registry_keys() -> None:
+    assert set(SCORERS) == {
+        "build-skill",
+        "add-mcp-server",
+        "write-eval-gate",
+        "fix-empty-api-key",
+    }
+
+
+def _task(category: str) -> HarnessTask:
+    return HarnessTask(
+        id=f"task-{category}",
+        title="t",
+        category=category,
+        prompt="do it",
+        landmine="x",
+    )
+
+
+def test_score_run_maps_to_scorer(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({"skills/my-skill/SKILL.md": _SKILL_GOOD})
+    task = _task("build-skill")
+    run = AgentRun(
+        task_id=task.id,
+        condition=Condition.WITH_PRIMER,
+        workspace=ws,
+        transcript="did the thing",
+        input_tokens=40,
+        output_tokens=10,
+        errors=1,
+    )
+    score = score_run(task, run)
+    assert score.success is True
+    assert score.task_id == task.id
+    assert score.condition == Condition.WITH_PRIMER
+    assert score.total_tokens == 50
+    assert score.errors == 1
+
+
+def test_score_run_carries_failure(workspace_factory: WorkspaceFactory) -> None:
+    ws = workspace_factory({"skills/my-skill/SKILL.md": _SKILL_WRONG_KEY})
+    task = _task("build-skill")
+    run = AgentRun(
+        task_id=task.id,
+        condition=Condition.BASELINE,
+        workspace=ws,
+        transcript="",
+        input_tokens=100,
+        output_tokens=50,
+        errors=3,
+    )
+    score = score_run(task, run)
+    assert score.success is False
+    assert score.total_tokens == 150
+    assert score.errors == 3
+
+
+def test_score_run_unknown_category(tmp_path: Path) -> None:
+    task = _task("no-such-category")
+    run = AgentRun(
+        task_id=task.id,
+        condition=Condition.BASELINE,
+        workspace=tmp_path,
+        transcript="",
+        input_tokens=0,
+        output_tokens=0,
+        errors=0,
+    )
+    with pytest.raises(KeyError):
+        score_run(task, run)

--- a/harness-eval/tests/test_tasks.py
+++ b/harness-eval/tests/test_tasks.py
@@ -1,0 +1,33 @@
+"""Task-catalog integrity: non-empty, unique ids, bijective category coverage
+against the scorer registry, and every task fully populated."""
+
+from __future__ import annotations
+
+from harness_eval.scoring import SCORERS
+from harness_eval.tasks import TASKS
+
+
+def test_tasks_non_empty() -> None:
+    assert len(TASKS) > 0
+
+
+def test_task_ids_unique() -> None:
+    ids = [task.id for task in TASKS]
+    assert len(ids) == len(set(ids))
+
+
+def test_task_categories_are_a_subset_of_scorers() -> None:
+    categories = {task.category for task in TASKS}
+    assert categories <= set(SCORERS)
+
+
+def test_every_scorer_is_covered_by_a_task() -> None:
+    categories = {task.category for task in TASKS}
+    assert set(SCORERS) <= categories
+
+
+def test_tasks_are_fully_populated() -> None:
+    for task in TASKS:
+        assert task.prompt.strip()
+        assert task.title.strip()
+        assert task.landmine.strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "agentos-dispatcher",
     "agentos-worker",
     "agentos-runner",
+    "harness-eval",
 ]
 
 [tool.uv]
@@ -23,6 +24,7 @@ members = [
     "apps/dispatcher",
     "apps/worker",
     "runner",
+    "harness-eval",
 ]
 
 [tool.uv.sources]
@@ -32,6 +34,7 @@ agentos-api = { workspace = true }
 agentos-dispatcher = { workspace = true }
 agentos-worker = { workspace = true }
 agentos-runner = { workspace = true }
+harness-eval = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -54,6 +57,7 @@ testpaths = [
     "runner/tests",
     "compose/tests",
     "examples/tests",
+    "harness-eval/tests",
 ]
 
 [tool.ruff]
@@ -76,6 +80,7 @@ mypy_path = [
     "apps/dispatcher/src",
     "apps/worker/src",
     "runner/src",
+    "harness-eval/src",
 ]
 files = [
     "packages/aci-protocol/src",
@@ -84,6 +89,7 @@ files = [
     "apps/dispatcher/src",
     "apps/worker/src",
     "runner/src",
+    "harness-eval/src",
 ]
 
 # The official kubernetes client ships no type stubs; keep its boundary typed

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "agentos-runner",
     "agentos-worker",
     "agentos-workspace",
+    "harness-eval",
     "plugin-format",
 ]
 
@@ -159,6 +160,7 @@ dependencies = [
     { name = "agentos-dispatcher" },
     { name = "agentos-runner" },
     { name = "agentos-worker" },
+    { name = "harness-eval" },
     { name = "plugin-format" },
 ]
 
@@ -179,6 +181,7 @@ requires-dist = [
     { name = "agentos-dispatcher", editable = "apps/dispatcher" },
     { name = "agentos-runner", editable = "runner" },
     { name = "agentos-worker", editable = "apps/worker" },
+    { name = "harness-eval", editable = "harness-eval" },
     { name = "plugin-format", editable = "packages/plugin-format" },
 ]
 
@@ -852,6 +855,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "harness-eval"
+version = "0.0.0"
+source = { editable = "harness-eval" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2" },
+    { name = "pyyaml", specifier = ">=6" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements the ADR-0021 consequence: publish the harness's own before/after eval delta measuring a coding agent's task-success with vs without the AgentOS primer (`agentos guide`, #322).

## What

- **`harness-eval` package** (new uv workspace member): four realistic AgentOS tasks (build a skill, add an MCP server, write an eval gate, fix an empty API key), each keyed on one primer landmine. Deterministic per-category scorers (no LLM judge, so runs are reproducible). A run loop scores every task under a **baseline** and a **with-primer** condition and rolls up **accuracy, mean token use, and error rate** into a before-after `DeltaReport`.
- **Drivers**: a `FakeDriver` for deterministic no-spend runs (used by tests and the CI smoke), and a `ClaudeCodeDriver` that runs a real agent in a fresh seeded bundle, isolated from host config (strict MCP config, `project,local` setting sources only) so the baseline is a true no-AgentOS-knowledge control.
- **Single entry point**: `agentos dev harness-eval` runs the deterministic fake-driver smoke; documented in `harness-eval/README.md` and the CLI reference. Command manifest regenerated.
- **`docs/harness-eval-delta.md`**: a real isolated **n=1 pilot** result plus a publishable summary, framed honestly: it proves the harness runs end to end and produces the three metrics, not the primer's value. A meaningful delta needs many trials per cell across models (tracked in #332).

## Review

Built test-first (contract committed before implementation). Reviewed by code-reviewer, scope-creep-reviewer, spec-vs-impl-reviewer, and a cross-model Codex pass; Codex's findings (baseline config contamination, cache-token undercount, unrecorded invocation failures, scorer fail-open gaps) were all fixed and the pilot re-run under isolation. Full Python suite (47) and CLI cargo tests (248) green; ruff + mypy clean.

Closes #326