### PR TITLE
Fix text-stats-engine example's invalid string-pointer mcpServers

### DIFF
--- a/examples/tests/test_example_mcp_declarations.py
+++ b/examples/tests/test_example_mcp_declarations.py
@@ -1,0 +1,85 @@
+"""Every example bundle declares its MCP servers in a form the real runner loads.
+
+Two landmines the ``agentos guide`` documents get enforced here across *all*
+example bundles (discovered dynamically, so a future third example is covered
+without editing this file):
+
+1. A plugin manifest's ``mcpServers`` must be an inline **object**, never a
+   string path. The string-pointer form (``"mcpServers": ".mcp.json"``) is
+   silently ignored by Claude Code, disabling MCP loading entirely.
+2. An in-bundle stdio server's script reference must be cwd-independent
+   (``${CLAUDE_PLUGIN_ROOT}``-qualified or absolute). A bare relative path like
+   ``scripts/engine_server.py`` only spawns when cwd happens to be the bundle
+   root. This is checked on both ``command`` and every ``args`` entry, for any
+   interpreter (python, node, shell, ...), so a future non-python example is
+   covered too.
+"""
+
+import json
+import os
+from pathlib import Path
+
+EXAMPLES = Path(__file__).resolve().parents[1]
+
+# A string that ends in one of these is a reference to a script shipped inside
+# the bundle -- it has to resolve against the bundle root, so it must be
+# cwd-independent. A bare interpreter name (``python3``, ``node``) has no such
+# extension and is resolved from PATH, so it is correctly left alone.
+_SCRIPT_SUFFIXES = (".py", ".js", ".mjs", ".cjs", ".ts", ".sh", ".rb")
+
+
+def _discover_bundles() -> list[Path]:
+    """Immediate ``examples/`` subdirs that carry a plugin manifest."""
+    return sorted(
+        child
+        for child in EXAMPLES.iterdir()
+        if child.is_dir()
+        and child.name != "tests"
+        and (child / ".claude-plugin" / "plugin.json").is_file()
+    )
+
+
+def _is_bundle_script_ref(value: object) -> bool:
+    return isinstance(value, str) and value.endswith(_SCRIPT_SUFFIXES)
+
+
+def test_no_example_manifest_uses_string_pointer_mcpservers() -> None:
+    violations: list[str] = []
+    for bundle in _discover_bundles():
+        manifest = json.loads((bundle / ".claude-plugin" / "plugin.json").read_text())
+        if "mcpServers" not in manifest:
+            continue
+        value = manifest["mcpServers"]
+        if not isinstance(value, dict):
+            violations.append(
+                f"{bundle.name}: mcpServers must be an inline object, got "
+                f"{type(value).__name__} {value!r} (string-pointer form silently "
+                f"disables MCP loading)"
+            )
+    assert not violations, "String-pointer mcpServers declarations found:\n" + "\n".join(
+        violations
+    )
+
+
+def test_example_mcp_server_script_args_are_cwd_independent() -> None:
+    violations: list[str] = []
+    for bundle in _discover_bundles():
+        mcp_path = bundle / ".mcp.json"
+        if not mcp_path.is_file():
+            continue
+        servers = json.loads(mcp_path.read_text()).get("mcpServers", {})
+        for name, spec in servers.items():
+            candidates = [spec.get("command", ""), *spec.get("args", [])]
+            for value in candidates:
+                if not _is_bundle_script_ref(value):
+                    continue
+                if value.startswith("${CLAUDE_PLUGIN_ROOT}") or os.path.isabs(value):
+                    continue
+                violations.append(
+                    f"{bundle.name}/{name}: script reference {value!r} is a bare "
+                    f"relative path; use a ${{CLAUDE_PLUGIN_ROOT}}-qualified or "
+                    f"absolute path so the server spawns regardless of cwd"
+                )
+    assert not violations, "cwd-dependent MCP server script args found:\n" + "\n".join(
+        violations
+    )

--- a/examples/text-stats-engine/.claude-plugin/plugin.json
+++ b/examples/text-stats-engine/.claude-plugin/plugin.json
@@ -3,6 +3,5 @@
   "version": "0.1.0",
   "description": "Template bundle: an engine packaged as an in-bundle stdio MCP server.",
   "author": { "name": "CurieTech" },
-  "keywords": ["template", "mcp", "stdio", "engine"],
-  "mcpServers": ".mcp.json"
+  "keywords": ["template", "mcp", "stdio", "engine"]
 }

--- a/examples/text-stats-engine/.mcp.json
+++ b/examples/text-stats-engine/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "text-stats-engine": {
       "command": "python3",
-      "args": ["scripts/engine_server.py"]
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/engine_server.py"]
     }
   }
 }

--- a/examples/text-stats-engine/README.md
+++ b/examples/text-stats-engine/README.md
@@ -11,7 +11,7 @@ template paves.
 
 ```
 text-stats-engine/
-  .claude-plugin/plugin.json   manifest; points mcpServers at .mcp.json
+  .claude-plugin/plugin.json   bundle manifest; the local .mcp.json is auto-loaded
   .mcp.json                    declares the stdio server (command + args)
   scripts/engine_server.py     the engine: a stdlib-only stdio MCP server
   skills/text-stats/SKILL.md   a skill that drives the engine's tools
@@ -25,11 +25,11 @@ for a tiny deterministic text-statistics engine (`word_count`, `char_count`,
 `reading_time_minutes`).
 
 The `.mcp.json` declaration is what makes it "in-bundle": the `command` +
-`args` point at a script *inside the bundle*, resolved relative to the bundle
-root, so the harness spawns it as a child process. This validates against
-`plugin_format.validate_bundle` unchanged — the format already accepts stdio MCP
-servers (the `McpServer` model), which is exactly the surface this template
-exploits.
+`args` point at a script *inside the bundle*, `${CLAUDE_PLUGIN_ROOT}`-qualified
+so the harness spawns it as a child process regardless of cwd. This validates
+against `plugin_format.validate_bundle` unchanged — the format already accepts
+stdio MCP servers (the `McpServer` model), which is exactly the surface this
+template exploits.
 
 ## Run it end-to-end
 


### PR DESCRIPTION
The `text-stats-engine` example's `plugin.json` declared `"mcpServers": ".mcp.json"` — an invalid string-pointer form that silently disables MCP loading, the exact landmine `agentos guide` documents. A bundle copied from this template would fall back to WebFetch/Bash and answer by guessing while looking correct.

## Changes
- Drop the string-pointer `mcpServers` key from `plugin.json` (the local `.mcp.json` auto-loads, matching the `weather` example).
- Qualify the engine server arg with `${CLAUDE_PLUGIN_ROOT}` so the stdio server spawns regardless of cwd.
- Correct the README, which documented the buggy shape.
- Add `examples/tests/test_example_mcp_declarations.py`: an enforcement gate over **all** example bundles (discovered dynamically) — no string-pointer `mcpServers`, and every in-bundle stdio script reference is `${CLAUDE_PLUGIN_ROOT}`-qualified/absolute. Wired into CI via the `examples/tests` testpath.

## Scope notes / follow-ups
- **Frozen contract, not touched:** `plugin_format.validate_bundle` currently *accepts* the string-pointer form as valid — that leniency is the root of the false-green. Tightening it is a separate reviewed change per `packages/CLAUDE.md` (frozen interface). The enforcement gate therefore lives in `examples/tests/`, and hardening the validator itself is a recommended follow-up.
- **Runtime AC deferred:** the literal AC "loads via `agentos skill up` + a turn" and a runtime CI gate that observes the model calling the MCP tool both require a real model credential (`--fake-model` skips MCP loading entirely). This diff fixes the two root causes and enforces them statically; a credential-gated runtime eval is a follow-up (needs a CI secret + per-run cost decision).

Closes #336