### PR TITLE
Fix local deploy default Slack channel to satisfy the API's channel-ID validation

### DIFF
--- a/apps/api/tests/test_slack_channel_default.py
+++ b/apps/api/tests/test_slack_channel_default.py
@@ -1,0 +1,28 @@
+"""The CLI's default Slack channel must satisfy the API's channel-ID validation.
+
+Regression guard for #341: the CLI shipped `#local-dev` as its default channel,
+which the API's own AgentCreate validator rejects with 422, so
+`agentos local deploy` with no --slack-channel failed on a fresh stack. This test
+reads the real Rust const and runs it through the real API validator so the two
+literals cannot drift back apart across the language boundary.
+"""
+
+import re
+from pathlib import Path
+
+from agentos_api.schemas import _validate_slack_channel_id
+
+_API_RS = Path(__file__).resolve().parents[3] / "cli" / "src" / "api.rs"
+_DEFAULT_RE = re.compile(r'DEFAULT_SLACK_CHANNEL:\s*&str\s*=\s*"([^"]*)"')
+
+
+def _cli_default_channel() -> str:
+    match = _DEFAULT_RE.search(_API_RS.read_text(encoding="utf-8"))
+    assert match, f"could not find DEFAULT_SLACK_CHANNEL in {_API_RS}"
+    return match.group(1)
+
+
+def test_cli_default_channel_passes_api_validation() -> None:
+    value = _cli_default_channel()
+    # Validator raises on a bad shape and echoes the value back on success.
+    assert _validate_slack_channel_id(value) == value

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -676,7 +676,7 @@
             },
             {
               "global": false,
-              "help": "Slack channel to bind the agent to. On first create it defaults to #local-dev; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
+              "help": "Slack channel to bind the agent to. On first create it defaults to C0LOCALDEV; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
               "id": "slack_channel",
               "long": "slack-channel",
               "positional": false,
@@ -1234,7 +1234,7 @@
             },
             {
               "global": false,
-              "help": "Slack channel to bind the agent to. On first create it defaults to #local-dev; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
+              "help": "Slack channel to bind the agent to. On first create it defaults to C0LOCALDEV; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
               "id": "slack_channel",
               "long": "slack-channel",
               "positional": false,

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -16,8 +16,10 @@ pub struct ApiClient {
 }
 
 /// The channel used when an agent is first created if `--slack-channel` is
-/// omitted; on an existing agent an omitted channel is left untouched.
-pub const DEFAULT_SLACK_CHANNEL: &str = "#local-dev";
+/// omitted; on an existing agent an omitted channel is left untouched. Must
+/// satisfy the platform API's channel-ID validation (`^[CDG][A-Z0-9]{7,}$`),
+/// so this is a valid Slack channel-ID shape, not a `#name`.
+pub const DEFAULT_SLACK_CHANNEL: &str = "C0LOCALDEV";
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Agent {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1136,6 +1136,11 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn default_channel_passes_local_validation() {
+        assert!(validate_slack_channel(crate::api::DEFAULT_SLACK_CHANNEL).is_ok());
+    }
+
+    #[test]
     fn explicit_cases_path_wins() {
         let path = resolve_cases_path(
             Some(PathBuf::from("/x/cases.json")),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -365,7 +365,7 @@ enum LocalAction {
         #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
         api_key: String,
         /// Slack channel to bind the agent to. On first create it defaults to
-        /// #local-dev; on redeploy it is only moved when you pass this flag, so
+        /// C0LOCALDEV; on redeploy it is only moved when you pass this flag, so
         /// omitting it leaves the deployed agent's channel untouched.
         #[arg(long)]
         slack_channel: Option<String>,
@@ -577,7 +577,7 @@ enum ClusterAction {
         #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
         api_key: String,
         /// Slack channel to bind the agent to. On first create it defaults to
-        /// #local-dev; on redeploy it is only moved when you pass this flag, so
+        /// C0LOCALDEV; on redeploy it is only moved when you pass this flag, so
         /// omitting it leaves the deployed agent's channel untouched.
         #[arg(long)]
         slack_channel: Option<String>,


### PR DESCRIPTION
## What

`agentos local deploy` with no `--slack-channel` 422'd on a fresh stack: the CLI's default `DEFAULT_SLACK_CHANNEL` was `#local-dev`, but the platform API's `AgentCreate` validator requires the Slack channel-ID shape `^[CDG][A-Z0-9]{7,}$` (`apps/api/src/agentos_api/schemas.py`). A `#name` can never match, so the documented happy path was broken out of the box.

## Changes

- Change `DEFAULT_SLACK_CHANNEL` to `C0LOCALDEV`, a valid channel-ID shape that satisfies both the API validator and the CLI's own preflight (`cli/src/api.rs`).
- Update the `local deploy` / `cluster deploy` `--slack-channel` help text and the regenerated command manifest so the discoverability surface no longer advertises a value the API would reject.
- Add a cross-language regression test (`apps/api/tests/test_slack_channel_default.py`) that reads the real Rust const and runs it through the real API validator, so the two literals can't drift apart again (AC2).
- Add a Rust unit test that the default passes the CLI local preflight.

## Verification

- `cargo test --locked` (cli): 288 passed, incl. the `command_surface` manifest drift gate (8).
- `uv run pytest tests/test_slack_channel_default.py` (apps/api): passed.
- `cargo fmt --check`, `cargo clippy -D warnings`, `ruff check`, `mypy`: clean.

Closes #341