### PR TITLE
Make the local tier go live at skill-tier parity when a credential is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ the smaller `core` profile (API, worker, Postgres, Valkey, MinIO). Then
 `agentos local deploy` pushes a bundle to the compose API, and
 `agentos local message "..."` drives a message through the real
 queue -> worker -> sandboxed runner -> reply path with no Slack and no
-Kubernetes. The compose worker runs the fake model by default; for a real model,
-export `CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) and set
-`AGENTOS_FAKE_MODEL=0` in the compose environment. See the local runbook below.
+Kubernetes. The compose worker runs the fake model by default, but exporting
+`CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) in your shell is enough for a
+real model -- `agentos local up` flips to live automatically when a credential is
+present, matching `skill up`, so there is no manual `AGENTOS_FAKE_MODEL=0` step.
+See the local runbook below.
 
 **`cluster` (deployed Helm release).** `agentos cluster up` installs the platform
 on Kubernetes and `agentos cluster message "..."` drives the deployed release end
@@ -256,7 +258,7 @@ agentos local message "what changed in the last deploy?"
 
 `local up` runs the worker as the `agentos-worker` compose service (fake model by
 default), so there is nothing to hand-run. For a real model, export a credential
-and set `AGENTOS_FAKE_MODEL=0` in the compose environment. The manual runbook
+in your shell and `local up` goes live automatically. The manual runbook
 below is the equivalent with a host-process worker, useful when iterating on the
 worker itself from source. The console UI is served at
 `http://localhost:28080/?api=1` when you use the default `full` profile.

--- a/cli/README.md
+++ b/cli/README.md
@@ -351,8 +351,8 @@ suffix). `local message` composes with `--channel`, `--thread`, and
 `--timeout-secs` and rejects the cluster only flags (`--namespace`,
 `--release`, `--force-wire`, ...)
 with a clear error. The compose worker runs the fake model by default (a canned
-reply, no credentials); export a credential and set `AGENTOS_FAKE_MODEL=0` in the
-compose environment for a real model.
+reply, no credentials); export a credential in your shell and `local up` goes
+live automatically for a real model.
 
 Use `agentos local comms --slack` when you want the same compose stack to talk
 to a real Slack workspace. Connect reads `SLACK_APP_TOKEN` and

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -361,6 +361,7 @@
             }
           ],
           "hidden": false,
+          "long_about": "Bring the dev stack up (`core` with `--minimal`, else `full`) and print URLs. Add `--slack` for the optional dispatcher.\n\nModel parity with `agentos skill up`: `local up` runs the real model when a model credential is present in the shell (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `AGENTOS_CREDENTIALS`), and the offline fake model otherwise. Set `AGENTOS_FAKE_MODEL=1` to force the fake even with a credential; set `AGENTOS_FAKE_MODEL=0` (or provide a credential) to go live.",
           "name": "up"
         },
         {

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -171,6 +171,10 @@ pub fn primer() -> Primer {
                 detail: "A string-pointer declaration silently fails to load; use the bare inline object form.",
             },
             Landmine {
+                title: "Fake vs live model is symmetric across skill and local",
+                detail: "`agentos skill up` and `agentos local up` both run the real model when a credential is present and the fake model otherwise; `agentos skill up --fake-model` or AGENTOS_FAKE_MODEL=1 forces the offline fake at either tier.",
+            },
+            Landmine {
                 title: "In-cluster sandboxes need dnsPolicy ClusterFirst",
                 detail: "Otherwise the bound bundle fetch cannot resolve the in-cluster object store.",
             },

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -36,6 +36,63 @@ const ENDPOINTS: &[(&str, &str, bool)] = &[
     ("OTel HTTP", "localhost:24318", false),
 ];
 
+/// Credential env vars the compose stack forwards from the shell (bare names in
+/// `compose.dev.yaml`). Any one set non-empty makes `local up` go live, matching
+/// `skill up`. Empty counts as unset (the empty-string-is-not-a-credential rule).
+pub const CREDENTIAL_ENV_VARS: &[&str] = &[
+    "AGENTOS_CREDENTIALS",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+];
+
+/// The model mode `local up` resolves from the shell so the local tier reaches
+/// skill-tier parity: a credential present makes local go live exactly like
+/// `skill up`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ModelMode {
+    /// A credential is present and fake is not pinned truthy: inject
+    /// AGENTOS_FAKE_MODEL=0 so local goes live like `skill up`.
+    LiveFromCredential,
+    /// A credential is present but AGENTOS_FAKE_MODEL is pinned truthy: run fake
+    /// anyway (the operator asked for it) but warn loudly.
+    FakePinnedDespiteCredential,
+    /// No credential: compose's fake default stands; nothing to inject.
+    DefaultFake,
+}
+
+/// Match the runner's truthy parse of `AGENTOS_FAKE_MODEL`
+/// (`runner/src/agentos_runner/__main__.py`): lowercase one of `1`/`true`/`yes`.
+fn fake_model_is_truthy(v: &str) -> bool {
+    matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+}
+
+/// Pure parity core. `explicit_fake_model` is the shell AGENTOS_FAKE_MODEL (None
+/// when unset or empty). `has_credential` is whether any CREDENTIAL_ENV_VARS is
+/// set non-empty.
+pub fn resolve_model_mode(explicit_fake_model: Option<&str>, has_credential: bool) -> ModelMode {
+    if !has_credential {
+        return ModelMode::DefaultFake;
+    }
+    match explicit_fake_model {
+        Some(v) if fake_model_is_truthy(v) => ModelMode::FakePinnedDespiteCredential,
+        _ => ModelMode::LiveFromCredential,
+    }
+}
+
+/// Snapshot the shell for the parity decision. An empty AGENTOS_FAKE_MODEL is
+/// treated as unset (matches compose's `${AGENTOS_FAKE_MODEL:-1}` and the
+/// empty-string-is-not-a-credential rule); a credential is any non-empty
+/// CREDENTIAL_ENV_VARS value.
+pub fn model_mode_from_env() -> ModelMode {
+    let explicit = std::env::var("AGENTOS_FAKE_MODEL")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let has_credential = CREDENTIAL_ENV_VARS
+        .iter()
+        .any(|v| std::env::var(v).map(|s| !s.is_empty()).unwrap_or(false));
+    resolve_model_mode(explicit.as_deref(), has_credential)
+}
+
 /// Flags shared by every `local` verb.
 pub struct LocalOpts {
     pub file: String,
@@ -43,6 +100,9 @@ pub struct LocalOpts {
     pub minimal: bool,
     pub local_model: Option<String>,
     pub slack: bool,
+    /// Model mode resolved from the shell (skill-tier parity). Only `up`
+    /// consumes it; `down`/`status` set `DefaultFake`.
+    pub model_mode: ModelMode,
 }
 
 pub struct LocalDownOpts {
@@ -86,8 +146,12 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
         plain("--wait"),
     ]);
     let mut cmd = OpsCommand::new("docker", args);
-    if let Some(model) = &o.local_model {
-        cmd = cmd.with_env(vec![
+    // `with_env` REPLACES the env vec, so build it once. `--local-model` and the
+    // credential-driven live injection are mutually exclusive: local-model
+    // carries its own live env (AGENTOS_FAKE_MODEL=0 + the ollama routing), so
+    // the parity injection only applies when no local model is requested.
+    let env: Vec<(String, String)> = if let Some(model) = &o.local_model {
+        vec![
             ("AGENTOS_FAKE_MODEL".into(), "0".into()),
             (
                 "AGENTOS_MODEL_BASE_URL".into(),
@@ -99,7 +163,17 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
             // `agentos_default`, regardless of the working-directory basename
             // (which is what compose otherwise derives the project name from).
             ("COMPOSE_PROJECT_NAME".into(), "agentos".into()),
-        ]);
+        ]
+    } else if o.model_mode == ModelMode::LiveFromCredential {
+        // A credential is present: flip compose's fake default to live, matching
+        // `skill up`. (FakePinnedDespiteCredential/DefaultFake inject nothing so
+        // compose's `${AGENTOS_FAKE_MODEL:-1}` default stands.)
+        vec![("AGENTOS_FAKE_MODEL".into(), "0".into())]
+    } else {
+        Vec::new()
+    };
+    if !env.is_empty() {
+        cmd = cmd.with_env(env);
     }
     cmd
 }
@@ -150,6 +224,21 @@ pub async fn up(o: LocalOpts) -> Result<()> {
     require_on_path("docker")?;
     let cl = ui.checklist();
     run_step(&cl, "starting dev stack", "up", &cmd).await?;
+    // `--local-model` is its own live path (routes to ollama); the shell-credential
+    // parity note only applies when no local model was requested.
+    if o.local_model.is_none() {
+        match o.model_mode {
+            ModelMode::LiveFromCredential => ui.note(
+                "Running the LIVE model: a credential is set in your shell (parity with `agentos skill up`). Set AGENTOS_FAKE_MODEL=1 to force the offline fake model.",
+            ),
+            ModelMode::FakePinnedDespiteCredential => ui.warn(
+                "Running the FAKE model despite a credential in your shell: AGENTOS_FAKE_MODEL is pinned on. Unset it or set AGENTOS_FAKE_MODEL=0 to go live.",
+            ),
+            ModelMode::DefaultFake => ui.note(
+                "Running the fake model (no credential set). Provide a credential (ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN / AGENTOS_CREDENTIALS) or --local-model to go live.",
+            ),
+        }
+    }
     for (label, url, is_core) in ENDPOINTS {
         // Under `--minimal` only the `core` services started, so advertise only
         // their endpoints; the `full`-only URLs would 404.
@@ -273,6 +362,7 @@ mod tests {
             minimal: false,
             local_model: None,
             slack: false,
+            model_mode: ModelMode::DefaultFake,
         }
     }
 
@@ -283,6 +373,7 @@ mod tests {
             minimal: false,
             local_model: Some(model.into()),
             slack: false,
+            model_mode: ModelMode::DefaultFake,
         }
     }
 
@@ -348,6 +439,106 @@ mod tests {
         assert!(cmd.env.contains(&(
             String::from("COMPOSE_PROJECT_NAME"),
             String::from("agentos"),
+        )));
+    }
+
+    #[test]
+    fn resolve_model_mode_truth_table() {
+        // No credential -> DefaultFake regardless of any pin.
+        assert_eq!(resolve_model_mode(None, false), ModelMode::DefaultFake);
+        assert_eq!(resolve_model_mode(Some("1"), false), ModelMode::DefaultFake);
+        assert_eq!(
+            resolve_model_mode(Some("banana"), false),
+            ModelMode::DefaultFake
+        );
+        // Credential + no explicit pin -> live.
+        assert_eq!(
+            resolve_model_mode(None, true),
+            ModelMode::LiveFromCredential
+        );
+        // Credential + truthy pin (any casing the runner accepts) -> fake pinned.
+        for pin in ["1", "true", "YES", "Yes"] {
+            assert_eq!(
+                resolve_model_mode(Some(pin), true),
+                ModelMode::FakePinnedDespiteCredential,
+                "pin {pin:?} should pin fake"
+            );
+        }
+        // Credential + non-truthy pin -> live (0/off/garbage are not "fake on").
+        // A whitespace-padded value like " true " is not truthy because the
+        // runner does not trim before comparing.
+        for pin in ["0", "banana", "off", "", " true "] {
+            assert_eq!(
+                resolve_model_mode(Some(pin), true),
+                ModelMode::LiveFromCredential,
+                "pin {pin:?} should stay live"
+            );
+        }
+    }
+
+    #[test]
+    fn up_live_from_credential_injects_fake_zero() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.model_mode = ModelMode::LiveFromCredential;
+        let cmd = up_command(&o);
+        assert!(
+            cmd.env
+                .contains(&(String::from("AGENTOS_FAKE_MODEL"), String::from("0"))),
+            "live-from-credential must inject AGENTOS_FAKE_MODEL=0; env={:?}",
+            cmd.env
+        );
+        assert!(
+            cmd.display().contains("AGENTOS_FAKE_MODEL=0"),
+            "display must show the injected env: {}",
+            cmd.display()
+        );
+    }
+
+    #[test]
+    fn up_fake_pinned_does_not_inject() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.model_mode = ModelMode::FakePinnedDespiteCredential;
+        let cmd = up_command(&o);
+        assert!(
+            !cmd.env.iter().any(|(k, _)| k == "AGENTOS_FAKE_MODEL"),
+            "fake-pinned must leave compose's default alone; env={:?}",
+            cmd.env
+        );
+    }
+
+    #[test]
+    fn up_default_fake_does_not_inject() {
+        let cmd = up_command(&opts(DEFAULT_COMPOSE_FILE));
+        assert!(
+            !cmd.env.iter().any(|(k, _)| k == "AGENTOS_FAKE_MODEL"),
+            "default-fake must leave compose's default alone; env={:?}",
+            cmd.env
+        );
+    }
+
+    #[test]
+    fn up_local_model_unchanged_by_model_mode() {
+        // --local-model owns the live env; a LiveFromCredential model_mode must
+        // not duplicate or override it (exactly one AGENTOS_FAKE_MODEL=0, plus the
+        // ollama routing env).
+        let mut o = opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b");
+        o.model_mode = ModelMode::LiveFromCredential;
+        let cmd = up_command(&o);
+        assert_eq!(
+            cmd.env
+                .iter()
+                .filter(|(k, _)| k == "AGENTOS_FAKE_MODEL")
+                .count(),
+            1,
+            "exactly one AGENTOS_FAKE_MODEL under --local-model; env={:?}",
+            cmd.env
+        );
+        assert!(cmd
+            .env
+            .contains(&(String::from("AGENTOS_MODEL"), String::from("qwen3:4b"))));
+        assert!(cmd.env.contains(&(
+            String::from("AGENTOS_MODEL_BASE_URL"),
+            String::from("http://ollama:11434"),
         )));
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -224,6 +224,12 @@ enum SkillAction {
 #[derive(Subcommand)]
 enum LocalAction {
     /// Bring the dev stack up (`core` with `--minimal`, else `full`) and print URLs. Add `--slack` for the optional dispatcher.
+    ///
+    /// Model parity with `agentos skill up`: `local up` runs the real model when a
+    /// model credential is present in the shell (`ANTHROPIC_API_KEY`,
+    /// `CLAUDE_CODE_OAUTH_TOKEN`, or `AGENTOS_CREDENTIALS`), and the offline fake
+    /// model otherwise. Set `AGENTOS_FAKE_MODEL=1` to force the fake even with a
+    /// credential; set `AGENTOS_FAKE_MODEL=0` (or provide a credential) to go live.
     Up {
         /// Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override.
         #[arg(short = 'f', long)]
@@ -789,6 +795,7 @@ async fn run(command: Command) -> Result<()> {
                     minimal,
                     local_model,
                     slack,
+                    model_mode: local::model_mode_from_env(),
                 })
                 .await
             }
@@ -806,6 +813,7 @@ async fn run(command: Command) -> Result<()> {
                         minimal: false,
                         local_model: None,
                         slack: false,
+                        model_mode: local::ModelMode::DefaultFake,
                     },
                     wipe,
                     yes,
@@ -820,6 +828,7 @@ async fn run(command: Command) -> Result<()> {
                     minimal: false,
                     local_model: None,
                     slack: false,
+                    model_mode: local::ModelMode::DefaultFake,
                 })
                 .await
             }

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -411,9 +411,12 @@ services:
       - AGENTOS_API_BASE_URL=http://localhost:28000
       - SLACK_API_BASE_URL=${SLACK_API_BASE_URL-http://localhost:8155/api/}
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-xoxb-dev}
-      # Fake model by default (no credential needed). For a real model set
-      # AGENTOS_FAKE_MODEL=0 and provide a credential in your SHELL (never in this
-      # file): the bare names below forward it from your environment only if set.
+      # Fake model by default (no credential needed). `agentos local up` reaches
+      # skill-tier parity: when a credential (one of the bare names below) is set
+      # in your SHELL it injects AGENTOS_FAKE_MODEL=0 automatically, so local goes
+      # live like `skill up`. Set AGENTOS_FAKE_MODEL=1 in your shell to force the
+      # fake model even with a credential. Provide credentials in the SHELL only,
+      # never in this file: the bare names below forward from your environment.
       - AGENTOS_FAKE_MODEL=${AGENTOS_FAKE_MODEL:-1}
       - ANTHROPIC_API_KEY
       - CLAUDE_CODE_OAUTH_TOKEN


### PR DESCRIPTION
## Problem
`agentos local up` silently ran the canned fake model even with a credential set, while `skill up` went live. The same credential produced different model behavior across tiers, which cost a cold-start dogfood run a full debugging cycle and briefly looked like the bundle had diverged -- undermining the parity guarantee the harness exists to prove.

## Fix (parity, the ticket's preferred option)
- `local up` now injects `AGENTOS_FAKE_MODEL=0` when a model credential (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` / `AGENTOS_CREDENTIALS`) is present in the shell, so local goes live exactly like `skill up`. The compose default stays fake when no credential is set.
- When `local up` would run fake despite a credential (`AGENTOS_FAKE_MODEL` pinned truthy), it prints an unmissable `warn`; it also notes the live/fake decision otherwise. This covers the AC's warning floor for the one residual case.
- The truthy parse mirrors the runner's exactly (`.lower() in (1/true/yes)`, no trim).
- Behavior is documented in `agentos guide` (landmine), `local up --help`, the compose comment, and the READMEs.

## Verification
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (292 pass, incl. 5 new parity tests).
- Manual dry-run: credential present -> `AGENTOS_FAKE_MODEL=0` injected; no credential -> no injection (compose default fake); credential + pinned fake -> no injection + loud warn.
- Reviewed by code-reviewer, scope-creep-reviewer, spec-vs-impl-reviewer (all pass) and a cross-model Codex pass (one P2 on the truthy-parse trim, fixed).

Closes #343