### PR TITLE
Add offline MCP load check (agentos skill check)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -15,7 +15,7 @@ disk and targets no environment.
 
 | Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
 |---|---|---|---|---|---|
-| `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
+| `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `check` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
 | `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
 | `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `deploy` `kill` `resume` `budget` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
 
@@ -116,6 +116,7 @@ HTTP surface directly. No platform, no queue, no API, no Slack, no cluster.
 | Command | What it does |
 |---|---|
 | `agentos skill up` | Boot the local runner image in Docker with the ACI boot env (runner/README.md recipe), wait for health, print the boxed env summary. `--fake-model` runs offline; `--network` and `--otel-endpoint` join the compose stack for traces; `--model <id>` forwards `AGENTOS_MODEL` (omit for the SDK default). |
+| `agentos skill check` | Run an offline, credential free MCP load check and report declared servers, matches, and verdict. |
 | `agentos skill message "..."` | Send a synthetic Slack event: POST an ACI `event` frame to the local runner and stream the NDJSON reply (text deltas, tool notes, side effect flags, final). Abort a live turn with Ctrl-C. |
 | `agentos skill eval` | Run `evals/cases.json` through the runner as `eval_case` events; prints a per case result table plus a pass or fail rollup; nonzero exit on failure. |
 | `agentos skill status` | Show the local runner's session status. |

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -201,6 +201,43 @@
           "name": "up"
         },
         {
+          "about": "Check that the bundle's MCP servers load in an offline runner container",
+          "args": [
+            {
+              "default_values": [
+                "."
+              ],
+              "global": false,
+              "help": "Plugin bundle directory",
+              "id": "plugin_dir",
+              "long": "plugin-dir",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Runner image. Defaults to the same image resolution as `skill up`",
+              "id": "image",
+              "long": "image",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "30"
+              ],
+              "global": false,
+              "help": "Check deadline in seconds, forwarded to the runner container",
+              "id": "timeout",
+              "long": "timeout",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "check"
+        },
+        {
           "about": "Stop and remove the local runner container",
           "hidden": false,
           "name": "down"

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -10,10 +10,11 @@ use std::time::{Duration, Instant};
 use agentos_aci_protocol::{Budget, EventType, OutboundEvent, SessionStatus};
 use anyhow::{bail, Context, Result};
 use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 
 use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
 use crate::bundle::pack_tar_gz;
-use crate::docker::{self, StartSpec};
+use crate::docker::{self, CheckSpec, StartSpec};
 use crate::evals::{load_suite, turn_passes};
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
@@ -70,6 +71,144 @@ pub struct StartOpts {
     pub budget: String,
     pub model: Option<String>,
     pub local_model: Option<String>,
+}
+
+/// The versioned report emitted by `agentos_runner.check`.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CheckReport {
+    pub check: String,
+    pub version: u64,
+    pub plugin_dir: String,
+    pub declared: Vec<DeclaredServer>,
+    /// Opaque pass-through of the runner's registered-server list. Never read by
+    /// the human render (only round-tripped through `--json`), so it is kept as
+    /// raw JSON: it round-trips losslessly and can never fail `parse_check_report`
+    /// on a future tool/server shape.
+    pub registered: Vec<serde_json::Value>,
+    pub matches: Vec<CheckMatch>,
+    pub verdict: String,
+    pub reasons: Vec<String>,
+    pub hints: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeclaredServer {
+    pub name: String,
+    pub source: String,
+    pub form: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CheckMatch {
+    pub declared: String,
+    pub registered: Option<String>,
+    pub connected: bool,
+    pub tool_count: u64,
+}
+
+/// Parse the frozen runner to CLI check report contract.
+pub fn parse_check_report(stdout: &str) -> Result<CheckReport> {
+    let report: CheckReport = serde_json::from_str(stdout)
+        .context("runner check output is not valid JSON for the check report contract")?;
+    if report.version != 1 {
+        bail!(
+            "runner check report contract version {} is unsupported; expected version 1",
+            report.version
+        );
+    }
+    Ok(report)
+}
+
+/// Map a runner check verdict to the CLI semantic exit contract.
+pub fn check_outcome(report: &CheckReport) -> std::result::Result<(), crate::exit::CliError> {
+    match report.verdict.as_str() {
+        "green" => Ok(()),
+        "red" => Err(crate::exit::CliError {
+            message: "MCP load check reported red".into(),
+            fix: None,
+            class: crate::exit::ExitClass::Failure,
+        }
+        .with_fix(
+            "declare MCP servers as an inline object in .claude-plugin/plugin.json (or a bare .mcp.json); run agentos skill check again",
+        )),
+        "invalid_bundle" => {
+            // An invalid bundle is a deterministic input error (exit 2, Usage),
+            // matching the runner's own `check.py` exit-2 for this verdict: the
+            // bundle dir exists but fails structural validation, so retrying the
+            // same argv fails identically. Surface the structural `reasons` so
+            // the user sees WHY the bundle is invalid.
+            let mut message = String::from("MCP load check reported an invalid bundle");
+            if !report.reasons.is_empty() {
+                message.push_str(": ");
+                message.push_str(&report.reasons.join("; "));
+            }
+            Err(crate::exit::CliError::usage(message).with_fix(
+                "fix the reported bundle-structure errors (.claude-plugin/plugin.json and skills/) and run agentos skill check again",
+            ))
+        }
+        verdict => Err(crate::exit::CliError {
+            message: format!("MCP load check reported unknown verdict '{verdict}'"),
+            fix: None,
+            class: crate::exit::ExitClass::Failure,
+        }),
+    }
+}
+
+/// Run the offline MCP load check for a plugin bundle.
+pub async fn check(plugin_dir: PathBuf, image: String, timeout_s: u64) -> Result<()> {
+    let requested_dir = plugin_dir.display().to_string();
+    let plugin_dir = plugin_dir.canonicalize().map_err(|err| {
+        crate::exit::CliError::usage(format!("plugin dir not found: {requested_dir}: {err}"))
+    })?;
+    read_manifest(&plugin_dir).map_err(|err| {
+        crate::exit::CliError::usage(format!("plugin dir is not a usable bundle: {err}"))
+    })?;
+
+    let spec = CheckSpec {
+        image,
+        plugin_dir: plugin_dir.display().to_string(),
+        timeout_s,
+    };
+    let (status, stdout, stderr) = docker::docker_capture(&spec.run_args()).await?;
+    // A container that DID run and produced parseable JSON is data (a
+    // green/red/invalid verdict) regardless of its exit code. Only when the
+    // stdout is NOT a valid report is this a real docker failure -- surface the
+    // captured stderr (e.g. "Cannot connect to the Docker daemon") so the true
+    // cause is visible instead of being dropped. Stays a plain Failure (exit 1);
+    // Transient/exit 3 is reserved for reqwest connect/timeout errors (#323).
+    let report = parse_check_report(&stdout).map_err(|err| {
+        anyhow::anyhow!(
+            "runner check output violated the check report contract: {err}; \
+             docker exited {status}; stdout: {stdout}; stderr: {stderr}"
+        )
+    })?;
+
+    let ui = crate::ui::ui();
+    if ui.json() {
+        ui.emit_json(&serde_json::to_value(&report)?);
+    } else {
+        let mut lines = vec![format!("declared: {}", report.declared.len())];
+        lines.extend(report.matches.iter().map(|entry| {
+            format!(
+                "match: {} -> {} (connected: {}, tools: {})",
+                entry.declared,
+                entry.registered.as_deref().unwrap_or("none"),
+                entry.connected,
+                entry.tool_count
+            )
+        }));
+        lines.push(format!("verdict: {}", report.verdict));
+        lines.extend(
+            report
+                .reasons
+                .iter()
+                .map(|reason| format!("reason: {reason}")),
+        );
+        lines.extend(report.hints.iter().map(|hint| format!("hint: {hint}")));
+        ui.payload_plain(&lines.join("\n"));
+    }
+
+    check_outcome(&report).map_err(anyhow::Error::from)
 }
 
 pub fn init(name: Option<String>, dir: Option<PathBuf>, from_spec: Option<PathBuf>) -> Result<()> {

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -33,6 +33,41 @@ pub struct StartSpec {
     pub passthrough_env: Vec<String>,
 }
 
+/// Everything `docker run` needs for a one shot offline MCP load check.
+#[derive(Debug, Clone)]
+pub struct CheckSpec {
+    pub image: String,
+    pub plugin_dir: String,
+    pub timeout_s: u64,
+}
+
+impl CheckSpec {
+    /// The one shot check container argv (after the `docker` executable).
+    pub fn run_args(&self) -> Vec<String> {
+        vec![
+            "run".into(),
+            "--rm".into(),
+            // Offline contract: the check must never reach the network. A bundle
+            // with a remote (`url:`) MCP server, or a stdio server that phones
+            // home at startup, must fail (red) rather than pass by connecting
+            // out. `--network none` is empirically verified NOT to break the
+            // legitimate in-bundle stdio-server case.
+            "--network".into(),
+            "none".into(),
+            "-v".into(),
+            format!("{}:/plugin:ro", self.plugin_dir),
+            "-e".into(),
+            "AGENTOS_PLUGIN_DIR=/plugin".into(),
+            "-e".into(),
+            format!("AGENTOS_CHECK_TIMEOUT_S={}", self.timeout_s),
+            self.image.clone(),
+            "python".into(),
+            "-m".into(),
+            "agentos_runner.check".into(),
+        ]
+    }
+}
+
 impl StartSpec {
     /// The `docker run` argument vector (after the `docker` executable).
     pub fn run_args(&self) -> Vec<String> {
@@ -87,20 +122,34 @@ impl StartSpec {
 
 /// Run a docker subcommand, returning trimmed stdout; stderr on failure.
 pub async fn docker(args: &[String]) -> Result<String> {
+    let (status, stdout, stderr) = docker_capture(args).await?;
+    if !status.success() {
+        bail!(
+            "docker {} failed ({}): {}",
+            args.first().map(String::as_str).unwrap_or(""),
+            status,
+            stderr
+        );
+    }
+    Ok(stdout)
+}
+
+/// Run a docker subcommand and capture its status plus both output streams.
+///
+/// A check container's nonzero verdict is data, so unlike [`docker`] this does
+/// not turn an unsuccessful child exit into an error. Failure to invoke Docker
+/// remains an error.
+pub async fn docker_capture(args: &[String]) -> Result<(std::process::ExitStatus, String, String)> {
     let output = Command::new("docker")
         .args(args)
         .output()
         .await
         .context("failed to invoke docker; is Docker installed and on PATH?")?;
-    if !output.status.success() {
-        bail!(
-            "docker {} failed ({}): {}",
-            args.first().map(String::as_str).unwrap_or(""),
-            output.status,
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    Ok((
+        output.status,
+        String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        String::from_utf8_lossy(&output.stderr).trim().to_string(),
+    ))
 }
 
 /// Create a docker network. Returns `Ok(true)` when this call created it and

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -89,6 +89,13 @@ pub fn primer() -> Primer {
             },
             Rung {
                 tier: "skill",
+                command: "agentos skill check",
+                purpose: "Prove the bundle's MCP tools actually load -- offline, no credential. \
+                          A green --fake-model does NOT cover this (the fake model never calls \
+                          MCP tools).",
+            },
+            Rung {
+                tier: "skill",
                 command: "agentos skill eval",
                 purpose: "Run evals/cases.json in-process. This is the promotion gate; it must be green.",
             },
@@ -168,7 +175,7 @@ pub fn primer() -> Primer {
             },
             Landmine {
                 title: "MCP servers must be inline objects in .mcp.json",
-                detail: "A string-pointer declaration silently fails to load; use the bare inline object form.",
+                detail: "A string-pointer declaration silently fails to load; use the bare inline object form. Run `agentos skill check` to catch this offline before deploy.",
             },
             Landmine {
                 title: "In-cluster sandboxes need dnsPolicy ClusterFirst",
@@ -195,6 +202,10 @@ pub fn primer() -> Primer {
             Recovery {
                 symptom: "\"(no response)\" or an empty reply",
                 fix: "You are on the fake model (--fake-model, or a sealed install). Provide a credential to go live.",
+            },
+            Recovery {
+                symptom: "the agent answers but never calls your MCP tools",
+                fix: "Run `agentos skill check` -- a RED verdict names the server that failed to load and how to fix the declaration.",
             },
             Recovery {
                 symptom: "a command \"does not exist\"",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -186,6 +186,18 @@ enum SkillAction {
         )]
         local_model: Option<String>,
     },
+    /// Check that the bundle's MCP servers load in an offline runner container.
+    Check {
+        /// Plugin bundle directory.
+        #[arg(long, default_value = ".")]
+        plugin_dir: PathBuf,
+        /// Runner image. Defaults to the same image resolution as `skill up`.
+        #[arg(long)]
+        image: Option<String>,
+        /// Check deadline in seconds, forwarded to the runner container.
+        #[arg(long, default_value_t = 30)]
+        timeout: u64,
+    },
     /// Stop and remove the local runner container.
     Down,
     /// Show the local runner's session status.
@@ -763,6 +775,18 @@ async fn run(command: Command) -> Result<()> {
                     local_model,
                 })
                 .await
+            }
+            SkillAction::Check {
+                plugin_dir,
+                image,
+                timeout,
+            } => {
+                let image = artifacts::resolve_image(
+                    image.as_deref(),
+                    artifacts::Channel::current(),
+                    artifacts::version(),
+                );
+                commands::check(plugin_dir, image, timeout).await
             }
             SkillAction::Down => commands::stop().await,
             SkillAction::Status { url } => commands::status(url).await,

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -35,6 +35,7 @@ fn process_help_routes_positive_forms() {
         &["skill", "status"],
         &["skill", "message"],
         &["skill", "eval"],
+        &["skill", "check"],
         &["local", "up"],
         &["local", "down"],
         &["local", "status"],

--- a/cli/tests/skill_check.rs
+++ b/cli/tests/skill_check.rs
@@ -1,0 +1,298 @@
+//! Stream B tests for `agentos skill check` (issue #337): the offline,
+//! credential-free MCP load check.
+//!
+//! These pin the frozen Section-3 runner<->CLI JSON seam and the docker argv
+//! for the one-shot check container. They are written test-first: the public
+//! API they reference (`docker::CheckSpec`, `commands::parse_check_report`,
+//! `commands::check_outcome`, `commands::CheckReport`) does not exist yet, so
+//! this binary fails to compile until the Implementer adds it. That RED state
+//! is the intended contract handoff.
+
+use agentos::commands::{check_outcome, parse_check_report};
+use agentos::docker::CheckSpec;
+use agentos::exit::ExitClass;
+
+/// A realistic green seam payload (Section 3): declared server registered as a
+/// connected, plugin-owned (`scope: "dynamic"`) server with tools.
+const GREEN_JSON: &str = r#"{
+  "check": "mcp-load",
+  "version": 1,
+  "plugin_dir": "/plugin",
+  "declared": [
+    { "name": "text-stats-engine", "source": "plugin.json", "form": "inline" }
+  ],
+  "registered": [
+    {
+      "name": "plugin:text-stats-engine:text-stats-engine",
+      "status": "connected",
+      "tools": ["count_words", "top_words"],
+      "error": null,
+      "scope": "dynamic"
+    }
+  ],
+  "matches": [
+    { "declared": "text-stats-engine", "registered": "plugin:text-stats-engine:text-stats-engine", "connected": true, "tool_count": 2 }
+  ],
+  "verdict": "green",
+  "reasons": [],
+  "hints": []
+}"#;
+
+/// A realistic red seam payload (Section 3): the #336 string-pointer form, whose
+/// declared server never registers. `reasons` non-empty; the inline-object
+/// fingerprint rides in `hints`.
+const RED_JSON: &str = r#"{
+  "check": "mcp-load",
+  "version": 1,
+  "plugin_dir": "/plugin",
+  "declared": [
+    { "name": "text-stats-engine", "source": "plugin.json", "form": "string_pointer" }
+  ],
+  "registered": [],
+  "matches": [
+    { "declared": "text-stats-engine", "registered": null, "connected": false, "tool_count": 0 }
+  ],
+  "verdict": "red",
+  "reasons": [
+    "declared text-stats-engine never registered",
+    "declared 1 MCP server(s); none registered with tools"
+  ],
+  "hints": [
+    "plugin.json 'mcpServers' is a string pointer; the real loader silently ignores this form — inline the object"
+  ]
+}"#;
+
+/// The verbatim runner shape: `registered[].tools` items are SDK `McpToolInfo`
+/// OBJECTS (`{"name": ..., "annotations"?: ...}`), NOT strings. This is the real
+/// contract the runner emits; it must parse and map to Ok.
+const GREEN_OBJECT_TOOLS_JSON: &str = r#"{
+  "check": "mcp-load",
+  "version": 1,
+  "plugin_dir": "/plugin",
+  "declared": [
+    { "name": "mcp-green", "source": "plugin.json", "form": "inline" }
+  ],
+  "registered": [
+    {
+      "name": "plugin:mcp-green:green-probe",
+      "status": "connected",
+      "serverInfo": { "name": "mcp-green-probe", "version": "1.28.1" },
+      "scope": "dynamic",
+      "tools": [ { "name": "word_count", "annotations": {} } ]
+    }
+  ],
+  "matches": [
+    { "declared": "mcp-green", "registered": "plugin:mcp-green:green-probe", "connected": true, "tool_count": 1 }
+  ],
+  "verdict": "green",
+  "reasons": [],
+  "hints": []
+}"#;
+
+/// A realistic invalid-bundle seam payload (Section 3): the bundle dir exists
+/// but fails structural `plugin_format` validation, which the runner reports as
+/// `verdict: "invalid_bundle"` with the validation errors in `reasons`. The CLI
+/// must map this to a Usage error (exit 2), matching the runner's own exit 2.
+const INVALID_BUNDLE_JSON: &str = r#"{
+  "check": "mcp-load",
+  "version": 1,
+  "plugin_dir": "/plugin",
+  "declared": [],
+  "registered": [],
+  "matches": [],
+  "verdict": "invalid_bundle",
+  "reasons": [
+    "skills/: no SKILL.md found for declared skill 'text-stats'",
+    ".claude-plugin/plugin.json: 'name' is required"
+  ],
+  "hints": []
+}"#;
+
+/// A future-version payload the CLI must hard-fail on (Section 7(e)).
+const VERSION_2_JSON: &str = r#"{
+  "check": "mcp-load",
+  "version": 2,
+  "plugin_dir": "/plugin",
+  "declared": [],
+  "registered": [],
+  "matches": [],
+  "verdict": "green",
+  "reasons": [],
+  "hints": []
+}"#;
+
+// --- Test 6: CheckSpec::run_args exact argv --------------------------------
+
+#[test]
+fn check_run_args_are_the_exact_offline_argv() {
+    let spec = CheckSpec {
+        image: "agentos-runner".into(),
+        plugin_dir: "/tmp/deal-desk".into(),
+        timeout_s: 30,
+    };
+    let args = spec.run_args();
+
+    // The argv MUST be exactly this vector, in this order.
+    let expected: Vec<String> = [
+        "run",
+        "--rm",
+        "--network",
+        "none",
+        "-v",
+        "/tmp/deal-desk:/plugin:ro",
+        "-e",
+        "AGENTOS_PLUGIN_DIR=/plugin",
+        "-e",
+        "AGENTOS_CHECK_TIMEOUT_S=30",
+        "agentos-runner",
+        "python",
+        "-m",
+        "agentos_runner.check",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    assert_eq!(
+        args, expected,
+        "check run_args drifted from the frozen argv"
+    );
+
+    let joined = args.join(" ");
+    // Offline contract: the check container is network-isolated.
+    assert!(
+        joined.contains("--network none"),
+        "check must run with --network none (offline contract)"
+    );
+    // Read-only bundle mount.
+    assert!(joined.contains("-v /tmp/deal-desk:/plugin:ro"));
+    // The timeout is plumbed through as the container deadline.
+    assert!(joined.contains("-e AGENTOS_CHECK_TIMEOUT_S=30"));
+    // The CMD override runs check mode, not the ACI session entrypoint.
+    assert!(joined.ends_with("python -m agentos_runner.check"));
+
+    // Absence: check mode is not an ACI session and carries no credentials.
+    assert!(!joined.contains("-p "), "check must not publish a port");
+    assert!(
+        !args.iter().any(|a| a == "-p"),
+        "check must not publish a port"
+    );
+    assert!(
+        !joined.contains("--name"),
+        "check is one-shot, no container name"
+    );
+    assert!(!joined.contains("AGENTOS_SESSION_ID"));
+    assert!(!joined.contains("AGENTOS_SANDBOX_ID"));
+    assert!(!joined.contains("AGENTOS_BUDGET"));
+    assert!(!joined.contains("AGENTOS_FAKE_MODEL"));
+    // No credential env of any kind (spike-verified credential-free connect).
+    assert!(!joined.contains("ANTHROPIC"));
+    assert!(!joined.contains("CLAUDE_CODE_OAUTH_TOKEN"));
+    assert!(!joined.contains("API_KEY"));
+}
+
+#[test]
+fn check_run_args_carry_the_specced_timeout() {
+    let spec = CheckSpec {
+        image: "ghcr.io/example/agentos-runner:1.2.3".into(),
+        plugin_dir: "/work/bundle".into(),
+        timeout_s: 45,
+    };
+    let joined = spec.run_args().join(" ");
+    assert!(joined.contains("-e AGENTOS_CHECK_TIMEOUT_S=45"));
+    assert!(joined.contains("-v /work/bundle:/plugin:ro"));
+    assert!(joined.contains("ghcr.io/example/agentos-runner:1.2.3"));
+}
+
+// --- Test 7: verdict-JSON -> outcome mapping -------------------------------
+
+#[test]
+fn green_report_parses_and_maps_to_ok() {
+    let report = parse_check_report(GREEN_JSON).expect("green seam JSON parses");
+    assert_eq!(report.version, 1);
+    assert_eq!(report.verdict, "green");
+    assert!(report.reasons.is_empty(), "green carries no reasons");
+
+    check_outcome(&report).expect("a green verdict maps to Ok(())");
+}
+
+#[test]
+fn green_report_with_object_tools_parses_and_maps_to_ok() {
+    // Guards the real runner seam: `tools` items are McpToolInfo objects, not
+    // strings. `registered` is opaque pass-through JSON, so any tool/server
+    // shape parses cleanly (the whole tools-shape bug class is eliminated).
+    let report =
+        parse_check_report(GREEN_OBJECT_TOOLS_JSON).expect("object-tools seam JSON parses");
+    assert_eq!(report.version, 1);
+    assert_eq!(report.verdict, "green");
+    assert_eq!(report.registered.len(), 1);
+    assert!(
+        !report.registered.is_empty(),
+        "the object-shaped registered server round-trips through opaque JSON"
+    );
+
+    check_outcome(&report).expect("a green verdict with object tools maps to Ok(())");
+}
+
+#[test]
+fn red_report_maps_to_failure_with_a_fix_hint() {
+    let report = parse_check_report(RED_JSON).expect("red seam JSON parses");
+    assert_eq!(report.verdict, "red");
+    assert!(!report.reasons.is_empty(), "red must carry reasons");
+
+    let err = check_outcome(&report).expect_err("a red verdict maps to Err");
+    assert_eq!(
+        err.class,
+        ExitClass::Failure,
+        "red is a plain Failure (exit 1)"
+    );
+    let fix = err
+        .fix
+        .expect("red outcome must carry an actionable fix hint");
+    assert!(!fix.trim().is_empty(), "the fix hint must be non-empty");
+}
+
+#[test]
+fn invalid_bundle_report_maps_to_usage_exit_2_with_reasons() {
+    let report = parse_check_report(INVALID_BUNDLE_JSON).expect("invalid_bundle seam JSON parses");
+    assert_eq!(report.verdict, "invalid_bundle");
+    assert!(
+        !report.reasons.is_empty(),
+        "invalid_bundle must carry structural reasons"
+    );
+
+    let err = check_outcome(&report).expect_err("an invalid_bundle verdict maps to Err");
+    assert_eq!(
+        err.class,
+        ExitClass::Usage,
+        "invalid_bundle is a Usage error (exit 2), matching the runner's exit 2"
+    );
+    // The structural validation errors must surface in the message so the user
+    // sees WHY the bundle is invalid.
+    assert!(
+        err.message
+            .contains("no SKILL.md found for declared skill 'text-stats'"),
+        "the message must carry the structural reasons, got: {}",
+        err.message
+    );
+    let fix = err
+        .fix
+        .expect("invalid_bundle outcome must carry an actionable fix hint");
+    assert!(!fix.trim().is_empty(), "the fix hint must be non-empty");
+}
+
+#[test]
+fn version_mismatch_is_a_parse_error_naming_the_contract() {
+    let err = parse_check_report(VERSION_2_JSON)
+        .expect_err("a version != 1 payload must hard-fail the parse");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("version") || msg.contains("contract"),
+        "the version-drift error must name the version/contract, got: {msg}"
+    );
+}
+
+#[test]
+fn garbage_stdout_is_a_parse_error() {
+    parse_check_report("this is not json at all {{{")
+        .expect_err("unparseable stdout must be an error, not a silent green");
+}

--- a/runner/README.md
+++ b/runner/README.md
@@ -76,6 +76,34 @@ curl -sN -X POST http://localhost:18080/v1/event -H 'Content-Type: application/j
   -d '{"kind":"event","type":"message","text":"hi","user":"U","ts":"1.0"}'
 ```
 
+## MCP load check (offline, credential-free)
+
+`python -m agentos_runner.check` is a separate, one-shot entrypoint (issue #337)
+that answers "do this bundle's MCP tools actually load?" without a model turn. It
+validates the bundle via the frozen `load_plugins`, then builds a real
+`ClaudeSDKClient` and `connect()`s (no query), polls `get_mcp_status()` until the
+bundle's own servers settle, and compares the **declared** servers against the
+plugin-owned **registered** ones. It reads `AGENTOS_PLUGIN_DIR` (and optional
+`AGENTOS_CHECK_TIMEOUT_S`, default 30); it forwards and reads **no** credential.
+
+```bash
+AGENTOS_PLUGIN_DIR=/plugin python -m agentos_runner.check
+```
+
+It prints exactly one JSON object to **stdout** (all logging goes to **stderr**)
+and exits with the verdict code:
+
+- `0` green: every declared MCP server registered connected with at least one tool
+- `1` red: a declared server failed to load (never registered, connected with zero
+  tools, `failed`/`needs-auth`/`pending` at the deadline, or the init timed out)
+- `2` invalid_bundle: the bundle fails `plugin_format` validation or the plugin dir
+  is missing
+
+The JSON shape (frozen contract) is `{check, version, plugin_dir, declared,
+registered, matches, verdict, reasons, hints}`; `reasons` is non-empty iff the
+verdict is not green, and the #336 string-pointer fingerprint surfaces in `hints`.
+The `agentos skill check` CLI verb wraps this as a one-shot container.
+
 ## Verify (from repo root)
 
 ```bash

--- a/runner/src/agentos_runner/check.py
+++ b/runner/src/agentos_runner/check.py
@@ -1,0 +1,348 @@
+"""Offline, credential-free MCP load check (issue #337).
+
+Run as ``python -m agentos_runner.check`` with ``AGENTOS_PLUGIN_DIR`` pointing at a
+Claude Code plugin bundle. The check:
+
+1. validates the bundle via the frozen ``load_plugins`` (``PluginBundleError`` ->
+   ``invalid_bundle``),
+2. parses the bundle's **declared** MCP servers (``extract_declared``),
+3. builds a real ``ClaudeSDKClient`` via ``build_options`` and ``connect()`` -- no
+   query, no model turn -- then polls ``get_mcp_status()`` until the bundle's own
+   servers settle, and
+4. compares declared intent against the plugin-owned registered servers
+   (``evaluate``), emitting exactly one JSON object to **stdout** (all logging to
+   **stderr**) and exiting 0 (green) / 1 (red) / 2 (invalid_bundle).
+
+There is **no credential path**: the spike verified ``connect()`` succeeds with
+zero credential and an empty HOME, and this module never issues a ``query()``.
+The runner<->CLI JSON seam is frozen in the plan (Section 3).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from claude_agent_sdk import ClaudeSDKClient
+
+from .adapter import build_options
+from .plugin import PluginBundleError, load_plugins
+
+logger = logging.getLogger(__name__)
+
+CHECK_NAME = "mcp-load"
+CHECK_VERSION = 1
+_DEFAULT_TIMEOUT_S = 30
+_POLL_INTERVAL_S = 1.0
+
+_STRING_POINTER_HINT = (
+    "plugin.json 'mcpServers' is a string pointer; the real loader silently "
+    "ignores this form — inline the object"
+)
+
+_EXIT_CODES = {"green": 0, "red": 1, "invalid_bundle": 2}
+
+
+# --------------------------------------------------------------------------- #
+# Declared-server extraction (bundle intent)
+# --------------------------------------------------------------------------- #
+def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
+    """Parse the bundle's declared MCP servers into ``{name, source, form}`` rows.
+
+    Covers all three declaration forms (plan Section 3): a ``plugin.json``
+    ``mcpServers`` object (``inline``), a ``mcpServers`` string pointer resolved
+    relative to the bundle root (``string_pointer``; a missing pointed file still
+    surfaces the intent), and a bare-root ``.mcp.json`` (``bare_file``, deduped by
+    name against the above).
+    """
+
+    root = Path(plugin_dir)
+    declared: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def _add(name: str, source: str, form: str) -> None:
+        if name not in seen:
+            declared.append({"name": name, "source": source, "form": form})
+            seen.add(name)
+
+    manifest = _read_json(root / ".claude-plugin" / "plugin.json")
+    mcp = manifest.get("mcpServers") if isinstance(manifest, dict) else None
+
+    if isinstance(mcp, dict):
+        for name in mcp:
+            _add(str(name), "plugin.json", "inline")
+    elif isinstance(mcp, str):
+        pointed = _read_json(root / mcp)
+        names = _server_names(pointed)
+        if names:
+            for name in names:
+                _add(name, "plugin.json", "string_pointer")
+        else:
+            # Pointed file missing/unparseable: the intent (a string-pointer
+            # declaration) still surfaces so the caller can drive a red verdict.
+            manifest_name = manifest.get("name") if isinstance(manifest, dict) else None
+            fallback = str(manifest_name) if manifest_name else mcp
+            _add(fallback, "plugin.json", "string_pointer")
+
+    bare = _read_json(root / ".mcp.json")
+    for name in _server_names(bare):
+        _add(name, ".mcp.json", "bare_file")
+
+    return declared
+
+
+def _server_names(payload: Any) -> list[str]:
+    if isinstance(payload, dict):
+        servers = payload.get("mcpServers")
+        if isinstance(servers, dict):
+            return [str(name) for name in servers]
+    return []
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Verdict (pure: no I/O, no SDK)
+# --------------------------------------------------------------------------- #
+def evaluate(
+    declared: list[dict[str, Any]], registered: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Compute the verdict from declared intent vs registered MCP servers.
+
+    The registered list is ``McpServerStatus``-shaped. Only the bundle's **own**
+    servers (``scope == "dynamic"`` or a ``plugin:``-prefixed name when scope is
+    absent) affect the verdict; ambient project/user servers never do. The rule is
+    declared-anchored: one match row per declared server, green iff every declared
+    server matched a connected own-server with at least one tool (plan Section 3).
+    """
+
+    own = [s for s in registered if _plugin_owned(s)]
+    matches: list[dict[str, Any]] = []
+    reasons: list[str] = []
+    hints: list[str] = []
+
+    if any(d.get("form") == "string_pointer" for d in declared):
+        hints.append(_STRING_POINTER_HINT)
+
+    connected_with_tools = 0
+    for row in declared:
+        name = str(row["name"])
+        match = _find_match(name, own)
+        tool_count = len(match.get("tools") or []) if match is not None else 0
+        connected = match is not None and match.get("status") == "connected" and tool_count >= 1
+        if connected:
+            connected_with_tools += 1
+        else:
+            reasons.append(_reason_for(name, match))
+        matches.append(
+            {
+                "declared": name,
+                "registered": match["name"] if match is not None else None,
+                "connected": connected,
+                "tool_count": tool_count,
+            }
+        )
+
+    if declared and connected_with_tools == 0:
+        reasons.append(
+            f"declared {len(declared)} MCP server(s); none registered with tools"
+        )
+
+    verdict = "red" if reasons else "green"
+    return {"matches": matches, "verdict": verdict, "reasons": reasons, "hints": hints}
+
+
+def _plugin_owned(status: dict[str, Any]) -> bool:
+    scope = status.get("scope")
+    if scope == "dynamic":
+        return True
+    return scope is None and str(status.get("name", "")).startswith("plugin:")
+
+
+def _find_match(name: str, own: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for server in own:
+        registered_name = str(server.get("name", ""))
+        if registered_name == name or registered_name.endswith(":" + name):
+            return server
+    return None
+
+
+def _reason_for(name: str, match: dict[str, Any] | None) -> str:
+    if match is None:
+        return f"declared {name} never registered"
+    status = match.get("status")
+    if status == "failed":
+        error = match.get("error")
+        return str(error) if error else f"declared {name} failed to connect"
+    if status == "pending":
+        return f"declared {name} did not finish initializing"
+    if status == "needs-auth":
+        return (
+            f"declared {name} needs authentication; the offline check is "
+            "credential-free and cannot validate a credential-gated server"
+        )
+    if status == "connected":
+        return f"declared {name} connected with zero tools"
+    return f"declared {name} registered with status {status!r} and no tools"
+
+
+# --------------------------------------------------------------------------- #
+# Real-loader run
+# --------------------------------------------------------------------------- #
+async def run_check(plugin_dir: str) -> dict[str, Any]:
+    """Validate, connect, poll, and assemble the full Section-3 result dict."""
+
+    try:
+        plugins = load_plugins(plugin_dir)
+    except PluginBundleError as exc:
+        return _invalid_bundle_result(plugin_dir, [str(exc)])
+
+    declared = extract_declared(plugin_dir)
+    timeout_s = _timeout_s()
+
+    try:
+        registered = await asyncio.wait_for(_connect_and_poll(plugins), timeout_s)
+    except TimeoutError:
+        return _red_result(
+            plugin_dir, declared, f"MCP init did not complete within {timeout_s}s"
+        )
+    except Exception as exc:
+        # A non-timeout failure while setting up the MCP client (Claude CLI
+        # subprocess fails to start, an incompatible --image, an SDK error)
+        # would otherwise escape main() before any JSON is printed, and the CLI
+        # would report an opaque contract violation. Surface it as a valid RED
+        # result naming the failure instead of swallowing it. A genuinely
+        # malformed bundle is still invalid_bundle (caught above), not red.
+        return _red_result(
+            plugin_dir,
+            declared,
+            f"MCP client failed to start: {type(exc).__name__}: {exc}",
+        )
+
+    return _assemble(plugin_dir, declared, registered, evaluate(declared, registered))
+
+
+def _red_result(
+    plugin_dir: str, declared: list[dict[str, Any]], reason: str
+) -> dict[str, Any]:
+    """Assemble a RED result (no registered servers) with a single override reason.
+
+    Shared by the timeout and MCP-client-startup failure paths in ``run_check``:
+    both assemble the base result from empty registered servers, then force the
+    verdict red with their own single reason string.
+    """
+
+    result = _assemble(plugin_dir, declared, [], evaluate(declared, []))
+    result["verdict"] = "red"
+    result["reasons"] = [reason]
+    return result
+
+
+async def _connect_and_poll(plugins: list[Any]) -> list[dict[str, Any]]:
+    """Connect a real client and poll get_mcp_status until own servers settle.
+
+    Runs no query. Returns the verbatim ``mcpServers`` list once no plugin-owned
+    server is still ``pending`` (ambient servers included for transparency). The
+    caller wraps this in ``asyncio.wait_for``; ``disconnect()`` runs on every path.
+    """
+
+    options = build_options(
+        plugins=plugins,
+        model=None,
+        system_prompt=None,
+        max_turns=1,
+        max_budget_usd=None,
+        resume=None,
+    )
+    client = ClaudeSDKClient(options)
+    await client.connect()
+    try:
+        while True:
+            status = await client.get_mcp_status()
+            servers = [dict(s) for s in status.get("mcpServers", [])]
+            pending = [
+                s
+                for s in servers
+                if _plugin_owned(s) and s.get("status") == "pending"
+            ]
+            if not pending:
+                return servers
+            await asyncio.sleep(_POLL_INTERVAL_S)
+    finally:
+        await client.disconnect()
+
+
+def _assemble(
+    plugin_dir: str,
+    declared: list[dict[str, Any]],
+    registered: list[dict[str, Any]],
+    verdict: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "check": CHECK_NAME,
+        "version": CHECK_VERSION,
+        "plugin_dir": plugin_dir,
+        "declared": declared,
+        "registered": registered,
+        "matches": verdict["matches"],
+        "verdict": verdict["verdict"],
+        "reasons": verdict["reasons"],
+        "hints": verdict["hints"],
+    }
+
+
+def _invalid_bundle_result(plugin_dir: str, reasons: list[str]) -> dict[str, Any]:
+    return {
+        "check": CHECK_NAME,
+        "version": CHECK_VERSION,
+        "plugin_dir": plugin_dir,
+        "declared": [],
+        "registered": [],
+        "matches": [],
+        "verdict": "invalid_bundle",
+        "reasons": reasons,
+        "hints": [],
+    }
+
+
+def _timeout_s() -> int:
+    raw = os.environ.get("AGENTOS_CHECK_TIMEOUT_S")
+    if not raw:
+        return _DEFAULT_TIMEOUT_S
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_TIMEOUT_S
+    return value if value > 0 else _DEFAULT_TIMEOUT_S
+
+
+# --------------------------------------------------------------------------- #
+# Module entry
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+    plugin_dir = os.environ.get("AGENTOS_PLUGIN_DIR")
+    if not plugin_dir or not Path(plugin_dir).is_dir():
+        result = _invalid_bundle_result(
+            plugin_dir or "", [f"plugin dir not found: {plugin_dir!r}"]
+        )
+        print(json.dumps(result))
+        return _EXIT_CODES["invalid_bundle"]
+
+    result = asyncio.run(run_check(plugin_dir))
+    print(json.dumps(result))
+    return _EXIT_CODES.get(str(result["verdict"]), 1)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/runner/tests/fixtures/mcp_green/.claude-plugin/plugin.json
+++ b/runner/tests/fixtures/mcp_green/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcp-green",
+  "version": "0.1.0",
+  "description": "Valid bundle: one inline stdio MCP server that registers a single tool.",
+  "mcpServers": {
+    "green-probe": {
+      "command": "python3",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/probe_server.py"]
+    }
+  }
+}

--- a/runner/tests/fixtures/mcp_green/scripts/probe_server.py
+++ b/runner/tests/fixtures/mcp_green/scripts/probe_server.py
@@ -1,0 +1,20 @@
+"""Tiny stdio MCP server for the mcp_green fixture: exposes exactly one tool.
+
+Copied/adapted from the plan's verified reference server; used by the real
+loader (Claude Code CLI --plugin-dir) to prove that a well-formed inline
+mcpServers declaration actually spawns and registers a tool.
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("mcp-green-probe")
+
+
+@mcp.tool()
+def word_count(text: str) -> int:
+    """Count whitespace-separated words."""
+    return len(text.split())
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/runner/tests/fixtures/mcp_green/skills/green/SKILL.md
+++ b/runner/tests/fixtures/mcp_green/skills/green/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: green
+description: Placeholder skill so the bundle passes plugin-format validation.
+allowed-tools: []
+---
+
+# Green
+
+Placeholder skill body; the bundle exists to exercise MCP tool loading.

--- a/runner/tests/fixtures/mcp_red_broken/.claude-plugin/plugin.json
+++ b/runner/tests/fixtures/mcp_red_broken/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "mcp-red-broken",
+  "version": "0.1.0",
+  "description": "Inline MCP server whose command exits immediately, so it reaches status failed.",
+  "mcpServers": {
+    "broken-probe": {
+      "command": "false"
+    }
+  }
+}

--- a/runner/tests/fixtures/mcp_red_broken/skills/broken/SKILL.md
+++ b/runner/tests/fixtures/mcp_red_broken/skills/broken/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: broken
+description: Placeholder skill so the bundle passes plugin-format validation.
+allowed-tools: []
+---
+
+# Broken
+
+Placeholder skill body; the inline MCP server exits immediately and reaches status failed.

--- a/runner/tests/fixtures/mcp_red_pointer/.claude-plugin/plugin.json
+++ b/runner/tests/fixtures/mcp_red_pointer/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "mcp-red-pointer",
+  "version": "0.1.0",
+  "description": "Mirrors #336: mcpServers is a string pointer to a non-root file, silently ignored by the real loader.",
+  "mcpServers": "config/mcp.json"
+}

--- a/runner/tests/fixtures/mcp_red_pointer/config/mcp.json
+++ b/runner/tests/fixtures/mcp_red_pointer/config/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "pointer-probe": {
+      "command": "python3",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/probe_server.py"]
+    }
+  }
+}

--- a/runner/tests/fixtures/mcp_red_pointer/skills/red/SKILL.md
+++ b/runner/tests/fixtures/mcp_red_pointer/skills/red/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: red
+description: Placeholder skill so the bundle passes plugin-format validation.
+allowed-tools: []
+---
+
+# Red
+
+Placeholder skill body; the bundle's MCP declaration is the broken string-pointer form.

--- a/runner/tests/test_check.py
+++ b/runner/tests/test_check.py
@@ -1,0 +1,335 @@
+"""Tests for the offline MCP load check (`agentos_runner.check`, issue #337).
+
+Test-first: these pin the frozen runner<->CLI JSON seam (plan Section 3) and the
+verdict rules. Until ``check.py`` exists the module import fails collection --
+that is the intended red for the Stage-2 test-writer pass.
+
+Mocking discipline (plan Section 5): nothing here is mocked. Tests 1-3 are pure
+functions over real fixture dirs and literal ``McpServerStatus``-shaped dicts;
+test 4 runs the module as a subprocess; test 5 drives the *real* Claude Code
+loader (gated on the ``claude`` CLI being present).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import anyio
+import pytest
+from agentos_runner.check import evaluate, extract_declared, run_check
+
+_HERE = Path(__file__).resolve().parent
+_FIXTURES = _HERE / "fixtures"
+_MCP_GREEN = _FIXTURES / "mcp_green"
+_MCP_RED_POINTER = _FIXTURES / "mcp_red_pointer"
+_MCP_RED_BROKEN = _FIXTURES / "mcp_red_broken"
+_PLUGIN_FORMAT_FIXTURES = _HERE.parents[1] / "packages/plugin-format/tests/fixtures"
+
+_CLAUDE_ON_PATH = shutil.which("claude") is not None
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _declared(name: str, source: str = "plugin.json", form: str = "inline") -> dict:
+    return {"name": name, "source": source, "form": form}
+
+
+def _tool(name: str) -> dict:
+    return {"name": name}
+
+
+def _status(
+    name: str,
+    *,
+    status: str = "connected",
+    scope: str | None = "dynamic",
+    tools: list[dict] | None = None,
+    error: str | None = None,
+) -> dict:
+    entry: dict = {"name": name, "status": status, "tools": list(tools or [])}
+    if scope is not None:
+        entry["scope"] = scope
+    if error is not None:
+        entry["error"] = error
+    return entry
+
+
+def _write_bundle(
+    root: Path, manifest: dict, *, mcp_files: dict[str, dict] | None = None
+) -> Path:
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+    for rel, payload in (mcp_files or {}).items():
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(payload), encoding="utf-8")
+    return root
+
+
+# --------------------------------------------------------------------------- #
+# Test 1 -- declared extraction over real bundle dirs (no mocks)
+# --------------------------------------------------------------------------- #
+def test_extract_inline_object_form() -> None:
+    # Canonical declared shape: exactly {name, source, form}, nothing else.
+    assert extract_declared(str(_MCP_GREEN)) == [
+        {"name": "green-probe", "source": "plugin.json", "form": "inline"}
+    ]
+
+
+def test_extract_string_pointer_form() -> None:
+    declared = extract_declared(str(_MCP_RED_POINTER))
+    by_name = {d["name"]: d for d in declared}
+    assert "pointer-probe" in by_name
+    assert by_name["pointer-probe"]["form"] == "string_pointer"
+    assert by_name["pointer-probe"]["source"] == "plugin.json"
+
+
+def test_extract_string_pointer_missing_file_is_red_path(tmp_path: Path) -> None:
+    # Intent still surfaces (a string-pointer declaration is visible) even though
+    # the pointed file does not exist; and the missing target drives a red verdict.
+    bundle = _write_bundle(
+        tmp_path / "missing_ptr", {"name": "missing-ptr", "mcpServers": "config/nope.json"}
+    )
+    declared = extract_declared(str(bundle))
+    assert declared, "a string-pointer declaration must still surface as a declared entry"
+    assert all(d["form"] == "string_pointer" for d in declared)
+    result = evaluate(declared, [])
+    assert result["verdict"] == "red"
+    assert result["reasons"]
+
+
+def test_extract_bare_mcp_json_form(tmp_path: Path) -> None:
+    bundle = _write_bundle(
+        tmp_path / "bare",
+        {"name": "bare-bundle"},
+        mcp_files={".mcp.json": {"mcpServers": {"bare-probe": {"command": "python3"}}}},
+    )
+    declared = extract_declared(str(bundle))
+    by_name = {d["name"]: d for d in declared}
+    assert "bare-probe" in by_name
+    assert by_name["bare-probe"]["form"] == "bare_file"
+    assert by_name["bare-probe"]["source"] == ".mcp.json"
+
+
+def test_extract_no_mcp_anywhere_is_empty(tmp_path: Path) -> None:
+    bundle = _write_bundle(tmp_path / "nomcp", {"name": "no-mcp-bundle"})
+    assert extract_declared(str(bundle)) == []
+
+
+# --------------------------------------------------------------------------- #
+# Test 2 -- verdict pure function over literal McpServerStatus-shaped dicts
+# --------------------------------------------------------------------------- #
+def test_verdict_zero_declared_is_green() -> None:
+    result = evaluate([], [_status("plugin:x:y", tools=[_tool("t")])])
+    assert result["verdict"] == "green"
+    assert result["reasons"] == []
+
+
+def test_verdict_declared_none_registered_is_red() -> None:
+    result = evaluate([_declared("a")], [])
+    assert result["verdict"] == "red"
+    assert result["reasons"]
+
+
+def test_verdict_connected_with_zero_tools_is_red() -> None:
+    result = evaluate([_declared("a")], [_status("plugin:x:a", tools=[])])
+    assert result["verdict"] == "red"
+    assert result["reasons"]
+
+
+def test_verdict_failed_propagates_error_into_reasons() -> None:
+    result = evaluate(
+        [_declared("a")],
+        [_status("plugin:x:a", status="failed", tools=[], error="spawn ENOENT: bad-command")],
+    )
+    assert result["verdict"] == "red"
+    assert any("spawn ENOENT" in r for r in result["reasons"])
+
+
+def test_verdict_needs_auth_is_red() -> None:
+    result = evaluate([_declared("a")], [_status("plugin:x:a", status="needs-auth", tools=[])])
+    assert result["verdict"] == "red"
+    assert result["reasons"]
+
+
+def test_verdict_pending_at_deadline_is_red() -> None:
+    result = evaluate([_declared("a")], [_status("plugin:x:a", status="pending", tools=[])])
+    assert result["verdict"] == "red"
+    assert result["reasons"]
+
+
+def test_verdict_scoped_dynamic_name_matches_declared() -> None:
+    # plugin:<bundle>:<server> with scope "dynamic" matches declared "probe" by
+    # the :-segment suffix rule.
+    result = evaluate(
+        [_declared("probe")],
+        [_status("plugin:mybundle:probe", scope="dynamic", tools=[_tool("word_count")])],
+    )
+    assert result["verdict"] == "green"
+    assert result["reasons"] == []
+
+
+def test_verdict_scope_missing_name_prefix_fallback_is_green() -> None:
+    # scope key intentionally absent -> plugin_owned via the "plugin:" name-prefix
+    # fallback (Section 3 rule 1), so the server still counts and the verdict is green.
+    own = _status("plugin:mybundle:probe", scope=None, tools=[_tool("word_count")])
+    assert "scope" not in own
+    result = evaluate([_declared("probe")], [own])
+    assert result["verdict"] == "green"
+
+
+def test_verdict_partial_registration_is_red() -> None:
+    # Two declared, only one connected-with-tools -> red (partial coverage).
+    result = evaluate(
+        [_declared("a"), _declared("b")],
+        [_status("plugin:x:a", tools=[_tool("t")])],
+    )
+    assert result["verdict"] == "red"
+    assert result["reasons"]
+
+
+def test_verdict_unmatched_declared_with_ambient_connected_is_red() -> None:
+    # F2 hole (load-bearing): a declared own-server that never registered must go
+    # RED even when the host has an AMBIENT (scope project/user) connected-with-tools
+    # server present. Deletion check: without the own-server filter + declared-
+    # anchoring, a globally-aggregate "is anything connected with tools?" rule would
+    # count the ambient server and FALSE-GREEN this exact shape -- the #336 slip.
+    #
+    # The ambient server's NAME collides with the declared server by the
+    # :-segment-suffix rule ("something:probe" ends with ":probe"), so declared-
+    # anchoring ALONE is not enough: _find_match would match it. Only the scope
+    # own-filter (scope=="project" is not plugin-owned) excludes it and keeps this
+    # RED. Deletion check: remove the scope own-filter and this test false-greens.
+    ambient = _status("something:probe", scope="project", tools=[_tool("ambient_tool")])
+    result = evaluate([_declared("probe")], [ambient])
+    assert result["verdict"] == "red"
+    assert result["reasons"]
+
+
+def test_verdict_ambient_server_never_flips_green() -> None:
+    own = _status("plugin:x:a", scope="dynamic", tools=[_tool("t")])
+    ambient = _status("proj-server", scope="user", tools=[_tool("ambient_tool")])
+    result = evaluate([_declared("a")], [own, ambient])
+    assert result["verdict"] == "green"
+
+
+def test_verdict_ambient_server_never_rescues_red() -> None:
+    failed_own = _status("plugin:x:a", status="failed", tools=[], error="boom")
+    ambient = _status("proj-server", scope="project", tools=[_tool("ambient_tool")])
+    result = evaluate([_declared("a")], [failed_own, ambient])
+    assert result["verdict"] == "red"
+
+
+# --------------------------------------------------------------------------- #
+# Test 3 -- string-pointer fingerprint (hints, not reasons) + reasons invariant
+# --------------------------------------------------------------------------- #
+def test_string_pointer_fingerprint_lives_in_hints_not_reasons() -> None:
+    # The real loader silently ignores the string-pointer form, so nothing
+    # registers; the diagnostic fingerprint must surface in `hints`.
+    # Deletion check: remove the hint emission and this fails.
+    declared = extract_declared(str(_MCP_RED_POINTER))
+    result = evaluate(declared, [])
+    assert result["verdict"] == "red"
+    assert any("string pointer" in h.lower() for h in result["hints"])
+    assert not any("string pointer" in r.lower() for r in result["reasons"])
+
+
+def test_reasons_nonempty_iff_verdict_not_green_and_green_may_carry_hints() -> None:
+    green = evaluate([], [])
+    assert green["verdict"] == "green"
+    assert green["reasons"] == []
+
+    red = evaluate([_declared("a")], [])
+    assert red["verdict"] == "red"
+    assert red["reasons"]
+
+    # E8 bare-file-rescued shape: declared as a string pointer but registered
+    # anyway (a coexisting bare .mcp.json). Verdict is GREEN, reasons empty, yet
+    # the advisory string-pointer fingerprint still appears in hints.
+    rescued = evaluate(
+        [_declared("probe", form="string_pointer")],
+        [_status("plugin:x:probe", scope="dynamic", tools=[_tool("t")])],
+    )
+    assert rescued["verdict"] == "green"
+    assert rescued["reasons"] == []
+    assert any("string pointer" in h.lower() for h in rescued["hints"])
+
+
+# --------------------------------------------------------------------------- #
+# Test 4 -- JSON purity + exit codes (module run as a subprocess)
+# --------------------------------------------------------------------------- #
+def _run_module(
+    plugin_dir: str, env_extra: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "AGENTOS_PLUGIN_DIR": plugin_dir}
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, "-m", "agentos_runner.check"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+
+
+def test_module_nonexistent_dir_exits_2_with_invalid_bundle_json(tmp_path: Path) -> None:
+    proc = _run_module(str(tmp_path / "does-not-exist"), env_extra={"HOME": str(tmp_path)})
+    assert proc.returncode == 2
+    # stdout must be exactly ONE json.loads-able document (stderr may carry logs).
+    doc = json.loads(proc.stdout)
+    assert doc["verdict"] == "invalid_bundle"
+    assert doc["reasons"]
+
+
+def test_module_invalid_bundle_exits_2_with_json(tmp_path: Path) -> None:
+    bad = _PLUGIN_FORMAT_FIXTURES / "bad_manifest_name"
+    proc = _run_module(str(bad), env_extra={"HOME": str(tmp_path)})
+    assert proc.returncode == 2
+    doc = json.loads(proc.stdout)
+    assert doc["verdict"] == "invalid_bundle"
+    assert doc["reasons"]
+
+
+# --------------------------------------------------------------------------- #
+# Test 5 -- real-loader integration (gated on the real `claude` CLI, isolated HOME)
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(
+    not _CLAUDE_ON_PATH,
+    reason="requires the real `claude` CLI on PATH to spawn MCP servers",
+)
+def test_run_check_green_bundle_registers_tools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Isolated HOME (plan Section 5, E7): the CLI caches a failed MCP connection
+    # ~15 min so consecutive host runs go flaky, and an ambient HOME leaks
+    # project/user MCP servers into the status; a clean HOME leaves only the
+    # bundle's own servers. No credential env is set (spike: connect() is
+    # credential-free and there is no query() in the code path).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    result = anyio.run(run_check, str(_MCP_GREEN))
+    assert result["verdict"] == "green", result
+    assert result["reasons"] == []
+
+
+@pytest.mark.skipif(
+    not _CLAUDE_ON_PATH,
+    reason="requires the real `claude` CLI on PATH to spawn MCP servers",
+)
+def test_run_check_red_pointer_bundle_is_red(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    result = anyio.run(run_check, str(_MCP_RED_POINTER))
+    assert result["verdict"] == "red", result
+    assert result["reasons"]


### PR DESCRIPTION
## What

`agentos skill check` — an offline, credential-free way to detect a bundle whose declared MCP servers silently fail to load. The skill-tier offline loop (`skill up --fake-model` + `skill eval`) never exercises MCP loading, so a bundle with a broken `mcpServers` declaration passes green while shipping zero tools (the #336 landmine).

## How

Runs the runner image one-shot in a new check mode (`python -m agentos_runner.check`) that validates the bundle, connects the **real** Claude Code loader with **no model turn**, reads `get_mcp_status()`, and reports a declared-vs-registered verdict filtered to the bundle's own (`scope=="dynamic"`) servers so ambient project/user MCP servers can't skew it.

- **RED** when a declared server never registers (the invalid `"mcpServers": "<path>"` string-pointer form) or fails to connect; **GREEN** when the tools load.
- Credential-free and network-isolated (`--network none`); semantic exit codes `0` green / `1` red / `2` invalid-bundle; honors the global `--json`.
- Guide primer documents the detector.

Verified end-to-end against real bundles in-container (green, string-pointer red, broken-server red, the `examples/text-stats-engine` #336 reproduction, invalid-bundle exit 2) with no credential set.

Closes #337