### PR TITLE
Emit a machine-readable reply object for message --json

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -376,8 +376,11 @@ control flow are machine-first.
 
 **`--json`** (global) switches the read/report commands `agentos skill status`
 and `agentos skill eval` to a single machine-readable JSON object on **stdout**;
-all human and log text (progress, notes, warnings) goes to **stderr**, so a
-plain `... --json | jq` yields clean data. On failure under `--json`, the error
+it also switches `agentos local message` and `agentos cluster message` to emit
+`{"reply": ..., "thread": ..., "finalized": ...}` (the model's reply, which is
+null on a no-edit completion, plus the thread the turn ran under). All human and
+log text (progress, notes, warnings) goes to **stderr**, so a plain
+`... --json | jq` yields clean data. On failure under `--json`, the error
 is emitted to stdout as `{"error": "<message>", "fix": "<hint>"|null}` instead of
 a prose message, so an agent can recover without parsing prose. `NO_COLOR`,
 `CLICOLOR`, and `--color=never` are honored on every command.

--- a/cli/schema/message.schema.json
+++ b/cli/schema/message.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "agentos local|cluster message --json",
+  "description": "The agent-facing payload of `agentos local message --json` and `agentos cluster message --json`: the model's final reply text (null when the worker finished the turn without editing the placeholder), the thread the turn ran under, and whether a reply was captured. All keys are CLI-owned and locked.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["reply", "thread", "finalized"],
+  "properties": {
+    "reply": { "type": ["string", "null"] },
+    "thread": { "type": "string" },
+    "finalized": { "type": "boolean" }
+  }
+}

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -294,6 +294,19 @@ pub fn dry_run_lines(opts: &MessageOpts, advertise_host: &str) -> Vec<String> {
     lines
 }
 
+/// The machine-readable reply object for `local`/`cluster message --json`
+/// (issue #353): the model's reply text (null when the worker finished without
+/// editing the placeholder), the thread the turn ran under, and whether a reply
+/// was captured. Pure so it stays contract-testable against
+/// `cli/schema/message.schema.json`.
+pub fn message_reply_json(thread: &str, reply: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "reply": reply,
+        "thread": thread,
+        "finalized": reply.is_some(),
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Effectful helpers
 // ---------------------------------------------------------------------------
@@ -472,14 +485,22 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     match outcome {
         Outcome::Replied(reply) => {
             step.done("");
-            ui.answer(&reply);
-            ui.print_tokens("\n");
+            if ui.json() {
+                ui.emit_json(&message_reply_json(&thread_ts, Some(&reply)));
+            } else {
+                ui.answer(&reply);
+                ui.print_tokens("\n");
+            }
             persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
             step.done("no edit");
-            ui.warn("the worker finished the turn but never edited the placeholder");
+            if ui.json() {
+                ui.emit_json(&message_reply_json(&thread_ts, None));
+            } else {
+                ui.warn("the worker finished the turn but never edited the placeholder");
+            }
             persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
@@ -613,14 +634,22 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     match outcome {
         Outcome::Replied(reply) => {
             step.done("");
-            ui.answer(&reply);
-            ui.print_tokens("\n");
+            if ui.json() {
+                ui.emit_json(&message_reply_json(&thread_ts, Some(&reply)));
+            } else {
+                ui.answer(&reply);
+                ui.print_tokens("\n");
+            }
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
             step.done("no edit");
-            ui.warn("the worker finished the turn but never edited the placeholder");
+            if ui.json() {
+                ui.emit_json(&message_reply_json(&thread_ts, None));
+            } else {
+                ui.warn("the worker finished the turn but never edited the placeholder");
+            }
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -6,6 +6,7 @@
 
 use agentos::commands::{eval_json, status_json};
 use agentos::exit;
+use agentos::message::message_reply_json;
 use agentos_aci_protocol::SessionStatus;
 
 fn load_schema(name: &str) -> serde_json::Value {
@@ -55,6 +56,53 @@ fn error_json_validates_against_error_schema() {
     assert!(
         v.is_valid(&value),
         "error_json output must validate against error.schema.json: {value}"
+    );
+}
+
+#[test]
+fn message_reply_json_validates_against_message_schema() {
+    let schema = load_schema("message.schema.json");
+    let v = validator(&schema);
+    // Replied case: a non-null reply and finalized true.
+    let replied = message_reply_json("1700000000.000100", Some("the answer is 42"));
+    assert!(
+        v.is_valid(&replied),
+        "message_reply_json (replied) must validate against message.schema.json: {replied}"
+    );
+    // Pin the values, not just the types: the reply text must pass through, the
+    // thread must echo the input, and finalized must track reply.is_some().
+    assert_eq!(replied["reply"], serde_json::json!("the answer is 42"));
+    assert_eq!(replied["thread"], serde_json::json!("1700000000.000100"));
+    assert_eq!(replied["finalized"], serde_json::json!(true));
+    // No-edit completion: reply null, finalized false, must also validate.
+    let no_edit = message_reply_json("1700000000.000100", None);
+    assert!(
+        v.is_valid(&no_edit),
+        "message_reply_json (no edit) must validate against message.schema.json: {no_edit}"
+    );
+    // Pin the no-edit values: null reply, thread passthrough, finalized false.
+    assert!(
+        no_edit["reply"].is_null(),
+        "no-edit reply must be JSON null: {no_edit}"
+    );
+    assert_eq!(no_edit["thread"], serde_json::json!("1700000000.000100"));
+    assert_eq!(no_edit["finalized"], serde_json::json!(false));
+}
+
+#[test]
+fn message_schema_gate_has_teeth() {
+    // negative control: proves the schema gate discriminates
+    let schema = load_schema("message.schema.json");
+    let mut value = message_reply_json("1700000000.000100", Some("hi"));
+    // Strip a required key; a schema with real teeth must now reject.
+    value
+        .as_object_mut()
+        .expect("message_reply_json returns a JSON object")
+        .remove("reply");
+    let v = validator(&schema);
+    assert!(
+        !v.is_valid(&value),
+        "message schema must reject an object missing the required `reply` key"
     );
 }
 


### PR DESCRIPTION
Under `--json`, `agentos local message` and `agentos cluster message` previously suppressed the reply, leaving scripts and graders to scrape human-formatted stdout for the model's answer (cold-start run-2 had to grep for its proof token). Both tiers now emit a documented `{"reply", "thread", "finalized"}` object on stdout.

- `message_reply_json` pure builder plus committed `cli/schema/message.schema.json`, mirroring the existing status/eval JSON-contract pattern (pure builder + schema + `json_contract.rs` validation).
- `reply` is null and `finalized` false on a no-edit completion; `finalized == reply.is_some()`. A timeout keeps its Transient (exit 3) signal with no JSON.
- Human (non-`--json`) output paths are byte-preserved; the new lines are gated on the pre-existing `ui.json()`.
- Tests validate both the replied and no-edit cases against the schema, pin the field values (defending the finalized invariant and reply/thread passthrough), and keep a schema-teeth negative control.
- README documents the new object.

Reviewed by code-reviewer, scope-creep-reviewer, spec-vs-impl-reviewer, and a Codex cross-model pass. The non-reply terminal states (timeout and `--dry-run`) that stay stdout-empty under `--json` are tracked as a deferred follow-up in #354.

Closes #353