### PR TITLE
Pin numeric runAsUser on Langfuse web + worker containers (#351)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -98,6 +98,14 @@ jobs:
           set -euo pipefail
           bash charts/agentos/ci/litellm-sidecar-assertions.sh
 
+      # Prove the Langfuse web+worker containers carry a numeric runAsUser
+      # alongside runAsNonRoot (issue #351) so the kubelet can verify non-root
+      # and the pods actually start on an enforcing cluster.
+      - name: helm render assertions (langfuse runAsUser)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/langfuse-runasuser-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/agentos/ci/langfuse-runasuser-assertions.sh
+++ b/charts/agentos/ci/langfuse-runasuser-assertions.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #351 (Langfuse pods die with
+# CreateContainerConfigError). Kubernetes enforces `runAsNonRoot: true` by
+# requiring a numeric uid it can verify is non-root, taken from either a numeric
+# `runAsUser` in the securityContext or a numeric `USER` in the image. Both
+# Langfuse images declare a NAMED user (nextjs for web, expressjs for worker),
+# which the kubelet cannot resolve to a number, so `runAsNonRoot: true` with no
+# numeric `runAsUser` makes the kubelet refuse to create the container.
+#
+# This asserts that BOTH the langfuse-web and langfuse-worker containers carry a
+# numeric `runAsUser` (>= 1, pinned to the verified image uid 1001) alongside
+# `runAsNonRoot: true`, so the pods actually start on an enforcing cluster. It
+# fails loudly, naming the container, if `runAsUser` is absent while
+# `runAsNonRoot: true` -- that is the exact #351 regression.
+#
+# Runnable locally (from anywhere) and from CI.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RENDER="$TMP/langfuse.yaml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+echo "=== Rendering templates/langfuse.yaml ==="
+helm template "$CHART" --show-only templates/langfuse.yaml > "$RENDER"
+
+# Assert the securityContext of one Langfuse Deployment's first container.
+# $1 = rendered multi-doc YAML file, $2 = deployment name suffix
+# (-langfuse-web / -langfuse-worker), $3 = expected numeric runAsUser.
+assert_container() {
+  python3 -c '
+import sys, yaml
+path, suffix, want = sys.argv[1], sys.argv[2], int(sys.argv[3])
+
+dep = None
+for doc in yaml.safe_load_all(open(path)):
+    if not doc:
+        continue
+    if doc.get("kind") == "Deployment" and doc.get("metadata", {}).get("name", "").endswith(suffix):
+        dep = doc
+        break
+if dep is None:
+    sys.stderr.write("no Deployment ending in %r found in rendered langfuse.yaml\n" % suffix)
+    sys.exit(2)
+
+container = dep["spec"]["template"]["spec"]["containers"][0]
+name = container.get("name")
+sc = container.get("securityContext") or {}
+
+if sc.get("runAsNonRoot") is not True:
+    sys.stderr.write("container %r: securityContext.runAsNonRoot must be true; got %r\n" % (name, sc.get("runAsNonRoot")))
+    sys.exit(3)
+
+if "runAsUser" not in sc:
+    sys.stderr.write("container %r: runAsNonRoot is true but runAsUser is ABSENT -- the kubelet cannot verify the named image user, this is the #351 CreateContainerConfigError regression\n" % name)
+    sys.exit(3)
+
+uid = sc["runAsUser"]
+if not isinstance(uid, int) or isinstance(uid, bool):
+    sys.stderr.write("container %r: runAsUser must be an integer; got %r (%s)\n" % (name, uid, type(uid).__name__))
+    sys.exit(3)
+if uid < 1:
+    sys.stderr.write("container %r: runAsUser must be >= 1 (non-root); got %d\n" % (name, uid))
+    sys.exit(3)
+if uid != want:
+    sys.stderr.write("container %r: runAsUser must equal %d (verified image uid); got %d\n" % (name, want, uid))
+    sys.exit(3)
+
+sys.stdout.write("  ok: %s carries runAsNonRoot: true + runAsUser: %d\n" % (name, uid))
+' "$1" "$2" "$3" || fail "container assertion failed for deployment suffix '$2' (see message above)"
+}
+
+echo "=== Assertion: langfuse-web carries a numeric runAsUser (== 1001) ==="
+assert_container "$RENDER" "-langfuse-web" 1001
+
+echo "=== Assertion: langfuse-worker carries a numeric runAsUser (== 1001) ==="
+assert_container "$RENDER" "-langfuse-worker" 1001
+
+echo
+echo "PASS: both langfuse-web and langfuse-worker pin runAsUser: 1001 alongside runAsNonRoot: true (issue #351); the kubelet can verify non-root and the pods start."

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -108,10 +108,17 @@ langfuse:
     # image runs as a non-root uid and needs no Linux capabilities, so all are
     # dropped and privilege escalation is denied. readOnlyRootFilesystem stays
     # false -- the Next.js server writes to its rootfs (.next cache, /tmp).
+    # The numeric runAsUser is required, not optional (issue #351): runAsNonRoot:
+    # true alone is unverifiable because both Langfuse images declare a NAMED user
+    # (nextjs for web, expressjs for worker), and the kubelet refuses to create a
+    # container whose non-root uid it cannot confirm, failing with
+    # CreateContainerConfigError. Both named users resolve to uid 1001, so the
+    # numeric uid is pinned here.
     # To opt out, override the fields (e.g. runAsNonRoot: false for a fork whose
     # image must run as root), or set the whole block to null to drop it.
     containerSecurityContext:
       runAsNonRoot: true
+      runAsUser: 1001
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false
       capabilities:
@@ -123,9 +130,11 @@ langfuse:
     resources:
       requests: { cpu: 150m, memory: 384Mi }
       limits: { cpu: "1", memory: 1Gi }
-    # See langfuse.web.containerSecurityContext above.
+    # See langfuse.web.containerSecurityContext above. The worker image's named
+    # user is expressjs (also uid 1001), so it shares the same numeric runAsUser.
     containerSecurityContext:
       runAsNonRoot: true
+      runAsUser: 1001
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: false
       capabilities:


### PR DESCRIPTION
## Problem
The chart set `runAsNonRoot: true` on both Langfuse containers with no numeric `runAsUser`. Kubernetes verifies `runAsNonRoot` from a numeric uid (either `runAsUser` or a numeric image `USER`), but both Langfuse images declare a *named* user (`nextjs` for web, `expressjs` for worker), so an enforcing kubelet refuses to create the container with `CreateContainerConfigError`. The pods never start, and `cluster up`'s `helm --wait` correctly stays at `pending-install`.

## Fix
Add `runAsUser: 1001` (the verified image uid) to `langfuse.web` and `langfuse.worker` `containerSecurityContext`. The rest of the restricted-PSS block is unchanged. `modelPricing` is deliberately untouched: its Job carries no securityContext, so it never hit the error; its field "Error" was downstream of Langfuse being unhealthy and clears once web+worker are Ready.

The uid was confirmed, not guessed: both `langfuse/langfuse:3` (`nextjs`) and `langfuse/langfuse-worker:3` (`expressjs`) resolve to uid 1001.

## Verification
- Live k3s (enforcing) E2E: fixed pods run as `uid=1001`; a pre-fix control (no `runAsUser`) reproduced the exact issue error `container has runAsNonRoot and image has non-numeric user (nextjs)`.
- New chart-owned render-assertion (`charts/agentos/ci/langfuse-runasuser-assertions.sh`) wired as a CI step guards the regression; verified non-vacuous (fails loudly when `runAsUser` is stripped).
- `helm lint` (all overlays) and the existing assertion suites pass.

Closes #351