### PR TITLE
cluster deploy self-plumbs the API port-forward

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -159,7 +159,7 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `agentos cluster status` | Report release health, pod readiness, and access URLs (read-only). |
 | `agentos cluster comms --slack` | Connect or disconnect a real Slack workspace with a thin `helm upgrade --reuse-values`; env-backed tokens are masked in dry-run output. |
 | `agentos cluster message "..."` | Drive the deployed release end to end with zero Slack: self plumbs kubectl port forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply. |
-| `agentos cluster deploy` | Package the bundle as tar.gz and push it to the platform API (`--api-url`, default `http://localhost:8000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
+| `agentos cluster deploy` | Package the bundle as tar.gz and push it to the platform API. Omitting `--api-url` self-plumbs a kubectl port-forward to the in-cluster API (released when the deploy returns); `--namespace`/`--release` target the release (default `agentos`). An explicit `--api-url` (or `AGENTOS_API_URL`) is dialed directly with no self-managed forward. Auth via `--api-key` or `AGENTOS_API_KEY`. |
 | `agentos cluster kill <agent> --yes` | Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`). Destructive: refuses without `--yes`. |
 | `agentos cluster resume <agent>` | Resume a killed agent via the platform API (`POST /agents/{id}/resume`). |
 | `agentos cluster budget <agent> --limit <n>` | Set the agent's daily spend cap in USD via the platform API (`PUT /agents/{id}/budget`, `BudgetConfig.max_usd_per_day`); the per-run token cap is left at the platform default. |

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1247,12 +1247,9 @@
               "required": false
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to auto port-forward to the in-cluster API; pass a URL (or set AGENTOS_API_URL) to dial it directly",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
@@ -1298,6 +1295,22 @@
               "help": "Version label; defaults to <manifest version>-<unix time>",
               "id": "label",
               "long": "label",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -588,9 +588,9 @@ enum ClusterAction {
         /// Plugin bundle directory.
         #[arg(long, default_value = ".")]
         plugin_dir: PathBuf,
-        /// Platform API base URL.
-        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
-        api_url: String,
+        /// Platform API base URL. Omit to auto port-forward to the in-cluster API; pass a URL (or set AGENTOS_API_URL) to dial it directly.
+        #[arg(long, env = "AGENTOS_API_URL")]
+        api_url: Option<String>,
         /// Platform API key.
         #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
         api_key: String,
@@ -605,6 +605,12 @@ enum ClusterAction {
         /// Version label; defaults to <manifest version>-<unix time>.
         #[arg(long)]
         label: Option<String>,
+        /// Kubernetes namespace of the release. Default: agentos.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Helm release name. Default: agentos.
+        #[arg(long)]
+        release: Option<String>,
     },
     // Agent-lifecycle verbs (kill/resume/budget/delete) speak the platform API
     // like `deploy` does. Design decision (#149): extend the existing `cluster`
@@ -1150,10 +1156,40 @@ async fn run(command: Command) -> Result<()> {
                 slack_channel,
                 env,
                 label,
+                namespace,
+                release,
             } => {
-                let connect_hint = format!(
-                    "the platform API at {api_url} is unreachable. `cluster deploy` does not port-forward for you; open one first, e.g.:\n    kubectl -n agentos port-forward svc/agentos-api 8000:8000\nthen re-run (or pass --api-url if your API is elsewhere)."
-                );
+                let namespace = namespace.unwrap_or_else(|| "agentos".to_string());
+                let release = release.unwrap_or_else(|| "agentos".to_string());
+                // No --api-url (and no AGENTOS_API_URL) means "the in-cluster API":
+                // self-plumb a port-forward the way `cluster message` does, so a
+                // first deploy against a healthy cluster needs no manual kubectl.
+                // The child is bound into `_api_pf` and stays alive across the
+                // deploy await (killed on drop once deploy returns). An explicit
+                // --api-url / AGENTOS_API_URL (any value) is dialed as given.
+                let (api_url, connect_hint, _api_pf) = match api_url {
+                    None => {
+                        ops::require_on_path("kubectl")?;
+                        let pf = message::start_api_port_forward(
+                            &namespace,
+                            &release,
+                            message::DEFAULT_API_LOCAL_PORT,
+                        )
+                        .await?;
+                        let forwarded =
+                            format!("http://localhost:{}", message::DEFAULT_API_LOCAL_PORT);
+                        let hint = format!(
+                            "the platform API did not respond through the automatic port-forward to svc/{release}-api in namespace {namespace}. Check the release is healthy with `agentos cluster status`."
+                        );
+                        (forwarded, hint, Some(pf))
+                    }
+                    Some(url) => {
+                        let hint = format!(
+                            "the platform API at {url} is unreachable. Pass a reachable --api-url, or omit it to use the automatic in-cluster port-forward."
+                        );
+                        (url, hint, None)
+                    }
+                };
                 commands::deploy(DeployOpts {
                     plugin_dir,
                     api_url,
@@ -1310,6 +1346,65 @@ mod tests {
                 action: LocalAction::Message { api_key, .. },
             } => assert_eq!(api_key, "K"),
             _ => panic!("expected local message command"),
+        }
+    }
+
+    #[test]
+    fn cluster_deploy_parses_namespace_and_release() {
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "cluster",
+            "deploy",
+            "--namespace",
+            "ns1",
+            "--release",
+            "rel1",
+        ])
+        .expect("cluster deploy --namespace --release should parse");
+        match cli.command {
+            Command::Cluster {
+                action:
+                    ClusterAction::Deploy {
+                        namespace, release, ..
+                    },
+            } => {
+                assert_eq!(namespace, Some("ns1".to_string()));
+                assert_eq!(release, Some("rel1".to_string()));
+            }
+            _ => panic!("expected cluster deploy command"),
+        }
+    }
+
+    #[test]
+    fn cluster_deploy_api_url_is_optional() {
+        // The env fallback (env = "AGENTOS_API_URL") would populate api_url from
+        // the ambient process environment; clear it so the omitted-flag case
+        // genuinely observes None.
+        std::env::remove_var("AGENTOS_API_URL");
+        // Omitting --api-url must yield None so the handler self-plumbs the
+        // port-forward; a default_value here would silently disable that path.
+        let cli = Cli::try_parse_from(["agentos", "cluster", "deploy"])
+            .expect("cluster deploy with no --api-url should parse");
+        match cli.command {
+            Command::Cluster {
+                action: ClusterAction::Deploy { api_url, .. },
+            } => assert_eq!(api_url, None),
+            _ => panic!("expected cluster deploy command"),
+        }
+        // An explicit --api-url is carried through as Some and dialed as given.
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "cluster",
+            "deploy",
+            "--api-url",
+            "http://localhost:8000",
+        ])
+        .expect("cluster deploy --api-url should parse");
+        match cli.command {
+            Command::Cluster {
+                action: ClusterAction::Deploy { api_url, .. },
+            } => assert_eq!(api_url, Some("http://localhost:8000".to_string())),
+            _ => panic!("expected cluster deploy command"),
         }
     }
 

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -151,6 +151,14 @@ pub fn port_forward_command(
     )
 }
 
+/// The API port-forward `cluster deploy` self-plumbs to reach the in-cluster
+/// platform API: `kubectl -n <ns> port-forward svc/<release>-api <local>:8000`.
+/// A thin pure wrapper over [`port_forward_command`] so the "deploy forwards to
+/// svc/<release>-api remote 8000" contract lives in one testable place.
+pub fn api_port_forward_command(namespace: &str, release: &str, local_port: u16) -> OpsCommand {
+    port_forward_command(namespace, release, "api", local_port, API_REMOTE_PORT)
+}
+
 /// `kubectl config view --minify -o jsonpath={...server}`: the kubeconfig's
 /// current-context API server URL, used to pick the local egress IP.
 fn server_url_command() -> OpsCommand {
@@ -355,8 +363,23 @@ async fn start_port_forward(
     local_port: u16,
     label: &str,
 ) -> Result<tokio::process::Child> {
+    // Refuse up front if something already owns local_port: a spawned
+    // `kubectl port-forward` would fail to bind and `wait_for_tcp` would then
+    // connect to that unrelated listener, silently sending traffic to the wrong
+    // endpoint. Checking before we spawn makes the common case (a stale or
+    // concurrent port-forward) deterministic; the post-spawn `try_wait` below
+    // still covers the residual bind race.
+    if tokio::net::TcpStream::connect(("127.0.0.1", local_port))
+        .await
+        .is_ok()
+    {
+        bail!(
+            "localhost:{local_port} is already in use (another agentos message/deploy \
+             or a stale port-forward); free it before retrying the {label} port-forward"
+        );
+    }
     crate::ui::ui().plumbing(&format!("+ {}", cmd.display()));
-    let child = tokio::process::Command::new(&cmd.program)
+    let mut child = tokio::process::Command::new(&cmd.program)
         .args(cmd.argv())
         .kill_on_drop(true)
         .stdout(Stdio::null())
@@ -366,7 +389,33 @@ async fn start_port_forward(
     wait_for_tcp(local_port, Duration::from_secs(15))
         .await
         .with_context(|| format!("the {label} port-forward never opened localhost:{local_port}"))?;
+    // wait_for_tcp only proves *something* accepts local_port; if kubectl lost a
+    // bind race to an unrelated listener it has already exited and we would be
+    // talking to that squatter. Fail loud instead of silently using the wrong
+    // endpoint.
+    if let Ok(Some(status)) = child.try_wait() {
+        bail!(
+            "the {label} port-forward exited early ({status}); is localhost:{local_port} \
+             already in use by another agentos message/deploy or a stale port-forward?"
+        );
+    }
     Ok(child)
+}
+
+/// Spawn the `cluster deploy` API port-forward and block until it accepts TCP.
+/// The returned child is killed on drop, so the caller must keep it alive for as
+/// long as it dials `http://localhost:<local_port>`.
+pub async fn start_api_port_forward(
+    namespace: &str,
+    release: &str,
+    local_port: u16,
+) -> Result<tokio::process::Child> {
+    start_port_forward(
+        &api_port_forward_command(namespace, release, local_port),
+        local_port,
+        "api",
+    )
+    .await
 }
 
 /// Poll-connect to `localhost:port` until it accepts or the timeout elapses.
@@ -706,6 +755,15 @@ mod tests {
         assert_eq!(
             cmd.display(),
             "kubectl -n agentos port-forward svc/agentos-valkey 56381:6379"
+        );
+    }
+
+    #[test]
+    fn api_port_forward_command_targets_api_svc_and_remote_8000() {
+        let cmd = api_port_forward_command("agentos", "agentos", 8123);
+        assert_eq!(
+            cmd.display(),
+            "kubectl -n agentos port-forward svc/agentos-api 8123:8000"
         );
     }
 

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -752,7 +752,7 @@ pub fn host_from_server_url(server: &str) -> Option<String> {
 // ---------------------------------------------------------------------------
 
 /// Fail with a clear one-line error if `bin` is not on `PATH`.
-pub(crate) fn require_on_path(bin: &str) -> Result<()> {
+pub fn require_on_path(bin: &str) -> Result<()> {
     let found = std::env::var_os("PATH")
         .map(|paths| std::env::split_paths(&paths).any(|dir| dir.join(bin).is_file()))
         .unwrap_or(false);

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -134,28 +134,31 @@ the stack.
 ## Deploy a bundle to the cluster
 
 Before `agentos cluster message` can drive an agent, a bundle must be deployed to
-the in-cluster platform API with `agentos cluster deploy`. The `agentos-api`
-service is ClusterIP, but the UI is exposed on a NodePort (`:30080`) and its
-nginx reverse-proxies `/api/` to the in-cluster API, so a `/api`-suffixed node
-URL reaches the API with no port-forward. Take the UI URL from `agentos cluster
-status` and give `cluster deploy` its `/api` path:
+the in-cluster platform API with `agentos cluster deploy`. Omit `--api-url`
+entirely (do not leave it at a default value; simply omit it) and `cluster
+deploy` self-plumbs a kubectl port-forward to the in-cluster `agentos-api`
+service the same way `cluster message` does, and releases it when the deploy
+returns. So a first deploy against a healthy cluster needs no manual port-forward:
+
+```bash
+agentos cluster deploy --plugin-dir <bundle-dir> --api-key agentos-dev-key
+```
+
+The port-forward targets the `agentos`/`agentos` namespace and release by
+default; pass `--namespace`/`--release` to point it at a non-default release,
+mirroring `cluster message`.
+
+Passing an explicit `--api-url` (or setting `AGENTOS_API_URL`) dials that
+endpoint as given, with no self-managed port-forward, for when you already have a
+route to the API. The UI
+is exposed on a NodePort (`:30080`) whose nginx reverse-proxies `/api/` to the
+in-cluster API, so a `/api`-suffixed node URL from `agentos cluster status`
+reaches the API directly. Take the UI URL and give `cluster deploy` its `/api`
+path:
 
 ```bash
 agentos cluster deploy --plugin-dir <bundle-dir> \
   --api-url http://<node>:30080/api --api-key agentos-dev-key
-```
-
-If you installed with `--no-expose` (no NodePort) or otherwise can't reach the
-node port, fall back to a manual port-forward of the ClusterIP service. `cluster
-deploy` does not self-manage one, so its default `--api-url
-http://localhost:8000` is unreachable until you forward the API yourself. Run the
-port-forward first, deploy, then release it:
-
-```bash
-kubectl port-forward svc/agentos-api 8000:8000 -n agentos &
-agentos cluster deploy --plugin-dir <bundle-dir> \
-  --api-url http://localhost:8000 --api-key agentos-dev-key
-kill %1   # cluster message plumbs its own forwards, so this one is no longer needed
 ```
 
 Without a deploy, `agentos cluster message` fails with `no agents are deployed on


### PR DESCRIPTION
`agentos cluster deploy` did not port-forward to the in-cluster platform API the way `agentos cluster message` does, so a first deploy (the natural deploy-then-message order) failed with `platform API at http://localhost:8000 is unreachable` until the operator ran `kubectl port-forward` by hand.

Now, omitting `--api-url` auto-establishes a kubectl port-forward to the in-cluster `agentos-api` service (matching `cluster message`) and releases it when the deploy returns, so a first deploy against a healthy cluster needs no manual port-forward.

- The self-forward is gated on the flag being **omitted** (`Option<String>`), not on its value, so an explicit `--api-url` / `AGENTOS_API_URL` (including `http://localhost:8000`, as the e2e deploy leg passes) is always dialed as given.
- Adds `--namespace`/`--release` to target the port-forward, mirroring `cluster message`.
- `start_port_forward` refuses up front when the local port is already in use and fails loud if kubectl exits early, so a stale or concurrent forward cannot silently divert traffic (hardens `cluster message` too).

Verified live on k8scratch: explicit `--api-url` dials directly with no forward; omitted `--api-url` takes the self-forward path; the port-collision guard fires deterministically. Full CLI suite (306) plus fmt/clippy green.

Closes #352