### PR TITLE
Fix cluster-tier crash-loop: split controller networkpolicies RBAC + add install-time gate

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -106,6 +106,15 @@ jobs:
           set -euo pipefail
           bash charts/agentos/ci/langfuse-runasuser-assertions.sh
 
+      # Prove the controller NetworkPolicy RBAC split (issue #350): exactly one
+      # read-only cluster grant (get/list/watch) so the informer syncs, no
+      # cluster-wide mutate anywhere (#66 guarded), namespaced mutate intact, and
+      # the controller-ready install gate renders/suppresses with its flags.
+      - name: helm render assertions (controller netpol RBAC)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/controller-rbac-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/agentos/CLAUDE.md
+++ b/charts/agentos/CLAUDE.md
@@ -24,13 +24,17 @@ component and rail detail in `charts/agentos/README.md`.
   empty by default; an unset allowlist must never mean allow-all. If you add
   a new egress destination the runner needs, it goes into this allowlist
   explicitly -- never widen the default-deny baseline itself.
-- **Both preflights are mandatory Helm hooks, not advisory scripts.** The
-  CPU-AVX/ClickHouse-pin check (`preflights.avxCheck`) and the
-  NetworkPolicy-enforcement probe (`preflights.networkPolicyProbe`) block a
-  broken install. Do not make either skippable by default, and do not add a
-  new cluster-dependent assumption (a CNI feature, a kernel feature) without
-  a matching preflight -- an assumption that silently fails on a customer
-  cluster is exactly the failure mode these exist to prevent.
+- **The preflights are mandatory Helm hooks, not advisory scripts.** The
+  CPU-AVX/ClickHouse-pin check (`preflights.avxCheck`), the
+  NetworkPolicy-enforcement probe (`preflights.networkPolicyProbe`), and the
+  controller-ready gate (`preflights.controllerReady`, which fails the install
+  if the vendored agent-sandbox controller cannot sync its cluster-scope
+  NetworkPolicy informer -- issue #350) block a broken install. Do not make
+  any of them skippable by default, and do not add a new cluster-dependent
+  assumption (a CNI feature, a kernel feature, an RBAC grant the controller
+  needs to start) without a matching preflight -- an assumption that silently
+  fails on a customer cluster is exactly the failure mode these exist to
+  prevent.
 - **gVisor needs `runsc` on the node; the chart cannot install it.** On a
   cluster without it, use the ready-made overlay
   `-f charts/agentos/values-e2e-nogvisor.yaml` (sets `runtimeClassName=""` and

--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -442,17 +442,23 @@ to install only the control plane + backing stores without the runner substrate.
   on `pods`, `services`, and `persistentvolumeclaims` (it places sandbox pods
   and their Services), full control of the `sandboxes` / `sandboxclaims` /
   `sandboxtemplates` / `sandboxwarmpools` custom resources, `get/patch/update`
-  on those four CRDs by name, plus `leases` (leader-election) and `events`. Its NetworkPolicy permission has been
-  **de-scoped from cluster-wide to the release namespace only** (issue #66):
-  the vendored manifest drops the `networkpolicies` rule from its
-  `agent-sandbox-controller-extensions` ClusterRole, and a namespaced
-  `Role`/`RoleBinding` (`agent-sandbox-controller-networkpolicies`, rendered by
-  `templates/agent-sandbox.yaml`) re-grants it in `.Release.Namespace` only.
-  This confines the blast radius: a compromised controller (or a leaked SA
-  token) can no longer delete the fail-closed egress NetworkPolicy that IS
-  Rail 1's containment in any *other* namespace. It is not eliminated for this
-  release's own namespace, where the controller legitimately manages those
-  policies and so still holds delete on them. The Deployment is also hardened
+  on those four CRDs by name, plus `leases` (leader-election) and `events`. Its NetworkPolicy permission is
+  **split by verb along the read/mutate line** (issue #350, ADR-0023): the
+  vendored manifest drops the `networkpolicies` rule from its
+  `agent-sandbox-controller-extensions` ClusterRole, and `templates/agent-sandbox.yaml`
+  replaces it with (1) a cluster-scoped **read-only** ClusterRole/ClusterRoleBinding
+  (`agent-sandbox-controller-networkpolicies-read`) granting only
+  `get/list/watch` cluster-wide, and (2) a namespaced
+  `Role`/`RoleBinding` (`agent-sandbox-controller-networkpolicies`) granting the
+  mutating verbs `create/delete/patch/update` (plus `get`) in `.Release.Namespace`
+  only. The cluster-wide read is required because the upstream controller's
+  NetworkPolicy informer LISTs/WATCHes at cluster scope; without it the controller
+  crash-loops before any `SandboxClaim` binds (#350). #66's guarantee still holds
+  in its load-bearing form -- **no cluster-wide mutate**: a compromised controller
+  (or a leaked SA token) can no longer delete the fail-closed egress NetworkPolicy
+  that IS Rail 1's containment in any *other* namespace, because delete/patch are
+  confined to this release's own namespace, where the controller legitimately
+  manages those policies. The Deployment is also hardened
   with a non-root
   (uid 65532) / read-only-rootfs / drop-ALL-caps / RuntimeDefault-seccomp
   securityContext. On a shared multi-tenant cluster, prefer running the

--- a/charts/agentos/ci/controller-rbac-assertions.sh
+++ b/charts/agentos/ci/controller-rbac-assertions.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #350 (controller NetworkPolicy RBAC:
+# cluster-read + namespaced-mutate split, plus the install-time controller-ready
+# gate). Pins the verb-split shape so re-vendoring the upstream agent-sandbox
+# controller -- or any RBAC edit -- cannot silently regress in EITHER direction:
+# re-widening mutate to cluster scope (regresses #66) or re-breaking the
+# informer by confining cluster LIST/WATCH to a namespaced Role (the #350
+# crash-loop). See docs/adr/0023-controller-networkpolicy-rbac-cluster-read-namespace-mutate.md.
+#
+# Four assertions (plan §4), scanning the FULL multi-doc render (ClusterRoles
+# come from BOTH templates/agent-sandbox.yaml and the vendored
+# files/agent-sandbox/controller.yaml, so no --show-only):
+#
+#   (a) Exactly ONE cluster-scope ClusterRole grants networkpolicies, its verb
+#       set is exactly {get,list,watch}, bound to SA agent-sandbox-controller in
+#       agent-sandbox-system. (informer can sync; read-only)
+#   (b) NO ClusterRole grants any mutate verb on networkpolicies anywhere
+#       (the #66 regression tripwire; passes today, guards future re-vendoring).
+#   (c) A namespaced Role agent-sandbox-controller-networkpolicies in the release
+#       namespace keeps create/delete/patch/update/get and drops list/watch,
+#       bound to the same SA.
+#   (d) The controller-ready preflight gate renders with defaults and suppresses
+#       correctly under agentSandbox.controller.deploy=false and
+#       preflights.controllerReady.enabled=false.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly, naming the
+# violated assertion.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Deterministic release name + namespace so the release-namespace assertion (c)
+# is unambiguous. agentos.fullname collapses to the release name here (the chart
+# name "agentos" is a substring of "agentos-assert").
+RELEASE="agentos-assert"
+NS="agentos-assert"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+DEFAULT="$TMP/default.yaml"
+NOCTRL="$TMP/noctrl.yaml"
+NOGATE="$TMP/nogate.yaml"
+
+echo "=== Rendering chart (defaults) ==="
+helm template "$RELEASE" "$CHART" --namespace "$NS" > "$DEFAULT"
+
+echo "=== Rendering chart (agentSandbox.controller.deploy=false) ==="
+helm template "$RELEASE" "$CHART" --namespace "$NS" \
+  --set agentSandbox.controller.deploy=false > "$NOCTRL"
+
+echo "=== Rendering chart (preflights.controllerReady.enabled=false) ==="
+helm template "$RELEASE" "$CHART" --namespace "$NS" \
+  --set preflights.controllerReady.enabled=false > "$NOGATE"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# All four assertions run in one PyYAML pass over the three renders. The Python
+# emits an "ok:" line per assertion and exits nonzero (printing the reason) on
+# the first violation, which the bash fail() then surfaces by assertion label.
+ASSERT_PY="$TMP/assert.py"
+cat > "$ASSERT_PY" <<'PY'
+import sys, yaml
+
+default_path, noctrl_path, nogate_path, release_ns = sys.argv[1:5]
+
+CONTROLLER_SA = ("agent-sandbox-controller", "agent-sandbox-system")
+NP_ROLE = "agent-sandbox-controller-networkpolicies"
+READ_SUFFIX = "networkpolicies-read"
+PREFLIGHT_SUFFIX = "-preflight-controller"
+MUTATE_VERBS = {"create", "delete", "patch", "update", "deletecollection", "*"}
+
+
+def load(path):
+    with open(path) as f:
+        return [d for d in yaml.safe_load_all(f) if d]
+
+
+def docs_of_kind(docs, kind):
+    return [d for d in docs if d.get("kind") == kind]
+
+
+def rule_is_about_networkpolicies(rule):
+    # A rule may list several resources/apiGroups in one entry; treat it as
+    # touching networkpolicies if "networkpolicies" (or the "*" wildcard) is in
+    # its resources.
+    resources = rule.get("resources") or []
+    return "networkpolicies" in resources or "*" in resources
+
+
+def networkpolicy_verbs(role):
+    verbs = set()
+    for rule in role.get("rules") or []:
+        if rule_is_about_networkpolicies(rule):
+            verbs.update(rule.get("verbs") or [])
+    return verbs
+
+
+def role_mentions_networkpolicies(role):
+    return any(rule_is_about_networkpolicies(r) for r in (role.get("rules") or []))
+
+
+def binding_targets(binding, role_kind, role_name):
+    ref = binding.get("roleRef") or {}
+    if ref.get("kind") != role_kind or ref.get("name") != role_name:
+        return False
+    for subj in binding.get("subjects") or []:
+        if (
+            subj.get("kind") == "ServiceAccount"
+            and (subj.get("name"), subj.get("namespace")) == CONTROLLER_SA
+        ):
+            return True
+    return False
+
+
+def die(msg):
+    sys.stdout.write(msg + "\n")
+    sys.exit(1)
+
+
+default_docs = load(default_path)
+noctrl_docs = load(noctrl_path)
+nogate_docs = load(nogate_path)
+
+cluster_roles = docs_of_kind(default_docs, "ClusterRole")
+cluster_role_bindings = docs_of_kind(default_docs, "ClusterRoleBinding")
+
+# --- (a) Exactly one cluster-scope read grant, nothing more ---
+np_cluster_roles = [cr for cr in cluster_roles if role_mentions_networkpolicies(cr)]
+if len(np_cluster_roles) != 1:
+    names = sorted((cr.get("metadata") or {}).get("name") for cr in np_cluster_roles)
+    die(
+        "(a) exactly one cluster read grant — expected exactly 1 ClusterRole "
+        "with a networkpolicies rule, found %d: %s" % (len(np_cluster_roles), names)
+    )
+read_cr = np_cluster_roles[0]
+read_cr_name = (read_cr.get("metadata") or {}).get("name")
+verbs = networkpolicy_verbs(read_cr)
+if verbs != {"get", "list", "watch"}:
+    die(
+        "(a) exactly one cluster read grant — ClusterRole %r networkpolicies "
+        "verbs must be exactly {get, list, watch}, got %s"
+        % (read_cr_name, sorted(verbs))
+    )
+if not any(binding_targets(b, "ClusterRole", read_cr_name) for b in cluster_role_bindings):
+    die(
+        "(a) exactly one cluster read grant — no ClusterRoleBinding binds "
+        "ClusterRole %r to ServiceAccount agent-sandbox-controller in "
+        "agent-sandbox-system" % read_cr_name
+    )
+print("  ok: (a) exactly one networkpolicies ClusterRole %r, verbs {get,list,watch}, bound to the controller SA" % read_cr_name)
+
+# --- (b) No cluster-wide mutate, anywhere ---
+for cr in cluster_roles:
+    name = (cr.get("metadata") or {}).get("name")
+    bad = networkpolicy_verbs(cr) & MUTATE_VERBS
+    if bad:
+        die(
+            "(b) no cluster-wide mutate — ClusterRole %r grants mutate verb(s) "
+            "%s on networkpolicies (regresses #66)" % (name, sorted(bad))
+        )
+print("  ok: (b) no ClusterRole grants create/delete/patch/update/* on networkpolicies")
+
+# --- (c) Namespaced mutate intact ---
+np_roles = [
+    r
+    for r in docs_of_kind(default_docs, "Role")
+    if (r.get("metadata") or {}).get("name") == NP_ROLE
+]
+if len(np_roles) != 1:
+    die("(c) namespaced mutate intact — expected exactly one Role %r, found %d" % (NP_ROLE, len(np_roles)))
+np_role = np_roles[0]
+role_ns = (np_role.get("metadata") or {}).get("namespace")
+if role_ns != release_ns:
+    die("(c) namespaced mutate intact — Role %r must be in the release namespace %r, got %r" % (NP_ROLE, release_ns, role_ns))
+rverbs = networkpolicy_verbs(np_role)
+required = {"create", "delete", "patch", "update", "get"}
+missing = required - rverbs
+if missing:
+    die("(c) namespaced mutate intact — Role %r networkpolicies verbs must be a superset of %s, missing %s" % (NP_ROLE, sorted(required), sorted(missing)))
+forbidden = {"list", "watch"} & rverbs
+if forbidden:
+    die("(c) namespaced mutate intact — Role %r must NOT grant %s on networkpolicies (now served cluster-wide, #350)" % (NP_ROLE, sorted(forbidden)))
+role_bindings = [
+    rb
+    for rb in docs_of_kind(default_docs, "RoleBinding")
+    if (rb.get("metadata") or {}).get("namespace") == release_ns
+]
+if not any(binding_targets(rb, "Role", NP_ROLE) for rb in role_bindings):
+    die("(c) namespaced mutate intact — no RoleBinding in %r binds Role %r to the controller SA" % (release_ns, NP_ROLE))
+print("  ok: (c) namespaced Role %r keeps create/delete/patch/update/get, drops list/watch, bound to the controller SA" % NP_ROLE)
+
+# --- (d) Gate renders/suppresses with its flags ---
+def names_by_kind(docs, kind):
+    return [(d.get("metadata") or {}).get("name") for d in docs_of_kind(docs, kind)]
+
+def has_suffix(names, suffix):
+    return [n for n in names if n and n.endswith(suffix)]
+
+# (d.1) defaults: preflight Job + its ServiceAccount render.
+default_jobs = has_suffix(names_by_kind(default_docs, "Job"), PREFLIGHT_SUFFIX)
+if not default_jobs:
+    die("(d) gate renders — defaults must render a Job whose name ends with %r; none found" % PREFLIGHT_SUFFIX)
+default_sas = has_suffix(names_by_kind(default_docs, "ServiceAccount"), PREFLIGHT_SUFFIX)
+if not default_sas:
+    die("(d) gate renders — defaults must render a ServiceAccount whose name ends with %r; none found" % PREFLIGHT_SUFFIX)
+print("  ok: (d.1) defaults render preflight Job %s and its ServiceAccount" % default_jobs)
+
+# (d.2) controller.deploy=false: NONE of the gate Job, the read ClusterRole/CRB,
+# the namespaced Role/RoleBinding render.
+noctrl_offenders = []
+noctrl_offenders += ["Job " + n for n in has_suffix(names_by_kind(noctrl_docs, "Job"), PREFLIGHT_SUFFIX)]
+noctrl_offenders += ["ClusterRole " + n for n in has_suffix(names_by_kind(noctrl_docs, "ClusterRole"), READ_SUFFIX)]
+noctrl_offenders += [
+    "ClusterRoleBinding " + n
+    for n in has_suffix(names_by_kind(noctrl_docs, "ClusterRoleBinding"), READ_SUFFIX)
+]
+noctrl_offenders += ["Role " + n for n in names_by_kind(noctrl_docs, "Role") if n == NP_ROLE]
+noctrl_offenders += ["RoleBinding " + n for n in names_by_kind(noctrl_docs, "RoleBinding") if n == NP_ROLE]
+if noctrl_offenders:
+    die("(d) gate suppresses — with controller.deploy=false these must NOT render: %s" % noctrl_offenders)
+print("  ok: (d.2) controller.deploy=false suppresses the gate Job, the read ClusterRole/CRB, and the namespaced Role/RoleBinding")
+
+# (d.3) controllerReady.enabled=false (deploy still true): Job absent, but the
+# read ClusterRole and namespaced Role STILL render (RBAC split is independent).
+nogate_jobs = has_suffix(names_by_kind(nogate_docs, "Job"), PREFLIGHT_SUFFIX)
+if nogate_jobs:
+    die("(d) gate suppresses — with controllerReady.enabled=false the preflight Job must be absent, found %s" % nogate_jobs)
+nogate_read = has_suffix(names_by_kind(nogate_docs, "ClusterRole"), READ_SUFFIX)
+if not nogate_read:
+    die("(d) RBAC split independent of gate — with controllerReady.enabled=false the read ClusterRole (*%s) must still render" % READ_SUFFIX)
+nogate_role = [n for n in names_by_kind(nogate_docs, "Role") if n == NP_ROLE]
+if not nogate_role:
+    die("(d) RBAC split independent of gate — with controllerReady.enabled=false Role %r must still render" % NP_ROLE)
+print("  ok: (d.3) controllerReady.enabled=false suppresses only the Job; the RBAC split still renders")
+PY
+
+if ! out="$(python3 "$ASSERT_PY" "$DEFAULT" "$NOCTRL" "$NOGATE" "$NS" 2>&1)"; then
+  fail "$out"
+fi
+echo "$out"
+
+echo
+echo "PASS: exactly one read-only cluster networkpolicies grant (get/list/watch, bound to the controller SA); no cluster-wide mutate anywhere; namespaced Role keeps mutate and drops list/watch; the controller-ready gate renders on defaults and suppresses correctly under both flags."

--- a/charts/agentos/files/agent-sandbox/controller.yaml
+++ b/charts/agentos/files/agent-sandbox/controller.yaml
@@ -1,13 +1,17 @@
 # NOTE: This is the upstream kubernetes-sigs/agent-sandbox v0.5.0 controller
-# bundle, with two AgentOS security patches (issue #66):
+# bundle, with two AgentOS security patches (issues #66 and #350):
 #   1. The cluster-wide `networkpolicies` rule has been REMOVED from the
-#      agent-sandbox-controller-extensions ClusterRole below. That permission is
-#      re-granted, scoped to the release namespace only, by a namespaced
-#      Role/RoleBinding in templates/agent-sandbox.yaml, so a compromised
-#      controller SA cannot delete the fail-closed egress policy (Rail 1) in
-#      any other namespace.
+#      agent-sandbox-controller-extensions ClusterRole below. It is replaced by a
+#      verb SPLIT in templates/agent-sandbox.yaml (issue #350, ADR-0023): a
+#      cluster-scoped read-only ClusterRole grants get/list/watch (which the
+#      controller's cluster-scope NetworkPolicy informer needs to sync), while a
+#      namespaced Role/RoleBinding grants the mutating verbs
+#      create/delete/patch/update (plus get) confined to the release namespace, so
+#      a compromised controller SA cannot delete the fail-closed egress policy
+#      (Rail 1) in any other namespace.
 #   2. The Deployment carries a non-root / read-only-rootfs securityContext.
-# Re-vendoring a newer upstream release must re-apply both patches.
+# Re-vendoring a newer upstream release must re-apply both patches -- including the
+# cluster-read + namespaced-mutate split in patch 1.
 kind: Namespace
 apiVersion: v1
 metadata:

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -20,15 +20,54 @@ the worker claims from, plus (optionally) the vendored upstream controller.
 {{ .Files.Get "files/agent-sandbox/controller.yaml" }}
 ---
 {{/*
-Scoped replacement (#66) for the networkpolicies grant removed from the vendored
-controller's cluster-wide agent-sandbox-controller-extensions ClusterRole. The
-controller manages one NetworkPolicy per Sandbox, and this chart creates all
-Sandboxes in the release namespace (the worker's AGENTOS_NAMESPACE is
-.Release.Namespace), so a namespaced Role confines that power here: a compromised
-controller SA cannot delete the fail-closed egress policy (Rail 1) in any other
-namespace. Cross-namespace binding is intentional -- the SA lives in
-agent-sandbox-system, the NetworkPolicies it manages live in this namespace.
+NetworkPolicy RBAC for the vendored controller, split by verb along the
+read/mutate line (issue #350, ADR-0023). The upstream v0.5.0 controller runs a
+CLUSTER-scope NetworkPolicy informer (upstream `Owns(&networkingv1.NetworkPolicy{})`
+with no cache namespace scoping and no `--namespace` flag), so it needs
+cluster-wide get/list/watch to sync -- a namespaced Role alone can never satisfy a
+cluster-scope LIST, so the informer cache never syncs, the manager aborts, and the
+controller crash-loops (no SandboxClaim ever binds -- issue #350). The read-only
+ClusterRole below is that minimum, and grants nothing more.
+
+#66's guarantee is preserved in its load-bearing form -- NO cluster-wide mutate:
+create/delete/patch/update stay confined to the namespaced Role in
+.Release.Namespace (this chart creates every Sandbox there, the worker's
+AGENTOS_NAMESPACE is .Release.Namespace), so a compromised controller SA still
+cannot delete the fail-closed egress policy (Rail 1) in any other namespace.
+Cross-namespace binding is intentional -- the SA lives in agent-sandbox-system,
+the NetworkPolicies it manages live in this namespace.
 */}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-sandbox-controller-networkpolicies-read
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-sandbox-controller-networkpolicies-read
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: agent-sandbox-controller
+  namespace: agent-sandbox-system
+roleRef:
+  kind: ClusterRole
+  name: agent-sandbox-controller-networkpolicies-read
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -45,10 +84,8 @@ rules:
   - create
   - delete
   - get
-  - list
   - patch
   - update
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/agentos/templates/preflight-controller.yaml
+++ b/charts/agentos/templates/preflight-controller.yaml
@@ -1,0 +1,188 @@
+{{- if and .Values.agentSandbox.controller.deploy .Values.preflights.controllerReady.enabled }}
+{{/*
+Preflight (c): controller-ready install-time gate (issue #350, ADR-0023).
+
+The vendored agent-sandbox controller runs a CLUSTER-scope NetworkPolicy
+informer; if its RBAC cannot satisfy that cluster LIST, the manager crash-loops
+and no SandboxClaim ever binds. The vendored Deployment has NO readiness probe,
+so `rollout status` passes while the manager still blocks on cache sync -- the
+load-bearing signal is the "Starting workers" log line, emitted only after all
+informer caches sync. This post-install/post-upgrade hook Job fails the Helm
+operation unless the controller reaches that state, so an RBAC regression fails
+at install, not at first turn.
+
+The gate is read-only: its Role can only get/list/watch deployments + pods and
+read pod logs in agent-sandbox-system. Gated on agentSandbox.controller.deploy
+so it never runs against a BYO controller this release does not own.
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentos.fullname" . }}-preflight-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "agentos.fullname" . }}-preflight-controller
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "agentos.fullname" . }}-preflight-controller
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,test
+    "helm.sh/hook-weight": "-4"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "agentos.fullname" . }}-preflight-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "agentos.fullname" . }}-preflight-controller
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agentos.fullname" . }}-preflight-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade,test
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- include "agentos.labels" . | nindent 8 }}
+        {{- include "agentos.selectorLabels" (dict "root" . "component" "preflight-controller") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "agentos.fullname" . }}-preflight-controller
+      restartPolicy: Never
+      containers:
+        - name: controller-ready
+          image: {{ .Values.preflights.controllerReady.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: CONTROLLER_NS
+              value: "agent-sandbox-system"
+            - name: DEPLOY
+              value: "agent-sandbox-controller"
+            - name: TIMEOUT
+              value: {{ .Values.preflights.controllerReady.timeoutSeconds | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -u
+              # Short fixed budget for the preliminary rollout-status check,
+              # deliberately much smaller than ${TIMEOUT}. It caps the total
+              # wall-clock at ~ROLLOUT_TIMEOUT + TIMEOUT (~210s) so the Job stays
+              # safely under Helm's default 300s install/upgrade hook timeout and
+              # its FAIL diagnostic always prints -- even on Pending /
+              # ImagePullBackOff paths where the controller never becomes
+              # Available -- instead of Helm killing the Job generically first.
+              ROLLOUT_TIMEOUT=30
+              echo "== AgentOS controller-ready preflight =="
+              echo "controller: deployment/${DEPLOY}  namespace: ${CONTROLLER_NS}  timeout: ${TIMEOUT}s"
+
+              # Existence/schedule check only, bounded by the short
+              # ROLLOUT_TIMEOUT (not ${TIMEOUT}). The vendored Deployment has NO
+              # readiness probe (D2), so a passing rollout is NOT proof the
+              # informer caches synced -- this rc is informative only; the poll
+              # loop below (bounded by ${TIMEOUT}) is the real gate.
+              kubectl rollout status "deployment/${DEPLOY}" -n "${CONTROLLER_NS}" \
+                --timeout="${ROLLOUT_TIMEOUT}s" 2>/dev/null
+              rc=$?
+              echo "rollout status rc=${rc} (informative only)"
+
+              # The load-bearing assertion: poll the controller log for
+              # "Starting workers" (emitted only after all informer caches
+              # sync). Fail fast on a forbidden-networkpolicies log line or a
+              # restarting pod -- those are the #350 crash-loop signature.
+              elapsed=0
+              while [ "${elapsed}" -lt "${TIMEOUT}" ]; do
+                logs=$(kubectl logs "deployment/${DEPLOY}" -n "${CONTROLLER_NS}" --tail=-1 2>/dev/null || true)
+
+                if echo "${logs}" | grep -q "Starting workers"; then
+                  echo "RESULT: PASS -- agent-sandbox-controller Available and informer caches synced ('Starting workers' observed)."
+                  exit 0
+                fi
+
+                restarts=$(kubectl get pods -n "${CONTROLLER_NS}" -l app=agent-sandbox-controller \
+                  -o jsonpath='{.items[*].status.containerStatuses[*].restartCount}' 2>/dev/null || true)
+                restarted=0
+                for r in ${restarts}; do
+                  if [ "${r}" -gt 0 ] 2>/dev/null; then
+                    restarted=1
+                  fi
+                done
+
+                # A previous container's logs only exist once the pod has
+                # restarted, so only fetch --previous then -- skips a wasted
+                # kubectl call every poll on the healthy path.
+                prev=""
+                if [ "${restarted}" -eq 1 ]; then
+                  prev=$(kubectl logs "deployment/${DEPLOY}" -n "${CONTROLLER_NS}" --tail=-1 --previous 2>/dev/null || true)
+                fi
+
+                if echo "${logs}" | grep -Eq "networkpolicies.*[Ff]orbidden" \
+                   || echo "${prev}" | grep -Eq "networkpolicies.*[Ff]orbidden" \
+                   || [ "${restarted}" -eq 1 ]; then
+                  echo "detected controller failure (forbidden networkpolicies log and/or restartCount>0)."
+                  break
+                fi
+
+                sleep 5
+                elapsed=$(( elapsed + 5 ))
+              done
+
+              echo "---"
+              echo "FAIL diagnostic: last controller log lines:"
+              kubectl logs "deployment/${DEPLOY}" -n "${CONTROLLER_NS}" --tail=40 2>/dev/null || true
+              echo "---"
+              echo "controller pod status:"
+              kubectl get pods -n "${CONTROLLER_NS}" -l app=agent-sandbox-controller 2>/dev/null || true
+              echo "---"
+              echo "RESULT: FAIL -- controller did not reach 'Starting workers' -- its NetworkPolicy"
+              echo "        informer likely cannot sync. Verify ClusterRole"
+              echo "        agent-sandbox-controller-networkpolicies-read exists and grants"
+              echo "        get/list/watch on networkpolicies cluster-wide (issue #350 / ADR-0023)."
+              echo "        If this is an upgrade over a previously crash-looping controller, the"
+              echo "        pod may still be in CrashLoopBackOff backoff -- delete the controller"
+              echo "        pod and re-run 'helm test <release>'."
+              exit 1
+          resources:
+            {{- toYaml .Values.preflights.controllerReady.resources | nindent 12 }}
+{{- end }}

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -604,6 +604,23 @@ preflights:
     resources:
       requests: { cpu: 50m, memory: 64Mi }
       limits: { cpu: 250m, memory: 128Mi }
+  # (c) Controller-ready install-time gate. The vendored agent-sandbox controller
+  # runs a CLUSTER-scope NetworkPolicy informer; if its RBAC cannot satisfy that
+  # cluster LIST the manager crash-loops and no SandboxClaim ever binds (issue
+  # #350). This post-install/upgrade hook Job fails the Helm operation unless the
+  # controller reaches "Starting workers" (all informer caches synced), so an RBAC
+  # regression fails at install, not at first turn. Gated also on
+  # agentSandbox.controller.deploy.
+  controllerReady:
+    enabled: true
+    image: alpine/k8s:1.31.2
+    # Max seconds to wait for the controller to become Available and log
+    # "Starting workers". Sized for a fresh install; an upgrade over a
+    # crash-looping controller may need a manual pod delete + `helm test`.
+    timeoutSeconds: 180
+    resources:
+      requests: { cpu: 50m, memory: 64Mi }
+      limits: { cpu: 250m, memory: 128Mi }
 
 # ---------------------------------------------------------------------------
 # Agent Sandbox substrate. The runner SandboxTemplate + SandboxWarmPool

--- a/docs/adr/0023-controller-networkpolicy-rbac-cluster-read-namespace-mutate.md
+++ b/docs/adr/0023-controller-networkpolicy-rbac-cluster-read-namespace-mutate.md
@@ -1,0 +1,95 @@
+# 23. Controller NetworkPolicy RBAC: cluster-scope read, namespace-scope mutate
+
+Date: 2026-07-13
+Status: Accepted
+
+## Context
+
+The umbrella chart vendors the upstream `kubernetes-sigs/agent-sandbox` v0.5.0
+controller (`registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.5.0`) as
+release manifests under `charts/agentos/files/agent-sandbox/controller.yaml`.
+The controller reconciles a shared `NetworkPolicy` per `SandboxTemplate`
+(`extensions/controllers/sandboxtemplate_controller.go:253`,
+`Owns(&networkingv1.NetworkPolicy{})`).
+
+[ADR-less PR #189 / issue #66] hardened this controller: it **removed the
+cluster-wide `networkpolicies` grant** from the vendored
+`agent-sandbox-controller-extensions` ClusterRole and re-granted it as a
+**namespaced** `Role`/`RoleBinding` (`agent-sandbox-controller-networkpolicies`,
+`namespace: {{ .Release.Namespace }}`). The security intent is load-bearing: a
+compromised controller SA (or leaked token) must not be able to delete the
+fail-closed egress `NetworkPolicy` (Rail 1) in any *other* namespace and then
+exfiltrate. #66's live check proved `kubectl auth can-i delete networkpolicies`
+was `no` cluster-wide and in every namespace but the release namespace.
+
+That hardening broke the controller's ability to start. A `controller-runtime`
+manager backs `Owns(&NetworkPolicy{})` with an **informer that LISTs/WATCHes at
+cluster scope** (the vendored manager sets no cache namespace scoping;
+`cmd/agent-sandbox-controller/main.go:262` calls `ctrl.NewManager` with no
+`Cache.DefaultNamespaces`). A namespaced Role cannot satisfy a cluster-scope
+LIST, so the NetworkPolicy informer cache never syncs and the manager aborts ->
+CrashLoopBackOff -> **no `SandboxClaim` ever binds -> not a single turn runs at
+the cluster tier**. Field evidence: cold-start parity-ladder run 2 (v0.3.0
+release binary, k3s v1.35). This is invisible at the skill and local tiers, which
+use the docker substrate, not this controller (issue #350).
+
+### Alternatives weighed
+
+1. **Namespace-scope the controller's cache/informer** (the "cleanest" fix: a
+   `--namespace` flag or `cache.Options.DefaultNamespaces`, so its NetworkPolicy
+   LIST is namespaced and the existing namespaced Role suffices). **Rejected as
+   infeasible without recompiling upstream.** v0.5.0's binary exposes no
+   namespace-scoping flag (`main.go` defines `--leader-elect`,
+   `--leader-election-namespace`, `--webhook-namespace`, `--extensions`,
+   concurrency/pprof knobs -- and no `--namespace`), and the manager hardcodes a
+   cluster-wide cache. Achieving this would require patching and rebuilding the
+   vendored public image, a maintenance burden (re-patch on every upstream bump)
+   far out of proportion to a chart RBAC fix.
+
+2. **Re-widen the ClusterRole to full `networkpolicies`** (grant cluster-wide
+   create/delete/get/list/patch/update/watch back). **Rejected: regresses #66.**
+   It re-opens the exact cross-namespace egress-policy-deletion hole the
+   fail-closed-egress invariant exists to prevent.
+
+## Decision
+
+Split the controller's `networkpolicies` RBAC by verb along the read/mutate line:
+
+- **Cluster-scope, read-only.** A new `ClusterRole` +
+  `ClusterRoleBinding` grants **only `get`, `list`, `watch`** on
+  `networkpolicies` to the `agent-sandbox-controller` SA. This is the minimum the
+  cluster-wide informer needs to sync, and it contains no ability to change
+  anything.
+- **Namespace-scope, mutating.** The existing namespaced `Role`/`RoleBinding`
+  (`agent-sandbox-controller-networkpolicies`, in `.Release.Namespace`) keeps the
+  **mutating verbs `create`, `delete`, `patch`, `update`** (plus `get`), so the
+  controller can only create/update/delete NetworkPolicies in the release
+  namespace -- where this chart creates all Sandboxes.
+
+The security guarantee #66 established is preserved in its load-bearing form: the
+controller SA has **no cluster-wide mutate** on networkpolicies, so a compromised
+SA still cannot delete or alter the fail-closed egress policy in any other
+namespace. The only new grant is read visibility, which cannot be used to defeat
+containment. When a cluster-scope watch is genuinely required -- and here it is,
+because the upstream binary offers no namespaced alternative -- least privilege
+means read-only cluster-wide, mutate namespaced.
+
+Additionally, add an **install-time gate** so a future RBAC regression fails the
+install, not the first turn: a `helm test` / hook Job asserts the controller
+Deployment becomes Available and its log shows the manager reached
+`Starting workers` (which is emitted only after all informer caches, including
+NetworkPolicy, sync). Gated on `agentSandbox.controller.deploy`.
+
+## Consequences
+
+- A real-model `cluster up` on stock k8s (>= 1.31) brings the controller to
+  Running and binds `SandboxClaim`s with no manual RBAC patch.
+- The controller SA gains cluster-wide **read** on networkpolicies. This is a
+  deliberate, documented widening from #66's zero cluster-wide access, justified
+  by the informer's structural requirement; it grants no mutate power.
+- Re-vendoring a newer upstream release must re-apply this verb split alongside
+  #66's securityContext patch (noted in `controller.yaml`'s header comment). If a
+  future upstream release adds namespace-scoped caching, Alternative 1 becomes
+  viable and should supersede this ADR.
+- The install-time gate adds one hook Job to the controller-deploy path; it is
+  skipped when `agentSandbox.controller.deploy` is false.


### PR DESCRIPTION
## Problem
On a real-model `cluster up` (k3s v1.35, cold-start dogfood run 2), the vendored `agent-sandbox` v0.5.0 controller crash-looped with `networkpolicies.networking.k8s.io is forbidden ... cannot list ... at the cluster scope`. With the controller down, no `SandboxClaim` binds, so **not a single turn runs at the cluster tier** (#350, HIGH).

## Root cause (source-confirmed)
The controller runs a **cluster-scope** NetworkPolicy informer (upstream `Owns(&NetworkPolicy{})`; the manager sets no cache namespace scoping and the v0.5.0 binary has no `--namespace` flag). #66 confined **all** networkpolicies verbs to a namespaced Role, which a cluster-scope LIST can never satisfy, so the informer cache never syncs and the manager blocks before reaching `Starting workers`.

## Fix (ADR-0023)
- **RBAC verb split** (`templates/agent-sandbox.yaml`): a cluster-scoped read-only ClusterRole (`get/list/watch`, what the informer needs to sync) + the existing namespaced Role narrowed to the mutating verbs (`create/delete/patch/update/get`, `list`/`watch` dropped). #66's guarantee holds in its load-bearing form — **no cluster-wide mutate** — so a compromised controller SA still cannot delete the fail-closed egress policy in any other namespace.
- **Install-time gate** (`templates/preflight-controller.yaml`): a `post-install,post-upgrade,test` hook Job (read-only RBAC) that fails the Helm operation unless the controller reaches `Starting workers`, so a future RBAC regression fails at install, not at first turn.
- **CI contract** (`ci/controller-rbac-assertions.sh`, wired into `helm-ci`) pins the verb split + gate shape.
- Option A (a namespace-scoped informer) is infeasible without rebuilding the vendored image; ADR-0023 records why.

## Verification (real k8s v1.35 / k8scratch)
- Controller reaches Running (restartCount 0) and logs `Starting workers` + `Successfully created shared NetworkPolicy` — **no manual RBAC patch**; a claim's shared NetworkPolicy lands in the release namespace.
- `kubectl auth can-i` for the controller SA: cluster-wide list/get/watch = yes; delete/create/patch in other namespaces and cluster-wide = **no**; mutate in the release namespace = yes.
- Gate **PASSes** on the healthy install; deleting the read ClusterRole reproduces the exact `forbidden` error and the gate **FAILs** with the NetworkPolicy-RBAC diagnostic.
- `helm lint` + render-assertions green on default, `values-dev`, and `values-dev + values-e2e-nogvisor`.

Closes #350