### PR TITLE
cluster deploy reaches the platform API via the UI /api proxy

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -159,16 +159,17 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `agentos cluster status` | Report release health, pod readiness, and access URLs (read-only). |
 | `agentos cluster comms --slack` | Connect or disconnect a real Slack workspace with a thin `helm upgrade --reuse-values`; env-backed tokens are masked in dry-run output. |
 | `agentos cluster message "..."` | Drive the deployed release end to end with zero Slack: self plumbs kubectl port forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply. |
-| `agentos cluster deploy` | Package the bundle as tar.gz and push it to the platform API (`--api-url`, default `http://localhost:8000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
+| `agentos cluster deploy` | Package the bundle as tar.gz and push it to the platform API. Reaches the API through the deployed release's UI `/api` NodePort proxy when `--api-url` is omitted (no port-forward); pass `--api-url` / `AGENTOS_API_URL` to target it directly. Auth via `--api-key` or `AGENTOS_API_KEY`. |
 | `agentos cluster kill <agent> --yes` | Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`). Destructive: refuses without `--yes`. |
 | `agentos cluster resume <agent>` | Resume a killed agent via the platform API (`POST /agents/{id}/resume`). |
 | `agentos cluster budget <agent> --limit <n>` | Set the agent's daily spend cap in USD via the platform API (`PUT /agents/{id}/budget`, `BudgetConfig.max_usd_per_day`); the per-run token cap is left at the platform default. |
 | `agentos cluster delete <agent> --yes` | Delete an agent via the platform API (`DELETE /agents/{id}`). Destructive and irreversible: refuses without `--yes`. |
 
 The four lifecycle verbs (`kill`, `resume`, `budget`, `delete`) act on a
-deployed release's agents through the same platform API as `cluster deploy`
-(`--api-url`, default `http://localhost:8000`; auth via `--api-key` or
-`AGENTOS_API_KEY`). They resolve `<agent>` (a name or id) to its API id with the
+deployed release's agents through the same platform API, defaulting `--api-url`
+to `http://localhost:8000` (auth via `--api-key` or `AGENTOS_API_KEY`). Unlike
+`cluster deploy`, they do not auto-discover the UI proxy -- pass `--api-url` or
+port-forward the API yourself. They resolve `<agent>` (a name or id) to its API id with the
 same lookup `deploy` uses. Each takes `--dry-run` (prints the plan, makes no
 request); the destructive `kill`/`delete` also require `--yes`.
 

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1247,14 +1247,33 @@
               "required": false
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to auto-discover the deployed release's UI `/api` proxy (NodePort + node host); no port-forward. AGENTOS_API_URL or an explicit value is dialed as given",
               "id": "api_url",
               "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release (for UI proxy discovery). Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name (for UI proxy discovery). Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -588,9 +588,17 @@ enum ClusterAction {
         /// Plugin bundle directory.
         #[arg(long, default_value = ".")]
         plugin_dir: PathBuf,
-        /// Platform API base URL.
-        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
-        api_url: String,
+        /// Platform API base URL. Omit to auto-discover the deployed release's UI
+        /// `/api` proxy (NodePort + node host); no port-forward. AGENTOS_API_URL or
+        /// an explicit value is dialed as given.
+        #[arg(long, env = "AGENTOS_API_URL")]
+        api_url: Option<String>,
+        /// Kubernetes namespace of the release (for UI proxy discovery). Default: agentos.
+        #[arg(long, default_value = "agentos")]
+        namespace: String,
+        /// Helm release name (for UI proxy discovery). Default: agentos.
+        #[arg(long, default_value = "agentos")]
+        release: String,
         /// Platform API key.
         #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
         api_key: String,
@@ -1146,13 +1154,22 @@ async fn run(command: Command) -> Result<()> {
             ClusterAction::Deploy {
                 plugin_dir,
                 api_url,
+                namespace,
+                release,
                 api_key,
                 slack_channel,
                 env,
                 label,
             } => {
+                // An explicit --api-url / AGENTOS_API_URL is dialed as given;
+                // otherwise reach the platform API through the deployed release's
+                // UI `/api` NodePort proxy (never self-plumb a port-forward).
+                let api_url = match api_url {
+                    Some(url) => url,
+                    None => ops::discover_ui_api_url(&namespace, &release).await?,
+                };
                 let connect_hint = format!(
-                    "the platform API at {api_url} is unreachable. `cluster deploy` does not port-forward for you; open one first, e.g.:\n    kubectl -n agentos port-forward svc/agentos-api 8000:8000\nthen re-run (or pass --api-url if your API is elsewhere)."
+                    "the platform API at {api_url} is unreachable. `cluster deploy` reaches the API through the UI /api proxy (no port-forward); confirm the release is healthy with `agentos cluster status`, or pass --api-url to target the API directly."
                 );
                 commands::deploy(DeployOpts {
                     plugin_dir,
@@ -1310,6 +1327,72 @@ mod tests {
                 action: LocalAction::Message { api_key, .. },
             } => assert_eq!(api_key, "K"),
             _ => panic!("expected local message command"),
+        }
+    }
+
+    #[test]
+    fn cluster_deploy_defaults_to_proxy_discovery() {
+        let cli = Cli::try_parse_from(["agentos", "cluster", "deploy"])
+            .expect("cluster deploy should parse");
+        match cli.command {
+            Command::Cluster {
+                action:
+                    ClusterAction::Deploy {
+                        api_url,
+                        namespace,
+                        release,
+                        ..
+                    },
+            } => {
+                assert_eq!(api_url, None);
+                assert_eq!(namespace, "agentos");
+                assert_eq!(release, "agentos");
+            }
+            _ => panic!("expected cluster deploy command"),
+        }
+    }
+
+    #[test]
+    fn cluster_deploy_accepts_explicit_api_url() {
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "cluster",
+            "deploy",
+            "--api-url",
+            "http://h:30080/api",
+        ])
+        .expect("cluster deploy --api-url should parse");
+        match cli.command {
+            Command::Cluster {
+                action: ClusterAction::Deploy { api_url, .. },
+            } => assert_eq!(api_url.as_deref(), Some("http://h:30080/api")),
+            _ => panic!("expected cluster deploy command"),
+        }
+    }
+
+    #[test]
+    fn cluster_deploy_captures_namespace_and_release() {
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "cluster",
+            "deploy",
+            "--namespace",
+            "ns1",
+            "--release",
+            "rel1",
+        ])
+        .expect("cluster deploy --namespace --release should parse");
+        match cli.command {
+            Command::Cluster {
+                action:
+                    ClusterAction::Deploy {
+                        namespace, release, ..
+                    },
+            } => {
+                assert_eq!(namespace, "ns1");
+                assert_eq!(release, "rel1");
+            }
+            _ => panic!("expected cluster deploy command"),
         }
     }
 

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1121,20 +1121,96 @@ fn print_pod_summary(pods: &[serde_json::Value]) -> (usize, usize, Vec<String>) 
     (ready, total, unhealthy)
 }
 
-/// Resolve the node host: the kubeconfig cluster server hostname, falling back
-/// to the first node's InternalIP.
-async fn discover_host() -> String {
+/// Resolve a routable node host: kubeconfig cluster server hostname, falling
+/// back to the first node's InternalIP. None when neither is available.
+async fn resolve_node_host() -> Option<String> {
     if let Ok((true, out, _)) = run_capture(&kubeconfig_host_cmd()).await {
         if let Some(host) = host_from_server_url(out.trim()) {
-            return host;
+            return Some(host);
         }
     }
     if let Ok((true, out, _)) = run_capture(&nodes_cmd()).await {
         if let Some(ip) = node_internal_ip(&out) {
-            return ip;
+            return Some(ip);
         }
     }
-    "localhost".to_string()
+    None
+}
+
+/// Resolve the node host: the kubeconfig cluster server hostname, falling back
+/// to the first node's InternalIP, then to the literal `localhost`.
+async fn discover_host() -> String {
+    resolve_node_host()
+        .await
+        .unwrap_or_else(|| "localhost".to_string())
+}
+
+/// Format an `http://host:port<path>` URL for a node, bracketing an IPv6 host
+/// literal so the authority is valid (`::1` -> `[::1]`). `host` is expected
+/// unbracketed (as `resolve_node_host` returns it); `path` is appended verbatim
+/// (`/api`, `/?api=1`, or `""`).
+fn node_http_url(host: &str, port: u16, path: &str) -> String {
+    if host.contains(':') {
+        format!("http://[{host}]:{port}{path}")
+    } else {
+        format!("http://{host}:{port}{path}")
+    }
+}
+
+/// A usage error (exit 2) whose fix hint points the operator at `--api-url`,
+/// the escape hatch for every UI-proxy discovery failure.
+fn api_url_usage_err(msg: impl Into<String>) -> anyhow::Error {
+    crate::exit::CliError::usage(msg)
+        .with_fix("pass --api-url")
+        .into()
+}
+
+/// Build the UI `/api` proxy base URL (`http://<host>:<ui-nodeport>/api`) from
+/// the UI service JSON and a resolved node host, or an actionable usage error.
+/// `cluster deploy` reaches the platform API through this proxy (the UI pod
+/// serves `/api`), so it never falls back to a port-forward.
+fn ui_api_url_from_parts(ui_svc_json: &str, host: Option<&str>) -> Result<String> {
+    match parse_service(ui_svc_json) {
+        Some((svc_type, node_port, _)) if svc_type == "NodePort" => {
+            let np = node_port.ok_or_else(|| {
+                api_url_usage_err(
+                    "the UI service is NodePort but has not been assigned a nodePort yet; wait for the release to settle or pass --api-url to target the API directly",
+                )
+            })?;
+            let host = host.ok_or_else(|| {
+                api_url_usage_err(
+                    "could not determine a node host to reach the UI /api proxy; pass --api-url to target the API directly",
+                )
+            })?;
+            Ok(node_http_url(host, np, "/api"))
+        }
+        Some(_) => Err(api_url_usage_err(
+            "the UI service is not NodePort-exposed (installed with --no-expose?); re-run `cluster up` without --no-expose or pass --api-url to target the API directly",
+        )),
+        None => Err(api_url_usage_err(
+            "could not read the UI service to discover the platform API URL; pass --api-url to target the API directly",
+        )),
+    }
+}
+
+/// Discover the UI `/api` proxy URL for a NodePort-exposed release so
+/// `cluster deploy` reaches the platform API with no port-forward.
+pub async fn discover_ui_api_url(namespace: &str, release: &str) -> Result<String> {
+    let common = CommonOpts {
+        namespace: namespace.to_string(),
+        release: release.to_string(),
+        dry_run: false,
+    };
+    let svc_json = match run_capture(&svc_cmd(&common, "ui")).await {
+        Ok((true, out, _)) => out,
+        _ => {
+            return Err(api_url_usage_err(format!(
+                "could not read the {release}-ui service in namespace {namespace} to discover the platform API URL; pass --api-url to target the API directly"
+            )))
+        }
+    };
+    let host = resolve_node_host().await;
+    ui_api_url_from_parts(&svc_json, host.as_deref())
 }
 
 /// First node InternalIP from `kubectl get nodes -o json`.
@@ -1173,7 +1249,7 @@ async fn print_service_url(o: &CommonOpts, suffix: &str, label: &str, host: &str
     match parse_service(&out) {
         Some((svc_type, node_port, _port)) if svc_type == "NodePort" => {
             if let Some(np) = node_port {
-                ui.kv(label, &ui.url(&format!("http://{host}:{np}{suffix_path}")));
+                ui.kv(label, &ui.url(&node_http_url(host, np, suffix_path)));
             } else {
                 ui.kv(
                     label,
@@ -2075,5 +2151,71 @@ mod tests {
     fn helm_get_values_reads_user_supplied_values_as_json() {
         let cmd = helm_get_values_cmd(&common());
         assert_eq!(cmd.display(), "helm get values agentos -n agentos -o json");
+    }
+
+    #[test]
+    fn ui_api_url_nodeport_with_host_builds_proxy_url() {
+        let json = r#"{"spec":{"type":"NodePort","ports":[{"port":80,"nodePort":31234}]}}"#;
+        let url = ui_api_url_from_parts(json, Some("10.0.0.5")).expect("should build a proxy URL");
+        assert_eq!(url, "http://10.0.0.5:31234/api");
+    }
+
+    #[test]
+    fn node_http_url_brackets_ipv6_and_appends_path() {
+        assert_eq!(
+            node_http_url("10.0.0.5", 31234, "/api"),
+            "http://10.0.0.5:31234/api"
+        );
+        assert_eq!(
+            node_http_url("::1", 31234, "/api"),
+            "http://[::1]:31234/api"
+        );
+        assert_eq!(
+            node_http_url("node.local", 30080, "/?api=1"),
+            "http://node.local:30080/?api=1"
+        );
+        assert_eq!(
+            node_http_url("10.0.0.5", 30080, ""),
+            "http://10.0.0.5:30080"
+        );
+    }
+
+    #[test]
+    fn ui_api_url_ipv6_host_is_bracketed() {
+        let json = r#"{"spec":{"type":"NodePort","ports":[{"port":80,"nodePort":31234}]}}"#;
+        let url = ui_api_url_from_parts(json, Some("::1")).expect("should build a proxy URL");
+        assert_eq!(url, "http://[::1]:31234/api");
+    }
+
+    #[test]
+    fn ui_api_url_nodeport_without_host_errs_mentioning_api_url() {
+        let json = r#"{"spec":{"type":"NodePort","ports":[{"port":80,"nodePort":31234}]}}"#;
+        let err = ui_api_url_from_parts(json, None).expect_err("a missing host must error");
+        assert!(err.to_string().contains("--api-url"), "{err}");
+    }
+
+    #[test]
+    fn ui_api_url_nodeport_without_assigned_nodeport_errs_mentioning_api_url() {
+        let json = r#"{"spec":{"type":"NodePort","ports":[{"port":80}]}}"#;
+        let err = ui_api_url_from_parts(json, Some("10.0.0.5"))
+            .expect_err("an unassigned nodePort must error");
+        assert!(err.to_string().contains("--api-url"), "{err}");
+    }
+
+    #[test]
+    fn ui_api_url_clusterip_errs_mentioning_no_expose_and_api_url() {
+        let json = r#"{"spec":{"type":"ClusterIP","ports":[{"port":80}]}}"#;
+        let err = ui_api_url_from_parts(json, Some("10.0.0.5"))
+            .expect_err("a non-NodePort service must error");
+        let msg = err.to_string();
+        assert!(msg.contains("--no-expose"), "{msg}");
+        assert!(msg.contains("--api-url"), "{msg}");
+    }
+
+    #[test]
+    fn ui_api_url_malformed_json_errs_mentioning_api_url() {
+        let err =
+            ui_api_url_from_parts("", Some("10.0.0.5")).expect_err("malformed JSON must error");
+        assert!(err.to_string().contains("--api-url"), "{err}");
     }
 }

--- a/docs/adr/0024-deploy-reaches-api-via-ui-proxy.md
+++ b/docs/adr/0024-deploy-reaches-api-via-ui-proxy.md
@@ -1,0 +1,65 @@
+# 24. `cluster deploy` reaches the platform API via the UI `/api` proxy
+
+Date: 2026-07-13
+Status: Accepted
+
+Supersedes the abandoned self-plumbed port-forward approach for `cluster deploy`
+(#352 / PR #357). Implements [#359](https://github.com/curie-eng/agentos/issues/359).
+
+## Context
+
+`agentos cluster deploy` ships a bundle to the deployed release's platform API
+over plain HTTP (find-or-create agent, create version, upload bundle, create
+deployment). Until now it defaulted `--api-url` to `http://localhost:8000` and
+required the operator to first open a `kubectl port-forward svc/agentos-api`
+themselves. That is a manual pre-step the CLI cannot verify, and the failure mode
+(a connection refused against localhost) is opaque.
+
+A prior attempt (#352 / PR #357) had `cluster deploy` self-plumb its own
+port-forward. That was abandoned: it duplicates the port-forward machinery
+`cluster message` already owns, and adds a child-process lifecycle to a verb that
+otherwise just makes HTTP calls.
+
+The release already exposes the UI on a NodePort by default (`cluster up` sets
+`ui.service.type=NodePort` unless `--no-expose`), and the UI pod serves the
+platform API under `/api`. So a routable path to the API already exists with no
+tunnel: `http://<node-host>:<ui-nodeport>/api`.
+
+## Decision
+
+When `--api-url` (and `AGENTOS_API_URL`) is omitted, `cluster deploy`
+auto-discovers the UI `/api` proxy URL and dials that. It reads the
+`<release>-ui` service, requires it to be NodePort-exposed, resolves a routable
+node host (kubeconfig `cluster.server` hostname, falling back to the first node's
+InternalIP), and builds `http://<host>:<ui-nodeport>/api`. It **never** self-plumbs
+a port-forward.
+
+An explicit `--api-url` or `AGENTOS_API_URL` is still dialed exactly as given.
+Every discovery failure (UI service unreadable, not NodePort-exposed, no assigned
+nodePort, no resolvable host) is a usage error naming `--api-url` as the escape
+hatch; the non-NodePort case also names `--no-expose` as the likely cause.
+
+This is deliberately asymmetric with `cluster message`, which continues to
+self-plumb a `kubectl port-forward`: `message` enqueues onto in-cluster Valkey,
+which has no HTTP proxy, so a tunnel is the only path. `deploy` speaks only HTTP
+to the API, and the UI's `/api` proxy is already an HTTP path, so no tunnel is
+needed.
+
+## Consequences
+
+- `cluster deploy` works out of the box against a default (exposed) release with
+  no manual port-forward and no `--api-url`.
+- A `--no-expose` release has no NodePort proxy; `cluster deploy` there must pass
+  `--api-url` explicitly. The usage error says so.
+- On a managed/multi-node cluster the kubeconfig `cluster.server` host is
+  typically a control-plane endpoint that does not expose Service NodePorts, so
+  auto-discovery there yields an unreachable URL; the operator passes `--api-url`
+  explicitly (the same escape hatch as `--no-expose`). This mirrors the discovery
+  `cluster status` already performs and is a deliberate scope boundary of #359.
+- `cluster deploy` gains `--namespace` / `--release` (default `agentos`) purely to
+  locate the UI service for discovery; they do not change the shipped bytes.
+- Discovery reuses the existing status-path host/service helpers (`resolve_node_host`,
+  `parse_service`), so there is one definition of "the node host" and "read the UI
+  service" across `cluster status` and `cluster deploy`.
+- The port-forward-based deploy approach (#352 / PR #357) is not revived; the
+  tunnel stays exclusive to `cluster message`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -135,21 +135,25 @@ the stack.
 
 Before `agentos cluster message` can drive an agent, a bundle must be deployed to
 the in-cluster platform API with `agentos cluster deploy`. The `agentos-api`
-service is ClusterIP, but the UI is exposed on a NodePort (`:30080`) and its
-nginx reverse-proxies `/api/` to the in-cluster API, so a `/api`-suffixed node
-URL reaches the API with no port-forward. Take the UI URL from `agentos cluster
-status` and give `cluster deploy` its `/api` path:
+service is ClusterIP, but the UI is exposed on a NodePort and its nginx
+reverse-proxies `/api/` to the in-cluster API. With no `--api-url`, `cluster
+deploy` auto-discovers that UI `/api` NodePort proxy (reading the `<release>-ui`
+service and resolving a routable node host) and dials it -- no port-forward and no
+manual URL:
 
 ```bash
-agentos cluster deploy --plugin-dir <bundle-dir> \
-  --api-url http://<node>:30080/api --api-key agentos-dev-key
+agentos cluster deploy --plugin-dir <bundle-dir> --api-key agentos-dev-key
 ```
 
-If you installed with `--no-expose` (no NodePort) or otherwise can't reach the
-node port, fall back to a manual port-forward of the ClusterIP service. `cluster
-deploy` does not self-manage one, so its default `--api-url
-http://localhost:8000` is unreachable until you forward the API yourself. Run the
-port-forward first, deploy, then release it:
+An explicit `--api-url` (e.g. `http://<node>:30080/api`) or `AGENTOS_API_URL` is
+honored exactly as given, overriding discovery.
+
+Discovery fails with a usage error telling you to pass `--api-url` when the UI is
+not NodePort-exposed (installed with `--no-expose`) or a routable node host can't
+be determined -- for example a managed/multi-node cluster whose kubeconfig points
+at a control-plane endpoint that does not expose NodePorts. `cluster deploy` does
+not self-plumb a port-forward, so in that case pass `--api-url` explicitly (a node
+URL, or a ClusterIP you forward yourself). If you must forward the ClusterIP:
 
 ```bash
 kubectl port-forward svc/agentos-api 8000:8000 -n agentos &


### PR DESCRIPTION
`agentos cluster deploy` no longer needs a manual kubectl port-forward. When `--api-url` is omitted it auto-discovers the deployed release's UI `/api` NodePort proxy (UI service nodePort + kubeconfig node host) and dials it; an explicit `--api-url` / `AGENTOS_API_URL` is dialed as given. Deploy speaks only HTTP and the UI's nginx already reverse-proxies `/api/` to the in-cluster API, so no tunnel is needed (unlike `cluster message`, which self-plumbs a port-forward for in-cluster Valkey).

Discovery failures (not NodePort-exposed / `--no-expose`, no resolvable node host, unreadable UI service) return a clear usage error pointing at `--api-url`; deploy never self-plumbs a port-forward. Adds `--namespace`/`--release` to locate the UI service, a shared node-URL builder that brackets IPv6 hosts (also correcting the `cluster status` access-URL path), and ADR-0024 recording the deploy-via-proxy / message-tunnels-for-Valkey decision.

Live-verified on a real cluster: a NodePort `*-ui` service resolves to `http://<node>:<nodeport>/api`; ClusterIP, missing-service, and no-host cases each return the usage error; an explicit `--api-url` bypasses discovery.

Closes #359