### PR TITLE
guide: document gVisor fail-closed opt-out on no-runsc cluster

### DIFF
--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -190,6 +190,10 @@ pub fn primer() -> Primer {
                 detail: "A connect that rotates a secret must also roll the pod; `agentos cluster comms` does this for you.",
             },
             Landmine {
+                title: "A real-model `cluster up` fails closed without a gVisor runtime",
+                detail: "On a cluster with no `runsc` RuntimeClass, the default `security.gvisor.mode=auto` renders a blocking enforcement preflight for a real (non-fake) model, so `agentos cluster up` fails closed instead of running runner pods on the host kernel. Install anyway with `agentos cluster up --set security.gvisor.mode=off` (no kernel isolation, knowingly), use `--fake-model` (the sealed path skips the preflight), or install runsc on the nodes. This is the security posture, not a bug.",
+            },
+            Landmine {
                 title: "An empty-string API key is not \"unset\"",
                 detail: "It trips the CLI auth gate. Omit the flag or env entirely to fall back, rather than passing an empty value.",
             },
@@ -202,6 +206,10 @@ pub fn primer() -> Primer {
             Recovery {
                 symptom: "authentication_failed from a live model",
                 fix: "A real credential is empty or being overridden. Unset the empty one; set AGENTOS_MODEL_CREDENTIALS for `agentos cluster up`.",
+            },
+            Recovery {
+                symptom: "`agentos cluster up` hangs ~2 min then dies with `job agentos-preflight-gvisor failed: DeadlineExceeded`",
+                fix: "A real-model install on a cluster with no `runsc` RuntimeClass fails closed under `security.gvisor.mode=auto`. Opt out with `agentos cluster up --set security.gvisor.mode=off`, or use `--fake-model`, or install runsc on the nodes.",
             },
             Recovery {
                 symptom: "\"(no response)\" or an empty reply",

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -183,6 +183,29 @@ fn guide_json_emits_pure_structured_data_on_stdout() {
 }
 
 #[test]
+fn guide_documents_gvisor_fail_closed_opt_out() {
+    // AC (#363): a real-model `cluster up` on a no-runsc cluster fails closed under
+    // the default gVisor mode; the opt-out and its preflight symptom must both be
+    // discoverable in the primer -- in the Markdown default and the --json variant.
+    let md = out_str(&run(&["guide"]));
+    let json = out_str(&run(&["guide", "--json"]));
+    for (label, text) in [("markdown", &md), ("json", &json)] {
+        assert!(
+            text.contains("security.gvisor.mode=off"),
+            "{label} primer missing the gVisor opt-out `security.gvisor.mode=off`\n{text}"
+        );
+        assert!(
+            text.contains("agentos-preflight-gvisor"),
+            "{label} primer missing the preflight symptom `agentos-preflight-gvisor`\n{text}"
+        );
+        assert!(
+            text.contains("running runner pods on the host kernel"),
+            "{label} primer missing the Landmine detail `running runner pods on the host kernel`\n{text}"
+        );
+    }
+}
+
+#[test]
 fn guide_is_registered_in_the_manifest() {
     let surface = Surface::load();
     assert!(


### PR DESCRIPTION
On a cluster with no \`runsc\` RuntimeClass, a real-model \`agentos cluster up\` fails closed by design: the default \`security.gvisor.mode=auto\` renders a blocking gVisor-enforcement preflight, so the install dies rather than silently running runner pods on the host kernel. That posture is correct and unchanged. The problem was discoverability: the happy path hung ~2 minutes then died with a cryptic \`job agentos-preflight-gvisor failed: DeadlineExceeded\`, and the remediation lived only in \`values.yaml\`.

This documents it in the \`agentos guide\` primer (docs-only):

- A new landmine names the fail-closed behavior up front and the opt-out (\`--set security.gvisor.mode=off\`), plus \`--fake-model\` and installing runsc.
- A new recovery entry keys the \`DeadlineExceeded\` preflight symptom to the same remediations, for an agent who already hit the timeout.
- A regression test asserts both the Markdown and \`--json\` primer surface the opt-out, the symptom, and the landmine detail.

Both entries render from the single \`primer()\` data model, so Markdown and \`--json\` stay in sync. Fail-closed enforcement is untouched.

Reviewed by code-reviewer, scope-creep-reviewer, and a cross-model Codex pass (all clean); full CLI suite green (314 tests).

Closes #363