### PR TITLE
message --json: structured stdout for timeout and dry-run terminal states

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -379,8 +379,15 @@ control flow are machine-first.
 **`--json`** (global) switches the read/report commands `agentos skill status`
 and `agentos skill eval` to a single machine-readable JSON object on **stdout**;
 it also switches `agentos local message` and `agentos cluster message` to emit
+one structured line per terminal state on stdout: a completed turn emits
 `{"reply": ..., "thread": ..., "finalized": ...}` (the model's reply, which is
-null on a no-edit completion, plus the thread the turn ran under). All human and
+null on a no-edit completion, plus the thread the turn ran under); a **timeout**
+emits `{"reply": null, "finalized": false, "timed_out": true}` before exiting 3
+(transient); and `--json --dry-run` emits a planned-action descriptor
+`{"dry_run": true, "target": "local"|"cluster", "stream": ..., "channel": ...,
+"reply_endpoint": ...}` (`channel` is null when it would be resolved from the sole
+deployed agent). The three shapes are the `oneOf` in `cli/schema/message.schema.json`.
+All human and
 log text (progress, notes, warnings) goes to **stderr**, so a plain
 `... --json | jq` yields clean data. On failure under `--json`, the error
 is emitted to stdout as `{"error": "<message>", "fix": "<hint>"|null}` instead of

--- a/cli/schema/message.schema.json
+++ b/cli/schema/message.schema.json
@@ -1,13 +1,45 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "agentos local|cluster message --json",
-  "description": "The agent-facing payload of `agentos local message --json` and `agentos cluster message --json`: the model's final reply text (null when the worker finished the turn without editing the placeholder), the thread the turn ran under, and whether a reply was captured. All keys are CLI-owned and locked.",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["reply", "thread", "finalized"],
-  "properties": {
-    "reply": { "type": ["string", "null"] },
-    "thread": { "type": "string" },
-    "finalized": { "type": "boolean" }
-  }
+  "description": "The agent-facing payload of `agentos local message --json` and `agentos cluster message --json`. Exactly one of three terminal-state shapes is emitted per invocation: a reply object (the model's final reply text, the thread the turn ran under, and whether a reply was captured), a timeout object (no reply captured before the deadline), or a dry-run descriptor (what a real run would enqueue). All keys are CLI-owned and locked.",
+  "oneOf": [
+    {
+      "title": "reply",
+      "description": "A finished turn: `reply` is the model's final reply text (null when the worker finished the turn without editing the placeholder), `thread` is the thread the turn ran under, `finalized` is whether a reply was captured.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reply", "thread", "finalized"],
+      "properties": {
+        "reply": { "type": ["string", "null"] },
+        "thread": { "type": "string" },
+        "finalized": { "type": "boolean" }
+      }
+    },
+    {
+      "title": "timeout",
+      "description": "The turn did not finalize before the deadline: `reply` is null, `finalized` is false, and `timed_out` marks the terminal state (exit code 3, Transient).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reply", "finalized", "timed_out"],
+      "properties": {
+        "reply": { "type": "null" },
+        "finalized": { "const": false },
+        "timed_out": { "const": true }
+      }
+    },
+    {
+      "title": "dry-run",
+      "description": "A `--dry-run` preview: `target` is `local` or `cluster`, `stream` is the Valkey stream, `channel` is the resolved channel (null when it would be taken from the sole deployed agent), `reply_endpoint` is the stub URL a real run would advertise.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dry_run", "target", "stream", "channel", "reply_endpoint"],
+      "properties": {
+        "dry_run": { "const": true },
+        "target": { "enum": ["local", "cluster"] },
+        "stream": { "type": "string" },
+        "channel": { "type": ["string", "null"] },
+        "reply_endpoint": { "type": "string" }
+      }
+    }
+  ]
 }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -307,6 +307,40 @@ pub fn message_reply_json(thread: &str, reply: Option<&str>) -> serde_json::Valu
     })
 }
 
+/// The machine-readable object for a `local`/`cluster message --json` **timeout**
+/// (issue #354): no reply was captured before the deadline, so `reply` is null,
+/// `finalized` is false, and `timed_out` marks the terminal state distinctly from
+/// a no-edit completion. Emitted just before the transient exit so a `--json`
+/// caller gets a structured line, not empty stdout. Pure so it stays
+/// contract-testable against `cli/schema/message.schema.json`.
+pub fn message_timeout_json() -> serde_json::Value {
+    serde_json::json!({
+        "reply": serde_json::Value::Null,
+        "finalized": false,
+        "timed_out": true,
+    })
+}
+
+/// The machine-readable descriptor for `local`/`cluster message --json --dry-run`
+/// (issue #354): what a real run would enqueue, without touching the network.
+/// `target` is `"local"` or `"cluster"`, `channel` is null when it would be
+/// resolved from the sole deployed agent. Pure so it stays contract-testable
+/// against `cli/schema/message.schema.json`.
+pub fn message_dry_run_json(
+    target: &str,
+    stream: &str,
+    channel: Option<&str>,
+    reply_endpoint: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "dry_run": true,
+        "target": target,
+        "stream": stream,
+        "channel": channel,
+        "reply_endpoint": reply_endpoint,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Effectful helpers
 // ---------------------------------------------------------------------------
@@ -402,11 +436,19 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     let api_base = local_api_base(opts.api_url.as_deref());
 
     if opts.dry_run {
+        let reply_endpoint = format!("http://localhost:{DEFAULT_LOCAL_STUB_PORT}/api/");
+        if ui.json() {
+            ui.emit_json(&message_dry_run_json(
+                "local",
+                &opts.stream,
+                opts.channel.as_deref(),
+                &reply_endpoint,
+            ));
+            return Ok(());
+        }
         ui.payload_plain("local mode (compose stack; no kubectl/helm)");
         ui.payload_plain(&format!("enqueue onto redis {valkey_url}"));
-        ui.payload_plain(&format!(
-            "stub advertised at http://localhost:{DEFAULT_LOCAL_STUB_PORT}/api/"
-        ));
+        ui.payload_plain(&format!("stub advertised at {reply_endpoint}"));
         match opts.channel.as_deref() {
             Some(channel) => ui.payload_plain(&format!("channel {channel}")),
             None => ui.payload_plain(&format!(
@@ -506,9 +548,13 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
         }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
-            ui.note("stream diagnostics:");
-            let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
-            ui.note(&diag);
+            if ui.json() {
+                ui.emit_json(&message_timeout_json());
+            } else {
+                ui.note("stream diagnostics:");
+                let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
+                ui.note(&diag);
+            }
             // A timeout is retryable (the worker may still be working, or a
             // transient stall), so it maps to the transient exit code, not failure.
             std::process::exit(crate::exit::ExitClass::Transient.code());
@@ -527,6 +573,15 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
             .listen_host
             .clone()
             .unwrap_or_else(|| "<auto-detected-local-ip>".to_string());
+        if ui.json() {
+            ui.emit_json(&message_dry_run_json(
+                "cluster",
+                &opts.stream,
+                opts.channel.as_deref(),
+                &advertised_url(&host, opts.listen_port),
+            ));
+            return Ok(());
+        }
         for line in dry_run_lines(&opts, &host) {
             ui.payload_plain(&line);
         }
@@ -655,9 +710,13 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
         }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
-            ui.note("stream diagnostics:");
-            let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
-            ui.note(&diag);
+            if ui.json() {
+                ui.emit_json(&message_timeout_json());
+            } else {
+                ui.note("stream diagnostics:");
+                let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
+                ui.note(&diag);
+            }
             // A timeout is retryable (the worker may still be working, or a
             // transient stall), so it maps to the transient exit code, not failure.
             std::process::exit(crate::exit::ExitClass::Transient.code());
@@ -861,5 +920,39 @@ mod tests {
             lines.iter().any(|l| l.contains("slack_channel")),
             "channel placeholder when omitted: {lines:?}"
         );
+    }
+
+    #[test]
+    fn message_timeout_json_marks_the_terminal_state() {
+        let v = message_timeout_json();
+        assert!(v["reply"].is_null(), "{v}");
+        assert_eq!(v["finalized"], serde_json::json!(false));
+        assert_eq!(v["timed_out"], serde_json::json!(true));
+        // The reply builder's key set is a different shape (no timed_out), so a
+        // consumer can discriminate the two terminal states.
+        assert!(v.get("thread").is_none(), "timeout carries no thread: {v}");
+    }
+
+    #[test]
+    fn message_dry_run_json_carries_the_planned_action() {
+        // Explicit channel passes through verbatim.
+        let v = message_dry_run_json(
+            "local",
+            "agentos:turns",
+            Some("C123"),
+            "http://localhost:8155/api/",
+        );
+        assert_eq!(v["dry_run"], serde_json::json!(true));
+        assert_eq!(v["target"], serde_json::json!("local"));
+        assert_eq!(v["stream"], serde_json::json!("agentos:turns"));
+        assert_eq!(v["channel"], serde_json::json!("C123"));
+        assert_eq!(
+            v["reply_endpoint"],
+            serde_json::json!("http://localhost:8155/api/")
+        );
+        // Omitted channel is JSON null, not a placeholder string.
+        let v = message_dry_run_json("cluster", "s", None, "http://10.1.2.3:8155/api/");
+        assert!(v["channel"].is_null(), "{v}");
+        assert_eq!(v["target"], serde_json::json!("cluster"));
     }
 }

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -6,7 +6,7 @@
 
 use agentos::commands::{eval_json, status_json};
 use agentos::exit;
-use agentos::message::message_reply_json;
+use agentos::message::{message_dry_run_json, message_reply_json, message_timeout_json};
 use agentos_aci_protocol::SessionStatus;
 
 fn load_schema(name: &str) -> serde_json::Value {
@@ -87,6 +87,78 @@ fn message_reply_json_validates_against_message_schema() {
     );
     assert_eq!(no_edit["thread"], serde_json::json!("1700000000.000100"));
     assert_eq!(no_edit["finalized"], serde_json::json!(false));
+}
+
+#[test]
+fn message_timeout_json_validates_against_message_schema() {
+    let schema = load_schema("message.schema.json");
+    let v = validator(&schema);
+    let timed_out = message_timeout_json();
+    assert!(
+        v.is_valid(&timed_out),
+        "message_timeout_json must validate against message.schema.json: {timed_out}"
+    );
+    // Pin the timeout shape: null reply, finalized false, timed_out true.
+    assert!(
+        timed_out["reply"].is_null(),
+        "timeout reply must be JSON null: {timed_out}"
+    );
+    assert_eq!(timed_out["finalized"], serde_json::json!(false));
+    assert_eq!(timed_out["timed_out"], serde_json::json!(true));
+}
+
+#[test]
+fn message_dry_run_json_validates_against_message_schema() {
+    let schema = load_schema("message.schema.json");
+    let v = validator(&schema);
+    // Explicit channel (local target).
+    let with_channel = message_dry_run_json(
+        "local",
+        "agentos:turns",
+        Some("C123"),
+        "http://localhost:8155/api/",
+    );
+    assert!(
+        v.is_valid(&with_channel),
+        "message_dry_run_json (with channel) must validate: {with_channel}"
+    );
+    assert_eq!(with_channel["dry_run"], serde_json::json!(true));
+    assert_eq!(with_channel["target"], serde_json::json!("local"));
+    assert_eq!(with_channel["channel"], serde_json::json!("C123"));
+    // Null channel (cluster target, sole-agent resolution).
+    let no_channel = message_dry_run_json(
+        "cluster",
+        "agentos:turns",
+        None,
+        "http://10.1.2.3:8155/api/",
+    );
+    assert!(
+        v.is_valid(&no_channel),
+        "message_dry_run_json (no channel) must validate: {no_channel}"
+    );
+    assert!(
+        no_channel["channel"].is_null(),
+        "omitted channel must be JSON null: {no_channel}"
+    );
+    assert_eq!(no_channel["target"], serde_json::json!("cluster"));
+}
+
+#[test]
+fn message_schema_variants_are_mutually_exclusive() {
+    // The schema is a oneOf; each builder's output must match exactly one variant.
+    let schema = load_schema("message.schema.json");
+    let v = validator(&schema);
+    for value in [
+        message_reply_json("1700000000.000100", Some("hi")),
+        message_reply_json("1700000000.000100", None),
+        message_timeout_json(),
+        message_dry_run_json("local", "s", Some("C1"), "http://x/api/"),
+    ] {
+        assert!(
+            v.is_valid(&value),
+            "each builder output must satisfy the oneOf: {value}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What

Follow-up from #353. Two `agentos local|cluster message --json` terminal states still produced **empty stdout**:

- **Timeout** (`Outcome::TimedOut`) exits 3 directly, bypassing the `--json` handler.
- **`--json --dry-run`** printed via `payload_plain`, which is suppressed under `--json`.

## Fix

- Timeout now emits `{"reply": null, "finalized": false, "timed_out": true}` before the transient exit.
- `--json --dry-run` emits a planned-action descriptor `{"dry_run": true, "target": "local"|"cluster", "stream", "channel", "reply_endpoint"}` (`channel` is null when resolved from the sole deployed agent).
- `cli/schema/message.schema.json` becomes a `oneOf` of the reply / timeout / dry-run shapes.
- Added contract tests (`cli/tests/json_contract.rs`) + unit tests (`cli/src/message.rs`) mirroring the existing `dry_run_*` tests, and updated `cli/README.md`.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)