### PR TITLE
Add awaiting-approval to the frozen ACI contract

### DIFF
--- a/apps/ui/src/fixtures/traces.ts
+++ b/apps/ui/src/fixtures/traces.ts
@@ -50,14 +50,14 @@ export function traceSpans(t: TraceSummary): TraceSpan[] {
       detail: "deal-desk · skill.md",
       offset: "+12ms",
       kind: "skill",
-      event: { type: "tool_note", version: "0.1.0", text: "matched skill deal-desk", tool: "router" },
+      event: { type: "tool_note", version: "0.2.0", text: "matched skill deal-desk", tool: "router" },
     },
     {
       label: "Tool call",
       detail: `salesforce.get_deal(id: ${dealId})`,
       offset: "+840ms",
       kind: "tool",
-      event: { type: "tool_note", version: "0.1.0", text: `salesforce.get_deal(id: ${dealId})`, tool: "salesforce.get_deal" },
+      event: { type: "tool_note", version: "0.2.0", text: `salesforce.get_deal(id: ${dealId})`, tool: "salesforce.get_deal" },
     },
     bad
       ? {
@@ -66,14 +66,14 @@ export function traceSpans(t: TraceSummary): TraceSpan[] {
           offset: "+1.8s",
           kind: "response",
           bad: true,
-          event: { type: "error", version: "0.1.0", message: "approver 'Dana' not found in policy.yaml", classification: "hallucinated-value" },
+          event: { type: "error", version: "0.2.0", message: "approver 'Dana' not found in policy.yaml", classification: "hallucinated-value" },
         }
       : {
           label: "Response",
           detail: "Verdict returned · routed to J. Whitfield",
           offset: "+2.1s",
           kind: "response",
-          event: { type: "final", version: "0.1.0", text: "Verdict returned · routed to J. Whitfield", status: "done" },
+          event: { type: "final", version: "0.2.0", text: "Verdict returned · routed to J. Whitfield", status: "done" },
         },
   ];
 }

--- a/docs/adr/0010-approval-gates-and-human-in-the-loop.md
+++ b/docs/adr/0010-approval-gates-and-human-in-the-loop.md
@@ -1,7 +1,7 @@
 # 10. Approval gates and human-in-the-loop
 
 Date: 2026-07-09
-Status: Proposed
+Status: Accepted (2026-07-13)
 
 ## Context
 

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.1.0";
+pub const PROTOCOL_VERSION: &str = "0.2.0";
 
 fn require_protocol_version<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
@@ -30,6 +30,8 @@ pub enum SessionStatus {
     IdleAwaitingInput,
     #[serde(rename = "classified-failure")]
     ClassifiedFailure,
+    #[serde(rename = "awaiting-approval")]
+    AwaitingApproval,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -97,6 +99,15 @@ pub struct QueuedTurn {
     pub received_at: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalRequest {
+    pub tool: String,
+    pub tool_use_id: String,
+    pub input_digest: String,
+    pub prompt: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", deny_unknown_fields)]
 pub enum InboundMessage {
@@ -137,6 +148,10 @@ pub enum OutboundEvent {
         text: String,
         #[serde(default)]
         status: SessionStatus,
+        #[serde(default)]
+        session_id: Option<String>,
+        #[serde(default)]
+        approval_request: Option<ApprovalRequest>,
     },
     #[serde(rename = "error")]
     ErrorEvent {
@@ -167,6 +182,8 @@ mod tests {
             version: PROTOCOL_VERSION.to_string(),
             text: "hi".to_string(),
             status: SessionStatus::Done,
+            session_id: None,
+            approval_request: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -194,7 +211,7 @@ mod tests {
 
     #[test]
     fn rejects_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.1.0","text":"x","status":"done","extra":1}"#;
+        let raw = r#"{"type":"final","version":"0.2.0","text":"x","status":"done","extra":1}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
     }
 }

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -5,30 +5,42 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+export type InputDigest = string;
+export type Prompt = string;
+export type Tool = string;
+export type ToolUseId = string;
 export type MaxOutputTokensPerRun = number;
 export type MaxUsdPerDay = number;
 export type TaskBudgetHint = number | null;
 export type Classification = string | null;
 export type Message = string;
 export type Type = "error";
-export type Version = "0.1.0";
+export type Version = "0.2.0";
 export type Kind = "event";
 export type Text = string;
 export type Ts = string;
 export type Type1 = "message" | "job" | "eval_case";
 export type User = string;
+export type SessionId = string | null;
 /**
  * Terminal or awaiting status of a session, from the output contract.
  *
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
+ *
+ * ``awaiting-approval`` is a non-terminal pause: the session has stopped on a
+ * human-in-the-loop approval gate (ADR-0010) and the platform suspends it
+ * (ADR-0003) until the approval is resolved, then resumes. It is additive to
+ * the three original values, so an old consumer that does not know the token
+ * simply cannot decode a paused frame -- a paused session never reaches a
+ * consumer that predates the gate.
  */
-export type SessionStatus = "done" | "idle-awaiting-input" | "classified-failure";
+export type SessionStatus = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 export type Text1 = string;
 export type Type2 = "final";
-export type Version1 = "0.1.0";
+export type Version1 = "0.2.0";
 /**
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
@@ -38,21 +50,21 @@ export type Endpoint = string | null;
 export type Headers = string | null;
 export type Protocol = string | null;
 /**
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
 export type Text2 = string;
 export type Type3 = "text_delta";
-export type Version2 = "0.1.0";
+export type Version2 = "0.2.0";
 export type Text3 = string;
-export type Tool = string | null;
-export type Type4 = "tool_note";
-export type Version3 = "0.1.0";
-export type Detail = string | null;
 export type Tool1 = string | null;
+export type Type4 = "tool_note";
+export type Version3 = "0.2.0";
+export type Detail = string | null;
+export type Tool2 = string | null;
 export type Type5 = "side_effect_flag";
-export type Version4 = "0.1.0";
+export type Version4 = "0.2.0";
 export type Author = string;
 export type ConversationId = string;
 export type EventId = string;
@@ -65,20 +77,47 @@ export type CredentialsRef = string | null;
 export type MemoryRef = string | null;
 export type PluginDir = string;
 export type SandboxId = string;
-export type SessionId = string;
+export type SessionId1 = string;
 /**
  * Terminal or awaiting status of a session, from the output contract.
  *
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * ``awaiting-approval`` is a non-terminal pause: the session has stopped on a
+ * human-in-the-loop approval gate (ADR-0010) and the platform suspends it
+ * (ADR-0003) until the approval is resolved, then resumes. It is additive to
+ * the three original values, so an old consumer that does not know the token
+ * simply cannot decode a paused frame -- a paused session never reaches a
+ * consumer that predates the gate.
+ *
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
-export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure";
+export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 
-export interface ACIProtocolV010 {
+export interface ACIProtocolV020 {
   [k: string]: unknown;
+}
+/**
+ * The tool call that tripped an approval gate, carried on a paused final.
+ *
+ * Emitted by the runner on a ``Final`` whose status is ``awaiting-approval`` so
+ * the platform can build the durable approval record (and the human-facing
+ * card) without reconstructing the tool from a preceding ``tool_note``.
+ * ``tool_use_id`` is the SDK's per-call id and the correlation key that ties
+ * the runner's permission callback, the durable record, and the resume
+ * decision together. ``input_digest`` is a stable digest of the tool input for
+ * display and tamper-evidence; ``prompt`` is the human-readable ask.
+ *
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
+ * via the `definition` "ApprovalRequest".
+ */
+export interface ApprovalRequest {
+  input_digest: InputDigest;
+  prompt: Prompt;
+  tool: Tool;
+  tool_use_id: ToolUseId;
 }
 /**
  * Per-agent budget spec, carried as JSON in AGENTOS_BUDGET.
@@ -86,7 +125,7 @@ export interface ACIProtocolV010 {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -97,7 +136,7 @@ export interface Budget {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -109,7 +148,7 @@ export interface ErrorEvent {
 /**
  * An inbound event delivered into a live session (initial or follow-up).
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -120,12 +159,14 @@ export interface Event {
   user: User;
 }
 /**
- * The terminal response event, carrying the session status.
+ * The terminal (or awaiting-approval) response event, carrying the status.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
+  approval_request?: ApprovalRequest | null;
+  session_id?: SessionId;
   status?: SessionStatus;
   text: Text1;
   type: Type2;
@@ -134,7 +175,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -148,7 +189,7 @@ export interface Interrupt {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -159,7 +200,7 @@ export interface OtelConfig {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -170,12 +211,12 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
   text: Text3;
-  tool?: Tool;
+  tool?: Tool1;
   type: Type4;
   version: Version3;
 }
@@ -185,12 +226,12 @@ export interface ToolNote {
  * Its presence gates the no-retry-after-side-effects rule (section 2b): a
  * failed run carrying this flag escalates to a human instead of retrying.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
   detail?: Detail;
-  tool?: Tool1;
+  tool?: Tool2;
   type: Type5;
   version: Version4;
 }
@@ -202,7 +243,7 @@ export interface SideEffectFlag {
  * stream-encoding helpers live with the producer (the dispatcher), not on this
  * frozen model, so the contract stays transport-agnostic.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -230,7 +271,7 @@ export interface QueuedTurn {
  * (its ``slack_api_base_url``, i.e. real Slack), so a producer that does not set
  * it keeps the pre-#19 behavior.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {
@@ -245,7 +286,7 @@ export interface ReplyHandle {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -255,5 +296,5 @@ export interface SessionConfig {
   otel?: OtelConfig;
   plugin_dir: PluginDir;
   sandbox_id: SandboxId;
-  session_id: SessionId;
+  session_id: SessionId1;
 }

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -1,5 +1,35 @@
 {
   "$defs": {
+    "ApprovalRequest": {
+      "additionalProperties": false,
+      "description": "The tool call that tripped an approval gate, carried on a paused final.\n\nEmitted by the runner on a ``Final`` whose status is ``awaiting-approval`` so\nthe platform can build the durable approval record (and the human-facing\ncard) without reconstructing the tool from a preceding ``tool_note``.\n``tool_use_id`` is the SDK's per-call id and the correlation key that ties\nthe runner's permission callback, the durable record, and the resume\ndecision together. ``input_digest`` is a stable digest of the tool input for\ndisplay and tamper-evidence; ``prompt`` is the human-readable ask.",
+      "properties": {
+        "input_digest": {
+          "title": "Input Digest",
+          "type": "string"
+        },
+        "prompt": {
+          "title": "Prompt",
+          "type": "string"
+        },
+        "tool": {
+          "title": "Tool",
+          "type": "string"
+        },
+        "tool_use_id": {
+          "title": "Tool Use Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "input_digest",
+        "prompt",
+        "tool",
+        "tool_use_id"
+      ],
+      "title": "ApprovalRequest",
+      "type": "object"
+    },
     "Budget": {
       "additionalProperties": false,
       "description": "Per-agent budget spec, carried as JSON in AGENTOS_BUDGET.\n\n``task_budget_hint`` is the optional hint passed through to the model so it\nself paces (section 6b); it is not a hard ceiling.",
@@ -58,7 +88,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "const": "0.2.0",
           "title": "Version",
           "type": "string"
         }
@@ -114,8 +144,31 @@
     },
     "Final": {
       "additionalProperties": false,
-      "description": "The terminal response event, carrying the session status.",
+      "description": "The terminal (or awaiting-approval) response event, carrying the status.",
       "properties": {
+        "approval_request": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ApprovalRequest"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Session Id"
+        },
         "status": {
           "$ref": "#/$defs/SessionStatus",
           "default": "done"
@@ -130,7 +183,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "const": "0.2.0",
           "title": "Version",
           "type": "string"
         }
@@ -384,11 +437,12 @@
       "type": "object"
     },
     "SessionStatus": {
-      "description": "Terminal or awaiting status of a session, from the output contract.\n\nWire tokens follow the section 0 spelling; ``classified failure`` in prose\nbecomes the token ``classified-failure`` on the wire.",
+      "description": "Terminal or awaiting status of a session, from the output contract.\n\nWire tokens follow the section 0 spelling; ``classified failure`` in prose\nbecomes the token ``classified-failure`` on the wire.\n\n``awaiting-approval`` is a non-terminal pause: the session has stopped on a\nhuman-in-the-loop approval gate (ADR-0010) and the platform suspends it\n(ADR-0003) until the approval is resolved, then resumes. It is additive to\nthe three original values, so an old consumer that does not know the token\nsimply cannot decode a paused frame -- a paused session never reaches a\nconsumer that predates the gate.",
       "enum": [
         "done",
         "idle-awaiting-input",
-        "classified-failure"
+        "classified-failure",
+        "awaiting-approval"
       ],
       "title": "SessionStatus",
       "type": "string"
@@ -427,7 +481,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "const": "0.2.0",
           "title": "Version",
           "type": "string"
         }
@@ -453,7 +507,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "const": "0.2.0",
           "title": "Version",
           "type": "string"
         }
@@ -492,7 +546,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "const": "0.2.0",
           "title": "Version",
           "type": "string"
         }
@@ -508,6 +562,6 @@
   },
   "$id": "https://curie.tech/agentos/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.1.0",
-  "title": "ACI Protocol v0.1.0"
+  "protocolVersion": "0.2.0",
+  "title": "ACI Protocol v0.2.0"
 }

--- a/packages/aci-protocol/src/aci_protocol/__init__.py
+++ b/packages/aci-protocol/src/aci_protocol/__init__.py
@@ -11,6 +11,7 @@ PROTOCOL_VERSION and regenerate the committed schema and types.
 from .conformance import ConformanceReport, Producer, run_conformance
 from .events import (
     OUTBOUND_EVENT_TYPES,
+    ApprovalRequest,
     ErrorEvent,
     Event,
     Final,
@@ -57,6 +58,7 @@ __all__ = [
     "TextDelta",
     "ToolNote",
     "Final",
+    "ApprovalRequest",
     "ErrorEvent",
     "SideEffectFlag",
     "OutboundEvent",

--- a/packages/aci-protocol/src/aci_protocol/conformance.py
+++ b/packages/aci-protocol/src/aci_protocol/conformance.py
@@ -17,6 +17,7 @@ from collections.abc import Callable, Iterable
 from pydantic import BaseModel
 
 from .events import (
+    ApprovalRequest,
     ErrorEvent,
     Event,
     Final,
@@ -45,7 +46,18 @@ Producer = Callable[[Event | Interrupt], Iterable[str]]
 _OUTBOUND_SAMPLES: tuple[OutboundEventModel, ...] = (
     TextDelta(text="partial output"),
     ToolNote(text="calling a tool", tool="search"),
-    Final(text="final answer", status=SessionStatus.DONE),
+    Final(text="final answer", status=SessionStatus.DONE, session_id="sess-abc"),
+    Final(
+        text="paused for approval",
+        status=SessionStatus.AWAITING_APPROVAL,
+        session_id="sess-abc",
+        approval_request=ApprovalRequest(
+            tool="apply_discount",
+            tool_use_id="toolu_01",
+            input_digest="sha256:deadbeef",
+            prompt="Apply a 30% discount to deal ACME-123?",
+        ),
+    ),
     ErrorEvent(message="something failed", classification="model-error"),
     SideEffectFlag(tool="send_email", detail="one email sent"),
 )

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -30,11 +30,19 @@ class SessionStatus(StrEnum):
 
     Wire tokens follow the section 0 spelling; ``classified failure`` in prose
     becomes the token ``classified-failure`` on the wire.
+
+    ``awaiting-approval`` is a non-terminal pause: the session has stopped on a
+    human-in-the-loop approval gate (ADR-0010) and the platform suspends it
+    (ADR-0003) until the approval is resolved, then resumes. It is additive to
+    the three original values, so an old consumer that does not know the token
+    simply cannot decode a paused frame -- a paused session never reaches a
+    consumer that predates the gate.
     """
 
     DONE = "done"
     IDLE_AWAITING_INPUT = "idle-awaiting-input"
     CLASSIFIED_FAILURE = "classified-failure"
+    AWAITING_APPROVAL = "awaiting-approval"
 
 
 # --- Inbound channel messages -------------------------------------------------
@@ -88,12 +96,38 @@ class ToolNote(_OutboundBase):
     tool: str | None = None
 
 
+class ApprovalRequest(BaseModel):
+    """The tool call that tripped an approval gate, carried on a paused final.
+
+    Emitted by the runner on a ``Final`` whose status is ``awaiting-approval`` so
+    the platform can build the durable approval record (and the human-facing
+    card) without reconstructing the tool from a preceding ``tool_note``.
+    ``tool_use_id`` is the SDK's per-call id and the correlation key that ties
+    the runner's permission callback, the durable record, and the resume
+    decision together. ``input_digest`` is a stable digest of the tool input for
+    display and tamper-evidence; ``prompt`` is the human-readable ask.
+    """
+
+    model_config = _STRICT
+
+    tool: str
+    tool_use_id: str
+    input_digest: str
+    prompt: str
+
+
 class Final(_OutboundBase):
-    """The terminal response event, carrying the session status."""
+    """The terminal (or awaiting-approval) response event, carrying the status."""
 
     type: Literal["final"] = "final"
     text: str
     status: SessionStatus = SessionStatus.DONE
+    # The harness session id for this turn. Optional and additive: it lets the
+    # worker rehydrate the exact session on resume (ADR-0003) instead of guessing
+    # a history ref. Absent (None) on producers that do not surface one.
+    session_id: str | None = None
+    # Present only when ``status`` is ``awaiting-approval``: the gated tool call.
+    approval_request: ApprovalRequest | None = None
 
 
 class ErrorEvent(_OutboundBase):

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -18,6 +18,7 @@ from typing import Any, Literal, Union, get_args, get_origin
 from pydantic import BaseModel
 
 from .events import (
+    ApprovalRequest,
     ErrorEvent,
     Event,
     Final,
@@ -217,6 +218,8 @@ mod tests {
             version: PROTOCOL_VERSION.to_string(),
             text: "hi".to_string(),
             status: SessionStatus::Done,
+            session_id: None,
+            approval_request: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -244,7 +247,7 @@ mod tests {
 
     #[test]
     fn rejects_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.1.0","text":"x","status":"done","extra":1}"#;
+        let raw = r#"{"type":"final","version":"0.2.0","text":"x","status":"done","extra":1}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
     }
 }
@@ -272,6 +275,7 @@ def render_rust() -> str:
         _struct(SessionConfig),
         _struct(ReplyHandle),
         _struct(QueuedTurn),
+        _struct(ApprovalRequest),
         _tagged_enum("InboundMessage", "kind", (Event, Interrupt)),
         _tagged_enum(
             "OutboundEvent",

--- a/packages/aci-protocol/src/aci_protocol/schema_export.py
+++ b/packages/aci-protocol/src/aci_protocol/schema_export.py
@@ -16,6 +16,7 @@ from pydantic import RootModel
 from pydantic.json_schema import models_json_schema
 
 from .events import (
+    ApprovalRequest,
     ErrorEvent,
     Event,
     Final,
@@ -54,6 +55,7 @@ _MODELS = (
     TextDelta,
     ToolNote,
     Final,
+    ApprovalRequest,
     ErrorEvent,
     SideEffectFlag,
     ReplyHandle,

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -13,6 +13,6 @@ generated TypeScript, not just by the NDJSON decoder. Keep the two in lockstep;
 
 from typing import Final, Literal
 
-PROTOCOL_VERSION: Final = "0.1.0"
+PROTOCOL_VERSION: Final = "0.2.0"
 
-ProtocolVersionLiteral = Literal["0.1.0"]
+ProtocolVersionLiteral = Literal["0.2.0"]

--- a/packages/aci-protocol/tests/test_conformance.py
+++ b/packages/aci-protocol/tests/test_conformance.py
@@ -23,7 +23,7 @@ def test_library_checks_run_without_a_producer() -> None:
 
 def test_a_broken_producer_fails_the_stream_check() -> None:
     def broken(_message: Event | Interrupt) -> Iterable[str]:
-        return ['{"type": "text_delta", "version": "0.1.0", "text": "no final"}\n']
+        return ['{"type": "text_delta", "version": "0.2.0", "text": "no final"}\n']
 
     report = run_conformance(broken)
     assert not report.passed

--- a/packages/aci-protocol/tests/test_events.py
+++ b/packages/aci-protocol/tests/test_events.py
@@ -1,6 +1,7 @@
 import pytest
 from aci_protocol import (
     PROTOCOL_VERSION,
+    ApprovalRequest,
     ErrorEvent,
     Event,
     Final,
@@ -75,3 +76,40 @@ def test_models_reject_unknown_fields() -> None:
 def test_session_status_wire_values() -> None:
     assert SessionStatus.IDLE_AWAITING_INPUT.value == "idle-awaiting-input"
     assert SessionStatus.CLASSIFIED_FAILURE.value == "classified-failure"
+    assert SessionStatus.AWAITING_APPROVAL.value == "awaiting-approval"
+
+
+def test_final_defaults_optional_approval_fields_to_none() -> None:
+    final = Final(text="ok")
+    assert final.session_id is None
+    assert final.approval_request is None
+
+
+def test_awaiting_approval_final_round_trips_through_the_union() -> None:
+    # A paused final carries the gated tool call so the platform builds the
+    # durable record without reconstructing it from a prior tool_note.
+    final = Final(
+        text="paused",
+        status=SessionStatus.AWAITING_APPROVAL,
+        session_id="sess-1",
+        approval_request=ApprovalRequest(
+            tool="apply_discount",
+            tool_use_id="toolu_01",
+            input_digest="sha256:beef",
+            prompt="Approve 30% discount?",
+        ),
+    )
+    decoded = _OUTBOUND.validate_python(final.model_dump(mode="json"))
+    assert isinstance(decoded, Final)
+    assert decoded.status is SessionStatus.AWAITING_APPROVAL
+    assert decoded.session_id == "sess-1"
+    assert decoded.approval_request is not None
+    assert decoded.approval_request.tool == "apply_discount"
+    assert decoded.approval_request.tool_use_id == "toolu_01"
+
+
+def test_approval_request_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        ApprovalRequest(
+            tool="t", tool_use_id="u", input_digest="d", prompt="p", extra=1  # type: ignore[call-arg]
+        )

--- a/runner/src/agentos_runner/translate.py
+++ b/runner/src/agentos_runner/translate.py
@@ -129,7 +129,13 @@ def _translate_result(
             events.append(
                 ErrorEvent(message=text, classification=subtype or "server-error")
             )
-        events.append(Final(text=text, status=SessionStatus.CLASSIFIED_FAILURE))
+        events.append(
+            Final(
+                text=text,
+                status=SessionStatus.CLASSIFIED_FAILURE,
+                session_id=message.session_id,
+            )
+        )
         return events
 
     # The SDK's ``result`` is authoritative when present. When it is empty on an
@@ -137,4 +143,10 @@ def _translate_result(
     # so a reasoning model whose result-extraction returned empty (issue #107)
     # still delivers its answer. Provider-agnostic: it only fires when result is
     # empty, so non-reasoning models and the fake-model path are unaffected.
-    return [Final(text=message.result or state.assistant_text, status=SessionStatus.DONE)]
+    return [
+        Final(
+            text=message.result or state.assistant_text,
+            status=SessionStatus.DONE,
+            session_id=message.session_id,
+        )
+    ]

--- a/runner/tests/test_translate.py
+++ b/runner/tests/test_translate.py
@@ -57,6 +57,19 @@ def test_result_success_is_final_done() -> None:
     assert [e.type for e in events] == ["final"]
     assert events[0].status == SessionStatus.DONE
     assert events[0].text == "answer"
+    # The SDK session id is surfaced on the final so the worker can rehydrate the
+    # exact session on resume (ADR-0003) rather than guessing a history ref.
+    assert events[0].session_id == "s"
+
+
+def test_result_error_final_carries_session_id() -> None:
+    msg = ResultMessage(
+        subtype="error_during_execution", duration_ms=1, duration_api_ms=1, is_error=True,
+        num_turns=1, session_id="s", result="boom",
+    )
+    events = _translate(msg)
+    assert events[-1].type == "final"
+    assert events[-1].session_id == "s"
 
 
 def test_reasoning_model_empty_result_falls_back_to_assistant_text() -> None:


### PR DESCRIPTION
First slice of the approval-gates epic (#22, ADR-0010): the frozen `aci-protocol`
change every later lane compiles against, landed on its own per the frozen-contract
rule before dependent work proceeds.

## Changes
- `SessionStatus` gains `awaiting-approval`, a non-terminal pause: the session
  suspends until the approval resolves (ADR-0003), then resumes.
- `Final` gains two optional, additive fields: `session_id` (the SDK session id the
  worker rehydrates from on resume, the gap `apps/worker/CLAUDE.md` warns about) and
  `approval_request` (the gated tool call, so the worker builds the durable record
  without reconstructing it from a preceding `tool_note`).
- Bump `PROTOCOL_VERSION` 0.1.0 -> 0.2.0 and regenerate the committed JSON Schema,
  Rust crate, and TypeScript (no hand-edits to generated artifacts).
- Runner stamps `session_id` on the terminal finals (`translate.py`).
- Promote ADR-0010 Proposed -> Accepted. **Flagged for review**: this is the point we
  commit to the decision; push back here if that is premature.

## Verification
- `uv run pytest packages/aci-protocol/tests runner/tests -q`: 154 passed, 3 skipped
  (credential-gated live tests). New coverage: awaiting-approval wire value, a paused
  `Final` round-trip through the union, and `session_id` stamping.
- JSON Schema / Rust / TypeScript regenerated with no drift (schema-compat gate green);
  generated TypeScript compiles under `tsc`; the UI typechecks against the bumped types.
- `ruff` + `mypy` clean.
- `cargo check` on the generated Rust was not run locally (no Rust toolchain on the dev
  machine); the Rust source is verified against the models by the drift test, and CI's
  `cargo test` covers the compile.

Part of #244. Does not close it: this is only the contract slice. The durable Approval
record, the `canUseTool` gate, and the Slack resolve flow follow in subsequent PRs.