### PR TITLE
local eval / cluster eval: the same evals at every tier (parity gate)

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -678,6 +678,107 @@ export const commandManifest = {
           "name": "message"
         },
         {
+          "about": "Run the bundle's `evals/cases.json` through the local tier and grade with the same grader `skill eval` uses (the per-tier parity gate)",
+          "args": [
+            {
+              "global": false,
+              "help": "Eval case file (default: `evals/cases.json` here, then the recorded bundle's)",
+              "id": "cases",
+              "long": "cases",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Slack channel id to send as; must match the target agent's slack_channel. Omit to use the sole deployed agent's channel",
+              "id": "channel",
+              "long": "channel",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "valkeypass"
+              ],
+              "env": "AGENTOS_VALKEY_PASSWORD",
+              "global": false,
+              "help": "Valkey password (compose default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
+              "id": "valkey_password",
+              "long": "valkey-password",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Platform API base URL for the channel lookup",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key for the default-channel lookup",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "U-agentos-message"
+              ],
+              "global": false,
+              "help": "Synthetic Slack user id for the enqueued events",
+              "id": "user",
+              "long": "user",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos:runs"
+              ],
+              "env": "AGENTOS_STREAM",
+              "global": false,
+              "help": "Stream the dispatcher enqueues onto",
+              "id": "stream",
+              "long": "stream",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "300"
+              ],
+              "global": false,
+              "help": "How long to wait for each case's reply. Default: 300 seconds",
+              "id": "timeout_secs",
+              "long": "timeout-secs",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the plan that a real run would produce, and exit",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "eval"
+        },
+        {
           "about": "Push the bundle to the local platform API and deploy it",
           "args": [
             {
@@ -1234,6 +1335,162 @@ export const commandManifest = {
           ],
           "hidden": false,
           "name": "message"
+        },
+        {
+          "about": "Run the bundle's `evals/cases.json` through the deployed Kubernetes release and grade with the same grader `skill eval` uses (the per-tier parity gate)",
+          "args": [
+            {
+              "global": false,
+              "help": "Eval case file (default: `evals/cases.json` here, then the recorded bundle's)",
+              "id": "cases",
+              "long": "cases",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Slack channel id to send as; must match the target agent's slack_channel. Omit to use the sole deployed agent's channel",
+              "id": "channel",
+              "long": "channel",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Host the in-cluster worker uses to reach the stub. Omit to auto-detect the local IP the kernel would use to reach the cluster",
+              "id": "listen_host",
+              "long": "listen-host",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "8155"
+              ],
+              "global": false,
+              "help": "Port the stub binds (0.0.0.0); the worker posts here",
+              "id": "listen_port",
+              "long": "listen-port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "56381"
+              ],
+              "global": false,
+              "help": "Local port the Valkey port-forward binds",
+              "id": "valkey_local_port",
+              "long": "valkey-local-port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "valkeypass"
+              ],
+              "env": "AGENTOS_VALKEY_PASSWORD",
+              "global": false,
+              "help": "Valkey password (chart default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
+              "id": "valkey_password",
+              "long": "valkey-password",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "8123"
+              ],
+              "global": false,
+              "help": "Local port the API port-forward binds (default-channel lookup)",
+              "id": "api_local_port",
+              "long": "api-local-port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key for the default-channel lookup",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "U-agentos-message"
+              ],
+              "global": false,
+              "help": "Synthetic Slack user id for the enqueued events",
+              "id": "user",
+              "long": "user",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos:runs"
+              ],
+              "env": "AGENTOS_STREAM",
+              "global": false,
+              "help": "Stream the dispatcher enqueues onto",
+              "id": "stream",
+              "long": "stream",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "300"
+              ],
+              "global": false,
+              "help": "How long to wait for each case's reply. Default: 300 seconds",
+              "id": "timeout_secs",
+              "long": "timeout-secs",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the kubectl commands, stub URL, and enqueue description that a real run would produce, and exit without executing anything",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "eval"
         },
         {
           "about": "Push the bundle to the platform API and deploy it",

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,12 +16,15 @@ disk and targets no environment.
 | Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
 |---|---|---|---|---|---|
 | `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `check` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
-| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
-| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `deploy` `kill` `resume` `budget` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
+| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `eval` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `eval` `deploy` `kill` `resume` `budget` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
 
 The universal quartet `up`/`down`/`status`/`message` is on all three targets;
-`skill` adds `eval`, while `local` and `cluster` add `comms` plus `deploy`; `cluster`
-further adds the agent-lifecycle verbs `kill`/`resume`/`budget`/`delete`. The distinction
+`skill` adds `eval`, while `local` and `cluster` add `comms`, `eval`, plus `deploy`; `cluster`
+further adds the agent-lifecycle verbs `kill`/`resume`/`budget`/`delete`. `eval` is on
+all three: it runs the SAME `evals/cases.json` with the SAME grader at each tier (the
+per-tier parity gate), so a suite that passes at `skill` can be re-asserted verbatim at
+`local` and `cluster`. The distinction
 that matters: `skill` is the **runner-only** loop, talking straight to a runner
 container's ACI HTTP surface with no platform in front; `local` and `cluster`
 put the **full platform** (queue, worker, sandbox) in front of the identical
@@ -144,6 +147,7 @@ the optional Slack dispatcher.
 | `agentos local status` | Show the compose stack's service status (`docker compose ps`). |
 | `agentos local comms --slack` | Connect or disconnect a real Slack workspace for the compose stack. Reads `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN`, masks them in dry run output, starts or stops the dispatcher, and switches the worker between real Slack and the local stub. |
 | `agentos local message "..."` | Drive the local compose stack end to end with zero Slack. Enqueues straight to the compose Valkey and lets the containerized worker answer. |
+| `agentos local eval` | Run the bundle's `evals/cases.json` through the compose stack's enqueue -> worker -> sandbox -> reply path (one synthetic turn per case) and grade each captured reply with the SAME grader `skill eval` uses. Prints the identical per-case table + rollup; nonzero exit on failure. `--cases` overrides the file; `--dry-run` prints the plan. |
 | `agentos local deploy` | Package the bundle as tar.gz and push it to the compose platform API (`--api-url`, default `http://localhost:28000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
 
 ## `cluster` target: deployed Helm release
@@ -159,6 +163,7 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `agentos cluster status` | Report release health, pod readiness, and access URLs (read-only). |
 | `agentos cluster comms --slack` | Connect or disconnect a real Slack workspace with a thin `helm upgrade --reuse-values`; env-backed tokens are masked in dry-run output. |
 | `agentos cluster message "..."` | Drive the deployed release end to end with zero Slack: self plumbs kubectl port forwards, points the deployed worker at a local Slack stub (`helm upgrade --reuse-values`), enqueues, and prints the reply. |
+| `agentos cluster eval` | Run the bundle's `evals/cases.json` through the deployed release (self-plumbed port-forwards + per-turn reply stub, one synthetic turn per case) and grade each captured reply with the SAME grader `skill eval` uses. Prints the identical per-case table + rollup; nonzero exit on failure. `--cases` overrides the file; `--dry-run` prints the plan. |
 | `agentos cluster deploy` | Package the bundle as tar.gz and push it to the platform API. Reaches the API through the deployed release's UI `/api` NodePort proxy when `--api-url` is omitted (no port-forward); pass `--api-url` / `AGENTOS_API_URL` to target it directly. Auth via `--api-key` or `AGENTOS_API_KEY`. |
 | `agentos cluster kill <agent> --yes` | Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`). Destructive: refuses without `--yes`. |
 | `agentos cluster resume <agent>` | Resume a killed agent via the platform API (`POST /agents/{id}/resume`). |

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -675,6 +675,107 @@
           "name": "message"
         },
         {
+          "about": "Run the bundle's `evals/cases.json` through the local tier and grade with the same grader `skill eval` uses (the per-tier parity gate)",
+          "args": [
+            {
+              "global": false,
+              "help": "Eval case file (default: `evals/cases.json` here, then the recorded bundle's)",
+              "id": "cases",
+              "long": "cases",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Slack channel id to send as; must match the target agent's slack_channel. Omit to use the sole deployed agent's channel",
+              "id": "channel",
+              "long": "channel",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "valkeypass"
+              ],
+              "env": "AGENTOS_VALKEY_PASSWORD",
+              "global": false,
+              "help": "Valkey password (compose default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
+              "id": "valkey_password",
+              "long": "valkey-password",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Platform API base URL for the channel lookup",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key for the default-channel lookup",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "U-agentos-message"
+              ],
+              "global": false,
+              "help": "Synthetic Slack user id for the enqueued events",
+              "id": "user",
+              "long": "user",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos:runs"
+              ],
+              "env": "AGENTOS_STREAM",
+              "global": false,
+              "help": "Stream the dispatcher enqueues onto",
+              "id": "stream",
+              "long": "stream",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "300"
+              ],
+              "global": false,
+              "help": "How long to wait for each case's reply. Default: 300 seconds",
+              "id": "timeout_secs",
+              "long": "timeout-secs",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the plan that a real run would produce, and exit",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "eval"
+        },
+        {
           "about": "Push the bundle to the local platform API and deploy it",
           "args": [
             {
@@ -1231,6 +1332,162 @@
           ],
           "hidden": false,
           "name": "message"
+        },
+        {
+          "about": "Run the bundle's `evals/cases.json` through the deployed Kubernetes release and grade with the same grader `skill eval` uses (the per-tier parity gate)",
+          "args": [
+            {
+              "global": false,
+              "help": "Eval case file (default: `evals/cases.json` here, then the recorded bundle's)",
+              "id": "cases",
+              "long": "cases",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Slack channel id to send as; must match the target agent's slack_channel. Omit to use the sole deployed agent's channel",
+              "id": "channel",
+              "long": "channel",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Host the in-cluster worker uses to reach the stub. Omit to auto-detect the local IP the kernel would use to reach the cluster",
+              "id": "listen_host",
+              "long": "listen-host",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "8155"
+              ],
+              "global": false,
+              "help": "Port the stub binds (0.0.0.0); the worker posts here",
+              "id": "listen_port",
+              "long": "listen-port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "56381"
+              ],
+              "global": false,
+              "help": "Local port the Valkey port-forward binds",
+              "id": "valkey_local_port",
+              "long": "valkey-local-port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "valkeypass"
+              ],
+              "env": "AGENTOS_VALKEY_PASSWORD",
+              "global": false,
+              "help": "Valkey password (chart default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
+              "id": "valkey_password",
+              "long": "valkey-password",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "8123"
+              ],
+              "global": false,
+              "help": "Local port the API port-forward binds (default-channel lookup)",
+              "id": "api_local_port",
+              "long": "api-local-port",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key for the default-channel lookup",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "U-agentos-message"
+              ],
+              "global": false,
+              "help": "Synthetic Slack user id for the enqueued events",
+              "id": "user",
+              "long": "user",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos:runs"
+              ],
+              "env": "AGENTOS_STREAM",
+              "global": false,
+              "help": "Stream the dispatcher enqueues onto",
+              "id": "stream",
+              "long": "stream",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "300"
+              ],
+              "global": false,
+              "help": "How long to wait for each case's reply. Default: 300 seconds",
+              "id": "timeout_secs",
+              "long": "timeout-secs",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print the kubectl commands, stub URL, and enqueue description that a real run would produce, and exit without executing anything",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "eval"
         },
         {
           "about": "Push the bundle to the platform API and deploy it",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -854,7 +854,6 @@ pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()
     let ui = crate::ui::ui();
 
     let total = suite.cases.len();
-    let mut passed = 0usize;
     // (id, passed, seconds) rows, rendered as one table once the run finishes.
     let mut results: Vec<(String, bool, f64)> = Vec::with_capacity(total);
     let bar = ui.progress_bar(total as u64, "running evals");
@@ -864,27 +863,33 @@ pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()
             .send_event(EventType::EvalCase, &case.input, "U-eval", |_| {})
             .await?;
         let elapsed = started.elapsed().as_secs_f64();
-        let ok = turn_passes(case, &events);
-        if ok {
-            passed += 1;
-        }
-        results.push((case.id.clone(), ok, elapsed));
+        results.push((case.id.clone(), turn_passes(case, &events), elapsed));
         bar.inc(1);
     }
     bar.finish();
 
-    // Under --json the whole roll-up is one machine payload on stdout; the human
-    // table + verdict lines are suppressed so they cannot corrupt it.
+    report_eval(&results)
+}
+
+/// Render a finished eval run identically for every tier (`skill`, `local`,
+/// `cluster`): under `--json` the whole roll-up is one machine payload on
+/// stdout; otherwise the per-case table is payload -> stdout and the roll-up
+/// verdict is a diagnostic -> stderr. A failing run exits `Failure`. Shared so
+/// `local eval`/`cluster eval` print the same summary `skill eval` does (the
+/// per-tier parity gate), not a hand-mirrored one.
+pub fn report_eval(results: &[(String, bool, f64)]) -> Result<()> {
+    let ui = crate::ui::ui();
+    let total = results.len();
+    let passed = results.iter().filter(|(_, ok, _)| *ok).count();
+
     if ui.json() {
-        ui.emit_json(&eval_json(&results, passed, total));
+        ui.emit_json(&eval_json(results, passed, total));
         if passed < total {
             std::process::exit(crate::exit::ExitClass::Failure.code());
         }
         return Ok(());
     }
 
-    // The result table is payload -> stdout; the roll-up verdict is a
-    // diagnostic -> stderr.
     let rows: Vec<Vec<String>> = results
         .iter()
         .map(|(name, ok, seconds)| {

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -125,6 +125,11 @@ pub fn primer() -> Primer {
                 purpose: "Drive the real product loop end to end -- the path a Slack mention would take.",
             },
             Rung {
+                tier: "local",
+                command: "agentos local eval",
+                purpose: "Re-run the SAME evals/cases.json through the local tier -- the per-tier parity gate. A pass here that failed at skill (or vice versa) is the harness catching an environment bug.",
+            },
+            Rung {
                 tier: "cluster",
                 command: "agentos cluster up",
                 purpose: "Install the release on Kubernetes via Helm.",
@@ -138,6 +143,11 @@ pub fn primer() -> Primer {
                 tier: "cluster",
                 command: "agentos cluster message \"hello\"",
                 purpose: "Drive the same loop on the cluster.",
+            },
+            Rung {
+                tier: "cluster",
+                command: "agentos cluster eval",
+                purpose: "Re-assert the SAME evals/cases.json on the cluster with the same grader -- the per-tier parity gate at the tier that matters most before prod.",
             },
         ],
         decision_logic: vec![
@@ -164,8 +174,11 @@ pub fn primer() -> Primer {
             Decision {
                 question: "how an eval gates promotion",
                 answer: "evals/cases.json is the contract. `agentos skill eval` must be green before \
-                         you deploy; merging to main promotes to prod (git flow is the deploy model). \
-                         Never promote a bundle whose evals are red.",
+                         you deploy; `agentos local eval` and `agentos cluster eval` re-run the SAME \
+                         cases with the SAME grader at each tier (the per-tier parity gate), so a \
+                         suite that is green at skill can be re-asserted verbatim once deployed. \
+                         Merging to main promotes to prod (git flow is the deploy model). Never \
+                         promote a bundle whose evals are red.",
             },
         ],
         landmines: vec![

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -367,6 +367,46 @@ enum LocalAction {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Run the bundle's `evals/cases.json` through the local tier and grade with
+    /// the same grader `skill eval` uses (the per-tier parity gate).
+    Eval {
+        /// Eval case file (default: `evals/cases.json` here, then the recorded
+        /// bundle's).
+        #[arg(long)]
+        cases: Option<PathBuf>,
+        /// Slack channel id to send as; must match the target agent's
+        /// slack_channel. Omit to use the sole deployed agent's channel.
+        #[arg(long)]
+        channel: Option<String>,
+        /// Valkey password (compose default `valkeypass`). Prefer the
+        /// AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the
+        /// command line, where it leaks via `ps` and shell history.
+        #[arg(
+            long,
+            env = "AGENTOS_VALKEY_PASSWORD",
+            hide_env_values = true,
+            default_value = message::DEFAULT_VALKEY_PASSWORD
+        )]
+        valkey_password: String,
+        /// Platform API base URL for the channel lookup.
+        #[arg(long)]
+        api_url: Option<String>,
+        /// Platform API key for the default-channel lookup.
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY)]
+        api_key: String,
+        /// Synthetic Slack user id for the enqueued events.
+        #[arg(long, default_value = message::DEFAULT_USER)]
+        user: String,
+        /// Stream the dispatcher enqueues onto.
+        #[arg(long, env = "AGENTOS_STREAM", default_value = message::DEFAULT_STREAM)]
+        stream: String,
+        /// How long to wait for each case's reply. Default: 300 seconds.
+        #[arg(long, default_value_t = message::DEFAULT_TIMEOUT_SECS)]
+        timeout_secs: u64,
+        /// Print the plan that a real run would produce, and exit.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Push the bundle to the local platform API and deploy it.
     Deploy {
         /// Plugin bundle directory.
@@ -578,6 +618,64 @@ enum ClusterAction {
         /// Default: 300 seconds.
         #[arg(long)]
         timeout_secs: Option<u64>,
+        /// Print the kubectl commands, stub URL, and enqueue description that a
+        /// real run would produce, and exit without executing anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Run the bundle's `evals/cases.json` through the deployed Kubernetes
+    /// release and grade with the same grader `skill eval` uses (the per-tier
+    /// parity gate).
+    Eval {
+        /// Eval case file (default: `evals/cases.json` here, then the recorded
+        /// bundle's).
+        #[arg(long)]
+        cases: Option<PathBuf>,
+        /// Slack channel id to send as; must match the target agent's
+        /// slack_channel. Omit to use the sole deployed agent's channel.
+        #[arg(long)]
+        channel: Option<String>,
+        /// Kubernetes namespace of the release. Default: agentos.
+        #[arg(long, default_value = "agentos")]
+        namespace: String,
+        /// Helm release name. Default: agentos.
+        #[arg(long, default_value = "agentos")]
+        release: String,
+        /// Host the in-cluster worker uses to reach the stub. Omit to auto-detect
+        /// the local IP the kernel would use to reach the cluster.
+        #[arg(long)]
+        listen_host: Option<String>,
+        /// Port the stub binds (0.0.0.0); the worker posts here.
+        #[arg(long, default_value_t = message::DEFAULT_LISTEN_PORT)]
+        listen_port: u16,
+        /// Local port the Valkey port-forward binds.
+        #[arg(long, default_value_t = message::DEFAULT_VALKEY_LOCAL_PORT)]
+        valkey_local_port: u16,
+        /// Valkey password (chart default `valkeypass`). Prefer the
+        /// AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the
+        /// command line, where it leaks via `ps` and shell history.
+        #[arg(
+            long,
+            env = "AGENTOS_VALKEY_PASSWORD",
+            hide_env_values = true,
+            default_value = message::DEFAULT_VALKEY_PASSWORD
+        )]
+        valkey_password: String,
+        /// Local port the API port-forward binds (default-channel lookup).
+        #[arg(long, default_value_t = message::DEFAULT_API_LOCAL_PORT)]
+        api_local_port: u16,
+        /// Platform API key for the default-channel lookup.
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY)]
+        api_key: String,
+        /// Synthetic Slack user id for the enqueued events.
+        #[arg(long, default_value = message::DEFAULT_USER)]
+        user: String,
+        /// Stream the dispatcher enqueues onto.
+        #[arg(long, env = "AGENTOS_STREAM", default_value = message::DEFAULT_STREAM)]
+        stream: String,
+        /// How long to wait for each case's reply. Default: 300 seconds.
+        #[arg(long, default_value_t = message::DEFAULT_TIMEOUT_SECS)]
+        timeout_secs: u64,
         /// Print the kubectl commands, stub URL, and enqueue description that a
         /// real run would produce, and exit without executing anything.
         #[arg(long)]
@@ -944,6 +1042,37 @@ async fn run(command: Command) -> Result<()> {
                 })
                 .await
             }
+            LocalAction::Eval {
+                cases,
+                channel,
+                valkey_password,
+                api_url,
+                api_key,
+                user,
+                stream,
+                timeout_secs,
+                dry_run,
+            } => {
+                message::eval(message::EvalOpts {
+                    cases,
+                    channel,
+                    namespace: "agentos".into(),
+                    release: "agentos".into(),
+                    listen_host: None,
+                    listen_port: message::DEFAULT_LISTEN_PORT,
+                    valkey_local_port: message::DEFAULT_VALKEY_LOCAL_PORT,
+                    valkey_password,
+                    api_local_port: message::DEFAULT_API_LOCAL_PORT,
+                    api_key,
+                    user,
+                    stream,
+                    timeout_secs,
+                    dry_run,
+                    local: true,
+                    api_url,
+                })
+                .await
+            }
             LocalAction::Deploy {
                 plugin_dir,
                 api_url,
@@ -1151,6 +1280,42 @@ async fn run(command: Command) -> Result<()> {
                     user,
                     stream,
                     timeout_secs: resolved.timeout_secs,
+                    dry_run,
+                    local: false,
+                    api_url: None,
+                })
+                .await
+            }
+            ClusterAction::Eval {
+                cases,
+                channel,
+                namespace,
+                release,
+                listen_host,
+                listen_port,
+                valkey_local_port,
+                valkey_password,
+                api_local_port,
+                api_key,
+                user,
+                stream,
+                timeout_secs,
+                dry_run,
+            } => {
+                message::eval(message::EvalOpts {
+                    cases,
+                    channel,
+                    namespace,
+                    release,
+                    listen_host,
+                    listen_port,
+                    valkey_local_port,
+                    valkey_password,
+                    api_local_port,
+                    api_key,
+                    user,
+                    stream,
+                    timeout_secs,
                     dry_run,
                     local: false,
                     api_url: None,

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -23,15 +23,18 @@
 //!    once, instead of contending for a single `worker.slackApiBaseUrl`.
 
 use std::env;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
+use redis::aio::MultiplexedConnection;
 
 use crate::api::{Agent, ApiClient};
 use crate::chat::{
     await_reply, continue_hint_line, continue_hint_long_line, resolve_targets, Outcome, SlackStub,
 };
+use crate::evals::{EvalCase, EvalSuite};
 use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
 use crate::queue::{self, connect, diagnostics, synthetic_turn, xadd};
 use crate::state::{save_turn, TurnContext, TurnVerb};
@@ -724,6 +727,286 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// eval: the same evals/cases.json at the local and cluster tiers
+// ---------------------------------------------------------------------------
+
+/// Options for `agentos local eval` / `agentos cluster eval`, mirroring their
+/// clap flags. The connection surface is the `message` subset (no per-turn
+/// `text`/`thread`); `cases` selects the suite and `local` picks the tier.
+pub struct EvalOpts {
+    /// Explicit eval-case file; `None` resolves `evals/cases.json` like
+    /// `skill eval` (cwd, then the recorded bundle dir).
+    pub cases: Option<PathBuf>,
+    pub channel: Option<String>,
+    pub namespace: String,
+    pub release: String,
+    pub listen_host: Option<String>,
+    pub listen_port: u16,
+    pub valkey_local_port: u16,
+    pub valkey_password: String,
+    pub api_local_port: u16,
+    pub api_key: String,
+    pub user: String,
+    pub stream: String,
+    pub timeout_secs: u64,
+    pub dry_run: bool,
+    /// Local mode: drive the compose stack instead of a Kubernetes release.
+    pub local: bool,
+    /// Local mode only: platform API base URL for the channel lookup.
+    pub api_url: Option<String>,
+}
+
+/// Grade one tier turn's reply with the SAME grader `skill eval` uses. A turn
+/// passes only when the worker finalized it WITH reply text (`Replied`) and that
+/// text satisfies the case's grader -- the exact condition `evals::turn_passes`
+/// enforces over the runner's event stream, applied here to the reply the
+/// message enqueue+await path captures. `CompletedNoEdit` (finished, no
+/// placeholder edit) and `TimedOut` never pass, mirroring `turn_passes`'s
+/// requirement that the turn reach a `done` final.
+pub fn reply_passes(case: &EvalCase, outcome: &Outcome) -> bool {
+    match outcome {
+        Outcome::Replied(reply) => case.grader.grade(reply),
+        Outcome::CompletedNoEdit | Outcome::TimedOut => false,
+    }
+}
+
+/// The plan a `--dry-run` eval prints: the tier, the suite/case count, and the
+/// same enqueue/port-forward description a real run would produce. Pure so the
+/// rendering is unit-testable with no stack or cluster (mirrors `dry_run_lines`).
+pub fn eval_dry_run_lines(opts: &EvalOpts, suite_name: &str, case_count: usize) -> Vec<String> {
+    let tier = if opts.local { "local" } else { "cluster" };
+    let mut lines = vec![format!(
+        "grade {case_count} case(s) from suite {suite_name:?} against the {tier} tier"
+    )];
+    if opts.local {
+        let valkey_url = local_valkey_url(&opts.valkey_password);
+        let api_base = local_api_base(opts.api_url.as_deref());
+        lines.push("local mode (compose stack; no kubectl/helm)".to_string());
+        lines.push(format!("enqueue onto redis {valkey_url}"));
+        lines.push(format!(
+            "stub advertised at http://localhost:{DEFAULT_LOCAL_STUB_PORT}/api/"
+        ));
+        match opts.channel.as_deref() {
+            Some(channel) => lines.push(format!("channel {channel}")),
+            None => lines.push(format!(
+                "channel <the sole deployed agent via {api_base}/agents>"
+            )),
+        }
+    } else {
+        let host = opts
+            .listen_host
+            .clone()
+            .unwrap_or_else(|| "<auto-detected-local-ip>".to_string());
+        lines.push(
+            port_forward_command(
+                &opts.namespace,
+                &opts.release,
+                "valkey",
+                opts.valkey_local_port,
+                VALKEY_REMOTE_PORT,
+            )
+            .display(),
+        );
+        if opts.channel.is_none() {
+            lines.push(
+                port_forward_command(
+                    &opts.namespace,
+                    &opts.release,
+                    "api",
+                    opts.api_local_port,
+                    API_REMOTE_PORT,
+                )
+                .display(),
+            );
+        }
+        lines.push(format!(
+            "stub advertised at {}",
+            advertised_url(&host, opts.listen_port)
+        ));
+    }
+    lines.push(format!(
+        "enqueue one synthetic QueuedTurn per case on stream {}",
+        opts.stream
+    ));
+    lines
+}
+
+/// Resolve the eval suite the way `skill eval` does: an explicit `--cases`
+/// wins, else `evals/cases.json` in the cwd, then the recorded bundle dir.
+fn resolve_suite(explicit: Option<PathBuf>) -> Result<EvalSuite> {
+    let state_plugin_dir = crate::state::load(Path::new("."))?.map(|s| PathBuf::from(s.plugin_dir));
+    let path =
+        crate::commands::resolve_cases_path(explicit, Path::new("."), state_plugin_dir.as_deref())?;
+    crate::evals::load_suite(&path)
+}
+
+/// The shared per-tier eval engine: enqueue one synthetic `QueuedTurn` per case
+/// through the already-stood-up stub + Valkey (the same enqueue+await path a
+/// single `message` walks), grade the captured reply, and collect
+/// `(id, passed, seconds)` rows for `report_eval`. Tier-agnostic: the caller
+/// binds the stub/connection for its tier, then hands them here.
+async fn run_eval_turns(
+    opts: &EvalOpts,
+    channel: &str,
+    suite: &EvalSuite,
+    conn: &mut MultiplexedConnection,
+    stub: &mut SlackStub,
+) -> Result<Vec<(String, bool, f64)>> {
+    let ui = crate::ui::ui();
+    let total = suite.cases.len();
+    let bar = ui.progress_bar(total as u64, "running evals");
+    let mut results: Vec<(String, bool, f64)> = Vec::with_capacity(total);
+    for case in &suite.cases {
+        // Each case is its own thread so turns never cross-talk on the stub.
+        let (channel_id, thread_ts, placeholder_ts) = resolve_targets(Some(channel), None);
+        let reply_endpoint = stub.base_api_url().to_string();
+        let event = synthetic_turn(
+            &channel_id,
+            &opts.user,
+            &case.input,
+            &thread_ts,
+            &placeholder_ts,
+            Some(reply_endpoint),
+        );
+        let started = Instant::now();
+        let stream_id = xadd(conn, &opts.stream, &event).await?;
+        let outcome = await_reply(
+            stub,
+            conn,
+            &opts.stream,
+            &stream_id,
+            &placeholder_ts,
+            Duration::from_secs(opts.timeout_secs),
+        )
+        .await;
+        let elapsed = started.elapsed().as_secs_f64();
+        results.push((case.id.clone(), reply_passes(case, &outcome), elapsed));
+        bar.inc(1);
+    }
+    bar.finish();
+    Ok(results)
+}
+
+/// The shared `eval` handler: run the bundle's `evals/cases.json` through the
+/// target tier's message enqueue+await path and grade with the shared grader,
+/// so a suite that passes at `skill` can be re-asserted verbatim at `local` and
+/// `cluster` (issue #344, the per-tier parity gate).
+pub async fn eval(opts: EvalOpts) -> Result<()> {
+    let suite = resolve_suite(opts.cases.clone())?;
+    if opts.local {
+        eval_local(opts, suite).await
+    } else {
+        eval_cluster(opts, suite).await
+    }
+}
+
+async fn eval_local(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
+    let ui = crate::ui::ui();
+    let valkey_url = local_valkey_url(&opts.valkey_password);
+    let api_base = local_api_base(opts.api_url.as_deref());
+
+    if opts.dry_run {
+        for line in eval_dry_run_lines(&opts, &suite.name, suite.cases.len()) {
+            ui.payload_plain(&line);
+        }
+        return Ok(());
+    }
+
+    let mut conn = connect(&valkey_url).await?;
+    let mut stub = SlackStub::start("127.0.0.1", DEFAULT_LOCAL_STUB_PORT, "localhost").await?;
+    ui.note(&format!(
+        "slack stub listening; the worker posts to {}",
+        stub.base_api_url()
+    ));
+
+    let channel = match opts.channel.as_deref() {
+        Some(channel) => channel.to_string(),
+        None => {
+            let api = ApiClient::new(&api_base, &opts.api_key)?;
+            let agents = api.list_agents().await.with_context(|| {
+                format!("listing agents via {api_base} (is `agentos local up` running?)")
+            })?;
+            select_channel(&agents, None)?
+        }
+    };
+    ui.note(&format!("routing to channel {channel}"));
+
+    let results = run_eval_turns(&opts, &channel, &suite, &mut conn, &mut stub).await?;
+    crate::commands::report_eval(&results)
+}
+
+async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
+    let ui = crate::ui::ui();
+
+    if opts.dry_run {
+        for line in eval_dry_run_lines(&opts, &suite.name, suite.cases.len()) {
+            ui.payload_plain(&line);
+        }
+        return Ok(());
+    }
+
+    require_on_path("kubectl")?;
+
+    let advertise_host = resolve_advertise_host(opts.listen_host.as_deref()).await?;
+    let mut stub = SlackStub::start("0.0.0.0", opts.listen_port, &advertise_host).await?;
+    ui.note(&format!(
+        "slack stub listening; the worker will post to {}",
+        stub.base_api_url()
+    ));
+
+    // Valkey port-forward for the enqueue, kept alive for the whole eval loop.
+    let _valkey_pf = start_port_forward(
+        &port_forward_command(
+            &opts.namespace,
+            &opts.release,
+            "valkey",
+            opts.valkey_local_port,
+            VALKEY_REMOTE_PORT,
+        ),
+        opts.valkey_local_port,
+        "valkey",
+    )
+    .await?;
+
+    let channel = match opts.channel.as_deref() {
+        Some(channel) => channel.to_string(),
+        None => {
+            let _api_pf = start_port_forward(
+                &port_forward_command(
+                    &opts.namespace,
+                    &opts.release,
+                    "api",
+                    opts.api_local_port,
+                    API_REMOTE_PORT,
+                ),
+                opts.api_local_port,
+                "api",
+            )
+            .await?;
+            let api = ApiClient::new(
+                &format!("http://localhost:{}", opts.api_local_port),
+                &opts.api_key,
+            )?;
+            let agents = api
+                .list_agents()
+                .await
+                .context("listing agents through the api port-forward")?;
+            select_channel(&agents, None)?
+        }
+    };
+    ui.note(&format!("routing to channel {channel}"));
+
+    let valkey_url = format!(
+        "redis://:{}@localhost:{}",
+        opts.valkey_password, opts.valkey_local_port
+    );
+    let mut conn = connect(&valkey_url).await?;
+
+    let results = run_eval_turns(&opts, &channel, &suite, &mut conn, &mut stub).await?;
+    crate::commands::report_eval(&results)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -954,5 +1237,126 @@ mod tests {
         let v = message_dry_run_json("cluster", "s", None, "http://10.1.2.3:8155/api/");
         assert!(v["channel"].is_null(), "{v}");
         assert_eq!(v["target"], serde_json::json!("cluster"));
+    }
+
+    // --- eval parity verb ---------------------------------------------------
+
+    use crate::evals::{EvalCase, Grader, GraderKind};
+
+    fn eval_opts(local: bool, channel: Option<&str>) -> EvalOpts {
+        EvalOpts {
+            cases: None,
+            channel: channel.map(str::to_string),
+            namespace: "agentos".into(),
+            release: "agentos".into(),
+            listen_host: None,
+            listen_port: DEFAULT_LISTEN_PORT,
+            valkey_local_port: DEFAULT_VALKEY_LOCAL_PORT,
+            valkey_password: DEFAULT_VALKEY_PASSWORD.into(),
+            api_local_port: DEFAULT_API_LOCAL_PORT,
+            api_key: DEFAULT_API_KEY.into(),
+            user: DEFAULT_USER.into(),
+            stream: DEFAULT_STREAM.into(),
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+            dry_run: true,
+            local,
+            api_url: None,
+        }
+    }
+
+    fn eval_case(kind: GraderKind, expected: &str) -> EvalCase {
+        EvalCase {
+            id: "c1".into(),
+            input: "ping".into(),
+            grader: Grader {
+                kind,
+                expected: expected.into(),
+                case_sensitive: false,
+            },
+        }
+    }
+
+    #[test]
+    fn reply_passes_only_on_a_matching_captured_reply() {
+        let case = eval_case(GraderKind::Contains, "pong");
+        // Replied + grader matches -> pass; the shared Grader grades the reply.
+        assert!(reply_passes(
+            &case,
+            &Outcome::Replied("the answer is PONG".into())
+        ));
+        // Replied but grader misses -> fail.
+        assert!(!reply_passes(&case, &Outcome::Replied("nope".into())));
+        // No reply text and no completion never pass, mirroring turn_passes.
+        assert!(!reply_passes(&case, &Outcome::CompletedNoEdit));
+        assert!(!reply_passes(&case, &Outcome::TimedOut));
+    }
+
+    #[test]
+    fn local_eval_dry_run_plan_names_the_tier_suite_and_enqueue() {
+        // The `local eval` path with no live stack: the plan is a pure render.
+        let lines = eval_dry_run_lines(&eval_opts(true, Some("C123")), "smoke", 3);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "grade 3 case(s) from suite \"smoke\" against the local tier"),
+            "{lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "enqueue onto redis redis://:valkeypass@localhost:26379"),
+            "{lines:?}"
+        );
+        assert!(lines.iter().any(|l| l == "channel C123"), "{lines:?}");
+        // No cluster plumbing (a kubectl port-forward command) leaks into the
+        // local plan; the "no kubectl/helm" descriptor line is fine.
+        assert!(
+            !lines.iter().any(|l| l.starts_with("kubectl ")),
+            "local plan has no kubectl command: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(
+                |l| l.contains("enqueue one synthetic QueuedTurn per case on stream")
+                    && l.contains(DEFAULT_STREAM)
+            ),
+            "{lines:?}"
+        );
+    }
+
+    #[test]
+    fn local_eval_dry_run_names_the_channel_lookup_when_omitted() {
+        let lines = eval_dry_run_lines(&eval_opts(true, None), "smoke", 1);
+        assert!(
+            lines.iter().any(|l| l.contains("sole deployed agent")),
+            "channel placeholder when omitted: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn cluster_eval_dry_run_plan_lists_the_valkey_forward_and_stub() {
+        let lines = eval_dry_run_lines(&eval_opts(false, Some("C1")), "smoke", 2);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "grade 2 case(s) from suite \"smoke\" against the cluster tier"),
+            "{lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l == "kubectl -n agentos port-forward svc/agentos-valkey 56381:6379"),
+            "{lines:?}"
+        );
+        // Explicit channel -> no api forward.
+        assert!(
+            !lines.iter().any(|l| l.contains("svc/agentos-api")),
+            "explicit channel needs no api forward: {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.starts_with("stub advertised at http://")),
+            "{lines:?}"
+        );
     }
 }

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -40,11 +40,13 @@ fn process_help_routes_positive_forms() {
         &["local", "down"],
         &["local", "status"],
         &["local", "message"],
+        &["local", "eval"],
         &["local", "deploy"],
         &["cluster", "up"],
         &["cluster", "down"],
         &["cluster", "status"],
         &["cluster", "message"],
+        &["cluster", "eval"],
         &["cluster", "deploy"],
         &["init"],
     ];


### PR DESCRIPTION
## Friction

The parity promise is "the same bundle and the same evals stay green at every tier (skill → local → cluster)", but `eval` existed **only** under `skill`. Re-running a suite at the local/cluster tier meant hand-driving each case through `local message`/`cluster message` and `grep`-ing the expected token — real friction, and it meant the parity claim couldn't be checked with one blessed command at the tiers that matter most.

## What

`agentos local eval [--cases …]` and `agentos cluster eval [--cases …]` run the bundle's `evals/cases.json` through that tier's **message enqueue+await path** (one synthetic `QueuedTurn` per case, the same path a Slack mention walks) and grade each captured reply.

- **One grader, three tiers.** Grading reuses `evals::{EvalCase, Grader}` verbatim; `reply_passes` applies the exact pass condition `evals::turn_passes` enforces (finalized-with-reply + grader match) to the reply the message path captures. A `report_eval` helper (extracted from `skill eval`) prints the **identical** per-case table + rollup at every tier.
- `Eval` variants on `LocalAction`/`ClusterAction` in `main.rs` + dispatch; each has a `--dry-run` like its `message` sibling.
- Documented in `agentos guide` (two new parity-ladder rungs + the promotion-gate decision) and `cli/README.md`. Regenerated `cli/command-manifest.json` (the drift gate) and extended the command-surface test.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass. New unit tests cover `reply_passes` and the `local`/`cluster` dry-run plan builders (the `local eval` path test). The verbs were smoke-run via `--dry-run` against the dev stack.

`cluster eval` cannot be live-verified without a cluster — the same bar as the existing untested `cluster message`.

Related: #332 (multi-sample/variance-aware runs) builds on this plumbing.

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)