### PR TITLE
eval: pluggable scorer seam above the port + tier-1 trajectory matcher

### DIFF
--- a/apps/worker/src/agentos_worker/eval/__init__.py
+++ b/apps/worker/src/agentos_worker/eval/__init__.py
@@ -17,6 +17,15 @@ from .models import (
 from .recorder import SCORE_NAME, IngestionError, LangfuseEvalRecorder
 from .run import load_suite, run_eval_suite
 from .runner import EvalRunner
+from .scorer import (
+    GraderScorer,
+    Scorer,
+    ScoreResult,
+    TrajectoryMode,
+    TrajectoryScorer,
+    TrajectorySpec,
+    match_trajectory,
+)
 from .stream import (
     EvalReport,
     EvalReporter,
@@ -36,11 +45,18 @@ __all__ = [
     "EvalStreamConsumer",
     "EvalSuite",
     "EvalWorkItem",
-    "load_suite_from_bundle",
     "Grader",
     "GraderKind",
+    "GraderScorer",
     "IngestionError",
     "LangfuseEvalRecorder",
+    "Scorer",
+    "ScoreResult",
+    "TrajectoryMode",
+    "TrajectoryScorer",
+    "TrajectorySpec",
     "load_suite",
+    "load_suite_from_bundle",
+    "match_trajectory",
     "run_eval_suite",
 ]

--- a/apps/worker/src/agentos_worker/eval/runner.py
+++ b/apps/worker/src/agentos_worker/eval/runner.py
@@ -19,17 +19,28 @@ from __future__ import annotations
 import time
 
 import aiohttp
-from aci_protocol import ErrorEvent, Event, Final, SessionStatus, TextDelta
+from aci_protocol import ErrorEvent, Event, Final, SessionStatus, TextDelta, ToolNote
 
 from ..runner_client import RunnerClient, RunnerError
 from .models import EvalCase, EvalCaseResult, EvalRunResult, EvalSuite
+from .scorer import GraderScorer, Scorer
 
 
 class EvalRunner:
-    """Executes eval suites against a runner endpoint and grades the answers."""
+    """Executes eval suites against a runner endpoint and scores the answers.
 
-    def __init__(self, runner: RunnerClient) -> None:
+    Scoring goes through the swappable :class:`~.scorer.Scorer` seam. The default
+    is :class:`~.scorer.GraderScorer`, which applies the case's frozen grader to
+    the answer text (behavior-preserving); pass a different scorer (e.g. a
+    :class:`~.scorer.TrajectoryScorer` over the tool-call sequence) to score the
+    same turns differently. The runner still owns the completion gate (a
+    classified-failure or non-``done`` turn fails regardless of the scorer), so a
+    scorer only ever judges a turn that actually completed.
+    """
+
+    def __init__(self, runner: RunnerClient, *, scorer: Scorer | None = None) -> None:
         self._runner = runner
+        self._scorer: Scorer = scorer if scorer is not None else GraderScorer()
 
     async def run(
         self, suite: EvalSuite, *, base_url: str, version: str, token: str | None = None
@@ -43,6 +54,7 @@ class EvalRunner:
         start = time.monotonic()
         event = Event(type="eval_case", text=case.input, user="eval", ts="0")
         parts: list[str] = []
+        trajectory: list[str] = []
         final_text: str | None = None
         final_status: SessionStatus | None = None
         error_detail: str | None = None
@@ -52,6 +64,10 @@ class EvalRunner:
                 async for frame in turn:
                     if isinstance(frame, TextDelta):
                         parts.append(frame.text)
+                    elif isinstance(frame, ToolNote):
+                        # The tool-call trajectory the scorer seam can match on.
+                        if frame.tool is not None:
+                            trajectory.append(frame.tool)
                     elif isinstance(frame, Final):
                         final_text = frame.text
                         final_status = frame.status
@@ -90,9 +106,13 @@ class EvalRunner:
                 latency_ms=_elapsed_ms(start),
                 error=f"turn did not complete (status={final_status})",
             )
+        # The turn completed cleanly, so a negative verdict is the scorer saying
+        # "no", not a runner/turn error -- keep `error` reserved for the latter
+        # (exceptions, classified failures, incomplete turns handled above).
+        verdict = self._scorer.score(case, output, trajectory)
         return EvalCaseResult(
             case_id=case.id,
-            passed=case.grader.grade(output),
+            passed=verdict.passed,
             output=output,
             latency_ms=_elapsed_ms(start),
         )

--- a/apps/worker/src/agentos_worker/eval/scorer.py
+++ b/apps/worker/src/agentos_worker/eval/scorer.py
@@ -1,0 +1,168 @@
+"""The scorer seam: how a completed turn becomes pass/fail, above the eval port.
+
+Today scoring is a single deterministic string-grader family (:class:`Grader`
+in ``models.py``): a case names a grader and the runner applies it to the final
+answer text. This module lifts that decision into a swappable seam so a scorer
+can look at more than the answer text -- specifically the **tool-call trajectory**
+the turn produced -- without touching the frozen eval-case schema or the recorder.
+
+The pipeline is unchanged end to end: frozen case -> scorer (swappable) -> the
+existing :class:`~.recorder.LangfuseEvalRecorder`. The scorer only replaces the
+inline ``case.grader.grade(output)`` call inside :class:`~.runner.EvalRunner`; it
+returns a plain pass/fail (plus a human detail string), which the runner folds
+into the same :class:`~.models.EvalCaseResult` the recorder already writes. So a
+non-``contains`` scorer records its verdict through the identical path.
+
+Two scorers ship here:
+
+* :class:`GraderScorer` -- wraps the frozen :class:`Grader`, scoring the answer
+  text exactly as before. It is the default, so existing suites are unaffected.
+* :class:`TrajectoryScorer` -- the tier-1 **deterministic trajectory matcher**
+  over the observed tool-call sequence (exact / in-order / any-order / precision
+  / recall). It is configured *above the port* (a ``case_id -> spec`` mapping the
+  run layer supplies), not from a new field on the frozen case -- adding a
+  per-case trajectory expectation to ``EvalCase`` would change the frozen
+  eval-case schema, which is deliberately out of scope here.
+
+LLM-as-judge and hosted-eval-API scorers are the later, costlier tiers named in
+the INTERFACE; they conform to the same :class:`Scorer` protocol but are not
+built here.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Protocol, runtime_checkable
+
+from .models import EvalCase
+
+
+@dataclass(frozen=True)
+class ScoreResult:
+    """A scorer's verdict for one case: pass/fail plus a human-readable reason."""
+
+    passed: bool
+    detail: str | None = None
+
+
+@runtime_checkable
+class Scorer(Protocol):
+    """The seam: turn a completed turn's observations into a pass/fail verdict.
+
+    ``output`` is the graded answer text (the runner's ``final`` text, or the
+    accumulated deltas). ``trajectory`` is the ordered tool-call sequence the turn
+    produced (the ``tool`` field of each ``tool_note`` frame, in emission order).
+    A scorer uses whichever it needs; the string graders ignore the trajectory,
+    the trajectory matcher ignores the text.
+    """
+
+    def score(self, case: EvalCase, output: str, trajectory: Sequence[str]) -> ScoreResult: ...
+
+
+class GraderScorer:
+    """Default scorer: apply the case's frozen :class:`Grader` to the answer text.
+
+    Behavior-preserving -- this is exactly the ``case.grader.grade(output)`` the
+    runner used inline, now expressed through the seam so it is one swappable
+    implementation among several.
+    """
+
+    def score(self, case: EvalCase, output: str, trajectory: Sequence[str]) -> ScoreResult:
+        del trajectory  # text grader: the tool-call sequence is irrelevant
+        passed = case.grader.grade(output)
+        return ScoreResult(passed=passed, detail=None if passed else "grader did not match")
+
+
+class TrajectoryMode(StrEnum):
+    """How an observed tool-call sequence is compared against the expected one."""
+
+    #: The observed sequence equals the expected one (order and multiplicity).
+    EXACT = "exact"
+    #: The expected sequence is a subsequence of the observed one (order kept,
+    #: extra calls between allowed).
+    IN_ORDER = "in_order"
+    #: Every expected call appears in the observed sequence with at least its
+    #: expected multiplicity; order is ignored.
+    ANY_ORDER = "any_order"
+    #: Fraction of observed calls that were expected is >= ``threshold`` (guards
+    #: against extra/hallucinated tool calls).
+    PRECISION = "precision"
+    #: Fraction of expected tools that were observed is >= ``threshold`` (guards
+    #: against missing tool calls).
+    RECALL = "recall"
+
+
+@dataclass(frozen=True)
+class TrajectorySpec:
+    """The expected tool trajectory for one case and how to compare it."""
+
+    expected: tuple[str, ...]
+    mode: TrajectoryMode = TrajectoryMode.IN_ORDER
+    #: Pass threshold for the ratio modes (PRECISION / RECALL); ignored otherwise.
+    threshold: float = 1.0
+
+
+def _is_subsequence(expected: Sequence[str], observed: Sequence[str]) -> bool:
+    """True if ``expected`` appears in ``observed`` in order (gaps allowed)."""
+    it = iter(observed)
+    return all(any(o == e for o in it) for e in expected)
+
+
+def match_trajectory(spec: TrajectorySpec, trajectory: Sequence[str]) -> ScoreResult:
+    """Grade one observed tool-call sequence against a spec (pure, testable)."""
+    observed = list(trajectory)
+    expected = list(spec.expected)
+    detail = f"mode={spec.mode} expected={expected} observed={observed}"
+
+    if spec.mode is TrajectoryMode.EXACT:
+        passed = observed == expected
+    elif spec.mode is TrajectoryMode.IN_ORDER:
+        passed = _is_subsequence(expected, observed)
+    elif spec.mode is TrajectoryMode.ANY_ORDER:
+        passed = not (Counter(expected) - Counter(observed))
+    elif spec.mode is TrajectoryMode.PRECISION:
+        # Of the calls the agent made, how many were expected. No calls -> nothing
+        # unexpected, so precision is vacuously 1.0.
+        expected_set = set(expected)
+        ratio = 1.0 if not observed else sum(o in expected_set for o in observed) / len(observed)
+        passed = ratio >= spec.threshold
+        detail = f"{detail} precision={ratio:.3f} threshold={spec.threshold}"
+    else:  # RECALL
+        # Of the expected tools, how many the agent actually used. No expectations
+        # -> nothing to miss, so recall is vacuously 1.0.
+        observed_set = set(observed)
+        expected_set = set(expected)
+        ratio = 1.0 if not expected_set else sum(e in observed_set for e in expected_set) / len(
+            expected_set
+        )
+        passed = ratio >= spec.threshold
+        detail = f"{detail} recall={ratio:.3f} threshold={spec.threshold}"
+
+    return ScoreResult(passed=passed, detail=None if passed else detail)
+
+
+@dataclass
+class TrajectoryScorer:
+    """Deterministic tier-1 scorer: match the observed tool calls against a spec.
+
+    Specs are keyed by ``case.id`` and supplied by the run layer (above the eval
+    port), not read from the frozen case. A case with no spec and no ``default``
+    fails closed with an explanatory detail, so a misconfigured run never scores
+    green by omission -- the same deny-by-default posture the grader family has.
+    """
+
+    specs: Mapping[str, TrajectorySpec] = field(default_factory=dict)
+    default: TrajectorySpec | None = None
+
+    def score(self, case: EvalCase, output: str, trajectory: Sequence[str]) -> ScoreResult:
+        del output  # trajectory matcher: the answer text is irrelevant
+        spec = self.specs.get(case.id, self.default)
+        if spec is None:
+            return ScoreResult(
+                passed=False,
+                detail=f"no trajectory spec for case {case.id!r}",
+            )
+        return match_trajectory(spec, trajectory)

--- a/apps/worker/tests/eval/conftest.py
+++ b/apps/worker/tests/eval/conftest.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import boto3
 import pytest
-from aci_protocol import Final, SessionStatus
+from aci_protocol import Final, SessionStatus, ToolNote
 from agentos_worker.bundle_store import BundleStore
 from agentos_worker.config import WorkerConfig
 from agentos_worker.eval import EvalSuite
@@ -69,6 +69,10 @@ class FakeEvalRunner:
         # Inputs whose turn ends idle-awaiting-input (an incomplete turn) while
         # still carrying text in responses[input].
         self.idle_inputs: set[str] = set()
+        # Per-input tool-call trajectory: the ordered tool names emitted as
+        # tool_note frames before the final, so scorer-seam tests can drive the
+        # tool-call sequence a turn produced.
+        self.tool_calls: dict[str, list[str]] = {}
         self.default_output = ""
         self.seen: list[dict[str, str]] = []
 
@@ -90,6 +94,9 @@ class FakeEvalRunner:
             status = SessionStatus.DONE
         resp = web.StreamResponse(status=200, headers={"Content-Type": "application/x-ndjson"})
         await resp.prepare(request)
+        for tool in self.tool_calls.get(text, []):
+            note = ToolNote(text=f"calling {tool}", tool=tool)
+            await resp.write((note.model_dump_json() + "\n").encode("utf-8"))
         frame = Final(text=output, status=status)
         await resp.write((frame.model_dump_json() + "\n").encode("utf-8"))
         await resp.write_eof()

--- a/apps/worker/tests/eval/test_scorer.py
+++ b/apps/worker/tests/eval/test_scorer.py
@@ -1,0 +1,192 @@
+"""Scorer-seam tests: the swappable scorer above the eval port.
+
+Two layers: the pure trajectory matcher (all five deterministic modes) and the
+seam wired through ``EvalRunner`` end to end -- a non-``contains`` scorer scoring
+the tool-call trajectory of a real (fake-runner) turn, then recorded through the
+existing recorder's ``EvalRunResult`` shape unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from agentos_worker.eval import (
+    EvalCase,
+    EvalRunner,
+    EvalSuite,
+    Grader,
+    GraderKind,
+    GraderScorer,
+    Scorer,
+    ScoreResult,
+    TrajectoryMode,
+    TrajectoryScorer,
+    TrajectorySpec,
+    match_trajectory,
+)
+
+CONTAINS = GraderKind.CONTAINS
+
+
+def _case(cid: str = "c") -> EvalCase:
+    return EvalCase(id=cid, input="q", grader=Grader(kind=CONTAINS, expected="x"))
+
+
+# --- pure trajectory matcher ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected", "observed", "passes"),
+    [
+        # EXACT: order and multiplicity must match.
+        (TrajectoryMode.EXACT, ["a", "b"], ["a", "b"], True),
+        (TrajectoryMode.EXACT, ["a", "b"], ["a", "b", "c"], False),
+        (TrajectoryMode.EXACT, ["a", "b"], ["b", "a"], False),
+        # IN_ORDER: expected is a subsequence, extra calls between are fine.
+        (TrajectoryMode.IN_ORDER, ["a", "c"], ["a", "b", "c"], True),
+        (TrajectoryMode.IN_ORDER, ["a", "c"], ["c", "a"], False),
+        # ANY_ORDER: multiset containment, order ignored.
+        (TrajectoryMode.ANY_ORDER, ["a", "b"], ["b", "x", "a"], True),
+        (TrajectoryMode.ANY_ORDER, ["a", "a"], ["a", "b"], False),
+    ],
+)
+def test_trajectory_modes_membership(
+    mode: TrajectoryMode, expected: list[str], observed: list[str], passes: bool
+) -> None:
+    spec = TrajectorySpec(expected=tuple(expected), mode=mode)
+    assert match_trajectory(spec, observed).passed is passes
+
+
+def test_precision_penalizes_extra_calls() -> None:
+    spec = TrajectorySpec(expected=("a", "b"), mode=TrajectoryMode.PRECISION, threshold=1.0)
+    # All observed calls are expected -> precision 1.0 -> pass.
+    assert match_trajectory(spec, ["a", "b"]).passed is True
+    # A hallucinated extra call drops precision below 1.0 -> fail at threshold 1.0.
+    assert match_trajectory(spec, ["a", "b", "junk"]).passed is False
+    # ...but a lower threshold tolerates it.
+    lenient = TrajectorySpec(expected=("a", "b"), mode=TrajectoryMode.PRECISION, threshold=0.6)
+    assert match_trajectory(lenient, ["a", "b", "junk"]).passed is True
+
+
+def test_recall_penalizes_missing_calls() -> None:
+    spec = TrajectorySpec(expected=("a", "b"), mode=TrajectoryMode.RECALL, threshold=1.0)
+    assert match_trajectory(spec, ["a", "b"]).passed is True
+    # Missing one expected tool -> recall 0.5 -> fail at 1.0, pass at 0.5.
+    assert match_trajectory(spec, ["a"]).passed is False
+    assert match_trajectory(
+        TrajectorySpec(expected=("a", "b"), mode=TrajectoryMode.RECALL, threshold=0.5),
+        ["a"],
+    ).passed is True
+
+
+def test_failed_match_carries_a_debuggable_detail() -> None:
+    result = match_trajectory(TrajectorySpec(expected=("a",), mode=TrajectoryMode.EXACT), ["b"])
+    assert result.passed is False
+    assert result.detail is not None
+    assert "expected=['a']" in result.detail and "observed=['b']" in result.detail
+
+
+# --- the seam contract ------------------------------------------------------
+
+
+def test_grader_scorer_matches_the_frozen_grader() -> None:
+    scorer = GraderScorer()
+    case = EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="Paris"))
+    assert scorer.score(case, "The capital is Paris.", []).passed is True
+    assert scorer.score(case, "The capital is Berlin.", []).passed is False
+
+
+def test_scorers_satisfy_the_protocol() -> None:
+    # runtime_checkable Protocol: both shipped scorers are structural Scorers.
+    assert isinstance(GraderScorer(), Scorer)
+    assert isinstance(TrajectoryScorer(), Scorer)
+
+
+def test_trajectory_scorer_fails_closed_without_a_spec() -> None:
+    # Deny-by-default: a case with no spec (and no default) cannot pass by omission.
+    result = TrajectoryScorer().score(_case("unknown"), "output", ["a", "b"])
+    assert result.passed is False
+    assert result.detail is not None and "no trajectory spec" in result.detail
+
+
+def test_trajectory_scorer_uses_a_default_spec_when_present() -> None:
+    scorer = TrajectoryScorer(
+        default=TrajectorySpec(expected=("a",), mode=TrajectoryMode.ANY_ORDER)
+    )
+    assert scorer.score(_case(), "out", ["a", "b"]).passed is True
+    assert scorer.score(_case(), "out", ["b"]).passed is False
+
+
+# --- seam wired through EvalRunner end to end -------------------------------
+
+
+def test_trajectory_scorer_scores_a_real_turn_through_the_runner(make_eval_harness) -> None:
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            # The fake runner emits these tool_note frames before its final; the
+            # answer text is deliberately unrelated so ONLY the trajectory decides.
+            fake.responses = {"do the thing": "whatever", "skip a step": "whatever"}
+            fake.tool_calls = {
+                "do the thing": ["search", "fetch", "summarize"],
+                "skip a step": ["search", "summarize"],
+            }
+            suite = EvalSuite(
+                name="trajectory",
+                cases=[
+                    # The grader would pass on any text (contains ""), so a green
+                    # here proves the trajectory scorer -- not the grader -- decided.
+                    EvalCase(id="full", input="do the thing", grader=_grader_any()),
+                    EvalCase(id="partial", input="skip a step", grader=_grader_any()),
+                ],
+            )
+            scorer = TrajectoryScorer(
+                specs={
+                    "full": TrajectorySpec(
+                        expected=("search", "fetch", "summarize"), mode=TrajectoryMode.IN_ORDER
+                    ),
+                    "partial": TrajectorySpec(
+                        expected=("search", "fetch", "summarize"), mode=TrajectoryMode.IN_ORDER
+                    ),
+                }
+            )
+            result = await EvalRunner(client, scorer=scorer).run(
+                suite, base_url=base_url, version="v1"
+            )
+
+            by_id = {r.case_id: r for r in result.results}
+            # "full" made all three calls in order -> pass; "partial" missed
+            # "fetch" -> the in-order subsequence fails.
+            assert by_id["full"].passed is True
+            assert by_id["partial"].passed is False
+            assert result.summary() == "1/2 passed"
+
+    asyncio.run(go())
+
+
+def test_default_runner_still_uses_the_grader(make_eval_harness) -> None:
+    # No scorer passed -> GraderScorer default -> the tool-call trajectory is
+    # ignored and the answer text decides, exactly as before this seam.
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "the answer is 4"}
+            fake.tool_calls = {"q": ["irrelevant_tool"]}
+            suite = EvalSuite(
+                name="grader",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(client).run(suite, base_url=base_url, version="v1")
+            assert result.results[0].passed is True
+
+    asyncio.run(go())
+
+
+def _grader_any() -> Grader:
+    # A grader that matches any output (contains the empty string), used to prove
+    # the trajectory scorer is what gates the case.
+    return Grader(kind=CONTAINS, expected="")
+
+
+def test_score_result_is_a_simple_verdict() -> None:
+    r = ScoreResult(passed=True)
+    assert r.passed is True and r.detail is None

--- a/docs/interfaces/evals/INTERFACE.md
+++ b/docs/interfaces/evals/INTERFACE.md
@@ -1,7 +1,7 @@
 # INTERFACE: Evals (case + scorer)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 grader family &nbsp;·&nbsp; **Swap-readiness grade:** B
+> **Kind:** SOFT (scorer slot now a typed `Scorer` Protocol) &nbsp;·&nbsp; **Implementations today:** 2 scorers (grader family + deterministic trajectory matcher) &nbsp;·&nbsp; **Swap-readiness grade:** B
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -13,13 +13,15 @@ The eval seam is defined by two wire contracts, not a code interface: the `agent
 
 Request side — one stream field `payload` (`STREAM_PAYLOAD_FIELD`, `apps/worker/src/agentos_worker/eval/stream.py:72`) holding an `EvalWorkItem` JSON (`stream.py:76`): `agent_id`, `version_id`, `sha`, `suite`, `bundle_ref`, `target_url`, `requested_at`. Consumer group `agentos-eval-workers` reads it (`stream.py:6`, `stream.py:181`).
 
-Case + grader models — `EvalCase` is `{id, input, grader}` (`eval/models.py:53`); `Grader` is `{kind: GraderKind, expected, case_sensitive}` (`models.py:26`) where `GraderKind` is the enum-dispatched family `EXACT | CONTAINS | REGEX` (`models.py:18`), applied by `Grader.grade(output)` (`models.py:39`). This is the single "grader family" — deny-by-default, string-shaped only; an LLM-judge grader is explicitly a later addition (`models.py:27`).
+Case + grader models — `EvalCase` is `{id, input, grader}` (`eval/models.py:53`); `Grader` is `{kind: GraderKind, expected, case_sensitive}` (`models.py:26`) where `GraderKind` is the enum-dispatched family `EXACT | CONTAINS | REGEX` (`models.py:18`), applied by `Grader.grade(output)` (`models.py:39`). This is the single "grader family" — deny-by-default, string-shaped only.
+
+Scorer seam — the pass/fail decision is now a swappable `Scorer` Protocol above the port (`eval/scorer.py`): `score(case, output, trajectory) -> ScoreResult`. `EvalRunner` captures both the answer text and the tool-call `trajectory` (the ordered `tool` field of each `tool_note` frame) and delegates to an injected scorer, defaulting to `GraderScorer` (the frozen grader over the text — behavior-preserving). The second, tier-1 scorer is `TrajectoryScorer`: a deterministic matcher over the tool-call sequence with modes `EXACT | IN_ORDER | ANY_ORDER | PRECISION | RECALL`, configured above the port via a `case_id -> TrajectorySpec` mapping the run layer supplies (NOT a field on the frozen case — a per-case trajectory expectation would change the frozen eval-case schema, deliberately out of scope). LLM-judge and hosted-eval-API scorers are the later, costlier tiers; they conform to the same Protocol but are not built.
 
 Result side — `LangfuseEvalRecorder.record()` (`eval/recorder.py:47`) posts, per case, a trace tagged `["eval", f"version:{run.version}", f"suite:{run.suite}"]` (`recorder.py:82`) plus an `eval_pass` numeric score `1.0/0.0` (`SCORE_NAME`, `recorder.py:25`; `_score_event`, `recorder.py:96`). The read path is `GET /matrix` returning `EvalMatrix`, querying traces by those tags (`apps/api/src/agentos_api/routers/evals.py:16`; `list_traces_by_tags(["eval", f"suite:{suite}"])` at `evals.py:23`).
 
 ## Implementations today
 
-One grader family (the three deterministic `GraderKind` variants) and one store (Langfuse, via `LangfuseEvalRecorder`). No second scorer or second store adapter exists.
+Two scorers through the `Scorer` seam — the three-variant deterministic grader family (`GraderScorer`, the default) and the deterministic tool-call trajectory matcher (`TrajectoryScorer`, five modes) — and one store (Langfuse, via `LangfuseEvalRecorder`). Both scorers write results through the identical recorder/`EvalRunResult` path. No LLM-judge/hosted scorer and no second store adapter exists yet.
 
 ## Known leakage
 


### PR DESCRIPTION
## What

Part of #26 (eval experience epic). Interface: `docs/interfaces/evals/INTERFACE.md`.

Scoring was an inline `case.grader.grade(output)` — one string-grader family, no way to score on anything but the answer text. This lifts the pass/fail decision into a **swappable `Scorer` seam above the eval port** (frozen case → scorer → the existing recorder) and ships the **tier-1 deterministic trajectory matcher** over the tool-call sequence.

- `eval/scorer.py`: a typed `Scorer` Protocol + `ScoreResult`; `GraderScorer` (wraps the frozen grader — the **default**, behavior-preserving); `TrajectoryScorer` + `TrajectoryMode` (`EXACT / IN_ORDER / ANY_ORDER / PRECISION / RECALL`) + `TrajectorySpec`, with a pure, testable `match_trajectory`.
- `runner.py`: `EvalRunner` captures the tool-call **trajectory** (the `tool` field of each `tool_note` frame) and delegates pass/fail to an injected scorer, defaulting to `GraderScorer` so existing suites are unchanged. The completion gate (classified-failure / non-`done`) stays in the runner.
- Both scorers write through the **unchanged** `LangfuseEvalRecorder` / `EvalRunResult` path — the recorder and its tag convention are untouched.
- `docs/interfaces/evals/INTERFACE.md` updated (scorer slot is now a typed Protocol; two scorers today).

## Frozen schema

The frozen eval-case schema (`EvalCase`/`Grader`/`EvalSuite`, `apps/worker/schema/eval-cases.schema.json`) is **deliberately not touched**. `TrajectoryScorer` is configured *above the port* via a `case_id → TrajectorySpec` mapping the run layer supplies, not a new field on `EvalCase` — a per-case trajectory expectation would change the frozen schema, which the task said to stop on. LLM-judge and hosted-eval-API scorers (the later, costlier tiers) conform to the same Protocol but are out of scope.

## Tests / gate

New `test_scorer.py`: all five trajectory modes, the seam/Protocol contract, deny-by-default without a spec, and the trajectory scorer scoring a **real fake-runner turn end to end** (grader would pass on any text, so a green proves the trajectory scorer decided), plus a default-path parity test. `ruff` + `mypy` clean; `pytest` green on the non-service eval suites.

4 pre-existing `test_stream.py` failures are environmental (Langfuse/cluster not in the local dev stack) and fail identically on clean `origin/main`.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)