### PR TITLE
Durable approval record + suspend/resume lifecycle

### DIFF
--- a/apps/api/alembic/versions/0008_approvals.py
+++ b/apps/api/alembic/versions/0008_approvals.py
@@ -1,0 +1,66 @@
+"""add approvals (durable human-in-the-loop approval records, #22 / ADR-0010)
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-07-13
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "agentos"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "approvals",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("conversation_id", sa.String(), nullable=False),
+        sa.Column("session_id", sa.String(), nullable=True),
+        sa.Column("channel", sa.String(), nullable=False),
+        sa.Column("reply_placeholder", sa.String(), nullable=False),
+        sa.Column("reply_endpoint", sa.String(), nullable=True),
+        sa.Column("tool", sa.String(), nullable=False),
+        sa.Column("tool_use_id", sa.String(), nullable=False),
+        sa.Column("input_digest", sa.String(), nullable=False),
+        sa.Column("prompt", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("requested_by", sa.String(), nullable=False),
+        sa.Column("resolved_by", sa.String(), nullable=True),
+        sa.Column("resolved_at", sa.DateTime(), nullable=True),
+        sa.Column("resumed_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"
+        ),
+        # Idempotent re-suspend: a reclaimed turn that re-emits the same gate for
+        # the same tool call must not create a second pending record.
+        sa.UniqueConstraint(
+            "agent_id",
+            "conversation_id",
+            "tool_use_id",
+            name="uq_approval_agent_conv_tooluse",
+        ),
+        schema=SCHEMA,
+    )
+    op.create_index("ix_approvals_agent_id", "approvals", ["agent_id"], schema=SCHEMA)
+    # The reconcile sweep filters resolved-but-not-resumed records by status.
+    op.create_index("ix_approvals_status", "approvals", ["status"], schema=SCHEMA)
+
+
+def downgrade() -> None:
+    op.drop_table("approvals", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -161,6 +161,126 @@
         "title": "AppConfig",
         "type": "object"
       },
+      "ApprovalOut": {
+        "description": "A durable approval record as returned to the caller (#22).",
+        "properties": {
+          "agent_id": {
+            "format": "uuid",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "channel": {
+            "title": "Channel",
+            "type": "string"
+          },
+          "conversation_id": {
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "input_digest": {
+            "title": "Input Digest",
+            "type": "string"
+          },
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "requested_by": {
+            "title": "Requested By",
+            "type": "string"
+          },
+          "resolved_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved At"
+          },
+          "resolved_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved By"
+          },
+          "status": {
+            "enum": [
+              "pending",
+              "approved",
+              "rejected"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "tool": {
+            "title": "Tool",
+            "type": "string"
+          },
+          "tool_use_id": {
+            "title": "Tool Use Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "conversation_id",
+          "channel",
+          "tool",
+          "tool_use_id",
+          "input_digest",
+          "prompt",
+          "status",
+          "requested_by",
+          "resolved_by",
+          "resolved_at",
+          "created_at"
+        ],
+        "title": "ApprovalOut",
+        "type": "object"
+      },
+      "ApprovalResolveIn": {
+        "description": "Resolve a pending approval. ``actor`` is the identity resolving it (the\nSlack user who clicked); it is recorded as ``resolved_by`` and must differ\nfrom the requester (self-approval is blocked). The channel-membership\nauthorizer check runs on top of this in the Slack resolve path (#246).",
+        "properties": {
+          "actor": {
+            "title": "Actor",
+            "type": "string"
+          },
+          "decision": {
+            "enum": [
+              "approved",
+              "rejected"
+            ],
+            "title": "Decision",
+            "type": "string"
+          }
+        },
+        "required": [
+          "decision",
+          "actor"
+        ],
+        "title": "ApprovalResolveIn",
+        "type": "object"
+      },
       "BehaviorPacksConfig": {
         "description": "An agent's opt-in behavior packs. Validated on write and stored as JSON on\nthe agent row; the worker parses the same JSON at bind time.",
         "properties": {
@@ -1821,6 +1941,233 @@
         "summary": "Update Agent",
         "tags": [
           "agents"
+        ]
+      }
+    },
+    "/agents/{agent_id}/approvals": {
+      "get": {
+        "operationId": "list_approvals_agents__agent_id__approvals_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status_filter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status Filter"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ApprovalOut"
+                  },
+                  "title": "Response List Approvals Agents  Agent Id  Approvals Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Approvals",
+        "tags": [
+          "approvals"
+        ]
+      }
+    },
+    "/agents/{agent_id}/approvals/{approval_id}": {
+      "get": {
+        "operationId": "get_approval_agents__agent_id__approvals__approval_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "approval_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Approval Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Approval",
+        "tags": [
+          "approvals"
+        ]
+      }
+    },
+    "/agents/{agent_id}/approvals/{approval_id}/resolve": {
+      "post": {
+        "operationId": "resolve_approval_agents__agent_id__approvals__approval_id__resolve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "approval_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Approval Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalResolveIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Resolve Approval",
+        "tags": [
+          "approvals"
         ]
       }
     },

--- a/apps/api/src/agentos_api/approvals.py
+++ b/apps/api/src/agentos_api/approvals.py
@@ -1,0 +1,39 @@
+"""Approval resolve notification over Valkey (#22, API half).
+
+Mirrors the kill-switch seam (``killswitch.py``): the durable ``Approval`` row in
+Postgres is the source of truth; this publishes a wake-up so a running worker
+resumes the suspended session within seconds instead of waiting for its periodic
+reconcile sweep. A resolve that happens while every worker is down reaches no
+subscriber, which is fine -- the worker's startup reconcile finds the
+resolved-but-not-resumed row and resumes it. So this signal is an optimization,
+never the mechanism of record.
+
+- event: PUBLISH on ``agentos:approval-events`` a JSON {approval_id, agent_id,
+  decision, ts}. The worker loads the full record by ``approval_id`` and resumes.
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import redis.asyncio as redis
+
+APPROVAL_CHANNEL = "agentos:approval-events"
+
+
+class ApprovalNotifier:
+    def __init__(self, client: redis.Redis) -> None:
+        self._client = client
+
+    async def resolved(
+        self, approval_id: uuid.UUID, agent_id: uuid.UUID, decision: str
+    ) -> None:
+        """Publish that an approval was resolved. Best-effort wake-up only."""
+
+        event = {
+            "approval_id": str(approval_id),
+            "agent_id": str(agent_id),
+            "decision": decision,
+            "ts": datetime.now(UTC).isoformat(),
+        }
+        await self._client.publish(APPROVAL_CHANNEL, json.dumps(event))

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -1,12 +1,12 @@
 """Database access helpers for agents, versions, and deployments."""
 
 import uuid
-from typing import Any
+from typing import Any, Literal
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import Agent, AgentVersion, Deployment, Environment
+from .models import Agent, AgentVersion, Approval, ApprovalStatus, Deployment, Environment
 from .schemas import AgentCreate, DeploymentCreate, VersionCreate
 
 
@@ -258,3 +258,64 @@ async def get_deployment(
     session: AsyncSession, deployment_id: uuid.UUID
 ) -> Deployment | None:
     return await session.get(Deployment, deployment_id)
+
+
+# -- approvals (#22) ----------------------------------------------------------
+
+# The outcome of a resolve attempt, mapped to an HTTP status by the router.
+ResolveOutcome = Literal["not_found", "self_approval", "already_resolved", "resolved"]
+
+
+async def get_approval(
+    session: AsyncSession, approval_id: uuid.UUID
+) -> Approval | None:
+    return await session.get(Approval, approval_id)
+
+
+async def list_approvals(
+    session: AsyncSession,
+    agent_id: uuid.UUID,
+    status: str | None = None,
+) -> list[Approval]:
+    stmt = select(Approval).where(Approval.agent_id == agent_id)
+    if status is not None:
+        stmt = stmt.where(Approval.status == status)
+    stmt = stmt.order_by(Approval.created_at)
+    result = await session.scalars(stmt)
+    return list(result)
+
+
+async def resolve_approval(
+    session: AsyncSession,
+    approval_id: uuid.UUID,
+    decision: str,
+    actor: str,
+) -> tuple[ResolveOutcome, Approval | None]:
+    """Resolve a pending approval exactly once, server-side.
+
+    The resolve-once guarantee is a compare-and-set: the UPDATE only matches a row
+    still ``pending``, so a second concurrent resolver flips nothing (rowcount 0)
+    and is told it was already resolved. Self-approval (``actor`` equals the
+    requester) is refused before the CAS. Returns the outcome tag and the record.
+    """
+    approval = await session.get(Approval, approval_id)
+    if approval is None:
+        return ("not_found", None)
+    if approval.requested_by == actor:
+        return ("self_approval", approval)
+    result = await session.execute(
+        update(Approval)
+        .where(
+            Approval.id == approval_id,
+            Approval.status == ApprovalStatus.pending.value,
+        )
+        .values(status=decision, resolved_by=actor, resolved_at=func.now())
+        .returning(Approval.id)
+        .execution_options(synchronize_session=False)
+    )
+    won = result.first() is not None
+    await session.commit()
+    await session.refresh(approval)
+    if not won:
+        return ("already_resolved", approval)
+    return ("resolved", approval)

--- a/apps/api/src/agentos_api/deps.py
+++ b/apps/api/src/agentos_api/deps.py
@@ -6,6 +6,7 @@ from typing import Annotated
 from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from .approvals import ApprovalNotifier
 from .evalqueue import EvalQueue
 from .github_checks import GitHubStatusReporter
 from .k8s import PodLister, PodLogReader
@@ -45,6 +46,11 @@ def get_kill_switch(request: Request) -> KillSwitch:
     return kill_switch
 
 
+def get_approval_notifier(request: Request) -> ApprovalNotifier:
+    notifier: ApprovalNotifier = request.app.state.approval_notifier
+    return notifier
+
+
 def get_eval_queue(request: Request) -> EvalQueue:
     eval_queue: EvalQueue = request.app.state.eval_queue
     return eval_queue
@@ -61,5 +67,6 @@ StoreDep = Annotated[BundleStore, Depends(get_store)]
 PodLogReaderDep = Annotated[PodLogReader, Depends(get_pod_log_reader)]
 PodListerDep = Annotated[PodLister, Depends(get_pod_lister)]
 KillSwitchDep = Annotated[KillSwitch, Depends(get_kill_switch)]
+ApprovalNotifierDep = Annotated[ApprovalNotifier, Depends(get_approval_notifier)]
 EvalQueueDep = Annotated[EvalQueue, Depends(get_eval_queue)]
 GitHubReporterDep = Annotated[GitHubStatusReporter, Depends(get_github_reporter)]

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -11,6 +11,7 @@ import httpx
 import redis.asyncio as redis
 from fastapi import FastAPI
 
+from .approvals import ApprovalNotifier
 from .config import get_settings
 from .db import create_engine, create_sessionmaker
 from .evalqueue import EvalQueue
@@ -20,6 +21,7 @@ from .killswitch import KillSwitch
 from .langfuse import LangfuseClient
 from .routers import (
     agents,
+    approvals,
     bundles,
     config,
     control,
@@ -53,6 +55,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     valkey: redis.Redis = redis.from_url(settings.valkey_dsn())
     app.state.valkey = valkey
     app.state.kill_switch = KillSwitch(valkey)
+    app.state.approval_notifier = ApprovalNotifier(valkey)
     app.state.eval_queue = EvalQueue(valkey)
     app.state.github_reporter = GitHubStatusReporter(
         http_client,
@@ -77,6 +80,7 @@ def create_app() -> FastAPI:
 
     app.include_router(config.router)
     app.include_router(agents.router)
+    app.include_router(approvals.router)
     app.include_router(deployments.router)
     app.include_router(bundles.router)
     app.include_router(github.router)

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -22,6 +22,15 @@ class Environment(enum.StrEnum):
     dev = "dev"
 
 
+class ApprovalStatus(enum.StrEnum):
+    """Lifecycle of an approval. ``pending`` is the only non-terminal value; a
+    resolve compare-and-sets it to ``approved`` or ``rejected`` exactly once."""
+
+    pending = "pending"
+    approved = "approved"
+    rejected = "rejected"
+
+
 class Agent(Base):
     __tablename__ = "agents"
 
@@ -135,6 +144,71 @@ class WorkflowStateEntry(Base):
     # Monotonic per-entry counter for compare-and-set: a put may pass the version
     # it last read, and the write is rejected if the stored version moved on.
     version: Mapped[int] = mapped_column(default=1)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        server_default=func.now(), onupdate=func.now()
+    )
+
+
+class Approval(Base):
+    """A durable human-in-the-loop approval request (#22, ADR-0010).
+
+    Created ``pending`` by the worker when a session pauses on an approval gate
+    (ACI ``SessionStatus.awaiting-approval``) and resolved once, server-side, by
+    the resolve endpoint. The record is the source of truth that outlives the
+    suspend/resume of the paused session and every component restart: it holds
+    both what is needed to resume (``conversation_id``, ``session_id``, and the
+    reply handle) and the gate details shown to the approver (``tool``,
+    ``prompt``). Resolve is a compare-and-set on ``status`` (``pending`` ->
+    ``approved``/``rejected``), so the loser of a click race is told it was
+    already resolved, and a resolver may never be the requester (self-approval is
+    blocked). ``status`` is a plain string (not a DB enum) to keep the migration
+    minimal; ``ApprovalStatus`` carries the values in code.
+    """
+
+    __tablename__ = "approvals"
+    __table_args__ = (
+        UniqueConstraint(
+            "agent_id",
+            "conversation_id",
+            "tool_use_id",
+            name="uq_approval_agent_conv_tooluse",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE"), index=True
+    )
+    # Routing to resume the paused session: the thread key the run belongs to and
+    # the SDK session id the replacement runner rehydrates from (ACI Final.session_id).
+    conversation_id: Mapped[str]
+    session_id: Mapped[str | None] = mapped_column(default=None)
+    # The reply handle the resumed turn's output is delivered through, stored so a
+    # resume days later (past the Valkey route TTL) can still reconstruct it.
+    channel: Mapped[str]
+    reply_placeholder: Mapped[str]
+    reply_endpoint: Mapped[str | None] = mapped_column(default=None)
+    # The gated tool call, surfaced to the approver on the card.
+    tool: Mapped[str]
+    tool_use_id: Mapped[str]
+    input_digest: Mapped[str]
+    prompt: Mapped[str]
+    status: Mapped[str] = mapped_column(
+        default=ApprovalStatus.pending.value,
+        server_default=ApprovalStatus.pending.value,
+        index=True,
+    )
+    # Who triggered the request (the turn's author); a resolver equal to this is
+    # blocked as self-approval.
+    requested_by: Mapped[str]
+    resolved_by: Mapped[str | None] = mapped_column(default=None)
+    resolved_at: Mapped[datetime | None] = mapped_column(default=None)
+    # Set when the resumed turn has been enqueued, so the reconcile sweep never
+    # resumes the same approval twice.
+    resumed_at: Mapped[datetime | None] = mapped_column(default=None)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         server_default=func.now(), onupdate=func.now()

--- a/apps/api/src/agentos_api/routers/approvals.py
+++ b/apps/api/src/agentos_api/routers/approvals.py
@@ -1,0 +1,79 @@
+"""Approval records: list, read, and resolve-once (#22, ADR-0010).
+
+The durable ``Approval`` row is created by the worker when a session pauses on an
+approval gate; this router is the read + resolve surface. Resolve is server-side
+and resolve-once: a compare-and-set flips ``pending`` to the decision exactly
+once (the loser of a click race gets 409), self-approval is refused (403), and on
+a winning resolve a wake-up is published so the worker resumes the suspended
+session. The Slack click path (#246) calls this endpoint after its
+channel-membership authorizer check; the check is deliberately layered on top of
+this server-side resolve, not a substitute for it.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from .. import crud
+from ..auth import require_api_key
+from ..deps import ApprovalNotifierDep, SessionDep
+from ..schemas import ApprovalOut, ApprovalResolveIn
+
+router = APIRouter(
+    prefix="/agents/{agent_id}",
+    tags=["approvals"],
+    dependencies=[Depends(require_api_key)],
+)
+
+
+@router.get("/approvals", response_model=list[ApprovalOut])
+async def list_approvals(
+    agent_id: uuid.UUID, session: SessionDep, status_filter: str | None = None
+) -> list[ApprovalOut]:
+    if await crud.get_agent(session, agent_id) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+    approvals = await crud.list_approvals(session, agent_id, status_filter)
+    return [ApprovalOut.model_validate(a) for a in approvals]
+
+
+@router.get("/approvals/{approval_id}", response_model=ApprovalOut)
+async def get_approval(
+    agent_id: uuid.UUID, approval_id: uuid.UUID, session: SessionDep
+) -> ApprovalOut:
+    approval = await crud.get_approval(session, approval_id)
+    if approval is None or approval.agent_id != agent_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+    return ApprovalOut.model_validate(approval)
+
+
+@router.post("/approvals/{approval_id}/resolve", response_model=ApprovalOut)
+async def resolve_approval(
+    agent_id: uuid.UUID,
+    approval_id: uuid.UUID,
+    data: ApprovalResolveIn,
+    session: SessionDep,
+    notifier: ApprovalNotifierDep,
+) -> ApprovalOut:
+    # Scope the resolve to the agent in the path first, so a cross-agent id is a
+    # 404 and never reaches the compare-and-set.
+    existing = await crud.get_approval(session, approval_id)
+    if existing is None or existing.agent_id != agent_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+
+    outcome, approval = await crud.resolve_approval(
+        session, approval_id, data.decision, data.actor
+    )
+    if outcome == "self_approval":
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "you cannot resolve your own approval request"
+        )
+    if outcome == "already_resolved":
+        assert approval is not None
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"already resolved by {approval.resolved_by}",
+        )
+    # A winning resolve: publish the wake-up so a live worker resumes promptly.
+    assert approval is not None
+    await notifier.resolved(approval_id, agent_id, data.decision)
+    return ApprovalOut.model_validate(approval)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -445,3 +445,33 @@ class StateEntryOut(BaseModel):
     value: Any
     version: int
     updated_at: datetime
+
+
+class ApprovalOut(BaseModel):
+    """A durable approval record as returned to the caller (#22)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    agent_id: uuid.UUID
+    conversation_id: str
+    channel: str
+    tool: str
+    tool_use_id: str
+    input_digest: str
+    prompt: str
+    status: Literal["pending", "approved", "rejected"]
+    requested_by: str
+    resolved_by: str | None
+    resolved_at: datetime | None
+    created_at: datetime
+
+
+class ApprovalResolveIn(BaseModel):
+    """Resolve a pending approval. ``actor`` is the identity resolving it (the
+    Slack user who clicked); it is recorded as ``resolved_by`` and must differ
+    from the requester (self-approval is blocked). The channel-membership
+    authorizer check runs on top of this in the Slack resolve path (#246)."""
+
+    decision: Literal["approved", "rejected"]
+    actor: str

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -1,0 +1,174 @@
+"""Approval records: resolve-once, self-approval block, and the resume wake-up.
+
+Nothing mocked. The durable record + compare-and-set run against the disposable
+migrated Postgres; the resolve wake-up is asserted on the real compose Valkey.
+Pending rows are seeded through the worker's own ``ApprovalStore``, so this also
+covers ``create_pending`` against real Postgres (the write path the kernel uses).
+"""
+
+import asyncio
+import json
+import time
+import uuid
+from typing import Any
+
+import redis
+from agentos_api.approvals import APPROVAL_CHANNEL
+from agentos_api.config import get_settings
+from agentos_worker.approvals import ApprovalStore
+from agentos_worker.config import WorkerConfig
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+def _agent(client: Any, headers: dict[str, str]) -> str:
+    resp = client.post(
+        "/agents",
+        json={"name": "approval-agent", "slack_channel": "C000000A01"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    agent_id: str = resp.json()["id"]
+    return agent_id
+
+
+def _seed_pending(
+    agent_id: str,
+    *,
+    requested_by: str = "U_REQ",
+    tool_use_id: str = "toolu_1",
+    conversation_id: str = "th-1",
+) -> str:
+    """Insert a pending approval via the worker ApprovalStore (real Postgres)."""
+
+    async def go() -> uuid.UUID:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            store = ApprovalStore(engine, WorkerConfig())
+            return await store.create_pending(
+                agent_id=uuid.UUID(agent_id),
+                conversation_id=conversation_id,
+                session_id="sdk-sess-1",
+                channel="C000000A01",
+                reply_placeholder="p-1",
+                reply_endpoint=None,
+                tool="apply_discount",
+                tool_use_id=tool_use_id,
+                input_digest="sha256:abc",
+                prompt="Apply a 30% discount to ACME-1?",
+                requested_by=requested_by,
+            )
+        finally:
+            await engine.dispose()
+
+    return str(asyncio.run(go()))
+
+
+def _read_published(pubsub: Any, timeout: float = 3.0) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        message = pubsub.get_message(ignore_subscribe_messages=True, timeout=0.2)
+        if message and message.get("type") == "message":
+            data: dict[str, Any] = json.loads(message["data"])
+            return data
+    raise AssertionError("no approval event was published")
+
+
+def test_resolve_approves_and_publishes_wakeup(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    approval_id = _seed_pending(aid, requested_by="U_REQ")
+
+    sub = redis.Redis.from_url(get_settings().valkey_dsn(), decode_responses=True)
+    pubsub = sub.pubsub()
+    pubsub.subscribe(APPROVAL_CHANNEL)
+    pubsub.get_message(timeout=1.0)  # drain the subscribe confirmation
+    try:
+        resp = client.post(
+            f"/agents/{aid}/approvals/{approval_id}/resolve",
+            json={"decision": "approved", "actor": "U_APPROVER"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "approved"
+        assert resp.json()["resolved_by"] == "U_APPROVER"
+
+        event = _read_published(pubsub)
+        assert event["approval_id"] == approval_id
+        assert event["decision"] == "approved"
+    finally:
+        pubsub.close()
+        sub.close()
+
+
+def test_self_approval_is_blocked(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    approval_id = _seed_pending(aid, requested_by="U_REQ")
+
+    resp = client.post(
+        f"/agents/{aid}/approvals/{approval_id}/resolve",
+        json={"decision": "approved", "actor": "U_REQ"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 403, resp.text
+    # And it stays pending, resolvable by someone else.
+    got = client.get(f"/agents/{aid}/approvals/{approval_id}", headers=auth_headers)
+    assert got.json()["status"] == "pending"
+
+
+def test_second_resolver_gets_already_resolved(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    approval_id = _seed_pending(aid, requested_by="U_REQ")
+
+    first = client.post(
+        f"/agents/{aid}/approvals/{approval_id}/resolve",
+        json={"decision": "approved", "actor": "U_A"},
+        headers=auth_headers,
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        f"/agents/{aid}/approvals/{approval_id}/resolve",
+        json={"decision": "rejected", "actor": "U_B"},
+        headers=auth_headers,
+    )
+    assert second.status_code == 409, second.text
+    assert "already resolved by U_A" in second.json()["detail"]
+    # The first decision stands; the loser did not flip it.
+    got = client.get(f"/agents/{aid}/approvals/{approval_id}", headers=auth_headers)
+    assert got.json()["status"] == "approved"
+
+
+def test_get_and_list_by_status(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    a1 = _seed_pending(aid, tool_use_id="toolu_1", conversation_id="th-1")
+    a2 = _seed_pending(aid, tool_use_id="toolu_2", conversation_id="th-2")
+
+    listed = client.get(
+        f"/agents/{aid}/approvals?status_filter=pending", headers=auth_headers
+    )
+    assert listed.status_code == 200
+    assert {a["id"] for a in listed.json()} == {a1, a2}
+
+    one = client.get(f"/agents/{aid}/approvals/{a1}", headers=auth_headers)
+    assert one.status_code == 200
+    assert one.json()["tool"] == "apply_discount"
+
+
+def test_resolve_unknown_approval_is_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    missing = "00000000-0000-0000-0000-000000000000"
+    resp = client.post(
+        f"/agents/{aid}/approvals/{missing}/resolve",
+        json={"decision": "approved", "actor": "U_A"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404, resp.text

--- a/apps/worker/src/agentos_worker/approval_resumer.py
+++ b/apps/worker/src/agentos_worker/approval_resumer.py
@@ -1,0 +1,176 @@
+"""Resume a suspended session when its approval is resolved (#22, worker half).
+
+Mirrors the kill-switch consumer (``killswitch.py``): the API publishes on
+``agentos:approval-events`` when an approval is resolved, and this subscriber
+wakes up and resumes the paused session. The durable ``Approval`` row is the
+source of truth, so a resolve that happened while every worker was down (the
+publish reached no subscriber) is caught by a periodic reconcile sweep.
+
+The resume itself does NOT reach into the kernel. It enqueues a *synthetic turn*
+onto the same runs stream the dispatcher feeds, so it flows through the proven
+consumer -> route -> claim path: a turn for a thread whose sandbox is SUSPENDED
+raises SuspendedThreadError and the kernel resumes (rehydrates from history) and
+delivers the approval outcome. Reusing that path inherits the concurrency,
+ordering, and crash-recovery guarantees instead of a second kernel entrypoint.
+
+Exactly-once resume is the kernel's done-marker on the synthetic event's stable
+``event_id``: a re-enqueue (pubsub racing the sweep, or a crash before
+``mark_resumed``) is skipped downstream. ``mark_resumed`` then stops the sweep
+from re-enqueuing a settled resume.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from aci_protocol import QueuedTurn, ReplyHandle
+from agentos_dispatcher.queue import to_stream_fields
+from redis.asyncio import Redis
+
+from .approvals import ApprovalRecord, ApprovalStore
+from .config import WorkerConfig
+
+logger = logging.getLogger(__name__)
+
+APPROVAL_CHANNEL = "agentos:approval-events"
+
+# The synthetic resume event's author, and the stable event-id prefix that makes
+# the kernel's done-marker dedupe a re-enqueued resume.
+_RESUME_AUTHOR = "agentos-approvals"
+_RESUME_EVENT_PREFIX = "approval-resume-"
+
+
+class ApprovalResumer:
+    """Subscribes to approval resolutions and resumes the paused sessions."""
+
+    def __init__(
+        self,
+        *,
+        redis: Redis,
+        store: ApprovalStore,
+        config: WorkerConfig,
+    ) -> None:
+        self._redis = redis
+        self._store = store
+        self._config = config
+        self._stop = asyncio.Event()
+
+    def request_stop(self) -> None:
+        self._stop.set()
+
+    async def run(self) -> None:
+        """Subscribe to resolutions and periodically reconcile until stopped.
+
+        The first reconcile is deliberately deferred one interval rather than run
+        at t=0: the runs consumer group is created at ``$`` (only new entries), so
+        a synthetic turn enqueued before that group exists on a first-ever boot
+        would be dropped. By one interval in, the consumer has created its group.
+        On every later boot the group already exists, and the pubsub fast path
+        covers the common case regardless.
+        """
+        pubsub = self._redis.pubsub()
+        await pubsub.subscribe(APPROVAL_CHANNEL)
+        interval = self._config.approval_reconcile_interval_s
+        last_sweep = 0.0
+        elapsed = 0.0
+        try:
+            while not self._stop.is_set():
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True, timeout=1.0
+                )
+                if message is not None:
+                    await self._handle(message)
+                elapsed += 1.0
+                if elapsed - last_sweep >= interval:
+                    last_sweep = elapsed
+                    await self._reconcile_safe()
+        finally:
+            await pubsub.unsubscribe(APPROVAL_CHANNEL)
+            await pubsub.aclose()  # type: ignore[no-untyped-call]
+
+    async def _handle(self, message: dict[str, object]) -> None:
+        try:
+            payload = json.loads(_as_text(message["data"]))
+            approval_id = uuid.UUID(payload["approval_id"])
+        except (KeyError, ValueError, TypeError, json.JSONDecodeError):
+            logger.exception("malformed approval event: %r", message.get("data"))
+            return
+        record = await self._store.get(approval_id)
+        if record is None:
+            logger.warning("approval %s resolved but no record found", approval_id)
+            return
+        await self._resume(record)
+
+    async def _reconcile_safe(self) -> None:
+        # A sweep failure (a transient DB blip) must not tear down the subscriber
+        # and miss every later resolution; log and let the next tick retry.
+        try:
+            await self.reconcile_once()
+        except Exception:
+            logger.exception("approval reconcile sweep failed")
+
+    async def reconcile_once(self) -> int:
+        """Resume every resolved-but-not-yet-resumed approval. Returns the count.
+
+        The missed-message guard: a resolve that fired while all workers were down
+        published to nobody, so nothing consumed the wake-up. This finds those
+        durable rows and drives their resume.
+        """
+        records = await self._store.list_resolved_unresumed()
+        for record in records:
+            await self._resume(record)
+        return len(records)
+
+    async def _resume(self, record: ApprovalRecord) -> None:
+        if record.status not in ("approved", "rejected"):
+            return
+        turn = QueuedTurn(
+            event_id=f"{_RESUME_EVENT_PREFIX}{record.id}",
+            conversation_id=record.conversation_id,
+            author=_RESUME_AUTHOR,
+            text=_resume_text(record),
+            reply_handle=ReplyHandle(
+                channel=record.channel,
+                placeholder=record.reply_placeholder,
+                endpoint=record.reply_endpoint,
+            ),
+            received_at=datetime.now(UTC).isoformat(),
+        )
+        # Enqueue before mark_resumed: a re-enqueue is idempotent downstream (the
+        # kernel's done-marker on the stable event_id), whereas a mark that landed
+        # before a failed enqueue would strand the resume.
+        # redis-py types the fields arg as an invariant broad mapping, so a plain
+        # dict[str, str] does not match; cast (the dispatcher's enqueue does the same).
+        await self._redis.xadd(
+            self._config.stream, cast("dict[Any, Any]", to_stream_fields(turn))
+        )
+        await self._store.mark_resumed(record.id)
+        logger.info(
+            "enqueued approval resume for %s (%s) on thread %s",
+            record.id,
+            record.status,
+            record.conversation_id,
+        )
+
+
+def _resume_text(record: ApprovalRecord) -> str:
+    if record.status == "approved":
+        return (
+            f"[approval approved] The request to use {record.tool} was approved. "
+            "Proceed with it."
+        )
+    return (
+        f"[approval rejected] The request to use {record.tool} was rejected. "
+        "Do not proceed; acknowledge the rejection and continue without it."
+    )
+
+
+def _as_text(data: object) -> str:
+    if isinstance(data, bytes):
+        return data.decode("utf-8")
+    return str(data)

--- a/apps/worker/src/agentos_worker/approvals.py
+++ b/apps/worker/src/agentos_worker/approvals.py
@@ -1,0 +1,167 @@
+"""Worker-side access to the durable ``approvals`` table (#22, ADR-0010).
+
+The API owns the table's schema and migration and the resolve-once compare-and-set
+endpoint; the worker writes the *pending* record when a session pauses on a gate
+and marks it *resumed* once the resumed turn is enqueued. Like ``binding.py`` this
+is a thin raw-SQL layer over the same shared Postgres via the worker's async
+engine, deliberately not an import of the API package (which would pull FastAPI
+and the ORM into the worker). The column set here must track the API migration.
+
+Two writers, one table, by design: the worker only INSERTs pending rows and sets
+``resumed_at``; the pending -> approved/rejected transition is the API's atomic
+CAS. They never contend on the same column.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from .config import WorkerConfig
+
+
+class ApprovalRecord(BaseModel):
+    """A durable approval row, as the resumer needs it to rebuild the turn."""
+
+    id: uuid.UUID
+    agent_id: uuid.UUID
+    conversation_id: str
+    session_id: str | None
+    channel: str
+    reply_placeholder: str
+    reply_endpoint: str | None
+    tool: str
+    prompt: str
+    status: str
+
+
+_INSERT_PENDING = """
+INSERT INTO {schema}.approvals (
+    id, agent_id, conversation_id, session_id, channel, reply_placeholder,
+    reply_endpoint, tool, tool_use_id, input_digest, prompt, requested_by
+) VALUES (
+    :id, :agent_id, :conversation_id, :session_id, :channel, :reply_placeholder,
+    :reply_endpoint, :tool, :tool_use_id, :input_digest, :prompt, :requested_by
+)
+ON CONFLICT (agent_id, conversation_id, tool_use_id) DO NOTHING
+RETURNING id
+"""
+
+_SELECT_EXISTING_ID = """
+SELECT id FROM {schema}.approvals
+WHERE agent_id = :agent_id AND conversation_id = :conversation_id
+  AND tool_use_id = :tool_use_id
+"""
+
+_SELECT_RESOLVED_UNRESUMED = """
+SELECT id, agent_id, conversation_id, session_id, channel, reply_placeholder,
+       reply_endpoint, tool, prompt, status
+FROM {schema}.approvals
+WHERE status IN ('approved', 'rejected') AND resumed_at IS NULL
+ORDER BY resolved_at
+"""
+
+_SELECT_ONE = """
+SELECT id, agent_id, conversation_id, session_id, channel, reply_placeholder,
+       reply_endpoint, tool, prompt, status
+FROM {schema}.approvals
+WHERE id = :id
+"""
+
+_MARK_RESUMED = """
+UPDATE {schema}.approvals SET resumed_at = now()
+WHERE id = :id AND resumed_at IS NULL
+"""
+
+
+class ApprovalStore:
+    """Create pending approvals and mark them resumed (raw SQL, shared engine)."""
+
+    def __init__(self, engine: AsyncEngine, config: WorkerConfig) -> None:
+        self._engine = engine
+        schema = config.db_schema
+        self._insert = text(_INSERT_PENDING.format(schema=schema))
+        self._existing = text(_SELECT_EXISTING_ID.format(schema=schema))
+        self._resolved = text(_SELECT_RESOLVED_UNRESUMED.format(schema=schema))
+        self._one = text(_SELECT_ONE.format(schema=schema))
+        self._mark_resumed = text(_MARK_RESUMED.format(schema=schema))
+
+    async def create_pending(
+        self,
+        *,
+        agent_id: uuid.UUID,
+        conversation_id: str,
+        session_id: str | None,
+        channel: str,
+        reply_placeholder: str,
+        reply_endpoint: str | None,
+        tool: str,
+        tool_use_id: str,
+        input_digest: str,
+        prompt: str,
+        requested_by: str,
+    ) -> uuid.UUID:
+        """Insert a pending approval, or return the existing id on a re-suspend.
+
+        Idempotent on ``(agent_id, conversation_id, tool_use_id)``: a reclaimed
+        turn that re-emits the same gate does not create a second record, so the
+        suspend/resume cycle stays single-writer safe.
+        """
+        params = {
+            "id": uuid.uuid4(),
+            "agent_id": agent_id,
+            "conversation_id": conversation_id,
+            "session_id": session_id,
+            "channel": channel,
+            "reply_placeholder": reply_placeholder,
+            "reply_endpoint": reply_endpoint,
+            "tool": tool,
+            "tool_use_id": tool_use_id,
+            "input_digest": input_digest,
+            "prompt": prompt,
+            "requested_by": requested_by,
+        }
+        async with self._engine.begin() as conn:
+            result = await conn.execute(self._insert, params)
+            row = result.first()
+            if row is not None:
+                return uuid.UUID(str(row[0]))
+            # Conflict: the row already exists (a reclaim re-ran the turn).
+            existing = await conn.execute(
+                self._existing,
+                {
+                    "agent_id": agent_id,
+                    "conversation_id": conversation_id,
+                    "tool_use_id": tool_use_id,
+                },
+            )
+            return uuid.UUID(str(existing.scalar_one()))
+
+    async def get(self, approval_id: uuid.UUID) -> ApprovalRecord | None:
+        async with self._engine.connect() as conn:
+            result = await conn.execute(self._one, {"id": approval_id})
+            row = result.mappings().first()
+        return ApprovalRecord.model_validate(dict(row)) if row is not None else None
+
+    async def list_resolved_unresumed(self) -> list[ApprovalRecord]:
+        """Resolved approvals whose session has not been resumed yet.
+
+        The startup reconcile sweep reads this to catch resolutions that happened
+        while every worker was down (the pubsub wake-up reached no subscriber)."""
+        async with self._engine.connect() as conn:
+            result = await conn.execute(self._resolved)
+            rows = result.mappings().all()
+        return [ApprovalRecord.model_validate(dict(r)) for r in rows]
+
+    async def mark_resumed(self, approval_id: uuid.UUID) -> bool:
+        """Claim the resume for this approval. Returns True for the winner.
+
+        The ``resumed_at IS NULL`` guard makes this a compare-and-set, so a pubsub
+        wake-up racing the reconcile sweep enqueues the resume turn exactly once.
+        """
+        async with self._engine.begin() as conn:
+            result = await conn.execute(self._mark_resumed, {"id": approval_id})
+        return bool(result.rowcount)

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -158,6 +158,21 @@ class WorkerConfig(BaseSettings):
         validation_alias="AGENTOS_BOOTING_TEXT",
     )
 
+    # Shown on the placeholder when a turn pauses on an approval gate (#22), so the
+    # thread does not sit on "working" while the session is suspended. The Slack
+    # approval card + buttons are the #246 slice; this is the plain-text fallback.
+    awaiting_approval_text: str = Field(
+        default="Paused, waiting for approval.",
+        validation_alias="AGENTOS_AWAITING_APPROVAL_TEXT",
+    )
+
+    # How often the approval resumer sweeps Postgres for resolved-but-not-resumed
+    # approvals (#22), the fallback for a resolve whose pubsub wake-up reached no
+    # worker. The pubsub path is the fast path; this only bounds the worst case.
+    approval_reconcile_interval_s: float = Field(
+        default=30.0, validation_alias="AGENTOS_APPROVAL_RECONCILE_INTERVAL_S"
+    )
+
     # Stream / consumer group (must match the dispatcher's AGENTOS_STREAM)
     stream: str = Field(default="agentos:runs", validation_alias="AGENTOS_STREAM")
     consumer_group: str = Field(

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, field
 
 import aiohttp
 from aci_protocol import (
+    ApprovalRequest,
     ErrorEvent,
     Event,
     Final,
@@ -43,6 +44,7 @@ from aci_protocol import (
     ToolNote,
 )
 
+from .approvals import ApprovalStore
 from .behaviorpacks import (
     BehaviorPacks,
     NavPack,
@@ -78,6 +80,15 @@ class TurnOutcome:
     text: str = ""
     status: SessionStatus | None = None
     steered: bool = False
+    # The turn paused on an approval gate (SessionStatus.awaiting-approval). This
+    # is neither success nor a retryable failure: the kernel persists a durable
+    # approval record and suspends the session, to be resumed on resolution.
+    awaiting_approval: bool = False
+    # The SDK session id (ACI Final.session_id), threaded through so suspend can
+    # record the exact rehydrate ref; and the gated tool call, so the durable
+    # record is built without reconstructing it from a prior tool_note.
+    session_id: str | None = None
+    approval_request: ApprovalRequest | None = None
 
 
 @dataclass
@@ -108,6 +119,8 @@ class _StreamAccumulator:
     classification: str | None = None
     status: SessionStatus | None = None
     final_text: str | None = None
+    session_id: str | None = None
+    approval_request: ApprovalRequest | None = None
 
     def rendered(self) -> str:
         return self.final_text if self.final_text is not None else "".join(self.text_parts)
@@ -190,6 +203,7 @@ class Kernel:
         config: WorkerConfig,
         binding: BindingResolver | None = None,
         killswitch: KillSwitch | None = None,
+        approvals: ApprovalStore | None = None,
     ) -> None:
         self._substrate = substrate
         self._runner = runner
@@ -202,6 +216,10 @@ class Kernel:
         # it resolves channel -> agent -> bundle/budget and gates killed agents.
         self._binding = binding
         self._killswitch = killswitch
+        # The durable approval store (#22). Optional: without it (and without
+        # binding), an awaiting-approval final cannot be persisted and is
+        # escalated rather than silently dropped.
+        self._approvals = approvals
         # Which threads are running which agent, so a kill interrupts the agent's
         # live turns. Populated while a turn owner streams.
         self._active_by_agent: dict[uuid.UUID, set[str]] = {}
@@ -295,6 +313,16 @@ class Kernel:
                 outcome = await self._attempt(
                     qevent, release_order, boot_env, agent_id, nav, packs
                 )
+
+                # The turn paused on an approval gate: persist the durable record
+                # and suspend the session (first, before the success/side-effect/
+                # retry branches, since awaiting-approval is none of those). The
+                # Slack event is then marked done -- the resume arrives later as a
+                # fresh synthetic turn, not a replay of this event.
+                if outcome.awaiting_approval:
+                    await self._suspend_for_approval(qevent, agent_id, outcome)
+                    await self._markers.mark_done(event_id)
+                    return
 
                 if outcome.terminal_ok:
                     await self._markers.mark_done(event_id)
@@ -615,8 +643,23 @@ class Kernel:
         elif isinstance(frame, Final):
             acc.status = frame.status
             acc.final_text = frame.text
+            acc.session_id = frame.session_id
+            acc.approval_request = frame.approval_request
 
     async def _finish(self, acc: _StreamAccumulator, reply: _ThrottledReply) -> TurnOutcome:
+        if acc.status is SessionStatus.AWAITING_APPROVAL:
+            # A pause, not a terminal state: do not finalize the placeholder as an
+            # answer. process_event persists the record, suspends, and (in the
+            # Slack path, #246) posts the approval card.
+            return TurnOutcome(
+                terminal_ok=False,
+                awaiting_approval=True,
+                status=acc.status,
+                session_id=acc.session_id,
+                approval_request=acc.approval_request,
+                saw_side_effect=acc.saw_side_effect,
+                text=acc.rendered(),
+            )
         if acc.status in (SessionStatus.DONE, SessionStatus.IDLE_AWAITING_INPUT):
             text = acc.rendered()
             await reply.finalize(text)
@@ -643,6 +686,75 @@ class Kernel:
             text=message,
             endpoint=qevent.reply_handle.endpoint,
         )
+
+    async def _suspend_for_approval(
+        self, qevent: QueuedTurn, agent_id: uuid.UUID | None, outcome: TurnOutcome
+    ) -> None:
+        """Persist a durable pending approval and suspend the session (#22).
+
+        Ordering is persist-before-suspend (the ack is process_event's mark_done
+        + return): the durable row is the source of truth, so a crash after
+        persisting but before suspending still resolves correctly -- the resume
+        path finds the live/idle sandbox (or cold-claims a fresh one) and
+        rehydrates from the recorded session id. If approvals are not configured,
+        or the runner emitted awaiting-approval without the request detail,
+        escalate rather than silently drop.
+        """
+        thread = qevent.conversation_id
+        ar = outcome.approval_request
+        if self._approvals is None or agent_id is None or ar is None:
+            await self._escalate(
+                qevent,
+                "The agent asked for approval, but approvals are not configured "
+                "for this run. Flagging for a human.",
+            )
+            return
+
+        await self._approvals.create_pending(
+            agent_id=agent_id,
+            conversation_id=thread,
+            session_id=outcome.session_id,
+            channel=qevent.reply_handle.channel,
+            reply_placeholder=qevent.reply_handle.placeholder,
+            reply_endpoint=qevent.reply_handle.endpoint,
+            tool=ar.tool,
+            tool_use_id=ar.tool_use_id,
+            input_digest=ar.input_digest,
+            prompt=ar.prompt,
+            requested_by=qevent.author,
+        )
+
+        # Suspend under the per-thread route lock so a concurrent follow-up cannot
+        # adopt the idle sandbox between the record and the suspend: a follow-up
+        # after this finds the route SUSPENDED and resumes instead. A suspend
+        # failure is non-fatal -- the durable record already exists, so the resume
+        # path still runs (cold-claiming a fresh sandbox if the route is gone).
+        #
+        # SACRED-MODULE REVIEW: the one edge to scrutinize in the mandated
+        # spec-vs-impl + side-effects-detective pass is the finish-race interaction
+        # (a follow-up opening a fresh turn on the idle sandbox at the same instant
+        # the awaiting-approval final lands).
+        try:
+            async with self._lock.hold(self._config.lock_key(thread)):
+                await asyncio.to_thread(
+                    self._substrate.suspend, thread, history_ref=outcome.session_id
+                )
+        except SandboxError as exc:
+            logger.warning("suspend-for-approval failed for %s: %s", qevent.event_id, exc)
+
+        # Surface the pause on the placeholder (best-effort); the Slack approval
+        # card + buttons are the #246 slice.
+        try:
+            await self._sink.update(
+                channel=qevent.reply_handle.channel,
+                ts=qevent.reply_handle.placeholder,
+                text=self._config.awaiting_approval_text,
+                endpoint=qevent.reply_handle.endpoint,
+            )
+        except Exception:
+            logger.warning(
+                "awaiting-approval placeholder update failed for %s", qevent.event_id
+            )
 
     def _backoff(self, attempt: int) -> float:
         raw: float = self._config.retry_backoff_base_s * (2 ** (attempt - 1))

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -21,6 +21,8 @@ import redis
 from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
+from .approval_resumer import ApprovalResumer
+from .approvals import ApprovalStore
 from .binding import BindingResolver
 from .bundle_store import BundleStore
 from .config import WorkerConfig
@@ -52,6 +54,7 @@ class Runtime:
 
     consumer: Consumer
     killswitch: KillSwitch
+    approval_resumer: ApprovalResumer
     eval_consumer: EvalStreamConsumer
     runner: RunnerClient
     async_redis: AsyncRedis
@@ -162,6 +165,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     )
     engine = create_async_engine(config.database_url, pool_pre_ping=True)
     binding = BindingResolver(engine, config)
+    approval_store = ApprovalStore(engine, config)
     kernel = Kernel(
         substrate=substrate,
         runner=runner,
@@ -177,10 +181,14 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         markers=Markers(async_redis, config),
         config=config,
         binding=binding,
+        approvals=approval_store,
     )
     killswitch = KillSwitch(async_redis, on_kill=kernel.interrupt_agent)
     kernel.attach_killswitch(killswitch)
     consumer = Consumer(redis=async_redis, kernel=kernel, config=config)
+    approval_resumer = ApprovalResumer(
+        redis=async_redis, store=approval_store, config=config
+    )
 
     # The eval lane (F3): a second consumer group on agentos:evals, on its own
     # Valkey connection so its blocking read never stalls the runs consumer. It
@@ -218,6 +226,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     return Runtime(
         consumer=consumer,
         killswitch=killswitch,
+        approval_resumer=approval_resumer,
         eval_consumer=eval_consumer,
         runner=runner,
         async_redis=async_redis,
@@ -239,6 +248,7 @@ async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
     def _stop() -> None:
         rt.consumer.request_stop()
         rt.killswitch.request_stop()
+        rt.approval_resumer.request_stop()
         rt.eval_consumer.request_stop()
         hb_stop.set()
 
@@ -250,6 +260,7 @@ async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
         await asyncio.gather(
             rt.consumer.run(),
             rt.killswitch.run(),
+            rt.approval_resumer.run(),
             rt.eval_consumer.run(),
             run_heartbeat(config.heartbeat_file, config.heartbeat_interval_s, hb_stop),
         )

--- a/apps/worker/src/agentos_worker/sandbox/types.py
+++ b/apps/worker/src/agentos_worker/sandbox/types.py
@@ -85,8 +85,12 @@ class SubstrateConfig:
     # How long a live route stays bound with no touch. After expiry the claim
     # is an orphan and reap_orphans() deletes it.
     route_ttl_seconds: int = 3600
-    # Suspended routes wait longer: the thread may come back tomorrow.
-    suspended_route_ttl_seconds: int = 86400
+    # Suspended routes wait longer: the thread may come back tomorrow. Approvals
+    # (ADR-0010) are the first production suspend trigger and can pause for days
+    # awaiting a human, so this is a week -- long enough that the Valkey route
+    # (which carries the rehydrate ref) outlives a realistic approval wait. The
+    # durable Approval row is still the source of truth if it does expire.
+    suspended_route_ttl_seconds: int = 604800
     # How long claim() waits for a claim to bind a ready sandbox before raising
     # ClaimTimeoutError. This is a genuinely END-TO-END budget: a single shared
     # deadline in SandboxSubstrate._claim_fresh spans BOTH the bind phase and the

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -343,6 +343,7 @@ async def kernel_harness(
     *,
     binding: object | None = None,
     with_killswitch: bool = False,
+    approvals: object | None = None,
     **config_overrides: object,
 ) -> AsyncIterator[Harness]:
     """Assemble a live kernel wired to a fake runner and real Valkey."""
@@ -385,6 +386,7 @@ async def kernel_harness(
         markers=Markers(async_redis, config),
         config=config,
         binding=binding,  # type: ignore[arg-type]
+        approvals=approvals,  # type: ignore[arg-type]
     )
     killswitch = None
     if with_killswitch:

--- a/apps/worker/tests/kernel/test_kernel_approval.py
+++ b/apps/worker/tests/kernel/test_kernel_approval.py
@@ -1,0 +1,165 @@
+"""Kernel awaiting-approval lifecycle (#22): the sacred-module slice.
+
+Against real Valkey, the real substrate, and the fake runner. The runner scripts
+an ``awaiting-approval`` final carrying the gated tool call; the kernel must
+persist a durable pending approval, suspend the session, and mark the event done
+(so it is not replayed). The ApprovalStore is a recording double here on purpose:
+this suite is Valkey-only by design (like the binding stub), and the store's real
+Postgres SQL is exercised against a migrated database in the API suite
+(test_approvals.py). What is under test is the kernel's orchestration, not the SQL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+from aci_protocol import (
+    ApprovalRequest,
+    Final,
+    QueuedTurn,
+    ReplyHandle,
+    SessionStatus,
+    TextDelta,
+)
+from agentos_worker.behaviorpacks import BehaviorPacks
+from agentos_worker.binding import AGENT_ID_ENV, BUDGET_ENV, PLUGIN_DIR_ENV, ResolvedDeployment
+
+
+class StubBinding:
+    """A BindingResolver-shaped stub with canned per-channel resolutions."""
+
+    def __init__(self, by_channel: dict[str, ResolvedDeployment]) -> None:
+        self._by_channel = by_channel
+
+    async def resolve(self, channel: str) -> ResolvedDeployment | None:
+        return self._by_channel.get(channel)
+
+    def boot_env(self, resolved: ResolvedDeployment, thread_key: str) -> dict[str, str]:
+        return {
+            BUDGET_ENV: '{"max_output_tokens_per_run":100000,"max_usd_per_day":10.0}',
+            AGENT_ID_ENV: str(resolved.agent_id),
+            PLUGIN_DIR_ENV: "/bundles/current",
+        }
+
+    def packs_for(self, resolved: ResolvedDeployment) -> BehaviorPacks:
+        return BehaviorPacks.from_config(resolved.behavior_packs)
+
+
+class FakeApprovalStore:
+    """Records create_pending calls; the kernel's only store call on suspend."""
+
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    async def create_pending(self, **kwargs: Any) -> uuid.UUID:
+        self.created.append(kwargs)
+        return uuid.uuid4()
+
+
+def _resolved(agent_id: uuid.UUID) -> ResolvedDeployment:
+    return ResolvedDeployment(
+        agent_id=agent_id,
+        version_id=uuid.uuid4(),
+        version_label="v1",
+        bundle_ref="bundles/x.zip",
+        max_usd_per_day=None,
+        max_output_tokens_per_run=None,
+    )
+
+
+def _qevent(text: str, *, channel: str, thread: str, placeholder: str) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U1",
+        text=text,
+        reply_handle=ReplyHandle(channel=channel, placeholder=placeholder),
+        received_at="2026-07-13T00:00:00+00:00",
+    )
+
+
+def _awaiting_script() -> list[Any]:
+    return [
+        TextDelta(text="I need sign-off to apply this discount."),
+        Final(
+            text="Requesting approval.",
+            status=SessionStatus.AWAITING_APPROVAL,
+            session_id="sdk-sess-1",
+            approval_request=ApprovalRequest(
+                tool="apply_discount",
+                tool_use_id="toolu_42",
+                input_digest="sha256:abc",
+                prompt="Apply a 30% discount to ACME-1?",
+            ),
+        ),
+    ]
+
+
+def test_awaiting_approval_persists_and_suspends(make_harness) -> None:
+    async def go() -> None:
+        agent_id = uuid.uuid4()
+        store = FakeApprovalStore()
+        binding = StubBinding({"C-bound": _resolved(agent_id)})
+        async with make_harness(binding=binding, approvals=store) as h:
+            h.runner.turn_scripts = [_awaiting_script()]
+            ev = _qevent(
+                "give acme a 30% discount",
+                channel="C-bound",
+                thread="th-appr",
+                placeholder="p-appr",
+            )
+            await h.kernel.process_event(ev)
+
+            # A durable pending approval was persisted with the gate + routing so
+            # the resume path can rebuild the turn without the live sandbox.
+            assert len(store.created) == 1
+            rec = store.created[0]
+            assert rec["agent_id"] == agent_id
+            assert rec["conversation_id"] == "th-appr"
+            assert rec["tool"] == "apply_discount"
+            assert rec["tool_use_id"] == "toolu_42"
+            assert rec["prompt"] == "Apply a 30% discount to ACME-1?"
+            assert rec["session_id"] == "sdk-sess-1"
+            assert rec["channel"] == "C-bound"
+            assert rec["reply_placeholder"] == "p-appr"
+            assert rec["requested_by"] == "U1"
+
+            # The session was suspended: the pod flipped to Suspended in the fake
+            # control plane (real suspend deletes it; the fake flips the mode).
+            assert any(
+                s.operating_mode == "Suspended" for s in h.fake_k8s.sandboxes.values()
+            )
+
+            # Terminally handled (marked done, not replayed); the placeholder shows
+            # the paused state, never the model's interim text as a final answer.
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+            assert h.sink.last_text == h.config.awaiting_approval_text
+
+    asyncio.run(go())
+
+
+def test_awaiting_approval_without_store_escalates(make_harness) -> None:
+    async def go() -> None:
+        agent_id = uuid.uuid4()
+        binding = StubBinding({"C-bound": _resolved(agent_id)})
+        # No approvals store wired: the gate cannot be persisted, so the kernel
+        # escalates to a human rather than silently dropping the request.
+        async with make_harness(binding=binding, approvals=None) as h:
+            h.runner.turn_scripts = [_awaiting_script()]
+            ev = _qevent(
+                "discount please", channel="C-bound", thread="th-x", placeholder="p-x"
+            )
+            await h.kernel.process_event(ev)
+
+            assert h.sink.last_text is not None
+            assert "approval" in h.sink.last_text.lower()
+            assert "not configured" in h.sink.last_text.lower()
+            # Not suspended, but still terminally handled (no infinite reclaim).
+            assert all(
+                s.operating_mode == "Running" for s in h.fake_k8s.sandboxes.values()
+            )
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_approval_resumer.py
+++ b/apps/worker/tests/test_approval_resumer.py
@@ -1,0 +1,136 @@
+"""ApprovalResumer: a resolved approval becomes a synthetic resume turn (#22).
+
+Against the real compose Valkey (never mocked): the resumer enqueues onto a real
+stream and we read it back. The ApprovalStore is a recording double so the test
+does not need Postgres; the store's real SQL is covered in the API suite. What is
+under test is the resume-enqueue logic (stable event id, rebuilt reply handle,
+outcome text) and the reconcile/pubsub entry points.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+from agentos_dispatcher.queue import from_stream_fields
+from agentos_worker.approval_resumer import ApprovalResumer
+from agentos_worker.approvals import ApprovalRecord
+from agentos_worker.config import WorkerConfig
+from redis.asyncio import Redis as AsyncRedis
+
+_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
+_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
+_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
+
+
+class FakeStore:
+    """Records mark_resumed; serves a canned resolved-unresumed set."""
+
+    def __init__(self, records: list[ApprovalRecord]) -> None:
+        self._records = records
+        self.resumed: list[uuid.UUID] = []
+
+    async def list_resolved_unresumed(self) -> list[ApprovalRecord]:
+        return list(self._records)
+
+    async def get(self, approval_id: uuid.UUID) -> ApprovalRecord | None:
+        return next((r for r in self._records if r.id == approval_id), None)
+
+    async def mark_resumed(self, approval_id: uuid.UUID) -> bool:
+        self.resumed.append(approval_id)
+        return True
+
+
+def _record(status: str, *, tool: str = "apply_discount") -> ApprovalRecord:
+    return ApprovalRecord(
+        id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        conversation_id="th-9",
+        session_id="sdk-sess-1",
+        channel="C000000A01",
+        reply_placeholder="p-9",
+        reply_endpoint=None,
+        tool=tool,
+        prompt="Apply a 30% discount to ACME-1?",
+        status=status,
+    )
+
+
+@asynccontextmanager
+async def _resumer(
+    records: list[ApprovalRecord],
+) -> AsyncIterator[tuple[ApprovalResumer, FakeStore, AsyncRedis, str]]:
+    client: AsyncRedis = AsyncRedis(
+        host=_VALKEY_HOST,
+        port=_VALKEY_PORT,
+        password=_VALKEY_PW or None,
+        decode_responses=True,
+    )
+    try:
+        await client.ping()
+    except Exception as exc:  # noqa: BLE001
+        await client.aclose()
+        pytest.skip(f"Valkey not reachable: {exc}")
+    stream = f"test:agentos:runs:{uuid.uuid4().hex}"
+    store = FakeStore(records)
+    config = WorkerConfig(stream=stream)
+    resumer = ApprovalResumer(redis=client, store=store, config=config)
+    try:
+        yield resumer, store, client, stream
+    finally:
+        await client.delete(stream)
+        await client.aclose()
+
+
+def test_reconcile_enqueues_synthetic_resume_turn() -> None:
+    async def go() -> None:
+        rec = _record("approved")
+        async with _resumer([rec]) as (resumer, store, client, stream):
+            count = await resumer.reconcile_once()
+            assert count == 1
+            assert store.resumed == [rec.id]
+
+            entries = await client.xrange(stream)
+            assert len(entries) == 1
+            _entry_id, fields = entries[0]
+            turn = from_stream_fields(fields)
+            # Stable event id -> the kernel's done-marker dedupes a re-enqueue.
+            assert turn.event_id == f"approval-resume-{rec.id}"
+            assert turn.conversation_id == "th-9"
+            # Reply handle rebuilt from the durable record, not a live route.
+            assert turn.reply_handle.channel == "C000000A01"
+            assert turn.reply_handle.placeholder == "p-9"
+            assert "approved" in turn.text.lower()
+
+    asyncio.run(go())
+
+
+def test_reject_resume_carries_the_rejection() -> None:
+    async def go() -> None:
+        rec = _record("rejected")
+        async with _resumer([rec]) as (resumer, _store, client, stream):
+            await resumer.reconcile_once()
+            entries = await client.xrange(stream)
+            turn = from_stream_fields(entries[0][1])
+            assert "rejected" in turn.text.lower()
+
+    asyncio.run(go())
+
+
+def test_pubsub_handle_resumes_the_named_approval() -> None:
+    async def go() -> None:
+        rec = _record("approved")
+        async with _resumer([rec]) as (resumer, store, client, stream):
+            message = {"data": json.dumps({"approval_id": str(rec.id)})}
+            await resumer._handle(message)
+            assert store.resumed == [rec.id]
+            entries = await client.xrange(stream)
+            assert len(entries) == 1
+            assert from_stream_fields(entries[0][1]).conversation_id == "th-9"
+
+    asyncio.run(go())


### PR DESCRIPTION
Second slice of the approval-gates epic (#22, ADR-0010): the durable core that
pauses a session on an approval gate and resumes it on resolution. CLI-verifiable
without Slack.

**Stacked on #369** (the `awaiting-approval` contract change) — review that first;
this branch targets it, so the diff here is only the durable-core changes.

## API
- Durable `Approval` record (Postgres) + migration `0008` with **resolve-once
  compare-and-set**: a resolve flips `pending -> approved/rejected` exactly once
  (the click-race loser gets 409), self-approval is refused (403).
- `routers/approvals.py` (get / list / resolve) and an `ApprovalNotifier` that
  publishes a resume wake-up on `agentos:approval-events`, mirroring the kill switch.

## Worker
- **Kernel (sacred module)** handles an `awaiting-approval` final: captures the SDK
  session id + gated tool call off the final, persists a pending record, suspends
  the session, marks the event done. Persist-before-suspend-before-ack keeps a
  crash mid-pause resolvable.
- `ApprovalStore`: raw SQL over the shared engine (like `binding.py`) to write the
  pending row and mark it resumed.
- `ApprovalResumer`: subscribes to resolutions and enqueues a **synthetic turn**
  onto the runs stream, so the existing `claim -> SuspendedThreadError -> resume`
  path rehydrates and delivers the outcome. A periodic reconcile sweep catches a
  resolve whose wake-up reached no worker. Suspended-route TTL raised to a week for
  multi-day pauses; the durable row stays the source of truth.

## Verification
- API suite (200 passed): resolve CAS, self-approval 403, already-resolved 409,
  and the real-Valkey wake-up publish; against the disposable migrated Postgres.
- Worker suite (295 passed): the kernel suspend-on-approval lifecycle test (real
  Valkey + fake runner) and the resumer enqueue against real Valkey.
- ruff + mypy clean; committed OpenAPI regenerated.

## Review asks
- **This touches the sacred kernel** (`kernel.py`): per `apps/worker/CLAUDE.md` it
  needs the adversarial spec-vs-impl + side-effects-detective review before merge.
  The one edge flagged in-code for that pass is the finish-race-vs-suspend
  interaction (a follow-up opening a fresh turn on the idle sandbox at the instant
  the awaiting-approval final lands).
- The worker writes the `approvals` table via raw SQL (mirroring `binding.py`)
  rather than through the API, to avoid a new API-up dependency on the suspend path.

Part of #244. The runner `canUseTool` gate that actually emits `awaiting-approval`
(#245) and the Slack card + authorizer (#246) follow; the full restart -> resolve
-> resume E2E rides the epic acceptance demo once those land.