### PR TITLE
Console/CLI parity: attach cliCommand hints to wired surfaces (#279)

### DIFF
--- a/apps/ui/src/components/modals/NewAgentModal.tsx
+++ b/apps/ui/src/components/modals/NewAgentModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { C } from "../../tokens";
-import { Button } from "../../primitives";
+import { Button, CliHint, cliCommand } from "../../primitives";
 import { SkillEditor } from "../SkillEditor";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
@@ -267,6 +267,7 @@ export function NewAgentModal() {
         <span style={{ fontSize: 12, color: C.muted, fontFamily: C.mono }}>
           deploys to <span style={{ color: C.text2 }}>{channel.trim() || "your channel"}</span>
         </span>
+        <CliHint command={cliCommand("init", { name: name.trim() || "agent" })} label="scaffold via CLI" />
         <div style={{ marginLeft: "auto", display: "flex", gap: 10 }}>
           <Button label="Cancel" variant="ghost" onClick={() => dispatch({ type: "closeModal" })} />
           {state.deploying ? (

--- a/apps/ui/src/primitives/SectionTitle.tsx
+++ b/apps/ui/src/primitives/SectionTitle.tsx
@@ -1,11 +1,16 @@
+import type { ReactNode } from "react";
 import { C } from "../tokens";
 
 // View heading: 26px/400 title with an optional muted subtitle. Ported from
 // sectionTitle(). Headings are deliberately not bold-heavy per the design.
-export function SectionTitle({ title, sub }: { title: string; sub?: string }) {
+// `right` renders a trailing control (e.g. a CliHint) on the title row.
+export function SectionTitle({ title, sub, right }: { title: string; sub?: string; right?: ReactNode }) {
   return (
     <div style={{ marginBottom: 20 }}>
-      <h1 style={{ fontSize: 26, fontWeight: 400, color: C.text, margin: "0 0 4px" }}>{title}</h1>
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <h1 style={{ fontSize: 26, fontWeight: 400, color: C.text, margin: "0 0 4px" }}>{title}</h1>
+        {right ? <div style={{ marginLeft: "auto" }}>{right}</div> : null}
+      </div>
       {sub ? <p style={{ fontSize: 14, color: C.muted, margin: 0 }}>{sub}</p> : null}
     </div>
   );

--- a/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.test.tsx
@@ -276,3 +276,18 @@ describe("WiredAgentDetail — promote-to-prod (item 6)", () => {
     expect(vi.mocked(createDeployment)).not.toHaveBeenCalled();
   });
 });
+
+describe("WiredAgentDetail — CLI hint (#279)", () => {
+  it("renders the deploy CLI hint sourced from the manifest next to Deploy", async () => {
+    renderDetail();
+
+    // Deploy only renders once versions + bundle files resolve.
+    expect(await screen.findByRole("button", { name: "Deploy new version" })).toBeInTheDocument();
+
+    // The hint copies the exact `agentos cluster deploy` (env clamps to prod at
+    // level 3), resolved from the command manifest via cliCommand().
+    expect(
+      screen.getByRole("button", { name: "Copy command: agentos cluster deploy" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/views/wired/WiredAgentDetail.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { C } from "../../tokens";
-import { Button, Card, Chip, Dot, Notice } from "../../primitives";
+import { Button, Card, Chip, CliHint, Dot, Notice, cliCommand } from "../../primitives";
 import { SkillEditor } from "../../components/SkillEditor";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
@@ -513,7 +513,8 @@ export function WiredAgentDetail() {
                 {dirty ? "unsaved edits" : "no changes"}
               </span>
             )}
-            <div style={{ marginLeft: "auto" }}>
+            <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8 }}>
+              <CliHint command={cliCommand(state.env === "prod" ? "cluster.deploy" : "local.deploy")} />
               {deploying ? (
                 <Button label="Deploying…" variant="primary" disabled />
               ) : (

--- a/apps/ui/src/views/wired/WiredAgents.tsx
+++ b/apps/ui/src/views/wired/WiredAgents.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { C } from "../../tokens";
-import { Card, SectionTitle, Button, Dot, EmptyState, Notice } from "../../primitives";
+import { Card, SectionTitle, Button, CliHint, Dot, EmptyState, Notice, cliCommand } from "../../primitives";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
 import { useAllDeployments } from "../../api/hooks";
@@ -60,7 +60,8 @@ export function WiredAgents() {
         <div>
           <SectionTitle title="Agents" />
         </div>
-        <div style={{ marginLeft: "auto" }}>
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8 }}>
+          <CliHint command={cliCommand("init")} />
           <Button label="New agent" variant="primary" icon="+" onClick={() => dispatch({ type: "openModal", modal: "new-agent" })} />
         </div>
       </div>

--- a/apps/ui/src/views/wired/WiredOverview.tsx
+++ b/apps/ui/src/views/wired/WiredOverview.tsx
@@ -1,5 +1,5 @@
 import { C } from "../../tokens";
-import { Card, SectionTitle, Button, Dot, Notice } from "../../primitives";
+import { Card, SectionTitle, Button, CliHint, Dot, Notice, cliCommand } from "../../primitives";
 import { hoverBg } from "../../lib/style";
 import { formatLatency } from "../../lib/format";
 import { useStore } from "../../state/store";
@@ -119,7 +119,11 @@ function LiveOverview({ agents }: { agents: AgentOut[] }) {
   return (
     <div>
       {justDeployed ? <DeployedPanel name={justDeployed.name} channel={justDeployed.channel} /> : null}
-      <SectionTitle title="Overview" sub={`${scoped.length} ${scoped.length === 1 ? "agent" : "agents"} · ${state.env} · live data`} />
+      <SectionTitle
+        title="Overview"
+        sub={`${scoped.length} ${scoped.length === 1 ? "agent" : "agents"} · ${state.env} · live data`}
+        right={<CliHint command={cliCommand(state.env === "prod" ? "cluster.status" : "local.status")} />}
+      />
       <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 14, marginBottom: 22 }}>
         {stats.map((x) => stat(x[0], x[1]))}
       </div>

--- a/apps/ui/src/views/wired/WiredVersions.tsx
+++ b/apps/ui/src/views/wired/WiredVersions.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { C } from "../../tokens";
-import { Button, Card, SectionTitle, Chip, Dot, Modal, Notice } from "../../primitives";
+import { Button, Card, SectionTitle, Chip, CliHint, Dot, Modal, Notice, cliCommand } from "../../primitives";
 import { useStore } from "../../state/store";
 import { useAgents, useAgentVersions } from "../../api/hooks";
 import { ComingSoon } from "./WiredStubs";
@@ -104,6 +104,12 @@ function VersionsTable({ agentId }: { agentId: string }) {
   const grid = "1.1fr 0.9fr 1fr 1.3fr 1fr 0.8fr";
   return (
     <Card>
+      <div style={{ display: "flex", alignItems: "center", marginBottom: 12 }}>
+        <span style={{ fontSize: 13, fontWeight: 500, color: C.text }}>Versions</span>
+        <div style={{ marginLeft: "auto" }}>
+          <CliHint command={cliCommand(state.env === "prod" ? "cluster.status" : "local.status")} />
+        </div>
+      </div>
       <div
         style={{
           display: "grid",


### PR DESCRIPTION
Part of the console/CLI parity epic (#145). Depends on #278 (`CliHint` + `cliCommand()` + committed manifest), which is merged.

## What
Attaches `CliHint` (resolved via `cliCommand()` from the committed command manifest) to the real wired surfaces, so each console action advertises the exact `agentos …` command a user could run instead — with no hardcoded command strings:

- **WiredAgentDetail** — Deploy new version → `cluster deploy` / `local deploy` (env-aware)
- **WiredAgents** — New agent → `agentos init`
- **NewAgentModal** — scaffold → `agentos init <name>` (name from the form)
- **WiredOverview** — header → `cluster status` / `local status`
- **WiredVersions** — header → `cluster status` / `local status`

`SectionTitle` gains an optional `right` slot to host the trailing hint.

## Scope note
The issue also mentions migrating `apps/ui/src/views/Terminal.tsx` — that file does **not** exist in the tree (stale scope), so that part is skipped, as is the fixture-only Evals matrix / local-dev panels (not wired surfaces). Frontend only.

## Tests
Adds an RTL test asserting the deploy hint resolves to `agentos cluster deploy` from the manifest. Full UI suite green (110 tests), lint + typecheck clean, no manifest drift.

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)