### PR TITLE
Console/CLI parity: parity test + honest noCliEquivalent state + sync invariants (#280)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,10 @@ just that unit tests pass.
   non-interactive (a `--yes`/`--force` path, never blocking on stdin), and errors
   as `{"error","fix"}` recovery instructions. Exit-code scheme: see
   `cli/README.md`.
+- **Console/CLI parity is a two-sided invariant (epic #145):** any CLI
+  command-surface change regenerates the committed manifest (`cli/CLAUDE.md`),
+  and every wired console action maps to a real command or an explicit
+  `noCliEquivalent` (`apps/ui/CLAUDE.md`). Keep both sides in the same change.
 
 ## Playwright: two modes
 

--- a/apps/ui/CLAUDE.md
+++ b/apps/ui/CLAUDE.md
@@ -34,6 +34,17 @@ structure and wiring detail in `apps/ui/README.md`.
 - **The demo-controls bar from the design is deliberately not shipped.**
   `?dev=1` gives an equivalent state switcher for development; keep it
   hidden without that param so the product view stays clean.
+- **Console/CLI parity: hints resolve from the manifest, never hardcoded**
+  (epic #145). CLI hints on wired surfaces come from `cliCommand()`
+  (`src/primitives/cliCommand.ts`), which is typed against the committed
+  command manifest (`src/generated/commandManifest.ts`) — never hand-write an
+  `agentos …` string in a component. Every wired action is enumerated in the
+  parity registry (`src/primitives/parity.ts`) and must map to EITHER a real
+  `command` (an `ActionId`) OR an explicit `noCliEquivalent` marker that renders
+  the honest amber `CliHint` linking to the tracking issue. Adding a wired
+  action means adding its parity entry; `CliHint.parity.test.tsx` fails on a
+  silent gap. When the CLI surface changes, run `pnpm gen:manifest` and commit
+  the regenerated manifest (CI drift-checks it).
 
 ## Playwright ports (do not confuse these)
 

--- a/apps/ui/src/primitives/CliHint.parity.test.tsx
+++ b/apps/ui/src/primitives/CliHint.parity.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CliHint } from "./CliHint";
+import { cliCommand } from "./cliCommand";
+import { WIRED_ACTIONS, PARITY_TRACKING_ISSUE } from "./parity";
+import { StoreProvider } from "../state/store";
+
+// Console/CLI parity gate (epic #145): every wired UI action must map to EITHER
+// a real command resolved from the committed manifest OR an explicit
+// `noCliEquivalent` marker pointing at the tracking issue. This test enumerates
+// the parity registry and fails the moment a wired action ships without a
+// deliberate mapping — the honest amber state is only for genuinely-unmapped
+// actions, never a silent gap.
+
+describe("console/CLI parity registry (#280)", () => {
+  it("lists at least the known wired actions", () => {
+    // A guard against the registry being emptied/short-circuited.
+    expect(WIRED_ACTIONS.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("every wired action maps to a real command or an explicit noCliEquivalent", () => {
+    for (const action of WIRED_ACTIONS) {
+      if ("command" in action.mapping) {
+        // Resolves against the manifest without throwing, and yields an
+        // `agentos …` invocation. `cliCommand` throws on an unknown path, so
+        // this catches a command id that is not a real manifest leaf.
+        const rendered = cliCommand(action.mapping.command);
+        expect(rendered.startsWith("agentos ")).toBe(true);
+      } else {
+        // The honest gap: a tracking-issue URL, not an empty string.
+        expect(action.mapping.noCliEquivalent).toMatch(/^https?:\/\//);
+      }
+    }
+  });
+
+  it("the four former parity-gap actions now resolve to real CLI verbs", () => {
+    // #149 landed kill/resume/budget/delete, so these are commands, not gaps.
+    for (const id of ["kill", "resume", "budget", "delete"]) {
+      const action = WIRED_ACTIONS.find((a) => a.id === id);
+      expect(action, `missing wired action: ${id}`).toBeDefined();
+      expect("command" in action!.mapping).toBe(true);
+    }
+  });
+});
+
+describe("CliHint — noCliEquivalent amber state (#280)", () => {
+  function renderHint(el: React.ReactElement) {
+    return render(<StoreProvider level={3}>{el}</StoreProvider>);
+  }
+
+  it("renders the amber glyph and links to the tracking issue instead of copying", () => {
+    renderHint(<CliHint noCliEquivalent={PARITY_TRACKING_ISSUE} />);
+    const btn = screen.getByRole("button", { name: /no cli equivalent/i });
+    expect(btn).toHaveAttribute("data-no-cli", "true");
+    // It carries no "Copy command" affordance.
+    expect(screen.queryByRole("button", { name: /copy command/i })).toBeNull();
+  });
+
+  it("still renders the copy affordance for a real command", () => {
+    renderHint(<CliHint command="agentos cluster deploy" />);
+    expect(
+      screen.getByRole("button", { name: "Copy command: agentos cluster deploy" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/primitives/CliHint.tsx
+++ b/apps/ui/src/primitives/CliHint.tsx
@@ -12,17 +12,71 @@ import { useStore } from "../state/store";
 // touch, a tap copies directly (there is no hover step to gate on). The
 // morph is driven by hover/focus state and a transient "copied" flag, all
 // CSS transitions so it degrades gracefully.
+//
+// Honest no-equivalent state (epic #145): a wired action with no CLI verb yet
+// passes `noCliEquivalent={<tracking issue url>}` instead of a `command`. That
+// renders an amber `◇` glyph whose tooltip says there is no CLI equivalent and
+// whose click opens the tracking issue in a new tab — it never copies a
+// misleading command. The parity test (CliHint.parity.test.tsx) enforces that
+// every wired action resolves to a `command` or an explicit `noCliEquivalent`.
 
 const COPIED_RESET_MS = 1200;
 
-export function CliHint({ command, label }: { command: string; label?: string }) {
+export function CliHint({
+  command,
+  label,
+  noCliEquivalent,
+}: {
+  command?: string;
+  label?: string;
+  noCliEquivalent?: string;
+}) {
   const { dispatch } = useStore();
   const [active, setActive] = useState(false); // hover or keyboard focus
   const [copied, setCopied] = useState(false);
 
+  // Amber "no CLI equivalent yet" affordance: link out to the tracking issue
+  // rather than copy. Kept a real <button> for keyboard parity with the copy
+  // mode; the click opens the issue in a new tab.
+  if (noCliEquivalent !== undefined) {
+    return (
+      <button
+        type="button"
+        onClick={() => window.open(noCliEquivalent, "_blank", "noopener,noreferrer")}
+        onMouseEnter={() => setActive(true)}
+        onMouseLeave={() => setActive(false)}
+        onFocus={() => setActive(true)}
+        onBlur={() => setActive(false)}
+        title="No CLI equivalent yet — open the tracking issue"
+        aria-label="No CLI equivalent yet; open the tracking issue"
+        data-no-cli="true"
+        style={{
+          background: "transparent",
+          border: "none",
+          color: C.warn,
+          cursor: "pointer",
+          fontFamily: C.mono,
+          fontSize: 12,
+          padding: "2px 4px",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          opacity: active ? 1 : 0.85,
+        }}
+      >
+        <span aria-hidden="true" style={{ color: C.warn, width: "1.4em", textAlign: "center" }}>
+          ◇
+        </span>
+        {label ? <span>{label}</span> : null}
+      </button>
+    );
+  }
+
+  const cmd = command ?? "";
+
   function copy() {
     if (navigator.clipboard) {
-      void navigator.clipboard.writeText(command).catch(() => {});
+      void navigator.clipboard.writeText(cmd).catch(() => {});
     }
     dispatch({ type: "toast", message: "Copied" });
     setCopied(true);
@@ -41,8 +95,8 @@ export function CliHint({ command, label }: { command: string; label?: string })
       onMouseLeave={() => setActive(false)}
       onFocus={() => setActive(true)}
       onBlur={() => setActive(false)}
-      title={`$ ${command}`}
-      aria-label={`Copy command: ${command}`}
+      title={`$ ${cmd}`}
+      aria-label={`Copy command: ${cmd}`}
       data-copied={copied ? "true" : "false"}
       style={{
         background: "transparent",

--- a/apps/ui/src/primitives/index.ts
+++ b/apps/ui/src/primitives/index.ts
@@ -5,6 +5,7 @@ export { Button, type ButtonVariant } from "./Button";
 export { Card } from "./Card";
 export { CopyButton } from "./CopyButton";
 export { CliHint } from "./CliHint";
+export { WIRED_ACTIONS, PARITY_TRACKING_ISSUE, type WiredAction, type CliMapping } from "./parity";
 export { cliCommand, type ActionId, type CliContext } from "./cliCommand";
 export { SectionTitle } from "./SectionTitle";
 export { EmptyState } from "./EmptyState";

--- a/apps/ui/src/primitives/parity.ts
+++ b/apps/ui/src/primitives/parity.ts
@@ -1,0 +1,66 @@
+// Console/CLI parity registry (epic #145).
+//
+// The single source of truth for "which wired console action maps to which
+// `agentos` command". Every action a wired surface exposes is listed here with
+// EITHER a manifest-derived `command` (an `ActionId`, so a renamed/removed CLI
+// verb breaks `pnpm typecheck` at this call site) OR an explicit
+// `noCliEquivalent` marker carrying the tracking issue for the gap.
+//
+// The parity test (`CliHint.parity.test.tsx`) enumerates this registry and
+// asserts each entry resolves to a real command or an honest gap — so a new
+// wired action cannot ship without a deliberate CLI mapping decision. Surfaces
+// render `CliHint` from these same entries, so the hint a user sees and the
+// invariant the test enforces never drift.
+
+import type { ActionId } from "./cliCommand";
+
+// The parity epic tracks every still-unmapped wired action; a `noCliEquivalent`
+// entry links here until a dedicated verb lands.
+export const PARITY_TRACKING_ISSUE = "https://github.com/curie-eng/agentos/issues/145";
+
+export type CliMapping =
+  | { readonly command: ActionId }
+  | { readonly noCliEquivalent: string };
+
+export interface WiredAction {
+  /** Stable id for the wired action (surface-agnostic). */
+  readonly id: string;
+  /** Human-readable description of the console action. */
+  readonly label: string;
+  /** Its CLI mapping: a real command, or an explicit no-equivalent marker. */
+  readonly mapping: CliMapping;
+}
+
+// The wired actions, grouped by surface in comments. `deploy`/`status`/`message`
+// are env-scoped in the UI (prod -> cluster, dev -> local); both tiers are
+// listed so the parity gate covers each concrete command the surface can emit.
+export const WIRED_ACTIONS: readonly WiredAction[] = [
+  // WiredAgents / NewAgentModal
+  { id: "scaffold-agent", label: "New agent / scaffold", mapping: { command: "init" } },
+
+  // WiredAgentDetail — Deploy new version (env-scoped)
+  { id: "deploy-cluster", label: "Deploy new version (prod)", mapping: { command: "cluster.deploy" } },
+  { id: "deploy-local", label: "Deploy new version (dev)", mapping: { command: "local.deploy" } },
+
+  // WiredOverview / WiredVersions — status (env-scoped)
+  { id: "status-cluster", label: "Overview / versions status (prod)", mapping: { command: "cluster.status" } },
+  { id: "status-local", label: "Overview / versions status (dev)", mapping: { command: "local.status" } },
+
+  // Send-message / test-turn (env-scoped)
+  { id: "message-cluster", label: "Send message / test turn (prod)", mapping: { command: "cluster.message" } },
+  { id: "message-local", label: "Send message / test turn (dev)", mapping: { command: "local.message" } },
+
+  // Evals matrix
+  { id: "eval", label: "Run eval suite", mapping: { command: "skill.eval" } },
+
+  // Lifecycle controls — real verbs since #149 landed kill/resume/budget/delete.
+  { id: "kill", label: "Kill a run", mapping: { command: "cluster.kill" } },
+  { id: "resume", label: "Resume a run", mapping: { command: "cluster.resume" } },
+  { id: "budget", label: "Set budget", mapping: { command: "cluster.budget" } },
+  { id: "delete", label: "Delete an agent", mapping: { command: "cluster.delete" } },
+
+  // Genuinely-unmapped actions: no dedicated CLI verb exists yet. These render
+  // the honest amber glyph linking to the parity epic instead of a command.
+  { id: "rollback", label: "Roll back to an earlier version", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
+  { id: "promote-to-prod", label: "Promote dev version to prod", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
+] as const;

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -12,6 +12,14 @@ release with `up`, `status`, `down`, `comms`, `message`, and `deploy`. Full comm
 
 ## Load-bearing invariants
 
+- **The command manifest is a committed artifact; regenerate it in the same
+  change as any command-surface edit (console/CLI parity, epic #145).** Any
+  change to a clap `Command`/subcommand or an `*Action` enum — a renamed verb,
+  a new subcommand, a changed flag — must regenerate `cli/command-manifest.json`
+  and the committed `apps/ui/src/generated/commandManifest.ts` (`pnpm
+  gen:manifest` in `apps/ui`) in the same commit. CI drift-checks the committed
+  TS manifest, and the console's `cliCommand()` hints are typed against it, so a
+  stale manifest breaks the UI build. Never edit the manifest by hand.
 - **Never hand-write the ACI types.** `Cargo.toml` depends on
   `agentos-aci-protocol` at `../packages/aci-protocol/generated/rust` --
   that crate is generated from the frozen Pydantic models. If a type you


### PR DESCRIPTION
Part of the console/CLI parity epic (#145). Builds on #278/#279.

## What
- **Parity registry** (`apps/ui/src/primitives/parity.ts`) — the single source of truth mapping every wired console action to EITHER a manifest-derived `command` (a typed `ActionId`, so a renamed/removed verb breaks typecheck at the call site) OR an explicit `noCliEquivalent` marker.
- **Parity test** (`CliHint.parity.test.tsx`) enumerates the registry and asserts each action resolves to a real command or an honest gap — a new wired action cannot ship without a deliberate mapping decision. Also asserts the four former gap actions (kill/resume/budget/delete) now resolve to the real `cluster` verbs #149 landed.
- **Honest amber state** — `CliHint` gains a `noCliEquivalent` prop rendering an amber `◇` glyph whose tooltip says there is no CLI equivalent and whose click opens the tracking issue, instead of copying a misleading command. Only genuinely-unmapped actions (rollback, promote-to-prod) use it.
- **Sync invariants documented** in `cli/CLAUDE.md` (any `Command`/`*Action` change regenerates the committed manifest in the same change), `apps/ui/CLAUDE.md` (hints resolve via `cliCommand()`; never hardcode `agentos …`; new actions map to a command or `noCliEquivalent`), and one line in root `AGENTS.md` pointing at both.

## Dependency note
The surface JSX wiring that renders these hints is #279 (separate PR). This PR's registry + test + amber state stand alone: they validate against the committed manifest and the parity registry, independent of #279's JSX. When #279 merges, its surfaces render `CliHint` from these same mappings.

## Verify
Lint + typecheck clean, full UI suite green (114 tests, incl. the new parity + amber tests), no manifest drift.

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)