### PR TITLE
Bundle format: system prompt in the bundle manifest (#271)

### DIFF
--- a/packages/plugin-format/schema/plugin-format.schema.json
+++ b/packages/plugin-format/schema/plugin-format.schema.json
@@ -297,6 +297,18 @@
           "default": null,
           "title": "Repository"
         },
+        "systemPrompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Systemprompt"
+        },
         "version": {
           "anyOf": [
             {

--- a/packages/plugin-format/src/plugin_format/models.py
+++ b/packages/plugin-format/src/plugin_format/models.py
@@ -54,6 +54,11 @@ class PluginManifest(BaseModel):
     agents: str | list[str] | None = None
     hooks: str | dict[str, Any] | None = None
     mcpServers: str | dict[str, Any] | None = None
+    # AgentOS authoring extension (epic #30): the agent's system prompt, shipped
+    # in the bundle and versioned with it rather than only supplied out-of-band
+    # via the ``AGENTOS_SYSTEM_PROMPT`` env var. Inline prompt text; applied at
+    # runner boot, with the env var taking precedence for backward compatibility.
+    systemPrompt: str | None = None
 
 
 class SkillFrontmatter(BaseModel):

--- a/packages/plugin-format/tests/test_models.py
+++ b/packages/plugin-format/tests/test_models.py
@@ -35,3 +35,15 @@ def test_mcp_server_accepts_stdio_and_remote_shapes() -> None:
     remote = McpServer.model_validate({"type": "http", "url": "https://example.com"})
     assert stdio.command == "python"
     assert remote.url == "https://example.com"
+
+
+def test_manifest_system_prompt_field() -> None:
+    """The AgentOS ``systemPrompt`` authoring extension round-trips (#271)."""
+    manifest = PluginManifest.model_validate(
+        {"name": "demo", "systemPrompt": "Be terse; cite the CRM record, not the message."}
+    )
+    assert manifest.systemPrompt == "Be terse; cite the CRM record, not the message."
+    # Absent -> None (backward compatible; bundles without it still validate).
+    assert PluginManifest.model_validate({"name": "demo"}).systemPrompt is None
+    # Serializes back under the verbatim camelCase key.
+    assert manifest.model_dump(exclude_none=True)["systemPrompt"].startswith("Be terse")

--- a/runner/src/agentos_runner/__init__.py
+++ b/runner/src/agentos_runner/__init__.py
@@ -15,7 +15,7 @@ from .config import RunnerConfig
 from .conformance import conformance_producer
 from .fake import FakeModelSession
 from .otel import RunTracer, build_tracer_provider
-from .plugin import PluginBundleError, load_plugins
+from .plugin import PluginBundleError, load_bundle_system_prompt, load_plugins
 from .server import create_app
 from .session import SessionRunner
 from .side_effects import DEFAULT_IDEMPOTENT_TOOLS, SideEffectClassifier
@@ -35,6 +35,7 @@ __all__ = [
     "build_tracer_provider",
     "PluginBundleError",
     "load_plugins",
+    "load_bundle_system_prompt",
     "create_app",
     "SessionRunner",
     "SideEffectClassifier",

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -18,7 +18,7 @@ from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .otel import RunTracer, build_tracer_provider
-from .plugin import load_plugins
+from .plugin import load_bundle_system_prompt, load_plugins
 from .sdk_auth import UnsupportedCredentialError, resolve_sdk_env
 from .server import create_app
 from .session import SessionRunner
@@ -41,6 +41,13 @@ def build_runner(
     (OTel export included). It never reaches the Anthropic API.
     """
 
+    # The effective system prompt: the ``AGENTOS_SYSTEM_PROMPT`` env value wins
+    # for backward compatibility; otherwise fall back to the ``systemPrompt``
+    # shipped in the bundle manifest (versioned with the agent, epic #30).
+    system_prompt = config.system_prompt
+    if system_prompt is None:
+        system_prompt = load_bundle_system_prompt(config.session.plugin_dir)
+
     def factory() -> ModelSession:
         if fake_model:
             return FakeModelSession()
@@ -48,7 +55,7 @@ def build_runner(
         options = build_options(
             plugins=plugins,
             model=config.model,
-            system_prompt=config.system_prompt,
+            system_prompt=system_prompt,
             max_turns=config.max_turns,
             max_budget_usd=config.max_usd_per_day,
             resume=config.history_ref,

--- a/runner/src/agentos_runner/plugin.py
+++ b/runner/src/agentos_runner/plugin.py
@@ -9,14 +9,46 @@ a silent skip: a runner that booted with a broken bundle would answer with the
 wrong (empty) capability set.
 """
 
+import json
 from pathlib import Path
 
 from claude_agent_sdk import SdkPluginConfig
-from plugin_format import validate_bundle
+from plugin_format import PluginManifest, validate_bundle
+
+# The manifest lives at .claude-plugin/plugin.json; a bare plugin.json at the
+# bundle root is accepted as a fallback, mirroring plugin_format's own lookup.
+_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
 
 
 class PluginBundleError(RuntimeError):
     """Raised when the mounted plugin bundle fails validation."""
+
+
+def load_bundle_system_prompt(plugin_dir: str | None) -> str | None:
+    """Return the ``systemPrompt`` declared in the bundle manifest, if any.
+
+    The system prompt travels in the bundle (manifest field, epic #30) so it is
+    versioned with the agent rather than supplied only out-of-band via
+    ``AGENTOS_SYSTEM_PROMPT``. Returns ``None`` when there is no plugin dir, no
+    manifest, or no ``systemPrompt`` field. Best-effort and non-fatal: a bundle
+    that fails to parse here is caught by ``load_plugins`` at startup, which is
+    the authoritative validation gate, so this reader stays quiet.
+    """
+
+    if not plugin_dir:
+        return None
+    root = Path(plugin_dir)
+    manifest_path = next(
+        (root / loc for loc in _MANIFEST_LOCATIONS if (root / loc).is_file()), None
+    )
+    if manifest_path is None:
+        return None
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest = PluginManifest.model_validate(data)
+    except (json.JSONDecodeError, ValueError, OSError):
+        return None
+    return manifest.systemPrompt
 
 
 def load_plugins(plugin_dir: str | None) -> list[SdkPluginConfig]:

--- a/runner/tests/test_plugin.py
+++ b/runner/tests/test_plugin.py
@@ -23,3 +23,37 @@ def test_invalid_bundle_raises() -> None:
     bundle = _FIXTURES / "bad_manifest_name"
     with pytest.raises(PluginBundleError):
         load_plugins(str(bundle))
+
+
+def test_bundle_system_prompt_read_from_manifest(tmp_path: Path) -> None:
+    """The manifest ``systemPrompt`` is read from the bundle (epic #30, #271)."""
+    from agentos_runner import load_bundle_system_prompt
+
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(
+        '{"name": "demo", "systemPrompt": "Be terse and cite the CRM."}',
+        encoding="utf-8",
+    )
+    assert load_bundle_system_prompt(str(tmp_path)) == "Be terse and cite the CRM."
+
+
+def test_bundle_system_prompt_absent_is_none(tmp_path: Path) -> None:
+    from agentos_runner import load_bundle_system_prompt
+
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(
+        '{"name": "demo"}', encoding="utf-8"
+    )
+    assert load_bundle_system_prompt(str(tmp_path)) is None
+    # No plugin dir, and a dir with no manifest, both resolve to None.
+    assert load_bundle_system_prompt(None) is None
+    assert load_bundle_system_prompt("") is None
+
+
+def test_bundle_system_prompt_bad_manifest_is_none(tmp_path: Path) -> None:
+    """A malformed manifest is non-fatal here (load_plugins is the real gate)."""
+    from agentos_runner import load_bundle_system_prompt
+
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text("{ not json", encoding="utf-8")
+    assert load_bundle_system_prompt(str(tmp_path)) is None


### PR DESCRIPTION
Part of the bundle format & authoring extensions epic (#30). Interface: `docs/interfaces/bundle-format/INTERFACE.md`; frozen seam `packages/plugin-format`.

## What
The agent's system prompt now ships **in the bundle**, versioned with the agent, instead of only being supplied out-of-band via the `AGENTOS_SYSTEM_PROMPT` env var.

- **`packages/plugin-format`** — adds `systemPrompt: str | None` to `PluginManifest` (`.claude-plugin/plugin.json`). Lenient/additive and backward compatible (bundles without it validate unchanged). The committed JSON schema is regenerated in the same commit (`./scripts/check-contracts.sh` / `python -m plugin_format.schema_export`); `tests/test_schema_compat.py` stays green.
- **`runner`** — `load_bundle_system_prompt()` reads the manifest field from the mounted bundle; `build_runner` applies it at boot. **`AGENTOS_SYSTEM_PROMPT` takes precedence**, so the existing env path keeps working for compatibility.

## Frozen-contract discipline
This is an authorized frozen-contract change for `plugin-format` (the epic #30 authoring-extension mechanism — same as the sibling `hooks`/approval-policy tickets). No protocol version bump (plugin-format carries none). Schema regenerated and committed with the model change; the change is purely additive.

## Verify
`uv run pytest packages/plugin-format/tests runner/tests/test_plugin.py` green (34), plus runner smoke/config green; `uv run ruff check` + `uv run mypy` clean; schema drift-check clean.

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)