### PR TITLE
Bundle format: consume the manifest hooks field (PreToolUse guardrails) (#272)

### DIFF
--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -36,11 +36,14 @@ design so future Claude Code keys still validate.
 
 ## Known leakage
 
-By intent, the entire format is Claude-Code-shaped — that is the wedge, not a leak. The one live
-gap is the `hooks` field: it is modeled and preserved (`models.py:55`) but currently dead (no
-runner consumption). Epic #30 defines the meaning, validation contract, and runner consumption of
-`hooks` alongside new approval/trigger declarations, so the field's presence in the frozen shape is
-a placeholder the second consumer must not repurpose.
+By intent, the entire format is Claude-Code-shaped — that is the wedge, not a leak. The `hooks`
+field is no longer dead: as of #272 it is validated at deploy time (`HookMatcherConfig` /
+`HookDefinition` in `models.py`, enforced by `_validate_hooks` in `validate.py`) and its
+`PreToolUse` command hooks are consumed by the runner (`runner/src/agentos_runner/hooks.py`),
+which translates them into SDK `HookMatcher` guardrails that run before a matching tool call (exit 0
+allows, exit 2 denies). Only `PreToolUse` is wired today; other hook events validate but are not yet
+consumed. Epic #30 continues to define the remaining authoring extensions (approval-policy and
+trigger declarations) alongside this.
 
 ## Cross-links
 

--- a/packages/plugin-format/README.md
+++ b/packages/plugin-format/README.md
@@ -32,6 +32,18 @@ Pydantic models mirroring the Claude Code shapes:
 - `McpServer` / `McpConfig` (`.mcp.json`): `mcpServers` maps a name to a server
   that is either stdio (`command`, `args?`, `env?`) or remote (`type`, `url`,
   `headers?`).
+- `HookMatcherConfig` / `HookDefinition` (the manifest `hooks` field): `hooks`
+  may be an inline object or a path to a hooks JSON file, shaped
+  `{event: [{matcher?, hooks: [{type, command}]}]}` (the Claude Code hooks
+  structure). `matcher` is a tool-name pattern (`"Bash"`, `"Write|Edit"`; absent
+  = all tools); each action carries a `type` (today only `"command"`, which
+  requires a non-empty `command`). **Deploy-time validation** rejects a missing
+  hooks file, invalid JSON, a malformed shape, or a `command` hook with no
+  command. **Runner consumption** (`runner`): the manifest's `PreToolUse`
+  command hooks are translated into SDK `HookMatcher` callbacks and run before a
+  matching tool call — exit 0 allows, exit 2 denies (stderr = reason), any other
+  non-zero is a non-blocking hook error. Only `PreToolUse` is consumed today;
+  other events validate but are not yet wired.
 - `scripts/` is a directory convention (no manifest schema of its own).
 
 `validate_bundle(path) -> ValidationResult` is the entry point the bundle pipeline calls. It
@@ -48,7 +60,8 @@ if not result.valid:
 Error codes include `bundle.missing`, `manifest.missing`,
 `manifest.invalid_json`, `manifest.invalid`, `manifest.name_invalid`,
 `skill.frontmatter_missing`, `skill.frontmatter_invalid`, `mcp.invalid_json`,
-`mcp.server_incomplete`, `scripts.not_a_directory`.
+`mcp.server_incomplete`, `hooks.declared_missing`, `hooks.invalid_json`,
+`hooks.invalid`, `hooks.command_missing`, `scripts.not_a_directory`.
 
 ## Frozen-interface rule
 

--- a/packages/plugin-format/schema/plugin-format.schema.json
+++ b/packages/plugin-format/schema/plugin-format.schema.json
@@ -39,6 +39,60 @@
       "title": "Author",
       "type": "object"
     },
+    "HookDefinition": {
+      "additionalProperties": true,
+      "description": "One hook action inside a matcher's ``hooks`` list.\n\nThe Claude Code plugin ``hooks`` shape: a single action of a given ``type``.\nToday only ``type: \"command\"`` exists (run a shell command); ``command`` is\nrequired for it. Kept lenient so a future hook type still validates, but the\ndeploy-time validator (``validate.py``) enforces that a ``command`` hook\nactually carries a command so a malformed guardrail is caught before ship.",
+      "properties": {
+        "command": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Command"
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "HookDefinition",
+      "type": "object"
+    },
+    "HookMatcherConfig": {
+      "additionalProperties": true,
+      "description": "One matcher entry under a hook event (e.g. ``PreToolUse``).\n\n``matcher`` is a tool-name pattern (``\"Bash\"``, ``\"Write|Edit\"``; absent or\nempty means \"all tools\"); ``hooks`` is the list of actions to run when a tool\ncall matches. Mirrors the Claude Code hooks structure verbatim.",
+      "properties": {
+        "hooks": {
+          "items": {
+            "$ref": "#/$defs/HookDefinition"
+          },
+          "title": "Hooks",
+          "type": "array"
+        },
+        "matcher": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Matcher"
+        }
+      },
+      "title": "HookMatcherConfig",
+      "type": "object"
+    },
     "McpConfig": {
       "additionalProperties": true,
       "description": "The `.mcp.json` document.",

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -9,6 +9,8 @@ escalates to the orchestrator.
 from .archive import UnsupportedArchive, bundle_root, safe_extract
 from .models import (
     Author,
+    HookDefinition,
+    HookMatcherConfig,
     McpConfig,
     McpServer,
     PluginManifest,
@@ -25,6 +27,8 @@ __all__ = [
     "SkillFrontmatter",
     "McpServer",
     "McpConfig",
+    "HookDefinition",
+    "HookMatcherConfig",
     "validate_bundle",
     "ValidationResult",
     "ValidationIssue",

--- a/packages/plugin-format/src/plugin_format/models.py
+++ b/packages/plugin-format/src/plugin_format/models.py
@@ -76,6 +76,36 @@ class SkillFrontmatter(BaseModel):
     allowed_tools: list[str] | None = Field(default=None, alias="allowed-tools")
 
 
+class HookDefinition(BaseModel):
+    """One hook action inside a matcher's ``hooks`` list.
+
+    The Claude Code plugin ``hooks`` shape: a single action of a given ``type``.
+    Today only ``type: "command"`` exists (run a shell command); ``command`` is
+    required for it. Kept lenient so a future hook type still validates, but the
+    deploy-time validator (``validate.py``) enforces that a ``command`` hook
+    actually carries a command so a malformed guardrail is caught before ship.
+    """
+
+    model_config = _LENIENT
+
+    type: str
+    command: str | None = None
+
+
+class HookMatcherConfig(BaseModel):
+    """One matcher entry under a hook event (e.g. ``PreToolUse``).
+
+    ``matcher`` is a tool-name pattern (``"Bash"``, ``"Write|Edit"``; absent or
+    empty means "all tools"); ``hooks`` is the list of actions to run when a tool
+    call matches. Mirrors the Claude Code hooks structure verbatim.
+    """
+
+    model_config = _LENIENT
+
+    matcher: str | None = None
+    hooks: list[HookDefinition] = Field(default_factory=list)
+
+
 class McpServer(BaseModel):
     """One entry in `.mcp.json` mcpServers.
 

--- a/packages/plugin-format/src/plugin_format/schema_export.py
+++ b/packages/plugin-format/src/plugin_format/schema_export.py
@@ -10,9 +10,25 @@ from typing import Any
 
 from pydantic.json_schema import models_json_schema
 
-from .models import Author, McpConfig, McpServer, PluginManifest, SkillFrontmatter
+from .models import (
+    Author,
+    HookDefinition,
+    HookMatcherConfig,
+    McpConfig,
+    McpServer,
+    PluginManifest,
+    SkillFrontmatter,
+)
 
-_MODELS = (PluginManifest, Author, SkillFrontmatter, McpServer, McpConfig)
+_MODELS = (
+    PluginManifest,
+    Author,
+    SkillFrontmatter,
+    McpServer,
+    McpConfig,
+    HookMatcherConfig,
+    HookDefinition,
+)
 
 SCHEMA_ID = "https://curie.tech/agentos/plugin-format.schema.json"
 

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -11,9 +11,13 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
-from .models import McpConfig, PluginManifest, SkillFrontmatter
+from .models import HookMatcherConfig, McpConfig, PluginManifest, SkillFrontmatter
+
+# The hooks field is a mapping of event name -> list of matcher entries. Reused
+# to validate both the inline object and a declared hooks file.
+_HOOKS_ADAPTER = TypeAdapter(dict[str, list[HookMatcherConfig]])
 
 # Claude Code plugin names are kebab-case: lowercase alphanumerics and hyphens.
 _NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
@@ -66,6 +70,7 @@ def validate_bundle(path: str | Path) -> ValidationResult:
     if manifest is not None:
         _validate_skills(root, c)
         _validate_mcp(root, manifest, c)
+        _validate_hooks(root, manifest, c)
         _validate_scripts(root, c)
 
     return c.result()
@@ -186,6 +191,61 @@ def _validate_mcp_object(obj: object, location: str, c: _Collector) -> None:
                 f"mcp server {name!r} must define either 'command' (stdio) or 'url' (remote)",
                 location,
             )
+
+
+def _validate_hooks(root: Path, manifest: PluginManifest, c: _Collector) -> None:
+    """Validate the manifest ``hooks`` declaration (deploy-time gate, #272).
+
+    ``hooks`` may be an inline object or a path to a hooks JSON file; either form
+    must parse as ``{event: [ {matcher?, hooks: [{type, command}]} ]}``. A
+    ``command`` hook must carry a non-empty ``command`` so a malformed guardrail
+    is rejected before it ships (the runner enforces PreToolUse at run time).
+    """
+
+    declared = manifest.hooks
+    if declared is None:
+        return
+
+    if isinstance(declared, str):
+        hooks_path = root / declared
+        if not hooks_path.is_file():
+            c.error(
+                "hooks.declared_missing",
+                f"manifest hooks path {declared!r} was not found",
+                "plugin.json",
+            )
+            return
+        location = str(Path(declared))
+        try:
+            data: object = json.loads(hooks_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            c.error("hooks.invalid_json", f"{location} is not valid JSON: {exc}", location)
+            return
+    elif isinstance(declared, dict):
+        location = "plugin.json (hooks)"
+        data = declared
+    else:
+        c.error("hooks.invalid", "hooks must be an object or a path string", "plugin.json")
+        return
+
+    try:
+        parsed = _HOOKS_ADAPTER.validate_python(data)
+    except ValidationError as exc:
+        for issue in _explain(exc):
+            c.error("hooks.invalid", issue, location)
+        return
+
+    # Each command-type hook must actually declare a command.
+    for event, matchers in parsed.items():
+        for m_i, matcher in enumerate(matchers):
+            for h_i, hook in enumerate(matcher.hooks):
+                if hook.type == "command" and not (hook.command and hook.command.strip()):
+                    c.error(
+                        "hooks.command_missing",
+                        f"{event}[{m_i}].hooks[{h_i}]: a 'command' hook must define a "
+                        "non-empty command",
+                        location,
+                    )
 
 
 def _validate_scripts(root: Path, c: _Collector) -> None:

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -53,3 +53,50 @@ def test_error_messages_carry_location_and_are_actionable() -> None:
     issue = next(i for i in result.errors if i.code == "skill.frontmatter_invalid")
     assert issue.location.endswith("SKILL.md")
     assert "description" in issue.message
+
+
+def _bundle(tmp_path: Path, manifest: str) -> Path:
+    """Write a minimal valid bundle carrying the given manifest JSON."""
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(manifest, encoding="utf-8")
+    return tmp_path
+
+
+def test_inline_valid_pretooluse_hook_passes(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "hooks": {"PreToolUse": [{"matcher": "Bash", '
+        '"hooks": [{"type": "command", "command": "./guard.sh"}]}]}}',
+    )
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+
+
+def test_command_hook_without_command_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "hooks": {"PreToolUse": [{"matcher": "Bash", '
+        '"hooks": [{"type": "command"}]}]}}',
+    )
+    assert "hooks.command_missing" in _codes(bundle)
+
+
+def test_malformed_hooks_shape_is_rejected(tmp_path: Path) -> None:
+    # A matcher entry must be an object with a hooks list, not a bare string.
+    bundle = _bundle(tmp_path, '{"name": "demo", "hooks": {"PreToolUse": ["nope"]}}')
+    assert "hooks.invalid" in _codes(bundle)
+
+
+def test_declared_hooks_file_missing_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path, '{"name": "demo", "hooks": "hooks/hooks.json"}')
+    assert "hooks.declared_missing" in _codes(bundle)
+
+
+def test_declared_hooks_file_is_validated(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path, '{"name": "demo", "hooks": "hooks/hooks.json"}')
+    hooks_dir = bundle / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "hooks.json").write_text(
+        '{"PreToolUse": [{"hooks": [{"type": "command"}]}]}', encoding="utf-8"
+    )
+    assert "hooks.command_missing" in _codes(bundle)

--- a/runner/src/agentos_runner/__init__.py
+++ b/runner/src/agentos_runner/__init__.py
@@ -14,6 +14,7 @@ from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .config import RunnerConfig
 from .conformance import conformance_producer
 from .fake import FakeModelSession
+from .hooks import load_bundle_hooks
 from .otel import RunTracer, build_tracer_provider
 from .plugin import PluginBundleError, load_bundle_system_prompt, load_plugins
 from .server import create_app
@@ -36,6 +37,7 @@ __all__ = [
     "PluginBundleError",
     "load_plugins",
     "load_bundle_system_prompt",
+    "load_bundle_hooks",
     "create_app",
     "SessionRunner",
     "SideEffectClassifier",

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -17,6 +17,7 @@ from aiohttp import web
 from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .config import RunnerConfig
 from .fake import FakeModelSession
+from .hooks import load_bundle_hooks
 from .otel import RunTracer, build_tracer_provider
 from .plugin import load_bundle_system_prompt, load_plugins
 from .sdk_auth import UnsupportedCredentialError, resolve_sdk_env
@@ -47,6 +48,9 @@ def build_runner(
     system_prompt = config.system_prompt
     if system_prompt is None:
         system_prompt = load_bundle_system_prompt(config.session.plugin_dir)
+    # In-bundle PreToolUse guardrails declared in the manifest hooks field (#272),
+    # translated into SDK HookMatcher callbacks. None when the bundle declares none.
+    bundle_hooks = load_bundle_hooks(config.session.plugin_dir)
 
     def factory() -> ModelSession:
         if fake_model:
@@ -61,6 +65,7 @@ def build_runner(
             resume=config.history_ref,
             task_budget_hint=config.session.budget.task_budget_hint,
             env=sdk_env or {},
+            hooks=bundle_hooks,
         )
         return ClaudeAgentSession(options)
 

--- a/runner/src/agentos_runner/adapter.py
+++ b/runner/src/agentos_runner/adapter.py
@@ -16,9 +16,15 @@ this boundary and nothing above it is. ``aci-protocol`` is never mocked.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
-from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, SdkPluginConfig, TaskBudget
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    HookMatcher,
+    SdkPluginConfig,
+    TaskBudget,
+)
 
 
 class ModelSession(Protocol):
@@ -55,6 +61,7 @@ def build_options(
     resume: str | None,
     task_budget_hint: int | None = None,
     env: dict[str, str] | None = None,
+    hooks: dict[str, list[HookMatcher]] | None = None,
 ) -> ClaudeAgentOptions:
     """Assemble ClaudeAgentOptions for the session.
 
@@ -81,6 +88,10 @@ def build_options(
         task_budget=task_budget,
         permission_mode="bypassPermissions",
         env=env or {},
+        # In-bundle PreToolUse guardrails from the manifest hooks field (#272).
+        # Empty/None means no bundle hooks; the SDK default applies. The event
+        # keys are the SDK's HookEvent literals (we emit only "PreToolUse").
+        hooks=cast("Any", hooks),
     )
 
 

--- a/runner/src/agentos_runner/hooks.py
+++ b/runner/src/agentos_runner/hooks.py
@@ -1,0 +1,184 @@
+"""Consume the bundle manifest ``hooks`` field as SDK PreToolUse guardrails.
+
+The plugin-format ``hooks`` declaration (validated at deploy by
+``plugin_format.validate_bundle``) gives builders deterministic, in-bundle
+guardrails that complement platform-level gates. This module reads that
+declaration from the mounted bundle and translates its **PreToolUse** entries
+into ``claude_agent_sdk`` ``HookMatcher`` callbacks, so a declared command runs
+before a matching tool call and can block it.
+
+Only ``PreToolUse`` is consumed here (the deterministic before-the-tool gate the
+issue scopes); other events are validated by plugin-format but not yet wired.
+Each ``type: "command"`` hook runs the command through ``/bin/sh -c`` with the
+hook input JSON on stdin, following the Claude Code convention: exit 0 allows the
+tool call, exit 2 denies it (stderr is the reason), any other non-zero is a
+non-blocking hook error that lets the call proceed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from claude_agent_sdk import HookMatcher
+from plugin_format import HookMatcherConfig, PluginManifest
+from pydantic import TypeAdapter, ValidationError
+
+_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
+_HOOKS_ADAPTER = TypeAdapter(dict[str, list[HookMatcherConfig]])
+
+# Deny convention (Claude Code): a command hook that exits with this code blocks
+# the tool call; its stderr becomes the reason surfaced to the model.
+_DENY_EXIT_CODE = 2
+_HOOK_TIMEOUT_S = 60.0
+
+
+def _load_manifest_hooks(plugin_dir: str | None) -> dict[str, list[HookMatcherConfig]] | None:
+    """Read + parse the manifest ``hooks`` declaration from the bundle.
+
+    Returns the parsed hooks mapping, or ``None`` when there is no plugin dir, no
+    manifest, or no ``hooks`` field. Best-effort: a bundle that fails to parse
+    here is caught by ``load_plugins``/``validate_bundle`` at startup, the
+    authoritative gate, so this stays quiet.
+    """
+
+    if not plugin_dir:
+        return None
+    root = Path(plugin_dir)
+    manifest_path = next(
+        (root / loc for loc in _MANIFEST_LOCATIONS if (root / loc).is_file()), None
+    )
+    if manifest_path is None:
+        return None
+    try:
+        manifest = PluginManifest.model_validate(
+            json.loads(manifest_path.read_text(encoding="utf-8"))
+        )
+    except (json.JSONDecodeError, ValueError, OSError):
+        return None
+
+    declared = manifest.hooks
+    if declared is None:
+        return None
+    if isinstance(declared, str):
+        hooks_path = root / declared
+        if not hooks_path.is_file():
+            return None
+        try:
+            data: object = json.loads(hooks_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+    else:
+        data = declared
+
+    try:
+        return _HOOKS_ADAPTER.validate_python(data)
+    except ValidationError:
+        return None
+
+
+async def _run_command_hook(command: str, hook_input: Any) -> dict[str, Any]:
+    """Run one command hook and map its exit to a PreToolUse decision.
+
+    exit 0 -> allow (empty output, proceed); exit ``_DENY_EXIT_CODE`` -> deny with
+    the command's stderr as the reason; any other exit -> non-blocking error.
+    """
+
+    try:
+        payload = json.dumps(hook_input, default=str)
+    except (TypeError, ValueError):
+        payload = "{}"
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "/bin/sh",
+            "-c",
+            command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await asyncio.wait_for(
+            proc.communicate(input=payload.encode("utf-8")), timeout=_HOOK_TIMEOUT_S
+        )
+    except (TimeoutError, OSError) as exc:
+        # A hook that cannot run is a non-blocking error: surface context but do
+        # not silently deny the tool (deploy-time validation already rejected
+        # malformed declarations).
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": f"bundle hook failed to run: {exc}",
+            }
+        }
+
+    if proc.returncode == _DENY_EXIT_CODE:
+        reason = err.decode("utf-8", "replace").strip() or "blocked by bundle PreToolUse hook"
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }
+    if proc.returncode not in (0, _DENY_EXIT_CODE):
+        context = err.decode("utf-8", "replace").strip() or out.decode("utf-8", "replace").strip()
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": f"bundle hook exited {proc.returncode}: {context}",
+            }
+        }
+    return {}
+
+
+def _make_callback(commands: list[str]) -> Any:
+    """Build one SDK hook callback that runs each command hook in order.
+
+    The first command to deny wins (short-circuits); otherwise the tool proceeds.
+    """
+
+    async def _callback(hook_input: Any, _tool_use_id: str | None, _ctx: Any) -> dict[str, Any]:
+        for command in commands:
+            result = await _run_command_hook(command, hook_input)
+            decision = result.get("hookSpecificOutput", {}).get("permissionDecision")
+            if decision == "deny":
+                return result
+        return {}
+
+    return _callback
+
+
+def load_bundle_hooks(plugin_dir: str | None) -> dict[str, list[HookMatcher]] | None:
+    """Translate the bundle's PreToolUse hooks into SDK ``HookMatcher`` config.
+
+    Returns a ``{"PreToolUse": [HookMatcher, ...]}`` mapping for
+    ``ClaudeAgentOptions.hooks``, or ``None`` when the bundle declares no usable
+    PreToolUse command hooks. Non-command hook actions are skipped (only
+    ``type: "command"`` is executable here); other events are ignored for now.
+    """
+
+    parsed = _load_manifest_hooks(plugin_dir)
+    if not parsed:
+        return None
+
+    pre_tool_use = parsed.get("PreToolUse")
+    if not pre_tool_use:
+        return None
+
+    matchers: list[HookMatcher] = []
+    for entry in pre_tool_use:
+        commands = [
+            h.command
+            for h in entry.hooks
+            if h.type == "command" and h.command and h.command.strip()
+        ]
+        if not commands:
+            continue
+        matchers.append(HookMatcher(matcher=entry.matcher, hooks=[_make_callback(commands)]))
+
+    if not matchers:
+        return None
+    return {"PreToolUse": matchers}

--- a/runner/tests/test_hooks.py
+++ b/runner/tests/test_hooks.py
@@ -1,0 +1,120 @@
+"""Bundle PreToolUse hook consumption (#272): manifest -> SDK HookMatcher."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import anyio
+from agentos_runner import load_bundle_hooks
+
+
+def _bundle(tmp_path: Path, hooks: object) -> str:
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "demo", "hooks": hooks}), encoding="utf-8"
+    )
+    return str(tmp_path)
+
+
+def test_no_bundle_or_no_hooks_is_none(tmp_path: Path) -> None:
+    assert load_bundle_hooks(None) is None
+    assert load_bundle_hooks("") is None
+    # A manifest without hooks.
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(
+        '{"name": "demo"}', encoding="utf-8"
+    )
+    assert load_bundle_hooks(str(tmp_path)) is None
+
+
+def test_pretooluse_command_hook_becomes_matcher(tmp_path: Path) -> None:
+    plugin_dir = _bundle(
+        tmp_path,
+        {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "true"}]}]},
+    )
+    hooks = load_bundle_hooks(plugin_dir)
+    assert hooks is not None
+    matchers = hooks["PreToolUse"]
+    assert len(matchers) == 1
+    assert matchers[0].matcher == "Bash"
+    assert len(matchers[0].hooks) == 1  # one callback wrapping the command(s)
+
+
+def test_non_pretooluse_events_are_ignored(tmp_path: Path) -> None:
+    plugin_dir = _bundle(
+        tmp_path,
+        {"PostToolUse": [{"hooks": [{"type": "command", "command": "true"}]}]},
+    )
+    assert load_bundle_hooks(plugin_dir) is None
+
+
+def test_non_command_hook_actions_are_skipped(tmp_path: Path) -> None:
+    plugin_dir = _bundle(
+        tmp_path,
+        {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "someFutureType"}]}]},
+    )
+    assert load_bundle_hooks(plugin_dir) is None
+
+
+def test_hook_callback_denies_on_exit_2(tmp_path: Path) -> None:
+    plugin_dir = _bundle(
+        tmp_path,
+        {
+            "PreToolUse": [
+                {"hooks": [{"type": "command", "command": "echo blocked 1>&2; exit 2"}]}
+            ]
+        },
+    )
+    hooks = load_bundle_hooks(plugin_dir)
+    assert hooks is not None
+    callback = hooks["PreToolUse"][0].hooks[0]
+
+    async def go() -> dict:
+        return await callback({"tool_name": "Bash", "tool_input": {}}, "tuid", {})
+
+    out = anyio.run(go)
+    decision = out["hookSpecificOutput"]
+    assert decision["hookEventName"] == "PreToolUse"
+    assert decision["permissionDecision"] == "deny"
+    assert "blocked" in decision["permissionDecisionReason"]
+
+
+def test_hook_callback_allows_on_exit_0(tmp_path: Path) -> None:
+    plugin_dir = _bundle(
+        tmp_path,
+        {"PreToolUse": [{"hooks": [{"type": "command", "command": "exit 0"}]}]},
+    )
+    hooks = load_bundle_hooks(plugin_dir)
+    assert hooks is not None
+    callback = hooks["PreToolUse"][0].hooks[0]
+
+    async def go() -> dict:
+        return await callback({"tool_name": "Bash", "tool_input": {}}, "tuid", {})
+
+    assert anyio.run(go) == {}
+
+
+def test_first_denying_command_short_circuits(tmp_path: Path) -> None:
+    plugin_dir = _bundle(
+        tmp_path,
+        {
+            "PreToolUse": [
+                {
+                    "hooks": [
+                        {"type": "command", "command": "exit 0"},
+                        {"type": "command", "command": "echo no 1>&2; exit 2"},
+                    ]
+                }
+            ]
+        },
+    )
+    hooks = load_bundle_hooks(plugin_dir)
+    assert hooks is not None
+    callback = hooks["PreToolUse"][0].hooks[0]
+
+    async def go() -> dict:
+        return await callback({"tool_name": "Bash", "tool_input": {}}, "tuid", {})
+
+    out = anyio.run(go)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"


### PR DESCRIPTION
Part of the bundle format & authoring extensions epic (#30). Frozen seam: `packages/plugin-format`.

## What
The manifest `hooks` field was modeled and preserved but **never validated or consumed** (the interface doc's one "known leakage"). This lands both halves:

**Deploy-time validation (`packages/plugin-format`)**
- New `HookMatcherConfig` / `HookDefinition` models and `_validate_hooks`.
- `hooks` may be an inline object or a path to a hooks JSON file, shaped `{event: [{matcher?, hooks: [{type, command}]}]}`.
- A missing hooks file, invalid JSON, a malformed shape, or a `command` hook with no command is **rejected at deploy** (`hooks.declared_missing` / `hooks.invalid_json` / `hooks.invalid` / `hooks.command_missing`).

**Run-time enforcement (`runner`)**
- `load_bundle_hooks()` translates the manifest's **PreToolUse** command hooks into SDK `HookMatcher` callbacks, wired via `ClaudeAgentOptions.hooks`.
- A declared command runs before a matching tool call: **exit 0 allows, exit 2 denies** (stderr = reason surfaced to the model), any other non-zero is a non-blocking hook error.
- Scope: only `PreToolUse` is consumed today (the deterministic before-the-tool gate the issue scopes); other events validate but are not yet wired — noted in code + docs.

## Frozen-contract discipline
Committed JSON schema regenerated with the model change (`./scripts/check-contracts.sh` / `python -m plugin_format.schema_export`); `test_schema_compat.py` stays green. Additive/backward-compatible; no protocol-version bump (plugin-format carries none). `plugin-format` base models stay lenient (`extra="allow"`); the new hook models validate the load-bearing fields so a malformed guardrail is caught.

## Docs
`hooks` contract documented in the plugin-format README and `docs/interfaces/bundle-format/INTERFACE.md` (no longer the dead field).

## Verify
`uv run pytest packages/plugin-format/tests runner/tests/test_hooks.py runner/tests/test_plugin.py runner/tests/test_smoke.py` green (53), incl. deny-on-exit-2 / allow-on-exit-0 / short-circuit callback tests; `uv run ruff check` + `uv run mypy` clean; schema drift-check clean.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)