### PR TITLE
Bundle format: approval-policy + trigger declarations in the manifest (#273)

### DIFF
--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -45,6 +45,14 @@ allows, exit 2 denies). Only `PreToolUse` is wired today; other hook events vali
 consumed. Epic #30 continues to define the remaining authoring extensions (approval-policy and
 trigger declarations) alongside this.
 
+The bundle also carries two AgentOS authoring extensions that are **deploy-time validated** (shape
+enforced, malformed declarations rejected) but whose **runtime consumption is a separate not-yet-built
+seam**: `triggers` (a list of `cron`/`webhook` declarations for waking the agent beyond chat, #273/#270
+— see the [triggers seam](../triggers/INTERFACE.md)) and `approvalPolicy` (`{gates: [{gate, route}]}`
+approval declarations, #273). Their validators live alongside the others in `validate.py`
+(`triggers.*` / `approval_policy.*` error codes); a future kernel/ingress consumer reads these same
+declarations.
+
 ## Cross-links
 
 - **Guide:** [workflow-agent-conversion.md](./workflow-agent-conversion.md) — converting an existing workflow agent (deterministic pipeline + LLM at the edges) onto a bundle end to end (#275).

--- a/docs/interfaces/triggers/INTERFACE.md
+++ b/docs/interfaces/triggers/INTERFACE.md
@@ -33,6 +33,14 @@ another hardcoded handler. The two that exist:
 The two share no abstraction: one is a Slack Bolt event listener, the other a FastAPI
 route with GitHub HMAC auth. They converge only downstream (both end up enqueuing work).
 
+**Declaration vs. consumption (#273/#270).** The bundle manifest now carries deploy-time-validated
+`triggers` declarations (`cron` with a `schedule`, `webhook` with a `path`; `TriggerDeclaration` in
+`packages/plugin-format`, `triggers.*` validation codes), so an agent's non-chat wake-ups ship in one
+reviewable artifact and a malformed declaration is rejected at deploy. This is the *declaration*
+surface only — the *runtime* that acts on a declared trigger (a cron scheduler, a per-agent webhook
+ingress) is still the open Epic #29 question above and is not built. Declaring a trigger validates its
+shape; it does not yet wire a live wake-up.
+
 ## Implementations today
 
 Two, both hardcoded, in two different processes:

--- a/packages/plugin-format/README.md
+++ b/packages/plugin-format/README.md
@@ -44,6 +44,20 @@ Pydantic models mirroring the Claude Code shapes:
   matching tool call — exit 0 allows, exit 2 denies (stderr = reason), any other
   non-zero is a non-blocking hook error. Only `PreToolUse` is consumed today;
   other events validate but are not yet wired.
+- `TriggerDeclaration` (the manifest `triggers` field, an AgentOS extension for
+  triggers beyond chat, #273/#270): a list of `{type, ...}`. `type` is `cron`
+  (requires a non-empty `schedule` cron expression) or `webhook` (requires a
+  non-empty `path`). Declaring triggers in the bundle keeps an agent's full
+  wake-up behavior in one reviewable artifact. **Deploy-time validation** rejects
+  an unknown type, a cron trigger without a schedule, or a webhook trigger
+  without a path. Runtime consumption (kernel cron scheduling / webhook ingress)
+  is a separate not-yet-built seam (see `docs/interfaces/triggers/INTERFACE.md`),
+  so this is validation only today.
+- `ApprovalPolicy` / `ApprovalGate` (the manifest `approvalPolicy` field, #273):
+  `{gates: [{gate, route}]}` — each gate names a pause point and the approval
+  route that decides it; both are required. **Deploy-time validation** rejects a
+  malformed policy or a gate missing `gate`/`route`. Runtime approval routing is
+  a separate not-yet-built seam, so this is validation only today.
 - `scripts/` is a directory convention (no manifest schema of its own).
 
 `validate_bundle(path) -> ValidationResult` is the entry point the bundle pipeline calls. It
@@ -61,7 +75,10 @@ Error codes include `bundle.missing`, `manifest.missing`,
 `manifest.invalid_json`, `manifest.invalid`, `manifest.name_invalid`,
 `skill.frontmatter_missing`, `skill.frontmatter_invalid`, `mcp.invalid_json`,
 `mcp.server_incomplete`, `hooks.declared_missing`, `hooks.invalid_json`,
-`hooks.invalid`, `hooks.command_missing`, `scripts.not_a_directory`.
+`hooks.invalid`, `hooks.command_missing`, `triggers.invalid`,
+`triggers.unknown_type`, `triggers.cron_missing_schedule`,
+`triggers.webhook_missing_path`, `approval_policy.invalid`,
+`approval_policy.incomplete`, `scripts.not_a_directory`.
 
 ## Frozen-interface rule
 

--- a/packages/plugin-format/schema/plugin-format.schema.json
+++ b/packages/plugin-format/schema/plugin-format.schema.json
@@ -1,5 +1,40 @@
 {
   "$defs": {
+    "ApprovalGate": {
+      "additionalProperties": true,
+      "description": "One approval gate declaration: a gate point plus the route it sends to.\n\n``gate`` names the point at which the agent pauses for approval (e.g. a tool\nclass or lifecycle point); ``route`` names the approval route that decides.\nBoth are required \u2014 an incomplete gate is rejected at deploy.",
+      "properties": {
+        "gate": {
+          "title": "Gate",
+          "type": "string"
+        },
+        "route": {
+          "title": "Route",
+          "type": "string"
+        }
+      },
+      "required": [
+        "gate",
+        "route"
+      ],
+      "title": "ApprovalGate",
+      "type": "object"
+    },
+    "ApprovalPolicy": {
+      "additionalProperties": true,
+      "description": "The manifest ``approvalPolicy`` object: a list of gate declarations.",
+      "properties": {
+        "gates": {
+          "items": {
+            "$ref": "#/$defs/ApprovalGate"
+          },
+          "title": "Gates",
+          "type": "array"
+        }
+      },
+      "title": "ApprovalPolicy",
+      "type": "object"
+    },
     "Author": {
       "additionalProperties": true,
       "description": "The plugin manifest author object (or it may be a plain string).",
@@ -219,6 +254,19 @@
           "default": null,
           "title": "Agents"
         },
+        "approvalPolicy": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Approvalpolicy"
+        },
         "author": {
           "anyOf": [
             {
@@ -363,6 +411,19 @@
           "default": null,
           "title": "Systemprompt"
         },
+        "triggers": {
+          "anyOf": [
+            {
+              "items": {},
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Triggers"
+        },
         "version": {
           "anyOf": [
             {
@@ -415,6 +476,45 @@
         "description"
       ],
       "title": "SkillFrontmatter",
+      "type": "object"
+    },
+    "TriggerDeclaration": {
+      "additionalProperties": true,
+      "description": "One trigger that can wake the agent, declared in the bundle (#273/#270).\n\n``type`` is ``\"cron\"`` (requires a ``schedule`` cron expression) or\n``\"webhook\"`` (requires a ``path`` the webhook ingress routes to). Declaring\ntriggers in the bundle keeps an agent's full behavior in one reviewable\nartifact; the kernel/ingress consumes them (not built here \u2014 deploy-time\nvalidation only, so a malformed declaration is rejected before ship).",
+      "properties": {
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Schedule"
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "TriggerDeclaration",
       "type": "object"
     }
   },

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -8,6 +8,8 @@ escalates to the orchestrator.
 
 from .archive import UnsupportedArchive, bundle_root, safe_extract
 from .models import (
+    ApprovalGate,
+    ApprovalPolicy,
     Author,
     HookDefinition,
     HookMatcherConfig,
@@ -15,6 +17,7 @@ from .models import (
     McpServer,
     PluginManifest,
     SkillFrontmatter,
+    TriggerDeclaration,
 )
 from .validate import ValidationIssue, ValidationResult, validate_bundle
 
@@ -29,6 +32,9 @@ __all__ = [
     "McpConfig",
     "HookDefinition",
     "HookMatcherConfig",
+    "TriggerDeclaration",
+    "ApprovalPolicy",
+    "ApprovalGate",
     "validate_bundle",
     "ValidationResult",
     "ValidationIssue",

--- a/packages/plugin-format/src/plugin_format/models.py
+++ b/packages/plugin-format/src/plugin_format/models.py
@@ -59,6 +59,56 @@ class PluginManifest(BaseModel):
     # via the ``AGENTOS_SYSTEM_PROMPT`` env var. Inline prompt text; applied at
     # runner boot, with the env var taking precedence for backward compatibility.
     systemPrompt: str | None = None
+    # AgentOS authoring extensions (epic #30 / #29), validated at deploy time by
+    # ``validate.py``. Kept loosely typed on the manifest (the models stay
+    # lenient); the dedicated ``TriggerDeclaration`` / ``ApprovalPolicy`` models
+    # below carry the shape the validator enforces.
+    triggers: list[Any] | None = None
+    approvalPolicy: dict[str, Any] | None = None
+
+
+# Trigger types the manifest may declare beyond inbound chat (epic #29). The
+# validator enforces the per-type required field.
+_TRIGGER_TYPES = ("cron", "webhook")
+
+
+class TriggerDeclaration(BaseModel):
+    """One trigger that can wake the agent, declared in the bundle (#273/#270).
+
+    ``type`` is ``"cron"`` (requires a ``schedule`` cron expression) or
+    ``"webhook"`` (requires a ``path`` the webhook ingress routes to). Declaring
+    triggers in the bundle keeps an agent's full behavior in one reviewable
+    artifact; the kernel/ingress consumes them (not built here — deploy-time
+    validation only, so a malformed declaration is rejected before ship).
+    """
+
+    model_config = _LENIENT
+
+    type: str
+    schedule: str | None = None
+    path: str | None = None
+
+
+class ApprovalGate(BaseModel):
+    """One approval gate declaration: a gate point plus the route it sends to.
+
+    ``gate`` names the point at which the agent pauses for approval (e.g. a tool
+    class or lifecycle point); ``route`` names the approval route that decides.
+    Both are required — an incomplete gate is rejected at deploy.
+    """
+
+    model_config = _LENIENT
+
+    gate: str
+    route: str
+
+
+class ApprovalPolicy(BaseModel):
+    """The manifest ``approvalPolicy`` object: a list of gate declarations."""
+
+    model_config = _LENIENT
+
+    gates: list[ApprovalGate] = Field(default_factory=list)
 
 
 class SkillFrontmatter(BaseModel):

--- a/packages/plugin-format/src/plugin_format/schema_export.py
+++ b/packages/plugin-format/src/plugin_format/schema_export.py
@@ -11,6 +11,8 @@ from typing import Any
 from pydantic.json_schema import models_json_schema
 
 from .models import (
+    ApprovalGate,
+    ApprovalPolicy,
     Author,
     HookDefinition,
     HookMatcherConfig,
@@ -18,6 +20,7 @@ from .models import (
     McpServer,
     PluginManifest,
     SkillFrontmatter,
+    TriggerDeclaration,
 )
 
 _MODELS = (
@@ -28,6 +31,9 @@ _MODELS = (
     McpConfig,
     HookMatcherConfig,
     HookDefinition,
+    TriggerDeclaration,
+    ApprovalPolicy,
+    ApprovalGate,
 )
 
 SCHEMA_ID = "https://curie.tech/agentos/plugin-format.schema.json"

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -13,11 +13,20 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
-from .models import HookMatcherConfig, McpConfig, PluginManifest, SkillFrontmatter
+from .models import (
+    _TRIGGER_TYPES,
+    ApprovalPolicy,
+    HookMatcherConfig,
+    McpConfig,
+    PluginManifest,
+    SkillFrontmatter,
+    TriggerDeclaration,
+)
 
 # The hooks field is a mapping of event name -> list of matcher entries. Reused
 # to validate both the inline object and a declared hooks file.
 _HOOKS_ADAPTER = TypeAdapter(dict[str, list[HookMatcherConfig]])
+_TRIGGERS_ADAPTER = TypeAdapter(list[TriggerDeclaration])
 
 # Claude Code plugin names are kebab-case: lowercase alphanumerics and hyphens.
 _NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
@@ -71,6 +80,8 @@ def validate_bundle(path: str | Path) -> ValidationResult:
         _validate_skills(root, c)
         _validate_mcp(root, manifest, c)
         _validate_hooks(root, manifest, c)
+        _validate_triggers(manifest, c)
+        _validate_approval_policy(manifest, c)
         _validate_scripts(root, c)
 
     return c.result()
@@ -246,6 +257,88 @@ def _validate_hooks(root: Path, manifest: PluginManifest, c: _Collector) -> None
                         "non-empty command",
                         location,
                     )
+
+
+def _validate_triggers(manifest: PluginManifest, c: _Collector) -> None:
+    """Validate the manifest ``triggers`` declarations (deploy-time gate, #273).
+
+    ``triggers`` is a list of ``{type, ...}``. ``type`` must be a known kind
+    (``cron``/``webhook``); a ``cron`` trigger requires a non-empty ``schedule``
+    and a ``webhook`` trigger a non-empty ``path``. Malformed declarations are
+    rejected at deploy so an agent's non-chat wake-ups fail loudly before ship.
+    """
+
+    declared = manifest.triggers
+    if declared is None:
+        return
+    if not isinstance(declared, list):
+        c.error("triggers.invalid", "triggers must be a list of declarations", "plugin.json")
+        return
+
+    try:
+        parsed = _TRIGGERS_ADAPTER.validate_python(declared)
+    except ValidationError as exc:
+        for issue in _explain(exc):
+            c.error("triggers.invalid", issue, "plugin.json (triggers)")
+        return
+
+    for i, trigger in enumerate(parsed):
+        loc = f"plugin.json (triggers[{i}])"
+        if trigger.type not in _TRIGGER_TYPES:
+            c.error(
+                "triggers.unknown_type",
+                f"trigger type {trigger.type!r} is not one of {list(_TRIGGER_TYPES)}",
+                loc,
+            )
+            continue
+        if trigger.type == "cron" and not (trigger.schedule and trigger.schedule.strip()):
+            c.error(
+                "triggers.cron_missing_schedule",
+                "a 'cron' trigger must define a non-empty 'schedule'",
+                loc,
+            )
+        if trigger.type == "webhook" and not (trigger.path and trigger.path.strip()):
+            c.error(
+                "triggers.webhook_missing_path",
+                "a 'webhook' trigger must define a non-empty 'path'",
+                loc,
+            )
+
+
+def _validate_approval_policy(manifest: PluginManifest, c: _Collector) -> None:
+    """Validate the manifest ``approvalPolicy`` declaration (deploy-time, #273).
+
+    Shape ``{gates: [{gate, route}]}``: each gate names a pause point and the
+    route that decides. A malformed policy or a gate missing its ``gate``/``route``
+    is rejected at deploy.
+    """
+
+    declared = manifest.approvalPolicy
+    if declared is None:
+        return
+    if not isinstance(declared, dict):
+        c.error(
+            "approval_policy.invalid",
+            "approvalPolicy must be an object with a 'gates' list",
+            "plugin.json",
+        )
+        return
+
+    try:
+        policy = ApprovalPolicy.model_validate(declared)
+    except ValidationError as exc:
+        for issue in _explain(exc):
+            c.error("approval_policy.invalid", issue, "plugin.json (approvalPolicy)")
+        return
+
+    for i, gate in enumerate(policy.gates):
+        loc = f"plugin.json (approvalPolicy.gates[{i}])"
+        if not (gate.gate and gate.gate.strip()) or not (gate.route and gate.route.strip()):
+            c.error(
+                "approval_policy.incomplete",
+                "an approval gate must define a non-empty 'gate' and 'route'",
+                loc,
+            )
 
 
 def _validate_scripts(root: Path, c: _Collector) -> None:

--- a/packages/plugin-format/tests/test_models.py
+++ b/packages/plugin-format/tests/test_models.py
@@ -47,3 +47,19 @@ def test_manifest_system_prompt_field() -> None:
     assert PluginManifest.model_validate({"name": "demo"}).systemPrompt is None
     # Serializes back under the verbatim camelCase key.
     assert manifest.model_dump(exclude_none=True)["systemPrompt"].startswith("Be terse")
+
+
+def test_manifest_trigger_and_approval_policy_fields() -> None:
+    """The AgentOS trigger + approval-policy authoring extensions parse (#273)."""
+    manifest = PluginManifest.model_validate(
+        {
+            "name": "demo",
+            "triggers": [{"type": "cron", "schedule": "0 9 * * 1-5"}],
+            "approvalPolicy": {"gates": [{"gate": "PreToolUse", "route": "manager"}]},
+        }
+    )
+    assert manifest.triggers == [{"type": "cron", "schedule": "0 9 * * 1-5"}]
+    assert manifest.approvalPolicy == {"gates": [{"gate": "PreToolUse", "route": "manager"}]}
+    # Absent -> None (backward compatible).
+    bare = PluginManifest.model_validate({"name": "demo"})
+    assert bare.triggers is None and bare.approvalPolicy is None

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -9,6 +9,13 @@ def _codes(path: Path) -> set[str]:
     return {issue.code for issue in validate_bundle(path).errors}
 
 
+def _bundle(tmp_path: Path, manifest: str) -> Path:
+    """Write a minimal bundle carrying the given manifest JSON."""
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(manifest, encoding="utf-8")
+    return tmp_path
+
+
 def test_valid_bundle_passes() -> None:
     result = validate_bundle(FIXTURES / "valid_bundle")
     assert result.valid, result.errors
@@ -100,3 +107,75 @@ def test_declared_hooks_file_is_validated(tmp_path: Path) -> None:
         '{"PreToolUse": [{"hooks": [{"type": "command"}]}]}', encoding="utf-8"
     )
     assert "hooks.command_missing" in _codes(bundle)
+
+
+def test_valid_cron_and_webhook_triggers_pass(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "triggers": ['
+        '{"type": "cron", "schedule": "0 9 * * 1-5"}, '
+        '{"type": "webhook", "path": "/hooks/deploy"}]}',
+    )
+    assert validate_bundle(bundle).valid
+
+
+def test_cron_trigger_without_schedule_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path, '{"name": "demo", "triggers": [{"type": "cron"}]}')
+    assert "triggers.cron_missing_schedule" in _codes(bundle)
+
+
+def test_webhook_trigger_without_path_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path, '{"name": "demo", "triggers": [{"type": "webhook"}]}')
+    assert "triggers.webhook_missing_path" in _codes(bundle)
+
+
+def test_unknown_trigger_type_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path, '{"name": "demo", "triggers": [{"type": "kafka"}]}')
+    assert "triggers.unknown_type" in _codes(bundle)
+
+
+def test_malformed_triggers_shape_is_rejected(tmp_path: Path) -> None:
+    # A non-list triggers value is rejected (the manifest type gate catches it).
+    bundle = _bundle(tmp_path, '{"name": "demo", "triggers": "nope"}')
+    assert not validate_bundle(bundle).valid
+
+
+def test_trigger_entry_not_object_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path, '{"name": "demo", "triggers": ["nope"]}')
+    assert "triggers.invalid" in _codes(bundle)
+
+
+def test_valid_approval_policy_passes(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "PreToolUse", "route": "manager-approval"}]}}',
+    )
+    assert validate_bundle(bundle).valid
+
+
+def test_approval_gate_missing_route_is_rejected(tmp_path: Path) -> None:
+    # A gate missing its 'route' field entirely -> policy fails to validate.
+    bundle = _bundle(
+        tmp_path, '{"name": "demo", "approvalPolicy": {"gates": [{"gate": "PreToolUse"}]}}'
+    )
+    assert "approval_policy.invalid" in _codes(bundle)
+
+
+def test_approval_gate_empty_fields_are_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": [{"gate": " ", "route": "r"}]}}',
+    )
+    assert "approval_policy.incomplete" in _codes(bundle)
+
+
+def test_malformed_approval_policy_shape_is_rejected(tmp_path: Path) -> None:
+    # A non-object approvalPolicy is rejected (the manifest type gate catches it).
+    bundle = _bundle(tmp_path, '{"name": "demo", "approvalPolicy": "nope"}')
+    assert not validate_bundle(bundle).valid
+
+
+def test_approval_policy_gates_wrong_type_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path, '{"name": "demo", "approvalPolicy": {"gates": "nope"}}')
+    assert "approval_policy.invalid" in _codes(bundle)


### PR DESCRIPTION
Part of the bundle format & authoring extensions epic (#30), coordinating with triggers-beyond-chat (#29). Frozen seam: `packages/plugin-format`.

## What
Adds two AgentOS authoring extensions to the manifest, each **deploy-time validated** like MCP config (malformed declarations rejected at deploy).

**Trigger declarations (`triggers`)** — a list of `{type, ...}`:
- `cron` requires a non-empty `schedule`; `webhook` requires a non-empty `path`; unknown types are rejected.
- Codes: `triggers.invalid`, `triggers.unknown_type`, `triggers.cron_missing_schedule`, `triggers.webhook_missing_path`.

**Approval-policy (`approvalPolicy`)** — `{gates: [{gate, route}]}`:
- Each gate names a pause point plus the approval route that decides it; both required.
- Codes: `approval_policy.invalid`, `approval_policy.incomplete`.

New `TriggerDeclaration` / `ApprovalPolicy` / `ApprovalGate` models; validation in `validate.py`.

## Note on #270
#270 (trigger declarations) is **closed**, but the field never actually landed in `plugin-format` (no `triggers` field in the models or schema on `main`). So this implements **both** approval-policy and trigger declarations rather than scoping to approval-policy only. If a separate triggers change is in flight elsewhere, flag it and I'll rebase.

## Scope boundary
Deploy-time validation + documentation only. **Runtime consumption is a separate not-yet-built seam** — the triggers seam is explicitly unbuilt (`docs/interfaces/triggers/INTERFACE.md`, Epic #29), and approval routing isn't built either. Declaring a trigger/policy validates its shape; it does not yet wire a live wake-up or gate. Documented as such. No protocol-version bump (plugin-format carries none).

## Frozen-contract discipline
Committed JSON schema regenerated with the model change; `test_schema_compat.py` green. Base models stay lenient (`extra="allow"`); the new declaration models validate the load-bearing fields.

## Docs
Field contracts documented in the plugin-format README, `docs/interfaces/bundle-format/INTERFACE.md`, and `docs/interfaces/triggers/INTERFACE.md` (declaration-vs-consumption split).

## Verify
`uv run pytest packages/plugin-format/tests` green (39, incl. cron/webhook/approval validation tests); `uv run ruff check` + `uv run mypy` clean; schema drift-check clean.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)