### PR TITLE
storage: extract the ObjectStore port; defer the second adapter [#282]

### DIFF
--- a/apps/api/src/agentos_api/deploy.py
+++ b/apps/api/src/agentos_api/deploy.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from . import bundles, crud
 from .models import AgentVersion
 from .schemas import BundleOut
-from .storage import BundleStore
+from .storage import ObjectStore
 
 
 class BundleInvalid(Exception):
@@ -43,7 +43,7 @@ def validate_archive(data: bytes) -> tuple[str, str]:
 
 
 async def store_bundle(
-    store: BundleStore,
+    store: ObjectStore,
     session: AsyncSession,
     agent_id: uuid.UUID,
     version: AgentVersion,

--- a/apps/api/src/agentos_api/deps.py
+++ b/apps/api/src/agentos_api/deps.py
@@ -11,7 +11,7 @@ from .github_checks import GitHubStatusReporter
 from .k8s import PodLister, PodLogReader
 from .killswitch import KillSwitch
 from .langfuse import LangfuseClient
-from .storage import BundleStore
+from .storage import ObjectStore
 
 
 async def get_session(request: Request) -> AsyncIterator[AsyncSession]:
@@ -25,8 +25,8 @@ def get_langfuse(request: Request) -> LangfuseClient:
     return client
 
 
-def get_store(request: Request) -> BundleStore:
-    store: BundleStore = request.app.state.bundle_store
+def get_store(request: Request) -> ObjectStore:
+    store: ObjectStore = request.app.state.bundle_store
     return store
 
 
@@ -57,7 +57,7 @@ def get_github_reporter(request: Request) -> GitHubStatusReporter:
 
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 LangfuseDep = Annotated[LangfuseClient, Depends(get_langfuse)]
-StoreDep = Annotated[BundleStore, Depends(get_store)]
+StoreDep = Annotated[ObjectStore, Depends(get_store)]
 PodLogReaderDep = Annotated[PodLogReader, Depends(get_pod_log_reader)]
 PodListerDep = Annotated[PodLister, Depends(get_pod_lister)]
 KillSwitchDep = Annotated[KillSwitch, Depends(get_kill_switch)]

--- a/apps/api/src/agentos_api/gitflow.py
+++ b/apps/api/src/agentos_api/gitflow.py
@@ -24,7 +24,7 @@ from .config import Settings
 from .evalqueue import EvalJobRequest, EvalQueue, now_iso
 from .models import Environment
 from .schemas import WebhookResult
-from .storage import BundleStore
+from .storage import ObjectStore
 
 _ZERO_SHA = "0" * 40
 # A full lowercase-hex git object id: SHA-1 (40) or SHA-256 (64).
@@ -112,7 +112,7 @@ def clone_and_archive(clone_url: str, sha: str, settings: Settings) -> bytes:
 
 async def process_push(
     session: AsyncSession,
-    store: BundleStore,
+    store: ObjectStore,
     settings: Settings,
     eval_queue: EvalQueue,
     payload: dict[str, object],

--- a/apps/api/src/agentos_api/storage.py
+++ b/apps/api/src/agentos_api/storage.py
@@ -1,12 +1,24 @@
-"""Immutable bundle storage on MinIO/S3.
+"""Immutable bundle storage: the object-store port and its S3/MinIO backing.
 
 Bundles are written once per (agent, version) under a deterministic key and never
 mutated (B2 constraint: immutability = write-once key, no dedup/GC/signing). boto3
 is synchronous, so each call is offloaded to a worker thread to keep the event
 loop free.
+
+## The port
+
+``ObjectStore`` (this module) is the storage port: the five operations the bundle
+pipeline needs, plus the **write-once/no-mutation key discipline** promoted here
+from convention into the contract (see the Protocol docstring). ``BundleStore``
+is the one concrete backing today, the S3/MinIO client. Consumers
+(``deps``/``gitflow``/``deploy``) type against ``ObjectStore``, so a future
+non-S3 backend (GCS-native, Azure Blob) is a drop-in that satisfies the Protocol
+rather than a rewrite of every call site. The GCS/Azure adapter itself is
+deliberately NOT built (no non-S3 demand today; ADR-0007, ADR-0026) — this
+extraction only makes it a drop-in when that demand arrives.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import boto3
 from botocore.client import Config as BotoConfig
@@ -19,17 +31,66 @@ if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
 
 
+@runtime_checkable
+class ObjectStore(Protocol):
+    """The storage port: immutable, key-addressed bundle bytes.
+
+    Contract (part of the port, not backend-specific):
+
+    - **Write-once / no-mutation.** A ``put`` to a key that already exists is a
+      programming error, not a supported update: bundles are addressed by a
+      deterministic ``(agent, version)`` key and never mutated. Callers derive
+      keys so a rewrite never happens; a backend need not enforce it, but it must
+      not *rely* on mutation semantics either. There is no delete/GC/signing in
+      the port.
+    - **Bytes in, bytes out.** ``get`` returns exactly the bytes ``put`` stored.
+    - **Bucket/namespace bootstrap.** ``ensure_bucket`` is idempotent.
+
+    A second implementation (GCS, Azure Blob) satisfies this Protocol; it is not
+    required to be S3/boto3, only to honor these semantics.
+    """
+
+    async def ensure_bucket(self) -> None:
+        """Create the bundle bucket/namespace if absent (idempotent)."""
+        ...
+
+    async def exists(self, key: str) -> bool:
+        """True if an object is stored at ``key``."""
+        ...
+
+    async def put(self, key: str, data: bytes, content_type: str) -> None:
+        """Store ``data`` at ``key`` (write-once; see the class contract)."""
+        ...
+
+    async def get(self, key: str) -> bytes:
+        """Return the bytes stored at ``key``; raises if absent."""
+        ...
+
+
+def build_s3_client(settings: Settings) -> "S3Client":
+    """Construct the path-style S3 client shared by every S3-backed store.
+
+    Path-style addressing is required for MinIO and works with AWS S3, so this is
+    the single construction the API writer and the worker reader must agree on
+    (the seam the blob-storage INTERFACE flags as "hand-aligned client sites").
+    Centralizing it here removes one copy of that alignment.
+    """
+    return boto3.client(
+        "s3",
+        endpoint_url=settings.s3_endpoint_url,
+        aws_access_key_id=settings.s3_access_key,
+        aws_secret_access_key=settings.s3_secret_key,
+        region_name=settings.s3_region,
+        config=BotoConfig(s3={"addressing_style": "path"}),
+    )
+
+
 class BundleStore:
+    """S3/MinIO backing for the ``ObjectStore`` port (the one impl today)."""
+
     def __init__(self, settings: Settings) -> None:
         self._bucket = settings.bundle_bucket
-        self._client: S3Client = boto3.client(
-            "s3",
-            endpoint_url=settings.s3_endpoint_url,
-            aws_access_key_id=settings.s3_access_key,
-            aws_secret_access_key=settings.s3_secret_key,
-            region_name=settings.s3_region,
-            config=BotoConfig(s3={"addressing_style": "path"}),
-        )
+        self._client: S3Client = build_s3_client(settings)
 
     async def ensure_bucket(self) -> None:
         await run_in_threadpool(self._ensure_bucket_sync)

--- a/apps/api/tests/test_storage_port.py
+++ b/apps/api/tests/test_storage_port.py
@@ -1,0 +1,77 @@
+"""The ObjectStore port: an in-memory backing conforms, and BundleStore does too.
+
+These are pure unit tests -- no MinIO/S3 required. They pin the extracted port
+(#282, ADR-0026): a second, non-S3 implementation is a drop-in as long as it
+satisfies the Protocol, and the existing BundleStore already does.
+"""
+
+import anyio
+import pytest
+from agentos_api.config import Settings
+from agentos_api.storage import BundleStore, ObjectStore, build_s3_client
+
+
+class InMemoryObjectStore:
+    """A non-S3 backing that satisfies ObjectStore -- the "drop-in" this port
+    exists to enable. Enforces the write-once discipline the port promotes into
+    its contract."""
+
+    def __init__(self) -> None:
+        self._objects: dict[str, bytes] = {}
+
+    async def ensure_bucket(self) -> None:
+        return None
+
+    async def exists(self, key: str) -> bool:
+        return key in self._objects
+
+    async def put(self, key: str, data: bytes, content_type: str) -> None:
+        if key in self._objects:
+            raise ValueError(f"write-once violation: {key} already stored")
+        self._objects[key] = data
+
+    async def get(self, key: str) -> bytes:
+        return self._objects[key]
+
+
+def test_in_memory_store_satisfies_port() -> None:
+    store = InMemoryObjectStore()
+    assert isinstance(store, ObjectStore)
+
+
+def test_in_memory_round_trip_and_write_once() -> None:
+    async def go() -> None:
+        store: ObjectStore = InMemoryObjectStore()
+        await store.ensure_bucket()
+        assert await store.exists("k") is False
+        await store.put("k", b"bundle-bytes", "application/zip")
+        assert await store.exists("k") is True
+        assert await store.get("k") == b"bundle-bytes"
+        # Write-once: a second put to the same key is a violation, not an update.
+        with pytest.raises(ValueError):
+            await store.put("k", b"other", "application/zip")
+
+    anyio.run(go)
+
+
+def _settings() -> Settings:
+    return Settings(
+        s3_endpoint_url="http://localhost:29000",
+        s3_access_key="minioadmin",
+        s3_secret_key="minioadmin",
+        s3_region="us-east-1",
+        bundle_bucket="bundles",
+    )
+
+
+def test_bundle_store_satisfies_port() -> None:
+    # boto3.client construction is offline; no network call is made here.
+    store = BundleStore(_settings())
+    assert isinstance(store, ObjectStore)
+
+
+def test_build_s3_client_is_path_style() -> None:
+    client = build_s3_client(_settings())
+    # Path-style addressing is the alignment MinIO requires; assert the shared
+    # factory pins it so a second S3-backed site cannot silently drift.
+    assert client.meta.config.s3["addressing_style"] == "path"

--- a/apps/worker/src/agentos_worker/bundle_store.py
+++ b/apps/worker/src/agentos_worker/bundle_store.py
@@ -16,7 +16,7 @@ the plugin root the runner sees matches the root the API validated on upload.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import boto3
 from botocore.client import Config as BotoConfig
@@ -28,8 +28,29 @@ if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
 
 
+@runtime_checkable
+class BundleReader(Protocol):
+    """The read side of the storage port the worker needs (bytes by key).
+
+    The API owns the full ``ObjectStore`` port (write + read); the worker only
+    ever reads a bundle by key, so its slice of the port is this one method. A
+    future non-S3 backend (GCS/Azure) supplies a reader satisfying this Protocol;
+    the adapter itself is deferred until a non-S3 backend actually lands
+    (ADR-0007, ADR-0026). Kept as a local Protocol because the worker
+    deliberately does not import the API package (see ``binding.py``).
+    """
+
+    def get(self, key: str) -> bytes:
+        """Fetch the object bytes for ``key``; raises on a missing key/error."""
+        ...
+
+
 class BundleStore:
-    """Fetches bundle bytes by key from the bundles bucket."""
+    """S3/MinIO backing for the worker's ``BundleReader`` slice of the port.
+
+    Mirrors the API's ``ObjectStore`` construction (path-style addressing) so the
+    env names line up; a second backend is a drop-in ``BundleReader``.
+    """
 
     def __init__(self, config: WorkerConfig) -> None:
         self._bucket = config.bundle_bucket

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -48,7 +48,7 @@ from ..binding import (
     SESSION_ID_ENV,
     apply_model_env,
 )
-from ..bundle_store import BundleStore
+from ..bundle_store import BundleReader
 from ..config import WorkerConfig
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
@@ -160,7 +160,7 @@ class EvalStreamConsumer(StreamConsumer):
         *,
         redis: Redis,
         config: WorkerConfig,
-        bundle_store: BundleStore,
+        bundle_store: BundleReader,
         substrate: SandboxSubstrate,
         reporter: EvalReporter,
         recorder: LangfuseEvalRecorder,

--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -52,7 +52,7 @@ from ..binding import (
     FAKE_MODEL_ENV,
     PLUGIN_DIR_ENV,
 )
-from ..bundle_store import BundleStore, extract_bundle
+from ..bundle_store import BundleReader, extract_bundle
 from .k8s import (
     MANAGED_BY_LABEL,
     MANAGED_BY_VALUE,
@@ -104,7 +104,7 @@ class DockerSandboxClient:
         self,
         *,
         image: str,
-        bundle_store: BundleStore,
+        bundle_store: BundleReader,
         network: str | None = None,
         otel_endpoint: str | None = None,
         host: str = "127.0.0.1",

--- a/docs/adr/0026-extract-storage-port-defer-second-adapter.md
+++ b/docs/adr/0026-extract-storage-port-defer-second-adapter.md
@@ -1,0 +1,70 @@
+# 26. Extract the storage port now; defer the second (GCS/Azure) adapter
+
+Date: 2026-07-13
+
+Status: Accepted
+
+Refines how ADR-0007 (adopt-not-build) applies to the blob-storage seam. Issue
+[#282](https://github.com/curie-eng/agentos/issues/282), epic #83. Does **not**
+supersede ADR-0007 — it keeps 0007's core rule (no second backend ahead of
+demand) and changes only *where the line is drawn in code* for this one seam.
+
+## Context
+
+ADR-0007 and the shipped blob-storage INTERFACE.md hold that "the S3 protocol IS
+the port": there is no `StorageInterface` class, and one is extracted only when a
+non-S3 backend demands it, because the second implementation teaches the
+interface. That restraint has a real cost the INTERFACE already flags: the seam
+bleeds through **three hand-aligned client sites** (the API's boto3 writer, the
+worker's boto3 reader, the chart's `mc` init) that must agree on
+endpoint/credentials/bucket/addressing by convention, not by any shared type. The
+write-once/no-mutation immutability guarantee likewise lives only in prose.
+
+Two things are true at once: (a) there is no non-S3 customer, so building a
+GCS/Azure *adapter* would be speculative and is correctly deferred; but (b) the
+five S3 operations and the write-once discipline are already stable and known —
+they are not a guess about a future backend, they are today's contract. Naming
+that contract in code is not the same speculative act 0007 warns against
+(inventing an abstraction whose *shape* is a guess).
+
+## Decision
+
+Extract the port as a **structural `Protocol`, not a rewrite**, and defer the
+adapter:
+
+- `ObjectStore` `Protocol` in `apps/api/.../storage.py` captures the five ops
+  (`ensure_bucket`/`exists`/`put`/`get`) and **promotes the write-once/no-mutation
+  guarantee from convention into the port's documented contract** (the ticket's
+  explicit ask). The existing `BundleStore` structurally satisfies it unchanged;
+  consumers (`deps`/`gitflow`/`deploy`) now type against `ObjectStore`, so a
+  second backend is a drop-in that implements the Protocol rather than a rewrite
+  of every call site.
+- A shared `build_s3_client(settings)` factory centralizes the path-style client
+  construction, removing one copy of the "hand-aligned" duplication.
+- The worker keeps its own `BundleReader` Protocol (its read-only slice of the
+  port), because it deliberately does not import the API package (`binding.py`).
+- **No second adapter is built.** GCS/Azure remains gated on a genuine non-S3
+  customer, exactly as ADR-0007 and #282 require. The chart's `mc` init is left
+  as-is (a third dialect) and noted as the remaining aligned site.
+
+## Alternatives considered
+
+- **Do nothing (leave the seam un-abstracted, per the letter of 0007).** Rejected
+  for this slice: the five ops and write-once rule are stable *today*, so naming
+  them is documentation-in-code, not speculation; and it makes the eventual
+  adapter a genuinely small, reviewable change instead of a three-site sweep.
+- **Build the GCS/Azure adapter now.** Rejected: no non-S3 demand, nothing to
+  verify against — this is the speculative build 0007 exists to prevent.
+- **A new shared `storage` package both apps import.** Rejected as churn for one
+  impl; the worker's no-API-import boundary makes a local read Protocol the
+  lighter, honest seam. Consolidation can come with the second backend.
+
+## Consequences
+
+- The port is real and typed; the write-once guarantee is contractual, not just
+  convention. A future GCS/Azure adapter implements `ObjectStore` /
+  `BundleReader` and wires into the same consumers with no call-site churn.
+- The chart `mc` init and the worker/API client construction are still two
+  physically separate S3 clients; fully unifying them (or the `mc` path) is left
+  for when the second backend lands. INTERFACE.md is updated to Kind CLEAN with
+  this scope noted.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -18,7 +18,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Model provider / credentials | SOFT | 1 (Anthropic) | not separately graded | #24, #46 | [interfaces/model-provider/INTERFACE.md](interfaces/model-provider/INTERFACE.md) |
 | Telemetry / OTEL | SOFT | 1 | B+ | #47 | [interfaces/telemetry-otel/INTERFACE.md](interfaces/telemetry-otel/INTERFACE.md) |
 | Evals (case + scorer) | SOFT | 1 grader family | B | #8, #26 | [interfaces/evals/INTERFACE.md](interfaces/evals/INTERFACE.md) |
-| Blob storage (S3/MinIO) | SOFT | 2 concretes | B+ | #83 | [interfaces/blob-storage/INTERFACE.md](interfaces/blob-storage/INTERFACE.md) |
+| Blob storage (S3/MinIO) | CLEAN | 1 backend behind the ObjectStore port | A- | #83 | [interfaces/blob-storage/INTERFACE.md](interfaces/blob-storage/INTERFACE.md) |
 | Relational DB (Postgres) | SOFT | 1 | A- | #84 | [interfaces/relational-db/INTERFACE.md](interfaces/relational-db/INTERFACE.md) |
 | Queue / stream (Valkey) | SOFT | 1 (redis-py) | not separately graded | #85, #7 | [interfaces/queue-stream/INTERFACE.md](interfaces/queue-stream/INTERFACE.md) |
 | Bundle format | CLEAN, frozen | 1 | not separately graded | #30 | [interfaces/bundle-format/INTERFACE.md](interfaces/bundle-format/INTERFACE.md) |

--- a/docs/interfaces/blob-storage/INTERFACE.md
+++ b/docs/interfaces/blob-storage/INTERFACE.md
@@ -1,20 +1,21 @@
 # INTERFACE: Blob storage (S3/MinIO)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 &nbsp;·&nbsp; **Swap-readiness grade:** B+
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 backend (S3/MinIO) behind the `ObjectStore` port &nbsp;·&nbsp; **Swap-readiness grade:** A-
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
 ## The black line
 
 Immutable plugin bundles are addressed by a deterministic `(agent, version)` key in
-an S3-compatible object store. The swappable thing is the **backend behind the S3
-wire protocol** (MinIO today, AWS S3 or any path-style S3 API tomorrow). What stays
-opinionated core is the write-once/no-mutation key discipline and the bundle bytes
-themselves. This is a deliberately un-abstracted seam: **the S3 protocol IS the port**
-— there is no `StorageInterface` class, and one is extracted only when a non-S3
-backend actually demands it (per the vision doc's "second implementation teaches the
-interface" restraint).
+an object store, behind the **`ObjectStore` port** (`apps/api/.../storage.py`,
+#282 / ADR-0026): `ensure_bucket` / `exists` / `put` / `get`, with the
+write-once/no-mutation key discipline promoted from convention **into the port's
+contract**. The one backing today is S3/MinIO (`BundleStore`); a future non-S3
+backend (GCS-native, Azure Blob) is a drop-in that satisfies the Protocol. The
+GCS/Azure adapter itself is deliberately **not built** — it stays gated on a real
+non-S3 customer (ADR-0007), so only the *port* is extracted now, not a speculative
+second implementation.
 
 ## Current contract
 
@@ -31,21 +32,27 @@ configured entirely through env/settings — no code changes:
 
 ## Implementations today
 
-Two concrete client sites plus a third in the chart:
+One backend (S3/MinIO) behind the port, plus the chart's `mc` init:
 
-- **API writer** — `apps/api/src/agentos_api/storage.py:22` (`BundleStore`, async-offloaded boto3 write path).
-- **Worker reader** — `apps/worker/src/agentos_worker/bundle_store.py:37` (`BundleStore`, read-only `get`, path-style, "same construction the API's write path uses").
-- **Chart bundle-fetch init** — `charts/agentos/templates/agent-sandbox.yaml:110-111` uses the `mc` CLI (`mc alias set` / `mc cp`) rather than boto3, a third dialect of the same S3 protocol.
+- **`ObjectStore` port** — `apps/api/src/agentos_api/storage.py` (`Protocol`: the
+  five ops + the write-once contract). Consumers (`deps`/`gitflow`/`deploy`) type
+  against it, so a second backend is a drop-in.
+- **API writer** — `apps/api/.../storage.py` `BundleStore`, the S3/MinIO backing
+  (async-offloaded boto3); client built by the shared `build_s3_client` factory.
+- **Worker reader** — `apps/worker/.../bundle_store.py`: a local `BundleReader`
+  Protocol (the read-only slice of the port; the worker does not import the API
+  package) with `BundleStore` as its S3/MinIO backing.
+- **Chart bundle-fetch init** — `charts/agentos/templates/agent-sandbox.yaml`
+  uses the `mc` CLI, still a third dialect of the same S3 protocol (left as-is).
 
 ## Known leakage
 
-The seam bleeds through **three hand-aligned client sites** that must agree on the
-same endpoint/credentials/bucket by convention, not by a shared interface: the API's
-boto3 writer, the worker's boto3 reader, and the chart's `mc`-based init container.
-The worker's docstring even notes it mirrors the API "so the env names line up." A
-switch to a fundamentally different backend (e.g. GCS-native rather than its S3
-compatibility layer) would touch all three independently — that is the cost of not
-abstracting, and the trigger that would justify extracting a real port.
+The port now names the contract, but two physically separate S3 clients remain
+(API/worker) plus the chart's `mc` init — fully unifying the client construction
+(and the `mc` path) is left for when a second, non-S3 backend actually lands, at
+which point the adapter is a drop-in `ObjectStore`/`BundleReader` rather than a
+three-site sweep. Building that adapter ahead of a real non-S3 customer is still
+out of scope (ADR-0007, ADR-0026).
 
 ## Cross-links
 


### PR DESCRIPTION
## What

Does the **actionable slice** of #282: extract a clean storage port and put the existing S3/MinIO client behind it, so a future non-S3 backend is a drop-in. The **GCS/Azure adapter is deliberately NOT built** — no non-S3 customer exists to verify against, so it stays gated per ADR-0007.

## Changes

- **`ObjectStore` Protocol** (`apps/api/.../storage.py`): the five ops (`ensure_bucket`/`exists`/`put`/`get`) with the **write-once/no-mutation guarantee promoted from convention into the contract** (the ticket's explicit ask).
- `BundleStore` is the one S3/MinIO backing; consumers (`deps`/`gitflow`/`deploy`) now type against `ObjectStore`, so a second backend needs no call-site churn.
- Shared `build_s3_client(settings)` factory centralizes the path-style construction (removes one copy of the "hand-aligned client sites" the INTERFACE flags).
- Worker keeps a local `BundleReader` Protocol (its read-only slice; it deliberately does not import the API package). `docker.py`/`eval/stream.py` type against it.

## Design note (ADR-0007 tension)

ADR-0007 + the shipped INTERFACE said "the S3 protocol IS the port; extract only on a second backend." **ADR-0026** (added here) refines how 0007 applies to this one seam: the five ops + write-once rule are stable *today* (not a guess about a future backend), so naming them in a `Protocol` is documentation-in-code, not the speculative adapter 0007 forbids. 0007's core rule — no second backend ahead of demand — is unchanged.

## Docs / tests

- ADR-0026; blob-storage `INTERFACE.md` SOFT → CLEAN; interfaces index updated.
- `apps/api/tests/test_storage_port.py`: port conformance (an in-memory drop-in + `BundleStore` both satisfy `ObjectStore`), write-once round-trip, path-style factory. No MinIO needed. api/worker lanes green (ruff/mypy/pytest; no OpenAPI drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)