### PR TITLE
queue-stream: extract a thin broker port at the non-sacred seams [#284]

### DIFF
--- a/apps/dispatcher/src/agentos_dispatcher/queue.py
+++ b/apps/dispatcher/src/agentos_dispatcher/queue.py
@@ -22,16 +22,35 @@ dedupe because it is O(1), TTL-bounded (no unbounded dedupe set to prune), and
 does not require scanning the Stream.
 """
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 from aci_protocol import QueuedTurn
 
 from .config import DispatcherConfig
 
-if TYPE_CHECKING:
-    from redis import Redis
-
 STREAM_PAYLOAD_FIELD = "payload"
+
+
+@runtime_checkable
+class StreamPublisher(Protocol):
+    """The stream-broker port (producer side): append an entry + dedupe-claim.
+
+    Issue #284 / ADR-0027. The producer's whole coupling to the broker is these
+    two verbs: ``xadd`` (append the one-``payload`` entry to the stream) and a
+    ``SET NX EX`` dedupe-claim (``set``). Typing the producer against this
+    Protocol makes a future non-redis broker a drop-in on the write side. The
+    consumer side has its own port (``StreamBroker`` in the worker). ``redis.Redis``
+    structurally satisfies this, so it is the one backing today with no adapter.
+    The verbs are typed permissively to match redis-py's signatures.
+    """
+
+    def xadd(self, name: Any, fields: Any) -> Any:
+        """Append an entry to ``name``; returns the assigned stream id."""
+        ...
+
+    def set(self, name: Any, value: Any, *, nx: bool = ..., ex: Any = ...) -> Any:
+        """``SET`` with ``NX``/``EX`` — the dedupe-claim beside the stream."""
+        ...
 
 
 def to_stream_fields(turn: QueuedTurn) -> dict[str, str]:
@@ -44,7 +63,7 @@ def from_stream_fields(fields: dict[str, str]) -> QueuedTurn:
     return QueuedTurn.model_validate_json(fields[STREAM_PAYLOAD_FIELD])
 
 
-def claim_event(redis_client: "Redis", config: "DispatcherConfig", event_id: str) -> bool:
+def claim_event(redis_client: "StreamPublisher", config: "DispatcherConfig", event_id: str) -> bool:
     """Claim a Slack event id for processing, returning True on the first claim.
 
     Uses ``SET NX EX`` so exactly one delivery of a given event id wins; retries
@@ -60,7 +79,7 @@ def claim_event(redis_client: "Redis", config: "DispatcherConfig", event_id: str
     return bool(claimed)
 
 
-def enqueue(redis_client: "Redis", config: "DispatcherConfig", turn: QueuedTurn) -> str:
+def enqueue(redis_client: "StreamPublisher", config: "DispatcherConfig", turn: QueuedTurn) -> str:
     """Append the normalized turn to the Valkey Stream, returning its Stream id."""
     # redis-py types the fields param as an invariant dict of a broad key/value
     # union, so a plain dict[str, str] does not match; cast to satisfy the stub.

--- a/apps/dispatcher/tests/test_broker_port.py
+++ b/apps/dispatcher/tests/test_broker_port.py
@@ -1,0 +1,27 @@
+"""The producer-side broker port: redis-py structurally satisfies StreamPublisher.
+
+Structural-conformance only -- no Valkey behavior is mocked (the real enqueue /
+dedupe behavior is covered against real Valkey in test_queue.py). This pins that
+the one backing today (redis.Redis) is a drop-in for the port, so a second broker
+that implements the same verbs is too.
+"""
+
+import redis
+from agentos_dispatcher.queue import StreamPublisher
+
+
+def test_redis_client_satisfies_publisher_port() -> None:
+    # Construction does not connect; no network call is made here.
+    client = redis.Redis(host="localhost", port=6379)
+    assert isinstance(client, StreamPublisher)
+
+
+def test_minimal_second_broker_satisfies_port() -> None:
+    class FakeBroker:
+        def xadd(self, name: object, fields: object) -> str:
+            return "0-1"
+
+        def set(self, name: object, value: object, *, nx: bool = False, ex: object = None) -> bool:
+            return True
+
+    assert isinstance(FakeBroker(), StreamPublisher)

--- a/apps/worker/src/agentos_worker/broker.py
+++ b/apps/worker/src/agentos_worker/broker.py
@@ -1,0 +1,83 @@
+"""The stream-broker port (consumer side): the Valkey Stream verbs, behind a type.
+
+Issue #284 / ADR-0027. The queue/stream seam was SOFT — "the redis-py Stream
+verbs ARE the port," with `redis.asyncio.Redis` coupled at every call site. This
+module draws a thin ``StreamBroker`` Protocol over exactly the consumer-group
+verbs the worker's stream plumbing uses, so a future non-redis broker (Redis
+Cluster, a managed stream, Kafka/NATS) is a drop-in behind the port rather than a
+grep-and-replace of every call site.
+
+Scope discipline:
+
+- **The seam is the non-sacred transport, not the kernel.** ``StreamConsumer``
+  (``stream_consumer.py``) holds the group-create / blocking-read / ack loop and
+  is routed through this port. The sacred concurrency kernel
+  (``kernel.py``/``consumer.py``/``threadlock.py``/``markers.py``) is NOT touched
+  — the sacred-module rule forbids it. ``consumer.py``'s ``XAUTOCLAIM``
+  crash-recovery call is part of the contract (declared on the Protocol) but it
+  keeps calling its inherited ``self._redis`` unchanged.
+- **The producer side has its own port**, ``StreamPublisher`` in the dispatcher
+  (`apps/dispatcher/.../queue.py`), because the producer is a *sync* redis client
+  in a different package. Together they are the broker seam.
+- **No second broker is built.** Valkey Streams is the adopted spine (ADR-0007);
+  this only makes the eventual swap a drop-in when a real second-broker demand
+  arrives.
+
+The verbs are typed permissively (``Any`` payloads/returns) to match the wire
+shape the code already casts at each site; ``redis.asyncio.Redis`` structurally
+satisfies the Protocol, so it is the one backing today with no adapter.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class StreamBroker(Protocol):
+    """The consumer-side stream contract: group semantics + crash recovery.
+
+    A second broker must honor: an ordered stream, consumer groups
+    (``xgroup_create`` / ``xreadgroup``), per-entry ack (``xack``), and
+    pending-entry reclaim for crash recovery (``xautoclaim``). Dedupe lives on the
+    producer side (``StreamPublisher``), beside the stream, not in these verbs.
+
+    The verbs are declared to return a bare ``Awaitable`` (not ``async def``) to
+    match how ``redis.asyncio.Redis`` types them, so the real client structurally
+    satisfies the port with no adapter; call sites still ``await`` them normally.
+    """
+
+    def xgroup_create(
+        self, name: Any, groupname: Any, id: Any = ..., mkstream: bool = ...
+    ) -> Awaitable[Any]:
+        """Create the consumer group (and stream, with ``mkstream``) if absent."""
+        ...
+
+    def xreadgroup(
+        self,
+        groupname: Any,
+        consumername: Any,
+        streams: Any,
+        count: Any = ...,
+        block: Any = ...,
+    ) -> Awaitable[Any]:
+        """Blocking consumer-group read; returns the raw stream/entry structure."""
+        ...
+
+    def xack(self, name: Any, groupname: Any, *ids: Any) -> Awaitable[Any]:
+        """Acknowledge a handled entry so it leaves the pending-entries list."""
+        ...
+
+    def xautoclaim(
+        self,
+        name: Any,
+        groupname: Any,
+        consumername: Any,
+        min_idle_time: Any,
+        start_id: Any = ...,
+        count: Any = ...,
+        justid: bool = ...,
+    ) -> Awaitable[Any]:
+        """Reclaim entries pending past ``min_idle_time`` from a dead consumer."""
+        ...

--- a/apps/worker/src/agentos_worker/stream_consumer.py
+++ b/apps/worker/src/agentos_worker/stream_consumer.py
@@ -18,7 +18,6 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import cast
 
-from redis.asyncio import Redis
 from redis.exceptions import (
     ConnectionError as RedisConnectionError,
 )
@@ -28,6 +27,8 @@ from redis.exceptions import (
 from redis.exceptions import (
     TimeoutError as RedisTimeoutError,
 )
+
+from .broker import StreamBroker
 
 # One stream entry as redis returns it with decode_responses=True.
 StreamEntry = tuple[str, dict[str, str]]
@@ -66,8 +67,12 @@ class StreamConsumer:
     business logic.
     """
 
-    def __init__(self, redis: Redis) -> None:
-        self._redis = redis
+    def __init__(self, redis: StreamBroker) -> None:
+        # The stream broker behind the port (#284). ``redis.asyncio.Redis`` is the
+        # one backing today and structurally satisfies ``StreamBroker``; a second
+        # broker is a drop-in. Named ``_redis`` still so the sacred consumer.py
+        # subclass (which reads ``self._redis`` for XAUTOCLAIM) is untouched.
+        self._redis: StreamBroker = redis
         self._stop = asyncio.Event()
 
     def request_stop(self) -> None:

--- a/apps/worker/tests/test_broker_port.py
+++ b/apps/worker/tests/test_broker_port.py
@@ -1,0 +1,37 @@
+"""The consumer-side broker port: redis.asyncio.Redis satisfies StreamBroker.
+
+Structural-conformance only -- no Valkey behavior is mocked (the real consume /
+ack / reclaim behavior is covered against real Valkey in the kernel + consumer
+suites). This pins that the one backing today is a drop-in for the port.
+"""
+
+from agentos_worker.broker import StreamBroker
+from agentos_worker.stream_consumer import StreamConsumer
+from redis.asyncio import Redis
+
+
+def test_async_redis_satisfies_broker_port() -> None:
+    # Construction does not connect; no network call is made here.
+    client = Redis(host="localhost", port=6379)
+    assert isinstance(client, StreamBroker)
+
+
+def test_stream_consumer_accepts_any_broker() -> None:
+    class FakeBroker:
+        async def xgroup_create(self, name, groupname, id="$", mkstream=False):  # noqa: ANN001, ANN201, A002
+            return True
+
+        async def xreadgroup(self, groupname, consumername, streams, count=None, block=None):  # noqa: ANN001, ANN201
+            return []
+
+        async def xack(self, name, groupname, *ids):  # noqa: ANN001, ANN201
+            return 0
+
+        async def xautoclaim(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+            return ("0-0", [])
+
+    broker = FakeBroker()
+    assert isinstance(broker, StreamBroker)
+    # A second broker drops into the consumer transport with no other change.
+    consumer = StreamConsumer(broker)  # type: ignore[arg-type]
+    assert consumer._redis is broker

--- a/docs/adr/0027-thin-broker-port-defer-second-broker.md
+++ b/docs/adr/0027-thin-broker-port-defer-second-broker.md
@@ -1,0 +1,76 @@
+# 27. A thin broker port at the non-sacred seams; defer the second broker
+
+Date: 2026-07-13
+
+Status: Accepted
+
+Refines how ADR-0007 (adopt-not-build) applies to the queue/stream seam. Issue
+[#284](https://github.com/curie-eng/agentos/issues/284), epic #85. Does **not**
+supersede ADR-0007 — it keeps the "no second broker ahead of demand" rule and
+changes only where the line is drawn in code, and is the queue-seam sibling of
+ADR-0026 (storage port).
+
+## Context
+
+The queue/stream seam was SOFT: "the redis-py Stream verbs ARE the port," with
+`redis.asyncio.Redis` / `redis.Redis` coupled at every call site (dispatcher
+producer, worker consumer transport, worker crash-recovery reclaim). The stream
+contract itself — one `payload` field, consumer groups, `XAUTOCLAIM` reclaim,
+dedupe-beside-the-stream — is stable and known today; it is not a guess about a
+future backend.
+
+The hard constraint: the correctness kernel
+(`kernel.py`/`consumer.py`/`threadlock.py`/`markers.py`) is **sacred** — one
+change owns it at a time, adversarial review required, no scope-creep edits. The
+`XREADGROUP`/`XACK`/`XAUTOCLAIM` verbs are split across a sacred file
+(`consumer.py`, which calls `xautoclaim`) and non-sacred files (the
+`StreamConsumer` transport base in `stream_consumer.py`; the dispatcher's
+`queue.py` producer).
+
+## Decision
+
+Draw a thin **broker port** over the stream verbs **at the non-sacred seams
+only**, and defer the second broker:
+
+- **Consumer side** — `StreamBroker` `Protocol` (`apps/worker/.../broker.py`)
+  declares the group/read/ack/reclaim verbs. `StreamConsumer` (non-sacred) is
+  retyped to hold a `StreamBroker` instead of a concrete `Redis`. The verbs
+  return a bare `Awaitable` (matching redis-py's typing) so
+  `redis.asyncio.Redis` **structurally** satisfies the port with no adapter.
+  The field stays named `_redis`, so the sacred `consumer.py` subclass — which
+  reads `self._redis` for its `XAUTOCLAIM` reclaim — is **not edited**; its call
+  now targets the port method by inheritance. `xautoclaim` is on the Protocol so
+  the contract is complete even though only the sacred file calls it.
+- **Producer side** — `StreamPublisher` `Protocol` (`apps/dispatcher/.../queue.py`)
+  declares the two verbs the producer uses: `xadd` and the `SET NX EX`
+  dedupe-claim. `enqueue`/`claim_event` are retyped to it. The producer is a
+  *sync* client in a different package, so it is a separate role-Protocol; the
+  two together are the broker seam.
+- **No sacred file is touched, and no second broker is built.** Valkey Streams is
+  the adopted spine (ADR-0007); this only makes the eventual swap (Redis Cluster,
+  a managed stream, Kafka/NATS) a drop-in when a real second-broker demand
+  arrives.
+
+## Alternatives considered
+
+- **Route the verbs through the port inside `consumer.py`.** Rejected: that is
+  the sacred concurrency kernel; the sacred-module rule forbids editing it as a
+  side effect of a seam refactor. The clean seam is the non-sacred transport
+  base, which `consumer.py` inherits — so the port lands without touching it.
+- **One unified broker Protocol for both sides.** Rejected: the producer is sync
+  and the consumer is async, in two packages with no shared home; a single
+  Protocol would be a false unification. Two role-Protocols is the honest shape.
+- **Build a second (Kafka/managed) broker now.** Rejected: no second-broker
+  demand, nothing to verify against — the speculative build ADR-0007 prevents.
+
+## Consequences
+
+- The stream contract is named and typed at both non-sacred seams; a second
+  broker implements the same verbs and drops into the consumer transport and the
+  producer with no call-site churn.
+- **Remaining coupling:** `consumer.py`'s `XAUTOCLAIM` call and `run.py`'s client
+  construction still reference redis directly (the sacred file by rule, the
+  composition root by design). The API's `main.py` redis is the kill-switch /
+  eval-queue, not the runs stream, and is out of scope. Fully unifying these is
+  left for when the second broker lands. INTERFACE.md moves SOFT → CLEAN with
+  this scope noted.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -20,7 +20,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Evals (case + scorer) | SOFT | 1 grader family | B | #8, #26 | [interfaces/evals/INTERFACE.md](interfaces/evals/INTERFACE.md) |
 | Blob storage (S3/MinIO) | SOFT | 2 concretes | B+ | #83 | [interfaces/blob-storage/INTERFACE.md](interfaces/blob-storage/INTERFACE.md) |
 | Relational DB (Postgres) | SOFT | 1 | A- | #84 | [interfaces/relational-db/INTERFACE.md](interfaces/relational-db/INTERFACE.md) |
-| Queue / stream (Valkey) | SOFT | 1 (redis-py) | not separately graded | #85, #7 | [interfaces/queue-stream/INTERFACE.md](interfaces/queue-stream/INTERFACE.md) |
+| Queue / stream (Valkey) | CLEAN | 1 (redis-py) behind the broker port | not separately graded | #85, #7 | [interfaces/queue-stream/INTERFACE.md](interfaces/queue-stream/INTERFACE.md) |
 | Bundle format | CLEAN, frozen | 1 | not separately graded | #30 | [interfaces/bundle-format/INTERFACE.md](interfaces/bundle-format/INTERFACE.md) |
 | Approval / authorizer | NONE | 0 | not separately graded | #22 | [interfaces/approval/INTERFACE.md](interfaces/approval/INTERFACE.md) |
 | Workflow state store | NONE | 0 (concrete AffinityStore) | not separately graded | #23 | [interfaces/workflow-state/INTERFACE.md](interfaces/workflow-state/INTERFACE.md) |

--- a/docs/interfaces/queue-stream/INTERFACE.md
+++ b/docs/interfaces/queue-stream/INTERFACE.md
@@ -1,20 +1,25 @@
 # INTERFACE: Queue / stream (Valkey)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 (redis-py) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 (redis-py) behind the broker port &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
 ## The black line
 
 The seam is the Valkey Stream wire contract between the dispatcher (producer) and the
-worker (consumer): a named stream carrying a frozen one-field payload, spoken over the
-redis-py client. This is mostly opinionated **core** — the routing, consumer-group
-concurrency, dedupe, and reclaim rules are AgentOS's own and not meant to be swapped —
-with a soft swap only at the broker level: any redis-compatible Stream backend (Valkey,
-Redis, a managed equivalent) is a URL change. A non-redis broker (Kafka, SQS) would
-touch the wire and is a rewrite, not a config swap. One implementation today; the port
-is the stream key + payload shape + redis-py Stream verbs, not a code interface.
+worker (consumer): a named stream carrying a frozen one-field payload. As of #284 /
+ADR-0027 the stream verbs are drawn behind a thin **broker port** at the two non-sacred
+seams — a `StreamPublisher` `Protocol` on the producer (`apps/dispatcher/.../queue.py`:
+`xadd` + the `SET NX EX` dedupe-claim) and a `StreamBroker` `Protocol` on the consumer
+transport (`apps/worker/.../broker.py`: `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`).
+The routing, consumer-group concurrency, dedupe, and reclaim rules stay opinionated
+**core**. `redis.Redis` / `redis.asyncio.Redis` structurally satisfy the ports, so
+redis-py is the one backing today with no adapter; a redis-compatible backend (Valkey,
+Redis, a managed equivalent) is still a URL change, and a non-redis broker (Kafka, SQS)
+is now a drop-in implementation of the two Protocols rather than a grep-and-replace of
+every call site. The **second broker itself is not built** — no second-broker demand
+exists (ADR-0007); only the port is extracted.
 
 ## Current contract
 
@@ -46,9 +51,29 @@ a consumer group with `XREADGROUP`/`XACK` and crash-recovery `XAUTOCLAIM`
 (`apps/worker/src/agentos_worker/eval/stream.py`), reinforcing the wire shape as the
 real contract.
 
+## The port (as of #284 / ADR-0027)
+
+Drawn only at the **non-sacred** seams; the sacred concurrency kernel
+(`kernel.py`/`consumer.py`/`threadlock.py`/`markers.py`) is not touched:
+
+- **Producer** — `StreamPublisher` (`apps/dispatcher/.../queue.py`): `xadd` and the
+  `SET NX EX` dedupe-claim. `enqueue`/`claim_event` type against it.
+- **Consumer transport** — `StreamBroker` (`apps/worker/.../broker.py`):
+  `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`. The non-sacred `StreamConsumer`
+  base (`stream_consumer.py`) holds a `StreamBroker`; the sacred `consumer.py` subclass
+  inherits it unchanged (its `XAUTOCLAIM` reclaim now targets the port by inheritance).
+
+The verbs return a bare `Awaitable`/value matching redis-py's own typing, so
+`redis.asyncio.Redis` / `redis.Redis` satisfy the ports structurally with no adapter.
+
 ## Known leakage
 
-The payload carried on this stream is `QueuedSlackEvent` — Slack-shaped by name
+- **Reclaim + composition root still touch redis directly.** `consumer.py`'s
+  `XAUTOCLAIM` call (sacred file, by rule) and `run.py`'s client construction (the
+  composition root, by design) reference redis directly; the API's `main.py` redis is
+  the kill-switch / eval-queue, not the runs stream, and is out of scope. Fully unifying
+  these is left for when a real second broker lands (ADR-0007, ADR-0027).
+- The payload carried on this stream is `QueuedSlackEvent` — Slack-shaped by name
 (`slack_event_id`, `thread_ts`, `placeholder_ts`). That vendor leakage is not the queue
 seam's own; it belongs to the [channel / ingress seam](../channel-ingress/INTERFACE.md),
 and #7 promotes the payload into `packages/aci-protocol` with channel-neutral names,
@@ -62,4 +87,4 @@ rewrites the wire and the consumer verbs.
 - **Epic(s):** #85 — vision: make the broker itself swappable behind the stream contract
 - **Epic(s):** #7 — payload promotion into `packages/aci-protocol` (overlaps the channel seam)
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — opinionated core (`agentos:runs` stream), not one of the six swap jobs
-- **ADR(s):** none directly on this seam
+- **ADR(s):** [ADR-0027](../../adr/0027-thin-broker-port-defer-second-broker.md) — the broker port at the non-sacred seams; [ADR-0007](../../adr/0007-adopt-not-build-boundaries.md) — adopt-not-build (Valkey adopted; second broker deferred)


### PR DESCRIPTION
## What

Does the **actionable slice** of #284: define a thin queue/stream broker port and route the existing Valkey Stream usage through it **at the non-sacred seams**, so a future non-redis broker is a drop-in. The **second broker is NOT built** (no demand; ADR-0007), and the **sacred concurrency kernel is untouched**.

## The seams (both outside `kernel.py`/`consumer.py`/`threadlock.py`/`markers.py`)

- **Producer** — `StreamPublisher` Protocol (`apps/dispatcher/.../queue.py`): `xadd` + the `SET NX EX` dedupe-claim. `enqueue`/`claim_event` type against it.
- **Consumer transport** — `StreamBroker` Protocol (`apps/worker/.../broker.py`): `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`. The non-sacred `StreamConsumer` base (`stream_consumer.py`) now holds a `StreamBroker`.

The verbs return a bare `Awaitable`/value matching redis-py's own typing, so `redis.Redis` / `redis.asyncio.Redis` satisfy the ports **structurally, with no adapter**.

## Sacred-file safety

`consumer.py` (sacred) is **not edited**: it inherits the retyped `StreamConsumer` base, and its `XAUTOCLAIM` reclaim call now targets the port by inheritance (the field stays named `_redis`). `xautoclaim` is declared on the Protocol so the contract is complete. `run.py`'s client construction (composition root) and the API's kill-switch/eval-queue redis are left as-is and noted as out of scope.

## Design note (ADR-0007 tension)

ADR-0007 + the shipped INTERFACE held "the redis-py verbs ARE the port." **ADR-0027** (added here) refines that for this seam: the stream verbs + dedupe + reclaim are stable *today*, so naming them in a `Protocol` at the non-sacred seams is documentation-in-code, not the speculative second broker 0007 forbids. 0007's core rule is unchanged.

## Docs / tests

- ADR-0027; queue-stream `INTERFACE.md` SOFT → CLEAN; interfaces index updated.
- Structural-conformance tests (no Valkey mocked — real behavior stays covered by the real-Valkey queue/kernel suites): redis clients + a minimal second broker satisfy the ports. mypy/ruff green; dispatcher suite 45 passed. (The 4 pre-existing `eval/test_stream.py` failures are environmental `httpx.ConnectError`, present on clean `origin/main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)