### PR TITLE
memory: learned-from provenance trace-back (#266)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -847,6 +847,101 @@
         "title": "LoadPackConfig",
         "type": "object"
       },
+      "MemoryEntryOut": {
+        "description": "One learned memory entry as returned to an operator.\n\n``index`` is the entry's position in the append-only log; it is the stable\nhandle the edit/delete endpoints (#267) address, and it survives as long as\nthe log is not consolidated (#265) or reordered.",
+        "properties": {
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "index": {
+            "title": "Index",
+            "type": "integer"
+          },
+          "provenance": {
+            "$ref": "#/components/schemas/MemoryProvenanceOut"
+          }
+        },
+        "required": [
+          "index",
+          "content",
+          "provenance"
+        ],
+        "title": "MemoryEntryOut",
+        "type": "object"
+      },
+      "MemoryProvenanceOut": {
+        "description": "Where a memory entry was learned from (#264 ``Provenance`` shape).",
+        "properties": {
+          "learned_from_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Learned From Session Id"
+          },
+          "recorded_at": {
+            "default": "",
+            "title": "Recorded At",
+            "type": "string"
+          },
+          "source_trace_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Source Trace Ids",
+            "type": "array"
+          }
+        },
+        "title": "MemoryProvenanceOut",
+        "type": "object"
+      },
+      "MemoryTraceBackOut": {
+        "description": "The learned-from trace-back for one memory entry (#266).\n\nResolves an entry's recorded provenance into the concrete session and source\ntraces the lesson was learned from -- the answer to \"how did it learn that?\".",
+        "properties": {
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "index": {
+            "title": "Index",
+            "type": "integer"
+          },
+          "learned_from_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Learned From Session Id"
+          },
+          "recorded_at": {
+            "default": "",
+            "title": "Recorded At",
+            "type": "string"
+          },
+          "source_traces": {
+            "items": {
+              "$ref": "#/components/schemas/SourceTraceOut"
+            },
+            "title": "Source Traces",
+            "type": "array"
+          }
+        },
+        "required": [
+          "index",
+          "content"
+        ],
+        "title": "MemoryTraceBackOut",
+        "type": "object"
+      },
       "MetricPoint": {
         "properties": {
           "ts": {
@@ -1163,6 +1258,25 @@
           }
         },
         "title": "SettingsPackConfig",
+        "type": "object"
+      },
+      "SourceTraceOut": {
+        "description": "One resolved source trace: its id plus a link to view it in Langfuse.",
+        "properties": {
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          },
+          "trace_url": {
+            "title": "Trace Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "trace_url"
+        ],
+        "title": "SourceTraceOut",
         "type": "object"
       },
       "StateAppendIn": {
@@ -2280,6 +2394,139 @@
         "summary": "Kill Agent",
         "tags": [
           "control"
+        ]
+      }
+    },
+    "/agents/{agent_id}/memory": {
+      "get": {
+        "description": "List an agent's learned memory entries, oldest first, with provenance.",
+        "operationId": "list_memory_agents__agent_id__memory_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MemoryEntryOut"
+                  },
+                  "title": "Response List Memory Agents  Agent Id  Memory Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Memory",
+        "tags": [
+          "memory"
+        ]
+      }
+    },
+    "/agents/{agent_id}/memory/{index}/provenance": {
+      "get": {
+        "description": "Resolve one entry's learned-from trace-back (#266).\n\nReturns the session and the source traces the lesson was distilled from,\neach with a Langfuse deep link. Reuses the provenance the runner recorded at\n``remember`` time -- it does not re-derive or invent provenance.",
+        "operationId": "memory_trace_back_agents__agent_id__memory__index__provenance_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "index",
+            "required": true,
+            "schema": {
+              "title": "Index",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryTraceBackOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Memory Trace Back",
+        "tags": [
+          "memory"
         ]
       }
     },

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -26,6 +26,7 @@ from .routers import (
     deployments,
     evals,
     github,
+    memory,
     observability,
     runs,
     state,
@@ -85,6 +86,7 @@ def create_app() -> FastAPI:
     app.include_router(evals.router)
     app.include_router(runs.router)
     app.include_router(state.router)
+    app.include_router(memory.router)
     return app
 
 

--- a/apps/api/src/agentos_api/routers/memory.py
+++ b/apps/api/src/agentos_api/routers/memory.py
@@ -1,0 +1,112 @@
+"""Agent memory API: inspect learned memory and trace it back to its sources.
+
+Memory is a scoped namespace over the durable state store (#264, ADR-0025): the
+runner writes an append-only log at namespace ``memory`` key ``log``, each item a
+``{content, provenance}`` record. This router is the read side of that log for
+operators -- it does NOT invent a second store. #266 adds the learned-from
+trace-back: given an entry, resolve the session and source traces it was learned
+from (the "how did it learn that?" answer). The edit/delete write side is #267.
+"""
+
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+
+from .. import crud
+from ..auth import require_api_key
+from ..config import get_settings
+from ..deps import SessionDep
+from ..models import WorkflowStateEntry
+from ..schemas import (
+    MemoryEntryOut,
+    MemoryProvenanceOut,
+    MemoryTraceBackOut,
+    SourceTraceOut,
+)
+
+router = APIRouter(
+    prefix="/agents", tags=["memory"], dependencies=[Depends(require_api_key)]
+)
+
+# The runner writes memory here (mirrors runner/agentos_runner/memory.py:
+# a single log-shaped key inside the reserved ``memory`` namespace).
+MEMORY_NAMESPACE = "memory"
+MEMORY_LOG_KEY = "log"
+
+
+async def _load_log(session: SessionDep, agent_id: uuid.UUID) -> list[dict[str, Any]]:
+    """Return the raw memory-log records for an agent (404 if the agent is gone).
+
+    An absent log is an empty list -- a fresh agent with no learned memory yet,
+    not an error. A non-list stored value is treated as empty rather than a 500;
+    the store's own shape guard (#248 append) keeps it a list in practice.
+    """
+    if await crud.get_agent(session, agent_id) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+    entry: WorkflowStateEntry | None = await session.scalar(
+        select(WorkflowStateEntry).where(
+            WorkflowStateEntry.agent_id == agent_id,
+            WorkflowStateEntry.namespace == MEMORY_NAMESPACE,
+            WorkflowStateEntry.key == MEMORY_LOG_KEY,
+        )
+    )
+    if entry is None or not isinstance(entry.value, list):
+        return []
+    return [item for item in entry.value if isinstance(item, dict) and "content" in item]
+
+
+def _provenance_of(record: dict[str, Any]) -> dict[str, Any]:
+    prov = record.get("provenance")
+    return prov if isinstance(prov, dict) else {}
+
+
+def _trace_url(trace_id: str) -> str:
+    """A Langfuse deep link for a source trace id (the trace-back target)."""
+    base = get_settings().langfuse_host.rstrip("/")
+    return f"{base}/trace/{trace_id}"
+
+
+@router.get("/{agent_id}/memory", response_model=list[MemoryEntryOut])
+async def list_memory(agent_id: uuid.UUID, session: SessionDep) -> list[MemoryEntryOut]:
+    """List an agent's learned memory entries, oldest first, with provenance."""
+    records = await _load_log(session, agent_id)
+    return [
+        MemoryEntryOut(
+            index=i,
+            content=str(rec.get("content", "")),
+            provenance=MemoryProvenanceOut(**_provenance_of(rec)),
+        )
+        for i, rec in enumerate(records)
+    ]
+
+
+@router.get(
+    "/{agent_id}/memory/{index}/provenance", response_model=MemoryTraceBackOut
+)
+async def memory_trace_back(
+    agent_id: uuid.UUID, index: int, session: SessionDep
+) -> MemoryTraceBackOut:
+    """Resolve one entry's learned-from trace-back (#266).
+
+    Returns the session and the source traces the lesson was distilled from,
+    each with a Langfuse deep link. Reuses the provenance the runner recorded at
+    ``remember`` time -- it does not re-derive or invent provenance.
+    """
+    records = await _load_log(session, agent_id)
+    if index < 0 or index >= len(records):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "memory entry not found")
+    record = records[index]
+    prov = _provenance_of(record)
+    trace_ids = prov.get("source_trace_ids") or []
+    return MemoryTraceBackOut(
+        index=index,
+        content=str(record.get("content", "")),
+        learned_from_session_id=prov.get("learned_from_session_id"),
+        recorded_at=prov.get("recorded_at", ""),
+        source_traces=[
+            SourceTraceOut(trace_id=str(tid), trace_url=_trace_url(str(tid)))
+            for tid in trace_ids
+        ],
+    )

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -445,3 +445,54 @@ class StateEntryOut(BaseModel):
     value: Any
     version: int
     updated_at: datetime
+
+
+# --- Agent memory (#266 trace-back; #267 inspect/edit/delete) ---------------
+
+
+class MemoryProvenanceOut(BaseModel):
+    """Where a memory entry was learned from (#264 ``Provenance`` shape)."""
+
+    learned_from_session_id: str | None = None
+    source_trace_ids: list[str] = Field(default_factory=list)
+    recorded_at: str = ""
+
+
+class SourceTraceOut(BaseModel):
+    """One resolved source trace: its id plus a link to view it in Langfuse."""
+
+    trace_id: str
+    trace_url: str
+
+
+class MemoryEntryOut(BaseModel):
+    """One learned memory entry as returned to an operator.
+
+    ``index`` is the entry's position in the append-only log; it is the stable
+    handle the edit/delete endpoints (#267) address, and it survives as long as
+    the log is not consolidated (#265) or reordered.
+    """
+
+    index: int
+    content: str
+    provenance: MemoryProvenanceOut
+
+
+class MemoryTraceBackOut(BaseModel):
+    """The learned-from trace-back for one memory entry (#266).
+
+    Resolves an entry's recorded provenance into the concrete session and source
+    traces the lesson was learned from -- the answer to "how did it learn that?".
+    """
+
+    index: int
+    content: str
+    learned_from_session_id: str | None = None
+    recorded_at: str = ""
+    source_traces: list[SourceTraceOut] = Field(default_factory=list)
+
+
+class MemoryEntryEdit(BaseModel):
+    """Edit the ``content`` of one memory entry (#267); provenance is preserved."""
+
+    content: str

--- a/apps/api/tests/test_memory.py
+++ b/apps/api/tests/test_memory.py
@@ -1,0 +1,110 @@
+"""Agent memory read + learned-from trace-back (#266).
+
+Seeds the runner-written memory log via the state append endpoint (the same wire
+the runner uses), then exercises the read/trace-back surface against the real
+compose Postgres.
+"""
+
+from typing import Any
+
+
+def _agent(client: Any, headers: dict[str, str]) -> str:
+    resp = client.post(
+        "/agents",
+        json={"name": "memory-agent", "slack_channel": "C000000M01"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    agent_id: str = resp.json()["id"]
+    return agent_id
+
+
+def _remember(client: Any, headers: dict[str, str], aid: str, record: dict) -> None:
+    """Append one {content, provenance} record to the memory log key."""
+    url = f"/agents/{aid}/state/memory/log/append"
+    r = client.post(url, json={"item": record}, headers=headers)
+    assert r.status_code == 200, r.text
+
+
+def test_list_memory_empty_for_fresh_agent(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    r = client.get(f"/agents/{aid}/memory", headers=auth_headers)
+    assert r.status_code == 200, r.text
+    assert r.json() == []
+
+
+def test_list_memory_returns_entries_with_provenance(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(
+        client,
+        auth_headers,
+        aid,
+        {
+            "content": "deploy is a git push",
+            "provenance": {
+                "learned_from_session_id": "sess-1",
+                "source_trace_ids": ["trace-a", "trace-b"],
+                "recorded_at": "2026-07-13T00:00:00+00:00",
+            },
+        },
+    )
+    _remember(client, auth_headers, aid, {"content": "no-provenance lesson"})
+
+    entries = client.get(f"/agents/{aid}/memory", headers=auth_headers).json()
+    assert len(entries) == 2
+    assert entries[0]["index"] == 0
+    assert entries[0]["content"] == "deploy is a git push"
+    assert entries[0]["provenance"]["source_trace_ids"] == ["trace-a", "trace-b"]
+    # A record with no recorded provenance degrades to empty provenance, not 500.
+    assert entries[1]["provenance"]["source_trace_ids"] == []
+
+
+def test_trace_back_resolves_sessions_and_traces(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(
+        client,
+        auth_headers,
+        aid,
+        {
+            "content": "prod push reuses the dev bundle",
+            "provenance": {
+                "learned_from_session_id": "sess-9",
+                "source_trace_ids": ["trace-x", "trace-y"],
+                "recorded_at": "2026-07-13T01:00:00+00:00",
+            },
+        },
+    )
+
+    r = client.get(f"/agents/{aid}/memory/0/provenance", headers=auth_headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["learned_from_session_id"] == "sess-9"
+    assert body["recorded_at"] == "2026-07-13T01:00:00+00:00"
+    trace_ids = [t["trace_id"] for t in body["source_traces"]]
+    assert trace_ids == ["trace-x", "trace-y"]
+    # Each source trace resolves to a viewable link.
+    for t in body["source_traces"]:
+        assert t["trace_url"].endswith(f"/trace/{t['trace_id']}")
+
+
+def test_trace_back_out_of_range_index_is_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(client, auth_headers, aid, {"content": "only one"})
+    r = client.get(f"/agents/{aid}/memory/5/provenance", headers=auth_headers)
+    assert r.status_code == 404, r.text
+
+
+def test_memory_unknown_agent_is_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    missing = "00000000-0000-0000-0000-000000000000"
+    r = client.get(f"/agents/{missing}/memory", headers=auth_headers)
+    assert r.status_code == 404, r.text

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -53,6 +53,12 @@ SESSION_ID_ENV = "AGENTOS_SESSION_ID"
 AGENT_ID_ENV = "AGENTOS_AGENT_ID"
 FAKE_MODEL_ENV = "AGENTOS_FAKE_MODEL"
 CREDENTIALS_ENV = "AGENTOS_CREDENTIALS"
+# The memory port (#264): the URL of the agent's memory namespace on the state
+# API, dereferenced by the runner at boot, plus the API key it authenticates
+# with. MEMORY_REF is the frozen ACI SessionConfig field; MEMORY_TOKEN is a
+# runner-local knob (not part of the frozen env), like AGENTOS_RUNNER_TOKEN.
+MEMORY_REF_ENV = "AGENTOS_MEMORY_REF"
+MEMORY_TOKEN_ENV = "AGENTOS_MEMORY_TOKEN"
 BASE_URL_ENV = "ANTHROPIC_BASE_URL"
 MODEL_ENV = "AGENTOS_MODEL"
 # Per-claim bearer token the runner enforces on its ACI POST routes (issue #63).
@@ -179,6 +185,15 @@ class BindingResolver:
         }
         if resolved.bundle_ref is not None:
             env[BUNDLE_REF_ENV] = resolved.bundle_ref
+        # Deliver the memory ref (#264): the agent's scoped namespace on the
+        # durable state store (#23/#248). The runner dereferences it at boot to
+        # load prior memory and to append learned records with provenance. The
+        # API key is forwarded as the memory token; a scoped, least-privilege
+        # memory token is future work (the state API has one shared key today).
+        base = self._config.api_base_url.rstrip("/")
+        env[MEMORY_REF_ENV] = f"{base}/agents/{resolved.agent_id}/state/memory"
+        if self._config.api_key:
+            env[MEMORY_TOKEN_ENV] = self._config.api_key
         # The agent's pinned model (#254) overrides the worker default; None
         # falls back to config.model inside apply_model_env.
         apply_model_env(env, self._config, model_override=resolved.model)

--- a/docs/adr/0025-memory-port-and-first-loader.md
+++ b/docs/adr/0025-memory-port-and-first-loader.md
@@ -1,0 +1,92 @@
+# 25. The memory port and its first loader: a scoped namespace over the durable state store
+
+Date: 2026-07-13
+
+Status: Accepted
+
+Implements the memory seam for epic [#28](https://github.com/curie-eng/agentos/issues/28),
+issue [#264](https://github.com/curie-eng/agentos/issues/264). This is the first
+loader for `AGENTOS_MEMORY_REF`, which until now was a `SessionConfig` field
+carried end-to-end but never dereferenced
+([`docs/interfaces/memory/INTERFACE.md`](../interfaces/memory/INTERFACE.md)).
+
+## Context
+
+Agent memory (durable lessons an agent carries across sessions, with provenance
+back to the turns they were learned from) is the seventh swappable job around the
+opinionated core. Per ADR-0016, we do not build an adapter framework ahead of a
+second implementation; we build the *first* implementation and let it define the
+port. There was no first loader, so the port was unbuilt on purpose.
+
+Two constraints shape the design:
+
+- **Memory lives outside the sandbox** (ADR-0003, stateless-first). Sandboxes do
+  not survive suspend/resume, so a resumed thread must rehydrate from an
+  external, durable resource. An emptyDir-scratch or in-process cache would be
+  lost on every suspend. So memory must be a network-reachable, rehydratable
+  store resolved from `memory_ref` at boot.
+- **We already landed a durable KV/document store** for #23/#248: an
+  agent-scoped, namespaced, Postgres-JSONB-backed store with a log-shaped
+  `append` endpoint and per-value/per-namespace size caps
+  (`apps/api` `/agents/{agent_id}/state/{namespace}/{key}`). Standing up a
+  second datastore (S3 objects, a bespoke memory service) for memory would be a
+  new seam to operate for no benefit the state store does not already give.
+
+## Decision
+
+**Memory is a scoped namespace (`memory`) over the existing durable state
+store, behind a small `MemoryStore` port.**
+
+- **The port** (`runner/src/agentos_runner/memory.py`) is a `Protocol` with two
+  methods: `load() -> list[MemoryRecord]` and `append(record)`. No query
+  language and no `consolidate` — consolidation is later work (#265/#266/#267).
+  A `MemoryRecord` is `content` plus a `Provenance` (`learned_from_session_id`,
+  `source_trace_ids`, `recorded_at`) — the entry→source-traces link the epic
+  calls for.
+- **The default backing** is `StateApiMemoryStore`: `load` GETs the single
+  log-shaped key in the agent's `memory` namespace; `append` POSTs to that key's
+  `/append` endpoint (#248). Durability, size caps, and survive-suspend/resume
+  come from the state store for free. `NullMemoryStore` is used when no ref is
+  configured, so the boot path is uniform.
+- **`AGENTOS_MEMORY_REF` resolution:** the ref is the URL of the agent's memory
+  namespace on the state API (`http(s)://api/agents/<id>/state/memory`). An
+  `s3://` or other scheme is reserved for a future loader and rejected loudly at
+  boot. The frozen ACI `SessionConfig.memory_ref` field is unchanged — no
+  frozen-contract change. The state-API bearer is a **runner-local** knob
+  (`AGENTOS_MEMORY_TOKEN`), like `AGENTOS_RUNNER_TOKEN`/`AGENTOS_MODEL`, not part
+  of the frozen env.
+- **Delivery into the sandbox:** at runner boot the store is resolved, prior
+  memory is loaded, and it is composed into the effective system prompt as a
+  memory preamble (so the model sees prior lessons as durable context). The write
+  side is `SessionRunner.remember(...)`, which stamps provenance and appends.
+- **Boot resilience:** an unsupported ref scheme fails the process loudly; a
+  *transient* load failure degrades to "no memory" rather than blocking boot, so
+  an agent still runs when its memory store is briefly unavailable.
+- **The worker delivers the ref:** `binding.boot_env` sets `AGENTOS_MEMORY_REF`
+  to the agent's namespace URL and forwards the API key as `AGENTOS_MEMORY_TOKEN`.
+
+## Alternatives considered
+
+- **A new S3/object-store memory backend.** Rejected: a second datastore to
+  operate when the durable state store already gives durability, agent-scoping,
+  namespacing, size caps, and an append log. The state store is the adopted
+  spine for exactly this cross-turn durable state.
+- **Auto-mounted memory MCP server for bundle code.** Deferred: exposing the
+  store to the model as a tool (rather than a boot-time preamble + runner-driven
+  append) is the same "later slice" the state store's own docstring flags. The
+  port here does not preclude it.
+- **Deriving `memory_ref` as an SDK resume id.** Rejected earlier and preserved:
+  `history_ref` (SDK resume) and `memory_ref` (externalized memory) are distinct
+  concepts (see `runner/config.py`); memory is not an SDK-resumable transcript.
+
+## Consequences
+
+- Memory is durable, provenance-carrying, and survives suspend/resume with no new
+  infrastructure.
+- **Known limitation:** the state API has one shared API key today, so forwarding
+  it as the memory token grants the sandbox that key's full scope. A scoped,
+  least-privilege memory token (or an API-side per-agent capability) is follow-up
+  work, tracked with the same auth-hardening as the rest of the API.
+- The automatic learned-record *extraction* that decides what to remember is out
+  of scope here (#265/#266/#267); this ADR lands the port, the loader, boot
+  wiring, and the write API `remember` calls.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -24,7 +24,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Bundle format | CLEAN, frozen | 1 | not separately graded | #30 | [interfaces/bundle-format/INTERFACE.md](interfaces/bundle-format/INTERFACE.md) |
 | Approval / authorizer | NONE | 0 | not separately graded | #22 | [interfaces/approval/INTERFACE.md](interfaces/approval/INTERFACE.md) |
 | Workflow state store | NONE | 0 (concrete AffinityStore) | not separately graded | #23 | [interfaces/workflow-state/INTERFACE.md](interfaces/workflow-state/INTERFACE.md) |
-| Memory | NONE (field only) | 0 loaders | not separately graded | #28 | [interfaces/memory/INTERFACE.md](interfaces/memory/INTERFACE.md) |
+| Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [interfaces/memory/INTERFACE.md](interfaces/memory/INTERFACE.md) |
 | Triggers | SOFT | 2 hardcoded (Slack, GH push) | not separately graded | #29 | [interfaces/triggers/INTERFACE.md](interfaces/triggers/INTERFACE.md) |
 
 ## Kind legend

--- a/docs/interfaces/memory/INTERFACE.md
+++ b/docs/interfaces/memory/INTERFACE.md
@@ -1,48 +1,68 @@
 # INTERFACE: Memory
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** NONE &nbsp;·&nbsp; **Implementations today:** 0 loaders &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 loader (`StateApiMemoryStore`) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
 ## The black line
 
-There is no black line yet — memory is a **field only**. `SessionConfig` carries an optional
-`memory_ref` (`packages/aci-protocol/src/aci_protocol/session.py:68`) mapped to the
-`AGENTOS_MEMORY_REF` env var (`:85` in `to_env`, `:115` in `from_env`; documented as "optional;
-S3 path / API URL" in the README contract table). The reference is plumbed end-to-end through the
-session contract but **never dereferenced**: there are zero memory loaders in the codebase today.
-The port (load / append / consolidate) is unbuilt on purpose — "the second implementation teaches
-the interface," and there is no first loader to teach it yet.
+The port is the `MemoryStore` `Protocol` in
+`runner/src/agentos_runner/memory.py` (issue #264, ADR-0025). Two methods:
+
+```python
+class MemoryStore(Protocol):
+    async def load(self) -> list[MemoryRecord]: ...
+    async def append(self, record: MemoryRecord) -> None: ...
+```
+
+A `MemoryRecord` is `content: str` plus a `Provenance`
+(`learned_from_session_id`, `source_trace_ids`, `recorded_at`) — the
+entry→source-traces link. `SessionConfig.memory_ref`
+(`packages/aci-protocol/src/aci_protocol/session.py:68`, `AGENTOS_MEMORY_REF`) is
+resolved to a concrete `MemoryStore` at runner boot by `resolve_memory`. The
+frozen ACI field is unchanged; the state-API bearer is a runner-local knob
+(`AGENTOS_MEMORY_TOKEN`), not part of the frozen env.
 
 ## Current contract
 
-The only committed surface is the optional string field:
-
-```python
-memory_ref: str | None = None   # session.py:68
-```
-
-and its env round-trip (`session.py:85`, `:115`). Nothing reads it. A future implementation must
-define the port — sketched by epic #28 as `load(memory_ref) -> records`,
-`append(record + provenance)`, `consolidate` — along with how `AGENTOS_MEMORY_REF` resolves (S3
-path vs API URL) and the shape of a provenance record. None of that exists in code on this branch.
+- **Resolution.** `resolve_memory(memory_ref, env)`: an absent ref →
+  `NullMemoryStore`; an `http(s)://` ref → `StateApiMemoryStore`; any other
+  scheme (`s3://` …) is reserved for a future loader and rejected loudly.
+- **Load side.** `load()` returns prior records oldest-first (empty when none).
+  At boot the runner loads memory and composes it into the effective system
+  prompt as a preamble — this is how memory is *delivered into the sandbox*. A
+  transient load failure degrades to "no memory" and does not block boot.
+- **Append side.** `append(record)` durably writes one record; provenance is
+  stamped by `SessionRunner.remember(content, source_trace_ids=...)`. The record
+  survives suspend/resume and is reloaded at the next boot.
 
 ## Implementations today
 
-Zero. `memory_ref` is carried by `SessionConfig` and forwarded into the sandbox environment; no
-producer or consumer dereferences it.
+One: **`StateApiMemoryStore`**, backing memory as a scoped `memory` namespace
+over the durable KV/document store landed for #23/#248
+(`apps/api` `/agents/{agent_id}/state/{namespace}/{key}`, Postgres JSONB).
+`load` GETs the single log-shaped key; `append` POSTs to that key's `/append`
+endpoint (#248), inheriting durability and the per-value/per-namespace size caps.
+The worker (`binding.boot_env`) delivers the ref as
+`http(s)://api/agents/<id>/state/memory` and forwards the API key as the memory
+token. `NullMemoryStore` is the no-ref sink.
 
 ## Known leakage
 
-Not applicable — nothing is built to leak. The load-bearing constraint the future implementation
-must honor: **memory lives OUTSIDE the sandbox.** Per ADR-0003 (stateless-first; session state is
-externalized and a resumed thread rehydrates from history, never from a surviving in-RAM process),
-the memory store must be an external, rehydratable resource resolved from `memory_ref`, not
-in-pod state — an emptyDir-scratch or in-process cache would be lost on every suspend/resume.
+- **Shared API key as the memory token.** The state API has one shared API key
+  today, so forwarding it into the sandbox as `AGENTOS_MEMORY_TOKEN` grants that
+  key's full scope. A scoped, least-privilege memory token is follow-up work
+  (ADR-0025, consequences).
+- **No consolidate / no query.** The port is deliberately `load`/`append` only;
+  consolidation and automatic learned-record extraction are later slices
+  (#265/#266/#267). The load-bearing constraint remains: **memory lives OUTSIDE
+  the sandbox** (ADR-0003) — the store is network-reachable and rehydratable, not
+  pod-local state.
 
 ## Cross-links
 
-- **Epic(s):** [#28](https://github.com/curie-eng/agentos/issues/28) — define the memory port (`load` / `append` / `consolidate`), `AGENTOS_MEMORY_REF` resolution, and the provenance record shape
+- **Epic(s):** [#28](https://github.com/curie-eng/agentos/issues/28) — the memory port, `AGENTOS_MEMORY_REF` resolution, provenance record shape
+- **Issue:** [#264](https://github.com/curie-eng/agentos/issues/264) — this first loader
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — memory is not one of the six swap-readiness Jobs; not separately graded
-- **ADR(s):** [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) — stateless-first; rehydrate on resume; externalize session state
+- **ADR(s):** [ADR-0025](../../adr/0025-memory-port-and-first-loader.md) — the port + first loader; [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) — stateless-first; rehydrate on resume; externalize session state

--- a/runner/src/agentos_runner/__init__.py
+++ b/runner/src/agentos_runner/__init__.py
@@ -15,6 +15,16 @@ from .config import RunnerConfig
 from .conformance import conformance_producer
 from .fake import FakeModelSession
 from .hooks import load_bundle_hooks
+from .memory import (
+    MemoryError,
+    MemoryRecord,
+    MemoryStore,
+    NullMemoryStore,
+    Provenance,
+    StateApiMemoryStore,
+    format_memory_preamble,
+    resolve_memory,
+)
 from .otel import RunTracer, build_tracer_provider
 from .plugin import PluginBundleError, load_bundle_system_prompt, load_plugins
 from .server import create_app
@@ -42,4 +52,12 @@ __all__ = [
     "SessionRunner",
     "SideEffectClassifier",
     "DEFAULT_IDEMPOTENT_TOOLS",
+    "MemoryStore",
+    "MemoryRecord",
+    "Provenance",
+    "NullMemoryStore",
+    "StateApiMemoryStore",
+    "MemoryError",
+    "resolve_memory",
+    "format_memory_preamble",
 ]

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -12,12 +12,14 @@ import logging
 import os
 import sys
 
+import anyio
 from aiohttp import web
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .hooks import load_bundle_hooks
+from .memory import MemoryRecord, MemoryStore, format_memory_preamble, resolve_memory
 from .otel import RunTracer, build_tracer_provider
 from .plugin import load_bundle_system_prompt, load_plugins
 from .sdk_auth import UnsupportedCredentialError, resolve_sdk_env
@@ -28,11 +30,25 @@ from .side_effects import SideEffectClassifier
 logger = logging.getLogger(__name__)
 
 
+def _compose_system_prompt(base: str | None, memory_preamble: str | None) -> str | None:
+    """Prepend the loaded-memory preamble to the effective system prompt.
+
+    Memory delivered from outside the sandbox becomes durable model context by
+    leading the system prompt; the bundle/env system prompt follows it. Either
+    part may be absent.
+    """
+
+    parts = [p for p in (memory_preamble, base) if p]
+    return "\n\n".join(parts) if parts else None
+
+
 def build_runner(
     config: RunnerConfig,
     *,
     fake_model: bool = False,
     sdk_env: dict[str, str] | None = None,
+    memory_store: MemoryStore | None = None,
+    memory_preamble: str | None = None,
 ) -> SessionRunner:
     """Wire a SessionRunner backed by a real claude-agent-sdk session.
 
@@ -48,6 +64,9 @@ def build_runner(
     system_prompt = config.system_prompt
     if system_prompt is None:
         system_prompt = load_bundle_system_prompt(config.session.plugin_dir)
+    # Prior memory loaded from outside the sandbox (#264) leads the system prompt
+    # so the model sees learned lessons as durable context.
+    system_prompt = _compose_system_prompt(system_prompt, memory_preamble)
     # In-bundle PreToolUse guardrails declared in the manifest hooks field (#272),
     # translated into SDK HookMatcher callbacks. None when the bundle declares none.
     bundle_hooks = load_bundle_hooks(config.session.plugin_dir)
@@ -82,7 +101,38 @@ def build_runner(
         trace_name=f"agentos-run:{config.session.session_id}",
         session_id=config.session.session_id,
         model=config.model,
+        memory_store=memory_store,
     )
+
+
+def _load_memory(config: RunnerConfig) -> tuple[MemoryStore, str | None]:
+    """Resolve AGENTOS_MEMORY_REF and load prior memory into a boot preamble.
+
+    Runs synchronously at boot (before the port is up), so a bad ref or an
+    unreachable store fails the process visibly rather than after serving. A
+    transient load failure degrades to "no memory" and does NOT block boot -- an
+    agent must still be able to run when its memory store is briefly unavailable.
+    """
+
+    store = resolve_memory(config.session.memory_ref, os.environ)
+
+    async def _load() -> list[MemoryRecord]:
+        return await store.load()
+
+    try:
+        records = anyio.run(_load)
+    except Exception as exc:  # noqa: BLE001 - degrade to no-memory, never fail boot
+        logger.warning(
+            "memory load failed session=%s error_class=%s: %s (booting without memory)",
+            config.session.session_id,
+            type(exc).__name__,
+            exc,
+        )
+        return store, None
+    logger.info(
+        "memory loaded session=%s records=%d", config.session.session_id, len(records)
+    )
+    return store, format_memory_preamble(records)
 
 
 def main() -> None:
@@ -107,7 +157,14 @@ def main() -> None:
         config.model,
         config.port,
     )
-    runner = build_runner(config, fake_model=fake_model, sdk_env=override)
+    memory_store, memory_preamble = _load_memory(config)
+    runner = build_runner(
+        config,
+        fake_model=fake_model,
+        sdk_env=override,
+        memory_store=memory_store,
+        memory_preamble=memory_preamble,
+    )
     app = create_app(runner, token=config.runner_token)
 
     async def _startup(_app: web.Application) -> None:

--- a/runner/src/agentos_runner/memory.py
+++ b/runner/src/agentos_runner/memory.py
@@ -1,0 +1,241 @@
+"""The memory port: resolve ``AGENTOS_MEMORY_REF`` and load/append agent memory.
+
+This is the first loader for the memory seam (issue #264, epic #28). Until now
+``memory_ref`` was a ``SessionConfig`` field carried end-to-end but never
+dereferenced (see ``docs/interfaces/memory/INTERFACE.md``). This module defines
+the port and its first concrete backing.
+
+Design (ADR-0025):
+
+- **Memory lives outside the sandbox** (ADR-0003, stateless-first). A resumed
+  thread must rehydrate from an external, durable resource, never from surviving
+  in-process state. So the store is reached over the network at boot, not held in
+  pod-local scratch.
+- **The backing reuses the durable KV/document store** landed for #23/#248
+  (``apps/api`` ``/agents/{agent_id}/state/{namespace}/{key}``, Postgres JSONB),
+  rather than inventing a new datastore. Memory is a **scoped namespace** over
+  that store: the log-shaped ``append`` endpoint gives us the append-only,
+  provenance-carrying write the memory port needs, and ``get`` gives us load.
+- **The port is small and swappable** -- ``load`` / ``append`` -- matching the
+  "seventh swappable job, one default backing" framing of the interface doc. A
+  future S3- or API-backed loader is a drop-in ``MemoryStore``.
+
+``AGENTOS_MEMORY_REF`` resolution: the ref is the URL of the agent's memory
+namespace on the state API (e.g. ``http://api:8000/agents/<id>/state/memory``).
+The runner authenticates to that API with ``AGENTOS_MEMORY_TOKEN`` (a
+runner-local knob, like ``AGENTOS_RUNNER_TOKEN``/``AGENTOS_MODEL`` -- NOT part of
+the frozen ACI ``SessionConfig`` env, so no frozen-contract change). An ``s3://``
+or other scheme is reserved for a future loader and rejected loudly today.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+# The single log-shaped key inside the agent's memory namespace. The whole
+# namespace is reserved for memory; one append-only log key keeps load a single
+# GET and append a single POST against the #248 log endpoint.
+MEMORY_LOG_KEY = "log"
+
+# Runner-local env carrying the bearer the state API expects (X-API-Key). Not a
+# model credential and not part of the frozen ACI SessionConfig -- resolved the
+# same way as the other runner-local knobs in config.py.
+MEMORY_TOKEN_ENV = "AGENTOS_MEMORY_TOKEN"
+
+
+class MemoryError(RuntimeError):
+    """A memory reference could not be resolved or dereferenced."""
+
+
+@dataclass(frozen=True)
+class Provenance:
+    """Where a memory record was learned from -- links the entry to its sources.
+
+    ``learned_from_session_id`` is the ACI session that produced the record;
+    ``source_trace_ids`` are the OTel/Langfuse trace ids of the turns the lesson
+    was distilled from. ``recorded_at`` is set at append time. This is the shape
+    the epic (#28) calls for: entry -> source trace ids.
+    """
+
+    learned_from_session_id: str | None = None
+    source_trace_ids: tuple[str, ...] = ()
+    recorded_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "learned_from_session_id": self.learned_from_session_id,
+            "source_trace_ids": list(self.source_trace_ids),
+            "recorded_at": self.recorded_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> Provenance:
+        return cls(
+            learned_from_session_id=data.get("learned_from_session_id"),
+            source_trace_ids=tuple(data.get("source_trace_ids") or ()),
+            recorded_at=data.get("recorded_at", ""),
+        )
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    """One durable memory entry: the learned content plus its provenance."""
+
+    content: str
+    provenance: Provenance = field(default_factory=Provenance)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"content": self.content, "provenance": self.provenance.to_dict()}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> MemoryRecord:
+        prov = data.get("provenance")
+        return cls(
+            content=data["content"],
+            provenance=Provenance.from_dict(prov) if isinstance(prov, Mapping) else Provenance(),
+        )
+
+
+@runtime_checkable
+class MemoryStore(Protocol):
+    """The memory port: load prior records, append a new one with provenance.
+
+    Deliberately narrow -- no query language, no consolidate (that is a later
+    slice, #265/#266/#267). A concrete store dereferences a ``memory_ref`` to a
+    durable, rehydratable backing that lives outside the sandbox.
+    """
+
+    async def load(self) -> list[MemoryRecord]:
+        """Return prior memory records, oldest first (empty when none)."""
+        ...
+
+    async def append(self, record: MemoryRecord) -> None:
+        """Durably append one record; it must survive suspend/resume."""
+        ...
+
+
+class NullMemoryStore:
+    """The no-memory store used when ``AGENTOS_MEMORY_REF`` is unset.
+
+    ``load`` yields nothing and ``append`` is a silent no-op, so the boot path is
+    uniform whether or not an agent has memory configured.
+    """
+
+    async def load(self) -> list[MemoryRecord]:
+        return []
+
+    async def append(self, record: MemoryRecord) -> None:  # noqa: ARG002 - null sink
+        return None
+
+
+class StateApiMemoryStore:
+    """Memory backed by the durable state store (#23/#248), the default loader.
+
+    ``memory_ref`` is the URL of the agent's memory namespace on the state API
+    (``.../agents/<id>/state/memory``). Load is a GET of the single log key;
+    append is a POST to the log's ``/append`` endpoint. The state API enforces
+    the size caps (#248) and the Postgres JSONB backing gives durability across
+    suspend/resume for free.
+    """
+
+    def __init__(self, namespace_url: str, token: str | None) -> None:
+        # Normalize to no trailing slash so key URLs compose cleanly.
+        self._base = namespace_url.rstrip("/")
+        self._token = token
+
+    @property
+    def _log_url(self) -> str:
+        return f"{self._base}/{MEMORY_LOG_KEY}"
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-API-Key": self._token} if self._token else {}
+
+    async def load(self) -> list[MemoryRecord]:
+        timeout = aiohttp.ClientTimeout(total=15)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(self._log_url, headers=self._headers()) as resp:
+                if resp.status == 404:
+                    # No memory written yet -- a fresh agent, not an error.
+                    return []
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise MemoryError(
+                        f"memory load failed: {resp.status} {body[:200]}"
+                    )
+                payload = await resp.json()
+        value = payload.get("value")
+        if not isinstance(value, list):
+            raise MemoryError("memory log is not a JSON array")
+        records: list[MemoryRecord] = []
+        for item in value:
+            if isinstance(item, Mapping) and "content" in item:
+                records.append(MemoryRecord.from_dict(item))
+        return records
+
+    async def append(self, record: MemoryRecord) -> None:
+        timeout = aiohttp.ClientTimeout(total=15)
+        body = json.dumps({"item": record.to_dict()})
+        headers = {**self._headers(), "Content-Type": "application/json"}
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                f"{self._log_url}/append", data=body, headers=headers
+            ) as resp:
+                if resp.status not in (200, 201):
+                    text = await resp.text()
+                    raise MemoryError(
+                        f"memory append failed: {resp.status} {text[:200]}"
+                    )
+
+
+def resolve_memory(memory_ref: str | None, env: Mapping[str, str]) -> MemoryStore:
+    """Resolve ``AGENTOS_MEMORY_REF`` to a concrete ``MemoryStore`` at boot.
+
+    An absent ref yields the ``NullMemoryStore`` (memory is optional). An
+    ``http(s)://`` ref is the state-API namespace URL and yields the default
+    ``StateApiMemoryStore``. Any other scheme (``s3://`` etc.) is reserved for a
+    future loader and rejected loudly rather than silently ignored, so a
+    misconfigured ref fails visibly at boot rather than dropping memory.
+    """
+
+    if not memory_ref:
+        return NullMemoryStore()
+    if memory_ref.startswith(("http://", "https://")):
+        return StateApiMemoryStore(memory_ref, env.get(MEMORY_TOKEN_ENV))
+    raise MemoryError(
+        f"unsupported AGENTOS_MEMORY_REF scheme: {memory_ref!r} "
+        "(only http(s):// state-API refs are implemented today)"
+    )
+
+
+def format_memory_preamble(records: Sequence[MemoryRecord]) -> str | None:
+    """Render prior memory as a system-prompt preamble, or None when empty.
+
+    This is how loaded memory is *delivered into the sandbox*: it is composed
+    into the runner's effective system prompt at boot, so the model sees prior
+    lessons as durable context. Provenance is summarized inline so a lesson is
+    traceable back to the turns it came from.
+    """
+
+    if not records:
+        return None
+    lines = ["# Agent memory (learned from prior sessions)", ""]
+    for record in records:
+        prov = record.provenance
+        traces = ", ".join(prov.source_trace_ids) if prov.source_trace_ids else ""
+        suffix = f"  (learned from traces: {traces})" if traces else ""
+        lines.append(f"- {record.content}{suffix}")
+    return "\n".join(lines)
+
+
+def utcnow_iso() -> str:
+    """An RFC3339 UTC timestamp for a provenance record's ``recorded_at``."""
+    return datetime.now(UTC).isoformat()

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -38,6 +38,7 @@ from claude_agent_sdk import AssistantMessage, ResultMessage
 
 from .adapter import ModelSession
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
+from .memory import MemoryRecord, MemoryStore, NullMemoryStore, Provenance, utcnow_iso
 from .otel import RunTracer, _GenerationSpan
 from .side_effects import SideEffectClassifier
 from .translate import TurnState, translate_message
@@ -84,6 +85,7 @@ class SessionRunner:
         trace_name: str,
         session_id: str | None = None,
         model: str | None = None,
+        memory_store: MemoryStore | None = None,
     ) -> None:
         self._factory = session_factory
         self._ceiling = ceiling
@@ -92,6 +94,10 @@ class SessionRunner:
         self._trace_name = trace_name
         self._session_id = session_id
         self._model = model
+        # The memory port (#264). Prior memory is loaded at boot and delivered
+        # via the system prompt; this store is the write side for learned records
+        # (append + provenance). NullMemoryStore when no AGENTOS_MEMORY_REF.
+        self._memory: MemoryStore = memory_store or NullMemoryStore()
 
         self._session: ModelSession | None = None
         self._turn_lock = anyio.Lock()
@@ -118,6 +124,31 @@ class SessionRunner:
         """True while a turn can still accept a steer (open, pre-terminal)."""
 
         return self._turn_open
+
+    async def remember(
+        self,
+        content: str,
+        *,
+        source_trace_ids: tuple[str, ...] = (),
+    ) -> None:
+        """Append a learned record to durable memory with provenance (#264).
+
+        Provenance links the entry to the session that produced it and the source
+        traces the lesson was distilled from. The write goes to the external
+        store, so the record survives suspend/resume and is reloaded at the next
+        boot. This is the write side of the memory port; the automatic
+        learned-record extraction that calls it is later work (#265/#266/#267).
+        """
+
+        record = MemoryRecord(
+            content=content,
+            provenance=Provenance(
+                learned_from_session_id=self._session_id,
+                source_trace_ids=source_trace_ids,
+                recorded_at=utcnow_iso(),
+            ),
+        )
+        await self._memory.append(record)
 
     async def start(self) -> None:
         """Create and connect the model session (rehydrating if configured)."""

--- a/runner/tests/test_memory.py
+++ b/runner/tests/test_memory.py
@@ -1,0 +1,188 @@
+"""The memory port: resolution, record shape, preamble, and the state-API store.
+
+The StateApiMemoryStore is exercised against a tiny in-memory fake of the #248
+log-shaped state endpoints (GET the key, POST .../append), so load/append and the
+provenance round-trip are verified end-to-end over real HTTP without the API.
+"""
+
+import anyio
+import pytest
+from agentos_runner.memory import (
+    MemoryError,
+    MemoryRecord,
+    NullMemoryStore,
+    Provenance,
+    StateApiMemoryStore,
+    format_memory_preamble,
+    resolve_memory,
+)
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+
+def _fake_state_app() -> tuple[web.Application, list]:
+    """A minimal fake of the state API's log key at /agents/A/state/memory/log."""
+    log: list = []
+    app = web.Application()
+
+    async def get_log(request: web.Request) -> web.Response:
+        if not log:
+            return web.json_response({"detail": "not found"}, status=404)
+        return web.json_response(
+            {"namespace": "memory", "key": "log", "value": list(log), "version": len(log)}
+        )
+
+    async def append_log(request: web.Request) -> web.Response:
+        body = await request.json()
+        log.append(body["item"])
+        return web.json_response(
+            {"namespace": "memory", "key": "log", "value": list(log), "version": len(log)}
+        )
+
+    app.router.add_get("/agents/A/state/memory/log", get_log)
+    app.router.add_post("/agents/A/state/memory/log/append", append_log)
+    return app, log
+
+
+def test_record_and_provenance_round_trip() -> None:
+    rec = MemoryRecord(
+        content="prefer ruff over flake8",
+        provenance=Provenance(
+            learned_from_session_id="sess-1",
+            source_trace_ids=("trace-a", "trace-b"),
+            recorded_at="2026-07-13T00:00:00+00:00",
+        ),
+    )
+    restored = MemoryRecord.from_dict(rec.to_dict())
+    assert restored == rec
+
+
+def test_resolve_absent_ref_is_null_store() -> None:
+    store = resolve_memory(None, {})
+    assert isinstance(store, NullMemoryStore)
+    assert anyio.run(store.load) == []
+    # Append on the null store is a silent no-op.
+    anyio.run(store.append, MemoryRecord(content="x"))
+
+
+def test_resolve_http_ref_is_state_store() -> None:
+    store = resolve_memory("http://api:8000/agents/A/state/memory", {})
+    assert isinstance(store, StateApiMemoryStore)
+
+
+def test_resolve_unsupported_scheme_raises() -> None:
+    with pytest.raises(MemoryError):
+        resolve_memory("s3://bucket/mem", {})
+
+
+def test_preamble_empty_is_none() -> None:
+    assert format_memory_preamble([]) is None
+
+
+def test_preamble_includes_content_and_traces() -> None:
+    records = [
+        MemoryRecord(
+            content="deploy is a git push",
+            provenance=Provenance(source_trace_ids=("t1",)),
+        ),
+        MemoryRecord(content="no-trace lesson"),
+    ]
+    preamble = format_memory_preamble(records)
+    assert preamble is not None
+    assert "deploy is a git push" in preamble
+    assert "t1" in preamble
+    assert "no-trace lesson" in preamble
+
+
+def test_state_store_load_empty_is_empty() -> None:
+    app, _ = _fake_state_app()
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            url = str(server.make_url("/agents/A/state/memory"))
+            store = StateApiMemoryStore(url, token=None)
+            assert await store.load() == []
+
+    anyio.run(go)
+
+
+def test_state_store_append_then_load_round_trip() -> None:
+    app, log = _fake_state_app()
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            url = str(server.make_url("/agents/A/state/memory"))
+            store = StateApiMemoryStore(url, token="k")
+            rec = MemoryRecord(
+                content="prod push reuses the dev bundle",
+                provenance=Provenance(
+                    learned_from_session_id="sess-9",
+                    source_trace_ids=("trace-x",),
+                    recorded_at="2026-07-13T00:00:00+00:00",
+                ),
+            )
+            await store.append(rec)
+            loaded = await store.load()
+            assert loaded == [rec]
+            # The provenance survived the persist/load round-trip.
+            assert loaded[0].provenance.source_trace_ids == ("trace-x",)
+            assert len(log) == 1
+
+    anyio.run(go)
+
+
+def test_session_runner_remember_appends_with_provenance() -> None:
+    from agentos_runner import RunTracer, SideEffectClassifier
+    from agentos_runner.fake import FakeModelSession
+    from agentos_runner.session import SessionRunner
+
+    class _Recording:
+        def __init__(self) -> None:
+            self.records: list[MemoryRecord] = []
+
+        async def load(self) -> list[MemoryRecord]:
+            return list(self.records)
+
+        async def append(self, record: MemoryRecord) -> None:
+            self.records.append(record)
+
+    store = _Recording()
+    runner = SessionRunner(
+        session_factory=FakeModelSession,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+        session_id="sess-42",
+        memory_store=store,
+    )
+
+    anyio.run(
+        lambda: runner.remember("lesson", source_trace_ids=("trace-7",))
+    )
+    assert len(store.records) == 1
+    prov = store.records[0].provenance
+    assert store.records[0].content == "lesson"
+    assert prov.learned_from_session_id == "sess-42"
+    assert prov.source_trace_ids == ("trace-7",)
+    assert prov.recorded_at  # a timestamp was stamped
+
+
+def test_state_store_load_rejects_non_array() -> None:
+    app = web.Application()
+
+    async def get_log(_request: web.Request) -> web.Response:
+        return web.json_response(
+            {"namespace": "memory", "key": "log", "value": {"not": "a list"}, "version": 1}
+        )
+
+    app.router.add_get("/agents/A/state/memory/log", get_log)
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            url = str(server.make_url("/agents/A/state/memory"))
+            store = StateApiMemoryStore(url, token=None)
+            with pytest.raises(MemoryError):
+                await store.load()
+
+    anyio.run(go)


### PR DESCRIPTION
Adds the learned-from trace-back surface over the #264 memory port (epic #28). **Provenance is the differentiator** — this is the API answer to "how did it learn that?".

## What
New `apps/api` `memory` router (read-only) over the reserved `memory`/`log` state namespace the runner writes to — no second store:
- `GET /agents/{id}/memory` — list learned entries (`index`, `content`, `provenance`), oldest first.
- `GET /agents/{id}/memory/{index}/provenance` — resolve one entry's trace-back: the `learned_from_session_id` and each source trace, with a Langfuse deep link. Reuses the recorded `Provenance` (#264 shape); does not re-derive or invent it.

Graceful degradation: fresh agent → `[]`; a record with no recorded provenance → empty provenance (not 500); out-of-range index / unknown agent → 404.

## Tests / verify
`apps/api/tests/test_memory.py` (list, trace-back, empty, 404s). OpenAPI regenerated; `test_openapi_drift` green. `ruff` + `mypy` clean.

## Stacking
Stacked on #379 (memory port); base is `main` but this branches off `task/264-memory-port` — rebase to main after #379 merges.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)