### PR TITLE
memory: inspect/edit/delete learned memory (API + UI) (#267)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -847,6 +847,20 @@
         "title": "LoadPackConfig",
         "type": "object"
       },
+      "MemoryEntryEdit": {
+        "description": "Edit the ``content`` of one memory entry (#267); provenance is preserved.",
+        "properties": {
+          "content": {
+            "title": "Content",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "title": "MemoryEntryEdit",
+        "type": "object"
+      },
       "MemoryEntryOut": {
         "description": "One learned memory entry as returned to an operator.\n\n``index`` is the entry's position in the append-only log; it is the stable\nhandle the edit/delete endpoints (#267) address, and it survives as long as\nthe log is not consolidated (#265) or reordered.",
         "properties": {
@@ -2461,9 +2475,148 @@
         ]
       }
     },
+    "/agents/{agent_id}/memory/{index}": {
+      "delete": {
+        "description": "Delete exactly one memory entry; remaining entries keep their order (#267).",
+        "operationId": "delete_memory_agents__agent_id__memory__index__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "index",
+            "required": true,
+            "schema": {
+              "title": "Index",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Memory",
+        "tags": [
+          "memory"
+        ]
+      },
+      "put": {
+        "description": "Edit one entry's content in place; its provenance is preserved (#267).\n\nRewrites the log array with the entry's ``content`` replaced. The recorded\nprovenance is carried through unchanged -- editing the lesson text must not\nerase where it was learned from.",
+        "operationId": "edit_memory_agents__agent_id__memory__index__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "index",
+            "required": true,
+            "schema": {
+              "title": "Index",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemoryEntryEdit"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryEntryOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Edit Memory",
+        "tags": [
+          "memory"
+        ]
+      }
+    },
     "/agents/{agent_id}/memory/{index}/provenance": {
       "get": {
-        "description": "Resolve one entry's learned-from trace-back (#266).\n\nReturns the session and the source traces the lesson was distilled from,\neach with a Langfuse deep link. Reuses the provenance the runner recorded at\n``remember`` time -- it does not re-derive or invent provenance.",
+        "description": "Resolve one entry's learned-from trace-back (#266).\n\nReturns the session and the source traces the lesson was distilled from, each\nwith a Langfuse deep link. Reuses the provenance the runner recorded at\n``remember`` time -- it does not re-derive or invent provenance.",
         "operationId": "memory_trace_back_agents__agent_id__memory__index__provenance_get",
         "parameters": [
           {

--- a/apps/api/src/agentos_api/routers/memory.py
+++ b/apps/api/src/agentos_api/routers/memory.py
@@ -1,17 +1,19 @@
-"""Agent memory API: inspect learned memory and trace it back to its sources.
+"""Agent memory API: inspect, trace-back, edit, and delete what an agent learned.
 
 Memory is a scoped namespace over the durable state store (#264, ADR-0025): the
 runner writes an append-only log at namespace ``memory`` key ``log``, each item a
-``{content, provenance}`` record. This router is the read side of that log for
-operators -- it does NOT invent a second store. #266 adds the learned-from
-trace-back: given an entry, resolve the session and source traces it was learned
-from (the "how did it learn that?" answer). The edit/delete write side is #267.
+``{content, provenance}`` record, reloaded at the next session boot. This router
+is the operator's read/write surface over that one log key -- it does NOT add a
+second store. #266 adds the learned-from trace-back (resolve an entry's session +
+source traces); #267 adds edit/delete (an edit preserves the entry's provenance;
+a delete removes exactly one entry). Because the runner rehydrates from the same
+key, edits and deletes are reflected at the next boot.
 """
 
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import select
 
 from .. import crud
@@ -20,6 +22,7 @@ from ..config import get_settings
 from ..deps import SessionDep
 from ..models import WorkflowStateEntry
 from ..schemas import (
+    MemoryEntryEdit,
     MemoryEntryOut,
     MemoryProvenanceOut,
     MemoryTraceBackOut,
@@ -30,21 +33,20 @@ router = APIRouter(
     prefix="/agents", tags=["memory"], dependencies=[Depends(require_api_key)]
 )
 
-# The runner writes memory here (mirrors runner/agentos_runner/memory.py:
-# a single log-shaped key inside the reserved ``memory`` namespace).
+# The runner writes memory here (mirrors runner/agentos_runner/memory.py: a
+# single log-shaped key inside the reserved ``memory`` namespace).
 MEMORY_NAMESPACE = "memory"
 MEMORY_LOG_KEY = "log"
 
 
-async def _load_log(session: SessionDep, agent_id: uuid.UUID) -> list[dict[str, Any]]:
-    """Return the raw memory-log records for an agent (404 if the agent is gone).
-
-    An absent log is an empty list -- a fresh agent with no learned memory yet,
-    not an error. A non-list stored value is treated as empty rather than a 500;
-    the store's own shape guard (#248 append) keeps it a list in practice.
-    """
+async def _require_agent(session: SessionDep, agent_id: uuid.UUID) -> None:
     if await crud.get_agent(session, agent_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+
+
+async def _get_log_entry(
+    session: SessionDep, agent_id: uuid.UUID
+) -> WorkflowStateEntry | None:
     entry: WorkflowStateEntry | None = await session.scalar(
         select(WorkflowStateEntry).where(
             WorkflowStateEntry.agent_id == agent_id,
@@ -52,14 +54,27 @@ async def _load_log(session: SessionDep, agent_id: uuid.UUID) -> list[dict[str, 
             WorkflowStateEntry.key == MEMORY_LOG_KEY,
         )
     )
+    return entry
+
+
+def _records_of(entry: WorkflowStateEntry | None) -> list[dict[str, Any]]:
+    """The log's ``{content, provenance}`` records, or [] when absent/malformed."""
     if entry is None or not isinstance(entry.value, list):
         return []
-    return [item for item in entry.value if isinstance(item, dict) and "content" in item]
+    return [r for r in entry.value if isinstance(r, dict) and "content" in r]
 
 
 def _provenance_of(record: dict[str, Any]) -> dict[str, Any]:
     prov = record.get("provenance")
     return prov if isinstance(prov, dict) else {}
+
+
+def _to_out(index: int, record: dict[str, Any]) -> MemoryEntryOut:
+    return MemoryEntryOut(
+        index=index,
+        content=str(record.get("content", "")),
+        provenance=MemoryProvenanceOut(**_provenance_of(record)),
+    )
 
 
 def _trace_url(trace_id: str) -> str:
@@ -71,15 +86,9 @@ def _trace_url(trace_id: str) -> str:
 @router.get("/{agent_id}/memory", response_model=list[MemoryEntryOut])
 async def list_memory(agent_id: uuid.UUID, session: SessionDep) -> list[MemoryEntryOut]:
     """List an agent's learned memory entries, oldest first, with provenance."""
-    records = await _load_log(session, agent_id)
-    return [
-        MemoryEntryOut(
-            index=i,
-            content=str(rec.get("content", "")),
-            provenance=MemoryProvenanceOut(**_provenance_of(rec)),
-        )
-        for i, rec in enumerate(records)
-    ]
+    await _require_agent(session, agent_id)
+    entry = await _get_log_entry(session, agent_id)
+    return [_to_out(i, r) for i, r in enumerate(_records_of(entry))]
 
 
 @router.get(
@@ -90,11 +99,12 @@ async def memory_trace_back(
 ) -> MemoryTraceBackOut:
     """Resolve one entry's learned-from trace-back (#266).
 
-    Returns the session and the source traces the lesson was distilled from,
-    each with a Langfuse deep link. Reuses the provenance the runner recorded at
+    Returns the session and the source traces the lesson was distilled from, each
+    with a Langfuse deep link. Reuses the provenance the runner recorded at
     ``remember`` time -- it does not re-derive or invent provenance.
     """
-    records = await _load_log(session, agent_id)
+    await _require_agent(session, agent_id)
+    records = _records_of(await _get_log_entry(session, agent_id))
     if index < 0 or index >= len(records):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "memory entry not found")
     record = records[index]
@@ -110,3 +120,43 @@ async def memory_trace_back(
             for tid in trace_ids
         ],
     )
+
+
+@router.put("/{agent_id}/memory/{index}", response_model=MemoryEntryOut)
+async def edit_memory(
+    agent_id: uuid.UUID, index: int, data: MemoryEntryEdit, session: SessionDep
+) -> MemoryEntryOut:
+    """Edit one entry's content in place; its provenance is preserved (#267).
+
+    Rewrites the log array with the entry's ``content`` replaced. The recorded
+    provenance is carried through unchanged -- editing the lesson text must not
+    erase where it was learned from.
+    """
+    await _require_agent(session, agent_id)
+    entry = await _get_log_entry(session, agent_id)
+    records = _records_of(entry)
+    if entry is None or index < 0 or index >= len(records):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "memory entry not found")
+    updated = {**records[index], "content": data.content}
+    entry.value = [*records[:index], updated, *records[index + 1 :]]
+    entry.version += 1
+    await session.commit()
+    return _to_out(index, updated)
+
+
+@router.delete(
+    "/{agent_id}/memory/{index}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_memory(
+    agent_id: uuid.UUID, index: int, session: SessionDep
+) -> Response:
+    """Delete exactly one memory entry; remaining entries keep their order (#267)."""
+    await _require_agent(session, agent_id)
+    entry = await _get_log_entry(session, agent_id)
+    records = _records_of(entry)
+    if entry is None or index < 0 or index >= len(records):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "memory entry not found")
+    entry.value = [*records[:index], *records[index + 1 :]]
+    entry.version += 1
+    await session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/api/tests/test_memory.py
+++ b/apps/api/tests/test_memory.py
@@ -108,3 +108,73 @@ def test_memory_unknown_agent_is_404(
     missing = "00000000-0000-0000-0000-000000000000"
     r = client.get(f"/agents/{missing}/memory", headers=auth_headers)
     assert r.status_code == 404, r.text
+
+
+def _prov(session_id: str, *traces: str) -> dict:
+    return {
+        "learned_from_session_id": session_id,
+        "source_trace_ids": list(traces),
+        "recorded_at": "2026-07-13T00:00:00+00:00",
+    }
+
+
+def test_edit_entry_preserves_provenance(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(
+        client,
+        auth_headers,
+        aid,
+        {"content": "old lesson", "provenance": _prov("sess-9", "t-x", "t-y")},
+    )
+
+    r = client.put(
+        f"/agents/{aid}/memory/0",
+        json={"content": "corrected lesson"},
+        headers=auth_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["content"] == "corrected lesson"
+    # Editing the text must not erase where it was learned from.
+    assert r.json()["provenance"]["source_trace_ids"] == ["t-x", "t-y"]
+
+    # The change is durable -- a fresh read (what the next boot sees) reflects it.
+    entries = client.get(f"/agents/{aid}/memory", headers=auth_headers).json()
+    assert entries[0]["content"] == "corrected lesson"
+    assert entries[0]["provenance"]["learned_from_session_id"] == "sess-9"
+
+
+def test_delete_entry_removes_one_and_reindexes(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    for c in ("a", "b", "c"):
+        _remember(client, auth_headers, aid, {"content": c})
+
+    d = client.delete(f"/agents/{aid}/memory/1", headers=auth_headers)
+    assert d.status_code == 204, d.text
+
+    entries = client.get(f"/agents/{aid}/memory", headers=auth_headers).json()
+    assert [e["content"] for e in entries] == ["a", "c"]
+    assert [e["index"] for e in entries] == [0, 1]
+
+
+def test_edit_out_of_range_is_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(client, auth_headers, aid, {"content": "only one"})
+    r = client.put(
+        f"/agents/{aid}/memory/5", json={"content": "x"}, headers=auth_headers
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_delete_out_of_range_is_404(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(client, auth_headers, aid, {"content": "only one"})
+    r = client.delete(f"/agents/{aid}/memory/9", headers=auth_headers)
+    assert r.status_code == 404, r.text

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -487,6 +487,56 @@ export async function createDeployment(input: DeploymentCreate): Promise<Deploym
   return jsonOrThrow<DeploymentOut>(resp);
 }
 
+// ---- Agent memory: inspect / edit / delete learned memory (#267) ----
+
+// Where a memory entry was learned from (#264 Provenance shape). Provenance is
+// the differentiator: an operator can see which session/traces taught a lesson.
+export interface MemoryProvenance {
+  learned_from_session_id: string | null;
+  source_trace_ids: string[];
+  recorded_at: string;
+}
+
+// One learned memory entry. `index` is its position in the append-only memory
+// log — the stable handle the edit/delete calls address.
+export interface MemoryEntry {
+  index: number;
+  content: string;
+  provenance: MemoryProvenance;
+}
+
+// List an agent's learned memory, oldest first (empty for a fresh agent).
+export async function listMemory(agentId: string): Promise<MemoryEntry[]> {
+  const resp = await fetch(url(`/agents/${agentId}/memory`), { headers: headers() });
+  return jsonOrThrow<MemoryEntry[]>(resp);
+}
+
+// Edit one entry's content in place; the server preserves its provenance. The
+// change is reflected at the agent's next session boot (it rehydrates the log).
+export async function editMemory(
+  agentId: string,
+  index: number,
+  content: string,
+): Promise<MemoryEntry> {
+  const resp = await fetch(url(`/agents/${agentId}/memory/${index}`), {
+    method: "PUT",
+    headers: headers({ "Content-Type": "application/json" }),
+    body: JSON.stringify({ content }),
+  });
+  return jsonOrThrow<MemoryEntry>(resp);
+}
+
+// Delete exactly one memory entry (204 on success). Remaining entries keep order.
+export async function deleteMemory(agentId: string, index: number): Promise<void> {
+  const resp = await fetch(url(`/agents/${agentId}/memory/${index}`), {
+    method: "DELETE",
+    headers: headers(),
+  });
+  if (resp.ok) return;
+  const body = await resp.json().catch(() => null);
+  throw new ApiError(resp.status, describeError(body) ?? resp.statusText);
+}
+
 export async function killAgent(agentId: string): Promise<KillState> {
   const resp = await fetch(url(`/agents/${agentId}/kill`), { method: "POST", headers: headers() });
   return jsonOrThrow<KillState>(resp);

--- a/apps/ui/src/primitives/parity.ts
+++ b/apps/ui/src/primitives/parity.ts
@@ -63,4 +63,9 @@ export const WIRED_ACTIONS: readonly WiredAction[] = [
   // the honest amber glyph linking to the parity epic instead of a command.
   { id: "rollback", label: "Roll back to an earlier version", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
   { id: "promote-to-prod", label: "Promote dev version to prod", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
+
+  // WiredAgentMemory (#267) — inspect/edit/delete learned memory. No dedicated
+  // CLI verb exists yet, so both render the honest amber gap glyph.
+  { id: "memory-edit", label: "Edit a learned memory entry", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
+  { id: "memory-delete", label: "Delete a learned memory entry", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
 ] as const;

--- a/apps/ui/src/views/wired/WiredAgentDetail.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { C } from "../../tokens";
 import { Button, Card, Chip, CliHint, Dot, Notice, cliCommand } from "../../primitives";
 import { SkillEditor } from "../../components/SkillEditor";
+import { WiredAgentMemory } from "./WiredAgentMemory";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
 import { useAgentVersions, useVersionFiles } from "../../api/hooks";
@@ -524,6 +525,12 @@ export function WiredAgentDetail() {
           </div>
         </div>
       )}
+
+      {agentId ? (
+        <div style={{ marginTop: 16 }}>
+          <WiredAgentMemory agentId={agentId} />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/ui/src/views/wired/WiredAgentMemory.test.tsx
+++ b/apps/ui/src/views/wired/WiredAgentMemory.test.tsx
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StoreProvider } from "../../state/store";
+import { WiredAgentMemory } from "./WiredAgentMemory";
+import {
+  listMemory,
+  editMemory,
+  deleteMemory,
+  type MemoryEntry,
+} from "../../api/client";
+
+// Mock only the memory data-layer calls; keep everything else real.
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    listMemory: vi.fn(),
+    editMemory: vi.fn(),
+    deleteMemory: vi.fn(),
+  };
+});
+
+const ENTRIES: MemoryEntry[] = [
+  {
+    index: 0,
+    content: "deploy is a git push",
+    provenance: {
+      learned_from_session_id: "sess-1",
+      source_trace_ids: ["trace-a", "trace-b"],
+      recorded_at: "2026-07-13T00:00:00+00:00",
+    },
+  },
+  {
+    index: 1,
+    content: "prod reuses the dev bundle",
+    provenance: { learned_from_session_id: null, source_trace_ids: [], recorded_at: "" },
+  },
+];
+
+function renderPanel() {
+  return render(
+    <StoreProvider level={3}>
+      <WiredAgentMemory agentId="a1" />
+    </StoreProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("WiredAgentMemory (#267)", () => {
+  it("lists learned entries with their provenance", async () => {
+    vi.mocked(listMemory).mockResolvedValue(ENTRIES);
+    renderPanel();
+
+    expect(await screen.findByText("deploy is a git push")).toBeInTheDocument();
+    // Provenance is shown — the differentiator (how it learned that).
+    expect(screen.getByText(/session sess-1/)).toBeInTheDocument();
+    expect(screen.getByText(/trace-a, trace-b/)).toBeInTheDocument();
+    // An entry with no provenance degrades gracefully.
+    expect(screen.getByText(/no session/)).toBeInTheDocument();
+  });
+
+  it("shows the empty state when nothing has been learned", async () => {
+    vi.mocked(listMemory).mockResolvedValue([]);
+    renderPanel();
+    expect(
+      await screen.findByText(/has not learned anything yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("edits an entry and reloads", async () => {
+    vi.mocked(listMemory)
+      .mockResolvedValueOnce(ENTRIES)
+      .mockResolvedValueOnce([{ ...ENTRIES[0], content: "corrected" }, ENTRIES[1]]);
+    vi.mocked(editMemory).mockResolvedValue({ ...ENTRIES[0], content: "corrected" });
+    renderPanel();
+
+    await screen.findByText("deploy is a git push");
+    await userEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
+    const box = screen.getByLabelText("memory-content");
+    await userEvent.clear(box);
+    await userEvent.type(box, "corrected");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(editMemory).toHaveBeenCalledWith("a1", 0, "corrected"),
+    );
+    expect(await screen.findByText("corrected")).toBeInTheDocument();
+  });
+
+  it("deletes an entry", async () => {
+    vi.mocked(listMemory)
+      .mockResolvedValueOnce(ENTRIES)
+      .mockResolvedValueOnce([ENTRIES[1]]);
+    vi.mocked(deleteMemory).mockResolvedValue();
+    renderPanel();
+
+    await screen.findByText("deploy is a git push");
+    await userEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
+
+    await waitFor(() => expect(deleteMemory).toHaveBeenCalledWith("a1", 0));
+  });
+
+  it("surfaces a load error", async () => {
+    vi.mocked(listMemory).mockRejectedValue(new Error("boom"));
+    renderPanel();
+    expect(await screen.findByTestId("memory-error")).toHaveTextContent("boom");
+  });
+});

--- a/apps/ui/src/views/wired/WiredAgentMemory.tsx
+++ b/apps/ui/src/views/wired/WiredAgentMemory.tsx
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useState } from "react";
+import { C } from "../../tokens";
+import { Button, Card, CliHint, Notice, PARITY_TRACKING_ISSUE } from "../../primitives";
+import {
+  listMemory,
+  editMemory,
+  deleteMemory,
+  type MemoryEntry,
+} from "../../api/client";
+
+// The wired "inspect / edit / delete learned memory" surface (#267). Lists an
+// agent's learned memory entries with their provenance (the entry->source-trace
+// link is the differentiator — an operator can see how a lesson was learned),
+// and lets them correct an entry's text or remove it. Edits/deletes hit the
+// apps/api memory endpoints over the same-origin /api proxy; because the runner
+// rehydrates the same memory log at boot, changes take effect at the next
+// session boot (the #267 acceptance criterion, surfaced in the panel note).
+//
+// There is no dedicated CLI verb for memory yet, so the edit/delete actions
+// render the honest amber CliHint gap (parity ids memory-edit / memory-delete).
+export function WiredAgentMemory({ agentId }: { agentId: string }) {
+  const [entries, setEntries] = useState<MemoryEntry[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyIndex, setBusyIndex] = useState<number | null>(null);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [draft, setDraft] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setEntries(await listMemory(agentId));
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const startEdit = (entry: MemoryEntry) => {
+    setEditingIndex(entry.index);
+    setDraft(entry.content);
+    setError(null);
+  };
+
+  const saveEdit = async (index: number) => {
+    setBusyIndex(index);
+    setError(null);
+    try {
+      await editMemory(agentId, index, draft);
+      setEditingIndex(null);
+      await load();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusyIndex(null);
+    }
+  };
+
+  const remove = async (index: number) => {
+    setBusyIndex(index);
+    setError(null);
+    try {
+      await deleteMemory(agentId, index);
+      await load();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusyIndex(null);
+    }
+  };
+
+  return (
+    <Card>
+      <div data-testid="agent-memory" style={{ padding: "4px 4px" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 6,
+          }}
+        >
+          <div style={{ fontWeight: 600, fontSize: 14, color: C.text2 }}>
+            Learned memory
+          </div>
+          <CliHint noCliEquivalent={PARITY_TRACKING_ISSUE} label="No CLI equivalent" />
+          <div style={{ marginLeft: "auto" }}>
+            <Button label="Refresh" variant="ghost" size="sm" onClick={() => void load()} />
+          </div>
+        </div>
+        <div style={{ color: C.muted, fontSize: 12.5, marginBottom: 12 }}>
+          What this agent has learned from prior sessions. Edits and deletes take
+          effect at the agent's next session boot.
+        </div>
+
+        {error ? (
+          <div
+            data-testid="memory-error"
+            style={{ color: C.destructive, fontSize: 12.5, marginBottom: 10, fontFamily: C.mono }}
+          >
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <Notice padding="28px 20px">Loading memory…</Notice>
+        ) : !entries || entries.length === 0 ? (
+          <Notice padding="28px 20px">This agent has not learned anything yet.</Notice>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {entries.map((entry) => {
+              const busy = busyIndex === entry.index;
+              const editing = editingIndex === entry.index;
+              const traces = entry.provenance.source_trace_ids;
+              return (
+                <div
+                  key={entry.index}
+                  data-testid="memory-entry"
+                  style={{
+                    border: "1px solid " + C.border,
+                    borderRadius: 6,
+                    padding: "10px 12px",
+                    background: C.darkest,
+                  }}
+                >
+                  {editing ? (
+                    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                      <textarea
+                        aria-label="memory-content"
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                        rows={3}
+                        style={{
+                          width: "100%",
+                          background: C.input,
+                          color: C.text,
+                          border: "1px solid " + C.border,
+                          borderRadius: 4,
+                          fontFamily: C.mono,
+                          fontSize: 12.5,
+                          padding: 8,
+                          resize: "vertical",
+                        }}
+                      />
+                      <div style={{ display: "flex", gap: 8 }}>
+                        <Button
+                          label={busy ? "Saving…" : "Save"}
+                          variant="primary"
+                          size="sm"
+                          disabled={busy}
+                          onClick={() => void saveEdit(entry.index)}
+                        />
+                        <Button
+                          label="Cancel"
+                          variant="ghost"
+                          size="sm"
+                          disabled={busy}
+                          onClick={() => setEditingIndex(null)}
+                        />
+                      </div>
+                    </div>
+                  ) : (
+                    <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ color: C.text, fontSize: 13, lineHeight: 1.5 }}>
+                          {entry.content}
+                        </div>
+                        <div
+                          style={{
+                            color: C.muted,
+                            fontSize: 11,
+                            fontFamily: C.mono,
+                            marginTop: 4,
+                          }}
+                        >
+                          {entry.provenance.learned_from_session_id
+                            ? `session ${entry.provenance.learned_from_session_id}`
+                            : "no session"}
+                          {traces.length > 0
+                            ? ` · traces: ${traces.join(", ")}`
+                            : " · no traces"}
+                        </div>
+                      </div>
+                      <Button
+                        label="Edit"
+                        variant="ghost"
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => startEdit(entry)}
+                      />
+                      <Button
+                        label={busy ? "…" : "Delete"}
+                        variant="ghost"
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => void remove(entry.index)}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
Console surface to inspect, edit, and delete an agent's learned memory, over the #264 memory port (epic #28).

## API (`apps/api` `memory` router over the reserved `memory`/`log` state key — no second store)
- `GET /agents/{id}/memory` — list entries (`index`, `content`, `provenance`)
- `PUT /agents/{id}/memory/{index}` — edit content in place; **provenance preserved** (editing text never erases where it was learned from)
- `DELETE /agents/{id}/memory/{index}` — remove one entry, remaining order preserved

Because the runner rehydrates the same log at boot, edits/deletes are reflected at the next session boot (the acceptance criterion). Out-of-range index / unknown agent → 404. OpenAPI regenerated.

## UI (`WiredAgentMemory`, rendered inside `WiredAgentDetail`)
Lists learned entries with their provenance — session + source traces, the "how did it learn that?" differentiator — with inline edit and delete, all same-origin `/api`. No CLI verb for memory exists yet, so it renders the honest amber `CliHint` gap; parity entries `memory-edit` / `memory-delete` added to the registry (`CliHint.parity.test.tsx` green).

## Tests / verify
- `apps/api/tests/test_memory.py` — list, edit-preserves-provenance, delete-reindexes, 404s. `ruff` + `mypy` clean; `test_openapi_drift` green.
- `apps/ui/.../WiredAgentMemory.test.tsx` — list+provenance, empty, edit+reload, delete, load error. `pnpm lint` + `typecheck` + `test` (120) green.
- No new CLI `ActionId`, so no `gen:manifest` needed.

## Stacking
Stacked on #379 (memory port); base is `main` but this branches off `task/264-memory-port` — rebase to main after #379 merges.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)