### PR TITLE
Resolve duplicate ADR numbers 0009 and 0025

### DIFF
--- a/docs/adr/0031-harness-neutral-runner-seams.md
+++ b/docs/adr/0031-harness-neutral-runner-seams.md
@@ -1,4 +1,4 @@
-# 9. Harness-neutral runner seams for the second harness
+# 31. Harness-neutral runner seams for the second harness
 
 Date: 2026-07-11
 Status: Proposed

--- a/docs/adr/0032-explicit-provider-egress.md
+++ b/docs/adr/0032-explicit-provider-egress.md
@@ -1,4 +1,4 @@
-# 25. Explicit named-provider egress, resolved at install
+# 32. Explicit named-provider egress, resolved at install
 
 Date: 2026-07-13
 Status: Accepted


### PR DESCRIPTION
Two ADR pairs on `main` share a number, breaking the sequential-numbering invariant (`docs/adr/` is the durable system of record). Renumber the less-referenced file in each pair to the next free integers, keeping the referenced doc stable:

- `0009-harness-neutral-runner-seams.md` -> `0031-harness-neutral-runner-seams.md` (kept `0009-per-agent-connector-auth.md`, referenced by the credential-plane ADR and the model-provider INTERFACE)
- `0025-explicit-provider-egress.md` -> `0032-explicit-provider-egress.md` (kept `0025-memory-port-and-first-loader.md`, referenced by the memory INTERFACE, `memory.py` modules, and the proactive-memory ADR)

Each renamed file's top heading is updated to match (`# 9.` -> `# 31.`, `# 25.` -> `# 32.`). Both renumber targets had zero inbound references, so no reference fixups were needed; all existing `ADR-0009`/`ADR-0025` references correctly point at the kept docs and are untouched.

Uses 0031/0032 (0029/0030 are reserved for separate in-flight ADR drafts). Docs-only, no behavior change.