### PR TITLE
ui: regenerate command manifest for cluster-up egress flags

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -889,7 +889,7 @@ export const commandManifest = {
       "name": "cluster",
       "subcommands": [
         {
-          "about": "Install or upgrade the AgentOS release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) to install with the real model and egress opened to the provider; without it the install is sealed (fake model, canned replies) and re-running with the env var set goes live",
+          "about": "Install or upgrade the AgentOS release via Helm (helm upgrade --install). By default it puts the UI and Langfuse on node ports for tailnet/LAN access; pass --no-expose to keep them ClusterIP-only. Set AGENTOS_MODEL_CREDENTIALS (an Anthropic API key) to install with the real model; without it the install is sealed (fake model, canned replies). A real model is still unreachable behind the fail-closed sandbox until you open its egress with --allow-egress-host <provider> (or --allow-web-egress <CIDR> for a raw range)",
           "args": [
             {
               "default_values": [
@@ -959,7 +959,15 @@ export const commandManifest = {
             },
             {
               "global": false,
-              "help": "Open runner egress to a declared destination for skill web access, repeatable CIDR, TCP 443. Additive to the model egress; omit to stay fully sealed",
+              "help": "Open runner egress to a named model provider's API host(s), resolved to narrow host routes at install time (repeatable). One of: anthropic, openrouter. For a raw CIDR, use --allow-web-egress",
+              "id": "allow_egress_host",
+              "long": "allow-egress-host",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Open runner egress to a declared destination for skill web access, repeatable CIDR, TCP 443. Additive to the provider egress; omit to stay fully sealed",
               "id": "allow_web_egress",
               "long": "allow-web-egress",
               "positional": false,


### PR DESCRIPTION
## Why

Main's CI is red on the **UI -> "Command manifest is current"** gate. PR #366 (explicit provider egress) reworded the `cluster up` about-text and added the `--allow-egress-host` flag, updating `cli/command-manifest.json` but not regenerating the downstream committed file `apps/ui/src/generated/commandManifest.ts`. The gate diffs the regenerated manifest against the committed one, so main -- and every branch cut from it -- fails.

## Fix

Ran `pnpm gen:manifest` in `apps/ui` and committed the result. Generated-file-only; no source change.

## Verification

- `pnpm gen:manifest` is now idempotent (re-run produces no further diff)
- `pnpm typecheck` clean
- `pnpm lint` clean
- Regenerated `.ts` now contains `allow_egress_host`, matching `cli/command-manifest.json`