### PR TITLE
Guard memory mutations with versions

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -923,21 +923,26 @@
         "type": "object"
       },
       "MemoryEntryEdit": {
-        "description": "Edit the ``content`` of one memory entry (#267); provenance is preserved.",
+        "description": "Edit one memory entry using its parent log version.\n\nThe required version prevents a stale positional index from changing an\nentry after the log has changed. Provenance is preserved.",
         "properties": {
           "content": {
             "title": "Content",
             "type": "string"
+          },
+          "expected_version": {
+            "title": "Expected Version",
+            "type": "integer"
           }
         },
         "required": [
-          "content"
+          "content",
+          "expected_version"
         ],
         "title": "MemoryEntryEdit",
         "type": "object"
       },
       "MemoryEntryOut": {
-        "description": "One learned memory entry as returned to an operator.\n\n``index`` is the entry's position in the append-only log; it is the stable\nhandle the edit/delete endpoints (#267) address, and it survives as long as\nthe log is not consolidated (#265) or reordered.",
+        "description": "One learned memory entry as returned to an operator.\n\n``index`` is the entry's current position in the memory log. It is valid for\nmutation only with this response's parent log ``version``. A mutation with\na stale version conflicts if another change has reordered the log.",
         "properties": {
           "content": {
             "title": "Content",
@@ -949,12 +954,17 @@
           },
           "provenance": {
             "$ref": "#/components/schemas/MemoryProvenanceOut"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
           }
         },
         "required": [
           "index",
           "content",
-          "provenance"
+          "provenance",
+          "version"
         ],
         "title": "MemoryEntryOut",
         "type": "object"
@@ -2552,7 +2562,7 @@
     },
     "/agents/{agent_id}/memory/{index}": {
       "delete": {
-        "description": "Delete exactly one memory entry; remaining entries keep their order (#267).",
+        "description": "Delete one entry using its parent log version.\n\nRemaining entries keep their order. A stale version conflicts before the\npositional index can address a changed or reordered log.",
         "operationId": "delete_memory_agents__agent_id__memory__index__delete",
         "parameters": [
           {
@@ -2571,6 +2581,17 @@
             "required": true,
             "schema": {
               "title": "Index",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Parent log version returned with the positional memory entry. A stale version conflicts if the log changed or reordered.",
+            "in": "query",
+            "name": "expected_version",
+            "required": true,
+            "schema": {
+              "description": "Parent log version returned with the positional memory entry. A stale version conflicts if the log changed or reordered.",
+              "title": "Expected Version",
               "type": "integer"
             }
           },
@@ -2612,7 +2633,7 @@
         ]
       },
       "put": {
-        "description": "Edit one entry's content in place; its provenance is preserved (#267).\n\nRewrites the log array with the entry's ``content`` replaced. The recorded\nprovenance is carried through unchanged -- editing the lesson text must not\nerase where it was learned from.",
+        "description": "Edit one entry's content using the parent log version.\n\nRewrites the log array with the entry's ``content`` replaced. The recorded\nprovenance is carried through unchanged. A stale version conflicts before\nthe positional index can address a changed or reordered log.",
         "operationId": "edit_memory_agents__agent_id__memory__index__put",
         "parameters": [
           {

--- a/apps/api/src/agentos_api/routers/memory.py
+++ b/apps/api/src/agentos_api/routers/memory.py
@@ -13,7 +13,7 @@ key, edits and deletes are reflected at the next boot.
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import select
 
 from .. import crud
@@ -28,6 +28,7 @@ from ..schemas import (
     MemoryTraceBackOut,
     SourceTraceOut,
 )
+from .state import _enforce_caps
 
 router = APIRouter(
     prefix="/agents", tags=["memory"], dependencies=[Depends(require_api_key)]
@@ -69,11 +70,12 @@ def _provenance_of(record: dict[str, Any]) -> dict[str, Any]:
     return prov if isinstance(prov, dict) else {}
 
 
-def _to_out(index: int, record: dict[str, Any]) -> MemoryEntryOut:
+def _to_out(index: int, record: dict[str, Any], version: int) -> MemoryEntryOut:
     return MemoryEntryOut(
         index=index,
         content=str(record.get("content", "")),
         provenance=MemoryProvenanceOut(**_provenance_of(record)),
+        version=version,
     )
 
 
@@ -88,7 +90,9 @@ async def list_memory(agent_id: uuid.UUID, session: SessionDep) -> list[MemoryEn
     """List an agent's learned memory entries, oldest first, with provenance."""
     await _require_agent(session, agent_id)
     entry = await _get_log_entry(session, agent_id)
-    return [_to_out(i, r) for i, r in enumerate(_records_of(entry))]
+    if entry is None:
+        return []
+    return [_to_out(i, r, entry.version) for i, r in enumerate(_records_of(entry))]
 
 
 @router.get(
@@ -126,35 +130,82 @@ async def memory_trace_back(
 async def edit_memory(
     agent_id: uuid.UUID, index: int, data: MemoryEntryEdit, session: SessionDep
 ) -> MemoryEntryOut:
-    """Edit one entry's content in place; its provenance is preserved (#267).
+    """Edit one entry's content using the parent log version.
 
     Rewrites the log array with the entry's ``content`` replaced. The recorded
-    provenance is carried through unchanged -- editing the lesson text must not
-    erase where it was learned from.
+    provenance is carried through unchanged. A stale version conflicts before
+    the positional index can address a changed or reordered log.
     """
     await _require_agent(session, agent_id)
-    entry = await _get_log_entry(session, agent_id)
+    entry: WorkflowStateEntry | None = await session.scalar(
+        select(WorkflowStateEntry)
+        .where(
+            WorkflowStateEntry.agent_id == agent_id,
+            WorkflowStateEntry.namespace == MEMORY_NAMESPACE,
+            WorkflowStateEntry.key == MEMORY_LOG_KEY,
+        )
+        .with_for_update()
+    )
+    if entry is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "memory entry not found")
+    if data.expected_version != entry.version:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"version mismatch: expected {data.expected_version}, "
+            f"stored {entry.version}",
+        )
     records = _records_of(entry)
-    if entry is None or index < 0 or index >= len(records):
+    if index < 0 or index >= len(records):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "memory entry not found")
     updated = {**records[index], "content": data.content}
-    entry.value = [*records[:index], updated, *records[index + 1 :]]
+    replacement = [*records[:index], updated, *records[index + 1 :]]
+    await _enforce_caps(
+        session, agent_id, MEMORY_NAMESPACE, MEMORY_LOG_KEY, replacement
+    )
+    entry.value = replacement
     entry.version += 1
     await session.commit()
-    return _to_out(index, updated)
+    return _to_out(index, updated, entry.version)
 
 
 @router.delete(
     "/{agent_id}/memory/{index}", status_code=status.HTTP_204_NO_CONTENT
 )
 async def delete_memory(
-    agent_id: uuid.UUID, index: int, session: SessionDep
+    agent_id: uuid.UUID,
+    index: int,
+    session: SessionDep,
+    expected_version: int = Query(
+        description=(
+            "Parent log version returned with the positional memory entry. "
+            "A stale version conflicts if the log changed or reordered."
+        )
+    ),
 ) -> Response:
-    """Delete exactly one memory entry; remaining entries keep their order (#267)."""
+    """Delete one entry using its parent log version.
+
+    Remaining entries keep their order. A stale version conflicts before the
+    positional index can address a changed or reordered log.
+    """
     await _require_agent(session, agent_id)
-    entry = await _get_log_entry(session, agent_id)
+    entry: WorkflowStateEntry | None = await session.scalar(
+        select(WorkflowStateEntry)
+        .where(
+            WorkflowStateEntry.agent_id == agent_id,
+            WorkflowStateEntry.namespace == MEMORY_NAMESPACE,
+            WorkflowStateEntry.key == MEMORY_LOG_KEY,
+        )
+        .with_for_update()
+    )
+    if entry is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "memory entry not found")
+    if expected_version != entry.version:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"version mismatch: expected {expected_version}, stored {entry.version}",
+        )
     records = _records_of(entry)
-    if entry is None or index < 0 or index >= len(records):
+    if index < 0 or index >= len(records):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "memory entry not found")
     entry.value = [*records[:index], *records[index + 1 :]]
     entry.version += 1

--- a/apps/api/src/agentos_api/routers/state.py
+++ b/apps/api/src/agentos_api/routers/state.py
@@ -142,7 +142,15 @@ async def append_state(
     """
     if await crud.get_agent(session, agent_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
-    entry = await _get_entry(session, agent_id, namespace, key)
+    entry: WorkflowStateEntry | None = await session.scalar(
+        select(WorkflowStateEntry)
+        .where(
+            WorkflowStateEntry.agent_id == agent_id,
+            WorkflowStateEntry.namespace == namespace,
+            WorkflowStateEntry.key == key,
+        )
+        .with_for_update()
+    )
     if entry is None:
         new_value = [data.item]
         await _enforce_caps(session, agent_id, namespace, key, new_value)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -501,14 +501,15 @@ class SourceTraceOut(BaseModel):
 class MemoryEntryOut(BaseModel):
     """One learned memory entry as returned to an operator.
 
-    ``index`` is the entry's position in the append-only log; it is the stable
-    handle the edit/delete endpoints (#267) address, and it survives as long as
-    the log is not consolidated (#265) or reordered.
+    ``index`` is the entry's current position in the memory log. It is valid for
+    mutation only with this response's parent log ``version``. A mutation with
+    a stale version conflicts if another change has reordered the log.
     """
 
     index: int
     content: str
     provenance: MemoryProvenanceOut
+    version: int
 
 
 class MemoryTraceBackOut(BaseModel):
@@ -526,6 +527,11 @@ class MemoryTraceBackOut(BaseModel):
 
 
 class MemoryEntryEdit(BaseModel):
-    """Edit the ``content`` of one memory entry (#267); provenance is preserved."""
+    """Edit one memory entry using its parent log version.
+
+    The required version prevents a stale positional index from changing an
+    entry after the log has changed. Provenance is preserved.
+    """
 
     content: str
+    expected_version: int

--- a/apps/api/tests/test_memory.py
+++ b/apps/api/tests/test_memory.py
@@ -5,7 +5,16 @@ the runner uses), then exercises the read/trace-back surface against the real
 compose Postgres.
 """
 
+import asyncio
+import threading
+import time
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any
+
+import asyncpg
+from agentos_api.config import get_settings
+from sqlalchemy import make_url
 
 
 def _agent(client: Any, headers: dict[str, str]) -> str:
@@ -19,11 +28,158 @@ def _agent(client: Any, headers: dict[str, str]) -> str:
     return agent_id
 
 
-def _remember(client: Any, headers: dict[str, str], aid: str, record: dict) -> None:
+def _remember(
+    client: Any, headers: dict[str, str], aid: str, record: dict[str, Any]
+) -> dict[str, Any]:
     """Append one {content, provenance} record to the memory log key."""
     url = f"/agents/{aid}/state/memory/log/append"
     r = client.post(url, json={"item": record}, headers=headers)
     assert r.status_code == 200, r.text
+    body: dict[str, Any] = r.json()
+    return body
+
+
+def _memory(client: Any, headers: dict[str, str], aid: str) -> list[dict[str, Any]]:
+    response = client.get(f"/agents/{aid}/memory", headers=headers)
+    assert response.status_code == 200, response.text
+    entries: list[dict[str, Any]] = response.json()
+    return entries
+
+
+def _asyncpg_dsn() -> str:
+    url = make_url(get_settings().database_url).set(drivername="postgresql")
+    return url.render_as_string(hide_password=False)
+
+
+async def _install_memory_update_gate() -> None:
+    connection = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        await connection.execute(
+            """
+            CREATE OR REPLACE FUNCTION agentos.test_memory_update_gate()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                PERFORM pg_advisory_xact_lock(391391);
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+        await connection.execute(
+            """
+            CREATE TRIGGER test_memory_update_gate
+            BEFORE UPDATE ON agentos.workflow_state_entries
+            FOR EACH ROW
+            EXECUTE FUNCTION agentos.test_memory_update_gate()
+            """
+        )
+    finally:
+        await connection.close()
+
+
+async def _remove_memory_update_gate() -> None:
+    connection = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        await connection.execute(
+            """
+            DROP TRIGGER IF EXISTS test_memory_update_gate
+            ON agentos.workflow_state_entries
+            """
+        )
+        await connection.execute(
+            "DROP FUNCTION IF EXISTS agentos.test_memory_update_gate()"
+        )
+    finally:
+        await connection.close()
+
+
+async def _wait_for_blocked_memory_requests(
+    minimum: int, requests: list[Future[Any]]
+) -> None:
+    connection = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            count = await connection.fetchval(
+                """
+                SELECT count(*)
+                FROM pg_stat_activity
+                WHERE datname = current_database()
+                  AND wait_event_type = 'Lock'
+                  AND query LIKE '%workflow_state_entries%'
+                """
+            )
+            if int(count) >= minimum:
+                return
+            completed = [request.result() for request in requests if request.done()]
+            assert not completed, f"request completed before blocking: {completed}"
+        raise AssertionError(f"only some of {minimum} memory requests blocked")
+    finally:
+        await connection.close()
+
+
+def _hold_memory_update_gate(
+    acquired: threading.Event,
+    release: threading.Event,
+    errors: list[Exception],
+) -> None:
+    async def hold() -> None:
+        connection = await asyncpg.connect(_asyncpg_dsn())
+        try:
+            await connection.execute("SELECT pg_advisory_lock(391391)")
+            acquired.set()
+            release.wait()
+            await connection.execute("SELECT pg_advisory_unlock(391391)")
+        finally:
+            await connection.close()
+
+    try:
+        asyncio.run(hold())
+    except Exception as error:
+        errors.append(error)
+        acquired.set()
+
+
+def _run_ordered_memory_requests(
+    first: Callable[[], Any], second: Callable[[], Any]
+) -> tuple[Any, Any]:
+    asyncio.run(_install_memory_update_gate())
+    acquired = threading.Event()
+    release = threading.Event()
+    lock_errors: list[Exception] = []
+    lock_thread = threading.Thread(
+        target=_hold_memory_update_gate,
+        args=(acquired, release, lock_errors),
+        daemon=True,
+    )
+    lock_thread.start()
+    try:
+        assert acquired.wait(timeout=10), "database gate was not acquired"
+        assert not lock_errors, lock_errors
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first_request = executor.submit(first)
+            try:
+                asyncio.run(_wait_for_blocked_memory_requests(1, [first_request]))
+                second_request = executor.submit(second)
+                asyncio.run(
+                    _wait_for_blocked_memory_requests(
+                        2, [first_request, second_request]
+                    )
+                )
+            finally:
+                release.set()
+            first_response = first_request.result(timeout=10)
+            second_response = second_request.result(timeout=10)
+    finally:
+        release.set()
+        lock_thread.join(timeout=10)
+        asyncio.run(_remove_memory_update_gate())
+
+    assert not lock_thread.is_alive(), "database gate did not release"
+    assert not lock_errors, lock_errors
+    return first_response, second_response
 
 
 def test_list_memory_empty_for_fresh_agent(
@@ -52,15 +208,19 @@ def test_list_memory_returns_entries_with_provenance(
             },
         },
     )
-    _remember(client, auth_headers, aid, {"content": "no-provenance lesson"})
+    appended = _remember(
+        client, auth_headers, aid, {"content": "no-provenance lesson"}
+    )
 
-    entries = client.get(f"/agents/{aid}/memory", headers=auth_headers).json()
+    entries = _memory(client, auth_headers, aid)
     assert len(entries) == 2
     assert entries[0]["index"] == 0
     assert entries[0]["content"] == "deploy is a git push"
     assert entries[0]["provenance"]["source_trace_ids"] == ["trace-a", "trace-b"]
+    assert entries[0]["version"] == appended["version"]
     # A record with no recorded provenance degrades to empty provenance, not 500.
     assert entries[1]["provenance"]["source_trace_ids"] == []
+    assert entries[1]["version"] == appended["version"]
 
 
 def test_trace_back_resolves_sessions_and_traces(
@@ -129,18 +289,23 @@ def test_edit_entry_preserves_provenance(
         {"content": "old lesson", "provenance": _prov("sess-9", "t-x", "t-y")},
     )
 
+    listed = _memory(client, auth_headers, aid)
     r = client.put(
         f"/agents/{aid}/memory/0",
-        json={"content": "corrected lesson"},
+        json={
+            "content": "corrected lesson",
+            "expected_version": listed[0]["version"],
+        },
         headers=auth_headers,
     )
     assert r.status_code == 200, r.text
     assert r.json()["content"] == "corrected lesson"
+    assert r.json()["version"] == listed[0]["version"] + 1
     # Editing the text must not erase where it was learned from.
     assert r.json()["provenance"]["source_trace_ids"] == ["t-x", "t-y"]
 
     # The change is durable -- a fresh read (what the next boot sees) reflects it.
-    entries = client.get(f"/agents/{aid}/memory", headers=auth_headers).json()
+    entries = _memory(client, auth_headers, aid)
     assert entries[0]["content"] == "corrected lesson"
     assert entries[0]["provenance"]["learned_from_session_id"] == "sess-9"
 
@@ -152,12 +317,18 @@ def test_delete_entry_removes_one_and_reindexes(
     for c in ("a", "b", "c"):
         _remember(client, auth_headers, aid, {"content": c})
 
-    d = client.delete(f"/agents/{aid}/memory/1", headers=auth_headers)
+    listed = _memory(client, auth_headers, aid)
+    d = client.delete(
+        f"/agents/{aid}/memory/1",
+        params={"expected_version": listed[0]["version"]},
+        headers=auth_headers,
+    )
     assert d.status_code == 204, d.text
 
-    entries = client.get(f"/agents/{aid}/memory", headers=auth_headers).json()
+    entries = _memory(client, auth_headers, aid)
     assert [e["content"] for e in entries] == ["a", "c"]
     assert [e["index"] for e in entries] == [0, 1]
+    assert {e["version"] for e in entries} == {listed[0]["version"] + 1}
 
 
 def test_edit_out_of_range_is_404(
@@ -165,8 +336,11 @@ def test_edit_out_of_range_is_404(
 ) -> None:
     aid = _agent(client, auth_headers)
     _remember(client, auth_headers, aid, {"content": "only one"})
+    version = _memory(client, auth_headers, aid)[0]["version"]
     r = client.put(
-        f"/agents/{aid}/memory/5", json={"content": "x"}, headers=auth_headers
+        f"/agents/{aid}/memory/5",
+        json={"content": "x", "expected_version": version},
+        headers=auth_headers,
     )
     assert r.status_code == 404, r.text
 
@@ -176,5 +350,255 @@ def test_delete_out_of_range_is_404(
 ) -> None:
     aid = _agent(client, auth_headers)
     _remember(client, auth_headers, aid, {"content": "only one"})
-    r = client.delete(f"/agents/{aid}/memory/9", headers=auth_headers)
+    version = _memory(client, auth_headers, aid)[0]["version"]
+    r = client.delete(
+        f"/agents/{aid}/memory/9",
+        params={"expected_version": version},
+        headers=auth_headers,
+    )
     assert r.status_code == 404, r.text
+
+
+def test_edit_requires_expected_version(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(client, auth_headers, aid, {"content": "keep this lesson"})
+
+    response = client.put(
+        f"/agents/{aid}/memory/0",
+        json={"content": "unversioned correction"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 422, response.text
+    assert _memory(client, auth_headers, aid)[0]["content"] == "keep this lesson"
+
+
+def test_delete_requires_expected_version_query_token(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(client, auth_headers, aid, {"content": "keep this lesson"})
+
+    response = client.delete(f"/agents/{aid}/memory/0", headers=auth_headers)
+
+    assert response.status_code == 422, response.text
+    assert [entry["content"] for entry in _memory(client, auth_headers, aid)] == [
+        "keep this lesson"
+    ]
+
+
+def test_runner_append_makes_operator_edit_token_stale_without_losing_append(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(client, auth_headers, aid, {"content": "original lesson"})
+    listed = _memory(client, auth_headers, aid)
+
+    appended = _remember(
+        client, auth_headers, aid, {"content": "runner learned another lesson"}
+    )
+    response = client.put(
+        f"/agents/{aid}/memory/0",
+        json={
+            "content": "operator correction",
+            "expected_version": listed[0]["version"],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 409, response.text
+    assert appended["version"] == listed[0]["version"] + 1
+    assert [entry["content"] for entry in _memory(client, auth_headers, aid)] == [
+        "original lesson",
+        "runner learned another lesson",
+    ]
+
+
+def test_stale_delete_does_not_remove_a_repositioned_entry(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(client, auth_headers, aid, {"content": "first lesson"})
+    _remember(client, auth_headers, aid, {"content": "second lesson"})
+    _remember(client, auth_headers, aid, {"content": "third lesson"})
+    listed = _memory(client, auth_headers, aid)
+    current_delete = client.delete(
+        f"/agents/{aid}/memory/0",
+        params={"expected_version": listed[0]["version"]},
+        headers=auth_headers,
+    )
+    assert current_delete.status_code == 204, current_delete.text
+
+    response = client.delete(
+        f"/agents/{aid}/memory/1",
+        params={"expected_version": listed[0]["version"]},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 409, response.text
+    assert [entry["content"] for entry in _memory(client, auth_headers, aid)] == [
+        "second lesson",
+        "third lesson",
+    ]
+
+
+def test_oversized_edit_is_rejected_without_changing_memory(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    seeded = _remember(
+        client,
+        auth_headers,
+        aid,
+        {"content": "bounded lesson", "provenance": _prov("sess_cap", "trace_cap")},
+    )
+    listed = _memory(client, auth_headers, aid)
+    get_settings().state_max_value_bytes = 100
+    try:
+        response = client.put(
+            f"/agents/{aid}/memory/0",
+            json={
+                "content": "x" * 200,
+                "expected_version": listed[0]["version"],
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 413, response.text
+        stored = client.get(
+            f"/agents/{aid}/state/memory/log", headers=auth_headers
+        ).json()
+        assert stored["version"] == seeded["version"]
+        assert stored["value"] == seeded["value"]
+    finally:
+        get_settings.cache_clear()
+
+
+def test_overlapping_edit_then_append_preserves_both_changes(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    seeded = _remember(client, auth_headers, aid, {"content": "draft lesson"})
+    listed = _memory(client, auth_headers, aid)
+    edited, appended = _run_ordered_memory_requests(
+        lambda: client.put(
+            f"/agents/{aid}/memory/0",
+            json={
+                "content": "reviewed lesson",
+                "expected_version": listed[0]["version"],
+            },
+            headers=auth_headers,
+        ),
+        lambda: client.post(
+            f"/agents/{aid}/state/memory/log/append",
+            json={"item": {"content": "runner follow up"}},
+            headers=auth_headers,
+        ),
+    )
+
+    assert edited.status_code == 200, edited.text
+    assert appended.status_code == 200, appended.text
+    assert edited.json()["version"] == seeded["version"] + 1
+    assert appended.json()["version"] == seeded["version"] + 2
+    stored = client.get(f"/agents/{aid}/state/memory/log", headers=auth_headers).json()
+    assert stored["version"] == seeded["version"] + 2
+    assert [record["content"] for record in stored["value"]] == [
+        "reviewed lesson",
+        "runner follow up",
+    ]
+
+
+def test_overlapping_append_then_edit_rejects_stale_edit(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    seeded = _remember(client, auth_headers, aid, {"content": "draft lesson"})
+    listed = _memory(client, auth_headers, aid)
+    appended, edited = _run_ordered_memory_requests(
+        lambda: client.post(
+            f"/agents/{aid}/state/memory/log/append",
+            json={"item": {"content": "runner follow up"}},
+            headers=auth_headers,
+        ),
+        lambda: client.put(
+            f"/agents/{aid}/memory/0",
+            json={
+                "content": "stale correction",
+                "expected_version": listed[0]["version"],
+            },
+            headers=auth_headers,
+        ),
+    )
+
+    assert appended.status_code == 200, appended.text
+    assert edited.status_code == 409, edited.text
+    assert appended.json()["version"] == seeded["version"] + 1
+    stored = client.get(f"/agents/{aid}/state/memory/log", headers=auth_headers).json()
+    assert stored["version"] == seeded["version"] + 1
+    assert [record["content"] for record in stored["value"]] == [
+        "draft lesson",
+        "runner follow up",
+    ]
+
+
+def test_overlapping_delete_then_append_preserves_both_changes(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    _remember(client, auth_headers, aid, {"content": "remove this lesson"})
+    seeded = _remember(client, auth_headers, aid, {"content": "keep this lesson"})
+    listed = _memory(client, auth_headers, aid)
+    deleted, appended = _run_ordered_memory_requests(
+        lambda: client.delete(
+            f"/agents/{aid}/memory/0",
+            params={"expected_version": listed[0]["version"]},
+            headers=auth_headers,
+        ),
+        lambda: client.post(
+            f"/agents/{aid}/state/memory/log/append",
+            json={"item": {"content": "runner follow up"}},
+            headers=auth_headers,
+        ),
+    )
+
+    assert deleted.status_code == 204, deleted.text
+    assert appended.status_code == 200, appended.text
+    assert appended.json()["version"] == seeded["version"] + 2
+    stored = client.get(f"/agents/{aid}/state/memory/log", headers=auth_headers).json()
+    assert stored["version"] == seeded["version"] + 2
+    assert [record["content"] for record in stored["value"]] == [
+        "keep this lesson",
+        "runner follow up",
+    ]
+
+
+def test_overlapping_append_then_delete_rejects_stale_delete(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    seeded = _remember(client, auth_headers, aid, {"content": "keep this lesson"})
+    listed = _memory(client, auth_headers, aid)
+    appended, deleted = _run_ordered_memory_requests(
+        lambda: client.post(
+            f"/agents/{aid}/state/memory/log/append",
+            json={"item": {"content": "runner follow up"}},
+            headers=auth_headers,
+        ),
+        lambda: client.delete(
+            f"/agents/{aid}/memory/0",
+            params={"expected_version": listed[0]["version"]},
+            headers=auth_headers,
+        ),
+    )
+
+    assert appended.status_code == 200, appended.text
+    assert deleted.status_code == 409, deleted.text
+    assert appended.json()["version"] == seeded["version"] + 1
+    stored = client.get(f"/agents/{aid}/state/memory/log", headers=auth_headers).json()
+    assert stored["version"] == seeded["version"] + 1
+    assert [record["content"] for record in stored["value"]] == [
+        "keep this lesson",
+        "runner follow up",
+    ]

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -497,10 +497,11 @@ export interface MemoryProvenance {
   recorded_at: string;
 }
 
-// One learned memory entry. `index` is its position in the append-only memory
-// log — the stable handle the edit/delete calls address.
+// One learned memory entry. `index` is its position in the append only memory
+// log. It is valid only with the accompanying parent log version.
 export interface MemoryEntry {
   index: number;
+  version: number;
   content: string;
   provenance: MemoryProvenance;
 }
@@ -517,21 +518,29 @@ export async function editMemory(
   agentId: string,
   index: number,
   content: string,
+  expectedVersion: number,
 ): Promise<MemoryEntry> {
   const resp = await fetch(url(`/agents/${agentId}/memory/${index}`), {
     method: "PUT",
     headers: headers({ "Content-Type": "application/json" }),
-    body: JSON.stringify({ content }),
+    body: JSON.stringify({ content, expected_version: expectedVersion }),
   });
   return jsonOrThrow<MemoryEntry>(resp);
 }
 
 // Delete exactly one memory entry (204 on success). Remaining entries keep order.
-export async function deleteMemory(agentId: string, index: number): Promise<void> {
-  const resp = await fetch(url(`/agents/${agentId}/memory/${index}`), {
-    method: "DELETE",
-    headers: headers(),
-  });
+export async function deleteMemory(
+  agentId: string,
+  index: number,
+  expectedVersion: number,
+): Promise<void> {
+  const resp = await fetch(
+    url(`/agents/${agentId}/memory/${index}${query({ expected_version: expectedVersion })}`),
+    {
+      method: "DELETE",
+      headers: headers(),
+    },
+  );
   if (resp.ok) return;
   const body = await resp.json().catch(() => null);
   throw new ApiError(resp.status, describeError(body) ?? resp.statusText);

--- a/apps/ui/src/views/wired/WiredAgentMemory.test.tsx
+++ b/apps/ui/src/views/wired/WiredAgentMemory.test.tsx
@@ -24,6 +24,7 @@ vi.mock("../../api/client", async (importOriginal) => {
 const ENTRIES: MemoryEntry[] = [
   {
     index: 0,
+    version: 7,
     content: "deploy is a git push",
     provenance: {
       learned_from_session_id: "sess-1",
@@ -33,6 +34,7 @@ const ENTRIES: MemoryEntry[] = [
   },
   {
     index: 1,
+    version: 7,
     content: "prod reuses the dev bundle",
     provenance: { learned_from_session_id: null, source_trace_ids: [], recorded_at: "" },
   },
@@ -86,7 +88,7 @@ describe("WiredAgentMemory (#267)", () => {
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() =>
-      expect(editMemory).toHaveBeenCalledWith("a1", 0, "corrected"),
+      expect(editMemory).toHaveBeenCalledWith("a1", 0, "corrected", 7),
     );
     expect(await screen.findByText("corrected")).toBeInTheDocument();
   });
@@ -101,7 +103,7 @@ describe("WiredAgentMemory (#267)", () => {
     await screen.findByText("deploy is a git push");
     await userEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
 
-    await waitFor(() => expect(deleteMemory).toHaveBeenCalledWith("a1", 0));
+    await waitFor(() => expect(deleteMemory).toHaveBeenCalledWith("a1", 0, 7));
   });
 
   it("surfaces a load error", async () => {

--- a/apps/ui/src/views/wired/WiredAgentMemory.tsx
+++ b/apps/ui/src/views/wired/WiredAgentMemory.tsx
@@ -48,11 +48,11 @@ export function WiredAgentMemory({ agentId }: { agentId: string }) {
     setError(null);
   };
 
-  const saveEdit = async (index: number) => {
+  const saveEdit = async (index: number, expectedVersion: number) => {
     setBusyIndex(index);
     setError(null);
     try {
-      await editMemory(agentId, index, draft);
+      await editMemory(agentId, index, draft, expectedVersion);
       setEditingIndex(null);
       await load();
     } catch (e) {
@@ -62,11 +62,11 @@ export function WiredAgentMemory({ agentId }: { agentId: string }) {
     }
   };
 
-  const remove = async (index: number) => {
+  const remove = async (index: number, expectedVersion: number) => {
     setBusyIndex(index);
     setError(null);
     try {
-      await deleteMemory(agentId, index);
+      await deleteMemory(agentId, index, expectedVersion);
       await load();
     } catch (e) {
       setError(String(e));
@@ -154,7 +154,7 @@ export function WiredAgentMemory({ agentId }: { agentId: string }) {
                           variant="primary"
                           size="sm"
                           disabled={busy}
-                          onClick={() => void saveEdit(entry.index)}
+                          onClick={() => void saveEdit(entry.index, entry.version)}
                         />
                         <Button
                           label="Cancel"
@@ -199,7 +199,7 @@ export function WiredAgentMemory({ agentId }: { agentId: string }) {
                         variant="ghost"
                         size="sm"
                         disabled={busy}
-                        onClick={() => void remove(entry.index)}
+                        onClick={() => void remove(entry.index, entry.version)}
                       />
                     </div>
                   )}


### PR DESCRIPTION
Memory edits and deletes now require the parent log version and return 409 when stale. Runner appends and operator mutations lock the same state row, and edits enforce existing size caps.

The API exposes the log version, the console sends it for edit and delete, and OpenAPI is regenerated. Positional indices remain the mutation handle only for the returned version. Stable record identifiers are deferred to a separate record shape migration.

Validated with the full Python, UI, and Playwright suites plus a live HTTP stale edit exercise.

Closes #391