### PR TITLE
Enforce CLI hint parity registry coverage

### DIFF
--- a/apps/ui/CLAUDE.md
+++ b/apps/ui/CLAUDE.md
@@ -35,16 +35,18 @@ structure and wiring detail in `apps/ui/README.md`.
   `?dev=1` gives an equivalent state switcher for development; keep it
   hidden without that param so the product view stays clean.
 - **Console/CLI parity: hints resolve from the manifest, never hardcoded**
-  (epic #145). CLI hints on wired surfaces come from `cliCommand()`
+  (epic #145). CLI hints on wired surfaces call `cliCommand()` directly
   (`src/primitives/cliCommand.ts`), which is typed against the committed
-  command manifest (`src/generated/commandManifest.ts`) — never hand-write an
-  `agentos …` string in a component. Every wired action is enumerated in the
-  parity registry (`src/primitives/parity.ts`) and must map to EITHER a real
-  `command` (an `ActionId`) OR an explicit `noCliEquivalent` marker that renders
-  the honest amber `CliHint` linking to the tracking issue. Adding a wired
-  action means adding its parity entry; `CliHint.parity.test.tsx` fails on a
-  silent gap. When the CLI surface changes, run `pnpm gen:manifest` and commit
-  the regenerated manifest (CI drift-checks it).
+  command manifest (`src/generated/commandManifest.ts`). Never hand write an
+  `agentos` command string in a component. `CliHint.parity.test.tsx` inventories
+  these direct calls recursively across the complete production `src` tree,
+  excluding tests, and requires every literal command to have a parity registry
+  mapping (`src/primitives/parity.ts`). It also verifies that each
+  `noCliEquivalent` hint uses typed action IDs whose entries point to
+  `PARITY_TRACKING_ISSUE`. A separate registry check verifies every entry is
+  either a real command or an explicit gap. When the CLI surface
+  changes, run `pnpm gen:manifest` and commit the regenerated manifest. CI
+  checks the manifest for drift.
 
 ## Playwright ports (do not confuse these)
 

--- a/apps/ui/src/primitives/CliHint.parity.test.tsx
+++ b/apps/ui/src/primitives/CliHint.parity.test.tsx
@@ -1,9 +1,213 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import * as ts from "typescript";
 import { CliHint } from "./CliHint";
 import { cliCommand } from "./cliCommand";
 import { WIRED_ACTIONS, PARITY_TRACKING_ISSUE } from "./parity";
+import type { WiredActionId } from "./parity";
 import { StoreProvider } from "../state/store";
+
+const PRODUCTION_ROOT = join(process.cwd(), "src");
+const EXPECTED_COMMAND_IDS = [
+  "cluster.deploy",
+  "cluster.status",
+  "init",
+  "local.deploy",
+  "local.status",
+] as const;
+const EXPECTED_NO_CLI_ACTION_IDS = [
+  "memory-delete",
+  "memory-edit",
+] as const satisfies readonly WiredActionId[];
+
+function isProductionTypeScriptFile(name: string): boolean {
+  const isTypeScript = name.endsWith(".ts") || name.endsWith(".tsx");
+  const isTest = [".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx"].some((suffix) =>
+    name.endsWith(suffix),
+  );
+  return isTypeScript && !isTest;
+}
+
+function discoverProductionSources(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .flatMap((entry) => {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) return discoverProductionSources(path);
+      return entry.isFile() && isProductionTypeScriptFile(entry.name) ? [path] : [];
+    });
+}
+
+function sourceLocation(sourceFile: ts.SourceFile, node: ts.Node): string {
+  const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  return `${relative(process.cwd(), sourceFile.fileName)}:${position.line + 1}:${position.character + 1}`;
+}
+
+function unwrapParentheses(expression: ts.Expression): ts.Expression {
+  let current = expression;
+  while (ts.isParenthesizedExpression(current)) current = current.expression;
+  return current;
+}
+
+function extractActionIds(argument: ts.Expression, sourceFile: ts.SourceFile): string[] {
+  if (ts.isStringLiteral(argument)) return [argument.text];
+  if (ts.isParenthesizedExpression(argument)) {
+    return extractActionIds(argument.expression, sourceFile);
+  }
+  if (ts.isConditionalExpression(argument)) {
+    return [
+      ...extractActionIds(argument.whenTrue, sourceFile),
+      ...extractActionIds(argument.whenFalse, sourceFile),
+    ];
+  }
+  throw new Error(
+    `${sourceLocation(sourceFile, argument)} uses unsupported cliCommand action syntax: ${ts.SyntaxKind[argument.kind]}`,
+  );
+}
+
+function isCliCommandCall(node: ts.Node): node is ts.CallExpression {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "cliCommand"
+  );
+}
+
+function findJsxAttribute(
+  node: ts.JsxOpeningElement | ts.JsxSelfClosingElement,
+  name: string,
+): ts.JsxAttribute | undefined {
+  return node.attributes.properties.find(
+    (attribute): attribute is ts.JsxAttribute =>
+      ts.isJsxAttribute(attribute) && attribute.name.getText() === name,
+  );
+}
+
+function jsxAttributeExpression(attribute: ts.JsxAttribute): ts.Expression | undefined {
+  const initializer = attribute.initializer;
+  return initializer && ts.isJsxExpression(initializer) ? initializer.expression : undefined;
+}
+
+interface ProductionUsage {
+  readonly commandIds: readonly { readonly id: string; readonly location: string }[];
+  readonly noCliActionIds: readonly { readonly id: string; readonly location: string }[];
+  readonly cliCommandViolations: readonly string[];
+  readonly cliHintViolations: readonly string[];
+}
+
+function scanProductionUsage(): ProductionUsage {
+  const commandIds: { id: string; location: string }[] = [];
+  const noCliActionIds: { id: string; location: string }[] = [];
+  const cliCommandViolations: string[] = [];
+  const cliHintViolations: string[] = [];
+
+  for (const path of discoverProductionSources(PRODUCTION_ROOT)) {
+    const sourceFile = ts.createSourceFile(
+      path,
+      readFileSync(path, "utf8"),
+      ts.ScriptTarget.Latest,
+      true,
+      path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+    );
+
+    function visit(node: ts.Node): void {
+      if (isCliCommandCall(node)) {
+        const argument = node.arguments[0];
+        if (!argument) {
+          cliCommandViolations.push(
+            `${sourceLocation(sourceFile, node)} calls cliCommand without an action id`,
+          );
+        } else {
+          try {
+            for (const id of extractActionIds(argument, sourceFile)) {
+              commandIds.push({ id, location: sourceLocation(sourceFile, argument) });
+            }
+          } catch (error) {
+            cliCommandViolations.push(error instanceof Error ? error.message : String(error));
+          }
+        }
+      }
+
+      if (
+        (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+        node.tagName.getText(sourceFile) === "CliHint"
+      ) {
+        const commandAttribute = findJsxAttribute(node, "command");
+        const noCliEquivalentAttribute = findJsxAttribute(node, "noCliEquivalent");
+        const actionIdsAttribute = findJsxAttribute(node, "actionIds");
+        const modeCount = Number(commandAttribute !== undefined) +
+          Number(noCliEquivalentAttribute !== undefined);
+
+        if (modeCount !== 1) {
+          cliHintViolations.push(
+            `${sourceLocation(sourceFile, node)} must pass exactly one CliHint mode: command or noCliEquivalent`,
+          );
+        }
+
+        if (commandAttribute) {
+          const expression = jsxAttributeExpression(commandAttribute);
+          const unwrapped = expression ? unwrapParentheses(expression) : undefined;
+          if (!unwrapped || !isCliCommandCall(unwrapped)) {
+            cliHintViolations.push(
+              `${sourceLocation(sourceFile, commandAttribute)} must pass a direct cliCommand call to CliHint command`,
+            );
+          }
+        }
+
+        if (noCliEquivalentAttribute) {
+          const issueExpression = jsxAttributeExpression(noCliEquivalentAttribute);
+          if (
+            !issueExpression ||
+            !ts.isIdentifier(issueExpression) ||
+            issueExpression.text !== "PARITY_TRACKING_ISSUE"
+          ) {
+            cliHintViolations.push(
+              `${sourceLocation(sourceFile, noCliEquivalentAttribute)} must pass PARITY_TRACKING_ISSUE directly to CliHint noCliEquivalent`,
+            );
+          }
+
+          if (!actionIdsAttribute) {
+            cliHintViolations.push(
+              `${sourceLocation(sourceFile, node)} must pass a direct actionIds array in noCliEquivalent mode`,
+            );
+          } else {
+            const actionIdsExpression = jsxAttributeExpression(actionIdsAttribute);
+            if (!actionIdsExpression || !ts.isArrayLiteralExpression(actionIdsExpression)) {
+              cliHintViolations.push(
+                `${sourceLocation(sourceFile, actionIdsAttribute)} must pass a direct actionIds array in noCliEquivalent mode`,
+              );
+            } else if (actionIdsExpression.elements.length === 0) {
+              cliHintViolations.push(
+                `${sourceLocation(sourceFile, actionIdsAttribute)} must contain at least one action id string literal`,
+              );
+            } else {
+              for (const element of actionIdsExpression.elements) {
+                if (!ts.isStringLiteral(element)) {
+                  cliHintViolations.push(
+                    `${sourceLocation(sourceFile, element)} uses unsupported actionIds syntax: ${ts.SyntaxKind[element.kind]}`,
+                  );
+                  continue;
+                }
+                noCliActionIds.push({
+                  id: element.text,
+                  location: sourceLocation(sourceFile, element),
+                });
+              }
+            }
+          }
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    }
+
+    visit(sourceFile);
+  }
+
+  return { commandIds, noCliActionIds, cliCommandViolations, cliHintViolations };
+}
 
 // Console/CLI parity gate (epic #145): every wired UI action must map to EITHER
 // a real command resolved from the committed manifest OR an explicit
@@ -41,6 +245,61 @@ describe("console/CLI parity registry (#280)", () => {
       expect("command" in action!.mapping).toBe(true);
     }
   });
+
+  it("covers every production cliCommand action in the registry", () => {
+    const usage = scanProductionUsage();
+    expect(usage.cliCommandViolations).toEqual([]);
+
+    const discoveredCommandIds = [...new Set(usage.commandIds.map((action) => action.id))].sort();
+    expect(
+      discoveredCommandIds,
+      "production cliCommand inventory must contain every expected command id",
+    ).toEqual(EXPECTED_COMMAND_IDS);
+
+    const mappedCommands = new Set<string>(
+      WIRED_ACTIONS.flatMap((action) =>
+        "command" in action.mapping ? [action.mapping.command] : [],
+      ),
+    );
+    for (const action of usage.commandIds) {
+      expect(
+        mappedCommands.has(action.id),
+        `${action.location} uses unregistered cliCommand action: ${action.id}`,
+      ).toBe(true);
+    }
+  });
+
+  it("requires every production CliHint to declare one direct parity mode", () => {
+    const usage = scanProductionUsage();
+    expect(usage.cliHintViolations).toEqual([]);
+
+    const discoveredNoCliActionIds = [
+      ...new Set(usage.noCliActionIds.map((action) => action.id)),
+    ].sort();
+    expect(
+      discoveredNoCliActionIds,
+      "production noCliEquivalent inventory must contain every expected wired action id",
+    ).toEqual(EXPECTED_NO_CLI_ACTION_IDS);
+
+    for (const discovered of usage.noCliActionIds) {
+      const action = WIRED_ACTIONS.find((candidate) => candidate.id === discovered.id);
+      expect(
+        action,
+        `${discovered.location} uses an unregistered noCliEquivalent action id: ${discovered.id}`,
+      ).toBeDefined();
+      expect(
+        action && "noCliEquivalent" in action.mapping
+          ? action.mapping.noCliEquivalent
+          : undefined,
+        `${discovered.location} must map ${discovered.id} to PARITY_TRACKING_ISSUE`,
+      ).toBe(PARITY_TRACKING_ISSUE);
+    }
+  });
+
+  it("removes the issue scoped unrendered registry entries", () => {
+    const staleIds = ["message-cluster", "message-local", "eval"];
+    expect(WIRED_ACTIONS.filter((action) => staleIds.includes(action.id))).toEqual([]);
+  });
 });
 
 describe("CliHint — noCliEquivalent amber state (#280)", () => {
@@ -49,7 +308,12 @@ describe("CliHint — noCliEquivalent amber state (#280)", () => {
   }
 
   it("renders the amber glyph and links to the tracking issue instead of copying", () => {
-    renderHint(<CliHint noCliEquivalent={PARITY_TRACKING_ISSUE} />);
+    renderHint(
+      <CliHint
+        noCliEquivalent={PARITY_TRACKING_ISSUE}
+        actionIds={["memory-edit"]}
+      />,
+    );
     const btn = screen.getByRole("button", { name: /no cli equivalent/i });
     expect(btn).toHaveAttribute("data-no-cli", "true");
     // It carries no "Copy command" affordance.

--- a/apps/ui/src/primitives/CliHint.tsx
+++ b/apps/ui/src/primitives/CliHint.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { C } from "../tokens";
 import { useStore } from "../state/store";
+import type { WiredActionId } from "./parity";
 
 // CliHint: a resting `>_` glyph that morphs in place into a copy button on
 // hover / keyboard-focus (cross-fades to `⧉`, accent color), previews the exact
@@ -16,21 +17,32 @@ import { useStore } from "../state/store";
 // Honest no-equivalent state (epic #145): a wired action with no CLI verb yet
 // passes `noCliEquivalent={<tracking issue url>}` instead of a `command`. That
 // renders an amber `◇` glyph whose tooltip says there is no CLI equivalent and
-// whose click opens the tracking issue in a new tab — it never copies a
-// misleading command. The parity test (CliHint.parity.test.tsx) enforces that
-// every wired action resolves to a `command` or an explicit `noCliEquivalent`.
+// whose click opens the tracking issue in a new tab. Typed action IDs identify
+// the registry entries for this mode, and the parity test verifies those IDs
+// link to `PARITY_TRACKING_ISSUE`. The same test scans direct `cliCommand`
+// calls across production source and checks their literal command mappings.
 
 const COPIED_RESET_MS = 1200;
+
+type CliHintProps =
+  | {
+      command?: string;
+      label?: string;
+      noCliEquivalent?: never;
+      actionIds?: never;
+    }
+  | {
+      command?: never;
+      label?: string;
+      noCliEquivalent: string;
+      actionIds: readonly WiredActionId[];
+    };
 
 export function CliHint({
   command,
   label,
   noCliEquivalent,
-}: {
-  command?: string;
-  label?: string;
-  noCliEquivalent?: string;
-}) {
+}: CliHintProps) {
   const { dispatch } = useStore();
   const [active, setActive] = useState(false); // hover or keyboard focus
   const [copied, setCopied] = useState(false);

--- a/apps/ui/src/primitives/parity.ts
+++ b/apps/ui/src/primitives/parity.ts
@@ -6,11 +6,12 @@
 // verb breaks `pnpm typecheck` at this call site) OR an explicit
 // `noCliEquivalent` marker carrying the tracking issue for the gap.
 //
-// The parity test (`CliHint.parity.test.tsx`) enumerates this registry and
-// asserts each entry resolves to a real command or an honest gap — so a new
-// wired action cannot ship without a deliberate CLI mapping decision. Surfaces
-// render `CliHint` from these same entries, so the hint a user sees and the
-// invariant the test enforces never drift.
+// Direct `cliCommand` calls are typed against the manifest. The parity test
+// recursively inventories those calls across the complete production `src`
+// tree, excluding tests, and verifies each literal command has a registry
+// mapping. It also checks that typed `noCliEquivalent` action IDs resolve to
+// entries linked to `PARITY_TRACKING_ISSUE`. Registry enumeration separately
+// verifies every entry is a real command or an explicit gap.
 
 import type { ActionId } from "./cliCommand";
 
@@ -34,7 +35,7 @@ export interface WiredAction {
 // The wired actions, grouped by surface in comments. `deploy`/`status`/`message`
 // are env-scoped in the UI (prod -> cluster, dev -> local); both tiers are
 // listed so the parity gate covers each concrete command the surface can emit.
-export const WIRED_ACTIONS: readonly WiredAction[] = [
+export const WIRED_ACTIONS = [
   // WiredAgents / NewAgentModal
   { id: "scaffold-agent", label: "New agent / scaffold", mapping: { command: "init" } },
 
@@ -45,13 +46,6 @@ export const WIRED_ACTIONS: readonly WiredAction[] = [
   // WiredOverview / WiredVersions — status (env-scoped)
   { id: "status-cluster", label: "Overview / versions status (prod)", mapping: { command: "cluster.status" } },
   { id: "status-local", label: "Overview / versions status (dev)", mapping: { command: "local.status" } },
-
-  // Send-message / test-turn (env-scoped)
-  { id: "message-cluster", label: "Send message / test turn (prod)", mapping: { command: "cluster.message" } },
-  { id: "message-local", label: "Send message / test turn (dev)", mapping: { command: "local.message" } },
-
-  // Evals matrix
-  { id: "eval", label: "Run eval suite", mapping: { command: "skill.eval" } },
 
   // Lifecycle controls — real verbs since #149 landed kill/resume/budget/delete.
   { id: "kill", label: "Kill a run", mapping: { command: "cluster.kill" } },
@@ -68,4 +62,6 @@ export const WIRED_ACTIONS: readonly WiredAction[] = [
   // CLI verb exists yet, so both render the honest amber gap glyph.
   { id: "memory-edit", label: "Edit a learned memory entry", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
   { id: "memory-delete", label: "Delete a learned memory entry", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
-] as const;
+] as const satisfies readonly WiredAction[];
+
+export type WiredActionId = (typeof WIRED_ACTIONS)[number]["id"];

--- a/apps/ui/src/views/wired/WiredAgentMemory.tsx
+++ b/apps/ui/src/views/wired/WiredAgentMemory.tsx
@@ -89,7 +89,11 @@ export function WiredAgentMemory({ agentId }: { agentId: string }) {
           <div style={{ fontWeight: 600, fontSize: 14, color: C.text2 }}>
             Learned memory
           </div>
-          <CliHint noCliEquivalent={PARITY_TRACKING_ISSUE} label="No CLI equivalent" />
+          <CliHint
+            noCliEquivalent={PARITY_TRACKING_ISSUE}
+            actionIds={["memory-edit", "memory-delete"]}
+            label="No CLI equivalent"
+          />
           <div style={{ marginLeft: "auto" }}>
             <Button label="Refresh" variant="ghost" size="sm" onClick={() => void load()} />
           </div>


### PR DESCRIPTION
Closes the registry to rendered surface gap by scanning production CLI hint call sites and validating command and explicit gap identities against `WIRED_ACTIONS`.

Removes the unused message and eval registry records and updates the UI parity guidance to describe the enforced contract.

Closes #392