### PR TITLE
Wire trajectory scoring through eval runs

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -707,6 +707,35 @@
             "title": "Agent Id",
             "type": "string"
           },
+          "case_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array",
+                "uniqueItems": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Case Ids"
+          },
+          "cases_sha256": {
+            "anyOf": [
+              {
+                "pattern": "^[0-9a-f]{64}$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cases Sha256"
+          },
           "suite": {
             "anyOf": [
               {
@@ -728,6 +757,20 @@
               }
             ],
             "title": "Target Url"
+          },
+          "trajectory_specs": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/TrajectorySpecRequest"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trajectory Specs"
           },
           "version_id": {
             "anyOf": [
@@ -1491,6 +1534,43 @@
           "tree"
         ],
         "title": "TraceTree",
+        "type": "object"
+      },
+      "TrajectorySpecRequest": {
+        "additionalProperties": false,
+        "description": "One strict trajectory scorer specification supplied by an API caller.",
+        "properties": {
+          "expected": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Expected",
+            "type": "array"
+          },
+          "mode": {
+            "default": "in_order",
+            "enum": [
+              "exact",
+              "in_order",
+              "any_order",
+              "precision",
+              "recall"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "threshold": {
+            "default": 1.0,
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Threshold",
+            "type": "number"
+          }
+        },
+        "required": [
+          "expected"
+        ],
+        "title": "TrajectorySpecRequest",
         "type": "object"
       },
       "ValidationError": {

--- a/apps/api/src/agentos_api/evalqueue.py
+++ b/apps/api/src/agentos_api/evalqueue.py
@@ -16,13 +16,14 @@ from datetime import UTC, datetime
 from typing import Any, cast
 
 import redis.asyncio as redis
-from pydantic import BaseModel
+
+from .schemas import TrajectorySelectionRequest
 
 EVAL_STREAM = "agentos:evals"
 STREAM_PAYLOAD_FIELD = "payload"
 
 
-class EvalJobRequest(BaseModel):
+class EvalJobRequest(TrajectorySelectionRequest):
     """One eval job: run ``suite`` against the version built from ``sha``."""
 
     agent_id: uuid.UUID

--- a/apps/api/src/agentos_api/routers/evals.py
+++ b/apps/api/src/agentos_api/routers/evals.py
@@ -85,6 +85,9 @@ async def trigger_eval(
             suite=suite,
             bundle_ref=version.bundle_ref,
             target_url=body.target_url,
+            trajectory_specs=body.trajectory_specs,
+            case_ids=body.case_ids,
+            cases_sha256=body.cases_sha256,
             requested_at=now_iso(),
         )
     )

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -3,9 +3,9 @@
 import re
 import uuid
 from datetime import datetime
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .models import Environment
 
@@ -383,7 +383,73 @@ class EvalMatrix(BaseModel):
     model_summaries: list[EvalModelSummary] = []
 
 
-class EvalTriggerRequest(BaseModel):
+class TrajectorySpecRequest(BaseModel):
+    """One strict trajectory scorer specification supplied by an API caller."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    expected: list[str]
+    mode: Literal["exact", "in_order", "any_order", "precision", "recall"] = (
+        "in_order"
+    )
+    threshold: float = Field(default=1.0, ge=0.0, le=1.0, allow_inf_nan=False)
+
+    @field_validator("expected", mode="before")
+    @classmethod
+    def _expected_is_string_list(cls, value: object) -> object:
+        if not isinstance(value, list) or not all(
+            isinstance(tool, str) for tool in value
+        ):
+            raise ValueError("expected must be a string list")
+        return value
+
+    @field_validator("threshold", mode="before")
+    @classmethod
+    def _threshold_is_number(cls, value: object) -> object:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("threshold must be a number")
+        return value
+
+
+class TrajectorySelectionRequest(BaseModel):
+    """Optional explicit trajectory selection and its eval case identity."""
+
+    trajectory_specs: dict[str, TrajectorySpecRequest] | None = None
+    case_ids: (
+        Annotated[
+            list[Annotated[str, Field(min_length=1)]],
+            Field(min_length=1, json_schema_extra={"uniqueItems": True}),
+        ]
+        | None
+    ) = None
+    cases_sha256: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
+
+    @field_validator("case_ids", mode="before")
+    @classmethod
+    def _case_ids_is_string_list(cls, value: object) -> object:
+        if value is None:
+            return value
+        if not isinstance(value, list) or not all(
+            isinstance(case_id, str) for case_id in value
+        ):
+            raise ValueError("case_ids must be a string list")
+        return value
+
+    @model_validator(mode="after")
+    def _identity_matches_selection(self) -> Self:
+        if self.trajectory_specs is None:
+            if self.case_ids is not None or self.cases_sha256 is not None:
+                raise ValueError("case identity requires trajectory_specs")
+            return self
+
+        if self.case_ids is None or self.cases_sha256 is None:
+            raise ValueError("trajectory_specs require case identity")
+        if len(set(self.case_ids)) != len(self.case_ids):
+            raise ValueError("case_ids must be unique")
+        return self
+
+
+class EvalTriggerRequest(TrajectorySelectionRequest):
     """Ask for an on-demand platform eval run for an agent (issue #10).
 
     Enqueues the same EvalJobRequest the git-push fan-out uses, minus the

--- a/apps/api/tests/test_evalqueue_integration.py
+++ b/apps/api/tests/test_evalqueue_integration.py
@@ -15,6 +15,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+import pytest
 import redis
 import redis.asyncio as aioredis
 from agentos_api.config import get_settings
@@ -28,7 +29,30 @@ VALID_FILES = {
 }
 
 
-def test_enqueue_lands_with_exact_shape() -> None:
+@pytest.mark.parametrize(
+    ("trajectory_specs", "case_ids", "cases_sha256"),
+    [
+        (None, None, None),
+        ({}, ["weather"], "a" * 64),
+        (
+            {
+                "weather": {
+                    "expected": ["WebSearch", "WebFetch"],
+                    "mode": "in_order",
+                    "threshold": 0.75,
+                }
+            },
+            ["weather"],
+            "b" * 64,
+        ),
+    ],
+    ids=["no_selection", "empty_selection", "explicit_selection"],
+)
+def test_enqueue_lands_with_exact_shape(
+    trajectory_specs: dict[str, object] | None,
+    case_ids: list[str] | None,
+    cases_sha256: str | None,
+) -> None:
     stream = f"agentos:evals:test-{secrets.token_hex(4)}"
     agent_id, version_id = uuid.uuid4(), uuid.uuid4()
     request = EvalJobRequest(
@@ -37,6 +61,9 @@ def test_enqueue_lands_with_exact_shape() -> None:
         sha="deadbeef",
         suite="default",
         bundle_ref="bundles/x/y.tar.gz",
+        trajectory_specs=trajectory_specs,
+        case_ids=case_ids,
+        cases_sha256=cases_sha256,
         requested_at=now_iso(),
     )
 
@@ -62,6 +89,9 @@ def test_enqueue_lands_with_exact_shape() -> None:
             "suite": "default",
             "bundle_ref": "bundles/x/y.tar.gz",
             "target_url": None,
+            "trajectory_specs": trajectory_specs,
+            "case_ids": case_ids,
+            "cases_sha256": cases_sha256,
             "requested_at": request.requested_at,
         }
     finally:
@@ -163,6 +193,9 @@ def test_dev_push_fans_out_prod_push_does_not(
     assert entry is not None, "dev push should fan out an eval job"
     assert entry["agent_id"] == agent["id"]
     assert entry["suite"] == "default"
+    assert entry["trajectory_specs"] is None
+    assert entry["case_ids"] is None
+    assert entry["cases_sha256"] is None
 
     # A prod push (same sha) promotes but must NOT add another eval entry.
     sync = redis.from_url(get_settings().valkey_dsn())

--- a/apps/api/tests/test_evals_trigger_integration.py
+++ b/apps/api/tests/test_evals_trigger_integration.py
@@ -11,6 +11,7 @@ import json
 import uuid
 from typing import Any
 
+import pytest
 import redis
 from agentos_api import crud
 from agentos_api.config import get_settings
@@ -19,6 +20,7 @@ from agentos_api.models import Environment
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 REPO = "octo/trigger-10"
+VALID_CASES_SHA256 = "a" * 64
 
 
 def _create_agent(client: Any, auth_headers: dict[str, str], name: str) -> dict[str, Any]:
@@ -141,6 +143,143 @@ def test_trigger_enqueues_for_active_dev_deployment(
     assert req.suite == get_settings().eval_default_suite
     assert req.bundle_ref == seeded["bundle_ref"]
     assert req.target_url is None
+    assert req.trajectory_specs is None
+    assert req.case_ids is None
+    assert req.cases_sha256 is None
+
+
+@pytest.mark.parametrize(
+    "trajectory_specs",
+    [
+        {},
+        {
+            "weather": {
+                "expected": ["WebSearch", "WebFetch"],
+                "mode": "in_order",
+                "threshold": 0.75,
+            }
+        },
+    ],
+    ids=["empty_selection", "explicit_selection"],
+)
+def test_trigger_propagates_explicit_trajectory_specs_to_stream(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trajectory_specs: dict[str, object],
+) -> None:
+    agent = _create_agent(client, auth_headers, "trigger-trajectory")
+    _seed(agent["id"])
+    case_ids = ["weather", "followup"]
+
+    resp = client.post(
+        "/evals/trigger",
+        json={
+            "agent_id": agent["id"],
+            "trajectory_specs": trajectory_specs,
+            "case_ids": case_ids,
+            "cases_sha256": VALID_CASES_SHA256,
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    payload = _payload_for_stream_id(resp.json()["stream_id"])
+    assert payload is not None
+    assert payload["trajectory_specs"] == trajectory_specs
+    assert payload["case_ids"] == case_ids
+    assert payload["cases_sha256"] == VALID_CASES_SHA256
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"expected": "WebSearch", "mode": "exact", "threshold": 1.0},
+        {"expected": ["WebSearch"], "mode": "sideways", "threshold": 1.0},
+        {"expected": ["WebSearch"], "mode": "exact", "threshold": 1.01},
+        {
+            "expected": ["WebSearch"],
+            "mode": "exact",
+            "threshold": 1.0,
+            "unexpected": True,
+        },
+    ],
+    ids=["expected", "mode", "threshold", "unknown_field"],
+)
+def test_trigger_rejects_invalid_trajectory_specs(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    spec: dict[str, object],
+) -> None:
+    agent = _create_agent(client, auth_headers, f"triggerinvalid{uuid.uuid4().hex[:8]}")
+    _seed(agent["id"])
+
+    resp = client.post(
+        "/evals/trigger",
+        json={
+            "agent_id": agent["id"],
+            "trajectory_specs": {"case": spec},
+            "case_ids": ["case"],
+            "cases_sha256": VALID_CASES_SHA256,
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert _count_eval_entries_for_agent(agent["id"]) == 0
+
+
+@pytest.mark.parametrize(
+    "selection",
+    [
+        {"trajectory_specs": {}},
+        {"trajectory_specs": {}, "case_ids": ["case"]},
+        {"trajectory_specs": {}, "cases_sha256": VALID_CASES_SHA256},
+        {"case_ids": ["case"], "cases_sha256": VALID_CASES_SHA256},
+        {
+            "trajectory_specs": {},
+            "case_ids": [],
+            "cases_sha256": VALID_CASES_SHA256,
+        },
+        {
+            "trajectory_specs": {},
+            "case_ids": ["case", "case"],
+            "cases_sha256": VALID_CASES_SHA256,
+        },
+        {"trajectory_specs": {}, "case_ids": ["case"], "cases_sha256": "a" * 63},
+        {"trajectory_specs": {}, "case_ids": ["case"], "cases_sha256": "A" * 64},
+        {"trajectory_specs": {}, "case_ids": ["case"], "cases_sha256": "g" * 64},
+    ],
+    ids=[
+        "missing_identity",
+        "missing_digest",
+        "missing_case_ids",
+        "identity_without_specs",
+        "empty_case_ids",
+        "duplicate_case_ids",
+        "short_digest",
+        "uppercase_digest",
+        "nonhex_digest",
+    ],
+)
+def test_trigger_rejects_invalid_trajectory_identity(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    selection: dict[str, object],
+) -> None:
+    agent = _create_agent(client, auth_headers, f"triggeridentity{uuid.uuid4().hex[:8]}")
+    _seed(agent["id"])
+
+    resp = client.post(
+        "/evals/trigger",
+        json={"agent_id": agent["id"], **selection},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert _count_eval_entries_for_agent(agent["id"]) == 0
 
 
 def test_trigger_requires_api_key(client: Any) -> None:

--- a/apps/worker/src/agentos_worker/eval/run.py
+++ b/apps/worker/src/agentos_worker/eval/run.py
@@ -28,6 +28,7 @@ from ..runner_client import RunnerClient
 from .models import EvalRunResult, EvalSuite
 from .recorder import LangfuseEvalRecorder
 from .runner import EvalRunner
+from .scorer import Scorer
 
 
 def load_suite(path: str | Path) -> EvalSuite:
@@ -42,6 +43,7 @@ async def run_eval_suite(
     recorder: LangfuseEvalRecorder | None = None,
     token: str | None = None,
     model: str | None = None,
+    scorer: Scorer | None = None,
 ) -> EvalRunResult:
     """Run a suite against a runner endpoint and, if configured, record it.
 
@@ -50,7 +52,7 @@ async def run_eval_suite(
     eval matrix can slice pass-rate/cost by model.
     """
     async with RunnerClient() as runner:
-        result = await EvalRunner(runner).run(
+        result = await EvalRunner(runner, scorer=scorer).run(
             suite, base_url=base_url, version=version, token=token, model=model
         )
     if recorder is not None:

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -26,6 +26,8 @@ acked, not a crash; a failing eval case is a failed count in the report.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
 import secrets
 import tempfile
@@ -37,7 +39,7 @@ from typing import Any, cast
 import httpx
 from aci_protocol import Budget
 from plugin_format import safe_extract
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from redis.asyncio import Redis
 
 from ..binding import (
@@ -53,9 +55,10 @@ from ..config import WorkerConfig
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
 from ..stream_consumer import ReadLoopSpec, StreamConsumer, StreamEntry
-from .models import EvalRunResult, EvalSuite
+from .models import EvalCaseResult, EvalRunResult, EvalSuite
 from .recorder import LangfuseEvalRecorder
 from .run import run_eval_suite
+from .scorer import Scorer, TrajectoryMode, TrajectoryScorer, TrajectorySpec
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +66,32 @@ logger = logging.getLogger(__name__)
 _EVAL_READ_ERROR_BACKOFF_S = 0.5
 
 STREAM_PAYLOAD_FIELD = "payload"
+
+
+class _TrajectorySpecInput(BaseModel):
+    """Strict stream and sidecar representation of one trajectory spec."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    expected: list[str]
+    mode: TrajectoryMode = TrajectoryMode.IN_ORDER
+    threshold: float = Field(default=1.0, ge=0.0, le=1.0, allow_inf_nan=False)
+
+    @field_validator("expected", mode="before")
+    @classmethod
+    def _expected_is_string_list(cls, value: object) -> object:
+        if not isinstance(value, list) or not all(
+            isinstance(tool, str) for tool in value
+        ):
+            raise ValueError("expected must be a string list")
+        return value
+
+    @field_validator("threshold", mode="before")
+    @classmethod
+    def _threshold_is_number(cls, value: object) -> object:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("threshold must be a number")
+        return value
 
 
 class EvalWorkItem(BaseModel):
@@ -74,7 +103,52 @@ class EvalWorkItem(BaseModel):
     suite: str
     bundle_ref: str | None = None
     target_url: str | None = None
+    trajectory_specs: dict[str, _TrajectorySpecInput] | None = None
+    case_ids: list[str] | None = None
+    cases_sha256: str | None = None
     requested_at: str
+
+    @field_validator("trajectory_specs", mode="before")
+    @classmethod
+    def _trajectory_specs_is_string_map(cls, value: object) -> object:
+        if value is None:
+            return value
+        if not isinstance(value, dict) or not all(
+            isinstance(case_id, str) for case_id in value
+        ):
+            raise ValueError("trajectory_specs must map case ids to specs")
+        return value
+
+    @field_validator("case_ids", mode="before")
+    @classmethod
+    def _case_ids_is_string_list(cls, value: object) -> object:
+        if value is None:
+            return value
+        if not isinstance(value, list) or not all(
+            isinstance(case_id, str) for case_id in value
+        ):
+            raise ValueError("case_ids must be a string list")
+        return value
+
+    @model_validator(mode="after")
+    def _trajectory_identity_matches_selection(self) -> EvalWorkItem:
+        if self.trajectory_specs is None:
+            if self.case_ids is not None or self.cases_sha256 is not None:
+                raise ValueError("case identity requires trajectory_specs")
+            return self
+
+        if (
+            not self.case_ids
+            or any(not case_id for case_id in self.case_ids)
+            or len(set(self.case_ids)) != len(self.case_ids)
+        ):
+            raise ValueError("explicit trajectory_specs require unique case_ids")
+        if self.cases_sha256 is None or (
+            len(self.cases_sha256) != 64
+            or any(char not in "0123456789abcdef" for char in self.cases_sha256)
+        ):
+            raise ValueError("explicit trajectory_specs require a lowercase sha256")
+        return self
 
     @classmethod
     def from_stream_fields(cls, fields: dict[str, str]) -> EvalWorkItem:
@@ -137,19 +211,61 @@ def load_suite_from_bundle(data: bytes, suite_name: str) -> EvalSuite | None:
     named with ``suite_name`` (the payload's authoritative name / Langfuse tag).
     Returns None on a corrupt archive or a missing/invalid suite file."""
     try:
-        with tempfile.TemporaryDirectory() as tmp:
-            dest = Path(tmp)
-            safe_extract(data, dest)
-            cases = next(
-                (p for p in dest.rglob("cases.json") if p.parent.name == "evals"), None
-            )
-            if cases is None:
-                return None
-            loaded = EvalSuite.model_validate_json(cases.read_text())
+        extracted = _extract_eval_files(data)
+        if extracted is None:
+            return None
+        cases_data, _trajectory_data = extracted
+        loaded = EvalSuite.model_validate_json(cases_data)
     except Exception:
         logger.exception("could not load eval suite from bundle")
         return None
     return EvalSuite(name=suite_name, cases=loaded.cases)
+
+
+def _extract_eval_files(data: bytes) -> tuple[bytes, bytes | None] | None:
+    """Extract exact cases bytes and the optional sibling trajectory sidecar."""
+    with tempfile.TemporaryDirectory() as tmp:
+        dest = Path(tmp)
+        safe_extract(data, dest)
+        cases = next(
+            (p for p in dest.rglob("cases.json") if p.parent.name == "evals"), None
+        )
+        if cases is None:
+            return None
+        sidecar = cases.parent / "trajectory.json"
+        return cases.read_bytes(), sidecar.read_bytes() if sidecar.is_file() else None
+
+
+def _load_trajectory_scorer(data: bytes | None) -> TrajectoryScorer | None:
+    """Load an optional evals/trajectory.json sidecar from its exact bytes."""
+    if data is None:
+        return None
+    raw = json.loads(data)
+    if not isinstance(raw, dict):
+        raise ValueError("evals/trajectory.json must contain an object")
+
+    specs: dict[str, _TrajectorySpecInput] = {}
+    for case_id, value in raw.items():
+        if not isinstance(case_id, str):
+            raise ValueError("trajectory spec case ids must be strings")
+        specs[case_id] = _TrajectorySpecInput.model_validate(value)
+
+    return _trajectory_scorer(specs)
+
+
+def _trajectory_scorer(
+    specs: dict[str, _TrajectorySpecInput],
+) -> TrajectoryScorer:
+    return TrajectoryScorer(
+        specs={
+            case_id: TrajectorySpec(
+                expected=tuple(spec.expected),
+                mode=spec.mode,
+                threshold=spec.threshold,
+            )
+            for case_id, spec in specs.items()
+        }
+    )
 
 
 class EvalStreamConsumer(StreamConsumer):
@@ -287,22 +403,60 @@ class EvalStreamConsumer(StreamConsumer):
 
     async def _run_and_report(self, item: EvalWorkItem) -> EvalRunResult:
         repo = await self._repo_lookup.repo_full_name(item.agent_id)
-        suite = await self._load_suite(item)
-        if suite is None:
+        loaded = await self._load_suite(item)
+        if loaded is None:
             return await self._report_failed(item, repo, "unresolvable suite/bundle")
+        suite, scorer, terminal_error = loaded
+
+        if terminal_error is not None:
+            failed_case_ids = (
+                item.case_ids
+                if item.trajectory_specs is not None and item.case_ids is not None
+                else [case.id for case in suite.cases]
+            )
+            result = EvalRunResult(
+                version=item.sha,
+                suite=suite.name,
+                model=self._eval_model(item),
+                results=[
+                    EvalCaseResult(
+                        case_id=case_id,
+                        passed=False,
+                        output="",
+                        latency_ms=0.0,
+                        error=terminal_error,
+                    )
+                    for case_id in failed_case_ids
+                ],
+            )
+            if self._recorder is not None:
+                await self._recorder.record(result)
+            await self._report(item, repo, result)
+            return result
 
         base_url, release_key, token = await self._acquire_target(item)
         if base_url is None:
             return await self._report_failed(item, repo, "runner provisioning failed")
         try:
-            result = await run_eval_suite(
-                suite,
-                base_url=base_url,
-                version=item.sha,
-                recorder=self._recorder,
-                token=token,
-                model=self._eval_model(item),
-            )
+            if scorer is None:
+                result = await run_eval_suite(
+                    suite,
+                    base_url=base_url,
+                    version=item.sha,
+                    recorder=self._recorder,
+                    token=token,
+                    model=self._eval_model(item),
+                )
+            else:
+                result = await run_eval_suite(
+                    suite,
+                    base_url=base_url,
+                    version=item.sha,
+                    recorder=self._recorder,
+                    token=token,
+                    model=self._eval_model(item),
+                    scorer=scorer,
+                )
         finally:
             if release_key is not None:
                 await asyncio.to_thread(self._substrate.release, release_key)
@@ -310,7 +464,9 @@ class EvalStreamConsumer(StreamConsumer):
         await self._report(item, repo, result)
         return result
 
-    async def _load_suite(self, item: EvalWorkItem) -> EvalSuite | None:
+    async def _load_suite(
+        self, item: EvalWorkItem
+    ) -> tuple[EvalSuite, Scorer | None, str | None] | None:
         if item.bundle_ref is None:
             return None
         try:
@@ -318,7 +474,34 @@ class EvalStreamConsumer(StreamConsumer):
         except Exception:
             logger.exception("could not fetch bundle %s", item.bundle_ref)
             return None
-        return load_suite_from_bundle(data, item.suite)
+        try:
+            extracted = _extract_eval_files(data)
+            if extracted is None:
+                return None
+            cases_data, trajectory_data = extracted
+            loaded = EvalSuite.model_validate_json(cases_data)
+            suite = EvalSuite(name=item.suite, cases=loaded.cases)
+        except Exception:
+            logger.exception("could not load eval suite from bundle")
+            return None
+        if item.trajectory_specs is not None:
+            deployed_case_ids = [case.id for case in suite.cases]
+            if (
+                hashlib.sha256(cases_data).hexdigest() != item.cases_sha256
+                or deployed_case_ids != item.case_ids
+            ):
+                return (
+                    suite,
+                    None,
+                    "selected eval cases do not match deployed bundle",
+                )
+            return suite, _trajectory_scorer(item.trajectory_specs), None
+        try:
+            scorer = _load_trajectory_scorer(trajectory_data)
+        except ValueError:
+            logger.exception("invalid evals/trajectory.json in bundle %s", item.bundle_ref)
+            return suite, None, "invalid trajectory configuration"
+        return suite, scorer, None
 
     async def _acquire_target(
         self, item: EvalWorkItem

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -13,6 +13,7 @@ provisioned-runner end-to-end (no ``target_url``) that tears the sandbox down.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
 import json
 import logging
@@ -26,6 +27,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import httpx
+import pytest
 import redis
 from agentos_worker.binding import BUDGET_ENV, BUNDLE_REF_ENV
 from agentos_worker.bundle_store import BundleStore
@@ -162,7 +164,14 @@ def _cfg(stream: str, group: str, **overrides: object) -> WorkerConfig:
 
 
 def _item(
-    *, suite: str, sha: str, bundle_ref: str | None, target_url: str | None
+    *,
+    suite: str,
+    sha: str,
+    bundle_ref: str | None,
+    target_url: str | None,
+    trajectory_specs: dict[str, object] | None = None,
+    case_ids: list[str] | None = None,
+    cases_sha256: str | None = None,
 ) -> EvalWorkItem:
     return EvalWorkItem(
         agent_id=uuid.uuid4(),
@@ -171,6 +180,9 @@ def _item(
         suite=suite,
         bundle_ref=bundle_ref,
         target_url=target_url,
+        trajectory_specs=trajectory_specs,
+        case_ids=case_ids,
+        cases_sha256=cases_sha256,
         requested_at="2026-07-05T00:00:00+00:00",
     )
 
@@ -336,6 +348,410 @@ def test_seam_full_consume_eval_report_cycle(make_eval_harness, bundles) -> None
     asyncio.run(go())
 
 
+@pytest.mark.parametrize(
+    (
+        "bundle_trajectory",
+        "selected_trajectory",
+        "tool_calls",
+        "output",
+        "idle",
+        "expected_passed",
+        "expected_total",
+    ),
+    [
+        (
+            {"ordered": {"expected": ["search", "fetch"], "mode": "exact"}},
+            None,
+            ["search", "fetch"],
+            "grader miss",
+            False,
+            1,
+            1,
+        ),
+        (
+            {"ordered": {"expected": ["search", "fetch"], "mode": "exact"}},
+            None,
+            ["fetch", "search"],
+            "grader pass",
+            False,
+            0,
+            1,
+        ),
+        ({}, None, ["search", "fetch"], "grader pass", False, 0, 1),
+        (None, None, ["fetch", "search"], "grader pass", False, 1, 1),
+        (
+            {"ordered": {"expected": ["search", "fetch"], "mode": "exact"}},
+            None,
+            ["search", "fetch"],
+            "grader pass",
+            True,
+            0,
+            1,
+        ),
+        (
+            {"ordered": {"expected": ["fetch", "search"], "mode": "exact"}},
+            {"ordered": {"expected": ["search", "fetch"], "mode": "exact"}},
+            ["search", "fetch"],
+            "grader miss",
+            False,
+            1,
+            1,
+        ),
+        (
+            {"ordered": {"expected": ["search", "fetch"], "mode": "exact"}},
+            {},
+            ["search", "fetch"],
+            "grader pass",
+            False,
+            0,
+            1,
+        ),
+    ],
+    ids=[
+        "matching_order",
+        "wrong_order",
+        "missing_spec",
+        "no_sidecar",
+        "incomplete_turn",
+        "explicit_map_precedence",
+        "explicit_empty_map",
+    ],
+)
+def test_stream_selects_trajectory_scorer_from_job_or_bundle(
+    make_eval_harness,
+    bundles,
+    bundle_trajectory: dict[str, object] | None,
+    selected_trajectory: dict[str, object] | None,
+    tool_calls: list[str],
+    output: str,
+    idle: bool,
+    expected_passed: int,
+    expected_total: int,
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="trajectory",
+                cases=[
+                    EvalCase(
+                        id="ordered",
+                        input="run tools",
+                        grader=Grader(kind=CONTAINS, expected="grader pass"),
+                    )
+                ],
+            )
+            fake.responses = {"run tools": output}
+            fake.tool_calls = {"run tools": tool_calls}
+            if idle:
+                fake.idle_inputs = {"run tools"}
+            bundle_ref = upload(_suite_bundle(suite, trajectory=bundle_trajectory))
+            explicit_case_ids = ["ordered"] if selected_trajectory is not None else None
+            explicit_cases_sha256 = (
+                hashlib.sha256(suite.model_dump_json().encode("utf-8")).hexdigest()
+                if selected_trajectory is not None
+                else None
+            )
+            token = uuid.uuid4().hex[:8]
+            cfg = _cfg(f"test:evals:{token}", f"g-{token}")
+            client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+            reports: list[dict[str, Any]] = []
+            async with httpx.AsyncClient(timeout=30.0) as lf_client:
+                consumer = _build_consumer(
+                    redis_client=client,
+                    cfg=cfg,
+                    bundle_store=store,
+                    substrate=_UnusedSubstrate(),
+                    reports=reports,
+                    lf_client=lf_client,
+                )
+                await consumer.ensure_group()
+                item = _item(
+                    suite="trajectory",
+                    sha=f"sha-{token}",
+                    bundle_ref=bundle_ref,
+                    target_url=base_url,
+                    trajectory_specs=selected_trajectory,
+                    case_ids=explicit_case_ids,
+                    cases_sha256=explicit_cases_sha256,
+                )
+                await client.xadd(cfg.eval_stream, {"payload": item.model_dump_json()})
+
+                await _drain_one(consumer, reports)
+
+                assert reports[0]["passed_count"] == expected_passed
+                assert reports[0]["total"] == expected_total
+                if selected_trajectory is not None:
+                    assert [frame["text"] for frame in fake.seen] == ["run tools"]
+
+            await client.delete(cfg.eval_stream)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_malformed_bundle_trajectory_records_terminal_case_failures(
+    make_eval_harness, bundles
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            suite = EvalSuite(
+                name="malformed",
+                cases=[
+                    EvalCase(
+                        id="first",
+                        input="first input",
+                        grader=Grader(kind=CONTAINS, expected="grader pass"),
+                    ),
+                    EvalCase(
+                        id="second",
+                        input="second input",
+                        grader=Grader(kind=CONTAINS, expected="grader pass"),
+                    ),
+                ],
+            )
+            fake.responses = {
+                "first input": "grader pass",
+                "second input": "grader pass",
+            }
+            bundle_ref = upload(_suite_bundle(suite, trajectory="{"))
+            token = uuid.uuid4().hex[:8]
+            sha = f"sha-{token}"
+            cfg = _cfg(f"test:evals:{token}", f"g-{token}")
+            client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+            reports: list[dict[str, Any]] = []
+            ingestions: list[dict[str, Any]] = []
+
+            def record_ingestion(request: httpx.Request) -> httpx.Response:
+                ingestions.append(json.loads(request.content))
+                return httpx.Response(200, json={"errors": []})
+
+            transport = httpx.MockTransport(record_ingestion)
+            async with httpx.AsyncClient(transport=transport) as lf_client:
+                consumer = _build_consumer(
+                    redis_client=client,
+                    cfg=cfg,
+                    bundle_store=store,
+                    substrate=_UnusedSubstrate(),
+                    reports=reports,
+                    lf_client=lf_client,
+                )
+                await consumer.ensure_group()
+                item = _item(
+                    suite="malformed",
+                    sha=sha,
+                    bundle_ref=bundle_ref,
+                    target_url=base_url,
+                )
+                await client.xadd(cfg.eval_stream, {"payload": item.model_dump_json()})
+
+                await _drain_one(consumer, reports)
+
+                assert fake.seen == []
+                assert reports[0]["passed_count"] == 0
+                assert reports[0]["total"] == 2
+                traces = [
+                    event["body"]
+                    for event in ingestions[0]["batch"]
+                    if event["type"] == "trace-create"
+                ]
+                assert sorted(trace["metadata"]["case_id"] for trace in traces) == [
+                    "first",
+                    "second",
+                ]
+                assert all(
+                    trace["metadata"]["error"] == "invalid trajectory configuration"
+                    for trace in traces
+                )
+                summary = await client.xpending(cfg.eval_stream, cfg.eval_consumer_group)
+                assert summary["pending"] == 0
+
+            await client.delete(cfg.eval_stream)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_invalid_direct_stream_trajectory_map_is_poison_acked(
+    make_eval_harness, bundles
+) -> None:
+    store, upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            fake.responses = {"run tools": "grader pass"}
+            suite = EvalSuite(
+                name="invalid",
+                cases=[
+                    EvalCase(
+                        id="ordered",
+                        input="run tools",
+                        grader=Grader(kind=CONTAINS, expected="grader pass"),
+                    )
+                ],
+            )
+            bundle_ref = upload(suite)
+            token = uuid.uuid4().hex[:8]
+            cfg = _cfg(f"test:evals:{token}", f"g-{token}")
+            client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+            reports: list[dict[str, Any]] = []
+            async with httpx.AsyncClient(timeout=30.0) as lf_client:
+                consumer = _build_consumer(
+                    redis_client=client,
+                    cfg=cfg,
+                    bundle_store=store,
+                    substrate=_UnusedSubstrate(),
+                    reports=reports,
+                    lf_client=lf_client,
+                )
+                await consumer.ensure_group()
+                item = _item(
+                    suite="invalid",
+                    sha=f"sha-{token}",
+                    bundle_ref=bundle_ref,
+                    target_url=base_url,
+                ).model_dump(mode="json")
+                item["trajectory_specs"] = {
+                    "ordered": {"expected": "search", "mode": "exact", "threshold": 1.0}
+                }
+                item["case_ids"] = ["ordered"]
+                item["cases_sha256"] = hashlib.sha256(
+                    suite.model_dump_json().encode("utf-8")
+                ).hexdigest()
+                await client.xadd(cfg.eval_stream, {"payload": json.dumps(item)})
+
+                task = asyncio.create_task(consumer.run())
+                await asyncio.sleep(0.5)
+                consumer.request_stop()
+                await task
+
+                assert reports == []
+                assert fake.seen == []
+                summary = await client.xpending(cfg.eval_stream, cfg.eval_consumer_group)
+                assert summary["pending"] == 0
+
+            await client.delete(cfg.eval_stream)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    ("deployed_cases", "selected_cases", "requested_ids"),
+    [
+        (
+            [("first", "deployed input")],
+            [("first", "selected input")],
+            ["first"],
+        ),
+        (
+            [("first", "first input"), ("second", "second input")],
+            [("first", "first input")],
+            ["first"],
+        ),
+        (
+            [("first", "first input")],
+            [("first", "first input")],
+            ["first", "missing"],
+        ),
+        (
+            [("first", "first input"), ("second", "second input")],
+            [("first", "first input"), ("second", "second input")],
+            ["second", "first"],
+        ),
+    ],
+    ids=["changed_input", "extra_deployed_case", "requested_extra_id", "dishonest_order"],
+)
+def test_explicit_trajectory_identity_mismatch_fails_requested_cases(
+    make_eval_harness,
+    bundles,
+    deployed_cases: list[tuple[str, str]],
+    selected_cases: list[tuple[str, str]],
+    requested_ids: list[str],
+) -> None:
+    store, upload = bundles
+
+    def make_suite(definitions: list[tuple[str, str]]) -> EvalSuite:
+        return EvalSuite(
+            name="identity",
+            cases=[
+                EvalCase(
+                    id=case_id,
+                    input=case_input,
+                    grader=Grader(kind=CONTAINS, expected="grader pass"),
+                )
+                for case_id, case_input in definitions
+            ],
+        )
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, _client):
+            deployed_suite = make_suite(deployed_cases)
+            selected_suite = make_suite(selected_cases)
+            fake.responses = {case.input: "grader pass" for case in deployed_suite.cases}
+            bundle_ref = upload(_suite_bundle(deployed_suite))
+            token = uuid.uuid4().hex[:8]
+            cfg = _cfg(f"test:evals:{token}", f"g-{token}")
+            client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+            reports: list[dict[str, Any]] = []
+            ingestions: list[dict[str, Any]] = []
+
+            def record_ingestion(request: httpx.Request) -> httpx.Response:
+                ingestions.append(json.loads(request.content))
+                return httpx.Response(200, json={"errors": []})
+
+            transport = httpx.MockTransport(record_ingestion)
+            async with httpx.AsyncClient(transport=transport) as lf_client:
+                consumer = _build_consumer(
+                    redis_client=client,
+                    cfg=cfg,
+                    bundle_store=store,
+                    substrate=_UnusedSubstrate(),
+                    reports=reports,
+                    lf_client=lf_client,
+                )
+                await consumer.ensure_group()
+                item = _item(
+                    suite="identity",
+                    sha=f"sha-{token}",
+                    bundle_ref=bundle_ref,
+                    target_url=base_url,
+                    trajectory_specs={},
+                    case_ids=requested_ids,
+                    cases_sha256=hashlib.sha256(
+                        selected_suite.model_dump_json().encode("utf-8")
+                    ).hexdigest(),
+                )
+                await client.xadd(cfg.eval_stream, {"payload": item.model_dump_json()})
+
+                await _drain_one(consumer, reports)
+
+                assert fake.seen == []
+                assert reports[0]["passed_count"] == 0
+                assert reports[0]["total"] == len(requested_ids)
+                traces = [
+                    event["body"]
+                    for event in ingestions[0]["batch"]
+                    if event["type"] == "trace-create"
+                ]
+                assert [trace["metadata"]["case_id"] for trace in traces] == requested_ids
+                assert all(
+                    trace["metadata"]["error"]
+                    == "selected eval cases do not match deployed bundle"
+                    for trace in traces
+                )
+                summary = await client.xpending(cfg.eval_stream, cfg.eval_consumer_group)
+                assert summary["pending"] == 0
+
+            await client.delete(cfg.eval_stream)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
 def test_malformed_payload_is_acked_and_dropped(make_eval_harness, bundles) -> None:
     """A payload that will never parse on any redelivery is logged, acked, and
     dropped -- never reported, never stuck pending."""
@@ -485,16 +901,25 @@ def test_provisioned_runner_end_to_end(make_eval_harness, bundles) -> None:
 
     async def go() -> None:
         async with make_eval_harness() as (base_url, fake, _client):
-            fake.responses = {"ping": "pong"}
+            fake.responses = {"ping": "grader miss"}
+            fake.tool_calls = {"ping": ["search", "fetch"]}
             port = int(base_url.rsplit(":", 1)[1])
+            suite = EvalSuite(
+                name="prov",
+                cases=[
+                    EvalCase(
+                        id="ordered",
+                        input="ping",
+                        grader=Grader(kind=CONTAINS, expected="pong"),
+                    )
+                ],
+            )
             bundle_ref = upload(
-                EvalSuite(
-                    name="prov",
-                    cases=[
-                        EvalCase(
-                            id="1", input="ping", grader=Grader(kind=CONTAINS, expected="pong")
-                        )
-                    ],
+                _suite_bundle(
+                    suite,
+                    trajectory={
+                        "ordered": {"expected": ["search", "fetch"], "mode": "exact"}
+                    },
                 )
             )
             token = uuid.uuid4().hex[:8]
@@ -634,7 +1059,9 @@ def test_pending_entry_from_a_dead_consumer_is_reclaimed(make_eval_harness, bund
 RUNNER_TOKEN_ENV = "AGENTOS_RUNNER_TOKEN"
 
 
-def _suite_bundle(suite: EvalSuite) -> bytes:
+def _suite_bundle(
+    suite: EvalSuite, *, trajectory: dict[str, object] | str | None = None
+) -> bytes:
     """A minimal tar.gz carrying evals/cases.json, so the real
     load_suite_from_bundle returns a real suite (the MinIO fetch is the only
     faked boundary)."""
@@ -644,6 +1071,13 @@ def _suite_bundle(suite: EvalSuite) -> bytes:
         info = tarfile.TarInfo("evals/cases.json")
         info.size = len(payload)
         tf.addfile(info, io.BytesIO(payload))
+        if trajectory is not None:
+            trajectory_payload = (
+                trajectory if isinstance(trajectory, str) else json.dumps(trajectory)
+            ).encode("utf-8")
+            trajectory_info = tarfile.TarInfo("evals/trajectory.json")
+            trajectory_info.size = len(trajectory_payload)
+            tf.addfile(trajectory_info, io.BytesIO(trajectory_payload))
     return buf.getvalue()
 
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha2",
  "tar",
  "tempfile",
  "time",
@@ -235,6 +236,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,7 +297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
 ]
 
@@ -374,6 +384,15 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -397,6 +416,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +436,16 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -608,6 +647,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1623,6 +1672,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,6 +1993,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,6 +53,7 @@ tokio = { version = "1", features = [
     "net",
     "sync",
 ] }
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -9,6 +9,8 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+use crate::evals::TrajectorySpecs;
+
 pub struct ApiClient {
     base_url: String,
     api_key: String,
@@ -87,6 +89,31 @@ pub struct DeployOutcome {
     pub bundle: Bundle,
     pub deployment: Deployment,
     pub channel: ChannelOutcome,
+}
+
+/// Identity returned when the API enqueues one platform eval invocation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalTriggerResult {
+    pub sha: String,
+    pub suite: String,
+}
+
+/// One structured worker verdict in the eval matrix.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalCell {
+    pub version: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalMatrixRow {
+    pub case_id: String,
+    pub cells: Vec<EvalCell>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalMatrix {
+    pub rows: Vec<EvalMatrixRow>,
 }
 
 /// Whether this endpoint would send the `X-API-Key` over cleartext HTTP to a
@@ -370,6 +397,53 @@ impl ApiClient {
                     "no agent found matching {identifier:?} (by name or id); deploy it first with `agentos cluster deploy`"
                 )
             })
+    }
+
+    /// Enqueue an on demand eval for the agent's active development deployment.
+    pub async fn trigger_eval(
+        &self,
+        agent_id: &str,
+        suite: &str,
+        trajectory_specs: Option<&TrajectorySpecs>,
+        case_ids: Option<&[String]>,
+        cases_sha256: Option<&str>,
+    ) -> Result<EvalTriggerResult> {
+        let resp = self
+            .http
+            .post(format!("{}/evals/trigger", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .json(&json!({
+                "agent_id": agent_id,
+                "suite": suite,
+                "trajectory_specs": trajectory_specs,
+                "case_ids": case_ids,
+                "cases_sha256": cases_sha256,
+            }))
+            .send()
+            .await
+            .context("POST /evals/trigger")?;
+        Self::expect_ok(resp, "triggering the eval")
+            .await?
+            .json()
+            .await
+            .context("decoding eval trigger result")
+    }
+
+    /// Read the structured worker outcomes recorded for one suite invocation.
+    pub async fn eval_matrix(&self, suite: &str) -> Result<EvalMatrix> {
+        let resp = self
+            .http
+            .get(format!("{}/evals/matrix", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .query(&[("suite", suite)])
+            .send()
+            .await
+            .context("GET /evals/matrix")?;
+        Self::expect_ok(resp, "reading the eval matrix")
+            .await?
+            .json()
+            .await
+            .context("decoding eval matrix")
     }
 
     /// Flip the agent kill switch on: `POST /agents/{id}/kill` (no request body).

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -15,7 +15,10 @@ use serde::{Deserialize, Serialize};
 use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
 use crate::bundle::pack_tar_gz;
 use crate::docker::{self, CheckSpec, StartSpec};
-use crate::evals::{load_suite, turn_passes};
+use crate::evals::{
+    load_suite, load_trajectory_sidecar, trajectory_turn_passes, turn_passes,
+    validate_trajectory_case_ids,
+};
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
 use crate::scaffold::{read_manifest, scaffold, scaffold_from_spec};
@@ -849,6 +852,10 @@ pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()
     let state_plugin_dir = state::load(Path::new("."))?.map(|s| PathBuf::from(s.plugin_dir));
     let cases_path = resolve_cases_path(cases_path, Path::new("."), state_plugin_dir.as_deref())?;
     let suite = load_suite(&cases_path)?;
+    let trajectory = load_trajectory_sidecar(&cases_path)?;
+    if trajectory.is_some() {
+        validate_trajectory_case_ids(&suite)?;
+    }
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
     let ui = crate::ui::ui();
@@ -863,7 +870,11 @@ pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()
             .send_event(EventType::EvalCase, &case.input, "U-eval", |_| {})
             .await?;
         let elapsed = started.elapsed().as_secs_f64();
-        results.push((case.id.clone(), turn_passes(case, &events), elapsed));
+        let passed = match trajectory.as_ref() {
+            Some(specs) => trajectory_turn_passes(case, &events, specs),
+            None => turn_passes(case, &events),
+        };
+        results.push((case.id.clone(), passed, elapsed));
         bar.inc(1);
     }
     bar.finish();

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -9,12 +9,14 @@
 //! Python models. Grading semantics mirror the platform's `Grader.grade`. This is
 //! the CLI-local seed of the K1 eval machinery, not a replacement for it.
 
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use agentos_aci_protocol::{OutboundEvent, SessionStatus};
 use anyhow::{anyhow, bail, Context, Result};
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// How a case's expected value is compared against the agent's answer.
 // `Serialize` is derived alongside `Deserialize` so the spec scaffold path
@@ -81,6 +83,157 @@ pub struct EvalCase {
 pub struct EvalSuite {
     pub name: String,
     pub cases: Vec<EvalCase>,
+}
+
+/// How an observed tool sequence is compared with one case's expectation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrajectoryMode {
+    Exact,
+    InOrder,
+    AnyOrder,
+    Precision,
+    Recall,
+}
+
+fn default_trajectory_mode() -> TrajectoryMode {
+    TrajectoryMode::InOrder
+}
+
+fn default_trajectory_threshold() -> f64 {
+    1.0
+}
+
+/// One case's trajectory expectation from `evals/trajectory.json`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrajectorySpec {
+    pub expected: Vec<String>,
+    #[serde(default = "default_trajectory_mode")]
+    pub mode: TrajectoryMode,
+    #[serde(default = "default_trajectory_threshold")]
+    pub threshold: f64,
+}
+
+pub type TrajectorySpecs = HashMap<String, TrajectorySpec>;
+
+/// Load the optional trajectory sidecar beside `cases.json`.
+///
+/// Presence selects trajectory scoring for the whole suite. An empty mapping is
+/// valid and therefore fails every case through the missing spec rule. Invalid
+/// content is a usage error instead of silently selecting the text grader.
+pub fn load_trajectory_sidecar(cases_path: &Path) -> Result<Option<TrajectorySpecs>> {
+    let path = cases_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("trajectory.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let invalid = |detail: String| {
+        crate::exit::CliError::usage(format!(
+            "{} is not a valid trajectory sidecar: {detail}",
+            path.display()
+        ))
+        .with_fix("fix evals/trajectory.json or remove it to use text grading")
+    };
+    let body = std::fs::read_to_string(&path)
+        .map_err(|err| invalid(format!("could not read it: {err}")))?;
+    let specs: TrajectorySpecs =
+        serde_json::from_str(&body).map_err(|err| invalid(err.to_string()))?;
+    for (case_id, spec) in &specs {
+        if !spec.threshold.is_finite() || !(0.0..=1.0).contains(&spec.threshold) {
+            return Err(invalid(format!(
+                "case {case_id:?} has threshold {}, expected a value from 0 through 1",
+                spec.threshold
+            ))
+            .into());
+        }
+    }
+    Ok(Some(specs))
+}
+
+/// Lowercase SHA256 of the exact selected `cases.json` bytes.
+pub fn cases_sha256(path: &Path) -> Result<String> {
+    let body = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(format!("{:x}", Sha256::digest(body)))
+}
+
+/// Validate the case identity required by explicit trajectory selection.
+pub fn validate_trajectory_case_ids(suite: &EvalSuite) -> Result<()> {
+    let mut case_ids = HashSet::with_capacity(suite.cases.len());
+    for case in &suite.cases {
+        if case.id.is_empty() {
+            return Err(crate::exit::CliError::usage(format!(
+                "suite {:?} contains an empty eval case id",
+                suite.name
+            ))
+            .with_fix("give every trajectory eval case a nonempty unique id")
+            .into());
+        }
+        if !case_ids.insert(case.id.as_str()) {
+            return Err(crate::exit::CliError::usage(format!(
+                "suite {:?} contains duplicate eval case id {:?}",
+                suite.name, case.id
+            ))
+            .with_fix("give every trajectory eval case a nonempty unique id")
+            .into());
+        }
+    }
+    Ok(())
+}
+
+/// Apply the same five deterministic trajectory modes as the platform worker.
+pub fn trajectory_matches(spec: &TrajectorySpec, observed: &[String]) -> bool {
+    match spec.mode {
+        TrajectoryMode::Exact => observed == spec.expected,
+        TrajectoryMode::InOrder => {
+            let mut expected = spec.expected.iter();
+            let mut next = expected.next();
+            for tool in observed {
+                if next.is_some_and(|wanted| wanted == tool) {
+                    next = expected.next();
+                }
+            }
+            next.is_none()
+        }
+        TrajectoryMode::AnyOrder => {
+            let mut remaining: HashMap<&str, usize> = HashMap::new();
+            for tool in &spec.expected {
+                *remaining.entry(tool.as_str()).or_default() += 1;
+            }
+            for tool in observed {
+                if let Some(count) = remaining.get_mut(tool.as_str()) {
+                    *count = count.saturating_sub(1);
+                }
+            }
+            remaining.values().all(|count| *count == 0)
+        }
+        TrajectoryMode::Precision => {
+            let expected: HashSet<&str> = spec.expected.iter().map(String::as_str).collect();
+            let ratio = if observed.is_empty() {
+                1.0
+            } else {
+                observed
+                    .iter()
+                    .filter(|tool| expected.contains(tool.as_str()))
+                    .count() as f64
+                    / observed.len() as f64
+            };
+            ratio >= spec.threshold
+        }
+        TrajectoryMode::Recall => {
+            let expected: HashSet<&str> = spec.expected.iter().map(String::as_str).collect();
+            let observed: HashSet<&str> = observed.iter().map(String::as_str).collect();
+            let ratio = if expected.is_empty() {
+                1.0
+            } else {
+                expected.intersection(&observed).count() as f64 / expected.len() as f64
+            };
+            ratio >= spec.threshold
+        }
+    }
 }
 
 /// Validate an assembled suite: reject an empty case list and eagerly compile
@@ -165,6 +318,39 @@ pub fn turn_passes(case: &EvalCase, events: &[OutboundEvent]) -> bool {
         })
     );
     completed && case.grader.grade(&graded_answer(events))
+}
+
+/// Grade a completed turn from its ordered `tool_note.tool` observations.
+/// A missing case spec fails closed. The same completed turn gate as text
+/// grading runs first, so classified failures and incomplete turns cannot pass.
+pub fn trajectory_turn_passes(
+    case: &EvalCase,
+    events: &[OutboundEvent],
+    specs: &TrajectorySpecs,
+) -> bool {
+    let completed = matches!(
+        events.last(),
+        Some(OutboundEvent::Final {
+            status: SessionStatus::Done,
+            ..
+        })
+    );
+    if !completed {
+        return false;
+    }
+    let Some(spec) = specs.get(&case.id) else {
+        return false;
+    };
+    let observed: Vec<String> = events
+        .iter()
+        .filter_map(|event| match event {
+            OutboundEvent::ToolNote {
+                tool: Some(tool), ..
+            } => Some(tool.clone()),
+            _ => None,
+        })
+        .collect();
+    trajectory_matches(spec, &observed)
 }
 
 /// One rendered result line: check-or-cross, name, duration (design canon).

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -34,7 +34,10 @@ use crate::api::{Agent, ApiClient};
 use crate::chat::{
     await_reply, continue_hint_line, continue_hint_long_line, resolve_targets, Outcome, SlackStub,
 };
-use crate::evals::{EvalCase, EvalSuite};
+use crate::evals::{
+    cases_sha256, load_trajectory_sidecar, validate_trajectory_case_ids, EvalCase, EvalSuite,
+    TrajectorySpecs,
+};
 use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
 use crate::queue::{self, connect, diagnostics, synthetic_turn, xadd};
 use crate::state::{save_turn, TurnContext, TurnVerb};
@@ -834,11 +837,21 @@ pub fn eval_dry_run_lines(opts: &EvalOpts, suite_name: &str, case_count: usize) 
 
 /// Resolve the eval suite the way `skill eval` does: an explicit `--cases`
 /// wins, else `evals/cases.json` in the cwd, then the recorded bundle dir.
-fn resolve_suite(explicit: Option<PathBuf>) -> Result<EvalSuite> {
+fn resolve_suite(
+    explicit: Option<PathBuf>,
+) -> Result<(EvalSuite, Option<(TrajectorySpecs, String)>)> {
     let state_plugin_dir = crate::state::load(Path::new("."))?.map(|s| PathBuf::from(s.plugin_dir));
     let path =
         crate::commands::resolve_cases_path(explicit, Path::new("."), state_plugin_dir.as_deref())?;
-    crate::evals::load_suite(&path)
+    let suite = crate::evals::load_suite(&path)?;
+    let trajectory = match load_trajectory_sidecar(&path)? {
+        Some(specs) => {
+            validate_trajectory_case_ids(&suite)?;
+            Some((specs, cases_sha256(&path)?))
+        }
+        None => None,
+    };
+    Ok((suite, trajectory))
 }
 
 /// The shared per-tier eval engine: enqueue one synthetic `QueuedTurn` per case
@@ -893,12 +906,229 @@ async fn run_eval_turns(
 /// so a suite that passes at `skill` can be re-asserted verbatim at `local` and
 /// `cluster` (issue #344, the per-tier parity gate).
 pub async fn eval(opts: EvalOpts) -> Result<()> {
-    let suite = resolve_suite(opts.cases.clone())?;
+    let (suite, trajectory) = resolve_suite(opts.cases.clone())?;
+    if let Some((trajectory_specs, cases_sha256)) = trajectory {
+        return if opts.local {
+            eval_local_trajectory(opts, suite, trajectory_specs, cases_sha256).await
+        } else {
+            eval_cluster_trajectory(opts, suite, trajectory_specs, cases_sha256).await
+        };
+    }
     if opts.local {
         eval_local(opts, suite).await
     } else {
         eval_cluster(opts, suite).await
     }
+}
+
+fn select_eval_agent<'a>(agents: &'a [Agent], channel: Option<&str>) -> Result<&'a Agent> {
+    if let Some(channel) = channel {
+        return agents
+            .iter()
+            .find(|agent| agent.slack_channel == channel)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no deployed agent uses channel {channel:?}; pass a channel from GET /agents"
+                )
+            });
+    }
+    match agents {
+        [] => bail!("no agents are deployed on the platform API; deploy one before running eval"),
+        [only] => Ok(only),
+        many => {
+            let listed = many
+                .iter()
+                .map(|agent| format!("{} -> {}", agent.name, agent.slack_channel))
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!("multiple agents are deployed; pass --channel to select one ({listed})")
+        }
+    }
+}
+
+fn current_matrix_results(
+    suite: &EvalSuite,
+    matrix: &crate::api::EvalMatrix,
+    sha: &str,
+    seconds: f64,
+) -> Result<Option<Vec<(String, bool, f64)>>> {
+    let mut results = Vec::with_capacity(suite.cases.len());
+    for case in &suite.cases {
+        let Some(row) = matrix.rows.iter().find(|row| row.case_id == case.id) else {
+            return Ok(None);
+        };
+        let Some(cell) = row.cells.iter().find(|cell| cell.version == sha) else {
+            return Ok(None);
+        };
+        let passed = match cell.status.as_str() {
+            "pass" => true,
+            "fail" => false,
+            "missing" => return Ok(None),
+            status => bail!(
+                "eval matrix returned invalid status {status:?} for case {:?}",
+                case.id
+            ),
+        };
+        results.push((case.id.clone(), passed, seconds));
+    }
+    Ok(Some(results))
+}
+
+async fn run_platform_trajectory_eval(
+    api: &ApiClient,
+    agent: &Agent,
+    suite: &EvalSuite,
+    trajectory_specs: &TrajectorySpecs,
+    cases_sha256: &str,
+    timeout_secs: u64,
+) -> Result<Vec<(String, bool, f64)>> {
+    let invocation = format!("{}_{}", suite.name, uuid::Uuid::new_v4().simple());
+    let case_ids: Vec<String> = suite.cases.iter().map(|case| case.id.clone()).collect();
+    let started = Instant::now();
+    let trigger = api
+        .trigger_eval(
+            &agent.id,
+            &invocation,
+            Some(trajectory_specs),
+            Some(&case_ids),
+            Some(cases_sha256),
+        )
+        .await?;
+    if trigger.suite != invocation {
+        bail!(
+            "eval trigger returned suite {:?}, expected {:?}",
+            trigger.suite,
+            invocation
+        );
+    }
+    let timeout = Duration::from_secs(timeout_secs);
+    loop {
+        let matrix = api.eval_matrix(&trigger.suite).await?;
+        let elapsed = started.elapsed();
+        if let Some(results) =
+            current_matrix_results(suite, &matrix, &trigger.sha, elapsed.as_secs_f64())?
+        {
+            return Ok(results);
+        }
+        if elapsed >= timeout {
+            return Err(crate::exit::CliError::transient(format!(
+                "timed out after {timeout_secs}s waiting for trajectory eval {:?} at sha {:?}",
+                trigger.suite, trigger.sha
+            ))
+            .with_fix("retry after the worker and Langfuse are healthy")
+            .into());
+        }
+        tokio::time::sleep(Duration::from_millis(100).min(timeout - elapsed)).await;
+    }
+}
+
+fn trajectory_eval_dry_run_lines(opts: &EvalOpts, suite: &EvalSuite) -> Vec<String> {
+    let tier = if opts.local { "local" } else { "cluster" };
+    let mut lines = vec![format!(
+        "trigger {} trajectory case(s) from suite {:?} against the {tier} tier",
+        suite.cases.len(),
+        suite.name
+    )];
+    if opts.local {
+        lines.push(format!(
+            "resolve the selected agent through {}/agents",
+            local_api_base(opts.api_url.as_deref())
+        ));
+    } else {
+        lines.push(
+            port_forward_command(
+                &opts.namespace,
+                &opts.release,
+                "api",
+                opts.api_local_port,
+                API_REMOTE_PORT,
+            )
+            .display(),
+        );
+    }
+    lines.push("POST /evals/trigger with a unique suite invocation".to_string());
+    lines.push("poll GET /evals/matrix for the returned sha".to_string());
+    lines
+}
+
+async fn eval_local_trajectory(
+    opts: EvalOpts,
+    suite: EvalSuite,
+    trajectory_specs: TrajectorySpecs,
+    cases_sha256: String,
+) -> Result<()> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        for line in trajectory_eval_dry_run_lines(&opts, &suite) {
+            ui.payload_plain(&line);
+        }
+        return Ok(());
+    }
+
+    let api_base = local_api_base(opts.api_url.as_deref());
+    let api = ApiClient::new(&api_base, &opts.api_key)?;
+    let agents = api.list_agents().await.with_context(|| {
+        format!("listing agents via {api_base} (is `agentos local up` running?)")
+    })?;
+    let agent = select_eval_agent(&agents, opts.channel.as_deref())?;
+    ui.note(&format!("running trajectory eval for agent {}", agent.name));
+    let results = run_platform_trajectory_eval(
+        &api,
+        agent,
+        &suite,
+        &trajectory_specs,
+        &cases_sha256,
+        opts.timeout_secs,
+    )
+    .await?;
+    crate::commands::report_eval(&results)
+}
+
+async fn eval_cluster_trajectory(
+    opts: EvalOpts,
+    suite: EvalSuite,
+    trajectory_specs: TrajectorySpecs,
+    cases_sha256: String,
+) -> Result<()> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        for line in trajectory_eval_dry_run_lines(&opts, &suite) {
+            ui.payload_plain(&line);
+        }
+        return Ok(());
+    }
+
+    require_on_path("kubectl")?;
+    let _api_pf = start_port_forward(
+        &port_forward_command(
+            &opts.namespace,
+            &opts.release,
+            "api",
+            opts.api_local_port,
+            API_REMOTE_PORT,
+        ),
+        opts.api_local_port,
+        "api",
+    )
+    .await?;
+    let api_base = format!("http://localhost:{}", opts.api_local_port);
+    let api = ApiClient::new(&api_base, &opts.api_key)?;
+    let agents = api
+        .list_agents()
+        .await
+        .context("listing agents through the api port forward")?;
+    let agent = select_eval_agent(&agents, opts.channel.as_deref())?;
+    ui.note(&format!("running trajectory eval for agent {}", agent.name));
+    let results = run_platform_trajectory_eval(
+        &api,
+        agent,
+        &suite,
+        &trajectory_specs,
+        &cases_sha256,
+        opts.timeout_secs,
+    )
+    .await?;
+    crate::commands::report_eval(&results)
 }
 
 async fn eval_local(opts: EvalOpts, suite: EvalSuite) -> Result<()> {

--- a/cli/tests/api_lifecycle.rs
+++ b/cli/tests/api_lifecycle.rs
@@ -7,11 +7,24 @@
 
 mod support;
 
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
 use agentos::api::{ApiClient, BudgetConfig};
 use agentos::commands::{self, AgentActionOpts};
-use support::{serve, Response};
+use support::{serve, MockServer, Response};
 
 const AGENT_ID: &str = "11111111-1111-1111-1111-111111111111";
+const VERSION_ID: &str = "22222222-2222-2222-2222-222222222222";
+const TRAJECTORY_CASES_JSON: &str = r#"{"name":"trajectory_parity","cases":[{"id":"ordered_tools","input":"use the tools","grader":{"kind":"contains","expected":"text path must not decide this"}}]}"#;
+const TRAJECTORY_CASES_SHA256: &str =
+    "a947e4b9fc49b552f62b2a7e0bced9a7123cb2e0528ebcf76b57356f880385ee";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentos")
+}
 
 /// A one-agent `GET /agents` list used by the handler-level resolution tests.
 fn agent_list() -> Response {
@@ -30,6 +43,124 @@ fn opts(base_url: &str, agent: &str, dry_run: bool) -> AgentActionOpts {
         agent: agent.to_string(),
         dry_run,
     }
+}
+
+fn write_trajectory_suite() -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let evals = dir.path().join("evals");
+    std::fs::create_dir(&evals).unwrap();
+    let cases = evals.join("cases.json");
+    std::fs::write(&cases, TRAJECTORY_CASES_JSON).unwrap();
+    std::fs::write(
+        evals.join("trajectory.json"),
+        r#"{"ordered_tools":{"expected":["Read","Bash"],"mode":"exact","threshold":1.0}}"#,
+    )
+    .unwrap();
+    (dir, cases)
+}
+
+fn trajectory_api(
+    current_status: &'static str,
+) -> (MockServer, Arc<Mutex<Option<String>>>, Arc<AtomicUsize>) {
+    let triggered_suite: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let matrix_polls = Arc::new(AtomicUsize::new(0));
+    let suite_for_server = Arc::clone(&triggered_suite);
+    let polls_for_server = Arc::clone(&matrix_polls);
+    let server = serve(move |req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list(),
+        ("POST", "/evals/trigger") => {
+            assert_eq!(req.header("x-api-key"), Some("k"));
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            assert_eq!(body["agent_id"], AGENT_ID);
+            assert_eq!(
+                body["trajectory_specs"],
+                serde_json::json!({
+                    "ordered_tools": {
+                        "expected": ["Read", "Bash"],
+                        "mode": "exact",
+                        "threshold": 1.0,
+                    },
+                })
+            );
+            assert_eq!(body["case_ids"], serde_json::json!(["ordered_tools"]));
+            assert_eq!(body["cases_sha256"], TRAJECTORY_CASES_SHA256);
+            let suite = body["suite"]
+                .as_str()
+                .expect("trajectory trigger carries a suite invocation")
+                .to_string();
+            assert!(suite.starts_with("trajectory_parity"), "suite: {suite}");
+            assert_ne!(suite, "trajectory_parity", "the invocation must be unique");
+            *suite_for_server.lock().unwrap() = Some(suite.clone());
+            Response::json(
+                200,
+                &serde_json::json!({
+                    "stream_id": "1_0",
+                    "agent_id": AGENT_ID,
+                    "version_id": VERSION_ID,
+                    "sha": "sha_current",
+                    "suite": suite,
+                    "bundle_ref": "bundles/agent/version.tar.gz",
+                })
+                .to_string(),
+            )
+        }
+        ("GET", path) if path.starts_with("/evals/matrix?") => {
+            let query = path.split_once('?').unwrap().1;
+            let params: HashMap<String, String> = serde_urlencoded::from_str(query).unwrap();
+            let expected_suite = suite_for_server
+                .lock()
+                .unwrap()
+                .clone()
+                .expect("matrix polling follows the trigger");
+            assert_eq!(params.get("suite"), Some(&expected_suite));
+            let poll = polls_for_server.fetch_add(1, Ordering::SeqCst);
+            let (sha, status) = if poll == 0 {
+                ("sha_stale", "pass")
+            } else {
+                ("sha_current", current_status)
+            };
+            Response::json(
+                200,
+                &serde_json::json!({
+                    "suite": expected_suite,
+                    "versions": [sha],
+                    "cases": ["ordered_tools"],
+                    "rows": [{
+                        "case_id": "ordered_tools",
+                        "cells": [{"version": sha, "status": status, "model": null}],
+                    }],
+                    "models": [],
+                    "model_summaries": [],
+                })
+                .to_string(),
+            )
+        }
+        other => panic!("unexpected trajectory eval request: {other:?}"),
+    });
+    (server, triggered_suite, matrix_polls)
+}
+
+fn eval_payload(output: &std::process::Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|err| {
+        panic!(
+            "eval stdout was not JSON: {err}; stdout={}; stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+#[cfg(unix)]
+fn fake_kubectl() -> tempfile::TempDir {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("kubectl");
+    std::fs::write(&path, "#!/bin/sh\nexec sleep 30\n").unwrap();
+    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).unwrap();
+    dir
 }
 
 // --- ApiClient methods: correct verb + path + body ------------------------
@@ -223,4 +354,93 @@ async fn dry_run_makes_no_request_for_any_verb() {
         server.recorded().is_empty(),
         "no dry-run verb may make a request"
     );
+}
+
+#[test]
+fn local_trajectory_eval_triggers_and_polls_the_structured_worker_result() {
+    let (server, triggered_suite, matrix_polls) = trajectory_api("pass");
+    let (_dir, cases) = write_trajectory_suite();
+
+    let output = Command::new(bin())
+        .args(["--json", "local", "eval", "--cases"])
+        .arg(&cases)
+        .args([
+            "--api-url",
+            &server.base_url,
+            "--api-key",
+            "k",
+            "--timeout-secs",
+            "3",
+        ])
+        .output()
+        .expect("run local trajectory eval");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload = eval_payload(&output);
+    assert_eq!(payload["passed"], 1);
+    assert_eq!(payload["failed"], 0);
+    assert_eq!(payload["cases"][0]["id"], "ordered_tools");
+    assert_eq!(payload["cases"][0]["passed"], true);
+    assert!(triggered_suite.lock().unwrap().is_some());
+    assert!(matrix_polls.load(Ordering::SeqCst) >= 2);
+
+    let paths: Vec<String> = server
+        .recorded()
+        .iter()
+        .map(|request| request.path.clone())
+        .collect();
+    assert!(paths.iter().any(|path| path == "/evals/trigger"));
+    assert!(paths.iter().any(|path| path.starts_with("/evals/matrix?")));
+}
+
+#[cfg(unix)]
+#[test]
+fn cluster_trajectory_eval_renders_failure_from_the_same_worker_result_path() {
+    let (server, triggered_suite, matrix_polls) = trajectory_api("fail");
+    let (_dir, cases) = write_trajectory_suite();
+    let kubectl = fake_kubectl();
+    let api_port = server.base_url.rsplit_once(':').unwrap().1;
+    let current_path = std::env::var_os("PATH").unwrap_or_default();
+    let path = std::env::join_paths(
+        std::iter::once(kubectl.path().to_path_buf()).chain(std::env::split_paths(&current_path)),
+    )
+    .unwrap();
+
+    let output = Command::new(bin())
+        .args(["--json", "cluster", "eval", "--cases"])
+        .arg(&cases)
+        .args([
+            "--listen-host",
+            "127.0.0.1",
+            "--api-local-port",
+            api_port,
+            "--api-key",
+            "k",
+            "--timeout-secs",
+            "3",
+        ])
+        .env("PATH", path)
+        .output()
+        .expect("run cluster trajectory eval");
+
+    assert_eq!(output.status.code(), Some(1));
+    let payload = eval_payload(&output);
+    assert_eq!(payload["passed"], 0);
+    assert_eq!(payload["failed"], 1);
+    assert_eq!(payload["cases"][0]["id"], "ordered_tools");
+    assert_eq!(payload["cases"][0]["passed"], false);
+    assert!(triggered_suite.lock().unwrap().is_some());
+    assert!(matrix_polls.load(Ordering::SeqCst) >= 2);
+
+    let paths: Vec<String> = server
+        .recorded()
+        .iter()
+        .map(|request| request.path.clone())
+        .collect();
+    assert!(paths.iter().any(|path| path == "/evals/trigger"));
+    assert!(paths.iter().any(|path| path.starts_with("/evals/matrix?")));
 }

--- a/cli/tests/runner_stream.rs
+++ b/cli/tests/runner_stream.rs
@@ -2,9 +2,15 @@
 
 mod support;
 
+use std::process::Command;
+
 use agentos::runner::RunnerClient;
 use agentos_aci_protocol::{EventType, OutboundEvent, SessionStatus, PROTOCOL_VERSION};
 use support::{serve, Response};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentos")
+}
 
 fn frame(json: serde_json::Value) -> String {
     serde_json::to_string(&json).unwrap()
@@ -25,6 +31,94 @@ fn happy_turn() -> Vec<String> {
             "type": "final", "version": PROTOCOL_VERSION, "text": "all done", "status": "done"
         })),
     ]
+}
+
+fn trajectory_turn(tools: &[(&str, &str)], final_text: &str) -> Vec<String> {
+    trajectory_turn_with_status(tools, final_text, "done")
+}
+
+fn trajectory_turn_with_status(
+    tools: &[(&str, &str)],
+    final_text: &str,
+    status: &str,
+) -> Vec<String> {
+    let mut frames: Vec<String> = tools
+        .iter()
+        .map(|(tool, text)| {
+            frame(serde_json::json!({
+                "type": "tool_note",
+                "version": PROTOCOL_VERSION,
+                "text": text,
+                "tool": tool,
+            }))
+        })
+        .collect();
+    frames.push(frame(serde_json::json!({
+        "type": "final",
+        "version": PROTOCOL_VERSION,
+        "text": final_text,
+        "status": status,
+    })));
+    frames
+}
+
+fn write_trajectory_case(
+    case_id: &str,
+    grader_expected: &str,
+    expected_tools: &[&str],
+) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let evals = dir.path().join("evals");
+    std::fs::create_dir(&evals).unwrap();
+    let cases = evals.join("cases.json");
+    std::fs::write(
+        &cases,
+        serde_json::to_vec(&serde_json::json!({
+            "name": "trajectory_parity",
+            "cases": [{
+                "id": case_id,
+                "input": "use the tools",
+                "grader": {
+                    "kind": "contains",
+                    "expected": grader_expected,
+                    "case_sensitive": false,
+                },
+            }],
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        evals.join("trajectory.json"),
+        serde_json::to_vec(&serde_json::json!({
+            (case_id): {
+                "expected": expected_tools,
+                "mode": "exact",
+            },
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    (dir, cases)
+}
+
+fn run_skill_eval(cases: &std::path::Path, runner_url: &str) -> std::process::Output {
+    Command::new(bin())
+        .args(["--json", "skill", "eval", "--cases"])
+        .arg(cases)
+        .args(["--url", runner_url])
+        .output()
+        .expect("run trajectory skill eval")
+}
+
+fn eval_payload(output: &std::process::Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|err| {
+        panic!(
+            "eval stdout was not JSON: {err}; stdout={}; stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
 }
 
 #[tokio::test]
@@ -120,4 +214,152 @@ async fn status_round_trips() {
     let status = client.status().await.unwrap();
     assert_eq!(status["status"], "done");
     assert_eq!(status["ready"], true);
+}
+
+#[test]
+fn skill_eval_fails_a_text_match_when_the_tool_trajectory_is_wrong() {
+    let server = serve(|req| {
+        assert_eq!(req.path, "/v1/event");
+        Response::ndjson(&trajectory_turn(
+            &[("Bash", "Read then Bash"), ("Read", "Bash then Read")],
+            "all done",
+        ))
+    });
+    let (_dir, cases) = write_trajectory_case("wrong_order", "all done", &["Read", "Bash"]);
+
+    let output = run_skill_eval(&cases, &server.base_url);
+
+    assert_eq!(output.status.code(), Some(1));
+    let payload = eval_payload(&output);
+    assert_eq!(payload["passed"], 0);
+    assert_eq!(payload["failed"], 1);
+    assert_eq!(payload["cases"][0]["id"], "wrong_order");
+    assert_eq!(payload["cases"][0]["passed"], false);
+}
+
+#[test]
+fn skill_eval_passes_from_tool_note_fields_in_the_observed_order() {
+    let server = serve(|req| {
+        assert_eq!(req.path, "/v1/event");
+        Response::ndjson(&trajectory_turn(
+            &[
+                ("Read", "the prose says Bash first"),
+                ("Bash", "the prose says Read second"),
+            ],
+            "text grader deliberately misses",
+        ))
+    });
+    let (_dir, cases) = write_trajectory_case(
+        "ordered_tools",
+        "text path must not decide this",
+        &["Read", "Bash"],
+    );
+
+    let output = run_skill_eval(&cases, &server.base_url);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload = eval_payload(&output);
+    assert_eq!(payload["passed"], 1);
+    assert_eq!(payload["failed"], 0);
+    assert_eq!(payload["cases"][0]["id"], "ordered_tools");
+    assert_eq!(payload["cases"][0]["passed"], true);
+}
+
+#[test]
+fn skill_eval_keeps_the_completed_turn_gate_for_a_matching_trajectory() {
+    let server = serve(|req| {
+        assert_eq!(req.path, "/v1/event");
+        Response::ndjson(&trajectory_turn_with_status(
+            &[("Read", "read")],
+            "all done",
+            "classified-failure",
+        ))
+    });
+    let (_dir, cases) = write_trajectory_case("failed_turn", "all done", &["Read"]);
+
+    let output = run_skill_eval(&cases, &server.base_url);
+
+    assert_eq!(output.status.code(), Some(1));
+    let payload = eval_payload(&output);
+    assert_eq!(payload["cases"][0]["id"], "failed_turn");
+    assert_eq!(payload["cases"][0]["passed"], false);
+}
+
+#[test]
+fn skill_eval_fails_closed_when_a_trajectory_case_has_no_spec() {
+    let server = serve(|req| {
+        assert_eq!(req.path, "/v1/event");
+        Response::ndjson(&trajectory_turn(&[("Read", "read")], "all done"))
+    });
+    let (dir, cases) = write_trajectory_case("specified", "all done", &["Read"]);
+    std::fs::write(
+        dir.path().join("evals/cases.json"),
+        r#"{"name":"trajectory_parity","cases":[{"id":"missing","input":"use the tools","grader":{"kind":"contains","expected":"all done"}}]}"#,
+    )
+    .unwrap();
+
+    let output = run_skill_eval(&cases, &server.base_url);
+
+    assert_eq!(output.status.code(), Some(1));
+    let payload = eval_payload(&output);
+    assert_eq!(payload["cases"][0]["id"], "missing");
+    assert_eq!(payload["cases"][0]["passed"], false);
+}
+
+#[test]
+fn skill_eval_rejects_duplicate_case_ids_before_runner_execution() {
+    let server = serve(|req| {
+        panic!(
+            "duplicate case ids must fail before runner request {} {}",
+            req.method, req.path
+        )
+    });
+    let (dir, cases) = write_trajectory_case("duplicate", "all done", &["Read"]);
+    std::fs::write(
+        dir.path().join("evals/cases.json"),
+        r#"{"name":"trajectory_parity","cases":[{"id":"duplicate","input":"first","grader":{"kind":"contains","expected":"all done"}},{"id":"duplicate","input":"second","grader":{"kind":"contains","expected":"all done"}}]}"#,
+    )
+    .unwrap();
+
+    let output = run_skill_eval(&cases, &server.base_url);
+
+    assert_eq!(output.status.code(), Some(2));
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        payload["error"].as_str().unwrap().contains("duplicate"),
+        "payload: {payload}"
+    );
+    assert!(server.recorded().is_empty());
+}
+
+#[test]
+fn ordinary_grader_suite_allows_duplicate_case_ids_without_trajectory_selection() {
+    let server = serve(|req| {
+        assert_eq!(req.path, "/v1/event");
+        Response::ndjson(&trajectory_turn(&[], "all done"))
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let cases = dir.path().join("cases.json");
+    std::fs::write(
+        &cases,
+        r#"{"name":"grader_parity","cases":[{"id":"duplicate","input":"first","grader":{"kind":"contains","expected":"all done"}},{"id":"duplicate","input":"second","grader":{"kind":"contains","expected":"all done"}}]}"#,
+    )
+    .unwrap();
+
+    let output = run_skill_eval(&cases, &server.base_url);
+
+    assert!(
+        output.status.success(),
+        "stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload = eval_payload(&output);
+    assert_eq!(payload["passed"], 2);
+    assert_eq!(payload["failed"], 0);
+    assert_eq!(server.recorded().len(), 2);
 }

--- a/examples/weather/evals/trajectory.json
+++ b/examples/weather/evals/trajectory.json
@@ -1,0 +1,10 @@
+{
+  "weather-answers": {
+    "expected": [
+      "WebSearch",
+      "WebFetch"
+    ],
+    "mode": "in_order",
+    "threshold": 1.0
+  }
+}


### PR DESCRIPTION
## Summary

Wires optional trajectory specifications through skill, local, and cluster eval runs. Platform jobs carry the exact selected case map and verify the deployed case file identity before scoring. Missing specifications and configuration mismatches fail closed.

Closes #389