### PR TITLE
Authed MCP example + skill-up config: --secret, .env loading, credential preflight, install.sh

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -198,6 +198,14 @@ export const commandManifest = {
               },
               "positional": false,
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Forward an environment variable BY NAME into the runner sandbox, so a bundle's authed MCP server can read a secret (e.g. an API token) the same way model credentials are forwarded: the value is read from your environment by docker and never placed in argv. Repeatable. Example: `--secret GITHUB_PERSONAL_ACCESS_TOKEN` with that var exported",
+              "id": "secret",
+              "long": "secret",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -195,6 +195,14 @@
               },
               "positional": false,
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Forward an environment variable BY NAME into the runner sandbox, so a bundle's authed MCP server can read a secret (e.g. an API token) the same way model credentials are forwarded: the value is read from your environment by docker and never placed in argv. Repeatable. Example: `--secret GITHUB_PERSONAL_ACCESS_TOKEN` with that var exported",
+              "id": "secret",
+              "long": "secret",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -71,6 +71,11 @@ pub struct StartOpts {
     pub budget: String,
     pub model: Option<String>,
     pub local_model: Option<String>,
+    /// Extra env var NAMES to forward by name into the runner sandbox, for a
+    /// bundle's authed MCP server to read a secret. Forwarded exactly like the
+    /// model credentials (docker reads the value from the caller's env; the
+    /// value never appears in argv). From `skill up --secret <NAME>`.
+    pub secret: Vec<String>,
 }
 
 /// The versioned report emitted by `agentos_runner.check`.
@@ -454,6 +459,20 @@ fn select_passthrough_env(suppress_credential: bool, byo_credential: Option<&str
     }
 }
 
+/// Append `--secret` env var NAMES to the model-credential passthrough list,
+/// de-duplicating. Unlike the model credential these are NOT suppressed under a
+/// fake/local model run: a bundle's authed MCP server needs its token
+/// regardless of which model drives the session. Names already present (a user
+/// passing a model-credential var as a secret) are not duplicated.
+fn merge_secret_env(mut passthrough: Vec<String>, secrets: &[String]) -> Vec<String> {
+    for name in secrets {
+        if !passthrough.contains(name) {
+            passthrough.push(name.clone());
+        }
+    }
+    passthrough
+}
+
 pub async fn start(opts: StartOpts) -> Result<()> {
     let plugin_dir = opts
         .plugin_dir
@@ -542,7 +561,19 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     // select_passthrough_env.
     let suppress_credential = opts.local_model.is_some() || opts.fake_model;
     let byo_credential = std::env::var("AGENTOS_CREDENTIALS").ok();
-    let passthrough_env = select_passthrough_env(suppress_credential, byo_credential.as_deref());
+    // Warn (do not fail) on a `--secret NAME` that is not set in the caller's
+    // env, since the by-name forward silently no-ops for an unset var (docker.rs).
+    for name in &opts.secret {
+        if std::env::var_os(name).is_none() {
+            crate::ui::ui().note(&format!(
+                "--secret {name}: not set in the environment; nothing will be forwarded for it"
+            ));
+        }
+    }
+    let passthrough_env = merge_secret_env(
+        select_passthrough_env(suppress_credential, byo_credential.as_deref()),
+        &opts.secret,
+    );
 
     let spec = StartSpec {
         image: opts.image.clone(),
@@ -1276,7 +1307,9 @@ async fn git_short_sha(dir: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_cases_path, select_passthrough_env, validate_slack_channel};
+    use super::{
+        merge_secret_env, resolve_cases_path, select_passthrough_env, validate_slack_channel,
+    };
     use std::path::PathBuf;
 
     #[test]
@@ -1377,6 +1410,51 @@ mod tests {
             vec![
                 "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
                 "ANTHROPIC_API_KEY".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn secret_env_appends_after_the_model_credential() {
+        // --secret names ride alongside the model credential, in order, so an
+        // authed MCP server gets its token next to the model token.
+        assert_eq!(
+            merge_secret_env(
+                select_passthrough_env(false, None),
+                &["GITHUB_PERSONAL_ACCESS_TOKEN".to_string()]
+            ),
+            vec![
+                "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+                "ANTHROPIC_API_KEY".to_string(),
+                "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn secret_env_forwarded_even_when_model_credential_suppressed() {
+        // A fake/local model suppresses the model credential but a bundle's MCP
+        // secret must still reach the sandbox.
+        assert_eq!(
+            merge_secret_env(
+                select_passthrough_env(true, None),
+                &["GITHUB_PERSONAL_ACCESS_TOKEN".to_string()]
+            ),
+            vec!["GITHUB_PERSONAL_ACCESS_TOKEN".to_string()]
+        );
+    }
+
+    #[test]
+    fn secret_env_deduplicates_against_the_credential_vars() {
+        // Passing a model-credential var as --secret must not duplicate it.
+        assert_eq!(
+            merge_secret_env(
+                select_passthrough_env(false, None),
+                &["ANTHROPIC_API_KEY".to_string()]
+            ),
+            vec![
+                "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+                "ANTHROPIC_API_KEY".to_string(),
             ]
         );
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -185,6 +185,13 @@ enum SkillAction {
             conflicts_with = "model"
         )]
         local_model: Option<String>,
+        /// Forward an environment variable BY NAME into the runner sandbox, so a
+        /// bundle's authed MCP server can read a secret (e.g. an API token) the
+        /// same way model credentials are forwarded: the value is read from your
+        /// environment by docker and never placed in argv. Repeatable. Example:
+        /// `--secret GITHUB_PERSONAL_ACCESS_TOKEN` with that var exported.
+        #[arg(long = "secret", value_name = "NAME")]
+        secret: Vec<String>,
     },
     /// Check that the bundle's MCP servers load in an offline runner container.
     Check {
@@ -884,6 +891,7 @@ async fn run(command: Command) -> Result<()> {
                 budget,
                 model,
                 local_model,
+                secret,
             } => {
                 let image = artifacts::resolve_image(
                     image.as_deref(),
@@ -901,6 +909,7 @@ async fn run(command: Command) -> Result<()> {
                     budget,
                     model,
                     local_model,
+                    secret,
                 })
                 .await
             }

--- a/examples/github-issues/.claude-plugin/plugin.json
+++ b/examples/github-issues/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "github-issues",
+  "version": "0.1.0",
+  "description": "Example bundle: an agent that reads and triages GitHub issues through the off-the-shelf GitHub MCP server, authenticated with a personal access token forwarded into the sandbox.",
+  "author": { "name": "CurieTech" },
+  "keywords": ["example", "mcp", "authed", "github", "stdio"]
+}

--- a/examples/github-issues/.gitignore
+++ b/examples/github-issues/.gitignore
@@ -1,0 +1,1 @@
+.agentos/

--- a/examples/github-issues/.mcp.json
+++ b/examples/github-issues/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "mcp-server-github",
+      "args": [],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/examples/github-issues/README.md
+++ b/examples/github-issues/README.md
@@ -1,0 +1,74 @@
+# github-issues — an agent on an authed, off-the-shelf MCP server
+
+An example bundle for the **"authenticated third-party MCP server"** shape: the
+agent's tools come from a server we do **not** write — the off-the-shelf
+[`@modelcontextprotocol/server-github`](https://www.npmjs.com/package/@modelcontextprotocol/server-github)
+stdio server — and reaching the service needs a **secret** (a GitHub personal
+access token). It exists to prove the end-to-end path for *any* authed MCP
+integration: declare the server in `.mcp.json`, and forward its credential into
+the sandbox at launch with `agentos skill up --secret <NAME>`.
+
+## What's here
+
+```
+github-issues/
+  .claude-plugin/plugin.json    bundle manifest
+  .mcp.json                     declares the off-the-shelf GitHub stdio server
+  skills/github-issues/SKILL.md  a skill that reads and triages issues
+```
+
+There is no server code in this bundle — that is the point. `.mcp.json` points
+`command` at `mcp-server-github`, the binary the reference server package
+installs. The runner image pre-installs that package
+(`runner/Dockerfile`: `npm install -g @modelcontextprotocol/server-github`), so
+the server starts with **no runtime network fetch**. The GitHub token is not in
+the bundle; it is forwarded by name at launch (below).
+
+## How the secret reaches the server
+
+`agentos skill up --secret GITHUB_PERSONAL_ACCESS_TOKEN` forwards the variable
+**by name** into the runner container — docker reads its value from your
+environment, so the token never appears in argv. Inside the sandbox the GitHub
+server reads `GITHUB_PERSONAL_ACCESS_TOKEN` from the environment (the `.mcp.json`
+`env` block also maps it explicitly). This is the same by-name forwarding the
+CLI already uses for model credentials; `--secret` just extends it to a bundle's
+own MCP secrets.
+
+## Run it end-to-end (manual)
+
+Prerequisites: the runner image built once (`agentos build`), a model credential
+in your environment (`CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`), and a
+GitHub PAT — a read-scoped (`public_repo` / `repo:read`) token is enough to list
+and read issues.
+
+```bash
+export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_your_token_here
+
+cd examples/github-issues
+
+# Optional: confirm the server binary is present and loads in an offline check.
+# It runs --network none and forwards no secret, so if the GitHub server
+# refuses to start without a token this may report red -- `skill up` below is
+# the real end-to-end test.
+agentos skill check
+
+# Boot the runner with the model credential AND the GitHub token forwarded.
+agentos skill up --secret GITHUB_PERSONAL_ACCESS_TOKEN
+
+# Ask it something that exercises the authed server.
+agentos skill message "List the open issues in curie-eng/agentos and group them by label."
+
+agentos skill down
+```
+
+If the message reply cites real issue titles/numbers from the repo, the authed
+MCP path worked end to end: token forwarded → server authenticated → tools
+called → answer grounded in live data.
+
+## Swapping in a different service
+
+The mechanism is service-agnostic. To point at another authed MCP server,
+change `.mcp.json` (`command`/`args` for a stdio server, or `type`/`url`/
+`headers` for a remote one) and forward its secret with `--secret <NAME>`. A
+remote server that authenticates with a bearer token, for example, reads the
+forwarded variable in its `headers` (`"Authorization": "Bearer ${TOKEN}"`).

--- a/examples/github-issues/skills/github-issues/SKILL.md
+++ b/examples/github-issues/skills/github-issues/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: github-issues
+description: Read, summarize, and triage GitHub issues and pull requests for a repository using the authenticated GitHub MCP server. Invoke whenever the user asks about open issues, wants a repo's issues summarized or triaged, asks to find issues by label or author, or asks to draft an issue.
+allowed-tools:
+  - github
+---
+
+# GitHub issue triage
+
+## When to run
+The user asks about a repository's issues or pull requests — to list open
+issues, summarize them, find ones by label/assignee/author, or draft a new
+issue for review.
+
+## How to answer
+1. Identify the repository (`owner/repo`). Ask if the user did not name one.
+2. Call the `github` server's tools:
+   - list/search issues to pull the current open set,
+   - fetch a single issue when the user asks about one in particular.
+3. Summarize plainly: title, number, author, labels, and a one-line gist.
+   Group by label or priority when triaging.
+4. When asked to draft an issue, write the title and body and show it for the
+   user to confirm — do not create it unless the user explicitly says to.
+
+## Notes
+`github` is the off-the-shelf `@modelcontextprotocol/server-github` stdio MCP
+server, declared in this bundle's `.mcp.json`. It authenticates with a GitHub
+personal access token read from `GITHUB_PERSONAL_ACCESS_TOKEN` in the sandbox
+environment. That token is NOT in the bundle: you forward it at launch with
+`agentos skill up --secret GITHUB_PERSONAL_ACCESS_TOKEN` (see the README), which
+passes the variable by name into the container the same way model credentials
+are forwarded. A read-scoped token is enough for listing and reading; creating
+an issue needs `repo`/`issues` write scope.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# One-command bootstrap for an agentos source checkout.
+#
+# Solves the bootstrap chicken-and-egg: the `agentos` CLI cannot install itself
+# because it does not exist until it is built. This script runs the single
+# pre-binary step -- `cargo install`, which builds AND drops `agentos` on PATH
+# (~/.cargo/bin) -- and then hands off to `agentos install` for the rest (uv
+# sync, pnpm install, runner image). Run it once, right after cloning:
+#
+#   git clone <repo> && cd agentos && ./install.sh
+#
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "==> cargo install --path cli (builds agentos and installs it to ~/.cargo/bin)"
+cargo install --path cli --force
+
+# Invoke the freshly installed binary by its absolute path so this works even
+# when ~/.cargo/bin is not yet on PATH in the current shell (a new clone on a
+# machine whose shell rc has not been re-sourced).
+CARGO_BIN="${CARGO_HOME:-$HOME/.cargo}/bin"
+echo "==> agentos install (deps + runner image)"
+"$CARGO_BIN/agentos" install
+
+echo
+echo "Done. If 'agentos' is not found in this shell, add ~/.cargo/bin to PATH"
+echo "(rustup writes ~/.cargo/env for this) and open a new shell."

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -23,6 +23,14 @@ RUN apt-get update \
 # The Claude Code CLI the SDK spawns for a real (non-fake) session.
 RUN npm install -g @anthropic-ai/claude-code
 
+# Off-the-shelf MCP servers pre-installed at build time so a bundle that
+# declares one starts it from the on-disk binary with NO runtime network fetch
+# (the runner rootfs is read-only at runtime, so an `npx`-style fetch would fail
+# anyway). Bundles reference these by the package's bin name, e.g.
+# `"command": "mcp-server-github"` -- see examples/github-issues. Add a line here
+# to bless another authed third-party MCP server for the same shape.
+RUN npm install -g @modelcontextprotocol/server-github
+
 WORKDIR /app
 
 # The three source trees the runner needs: the two frozen workspace packages and


### PR DESCRIPTION
## What

Makes the `agentos skill up` flow actually usable for an **authenticated** MCP
agent, end to end. Closes #400. Four related pieces:

### 1. Authed third-party MCP example
`examples/github-issues/` — an agent whose tools come from an **off-the-shelf,
authenticated** MCP server (`@modelcontextprotocol/server-github`); no server
code of our own. Manifest, `.mcp.json` (references the pre-baked binary), a
triage `SKILL.md`, and a README with the manual e2e recipe. Validates against
`plugin_format.validate_bundle`.

### 2. `agentos skill up --secret <NAME>`
Forwards an env var **by name** into the runner sandbox so a bundle's authed MCP
server can read its token — same by-name mechanism as the model credentials
(`docker` reads the value from the caller's env; never in argv), and **not**
suppressed under a fake/local model. `runner/Dockerfile` pre-installs
`mcp-server-github` at build time so it starts with no runtime fetch (the runner
rootfs is read-only at runtime). Regenerated `command-manifest.json` + committed
`commandManifest.ts`.

### 3. The CLI owns config: `.env` loading + a credential preflight
Previously `skill up` assumed the shell was pre-exported correctly and a bad
login surfaced only as a deep runtime *"model credential rejected by provider"*.
Now:
- **`.env` loading** — the CLI reads a **bundle-local `.env`** then the
  **repo-root `.env`** (non-overriding, via `dotenvy`). Precedence:
  `shell env > bundle .env > repo .env`, so an agent's own secret lives next to
  the agent and outranks platform defaults; a real export outranks both.
- **Preflight** — before booting the container, `skill up` prints (masked) which
  model credential and which `--secret` vars it will forward, **warns** when
  `AGENTOS_CREDENTIALS` is shadowing a present model token, and **fails fast**
  with an actionable message when no model credential is present. A bad login is
  now a clear CLI error, not a runtime provider reject.

### 4. `./install.sh` — one-command bootstrap
The `agentos` CLI can't bootstrap itself (it doesn't exist until built), and
`agentos install` leaves the binary in `target/debug`, off PATH. `install.sh`
runs the one pre-binary step (`cargo install --path cli` — builds AND installs
to `~/.cargo/bin`) then hands off to `agentos install`.

## Test

- `cargo fmt --check`, `cargo clippy -- -D warnings` clean.
- 12 unit tests across `merge_secret_env` / `select_passthrough_env` /
  `plan_model_credential` pass (only the pre-existing Valkey-backed
  `chat_enqueue.rs` integration tests flake when the compose stack is down).
- `plugin_format.validate_bundle('examples/github-issues')` → valid.
- Runner image built; `mcp-server-github` confirmed on the image PATH.
- Preflight exercised against the real bundle: missing credential → fail-fast
  before any container; `AGENTOS_CREDENTIALS` shadowing an OAuth token → warning;
  `--secret` presence reported.

## Follow-ups (not in this PR)
- Scaffold a gitignored `.env` in `agentos init` bundles so new bundles inherit
  the agent-local-secret home.
- Load the repo-root `.env` globally (all commands), not just the skill-up flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)