### PR TITLE
Rehydrate a thread's conversation across unplanned runner restarts

### DIFF
--- a/apps/worker/CLAUDE.md
+++ b/apps/worker/CLAUDE.md
@@ -47,14 +47,17 @@ stop -- that is scope creep on the sacred module.
   binding the warm pool, because env cannot be injected into an
   already-running pod. Expected latency, not a bug.
 - **Suspend deletes the pod.** Never assume a suspended sandbox's process or
-  prompt cache survives; `resume()` always rehydrates from
-  `AGENTOS_HISTORY_REF`.
+  prompt cache survives; a resumed or restarted sandbox rehydrates from external
+  state via `AGENTOS_HISTORY_REF`.
 - **The client seam is sync; unit tests fake only `SandboxClient`** (the K8s
   control plane) -- Valkey is never mocked.
-- **Producing a history ref is the caller's job.** The frozen ACI `final`
-  frame does not carry the SDK session id today; surfacing it is an
-  `aci-protocol` change -- stop and raise it in an issue/PR first, do not
-  invent a side channel.
+- **The history ref is a deterministic state-store URL, not an SDK session id**
+  (ADR-0029). `binding.boot_env` sets `AGENTOS_HISTORY_REF` to this thread's
+  transcript key on the durable state store (`.../state/transcript/<thread_key>`)
+  on **every** claim, so a fresh, restarted, or resumed sandbox all boot with the
+  same ref and the runner rehydrates the conversation as a preamble. There is no
+  SDK session id to capture off the ACI `final` frame and no frozen-contract
+  change; do not reintroduce a frame-captured resume id.
 
 ## Deployment-to-runtime binding (implemented)
 

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -32,6 +32,7 @@ import logging
 import secrets
 import uuid
 from typing import Any
+from urllib.parse import quote
 
 from aci_protocol import Budget
 from pydantic import BaseModel
@@ -59,6 +60,12 @@ CREDENTIALS_ENV = "AGENTOS_CREDENTIALS"
 # runner-local knob (not part of the frozen env), like AGENTOS_RUNNER_TOKEN.
 MEMORY_REF_ENV = "AGENTOS_MEMORY_REF"
 MEMORY_TOKEN_ENV = "AGENTOS_MEMORY_TOKEN"
+# The conversation-history port (#20, ADR-0029): the URL of THIS thread's
+# transcript key on the same durable state store, dereferenced by the runner at
+# boot to rehydrate the conversation after an unplanned restart, plus the API key
+# it authenticates with. Both are runner-local knobs, NOT frozen ACI env.
+HISTORY_REF_ENV = "AGENTOS_HISTORY_REF"
+HISTORY_TOKEN_ENV = "AGENTOS_HISTORY_TOKEN"
 BASE_URL_ENV = "ANTHROPIC_BASE_URL"
 MODEL_ENV = "AGENTOS_MODEL"
 # Per-claim bearer token the runner enforces on its ACI POST routes (issue #63).
@@ -194,6 +201,18 @@ class BindingResolver:
         env[MEMORY_REF_ENV] = f"{base}/agents/{resolved.agent_id}/state/memory"
         if self._config.api_key:
             env[MEMORY_TOKEN_ENV] = self._config.api_key
+        # Deliver the history ref (#20, ADR-0029): this thread's transcript key on
+        # the same state store. It is deterministic per (agent, thread), so a
+        # fresh, restarted, or resumed sandbox all boot with the same ref and the
+        # runner rehydrates the conversation identically -- an unplanned restart
+        # needs no special branch. thread_key is URL-encoded so a channel/ts with
+        # reserved characters cannot break the key path.
+        thread_segment = quote(thread_key, safe="")
+        env[HISTORY_REF_ENV] = (
+            f"{base}/agents/{resolved.agent_id}/state/transcript/{thread_segment}"
+        )
+        if self._config.api_key:
+            env[HISTORY_TOKEN_ENV] = self._config.api_key
         # The agent's pinned model (#254) overrides the worker default; None
         # falls back to config.model inside apply_model_env.
         apply_model_env(env, self._config, model_override=resolved.model)

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -222,3 +222,56 @@ def test_binding_boot_env_token_survives_credentials() -> None:
     env = resolver.boot_env(_resolved(), "thread-1")
     assert env.get(RUNNER_TOKEN_ENV), "the runner token must survive credential selection"
     assert env[CREDENTIALS_ENV] == "cred-1"
+
+
+# --- Conversation-history ref delivery (#20, ADR-0029) ------------------------
+# The env-var names are the cross-package contract with the runner; asserted by
+# their literal strings so this file never depends on a constant that only exists
+# after the feature lands.
+HISTORY_REF_ENV = "AGENTOS_HISTORY_REF"
+HISTORY_TOKEN_ENV = "AGENTOS_HISTORY_TOKEN"
+
+
+def test_binding_boot_env_sets_per_thread_transcript_ref() -> None:
+    resolver = BindingResolver.__new__(BindingResolver)
+    config = WorkerConfig()
+    resolver._config = config  # type: ignore[attr-defined]
+
+    resolved = _resolved()
+    env = resolver.boot_env(resolved, "1720000000.000100")
+    base = config.api_base_url.rstrip("/")
+    assert env[HISTORY_REF_ENV] == (
+        f"{base}/agents/{resolved.agent_id}/state/transcript/1720000000.000100"
+    )
+    # The API key is forwarded as the history token (shared with memory today).
+    assert env[HISTORY_TOKEN_ENV] == config.api_key
+
+
+def test_binding_boot_env_history_ref_is_deterministic_per_thread() -> None:
+    # Every claim for a thread yields the same ref, so a fresh, a restarted, and a
+    # resumed sandbox all rehydrate the same transcript (#20) with no special path.
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig()  # type: ignore[attr-defined]
+
+    resolved = _resolved()
+    first = resolver.boot_env(resolved, "t-1")[HISTORY_REF_ENV]
+    second = resolver.boot_env(resolved, "t-1")[HISTORY_REF_ENV]
+    assert first == second
+
+
+def test_binding_boot_env_url_encodes_thread_key() -> None:
+    # A thread key with reserved characters must not escape the transcript key
+    # path; it is percent-encoded (safe="") so slashes cannot inject a new path.
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig()  # type: ignore[attr-defined]
+
+    env = resolver.boot_env(_resolved(), "weird/../key")
+    assert "/state/transcript/weird%2F..%2Fkey" in env[HISTORY_REF_ENV]
+
+
+def test_binding_boot_env_omits_history_token_without_api_key() -> None:
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig(api_key="")  # type: ignore[attr-defined]
+
+    env = resolver.boot_env(_resolved(), "t-1")
+    assert HISTORY_TOKEN_ENV not in env

--- a/docs/adr/0029-conversation-history-port-and-first-loader.md
+++ b/docs/adr/0029-conversation-history-port-and-first-loader.md
@@ -1,0 +1,120 @@
+# 29. The conversation-history port and its first loader: transcript replay over the durable state store
+
+Date: 2026-07-14
+
+Status: Accepted
+
+Implements transcript persistence across unplanned runner restarts for issue
+[#20](https://github.com/curie-eng/agentos/issues/20). This is the first loader
+for `AGENTOS_HISTORY_REF`, the runner-local rehydration ref that until now was
+read into `RunnerConfig` and fed to the SDK `resume=` option but, in practice,
+never carried a usable value. It is the sibling of ADR-0025 (the memory port and
+its first loader): same store, same boot-preamble delivery, a different scope
+(per-thread conversation vs per-agent memory).
+
+## Context
+
+Sessions are stateless-first (ADR-0003): a suspended or restarted sandbox is a
+new pod, and its in-pod SDK transcript (on emptyDir) is gone. Today an unplanned
+runner-pod death mid-thread loses the conversation: the worker's route stays
+`LIVE` with no history ref, the next claim cold-boots a fresh, history-less
+sandbox, and the user is silently talking to an amnesiac agent. The
+suspend/resume path that was supposed to rehydrate is also unreached in
+production (nothing suspends, nothing produces a resume id) and, even if it were,
+it pointed the SDK `resume=` at transcript files that died with the pod.
+
+Two constraints shape the fix:
+
+- **History must live outside the sandbox and be harness-agnostic.** ADR-0011 and
+  ADR-0021 commit us to more than one coding-agent harness (OpenCode alongside
+  claude-agent-sdk). An SDK-native resume id is claude-agent-sdk-specific and
+  would have to be redone per harness; the rehydration mechanism must not assume
+  any one harness's transcript format or resume API.
+- **We already have the durable store this needs.** ADR-0025 landed an
+  agent-scoped, namespaced, Postgres-JSONB state store with a log-shaped `append`
+  endpoint and per-value/per-namespace size caps, reachable from the sandbox, and
+  used it to deliver agent *memory* as a boot-time system-prompt preamble.
+  Conversation history is the same shape of problem (durable, external,
+  rehydrated at boot) at a different scope.
+
+## Decision
+
+**Persist the per-thread conversation transcript as a scoped namespace over the
+existing state store, behind a small `TranscriptStore` port, and deliver it to a
+(re)started runner as a boot-time system-prompt preamble.** This is Option B
+(platform-owned, harness-agnostic replay), chosen over Option A (SDK-native
+resume).
+
+- **The port** (`runner/src/agentos_runner/history.py`) is a `Protocol` with two
+  methods, `load() -> list[TurnRecord]` and `append(record)`. A `TurnRecord` is a
+  `user` message plus the `assistant` reply (and a `ts`). No query language and
+  no summarization -- windowing/compaction is later work.
+- **The default backing** is `StateApiTranscriptStore` over the ADR-0025 state
+  store: the thread's transcript is the log-shaped key
+  `/agents/<agent_id>/state/transcript/<thread_key>`. `load` GETs the key (404 =
+  no prior turns), `append` POSTs one turn to the key's `/append` endpoint.
+  `NullTranscriptStore` is used when no ref is configured, so the boot path is
+  uniform. Durability, size caps, and survive-restart come from the state store
+  for free, with no new datastore to operate.
+- **`AGENTOS_HISTORY_REF` is repurposed as the transcript-namespace URL**, exactly
+  as ADR-0025 did for `AGENTOS_MEMORY_REF`: an `http(s)://` ref resolves to the
+  `StateApiTranscriptStore`; any other scheme (an old SDK-resume id, `s3://`) is
+  rejected loudly at boot. It is a runner-local env, never part of the frozen ACI
+  `SessionConfig`, so this is **not a frozen-contract change**. The state-API
+  bearer travels as the runner-local `AGENTOS_HISTORY_TOKEN`.
+- **The runner stops feeding `history_ref` to the SDK `resume=` option.** The
+  harness-specific resume path is retired in favor of the harness-agnostic
+  preamble; `build_options` keeps its `resume` parameter (an explicit caller may
+  still use it) but the boot path no longer wires history into it.
+- **Delivery into the sandbox:** at boot the store is resolved, prior turns are
+  loaded, and they are composed into the effective system prompt as a
+  conversation preamble (leading the prompt alongside the memory preamble), so a
+  restarted session sees the prior exchange as context. **Every claim for a thread
+  injects the same deterministic ref**, so a fresh, a restarted, and a resumed
+  sandbox all rehydrate identically -- the unplanned-restart case needs no special
+  worker/kernel branch.
+- **The write side** is the runner: after each turn reaches a successful terminal
+  `final`, it appends `{user, assistant}` to the transcript store. Best-effort --
+  a transient store failure logs and never fails the turn (and boot degrades to
+  "no history" rather than blocking, like memory).
+- **The worker delivers the ref:** `binding.boot_env` sets `AGENTOS_HISTORY_REF`
+  to the thread's transcript-namespace URL and forwards the API key as
+  `AGENTOS_HISTORY_TOKEN`, mirroring the memory-ref wiring.
+
+## Alternatives considered
+
+- **Option A -- SDK-native resume.** Surface the claude-agent-sdk `session_id` on
+  the ACI `Final` frame, persist the SDK's own transcript files durably, restore
+  them into the new pod, and `resume=<id>`. Rejected: it locks rehydration to
+  claude-agent-sdk (breaks with the ADR-0011/0021 multi-harness direction),
+  requires a frozen-contract change to carry the id, and couples our durable
+  store to the SDK's internal transcript file format. It buys the SDK's exact
+  prompt-cache continuity, but ADR-0003 already treats cache warmth as lost across
+  a restart, so that is not a benefit we are giving up.
+- **A new S3/object-store transcript backend.** Rejected for the same reason
+  ADR-0025 rejected it for memory: a second datastore to operate when the state
+  store already gives durability, agent-scoping, namespacing, size caps, and an
+  append log.
+- **Persist in Valkey (the affinity store).** Rejected: Valkey is the routing
+  store, not the durable state of record; the state store is the adopted spine for
+  cross-turn durable state, and reusing it keeps one durability story.
+
+## Consequences
+
+- An unplanned runner restart mid-thread rehydrates the conversation: the fresh
+  sandbox loads the thread's transcript and leads the system prompt with it. No
+  new infrastructure, no frozen-contract change, no sacred-kernel change; the
+  worker change is one `boot_env` block mirroring memory.
+- History and memory are distinct namespaces over one store: `transcript/<thread>`
+  (this conversation) vs `memory` (durable cross-session lessons). The runner
+  reinterpretation of `AGENTOS_HISTORY_REF` (URL, not SDK resume id) supersedes the
+  old `config.py` framing; `runner/CLAUDE.md` is updated to match.
+- **Known limitations (follow-up):** the transcript is an unbounded append log
+  under the state store's size caps, so a very long thread will eventually hit the
+  cap; windowing/summarization of the replayed context is deferred. The replay is
+  a prompt preamble, not a token-exact reconstruction of the prior context, so it
+  does not restore the model's original prompt cache (consistent with ADR-0003).
+  The state API has one shared key today, so forwarding it as the history token
+  grants the sandbox that key's scope -- the same auth-hardening follow-up ADR-0025
+  notes. Live proof of the pod-death-then-rehydrate path needs a real cluster; the
+  load-as-preamble mechanism is verified at boot without killing a pod.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -25,6 +25,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Approval / authorizer | NONE | 0 | not separately graded | #22 | [interfaces/approval/INTERFACE.md](interfaces/approval/INTERFACE.md) |
 | Workflow state store | NONE | 0 (concrete AffinityStore) | not separately graded | #23 | [interfaces/workflow-state/INTERFACE.md](interfaces/workflow-state/INTERFACE.md) |
 | Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [interfaces/memory/INTERFACE.md](interfaces/memory/INTERFACE.md) |
+| Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [interfaces/conversation-history/INTERFACE.md](interfaces/conversation-history/INTERFACE.md) |
 | Triggers | SOFT | 2 hardcoded (Slack, GH push) | not separately graded | #29 | [interfaces/triggers/INTERFACE.md](interfaces/triggers/INTERFACE.md) |
 
 ## Kind legend

--- a/docs/interfaces/conversation-history/INTERFACE.md
+++ b/docs/interfaces/conversation-history/INTERFACE.md
@@ -1,0 +1,77 @@
+# INTERFACE: Conversation history
+
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 loader (`StateApiTranscriptStore`) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+## The black line
+
+The port is the `TranscriptStore` `Protocol` in
+`runner/src/agentos_runner/history.py` (issue #20, ADR-0029). Two methods:
+
+```python
+class TranscriptStore(Protocol):
+    async def load(self) -> list[TurnRecord]: ...
+    async def append(self, record: TurnRecord) -> None: ...
+```
+
+A `TurnRecord` is `user: str` plus `assistant: str` (and a `ts`) — one
+conversation turn. `AGENTOS_HISTORY_REF` (a runner-local env, NOT a frozen ACI
+`SessionConfig` field) is resolved to a concrete `TranscriptStore` at runner boot
+by `resolve_history`. The state-API bearer is a runner-local knob
+(`AGENTOS_HISTORY_TOKEN`), like `AGENTOS_MEMORY_TOKEN`.
+
+This is the sibling seam of [Memory](../memory/INTERFACE.md): same store, same
+boot-preamble delivery, a different scope. Memory is per-agent durable lessons;
+history is *this thread's* conversation, so a restarted sandbox can rehydrate the
+turns already spoken.
+
+## Current contract
+
+- **Resolution.** `resolve_history(history_ref, env)`: an absent ref →
+  `NullTranscriptStore`; an `http(s)://` ref → `StateApiTranscriptStore`; any
+  other scheme (an old SDK-resume id, `s3://` …) is reserved for a future loader
+  and rejected loudly.
+- **Load side.** `load()` returns prior turns oldest-first (empty when none). At
+  boot the runner loads the transcript and composes it into the effective system
+  prompt as a conversation preamble (after the memory preamble, before the
+  bundle/env prompt) — this is how history is *delivered into the sandbox*,
+  harness-agnostically (plain prompt text, not any one harness's resume API). A
+  transient load failure degrades to "no history" and does not block boot.
+- **Append side.** `append(record)` durably writes one turn. The runner appends
+  `{user, assistant}` after each successful terminal `final`
+  (`SessionRunner._record_turn`), best-effort — a store failure never fails a
+  turn the user already received. Failed/budget/auth turns are not recorded.
+
+## Implementations today
+
+One: **`StateApiTranscriptStore`**, backing the transcript as a per-thread
+`transcript/<thread_key>` key over the durable KV/document store landed for
+#23/#248 (`apps/api` `/agents/{agent_id}/state/{namespace}/{key}`, Postgres
+JSONB). `load` GETs the key; `append` POSTs to the key's `/append` endpoint,
+inheriting durability and the per-value/per-namespace size caps.
+`NullTranscriptStore` is the no-ref sink. The worker (`binding.boot_env`)
+delivers the ref as `http(s)://api/agents/<id>/state/transcript/<thread_key>`
+(URL-encoded thread key) and forwards the API key as the history token. The ref
+is **deterministic per (agent, thread)**, so a fresh, a restarted, and a resumed
+sandbox all boot with the same ref and rehydrate identically — the
+unplanned-restart case needs no special worker/kernel branch.
+
+## Known leakage
+
+- **Shared API key as the history token.** Same as memory: the state API has one
+  shared key today, so forwarding it as `AGENTOS_HISTORY_TOKEN` grants that key's
+  scope. Scoped, least-privilege tokens are shared follow-up auth-hardening work.
+- **Unbounded append log under the state-store size caps.** A very long thread
+  will eventually hit the per-namespace/per-value cap; windowing/summarization of
+  the replayed context is deferred. The replay is a prompt preamble, not a
+  token-exact reconstruction, so it does not restore the model's original prompt
+  cache (consistent with ADR-0003, which assumes cache-cold on a restart).
+- **History lives OUTSIDE the sandbox** (ADR-0003) — the store is
+  network-reachable and rehydratable, never pod-local state.
+
+## Cross-links
+
+- **Issue:** [#20](https://github.com/curie-eng/agentos/issues/20) — transcript persistence across unplanned runner restarts
+- **ADR(s):** [ADR-0029](../../adr/0029-conversation-history-port-and-first-loader.md) — the port + first loader; [ADR-0025](../../adr/0025-memory-port-and-first-loader.md) — the sibling memory port; [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) — stateless-first; rehydrate on resume; externalize session state

--- a/runner/CLAUDE.md
+++ b/runner/CLAUDE.md
@@ -30,10 +30,15 @@ Docker via `agentos skill up`. Full behavior spec in `runner/README.md`.
   the worker's no-retry-after-side-effects rule depends on this flag being
   conservative.
 - **Rehydration on start is stateless-first** (ADR-0003): the runner
-  rehydrates from `AGENTOS_HISTORY_REF` (falling back to `AGENTOS_MEMORY_REF`)
-  on boot rather than assuming any surviving in-process state. Never write a
-  code path that depends on the runner having been "the same process" as an
-  earlier turn.
+  rehydrates external state on boot rather than assuming any surviving
+  in-process state. Two distinct external refs, each resolved to a store over
+  the durable state API and delivered as a system-prompt preamble, never a
+  surviving process: `AGENTOS_HISTORY_REF` is this thread's conversation
+  transcript (`history.py`, ADR-0029), `AGENTOS_MEMORY_REF` is the agent's
+  durable memory (`memory.py`, ADR-0025). `AGENTOS_HISTORY_REF` is a state-API
+  URL, no longer an SDK `resume` id, and is not fed to the SDK `resume=` path.
+  Never write a code path that depends on the runner having been "the same
+  process" as an earlier turn.
 - **One turn consumes the SDK generator at a time.** Steer and interrupt are
   side-channel injections whose output surfaces on the already-open
   `/v1/event` stream -- do not open a second concurrent generator for a steer.

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -18,6 +18,12 @@ from aiohttp import web
 from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .config import RunnerConfig
 from .fake import FakeModelSession
+from .history import (
+    TranscriptStore,
+    TurnRecord,
+    format_conversation_preamble,
+    resolve_history,
+)
 from .hooks import load_bundle_hooks
 from .memory import MemoryRecord, MemoryStore, format_memory_preamble, resolve_memory
 from .otel import RunTracer, build_tracer_provider
@@ -30,15 +36,20 @@ from .side_effects import SideEffectClassifier
 logger = logging.getLogger(__name__)
 
 
-def _compose_system_prompt(base: str | None, memory_preamble: str | None) -> str | None:
-    """Prepend the loaded-memory preamble to the effective system prompt.
+def _compose_system_prompt(
+    base: str | None,
+    memory_preamble: str | None,
+    conversation_preamble: str | None = None,
+) -> str | None:
+    """Prepend the loaded-memory and conversation preambles to the system prompt.
 
-    Memory delivered from outside the sandbox becomes durable model context by
-    leading the system prompt; the bundle/env system prompt follows it. Either
-    part may be absent.
+    State delivered from outside the sandbox becomes durable model context by
+    leading the system prompt: durable memory (ADR-0025) first, then this thread's
+    recovered conversation (ADR-0029), then the bundle/env system prompt. Any part
+    may be absent.
     """
 
-    parts = [p for p in (memory_preamble, base) if p]
+    parts = [p for p in (memory_preamble, conversation_preamble, base) if p]
     return "\n\n".join(parts) if parts else None
 
 
@@ -49,6 +60,8 @@ def build_runner(
     sdk_env: dict[str, str] | None = None,
     memory_store: MemoryStore | None = None,
     memory_preamble: str | None = None,
+    history_store: TranscriptStore | None = None,
+    conversation_preamble: str | None = None,
 ) -> SessionRunner:
     """Wire a SessionRunner backed by a real claude-agent-sdk session.
 
@@ -64,9 +77,10 @@ def build_runner(
     system_prompt = config.system_prompt
     if system_prompt is None:
         system_prompt = load_bundle_system_prompt(config.session.plugin_dir)
-    # Prior memory loaded from outside the sandbox (#264) leads the system prompt
-    # so the model sees learned lessons as durable context.
-    system_prompt = _compose_system_prompt(system_prompt, memory_preamble)
+    # Prior memory (#264) and this thread's recovered conversation (#20), both
+    # loaded from outside the sandbox, lead the system prompt so the model sees
+    # learned lessons and the prior exchange as durable context.
+    system_prompt = _compose_system_prompt(system_prompt, memory_preamble, conversation_preamble)
     # In-bundle PreToolUse guardrails declared in the manifest hooks field (#272),
     # translated into SDK HookMatcher callbacks. None when the bundle declares none.
     bundle_hooks = load_bundle_hooks(config.session.plugin_dir)
@@ -81,7 +95,11 @@ def build_runner(
             system_prompt=system_prompt,
             max_turns=config.max_turns,
             max_budget_usd=config.max_usd_per_day,
-            resume=config.history_ref,
+            # History is rehydrated harness-agnostically as a conversation preamble
+            # (ADR-0029), not through the SDK-specific resume path, so history_ref
+            # no longer feeds resume. build_options keeps the param for an explicit
+            # caller; the boot path passes None.
+            resume=None,
             task_budget_hint=config.session.budget.task_budget_hint,
             env=sdk_env or {},
             hooks=bundle_hooks,
@@ -102,6 +120,7 @@ def build_runner(
         session_id=config.session.session_id,
         model=config.model,
         memory_store=memory_store,
+        history_store=history_store,
     )
 
 
@@ -135,6 +154,36 @@ def _load_memory(config: RunnerConfig) -> tuple[MemoryStore, str | None]:
     return store, format_memory_preamble(records)
 
 
+def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
+    """Resolve AGENTOS_HISTORY_REF and load this thread's transcript into a preamble.
+
+    Mirrors ``_load_memory`` (ADR-0029): runs synchronously at boot so a bad ref
+    fails the process visibly, but a transient load failure degrades to "no
+    history" rather than blocking boot -- a thread must still run when its
+    transcript store is briefly unavailable (the answer just lacks prior context).
+    """
+
+    store = resolve_history(config.history_ref, os.environ)
+
+    async def _load() -> list[TurnRecord]:
+        return await store.load()
+
+    try:
+        turns = anyio.run(_load)
+    except Exception as exc:  # noqa: BLE001 - degrade to no-history, never fail boot
+        logger.warning(
+            "history load failed session=%s error_class=%s: %s (booting without history)",
+            config.session.session_id,
+            type(exc).__name__,
+            exc,
+        )
+        return store, None
+    logger.info(
+        "history loaded session=%s turns=%d", config.session.session_id, len(turns)
+    )
+    return store, format_conversation_preamble(turns)
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
     fake_model = os.environ.get("AGENTOS_FAKE_MODEL", "").lower() in ("1", "true", "yes")
@@ -158,12 +207,15 @@ def main() -> None:
         config.port,
     )
     memory_store, memory_preamble = _load_memory(config)
+    history_store, conversation_preamble = _load_history(config)
     runner = build_runner(
         config,
         fake_model=fake_model,
         sdk_env=override,
         memory_store=memory_store,
         memory_preamble=memory_preamble,
+        history_store=history_store,
+        conversation_preamble=conversation_preamble,
     )
     app = create_app(runner, token=config.runner_token)
 

--- a/runner/src/agentos_runner/config.py
+++ b/runner/src/agentos_runner/config.py
@@ -43,12 +43,13 @@ class RunnerConfig:
 
         The ACI-frozen vars are parsed by ``SessionConfig.from_env``; a malformed
         or missing required var raises there. ``history_ref`` is read only from an
-        explicit ``AGENTOS_HISTORY_REF``, which is an SDK ``resume`` session id
-        (transcript- or session-store-backed). It is deliberately NOT derived from
-        ``AGENTOS_MEMORY_REF``: the memory ref is an externalized-memory pointer
-        (S3 path / API URL), a different concept the SDK cannot resume from. The
-        worker/G1 is what turns externalized history into a resume id; the runner
-        only accepts one (ADR-0003, stateless-first).
+        explicit ``AGENTOS_HISTORY_REF``, the URL of this thread's transcript
+        namespace on the state API (ADR-0029, resolved by ``history.py`` into a
+        ``TranscriptStore`` and delivered as a boot preamble). It is deliberately
+        NOT derived from ``AGENTOS_MEMORY_REF``: memory is per-agent durable
+        lessons, history is this thread's conversation (ADR-0025 keeps them
+        distinct). Both live outside the sandbox and are rehydrated at boot
+        (ADR-0003, stateless-first).
         """
 
         session = SessionConfig.from_env(env)

--- a/runner/src/agentos_runner/history.py
+++ b/runner/src/agentos_runner/history.py
@@ -1,0 +1,211 @@
+"""The conversation-history port: resolve ``AGENTOS_HISTORY_REF`` and load/append
+this thread's transcript.
+
+This is the first loader for the history seam (issue #20). Until now
+``AGENTOS_HISTORY_REF`` was a runner-local ref read into ``RunnerConfig`` and fed
+to the SDK ``resume=`` option, but nothing produced a usable value and the SDK
+transcript it pointed at lived on the pod's emptyDir (lost on any restart). This
+module is the sibling of ``memory.py`` (ADR-0025): the same durable state store,
+the same boot-preamble delivery, a different scope.
+
+Design (ADR-0029):
+
+- **History lives outside the sandbox** (ADR-0003, stateless-first). An unplanned
+  runner-pod restart is a new pod with empty scratch, so a restarted thread must
+  rehydrate from an external, durable resource reached over the network at boot.
+- **The backing reuses the durable state store** landed for #23/#248 and #264
+  (``apps/api`` ``/agents/{agent_id}/state/{namespace}/{key}``, Postgres JSONB),
+  rather than inventing a new datastore. The thread's transcript is the
+  log-shaped key ``.../state/transcript/<thread_key>``: the ``append`` endpoint
+  gives the append-only write and ``get`` gives load.
+- **Harness-agnostic delivery.** Loaded turns are composed into the effective
+  system prompt as a conversation preamble, not replayed through any one
+  harness's resume API, so a second harness (ADR-0011/0021) rehydrates the same
+  way.
+
+``AGENTOS_HISTORY_REF`` resolution: the ref is the URL of the thread's transcript
+key on the state API (e.g. ``http://api:8000/agents/<id>/state/transcript/<thread>``).
+The runner authenticates with ``AGENTOS_HISTORY_TOKEN`` (a runner-local knob, like
+``AGENTOS_MEMORY_TOKEN`` -- NOT part of the frozen ACI ``SessionConfig``, so no
+frozen-contract change). An ``s3://`` or other scheme is reserved for a future
+loader and rejected loudly today.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+# Runner-local env carrying the bearer the state API expects (X-API-Key). Not a
+# model credential and not part of the frozen ACI SessionConfig -- resolved the
+# same way as AGENTOS_MEMORY_TOKEN and the other runner-local knobs.
+HISTORY_TOKEN_ENV = "AGENTOS_HISTORY_TOKEN"
+
+
+class HistoryError(RuntimeError):
+    """A history reference could not be resolved or dereferenced."""
+
+
+@dataclass(frozen=True)
+class TurnRecord:
+    """One conversation turn: the user message and the assistant's reply.
+
+    ``ts`` is set at append time (RFC3339 UTC) so a reloaded transcript keeps its
+    order and a turn is timestamped for debugging. The pair is the minimal
+    harness-agnostic unit: any harness can render it as prior context.
+    """
+
+    user: str
+    assistant: str
+    ts: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"user": self.user, "assistant": self.assistant, "ts": self.ts}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> TurnRecord:
+        return cls(
+            user=data.get("user", ""),
+            assistant=data.get("assistant", ""),
+            ts=data.get("ts", ""),
+        )
+
+
+@runtime_checkable
+class TranscriptStore(Protocol):
+    """The history port: load prior turns, append the latest one.
+
+    Deliberately narrow -- no query language, no summarization (windowing is a
+    later slice). A concrete store dereferences a ``history_ref`` to a durable,
+    rehydratable backing that lives outside the sandbox.
+    """
+
+    async def load(self) -> list[TurnRecord]:
+        """Return prior turns, oldest first (empty when none)."""
+        ...
+
+    async def append(self, record: TurnRecord) -> None:
+        """Durably append one turn; it must survive an unplanned restart."""
+        ...
+
+
+class NullTranscriptStore:
+    """The no-history store used when ``AGENTOS_HISTORY_REF`` is unset.
+
+    ``load`` yields nothing and ``append`` is a silent no-op, so the boot and
+    per-turn paths are uniform whether or not a thread has a transcript ref.
+    """
+
+    async def load(self) -> list[TurnRecord]:
+        return []
+
+    async def append(self, record: TurnRecord) -> None:  # noqa: ARG002 - null sink
+        return None
+
+
+class StateApiTranscriptStore:
+    """Transcript backed by the durable state store (#23/#248/#264), the default.
+
+    ``history_ref`` is the URL of the thread's transcript key on the state API
+    (``.../agents/<id>/state/transcript/<thread_key>``). Load is a GET of that
+    key; append is a POST to the key's ``/append`` endpoint. The state API
+    enforces the size caps and the Postgres JSONB backing gives durability across
+    an unplanned restart for free.
+    """
+
+    def __init__(self, key_url: str, token: str | None) -> None:
+        # Normalize to no trailing slash so the /append URL composes cleanly.
+        self._key_url = key_url.rstrip("/")
+        self._token = token
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-API-Key": self._token} if self._token else {}
+
+    async def load(self) -> list[TurnRecord]:
+        timeout = aiohttp.ClientTimeout(total=15)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(self._key_url, headers=self._headers()) as resp:
+                if resp.status == 404:
+                    # No transcript written yet -- a fresh thread, not an error.
+                    return []
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise HistoryError(f"history load failed: {resp.status} {body[:200]}")
+                payload = await resp.json()
+        value = payload.get("value")
+        if not isinstance(value, list):
+            raise HistoryError("transcript log is not a JSON array")
+        turns: list[TurnRecord] = []
+        for item in value:
+            if isinstance(item, Mapping) and "user" in item:
+                turns.append(TurnRecord.from_dict(item))
+        return turns
+
+    async def append(self, record: TurnRecord) -> None:
+        timeout = aiohttp.ClientTimeout(total=15)
+        body = json.dumps({"item": record.to_dict()})
+        headers = {**self._headers(), "Content-Type": "application/json"}
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                f"{self._key_url}/append", data=body, headers=headers
+            ) as resp:
+                if resp.status not in (200, 201):
+                    text = await resp.text()
+                    raise HistoryError(f"history append failed: {resp.status} {text[:200]}")
+
+
+def resolve_history(history_ref: str | None, env: Mapping[str, str]) -> TranscriptStore:
+    """Resolve ``AGENTOS_HISTORY_REF`` to a concrete ``TranscriptStore`` at boot.
+
+    An absent ref yields the ``NullTranscriptStore`` (history is optional). An
+    ``http(s)://`` ref is the state-API transcript-key URL and yields the default
+    ``StateApiTranscriptStore``. Any other scheme (an old SDK ``resume`` id,
+    ``s3://``, ...) is reserved for a future loader and rejected loudly rather
+    than silently dropped, so a misconfigured ref fails visibly at boot.
+    """
+
+    if not history_ref:
+        return NullTranscriptStore()
+    if history_ref.startswith(("http://", "https://")):
+        return StateApiTranscriptStore(history_ref, env.get(HISTORY_TOKEN_ENV))
+    raise HistoryError(
+        f"unsupported AGENTOS_HISTORY_REF scheme: {history_ref!r} "
+        "(only http(s):// state-API refs are implemented today)"
+    )
+
+
+def format_conversation_preamble(records: Sequence[TurnRecord]) -> str | None:
+    """Render prior turns as a system-prompt preamble, or None when empty.
+
+    This is how a reloaded transcript is delivered into the sandbox: it is
+    composed into the runner's effective system prompt at boot, so a restarted
+    session sees the prior exchange as context (harness-agnostic -- it is plain
+    prompt text, not a resume through any one harness's API).
+    """
+
+    if not records:
+        return None
+    lines = [
+        "# Conversation so far (recovered after a restart)",
+        "",
+        "This thread continued from earlier turns. Prior exchange, oldest first:",
+        "",
+    ]
+    for record in records:
+        lines.append(f"User: {record.user}")
+        lines.append(f"Assistant: {record.assistant}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def utcnow_iso() -> str:
+    """An RFC3339 UTC timestamp for a turn record's ``ts``."""
+    return datetime.now(UTC).isoformat()

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -38,6 +38,7 @@ from claude_agent_sdk import AssistantMessage, ResultMessage
 
 from .adapter import ModelSession
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
+from .history import NullTranscriptStore, TranscriptStore, TurnRecord
 from .memory import (
     ConsolidationResult,
     MemoryRecord,
@@ -94,6 +95,7 @@ class SessionRunner:
         session_id: str | None = None,
         model: str | None = None,
         memory_store: MemoryStore | None = None,
+        history_store: TranscriptStore | None = None,
     ) -> None:
         self._factory = session_factory
         self._ceiling = ceiling
@@ -106,6 +108,11 @@ class SessionRunner:
         # via the system prompt; this store is the write side for learned records
         # (append + provenance). NullMemoryStore when no AGENTOS_MEMORY_REF.
         self._memory: MemoryStore = memory_store or NullMemoryStore()
+        # The conversation-history port (#20). Prior turns are loaded at boot and
+        # delivered via the system prompt; this store is the write side, appended
+        # once per successful turn so a restarted sandbox rehydrates the thread.
+        # NullTranscriptStore when no AGENTOS_HISTORY_REF.
+        self._history: TranscriptStore = history_store or NullTranscriptStore()
 
         self._session: ModelSession | None = None
         self._turn_lock = anyio.Lock()
@@ -157,6 +164,34 @@ class SessionRunner:
             ),
         )
         await self._memory.append(record)
+
+    async def _record_turn(self, event: Event, state: TurnState) -> None:
+        """Append one completed turn to the durable conversation transcript (#20).
+
+        Only a successful terminal final sets ``state.final_text``; a failed,
+        budget-halted, or auth-halted turn leaves it None and is not persisted, so
+        the transcript holds the delivered exchange, not error stubs. Best-effort:
+        a transient store failure is logged and never propagated -- recording
+        history must not fail a turn the user already received an answer to.
+        """
+
+        if state.final_text is None:
+            return
+        try:
+            await self._history.append(
+                TurnRecord(
+                    user=event.text,
+                    assistant=state.final_text,
+                    ts=utcnow_iso(),
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - best-effort; never fail a completed turn
+            logger.warning(
+                "history append failed session=%s error_class=%s: %s",
+                self._session_id,
+                type(exc).__name__,
+                exc,
+            )
 
     async def consolidate_memory(self) -> ConsolidationResult:
         """Compact accumulated memory, merging duplicates and unioning provenance.
@@ -253,6 +288,9 @@ class SessionRunner:
                         self._status.value,
                         int((time.monotonic() - start) * 1000),
                     )
+                    # Persist the completed turn to the durable transcript so a
+                    # restarted sandbox can rehydrate this thread (#20).
+                    await self._record_turn(event, state)
                 except Exception as exc:  # noqa: BLE001 - the ACI stream must
                     # always terminate in a final; a raised SDK/transport error
                     # (CLI disconnect, auth expiry, model error) becomes a
@@ -339,6 +377,9 @@ class SessionRunner:
                     final = self._reclassify(outbound)
                     self._status = final.status
                     self._turn_open = False
+                    # Capture the delivered reply so run_turn can persist the
+                    # {user, assistant} pair to the conversation transcript (#20).
+                    state.final_text = final.text
                     yield to_ndjson_line(final)
                     return
                 yield to_ndjson_line(outbound)

--- a/runner/src/agentos_runner/translate.py
+++ b/runner/src/agentos_runner/translate.py
@@ -50,6 +50,11 @@ class TurnState:
     # but their empty-signature thinking block trips the SDK's result extraction,
     # leaving ``ResultMessage.result`` empty (issue #107).
     assistant_text: str = ""
+    # The delivered text of the terminal ``final`` for a successful turn, set by
+    # the session loop when a DONE/idle final is produced. It is the assistant
+    # reply recorded into the conversation transcript (#20); left None on a
+    # failure/budget/auth final so those turns are not persisted as history.
+    final_text: str | None = None
 
 
 def translate_message(

--- a/runner/tests/test_history.py
+++ b/runner/tests/test_history.py
@@ -1,0 +1,270 @@
+"""The conversation-history port: resolution, turn shape, preamble, the state-API
+store, and the per-turn append that persists a thread's transcript (#20).
+
+The StateApiTranscriptStore is exercised against a tiny in-memory fake of the
+#248 log-shaped state endpoints (GET the key, POST .../append), so load/append
+round-trip over real HTTP without the API. The write side is exercised by driving
+a real turn through the SessionRunner with the fake model.
+"""
+
+import anyio
+import pytest
+from agentos_runner.history import (
+    HistoryError,
+    NullTranscriptStore,
+    StateApiTranscriptStore,
+    TranscriptStore,
+    TurnRecord,
+    format_conversation_preamble,
+    resolve_history,
+)
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+
+def _fake_state_app() -> tuple[web.Application, list]:
+    """A minimal fake of the state key at /agents/A/state/transcript/t1."""
+    log: list = []
+    app = web.Application()
+    key = "/agents/A/state/transcript/t1"
+
+    async def get_key(request: web.Request) -> web.Response:
+        if not log:
+            return web.json_response({"detail": "not found"}, status=404)
+        return web.json_response(
+            {"namespace": "transcript", "key": "t1", "value": list(log), "version": len(log)}
+        )
+
+    async def append_key(request: web.Request) -> web.Response:
+        body = await request.json()
+        log.append(body["item"])
+        return web.json_response(
+            {"namespace": "transcript", "key": "t1", "value": list(log), "version": len(log)}
+        )
+
+    app.router.add_get(key, get_key)
+    app.router.add_post(f"{key}/append", append_key)
+    return app, log
+
+
+def test_turn_record_round_trip() -> None:
+    rec = TurnRecord(
+        user="what changed?", assistant="the deploy bumped v3", ts="2026-07-14T00:00:00+00:00"
+    )
+    assert TurnRecord.from_dict(rec.to_dict()) == rec
+
+
+def test_resolve_absent_ref_is_null_store() -> None:
+    store = resolve_history(None, {})
+    assert isinstance(store, NullTranscriptStore)
+    assert anyio.run(store.load) == []
+    # Append on the null store is a silent no-op.
+    anyio.run(store.append, TurnRecord(user="u", assistant="a"))
+
+
+def test_resolve_http_ref_is_state_store() -> None:
+    store = resolve_history("http://api:8000/agents/A/state/transcript/t1", {})
+    assert isinstance(store, StateApiTranscriptStore)
+
+
+def test_resolve_unsupported_scheme_raises() -> None:
+    # An old SDK-resume id (or any non-http ref) is rejected loudly, not silently
+    # dropped, so a misconfigured ref fails visibly at boot.
+    with pytest.raises(HistoryError):
+        resolve_history("sdk-session-abc123", {})
+    with pytest.raises(HistoryError):
+        resolve_history("s3://bucket/hist", {})
+
+
+def test_preamble_empty_is_none() -> None:
+    assert format_conversation_preamble([]) is None
+
+
+def test_preamble_includes_user_and_assistant_text_oldest_first() -> None:
+    turns = [
+        TurnRecord(user="deploy the app", assistant="pushed to dev"),
+        TurnRecord(user="and prod?", assistant="promoted to prod"),
+    ]
+    preamble = format_conversation_preamble(turns)
+    assert preamble is not None
+    assert "deploy the app" in preamble
+    assert "pushed to dev" in preamble
+    assert "and prod?" in preamble
+    assert "promoted to prod" in preamble
+    # Oldest first: the first turn's user text precedes the second turn's.
+    assert preamble.index("deploy the app") < preamble.index("and prod?")
+
+
+def test_state_store_load_empty_is_empty() -> None:
+    app, _ = _fake_state_app()
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            url = str(server.make_url("/agents/A/state/transcript/t1"))
+            store = StateApiTranscriptStore(url, token=None)
+            assert await store.load() == []
+
+    anyio.run(go)
+
+
+def test_state_store_append_then_load_round_trip() -> None:
+    app, log = _fake_state_app()
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            url = str(server.make_url("/agents/A/state/transcript/t1"))
+            store = StateApiTranscriptStore(url, token="k")
+            await store.append(
+                TurnRecord(user="q1", assistant="a1", ts="2026-07-14T00:00:00+00:00")
+            )
+            await store.append(TurnRecord(user="q2", assistant="a2"))
+            loaded = await store.load()
+            assert loaded == [
+                TurnRecord(user="q1", assistant="a1", ts="2026-07-14T00:00:00+00:00"),
+                TurnRecord(user="q2", assistant="a2"),
+            ]
+            assert len(log) == 2
+
+    anyio.run(go)
+
+
+def test_state_store_load_rejects_non_array() -> None:
+    app = web.Application()
+
+    async def get_key(_request: web.Request) -> web.Response:
+        return web.json_response(
+            {"namespace": "transcript", "key": "t1", "value": {"not": "a list"}, "version": 1}
+        )
+
+    app.router.add_get("/agents/A/state/transcript/t1", get_key)
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            url = str(server.make_url("/agents/A/state/transcript/t1"))
+            store = StateApiTranscriptStore(url, token=None)
+            with pytest.raises(HistoryError):
+                await store.load()
+
+    anyio.run(go)
+
+
+def _recording_runner(store: TranscriptStore):
+    """A SessionRunner wired to the fake model and a recording transcript store."""
+    from agentos_runner import RunTracer, SideEffectClassifier
+    from agentos_runner.fake import FakeModelSession, default_turn
+    from agentos_runner.session import SessionRunner
+
+    return SessionRunner(
+        session_factory=lambda: FakeModelSession(default_turn),
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+        session_id="sess-hist",
+        history_store=store,
+    )
+
+
+class _RecordingStore:
+    def __init__(self) -> None:
+        self.turns: list[TurnRecord] = []
+
+    async def load(self) -> list[TurnRecord]:
+        return list(self.turns)
+
+    async def append(self, record: TurnRecord) -> None:
+        self.turns.append(record)
+
+
+def test_successful_turn_is_appended_to_the_transcript() -> None:
+    from aci_protocol import Event
+
+    store = _RecordingStore()
+    runner = _recording_runner(store)
+
+    async def go() -> None:
+        await runner.start()
+        async for _line in runner.run_inbound(
+            Event(type="message", text="what changed?", user="U", ts="1")
+        ):
+            pass
+
+    anyio.run(go)
+
+    assert len(store.turns) == 1
+    assert store.turns[0].user == "what changed?"
+    # default_turn's terminal result text.
+    assert store.turns[0].assistant == "all done"
+    assert store.turns[0].ts  # a timestamp was stamped
+
+
+def test_failed_turn_is_not_appended() -> None:
+    # A turn that never produced a successful terminal final (final_text stays
+    # None) must not be recorded, so the transcript holds only delivered answers.
+    from aci_protocol import Event
+    from agentos_runner import RunTracer, SideEffectClassifier
+    from agentos_runner.session import SessionRunner
+    from agentos_runner.translate import TurnState
+
+    store = _RecordingStore()
+    runner = SessionRunner(
+        session_factory=lambda: None,  # type: ignore[arg-type,return-value]
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+        session_id="s",
+        history_store=store,
+    )
+    event = Event(type="message", text="q", user="U", ts="1")
+
+    # final_text None (a failed/aborted turn) -> no append.
+    anyio.run(lambda: runner._record_turn(event, TurnState()))
+    assert store.turns == []
+
+    # final_text set (a delivered answer) -> appended.
+    state = TurnState()
+    state.final_text = "the answer"
+    anyio.run(lambda: runner._record_turn(event, state))
+    assert len(store.turns) == 1
+    assert store.turns[0].assistant == "the answer"
+
+
+def test_compose_system_prompt_orders_memory_then_conversation_then_base() -> None:
+    # Boot delivery (ADR-0029): durable memory leads, then this thread's recovered
+    # conversation, then the bundle/env system prompt. Any part may be absent.
+    from agentos_runner.__main__ import _compose_system_prompt
+
+    assert _compose_system_prompt("BASE", "MEM", "CONV") == "MEM\n\nCONV\n\nBASE"
+    assert _compose_system_prompt("BASE", None, "CONV") == "CONV\n\nBASE"
+    assert _compose_system_prompt("BASE", "MEM", None) == "MEM\n\nBASE"
+    assert _compose_system_prompt(None, None, None) is None
+
+
+def test_record_turn_swallows_store_failure() -> None:
+    # A transient store failure must never fail a turn the user already answered.
+    from aci_protocol import Event
+    from agentos_runner import RunTracer, SideEffectClassifier
+    from agentos_runner.session import SessionRunner
+    from agentos_runner.translate import TurnState
+
+    class _BoomStore:
+        async def load(self) -> list[TurnRecord]:
+            return []
+
+        async def append(self, record: TurnRecord) -> None:
+            raise HistoryError("state API unavailable")
+
+    runner = SessionRunner(
+        session_factory=lambda: None,  # type: ignore[arg-type,return-value]
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+        session_id="s",
+        history_store=_BoomStore(),
+    )
+    state = TurnState()
+    state.final_text = "answer"
+    # Must not raise.
+    anyio.run(lambda: runner._record_turn(Event(type="message", text="q", user="U", ts="1"), state))


### PR DESCRIPTION
Closes #20.

An unplanned runner-pod restart mid-thread currently drops the conversation: the worker's route stays `LIVE` with no history ref, the next claim cold-boots a fresh, history-less sandbox, and the user is silently talking to an amnesiac agent. (The suspend/resume path meant to rehydrate is also unreached in production and pointed the SDK `resume=` at transcript files that died with the pod's emptyDir, so this is really built end-to-end for the first time.)

This persists each thread's transcript to the durable state store and replays it into a restarted sandbox as a boot preamble.

## Approach: Option B (platform-owned, harness-agnostic), per ADR-0029

Chosen over Option A (surface the SDK `session_id` on the ACI `Final` frame, persist the SDK's transcript files, `resume=<id>`), which locks rehydration to claude-agent-sdk against the multi-harness direction of ADR-0011/0021 and needs a frozen-contract change. This is the **sibling of the memory port (ADR-0025)**: same durable state store, same boot-preamble delivery, scoped per-thread instead of per-agent.

## What changed

- **`runner/history.py` (new):** the `TranscriptStore` port + `StateApiTranscriptStore` first loader + `NullTranscriptStore` + `resolve_history` + `format_conversation_preamble`, mirroring `memory.py`. A thread's transcript is the log-shaped state key `/agents/<id>/state/transcript/<thread_key>`; `load` GETs it, `append` POSTs one turn to `/append`.
- **Runner boot** (`__main__.py`): resolves `AGENTOS_HISTORY_REF`, loads prior turns, composes them into the system prompt after the memory preamble, and **stops feeding `history_ref` to the SDK `resume=` path** (harness-agnostic replay instead).
- **Per-turn write** (`session.py`/`translate.py`): after each successful terminal `final`, the runner appends `{user, assistant}` (`SessionRunner._record_turn`), best-effort so a store blip never fails a turn; failed/budget/auth turns are not recorded.
- **Worker** (`binding.boot_env`): sets `AGENTOS_HISTORY_REF` to the thread's transcript-key URL (URL-encoded thread key) and forwards the API key as `AGENTOS_HISTORY_TOKEN`. The ref is **deterministic per (agent, thread)**, so a fresh, restarted, or resumed sandbox all boot with the same ref and rehydrate identically — the unplanned-restart case needs no special worker/kernel branch.
- **Docs:** ADR-0029, a `conversation-history` seam INTERFACE.md + index entry, and updated runner/worker `CLAUDE.md` rehydrate notes (the old "surface the SDK session id, it's an aci-protocol change, stop and raise it" note is obsolete under this approach).

**No frozen-contract change** (`AGENTOS_HISTORY_REF` is a runner-local env, not a `SessionConfig` field), **no `kernel.py` change**, **no new datastore**, **no chart change**.

## Design notes (for review)
- **Reuses ADR-0025's state store**, not a new S3/Valkey store — one durability story. The generic `/{agent_id}/state/{namespace}/{key}` + `/append` contract was confirmed against the real `apps/api` router (no namespace allowlist), so `transcript/<thread>` behaves exactly like memory's `memory/log`.
- **Known limitations (documented in ADR-0029 + INTERFACE.md):** the transcript is an unbounded append log under the state-store size caps, so a very long thread eventually hits the cap (windowing/summarization deferred); the replay is a prompt preamble, not a token-exact prompt-cache restore (consistent with ADR-0003's cache-cold-on-restart); the shared state-API key is forwarded as the history token (same auth-hardening follow-up as memory).

## Verification
- `uv run ruff check .` and `uv run mypy` clean (111 source files).
- `pytest`: aci-protocol + runner + worker + dispatcher, **556 passed / 4 skipped**, against real Valkey + Postgres. New tests: the store loads/appends over real HTTP (incl. 404-empty and non-array rejection), resolve rejects non-http refs, the runner appends a completed turn through a real fake-model turn (and `_record_turn` skips a `final_text`-None turn and swallows a store failure), the boot preamble orders memory then conversation then base, and the worker sets a deterministic, URL-encoded per-thread history ref (omitting the token without an API key).
- `scripts/check-contracts.sh` passes (no frozen-contract change).

Note: live proof of the pod-death-then-rehydrate path needs a real cluster and is deferred; the load-as-preamble mechanism and the per-turn append are verified at boot/turn without killing a pod.