### PR TITLE
Harden git-flow image and API conflict/report paths

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,6 +22,13 @@ COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package agentos-api
 
 FROM python:3.13-slim
+# git is a RUNTIME dependency: the git-flow engine (gitflow.py) shells out to
+# `git clone --mirror` / `git archive` to build a bundle from a pushed sha. The
+# slim base does not ship it, so without this a push webhook fails
+# `git.archive_failed` and no deploy is ever built.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
 RUN groupadd -g 1000 app && useradd -u 1000 -g app -m -d /home/app app
 WORKDIR /app
 COPY --from=builder --chown=app:app /app/.venv /app/.venv

--- a/apps/api/src/agentos_api/github_checks.py
+++ b/apps/api/src/agentos_api/github_checks.py
@@ -6,9 +6,12 @@ failure, with the familiar "34/36 passed" description. The GitHub client is
 injectable so it can be mocked in tests.
 """
 
+import logging
 from typing import Literal
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 State = Literal["success", "failure", "pending", "error"]
 
@@ -55,6 +58,21 @@ class GitHubStatusReporter:
         target_url: str | None = None,
     ) -> State:
         state, description = eval_state(passed_count, total)
+        if not self._token.strip():
+            # No GitHub credential configured (local/dev, or a deploy without a
+            # GitHub App). There is nothing to post a commit status to, so skip
+            # the network call and return the computed state. Posting with an
+            # empty token sends an "Authorization: Bearer " header that httpx
+            # rejects (LocalProtocolError), which would 500 an otherwise
+            # successful eval report.
+            logger.info(
+                "no GitHub token configured; skipping commit-status post "
+                "for %s@%s (%s)",
+                repo_full_name,
+                sha,
+                description,
+            )
+            return state
         payload: dict[str, str] = {
             "state": state,
             "context": self._context,

--- a/apps/api/src/agentos_api/routers/agents.py
+++ b/apps/api/src/agentos_api/routers/agents.py
@@ -3,6 +3,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from starlette.concurrency import run_in_threadpool
 
 from .. import bundles, crud
@@ -25,7 +26,21 @@ router = APIRouter(
 
 @router.post("", response_model=AgentOut, status_code=status.HTTP_201_CREATED)
 async def create_agent(data: AgentCreate, session: SessionDep) -> AgentOut:
-    agent = await crud.create_agent(session, data)
+    # name and repo_full_name are unique. A collision is a caller conflict (409),
+    # not a server fault: catch the DB IntegrityError and map it, rather than
+    # letting it bubble as an opaque 500.
+    try:
+        agent = await crud.create_agent(session, data)
+    except IntegrityError as exc:
+        await session.rollback()
+        detail = str(exc.orig)
+        if "repo_full_name" in detail:
+            message = "an agent for that repository already exists"
+        elif "name" in detail:
+            message = "an agent with that name already exists"
+        else:
+            message = "agent violates a uniqueness constraint"
+        raise HTTPException(status.HTTP_409_CONFLICT, message) from exc
     return AgentOut.model_validate(agent)
 
 

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -1,0 +1,46 @@
+"""POST /agents conflict handling: a duplicate is a 409, not a 500.
+
+Real Postgres round-trip (the disposable-DB conftest provisions and migrates a
+throwaway database per run); name and repo_full_name are unique columns, so a
+collision must surface as a caller conflict, not an opaque server error.
+"""
+
+from typing import Any
+
+
+def _create(client: Any, headers: dict[str, str], **fields: Any) -> Any:
+    return client.post("/agents", json=fields, headers=headers)
+
+
+def test_duplicate_name_is_409(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    first = _create(client, auth_headers, name="dup-name", slack_channel="C0AAAAAA1")
+    assert first.status_code == 201, first.text
+
+    dup = _create(client, auth_headers, name="dup-name", slack_channel="C0BBBBBB2")
+    assert dup.status_code == 409, dup.text
+    assert "name" in dup.json()["detail"]
+
+
+def test_duplicate_repo_is_409(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    first = _create(
+        client,
+        auth_headers,
+        name="repo-agent-a",
+        slack_channel="C0CCCCCC3",
+        repo_full_name="octo/shared-repo",
+    )
+    assert first.status_code == 201, first.text
+
+    dup = _create(
+        client,
+        auth_headers,
+        name="repo-agent-b",
+        slack_channel="C0DDDDDD4",
+        repo_full_name="octo/shared-repo",
+    )
+    assert dup.status_code == 409, dup.text
+    assert "repository" in dup.json()["detail"]

--- a/apps/api/tests/test_github_checks.py
+++ b/apps/api/tests/test_github_checks.py
@@ -66,6 +66,26 @@ def test_report_eval_success_state() -> None:
     assert state == "success"
 
 
+def test_report_eval_skips_post_when_no_token() -> None:
+    # With no GitHub token (local/dev, or a deploy without a GitHub App) there is
+    # nothing to post a commit status to. The reporter must skip the network call
+    # entirely and return the computed state, rather than sending an empty
+    # "Authorization: Bearer " header that httpx rejects (LocalProtocolError),
+    # which would 500 an otherwise successful eval report.
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+        raise AssertionError("no GitHub request should be made without a token")
+
+    async def go() -> str:
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(transport=transport) as client:
+            reporter = GitHubStatusReporter(
+                client, api_url="https://api.github.com", token="", context="c"
+            )
+            return await reporter.report_eval("octo/demo", "abc123", 7, 7)
+
+    assert asyncio.run(go()) == "success"
+
+
 def test_report_eval_raises_typed_error_on_github_rejection() -> None:
     # An unknown repo/commit (or a bad token) makes GitHub reject the post. The
     # reporter must surface that as a typed GitHubReportError carrying the


### PR DESCRIPTION
## What

Three fixes surfaced by running the `git push` -> deploy -> eval pipeline end to end against the local compose stack. Each is small, isolated, and tested.

## Fixes

1. **git missing from the api image (blocks git-flow).** `gitflow.py` builds a bundle by shelling out to `git clone --mirror` and `git archive`, but the runtime stage of `apps/api/Dockerfile` (python:3.13-slim) never installs git. In the published image every push webhook fails `git.archive_failed` and no deploy is built, so "git push is the deploy" does not work in the shipped image. Fix: install git in the runtime stage.

2. **/evals/report 500s with no GitHub token (blocks the eval CI gate).** The eval reporter posts a GitHub commit status; with no token configured it sends `Authorization: Bearer ` (empty), which httpx rejects with `LocalProtocolError`, returning 500 for the whole report even though the eval ran and scored. The Langfuse recording is unaffected, so only the commit-status callback breaks. Fix: `GitHubStatusReporter.report_eval` skips the network call and returns the computed state when the token is blank.

3. **Duplicate agent create returns 500 instead of 409 (robustness).** `POST /agents` let a unique-constraint violation on `name` or `repo_full_name` bubble as an opaque 500. Fix: map the `IntegrityError` to a 409 with a clear message.

## How it was found

Ran the full pipeline on the compose stack: signed a GitHub push webhook, watched git-flow build and deploy, and the eval consumer run the suite on a real model. Fix 1 blocked the build until git was present; fix 2 returned 500 on the report even after 7/7 passed; fix 3 surfaced while registering the agent.

## Verification

- New tests: a no-token reporter case that asserts zero GitHub calls, and duplicate-agent 409 cases for both `name` and `repo_full_name`.
- `ruff check`, `mypy` (strict, 101 files), and the api suite pass, including `test_gitflow_integration` and `test_openapi_drift` (no drift).
- End to end on a rebuilt api image: `git push` deploys the bundle, the eval gate runs 7/7, and `/evals/report` returns 200.