### PR TITLE
Add interactive AgentOS terminal UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ your PATH (from the Quickstart above), the binary pulls the pinned runner
 image from GHCR on first run — nothing to build:
 
 ```bash
+agentos   # optional full-screen terminal UI for the same workflows
 agentos init my-agent && cd my-agent
 # Real model is the default. Export a credential first (forwarded into the runner
 # container): CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, or AGENTOS_CREDENTIALS.

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2,7 +2,7 @@
 // Do not edit by hand. Run `pnpm gen:manifest` (or any pre* script) to refresh.
 /* eslint-disable */
 export const commandManifest = {
-  "about": "AgentOS CLI: run a plugin locally, no Slack workspace needed",
+  "about": "AgentOS CLI: run `agentos` for the interactive terminal, or pass a subcommand for scripts",
   "args": [
     {
       "global": true,
@@ -1888,6 +1888,12 @@ export const commandManifest = {
       "hidden": false,
       "long_about": "Bootstrap a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo build` in `cli`, then builds the runner image. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
       "name": "install"
+    },
+    {
+      "about": "Open the interactive terminal interface",
+      "hidden": false,
+      "long_about": "Open the interactive terminal interface.\n\nA keyboard-driven terminal UI for humans: browse targets and actions, preview exact commands, fill required values, and run workflows without memorizing the full command surface.",
+      "name": "interactive"
     },
     {
       "about": "Run a repo dev script (contracts, chart-check, e2e) -- source checkout only",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -19,11 +19,14 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "crossterm",
+ "dotenvy",
  "flate2",
  "futures-util",
  "getrandom 0.4.3",
  "indicatif",
  "jsonschema",
+ "ratatui",
  "redis",
  "regex",
  "reqwest",
@@ -129,6 +132,15 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arcstr"
@@ -247,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,15 +272,24 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -352,6 +379,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +411,15 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -397,6 +447,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +520,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +551,27 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email_address"
@@ -481,6 +635,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -653,6 +813,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -680,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -690,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -856,6 +1027,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +1067,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1099,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -955,6 +1163,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +1186,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +1211,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -994,6 +1234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,9 +1256,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "micromap"
@@ -1045,11 +1294,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1139,6 +1389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1414,30 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "parking"
@@ -1331,10 +1614,76 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis"
-version = "1.3.0"
+name = "ratatui"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa6f8e4b491d7a8ef3a9550a4d71969bd0064f46e32b8dbbcc7fc60dad94fed"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "redis"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb5358643f48330db5c78856982faf39c93ba50c60d682b43d0344a3b649769"
 dependencies = [
  "arcstr",
  "async-lock",
@@ -1391,7 +1740,7 @@ dependencies = [
  "ahash",
  "fluent-uri",
  "getrandom 0.3.4",
- "hashbrown",
+ "hashbrown 0.17.1",
  "itoa",
  "micromap",
  "parking_lot",
@@ -1491,6 +1840,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "once_cell",
  "ring",
@@ -1540,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1555,6 +1913,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1629,6 +1993,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -1658,9 +2043,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1673,10 +2058,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1766,7 +2178,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -1801,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1953,6 +2367,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,9 +2427,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2147,6 +2578,28 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2369,6 +2822,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,6 +20,11 @@ axum = { version = "0.8", default-features = false, features = [
     "json",
 ] }
 clap = { version = "4", features = ["derive", "env"] }
+crossterm = "0.29"
+# Reads `.env` files (repo-root + bundle-local) into the process env so
+# `skill up` config lives in files the CLI owns rather than ambient shell
+# exports. Non-overriding load: a real shell export always wins over a file.
+dotenvy = "0.15"
 flate2 = "1"
 futures-util = "0.3"
 indicatif = "0.18"
@@ -33,6 +38,7 @@ redis = { version = "1.3", default-features = false, features = [
     "tokio-comp",
     "streams",
 ] }
+ratatui = { version = "0.30", default-features = false, features = ["crossterm_0_29"] }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/cli/README.md
+++ b/cli/README.md
@@ -36,6 +36,7 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 |---|---|
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed, a root `AGENTS.md`, and an installable `.claude/skills/using-agentos/SKILL.md` harness primer. |
 | `agentos init --from-spec <path>` | Scaffold **non-interactively** from an agent-authored spec file (JSON). The bundle name comes from the spec, not a positional argument. A coding agent interviews the human, writes the spec, then this command lays down the same plugin-format shape deterministically -- zero prompts. See the spec shape below. |
+| `agentos` | Open the keyboard-driven terminal interface. Explicit forms: `agentos interactive`, `agentos ui`, `agentos tui`. |
 | `agentos guide` | Print a self-contained primer (ADR-0021) for a coding agent driving the harness: the parity ladder, when/which decision logic, the landmines, and verify-first, to stdout. `--json` emits the same content as a structured variant (data on stdout). |
 | `agentos build` | Build the runner image locally: `docker build -f runner/Dockerfile -t agentos-runner .` from the repo root (found by walking up to `runner/Dockerfile`). `--tag` overrides the tag. Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
 
@@ -79,6 +80,35 @@ with the platform grader, not an oversight.
 ```bash
 agentos init --from-spec agent-spec.json   # bundle name (deal-desk) comes from the spec
 ```
+
+## `agentos` / `agentos interactive`
+
+The interactive terminal interface is a human-friendly command surface over the
+same `agentos ...` subcommands documented here. It opens a full-screen TUI with
+target navigation, action selection, command previews, and guarded execution:
+when an action needs values (for example message text or a channel id), the TUI
+temporarily leaves the alternate screen, prompts for the values, runs the exact
+previewed command, then returns to the interface.
+
+```bash
+agentos
+agentos interactive
+agentos ui
+agentos tui
+```
+
+Keyboard:
+
+| Key | Action |
+|---|---|
+| `Up`/`Down` or `k`/`j` | Move through actions |
+| `Tab` / `Left` / `Right` | Switch target filters |
+| `Enter` or `r` | Prompt for fields and run the selected command |
+| `q` or `Esc` | Exit |
+
+The first surface focuses on the common inner-loop and operations paths:
+`skill up/message/eval`, `local up/message/status`, `cluster status/message`,
+`install`, and `dev contracts`.
 
 ## `agentos install`
 

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1,5 +1,5 @@
 {
-  "about": "AgentOS CLI: run a plugin locally, no Slack workspace needed",
+  "about": "AgentOS CLI: run `agentos` for the interactive terminal, or pass a subcommand for scripts",
   "args": [
     {
       "global": true,
@@ -1885,6 +1885,12 @@
       "hidden": false,
       "long_about": "Bootstrap a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo build` in `cli`, then builds the runner image. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
       "name": "install"
+    },
+    {
+      "about": "Open the interactive terminal interface",
+      "hidden": false,
+      "long_about": "Open the interactive terminal interface.\n\nA keyboard-driven terminal UI for humans: browse targets and actions, preview exact commands, fill required values, and run workflows without memorizing the full command surface.",
+      "name": "interactive"
     },
     {
       "about": "Run a repo dev script (contracts, chart-check, e2e) -- source checkout only",

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -1,0 +1,712 @@
+//! Interactive terminal interface for AgentOS.
+//!
+//! This is a ratatui/crossterm surface over the existing clap command grammar:
+//! it does not invent a second implementation path. The TUI helps a human pick
+//! a target and action, previews the exact `agentos ...` command, prompts for
+//! any required values, then suspends the alternate screen and runs that command
+//! as a normal child process.
+
+use std::collections::BTreeMap;
+use std::io::{self, IsTerminal, Write};
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::{Frame, Terminal};
+
+#[derive(Clone, Debug)]
+struct Recipe {
+    target: &'static str,
+    title: &'static str,
+    description: &'static str,
+    args: Vec<ArgPart>,
+    fields: Vec<Field>,
+    notes: &'static [&'static str],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ArgPart {
+    Literal(&'static str),
+    Field(&'static str),
+    OptionalFlag {
+        flag: &'static str,
+        field: &'static str,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct Field {
+    key: &'static str,
+    label: &'static str,
+    default: Option<&'static str>,
+    required: bool,
+}
+
+#[derive(Debug)]
+struct App {
+    recipes: Vec<Recipe>,
+    targets: Vec<&'static str>,
+    target_idx: usize,
+    selected: usize,
+    message: String,
+}
+
+pub async fn run() -> Result<()> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return Err(crate::exit::usage(
+            "agentos interactive requires an interactive terminal; use the regular agentos subcommands in non-interactive sessions",
+        ));
+    }
+    let mut app = App::new();
+    let mut terminal = TerminalSession::enter()?;
+    let result = event_loop(&mut terminal.terminal, &mut app);
+    terminal.leave()?;
+    result
+}
+
+fn event_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App) -> Result<()> {
+    loop {
+        terminal.draw(|frame| draw(frame, app))?;
+        if !event::poll(Duration::from_millis(200))? {
+            continue;
+        }
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if app.handle_key(key)? {
+            break;
+        }
+    }
+    Ok(())
+}
+
+impl App {
+    fn new() -> Self {
+        let recipes = recipes();
+        App {
+            recipes,
+            targets: vec!["all", "skill", "local", "cluster", "dev"],
+            target_idx: 0,
+            selected: 0,
+            message: "Select an action. Enter runs it; q exits.".into(),
+        }
+    }
+
+    fn visible_indices(&self) -> Vec<usize> {
+        let target = self.targets[self.target_idx];
+        self.recipes
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, recipe)| (target == "all" || recipe.target == target).then_some(idx))
+            .collect()
+    }
+
+    fn selected_recipe(&self) -> Option<&Recipe> {
+        self.visible_indices()
+            .get(self.selected)
+            .and_then(|idx| self.recipes.get(*idx))
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> Result<bool> {
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => return Ok(true),
+            (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(true),
+            (KeyCode::Down | KeyCode::Char('j'), _) => self.move_selection(1),
+            (KeyCode::Up | KeyCode::Char('k'), _) => self.move_selection(-1),
+            (KeyCode::Tab | KeyCode::Right, _) => self.next_target(),
+            (KeyCode::BackTab | KeyCode::Left, _) => self.prev_target(),
+            (KeyCode::Enter, _) | (KeyCode::Char('r'), _) => self.run_selected()?,
+            _ => {}
+        }
+        Ok(false)
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        let len = self.visible_indices().len();
+        if len == 0 {
+            self.selected = 0;
+            return;
+        }
+        self.selected = ((self.selected as isize + delta).rem_euclid(len as isize)) as usize;
+    }
+
+    fn next_target(&mut self) {
+        self.target_idx = (self.target_idx + 1) % self.targets.len();
+        self.selected = 0;
+    }
+
+    fn prev_target(&mut self) {
+        self.target_idx = if self.target_idx == 0 {
+            self.targets.len() - 1
+        } else {
+            self.target_idx - 1
+        };
+        self.selected = 0;
+    }
+
+    fn run_selected(&mut self) -> Result<()> {
+        let Some(recipe) = self.selected_recipe().cloned() else {
+            return Ok(());
+        };
+        suspend_terminal()?;
+        let result = prompt_and_run(&recipe);
+        resume_terminal()?;
+        self.message = match result {
+            Ok(()) => format!("Finished: {}", recipe.title),
+            Err(err) => format!("Command failed to start or complete: {err:#}"),
+        };
+        Ok(())
+    }
+}
+
+struct TerminalSession {
+    terminal: Terminal<CrosstermBackend<io::Stdout>>,
+    active: bool,
+}
+
+impl TerminalSession {
+    fn enter() -> Result<Self> {
+        enable_raw_mode().context("enabling terminal raw mode")?;
+        execute!(io::stdout(), EnterAlternateScreen).context("entering alternate screen")?;
+        let backend = CrosstermBackend::new(io::stdout());
+        let mut terminal = Terminal::new(backend).context("creating terminal")?;
+        terminal.clear().ok();
+        Ok(TerminalSession {
+            terminal,
+            active: true,
+        })
+    }
+
+    fn leave(&mut self) -> Result<()> {
+        if self.active {
+            disable_raw_mode().ok();
+            execute!(io::stdout(), LeaveAlternateScreen).context("leaving alternate screen")?;
+            self.active = false;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        let _ = self.leave();
+    }
+}
+
+fn suspend_terminal() -> Result<()> {
+    disable_raw_mode().ok();
+    execute!(io::stdout(), LeaveAlternateScreen).context("leaving alternate screen")
+}
+
+fn resume_terminal() -> Result<()> {
+    print!("Press Enter to return to AgentOS interactive...");
+    io::stdout().flush().ok();
+    let mut line = String::new();
+    let _ = io::stdin().read_line(&mut line);
+    execute!(io::stdout(), EnterAlternateScreen).context("entering alternate screen")?;
+    enable_raw_mode().context("enabling terminal raw mode")
+}
+
+fn prompt_and_run(recipe: &Recipe) -> Result<()> {
+    println!("AgentOS interactive: {}", recipe.title);
+    println!("{}", recipe.description);
+    println!();
+
+    let mut values = BTreeMap::new();
+    for field in &recipe.fields {
+        let value = prompt_field(field)?;
+        values.insert(field.key.to_string(), value);
+    }
+    let argv = build_argv(recipe, &values);
+    println!();
+    println!("$ {}", render_command(&argv));
+    println!();
+    let status = Command::new(std::env::current_exe().context("resolving current executable")?)
+        .args(&argv)
+        .status()
+        .context("running selected agentos command")?;
+    if !status.success() {
+        anyhow::bail!("selected command exited with {status}");
+    }
+    Ok(())
+}
+
+fn prompt_field(field: &Field) -> Result<String> {
+    loop {
+        match field.default {
+            Some(default) => print!("{} [{default}]: ", field.label),
+            None => print!("{}: ", field.label),
+        }
+        io::stdout().flush().ok();
+        let mut line = String::new();
+        io::stdin()
+            .read_line(&mut line)
+            .context("reading interactive answer")?;
+        let trimmed = line.trim();
+        let value = if trimmed.is_empty() {
+            field.default.unwrap_or("").to_string()
+        } else {
+            trimmed.to_string()
+        };
+        if !field.required || !value.is_empty() {
+            return Ok(value);
+        }
+        println!("{} is required.", field.label);
+    }
+}
+
+fn build_argv(recipe: &Recipe, values: &BTreeMap<String, String>) -> Vec<String> {
+    let mut argv = Vec::new();
+    for part in &recipe.args {
+        match part {
+            ArgPart::Literal(value) => argv.push((*value).to_string()),
+            ArgPart::Field(field) => {
+                if let Some(value) = values.get(*field) {
+                    if !value.is_empty() {
+                        argv.push(value.clone());
+                    }
+                }
+            }
+            ArgPart::OptionalFlag { flag, field } => {
+                if let Some(value) = values.get(*field) {
+                    if !value.is_empty() {
+                        argv.push((*flag).to_string());
+                        argv.push(value.clone());
+                    }
+                }
+            }
+        }
+    }
+    argv
+}
+
+fn render_command(argv: &[String]) -> String {
+    std::iter::once("agentos".to_string())
+        .chain(argv.iter().map(|arg| shell_quote(arg)))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote(arg: &str) -> String {
+    if arg
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || "-_./:=@".contains(c))
+    {
+        arg.to_string()
+    } else {
+        format!("'{}'", arg.replace('\'', "'\\''"))
+    }
+}
+
+fn draw(frame: &mut Frame<'_>, app: &App) {
+    let area = frame.area();
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(12),
+            Constraint::Length(3),
+        ])
+        .split(area);
+
+    draw_header(frame, layout[0], app);
+    draw_body(frame, layout[1], app);
+    draw_footer(frame, layout[2], app);
+}
+
+fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let title = Line::from(vec![
+        Span::styled("AgentOS", Style::default().fg(Color::Cyan).bold()),
+        Span::raw(" interactive  "),
+        Span::styled(
+            format!("target: {}", app.targets[app.target_idx]),
+            Style::default().fg(Color::Yellow),
+        ),
+    ]);
+    frame.render_widget(
+        Paragraph::new(title)
+            .alignment(Alignment::Center)
+            .block(Block::default().borders(Borders::ALL)),
+        area,
+    );
+}
+
+fn draw_body(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(18),
+            Constraint::Percentage(36),
+            Constraint::Percentage(64),
+        ])
+        .split(area);
+    draw_targets(frame, chunks[0], app);
+    draw_actions(frame, chunks[1], app);
+    draw_detail(frame, chunks[2], app);
+}
+
+fn draw_targets(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let items: Vec<ListItem<'_>> = app
+        .targets
+        .iter()
+        .map(|target| ListItem::new(Line::from(*target)))
+        .collect();
+    let mut state = ListState::default();
+    state.select(Some(app.target_idx));
+    frame.render_stateful_widget(
+        List::new(items)
+            .block(Block::default().title("Targets").borders(Borders::ALL))
+            .highlight_style(Style::default().fg(Color::Black).bg(Color::Cyan)),
+        area,
+        &mut state,
+    );
+}
+
+fn draw_actions(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let visible = app.visible_indices();
+    let items: Vec<ListItem<'_>> = visible
+        .iter()
+        .filter_map(|idx| app.recipes.get(*idx))
+        .map(|recipe| {
+            ListItem::new(vec![
+                Line::from(Span::styled(recipe.title, Style::default().bold())),
+                Line::from(Span::styled(
+                    recipe.description,
+                    Style::default().fg(Color::Gray),
+                )),
+            ])
+        })
+        .collect();
+    let mut state = ListState::default();
+    if !items.is_empty() {
+        state.select(Some(app.selected.min(items.len() - 1)));
+    }
+    frame.render_stateful_widget(
+        List::new(items)
+            .block(Block::default().title("Actions").borders(Borders::ALL))
+            .highlight_style(Style::default().fg(Color::Black).bg(Color::Green)),
+        area,
+        &mut state,
+    );
+}
+
+fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let Some(recipe) = app.selected_recipe() else {
+        frame.render_widget(Clear, area);
+        return;
+    };
+    let values: BTreeMap<String, String> = recipe
+        .fields
+        .iter()
+        .filter_map(|field| {
+            field
+                .default
+                .map(|value| (field.key.to_string(), value.to_string()))
+        })
+        .collect();
+    let preview = build_argv(recipe, &values);
+    let mut lines = vec![
+        Line::from(Span::styled(recipe.title, Style::default().bold())),
+        Line::from(""),
+        Line::from(recipe.description),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Command preview",
+            Style::default().fg(Color::Yellow).bold(),
+        )),
+        Line::from(render_command(&preview)),
+        Line::from(""),
+    ];
+    if !recipe.fields.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "Prompts before run",
+            Style::default().fg(Color::Yellow).bold(),
+        )));
+        for field in &recipe.fields {
+            let default = field.default.unwrap_or("required");
+            lines.push(Line::from(format!("{}: {default}", field.label)));
+        }
+        lines.push(Line::from(""));
+    }
+    if !recipe.notes.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "Notes",
+            Style::default().fg(Color::Yellow).bold(),
+        )));
+        for note in recipe.notes {
+            lines.push(Line::from(format!("- {note}")));
+        }
+    }
+    frame.render_widget(
+        Paragraph::new(Text::from(lines))
+            .wrap(Wrap { trim: false })
+            .block(Block::default().title("Details").borders(Borders::ALL)),
+        area,
+    );
+}
+
+fn draw_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let text = Line::from(vec![
+        Span::styled("Up/Down", Style::default().bold()),
+        Span::raw(" action  "),
+        Span::styled("Tab/Left/Right", Style::default().bold()),
+        Span::raw(" target  "),
+        Span::styled("Enter/r", Style::default().bold()),
+        Span::raw(" run  "),
+        Span::styled("q/Esc", Style::default().bold()),
+        Span::raw(" quit    "),
+        Span::styled(&app.message, Style::default().fg(Color::Gray)),
+    ]);
+    frame.render_widget(
+        Paragraph::new(text)
+            .alignment(Alignment::Center)
+            .block(Block::default().borders(Borders::ALL)),
+        area,
+    );
+}
+
+fn recipes() -> Vec<Recipe> {
+    vec![
+        Recipe {
+            target: "skill",
+            title: "Start runner",
+            description: "Boot the current plugin bundle in a local runner container.",
+            args: vec![
+                ArgPart::Literal("skill"),
+                ArgPart::Literal("up"),
+                ArgPart::OptionalFlag {
+                    flag: "--plugin-dir",
+                    field: "plugin_dir",
+                },
+                ArgPart::OptionalFlag {
+                    flag: "--model",
+                    field: "model",
+                },
+            ],
+            fields: vec![
+                Field {
+                    key: "plugin_dir",
+                    label: "Plugin directory",
+                    default: Some("."),
+                    required: false,
+                },
+                Field {
+                    key: "model",
+                    label: "Model id (optional)",
+                    default: None,
+                    required: false,
+                },
+            ],
+            notes: &[
+                "Use --fake-model or --local-model from the regular CLI when you need those modes.",
+            ],
+        },
+        Recipe {
+            target: "skill",
+            title: "Send skill message",
+            description: "Send a synthetic event to the local runner and stream the reply.",
+            args: vec![
+                ArgPart::Literal("skill"),
+                ArgPart::Literal("message"),
+                ArgPart::Field("text"),
+            ],
+            fields: vec![Field {
+                key: "text",
+                label: "Message text",
+                default: None,
+                required: true,
+            }],
+            notes: &["Requires a running `agentos skill up` session."],
+        },
+        Recipe {
+            target: "skill",
+            title: "Run skill eval",
+            description: "Run evals/cases.json through the local runner.",
+            args: vec![
+                ArgPart::Literal("skill"),
+                ArgPart::Literal("eval"),
+                ArgPart::OptionalFlag {
+                    flag: "--cases",
+                    field: "cases",
+                },
+            ],
+            fields: vec![Field {
+                key: "cases",
+                label: "Cases file",
+                default: Some("evals/cases.json"),
+                required: false,
+            }],
+            notes: &[],
+        },
+        Recipe {
+            target: "local",
+            title: "Start local stack",
+            description: "Bring up the compose stack for the local platform loop.",
+            args: vec![ArgPart::Literal("local"), ArgPart::Literal("up")],
+            fields: vec![],
+            notes: &["Use the regular CLI for --minimal, --slack, or --local-model variants."],
+        },
+        Recipe {
+            target: "local",
+            title: "Send local message",
+            description: "Drive the compose stack end to end with zero Slack contact.",
+            args: vec![
+                ArgPart::Literal("local"),
+                ArgPart::Literal("message"),
+                ArgPart::Field("text"),
+                ArgPart::OptionalFlag {
+                    flag: "--channel",
+                    field: "channel",
+                },
+            ],
+            fields: vec![
+                Field {
+                    key: "text",
+                    label: "Message text",
+                    default: None,
+                    required: true,
+                },
+                Field {
+                    key: "channel",
+                    label: "Slack channel id (optional)",
+                    default: None,
+                    required: false,
+                },
+            ],
+            notes: &["Requires `agentos local up` and a deployed local agent."],
+        },
+        Recipe {
+            target: "local",
+            title: "Local status",
+            description: "Show compose service status.",
+            args: vec![ArgPart::Literal("local"), ArgPart::Literal("status")],
+            fields: vec![],
+            notes: &[],
+        },
+        Recipe {
+            target: "cluster",
+            title: "Cluster status",
+            description: "Report release health and access URLs.",
+            args: vec![
+                ArgPart::Literal("cluster"),
+                ArgPart::Literal("status"),
+                ArgPart::OptionalFlag {
+                    flag: "--namespace",
+                    field: "namespace",
+                },
+                ArgPart::OptionalFlag {
+                    flag: "--release",
+                    field: "release",
+                },
+            ],
+            fields: vec![
+                Field {
+                    key: "namespace",
+                    label: "Namespace",
+                    default: Some("agentos"),
+                    required: false,
+                },
+                Field {
+                    key: "release",
+                    label: "Release",
+                    default: Some("agentos"),
+                    required: false,
+                },
+            ],
+            notes: &[],
+        },
+        Recipe {
+            target: "cluster",
+            title: "Send cluster message",
+            description: "Drive a deployed release end to end with zero Slack contact.",
+            args: vec![
+                ArgPart::Literal("cluster"),
+                ArgPart::Literal("message"),
+                ArgPart::Field("text"),
+                ArgPart::OptionalFlag {
+                    flag: "--channel",
+                    field: "channel",
+                },
+            ],
+            fields: vec![
+                Field {
+                    key: "text",
+                    label: "Message text",
+                    default: None,
+                    required: true,
+                },
+                Field {
+                    key: "channel",
+                    label: "Slack channel id (optional)",
+                    default: None,
+                    required: false,
+                },
+            ],
+            notes: &["Requires an installed release and a deployed agent."],
+        },
+        Recipe {
+            target: "dev",
+            title: "Install checkout",
+            description: "Bootstrap a dev checkout: deps, CLI build, runner image.",
+            args: vec![ArgPart::Literal("install")],
+            fields: vec![],
+            notes: &["Starts nothing; run once after cloning."],
+        },
+        Recipe {
+            target: "dev",
+            title: "Check contracts",
+            description: "Run the frozen contract drift checks.",
+            args: vec![ArgPart::Literal("dev"), ArgPart::Literal("contracts")],
+            fields: vec![],
+            notes: &[],
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_argv_omits_empty_optional_flags() {
+        let recipe = Recipe {
+            target: "skill",
+            title: "x",
+            description: "x",
+            args: vec![
+                ArgPart::Literal("skill"),
+                ArgPart::Literal("message"),
+                ArgPart::Field("text"),
+                ArgPart::OptionalFlag {
+                    flag: "--channel",
+                    field: "channel",
+                },
+            ],
+            fields: vec![],
+            notes: &[],
+        };
+        let mut values = BTreeMap::new();
+        values.insert("text".to_string(), "hello world".to_string());
+        values.insert("channel".to_string(), String::new());
+        assert_eq!(
+            build_argv(&recipe, &values),
+            vec!["skill", "message", "hello world"]
+        );
+    }
+
+    #[test]
+    fn render_command_quotes_shell_specials() {
+        let argv = vec!["skill".into(), "message".into(), "hello world".into()];
+        assert_eq!(render_command(&argv), "agentos skill message 'hello world'");
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -15,6 +15,7 @@ pub mod eval_init;
 pub mod evals;
 pub mod exit;
 pub mod guide;
+pub mod interactive;
 pub mod local;
 pub mod message;
 pub mod ndjson;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,11 +23,11 @@ use clap::{Parser, Subcommand};
 #[command(
     name = "agentos",
     version,
-    about = "AgentOS CLI: run a plugin locally, no Slack workspace needed"
+    about = "AgentOS CLI: run `agentos` for the interactive terminal, or pass a subcommand for scripts"
 )]
 struct Cli {
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
     /// Show verbose plumbing (helm/kubectl/rollout/port-forward).
     #[arg(
         long,
@@ -108,6 +108,13 @@ enum Command {
     /// release binary has no source tree to install and errors clearly; a
     /// missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.
     Install,
+    /// Open the interactive terminal interface.
+    ///
+    /// A keyboard-driven terminal UI for humans: browse targets and actions,
+    /// preview exact commands, fill required values, and run workflows without
+    /// memorizing the full command surface.
+    #[command(alias = "ui", alias = "tui")]
+    Interactive,
     /// Run a repo dev script (contracts, chart-check, e2e) -- source checkout only.
     ///
     /// Thin wrappers over the repo's dev scripts so contributors get a unified
@@ -861,25 +868,29 @@ async fn main() {
     }
 }
 
-/// Dispatch one parsed command. Returns the command's `Result`; `main`
+/// Dispatch one parsed command. No subcommand opens the interactive terminal,
+/// matching `agentos interactive` / `agentos ui`. Returns the command's
+/// `Result`; `main`
 /// classifies any error into a semantic exit code (see `agentos::exit`).
-async fn run(command: Command) -> Result<()> {
+async fn run(command: Option<Command>) -> Result<()> {
     match command {
-        Command::Init {
+        None => agentos::interactive::run().await,
+        Some(Command::Init {
             name,
             dir,
             from_spec,
-        } => commands::init(name, dir, from_spec),
-        Command::Build { tag } => commands::build(&tag).await,
-        Command::Install => commands::install().await,
-        Command::Dev { action } => match action {
+        }) => commands::init(name, dir, from_spec),
+        Some(Command::Build { tag }) => commands::build(&tag).await,
+        Some(Command::Install) => commands::install().await,
+        Some(Command::Interactive) => agentos::interactive::run().await,
+        Some(Command::Dev { action }) => match action {
             DevAction::Contracts => commands::dev_script("scripts/check-contracts.sh").await,
             DevAction::ChartCheck => {
                 commands::dev_script("charts/agentos/ci/render-assertions.sh").await
             }
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
         },
-        Command::Skill { action } => match action {
+        Some(Command::Skill { action }) => match action {
             SkillAction::Up {
                 plugin_dir,
                 image,
@@ -938,7 +949,7 @@ async fn run(command: Command) -> Result<()> {
                 agentos::eval_init::run(agentos::eval_init::EvalInitOpts { out, force })
             }
         },
-        Command::Local { action } => match action {
+        Some(Command::Local { action }) => match action {
             LocalAction::Up {
                 file,
                 dry_run,
@@ -1124,7 +1135,7 @@ async fn run(command: Command) -> Result<()> {
                 .await
             }
         },
-        Command::Cluster { action } => match action {
+        Some(Command::Cluster { action }) => match action {
             ClusterAction::Up {
                 namespace,
                 release,
@@ -1456,12 +1467,12 @@ async fn run(command: Command) -> Result<()> {
                 .await
             }
         },
-        Command::Schema => {
+        Some(Command::Schema) => {
             use clap::CommandFactory;
             print!("{}", agentos::schema::manifest_json(&Cli::command()));
             Ok(())
         }
-        Command::Guide => agentos::guide::run(),
+        Some(Command::Guide) => agentos::guide::run(),
     }
 }
 
@@ -1479,21 +1490,38 @@ mod tests {
     fn build_defaults_tag_and_accepts_override() {
         let cli = Cli::try_parse_from(["agentos", "build"]).expect("build should parse");
         match cli.command {
-            Command::Build { tag } => assert_eq!(tag, "agentos-runner"),
+            Some(Command::Build { tag }) => assert_eq!(tag, "agentos-runner"),
             _ => panic!("expected build command"),
         }
         let cli = Cli::try_parse_from(["agentos", "build", "--tag", "my-runner:dev"])
             .expect("build --tag should parse");
         match cli.command {
-            Command::Build { tag } => assert_eq!(tag, "my-runner:dev"),
+            Some(Command::Build { tag }) => assert_eq!(tag, "my-runner:dev"),
             _ => panic!("expected build command"),
         }
     }
 
     #[test]
+    fn no_subcommand_defaults_to_interactive() {
+        let cli = Cli::try_parse_from(["agentos"]).expect("bare agentos should parse");
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
     fn install_parses() {
         let cli = Cli::try_parse_from(["agentos", "install"]).expect("install should parse");
-        assert!(matches!(cli.command, Command::Install));
+        assert!(matches!(cli.command, Some(Command::Install)));
+    }
+
+    #[test]
+    fn interactive_parses_with_aliases() {
+        let cli =
+            Cli::try_parse_from(["agentos", "interactive"]).expect("interactive should parse");
+        assert!(matches!(cli.command, Some(Command::Interactive)));
+        let cli = Cli::try_parse_from(["agentos", "ui"]).expect("ui alias should parse");
+        assert!(matches!(cli.command, Some(Command::Interactive)));
+        let cli = Cli::try_parse_from(["agentos", "tui"]).expect("tui alias should parse");
+        assert!(matches!(cli.command, Some(Command::Interactive)));
     }
 
     #[test]
@@ -1502,24 +1530,24 @@ mod tests {
             .expect("dev contracts should parse");
         assert!(matches!(
             cli.command,
-            Command::Dev {
+            Some(Command::Dev {
                 action: DevAction::Contracts
-            }
+            })
         ));
         let cli = Cli::try_parse_from(["agentos", "dev", "chart-check"])
             .expect("dev chart-check should parse");
         assert!(matches!(
             cli.command,
-            Command::Dev {
+            Some(Command::Dev {
                 action: DevAction::ChartCheck
-            }
+            })
         ));
         let cli = Cli::try_parse_from(["agentos", "dev", "e2e"]).expect("dev e2e should parse");
         assert!(matches!(
             cli.command,
-            Command::Dev {
+            Some(Command::Dev {
                 action: DevAction::E2e
-            }
+            })
         ));
     }
 
@@ -1528,9 +1556,9 @@ mod tests {
         let cli = Cli::try_parse_from(["agentos", "local", "message", "--api-key", "K", "hi"])
             .expect("local message --api-key should parse");
         match cli.command {
-            Command::Local {
+            Some(Command::Local {
                 action: LocalAction::Message { api_key, .. },
-            } => assert_eq!(api_key, "K"),
+            }) => assert_eq!(api_key, "K"),
             _ => panic!("expected local message command"),
         }
     }
@@ -1540,7 +1568,7 @@ mod tests {
         let cli = Cli::try_parse_from(["agentos", "cluster", "deploy"])
             .expect("cluster deploy should parse");
         match cli.command {
-            Command::Cluster {
+            Some(Command::Cluster {
                 action:
                     ClusterAction::Deploy {
                         api_url,
@@ -1548,7 +1576,7 @@ mod tests {
                         release,
                         ..
                     },
-            } => {
+            }) => {
                 assert_eq!(api_url, None);
                 assert_eq!(namespace, "agentos");
                 assert_eq!(release, "agentos");
@@ -1568,9 +1596,9 @@ mod tests {
         ])
         .expect("cluster deploy --api-url should parse");
         match cli.command {
-            Command::Cluster {
+            Some(Command::Cluster {
                 action: ClusterAction::Deploy { api_url, .. },
-            } => assert_eq!(api_url.as_deref(), Some("http://h:30080/api")),
+            }) => assert_eq!(api_url.as_deref(), Some("http://h:30080/api")),
             _ => panic!("expected cluster deploy command"),
         }
     }
@@ -1588,12 +1616,12 @@ mod tests {
         ])
         .expect("cluster deploy --namespace --release should parse");
         match cli.command {
-            Command::Cluster {
+            Some(Command::Cluster {
                 action:
                     ClusterAction::Deploy {
                         namespace, release, ..
                     },
-            } => {
+            }) => {
                 assert_eq!(namespace, "ns1");
                 assert_eq!(release, "rel1");
             }
@@ -1615,21 +1643,21 @@ mod tests {
         for (argv, verb) in cases {
             let cli = Cli::try_parse_from(argv).expect("local verb accepts -f");
             match cli.command {
-                Command::Local {
+                Some(Command::Local {
                     action: LocalAction::Up { file, .. },
-                } => {
+                }) => {
                     assert_eq!(verb, "up");
                     assert_eq!(file.as_deref(), Some("custom.yaml"));
                 }
-                Command::Local {
+                Some(Command::Local {
                     action: LocalAction::Down { file, .. },
-                } => {
+                }) => {
                     assert_eq!(verb, "down");
                     assert_eq!(file.as_deref(), Some("custom.yaml"));
                 }
-                Command::Local {
+                Some(Command::Local {
                     action: LocalAction::Status { file, .. },
-                } => {
+                }) => {
                     assert_eq!(verb, "status");
                     assert_eq!(file.as_deref(), Some("custom.yaml"));
                 }
@@ -1643,9 +1671,9 @@ mod tests {
         let cli = Cli::try_parse_from(["agentos", "local", "up", "--minimal"])
             .expect("local up --minimal should parse");
         match cli.command {
-            Command::Local {
+            Some(Command::Local {
                 action: LocalAction::Up { minimal, .. },
-            } => assert!(minimal),
+            }) => assert!(minimal),
             _ => panic!("expected local up command"),
         }
     }
@@ -1655,9 +1683,9 @@ mod tests {
         let cli = Cli::try_parse_from(["agentos", "local", "up", "--slack"])
             .expect("local up --slack should parse");
         match cli.command {
-            Command::Local {
+            Some(Command::Local {
                 action: LocalAction::Up { slack, .. },
-            } => assert!(slack),
+            }) => assert!(slack),
             _ => panic!("expected local up command"),
         }
     }
@@ -1675,7 +1703,7 @@ mod tests {
         ])
         .expect("local comms flags should parse");
         match cli.command {
-            Command::Local {
+            Some(Command::Local {
                 action:
                     LocalAction::Comms {
                         slack,
@@ -1683,7 +1711,7 @@ mod tests {
                         app_token,
                         ..
                     },
-            } => {
+            }) => {
                 assert!(slack);
                 assert!(disconnect);
                 assert_eq!(app_token, "X");
@@ -1697,9 +1725,9 @@ mod tests {
         let cli = Cli::try_parse_from(["agentos", "cluster", "kill", "deal-desk", "--yes"])
             .expect("cluster kill should parse");
         match cli.command {
-            Command::Cluster {
+            Some(Command::Cluster {
                 action: ClusterAction::Kill { agent, yes, .. },
-            } => {
+            }) => {
                 assert_eq!(agent, "deal-desk");
                 assert!(yes);
             }
@@ -1712,7 +1740,7 @@ mod tests {
         let cli = Cli::try_parse_from(["agentos", "cluster", "kill", "a"])
             .expect("cluster kill without flags should parse");
         match cli.command {
-            Command::Cluster {
+            Some(Command::Cluster {
                 action:
                     ClusterAction::Kill {
                         agent,
@@ -1720,7 +1748,7 @@ mod tests {
                         dry_run,
                         ..
                     },
-            } => {
+            }) => {
                 assert_eq!(agent, "a");
                 assert!(!yes);
                 assert!(!dry_run);
@@ -1734,9 +1762,9 @@ mod tests {
         let cli = Cli::try_parse_from(["agentos", "cluster", "resume", "a", "--dry-run"])
             .expect("cluster resume should parse");
         match cli.command {
-            Command::Cluster {
+            Some(Command::Cluster {
                 action: ClusterAction::Resume { agent, dry_run, .. },
-            } => {
+            }) => {
                 assert_eq!(agent, "a");
                 assert!(dry_run);
             }
@@ -1749,9 +1777,9 @@ mod tests {
         let cli = Cli::try_parse_from(["agentos", "cluster", "budget", "a", "--limit", "12.5"])
             .expect("cluster budget should parse");
         match cli.command {
-            Command::Cluster {
+            Some(Command::Cluster {
                 action: ClusterAction::Budget { agent, limit, .. },
-            } => {
+            }) => {
                 assert_eq!(agent, "a");
                 assert_eq!(limit, 12.5);
             }
@@ -1771,9 +1799,9 @@ mod tests {
         let cli = Cli::try_parse_from(["agentos", "cluster", "delete", "a", "--yes"])
             .expect("cluster delete should parse");
         match cli.command {
-            Command::Cluster {
+            Some(Command::Cluster {
                 action: ClusterAction::Delete { agent, yes, .. },
-            } => {
+            }) => {
                 assert_eq!(agent, "a");
                 assert!(yes);
             }
@@ -1794,7 +1822,7 @@ mod tests {
         ])
         .expect("cluster comms flags should parse");
         match cli.command {
-            Command::Cluster {
+            Some(Command::Cluster {
                 action:
                     ClusterAction::Comms {
                         slack,
@@ -1802,7 +1830,7 @@ mod tests {
                         app_token,
                         ..
                     },
-            } => {
+            }) => {
                 assert!(slack);
                 assert!(disconnect);
                 assert_eq!(app_token, "X");

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -49,6 +49,7 @@ fn process_help_routes_positive_forms() {
         &["cluster", "eval"],
         &["cluster", "deploy"],
         &["init"],
+        &["interactive"],
     ];
 
     for args in cases.iter().copied() {
@@ -110,7 +111,7 @@ fn process_help_top_level_lists_new_surface_and_hides_retired_verbs() {
     );
     let text = output_text(&output);
 
-    for needle in ["skill", "local", "cluster", "init"] {
+    for needle in ["skill", "local", "cluster", "init", "interactive"] {
         assert!(
             help_lists_subcommand(&text, needle),
             "missing {needle}\n{text}"

--- a/cli/tests/non_interactive.rs
+++ b/cli/tests/non_interactive.rs
@@ -67,6 +67,17 @@ fn json_global_flag_parses_before_subcommand() {
 }
 
 #[test]
+fn bare_agentos_requires_a_tty_in_non_interactive_contexts() {
+    let output = Command::new(bin()).output().expect("run bare agentos");
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "bare agentos should dispatch to the interactive UI and fail as usage without a TTY\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn skill_status_connection_refused_exits_transient() {
     // Hermetic: port 1 is reserved/closed, so the runner status call fails with
     // a connect error -> transient class -> exit 3 (safe to retry). RED until


### PR DESCRIPTION
## Summary

- Add a ratatui/crossterm-powered interactive terminal interface for AgentOS.
- Make bare `agentos` open the TUI, with explicit aliases `agentos interactive`, `agentos ui`, and `agentos tui`.
- Keep scriptable subcommands intact and add a non-TTY guard so automation gets a usage error instead of a hanging TUI.
- Document the new entrypoint and refresh the command manifest.

## Validation

- `cargo fmt`
- `cargo run --quiet -- schema > command-manifest.json`
- `cargo test`
- Non-TTY smoke run: bare `agentos` exits with usage code 2 and a clear TUI-required message.
