### PR TITLE
Guide MCP auth example from interactive UI

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1884,9 +1884,23 @@ export const commandManifest = {
       "name": "build"
     },
     {
-      "about": "Bootstrap a dev checkout: install deps and build, start nothing (source checkout only)",
+      "about": "Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only)",
+      "args": [
+        {
+          "global": false,
+          "help": "Reuse already-present artifacts while refreshing dependencies and builds",
+          "id": "update",
+          "long": "update",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
+        }
+      ],
       "hidden": false,
-      "long_about": "Bootstrap a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo build` in `cli`, then builds the runner image. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
+      "long_about": "Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo build` in `cli`, then builds the runner image. With `--update`, already-present heavyweight artifacts like the runner image are reused. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
       "name": "install"
     },
     {

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1910,12 +1910,12 @@ export const commandManifest = {
       "name": "interactive"
     },
     {
-      "about": "Store and manage local secrets in the OS credential store",
+      "about": "Store and manage local secrets in AgentOS private storage",
       "hidden": false,
       "name": "secrets",
       "subcommands": [
         {
-          "about": "Save a secret in the OS credential store. Prompts with hidden input by default",
+          "about": "Save a secret in AgentOS private storage. Prompts with hidden input by default",
           "args": [
             {
               "global": false,

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1896,6 +1896,54 @@ export const commandManifest = {
       "name": "interactive"
     },
     {
+      "about": "Store and manage local secrets in the OS credential store",
+      "hidden": false,
+      "name": "secrets",
+      "subcommands": [
+        {
+          "about": "Save a secret in the OS credential store. Prompts with hidden input by default",
+          "args": [
+            {
+              "global": false,
+              "help": "Environment-variable-style secret name, e.g. GITHUB_PERSONAL_ACCESS_TOKEN",
+              "id": "name",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Read the value from another environment variable instead of prompting",
+              "id": "from_env",
+              "long": "from-env",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "set"
+        },
+        {
+          "about": "List saved AgentOS secret names. Values are never printed",
+          "hidden": false,
+          "name": "list"
+        },
+        {
+          "about": "Remove a saved secret",
+          "args": [
+            {
+              "global": false,
+              "help": "Environment-variable-style secret name",
+              "id": "name",
+              "positional": true,
+              "required": true
+            }
+          ],
+          "hidden": false,
+          "name": "unset"
+        }
+      ]
+    },
+    {
       "about": "Run a repo dev script (contracts, chart-check, e2e) -- source checkout only",
       "hidden": false,
       "long_about": "Run a repo dev script (contracts, chart-check, e2e) -- source checkout only.\n\nThin wrappers over the repo's dev scripts so contributors get a unified `agentos <command>` surface; the scripts stay the implementation. A release binary has no scripts and errors clearly.",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pydantic-settings>=2.7",
     "kubernetes>=31.0",
     "aci-protocol",
+    "agentos-channel-protocol",
     "plugin-format",
     "agentos-dispatcher",
     "aiohttp>=3.11",

--- a/apps/worker/src/agentos_worker/blocks.py
+++ b/apps/worker/src/agentos_worker/blocks.py
@@ -30,6 +30,9 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+from channel_protocol import ChoiceIntent, ConfirmIntent, OutboundMessage
+from pydantic import ValidationError
+
 from .behaviorpacks import BehaviorPacks, NavPack, ensure_hub_button
 from .mrkdwn import to_mrkdwn
 
@@ -207,6 +210,27 @@ def _pairs(raw: Any) -> list[tuple[str, str]]:
     return out
 
 
+def _reply_from_message(message: OutboundMessage) -> Reply:
+    """Project the channel-neutral contract into this Slack renderer's inputs."""
+    buttons: list[tuple[str, str]] = []
+    if isinstance(message.interaction, ChoiceIntent):
+        buttons = [(option.label, option.value) for option in message.interaction.options]
+    elif isinstance(message.interaction, ConfirmIntent):
+        buttons = [
+            (message.interaction.confirm.label, message.interaction.confirm.value),
+            (message.interaction.cancel.label, message.interaction.cancel.value),
+        ]
+    return Reply(
+        text=message.text,
+        status=message.status,
+        header=message.header,
+        fields=[(item.label, item.value) for item in message.fields],
+        buttons=buttons,
+        links=[(item.label, item.url) for item in message.links],
+        footer=message.footer,
+    )
+
+
 def parse_reply(text: str) -> Reply | None:
     """A ``Reply`` if ``text`` contains a complete, valid ``agentos-reply`` block,
     else None. Defensive: any parse/shape error returns None so the caller falls
@@ -220,6 +244,13 @@ def parse_reply(text: str) -> Reply | None:
         return None
     if not isinstance(data, dict):
         return None
+    if "version" in data:
+        try:
+            return _reply_from_message(OutboundMessage.model_validate(data))
+        except ValidationError:
+            return None
+    # Migration-only compatibility for the original unversioned convention.
+    # New agents author the versioned channel-protocol shape above.
     status = data.get("status")
     header = data.get("header")
     footer = data.get("footer")

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -72,6 +72,41 @@ def test_parse_reply_extracts_a_complete_block() -> None:
     assert ("← Back", "home") in reply.buttons
 
 
+def test_parse_reply_maps_versioned_choice_contract_to_slack_actions() -> None:
+    reply = parse_reply(
+        "```agentos-reply\n"
+        '{"version":"1.0","text":"Which view?","interaction":'
+        '{"kind":"choice","id":"view","options":['
+        '{"label":"Open issues","value":"show open issues"}]}}\n'
+        "```"
+    )
+    assert reply is not None
+    assert reply.text == "Which view?"
+    assert reply.buttons == [("Open issues", "show open issues")]
+
+
+def test_parse_reply_maps_versioned_confirmation_to_two_actions() -> None:
+    reply = parse_reply(
+        "```agentos-reply\n"
+        '{"version":"1.0","text":"Deploy?","interaction":'
+        '{"kind":"confirm","id":"deploy","prompt":"Deploy?",'
+        '"confirm":{"label":"Deploy","value":"deploy"},'
+        '"cancel":{"label":"Cancel","value":"cancel"}}}\n'
+        "```"
+    )
+    assert reply is not None
+    assert reply.buttons == [("Deploy", "deploy"), ("Cancel", "cancel")]
+
+
+def test_versioned_reply_rejects_unknown_channel_native_fields() -> None:
+    assert (
+        parse_reply(
+            '```agentos-reply\n{"version":"1.0","text":"x","blocks":[]}\n```'
+        )
+        is None
+    )
+
+
 def test_parse_reply_none_without_a_block() -> None:
     assert parse_reply("just a normal answer") is None
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "unicode-width",
  "uuid",
 ]
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "agentos"
 version = "0.3.1"
 dependencies = [
@@ -26,10 +37,12 @@ dependencies = [
  "getrandom 0.4.3",
  "indicatif",
  "jsonschema",
+ "keyring",
  "ratatui",
  "redis",
  "regex",
  "reqwest",
+ "rpassword",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -134,6 +147,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +173,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +237,70 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -247,6 +391,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -314,8 +504,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -423,6 +623,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +696,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -542,6 +777,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +833,33 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -732,6 +1005,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +1054,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -838,6 +1134,36 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1054,6 +1380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1409,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -1174,6 +1520,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "4.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0298a59b384c540e408a600c8b375a09b49c3f97debc080e2c30675d79a6368a"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1626,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "micromap"
@@ -1410,6 +1786,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1867,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1911,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1834,6 +2254,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +2356,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +2458,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2478,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -2279,6 +2784,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,7 +2865,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2347,6 +2894,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -2433,6 +2997,7 @@ checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -2608,10 +3173,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -2690,6 +3277,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,6 +3334,78 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
 ]
 
 [[package]]
@@ -2825,3 +3493,43 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
+]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,6 +39,7 @@ redis = { version = "1.3", default-features = false, features = [
     "streams",
 ] }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm_0_29"] }
+unicode-width = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -59,6 +59,8 @@ tokio = { version = "1", features = [
     "net",
     "sync",
 ] }
+keyring = "4.1.5"
+rpassword = "7.5.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/README.md
+++ b/cli/README.md
@@ -127,9 +127,10 @@ history, command argv, `.env`, or AgentOS state files. On macOS this uses
 Keychain. AgentOS keeps a non-secret index of saved names under the user config
 directory only so `agentos secrets list` can show what it knows about; the
 secret values remain in the credential store. All values share one AgentOS vault
-item so macOS authorizes the workflow once. Old per-secret Keychain items are not
-opened automatically; re-save those names in the TUI once to move to the vault
-without triggering one authorization dialog per legacy item.
+item so macOS authorizes the workflow once. Legacy names remain visible. If an
+earlier run already populated the vault, AgentOS reconciles its index after one
+authorization; otherwise the TUI asks you to re-save only the credentials the
+workflow needs, without opening every legacy Keychain item.
 
 ```bash
 agentos secrets set GITHUB_PERSONAL_ACCESS_TOKEN

--- a/cli/README.md
+++ b/cli/README.md
@@ -110,15 +110,15 @@ Keyboard:
 | `q` or `Esc` | Exit |
 
 The first surface focuses on the common inner-loop and operations paths:
-`skill up/message/eval`, a live chat with the `examples/github-issues` agent,
+`skill up/message/eval`, an **Explore examples** picker with live agent chat,
 `secrets set/list/unset`, `local up/message/status`, `cluster status/message`,
 `install`, and `dev contracts`.
 
-The GitHub agent chat checks for a model credential plus
-`GITHUB_PERSONAL_ACCESS_TOKEN`, prompting to save missing values inside the TUI.
-It starts the authenticated MCP bundle once and opens a persistent conversation:
-type a message, read the reply, and continue for as many turns as needed. Leaving
-the chat stops the runner and returns to AgentOS.
+**Explore examples** opens a dialog for GitHub issues, Text stats engine, or
+Weather. After selection, AgentOS checks that example's credentials, starts its
+bundle once, and opens a persistent conversation. Type a message, read the
+reply, and continue for as many turns as needed. Leaving chat stops the runner
+and returns to AgentOS.
 
 ## `agentos secrets`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -37,6 +37,9 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed, a root `AGENTS.md`, and an installable `.claude/skills/using-agentos/SKILL.md` harness primer. |
 | `agentos init --from-spec <path>` | Scaffold **non-interactively** from an agent-authored spec file (JSON). The bundle name comes from the spec, not a positional argument. A coding agent interviews the human, writes the spec, then this command lays down the same plugin-format shape deterministically -- zero prompts. See the spec shape below. |
 | `agentos` | Open the keyboard-driven terminal interface. Explicit forms: `agentos interactive`, `agentos ui`, `agentos tui`. |
+| `agentos secrets set <NAME>` | Save a local secret in the OS credential store with hidden input. `--from-env <VAR>` reads from an existing environment variable for non-interactive use without putting the value in argv. |
+| `agentos secrets list` | List saved AgentOS secret names. Values are never printed. |
+| `agentos secrets unset <NAME>` | Remove a saved local secret. |
 | `agentos guide` | Print a self-contained primer (ADR-0021) for a coding agent driving the harness: the parity ladder, when/which decision logic, the landmines, and verify-first, to stdout. `--json` emits the same content as a structured variant (data on stdout). |
 | `agentos build` | Build the runner image locally: `docker build -f runner/Dockerfile -t agentos-runner .` from the repo root (found by walking up to `runner/Dockerfile`). `--tag` overrides the tag. Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
 
@@ -108,14 +111,45 @@ Keyboard:
 
 The first surface focuses on the common inner-loop, example verification, and
 operations paths: `skill up/message/eval`, a guided `examples/github-issues`
-MCP auth e2e, `local up/message/status`, `cluster status/message`, `install`,
-and `dev contracts`.
+MCP auth e2e, `secrets set/list/unset`, `local up/message/status`, `cluster
+status/message`, `install`, and `dev contracts`.
 
 The guided MCP auth example checks for a model credential plus
-`GITHUB_PERSONAL_ACCESS_TOKEN`, optionally builds the runner image, starts the
+`GITHUB_PERSONAL_ACCESS_TOKEN`, prompting to save missing values in the OS
+credential store. It then optionally builds the runner image, starts the
 `examples/github-issues` bundle with `--secret GITHUB_PERSONAL_ACCESS_TOKEN`,
 sends a live GitHub issue query, and stops the example runner afterward. It is
-the interactive form of the manual `agentos skill up --secret ...` runbook.
+the interactive form of the manual `agentos skill up --secret ...` runbook, but
+without requiring repeated shell exports.
+
+## `agentos secrets`
+
+Local secrets are stored in the OS credential store, not in the repo, shell
+history, command argv, `.env`, or AgentOS state files. On macOS this uses
+Keychain. AgentOS keeps a non-secret index of saved names under the user config
+directory only so `agentos secrets list` can show what it knows about; the
+secret values remain in the credential store.
+
+```bash
+agentos secrets set GITHUB_PERSONAL_ACCESS_TOKEN
+agentos secrets set ANTHROPIC_API_KEY
+agentos secrets list
+agentos secrets unset GITHUB_PERSONAL_ACCESS_TOKEN
+```
+
+For CI or other non-interactive setup, read from an existing environment
+variable instead of prompting:
+
+```bash
+agentos secrets set GITHUB_PERSONAL_ACCESS_TOKEN --from-env GITHUB_PAT
+```
+
+`agentos skill up --secret <NAME>` first uses a real environment variable when
+one is already set. If it is missing, the CLI tries the AgentOS secret store and
+hydrates the process environment just long enough for Docker to forward `-e
+<NAME>` into the runner. The same lookup applies to saved model credentials
+(`AGENTOS_CREDENTIALS`, `ANTHROPIC_API_KEY`, or `CLAUDE_CODE_OAUTH_TOKEN`) for
+live `skill up` runs.
 
 ## `agentos install`
 
@@ -155,7 +189,7 @@ HTTP surface directly. No platform, no queue, no API, no Slack, no cluster.
 
 | Command | What it does |
 |---|---|
-| `agentos skill up` | Boot the local runner image in Docker with the ACI boot env (runner/README.md recipe), wait for health, print the boxed env summary. `--fake-model` runs offline; `--network` and `--otel-endpoint` join the compose stack for traces; `--model <id>` forwards `AGENTOS_MODEL` (omit for the SDK default). |
+| `agentos skill up` | Boot the local runner image in Docker with the ACI boot env (runner/README.md recipe), wait for health, print the boxed env summary. `--fake-model` runs offline; `--network` and `--otel-endpoint` join the compose stack for traces; `--model <id>` forwards `AGENTOS_MODEL` (omit for the SDK default). `--secret <NAME>` forwards bundle MCP secrets by name, using the OS credential store when the env var is not exported. |
 | `agentos skill check` | Run an offline, credential free MCP load check and report declared servers, matches, and verdict. |
 | `agentos skill message "..."` | Send a synthetic Slack event: POST an ACI `event` frame to the local runner and stream the NDJSON reply (text deltas, tool notes, side effect flags, final). Abort a live turn with Ctrl-C. |
 | `agentos skill eval` | Run `evals/cases.json` through the runner as `eval_case` events; prints a per case result table plus a pass or fail rollup; nonzero exit on failure. |

--- a/cli/README.md
+++ b/cli/README.md
@@ -109,18 +109,16 @@ Keyboard:
 | `Enter` or `r` | Prompt for fields and run the selected command |
 | `q` or `Esc` | Exit |
 
-The first surface focuses on the common inner-loop, example verification, and
-operations paths: `skill up/message/eval`, a guided `examples/github-issues`
-MCP auth e2e, `secrets set/list/unset`, `local up/message/status`, `cluster
-status/message`, `install`, and `dev contracts`.
+The first surface focuses on the common inner-loop and operations paths:
+`skill up/message/eval`, a live chat with the `examples/github-issues` agent,
+`secrets set/list/unset`, `local up/message/status`, `cluster status/message`,
+`install`, and `dev contracts`.
 
-The guided MCP auth example checks for a model credential plus
-`GITHUB_PERSONAL_ACCESS_TOKEN`, prompting to save missing values in the OS
-credential store. It then optionally builds the runner image, starts the
-`examples/github-issues` bundle with `--secret GITHUB_PERSONAL_ACCESS_TOKEN`,
-sends a live GitHub issue query, and stops the example runner afterward. It is
-the interactive form of the manual `agentos skill up --secret ...` runbook, but
-without requiring repeated shell exports.
+The GitHub agent chat checks for a model credential plus
+`GITHUB_PERSONAL_ACCESS_TOKEN`, prompting to save missing values inside the TUI.
+It starts the authenticated MCP bundle once and opens a persistent conversation:
+type a message, read the reply, and continue for as many turns as needed. Leaving
+the chat stops the runner and returns to AgentOS.
 
 ## `agentos secrets`
 
@@ -128,7 +126,10 @@ Local secrets are stored in the OS credential store, not in the repo, shell
 history, command argv, `.env`, or AgentOS state files. On macOS this uses
 Keychain. AgentOS keeps a non-secret index of saved names under the user config
 directory only so `agentos secrets list` can show what it knows about; the
-secret values remain in the credential store.
+secret values remain in the credential store. All values share one AgentOS vault
+item so macOS authorizes the workflow once. Old per-secret Keychain items are not
+opened automatically; re-save those names in the TUI once to move to the vault
+without triggering one authorization dialog per legacy item.
 
 ```bash
 agentos secrets set GITHUB_PERSONAL_ACCESS_TOKEN

--- a/cli/README.md
+++ b/cli/README.md
@@ -153,16 +153,24 @@ live `skill up` runs.
 
 ## `agentos install`
 
-Contributor bootstrap for a fresh source checkout: install dependencies and
-build, but **start nothing**. Run it once after cloning; then `agentos local up`
-brings the stack up. From the repo root (found by walking up to
-`runner/Dockerfile`) it runs, in order and each idempotent, streaming output:
+Contributor bootstrap/update for a source checkout: install dependencies and
+build, but **start nothing**. Run it after cloning; rerun `./install.sh` later to
+refresh an existing checkout without reinstalling already-present artifacts.
+Then `agentos local up` brings the stack up. From the repo root (found by
+walking up to `runner/Dockerfile`) it runs, in order and each idempotent,
+streaming output:
 
 1. Copy `.env.example` to `.env` if `.env` is missing (otherwise left untouched).
 2. `uv sync` at the repo root (needs `uv`).
 3. `pnpm install` in `apps/ui` (needs `pnpm`).
 4. `cargo build` in `cli` (needs `cargo`).
 5. Build the runner image via `agentos build` (needs `docker`).
+
+`agentos install --update` is the rerun path used by `./install.sh` when an
+installed CLI already exists. It still refreshes dependencies and local builds,
+but skips rebuilding the `agentos-runner` image if that image is already present.
+`./install.sh` also skips the initial `cargo install --path cli --force` when the
+installed `agentos` binary is newer than the CLI sources.
 
 Each required tool is checked first; a missing one prints a pointer (e.g. `uv is
 not installed - https://docs.astral.sh/uv/`) and stops. Run outside a source

--- a/cli/README.md
+++ b/cli/README.md
@@ -106,9 +106,16 @@ Keyboard:
 | `Enter` or `r` | Prompt for fields and run the selected command |
 | `q` or `Esc` | Exit |
 
-The first surface focuses on the common inner-loop and operations paths:
-`skill up/message/eval`, `local up/message/status`, `cluster status/message`,
-`install`, and `dev contracts`.
+The first surface focuses on the common inner-loop, example verification, and
+operations paths: `skill up/message/eval`, a guided `examples/github-issues`
+MCP auth e2e, `local up/message/status`, `cluster status/message`, `install`,
+and `dev contracts`.
+
+The guided MCP auth example checks for a model credential plus
+`GITHUB_PERSONAL_ACCESS_TOKEN`, optionally builds the runner image, starts the
+`examples/github-issues` bundle with `--secret GITHUB_PERSONAL_ACCESS_TOKEN`,
+sends a live GitHub issue query, and stops the example runner afterward. It is
+the interactive form of the manual `agentos skill up --secret ...` runbook.
 
 ## `agentos install`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -37,7 +37,7 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed, a root `AGENTS.md`, and an installable `.claude/skills/using-agentos/SKILL.md` harness primer. |
 | `agentos init --from-spec <path>` | Scaffold **non-interactively** from an agent-authored spec file (JSON). The bundle name comes from the spec, not a positional argument. A coding agent interviews the human, writes the spec, then this command lays down the same plugin-format shape deterministically -- zero prompts. See the spec shape below. |
 | `agentos` | Open the keyboard-driven terminal interface. Explicit forms: `agentos interactive`, `agentos ui`, `agentos tui`. |
-| `agentos secrets set <NAME>` | Save a local secret in the OS credential store with hidden input. `--from-env <VAR>` reads from an existing environment variable for non-interactive use without putting the value in argv. |
+| `agentos secrets set <NAME>` | Save a local secret in AgentOS's mode-0600 credential file with hidden input. `--from-env <VAR>` reads from an existing environment variable for non-interactive use without putting the value in argv. |
 | `agentos secrets list` | List saved AgentOS secret names. Values are never printed. |
 | `agentos secrets unset <NAME>` | Remove a saved local secret. |
 | `agentos guide` | Print a self-contained primer (ADR-0021) for a coding agent driving the harness: the parity ladder, when/which decision logic, the landmines, and verify-first, to stdout. `--json` emits the same content as a structured variant (data on stdout). |
@@ -122,15 +122,12 @@ and returns to AgentOS.
 
 ## `agentos secrets`
 
-Local secrets are stored in the OS credential store, not in the repo, shell
-history, command argv, `.env`, or AgentOS state files. On macOS this uses
-Keychain. AgentOS keeps a non-secret index of saved names under the user config
-directory only so `agentos secrets list` can show what it knows about; the
-secret values remain in the credential store. All values share one AgentOS vault
-item so macOS authorizes the workflow once. Legacy names remain visible. If an
-earlier run already populated the vault, AgentOS reconciles its index after one
-authorization; otherwise the TUI asks you to re-save only the credentials the
-workflow needs, without opening every legacy Keychain item.
+Local secrets are stored in `~/.config/agentos/credentials.json` with mode 0600,
+not in the repo, shell history, command argv, `.env`, or AgentOS state files.
+This follows the prompt-free private-config pattern used by developer CLIs.
+AgentOS keeps a separate non-secret index so secret names can be listed without
+opening values. Existing Keychain credentials are copied into the private file
+on first use; AgentOS never writes to or deletes from Keychain during migration.
 
 ```bash
 agentos secrets set GITHUB_PERSONAL_ACCESS_TOKEN
@@ -199,7 +196,7 @@ HTTP surface directly. No platform, no queue, no API, no Slack, no cluster.
 
 | Command | What it does |
 |---|---|
-| `agentos skill up` | Boot the local runner image in Docker with the ACI boot env (runner/README.md recipe), wait for health, print the boxed env summary. `--fake-model` runs offline; `--network` and `--otel-endpoint` join the compose stack for traces; `--model <id>` forwards `AGENTOS_MODEL` (omit for the SDK default). `--secret <NAME>` forwards bundle MCP secrets by name, using the OS credential store when the env var is not exported. |
+| `agentos skill up` | Boot the local runner image in Docker with the ACI boot env (runner/README.md recipe), wait for health, print the boxed env summary. `--fake-model` runs offline; `--network` and `--otel-endpoint` join the compose stack for traces; `--model <id>` forwards `AGENTOS_MODEL` (omit for the SDK default). `--secret <NAME>` forwards bundle MCP secrets by name, using AgentOS private storage when the env var is not exported. |
 | `agentos skill check` | Run an offline, credential free MCP load check and report declared servers, matches, and verdict. |
 | `agentos skill message "..."` | Send a synthetic Slack event: POST an ACI `event` frame to the local runner and stream the NDJSON reply (text deltas, tool notes, side effect flags, final). Abort a live turn with Ctrl-C. |
 | `agentos skill eval` | Run `evals/cases.json` through the runner as `eval_case` events; prints a per case result table plus a pass or fail rollup; nonzero exit on failure. |

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1881,9 +1881,23 @@
       "name": "build"
     },
     {
-      "about": "Bootstrap a dev checkout: install deps and build, start nothing (source checkout only)",
+      "about": "Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only)",
+      "args": [
+        {
+          "global": false,
+          "help": "Reuse already-present artifacts while refreshing dependencies and builds",
+          "id": "update",
+          "long": "update",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
+        }
+      ],
       "hidden": false,
-      "long_about": "Bootstrap a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo build` in `cli`, then builds the runner image. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
+      "long_about": "Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo build` in `cli`, then builds the runner image. With `--update`, already-present heavyweight artifacts like the runner image are reused. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
       "name": "install"
     },
     {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1893,6 +1893,54 @@
       "name": "interactive"
     },
     {
+      "about": "Store and manage local secrets in the OS credential store",
+      "hidden": false,
+      "name": "secrets",
+      "subcommands": [
+        {
+          "about": "Save a secret in the OS credential store. Prompts with hidden input by default",
+          "args": [
+            {
+              "global": false,
+              "help": "Environment-variable-style secret name, e.g. GITHUB_PERSONAL_ACCESS_TOKEN",
+              "id": "name",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Read the value from another environment variable instead of prompting",
+              "id": "from_env",
+              "long": "from-env",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "set"
+        },
+        {
+          "about": "List saved AgentOS secret names. Values are never printed",
+          "hidden": false,
+          "name": "list"
+        },
+        {
+          "about": "Remove a saved secret",
+          "args": [
+            {
+              "global": false,
+              "help": "Environment-variable-style secret name",
+              "id": "name",
+              "positional": true,
+              "required": true
+            }
+          ],
+          "hidden": false,
+          "name": "unset"
+        }
+      ]
+    },
+    {
       "about": "Run a repo dev script (contracts, chart-check, e2e) -- source checkout only",
       "hidden": false,
       "long_about": "Run a repo dev script (contracts, chart-check, e2e) -- source checkout only.\n\nThin wrappers over the repo's dev scripts so contributors get a unified `agentos <command>` surface; the scripts stay the implementation. A release binary has no scripts and errors clearly.",

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1907,12 +1907,12 @@
       "name": "interactive"
     },
     {
-      "about": "Store and manage local secrets in the OS credential store",
+      "about": "Store and manage local secrets in AgentOS private storage",
       "hidden": false,
       "name": "secrets",
       "subcommands": [
         {
-          "about": "Save a secret in the OS credential store. Prompts with hidden input by default",
+          "about": "Save a secret in AgentOS private storage. Prompts with hidden input by default",
           "args": [
             {
               "global": false,

--- a/cli/src/channel.rs
+++ b/cli/src/channel.rs
@@ -1,0 +1,256 @@
+//! Terminal adapter for the rendering-neutral `agentos-reply` channel contract.
+
+use serde::Deserialize;
+
+pub const REPLY_FENCE: &str = "```agentos-reply";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalAction {
+    pub label: String,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalMessage {
+    pub lines: Vec<String>,
+    pub actions: Vec<TerminalAction>,
+    pub action_prompt: Option<String>,
+    pub allow_free_text: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Action {
+    label: String,
+    value: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MessageField {
+    label: String,
+    value: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MessageLink {
+    label: String,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", deny_unknown_fields)]
+enum Interaction {
+    #[serde(rename = "choice")]
+    Choice {
+        id: String,
+        prompt: Option<String>,
+        options: Vec<Action>,
+        #[serde(default = "default_true")]
+        allow_free_text: bool,
+    },
+    #[serde(rename = "confirm")]
+    Confirm {
+        id: String,
+        prompt: String,
+        confirm: Action,
+        cancel: Action,
+        #[serde(default)]
+        allow_free_text: bool,
+    },
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OutboundMessage {
+    version: String,
+    text: String,
+    status: Option<String>,
+    header: Option<String>,
+    #[serde(default)]
+    fields: Vec<MessageField>,
+    #[serde(default)]
+    links: Vec<MessageLink>,
+    footer: Option<String>,
+    interaction: Option<Interaction>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyMessage {
+    #[serde(default)]
+    text: String,
+    status: Option<String>,
+    header: Option<String>,
+    #[serde(default)]
+    fields: Vec<(String, String)>,
+    #[serde(default)]
+    buttons: Vec<(String, String)>,
+    #[serde(default)]
+    links: Vec<(String, String)>,
+    footer: Option<String>,
+}
+
+fn display_lines(
+    text: String,
+    status: Option<String>,
+    header: Option<String>,
+    fields: impl IntoIterator<Item = (String, String)>,
+    links: impl IntoIterator<Item = (String, String)>,
+    footer: Option<String>,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    if let Some(status) = status.filter(|value| !value.is_empty()) {
+        lines.push(status);
+    }
+    if let Some(header) = header.filter(|value| !value.is_empty()) {
+        lines.push(header);
+    }
+    for (label, value) in fields {
+        lines.push(format!("{label}: {value}"));
+    }
+    lines.extend(text.lines().map(str::to_string));
+    for (label, url) in links {
+        lines.push(format!("{label}: {url}"));
+    }
+    if let Some(footer) = footer.filter(|value| !value.is_empty()) {
+        lines.push(footer);
+    }
+    lines
+}
+
+/// Parse a complete fenced semantic message. Legacy button pairs remain readable
+/// during migration, but only the versioned shape is the public contract.
+pub fn parse_terminal_message(text: &str) -> Option<TerminalMessage> {
+    let start = text.find(REPLY_FENCE)? + REPLY_FENCE.len();
+    let rest = text
+        .get(start..)?
+        .strip_prefix('\n')
+        .unwrap_or(&text[start..]);
+    let end = rest.rfind("```")?;
+    let payload = rest[..end].trim();
+    let value: serde_json::Value = serde_json::from_str(payload).ok()?;
+    if value.get("version").is_some() {
+        let message: OutboundMessage = serde_json::from_value(value).ok()?;
+        if message.version != "1.0" {
+            return None;
+        }
+        let (actions, prompt, allow_free_text) = match message.interaction {
+            Some(Interaction::Choice {
+                id,
+                prompt,
+                options,
+                allow_free_text,
+            }) if !id.is_empty() && !options.is_empty() => (
+                options
+                    .into_iter()
+                    .map(|action| TerminalAction {
+                        label: action.label,
+                        value: action.value,
+                    })
+                    .collect(),
+                prompt,
+                allow_free_text,
+            ),
+            Some(Interaction::Confirm {
+                id,
+                prompt,
+                confirm,
+                cancel,
+                allow_free_text,
+            }) if !id.is_empty() => (
+                vec![
+                    TerminalAction {
+                        label: confirm.label,
+                        value: confirm.value,
+                    },
+                    TerminalAction {
+                        label: cancel.label,
+                        value: cancel.value,
+                    },
+                ],
+                Some(prompt),
+                allow_free_text,
+            ),
+            _ => (Vec::new(), None, true),
+        };
+        return Some(TerminalMessage {
+            lines: display_lines(
+                message.text,
+                message.status,
+                message.header,
+                message
+                    .fields
+                    .into_iter()
+                    .map(|item| (item.label, item.value)),
+                message.links.into_iter().map(|item| (item.label, item.url)),
+                message.footer,
+            ),
+            actions,
+            action_prompt: prompt,
+            allow_free_text,
+        });
+    }
+
+    let legacy: LegacyMessage = serde_json::from_value(value).ok()?;
+    Some(TerminalMessage {
+        lines: display_lines(
+            legacy.text,
+            legacy.status,
+            legacy.header,
+            legacy.fields,
+            legacy.links,
+            legacy.footer,
+        ),
+        actions: legacy
+            .buttons
+            .into_iter()
+            .map(|(label, value)| TerminalAction { label, value })
+            .collect(),
+        action_prompt: None,
+        allow_free_text: true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn choice_renders_labels_but_preserves_values() {
+        let message = parse_terminal_message(
+            "```agentos-reply\n{\"version\":\"1.0\",\"text\":\"Pick one\",\"interaction\":{\"kind\":\"choice\",\"id\":\"repo\",\"prompt\":\"Repository\",\"options\":[{\"label\":\"AgentOS\",\"value\":\"curie-eng/agentos\"}]}}\n```",
+        )
+        .unwrap();
+        assert_eq!(message.lines, ["Pick one"]);
+        assert_eq!(message.actions[0].label, "AgentOS");
+        assert_eq!(message.actions[0].value, "curie-eng/agentos");
+        assert!(message.allow_free_text);
+    }
+
+    #[test]
+    fn confirm_disables_free_text_by_default() {
+        let message = parse_terminal_message(
+            "```agentos-reply\n{\"version\":\"1.0\",\"text\":\"Deploy?\",\"interaction\":{\"kind\":\"confirm\",\"id\":\"deploy\",\"prompt\":\"Deploy?\",\"confirm\":{\"label\":\"Deploy\",\"value\":\"deploy\"},\"cancel\":{\"label\":\"Cancel\",\"value\":\"cancel\"}}}\n```",
+        )
+        .unwrap();
+        assert!(!message.allow_free_text);
+        assert_eq!(message.actions.len(), 2);
+    }
+
+    #[test]
+    fn rejects_native_widgets_and_unknown_versions() {
+        assert!(parse_terminal_message(
+            "```agentos-reply\n{\"version\":\"1.0\",\"text\":\"x\",\"blocks\":[]}\n```"
+        )
+        .is_none());
+        assert!(parse_terminal_message(
+            "```agentos-reply\n{\"version\":\"2.0\",\"text\":\"x\"}\n```"
+        )
+        .is_none());
+    }
+}

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -517,6 +517,9 @@ fn secret_store_env(name: &str) -> Result<Option<(String, String)>> {
     if std::env::var_os(name).is_some() {
         return Ok(None);
     }
+    if !crate::secrets::is_saved(name)? {
+        return Ok(None);
+    }
     if let Some(value) = crate::secrets::get_value(name)? {
         crate::ui::ui().note(&format!(
             "{name}: loaded from the OS credential store for this run"

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -605,15 +605,13 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     // the NAME (`-e NAME`); the value is supplied only to the Docker CLI child
     // process so Docker can copy it into the runner container.
     for name in &opts.secret {
-        if std::env::var_os(name).is_none() {
-            if !stored_env_contains(&docker_env, name) {
-                match secret_store_env(name)? {
-                    Some(pair) => docker_env.push(pair),
-                    None => {
-                        crate::ui::ui().note(&format!(
-                            "--secret {name}: not set in the environment or AgentOS secret store; nothing will be forwarded for it"
-                        ));
-                    }
+        if std::env::var_os(name).is_none() && !stored_env_contains(&docker_env, name) {
+            match secret_store_env(name)? {
+                Some(pair) => docker_env.push(pair),
+                None => {
+                    crate::ui::ui().note(&format!(
+                        "--secret {name}: not set in the environment or AgentOS secret store; nothing will be forwarded for it"
+                    ));
                 }
             }
         }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -473,6 +473,39 @@ fn merge_secret_env(mut passthrough: Vec<String>, secrets: &[String]) -> Vec<Str
     passthrough
 }
 
+fn secret_store_env(name: &str) -> Result<Option<(String, String)>> {
+    if std::env::var_os(name).is_some() {
+        return Ok(None);
+    }
+    if let Some(value) = crate::secrets::get_value(name)? {
+        crate::ui::ui().note(&format!(
+            "{name}: loaded from the OS credential store for this run"
+        ));
+        return Ok(Some((name.to_string(), value)));
+    }
+    Ok(None)
+}
+
+fn stored_env_contains(env: &[(String, String)], name: &str) -> bool {
+    env.iter().any(|(stored_name, _)| stored_name == name)
+}
+
+fn load_model_credentials_from_secret_store() -> Result<Vec<(String, String)>> {
+    // Prefer an explicitly BYO AgentOS credential when saved, otherwise hydrate
+    // the SDK credential names in the same order `select_passthrough_env` uses.
+    if let Some(pair) = secret_store_env("AGENTOS_CREDENTIALS")? {
+        return Ok(vec![pair]);
+    }
+    let mut env = Vec::new();
+    if let Some(pair) = secret_store_env("CLAUDE_CODE_OAUTH_TOKEN")? {
+        env.push(pair);
+    }
+    if let Some(pair) = secret_store_env("ANTHROPIC_API_KEY")? {
+        env.push(pair);
+    }
+    Ok(env)
+}
+
 pub async fn start(opts: StartOpts) -> Result<()> {
     let plugin_dir = opts
         .plugin_dir
@@ -560,14 +593,29 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     // the ambient SDK token alongside a chosen BYO credential. See
     // select_passthrough_env.
     let suppress_credential = opts.local_model.is_some() || opts.fake_model;
-    let byo_credential = std::env::var("AGENTOS_CREDENTIALS").ok();
-    // Warn (do not fail) on a `--secret NAME` that is not set in the caller's
-    // env, since the by-name forward silently no-ops for an unset var (docker.rs).
+    let mut docker_env = Vec::new();
+    if !suppress_credential {
+        docker_env.extend(load_model_credentials_from_secret_store()?);
+    }
+    let byo_credential = std::env::var("AGENTOS_CREDENTIALS").ok().or_else(|| {
+        stored_env_contains(&docker_env, "AGENTOS_CREDENTIALS").then_some("stored".to_string())
+    });
+    // Hydrate `--secret NAME` from the local OS credential store when it is not
+    // already present in the process env. The docker argv still forwards only
+    // the NAME (`-e NAME`); the value is supplied only to the Docker CLI child
+    // process so Docker can copy it into the runner container.
     for name in &opts.secret {
         if std::env::var_os(name).is_none() {
-            crate::ui::ui().note(&format!(
-                "--secret {name}: not set in the environment; nothing will be forwarded for it"
-            ));
+            if !stored_env_contains(&docker_env, name) {
+                match secret_store_env(name)? {
+                    Some(pair) => docker_env.push(pair),
+                    None => {
+                        crate::ui::ui().note(&format!(
+                            "--secret {name}: not set in the environment or AgentOS secret store; nothing will be forwarded for it"
+                        ));
+                    }
+                }
+            }
         }
     }
     let passthrough_env = merge_secret_env(
@@ -589,6 +637,7 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         model_base_url: model_base_url.clone(),
         model,
         passthrough_env,
+        docker_env,
     };
 
     let ui = crate::ui::ui();
@@ -596,7 +645,7 @@ pub async fn start(opts: StartOpts) -> Result<()> {
         "starting runner container '{}' from '{}'",
         opts.name, opts.image
     ));
-    let container_id = match docker::docker(&spec.run_args()).await {
+    let container_id = match docker::docker_with_env(&spec.run_args(), &spec.docker_env).await {
         Ok(id) => id,
         Err(err) => {
             if let Some(ollama) = &ollama_container {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -522,7 +522,7 @@ fn secret_store_env(name: &str) -> Result<Option<(String, String)>> {
     }
     if let Some(value) = crate::secrets::get_value(name)? {
         crate::ui::ui().note(&format!(
-            "{name}: loaded from the OS credential store for this run"
+            "{name}: loaded from AgentOS private storage for this run"
         ));
         return Ok(Some((name.to_string(), value)));
     }
@@ -643,7 +643,7 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     let byo_credential = std::env::var("AGENTOS_CREDENTIALS").ok().or_else(|| {
         stored_env_contains(&docker_env, "AGENTOS_CREDENTIALS").then_some("stored".to_string())
     });
-    // Hydrate `--secret NAME` from the local OS credential store when it is not
+    // Hydrate `--secret NAME` from AgentOS private storage when it is not
     // already present in the process env. The docker argv still forwards only
     // the NAME (`-e NAME`); the value is supplied only to the Docker CLI child
     // process so Docker can copy it into the runner container.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -314,11 +314,12 @@ pub async fn build(tag: &str) -> Result<()> {
     Ok(())
 }
 
-/// `agentos install`: from-a-checkout dev bootstrap -- install deps and build
-/// the runner image, but start nothing. Each step is idempotent and streams its
-/// output; a missing tool prints a friendly pointer and stops. A release binary
-/// has no source tree to install, so this errors clearly outside a checkout.
-pub async fn install() -> Result<()> {
+/// `agentos install`: from-a-checkout dev bootstrap/update -- install deps and
+/// build the runner image, but start nothing. Each step is idempotent and
+/// streams its output; update mode reuses already-present heavyweight artifacts.
+/// A missing tool prints a friendly pointer and stops. A release binary has no
+/// source tree to install, so this errors clearly outside a checkout.
+pub async fn install(update: bool) -> Result<()> {
     let ui = crate::ui::ui();
     let root = find_repo_root().context(
         "runner/Dockerfile not found here or in any parent directory. Run `agentos install` \
@@ -358,8 +359,16 @@ pub async fn install() -> Result<()> {
     require_tool("cargo", "cargo is not installed - https://rustup.rs/")?;
     run_step(&root.join("cli"), "cargo", &["build"], "cargo build (cli)").await?;
 
-    // 5. Build the runner image via the existing `build` handler.
-    build("agentos-runner").await?;
+    // 5. Build the runner image via the existing `build` handler. Update mode
+    // keeps reruns quick when the image is already present locally.
+    let runner_image = "agentos-runner";
+    if update && docker_image_exists(runner_image).await? {
+        ui.note(&format!(
+            "=== runner image '{runner_image}' already exists; skipping rebuild for --update ==="
+        ));
+    } else {
+        build(runner_image).await?;
+    }
 
     ui.success("Setup complete. Start the stack with: agentos local up");
     Ok(())
@@ -415,6 +424,21 @@ async fn run_step(dir: &Path, bin: &str, args: &[&str], label: &str) -> Result<(
         bail!("{label} failed ({status})");
     }
     Ok(())
+}
+
+async fn docker_image_exists(tag: &str) -> Result<bool> {
+    require_tool(
+        "docker",
+        "Docker is not installed or not on PATH. Install Docker Desktop/Engine and retry.",
+    )?;
+    let status = tokio::process::Command::new("docker")
+        .args(["image", "inspect", tag])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .context("failed to invoke docker")?;
+    Ok(status.success())
 }
 
 /// Whether `bin` resolves on PATH.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -326,16 +326,12 @@ pub async fn install(update: bool) -> Result<()> {
          from an agentos source checkout -- a release binary has nothing to install.",
     )?;
 
-    // 1. Seed .env from .env.example (idempotent: skip if .env already exists).
-    let env_path = root.join(".env");
-    let env_example = root.join(".env.example");
-    if env_path.exists() {
-        ui.note("=== .env already exists; leaving it untouched ===");
-    } else if env_example.exists() {
-        ui.note("=== cp .env.example .env ===");
-        std::fs::copy(&env_example, &env_path).context("failed to copy .env.example to .env")?;
-    } else {
-        ui.note("=== no .env.example to seed .env from; skipping ===");
+    // 1. Local config is user-owned. It is gitignored and only created once,
+    // so pulling newer AgentOS sources and rerunning install cannot replace it.
+    match seed_env_if_missing(&root)? {
+        EnvSeed::Preserved => ui.note("=== .env already exists; leaving it untouched ==="),
+        EnvSeed::Created => ui.note("=== seeded .env from .env.example ==="),
+        EnvSeed::NoTemplate => ui.note("=== no .env.example to seed .env from; skipping ==="),
     }
 
     // 2. uv sync (repo root).
@@ -372,6 +368,26 @@ pub async fn install(update: bool) -> Result<()> {
 
     ui.success("Setup complete. Start the stack with: agentos local up");
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EnvSeed {
+    Preserved,
+    Created,
+    NoTemplate,
+}
+
+fn seed_env_if_missing(root: &Path) -> Result<EnvSeed> {
+    let env_path = root.join(".env");
+    if env_path.exists() {
+        return Ok(EnvSeed::Preserved);
+    }
+    let env_example = root.join(".env.example");
+    if !env_example.exists() {
+        return Ok(EnvSeed::NoTemplate);
+    }
+    std::fs::copy(&env_example, &env_path).context("failed to copy .env.example to .env")?;
+    Ok(EnvSeed::Created)
 }
 
 /// `agentos dev <script>`: run a repo dev script by relative path. Thin wrapper
@@ -1379,13 +1395,34 @@ async fn git_short_sha(dir: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        merge_secret_env, resolve_cases_path, select_passthrough_env, validate_slack_channel,
+        merge_secret_env, resolve_cases_path, seed_env_if_missing, select_passthrough_env,
+        validate_slack_channel, EnvSeed,
     };
     use std::path::PathBuf;
 
     #[test]
     fn default_channel_passes_local_validation() {
         assert!(validate_slack_channel(crate::api::DEFAULT_SLACK_CHANNEL).is_ok());
+    }
+
+    #[test]
+    fn install_preserves_existing_local_config() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join(".env"), "USER_SETTING=keep-me\n").unwrap();
+        std::fs::write(
+            root.path().join(".env.example"),
+            "USER_SETTING=new-default\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            seed_env_if_missing(root.path()).unwrap(),
+            EnvSeed::Preserved
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.path().join(".env")).unwrap(),
+            "USER_SETTING=keep-me\n"
+        );
     }
 
     #[test]

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -31,6 +31,10 @@ pub struct StartSpec {
     /// Env vars forwarded from the caller's environment when set (model
     /// credentials for real-model runs; never baked into the args as values).
     pub passthrough_env: Vec<String>,
+    /// Env values supplied only to the Docker CLI process. Used for secrets
+    /// loaded from the OS credential store so they can be forwarded by `-e NAME`
+    /// without mutating the AgentOS process env or appearing in argv.
+    pub docker_env: Vec<(String, String)>,
 }
 
 /// Everything `docker run` needs for a one shot offline MCP load check.
@@ -110,7 +114,9 @@ impl StartSpec {
             args.push(format!("OTEL_EXPORTER_OTLP_ENDPOINT={endpoint}"));
         }
         for var in &self.passthrough_env {
-            if std::env::var_os(var).is_some() {
+            if std::env::var_os(var).is_some()
+                || self.docker_env.iter().any(|(name, _)| name == var)
+            {
                 args.push("-e".into());
                 args.push(var.clone());
             }
@@ -122,7 +128,13 @@ impl StartSpec {
 
 /// Run a docker subcommand, returning trimmed stdout; stderr on failure.
 pub async fn docker(args: &[String]) -> Result<String> {
-    let (status, stdout, stderr) = docker_capture(args).await?;
+    docker_with_env(args, &[]).await
+}
+
+/// Run a docker subcommand with extra environment values supplied only to the
+/// Docker CLI child process.
+pub async fn docker_with_env(args: &[String], env: &[(String, String)]) -> Result<String> {
+    let (status, stdout, stderr) = docker_capture_with_env(args, env).await?;
     if !status.success() {
         bail!(
             "docker {} failed ({}): {}",
@@ -140,8 +152,19 @@ pub async fn docker(args: &[String]) -> Result<String> {
 /// not turn an unsuccessful child exit into an error. Failure to invoke Docker
 /// remains an error.
 pub async fn docker_capture(args: &[String]) -> Result<(std::process::ExitStatus, String, String)> {
-    let output = Command::new("docker")
-        .args(args)
+    docker_capture_with_env(args, &[]).await
+}
+
+pub async fn docker_capture_with_env(
+    args: &[String],
+    env: &[(String, String)],
+) -> Result<(std::process::ExitStatus, String, String)> {
+    let mut cmd = Command::new("docker");
+    cmd.args(args);
+    for (name, value) in env {
+        cmd.env(name, value);
+    }
+    let output = cmd
         .output()
         .await
         .context("failed to invoke docker; is Docker installed and on PATH?")?;
@@ -320,6 +343,7 @@ mod tests {
             model_base_url: None,
             model: None,
             passthrough_env: vec!["AGENTOS_TEST_ENV_THAT_DOES_NOT_EXIST".into()],
+            docker_env: vec![],
         }
     }
 
@@ -358,6 +382,16 @@ mod tests {
         let joined = s.run_args().join(" ");
         assert!(!joined.contains("AGENTOS_FAKE_MODEL"));
         assert!(!joined.contains("AGENTOS_TEST_ENV_THAT_DOES_NOT_EXIST"));
+    }
+
+    #[test]
+    fn docker_env_marks_passthrough_name_without_leaking_value() {
+        let mut s = spec();
+        s.passthrough_env = vec!["GITHUB_PERSONAL_ACCESS_TOKEN".into()];
+        s.docker_env = vec![("GITHUB_PERSONAL_ACCESS_TOKEN".into(), "ghp-secret".into())];
+        let joined = s.run_args().join(" ");
+        assert!(joined.contains("-e GITHUB_PERSONAL_ACCESS_TOKEN"));
+        assert!(!joined.contains("ghp-secret"));
     }
 
     #[test]

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -32,7 +32,7 @@ pub struct StartSpec {
     /// credentials for real-model runs; never baked into the args as values).
     pub passthrough_env: Vec<String>,
     /// Env values supplied only to the Docker CLI process. Used for secrets
-    /// loaded from the OS credential store so they can be forwarded by `-e NAME`
+    /// loaded from AgentOS private storage so they can be forwarded by `-e NAME`
     /// without mutating the AgentOS process env or appearing in argv.
     pub docker_env: Vec<(String, String)>,
 }

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -68,7 +68,15 @@ enum TuiAction {
 
 #[derive(Clone, Copy, Debug)]
 enum Workflow {
-    GithubAgentChat,
+    ExploreExamples,
+}
+
+#[derive(Clone, Debug)]
+struct ExampleChoice {
+    name: &'static str,
+    description: &'static str,
+    directory: &'static str,
+    secrets: &'static [&'static str],
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -132,9 +140,7 @@ impl App {
         let recipes = recipes();
         App {
             recipes,
-            targets: vec![
-                "all", "skill", "examples", "secrets", "local", "cluster", "dev",
-            ],
+            targets: vec!["all", "skill", "secrets", "local", "cluster", "dev"],
             target_idx: 0,
             selected: 0,
             message: "Select an action. Enter runs it; q exits.".into(),
@@ -293,8 +299,8 @@ fn run_recipe_in_tui(
     let Some(values) = prompt_recipe_fields(terminal, app, recipe)? else {
         return Ok(format!("Canceled: {}", recipe.title));
     };
-    if matches!(recipe.kind, RecipeKind::Workflow(Workflow::GithubAgentChat)) {
-        run_github_agent_chat(terminal, app, &values)?;
+    if matches!(recipe.kind, RecipeKind::Workflow(Workflow::ExploreExamples)) {
+        explore_examples(terminal, app, &values)?;
         return Ok(format!("Finished: {}", recipe.title));
     }
     let mut view = RunView::new(recipe.title);
@@ -576,59 +582,73 @@ fn prompt_text(
     }
 }
 
-fn run_github_agent_chat(
+fn explore_examples(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &App,
     _values: &BTreeMap<String, String>,
 ) -> Result<()> {
+    let choices = example_choices()
+        .into_iter()
+        .map(|example| SelectChoice {
+            label: example.name.to_string(),
+            description: example.description.to_string(),
+            value: example,
+        })
+        .collect();
+    let Some(example) = prompt_select(
+        terminal,
+        app,
+        "Explore Examples",
+        "Choose an agent to run",
+        choices,
+    )?
+    else {
+        return Ok(());
+    };
+
     crate::secrets::sync_vault_index()?;
     ensure_model_credential_available(terminal, app)?;
-    ensure_secret_available(terminal, app, "GITHUB_PERSONAL_ACCESS_TOKEN")?;
-    let secret_env = github_chat_secret_env()?;
+    for name in example.secrets {
+        ensure_secret_available(terminal, app, name)?;
+    }
+    let secret_env = example_secret_env(example.secrets)?;
 
     let repo_root = find_repo_root(std::env::current_dir().context("reading current directory")?)
         .context(
         "could not find AgentOS repo root; run this workflow from the source checkout",
     )?;
-    let example_dir = repo_root.join("examples/github-issues");
-    if !example_dir.join(".mcp.json").is_file() {
-        anyhow::bail!(
-            "missing MCP auth example at {}; expected examples/github-issues/.mcp.json",
-            example_dir.display()
-        );
+    let example_dir = repo_root.join(example.directory);
+    if !example_dir.join(".claude-plugin/plugin.json").is_file() {
+        anyhow::bail!("missing example bundle at {}", example_dir.display());
     }
 
-    let container_name = "agentos-github-agent-chat";
+    let container_name = format!("agentos-example-{}", example.name);
     let port = "7247";
     let url = format!("http://localhost:{port}");
-    let mut setup = RunView::new("Starting GitHub agent");
+    let mut setup = RunView::new(&format!("Starting {}", example.name));
     let mut started = false;
     let run_result = (|| -> Result<()> {
-        run_agentos_in_tui_with_env(
-            terminal,
-            app,
-            &[
-                "skill".to_string(),
-                "up".to_string(),
-                "--plugin-dir".to_string(),
-                example_dir.display().to_string(),
-                "--port".to_string(),
-                port.to_string(),
-                "--name".to_string(),
-                container_name.to_string(),
-                "--secret".to_string(),
-                "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
-            ],
-            &repo_root,
-            &mut setup,
-            &secret_env,
-        )?;
+        let mut argv = vec![
+            "skill".to_string(),
+            "up".to_string(),
+            "--plugin-dir".to_string(),
+            example_dir.display().to_string(),
+            "--port".to_string(),
+            port.to_string(),
+            "--name".to_string(),
+            container_name.clone(),
+        ];
+        for name in example.secrets {
+            argv.push("--secret".to_string());
+            argv.push((*name).to_string());
+        }
+        run_agentos_in_tui_with_env(terminal, app, &argv, &repo_root, &mut setup, &secret_env)?;
         started = true;
-        chat_with_runner(terminal, &repo_root, &url)
+        chat_with_runner(terminal, &repo_root, &url, example.name)
     })();
 
     if started {
-        let mut cleanup = RunView::new("Stopping GitHub agent");
+        let mut cleanup = RunView::new(&format!("Stopping {}", example.name));
         if let Err(err) = run_agentos_in_tui(
             terminal,
             app,
@@ -650,7 +670,31 @@ fn run_github_agent_chat(
     Ok(())
 }
 
-fn github_chat_secret_env() -> Result<Vec<(String, String)>> {
+fn example_choices() -> Vec<ExampleChoice> {
+    vec![
+        ExampleChoice {
+            name: "GitHub issues",
+            description:
+                "Explore live repositories and issues through authenticated GitHub MCP tools",
+            directory: "examples/github-issues",
+            secrets: &["GITHUB_PERSONAL_ACCESS_TOKEN"],
+        },
+        ExampleChoice {
+            name: "Text stats engine",
+            description: "Use an in-bundle MCP server to inspect and analyze text",
+            directory: "examples/text-stats-engine",
+            secrets: &[],
+        },
+        ExampleChoice {
+            name: "Weather",
+            description: "Chat with the minimal weather agent bundle",
+            directory: "examples/weather",
+            secrets: &[],
+        },
+    ]
+}
+
+fn example_secret_env(extra_secrets: &[&str]) -> Result<Vec<(String, String)>> {
     let mut env = Vec::new();
     if ![
         "AGENTOS_CREDENTIALS",
@@ -671,9 +715,11 @@ fn github_chat_secret_env() -> Result<Vec<(String, String)>> {
             }
         }
     }
-    if std::env::var_os("GITHUB_PERSONAL_ACCESS_TOKEN").is_none() {
-        if let Some(value) = crate::secrets::get_value("GITHUB_PERSONAL_ACCESS_TOKEN")? {
-            env.push(("GITHUB_PERSONAL_ACCESS_TOKEN".to_string(), value));
+    for name in extra_secrets {
+        if std::env::var_os(name).is_none() {
+            if let Some(value) = crate::secrets::get_value(name)? {
+                env.push(((*name).to_string(), value));
+            }
         }
     }
     Ok(env)
@@ -690,20 +736,8 @@ fn ensure_secret_available(
     if crate::secrets::is_saved(name)? {
         return Ok(());
     }
-    if crate::secrets::needs_vault_upgrade(name)? {
-        let Some(value) = prompt_text(
-            terminal,
-            app,
-            "Update Credential Storage",
-            &format!("Re-enter {name} to move it into the AgentOS vault"),
-            None,
-            true,
-            false,
-        )?
-        else {
-            anyhow::bail!("{name} is required for this workflow");
-        };
-        return crate::secrets::save_value(name, &value);
+    if crate::secrets::needs_vault_upgrade(name)? && crate::secrets::migrate_legacy_value(name)? {
+        return Ok(());
     }
     let Some(save) = prompt_select(
         terminal,
@@ -764,19 +798,9 @@ fn ensure_model_credential_available(
         })
         .collect::<Vec<_>>();
     if let Some(name) = legacy_names.first() {
-        let Some(value) = prompt_text(
-            terminal,
-            app,
-            "Update Credential Storage",
-            &format!("Re-enter {name} to move it into the AgentOS vault"),
-            None,
-            true,
-            false,
-        )?
-        else {
-            anyhow::bail!("a supported model credential is required");
-        };
-        return crate::secrets::save_value(name, &value);
+        if crate::secrets::migrate_legacy_value(name)? {
+            return Ok(());
+        }
     }
 
     let choices = NAMES
@@ -810,22 +834,6 @@ fn ensure_model_credential_available(
         anyhow::bail!("a supported model credential is required");
     };
     crate::secrets::save_value(&name, &value)
-}
-
-fn secret_status(
-    name: &str,
-    saved_names: &BTreeSet<String>,
-    legacy_names: &BTreeSet<String>,
-) -> &'static str {
-    if std::env::var_os(name).is_some() {
-        "env"
-    } else if saved_names.contains(name) {
-        "saved"
-    } else if legacy_names.contains(name) {
-        "saved (upgrade needed)"
-    } else {
-        "missing"
-    }
 }
 
 fn model_credential_status(
@@ -865,21 +873,15 @@ fn secrets_status_lines() -> Vec<Line<'static>> {
         .into_iter()
         .filter(|name| !saved_names.contains(name))
         .collect::<BTreeSet<_>>();
-    vec![
-        Line::from(format!(
-            "Model credential: {}",
-            model_credential_status(&saved_names, &legacy_names)
-        )),
-        Line::from(format!(
-            "GITHUB_PERSONAL_ACCESS_TOKEN: {}",
-            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN", &saved_names, &legacy_names)
-        )),
-    ]
+    vec![Line::from(format!(
+        "Model credential: {}",
+        model_credential_status(&saved_names, &legacy_names)
+    ))]
 }
 
 fn maybe_add_secret_status(lines: &mut Vec<Line<'static>>, workflow: Workflow) {
     match workflow {
-        Workflow::GithubAgentChat => {
+        Workflow::ExploreExamples => {
             lines.push(Line::from(Span::styled(
                 "Credential status",
                 Style::default().fg(Color::Yellow).bold(),
@@ -958,6 +960,7 @@ impl RunView {
 
 #[derive(Debug)]
 struct ChatView {
+    agent_name: String,
     lines: Vec<String>,
     input: String,
     scroll: u16,
@@ -966,12 +969,12 @@ struct ChatView {
 }
 
 impl ChatView {
-    fn new() -> Self {
+    fn new(agent_name: &str) -> Self {
         Self {
+            agent_name: agent_name.to_string(),
             lines: vec![
-                "GitHub agent is ready.".to_string(),
-                "Ask about repositories, issues, pull requests, or anything its tools can answer."
-                    .to_string(),
+                format!("{agent_name} is ready."),
+                "Send a message to interact with this example agent.".to_string(),
                 String::new(),
             ],
             input: String::new(),
@@ -1001,8 +1004,9 @@ fn chat_with_runner(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     cwd: &Path,
     url: &str,
+    agent_name: &str,
 ) -> Result<()> {
-    let mut chat = ChatView::new();
+    let mut chat = ChatView::new(agent_name);
     loop {
         let Some(message) = read_chat_input(terminal, &mut chat)? else {
             return Ok(());
@@ -1079,7 +1083,7 @@ fn run_chat_turn(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .context("sending message to the GitHub agent")?;
+        .context("sending message to the example agent")?;
     let (tx, rx) = mpsc::channel();
     let stdout = child.stdout.take().context("capturing agent response")?;
     let stderr = child.stderr.take().context("capturing agent diagnostics")?;
@@ -1511,21 +1515,17 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             lines.push(Line::from("3. Remove from the OS credential store"));
             lines.push(Line::from(""));
         }
-        RecipeKind::Workflow(Workflow::GithubAgentChat) => {
+        RecipeKind::Workflow(Workflow::ExploreExamples) => {
             lines.push(Line::from(Span::styled(
-                "Interactive session",
+                "Example browser",
                 Style::default().fg(Color::Yellow).bold(),
             )));
-            lines.push(Line::from("1. Check model and GitHub credentials"));
-            lines.push(Line::from(
-                "2. Start the GitHub agent with its authenticated MCP tools",
-            ));
-            lines.push(Line::from(
-                "3. Chat with the agent for as many turns as needed",
-            ));
+            lines.push(Line::from("1. Choose an example agent"));
+            lines.push(Line::from("2. Start its runner and required tools"));
+            lines.push(Line::from("3. Chat for as many turns as needed"));
             lines.push(Line::from("4. Stop the runner when you leave chat"));
             lines.push(Line::from(""));
-            maybe_add_secret_status(&mut lines, Workflow::GithubAgentChat);
+            maybe_add_secret_status(&mut lines, Workflow::ExploreExamples);
         }
     }
     if !recipe.fields.is_empty() {
@@ -1642,7 +1642,7 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
     frame.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled("AgentOS", Style::default().fg(Color::Cyan).bold()),
-            Span::raw("  GitHub agent"),
+            Span::raw(format!("  {}", chat.agent_name)),
             if chat.thinking {
                 Span::styled("  thinking...", Style::default().fg(Color::Yellow))
             } else {
@@ -1951,15 +1951,15 @@ fn recipes() -> Vec<Recipe> {
             notes: &[],
         },
         Recipe {
-            target: "examples",
-            title: "Chat with GitHub agent",
-            description: "Start the GitHub MCP bundle and have a live conversation with the agent.",
-            kind: RecipeKind::Workflow(Workflow::GithubAgentChat),
+            target: "all",
+            title: "Explore examples",
+            description: "Choose an example agent, start it, and chat with it interactively.",
+            kind: RecipeKind::Workflow(Workflow::ExploreExamples),
             args: vec![],
             fields: vec![],
             notes: &[
                 "Requires a saved or environment model credential: ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or AGENTOS_CREDENTIALS.",
-                "Requires a saved or environment GITHUB_PERSONAL_ACCESS_TOKEN; the value is forwarded by name and not placed in argv.",
+                "Examples request any additional credentials they need after you choose one.",
                 "The runner stays up for a multi-turn conversation and stops when you leave chat.",
             ],
         },
@@ -2164,21 +2164,14 @@ mod tests {
     }
 
     #[test]
-    fn examples_target_includes_github_agent_chat() {
+    fn explore_examples_is_an_action_not_a_target_tab() {
         let app = App::new();
-        let idx = app
-            .targets
+        assert!(!app.targets.contains(&"examples"));
+        assert!(app
+            .recipes
             .iter()
-            .position(|target| *target == "examples")
-            .expect("examples target exists");
-        let mut app = app;
-        app.target_idx = idx;
-        let titles: Vec<&str> = app
-            .visible_indices()
-            .iter()
-            .map(|idx| app.recipes[*idx].title)
-            .collect();
-        assert!(titles.contains(&"Chat with GitHub agent"));
+            .any(|recipe| recipe.title == "Explore examples"));
+        assert_eq!(example_choices().len(), 3);
     }
 
     #[test]
@@ -2256,18 +2249,13 @@ mod tests {
     }
 
     #[test]
-    fn credential_status_uses_saved_names_without_secret_reads() {
+    fn model_status_uses_saved_names_without_secret_reads() {
         let saved = BTreeSet::from([
             "ANTHROPIC_API_KEY".to_string(),
             "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
         ]);
         let legacy = BTreeSet::new();
         assert_eq!(model_credential_status(&saved, &legacy), "available");
-        assert_eq!(
-            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN", &saved, &legacy),
-            "saved"
-        );
-        assert_eq!(secret_status("OPENAI_API_KEY", &saved, &legacy), "missing");
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -258,11 +258,17 @@ fn prompt_recipe_fields(
     recipe: &Recipe,
 ) -> Result<Option<BTreeMap<String, String>>> {
     let mut values = BTreeMap::new();
-    for field in &recipe.fields {
+    for (idx, field) in recipe.fields.iter().enumerate() {
+        let title = format!(
+            "{} · Step {} of {}",
+            recipe.title,
+            idx + 1,
+            recipe.fields.len()
+        );
         let Some(value) = prompt_text(
             terminal,
             app,
-            recipe.title,
+            &title,
             field.label,
             field.default,
             false,
@@ -537,7 +543,7 @@ fn prompt_text(
     loop {
         terminal.draw(|frame| {
             draw(frame, app);
-            draw_prompt(frame, title, label, default, &value, secret);
+            draw_prompt(frame, title, label, default, &value, secret, allow_empty);
         })?;
         let Event::Key(key) = event::read()? else {
             continue;
@@ -1398,27 +1404,34 @@ fn draw_prompt(
     default: Option<&str>,
     value: &str,
     secret: bool,
+    allow_empty: bool,
 ) {
     let area = centered_rect(64, 9, frame.area());
     let input_width = area.width.saturating_sub(3) as usize;
     let shown_value = input_window(value, secret, input_width);
-    let prompt = match default {
-        Some(default) => format!("{label} [{default}]"),
-        None => label.to_string(),
+    let guidance = match default {
+        Some(default) => format!("Default: {default}"),
+        None if secret => "Input is hidden while typing".to_string(),
+        None if allow_empty => "Optional: press Enter to skip".to_string(),
+        None => "Type a value".to_string(),
+    };
+    let submit_help = if default.is_some() {
+        "Enter use default    Esc cancel"
+    } else if allow_empty {
+        "Enter accept or skip    Esc cancel"
+    } else {
+        "Enter accept    Esc cancel"
     };
     let body = Text::from(vec![
-        Line::from(prompt),
-        Line::from(""),
+        Line::from(Span::styled(label, Style::default().bold())),
+        Line::from(Span::styled(guidance, Style::default().fg(Color::Gray))),
         Line::from(if shown_value.is_empty() {
             Span::styled(" ", Style::default().fg(Color::Gray))
         } else {
             Span::raw(&shown_value)
         }),
         Line::from(""),
-        Line::from(Span::styled(
-            "Enter accept    Esc cancel",
-            Style::default().fg(Color::Gray),
-        )),
+        Line::from(Span::styled(submit_help, Style::default().fg(Color::Gray))),
     ]);
     frame.render_widget(Clear, area);
     frame.render_widget(
@@ -1593,7 +1606,7 @@ fn recipes() -> Vec<Recipe> {
             fields: vec![
                 Field {
                     key: "repo",
-                    label: "GitHub repo to inspect",
+                    label: "Repository to query (owner/repo)",
                     default: Some("curie-eng/agentos"),
                     required: true,
                 },

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -3,14 +3,15 @@
 //! This is a ratatui/crossterm surface over the existing clap command grammar:
 //! it does not invent a second implementation path. The TUI helps a human pick
 //! a target and action, previews the exact `agentos ...` command, prompts for
-//! any required values, then either handles a small read-only action in the TUI
-//! or suspends the alternate screen and runs that command as a normal child
-//! process.
+//! any required values, then keeps prompts, command output, and workflow results
+//! inside the alternate-screen interface.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, BufRead, BufReader, IsTerminal};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -203,19 +204,15 @@ impl App {
         let Some(recipe) = self.selected_recipe().cloned() else {
             return Ok(());
         };
-        if let RecipeKind::Tui(action) = &recipe.kind {
-            self.message = match run_tui_action(*action, terminal, self) {
-                Ok(message) => message,
-                Err(err) => format!("Action failed: {err:#}"),
-            };
-            return Ok(());
-        }
-        suspend_terminal()?;
-        let result = prompt_and_run(&recipe);
-        resume_terminal()?;
+        let result = match &recipe.kind {
+            RecipeKind::Tui(action) => run_tui_action(*action, terminal, self),
+            RecipeKind::Command | RecipeKind::Workflow(_) => {
+                run_recipe_in_tui(terminal, self, &recipe)
+            }
+        };
         self.message = match result {
-            Ok(()) => format!("Finished: {}", recipe.title),
-            Err(err) => format!("Command failed to start or complete: {err:#}"),
+            Ok(message) => message,
+            Err(err) => format!("Action failed: {err:#}"),
         };
         Ok(())
     }
@@ -255,40 +252,59 @@ impl Drop for TerminalSession {
     }
 }
 
-fn suspend_terminal() -> Result<()> {
-    disable_raw_mode().ok();
-    execute!(io::stdout(), LeaveAlternateScreen).context("leaving alternate screen")
-}
-
-fn resume_terminal() -> Result<()> {
-    print!("Press Enter to return to AgentOS interactive...");
-    io::stdout().flush().ok();
-    let mut line = String::new();
-    let _ = io::stdin().read_line(&mut line);
-    execute!(io::stdout(), EnterAlternateScreen).context("entering alternate screen")?;
-    enable_raw_mode().context("enabling terminal raw mode")
-}
-
-fn prompt_and_run(recipe: &Recipe) -> Result<()> {
-    println!("AgentOS interactive: {}", recipe.title);
-    println!("{}", recipe.description);
-    println!();
-
+fn prompt_recipe_fields(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    recipe: &Recipe,
+) -> Result<Option<BTreeMap<String, String>>> {
     let mut values = BTreeMap::new();
     for field in &recipe.fields {
-        let value = prompt_field(field)?;
+        let Some(value) = prompt_text(
+            terminal,
+            app,
+            recipe.title,
+            field.label,
+            field.default,
+            false,
+            !field.required,
+        )?
+        else {
+            return Ok(None);
+        };
+        if field.required && value.is_empty() {
+            return Ok(None);
+        }
         values.insert(field.key.to_string(), value);
     }
-    match &recipe.kind {
+    Ok(Some(values))
+}
+
+fn run_recipe_in_tui(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    recipe: &Recipe,
+) -> Result<String> {
+    let Some(values) = prompt_recipe_fields(terminal, app, recipe)? else {
+        return Ok(format!("Canceled: {}", recipe.title));
+    };
+    let mut view = RunView::new(recipe.title);
+    let run_result = match &recipe.kind {
         RecipeKind::Command => {
             let argv = build_argv(recipe, &values);
-            println!();
-            run_agentos(&argv, Path::new("."))?;
+            run_agentos_in_tui(terminal, app, &argv, Path::new("."), &mut view)
         }
-        RecipeKind::Tui(_) => {}
-        RecipeKind::Workflow(Workflow::McpAuthExample) => run_mcp_auth_example(&values)?,
+        RecipeKind::Tui(_) => Ok(()),
+        RecipeKind::Workflow(Workflow::McpAuthExample) => {
+            run_mcp_auth_example(terminal, app, &values, &mut view)
+        }
+    };
+    if let Err(err) = &run_result {
+        view.push("");
+        view.push(format!("ERROR: {err:#}"));
     }
-    Ok(())
+    show_run_view(terminal, app, &mut view)?;
+    run_result?;
+    Ok(format!("Finished: {}", recipe.title))
 }
 
 fn run_tui_action(
@@ -318,6 +334,7 @@ fn run_tui_action(
                         "Custom secret name",
                         None,
                         false,
+                        false,
                     )?
                     else {
                         return Ok("Save secret canceled.".to_string());
@@ -326,7 +343,8 @@ fn run_tui_action(
                 }
             };
             crate::secrets::validate_name(&name)?;
-            let Some(value) = prompt_text(terminal, app, "Save Secret", &name, None, true)? else {
+            let Some(value) = prompt_text(terminal, app, "Save Secret", &name, None, true, false)?
+            else {
                 return Ok("Save secret canceled.".to_string());
             };
             crate::secrets::save_value(&name, &value)?;
@@ -361,6 +379,7 @@ fn run_tui_action(
                         "Custom secret name",
                         None,
                         false,
+                        false,
                     )?
                     else {
                         return Ok("Remove secret canceled.".to_string());
@@ -375,6 +394,7 @@ fn run_tui_action(
                 "Remove Secret",
                 &format!("Type {name} to confirm"),
                 None,
+                false,
                 false,
             )?
             else {
@@ -407,7 +427,7 @@ fn secret_name_choices_for(saved_names: &BTreeSet<String>) -> Vec<SelectChoice<S
         ),
         (
             "OPENAI_API_KEY",
-            "OpenAI API key for model or MCP workflows",
+            "OpenAI integrations (not AgentOS runner model auth)",
         ),
         (
             "GITHUB_PERSONAL_ACCESS_TOKEN",
@@ -511,6 +531,7 @@ fn prompt_text(
     label: &str,
     default: Option<&str>,
     secret: bool,
+    allow_empty: bool,
 ) -> Result<Option<String>> {
     let mut value = String::new();
     loop {
@@ -526,7 +547,13 @@ fn prompt_text(
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
             (KeyCode::Enter, _) => {
                 if value.is_empty() {
-                    return Ok(default.map(str::to_string));
+                    if let Some(default) = default {
+                        return Ok(Some(default.to_string()));
+                    }
+                    if allow_empty {
+                        return Ok(Some(String::new()));
+                    }
+                    continue;
                 }
                 return Ok(Some(value));
             }
@@ -541,7 +568,12 @@ fn prompt_text(
     }
 }
 
-fn run_mcp_auth_example(values: &BTreeMap<String, String>) -> Result<()> {
+fn run_mcp_auth_example(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    values: &BTreeMap<String, String>,
+    view: &mut RunView,
+) -> Result<()> {
     let repo = values
         .get("repo")
         .filter(|value| !value.is_empty())
@@ -559,8 +591,8 @@ fn run_mcp_auth_example(values: &BTreeMap<String, String>) -> Result<()> {
         .unwrap_or("7247");
     let should_build = yesish(values.get("build").map(String::as_str).unwrap_or("y"));
 
-    ensure_model_credential_available()?;
-    ensure_secret_available("GITHUB_PERSONAL_ACCESS_TOKEN")?;
+    ensure_model_credential_available(terminal, app)?;
+    ensure_secret_available(terminal, app, "GITHUB_PERSONAL_ACCESS_TOKEN")?;
 
     let repo_root = find_repo_root(std::env::current_dir().context("reading current directory")?)
         .context(
@@ -574,23 +606,25 @@ fn run_mcp_auth_example(values: &BTreeMap<String, String>) -> Result<()> {
         );
     }
 
-    println!("This workflow will verify the authenticated GitHub MCP example end to end.");
-    println!("Example bundle: {}", example_dir.display());
-    println!("Target repository: {repo}");
-    println!();
+    view.push("Authenticated GitHub MCP end-to-end verification");
+    view.push(format!("Example bundle: {}", example_dir.display()));
+    view.push(format!("Target repository: {repo}"));
+    view.push("");
 
     if should_build {
-        run_agentos(&["build".to_string()], &repo_root)?;
+        run_agentos_in_tui(terminal, app, &["build".to_string()], &repo_root, view)?;
     } else {
-        println!("Skipping runner image build because you answered no.");
-        println!();
+        view.push("Skipping runner image build.");
+        view.push("");
     }
 
     let container_name = "agentos-mcp-auth-example";
     let url = format!("http://localhost:{port}");
     let mut started = false;
     let run_result = (|| -> Result<()> {
-        run_agentos(
+        run_agentos_in_tui(
+            terminal,
+            app,
             &[
                 "skill".to_string(),
                 "up".to_string(),
@@ -604,9 +638,12 @@ fn run_mcp_auth_example(values: &BTreeMap<String, String>) -> Result<()> {
                 "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
             ],
             &repo_root,
+            view,
         )?;
         started = true;
-        run_agentos(
+        run_agentos_in_tui(
+            terminal,
+            app,
             &[
                 "skill".to_string(),
                 "message".to_string(),
@@ -615,22 +652,27 @@ fn run_mcp_auth_example(values: &BTreeMap<String, String>) -> Result<()> {
                 url,
             ],
             &repo_root,
+            view,
         )
     })();
 
     if started {
-        println!();
-        println!("Cleaning up the example runner...");
-        if let Err(err) = run_agentos(&["skill".to_string(), "down".to_string()], &example_dir) {
-            println!("Cleanup warning: {err:#}");
+        view.push("Cleaning up the example runner...");
+        if let Err(err) = run_agentos_in_tui(
+            terminal,
+            app,
+            &["skill".to_string(), "down".to_string()],
+            &example_dir,
+            view,
+        ) {
+            view.push(format!("Cleanup warning: {err:#}"));
         }
     }
 
     run_result?;
-    println!();
-    println!(
-        "Pass condition: the answer above should cite live issue titles or numbers from {repo}."
-    );
+    view.push(format!(
+        "PASS CONDITION: the answer above cites live issue titles or numbers from {repo}."
+    ));
     Ok(())
 }
 
@@ -641,30 +683,51 @@ fn yesish(value: &str) -> bool {
     )
 }
 
-fn ensure_secret_available(name: &str) -> Result<()> {
+fn ensure_secret_available(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    name: &str,
+) -> Result<()> {
     if std::env::var_os(name).is_some() {
-        println!("{name}: available from the current environment.");
         return Ok(());
     }
     if crate::secrets::has_value(name) {
-        println!("{name}: available from the AgentOS secret store.");
         return Ok(());
     }
-    println!("{name}: missing.");
-    if prompt_yes_no(
-        &format!("Save {name} in the OS credential store now?"),
-        true,
-    )? {
-        crate::secrets::set(crate::secrets::SetSecretOpts {
-            name: name.to_string(),
-            from_env: None,
-        })?;
-        return Ok(());
+    let Some(save) = prompt_select(
+        terminal,
+        app,
+        "Missing Credential",
+        &format!("{name} is required"),
+        vec![
+            SelectChoice {
+                label: "Save it now".to_string(),
+                description: "Store it in the OS credential store".to_string(),
+                value: true,
+            },
+            SelectChoice {
+                label: "Cancel workflow".to_string(),
+                description: "Return to AgentOS without running".to_string(),
+                value: false,
+            },
+        ],
+    )?
+    else {
+        anyhow::bail!("{name} is required for this workflow");
+    };
+    if !save {
+        anyhow::bail!("{name} is required for this workflow");
     }
-    anyhow::bail!("{name} is required for this workflow")
+    let Some(value) = prompt_text(terminal, app, "Save Secret", name, None, true, false)? else {
+        anyhow::bail!("{name} is required for this workflow");
+    };
+    crate::secrets::save_value(name, &value)
 }
 
-fn ensure_model_credential_available() -> Result<()> {
+fn ensure_model_credential_available(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+) -> Result<()> {
     const NAMES: &[&str] = &[
         "AGENTOS_CREDENTIALS",
         "ANTHROPIC_API_KEY",
@@ -672,66 +735,46 @@ fn ensure_model_credential_available() -> Result<()> {
     ];
     for name in NAMES {
         if std::env::var_os(name).is_some() {
-            println!("{name}: model credential available from the current environment.");
             return Ok(());
         }
     }
     for name in NAMES {
         if crate::secrets::has_value(name) {
-            println!("{name}: model credential available from the AgentOS secret store.");
             return Ok(());
         }
     }
 
-    println!("Model credential: missing.");
-    if !prompt_yes_no(
-        "Save a model credential in the OS credential store now?",
-        true,
-    )? {
-        anyhow::bail!(
-            "a model credential is required; save AGENTOS_CREDENTIALS, ANTHROPIC_API_KEY, or CLAUDE_CODE_OAUTH_TOKEN"
-        );
-    }
-    print!("Credential name [ANTHROPIC_API_KEY]: ");
-    io::stdout().flush().ok();
-    let mut line = String::new();
-    io::stdin()
-        .read_line(&mut line)
-        .context("reading credential name")?;
-    let name = if line.trim().is_empty() {
-        "ANTHROPIC_API_KEY"
-    } else {
-        line.trim()
+    let choices = NAMES
+        .iter()
+        .map(|name| SelectChoice {
+            label: (*name).to_string(),
+            description: "Supported by the AgentOS Claude SDK runner".to_string(),
+            value: (*name).to_string(),
+        })
+        .collect();
+    let Some(name) = prompt_select(
+        terminal,
+        app,
+        "Missing Model Credential",
+        "Choose a model credential to save",
+        choices,
+    )?
+    else {
+        anyhow::bail!("a supported model credential is required");
     };
-    if !NAMES.contains(&name) {
-        anyhow::bail!(
-            "unsupported model credential name {name}; use AGENTOS_CREDENTIALS, ANTHROPIC_API_KEY, or CLAUDE_CODE_OAUTH_TOKEN"
-        );
-    }
-    crate::secrets::set(crate::secrets::SetSecretOpts {
-        name: name.to_string(),
-        from_env: None,
-    })?;
-    Ok(())
-}
-
-fn prompt_yes_no(prompt: &str, default: bool) -> Result<bool> {
-    loop {
-        let suffix = if default { "[Y/n]" } else { "[y/N]" };
-        print!("{prompt} {suffix}: ");
-        io::stdout().flush().ok();
-        let mut line = String::new();
-        io::stdin().read_line(&mut line)?;
-        let value = line.trim().to_ascii_lowercase();
-        if value.is_empty() {
-            return Ok(default);
-        }
-        match value.as_str() {
-            "y" | "yes" => return Ok(true),
-            "n" | "no" => return Ok(false),
-            _ => println!("Please answer y or n."),
-        }
-    }
+    let Some(value) = prompt_text(
+        terminal,
+        app,
+        "Save Model Credential",
+        &name,
+        None,
+        true,
+        false,
+    )?
+    else {
+        anyhow::bail!("a supported model credential is required");
+    };
+    crate::secrets::save_value(&name, &value)
 }
 
 fn secret_status(name: &str) -> &'static str {
@@ -791,41 +834,203 @@ fn find_repo_root(mut dir: PathBuf) -> Option<PathBuf> {
     }
 }
 
-fn run_agentos(argv: &[String], cwd: &Path) -> Result<()> {
-    println!("$ {}", render_command(argv));
-    println!();
-    let status = Command::new(std::env::current_exe().context("resolving current executable")?)
+#[derive(Debug)]
+struct RunView {
+    title: String,
+    lines: Vec<String>,
+    scroll: u16,
+    follow: bool,
+    running: bool,
+}
+
+impl RunView {
+    fn new(title: &str) -> Self {
+        Self {
+            title: title.to_string(),
+            lines: Vec::new(),
+            scroll: 0,
+            follow: true,
+            running: true,
+        }
+    }
+
+    fn push(&mut self, line: impl Into<String>) {
+        self.lines.push(line.into());
+    }
+
+    fn follow_tail(&mut self, terminal_width: u16, terminal_height: u16) {
+        if self.follow {
+            let viewport = terminal_height.saturating_sub(8) as usize;
+            let output_width = terminal_width.saturating_sub(6).max(1) as usize;
+            self.scroll = wrap_output_lines(&self.lines, output_width)
+                .len()
+                .saturating_sub(viewport)
+                .min(u16::MAX as usize) as u16;
+        }
+    }
+}
+
+fn run_agentos_in_tui(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    argv: &[String],
+    cwd: &Path,
+    view: &mut RunView,
+) -> Result<()> {
+    view.push(format!("$ {}", render_command(argv)));
+    view.push("");
+    view.running = true;
+    let mut child = Command::new(std::env::current_exe().context("resolving current executable")?)
         .args(argv)
         .current_dir(cwd)
-        .status()
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .with_context(|| format!("running {}", render_command(argv)))?;
+
+    let (tx, rx) = mpsc::channel();
+    let stdout = child.stdout.take().context("capturing agentos stdout")?;
+    let stderr = child.stderr.take().context("capturing agentos stderr")?;
+    let readers = [stdout_reader(stdout, tx.clone()), stderr_reader(stderr, tx)];
+    let mut canceled = false;
+
+    let status_result = (|| -> Result<std::process::ExitStatus> {
+        loop {
+            while let Ok(line) = rx.try_recv() {
+                view.push(line);
+            }
+            let size = terminal.size()?;
+            view.follow_tail(size.width, size.height);
+            terminal.draw(|frame| {
+                draw(frame, app);
+                draw_run_view(frame, view);
+            })?;
+
+            if event::poll(Duration::from_millis(50))? {
+                if let Event::Key(key) = event::read()? {
+                    match (key.code, key.modifiers) {
+                        (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                            child.kill().context("canceling agentos command")?;
+                            canceled = true;
+                        }
+                        (KeyCode::Up | KeyCode::Char('k'), _) => {
+                            view.follow = false;
+                            view.scroll = view.scroll.saturating_sub(1);
+                        }
+                        (KeyCode::Down | KeyCode::Char('j'), _) => {
+                            view.scroll = view.scroll.saturating_add(1);
+                        }
+                        (KeyCode::End, _) => view.follow = true,
+                        _ => {}
+                    }
+                }
+            }
+            if let Some(status) = child.try_wait().context("waiting for agentos command")? {
+                break Ok(status);
+            }
+        }
+    })();
+
+    if status_result.is_err() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    for reader in readers {
+        let _ = reader.join();
+    }
+    while let Ok(line) = rx.try_recv() {
+        view.push(line);
+    }
+    view.running = false;
+    view.push("");
+    let status = status_result?;
+    if canceled {
+        view.push("Canceled by user.");
+        anyhow::bail!("{} was canceled", render_command(argv));
+    }
     if !status.success() {
+        view.push(format!("Exited with {status}."));
         anyhow::bail!("{} exited with {status}", render_command(argv));
     }
+    view.push("Completed successfully.");
+    view.push("");
     Ok(())
 }
 
-fn prompt_field(field: &Field) -> Result<String> {
+fn stdout_reader(
+    stdout: std::process::ChildStdout,
+    tx: mpsc::Sender<String>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || read_output(stdout, tx))
+}
+
+fn stderr_reader(
+    stderr: std::process::ChildStderr,
+    tx: mpsc::Sender<String>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || read_output(stderr, tx))
+}
+
+fn read_output(reader: impl io::Read, tx: mpsc::Sender<String>) {
+    for line in BufReader::new(reader).lines() {
+        match line {
+            Ok(line) => {
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+            Err(err) => {
+                let _ = tx.send(format!("Unable to read command output: {err}"));
+                break;
+            }
+        }
+    }
+}
+
+fn show_run_view(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    view: &mut RunView,
+) -> Result<()> {
+    view.running = false;
     loop {
-        match field.default {
-            Some(default) => print!("{} [{default}]: ", field.label),
-            None => print!("{}: ", field.label),
-        }
-        io::stdout().flush().ok();
-        let mut line = String::new();
-        io::stdin()
-            .read_line(&mut line)
-            .context("reading interactive answer")?;
-        let trimmed = line.trim();
-        let value = if trimmed.is_empty() {
-            field.default.unwrap_or("").to_string()
-        } else {
-            trimmed.to_string()
+        let size = terminal.size()?;
+        view.follow_tail(size.width, size.height);
+        terminal.draw(|frame| {
+            draw(frame, app);
+            draw_run_view(frame, view);
+        })?;
+        let Event::Key(key) = event::read()? else {
+            continue;
         };
-        if !field.required || !value.is_empty() {
-            return Ok(value);
+        match (key.code, key.modifiers) {
+            (KeyCode::Enter | KeyCode::Esc | KeyCode::Char('q'), _) => return Ok(()),
+            (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(()),
+            (KeyCode::Up | KeyCode::Char('k'), _) => {
+                view.follow = false;
+                view.scroll = view.scroll.saturating_sub(1);
+            }
+            (KeyCode::Down | KeyCode::Char('j'), _) => {
+                view.follow = false;
+                view.scroll = view.scroll.saturating_add(1);
+            }
+            (KeyCode::PageUp, _) => {
+                view.follow = false;
+                view.scroll = view.scroll.saturating_sub(10);
+            }
+            (KeyCode::PageDown, _) => {
+                view.follow = false;
+                view.scroll = view.scroll.saturating_add(10);
+            }
+            (KeyCode::Home, _) => {
+                view.follow = false;
+                view.scroll = 0;
+            }
+            (KeyCode::End, _) => view.follow = true,
+            _ => {}
         }
-        println!("{} is required.", field.label);
     }
 }
 
@@ -1056,7 +1261,11 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             Style::default().fg(Color::Yellow).bold(),
         )));
         for field in &recipe.fields {
-            let default = field.default.unwrap_or("required");
+            let default = field.default.unwrap_or(if field.required {
+                "required"
+            } else {
+                "optional"
+            });
             lines.push(Line::from(format!("{}: {default}", field.label)));
         }
         lines.push(Line::from(""));
@@ -1096,6 +1305,78 @@ fn draw_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
             .block(Block::default().borders(Borders::ALL)),
         area,
     );
+}
+
+fn draw_run_view(frame: &mut Frame<'_>, view: &RunView) {
+    let frame_area = frame.area();
+    let area = Rect {
+        x: frame_area.x.saturating_add(2),
+        y: frame_area.y.saturating_add(1),
+        width: frame_area.width.saturating_sub(4).max(20),
+        height: frame_area.height.saturating_sub(2).max(7),
+    };
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(5), Constraint::Length(2)])
+        .split(area);
+    let status = if view.running { "running" } else { "finished" };
+    let output_width = chunks[0].width.saturating_sub(2).max(1) as usize;
+    let wrapped_lines = wrap_output_lines(&view.lines, output_width);
+    let lines = wrapped_lines
+        .iter()
+        .map(|line| Line::from(line.as_str()))
+        .collect::<Vec<_>>();
+    let viewport = chunks[0].height.saturating_sub(2) as usize;
+    let max_scroll = wrapped_lines
+        .len()
+        .saturating_sub(viewport)
+        .min(u16::MAX as usize) as u16;
+
+    frame.render_widget(Clear, area);
+    frame.render_widget(
+        Paragraph::new(Text::from(lines))
+            .scroll((view.scroll.min(max_scroll), 0))
+            .block(
+                Block::default()
+                    .title(format!("{} · {status}", view.title))
+                    .borders(Borders::ALL),
+            ),
+        chunks[0],
+    );
+    let help = if view.running {
+        "Up/Down scroll    End follow output    Ctrl-C cancel"
+    } else {
+        "Up/Down or PgUp/PgDn scroll    Home/End jump    Enter return"
+    };
+    frame.render_widget(
+        Paragraph::new(Span::styled(help, Style::default().fg(Color::Gray)))
+            .alignment(Alignment::Center),
+        chunks[1],
+    );
+}
+
+fn wrap_output_lines(lines: &[String], max_width: usize) -> Vec<String> {
+    let mut wrapped = Vec::new();
+    for line in lines {
+        if line.is_empty() {
+            wrapped.push(String::new());
+            continue;
+        }
+        let mut current = String::new();
+        let mut width = 0;
+        for ch in line.chars() {
+            let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if !current.is_empty() && width + char_width > max_width {
+                wrapped.push(current);
+                current = String::new();
+                width = 0;
+            }
+            current.push(ch);
+            width += char_width;
+        }
+        wrapped.push(current);
+    }
+    wrapped
 }
 
 fn draw_prompt(
@@ -1326,8 +1607,8 @@ fn recipes() -> Vec<Recipe> {
                 },
             ],
             notes: &[
-                "Requires a model credential in the shell: ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or AGENTOS_CREDENTIALS.",
-                "Requires GITHUB_PERSONAL_ACCESS_TOKEN in the shell; the value is forwarded by name and not placed in argv.",
+                "Requires a saved or environment model credential: ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or AGENTOS_CREDENTIALS.",
+                "Requires a saved or environment GITHUB_PERSONAL_ACCESS_TOKEN; the value is forwarded by name and not placed in argv.",
                 "A passing run cites live GitHub issue titles or numbers.",
             ],
         },
@@ -1612,5 +1893,23 @@ mod tests {
         assert_eq!(input_window("abcdefgh", false, 5), "defgh");
         assert_eq!(input_window("ab界", false, 3), "b界");
         assert_eq!(input_window("secret", true, 4), "****");
+    }
+
+    #[test]
+    fn command_output_wraps_without_losing_wide_characters() {
+        let lines = vec!["abcdef".to_string(), "ab界cd".to_string(), String::new()];
+        assert_eq!(
+            wrap_output_lines(&lines, 4),
+            vec!["abcd", "ef", "ab界", "cd", ""]
+        );
+    }
+
+    #[test]
+    fn interactive_routes_do_not_restore_the_regular_terminal_mid_session() {
+        let source = include_str!("interactive.rs");
+        let old_suspend_path = ["suspend", "_terminal"].concat();
+        let old_line_prompt = ["prompt", "_field"].concat();
+        assert!(!source.contains(&old_suspend_path));
+        assert!(!source.contains(&old_line_prompt));
     }
 }

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -15,7 +15,10 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
+    MouseEventKind,
+};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -235,7 +238,8 @@ struct TerminalSession {
 impl TerminalSession {
     fn enter() -> Result<Self> {
         enable_raw_mode().context("enabling terminal raw mode")?;
-        execute!(io::stdout(), EnterAlternateScreen).context("entering alternate screen")?;
+        execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture)
+            .context("entering alternate screen")?;
         let backend = CrosstermBackend::new(io::stdout());
         let mut terminal = Terminal::new(backend).context("creating terminal")?;
         terminal.clear().ok();
@@ -248,7 +252,8 @@ impl TerminalSession {
     fn leave(&mut self) -> Result<()> {
         if self.active {
             disable_raw_mode().ok();
-            execute!(io::stdout(), LeaveAlternateScreen).context("leaving alternate screen")?;
+            execute!(io::stdout(), DisableMouseCapture, LeaveAlternateScreen)
+                .context("leaving alternate screen")?;
             self.active = false;
         }
         Ok(())
@@ -996,6 +1001,7 @@ struct ChatView {
     action_idx: usize,
     action_prompt: String,
     allow_free_text: bool,
+    composing: bool,
 }
 
 impl ChatView {
@@ -1021,12 +1027,12 @@ impl ChatView {
             action_idx: 0,
             action_prompt: "Try a prompt".to_string(),
             allow_free_text: true,
+            composing: false,
         }
     }
 
     fn max_scroll(&self, terminal_width: u16, terminal_height: u16) -> u16 {
-        let width = terminal_width.saturating_sub(4).max(1) as usize;
-        let viewport = terminal_height.saturating_sub(14) as usize;
+        let (width, viewport) = chat_transcript_dimensions(terminal_width, terminal_height);
         wrap_output_lines(&self.lines, width)
             .len()
             .saturating_sub(viewport)
@@ -1037,6 +1043,38 @@ impl ChatView {
         if self.follow {
             self.scroll = self.max_scroll(terminal_width, terminal_height);
         }
+    }
+
+    fn choice_count(&self) -> usize {
+        self.actions.len() + usize::from(self.allow_free_text)
+    }
+
+    fn free_text_selected(&self) -> bool {
+        self.allow_free_text && self.action_idx == self.actions.len()
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        let count = self.choice_count();
+        if count > 0 {
+            self.action_idx =
+                ((self.action_idx as isize + delta).rem_euclid(count as isize)) as usize;
+        }
+    }
+
+    fn scroll_up(&mut self, amount: u16, terminal_width: u16, terminal_height: u16) {
+        if self.follow {
+            self.scroll = self.max_scroll(terminal_width, terminal_height);
+        }
+        self.follow = false;
+        self.scroll = self.scroll.saturating_sub(amount);
+    }
+
+    fn scroll_down(&mut self, amount: u16, terminal_width: u16, terminal_height: u16) {
+        self.follow = false;
+        self.scroll = self
+            .scroll
+            .saturating_add(amount)
+            .min(self.max_scroll(terminal_width, terminal_height));
     }
 }
 
@@ -1062,6 +1100,7 @@ fn chat_with_runner(
         chat.action_idx = 0;
         chat.action_prompt = "Responses".to_string();
         chat.allow_free_text = true;
+        chat.composing = false;
         let argv = [
             "skill".to_string(),
             "message".to_string(),
@@ -1084,46 +1123,56 @@ fn read_chat_input(
         let size = terminal.size()?;
         chat.follow_tail(size.width, size.height);
         terminal.draw(|frame| draw_chat_view(frame, chat))?;
-        let Event::Key(key) = event::read()? else {
+        let event = event::read()?;
+        if let Event::Mouse(mouse) = event {
+            match mouse.kind {
+                MouseEventKind::ScrollUp => chat.scroll_up(3, size.width, size.height),
+                MouseEventKind::ScrollDown => chat.scroll_down(3, size.width, size.height),
+                _ => {}
+            }
             continue;
-        };
+        }
+        let Event::Key(key) = event else { continue };
         match (key.code, key.modifiers) {
-            (KeyCode::Esc, _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
-            (KeyCode::Enter, _) => {
-                if chat.allow_free_text && !chat.input.trim().is_empty() {
+            (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
+            (KeyCode::Esc, _) if chat.composing => chat.composing = false,
+            (KeyCode::Esc, _) => return Ok(None),
+            (KeyCode::Enter, _) if chat.composing => {
+                if !chat.input.trim().is_empty() {
                     return Ok(Some(chat.input.trim().to_string()));
                 }
-                if let Some(action) = chat.actions.get(chat.action_idx) {
+            }
+            (KeyCode::Enter, _) => {
+                if chat.free_text_selected() {
+                    chat.composing = true;
+                } else if let Some(action) = chat.actions.get(chat.action_idx) {
                     return Ok(Some(action.value.clone()));
                 }
             }
-            (KeyCode::Backspace, _) if chat.allow_free_text => {
+            (KeyCode::Backspace, _) if chat.composing => {
                 chat.input.pop();
             }
-            (KeyCode::PageUp, _) => {
+            (KeyCode::Up, _) if chat.composing => {
+                chat.scroll_up(1, size.width, size.height);
+            }
+            (KeyCode::Down, _) if chat.composing => {
+                chat.scroll_down(1, size.width, size.height);
+            }
+            (KeyCode::PageUp, _) => chat.scroll_up(10, size.width, size.height),
+            (KeyCode::PageDown, _) => chat.scroll_down(10, size.width, size.height),
+            (KeyCode::Home, _) if !chat.composing => {
                 chat.follow = false;
-                chat.scroll = chat.scroll.saturating_sub(10);
+                chat.scroll = 0;
             }
-            (KeyCode::PageDown, _) => {
-                chat.follow = false;
-                chat.scroll = chat
-                    .scroll
-                    .saturating_add(10)
-                    .min(chat.max_scroll(size.width, size.height));
+            (KeyCode::End, _) if !chat.composing => chat.follow = true,
+            (KeyCode::Down | KeyCode::Tab, _) if !chat.composing => {
+                chat.move_selection(1);
             }
-            (KeyCode::End, _) => chat.follow = true,
-            (KeyCode::Down | KeyCode::Tab, _) if !chat.actions.is_empty() => {
-                chat.action_idx = (chat.action_idx + 1) % chat.actions.len();
-            }
-            (KeyCode::Up | KeyCode::BackTab, _) if !chat.actions.is_empty() => {
-                chat.action_idx = if chat.action_idx == 0 {
-                    chat.actions.len() - 1
-                } else {
-                    chat.action_idx - 1
-                };
+            (KeyCode::Up | KeyCode::BackTab, _) if !chat.composing => {
+                chat.move_selection(-1);
             }
             (KeyCode::Char(ch), _)
-                if chat.allow_free_text && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+                if chat.composing && !key.modifiers.contains(KeyModifiers::CONTROL) =>
             {
                 chat.input.push(ch);
             }
@@ -1161,23 +1210,23 @@ fn run_chat_turn(
         chat.follow_tail(size.width, size.height);
         terminal.draw(|frame| draw_chat_view(frame, chat))?;
         if event::poll(Duration::from_millis(50))? {
-            if let Event::Key(key) = event::read()? {
+            let input_event = event::read()?;
+            if let Event::Mouse(mouse) = input_event {
+                match mouse.kind {
+                    MouseEventKind::ScrollUp => chat.scroll_up(3, size.width, size.height),
+                    MouseEventKind::ScrollDown => chat.scroll_down(3, size.width, size.height),
+                    _ => {}
+                }
+            } else if let Event::Key(key) = input_event {
                 match (key.code, key.modifiers) {
                     (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                         child.kill().context("canceling agent response")?;
                         canceled = true;
                     }
-                    (KeyCode::PageUp, _) => {
-                        chat.follow = false;
-                        chat.scroll = chat.scroll.saturating_sub(10);
-                    }
-                    (KeyCode::PageDown, _) => {
-                        chat.follow = false;
-                        chat.scroll = chat
-                            .scroll
-                            .saturating_add(10)
-                            .min(chat.max_scroll(size.width, size.height));
-                    }
+                    (KeyCode::Up, _) => chat.scroll_up(1, size.width, size.height),
+                    (KeyCode::Down, _) => chat.scroll_down(1, size.width, size.height),
+                    (KeyCode::PageUp, _) => chat.scroll_up(10, size.width, size.height),
+                    (KeyCode::PageDown, _) => chat.scroll_down(10, size.width, size.height),
                     (KeyCode::End, _) => chat.follow = true,
                     _ => {}
                 }
@@ -1215,6 +1264,7 @@ fn consume_chat_line(chat: &mut ChatView, envelope: &mut Vec<String>, line: Stri
                     .action_prompt
                     .unwrap_or_else(|| "Choose a response".to_string());
                 chat.allow_free_text = message.allow_free_text;
+                chat.composing = false;
             } else if let Some((fallback, _)) = raw.split_once(REPLY_FENCE) {
                 chat.lines.extend(
                     fallback
@@ -1789,14 +1839,16 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
     let actions = chat
         .actions
         .iter()
+        .map(|action| action.label.as_str())
+        .chain(chat.allow_free_text.then_some("Type a message..."))
         .enumerate()
-        .map(|(idx, action)| {
+        .map(|(idx, label)| {
             let prefix = if idx == chat.action_idx { "> " } else { "  " };
-            ListItem::new(format!("{prefix}{}. {}", idx + 1, action.label))
+            ListItem::new(format!("{prefix}{}. {label}", idx + 1))
         })
         .collect::<Vec<_>>();
     let mut action_state = ListState::default();
-    action_state.select((!chat.actions.is_empty()).then_some(chat.action_idx));
+    action_state.select((chat.choice_count() > 0).then_some(chat.action_idx));
     frame.render_stateful_widget(
         List::new(actions)
             .block(
@@ -1811,41 +1863,67 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
 
     let input_width = chunks[3].width.saturating_sub(4).max(1) as usize;
     let shown_input = input_window(&chat.input, false, input_width);
-    let input_style = if chat.thinking {
+    let input_style = if chat.thinking || !chat.composing {
         Style::default().fg(Color::DarkGray)
     } else {
         Style::default()
     };
+    let input_text = if chat.composing {
+        shown_input.as_str()
+    } else {
+        ""
+    };
     frame.render_widget(
-        Paragraph::new(Span::styled(shown_input.as_str(), input_style)).block(
+        Paragraph::new(Span::styled(input_text, input_style)).block(
             Block::default()
                 .title(if chat.thinking {
                     "Waiting for agent"
                 } else if !chat.allow_free_text {
                     "Select a response"
-                } else {
+                } else if chat.composing {
                     "Message"
+                } else {
+                    "Message (select Type a message...)"
                 })
                 .borders(Borders::ALL),
         ),
         chunks[3],
     );
-    if !chat.thinking && chat.allow_free_text {
+    if !chat.thinking && chat.composing {
         frame.set_cursor_position((
             chunks[3].x + 1 + UnicodeWidthStr::width(shown_input.as_str()) as u16,
             chunks[3].y + 1,
         ));
     }
     let help = if chat.thinking {
-        "Ctrl-C cancel response    PgUp/PgDn scroll    End latest"
+        "Up/Down or wheel scroll    PgUp/PgDn page    End latest    Ctrl-C cancel"
+    } else if chat.composing {
+        "Type message    Enter send    Up/Down or wheel scroll    Esc responses"
     } else {
-        "Up/Down choose response    Enter send    Type when allowed    Esc leave"
+        "Up/Down choose    Enter select    PgUp/PgDn or wheel scroll    Esc leave"
     };
     frame.render_widget(
         Paragraph::new(Span::styled(help, Style::default().fg(Color::Gray)))
             .alignment(Alignment::Center),
         chunks[4],
     );
+}
+
+fn chat_transcript_dimensions(terminal_width: u16, terminal_height: u16) -> (usize, usize) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(5),
+            Constraint::Length(3),
+            Constraint::Length(2),
+        ])
+        .split(Rect::new(0, 0, terminal_width, terminal_height));
+    (
+        chunks[1].width.saturating_sub(2).max(1) as usize,
+        chunks[1].height.saturating_sub(2) as usize,
+    )
 }
 
 fn run_view_dimensions(terminal_width: u16, terminal_height: u16) -> (usize, usize) {
@@ -2319,6 +2397,37 @@ mod tests {
         assert!(is_internal_chat_status("-- final (done)"));
         assert!(is_internal_chat_status("  -- final (failed)"));
         assert!(!is_internal_chat_status("The final answer is done."));
+    }
+
+    #[test]
+    fn chat_appends_free_text_as_the_final_choice() {
+        let mut chat = ChatView::new("demo", &["First".to_string(), "Second".to_string()]);
+        assert_eq!(chat.choice_count(), 3);
+        assert!(!chat.free_text_selected());
+
+        chat.move_selection(-1);
+        assert_eq!(chat.action_idx, 2);
+        assert!(chat.free_text_selected());
+
+        chat.allow_free_text = false;
+        chat.action_idx = 0;
+        assert_eq!(chat.choice_count(), 2);
+        assert!(!chat.free_text_selected());
+    }
+
+    #[test]
+    fn chat_scroll_up_moves_immediately_from_following_tail() {
+        let mut chat = ChatView::new("demo", &[]);
+        chat.lines = (0..80).map(|index| format!("line {index}")).collect();
+        let max_scroll = chat.max_scroll(80, 24);
+        assert!(max_scroll > 0);
+
+        chat.follow = true;
+        chat.scroll = 0;
+        chat.scroll_up(1, 80, 24);
+
+        assert!(!chat.follow);
+        assert_eq!(chat.scroll, max_scroll - 1);
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -406,6 +406,11 @@ fn secret_name_choices() -> Vec<SelectChoice<SecretNameChoice>> {
             value: SecretNameChoice::Name("AGENTOS_CREDENTIALS".to_string()),
         },
         SelectChoice {
+            label: "OPENAI_API_KEY".to_string(),
+            description: "OpenAI API key for model or MCP workflows".to_string(),
+            value: SecretNameChoice::Name("OPENAI_API_KEY".to_string()),
+        },
+        SelectChoice {
             label: "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
             description: "GitHub token for MCP examples or bundles".to_string(),
             value: SecretNameChoice::Name("GITHUB_PERSONAL_ACCESS_TOKEN".to_string()),
@@ -1535,6 +1540,9 @@ mod tests {
         assert!(choices
             .iter()
             .any(|choice| choice.value == SecretNameChoice::Custom));
+        assert!(choices
+            .iter()
+            .any(|choice| matches!(&choice.value, SecretNameChoice::Name(name) if name == "OPENAI_API_KEY")));
         assert!(choices.iter().any(
             |choice| matches!(&choice.value, SecretNameChoice::Name(name) if name == "GITHUB_PERSONAL_ACCESS_TOKEN")
         ));

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -8,6 +8,7 @@
 
 use std::collections::BTreeMap;
 use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
@@ -29,9 +30,21 @@ struct Recipe {
     target: &'static str,
     title: &'static str,
     description: &'static str,
+    kind: RecipeKind,
     args: Vec<ArgPart>,
     fields: Vec<Field>,
     notes: &'static [&'static str],
+}
+
+#[derive(Clone, Debug)]
+enum RecipeKind {
+    Command,
+    Workflow(Workflow),
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Workflow {
+    McpAuthExample,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -95,7 +108,7 @@ impl App {
         let recipes = recipes();
         App {
             recipes,
-            targets: vec!["all", "skill", "local", "cluster", "dev"],
+            targets: vec!["all", "skill", "examples", "local", "cluster", "dev"],
             target_idx: 0,
             selected: 0,
             message: "Select an action. Enter runs it; q exits.".into(),
@@ -227,16 +240,159 @@ fn prompt_and_run(recipe: &Recipe) -> Result<()> {
         let value = prompt_field(field)?;
         values.insert(field.key.to_string(), value);
     }
-    let argv = build_argv(recipe, &values);
+    match &recipe.kind {
+        RecipeKind::Command => {
+            let argv = build_argv(recipe, &values);
+            println!();
+            run_agentos(&argv, Path::new("."))?;
+        }
+        RecipeKind::Workflow(Workflow::McpAuthExample) => run_mcp_auth_example(&values)?,
+    }
+    Ok(())
+}
+
+fn run_mcp_auth_example(values: &BTreeMap<String, String>) -> Result<()> {
+    let repo = values
+        .get("repo")
+        .filter(|value| !value.is_empty())
+        .map(String::as_str)
+        .unwrap_or("curie-eng/agentos");
+    let message = values
+        .get("message")
+        .filter(|value| !value.is_empty())
+        .cloned()
+        .unwrap_or_else(|| format!("List the open issues in {repo} and group them by label."));
+    let port = values
+        .get("port")
+        .filter(|value| !value.is_empty())
+        .map(String::as_str)
+        .unwrap_or("7247");
+    let should_build = yesish(values.get("build").map(String::as_str).unwrap_or("y"));
+
+    require_env_any(&[
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "AGENTOS_CREDENTIALS",
+    ])?;
+    require_env("GITHUB_PERSONAL_ACCESS_TOKEN")?;
+
+    let repo_root = find_repo_root(std::env::current_dir().context("reading current directory")?)
+        .context(
+        "could not find AgentOS repo root; run this workflow from the source checkout",
+    )?;
+    let example_dir = repo_root.join("examples/github-issues");
+    if !example_dir.join(".mcp.json").is_file() {
+        anyhow::bail!(
+            "missing MCP auth example at {}; expected examples/github-issues/.mcp.json",
+            example_dir.display()
+        );
+    }
+
+    println!("This workflow will verify the authenticated GitHub MCP example end to end.");
+    println!("Example bundle: {}", example_dir.display());
+    println!("Target repository: {repo}");
     println!();
-    println!("$ {}", render_command(&argv));
+
+    if should_build {
+        run_agentos(&["build".to_string()], &repo_root)?;
+    } else {
+        println!("Skipping runner image build because you answered no.");
+        println!();
+    }
+
+    let container_name = "agentos-mcp-auth-example";
+    let url = format!("http://localhost:{port}");
+    let mut started = false;
+    let run_result = (|| -> Result<()> {
+        run_agentos(
+            &[
+                "skill".to_string(),
+                "up".to_string(),
+                "--plugin-dir".to_string(),
+                example_dir.display().to_string(),
+                "--port".to_string(),
+                port.to_string(),
+                "--name".to_string(),
+                container_name.to_string(),
+                "--secret".to_string(),
+                "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+            ],
+            &repo_root,
+        )?;
+        started = true;
+        run_agentos(
+            &[
+                "skill".to_string(),
+                "message".to_string(),
+                message,
+                "--url".to_string(),
+                url,
+            ],
+            &repo_root,
+        )
+    })();
+
+    if started {
+        println!();
+        println!("Cleaning up the example runner...");
+        if let Err(err) = run_agentos(&["skill".to_string(), "down".to_string()], &example_dir) {
+            println!("Cleanup warning: {err:#}");
+        }
+    }
+
+    run_result?;
+    println!();
+    println!(
+        "Pass condition: the answer above should cite live issue titles or numbers from {repo}."
+    );
+    Ok(())
+}
+
+fn yesish(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "" | "y" | "yes" | "true" | "1"
+    )
+}
+
+fn require_env(name: &str) -> Result<()> {
+    if std::env::var_os(name).is_some() {
+        return Ok(());
+    }
+    anyhow::bail!("{name} is not set. Export it in your shell, then rerun this workflow.")
+}
+
+fn require_env_any(names: &[&str]) -> Result<()> {
+    if names.iter().any(|name| std::env::var_os(name).is_some()) {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "no model credential is set. Export one of {} before running the live MCP auth workflow.",
+        names.join(", ")
+    )
+}
+
+fn find_repo_root(mut dir: PathBuf) -> Option<PathBuf> {
+    loop {
+        if dir.join("runner/Dockerfile").is_file() && dir.join("examples/github-issues").is_dir() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+fn run_agentos(argv: &[String], cwd: &Path) -> Result<()> {
+    println!("$ {}", render_command(argv));
     println!();
     let status = Command::new(std::env::current_exe().context("resolving current executable")?)
-        .args(&argv)
+        .args(argv)
+        .current_dir(cwd)
         .status()
-        .context("running selected agentos command")?;
+        .with_context(|| format!("running {}", render_command(argv)))?;
     if !status.success() {
-        anyhow::bail!("selected command exited with {status}");
+        anyhow::bail!("{} exited with {status}", render_command(argv));
     }
     Ok(())
 }
@@ -414,19 +570,37 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 .map(|value| (field.key.to_string(), value.to_string()))
         })
         .collect();
-    let preview = build_argv(recipe, &values);
     let mut lines = vec![
         Line::from(Span::styled(recipe.title, Style::default().bold())),
         Line::from(""),
         Line::from(recipe.description),
         Line::from(""),
-        Line::from(Span::styled(
-            "Command preview",
-            Style::default().fg(Color::Yellow).bold(),
-        )),
-        Line::from(render_command(&preview)),
-        Line::from(""),
     ];
+    match &recipe.kind {
+        RecipeKind::Command => {
+            let preview = build_argv(recipe, &values);
+            lines.push(Line::from(Span::styled(
+                "Command preview",
+                Style::default().fg(Color::Yellow).bold(),
+            )));
+            lines.push(Line::from(render_command(&preview)));
+            lines.push(Line::from(""));
+        }
+        RecipeKind::Workflow(Workflow::McpAuthExample) => {
+            lines.push(Line::from(Span::styled(
+                "Guided workflow",
+                Style::default().fg(Color::Yellow).bold(),
+            )));
+            lines.push(Line::from("1. Check model and GitHub token env vars"));
+            lines.push(Line::from("2. Build the runner image if requested"));
+            lines.push(Line::from(
+                "3. Start examples/github-issues with --secret GITHUB_PERSONAL_ACCESS_TOKEN",
+            ));
+            lines.push(Line::from("4. Send a live GitHub issue query"));
+            lines.push(Line::from("5. Stop the example runner"));
+            lines.push(Line::from(""));
+        }
+    }
     if !recipe.fields.is_empty() {
         lines.push(Line::from(Span::styled(
             "Prompts before run",
@@ -481,6 +655,7 @@ fn recipes() -> Vec<Recipe> {
             target: "skill",
             title: "Start runner",
             description: "Boot the current plugin bundle in a local runner container.",
+            kind: RecipeKind::Command,
             args: vec![
                 ArgPart::Literal("skill"),
                 ArgPart::Literal("up"),
@@ -515,6 +690,7 @@ fn recipes() -> Vec<Recipe> {
             target: "skill",
             title: "Send skill message",
             description: "Send a synthetic event to the local runner and stream the reply.",
+            kind: RecipeKind::Command,
             args: vec![
                 ArgPart::Literal("skill"),
                 ArgPart::Literal("message"),
@@ -532,6 +708,7 @@ fn recipes() -> Vec<Recipe> {
             target: "skill",
             title: "Run skill eval",
             description: "Run evals/cases.json through the local runner.",
+            kind: RecipeKind::Command,
             args: vec![
                 ArgPart::Literal("skill"),
                 ArgPart::Literal("eval"),
@@ -549,9 +726,50 @@ fn recipes() -> Vec<Recipe> {
             notes: &[],
         },
         Recipe {
+            target: "examples",
+            title: "Verify MCP auth example",
+            description: "Guided e2e for examples/github-issues using a live GitHub MCP server.",
+            kind: RecipeKind::Workflow(Workflow::McpAuthExample),
+            args: vec![],
+            fields: vec![
+                Field {
+                    key: "repo",
+                    label: "GitHub repo to inspect",
+                    default: Some("curie-eng/agentos"),
+                    required: true,
+                },
+                Field {
+                    key: "message",
+                    label: "Live verification prompt",
+                    default: Some(
+                        "List the open issues in curie-eng/agentos and group them by label.",
+                    ),
+                    required: true,
+                },
+                Field {
+                    key: "port",
+                    label: "Runner host port",
+                    default: Some("7247"),
+                    required: true,
+                },
+                Field {
+                    key: "build",
+                    label: "Build runner image first? (y/n)",
+                    default: Some("y"),
+                    required: true,
+                },
+            ],
+            notes: &[
+                "Requires a model credential in the shell: ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or AGENTOS_CREDENTIALS.",
+                "Requires GITHUB_PERSONAL_ACCESS_TOKEN in the shell; the value is forwarded by name and not placed in argv.",
+                "A passing run cites live GitHub issue titles or numbers.",
+            ],
+        },
+        Recipe {
             target: "local",
             title: "Start local stack",
             description: "Bring up the compose stack for the local platform loop.",
+            kind: RecipeKind::Command,
             args: vec![ArgPart::Literal("local"), ArgPart::Literal("up")],
             fields: vec![],
             notes: &["Use the regular CLI for --minimal, --slack, or --local-model variants."],
@@ -560,6 +778,7 @@ fn recipes() -> Vec<Recipe> {
             target: "local",
             title: "Send local message",
             description: "Drive the compose stack end to end with zero Slack contact.",
+            kind: RecipeKind::Command,
             args: vec![
                 ArgPart::Literal("local"),
                 ArgPart::Literal("message"),
@@ -589,6 +808,7 @@ fn recipes() -> Vec<Recipe> {
             target: "local",
             title: "Local status",
             description: "Show compose service status.",
+            kind: RecipeKind::Command,
             args: vec![ArgPart::Literal("local"), ArgPart::Literal("status")],
             fields: vec![],
             notes: &[],
@@ -597,6 +817,7 @@ fn recipes() -> Vec<Recipe> {
             target: "cluster",
             title: "Cluster status",
             description: "Report release health and access URLs.",
+            kind: RecipeKind::Command,
             args: vec![
                 ArgPart::Literal("cluster"),
                 ArgPart::Literal("status"),
@@ -629,6 +850,7 @@ fn recipes() -> Vec<Recipe> {
             target: "cluster",
             title: "Send cluster message",
             description: "Drive a deployed release end to end with zero Slack contact.",
+            kind: RecipeKind::Command,
             args: vec![
                 ArgPart::Literal("cluster"),
                 ArgPart::Literal("message"),
@@ -658,6 +880,7 @@ fn recipes() -> Vec<Recipe> {
             target: "dev",
             title: "Install checkout",
             description: "Bootstrap a dev checkout: deps, CLI build, runner image.",
+            kind: RecipeKind::Command,
             args: vec![ArgPart::Literal("install")],
             fields: vec![],
             notes: &["Starts nothing; run once after cloning."],
@@ -666,6 +889,7 @@ fn recipes() -> Vec<Recipe> {
             target: "dev",
             title: "Check contracts",
             description: "Run the frozen contract drift checks.",
+            kind: RecipeKind::Command,
             args: vec![ArgPart::Literal("dev"), ArgPart::Literal("contracts")],
             fields: vec![],
             notes: &[],
@@ -683,6 +907,7 @@ mod tests {
             target: "skill",
             title: "x",
             description: "x",
+            kind: RecipeKind::Command,
             args: vec![
                 ArgPart::Literal("skill"),
                 ArgPart::Literal("message"),
@@ -708,5 +933,23 @@ mod tests {
     fn render_command_quotes_shell_specials() {
         let argv = vec!["skill".into(), "message".into(), "hello world".into()];
         assert_eq!(render_command(&argv), "agentos skill message 'hello world'");
+    }
+
+    #[test]
+    fn examples_target_includes_mcp_auth_workflow() {
+        let app = App::new();
+        let idx = app
+            .targets
+            .iter()
+            .position(|target| *target == "examples")
+            .expect("examples target exists");
+        let mut app = app;
+        app.target_idx = idx;
+        let titles: Vec<&str> = app
+            .visible_indices()
+            .iter()
+            .map(|idx| app.recipes[*idx].title)
+            .collect();
+        assert!(titles.contains(&"Verify MCP auth example"));
     }
 }

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -878,13 +878,32 @@ impl RunView {
 
     fn follow_tail(&mut self, terminal_width: u16, terminal_height: u16) {
         if self.follow {
-            let viewport = terminal_height.saturating_sub(8) as usize;
-            let output_width = terminal_width.saturating_sub(6).max(1) as usize;
-            self.scroll = wrap_output_lines(&self.lines, output_width)
-                .len()
-                .saturating_sub(viewport)
-                .min(u16::MAX as usize) as u16;
+            self.scroll = self.max_scroll(terminal_width, terminal_height);
         }
+    }
+
+    fn max_scroll(&self, terminal_width: u16, terminal_height: u16) -> u16 {
+        let (output_width, viewport) = run_view_dimensions(terminal_width, terminal_height);
+        wrap_output_lines(&self.lines, output_width)
+            .len()
+            .saturating_sub(viewport)
+            .min(u16::MAX as usize) as u16
+    }
+
+    fn scroll_up(&mut self, amount: u16, terminal_width: u16, terminal_height: u16) {
+        if self.follow {
+            self.scroll = self.max_scroll(terminal_width, terminal_height);
+        }
+        self.follow = false;
+        self.scroll = self.scroll.saturating_sub(amount);
+    }
+
+    fn scroll_down(&mut self, amount: u16, terminal_width: u16, terminal_height: u16) {
+        self.follow = false;
+        self.scroll = self
+            .scroll
+            .saturating_add(amount)
+            .min(self.max_scroll(terminal_width, terminal_height));
     }
 }
 
@@ -933,11 +952,10 @@ fn run_agentos_in_tui(
                             canceled = true;
                         }
                         (KeyCode::Up | KeyCode::Char('k'), _) => {
-                            view.follow = false;
-                            view.scroll = view.scroll.saturating_sub(1);
+                            view.scroll_up(1, size.width, size.height);
                         }
                         (KeyCode::Down | KeyCode::Char('j'), _) => {
-                            view.scroll = view.scroll.saturating_add(1);
+                            view.scroll_down(1, size.width, size.height);
                         }
                         (KeyCode::End, _) => view.follow = true,
                         _ => {}
@@ -1027,20 +1045,16 @@ fn show_run_view(
             (KeyCode::Enter | KeyCode::Esc | KeyCode::Char('q'), _) => return Ok(()),
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(()),
             (KeyCode::Up | KeyCode::Char('k'), _) => {
-                view.follow = false;
-                view.scroll = view.scroll.saturating_sub(1);
+                view.scroll_up(1, size.width, size.height);
             }
             (KeyCode::Down | KeyCode::Char('j'), _) => {
-                view.follow = false;
-                view.scroll = view.scroll.saturating_add(1);
+                view.scroll_down(1, size.width, size.height);
             }
             (KeyCode::PageUp, _) => {
-                view.follow = false;
-                view.scroll = view.scroll.saturating_sub(10);
+                view.scroll_up(10, size.width, size.height);
             }
             (KeyCode::PageDown, _) => {
-                view.follow = false;
-                view.scroll = view.scroll.saturating_add(10);
+                view.scroll_down(10, size.width, size.height);
             }
             (KeyCode::Home, _) => {
                 view.follow = false;
@@ -1371,6 +1385,16 @@ fn draw_run_view(frame: &mut Frame<'_>, view: &RunView) {
             .alignment(Alignment::Center),
         chunks[1],
     );
+}
+
+fn run_view_dimensions(terminal_width: u16, terminal_height: u16) -> (usize, usize) {
+    let area_width = terminal_width.saturating_sub(4).max(20);
+    let area_height = terminal_height.saturating_sub(2).max(7);
+    let body_height = area_height.saturating_sub(2);
+    (
+        area_width.saturating_sub(2).max(1) as usize,
+        body_height.saturating_sub(2) as usize,
+    )
 }
 
 fn wrap_output_lines(lines: &[String], max_width: usize) -> Vec<String> {
@@ -1941,6 +1965,21 @@ mod tests {
             "saved"
         );
         assert_eq!(secret_status("OPENAI_API_KEY", &saved), "missing");
+    }
+
+    #[test]
+    fn first_scroll_up_moves_off_the_output_tail() {
+        let mut view = RunView::new("test");
+        for idx in 0..30 {
+            view.push(format!("line {idx}"));
+        }
+        view.follow_tail(80, 24);
+        let bottom = view.scroll;
+
+        view.scroll_up(1, 80, 24);
+
+        assert!(!view.follow);
+        assert_eq!(view.scroll, bottom - 1);
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -28,6 +28,8 @@ use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragra
 use ratatui::{Frame, Terminal};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+use crate::channel::{parse_terminal_message, TerminalAction, REPLY_FENCE};
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum SecretNameChoice {
     Name(String),
@@ -78,7 +80,6 @@ struct ExampleChoice {
     description: &'static str,
     directory: &'static str,
     secrets: &'static [&'static str],
-    suggestions: &'static [&'static str],
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -623,6 +624,7 @@ fn explore_examples(
     if !example_dir.join(".claude-plugin/plugin.json").is_file() {
         anyhow::bail!("missing example bundle at {}", example_dir.display());
     }
+    let starter_prompts = starter_prompts(&example_dir)?;
 
     let container_name = format!("agentos-example-{}", example.id);
     let port = "7247";
@@ -646,13 +648,7 @@ fn explore_examples(
         }
         run_agentos_in_tui_with_env(terminal, app, &argv, &repo_root, &mut setup, &secret_env)?;
         started = true;
-        chat_with_runner(
-            terminal,
-            &repo_root,
-            &url,
-            example.name,
-            example.suggestions,
-        )
+        chat_with_runner(terminal, &repo_root, &url, example.name, &starter_prompts)
     })();
 
     if started {
@@ -687,11 +683,6 @@ fn example_choices() -> Vec<ExampleChoice> {
                 "Explore live repositories and issues through authenticated GitHub MCP tools",
             directory: "examples/github-issues",
             secrets: &["GITHUB_PERSONAL_ACCESS_TOKEN"],
-            suggestions: &[
-                "List the open issues in curie-eng/agentos and group them by label.",
-                "Summarize the most recently updated pull requests in curie-eng/agentos.",
-                "Find open bug reports in curie-eng/agentos that need triage.",
-            ],
         },
         ExampleChoice {
             id: "text-stats-engine",
@@ -699,11 +690,6 @@ fn example_choices() -> Vec<ExampleChoice> {
             description: "Use an in-bundle MCP server to inspect and analyze text",
             directory: "examples/text-stats-engine",
             secrets: &[],
-            suggestions: &[
-                "Explain what text analysis tools you have.",
-                "Count the words and sentences in: AgentOS makes agents portable.",
-                "Analyze the readability of: Clear tools make complex work easier.",
-            ],
         },
         ExampleChoice {
             id: "weather",
@@ -711,13 +697,27 @@ fn example_choices() -> Vec<ExampleChoice> {
             description: "Chat with the minimal weather agent bundle",
             directory: "examples/weather",
             secrets: &[],
-            suggestions: &[
-                "What can this weather agent help me with?",
-                "Give me a concise weather briefing for San Francisco.",
-                "How should I ask you to compare weather between two cities?",
-            ],
         },
     ]
+}
+
+fn starter_prompts(example_dir: &Path) -> Result<Vec<String>> {
+    let path = example_dir.join(".claude-plugin/plugin.json");
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&path)
+            .with_context(|| format!("reading example manifest {}", path.display()))?,
+    )
+    .with_context(|| format!("parsing example manifest {}", path.display()))?;
+    Ok(value
+        .get("starterPrompts")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .map(str::to_string)
+        .filter(|prompt| !prompt.trim().is_empty())
+        .take(10)
+        .collect())
 }
 
 fn example_secret_env(extra_secrets: &[&str]) -> Result<Vec<(String, String)>> {
@@ -992,12 +992,14 @@ struct ChatView {
     scroll: u16,
     follow: bool,
     thinking: bool,
-    suggestions: Vec<String>,
-    suggestion_idx: usize,
+    actions: Vec<TerminalAction>,
+    action_idx: usize,
+    action_prompt: String,
+    allow_free_text: bool,
 }
 
 impl ChatView {
-    fn new(agent_name: &str, suggestions: &[&str]) -> Self {
+    fn new(agent_name: &str, suggestions: &[String]) -> Self {
         Self {
             agent_name: agent_name.to_string(),
             lines: vec![
@@ -1009,11 +1011,16 @@ impl ChatView {
             scroll: 0,
             follow: true,
             thinking: false,
-            suggestions: suggestions
+            actions: suggestions
                 .iter()
-                .map(|value| (*value).to_string())
+                .map(|value| TerminalAction {
+                    label: value.clone(),
+                    value: value.clone(),
+                })
                 .collect(),
-            suggestion_idx: 0,
+            action_idx: 0,
+            action_prompt: "Try a prompt".to_string(),
+            allow_free_text: true,
         }
     }
 
@@ -1038,7 +1045,7 @@ fn chat_with_runner(
     cwd: &Path,
     url: &str,
     agent_name: &str,
-    suggestions: &[&str],
+    suggestions: &[String],
 ) -> Result<()> {
     let mut chat = ChatView::new(agent_name, suggestions);
     loop {
@@ -1051,6 +1058,10 @@ fn chat_with_runner(
         chat.lines.push("Agent".to_string());
         chat.thinking = true;
         chat.follow = true;
+        chat.actions.clear();
+        chat.action_idx = 0;
+        chat.action_prompt = "Responses".to_string();
+        chat.allow_free_text = true;
         let argv = [
             "skill".to_string(),
             "message".to_string(),
@@ -1079,14 +1090,14 @@ fn read_chat_input(
         match (key.code, key.modifiers) {
             (KeyCode::Esc, _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
             (KeyCode::Enter, _) => {
-                if !chat.input.trim().is_empty() {
+                if chat.allow_free_text && !chat.input.trim().is_empty() {
                     return Ok(Some(chat.input.trim().to_string()));
                 }
-                if let Some(suggestion) = chat.suggestions.get(chat.suggestion_idx) {
-                    return Ok(Some(suggestion.clone()));
+                if let Some(action) = chat.actions.get(chat.action_idx) {
+                    return Ok(Some(action.value.clone()));
                 }
             }
-            (KeyCode::Backspace, _) => {
+            (KeyCode::Backspace, _) if chat.allow_free_text => {
                 chat.input.pop();
             }
             (KeyCode::PageUp, _) => {
@@ -1101,17 +1112,19 @@ fn read_chat_input(
                     .min(chat.max_scroll(size.width, size.height));
             }
             (KeyCode::End, _) => chat.follow = true,
-            (KeyCode::Down | KeyCode::Tab, _) if !chat.suggestions.is_empty() => {
-                chat.suggestion_idx = (chat.suggestion_idx + 1) % chat.suggestions.len();
+            (KeyCode::Down | KeyCode::Tab, _) if !chat.actions.is_empty() => {
+                chat.action_idx = (chat.action_idx + 1) % chat.actions.len();
             }
-            (KeyCode::Up | KeyCode::BackTab, _) if !chat.suggestions.is_empty() => {
-                chat.suggestion_idx = if chat.suggestion_idx == 0 {
-                    chat.suggestions.len() - 1
+            (KeyCode::Up | KeyCode::BackTab, _) if !chat.actions.is_empty() => {
+                chat.action_idx = if chat.action_idx == 0 {
+                    chat.actions.len() - 1
                 } else {
-                    chat.suggestion_idx - 1
+                    chat.action_idx - 1
                 };
             }
-            (KeyCode::Char(ch), _) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            (KeyCode::Char(ch), _)
+                if chat.allow_free_text && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
                 chat.input.push(ch);
             }
             _ => {}
@@ -1138,12 +1151,11 @@ fn run_chat_turn(
     let stderr = child.stderr.take().context("capturing agent diagnostics")?;
     let readers = [stdout_reader(stdout, tx.clone()), stderr_reader(stderr, tx)];
     let mut canceled = false;
+    let mut envelope = Vec::new();
 
     loop {
         while let Ok(line) = rx.try_recv() {
-            if !is_internal_chat_status(&line) {
-                chat.lines.push(line);
-            }
+            consume_chat_line(chat, &mut envelope, line);
         }
         let size = terminal.size()?;
         chat.follow_tail(size.width, size.height);
@@ -1176,9 +1188,7 @@ fn run_chat_turn(
                 let _ = reader.join();
             }
             while let Ok(line) = rx.try_recv() {
-                if !is_internal_chat_status(&line) {
-                    chat.lines.push(line);
-                }
+                consume_chat_line(chat, &mut envelope, line);
             }
             if canceled {
                 chat.lines.push("Response canceled.".to_string());
@@ -1190,6 +1200,45 @@ fn run_chat_turn(
             return Ok(());
         }
     }
+}
+
+fn consume_chat_line(chat: &mut ChatView, envelope: &mut Vec<String>, line: String) {
+    if !envelope.is_empty() {
+        envelope.push(line);
+        if reply_envelope_complete(&envelope.join("\n")) {
+            let raw = envelope.join("\n");
+            if let Some(message) = parse_terminal_message(&raw) {
+                chat.lines.extend(message.lines);
+                chat.actions = message.actions;
+                chat.action_idx = 0;
+                chat.action_prompt = message
+                    .action_prompt
+                    .unwrap_or_else(|| "Choose a response".to_string());
+                chat.allow_free_text = message.allow_free_text;
+            } else if let Some((fallback, _)) = raw.split_once(REPLY_FENCE) {
+                chat.lines.extend(
+                    fallback
+                        .trim()
+                        .lines()
+                        .filter(|line| !line.is_empty())
+                        .map(str::to_string),
+                );
+            }
+            envelope.clear();
+        }
+        return;
+    }
+    if line.contains(REPLY_FENCE) {
+        envelope.push(line);
+    } else if !is_internal_chat_status(&line) {
+        chat.lines.push(line);
+    }
+}
+
+fn reply_envelope_complete(text: &str) -> bool {
+    text.find(REPLY_FENCE)
+        .and_then(|start| text.get(start + REPLY_FENCE.len()..))
+        .is_some_and(|rest| rest.contains("```"))
 }
 
 fn is_internal_chat_status(line: &str) -> bool {
@@ -1737,27 +1786,27 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
         chunks[1],
     );
 
-    let suggestions = chat
-        .suggestions
+    let actions = chat
+        .actions
         .iter()
         .enumerate()
-        .map(|(idx, suggestion)| {
-            let prefix = if idx == chat.suggestion_idx {
-                "> "
-            } else {
-                "  "
-            };
-            ListItem::new(format!("{prefix}{}. {suggestion}", idx + 1))
+        .map(|(idx, action)| {
+            let prefix = if idx == chat.action_idx { "> " } else { "  " };
+            ListItem::new(format!("{prefix}{}. {}", idx + 1, action.label))
         })
         .collect::<Vec<_>>();
-    let mut suggestion_state = ListState::default();
-    suggestion_state.select(Some(chat.suggestion_idx));
+    let mut action_state = ListState::default();
+    action_state.select((!chat.actions.is_empty()).then_some(chat.action_idx));
     frame.render_stateful_widget(
-        List::new(suggestions)
-            .block(Block::default().title("Try a prompt").borders(Borders::ALL))
+        List::new(actions)
+            .block(
+                Block::default()
+                    .title(chat.action_prompt.as_str())
+                    .borders(Borders::ALL),
+            )
             .highlight_style(Style::default().fg(Color::Black).bg(Color::Cyan)),
         chunks[2],
-        &mut suggestion_state,
+        &mut action_state,
     );
 
     let input_width = chunks[3].width.saturating_sub(4).max(1) as usize;
@@ -1772,6 +1821,8 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
             Block::default()
                 .title(if chat.thinking {
                     "Waiting for agent"
+                } else if !chat.allow_free_text {
+                    "Select a response"
                 } else {
                     "Message"
                 })
@@ -1779,7 +1830,7 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
         ),
         chunks[3],
     );
-    if !chat.thinking {
+    if !chat.thinking && chat.allow_free_text {
         frame.set_cursor_position((
             chunks[3].x + 1 + UnicodeWidthStr::width(shown_input.as_str()) as u16,
             chunks[3].y + 1,
@@ -1788,7 +1839,7 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
     let help = if chat.thinking {
         "Ctrl-C cancel response    PgUp/PgDn scroll    End latest"
     } else {
-        "Up/Down choose prompt    Enter send    Type for free response    Esc leave"
+        "Up/Down choose response    Enter send    Type when allowed    Esc leave"
     };
     frame.render_widget(
         Paragraph::new(Span::styled(help, Style::default().fg(Color::Gray)))
@@ -2256,7 +2307,6 @@ mod tests {
         assert_eq!(examples.len(), 3);
         assert!(examples.iter().all(|example| {
             !example.id.is_empty()
-                && !example.suggestions.is_empty()
                 && example
                     .id
                     .chars()
@@ -2269,6 +2319,41 @@ mod tests {
         assert!(is_internal_chat_status("-- final (done)"));
         assert!(is_internal_chat_status("  -- final (failed)"));
         assert!(!is_internal_chat_status("The final answer is done."));
+    }
+
+    #[test]
+    fn chat_consumes_semantic_choices_without_printing_the_envelope() {
+        let mut chat = ChatView::new("demo", &[]);
+        let mut envelope = Vec::new();
+        consume_chat_line(&mut chat, &mut envelope, "```agentos-reply".to_string());
+        consume_chat_line(
+            &mut chat,
+            &mut envelope,
+            "{\"version\":\"1.0\",\"text\":\"Pick one\",\"interaction\":{\"kind\":\"choice\",\"id\":\"pick\",\"options\":[{\"label\":\"First\",\"value\":\"first-value\"}]}}".to_string(),
+        );
+        consume_chat_line(&mut chat, &mut envelope, "```".to_string());
+
+        assert!(envelope.is_empty());
+        assert!(chat.lines.iter().any(|line| line == "Pick one"));
+        assert!(!chat.lines.iter().any(|line| line.contains("agentos-reply")));
+        assert_eq!(chat.actions[0].label, "First");
+        assert_eq!(chat.actions[0].value, "first-value");
+        assert!(chat.allow_free_text);
+    }
+
+    #[test]
+    fn malformed_envelope_keeps_only_ordinary_text_fallback() {
+        let mut chat = ChatView::new("demo", &[]);
+        let mut envelope = Vec::new();
+        consume_chat_line(
+            &mut chat,
+            &mut envelope,
+            "Still useful\n```agentos-reply".to_string(),
+        );
+        consume_chat_line(&mut chat, &mut envelope, "{broken".to_string());
+        consume_chat_line(&mut chat, &mut envelope, "```".to_string());
+        assert!(chat.lines.iter().any(|line| line == "Still useful"));
+        assert!(!chat.lines.iter().any(|line| line.contains("{broken")));
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -108,7 +108,9 @@ impl App {
         let recipes = recipes();
         App {
             recipes,
-            targets: vec!["all", "skill", "examples", "local", "cluster", "dev"],
+            targets: vec![
+                "all", "skill", "examples", "secrets", "local", "cluster", "dev",
+            ],
             target_idx: 0,
             selected: 0,
             message: "Select an action. Enter runs it; q exits.".into(),
@@ -269,12 +271,8 @@ fn run_mcp_auth_example(values: &BTreeMap<String, String>) -> Result<()> {
         .unwrap_or("7247");
     let should_build = yesish(values.get("build").map(String::as_str).unwrap_or("y"));
 
-    require_env_any(&[
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-        "AGENTOS_CREDENTIALS",
-    ])?;
-    require_env("GITHUB_PERSONAL_ACCESS_TOKEN")?;
+    ensure_model_credential_available()?;
+    ensure_secret_available("GITHUB_PERSONAL_ACCESS_TOKEN")?;
 
     let repo_root = find_repo_root(std::env::current_dir().context("reading current directory")?)
         .context(
@@ -355,21 +353,143 @@ fn yesish(value: &str) -> bool {
     )
 }
 
-fn require_env(name: &str) -> Result<()> {
+fn ensure_secret_available(name: &str) -> Result<()> {
     if std::env::var_os(name).is_some() {
+        println!("{name}: available from the current environment.");
         return Ok(());
     }
-    anyhow::bail!("{name} is not set. Export it in your shell, then rerun this workflow.")
+    if crate::secrets::has_value(name) {
+        println!("{name}: available from the AgentOS secret store.");
+        return Ok(());
+    }
+    println!("{name}: missing.");
+    if prompt_yes_no(
+        &format!("Save {name} in the OS credential store now?"),
+        true,
+    )? {
+        crate::secrets::set(crate::secrets::SetSecretOpts {
+            name: name.to_string(),
+            from_env: None,
+        })?;
+        return Ok(());
+    }
+    anyhow::bail!("{name} is required for this workflow")
 }
 
-fn require_env_any(names: &[&str]) -> Result<()> {
-    if names.iter().any(|name| std::env::var_os(name).is_some()) {
-        return Ok(());
+fn ensure_model_credential_available() -> Result<()> {
+    const NAMES: &[&str] = &[
+        "AGENTOS_CREDENTIALS",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ];
+    for name in NAMES {
+        if std::env::var_os(name).is_some() {
+            println!("{name}: model credential available from the current environment.");
+            return Ok(());
+        }
     }
-    anyhow::bail!(
-        "no model credential is set. Export one of {} before running the live MCP auth workflow.",
-        names.join(", ")
-    )
+    for name in NAMES {
+        if crate::secrets::has_value(name) {
+            println!("{name}: model credential available from the AgentOS secret store.");
+            return Ok(());
+        }
+    }
+
+    println!("Model credential: missing.");
+    if !prompt_yes_no(
+        "Save a model credential in the OS credential store now?",
+        true,
+    )? {
+        anyhow::bail!(
+            "a model credential is required; save AGENTOS_CREDENTIALS, ANTHROPIC_API_KEY, or CLAUDE_CODE_OAUTH_TOKEN"
+        );
+    }
+    print!("Credential name [ANTHROPIC_API_KEY]: ");
+    io::stdout().flush().ok();
+    let mut line = String::new();
+    io::stdin()
+        .read_line(&mut line)
+        .context("reading credential name")?;
+    let name = if line.trim().is_empty() {
+        "ANTHROPIC_API_KEY"
+    } else {
+        line.trim()
+    };
+    if !NAMES.contains(&name) {
+        anyhow::bail!(
+            "unsupported model credential name {name}; use AGENTOS_CREDENTIALS, ANTHROPIC_API_KEY, or CLAUDE_CODE_OAUTH_TOKEN"
+        );
+    }
+    crate::secrets::set(crate::secrets::SetSecretOpts {
+        name: name.to_string(),
+        from_env: None,
+    })?;
+    Ok(())
+}
+
+fn prompt_yes_no(prompt: &str, default: bool) -> Result<bool> {
+    loop {
+        let suffix = if default { "[Y/n]" } else { "[y/N]" };
+        print!("{prompt} {suffix}: ");
+        io::stdout().flush().ok();
+        let mut line = String::new();
+        io::stdin().read_line(&mut line)?;
+        let value = line.trim().to_ascii_lowercase();
+        if value.is_empty() {
+            return Ok(default);
+        }
+        match value.as_str() {
+            "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => println!("Please answer y or n."),
+        }
+    }
+}
+
+fn secret_status(name: &str) -> &'static str {
+    if std::env::var_os(name).is_some() {
+        "env"
+    } else if crate::secrets::has_value(name) {
+        "saved"
+    } else {
+        "missing"
+    }
+}
+
+fn model_credential_status() -> &'static str {
+    for name in [
+        "AGENTOS_CREDENTIALS",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ] {
+        if std::env::var_os(name).is_some() || crate::secrets::has_value(name) {
+            return "available";
+        }
+    }
+    "missing"
+}
+
+fn secrets_status_lines() -> Vec<Line<'static>> {
+    vec![
+        Line::from(format!("Model credential: {}", model_credential_status())),
+        Line::from(format!(
+            "GITHUB_PERSONAL_ACCESS_TOKEN: {}",
+            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN")
+        )),
+    ]
+}
+
+fn maybe_add_secret_status(lines: &mut Vec<Line<'static>>, workflow: Workflow) {
+    match workflow {
+        Workflow::McpAuthExample => {
+            lines.push(Line::from(Span::styled(
+                "Credential status",
+                Style::default().fg(Color::Yellow).bold(),
+            )));
+            lines.extend(secrets_status_lines());
+            lines.push(Line::from(""));
+        }
+    }
 }
 
 fn find_repo_root(mut dir: PathBuf) -> Option<PathBuf> {
@@ -599,6 +719,7 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             lines.push(Line::from("4. Send a live GitHub issue query"));
             lines.push(Line::from("5. Stop the example runner"));
             lines.push(Line::from(""));
+            maybe_add_secret_status(&mut lines, Workflow::McpAuthExample);
         }
     }
     if !recipe.fields.is_empty() {
@@ -764,6 +885,54 @@ fn recipes() -> Vec<Recipe> {
                 "Requires GITHUB_PERSONAL_ACCESS_TOKEN in the shell; the value is forwarded by name and not placed in argv.",
                 "A passing run cites live GitHub issue titles or numbers.",
             ],
+        },
+        Recipe {
+            target: "secrets",
+            title: "Save secret",
+            description: "Store a local secret in the OS credential store with hidden input.",
+            kind: RecipeKind::Command,
+            args: vec![
+                ArgPart::Literal("secrets"),
+                ArgPart::Literal("set"),
+                ArgPart::Field("name"),
+            ],
+            fields: vec![Field {
+                key: "name",
+                label: "Secret name",
+                default: Some("GITHUB_PERSONAL_ACCESS_TOKEN"),
+                required: true,
+            }],
+            notes: &[
+                "The value is prompted with hidden input and saved in the OS credential store.",
+                "Use env-style names such as ANTHROPIC_API_KEY or GITHUB_PERSONAL_ACCESS_TOKEN.",
+            ],
+        },
+        Recipe {
+            target: "secrets",
+            title: "List saved secrets",
+            description: "List saved AgentOS secret names without printing values.",
+            kind: RecipeKind::Command,
+            args: vec![ArgPart::Literal("secrets"), ArgPart::Literal("list")],
+            fields: vec![],
+            notes: &["Only names are listed; secret values stay in the OS credential store."],
+        },
+        Recipe {
+            target: "secrets",
+            title: "Remove secret",
+            description: "Remove a saved secret from the OS credential store.",
+            kind: RecipeKind::Command,
+            args: vec![
+                ArgPart::Literal("secrets"),
+                ArgPart::Literal("unset"),
+                ArgPart::Field("name"),
+            ],
+            fields: vec![Field {
+                key: "name",
+                label: "Secret name",
+                default: Some("GITHUB_PERSONAL_ACCESS_TOKEN"),
+                required: true,
+            }],
+            notes: &[],
         },
         Recipe {
             target: "local",

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -44,9 +44,11 @@ enum RecipeKind {
     Workflow(Workflow),
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TuiAction {
+    SaveSecret,
     ListSecrets,
+    RemoveSecret,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -103,7 +105,7 @@ fn event_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut A
         let Event::Key(key) = event::read()? else {
             continue;
         };
-        if app.handle_key(key)? {
+        if app.handle_key(key, terminal)? {
             break;
         }
     }
@@ -139,7 +141,11 @@ impl App {
             .and_then(|idx| self.recipes.get(*idx))
     }
 
-    fn handle_key(&mut self, key: KeyEvent) -> Result<bool> {
+    fn handle_key(
+        &mut self,
+        key: KeyEvent,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    ) -> Result<bool> {
         match (key.code, key.modifiers) {
             (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => return Ok(true),
             (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(true),
@@ -147,7 +153,7 @@ impl App {
             (KeyCode::Up | KeyCode::Char('k'), _) => self.move_selection(-1),
             (KeyCode::Tab | KeyCode::Right, _) => self.next_target(),
             (KeyCode::BackTab | KeyCode::Left, _) => self.prev_target(),
-            (KeyCode::Enter, _) | (KeyCode::Char('r'), _) => self.run_selected()?,
+            (KeyCode::Enter, _) | (KeyCode::Char('r'), _) => self.run_selected(terminal)?,
             _ => {}
         }
         Ok(false)
@@ -176,12 +182,15 @@ impl App {
         self.selected = 0;
     }
 
-    fn run_selected(&mut self) -> Result<()> {
+    fn run_selected(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    ) -> Result<()> {
         let Some(recipe) = self.selected_recipe().cloned() else {
             return Ok(());
         };
         if let RecipeKind::Tui(action) = &recipe.kind {
-            self.message = match run_tui_action(action) {
+            self.message = match run_tui_action(*action, terminal, self) {
                 Ok(message) => message,
                 Err(err) => format!("Action failed: {err:#}"),
             };
@@ -268,8 +277,31 @@ fn prompt_and_run(recipe: &Recipe) -> Result<()> {
     Ok(())
 }
 
-fn run_tui_action(action: &TuiAction) -> Result<String> {
+fn run_tui_action(
+    action: TuiAction,
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+) -> Result<String> {
     match action {
+        TuiAction::SaveSecret => {
+            let Some(name) = prompt_text(
+                terminal,
+                app,
+                "Save Secret",
+                "Secret name",
+                Some("GITHUB_PERSONAL_ACCESS_TOKEN"),
+                false,
+            )?
+            else {
+                return Ok("Save secret canceled.".to_string());
+            };
+            crate::secrets::validate_name(&name)?;
+            let Some(value) = prompt_text(terminal, app, "Save Secret", &name, None, true)? else {
+                return Ok("Save secret canceled.".to_string());
+            };
+            crate::secrets::save_value(&name, &value)?;
+            Ok(format!("Saved {name} in the OS credential store."))
+        }
         TuiAction::ListSecrets => {
             let count = crate::secrets::list_names()?.len();
             Ok(match count {
@@ -277,6 +309,74 @@ fn run_tui_action(action: &TuiAction) -> Result<String> {
                 1 => "Showing 1 saved secret name.".to_string(),
                 n => format!("Showing {n} saved secret names."),
             })
+        }
+        TuiAction::RemoveSecret => {
+            let default = crate::secrets::list_names()?.into_iter().next();
+            let Some(name) = prompt_text(
+                terminal,
+                app,
+                "Remove Secret",
+                "Secret name",
+                default.as_deref().or(Some("GITHUB_PERSONAL_ACCESS_TOKEN")),
+                false,
+            )?
+            else {
+                return Ok("Remove secret canceled.".to_string());
+            };
+            crate::secrets::validate_name(&name)?;
+            let Some(confirm) = prompt_text(
+                terminal,
+                app,
+                "Remove Secret",
+                &format!("Type {name} to confirm"),
+                None,
+                false,
+            )?
+            else {
+                return Ok("Remove secret canceled.".to_string());
+            };
+            if confirm != name {
+                return Ok("Remove secret canceled.".to_string());
+            }
+            crate::secrets::remove_value(&name)?;
+            Ok(format!("Removed {name}."))
+        }
+    }
+}
+
+fn prompt_text(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    title: &str,
+    label: &str,
+    default: Option<&str>,
+    secret: bool,
+) -> Result<Option<String>> {
+    let mut value = String::new();
+    loop {
+        terminal.draw(|frame| {
+            draw(frame, app);
+            draw_prompt(frame, title, label, default, &value, secret);
+        })?;
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, _) => return Ok(None),
+            (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
+            (KeyCode::Enter, _) => {
+                if value.is_empty() {
+                    return Ok(default.map(str::to_string));
+                }
+                return Ok(Some(value));
+            }
+            (KeyCode::Backspace, _) => {
+                value.pop();
+            }
+            (KeyCode::Char(ch), _) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                value.push(ch);
+            }
+            _ => {}
         }
     }
 }
@@ -734,6 +834,16 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             lines.push(Line::from(render_command(&preview)));
             lines.push(Line::from(""));
         }
+        RecipeKind::Tui(TuiAction::SaveSecret) => {
+            lines.push(Line::from(Span::styled(
+                "TUI prompts",
+                Style::default().fg(Color::Yellow).bold(),
+            )));
+            lines.push(Line::from("1. Secret name"));
+            lines.push(Line::from("2. Secret value, hidden while typing"));
+            lines.push(Line::from("3. Save to the OS credential store"));
+            lines.push(Line::from(""));
+        }
         RecipeKind::Tui(TuiAction::ListSecrets) => {
             lines.push(Line::from(Span::styled(
                 "Saved secrets",
@@ -752,6 +862,16 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
                     lines.push(Line::from(format!("Unable to read secret index: {err:#}")));
                 }
             }
+            lines.push(Line::from(""));
+        }
+        RecipeKind::Tui(TuiAction::RemoveSecret) => {
+            lines.push(Line::from(Span::styled(
+                "TUI prompts",
+                Style::default().fg(Color::Yellow).bold(),
+            )));
+            lines.push(Line::from("1. Secret name"));
+            lines.push(Line::from("2. Type the same name to confirm removal"));
+            lines.push(Line::from("3. Remove from the OS credential store"));
             lines.push(Line::from(""));
         }
         RecipeKind::Workflow(Workflow::McpAuthExample) => {
@@ -816,6 +936,58 @@ fn draw_footer(frame: &mut Frame<'_>, area: Rect, app: &App) {
             .block(Block::default().borders(Borders::ALL)),
         area,
     );
+}
+
+fn draw_prompt(
+    frame: &mut Frame<'_>,
+    title: &str,
+    label: &str,
+    default: Option<&str>,
+    value: &str,
+    secret: bool,
+) {
+    let area = centered_rect(64, 9, frame.area());
+    let shown_value = if secret {
+        "*".repeat(value.chars().count())
+    } else {
+        value.to_string()
+    };
+    let prompt = match default {
+        Some(default) => format!("{label} [{default}]"),
+        None => label.to_string(),
+    };
+    let body = Text::from(vec![
+        Line::from(prompt),
+        Line::from(""),
+        Line::from(if shown_value.is_empty() {
+            Span::styled(" ", Style::default().fg(Color::Gray))
+        } else {
+            Span::raw(shown_value)
+        }),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Enter accept    Esc cancel",
+            Style::default().fg(Color::Gray),
+        )),
+    ]);
+    frame.render_widget(Clear, area);
+    frame.render_widget(
+        Paragraph::new(body)
+            .wrap(Wrap { trim: false })
+            .block(Block::default().title(title).borders(Borders::ALL)),
+        area,
+    );
+}
+
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let width = width.min(area.width.saturating_sub(2)).max(20);
+    let height = height.min(area.height.saturating_sub(2)).max(7);
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
 }
 
 fn recipes() -> Vec<Recipe> {
@@ -938,18 +1110,9 @@ fn recipes() -> Vec<Recipe> {
             target: "secrets",
             title: "Save secret",
             description: "Store a local secret in the OS credential store with hidden input.",
-            kind: RecipeKind::Command,
-            args: vec![
-                ArgPart::Literal("secrets"),
-                ArgPart::Literal("set"),
-                ArgPart::Field("name"),
-            ],
-            fields: vec![Field {
-                key: "name",
-                label: "Secret name",
-                default: Some("GITHUB_PERSONAL_ACCESS_TOKEN"),
-                required: true,
-            }],
+            kind: RecipeKind::Tui(TuiAction::SaveSecret),
+            args: vec![],
+            fields: vec![],
             notes: &[
                 "The value is prompted with hidden input and saved in the OS credential store.",
                 "Use env-style names such as ANTHROPIC_API_KEY or GITHUB_PERSONAL_ACCESS_TOKEN.",
@@ -968,18 +1131,9 @@ fn recipes() -> Vec<Recipe> {
             target: "secrets",
             title: "Remove secret",
             description: "Remove a saved secret from the OS credential store.",
-            kind: RecipeKind::Command,
-            args: vec![
-                ArgPart::Literal("secrets"),
-                ArgPart::Literal("unset"),
-                ArgPart::Field("name"),
-            ],
-            fields: vec![Field {
-                key: "name",
-                label: "Secret name",
-                default: Some("GITHUB_PERSONAL_ACCESS_TOKEN"),
-                required: true,
-            }],
+            kind: RecipeKind::Tui(TuiAction::RemoveSecret),
+            args: vec![],
+            fields: vec![],
             notes: &[],
         },
         Recipe {
@@ -1171,17 +1325,20 @@ mod tests {
     }
 
     #[test]
-    fn list_secrets_stays_inside_tui() {
+    fn secret_actions_stay_inside_tui() {
         let app = App::new();
-        let recipe = app
-            .recipes
-            .iter()
-            .find(|recipe| recipe.title == "List saved secrets")
-            .expect("list secrets recipe exists");
-        assert!(matches!(
-            recipe.kind,
-            RecipeKind::Tui(TuiAction::ListSecrets)
-        ));
-        assert!(recipe.args.is_empty());
+        for (title, action) in [
+            ("Save secret", TuiAction::SaveSecret),
+            ("List saved secrets", TuiAction::ListSecrets),
+            ("Remove secret", TuiAction::RemoveSecret),
+        ] {
+            let recipe = app
+                .recipes
+                .iter()
+                .find(|recipe| recipe.title == title)
+                .unwrap_or_else(|| panic!("{title} recipe exists"));
+            assert!(matches!(&recipe.kind, RecipeKind::Tui(actual) if *actual == action));
+            assert!(recipe.args.is_empty());
+        }
     }
 }

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -132,9 +132,7 @@ impl App {
         let recipes = recipes();
         App {
             recipes,
-            targets: vec![
-                "all", "skill", "examples", "secrets", "local", "cluster", "dev",
-            ],
+            targets: vec!["all", "skill", "secrets", "local", "cluster", "dev"],
             target_idx: 0,
             selected: 0,
             message: "Select an action. Enter runs it; q exits.".into(),
@@ -1848,7 +1846,7 @@ fn recipes() -> Vec<Recipe> {
             notes: &[],
         },
         Recipe {
-            target: "examples",
+            target: "skill",
             title: "Chat with GitHub agent",
             description: "Start the GitHub MCP bundle and have a live conversation with the agent.",
             kind: RecipeKind::Workflow(Workflow::GithubAgentChat),
@@ -2061,13 +2059,13 @@ mod tests {
     }
 
     #[test]
-    fn examples_target_includes_github_agent_chat() {
+    fn skill_target_includes_github_agent_chat() {
         let app = App::new();
         let idx = app
             .targets
             .iter()
-            .position(|target| *target == "examples")
-            .expect("examples target exists");
+            .position(|target| *target == "skill")
+            .expect("skill target exists");
         let mut app = app;
         app.target_idx = idx;
         let titles: Vec<&str> = app

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -73,6 +73,7 @@ enum Workflow {
 
 #[derive(Clone, Debug)]
 struct ExampleChoice {
+    id: &'static str,
     name: &'static str,
     description: &'static str,
     directory: &'static str,
@@ -362,7 +363,7 @@ fn run_tui_action(
                 return Ok("Save secret canceled.".to_string());
             };
             crate::secrets::save_value(&name, &value)?;
-            Ok(format!("Saved {name} in the OS credential store."))
+            Ok(format!("Saved {name} in AgentOS private storage."))
         }
         TuiAction::ListSecrets => {
             let count = crate::secrets::list_names()?.len();
@@ -480,7 +481,7 @@ fn saved_secret_choices() -> Result<Vec<SelectChoice<SecretNameChoice>>> {
         .into_iter()
         .map(|name| SelectChoice {
             label: name.clone(),
-            description: "Saved in the OS credential store".to_string(),
+            description: "Saved in AgentOS private storage".to_string(),
             value: SecretNameChoice::Name(name),
         })
         .collect();
@@ -606,7 +607,7 @@ fn explore_examples(
         return Ok(());
     };
 
-    crate::secrets::sync_vault_index()?;
+    crate::secrets::sync_secret_file()?;
     ensure_model_credential_available(terminal, app)?;
     for name in example.secrets {
         ensure_secret_available(terminal, app, name)?;
@@ -622,7 +623,7 @@ fn explore_examples(
         anyhow::bail!("missing example bundle at {}", example_dir.display());
     }
 
-    let container_name = format!("agentos-example-{}", example.name);
+    let container_name = format!("agentos-example-{}", example.id);
     let port = "7247";
     let url = format!("http://localhost:{port}");
     let mut setup = RunView::new(&format!("Starting {}", example.name));
@@ -673,6 +674,7 @@ fn explore_examples(
 fn example_choices() -> Vec<ExampleChoice> {
     vec![
         ExampleChoice {
+            id: "github-issues",
             name: "GitHub issues",
             description:
                 "Explore live repositories and issues through authenticated GitHub MCP tools",
@@ -680,12 +682,14 @@ fn example_choices() -> Vec<ExampleChoice> {
             secrets: &["GITHUB_PERSONAL_ACCESS_TOKEN"],
         },
         ExampleChoice {
+            id: "text-stats-engine",
             name: "Text stats engine",
             description: "Use an in-bundle MCP server to inspect and analyze text",
             directory: "examples/text-stats-engine",
             secrets: &[],
         },
         ExampleChoice {
+            id: "weather",
             name: "Weather",
             description: "Chat with the minimal weather agent bundle",
             directory: "examples/weather",
@@ -747,7 +751,7 @@ fn ensure_secret_available(
         vec![
             SelectChoice {
                 label: "Save it now".to_string(),
-                description: "Store it in the OS credential store".to_string(),
+                description: "Store it in AgentOS private storage".to_string(),
                 value: true,
             },
             SelectChoice {
@@ -1482,7 +1486,7 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             )));
             lines.push(Line::from("1. Choose a common secret name or Custom"));
             lines.push(Line::from("2. Secret value, hidden while typing"));
-            lines.push(Line::from("3. Save to the OS credential store"));
+            lines.push(Line::from("3. Save to AgentOS private storage"));
             lines.push(Line::from(""));
         }
         RecipeKind::Tui(TuiAction::ListSecrets) => {
@@ -1512,7 +1516,7 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             )));
             lines.push(Line::from("1. Choose a saved secret name or Custom"));
             lines.push(Line::from("2. Type the same name to confirm removal"));
-            lines.push(Line::from("3. Remove from the OS credential store"));
+            lines.push(Line::from("3. Remove from AgentOS private storage"));
             lines.push(Line::from(""));
         }
         RecipeKind::Workflow(Workflow::ExploreExamples) => {
@@ -1966,12 +1970,12 @@ fn recipes() -> Vec<Recipe> {
         Recipe {
             target: "secrets",
             title: "Save secret",
-            description: "Store a local secret in the OS credential store with hidden input.",
+            description: "Store a local secret in AgentOS private storage with hidden input.",
             kind: RecipeKind::Tui(TuiAction::SaveSecret),
             args: vec![],
             fields: vec![],
             notes: &[
-                "The value is prompted with hidden input and saved in the OS credential store.",
+                "The value is prompted with hidden input and saved in a mode-0600 config file.",
                 "Choose a common env var or enter any env-style custom name.",
             ],
         },
@@ -1982,12 +1986,12 @@ fn recipes() -> Vec<Recipe> {
             kind: RecipeKind::Tui(TuiAction::ListSecrets),
             args: vec![],
             fields: vec![],
-            notes: &["Only names are listed; secret values stay in the OS credential store."],
+            notes: &["Only names are listed; secret values stay in private storage."],
         },
         Recipe {
             target: "secrets",
             title: "Remove secret",
-            description: "Remove a saved secret from the OS credential store.",
+            description: "Remove a saved secret from AgentOS private storage.",
             kind: RecipeKind::Tui(TuiAction::RemoveSecret),
             args: vec![],
             fields: vec![],
@@ -2171,7 +2175,15 @@ mod tests {
             .recipes
             .iter()
             .any(|recipe| recipe.title == "Explore examples"));
-        assert_eq!(example_choices().len(), 3);
+        let examples = example_choices();
+        assert_eq!(examples.len(), 3);
+        assert!(examples.iter().all(|example| {
+            !example.id.is_empty()
+                && example
+                    .id
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+        }));
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -78,6 +78,7 @@ struct ExampleChoice {
     description: &'static str,
     directory: &'static str,
     secrets: &'static [&'static str],
+    suggestions: &'static [&'static str],
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -645,7 +646,13 @@ fn explore_examples(
         }
         run_agentos_in_tui_with_env(terminal, app, &argv, &repo_root, &mut setup, &secret_env)?;
         started = true;
-        chat_with_runner(terminal, &repo_root, &url, example.name)
+        chat_with_runner(
+            terminal,
+            &repo_root,
+            &url,
+            example.name,
+            example.suggestions,
+        )
     })();
 
     if started {
@@ -680,6 +687,11 @@ fn example_choices() -> Vec<ExampleChoice> {
                 "Explore live repositories and issues through authenticated GitHub MCP tools",
             directory: "examples/github-issues",
             secrets: &["GITHUB_PERSONAL_ACCESS_TOKEN"],
+            suggestions: &[
+                "List the open issues in curie-eng/agentos and group them by label.",
+                "Summarize the most recently updated pull requests in curie-eng/agentos.",
+                "Find open bug reports in curie-eng/agentos that need triage.",
+            ],
         },
         ExampleChoice {
             id: "text-stats-engine",
@@ -687,6 +699,11 @@ fn example_choices() -> Vec<ExampleChoice> {
             description: "Use an in-bundle MCP server to inspect and analyze text",
             directory: "examples/text-stats-engine",
             secrets: &[],
+            suggestions: &[
+                "Explain what text analysis tools you have.",
+                "Count the words and sentences in: AgentOS makes agents portable.",
+                "Analyze the readability of: Clear tools make complex work easier.",
+            ],
         },
         ExampleChoice {
             id: "weather",
@@ -694,6 +711,11 @@ fn example_choices() -> Vec<ExampleChoice> {
             description: "Chat with the minimal weather agent bundle",
             directory: "examples/weather",
             secrets: &[],
+            suggestions: &[
+                "What can this weather agent help me with?",
+                "Give me a concise weather briefing for San Francisco.",
+                "How should I ask you to compare weather between two cities?",
+            ],
         },
     ]
 }
@@ -970,10 +992,12 @@ struct ChatView {
     scroll: u16,
     follow: bool,
     thinking: bool,
+    suggestions: Vec<String>,
+    suggestion_idx: usize,
 }
 
 impl ChatView {
-    fn new(agent_name: &str) -> Self {
+    fn new(agent_name: &str, suggestions: &[&str]) -> Self {
         Self {
             agent_name: agent_name.to_string(),
             lines: vec![
@@ -985,12 +1009,17 @@ impl ChatView {
             scroll: 0,
             follow: true,
             thinking: false,
+            suggestions: suggestions
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
+            suggestion_idx: 0,
         }
     }
 
     fn max_scroll(&self, terminal_width: u16, terminal_height: u16) -> u16 {
         let width = terminal_width.saturating_sub(4).max(1) as usize;
-        let viewport = terminal_height.saturating_sub(9) as usize;
+        let viewport = terminal_height.saturating_sub(14) as usize;
         wrap_output_lines(&self.lines, width)
             .len()
             .saturating_sub(viewport)
@@ -1009,8 +1038,9 @@ fn chat_with_runner(
     cwd: &Path,
     url: &str,
     agent_name: &str,
+    suggestions: &[&str],
 ) -> Result<()> {
-    let mut chat = ChatView::new(agent_name);
+    let mut chat = ChatView::new(agent_name, suggestions);
     loop {
         let Some(message) = read_chat_input(terminal, &mut chat)? else {
             return Ok(());
@@ -1048,8 +1078,13 @@ fn read_chat_input(
         };
         match (key.code, key.modifiers) {
             (KeyCode::Esc, _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
-            (KeyCode::Enter, _) if !chat.input.trim().is_empty() => {
-                return Ok(Some(chat.input.trim().to_string()));
+            (KeyCode::Enter, _) => {
+                if !chat.input.trim().is_empty() {
+                    return Ok(Some(chat.input.trim().to_string()));
+                }
+                if let Some(suggestion) = chat.suggestions.get(chat.suggestion_idx) {
+                    return Ok(Some(suggestion.clone()));
+                }
             }
             (KeyCode::Backspace, _) => {
                 chat.input.pop();
@@ -1066,6 +1101,16 @@ fn read_chat_input(
                     .min(chat.max_scroll(size.width, size.height));
             }
             (KeyCode::End, _) => chat.follow = true,
+            (KeyCode::Down | KeyCode::Tab, _) if !chat.suggestions.is_empty() => {
+                chat.suggestion_idx = (chat.suggestion_idx + 1) % chat.suggestions.len();
+            }
+            (KeyCode::Up | KeyCode::BackTab, _) if !chat.suggestions.is_empty() => {
+                chat.suggestion_idx = if chat.suggestion_idx == 0 {
+                    chat.suggestions.len() - 1
+                } else {
+                    chat.suggestion_idx - 1
+                };
+            }
             (KeyCode::Char(ch), _) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                 chat.input.push(ch);
             }
@@ -1096,7 +1141,9 @@ fn run_chat_turn(
 
     loop {
         while let Ok(line) = rx.try_recv() {
-            chat.lines.push(line);
+            if !is_internal_chat_status(&line) {
+                chat.lines.push(line);
+            }
         }
         let size = terminal.size()?;
         chat.follow_tail(size.width, size.height);
@@ -1129,7 +1176,9 @@ fn run_chat_turn(
                 let _ = reader.join();
             }
             while let Ok(line) = rx.try_recv() {
-                chat.lines.push(line);
+                if !is_internal_chat_status(&line) {
+                    chat.lines.push(line);
+                }
             }
             if canceled {
                 chat.lines.push("Response canceled.".to_string());
@@ -1141,6 +1190,10 @@ fn run_chat_turn(
             return Ok(());
         }
     }
+}
+
+fn is_internal_chat_status(line: &str) -> bool {
+    line.trim().starts_with("-- final (")
 }
 
 fn run_agentos_in_tui(
@@ -1639,6 +1692,7 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
         .constraints([
             Constraint::Length(3),
             Constraint::Min(5),
+            Constraint::Length(5),
             Constraint::Length(3),
             Constraint::Length(2),
         ])
@@ -1683,7 +1737,30 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
         chunks[1],
     );
 
-    let input_width = chunks[2].width.saturating_sub(4).max(1) as usize;
+    let suggestions = chat
+        .suggestions
+        .iter()
+        .enumerate()
+        .map(|(idx, suggestion)| {
+            let prefix = if idx == chat.suggestion_idx {
+                "> "
+            } else {
+                "  "
+            };
+            ListItem::new(format!("{prefix}{}. {suggestion}", idx + 1))
+        })
+        .collect::<Vec<_>>();
+    let mut suggestion_state = ListState::default();
+    suggestion_state.select(Some(chat.suggestion_idx));
+    frame.render_stateful_widget(
+        List::new(suggestions)
+            .block(Block::default().title("Try a prompt").borders(Borders::ALL))
+            .highlight_style(Style::default().fg(Color::Black).bg(Color::Cyan)),
+        chunks[2],
+        &mut suggestion_state,
+    );
+
+    let input_width = chunks[3].width.saturating_sub(4).max(1) as usize;
     let shown_input = input_window(&chat.input, false, input_width);
     let input_style = if chat.thinking {
         Style::default().fg(Color::DarkGray)
@@ -1700,23 +1777,23 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
                 })
                 .borders(Borders::ALL),
         ),
-        chunks[2],
+        chunks[3],
     );
     if !chat.thinking {
         frame.set_cursor_position((
-            chunks[2].x + 1 + UnicodeWidthStr::width(shown_input.as_str()) as u16,
-            chunks[2].y + 1,
+            chunks[3].x + 1 + UnicodeWidthStr::width(shown_input.as_str()) as u16,
+            chunks[3].y + 1,
         ));
     }
     let help = if chat.thinking {
         "Ctrl-C cancel response    PgUp/PgDn scroll    End latest"
     } else {
-        "Enter send    Esc leave chat    PgUp/PgDn scroll    End latest"
+        "Up/Down choose prompt    Enter send    Type for free response    Esc leave"
     };
     frame.render_widget(
         Paragraph::new(Span::styled(help, Style::default().fg(Color::Gray)))
             .alignment(Alignment::Center),
-        chunks[3],
+        chunks[4],
     );
 }
 
@@ -2179,11 +2256,19 @@ mod tests {
         assert_eq!(examples.len(), 3);
         assert!(examples.iter().all(|example| {
             !example.id.is_empty()
+                && !example.suggestions.is_empty()
                 && example
                     .id
                     .chars()
                     .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
         }));
+    }
+
+    #[test]
+    fn chat_hides_internal_final_status() {
+        assert!(is_internal_chat_status("-- final (done)"));
+        assert!(is_internal_chat_status("  -- final (failed)"));
+        assert!(!is_internal_chat_status("The final answer is done."));
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -691,7 +691,7 @@ fn ensure_secret_available(
     if std::env::var_os(name).is_some() {
         return Ok(());
     }
-    if crate::secrets::has_value(name) {
+    if crate::secrets::is_saved(name)? {
         return Ok(());
     }
     let Some(save) = prompt_select(
@@ -738,10 +738,11 @@ fn ensure_model_credential_available(
             return Ok(());
         }
     }
-    for name in NAMES {
-        if crate::secrets::has_value(name) {
-            return Ok(());
-        }
+    let saved_names = crate::secrets::list_names()?
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    if NAMES.iter().any(|name| saved_names.contains(*name)) {
+        return Ok(());
     }
 
     let choices = NAMES
@@ -777,23 +778,23 @@ fn ensure_model_credential_available(
     crate::secrets::save_value(&name, &value)
 }
 
-fn secret_status(name: &str) -> &'static str {
+fn secret_status(name: &str, saved_names: &BTreeSet<String>) -> &'static str {
     if std::env::var_os(name).is_some() {
         "env"
-    } else if crate::secrets::has_value(name) {
+    } else if saved_names.contains(name) {
         "saved"
     } else {
         "missing"
     }
 }
 
-fn model_credential_status() -> &'static str {
+fn model_credential_status(saved_names: &BTreeSet<String>) -> &'static str {
     for name in [
         "AGENTOS_CREDENTIALS",
         "ANTHROPIC_API_KEY",
         "CLAUDE_CODE_OAUTH_TOKEN",
     ] {
-        if std::env::var_os(name).is_some() || crate::secrets::has_value(name) {
+        if std::env::var_os(name).is_some() || saved_names.contains(name) {
             return "available";
         }
     }
@@ -801,11 +802,22 @@ fn model_credential_status() -> &'static str {
 }
 
 fn secrets_status_lines() -> Vec<Line<'static>> {
+    let saved_names = match crate::secrets::list_names() {
+        Ok(names) => names.into_iter().collect::<BTreeSet<_>>(),
+        Err(err) => {
+            return vec![Line::from(format!(
+                "Unable to read saved credential names: {err:#}"
+            ))];
+        }
+    };
     vec![
-        Line::from(format!("Model credential: {}", model_credential_status())),
+        Line::from(format!(
+            "Model credential: {}",
+            model_credential_status(&saved_names)
+        )),
         Line::from(format!(
             "GITHUB_PERSONAL_ACCESS_TOKEN: {}",
-            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN")
+            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN", &saved_names)
         )),
     ]
 }
@@ -1902,6 +1914,20 @@ mod tests {
             wrap_output_lines(&lines, 4),
             vec!["abcd", "ef", "ab界", "cd", ""]
         );
+    }
+
+    #[test]
+    fn credential_status_uses_saved_names_without_secret_reads() {
+        let saved = BTreeSet::from([
+            "ANTHROPIC_API_KEY".to_string(),
+            "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+        ]);
+        assert_eq!(model_credential_status(&saved), "available");
+        assert_eq!(
+            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN", &saved),
+            "saved"
+        );
+        assert_eq!(secret_status("OPENAI_API_KEY", &saved), "missing");
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -7,7 +7,7 @@
 //! or suspends the alternate screen and runs that command as a normal child
 //! process.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -25,6 +25,7 @@ use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
 use ratatui::{Frame, Terminal};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum SecretNameChoice {
@@ -302,7 +303,7 @@ fn run_tui_action(
                 app,
                 "Save Secret",
                 "Choose a secret name",
-                secret_name_choices(),
+                secret_name_choices()?,
             )?
             else {
                 return Ok("Save secret canceled.".to_string());
@@ -388,39 +389,56 @@ fn run_tui_action(
     }
 }
 
-fn secret_name_choices() -> Vec<SelectChoice<SecretNameChoice>> {
-    vec![
-        SelectChoice {
-            label: "ANTHROPIC_API_KEY".to_string(),
-            description: "Anthropic API key for model calls".to_string(),
-            value: SecretNameChoice::Name("ANTHROPIC_API_KEY".to_string()),
-        },
-        SelectChoice {
-            label: "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
-            description: "Claude Code OAuth token for model calls".to_string(),
-            value: SecretNameChoice::Name("CLAUDE_CODE_OAUTH_TOKEN".to_string()),
-        },
-        SelectChoice {
-            label: "AGENTOS_CREDENTIALS".to_string(),
-            description: "Provider credential forwarded as AgentOS credentials".to_string(),
-            value: SecretNameChoice::Name("AGENTOS_CREDENTIALS".to_string()),
-        },
-        SelectChoice {
-            label: "OPENAI_API_KEY".to_string(),
-            description: "OpenAI API key for model or MCP workflows".to_string(),
-            value: SecretNameChoice::Name("OPENAI_API_KEY".to_string()),
-        },
-        SelectChoice {
-            label: "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
-            description: "GitHub token for MCP examples or bundles".to_string(),
-            value: SecretNameChoice::Name("GITHUB_PERSONAL_ACCESS_TOKEN".to_string()),
-        },
-        SelectChoice {
-            label: "Custom secret name".to_string(),
-            description: "Enter any env-style secret name".to_string(),
-            value: SecretNameChoice::Custom,
-        },
-    ]
+fn secret_name_choices() -> Result<Vec<SelectChoice<SecretNameChoice>>> {
+    let saved_names = crate::secrets::list_names()?.into_iter().collect();
+    Ok(secret_name_choices_for(&saved_names))
+}
+
+fn secret_name_choices_for(saved_names: &BTreeSet<String>) -> Vec<SelectChoice<SecretNameChoice>> {
+    let common = [
+        ("ANTHROPIC_API_KEY", "Anthropic API key for model calls"),
+        (
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "Claude Code OAuth token for model calls",
+        ),
+        (
+            "AGENTOS_CREDENTIALS",
+            "Provider credential forwarded as AgentOS credentials",
+        ),
+        (
+            "OPENAI_API_KEY",
+            "OpenAI API key for model or MCP workflows",
+        ),
+        (
+            "GITHUB_PERSONAL_ACCESS_TOKEN",
+            "GitHub token for MCP examples or bundles",
+        ),
+    ];
+    let mut choices = common
+        .into_iter()
+        .map(|(name, description)| {
+            let saved = saved_names.contains(name);
+            SelectChoice {
+                label: if saved {
+                    format!("{name} ✓")
+                } else {
+                    name.to_string()
+                },
+                description: if saved {
+                    format!("{description} (saved)")
+                } else {
+                    description.to_string()
+                },
+                value: SecretNameChoice::Name(name.to_string()),
+            }
+        })
+        .collect::<Vec<_>>();
+    choices.push(SelectChoice {
+        label: "Custom secret name".to_string(),
+        description: "Enter any env-style secret name".to_string(),
+        value: SecretNameChoice::Custom,
+    });
+    choices
 }
 
 fn saved_secret_choices() -> Result<Vec<SelectChoice<SecretNameChoice>>> {
@@ -1089,11 +1107,8 @@ fn draw_prompt(
     secret: bool,
 ) {
     let area = centered_rect(64, 9, frame.area());
-    let shown_value = if secret {
-        "*".repeat(value.chars().count())
-    } else {
-        value.to_string()
-    };
+    let input_width = area.width.saturating_sub(3) as usize;
+    let shown_value = input_window(value, secret, input_width);
     let prompt = match default {
         Some(default) => format!("{label} [{default}]"),
         None => label.to_string(),
@@ -1104,7 +1119,7 @@ fn draw_prompt(
         Line::from(if shown_value.is_empty() {
             Span::styled(" ", Style::default().fg(Color::Gray))
         } else {
-            Span::raw(shown_value)
+            Span::raw(&shown_value)
         }),
         Line::from(""),
         Line::from(Span::styled(
@@ -1119,6 +1134,28 @@ fn draw_prompt(
             .block(Block::default().title(title).borders(Borders::ALL)),
         area,
     );
+    frame.set_cursor_position((
+        area.x + 1 + UnicodeWidthStr::width(shown_value.as_str()) as u16,
+        area.y + 3,
+    ));
+}
+
+fn input_window(value: &str, secret: bool, max_width: usize) -> String {
+    if secret {
+        return "*".repeat(value.chars().count().min(max_width));
+    }
+
+    let mut width = 0;
+    let mut chars = Vec::new();
+    for ch in value.chars().rev() {
+        let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + char_width > max_width {
+            break;
+        }
+        width += char_width;
+        chars.push(ch);
+    }
+    chars.into_iter().rev().collect()
 }
 
 fn draw_select_prompt<T>(
@@ -1532,7 +1569,7 @@ mod tests {
 
     #[test]
     fn secret_name_choices_include_custom_and_do_not_default_to_github() {
-        let choices = secret_name_choices();
+        let choices = secret_name_choices_for(&BTreeSet::new());
         assert!(matches!(
             choices.first().map(|choice| &choice.value),
             Some(SecretNameChoice::Name(name)) if name == "ANTHROPIC_API_KEY"
@@ -1546,5 +1583,34 @@ mod tests {
         assert!(choices.iter().any(
             |choice| matches!(&choice.value, SecretNameChoice::Name(name) if name == "GITHUB_PERSONAL_ACCESS_TOKEN")
         ));
+    }
+
+    #[test]
+    fn secret_name_choices_mark_saved_common_keys() {
+        let saved = BTreeSet::from(["OPENAI_API_KEY".to_string()]);
+        let choices = secret_name_choices_for(&saved);
+        let openai = choices
+            .iter()
+            .find(|choice| {
+                matches!(&choice.value, SecretNameChoice::Name(name) if name == "OPENAI_API_KEY")
+            })
+            .expect("OpenAI choice exists");
+        let anthropic = choices
+            .iter()
+            .find(|choice| {
+                matches!(&choice.value, SecretNameChoice::Name(name) if name == "ANTHROPIC_API_KEY")
+            })
+            .expect("Anthropic choice exists");
+
+        assert_eq!(openai.label, "OPENAI_API_KEY ✓");
+        assert!(openai.description.ends_with("(saved)"));
+        assert_eq!(anthropic.label, "ANTHROPIC_API_KEY");
+    }
+
+    #[test]
+    fn input_window_keeps_the_caret_end_visible() {
+        assert_eq!(input_window("abcdefgh", false, 5), "defgh");
+        assert_eq!(input_window("ab界", false, 3), "b界");
+        assert_eq!(input_window("secret", true, 4), "****");
     }
 }

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -1032,7 +1032,7 @@ impl ChatView {
     }
 
     fn max_scroll(&self, terminal_width: u16, terminal_height: u16) -> u16 {
-        let (width, viewport) = chat_transcript_dimensions(terminal_width, terminal_height);
+        let (width, viewport) = chat_transcript_dimensions(self, terminal_width, terminal_height);
         wrap_output_lines(&self.lines, width)
             .len()
             .saturating_sub(viewport)
@@ -1786,13 +1786,14 @@ fn draw_run_view(frame: &mut Frame<'_>, view: &RunView) {
 
 fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
     let area = frame.area();
+    let (action_height, input_height) = chat_panel_heights(chat);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),
             Constraint::Min(5),
-            Constraint::Length(5),
-            Constraint::Length(3),
+            Constraint::Length(action_height),
+            Constraint::Length(input_height),
             Constraint::Length(2),
         ])
         .split(area);
@@ -1849,47 +1850,28 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
         .collect::<Vec<_>>();
     let mut action_state = ListState::default();
     action_state.select((chat.choice_count() > 0).then_some(chat.action_idx));
-    frame.render_stateful_widget(
-        List::new(actions)
-            .block(
-                Block::default()
-                    .title(chat.action_prompt.as_str())
-                    .borders(Borders::ALL),
-            )
-            .highlight_style(Style::default().fg(Color::Black).bg(Color::Cyan)),
-        chunks[2],
-        &mut action_state,
-    );
+    if action_height > 0 {
+        frame.render_stateful_widget(
+            List::new(actions)
+                .block(
+                    Block::default()
+                        .title(chat.action_prompt.as_str())
+                        .borders(Borders::ALL),
+                )
+                .highlight_style(Style::default().fg(Color::Black).bg(Color::Cyan)),
+            chunks[2],
+            &mut action_state,
+        );
+    }
 
     let input_width = chunks[3].width.saturating_sub(4).max(1) as usize;
     let shown_input = input_window(&chat.input, false, input_width);
-    let input_style = if chat.thinking || !chat.composing {
-        Style::default().fg(Color::DarkGray)
-    } else {
-        Style::default()
-    };
-    let input_text = if chat.composing {
-        shown_input.as_str()
-    } else {
-        ""
-    };
-    frame.render_widget(
-        Paragraph::new(Span::styled(input_text, input_style)).block(
-            Block::default()
-                .title(if chat.thinking {
-                    "Waiting for agent"
-                } else if !chat.allow_free_text {
-                    "Select a response"
-                } else if chat.composing {
-                    "Message"
-                } else {
-                    "Message (select Type a message...)"
-                })
-                .borders(Borders::ALL),
-        ),
-        chunks[3],
-    );
-    if !chat.thinking && chat.composing {
+    if input_height > 0 {
+        frame.render_widget(
+            Paragraph::new(Span::raw(shown_input.as_str()))
+                .block(Block::default().title("Message").borders(Borders::ALL)),
+            chunks[3],
+        );
         frame.set_cursor_position((
             chunks[3].x + 1 + UnicodeWidthStr::width(shown_input.as_str()) as u16,
             chunks[3].y + 1,
@@ -1909,14 +1891,33 @@ fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
     );
 }
 
-fn chat_transcript_dimensions(terminal_width: u16, terminal_height: u16) -> (usize, usize) {
+fn chat_panel_heights(chat: &ChatView) -> (u16, u16) {
+    if chat.thinking {
+        return (0, 0);
+    }
+    let choices = chat.choice_count().min(usize::from(u16::MAX)) as u16;
+    let action_height = if choices > 0 {
+        choices.saturating_add(2)
+    } else {
+        0
+    };
+    let input_height = if chat.composing { 3 } else { 0 };
+    (action_height, input_height)
+}
+
+fn chat_transcript_dimensions(
+    chat: &ChatView,
+    terminal_width: u16,
+    terminal_height: u16,
+) -> (usize, usize) {
+    let (action_height, input_height) = chat_panel_heights(chat);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(3),
             Constraint::Min(5),
-            Constraint::Length(5),
-            Constraint::Length(3),
+            Constraint::Length(action_height),
+            Constraint::Length(input_height),
             Constraint::Length(2),
         ])
         .split(Rect::new(0, 0, terminal_width, terminal_height));
@@ -2403,16 +2404,24 @@ mod tests {
     fn chat_appends_free_text_as_the_final_choice() {
         let mut chat = ChatView::new("demo", &["First".to_string(), "Second".to_string()]);
         assert_eq!(chat.choice_count(), 3);
+        assert_eq!(chat_panel_heights(&chat), (5, 0));
         assert!(!chat.free_text_selected());
 
         chat.move_selection(-1);
         assert_eq!(chat.action_idx, 2);
         assert!(chat.free_text_selected());
+        chat.composing = true;
+        assert_eq!(chat_panel_heights(&chat), (5, 3));
 
         chat.allow_free_text = false;
+        chat.composing = false;
         chat.action_idx = 0;
         assert_eq!(chat.choice_count(), 2);
+        assert_eq!(chat_panel_heights(&chat), (4, 0));
         assert!(!chat.free_text_selected());
+
+        chat.thinking = true;
+        assert_eq!(chat_panel_heights(&chat), (0, 0));
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -26,6 +26,19 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
 use ratatui::{Frame, Terminal};
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum SecretNameChoice {
+    Name(String),
+    Custom,
+}
+
+#[derive(Clone, Debug)]
+struct SelectChoice<T> {
+    label: String,
+    description: String,
+    value: T,
+}
+
 #[derive(Clone, Debug)]
 struct Recipe {
     target: &'static str,
@@ -284,16 +297,32 @@ fn run_tui_action(
 ) -> Result<String> {
     match action {
         TuiAction::SaveSecret => {
-            let Some(name) = prompt_text(
+            let Some(choice) = prompt_select(
                 terminal,
                 app,
                 "Save Secret",
-                "Secret name",
-                Some("GITHUB_PERSONAL_ACCESS_TOKEN"),
-                false,
+                "Choose a secret name",
+                secret_name_choices(),
             )?
             else {
                 return Ok("Save secret canceled.".to_string());
+            };
+            let name = match choice {
+                SecretNameChoice::Name(name) => name,
+                SecretNameChoice::Custom => {
+                    let Some(name) = prompt_text(
+                        terminal,
+                        app,
+                        "Save Secret",
+                        "Custom secret name",
+                        None,
+                        false,
+                    )?
+                    else {
+                        return Ok("Save secret canceled.".to_string());
+                    };
+                    name
+                }
             };
             crate::secrets::validate_name(&name)?;
             let Some(value) = prompt_text(terminal, app, "Save Secret", &name, None, true)? else {
@@ -311,17 +340,32 @@ fn run_tui_action(
             })
         }
         TuiAction::RemoveSecret => {
-            let default = crate::secrets::list_names()?.into_iter().next();
-            let Some(name) = prompt_text(
+            let Some(choice) = prompt_select(
                 terminal,
                 app,
                 "Remove Secret",
-                "Secret name",
-                default.as_deref().or(Some("GITHUB_PERSONAL_ACCESS_TOKEN")),
-                false,
+                "Choose a saved secret",
+                saved_secret_choices()?,
             )?
             else {
                 return Ok("Remove secret canceled.".to_string());
+            };
+            let name = match choice {
+                SecretNameChoice::Name(name) => name,
+                SecretNameChoice::Custom => {
+                    let Some(name) = prompt_text(
+                        terminal,
+                        app,
+                        "Remove Secret",
+                        "Custom secret name",
+                        None,
+                        false,
+                    )?
+                    else {
+                        return Ok("Remove secret canceled.".to_string());
+                    };
+                    name
+                }
             };
             crate::secrets::validate_name(&name)?;
             let Some(confirm) = prompt_text(
@@ -340,6 +384,99 @@ fn run_tui_action(
             }
             crate::secrets::remove_value(&name)?;
             Ok(format!("Removed {name}."))
+        }
+    }
+}
+
+fn secret_name_choices() -> Vec<SelectChoice<SecretNameChoice>> {
+    vec![
+        SelectChoice {
+            label: "ANTHROPIC_API_KEY".to_string(),
+            description: "Anthropic API key for model calls".to_string(),
+            value: SecretNameChoice::Name("ANTHROPIC_API_KEY".to_string()),
+        },
+        SelectChoice {
+            label: "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+            description: "Claude Code OAuth token for model calls".to_string(),
+            value: SecretNameChoice::Name("CLAUDE_CODE_OAUTH_TOKEN".to_string()),
+        },
+        SelectChoice {
+            label: "AGENTOS_CREDENTIALS".to_string(),
+            description: "Provider credential forwarded as AgentOS credentials".to_string(),
+            value: SecretNameChoice::Name("AGENTOS_CREDENTIALS".to_string()),
+        },
+        SelectChoice {
+            label: "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+            description: "GitHub token for MCP examples or bundles".to_string(),
+            value: SecretNameChoice::Name("GITHUB_PERSONAL_ACCESS_TOKEN".to_string()),
+        },
+        SelectChoice {
+            label: "Custom secret name".to_string(),
+            description: "Enter any env-style secret name".to_string(),
+            value: SecretNameChoice::Custom,
+        },
+    ]
+}
+
+fn saved_secret_choices() -> Result<Vec<SelectChoice<SecretNameChoice>>> {
+    let mut choices: Vec<SelectChoice<SecretNameChoice>> = crate::secrets::list_names()?
+        .into_iter()
+        .map(|name| SelectChoice {
+            label: name.clone(),
+            description: "Saved in the OS credential store".to_string(),
+            value: SecretNameChoice::Name(name),
+        })
+        .collect();
+    choices.push(SelectChoice {
+        label: "Custom secret name".to_string(),
+        description: "Remove a name not shown here".to_string(),
+        value: SecretNameChoice::Custom,
+    });
+    Ok(choices)
+}
+
+fn prompt_select<T: Clone>(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    title: &str,
+    label: &str,
+    choices: Vec<SelectChoice<T>>,
+) -> Result<Option<T>> {
+    if choices.is_empty() {
+        return Ok(None);
+    }
+    let mut selected = 0usize;
+    loop {
+        terminal.draw(|frame| {
+            draw(frame, app);
+            draw_select_prompt(frame, title, label, &choices, selected);
+        })?;
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, _) => return Ok(None),
+            (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
+            (KeyCode::Enter, _) => return Ok(Some(choices[selected].value.clone())),
+            (KeyCode::Down | KeyCode::Char('j'), _) => {
+                selected = (selected + 1) % choices.len();
+            }
+            (KeyCode::Up | KeyCode::Char('k'), _) => {
+                selected = if selected == 0 {
+                    choices.len() - 1
+                } else {
+                    selected - 1
+                };
+            }
+            (KeyCode::Char(ch), _) if ch.is_ascii_digit() => {
+                if let Some(digit) = ch.to_digit(10) {
+                    let idx = digit as usize;
+                    if idx > 0 && idx <= choices.len() {
+                        selected = idx - 1;
+                    }
+                }
+            }
+            _ => {}
         }
     }
 }
@@ -839,7 +976,7 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 "TUI prompts",
                 Style::default().fg(Color::Yellow).bold(),
             )));
-            lines.push(Line::from("1. Secret name"));
+            lines.push(Line::from("1. Choose a common secret name or Custom"));
             lines.push(Line::from("2. Secret value, hidden while typing"));
             lines.push(Line::from("3. Save to the OS credential store"));
             lines.push(Line::from(""));
@@ -869,7 +1006,7 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 "TUI prompts",
                 Style::default().fg(Color::Yellow).bold(),
             )));
-            lines.push(Line::from("1. Secret name"));
+            lines.push(Line::from("1. Choose a saved secret name or Custom"));
             lines.push(Line::from("2. Type the same name to confirm removal"));
             lines.push(Line::from("3. Remove from the OS credential store"));
             lines.push(Line::from(""));
@@ -973,6 +1110,52 @@ fn draw_prompt(
     frame.render_widget(Clear, area);
     frame.render_widget(
         Paragraph::new(body)
+            .wrap(Wrap { trim: false })
+            .block(Block::default().title(title).borders(Borders::ALL)),
+        area,
+    );
+}
+
+fn draw_select_prompt<T>(
+    frame: &mut Frame<'_>,
+    title: &str,
+    label: &str,
+    choices: &[SelectChoice<T>],
+    selected: usize,
+) {
+    let height = (choices.len() as u16)
+        .saturating_mul(2)
+        .saturating_add(6)
+        .min(18);
+    let area = centered_rect(74, height, frame.area());
+    let mut lines = vec![
+        Line::from(label.to_string()),
+        Line::from(Span::styled(
+            "Up/Down move    Enter choose    Esc cancel",
+            Style::default().fg(Color::Gray),
+        )),
+        Line::from(""),
+    ];
+    for (idx, choice) in choices.iter().enumerate() {
+        let focused = idx == selected;
+        let marker = if focused { ">" } else { " " };
+        let style = if focused {
+            Style::default().fg(Color::Black).bg(Color::Green)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker} {}. {}", idx + 1, choice.label),
+            style,
+        )));
+        lines.push(Line::from(Span::styled(
+            format!("     {}", choice.description),
+            Style::default().fg(Color::Gray),
+        )));
+    }
+    frame.render_widget(Clear, area);
+    frame.render_widget(
+        Paragraph::new(Text::from(lines))
             .wrap(Wrap { trim: false })
             .block(Block::default().title(title).borders(Borders::ALL)),
         area,
@@ -1115,7 +1298,7 @@ fn recipes() -> Vec<Recipe> {
             fields: vec![],
             notes: &[
                 "The value is prompted with hidden input and saved in the OS credential store.",
-                "Use env-style names such as ANTHROPIC_API_KEY or GITHUB_PERSONAL_ACCESS_TOKEN.",
+                "Choose a common env var or enter any env-style custom name.",
             ],
         },
         Recipe {
@@ -1340,5 +1523,20 @@ mod tests {
             assert!(matches!(&recipe.kind, RecipeKind::Tui(actual) if *actual == action));
             assert!(recipe.args.is_empty());
         }
+    }
+
+    #[test]
+    fn secret_name_choices_include_custom_and_do_not_default_to_github() {
+        let choices = secret_name_choices();
+        assert!(matches!(
+            choices.first().map(|choice| &choice.value),
+            Some(SecretNameChoice::Name(name)) if name == "ANTHROPIC_API_KEY"
+        ));
+        assert!(choices
+            .iter()
+            .any(|choice| choice.value == SecretNameChoice::Custom));
+        assert!(choices.iter().any(
+            |choice| matches!(&choice.value, SecretNameChoice::Name(name) if name == "GITHUB_PERSONAL_ACCESS_TOKEN")
+        ));
     }
 }

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -132,7 +132,9 @@ impl App {
         let recipes = recipes();
         App {
             recipes,
-            targets: vec!["all", "skill", "secrets", "local", "cluster", "dev"],
+            targets: vec![
+                "all", "skill", "examples", "secrets", "local", "cluster", "dev",
+            ],
             target_idx: 0,
             selected: 0,
             message: "Select an action. Enter runs it; q exits.".into(),
@@ -579,8 +581,10 @@ fn run_github_agent_chat(
     app: &App,
     _values: &BTreeMap<String, String>,
 ) -> Result<()> {
+    crate::secrets::sync_vault_index()?;
     ensure_model_credential_available(terminal, app)?;
     ensure_secret_available(terminal, app, "GITHUB_PERSONAL_ACCESS_TOKEN")?;
+    let secret_env = github_chat_secret_env()?;
 
     let repo_root = find_repo_root(std::env::current_dir().context("reading current directory")?)
         .context(
@@ -600,7 +604,7 @@ fn run_github_agent_chat(
     let mut setup = RunView::new("Starting GitHub agent");
     let mut started = false;
     let run_result = (|| -> Result<()> {
-        run_agentos_in_tui(
+        run_agentos_in_tui_with_env(
             terminal,
             app,
             &[
@@ -617,6 +621,7 @@ fn run_github_agent_chat(
             ],
             &repo_root,
             &mut setup,
+            &secret_env,
         )?;
         started = true;
         chat_with_runner(terminal, &repo_root, &url)
@@ -645,6 +650,35 @@ fn run_github_agent_chat(
     Ok(())
 }
 
+fn github_chat_secret_env() -> Result<Vec<(String, String)>> {
+    let mut env = Vec::new();
+    if ![
+        "AGENTOS_CREDENTIALS",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ]
+    .iter()
+    .any(|name| std::env::var_os(name).is_some())
+    {
+        for name in [
+            "AGENTOS_CREDENTIALS",
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+        ] {
+            if let Some(value) = crate::secrets::get_value(name)? {
+                env.push((name.to_string(), value));
+                break;
+            }
+        }
+    }
+    if std::env::var_os("GITHUB_PERSONAL_ACCESS_TOKEN").is_none() {
+        if let Some(value) = crate::secrets::get_value("GITHUB_PERSONAL_ACCESS_TOKEN")? {
+            env.push(("GITHUB_PERSONAL_ACCESS_TOKEN".to_string(), value));
+        }
+    }
+    Ok(env)
+}
+
 fn ensure_secret_available(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &App,
@@ -655,6 +689,21 @@ fn ensure_secret_available(
     }
     if crate::secrets::is_saved(name)? {
         return Ok(());
+    }
+    if crate::secrets::needs_vault_upgrade(name)? {
+        let Some(value) = prompt_text(
+            terminal,
+            app,
+            "Update Credential Storage",
+            &format!("Re-enter {name} to move it into the AgentOS vault"),
+            None,
+            true,
+            false,
+        )?
+        else {
+            anyhow::bail!("{name} is required for this workflow");
+        };
+        return crate::secrets::save_value(name, &value);
     }
     let Some(save) = prompt_select(
         terminal,
@@ -700,11 +749,34 @@ fn ensure_model_credential_available(
             return Ok(());
         }
     }
-    let saved_names = crate::secrets::list_names()?
-        .into_iter()
-        .collect::<BTreeSet<_>>();
-    if NAMES.iter().any(|name| saved_names.contains(*name)) {
-        return Ok(());
+    for name in NAMES {
+        if crate::secrets::is_saved(name)? {
+            return Ok(());
+        }
+    }
+    let legacy_names = NAMES
+        .iter()
+        .filter_map(|name| {
+            crate::secrets::needs_vault_upgrade(name)
+                .ok()
+                .filter(|needed| *needed)
+                .map(|_| (*name).to_string())
+        })
+        .collect::<Vec<_>>();
+    if let Some(name) = legacy_names.first() {
+        let Some(value) = prompt_text(
+            terminal,
+            app,
+            "Update Credential Storage",
+            &format!("Re-enter {name} to move it into the AgentOS vault"),
+            None,
+            true,
+            false,
+        )?
+        else {
+            anyhow::bail!("a supported model credential is required");
+        };
+        return crate::secrets::save_value(name, &value);
     }
 
     let choices = NAMES
@@ -740,17 +812,26 @@ fn ensure_model_credential_available(
     crate::secrets::save_value(&name, &value)
 }
 
-fn secret_status(name: &str, saved_names: &BTreeSet<String>) -> &'static str {
+fn secret_status(
+    name: &str,
+    saved_names: &BTreeSet<String>,
+    legacy_names: &BTreeSet<String>,
+) -> &'static str {
     if std::env::var_os(name).is_some() {
         "env"
     } else if saved_names.contains(name) {
         "saved"
+    } else if legacy_names.contains(name) {
+        "saved (upgrade needed)"
     } else {
         "missing"
     }
 }
 
-fn model_credential_status(saved_names: &BTreeSet<String>) -> &'static str {
+fn model_credential_status(
+    saved_names: &BTreeSet<String>,
+    legacy_names: &BTreeSet<String>,
+) -> &'static str {
     for name in [
         "AGENTOS_CREDENTIALS",
         "ANTHROPIC_API_KEY",
@@ -759,27 +840,39 @@ fn model_credential_status(saved_names: &BTreeSet<String>) -> &'static str {
         if std::env::var_os(name).is_some() || saved_names.contains(name) {
             return "available";
         }
+        if legacy_names.contains(name) {
+            return "saved (upgrade needed)";
+        }
     }
     "missing"
 }
 
 fn secrets_status_lines() -> Vec<Line<'static>> {
-    let saved_names = match crate::secrets::list_names() {
-        Ok(names) => names.into_iter().collect::<BTreeSet<_>>(),
+    let indexed_names = match crate::secrets::list_names() {
+        Ok(names) => names,
         Err(err) => {
             return vec![Line::from(format!(
                 "Unable to read saved credential names: {err:#}"
             ))];
         }
     };
+    let saved_names = indexed_names
+        .iter()
+        .filter(|name| crate::secrets::is_saved(name).unwrap_or(false))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let legacy_names = indexed_names
+        .into_iter()
+        .filter(|name| !saved_names.contains(name))
+        .collect::<BTreeSet<_>>();
     vec![
         Line::from(format!(
             "Model credential: {}",
-            model_credential_status(&saved_names)
+            model_credential_status(&saved_names, &legacy_names)
         )),
         Line::from(format!(
             "GITHUB_PERSONAL_ACCESS_TOKEN: {}",
-            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN", &saved_names)
+            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN", &saved_names, &legacy_names)
         )),
     ]
 }
@@ -1049,12 +1142,24 @@ fn run_agentos_in_tui(
     cwd: &Path,
     view: &mut RunView,
 ) -> Result<()> {
+    run_agentos_in_tui_with_env(terminal, app, argv, cwd, view, &[])
+}
+
+fn run_agentos_in_tui_with_env(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    argv: &[String],
+    cwd: &Path,
+    view: &mut RunView,
+    command_env: &[(String, String)],
+) -> Result<()> {
     view.push(format!("$ {}", render_command(argv)));
     view.push("");
     view.running = true;
     let mut child = Command::new(std::env::current_exe().context("resolving current executable")?)
         .args(argv)
         .current_dir(cwd)
+        .envs(command_env.iter().cloned())
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1846,7 +1951,7 @@ fn recipes() -> Vec<Recipe> {
             notes: &[],
         },
         Recipe {
-            target: "skill",
+            target: "examples",
             title: "Chat with GitHub agent",
             description: "Start the GitHub MCP bundle and have a live conversation with the agent.",
             kind: RecipeKind::Workflow(Workflow::GithubAgentChat),
@@ -2059,13 +2164,13 @@ mod tests {
     }
 
     #[test]
-    fn skill_target_includes_github_agent_chat() {
+    fn examples_target_includes_github_agent_chat() {
         let app = App::new();
         let idx = app
             .targets
             .iter()
-            .position(|target| *target == "skill")
-            .expect("skill target exists");
+            .position(|target| *target == "examples")
+            .expect("examples target exists");
         let mut app = app;
         app.target_idx = idx;
         let titles: Vec<&str> = app
@@ -2156,12 +2261,13 @@ mod tests {
             "ANTHROPIC_API_KEY".to_string(),
             "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
         ]);
-        assert_eq!(model_credential_status(&saved), "available");
+        let legacy = BTreeSet::new();
+        assert_eq!(model_credential_status(&saved, &legacy), "available");
         assert_eq!(
-            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN", &saved),
+            secret_status("GITHUB_PERSONAL_ACCESS_TOKEN", &saved, &legacy),
             "saved"
         );
-        assert_eq!(secret_status("OPENAI_API_KEY", &saved), "missing");
+        assert_eq!(secret_status("OPENAI_API_KEY", &saved, &legacy), "missing");
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -68,7 +68,7 @@ enum TuiAction {
 
 #[derive(Clone, Copy, Debug)]
 enum Workflow {
-    McpAuthExample,
+    GithubAgentChat,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -293,6 +293,10 @@ fn run_recipe_in_tui(
     let Some(values) = prompt_recipe_fields(terminal, app, recipe)? else {
         return Ok(format!("Canceled: {}", recipe.title));
     };
+    if matches!(recipe.kind, RecipeKind::Workflow(Workflow::GithubAgentChat)) {
+        run_github_agent_chat(terminal, app, &values)?;
+        return Ok(format!("Finished: {}", recipe.title));
+    }
     let mut view = RunView::new(recipe.title);
     let run_result = match &recipe.kind {
         RecipeKind::Command => {
@@ -300,9 +304,7 @@ fn run_recipe_in_tui(
             run_agentos_in_tui(terminal, app, &argv, Path::new("."), &mut view)
         }
         RecipeKind::Tui(_) => Ok(()),
-        RecipeKind::Workflow(Workflow::McpAuthExample) => {
-            run_mcp_auth_example(terminal, app, &values, &mut view)
-        }
+        RecipeKind::Workflow(_) => unreachable!("workflows run before the command view"),
     };
     if let Err(err) = &run_result {
         view.push("");
@@ -574,29 +576,11 @@ fn prompt_text(
     }
 }
 
-fn run_mcp_auth_example(
+fn run_github_agent_chat(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &App,
-    values: &BTreeMap<String, String>,
-    view: &mut RunView,
+    _values: &BTreeMap<String, String>,
 ) -> Result<()> {
-    let repo = values
-        .get("repo")
-        .filter(|value| !value.is_empty())
-        .map(String::as_str)
-        .unwrap_or("curie-eng/agentos");
-    let message = values
-        .get("message")
-        .filter(|value| !value.is_empty())
-        .cloned()
-        .unwrap_or_else(|| format!("List the open issues in {repo} and group them by label."));
-    let port = values
-        .get("port")
-        .filter(|value| !value.is_empty())
-        .map(String::as_str)
-        .unwrap_or("7247");
-    let should_build = yesish(values.get("build").map(String::as_str).unwrap_or("y"));
-
     ensure_model_credential_available(terminal, app)?;
     ensure_secret_available(terminal, app, "GITHUB_PERSONAL_ACCESS_TOKEN")?;
 
@@ -612,20 +596,10 @@ fn run_mcp_auth_example(
         );
     }
 
-    view.push("Authenticated GitHub MCP end-to-end verification");
-    view.push(format!("Example bundle: {}", example_dir.display()));
-    view.push(format!("Target repository: {repo}"));
-    view.push("");
-
-    if should_build {
-        run_agentos_in_tui(terminal, app, &["build".to_string()], &repo_root, view)?;
-    } else {
-        view.push("Skipping runner image build.");
-        view.push("");
-    }
-
-    let container_name = "agentos-mcp-auth-example";
+    let container_name = "agentos-github-agent-chat";
+    let port = "7247";
     let url = format!("http://localhost:{port}");
+    let mut setup = RunView::new("Starting GitHub agent");
     let mut started = false;
     let run_result = (|| -> Result<()> {
         run_agentos_in_tui(
@@ -644,49 +618,33 @@ fn run_mcp_auth_example(
                 "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
             ],
             &repo_root,
-            view,
+            &mut setup,
         )?;
         started = true;
-        run_agentos_in_tui(
-            terminal,
-            app,
-            &[
-                "skill".to_string(),
-                "message".to_string(),
-                message,
-                "--url".to_string(),
-                url,
-            ],
-            &repo_root,
-            view,
-        )
+        chat_with_runner(terminal, &repo_root, &url)
     })();
 
     if started {
-        view.push("Cleaning up the example runner...");
+        let mut cleanup = RunView::new("Stopping GitHub agent");
         if let Err(err) = run_agentos_in_tui(
             terminal,
             app,
             &["skill".to_string(), "down".to_string()],
             &example_dir,
-            view,
+            &mut cleanup,
         ) {
-            view.push(format!("Cleanup warning: {err:#}"));
+            cleanup.push(format!("Cleanup warning: {err:#}"));
+            show_run_view(terminal, app, &mut cleanup)?;
         }
     }
 
-    run_result?;
-    view.push(format!(
-        "PASS CONDITION: the answer above cites live issue titles or numbers from {repo}."
-    ));
+    if let Err(err) = run_result {
+        setup.push("");
+        setup.push(format!("ERROR: {err:#}"));
+        show_run_view(terminal, app, &mut setup)?;
+        return Err(err);
+    }
     Ok(())
-}
-
-fn yesish(value: &str) -> bool {
-    matches!(
-        value.trim().to_ascii_lowercase().as_str(),
-        "" | "y" | "yes" | "true" | "1"
-    )
 }
 
 fn ensure_secret_available(
@@ -830,7 +788,7 @@ fn secrets_status_lines() -> Vec<Line<'static>> {
 
 fn maybe_add_secret_status(lines: &mut Vec<Line<'static>>, workflow: Workflow) {
     match workflow {
-        Workflow::McpAuthExample => {
+        Workflow::GithubAgentChat => {
             lines.push(Line::from(Span::styled(
                 "Credential status",
                 Style::default().fg(Color::Yellow).bold(),
@@ -904,6 +862,185 @@ impl RunView {
             .scroll
             .saturating_add(amount)
             .min(self.max_scroll(terminal_width, terminal_height));
+    }
+}
+
+#[derive(Debug)]
+struct ChatView {
+    lines: Vec<String>,
+    input: String,
+    scroll: u16,
+    follow: bool,
+    thinking: bool,
+}
+
+impl ChatView {
+    fn new() -> Self {
+        Self {
+            lines: vec![
+                "GitHub agent is ready.".to_string(),
+                "Ask about repositories, issues, pull requests, or anything its tools can answer."
+                    .to_string(),
+                String::new(),
+            ],
+            input: String::new(),
+            scroll: 0,
+            follow: true,
+            thinking: false,
+        }
+    }
+
+    fn max_scroll(&self, terminal_width: u16, terminal_height: u16) -> u16 {
+        let width = terminal_width.saturating_sub(4).max(1) as usize;
+        let viewport = terminal_height.saturating_sub(9) as usize;
+        wrap_output_lines(&self.lines, width)
+            .len()
+            .saturating_sub(viewport)
+            .min(u16::MAX as usize) as u16
+    }
+
+    fn follow_tail(&mut self, terminal_width: u16, terminal_height: u16) {
+        if self.follow {
+            self.scroll = self.max_scroll(terminal_width, terminal_height);
+        }
+    }
+}
+
+fn chat_with_runner(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    cwd: &Path,
+    url: &str,
+) -> Result<()> {
+    let mut chat = ChatView::new();
+    loop {
+        let Some(message) = read_chat_input(terminal, &mut chat)? else {
+            return Ok(());
+        };
+        chat.lines.push("You".to_string());
+        chat.lines.push(message.clone());
+        chat.lines.push(String::new());
+        chat.lines.push("Agent".to_string());
+        chat.thinking = true;
+        chat.follow = true;
+        let argv = [
+            "skill".to_string(),
+            "message".to_string(),
+            message,
+            "--url".to_string(),
+            url.to_string(),
+        ];
+        run_chat_turn(terminal, cwd, &argv, &mut chat)?;
+        chat.thinking = false;
+        chat.lines.push(String::new());
+    }
+}
+
+fn read_chat_input(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    chat: &mut ChatView,
+) -> Result<Option<String>> {
+    chat.input.clear();
+    loop {
+        let size = terminal.size()?;
+        chat.follow_tail(size.width, size.height);
+        terminal.draw(|frame| draw_chat_view(frame, chat))?;
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        match (key.code, key.modifiers) {
+            (KeyCode::Esc, _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
+            (KeyCode::Enter, _) if !chat.input.trim().is_empty() => {
+                return Ok(Some(chat.input.trim().to_string()));
+            }
+            (KeyCode::Backspace, _) => {
+                chat.input.pop();
+            }
+            (KeyCode::PageUp, _) => {
+                chat.follow = false;
+                chat.scroll = chat.scroll.saturating_sub(10);
+            }
+            (KeyCode::PageDown, _) => {
+                chat.follow = false;
+                chat.scroll = chat
+                    .scroll
+                    .saturating_add(10)
+                    .min(chat.max_scroll(size.width, size.height));
+            }
+            (KeyCode::End, _) => chat.follow = true,
+            (KeyCode::Char(ch), _) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                chat.input.push(ch);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn run_chat_turn(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    cwd: &Path,
+    argv: &[String],
+    chat: &mut ChatView,
+) -> Result<()> {
+    let mut child = Command::new(std::env::current_exe().context("resolving current executable")?)
+        .args(argv)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("sending message to the GitHub agent")?;
+    let (tx, rx) = mpsc::channel();
+    let stdout = child.stdout.take().context("capturing agent response")?;
+    let stderr = child.stderr.take().context("capturing agent diagnostics")?;
+    let readers = [stdout_reader(stdout, tx.clone()), stderr_reader(stderr, tx)];
+    let mut canceled = false;
+
+    loop {
+        while let Ok(line) = rx.try_recv() {
+            chat.lines.push(line);
+        }
+        let size = terminal.size()?;
+        chat.follow_tail(size.width, size.height);
+        terminal.draw(|frame| draw_chat_view(frame, chat))?;
+        if event::poll(Duration::from_millis(50))? {
+            if let Event::Key(key) = event::read()? {
+                match (key.code, key.modifiers) {
+                    (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                        child.kill().context("canceling agent response")?;
+                        canceled = true;
+                    }
+                    (KeyCode::PageUp, _) => {
+                        chat.follow = false;
+                        chat.scroll = chat.scroll.saturating_sub(10);
+                    }
+                    (KeyCode::PageDown, _) => {
+                        chat.follow = false;
+                        chat.scroll = chat
+                            .scroll
+                            .saturating_add(10)
+                            .min(chat.max_scroll(size.width, size.height));
+                    }
+                    (KeyCode::End, _) => chat.follow = true,
+                    _ => {}
+                }
+            }
+        }
+        if let Some(status) = child.try_wait().context("waiting for agent response")? {
+            for reader in readers {
+                let _ = reader.join();
+            }
+            while let Ok(line) = rx.try_recv() {
+                chat.lines.push(line);
+            }
+            if canceled {
+                chat.lines.push("Response canceled.".to_string());
+                return Ok(());
+            }
+            if !status.success() {
+                anyhow::bail!("agent response exited with {status}");
+            }
+            return Ok(());
+        }
     }
 }
 
@@ -1271,20 +1408,21 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             lines.push(Line::from("3. Remove from the OS credential store"));
             lines.push(Line::from(""));
         }
-        RecipeKind::Workflow(Workflow::McpAuthExample) => {
+        RecipeKind::Workflow(Workflow::GithubAgentChat) => {
             lines.push(Line::from(Span::styled(
-                "Guided workflow",
+                "Interactive session",
                 Style::default().fg(Color::Yellow).bold(),
             )));
-            lines.push(Line::from("1. Check model and GitHub token env vars"));
-            lines.push(Line::from("2. Build the runner image if requested"));
+            lines.push(Line::from("1. Check model and GitHub credentials"));
             lines.push(Line::from(
-                "3. Start examples/github-issues with --secret GITHUB_PERSONAL_ACCESS_TOKEN",
+                "2. Start the GitHub agent with its authenticated MCP tools",
             ));
-            lines.push(Line::from("4. Send a live GitHub issue query"));
-            lines.push(Line::from("5. Stop the example runner"));
+            lines.push(Line::from(
+                "3. Chat with the agent for as many turns as needed",
+            ));
+            lines.push(Line::from("4. Stop the runner when you leave chat"));
             lines.push(Line::from(""));
-            maybe_add_secret_status(&mut lines, Workflow::McpAuthExample);
+            maybe_add_secret_status(&mut lines, Workflow::GithubAgentChat);
         }
     }
     if !recipe.fields.is_empty() {
@@ -1384,6 +1522,94 @@ fn draw_run_view(frame: &mut Frame<'_>, view: &RunView) {
         Paragraph::new(Span::styled(help, Style::default().fg(Color::Gray)))
             .alignment(Alignment::Center),
         chunks[1],
+    );
+}
+
+fn draw_chat_view(frame: &mut Frame<'_>, chat: &ChatView) {
+    let area = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(3),
+            Constraint::Length(2),
+        ])
+        .split(area);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("AgentOS", Style::default().fg(Color::Cyan).bold()),
+            Span::raw("  GitHub agent"),
+            if chat.thinking {
+                Span::styled("  thinking...", Style::default().fg(Color::Yellow))
+            } else {
+                Span::raw("")
+            },
+        ]))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::ALL)),
+        chunks[0],
+    );
+
+    let output_width = chunks[1].width.saturating_sub(2).max(1) as usize;
+    let wrapped = wrap_output_lines(&chat.lines, output_width);
+    let transcript = wrapped
+        .iter()
+        .map(|line| {
+            let style = match line.as_str() {
+                "You" => Style::default().fg(Color::Cyan).bold(),
+                "Agent" => Style::default().fg(Color::Green).bold(),
+                _ => Style::default(),
+            };
+            Line::from(Span::styled(line.as_str(), style))
+        })
+        .collect::<Vec<_>>();
+    let viewport = chunks[1].height.saturating_sub(2) as usize;
+    let max_scroll = wrapped
+        .len()
+        .saturating_sub(viewport)
+        .min(u16::MAX as usize) as u16;
+    frame.render_widget(
+        Paragraph::new(Text::from(transcript))
+            .scroll((chat.scroll.min(max_scroll), 0))
+            .block(Block::default().title("Conversation").borders(Borders::ALL)),
+        chunks[1],
+    );
+
+    let input_width = chunks[2].width.saturating_sub(4).max(1) as usize;
+    let shown_input = input_window(&chat.input, false, input_width);
+    let input_style = if chat.thinking {
+        Style::default().fg(Color::DarkGray)
+    } else {
+        Style::default()
+    };
+    frame.render_widget(
+        Paragraph::new(Span::styled(shown_input.as_str(), input_style)).block(
+            Block::default()
+                .title(if chat.thinking {
+                    "Waiting for agent"
+                } else {
+                    "Message"
+                })
+                .borders(Borders::ALL),
+        ),
+        chunks[2],
+    );
+    if !chat.thinking {
+        frame.set_cursor_position((
+            chunks[2].x + 1 + UnicodeWidthStr::width(shown_input.as_str()) as u16,
+            chunks[2].y + 1,
+        ));
+    }
+    let help = if chat.thinking {
+        "Ctrl-C cancel response    PgUp/PgDn scroll    End latest"
+    } else {
+        "Enter send    Esc leave chat    PgUp/PgDn scroll    End latest"
+    };
+    frame.render_widget(
+        Paragraph::new(Span::styled(help, Style::default().fg(Color::Gray)))
+            .alignment(Alignment::Center),
+        chunks[3],
     );
 }
 
@@ -1623,42 +1849,15 @@ fn recipes() -> Vec<Recipe> {
         },
         Recipe {
             target: "examples",
-            title: "Verify MCP auth example",
-            description: "Guided e2e for examples/github-issues using a live GitHub MCP server.",
-            kind: RecipeKind::Workflow(Workflow::McpAuthExample),
+            title: "Chat with GitHub agent",
+            description: "Start the GitHub MCP bundle and have a live conversation with the agent.",
+            kind: RecipeKind::Workflow(Workflow::GithubAgentChat),
             args: vec![],
-            fields: vec![
-                Field {
-                    key: "repo",
-                    label: "Repository to query (owner/repo)",
-                    default: Some("curie-eng/agentos"),
-                    required: true,
-                },
-                Field {
-                    key: "message",
-                    label: "Live verification prompt",
-                    default: Some(
-                        "List the open issues in curie-eng/agentos and group them by label.",
-                    ),
-                    required: true,
-                },
-                Field {
-                    key: "port",
-                    label: "Runner host port",
-                    default: Some("7247"),
-                    required: true,
-                },
-                Field {
-                    key: "build",
-                    label: "Build runner image first? (y/n)",
-                    default: Some("y"),
-                    required: true,
-                },
-            ],
+            fields: vec![],
             notes: &[
                 "Requires a saved or environment model credential: ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or AGENTOS_CREDENTIALS.",
                 "Requires a saved or environment GITHUB_PERSONAL_ACCESS_TOKEN; the value is forwarded by name and not placed in argv.",
-                "A passing run cites live GitHub issue titles or numbers.",
+                "The runner stays up for a multi-turn conversation and stops when you leave chat.",
             ],
         },
         Recipe {
@@ -1862,7 +2061,7 @@ mod tests {
     }
 
     #[test]
-    fn examples_target_includes_mcp_auth_workflow() {
+    fn examples_target_includes_github_agent_chat() {
         let app = App::new();
         let idx = app
             .targets
@@ -1876,7 +2075,7 @@ mod tests {
             .iter()
             .map(|idx| app.recipes[*idx].title)
             .collect();
-        assert!(titles.contains(&"Verify MCP auth example"));
+        assert!(titles.contains(&"Chat with GitHub agent"));
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -3,8 +3,9 @@
 //! This is a ratatui/crossterm surface over the existing clap command grammar:
 //! it does not invent a second implementation path. The TUI helps a human pick
 //! a target and action, previews the exact `agentos ...` command, prompts for
-//! any required values, then suspends the alternate screen and runs that command
-//! as a normal child process.
+//! any required values, then either handles a small read-only action in the TUI
+//! or suspends the alternate screen and runs that command as a normal child
+//! process.
 
 use std::collections::BTreeMap;
 use std::io::{self, IsTerminal, Write};
@@ -39,7 +40,13 @@ struct Recipe {
 #[derive(Clone, Debug)]
 enum RecipeKind {
     Command,
+    Tui(TuiAction),
     Workflow(Workflow),
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TuiAction {
+    ListSecrets,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -173,6 +180,13 @@ impl App {
         let Some(recipe) = self.selected_recipe().cloned() else {
             return Ok(());
         };
+        if let RecipeKind::Tui(action) = &recipe.kind {
+            self.message = match run_tui_action(action) {
+                Ok(message) => message,
+                Err(err) => format!("Action failed: {err:#}"),
+            };
+            return Ok(());
+        }
         suspend_terminal()?;
         let result = prompt_and_run(&recipe);
         resume_terminal()?;
@@ -248,9 +262,23 @@ fn prompt_and_run(recipe: &Recipe) -> Result<()> {
             println!();
             run_agentos(&argv, Path::new("."))?;
         }
+        RecipeKind::Tui(_) => {}
         RecipeKind::Workflow(Workflow::McpAuthExample) => run_mcp_auth_example(&values)?,
     }
     Ok(())
+}
+
+fn run_tui_action(action: &TuiAction) -> Result<String> {
+    match action {
+        TuiAction::ListSecrets => {
+            let count = crate::secrets::list_names()?.len();
+            Ok(match count {
+                0 => "No AgentOS secrets saved.".to_string(),
+                1 => "Showing 1 saved secret name.".to_string(),
+                n => format!("Showing {n} saved secret names."),
+            })
+        }
+    }
 }
 
 fn run_mcp_auth_example(values: &BTreeMap<String, String>) -> Result<()> {
@@ -706,6 +734,26 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             lines.push(Line::from(render_command(&preview)));
             lines.push(Line::from(""));
         }
+        RecipeKind::Tui(TuiAction::ListSecrets) => {
+            lines.push(Line::from(Span::styled(
+                "Saved secrets",
+                Style::default().fg(Color::Yellow).bold(),
+            )));
+            match crate::secrets::list_names() {
+                Ok(names) if names.is_empty() => {
+                    lines.push(Line::from("No AgentOS secrets saved."));
+                }
+                Ok(names) => {
+                    for name in names {
+                        lines.push(Line::from(format!("{name}  (value hidden)")));
+                    }
+                }
+                Err(err) => {
+                    lines.push(Line::from(format!("Unable to read secret index: {err:#}")));
+                }
+            }
+            lines.push(Line::from(""));
+        }
         RecipeKind::Workflow(Workflow::McpAuthExample) => {
             lines.push(Line::from(Span::styled(
                 "Guided workflow",
@@ -911,8 +959,8 @@ fn recipes() -> Vec<Recipe> {
             target: "secrets",
             title: "List saved secrets",
             description: "List saved AgentOS secret names without printing values.",
-            kind: RecipeKind::Command,
-            args: vec![ArgPart::Literal("secrets"), ArgPart::Literal("list")],
+            kind: RecipeKind::Tui(TuiAction::ListSecrets),
+            args: vec![],
             fields: vec![],
             notes: &["Only names are listed; secret values stay in the OS credential store."],
         },
@@ -1120,5 +1168,20 @@ mod tests {
             .map(|idx| app.recipes[*idx].title)
             .collect();
         assert!(titles.contains(&"Verify MCP auth example"));
+    }
+
+    #[test]
+    fn list_secrets_stays_inside_tui() {
+        let app = App::new();
+        let recipe = app
+            .recipes
+            .iter()
+            .find(|recipe| recipe.title == "List saved secrets")
+            .expect("list secrets recipe exists");
+        assert!(matches!(
+            recipe.kind,
+            RecipeKind::Tui(TuiAction::ListSecrets)
+        ));
+        assert!(recipe.args.is_empty());
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -26,6 +26,7 @@ pub mod retired;
 pub mod runner;
 pub mod scaffold;
 pub mod schema;
+pub mod secrets;
 pub mod spec;
 pub mod state;
 pub mod ui;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod api;
 pub mod artifacts;
 pub mod bundle;
+pub mod channel;
 pub mod chat;
 pub mod commands;
 pub mod comms;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -101,14 +101,19 @@ enum Command {
         #[arg(long, default_value = "agentos-runner")]
         tag: String,
     },
-    /// Bootstrap a dev checkout: install deps and build, start nothing (source checkout only).
+    /// Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only).
     ///
     /// From the repo root, runs (each idempotent, streaming output): copy
     /// `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in
-    /// `apps/ui`, `cargo build` in `cli`, then builds the runner image. A
-    /// release binary has no source tree to install and errors clearly; a
-    /// missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.
-    Install,
+    /// `apps/ui`, `cargo build` in `cli`, then builds the runner image. With
+    /// `--update`, already-present heavyweight artifacts like the runner image
+    /// are reused. A release binary has no source tree to install and errors
+    /// clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.
+    Install {
+        /// Reuse already-present artifacts while refreshing dependencies and builds.
+        #[arg(long)]
+        update: bool,
+    },
     /// Open the interactive terminal interface.
     ///
     /// A keyboard-driven terminal UI for humans: browse targets and actions,
@@ -906,7 +911,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             from_spec,
         }) => commands::init(name, dir, from_spec),
         Some(Command::Build { tag }) => commands::build(&tag).await,
-        Some(Command::Install) => commands::install().await,
+        Some(Command::Install { update }) => commands::install(update).await,
         Some(Command::Interactive) => agentos::interactive::run().await,
         Some(Command::Secrets { action }) => match action {
             SecretsAction::Set { name, from_env } => {
@@ -1542,7 +1547,20 @@ mod tests {
     #[test]
     fn install_parses() {
         let cli = Cli::try_parse_from(["agentos", "install"]).expect("install should parse");
-        assert!(matches!(cli.command, Some(Command::Install)));
+        assert!(matches!(
+            cli.command,
+            Some(Command::Install { update: false })
+        ));
+    }
+
+    #[test]
+    fn install_update_parses() {
+        let cli =
+            Cli::try_parse_from(["agentos", "install", "--update"]).expect("install should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Install { update: true })
+        ));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,7 @@ use agentos::comms::{self, CommsOpts, LocalCommsOpts};
 use agentos::local::{self, LocalDownOpts, LocalOpts};
 use agentos::message::{self, MessageOpts};
 use agentos::ops::{self, CommonOpts, DownOpts, UpOpts};
+use agentos::secrets;
 use agentos::state::{apply_continue, load_turn, CliTurnArgs, TurnVerb};
 use agentos::ui::{self, ColorFlag, Ui};
 use anyhow::Result;
@@ -115,6 +116,11 @@ enum Command {
     /// memorizing the full command surface.
     #[command(alias = "ui", alias = "tui")]
     Interactive,
+    /// Store and manage local secrets in the OS credential store.
+    Secrets {
+        #[command(subcommand)]
+        action: SecretsAction,
+    },
     /// Run a repo dev script (contracts, chart-check, e2e) -- source checkout only.
     ///
     /// Thin wrappers over the repo's dev scripts so contributors get a unified
@@ -149,6 +155,25 @@ enum DevAction {
     ChartCheck,
     /// Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`).
     E2e,
+}
+
+#[derive(Subcommand)]
+enum SecretsAction {
+    /// Save a secret in the OS credential store. Prompts with hidden input by default.
+    Set {
+        /// Environment-variable-style secret name, e.g. GITHUB_PERSONAL_ACCESS_TOKEN.
+        name: String,
+        /// Read the value from another environment variable instead of prompting.
+        #[arg(long)]
+        from_env: Option<String>,
+    },
+    /// List saved AgentOS secret names. Values are never printed.
+    List,
+    /// Remove a saved secret.
+    Unset {
+        /// Environment-variable-style secret name.
+        name: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -883,6 +908,13 @@ async fn run(command: Option<Command>) -> Result<()> {
         Some(Command::Build { tag }) => commands::build(&tag).await,
         Some(Command::Install) => commands::install().await,
         Some(Command::Interactive) => agentos::interactive::run().await,
+        Some(Command::Secrets { action }) => match action {
+            SecretsAction::Set { name, from_env } => {
+                secrets::set(secrets::SetSecretOpts { name, from_env })
+            }
+            SecretsAction::List => secrets::list(),
+            SecretsAction::Unset { name } => secrets::unset(secrets::UnsetSecretOpts { name }),
+        },
         Some(Command::Dev { action }) => match action {
             DevAction::Contracts => commands::dev_script("scripts/check-contracts.sh").await,
             DevAction::ChartCheck => {
@@ -1522,6 +1554,52 @@ mod tests {
         assert!(matches!(cli.command, Some(Command::Interactive)));
         let cli = Cli::try_parse_from(["agentos", "tui"]).expect("tui alias should parse");
         assert!(matches!(cli.command, Some(Command::Interactive)));
+    }
+
+    #[test]
+    fn secrets_subcommands_parse() {
+        let cli = Cli::try_parse_from(["agentos", "secrets", "set", "GITHUB_TOKEN"])
+            .expect("secrets set should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Secrets {
+                action: SecretsAction::Set { .. }
+            })
+        ));
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "secrets",
+            "set",
+            "GITHUB_TOKEN",
+            "--from-env",
+            "TMP_TOKEN",
+        ])
+        .expect("secrets set --from-env should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Secrets {
+                action: SecretsAction::Set {
+                    from_env: Some(_),
+                    ..
+                }
+            })
+        ));
+        let cli =
+            Cli::try_parse_from(["agentos", "secrets", "list"]).expect("secrets list should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Secrets {
+                action: SecretsAction::List
+            })
+        ));
+        let cli = Cli::try_parse_from(["agentos", "secrets", "unset", "GITHUB_TOKEN"])
+            .expect("secrets unset should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Secrets {
+                action: SecretsAction::Unset { .. }
+            })
+        ));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -121,7 +121,7 @@ enum Command {
     /// memorizing the full command surface.
     #[command(alias = "ui", alias = "tui")]
     Interactive,
-    /// Store and manage local secrets in the OS credential store.
+    /// Store and manage local secrets in AgentOS private storage.
     Secrets {
         #[command(subcommand)]
         action: SecretsAction,
@@ -164,7 +164,7 @@ enum DevAction {
 
 #[derive(Subcommand)]
 enum SecretsAction {
-    /// Save a secret in the OS credential store. Prompts with hidden input by default.
+    /// Save a secret in AgentOS private storage. Prompts with hidden input by default.
     Set {
         /// Environment-variable-style secret name, e.g. GITHUB_PERSONAL_ACCESS_TOKEN.
         name: String,

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -39,11 +39,7 @@ pub fn set(opts: SetSecretOpts) -> Result<()> {
             .with_context(|| format!("{var} is not set; cannot save {}", opts.name))?,
         None => prompt_secret(&opts.name)?,
     };
-    if value.is_empty() {
-        bail!("refusing to store an empty secret for {}", opts.name);
-    }
-    set_value(&opts.name, &value)?;
-    add_to_index(&opts.name)?;
+    save_value(&opts.name, &value)?;
     crate::ui::ui().success(&format!("saved {} in the OS credential store", opts.name));
     Ok(())
 }
@@ -64,9 +60,7 @@ pub fn list() -> Result<()> {
 }
 
 pub fn unset(opts: UnsetSecretOpts) -> Result<()> {
-    validate_name(&opts.name)?;
-    delete_value(&opts.name)?;
-    remove_from_index(&opts.name)?;
+    remove_value(&opts.name)?;
     crate::ui::ui().success(&format!("removed {}", opts.name));
     Ok(())
 }
@@ -94,6 +88,15 @@ pub fn set_value(name: &str, value: &str) -> Result<()> {
         .with_context(|| format!("saving {name} in the OS credential store"))
 }
 
+pub fn save_value(name: &str, value: &str) -> Result<()> {
+    validate_name(name)?;
+    if value.is_empty() {
+        bail!("refusing to store an empty secret for {name}");
+    }
+    set_value(name, value)?;
+    add_to_index(name)
+}
+
 pub fn delete_value(name: &str) -> Result<()> {
     validate_name(name)?;
     match entry(name)?.delete_credential() {
@@ -102,6 +105,12 @@ pub fn delete_value(name: &str) -> Result<()> {
             Err(err).with_context(|| format!("removing {name} from the OS credential store"))
         }
     }
+}
+
+pub fn remove_value(name: &str) -> Result<()> {
+    validate_name(name)?;
+    delete_value(name)?;
+    remove_from_index(name)
 }
 
 pub fn list_names() -> Result<Vec<String>> {

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -119,6 +119,30 @@ pub fn sync_vault_index() -> Result<()> {
     write_index(&index)
 }
 
+/// Move one required credential from the legacy per-secret Keychain layout to
+/// the consolidated vault. No value is shown or requested from the user.
+pub fn migrate_legacy_value(name: &str) -> Result<bool> {
+    if !needs_vault_upgrade(name)? {
+        return Ok(false);
+    }
+    let value = match legacy_entry(name)?.get_password() {
+        Ok(value) => value,
+        Err(keyring::Error::NoEntry) => return Ok(false),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("authorizing saved credential {name} for migration"));
+        }
+    };
+    save_value(name, &value)?;
+    match legacy_entry(name)?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => {}
+        Err(err) => crate::ui::ui().warn(&format!(
+            "migrated {name}, but could not remove its old credential-store item: {err}"
+        )),
+    }
+    Ok(true)
+}
+
 pub fn set_value(name: &str, value: &str) -> Result<()> {
     validate_name(name)?;
     let mut vault = read_vault()?;
@@ -197,6 +221,11 @@ fn prompt_secret(name: &str) -> Result<String> {
 fn vault_entry() -> Result<keyring::Entry> {
     keyring::Entry::new(SERVICE, VAULT_ACCOUNT)
         .context("opening the AgentOS OS credential-store vault")
+}
+
+fn legacy_entry(name: &str) -> Result<keyring::Entry> {
+    keyring::Entry::new(SERVICE, &format!("agentos:global:{name}"))
+        .with_context(|| format!("opening legacy OS credential-store entry for {name}"))
 }
 
 fn vault_cache() -> &'static Mutex<VaultCache> {

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -1,0 +1,230 @@
+//! OS-backed secret storage for local AgentOS workflows.
+//!
+//! Secret values live in the platform credential store via `keyring`. The only
+//! filesystem state here is a non-secret index of names so `agentos secrets
+//! list` can show what AgentOS has saved without needing credential-store
+//! enumeration support.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+const SERVICE: &str = "dev.curie.agentos";
+const ACCOUNT_PREFIX: &str = "agentos:global:";
+
+#[derive(Clone, Debug)]
+pub struct SetSecretOpts {
+    pub name: String,
+    pub from_env: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct UnsetSecretOpts {
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+struct SecretIndex {
+    names: BTreeSet<String>,
+}
+
+pub fn set(opts: SetSecretOpts) -> Result<()> {
+    validate_name(&opts.name)?;
+    let value = match opts.from_env {
+        Some(var) => std::env::var(&var)
+            .with_context(|| format!("{var} is not set; cannot save {}", opts.name))?,
+        None => prompt_secret(&opts.name)?,
+    };
+    if value.is_empty() {
+        bail!("refusing to store an empty secret for {}", opts.name);
+    }
+    set_value(&opts.name, &value)?;
+    add_to_index(&opts.name)?;
+    crate::ui::ui().success(&format!("saved {} in the OS credential store", opts.name));
+    Ok(())
+}
+
+pub fn list() -> Result<()> {
+    let names = list_names()?;
+    let ui = crate::ui::ui();
+    if ui.json() {
+        ui.emit_json(&serde_json::json!({ "secrets": names }));
+        return Ok(());
+    }
+    if names.is_empty() {
+        ui.note("no AgentOS secrets saved");
+    } else {
+        ui.payload_plain(&names.join("\n"));
+    }
+    Ok(())
+}
+
+pub fn unset(opts: UnsetSecretOpts) -> Result<()> {
+    validate_name(&opts.name)?;
+    delete_value(&opts.name)?;
+    remove_from_index(&opts.name)?;
+    crate::ui::ui().success(&format!("removed {}", opts.name));
+    Ok(())
+}
+
+pub fn get_value(name: &str) -> Result<Option<String>> {
+    validate_name(name)?;
+    let entry = entry(name)?;
+    match entry.get_password() {
+        Ok(value) => Ok(Some(value)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(err) => {
+            Err(err).with_context(|| format!("reading {name} from the OS credential store"))
+        }
+    }
+}
+
+pub fn has_value(name: &str) -> bool {
+    get_value(name).ok().flatten().is_some()
+}
+
+pub fn set_value(name: &str, value: &str) -> Result<()> {
+    validate_name(name)?;
+    entry(name)?
+        .set_password(value)
+        .with_context(|| format!("saving {name} in the OS credential store"))
+}
+
+pub fn delete_value(name: &str) -> Result<()> {
+    validate_name(name)?;
+    match entry(name)?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(err) => {
+            Err(err).with_context(|| format!("removing {name} from the OS credential store"))
+        }
+    }
+}
+
+pub fn list_names() -> Result<Vec<String>> {
+    let index = read_index()?;
+    Ok(index.names.into_iter().collect())
+}
+
+pub fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        bail!("secret name is required");
+    }
+    let valid = name
+        .chars()
+        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        && name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_uppercase() || c == '_');
+    if !valid {
+        bail!(
+            "secret name must look like an environment variable, e.g. GITHUB_PERSONAL_ACCESS_TOKEN"
+        );
+    }
+    Ok(())
+}
+
+fn prompt_secret(name: &str) -> Result<String> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        bail!("setting {name} requires a terminal; use --from-env VAR in non-interactive contexts");
+    }
+    print!("{name}: ");
+    io::stdout().flush().ok();
+    rpassword::read_password().context("reading secret from terminal")
+}
+
+fn entry(name: &str) -> Result<keyring::Entry> {
+    keyring::Entry::new(SERVICE, &account_name(name))
+        .with_context(|| format!("opening OS credential-store entry for {name}"))
+}
+
+fn account_name(name: &str) -> String {
+    format!("{ACCOUNT_PREFIX}{name}")
+}
+
+fn add_to_index(name: &str) -> Result<()> {
+    let mut index = read_index()?;
+    index.names.insert(name.to_string());
+    write_index(&index)
+}
+
+fn remove_from_index(name: &str) -> Result<()> {
+    let mut index = read_index()?;
+    index.names.remove(name);
+    write_index(&index)
+}
+
+fn read_index() -> Result<SecretIndex> {
+    let path = index_path()?;
+    if !path.is_file() {
+        return Ok(SecretIndex::default());
+    }
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("reading secret index {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing secret index {}", path.display()))
+}
+
+fn write_index(index: &SecretIndex) -> Result<()> {
+    let path = index_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating AgentOS config dir {}", parent.display()))?;
+    }
+    let body = serde_json::to_vec_pretty(index).context("serializing secret index")?;
+    write_private(&path, &body)
+}
+
+#[cfg(unix)]
+fn write_private(path: &Path, body: &[u8]) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("writing secret index {}", path.display()))?;
+    file.write_all(body)
+        .with_context(|| format!("writing secret index {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn write_private(path: &Path, body: &[u8]) -> Result<()> {
+    fs::write(path, body).with_context(|| format!("writing secret index {}", path.display()))
+}
+
+fn index_path() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var("AGENTOS_CONFIG_DIR") {
+        return Ok(PathBuf::from(dir).join("secrets.json"));
+    }
+    let home =
+        std::env::var("HOME").context("HOME is not set; cannot locate AgentOS config dir")?;
+    Ok(PathBuf::from(home).join(".config/agentos/secrets.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_env_like_names() {
+        assert!(validate_name("GITHUB_PERSONAL_ACCESS_TOKEN").is_ok());
+        assert!(validate_name("_TOKEN1").is_ok());
+        assert!(validate_name("github_token").is_err());
+        assert!(validate_name("1TOKEN").is_err());
+        assert!(validate_name("TOKEN-NOPE").is_err());
+    }
+
+    #[test]
+    fn account_names_are_scoped_under_agentos() {
+        assert_eq!(
+            account_name("GITHUB_PERSONAL_ACCESS_TOKEN"),
+            "agentos:global:GITHUB_PERSONAL_ACCESS_TOKEN"
+        );
+    }
+}

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -32,6 +32,8 @@ pub struct UnsetSecretOpts {
 struct SecretIndex {
     #[serde(default)]
     vault: bool,
+    #[serde(default)]
+    legacy_names: BTreeSet<String>,
     names: BTreeSet<String>,
 }
 
@@ -94,6 +96,29 @@ pub fn is_saved(name: &str) -> Result<bool> {
     Ok(index.vault && index.names.contains(name))
 }
 
+/// Whether a name belongs to the older one-Keychain-item-per-secret layout.
+/// This reads only the non-secret index and never opens Keychain.
+pub fn needs_vault_upgrade(name: &str) -> Result<bool> {
+    validate_name(name)?;
+    let index = read_index()?;
+    Ok(if index.vault {
+        index.legacy_names.contains(name)
+    } else {
+        index.names.contains(name)
+    })
+}
+
+/// Reconcile an older non-secret index with the consolidated vault. This opens
+/// exactly one credential-store item and never reads legacy per-secret items.
+pub fn sync_vault_index() -> Result<()> {
+    let vault = read_vault()?;
+    if vault.values.is_empty() {
+        return Ok(());
+    }
+    let index = reconcile_vault_names(read_index()?, vault.values.keys());
+    write_index(&index)
+}
+
 pub fn set_value(name: &str, value: &str) -> Result<()> {
     validate_name(name)?;
     let mut vault = read_vault()?;
@@ -132,11 +157,13 @@ pub fn remove_value(name: &str) -> Result<()> {
 
 pub fn list_names() -> Result<Vec<String>> {
     let index = read_index()?;
-    Ok(if index.vault {
-        index.names.into_iter().collect()
-    } else {
-        Vec::new()
-    })
+    Ok(index
+        .names
+        .into_iter()
+        .chain(index.legacy_names)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect())
 }
 
 pub fn validate_name(name: &str) -> Result<()> {
@@ -220,22 +247,44 @@ fn delete_vault() -> Result<()> {
 }
 
 fn add_to_index(name: &str) -> Result<()> {
-    let mut index = read_index()?;
+    let index = mark_vault_saved(read_index()?, name);
+    write_index(&index)
+}
+
+fn mark_vault_saved(mut index: SecretIndex, name: &str) -> SecretIndex {
     if !index.vault {
         // Older releases indexed one Keychain item per secret. Do not read
         // those items during migration: macOS would authorize each one
         // separately. Re-saving through the TUI creates the single vault and
-        // replaces the stale index without exposing a multi-prompt workflow.
-        index.names.clear();
+        // marks each re-saved name as upgraded without exposing a multi-prompt
+        // workflow or hiding the names that still use the legacy layout.
+        index.legacy_names.append(&mut index.names);
         index.vault = true;
     }
+    index.legacy_names.remove(name);
     index.names.insert(name.to_string());
-    write_index(&index)
+    index
+}
+
+fn reconcile_vault_names<'a>(
+    mut index: SecretIndex,
+    vault_names: impl Iterator<Item = &'a String>,
+) -> SecretIndex {
+    if !index.vault {
+        index.legacy_names.append(&mut index.names);
+        index.vault = true;
+    }
+    for name in vault_names {
+        index.legacy_names.remove(name);
+        index.names.insert(name.clone());
+    }
+    index
 }
 
 fn remove_from_index(name: &str) -> Result<()> {
     let mut index = read_index()?;
     index.names.remove(name);
+    index.legacy_names.remove(name);
     write_index(&index)
 }
 
@@ -310,6 +359,49 @@ mod tests {
 
         assert!(!index.vault);
         assert_eq!(index.names.len(), 2);
+    }
+
+    #[test]
+    fn upgrading_one_legacy_name_preserves_every_other_name() {
+        let legacy: SecretIndex = serde_json::from_str(
+            r#"{"names":["ANTHROPIC_API_KEY","GITHUB_PERSONAL_ACCESS_TOKEN","OPENAI_API_KEY"]}"#,
+        )
+        .unwrap();
+
+        let upgraded = mark_vault_saved(legacy, "ANTHROPIC_API_KEY");
+
+        assert!(upgraded.vault);
+        assert_eq!(
+            upgraded.names,
+            BTreeSet::from(["ANTHROPIC_API_KEY".to_string()])
+        );
+        assert_eq!(
+            upgraded.legacy_names,
+            BTreeSet::from([
+                "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+                "OPENAI_API_KEY".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn consolidated_vault_names_recover_a_stale_legacy_index() {
+        let legacy: SecretIndex = serde_json::from_str(
+            r#"{"names":["ANTHROPIC_API_KEY","GITHUB_PERSONAL_ACCESS_TOKEN","OPENAI_API_KEY"]}"#,
+        )
+        .unwrap();
+        let vault_names = [
+            "ANTHROPIC_API_KEY".to_string(),
+            "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+        ];
+
+        let recovered = reconcile_vault_names(legacy, vault_names.iter());
+
+        assert_eq!(recovered.names, BTreeSet::from(vault_names));
+        assert_eq!(
+            recovered.legacy_names,
+            BTreeSet::from(["OPENAI_API_KEY".to_string()])
+        );
     }
 
     #[test]

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -77,8 +77,11 @@ pub fn get_value(name: &str) -> Result<Option<String>> {
     }
 }
 
-pub fn has_value(name: &str) -> bool {
-    get_value(name).ok().flatten().is_some()
+/// Check the non-secret index without opening the platform credential store.
+/// UI status rendering must use this instead of `get_value`.
+pub fn is_saved(name: &str) -> Result<bool> {
+    validate_name(name)?;
+    Ok(read_index()?.names.contains(name))
 }
 
 pub fn set_value(name: &str, value: &str) -> Result<()> {

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -1,9 +1,8 @@
-//! OS-backed secret storage for local AgentOS workflows.
+//! Private local secret storage for AgentOS workflows.
 //!
-//! Secret values live together in one platform credential-store vault via
-//! `keyring`, so a workflow authorizes AgentOS once rather than once per key.
-//! The only filesystem state here is a non-secret index of names so `agentos
-//! secrets list` can show what AgentOS has saved without opening the vault.
+//! Secret values live in a mode-0600 file under the AgentOS config directory,
+//! avoiding repeated platform credential-store authorization dialogs. `keyring`
+//! remains only as a read-only migration path for older AgentOS installations.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -35,6 +34,8 @@ struct SecretIndex {
     #[serde(default)]
     legacy_names: BTreeSet<String>,
     names: BTreeSet<String>,
+    #[serde(default)]
+    file_names: BTreeSet<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -58,7 +59,7 @@ pub fn set(opts: SetSecretOpts) -> Result<()> {
         None => prompt_secret(&opts.name)?,
     };
     save_value(&opts.name, &value)?;
-    crate::ui::ui().success(&format!("saved {} in the OS credential store", opts.name));
+    crate::ui::ui().success(&format!("saved {} in AgentOS private storage", opts.name));
     Ok(())
 }
 
@@ -85,15 +86,27 @@ pub fn unset(opts: UnsetSecretOpts) -> Result<()> {
 
 pub fn get_value(name: &str) -> Result<Option<String>> {
     validate_name(name)?;
-    Ok(read_vault()?.values.get(name).cloned())
+    if let Some(value) = read_credentials()?.values.get(name).cloned() {
+        return Ok(Some(value));
+    }
+    sync_secret_file()?;
+    if let Some(value) = read_credentials()?.values.get(name).cloned() {
+        return Ok(Some(value));
+    }
+    if needs_vault_upgrade(name)? {
+        migrate_legacy_value(name)?;
+    }
+    Ok(read_credentials()?.values.get(name).cloned())
 }
 
-/// Check the non-secret index without opening the platform credential store.
+/// Check the non-secret index without opening any credential values.
 /// UI status rendering must use this instead of `get_value`.
 pub fn is_saved(name: &str) -> Result<bool> {
     validate_name(name)?;
     let index = read_index()?;
-    Ok(index.vault && index.names.contains(name))
+    Ok(index.file_names.contains(name)
+        || index.names.contains(name)
+        || index.legacy_names.contains(name))
 }
 
 /// Whether a name belongs to the older one-Keychain-item-per-secret layout.
@@ -110,17 +123,27 @@ pub fn needs_vault_upgrade(name: &str) -> Result<bool> {
 
 /// Reconcile an older non-secret index with the consolidated vault. This opens
 /// exactly one credential-store item and never reads legacy per-secret items.
-pub fn sync_vault_index() -> Result<()> {
+pub fn sync_secret_file() -> Result<()> {
+    let credentials = read_credentials()?;
+    if !credentials.values.is_empty() {
+        let index = reconcile_file_names(read_index()?, credentials.values.keys());
+        return write_index(&index);
+    }
+    let index = read_index()?;
+    if index.names.is_empty() {
+        return Ok(());
+    }
     let vault = read_vault()?;
     if vault.values.is_empty() {
         return Ok(());
     }
-    let index = reconcile_vault_names(read_index()?, vault.values.keys());
+    write_credentials(&vault)?;
+    let index = reconcile_file_names(index, vault.values.keys());
     write_index(&index)
 }
 
-/// Move one required credential from the legacy per-secret Keychain layout to
-/// the consolidated vault. No value is shown or requested from the user.
+/// Copy one required credential from the legacy per-secret Keychain layout to
+/// the private file. The old Keychain item is deliberately left untouched.
 pub fn migrate_legacy_value(name: &str) -> Result<bool> {
     if !needs_vault_upgrade(name)? {
         return Ok(false);
@@ -134,20 +157,16 @@ pub fn migrate_legacy_value(name: &str) -> Result<bool> {
         }
     };
     save_value(name, &value)?;
-    match legacy_entry(name)?.delete_credential() {
-        Ok(()) | Err(keyring::Error::NoEntry) => {}
-        Err(err) => crate::ui::ui().warn(&format!(
-            "migrated {name}, but could not remove its old credential-store item: {err}"
-        )),
-    }
     Ok(true)
 }
 
 pub fn set_value(name: &str, value: &str) -> Result<()> {
     validate_name(name)?;
-    let mut vault = read_vault()?;
-    vault.values.insert(name.to_string(), value.to_string());
-    write_vault(&vault)
+    let mut credentials = read_credentials()?;
+    credentials
+        .values
+        .insert(name.to_string(), value.to_string());
+    write_credentials(&credentials)
 }
 
 pub fn save_value(name: &str, value: &str) -> Result<()> {
@@ -161,14 +180,9 @@ pub fn save_value(name: &str, value: &str) -> Result<()> {
 
 pub fn delete_value(name: &str) -> Result<()> {
     validate_name(name)?;
-    let mut vault = read_vault()?;
-    if vault.values.remove(name).is_some() {
-        if vault.values.is_empty() {
-            delete_vault()?;
-        } else {
-            write_vault(&vault)?;
-        }
-        return Ok(());
+    let mut credentials = read_credentials()?;
+    if credentials.values.remove(name).is_some() {
+        write_credentials(&credentials)?;
     }
     Ok(())
 }
@@ -185,6 +199,7 @@ pub fn list_names() -> Result<Vec<String>> {
         .names
         .into_iter()
         .chain(index.legacy_names)
+        .chain(index.file_names)
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect())
@@ -249,63 +264,47 @@ fn read_vault() -> Result<SecretVault> {
     Ok(vault)
 }
 
-fn write_vault(vault: &SecretVault) -> Result<()> {
-    let raw = serde_json::to_string(vault).context("serializing the AgentOS credential vault")?;
-    vault_entry()?
-        .set_password(&raw)
-        .context("saving the AgentOS OS credential-store vault")?;
-    let mut cache = vault_cache()
-        .lock()
-        .map_err(|_| anyhow::anyhow!("AgentOS credential vault cache is unavailable"))?;
-    cache.loaded = true;
-    cache.vault = vault.clone();
-    Ok(())
+fn read_credentials() -> Result<SecretVault> {
+    let path = credentials_path()?;
+    if !path.is_file() {
+        return Ok(SecretVault::default());
+    }
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("reading AgentOS credentials {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("parsing AgentOS credentials {}", path.display()))
 }
 
-fn delete_vault() -> Result<()> {
-    match vault_entry()?.delete_credential() {
-        Ok(()) | Err(keyring::Error::NoEntry) => {}
-        Err(err) => return Err(err).context("removing the AgentOS credential-store vault"),
+fn write_credentials(credentials: &SecretVault) -> Result<()> {
+    let path = credentials_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating AgentOS config dir {}", parent.display()))?;
     }
-    let mut cache = vault_cache()
-        .lock()
-        .map_err(|_| anyhow::anyhow!("AgentOS credential vault cache is unavailable"))?;
-    cache.loaded = true;
-    cache.vault = SecretVault::default();
-    Ok(())
+    let body = serde_json::to_vec_pretty(credentials).context("serializing AgentOS credentials")?;
+    write_private(&path, &body)
 }
 
 fn add_to_index(name: &str) -> Result<()> {
-    let index = mark_vault_saved(read_index()?, name);
+    let index = mark_file_saved(read_index()?, name);
     write_index(&index)
 }
 
-fn mark_vault_saved(mut index: SecretIndex, name: &str) -> SecretIndex {
-    if !index.vault {
-        // Older releases indexed one Keychain item per secret. Do not read
-        // those items during migration: macOS would authorize each one
-        // separately. Re-saving through the TUI creates the single vault and
-        // marks each re-saved name as upgraded without exposing a multi-prompt
-        // workflow or hiding the names that still use the legacy layout.
-        index.legacy_names.append(&mut index.names);
-        index.vault = true;
-    }
+fn mark_file_saved(mut index: SecretIndex, name: &str) -> SecretIndex {
     index.legacy_names.remove(name);
-    index.names.insert(name.to_string());
+    index.names.remove(name);
+    index.file_names.insert(name.to_string());
     index
 }
 
-fn reconcile_vault_names<'a>(
+fn reconcile_file_names<'a>(
     mut index: SecretIndex,
-    vault_names: impl Iterator<Item = &'a String>,
+    file_names: impl Iterator<Item = &'a String>,
 ) -> SecretIndex {
-    if !index.vault {
-        index.legacy_names.append(&mut index.names);
-        index.vault = true;
-    }
-    for name in vault_names {
+    for name in file_names {
         index.legacy_names.remove(name);
-        index.names.insert(name.clone());
+        index.names.remove(name);
+        index.file_names.insert(name.clone());
     }
     index
 }
@@ -314,6 +313,7 @@ fn remove_from_index(name: &str) -> Result<()> {
     let mut index = read_index()?;
     index.names.remove(name);
     index.legacy_names.remove(name);
+    index.file_names.remove(name);
     write_index(&index)
 }
 
@@ -339,7 +339,7 @@ fn write_index(index: &SecretIndex) -> Result<()> {
 
 #[cfg(unix)]
 fn write_private(path: &Path, body: &[u8]) -> Result<()> {
-    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
     let mut file = fs::OpenOptions::new()
         .create(true)
@@ -347,23 +347,33 @@ fn write_private(path: &Path, body: &[u8]) -> Result<()> {
         .write(true)
         .mode(0o600)
         .open(path)
-        .with_context(|| format!("writing secret index {}", path.display()))?;
+        .with_context(|| format!("opening private file {}", path.display()))?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("securing private file {}", path.display()))?;
     file.write_all(body)
-        .with_context(|| format!("writing secret index {}", path.display()))
+        .with_context(|| format!("writing private file {}", path.display()))
 }
 
 #[cfg(not(unix))]
 fn write_private(path: &Path, body: &[u8]) -> Result<()> {
-    fs::write(path, body).with_context(|| format!("writing secret index {}", path.display()))
+    fs::write(path, body).with_context(|| format!("writing private file {}", path.display()))
 }
 
 fn index_path() -> Result<PathBuf> {
+    Ok(config_dir()?.join("secrets.json"))
+}
+
+fn credentials_path() -> Result<PathBuf> {
+    Ok(config_dir()?.join("credentials.json"))
+}
+
+fn config_dir() -> Result<PathBuf> {
     if let Ok(dir) = std::env::var("AGENTOS_CONFIG_DIR") {
-        return Ok(PathBuf::from(dir).join("secrets.json"));
+        return Ok(PathBuf::from(dir));
     }
     let home =
         std::env::var("HOME").context("HOME is not set; cannot locate AgentOS config dir")?;
-    Ok(PathBuf::from(home).join(".config/agentos/secrets.json"))
+    Ok(PathBuf::from(home).join(".config/agentos"))
 }
 
 #[cfg(test)]
@@ -397,19 +407,18 @@ mod tests {
         )
         .unwrap();
 
-        let upgraded = mark_vault_saved(legacy, "ANTHROPIC_API_KEY");
+        let upgraded = mark_file_saved(legacy, "ANTHROPIC_API_KEY");
 
-        assert!(upgraded.vault);
         assert_eq!(
             upgraded.names,
-            BTreeSet::from(["ANTHROPIC_API_KEY".to_string()])
-        );
-        assert_eq!(
-            upgraded.legacy_names,
             BTreeSet::from([
                 "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
                 "OPENAI_API_KEY".to_string()
             ])
+        );
+        assert_eq!(
+            upgraded.file_names,
+            BTreeSet::from(["ANTHROPIC_API_KEY".to_string()])
         );
     }
 
@@ -419,18 +428,18 @@ mod tests {
             r#"{"names":["ANTHROPIC_API_KEY","GITHUB_PERSONAL_ACCESS_TOKEN","OPENAI_API_KEY"]}"#,
         )
         .unwrap();
-        let vault_names = [
+        let file_names = [
             "ANTHROPIC_API_KEY".to_string(),
             "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
         ];
 
-        let recovered = reconcile_vault_names(legacy, vault_names.iter());
+        let recovered = reconcile_file_names(legacy, file_names.iter());
 
-        assert_eq!(recovered.names, BTreeSet::from(vault_names));
         assert_eq!(
-            recovered.legacy_names,
+            recovered.names,
             BTreeSet::from(["OPENAI_API_KEY".to_string()])
         );
+        assert_eq!(recovered.file_names, BTreeSet::from(file_names));
     }
 
     #[test]
@@ -449,5 +458,23 @@ mod tests {
 
         assert_eq!(decoded.values, vault.values);
         assert_eq!(VAULT_ACCOUNT, "agentos:global:vault");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_files_are_forced_to_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("credentials.json");
+        fs::write(&path, b"old").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_private(&path, br#"{"values":{}}"#).unwrap();
+
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 }

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -15,7 +15,6 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 const SERVICE: &str = "dev.curie.agentos";
-const ACCOUNT_PREFIX: &str = "agentos:global:";
 const VAULT_ACCOUNT: &str = "agentos:global:vault";
 
 #[derive(Clone, Debug)]
@@ -31,6 +30,8 @@ pub struct UnsetSecretOpts {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 struct SecretIndex {
+    #[serde(default)]
+    vault: bool,
     names: BTreeSet<String>,
 }
 
@@ -82,27 +83,15 @@ pub fn unset(opts: UnsetSecretOpts) -> Result<()> {
 
 pub fn get_value(name: &str) -> Result<Option<String>> {
     validate_name(name)?;
-    let mut vault = read_vault()?;
-    if let Some(value) = vault.values.get(name) {
-        return Ok(Some(value.clone()));
-    }
-
-    // Migrate legacy per-key entries lazily. Existing users authorize each old
-    // item at most once; all subsequent reads come from the single vault item.
-    if let Some(value) = read_legacy_value(name)? {
-        vault.values.insert(name.to_string(), value.clone());
-        write_vault(&vault)?;
-        let _ = delete_legacy_value(name);
-        return Ok(Some(value));
-    }
-    Ok(None)
+    Ok(read_vault()?.values.get(name).cloned())
 }
 
 /// Check the non-secret index without opening the platform credential store.
 /// UI status rendering must use this instead of `get_value`.
 pub fn is_saved(name: &str) -> Result<bool> {
     validate_name(name)?;
-    Ok(read_index()?.names.contains(name))
+    let index = read_index()?;
+    Ok(index.vault && index.names.contains(name))
 }
 
 pub fn set_value(name: &str, value: &str) -> Result<()> {
@@ -132,7 +121,7 @@ pub fn delete_value(name: &str) -> Result<()> {
         }
         return Ok(());
     }
-    delete_legacy_value(name)
+    Ok(())
 }
 
 pub fn remove_value(name: &str) -> Result<()> {
@@ -143,7 +132,11 @@ pub fn remove_value(name: &str) -> Result<()> {
 
 pub fn list_names() -> Result<Vec<String>> {
     let index = read_index()?;
-    Ok(index.names.into_iter().collect())
+    Ok(if index.vault {
+        index.names.into_iter().collect()
+    } else {
+        Vec::new()
+    })
 }
 
 pub fn validate_name(name: &str) -> Result<()> {
@@ -177,11 +170,6 @@ fn prompt_secret(name: &str) -> Result<String> {
 fn vault_entry() -> Result<keyring::Entry> {
     keyring::Entry::new(SERVICE, VAULT_ACCOUNT)
         .context("opening the AgentOS OS credential-store vault")
-}
-
-fn legacy_entry(name: &str) -> Result<keyring::Entry> {
-    keyring::Entry::new(SERVICE, &account_name(name))
-        .with_context(|| format!("opening OS credential-store entry for {name}"))
 }
 
 fn vault_cache() -> &'static Mutex<VaultCache> {
@@ -231,31 +219,16 @@ fn delete_vault() -> Result<()> {
     Ok(())
 }
 
-fn read_legacy_value(name: &str) -> Result<Option<String>> {
-    match legacy_entry(name)?.get_password() {
-        Ok(value) => Ok(Some(value)),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(err) => {
-            Err(err).with_context(|| format!("reading {name} from the OS credential store"))
-        }
-    }
-}
-
-fn delete_legacy_value(name: &str) -> Result<()> {
-    match legacy_entry(name)?.delete_credential() {
-        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-        Err(err) => {
-            Err(err).with_context(|| format!("removing legacy {name} credential-store entry"))
-        }
-    }
-}
-
-fn account_name(name: &str) -> String {
-    format!("{ACCOUNT_PREFIX}{name}")
-}
-
 fn add_to_index(name: &str) -> Result<()> {
     let mut index = read_index()?;
+    if !index.vault {
+        // Older releases indexed one Keychain item per secret. Do not read
+        // those items during migration: macOS would authorize each one
+        // separately. Re-saving through the TUI creates the single vault and
+        // replaces the stale index without exposing a multi-prompt workflow.
+        index.names.clear();
+        index.vault = true;
+    }
     index.names.insert(name.to_string());
     write_index(&index)
 }
@@ -329,11 +302,14 @@ mod tests {
     }
 
     #[test]
-    fn account_names_are_scoped_under_agentos() {
-        assert_eq!(
-            account_name("GITHUB_PERSONAL_ACCESS_TOKEN"),
-            "agentos:global:GITHUB_PERSONAL_ACCESS_TOKEN"
-        );
+    fn legacy_index_does_not_claim_per_key_secrets_are_in_the_vault() {
+        let index: SecretIndex = serde_json::from_str(
+            r#"{"names":["ANTHROPIC_API_KEY","GITHUB_PERSONAL_ACCESS_TOKEN"]}"#,
+        )
+        .unwrap();
+
+        assert!(!index.vault);
+        assert_eq!(index.names.len(), 2);
     }
 
     #[test]

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -1,20 +1,22 @@
 //! OS-backed secret storage for local AgentOS workflows.
 //!
-//! Secret values live in the platform credential store via `keyring`. The only
-//! filesystem state here is a non-secret index of names so `agentos secrets
-//! list` can show what AgentOS has saved without needing credential-store
-//! enumeration support.
+//! Secret values live together in one platform credential-store vault via
+//! `keyring`, so a workflow authorizes AgentOS once rather than once per key.
+//! The only filesystem state here is a non-secret index of names so `agentos
+//! secrets list` can show what AgentOS has saved without opening the vault.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 const SERVICE: &str = "dev.curie.agentos";
 const ACCOUNT_PREFIX: &str = "agentos:global:";
+const VAULT_ACCOUNT: &str = "agentos:global:vault";
 
 #[derive(Clone, Debug)]
 pub struct SetSecretOpts {
@@ -31,6 +33,19 @@ pub struct UnsetSecretOpts {
 struct SecretIndex {
     names: BTreeSet<String>,
 }
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+struct SecretVault {
+    values: BTreeMap<String, String>,
+}
+
+#[derive(Default)]
+struct VaultCache {
+    loaded: bool,
+    vault: SecretVault,
+}
+
+static VAULT_CACHE: OnceLock<Mutex<VaultCache>> = OnceLock::new();
 
 pub fn set(opts: SetSecretOpts) -> Result<()> {
     validate_name(&opts.name)?;
@@ -67,14 +82,20 @@ pub fn unset(opts: UnsetSecretOpts) -> Result<()> {
 
 pub fn get_value(name: &str) -> Result<Option<String>> {
     validate_name(name)?;
-    let entry = entry(name)?;
-    match entry.get_password() {
-        Ok(value) => Ok(Some(value)),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(err) => {
-            Err(err).with_context(|| format!("reading {name} from the OS credential store"))
-        }
+    let mut vault = read_vault()?;
+    if let Some(value) = vault.values.get(name) {
+        return Ok(Some(value.clone()));
     }
+
+    // Migrate legacy per-key entries lazily. Existing users authorize each old
+    // item at most once; all subsequent reads come from the single vault item.
+    if let Some(value) = read_legacy_value(name)? {
+        vault.values.insert(name.to_string(), value.clone());
+        write_vault(&vault)?;
+        let _ = delete_legacy_value(name);
+        return Ok(Some(value));
+    }
+    Ok(None)
 }
 
 /// Check the non-secret index without opening the platform credential store.
@@ -86,9 +107,9 @@ pub fn is_saved(name: &str) -> Result<bool> {
 
 pub fn set_value(name: &str, value: &str) -> Result<()> {
     validate_name(name)?;
-    entry(name)?
-        .set_password(value)
-        .with_context(|| format!("saving {name} in the OS credential store"))
+    let mut vault = read_vault()?;
+    vault.values.insert(name.to_string(), value.to_string());
+    write_vault(&vault)
 }
 
 pub fn save_value(name: &str, value: &str) -> Result<()> {
@@ -102,12 +123,16 @@ pub fn save_value(name: &str, value: &str) -> Result<()> {
 
 pub fn delete_value(name: &str) -> Result<()> {
     validate_name(name)?;
-    match entry(name)?.delete_credential() {
-        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-        Err(err) => {
-            Err(err).with_context(|| format!("removing {name} from the OS credential store"))
+    let mut vault = read_vault()?;
+    if vault.values.remove(name).is_some() {
+        if vault.values.is_empty() {
+            delete_vault()?;
+        } else {
+            write_vault(&vault)?;
         }
+        return Ok(());
     }
+    delete_legacy_value(name)
 }
 
 pub fn remove_value(name: &str) -> Result<()> {
@@ -149,9 +174,80 @@ fn prompt_secret(name: &str) -> Result<String> {
     rpassword::read_password().context("reading secret from terminal")
 }
 
-fn entry(name: &str) -> Result<keyring::Entry> {
+fn vault_entry() -> Result<keyring::Entry> {
+    keyring::Entry::new(SERVICE, VAULT_ACCOUNT)
+        .context("opening the AgentOS OS credential-store vault")
+}
+
+fn legacy_entry(name: &str) -> Result<keyring::Entry> {
     keyring::Entry::new(SERVICE, &account_name(name))
         .with_context(|| format!("opening OS credential-store entry for {name}"))
+}
+
+fn vault_cache() -> &'static Mutex<VaultCache> {
+    VAULT_CACHE.get_or_init(|| Mutex::new(VaultCache::default()))
+}
+
+fn read_vault() -> Result<SecretVault> {
+    let mut cache = vault_cache()
+        .lock()
+        .map_err(|_| anyhow::anyhow!("AgentOS credential vault cache is unavailable"))?;
+    if cache.loaded {
+        return Ok(cache.vault.clone());
+    }
+    let vault = match vault_entry()?.get_password() {
+        Ok(raw) => serde_json::from_str(&raw).context("parsing the AgentOS credential vault")?,
+        Err(keyring::Error::NoEntry) => SecretVault::default(),
+        Err(err) => return Err(err).context("reading the AgentOS OS credential-store vault"),
+    };
+    cache.loaded = true;
+    cache.vault = vault.clone();
+    Ok(vault)
+}
+
+fn write_vault(vault: &SecretVault) -> Result<()> {
+    let raw = serde_json::to_string(vault).context("serializing the AgentOS credential vault")?;
+    vault_entry()?
+        .set_password(&raw)
+        .context("saving the AgentOS OS credential-store vault")?;
+    let mut cache = vault_cache()
+        .lock()
+        .map_err(|_| anyhow::anyhow!("AgentOS credential vault cache is unavailable"))?;
+    cache.loaded = true;
+    cache.vault = vault.clone();
+    Ok(())
+}
+
+fn delete_vault() -> Result<()> {
+    match vault_entry()?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => {}
+        Err(err) => return Err(err).context("removing the AgentOS credential-store vault"),
+    }
+    let mut cache = vault_cache()
+        .lock()
+        .map_err(|_| anyhow::anyhow!("AgentOS credential vault cache is unavailable"))?;
+    cache.loaded = true;
+    cache.vault = SecretVault::default();
+    Ok(())
+}
+
+fn read_legacy_value(name: &str) -> Result<Option<String>> {
+    match legacy_entry(name)?.get_password() {
+        Ok(value) => Ok(Some(value)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(err) => {
+            Err(err).with_context(|| format!("reading {name} from the OS credential store"))
+        }
+    }
+}
+
+fn delete_legacy_value(name: &str) -> Result<()> {
+    match legacy_entry(name)?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(err) => {
+            Err(err).with_context(|| format!("removing legacy {name} credential-store entry"))
+        }
+    }
 }
 
 fn account_name(name: &str) -> String {
@@ -238,5 +334,23 @@ mod tests {
             account_name("GITHUB_PERSONAL_ACCESS_TOKEN"),
             "agentos:global:GITHUB_PERSONAL_ACCESS_TOKEN"
         );
+    }
+
+    #[test]
+    fn vault_round_trips_multiple_credentials_in_one_payload() {
+        let vault = SecretVault {
+            values: BTreeMap::from([
+                ("ANTHROPIC_API_KEY".to_string(), "model-secret".to_string()),
+                (
+                    "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+                    "github-secret".to_string(),
+                ),
+            ]),
+        };
+        let raw = serde_json::to_string(&vault).unwrap();
+        let decoded: SecretVault = serde_json::from_str(&raw).unwrap();
+
+        assert_eq!(decoded.values, vault.values);
+        assert_eq!(VAULT_ACCOUNT, "agentos:global:vault");
     }
 }

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -50,6 +50,9 @@ fn process_help_routes_positive_forms() {
         &["cluster", "deploy"],
         &["init"],
         &["interactive"],
+        &["secrets", "set"],
+        &["secrets", "list"],
+        &["secrets", "unset"],
     ];
 
     for args in cases.iter().copied() {
@@ -111,7 +114,14 @@ fn process_help_top_level_lists_new_surface_and_hides_retired_verbs() {
     );
     let text = output_text(&output);
 
-    for needle in ["skill", "local", "cluster", "init", "interactive"] {
+    for needle in [
+        "skill",
+        "local",
+        "cluster",
+        "init",
+        "interactive",
+        "secrets",
+    ] {
         assert!(
             help_lists_subcommand(&text, needle),
             "missing {needle}\n{text}"

--- a/docs/adr/0020-message-port-rendering-free-channel-interface.md
+++ b/docs/adr/0020-message-port-rendering-free-channel-interface.md
@@ -1,7 +1,7 @@
 # 20. The message port: a rendering-free channel interface with capability negotiation
 
 Date: 2026-07-11
-Status: Proposed
+Status: Accepted
 
 ## Context
 
@@ -149,6 +149,6 @@ fallback, and a native escape hatch that is never load-bearing.
   single change. This ADR does not require the full pluggable channel registry up
   front; the interaction-primitive half is driven now by the approval interface
   (ADR-0010), and the rest lands as real channels arrive.
-- Open: the exact capability enum and the intent set (`Confirm` and `Choice` in
-  v1, `Form` later) are pinned when the port lands in `aci-protocol` / the channel
-  package. This ADR fixes the shape and the rules, not the final field list.
+- The exact v1 capability enum and `Choice` / `Confirm` intent fields are pinned
+  in `packages/channel-protocol` and documented in the channel-interaction
+  interface. `Form` remains deferred until an agent needs it.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -15,6 +15,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Harness in-proc / ModelSession | CLEAN | 1 + fake | A- | (folds into #25) | [interfaces/harness-modelsession/INTERFACE.md](interfaces/harness-modelsession/INTERFACE.md) |
 | ACI producer (frozen protocol) | CLEAN, frozen | 1 + reference | A- | #25, #47 | [interfaces/aci-producer/INTERFACE.md](interfaces/aci-producer/INTERFACE.md) |
 | Channel / ingress (Slack) | SOFT | 1 | C | #7, #19, #27, #38 | [interfaces/channel-ingress/INTERFACE.md](interfaces/channel-ingress/INTERFACE.md) |
+| Channel interaction message | CLEAN | 2 renderers (Slack, terminal) | not separately graded | ADR-0020 | [interfaces/channel-interaction/INTERFACE.md](interfaces/channel-interaction/INTERFACE.md) |
 | Model provider / credentials | SOFT | 1 (Anthropic) | not separately graded | #24, #46 | [interfaces/model-provider/INTERFACE.md](interfaces/model-provider/INTERFACE.md) |
 | Telemetry / OTEL | SOFT | 1 | B+ | #47 | [interfaces/telemetry-otel/INTERFACE.md](interfaces/telemetry-otel/INTERFACE.md) |
 | Evals (case + scorer) | SOFT | 1 grader family | B | #8, #26 | [interfaces/evals/INTERFACE.md](interfaces/evals/INTERFACE.md) |

--- a/docs/interfaces/channel-ingress/INTERFACE.md
+++ b/docs/interfaces/channel-ingress/INTERFACE.md
@@ -65,3 +65,5 @@ is built (#27) — the channel-neutral rename comes with the second real channel
 - **Epic(s):** #38 — channel-seam hardening / follow-up
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 6 (Communication channel), grade C
 - **ADR(s):** none directly on this seam
+- **Interaction contract:** [Channel interaction](../channel-interaction/INTERFACE.md)
+  defines the semantic reply before this Slack adapter renders it.

--- a/docs/interfaces/channel-interaction/INTERFACE.md
+++ b/docs/interfaces/channel-interaction/INTERFACE.md
@@ -1,0 +1,67 @@
+# INTERFACE: Channel interaction
+
+> Part of the AgentOS swappable-seam catalog. **Kind:** CLEAN. **Version:** 1.0.
+
+## The black line
+
+Agents produce a semantic `OutboundMessage`; channel adapters render it. Slack
+may use Block Kit and the terminal may use a numbered selector, but neither
+widget appears in the contract. This is the interaction half of ADR-0020.
+
+The source of truth is
+`packages/channel-protocol/src/channel_protocol/models.py`; the committed JSON
+Schema is `packages/channel-protocol/schema/channel-protocol.schema.json`.
+
+## Message contract
+
+Every message has `version: "1.0"` and mandatory `text`. The text must be a
+complete usable reply after all optional fields are removed. Optional `status`,
+`header`, `fields`, `links`, and `footer` enrich presentation.
+
+An optional `interaction` is one semantic intent:
+
+- `choice`: an id, optional prompt, one to ten `{label, value}` options, and
+  `allow_free_text` (default `true`).
+- `confirm`: an id, prompt, semantic confirm and cancel actions, and
+  `allow_free_text` (default `false`).
+
+Action `label` is display text. Action `value` is the exact inbound message sent
+when selected. Values are conversation input, not trusted authorization tokens;
+the server must still authorize side effects and approvals.
+
+## ACI envelope
+
+Until ACI gains a native semantic-message event, a runner carries the message
+inside its final text as a complete fenced block:
+
+````text
+```agentos-reply
+{"version":"1.0","text":"Which view?","interaction":{"kind":"choice","id":"view","options":[{"label":"Open issues","value":"show open issues"}]}}
+```
+````
+
+Adapters must hide incomplete or malformed envelopes and fall back to ordinary
+text. The legacy unversioned `buttons: [[label, value]]` shape remains readable
+during migration but is not valid v1 authoring.
+
+## Adapter requirements
+
+- Render `text` even when no optional capability is supported.
+- Advertise capabilities; never infer them from the channel name.
+- Render choices and confirmations using native affordances when
+  `interactive-actions` is present and as numbered text otherwise.
+- Preserve action values exactly when converting a selection into inbound text.
+- Keep rendering and channel-native payloads inside the adapter.
+- Treat links as navigation, not conversation responses.
+- Never grant authority based only on an action id or value.
+
+## TUI behavior
+
+The AgentOS TUI advertises `interactive-actions`, `live-steering`, `streaming`,
+and `threading`. It shows response actions beside a free-response input when
+allowed, sends the selected value as the next turn, replaces stale actions after
+each reply, and never prints protocol fences or terminal status frames.
+
+Starter prompts are bundle metadata (`starterPrompts`), not response actions and
+not hardcoded into the TUI. They disappear after the first turn unless the agent
+returns a new interaction.

--- a/docs/interfaces/channel-interaction/INTERFACE.md
+++ b/docs/interfaces/channel-interaction/INTERFACE.md
@@ -61,9 +61,11 @@ The AgentOS TUI advertises `interactive-actions`, `live-steering`, `streaming`,
 and `threading`. It renders agent-authored actions first and appends `Type a
 message...` as the final selector option when free text is allowed. Selecting
 that option enters an explicit compose mode; it is a terminal affordance and is
-never added to the agent-authored contract. The TUI sends the selected action
-value or composed text as the next turn, replaces stale actions after each
-reply, and never prints protocol fences or terminal status frames.
+never added to the agent-authored contract. The selector expands to keep every
+contract option and the appended free-response option visible. The compose
+field is hidden until free response is selected. The TUI sends the selected
+action value or composed text as the next turn, replaces stale actions after
+each reply, and never prints protocol fences or terminal status frames.
 
 The conversation transcript remains scrollable while selecting, composing, and
 waiting for a response. Scrolling suspends tail-follow until the user returns to

--- a/docs/interfaces/channel-interaction/INTERFACE.md
+++ b/docs/interfaces/channel-interaction/INTERFACE.md
@@ -58,9 +58,17 @@ during migration but is not valid v1 authoring.
 ## TUI behavior
 
 The AgentOS TUI advertises `interactive-actions`, `live-steering`, `streaming`,
-and `threading`. It shows response actions beside a free-response input when
-allowed, sends the selected value as the next turn, replaces stale actions after
-each reply, and never prints protocol fences or terminal status frames.
+and `threading`. It renders agent-authored actions first and appends `Type a
+message...` as the final selector option when free text is allowed. Selecting
+that option enters an explicit compose mode; it is a terminal affordance and is
+never added to the agent-authored contract. The TUI sends the selected action
+value or composed text as the next turn, replaces stale actions after each
+reply, and never prints protocol fences or terminal status frames.
+
+The conversation transcript remains scrollable while selecting, composing, and
+waiting for a response. Scrolling suspends tail-follow until the user returns to
+the latest output. Transcript navigation is adapter state and must not alter the
+outbound message or its interaction intent.
 
 Starter prompts are bundle metadata (`starterPrompts`), not response actions and
 not hardcoded into the TUI. They disappear after the first turn unless the agent

--- a/examples/github-issues/.claude-plugin/plugin.json
+++ b/examples/github-issues/.claude-plugin/plugin.json
@@ -3,5 +3,10 @@
   "version": "0.1.0",
   "description": "Example bundle: an agent that reads and triages GitHub issues through the off-the-shelf GitHub MCP server, authenticated with a personal access token forwarded into the sandbox.",
   "author": { "name": "CurieTech" },
-  "keywords": ["example", "mcp", "authed", "github", "stdio"]
+  "keywords": ["example", "mcp", "authed", "github", "stdio"],
+  "starterPrompts": [
+    "List the open issues in curie-eng/agentos and group them by label.",
+    "Summarize the most recently updated pull requests in curie-eng/agentos.",
+    "Find open bug reports in curie-eng/agentos that need triage."
+  ]
 }

--- a/examples/github-issues/README.md
+++ b/examples/github-issues/README.md
@@ -36,9 +36,9 @@ own MCP secrets.
 
 ## Run it end-to-end (manual)
 
-For the interactive path, run `agentos`, choose **examples**, then **Chat with
-GitHub agent**. AgentOS starts the runner, keeps the entire conversation in its
-TUI, and stops the runner when you leave the chat.
+For the interactive path, run `agentos`, choose **Explore examples**, then
+**GitHub issues**. AgentOS starts the runner, keeps the entire conversation in
+its TUI, and stops the runner when you leave the chat.
 
 Prerequisites: the runner image built once (`agentos build`), a model credential
 in your environment (`CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`), and a

--- a/examples/github-issues/README.md
+++ b/examples/github-issues/README.md
@@ -36,6 +36,10 @@ own MCP secrets.
 
 ## Run it end-to-end (manual)
 
+For the interactive path, run `agentos`, choose **examples**, then **Chat with
+GitHub agent**. AgentOS starts the runner, keeps the entire conversation in its
+TUI, and stops the runner when you leave the chat.
+
 Prerequisites: the runner image built once (`agentos build`), a model credential
 in your environment (`CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`), and a
 GitHub PAT — a read-scoped (`public_repo` / `repo:read`) token is enough to list

--- a/examples/text-stats-engine/.claude-plugin/plugin.json
+++ b/examples/text-stats-engine/.claude-plugin/plugin.json
@@ -3,5 +3,10 @@
   "version": "0.1.0",
   "description": "Template bundle: an engine packaged as an in-bundle stdio MCP server.",
   "author": { "name": "CurieTech" },
-  "keywords": ["template", "mcp", "stdio", "engine"]
+  "keywords": ["template", "mcp", "stdio", "engine"],
+  "starterPrompts": [
+    "Explain what text analysis tools you have.",
+    "Count the words and sentences in: AgentOS makes agents portable.",
+    "Analyze the readability of: Clear tools make complex work easier."
+  ]
 }

--- a/examples/weather/.claude-plugin/plugin.json
+++ b/examples/weather/.claude-plugin/plugin.json
@@ -1,5 +1,10 @@
 {
   "name": "weather",
   "description": "The weather agent plugin.",
-  "version": "0.1.0"
+  "version": "0.1.0",
+  "starterPrompts": [
+    "What can this weather agent help me with?",
+    "Give me a concise weather briefing for San Francisco.",
+    "How should I ask you to compare weather between two cities?"
+  ]
 }

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# One-command bootstrap for an agentos source checkout.
+# One-command bootstrap/update for an agentos source checkout.
 #
 # Solves the bootstrap chicken-and-egg: the `agentos` CLI cannot install itself
-# because it does not exist until it is built. This script runs the single
-# pre-binary step -- `cargo install`, which builds AND drops `agentos` on PATH
-# (~/.cargo/bin) -- and then hands off to `agentos install` for the rest (uv
-# sync, pnpm install, runner image). Run it once, right after cloning:
+# because it does not exist until it is built. On a fresh checkout this script
+# runs the single pre-binary step -- `cargo install`, which builds AND drops
+# `agentos` on PATH (~/.cargo/bin) -- and then hands off to `agentos install`
+# for the rest (uv sync, pnpm install, runner image). On an existing install it
+# only refreshes the CLI when the source tree is newer than the installed binary,
+# then runs `agentos install --update` so already-present artifacts are reused.
 #
 #   git clone <repo> && cd agentos && ./install.sh
 #
@@ -13,15 +15,33 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-echo "==> cargo install --path cli (builds agentos and installs it to ~/.cargo/bin)"
-cargo install --path cli --force
-
 # Invoke the freshly installed binary by its absolute path so this works even
 # when ~/.cargo/bin is not yet on PATH in the current shell (a new clone on a
 # machine whose shell rc has not been re-sourced).
 CARGO_BIN="${CARGO_HOME:-$HOME/.cargo}/bin"
-echo "==> agentos install (deps + runner image)"
-"$CARGO_BIN/agentos" install
+AGENTOS_BIN="$CARGO_BIN/agentos"
+
+cli_sources_newer_than_binary() {
+  [[ ! -x "$AGENTOS_BIN" ]] && return 0
+  find cli -path cli/target -prune -o -type f -newer "$AGENTOS_BIN" -print -quit | grep -q .
+}
+
+UPDATE_ARGS=()
+if [[ -x "$AGENTOS_BIN" ]]; then
+  UPDATE_ARGS=(--update)
+  if cli_sources_newer_than_binary; then
+    echo "==> updating agentos CLI (source is newer than $AGENTOS_BIN)"
+    cargo install --path cli --force
+  else
+    echo "==> agentos CLI is already current at $AGENTOS_BIN"
+  fi
+else
+  echo "==> cargo install --path cli (builds agentos and installs it to ~/.cargo/bin)"
+  cargo install --path cli --force
+fi
+
+echo "==> agentos install ${UPDATE_ARGS[*]} (deps + runner image as needed)"
+"$AGENTOS_BIN" install "${UPDATE_ARGS[@]}"
 
 echo
 echo "Done. If 'agentos' is not found in this shell, add ~/.cargo/bin to PATH"

--- a/packages/channel-protocol/pyproject.toml
+++ b/packages/channel-protocol/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "agentos-channel-protocol"
+version = "0.1.0"
+description = "Rendering-neutral AgentOS channel message contract"
+requires-python = ">=3.13"
+dependencies = ["pydantic>=2.9"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/channel_protocol"]

--- a/packages/channel-protocol/schema/channel-protocol.schema.json
+++ b/packages/channel-protocol/schema/channel-protocol.schema.json
@@ -1,0 +1,290 @@
+{
+  "$defs": {
+    "Action": {
+      "additionalProperties": false,
+      "description": "A semantic response the user may select; adapters choose its widget.",
+      "properties": {
+        "label": {
+          "maxLength": 75,
+          "minLength": 1,
+          "title": "Label",
+          "type": "string"
+        },
+        "value": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "value"
+      ],
+      "title": "Action",
+      "type": "object"
+    },
+    "ChannelCapabilities": {
+      "additionalProperties": false,
+      "properties": {
+        "capabilities": {
+          "items": {
+            "$ref": "#/$defs/ChannelCapability"
+          },
+          "title": "Capabilities",
+          "type": "array"
+        },
+        "version": {
+          "const": "1.0",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version"
+      ],
+      "title": "ChannelCapabilities",
+      "type": "object"
+    },
+    "ChannelCapability": {
+      "enum": [
+        "interactive-actions",
+        "live-steering",
+        "streaming",
+        "rich-cards",
+        "threading",
+        "file-attachments"
+      ],
+      "title": "ChannelCapability",
+      "type": "string"
+    },
+    "ChoiceIntent": {
+      "additionalProperties": false,
+      "properties": {
+        "allow_free_text": {
+          "default": true,
+          "title": "Allow Free Text",
+          "type": "boolean"
+        },
+        "id": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "const": "choice",
+          "title": "Kind",
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "$ref": "#/$defs/Action"
+          },
+          "maxItems": 10,
+          "minItems": 1,
+          "title": "Options",
+          "type": "array"
+        },
+        "prompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Prompt"
+        }
+      },
+      "required": [
+        "kind",
+        "id",
+        "options"
+      ],
+      "title": "ChoiceIntent",
+      "type": "object"
+    },
+    "ConfirmIntent": {
+      "additionalProperties": false,
+      "properties": {
+        "allow_free_text": {
+          "default": false,
+          "title": "Allow Free Text",
+          "type": "boolean"
+        },
+        "cancel": {
+          "$ref": "#/$defs/Action"
+        },
+        "confirm": {
+          "$ref": "#/$defs/Action"
+        },
+        "id": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "kind": {
+          "const": "confirm",
+          "title": "Kind",
+          "type": "string"
+        },
+        "prompt": {
+          "title": "Prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "id",
+        "prompt",
+        "confirm",
+        "cancel"
+      ],
+      "title": "ConfirmIntent",
+      "type": "object"
+    },
+    "MessageField": {
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "value"
+      ],
+      "title": "MessageField",
+      "type": "object"
+    },
+    "MessageLink": {
+      "additionalProperties": false,
+      "properties": {
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "url": {
+          "title": "Url",
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "url"
+      ],
+      "title": "MessageLink",
+      "type": "object"
+    },
+    "OutboundMessage": {
+      "additionalProperties": false,
+      "description": "One adapter-neutral reply with a mandatory complete text fallback.",
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/$defs/MessageField"
+          },
+          "title": "Fields",
+          "type": "array"
+        },
+        "footer": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Footer"
+        },
+        "header": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Header"
+        },
+        "interaction": {
+          "anyOf": [
+            {
+              "discriminator": {
+                "mapping": {
+                  "choice": "#/$defs/ChoiceIntent",
+                  "confirm": "#/$defs/ConfirmIntent"
+                },
+                "propertyName": "kind"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/$defs/ChoiceIntent"
+                },
+                {
+                  "$ref": "#/$defs/ConfirmIntent"
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Interaction"
+        },
+        "links": {
+          "items": {
+            "$ref": "#/$defs/MessageLink"
+          },
+          "title": "Links",
+          "type": "array"
+        },
+        "status": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Status"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "version": {
+          "const": "1.0",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version",
+        "text"
+      ],
+      "title": "OutboundMessage",
+      "type": "object"
+    }
+  },
+  "$id": "https://curie.tech/agentos/channel-protocol.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "messageVersion": "1.0",
+  "title": "AgentOS Channel Protocol v1.0"
+}

--- a/packages/channel-protocol/src/channel_protocol/__init__.py
+++ b/packages/channel-protocol/src/channel_protocol/__init__.py
@@ -1,0 +1,27 @@
+"""Rendering-neutral messages shared by AgentOS channel adapters."""
+
+from .models import (
+    MESSAGE_VERSION,
+    Action,
+    ChannelCapabilities,
+    ChannelCapability,
+    ChoiceIntent,
+    ConfirmIntent,
+    InteractionIntent,
+    MessageField,
+    MessageLink,
+    OutboundMessage,
+)
+
+__all__ = [
+    "MESSAGE_VERSION",
+    "Action",
+    "ChannelCapability",
+    "ChannelCapabilities",
+    "ChoiceIntent",
+    "ConfirmIntent",
+    "InteractionIntent",
+    "MessageField",
+    "MessageLink",
+    "OutboundMessage",
+]

--- a/packages/channel-protocol/src/channel_protocol/models.py
+++ b/packages/channel-protocol/src/channel_protocol/models.py
@@ -1,0 +1,88 @@
+"""Versioned semantic messages rendered by Slack, the AgentOS TUI, and future channels."""
+
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+MessageVersion = Literal["1.0"]
+MESSAGE_VERSION: MessageVersion = "1.0"
+_STRICT = ConfigDict(extra="forbid")
+
+
+class ChannelCapability(StrEnum):
+    INTERACTIVE_ACTIONS = "interactive-actions"
+    LIVE_STEERING = "live-steering"
+    STREAMING = "streaming"
+    RICH_CARDS = "rich-cards"
+    THREADING = "threading"
+    FILE_ATTACHMENTS = "file-attachments"
+
+
+class ChannelCapabilities(BaseModel):
+    model_config = _STRICT
+
+    version: MessageVersion
+    capabilities: list[ChannelCapability] = Field(default_factory=list)
+
+
+class Action(BaseModel):
+    """A semantic response the user may select; adapters choose its widget."""
+
+    model_config = _STRICT
+
+    label: str = Field(min_length=1, max_length=75)
+    value: str = Field(min_length=1, max_length=255)
+
+
+class MessageField(BaseModel):
+    model_config = _STRICT
+
+    label: str
+    value: str
+
+
+class MessageLink(BaseModel):
+    model_config = _STRICT
+
+    label: str
+    url: str
+
+
+class ChoiceIntent(BaseModel):
+    model_config = _STRICT
+
+    kind: Literal["choice"]
+    id: str = Field(min_length=1, max_length=255)
+    prompt: str | None = None
+    options: list[Action] = Field(min_length=1, max_length=10)
+    allow_free_text: bool = True
+
+
+class ConfirmIntent(BaseModel):
+    model_config = _STRICT
+
+    kind: Literal["confirm"]
+    id: str = Field(min_length=1, max_length=255)
+    prompt: str
+    confirm: Action
+    cancel: Action
+    allow_free_text: bool = False
+
+
+InteractionIntent = Annotated[ChoiceIntent | ConfirmIntent, Field(discriminator="kind")]
+
+
+class OutboundMessage(BaseModel):
+    """One adapter-neutral reply with a mandatory complete text fallback."""
+
+    model_config = _STRICT
+
+    version: MessageVersion
+    text: str
+    status: str | None = None
+    header: str | None = None
+    fields: list[MessageField] = Field(default_factory=list)
+    links: list[MessageLink] = Field(default_factory=list)
+    footer: str | None = None
+    interaction: InteractionIntent | None = None

--- a/packages/channel-protocol/src/channel_protocol/schema_export.py
+++ b/packages/channel-protocol/src/channel_protocol/schema_export.py
@@ -1,0 +1,61 @@
+"""Export the committed AgentOS channel message JSON Schema."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic.json_schema import models_json_schema
+
+from .models import (
+    Action,
+    ChannelCapabilities,
+    ChoiceIntent,
+    ConfirmIntent,
+    MessageField,
+    MessageLink,
+    OutboundMessage,
+)
+
+SCHEMA_ID = "https://curie.tech/agentos/channel-protocol.schema.json"
+_MODELS = (
+    ChannelCapabilities,
+    OutboundMessage,
+    ChoiceIntent,
+    ConfirmIntent,
+    Action,
+    MessageField,
+    MessageLink,
+)
+
+
+def schema_path() -> Path:
+    return Path(__file__).resolve().parents[2] / "schema" / "channel-protocol.schema.json"
+
+
+def build_schema() -> dict[str, Any]:
+    _, top = models_json_schema(
+        [(model, "validation") for model in _MODELS],
+        ref_template="#/$defs/{model}",
+    )
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": SCHEMA_ID,
+        "title": "AgentOS Channel Protocol v1.0",
+        "messageVersion": "1.0",
+        **top,
+    }
+
+
+def render_schema() -> str:
+    return json.dumps(build_schema(), indent=2, sort_keys=True) + "\n"
+
+
+def write_schema() -> Path:
+    path = schema_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_schema(), encoding="utf-8")
+    return path
+
+
+if __name__ == "__main__":
+    print(f"wrote {write_schema()}")

--- a/packages/channel-protocol/tests/test_models.py
+++ b/packages/channel-protocol/tests/test_models.py
@@ -1,0 +1,41 @@
+import pytest
+from channel_protocol import Action, ChoiceIntent, ConfirmIntent, OutboundMessage
+from pydantic import ValidationError
+
+
+def test_choice_message_round_trips() -> None:
+    message = OutboundMessage(
+        version="1.0",
+        text="Pick a repository.",
+        interaction=ChoiceIntent(
+            kind="choice",
+            id="repo",
+            options=[Action(label="AgentOS", value="curie-eng/agentos")],
+        ),
+    )
+    decoded = OutboundMessage.model_validate_json(message.model_dump_json())
+    assert isinstance(decoded.interaction, ChoiceIntent)
+    assert decoded.interaction.options[0].value == "curie-eng/agentos"
+
+
+def test_confirm_is_semantic_and_free_text_is_off_by_default() -> None:
+    message = OutboundMessage(
+        version="1.0",
+        text="Deploy this change?",
+        interaction=ConfirmIntent(
+            kind="confirm",
+            id="deploy",
+            prompt="Deploy this change?",
+            confirm=Action(label="Deploy", value="deploy"),
+            cancel=Action(label="Cancel", value="cancel"),
+        ),
+    )
+    assert isinstance(message.interaction, ConfirmIntent)
+    assert message.interaction.allow_free_text is False
+
+
+def test_text_fallback_is_required_and_unknown_fields_are_rejected() -> None:
+    with pytest.raises(ValidationError):
+        OutboundMessage.model_validate({"version": "1.0"})
+    with pytest.raises(ValidationError):
+        OutboundMessage.model_validate({"version": "1.0", "text": "ok", "blocks": []})

--- a/packages/channel-protocol/tests/test_schema_compat.py
+++ b/packages/channel-protocol/tests/test_schema_compat.py
@@ -1,0 +1,7 @@
+from channel_protocol.schema_export import render_schema, schema_path
+
+
+def test_committed_schema_is_current() -> None:
+    assert schema_path().read_text(encoding="utf-8") == render_schema(), (
+        "channel protocol schema is stale; run python -m channel_protocol.schema_export"
+    )

--- a/packages/plugin-format/schema/plugin-format.schema.json
+++ b/packages/plugin-format/schema/plugin-format.schema.json
@@ -399,6 +399,21 @@
           "default": null,
           "title": "Repository"
         },
+        "starterPrompts": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Starterprompts"
+        },
         "systemPrompt": {
           "anyOf": [
             {

--- a/packages/plugin-format/src/plugin_format/models.py
+++ b/packages/plugin-format/src/plugin_format/models.py
@@ -59,6 +59,9 @@ class PluginManifest(BaseModel):
     # via the ``AGENTOS_SYSTEM_PROMPT`` env var. Inline prompt text; applied at
     # runner boot, with the env var taking precedence for backward compatibility.
     systemPrompt: str | None = None
+    # Initial terminal/chat affordances. These are bundle-authored conversation
+    # starters, not response actions; adapters discard them after the first turn.
+    starterPrompts: list[str] | None = None
     # AgentOS authoring extensions (epic #30 / #29), validated at deploy time by
     # ``validate.py``. Kept loosely typed on the manifest (the models stay
     # lenient); the dedicated ``TriggerDeclaration`` / ``ApprovalPolicy`` models

--- a/packages/plugin-format/tests/test_models.py
+++ b/packages/plugin-format/tests/test_models.py
@@ -49,6 +49,14 @@ def test_manifest_system_prompt_field() -> None:
     assert manifest.model_dump(exclude_none=True)["systemPrompt"].startswith("Be terse")
 
 
+def test_manifest_starter_prompts_round_trip() -> None:
+    manifest = PluginManifest.model_validate(
+        {"name": "demo", "starterPrompts": ["Show open issues", "Summarize activity"]}
+    )
+    assert manifest.starterPrompts == ["Show open issues", "Summarize activity"]
+    assert PluginManifest.model_validate({"name": "demo"}).starterPrompts is None
+
+
 def test_manifest_trigger_and_approval_policy_fields() -> None:
     """The AgentOS trigger + approval-policy authoring extensions parse (#273)."""
     manifest = PluginManifest.model_validate(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Relay (AgentOS) monorepo workspace root"
 requires-python = ">=3.13"
 dependencies = [
     "aci-protocol",
+    "agentos-channel-protocol",
     "plugin-format",
     "agentos-api",
     "agentos-dispatcher",
@@ -18,6 +19,7 @@ package = false
 [tool.uv.workspace]
 members = [
     "packages/aci-protocol",
+    "packages/channel-protocol",
     "packages/plugin-format",
     "apps/api",
     "apps/dispatcher",
@@ -27,6 +29,7 @@ members = [
 
 [tool.uv.sources]
 aci-protocol = { workspace = true }
+agentos-channel-protocol = { workspace = true }
 plugin-format = { workspace = true }
 agentos-api = { workspace = true }
 agentos-dispatcher = { workspace = true }
@@ -47,6 +50,7 @@ dev = [
 addopts = "--import-mode=importlib"
 testpaths = [
     "packages/aci-protocol/tests",
+    "packages/channel-protocol/tests",
     "packages/plugin-format/tests",
     "apps/api/tests",
     "apps/dispatcher/tests",
@@ -71,6 +75,7 @@ namespace_packages = true
 explicit_package_bases = true
 mypy_path = [
     "packages/aci-protocol/src",
+    "packages/channel-protocol/src",
     "packages/plugin-format/src",
     "apps/api/src",
     "apps/dispatcher/src",
@@ -79,6 +84,7 @@ mypy_path = [
 ]
 files = [
     "packages/aci-protocol/src",
+    "packages/channel-protocol/src",
     "packages/plugin-format/src",
     "apps/api/src",
     "apps/dispatcher/src",

--- a/scripts/check-contracts.sh
+++ b/scripts/check-contracts.sh
@@ -10,6 +10,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 aci_schema="packages/aci-protocol/schema/aci-protocol.schema.json"
+channel_schema="packages/channel-protocol/schema/channel-protocol.schema.json"
 plugin_schema="packages/plugin-format/schema/plugin-format.schema.json"
 eval_schema="apps/worker/schema/eval-cases.schema.json"
 ts_out="packages/aci-protocol/generated/ts/aci-protocol.ts"
@@ -17,6 +18,7 @@ rust_crate="packages/aci-protocol/generated/rust"
 
 echo "== regenerating JSON Schemas =="
 uv run python -m aci_protocol.schema_export
+uv run python -m channel_protocol.schema_export
 uv run python -m plugin_format.schema_export
 uv run python -m agentos_worker.eval.schema_export
 
@@ -35,7 +37,7 @@ npx --yes -p typescript@5 tsc --noEmit -p packages/aci-protocol/generated/ts/tsc
 
 echo "== checking for drift =="
 if ! git diff --exit-code -- \
-  "$aci_schema" "$plugin_schema" "$eval_schema" "$ts_out" "$rust_crate/src/lib.rs"; then
+  "$aci_schema" "$channel_schema" "$plugin_schema" "$eval_schema" "$ts_out" "$rust_crate/src/lib.rs"; then
   echo "ERROR: committed contract artifacts drifted from the models." >&2
   echo "The files above were regenerated and differ. Review, then commit them." >&2
   exit 1

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ resolution-markers = [
 members = [
     "aci-protocol",
     "agentos-api",
+    "agentos-channel-protocol",
     "agentos-dispatcher",
     "agentos-runner",
     "agentos-worker",
@@ -71,6 +72,17 @@ requires-dist = [
 ]
 
 [[package]]
+name = "agentos-channel-protocol"
+version = "0.1.0"
+source = { editable = "packages/channel-protocol" }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pydantic", specifier = ">=2.9" }]
+
+[[package]]
 name = "agentos-dispatcher"
 version = "0.0.0"
 source = { editable = "apps/dispatcher" }
@@ -120,6 +132,7 @@ version = "0.0.0"
 source = { editable = "apps/worker" }
 dependencies = [
     { name = "aci-protocol" },
+    { name = "agentos-channel-protocol" },
     { name = "agentos-dispatcher" },
     { name = "aiohttp" },
     { name = "asyncpg" },
@@ -136,6 +149,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aci-protocol", editable = "packages/aci-protocol" },
+    { name = "agentos-channel-protocol", editable = "packages/channel-protocol" },
     { name = "agentos-dispatcher", editable = "apps/dispatcher" },
     { name = "aiohttp", specifier = ">=3.11" },
     { name = "asyncpg", specifier = ">=0.30" },
@@ -156,6 +170,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aci-protocol" },
     { name = "agentos-api" },
+    { name = "agentos-channel-protocol" },
     { name = "agentos-dispatcher" },
     { name = "agentos-runner" },
     { name = "agentos-worker" },
@@ -176,6 +191,7 @@ dev = [
 requires-dist = [
     { name = "aci-protocol", editable = "packages/aci-protocol" },
     { name = "agentos-api", editable = "apps/api" },
+    { name = "agentos-channel-protocol", editable = "packages/channel-protocol" },
     { name = "agentos-dispatcher", editable = "apps/dispatcher" },
     { name = "agentos-runner", editable = "runner" },
     { name = "agentos-worker", editable = "apps/worker" },


### PR DESCRIPTION
## Summary
- add a guided `examples` target to the AgentOS terminal UI
- guide the `examples/github-issues` authenticated MCP e2e from inside `agentos`
- add `agentos secrets set/list/unset` backed by the OS credential store with hidden input
- let `skill up` load saved model credentials and `--secret` values from the credential store without putting values in argv
- add a `secrets` target to the TUI and prompt for missing MCP auth credentials during the guided flow
- document the guided workflow and local secret storage in the CLI README

## Test
- `cargo test --manifest-path cli/Cargo.toml --lib`
- `cargo test --manifest-path cli/Cargo.toml --test command_surface`
- `cargo test --manifest-path cli/Cargo.toml --bin agentos secrets_subcommands_parse`
- `cargo test --manifest-path cli/Cargo.toml --test chat_enqueue` (rerun after shared Valkey group flake)
- `cargo test --manifest-path cli/Cargo.toml`
