### PR TITLE
Add durable Approval record and awaiting-approval suspend/resume lifecycle

### DIFF
--- a/apps/api/alembic/versions/0008_approvals.py
+++ b/apps/api/alembic/versions/0008_approvals.py
@@ -1,0 +1,64 @@
+"""add approvals (durable human-approval records, #244 / ADR-0010)
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-07-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "agentos"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "approvals",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("conversation_id", sa.String(), nullable=False),
+        sa.Column("author", sa.String(), nullable=False),
+        sa.Column("summary", sa.String(), nullable=False),
+        sa.Column("reply_channel", sa.String(), nullable=False),
+        sa.Column("reply_placeholder", sa.String(), nullable=False),
+        sa.Column("reply_endpoint", sa.String(), nullable=True),
+        sa.Column("dedupe_key", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.Column("resolved_by", sa.String(), nullable=True),
+        sa.Column("resolution_note", sa.String(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column("resolved_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"
+        ),
+        sa.UniqueConstraint("dedupe_key", name="uq_approvals_dedupe_key"),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "ix_approvals_agent_id", "approvals", ["agent_id"], schema=SCHEMA
+    )
+    op.create_index(
+        "ix_approvals_conversation_id",
+        "approvals",
+        ["conversation_id"],
+        schema=SCHEMA,
+    )
+    op.create_index("ix_approvals_status", "approvals", ["status"], schema=SCHEMA)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_approvals_status", "approvals", schema=SCHEMA)
+    op.drop_index("ix_approvals_conversation_id", "approvals", schema=SCHEMA)
+    op.drop_index("ix_approvals_agent_id", "approvals", schema=SCHEMA)
+    op.drop_table("approvals", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -161,6 +161,251 @@
         "title": "AppConfig",
         "type": "object"
       },
+      "ApprovalCreate": {
+        "description": "A durable approval request (#244), created by the worker when a run ends\nawaiting-approval. ``dedupe_key`` is the triggering event id, so a\nredelivered turn adopts the existing record instead of forking a second one.",
+        "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "author": {
+            "minLength": 1,
+            "title": "Author",
+            "type": "string"
+          },
+          "conversation_id": {
+            "minLength": 1,
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "dedupe_key": {
+            "minLength": 1,
+            "title": "Dedupe Key",
+            "type": "string"
+          },
+          "expires_in_seconds": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires In Seconds"
+          },
+          "reply_channel": {
+            "minLength": 1,
+            "title": "Reply Channel",
+            "type": "string"
+          },
+          "reply_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reply Endpoint"
+          },
+          "reply_placeholder": {
+            "minLength": 1,
+            "title": "Reply Placeholder",
+            "type": "string"
+          },
+          "summary": {
+            "minLength": 1,
+            "title": "Summary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "conversation_id",
+          "author",
+          "summary",
+          "reply_channel",
+          "reply_placeholder",
+          "dedupe_key"
+        ],
+        "title": "ApprovalCreate",
+        "type": "object"
+      },
+      "ApprovalOut": {
+        "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "author": {
+            "title": "Author",
+            "type": "string"
+          },
+          "conversation_id": {
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "dedupe_key": {
+            "title": "Dedupe Key",
+            "type": "string"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "reply_channel": {
+            "title": "Reply Channel",
+            "type": "string"
+          },
+          "reply_endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reply Endpoint"
+          },
+          "reply_placeholder": {
+            "title": "Reply Placeholder",
+            "type": "string"
+          },
+          "resolution_note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolution Note"
+          },
+          "resolved_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved At"
+          },
+          "resolved_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved By"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "agent_id",
+          "conversation_id",
+          "author",
+          "summary",
+          "reply_channel",
+          "reply_placeholder",
+          "reply_endpoint",
+          "dedupe_key",
+          "status",
+          "expires_at",
+          "resolved_by",
+          "resolution_note",
+          "created_at",
+          "resolved_at"
+        ],
+        "title": "ApprovalOut",
+        "type": "object"
+      },
+      "ApprovalResolve": {
+        "description": "One resolution attempt. Exactly one attempt wins (compare-and-set);\nthe identity here is caller-asserted for now -- the server-side authorizer\n(channel membership, self-approval block) lands with #246.",
+        "properties": {
+          "decision": {
+            "enum": [
+              "approved",
+              "rejected"
+            ],
+            "title": "Decision",
+            "type": "string"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "resolved_by": {
+            "minLength": 1,
+            "title": "Resolved By",
+            "type": "string"
+          }
+        },
+        "required": [
+          "decision",
+          "resolved_by"
+        ],
+        "title": "ApprovalResolve",
+        "type": "object"
+      },
       "BehaviorPacksConfig": {
         "description": "An agent's opt-in behavior packs. Validated on write and stored as JSON on\nthe agent row; the worker parses the same JSON at bind time.",
         "properties": {
@@ -3568,6 +3813,305 @@
         "summary": "Read Version Files",
         "tags": [
           "agents"
+        ]
+      }
+    },
+    "/approvals": {
+      "get": {
+        "operationId": "list_approvals_approvals_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status_filter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status Filter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "conversation_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ApprovalOut"
+                  },
+                  "title": "Response List Approvals Approvals Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Approvals",
+        "tags": [
+          "approvals"
+        ]
+      },
+      "post": {
+        "description": "Create a pending approval; idempotent on ``dedupe_key``.\n\nA redelivered worker turn that re-requests the same approval gets the\nexisting record back (200) instead of forking a second pending record for\none human decision.",
+        "operationId": "create_approval_approvals_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Approval",
+        "tags": [
+          "approvals"
+        ]
+      }
+    },
+    "/approvals/{approval_id}": {
+      "get": {
+        "operationId": "get_approval_approvals__approval_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "approval_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Approval Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Approval",
+        "tags": [
+          "approvals"
+        ]
+      }
+    },
+    "/approvals/{approval_id}/resolve": {
+      "post": {
+        "description": "Claim the resolution (resolve-once) and wake the suspended session.\n\nExactly one resolver wins the conditional UPDATE; a loser gets 409 naming\nwho resolved it, and a past-SLA record flips to expired and returns 410.\nThe winner's response is sent only after the resume turn is enqueued.",
+        "operationId": "resolve_approval_approvals__approval_id__resolve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "approval_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Approval Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalResolve"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Resolve Approval",
+        "tags": [
+          "approvals"
         ]
       }
     },

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "kubernetes>=31",
     "redis>=5.0",
     "plugin-format",
+    "aci-protocol",
 ]
 
 [build-system]

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -77,6 +77,10 @@ class Settings(BaseSettings):
     valkey_port: int = 26379
     valkey_url: str | None = None
 
+    # The runs stream approval resolutions enqueue resume turns onto (#244).
+    # Must match the worker's AGENTOS_STREAM (its consumer side).
+    runs_stream: str = "agentos:runs"
+
     # Observability (OB1). kube_config_path points the runner-logs proxy at a
     # cluster; when unset the API tries in-cluster config, and if neither is
     # available the logs endpoint degrades to 503 rather than crashing.

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -1,13 +1,14 @@
-"""Database access helpers for agents, versions, and deployments."""
+"""Database access helpers for agents, versions, deployments, and approvals."""
 
 import uuid
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import Agent, AgentVersion, Deployment, Environment
-from .schemas import AgentCreate, DeploymentCreate, VersionCreate
+from .models import Agent, AgentVersion, Approval, ApprovalStatus, Deployment, Environment
+from .schemas import AgentCreate, ApprovalCreate, DeploymentCreate, VersionCreate
 
 
 async def get_version(
@@ -258,3 +259,121 @@ async def get_deployment(
     session: AsyncSession, deployment_id: uuid.UUID
 ) -> Deployment | None:
     return await session.get(Deployment, deployment_id)
+
+
+# -- approvals (#244, ADR-0010) -------------------------------------------------
+
+
+async def create_approval(session: AsyncSession, data: "ApprovalCreate") -> Approval:
+    """Insert a pending approval. Raises IntegrityError on a dedupe_key replay;
+    the router maps that to the existing record (idempotent creation)."""
+
+    expires_at = None
+    if data.expires_in_seconds is not None:
+        # Naive UTC, matching the DateTime columns (server_default func.now()
+        # stores naive timestamps in the session timezone, UTC in this stack).
+        expires_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(
+            seconds=data.expires_in_seconds
+        )
+    approval = Approval(
+        agent_id=data.agent_id,
+        conversation_id=data.conversation_id,
+        author=data.author,
+        summary=data.summary,
+        reply_channel=data.reply_channel,
+        reply_placeholder=data.reply_placeholder,
+        reply_endpoint=data.reply_endpoint,
+        dedupe_key=data.dedupe_key,
+        expires_at=expires_at,
+    )
+    session.add(approval)
+    await session.commit()
+    await session.refresh(approval)
+    return approval
+
+
+async def get_approval(session: AsyncSession, approval_id: uuid.UUID) -> Approval | None:
+    return await session.get(Approval, approval_id)
+
+
+async def get_approval_by_dedupe_key(
+    session: AsyncSession, dedupe_key: str
+) -> Approval | None:
+    result: Approval | None = await session.scalar(
+        select(Approval).where(Approval.dedupe_key == dedupe_key)
+    )
+    return result
+
+
+async def list_approvals(
+    session: AsyncSession,
+    *,
+    status: str | None = None,
+    agent_id: uuid.UUID | None = None,
+    conversation_id: str | None = None,
+    limit: int = 50,
+) -> list[Approval]:
+    stmt = select(Approval).order_by(Approval.created_at.desc()).limit(limit)
+    if status is not None:
+        stmt = stmt.where(Approval.status == status)
+    if agent_id is not None:
+        stmt = stmt.where(Approval.agent_id == agent_id)
+    if conversation_id is not None:
+        stmt = stmt.where(Approval.conversation_id == conversation_id)
+    result = await session.scalars(stmt)
+    return list(result)
+
+
+async def claim_approval_resolution(
+    session: AsyncSession,
+    approval_id: uuid.UUID,
+    *,
+    decision: str,
+    resolved_by: str,
+    note: str | None,
+) -> Approval | None:
+    """The resolve-once compare-and-set: exactly one resolver wins.
+
+    A conditional UPDATE guarded on ``status = 'pending'`` claims the record;
+    concurrent attempts see zero rows updated and get None back (the router
+    tells them who won). This is the claim-race primitive of ADR-0010.
+    """
+
+    result = await session.execute(
+        update(Approval)
+        .where(Approval.id == approval_id, Approval.status == ApprovalStatus.pending)
+        .values(
+            status=decision,
+            resolved_by=resolved_by,
+            resolution_note=note,
+            resolved_at=func.now(),
+        )
+        .returning(Approval.id)
+    )
+    claimed = result.scalar_one_or_none()
+    await session.commit()
+    if claimed is None:
+        return None
+    approval = await session.get(Approval, approval_id)
+    if approval is not None:
+        await session.refresh(approval)
+    return approval
+
+
+async def expire_approval(
+    session: AsyncSession, approval_id: uuid.UUID
+) -> Approval | None:
+    """Flip a pending approval past its SLA to expired (same CAS guard, so an
+    in-flight resolution that already won is never overwritten)."""
+
+    result = await session.execute(
+        update(Approval)
+        .where(Approval.id == approval_id, Approval.status == ApprovalStatus.pending)
+        .values(status=ApprovalStatus.expired, resolved_at=func.now())
+        .returning(Approval.id)
+    )
+    claimed = result.scalar_one_or_none()
+    await session.commit()
+    if claimed is None:
+        return None
+    return await session.get(Approval, approval_id)

--- a/apps/api/src/agentos_api/deps.py
+++ b/apps/api/src/agentos_api/deps.py
@@ -11,6 +11,7 @@ from .github_checks import GitHubStatusReporter
 from .k8s import PodLister, PodLogReader
 from .killswitch import KillSwitch
 from .langfuse import LangfuseClient
+from .resumequeue import ResumeQueue
 from .storage import ObjectStore
 
 
@@ -55,6 +56,11 @@ def get_github_reporter(request: Request) -> GitHubStatusReporter:
     return reporter
 
 
+def get_resume_queue(request: Request) -> ResumeQueue:
+    resume_queue: ResumeQueue = request.app.state.resume_queue
+    return resume_queue
+
+
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 LangfuseDep = Annotated[LangfuseClient, Depends(get_langfuse)]
 StoreDep = Annotated[ObjectStore, Depends(get_store)]
@@ -63,3 +69,4 @@ PodListerDep = Annotated[PodLister, Depends(get_pod_lister)]
 KillSwitchDep = Annotated[KillSwitch, Depends(get_kill_switch)]
 EvalQueueDep = Annotated[EvalQueue, Depends(get_eval_queue)]
 GitHubReporterDep = Annotated[GitHubStatusReporter, Depends(get_github_reporter)]
+ResumeQueueDep = Annotated[ResumeQueue, Depends(get_resume_queue)]

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -18,8 +18,10 @@ from .github_checks import GitHubStatusReporter
 from .k8s import build_lazy_pod_lister, build_lazy_pod_log_reader
 from .killswitch import KillSwitch
 from .langfuse import LangfuseClient
+from .resumequeue import ResumeQueue
 from .routers import (
     agents,
+    approvals,
     bundles,
     config,
     control,
@@ -55,6 +57,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.valkey = valkey
     app.state.kill_switch = KillSwitch(valkey)
     app.state.eval_queue = EvalQueue(valkey)
+    app.state.resume_queue = ResumeQueue(valkey, stream=settings.runs_stream)
     app.state.github_reporter = GitHubStatusReporter(
         http_client,
         api_url=settings.github_api_url,
@@ -87,6 +90,7 @@ def create_app() -> FastAPI:
     app.include_router(runs.router)
     app.include_router(state.router)
     app.include_router(memory.router)
+    app.include_router(approvals.router)
     return app
 
 

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -22,6 +22,17 @@ class Environment(enum.StrEnum):
     dev = "dev"
 
 
+class ApprovalStatus(enum.StrEnum):
+    """Lifecycle of a durable approval (ADR-0010). Stored as a plain string
+    column (like ``Deployment.status``) so the resolve-once compare-and-set is
+    a conditional UPDATE on the value, with these constants as the vocabulary."""
+
+    pending = "pending"
+    approved = "approved"
+    rejected = "rejected"
+    expired = "expired"
+
+
 class Agent(Base):
     __tablename__ = "agents"
 
@@ -102,6 +113,59 @@ class Deployment(Base):
     commit_sha: Mapped[str | None] = mapped_column(default=None)
     status: Mapped[str] = mapped_column(server_default="active")
     deployed_at: Mapped[datetime] = mapped_column(server_default=func.now())
+
+
+class Approval(Base):
+    """A durable human-approval request (#244, ADR-0010).
+
+    Created by the worker when a run ends ``awaiting-approval``; the session is
+    suspended while this row is pending, so the record must carry everything a
+    later resume needs (the conversation key and the reply handle) -- the pause
+    survives full component restarts because nothing lives in memory.
+
+    Resolve-once claim semantics: resolution is a conditional UPDATE guarded on
+    ``status = 'pending'`` (compare-and-set), so exactly one resolver wins and
+    losers are told who resolved it. ``dedupe_key`` (the triggering event id)
+    makes record creation idempotent under the worker's at-least-once redelivery.
+    """
+
+    __tablename__ = "approvals"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    # Nullable: a run without a deployment binding (the generic/dev path) can
+    # still gate on a human decision.
+    agent_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE"),
+        index=True,
+        default=None,
+    )
+    # The thread key routing keeps one live session per (the worker's
+    # conversation_id); the resume turn is enqueued back onto it.
+    conversation_id: Mapped[str] = mapped_column(index=True)
+    # Who authored the turn that raised the request. #246 blocks self-approval
+    # against this field; recorded now so existing rows carry it.
+    author: Mapped[str]
+    # The human-readable statement of what needs approval, from the run's
+    # approval request (the ACI final's approval_summary).
+    summary: Mapped[str]
+    # The reply handle of the requesting turn, replayed onto the resume turn so
+    # the resumed run streams into the same placeholder message.
+    reply_channel: Mapped[str]
+    reply_placeholder: Mapped[str]
+    reply_endpoint: Mapped[str | None] = mapped_column(default=None)
+    # Idempotency: the triggering event id. A reclaimed/redelivered turn that
+    # re-requests the same approval adopts the existing row instead of forking.
+    dedupe_key: Mapped[str] = mapped_column(unique=True)
+    status: Mapped[str] = mapped_column(server_default=ApprovalStatus.pending, index=True)
+    # Optional SLA: past this instant the record can no longer be approved or
+    # rejected; a resolve attempt flips it to expired instead.
+    expires_at: Mapped[datetime | None] = mapped_column(default=None)
+    resolved_by: Mapped[str | None] = mapped_column(default=None)
+    resolution_note: Mapped[str | None] = mapped_column(default=None)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    resolved_at: Mapped[datetime | None] = mapped_column(default=None)
 
 
 class WorkflowStateEntry(Base):

--- a/apps/api/src/agentos_api/resumequeue.py
+++ b/apps/api/src/agentos_api/resumequeue.py
@@ -1,0 +1,73 @@
+"""Approval-resolution fan-out: enqueue the resume turn onto the runs stream.
+
+Resolving a pending approval (#244, ADR-0010) must wake the suspended session.
+Rather than a bespoke resume channel, the API appends a normal ``QueuedTurn``
+onto the same ``agentos:runs`` stream the dispatcher feeds, so the resume walks
+the identical consumer -> kernel -> claim path a Slack mention takes: the kernel
+finds the thread's route suspended and rehydrates it (ADR-0003), and the
+platform-authored resolution text becomes the turn that continues the run.
+
+Wire encoding mirrors the dispatcher's seam exactly (a single ``payload`` field
+holding the model's JSON). The turn's ``event_id`` is deterministic per
+approval, so the worker's done-marker dedupes any double-enqueue.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import redis.asyncio as redis
+from aci_protocol import QueuedTurn, ReplyHandle
+
+from .models import Approval
+
+RUNS_STREAM = "agentos:runs"
+STREAM_PAYLOAD_FIELD = "payload"
+
+
+def resume_event_id(approval_id: object) -> str:
+    """The deterministic idempotency key of an approval's resume turn."""
+
+    return f"approval-{approval_id}-resolved"
+
+
+def build_resume_turn(approval: Approval) -> QueuedTurn:
+    """The turn that continues a suspended session with the human decision.
+
+    The text is platform-authored (not user input): it tells the model what was
+    decided, by whom, and to carry on accordingly. The reply handle replays the
+    requesting turn's placeholder so the resumed run streams into the same
+    message the "awaiting approval" notice was left on.
+    """
+
+    decision = approval.status
+    note = f" Note: {approval.resolution_note}." if approval.resolution_note else ""
+    text = (
+        f"[approval resolved] The request \"{approval.summary}\" was {decision} "
+        f"by {approval.resolved_by}.{note} Continue the task accordingly: proceed "
+        "with the approved action, or acknowledge the rejection and stop."
+    )
+    return QueuedTurn(
+        event_id=resume_event_id(approval.id),
+        conversation_id=approval.conversation_id,
+        author=approval.resolved_by or "approver",
+        text=text,
+        reply_handle=ReplyHandle(
+            channel=approval.reply_channel,
+            placeholder=approval.reply_placeholder,
+            endpoint=approval.reply_endpoint,
+        ),
+        received_at=datetime.now(UTC).isoformat(),
+    )
+
+
+class ResumeQueue:
+    """Producer half of the resume seam (the worker's runs consumer is the other)."""
+
+    def __init__(self, client: redis.Redis, stream: str = RUNS_STREAM) -> None:
+        self._client = client
+        self._stream = stream
+
+    async def enqueue(self, turn: QueuedTurn) -> str:
+        fields: dict[Any, Any] = {STREAM_PAYLOAD_FIELD: turn.model_dump_json()}
+        stream_id = await self._client.xadd(self._stream, fields)
+        return stream_id.decode() if isinstance(stream_id, bytes) else str(stream_id)

--- a/apps/api/src/agentos_api/routers/approvals.py
+++ b/apps/api/src/agentos_api/routers/approvals.py
@@ -1,0 +1,159 @@
+"""Durable approvals: create, inspect, and resolve-once (#244, ADR-0010).
+
+The worker creates a record when a run ends awaiting-approval and suspends the
+session; resolving the record enqueues the resume turn back onto the runs
+stream, so the whole pause/resume survives every component restarting. The
+resolve endpoint owns the claim race: a conditional UPDATE picks exactly one
+winner, losers get 409 with who resolved it, and a past-SLA record flips to
+expired (410) instead of resolving.
+
+Authorization today is the shared API key, like every router. WHO may resolve
+(channel membership, self-approval block) is the server-side authorizer of
+#246 and slots in at this endpoint -- the decision point is deliberately here,
+on the server that owns the record, never inside the sandbox.
+"""
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+
+from .. import crud
+from ..auth import require_api_key
+from ..deps import ResumeQueueDep, SessionDep
+from ..models import Approval, ApprovalStatus
+from ..resumequeue import build_resume_turn
+from ..schemas import ApprovalCreate, ApprovalOut, ApprovalResolve
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/approvals", tags=["approvals"], dependencies=[Depends(require_api_key)]
+)
+
+
+def _expired(approval: Approval) -> bool:
+    """True when a pending record's SLA has passed (naive-UTC comparison,
+    matching the DateTime columns)."""
+
+    return (
+        approval.expires_at is not None
+        and approval.expires_at <= datetime.now(UTC).replace(tzinfo=None)
+    )
+
+
+@router.post("", response_model=ApprovalOut, status_code=status.HTTP_201_CREATED)
+async def create_approval(
+    data: ApprovalCreate, session: SessionDep, response: Response
+) -> ApprovalOut:
+    """Create a pending approval; idempotent on ``dedupe_key``.
+
+    A redelivered worker turn that re-requests the same approval gets the
+    existing record back (200) instead of forking a second pending record for
+    one human decision.
+    """
+
+    try:
+        approval = await crud.create_approval(session, data)
+    except IntegrityError as exc:
+        await session.rollback()
+        existing = await crud.get_approval_by_dedupe_key(session, data.dedupe_key)
+        if existing is None:  # raced with a delete; surface the conflict as-is
+            raise HTTPException(
+                status.HTTP_409_CONFLICT, "approval violates a uniqueness constraint"
+            ) from exc
+        response.status_code = status.HTTP_200_OK
+        return ApprovalOut.model_validate(existing)
+    return ApprovalOut.model_validate(approval)
+
+
+@router.get("", response_model=list[ApprovalOut])
+async def list_approvals(
+    session: SessionDep,
+    status_filter: str | None = None,
+    agent_id: uuid.UUID | None = None,
+    conversation_id: str | None = None,
+    limit: int = 50,
+) -> list[ApprovalOut]:
+    approvals = await crud.list_approvals(
+        session,
+        status=status_filter,
+        agent_id=agent_id,
+        conversation_id=conversation_id,
+        limit=min(max(limit, 1), 200),
+    )
+    return [ApprovalOut.model_validate(a) for a in approvals]
+
+
+@router.get("/{approval_id}", response_model=ApprovalOut)
+async def get_approval(approval_id: uuid.UUID, session: SessionDep) -> ApprovalOut:
+    approval = await crud.get_approval(session, approval_id)
+    if approval is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+    return ApprovalOut.model_validate(approval)
+
+
+@router.post("/{approval_id}/resolve", response_model=ApprovalOut)
+async def resolve_approval(
+    approval_id: uuid.UUID,
+    data: ApprovalResolve,
+    session: SessionDep,
+    resume_queue: ResumeQueueDep,
+) -> ApprovalOut:
+    """Claim the resolution (resolve-once) and wake the suspended session.
+
+    Exactly one resolver wins the conditional UPDATE; a loser gets 409 naming
+    who resolved it, and a past-SLA record flips to expired and returns 410.
+    The winner's response is sent only after the resume turn is enqueued.
+    """
+
+    approval = await crud.get_approval(session, approval_id)
+    if approval is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+
+    if approval.status == ApprovalStatus.pending and _expired(approval):
+        expired = await crud.expire_approval(session, approval_id)
+        # None means a concurrent resolution won the CAS before the expiry did;
+        # fall through to the claim below, which will lose and report the winner.
+        if expired is not None:
+            raise HTTPException(
+                status.HTTP_410_GONE,
+                f"approval expired at {expired.expires_at} and can no longer be resolved",
+            )
+
+    claimed = await crud.claim_approval_resolution(
+        session,
+        approval_id,
+        decision=data.decision,
+        resolved_by=data.resolved_by,
+        note=data.note,
+    )
+    if claimed is None:
+        current = await crud.get_approval(session, approval_id)
+        if current is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+        if current.status == ApprovalStatus.expired:
+            raise HTTPException(
+                status.HTTP_410_GONE,
+                "approval expired and can no longer be resolved",
+            )
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"already resolved by {current.resolved_by} ({current.status})",
+        )
+
+    # Wake the suspended session: the resume turn rides the normal runs stream,
+    # so the kernel's ordinary consume -> claim path rehydrates the thread
+    # (ADR-0003) and delivers the decision. The turn's event_id is deterministic
+    # per approval, so the worker's done-marker absorbs a duplicate enqueue.
+    stream_id = await resume_queue.enqueue(build_resume_turn(claimed))
+    logger.info(
+        "approval %s %s by %s; resume turn enqueued (%s)",
+        approval_id,
+        claimed.status,
+        claimed.resolved_by,
+        stream_id,
+    )
+    return ApprovalOut.model_validate(claimed)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -249,6 +249,54 @@ class DeploymentOut(BaseModel):
     deployed_at: datetime
 
 
+class ApprovalCreate(BaseModel):
+    """A durable approval request (#244), created by the worker when a run ends
+    awaiting-approval. ``dedupe_key`` is the triggering event id, so a
+    redelivered turn adopts the existing record instead of forking a second one."""
+
+    agent_id: uuid.UUID | None = None
+    conversation_id: str = Field(min_length=1)
+    author: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+    reply_channel: str = Field(min_length=1)
+    reply_placeholder: str = Field(min_length=1)
+    reply_endpoint: str | None = None
+    dedupe_key: str = Field(min_length=1)
+    # Optional SLA: seconds from creation after which the record can only
+    # expire, never be approved or rejected.
+    expires_in_seconds: int | None = Field(default=None, gt=0)
+
+
+class ApprovalResolve(BaseModel):
+    """One resolution attempt. Exactly one attempt wins (compare-and-set);
+    the identity here is caller-asserted for now -- the server-side authorizer
+    (channel membership, self-approval block) lands with #246."""
+
+    decision: Literal["approved", "rejected"]
+    resolved_by: str = Field(min_length=1)
+    note: str | None = None
+
+
+class ApprovalOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    agent_id: uuid.UUID | None
+    conversation_id: str
+    author: str
+    summary: str
+    reply_channel: str
+    reply_placeholder: str
+    reply_endpoint: str | None
+    dedupe_key: str
+    status: str
+    expires_at: datetime | None
+    resolved_by: str | None
+    resolution_note: str | None
+    created_at: datetime
+    resolved_at: datetime | None
+
+
 class WebhookResult(BaseModel):
     """The outcome of processing a GitHub webhook event."""
 

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -131,8 +131,8 @@ async def _truncate() -> None:
         async with engine.begin() as conn:
             await conn.execute(
                 text(
-                    "TRUNCATE agentos.deployments, agentos.agent_versions, "
-                    "agentos.agents CASCADE"
+                    "TRUNCATE agentos.approvals, agentos.deployments, "
+                    "agentos.agent_versions, agentos.agents CASCADE"
                 )
             )
     finally:

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -1,0 +1,229 @@
+"""Durable approvals (#244): real Postgres + real Valkey round-trip.
+
+Exercises the record lifecycle against the disposable per-run database and the
+compose Valkey: idempotent creation on dedupe_key, the resolve-once
+compare-and-set (losers get 409 naming the winner, including under genuine
+concurrency), SLA expiry (410), and the resume turn enqueued onto a
+test-isolated runs stream as a valid frozen-contract QueuedTurn.
+"""
+
+import json
+import os
+import time
+import uuid
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+import redis
+from aci_protocol import QueuedTurn
+from agentos_api.config import get_settings
+from agentos_api.main import create_app
+from fastapi.testclient import TestClient
+
+_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
+_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
+_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
+
+
+@pytest.fixture
+def runs_stream() -> Iterator[str]:
+    """A per-test runs stream, so resolutions never feed the shared compose
+    worker's real ``agentos:runs`` consumer group."""
+
+    name = f"test:agentos:runs:{uuid.uuid4().hex}"
+    os.environ["RUNS_STREAM"] = name
+    get_settings.cache_clear()
+    yield name
+    os.environ.pop("RUNS_STREAM", None)
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def approvals_client(_disposable_db: Any, runs_stream: str) -> Iterator[TestClient]:
+    """A TestClient whose app was built after the stream override, so its
+    ResumeQueue targets the isolated stream."""
+
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def valkey(runs_stream: str) -> Iterator[redis.Redis]:
+    client = redis.Redis(
+        host=_VALKEY_HOST,
+        port=_VALKEY_PORT,
+        password=_VALKEY_PW or None,
+        decode_responses=True,
+    )
+    try:
+        client.ping()
+    except redis.exceptions.RedisError as exc:
+        pytest.skip(f"Valkey not reachable: {exc}")
+    yield client
+    client.delete(runs_stream)
+    client.close()
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "conversation_id": f"th-{uuid.uuid4().hex[:8]}",
+        "author": "U1",
+        "summary": "Give ACME a 20% discount",
+        "reply_channel": "C1",
+        "reply_placeholder": "p-1",
+        "dedupe_key": uuid.uuid4().hex,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_create_get_list_round_trip(
+    approvals_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    payload = _payload()
+    created = approvals_client.post("/approvals", json=payload, headers=auth_headers)
+    assert created.status_code == 201, created.text
+    body = created.json()
+    assert body["status"] == "pending"
+    assert body["summary"] == payload["summary"]
+    assert body["resolved_by"] is None
+
+    got = approvals_client.get(f"/approvals/{body['id']}", headers=auth_headers)
+    assert got.status_code == 200
+    assert got.json() == body
+
+    listed = approvals_client.get(
+        "/approvals",
+        params={"status_filter": "pending", "conversation_id": payload["conversation_id"]},
+        headers=auth_headers,
+    )
+    assert [a["id"] for a in listed.json()] == [body["id"]]
+
+
+def test_create_is_idempotent_on_dedupe_key(
+    approvals_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    payload = _payload()
+    first = approvals_client.post("/approvals", json=payload, headers=auth_headers)
+    assert first.status_code == 201
+    replay = approvals_client.post("/approvals", json=payload, headers=auth_headers)
+    assert replay.status_code == 200
+    assert replay.json()["id"] == first.json()["id"]
+
+
+def test_resolve_once_and_enqueue_resume_turn(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    payload = _payload(reply_endpoint="http://localhost:9999/api/")
+    created = approvals_client.post("/approvals", json=payload, headers=auth_headers).json()
+
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved", "resolved_by": "U9", "note": "ship it"},
+        headers=auth_headers,
+    )
+    assert resolved.status_code == 200, resolved.text
+    body = resolved.json()
+    assert body["status"] == "approved"
+    assert body["resolved_by"] == "U9"
+    assert body["resolved_at"] is not None
+
+    # The resume turn landed on the isolated runs stream as a valid frozen
+    # QueuedTurn, addressed back to the requesting thread and placeholder.
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{created['id']}-resolved"
+    assert turn.conversation_id == payload["conversation_id"]
+    assert turn.author == "U9"
+    assert turn.reply_handle.channel == "C1"
+    assert turn.reply_handle.placeholder == "p-1"
+    assert turn.reply_handle.endpoint == "http://localhost:9999/api/"
+    assert "approved by U9" in turn.text
+    assert "ship it" in turn.text
+
+    # The loser of the claim race is told who resolved it.
+    second = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "rejected", "resolved_by": "U2"},
+        headers=auth_headers,
+    )
+    assert second.status_code == 409
+    assert "already resolved by U9" in second.json()["detail"]
+    # And no second resume turn was enqueued.
+    assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_concurrent_resolvers_yield_exactly_one_winner(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals", json=_payload(), headers=auth_headers
+    ).json()
+
+    def attempt(actor: str) -> int:
+        response = approvals_client.post(
+            f"/approvals/{created['id']}/resolve",
+            json={"decision": "approved", "resolved_by": actor},
+            headers=auth_headers,
+        )
+        return response.status_code
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        codes = list(pool.map(attempt, [f"U{i}" for i in range(4)]))
+
+    assert sorted(codes) == [200, 409, 409, 409]
+    assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_expired_approval_cannot_be_resolved(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals", json=_payload(expires_in_seconds=1), headers=auth_headers
+    ).json()
+    assert created["expires_at"] is not None
+    time.sleep(1.1)
+
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved", "resolved_by": "U9"},
+        headers=auth_headers,
+    )
+    assert resolved.status_code == 410
+    got = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert got.json()["status"] == "expired"
+    # No resume turn for an expired record.
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_unknown_approval_is_404(
+    approvals_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    missing = approvals_client.post(
+        f"/approvals/{uuid.uuid4()}/resolve",
+        json={"decision": "approved", "resolved_by": "U9"},
+        headers=auth_headers,
+    )
+    assert missing.status_code == 404
+
+
+def test_requires_api_key(
+    approvals_client: TestClient, clean_db: None
+) -> None:
+    denied = approvals_client.post("/approvals", json=_payload())
+    assert denied.status_code in (401, 403)

--- a/apps/worker/src/agentos_worker/approvals.py
+++ b/apps/worker/src/agentos_worker/approvals.py
@@ -1,0 +1,82 @@
+"""The worker's approval-record client (#244, ADR-0010).
+
+When a run ends ``awaiting-approval`` the kernel persists a durable ``Approval``
+record before suspending the session, so the pending human decision survives
+every component restarting. The record lives server-side with the API (the
+authorizer of #246 is enforced there, where it cannot be spoofed from inside a
+sandbox); this module is the thin write client, mirroring the eval lane's
+``EvalReporter`` (same base URL + shared API key).
+
+Creation is idempotent: ``dedupe_key`` carries the triggering event id, so a
+reclaimed/redelivered turn that re-requests the same approval adopts the
+existing record (the API answers 200 instead of 201) rather than forking a
+second pending record for one human decision.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+from uuid import UUID
+
+import httpx
+from pydantic import BaseModel
+
+
+class ApprovalRequest(BaseModel):
+    """The creation payload, matching the API's ApprovalCreate schema."""
+
+    agent_id: UUID | None = None
+    conversation_id: str
+    author: str
+    summary: str
+    reply_channel: str
+    reply_placeholder: str
+    reply_endpoint: str | None = None
+    dedupe_key: str
+    expires_in_seconds: int | None = None
+
+
+@dataclass(frozen=True)
+class CreatedApproval:
+    """What the kernel needs back: the record's identity and its status."""
+
+    id: str
+    status: str
+
+
+class ApprovalBackendError(Exception):
+    """The approval record could not be created; the kernel escalates rather
+    than suspending a session no resolution could ever wake."""
+
+
+class ApprovalCreator(Protocol):
+    """The kernel-facing seam; tests supply a recording fake."""
+
+    async def create(self, request: ApprovalRequest) -> CreatedApproval: ...
+
+
+class ApprovalClient:
+    """HTTP implementation against the platform API's /approvals endpoint."""
+
+    def __init__(self, *, api_base_url: str, api_key: str, client: httpx.AsyncClient) -> None:
+        self._url = f"{api_base_url.rstrip('/')}/approvals"
+        self._headers = {"X-API-Key": api_key} if api_key else {}
+        self._client = client
+
+    async def create(self, request: ApprovalRequest) -> CreatedApproval:
+        try:
+            response = await self._client.post(
+                self._url,
+                content=request.model_dump_json(),
+                headers={**self._headers, "Content-Type": "application/json"},
+            )
+        except httpx.HTTPError as exc:
+            raise ApprovalBackendError(f"approval create failed: {exc}") from exc
+        # 201 is a fresh record; 200 is the idempotent dedupe_key replay.
+        if response.status_code not in (200, 201):
+            raise ApprovalBackendError(
+                f"approval create failed: HTTP {response.status_code}: {response.text}"
+            )
+        body = response.json()
+        return CreatedApproval(id=str(body["id"]), status=str(body["status"]))

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -43,6 +43,7 @@ from aci_protocol import (
     ToolNote,
 )
 
+from .approvals import ApprovalBackendError, ApprovalCreator, ApprovalRequest
 from .behaviorpacks import (
     BehaviorPacks,
     NavPack,
@@ -78,6 +79,9 @@ class TurnOutcome:
     text: str = ""
     status: SessionStatus | None = None
     steered: bool = False
+    # The approval summary off an awaiting-approval final (ADR-0010), persisted
+    # onto the durable record by the pause path. None on every other status.
+    approval_summary: str | None = None
 
 
 @dataclass
@@ -108,6 +112,7 @@ class _StreamAccumulator:
     classification: str | None = None
     status: SessionStatus | None = None
     final_text: str | None = None
+    approval_summary: str | None = None
 
     def rendered(self) -> str:
         return self.final_text if self.final_text is not None else "".join(self.text_parts)
@@ -190,6 +195,7 @@ class Kernel:
         config: WorkerConfig,
         binding: BindingResolver | None = None,
         killswitch: KillSwitch | None = None,
+        approvals: ApprovalCreator | None = None,
     ) -> None:
         self._substrate = substrate
         self._runner = runner
@@ -202,6 +208,10 @@ class Kernel:
         # it resolves channel -> agent -> bundle/budget and gates killed agents.
         self._binding = binding
         self._killswitch = killswitch
+        # The approval-record backend (#244). When absent (unwired tests, a
+        # deployment without the API), an awaiting-approval run degrades to an
+        # escalation instead of suspending a session nothing could ever resume.
+        self._approvals = approvals
         # Which threads are running which agent, so a kill interrupts the agent's
         # live turns. Populated while a turn owner streams.
         self._active_by_agent: dict[uuid.UUID, set[str]] = {}
@@ -295,6 +305,14 @@ class Kernel:
                 outcome = await self._attempt(
                     qevent, release_order, boot_env, agent_id, nav, packs
                 )
+
+                if outcome.status is SessionStatus.AWAITING_APPROVAL:
+                    # A gate fired (ADR-0010): persist the durable record, then
+                    # suspend the session until a human resolves it. The event
+                    # is done -- the resolution arrives as its own queued turn.
+                    await self._pause_for_approval(qevent, outcome, agent_id)
+                    await self._markers.mark_done(event_id)
+                    return
 
                 if outcome.terminal_ok:
                     await self._markers.mark_done(event_id)
@@ -559,7 +577,80 @@ class Kernel:
         try:
             return await asyncio.to_thread(self._substrate.claim, thread, env=boot_env)
         except SuspendedThreadError:
-            return await asyncio.to_thread(self._substrate.resume, thread)
+            # Resume with the same bound boot env a fresh claim gets (bundle
+            # ref, budget, refs): a suspended pod was deleted (ADR-0003), so
+            # the replacement boots from env alone; without this it would come
+            # up generic, without the agent's bundle.
+            return await asyncio.to_thread(self._substrate.resume, thread, env=boot_env)
+
+    async def _pause_for_approval(
+        self, qevent: QueuedTurn, outcome: TurnOutcome, agent_id: uuid.UUID | None
+    ) -> None:
+        """Persist the approval, suspend the session, and leave the pending notice.
+
+        Ordering is deliberate: the durable record exists before the sandbox is
+        suspended, so there is never a suspended session without a record that
+        can wake it. The converse crash (record created, suspend or notice
+        lost) self-heals -- creation is idempotent on the event id, and the
+        resume path cold-claims a fresh sandbox regardless (ADR-0003).
+        """
+
+        thread = qevent.conversation_id
+        summary = outcome.approval_summary or outcome.text or "Approval requested"
+
+        if self._approvals is None:
+            await self._escalate(
+                qevent,
+                "The run requested an approval, but no approval backend is "
+                "configured on this worker; flagging for a human instead of pausing.",
+            )
+            return
+
+        try:
+            created = await self._approvals.create(
+                ApprovalRequest(
+                    agent_id=agent_id,
+                    conversation_id=thread,
+                    author=qevent.author,
+                    summary=summary,
+                    reply_channel=qevent.reply_handle.channel,
+                    reply_placeholder=qevent.reply_handle.placeholder,
+                    reply_endpoint=qevent.reply_handle.endpoint,
+                    dedupe_key=qevent.event_id,
+                )
+            )
+        except ApprovalBackendError as exc:
+            logger.warning("approval create failed for %s: %s", qevent.event_id, exc)
+            await self._escalate(
+                qevent,
+                "The run requested an approval, but the approval record could "
+                "not be created; flagging for a human instead of pausing.",
+            )
+            return
+
+        try:
+            await asyncio.to_thread(self._substrate.suspend, thread, history_ref=None)
+        except SandboxError as exc:
+            # Non-fatal: the record is durable and the resume path cold-claims a
+            # fresh sandbox either way; a still-live sandbox is just reaped when
+            # its route expires.
+            logger.warning("suspend failed for thread %s: %s", thread, exc)
+
+        base = outcome.text.strip()
+        notice = (
+            f"Awaiting approval ({created.id}): {summary}\n"
+            "The session is paused and will resume once an authorized member "
+            "resolves this request."
+        )
+        await self._sink.update(
+            channel=qevent.reply_handle.channel,
+            ts=qevent.reply_handle.placeholder,
+            text=f"{base}\n\n{notice}" if base else notice,
+            endpoint=qevent.reply_handle.endpoint,
+        )
+        logger.info(
+            "thread %s suspended awaiting approval %s", thread, created.id
+        )
 
     async def _consume(
         self, qevent: QueuedTurn, turn: TurnStream, nav: NavPack | None = None
@@ -615,6 +706,7 @@ class Kernel:
         elif isinstance(frame, Final):
             acc.status = frame.status
             acc.final_text = frame.text
+            acc.approval_summary = frame.approval_summary
 
     async def _finish(self, acc: _StreamAccumulator, reply: _ThrottledReply) -> TurnOutcome:
         if acc.status in (SessionStatus.DONE, SessionStatus.IDLE_AWAITING_INPUT):
@@ -625,6 +717,17 @@ class Kernel:
                 saw_side_effect=acc.saw_side_effect,
                 text=text,
                 status=acc.status,
+            )
+        if acc.status is SessionStatus.AWAITING_APPROVAL:
+            # Terminal for this turn, but the placeholder edit is deferred to
+            # _pause_for_approval so the pending notice can carry the created
+            # record's id (or the escalation, when no backend is wired).
+            return TurnOutcome(
+                terminal_ok=True,
+                saw_side_effect=acc.saw_side_effect,
+                text=acc.rendered(),
+                status=acc.status,
+                approval_summary=acc.approval_summary,
             )
         # classified-failure, or the stream ended with no final at all.
         return TurnOutcome(

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -21,6 +21,7 @@ import redis
 from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
+from .approvals import ApprovalClient
 from .binding import BindingResolver
 from .bundle_store import BundleStore
 from .config import WorkerConfig
@@ -162,6 +163,9 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     )
     engine = create_async_engine(config.database_url, pool_pre_ping=True)
     binding = BindingResolver(engine, config)
+    # One API-lane HTTP client shared by the approval writer (#244) and the two
+    # eval-lane reporters below; httpx.AsyncClient is task-safe.
+    eval_http = httpx.AsyncClient(timeout=30.0)
     kernel = Kernel(
         substrate=substrate,
         runner=runner,
@@ -177,6 +181,9 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         markers=Markers(async_redis, config),
         config=config,
         binding=binding,
+        approvals=ApprovalClient(
+            api_base_url=config.api_base_url, api_key=config.api_key, client=eval_http
+        ),
     )
     killswitch = KillSwitch(async_redis, on_kill=kernel.interrupt_agent)
     kernel.attach_killswitch(killswitch)
@@ -194,7 +201,6 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         decode_responses=True,
         socket_timeout=config.valkey_socket_timeout_s,
     )
-    eval_http = httpx.AsyncClient(timeout=30.0)
     eval_consumer = EvalStreamConsumer(
         redis=eval_redis,
         config=config,

--- a/apps/worker/src/agentos_worker/sandbox/substrate.py
+++ b/apps/worker/src/agentos_worker/sandbox/substrate.py
@@ -114,29 +114,40 @@ class SandboxSubstrate:
             thread_key, history_ref, self._config.suspended_route_ttl_seconds
         )
 
-    def resume(self, thread_key: str) -> SandboxHandle:
+    def resume(
+        self, thread_key: str, *, env: dict[str, str] | None = None
+    ) -> SandboxHandle:
         """Rehydrate a suspended thread into a fresh claim.
 
         The suspended claim is retired (its process and cache are gone either
         way) and a new claim is created with ``AGENTOS_HISTORY_REF`` injected,
         so the replacement runner boots resuming from stored history.
+
+        ``env`` is the caller's bound boot env (bundle ref, budget, state
+        refs), the same one a fresh ``claim()`` would inject. The suspended
+        pod was deleted (ADR-0003), so the replacement boots from env alone;
+        resuming without it would boot a generic, bundle-less runner. The
+        session identity and any recorded history ref are preserved on top,
+        and the runner token is minted fresh when the caller did not already
+        mint one (issue #63: the old token died with the old claim).
         """
 
         record = self._affinity.get(thread_key)
         if record is None:
             raise NoRouteError(thread_key)
         old = record.handle
-        # A resume creates a NEW claim; the old token died with the old claim, so
-        # mint a fresh one into the new claim env (issue #63).
-        env = {SESSION_ENV: old.session_id, RUNNER_TOKEN_ENV: secrets.token_urlsafe(32)}
+        boot = dict(env) if env else {}
+        boot.setdefault(SESSION_ENV, old.session_id)
+        if not boot.get(RUNNER_TOKEN_ENV):
+            boot[RUNNER_TOKEN_ENV] = secrets.token_urlsafe(32)
         if old.history_ref is not None:
-            env[HISTORY_ENV] = old.history_ref
+            boot.setdefault(HISTORY_ENV, old.history_ref)
 
         self._k8s.delete_claim(old.claim_name)
         self._affinity.delete_if_claim(thread_key, old.claim_name)
         return self._claim_fresh(
             thread_key,
-            env=env,
+            env=boot,
             state=RouteState.LIVE,
             session_id=old.session_id,
             history_ref=old.history_ref,

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -343,6 +343,7 @@ async def kernel_harness(
     *,
     binding: object | None = None,
     with_killswitch: bool = False,
+    approvals: object | None = None,
     **config_overrides: object,
 ) -> AsyncIterator[Harness]:
     """Assemble a live kernel wired to a fake runner and real Valkey."""
@@ -385,6 +386,7 @@ async def kernel_harness(
         markers=Markers(async_redis, config),
         config=config,
         binding=binding,  # type: ignore[arg-type]
+        approvals=approvals,  # type: ignore[arg-type]
     )
     killswitch = None
     if with_killswitch:

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -1,0 +1,204 @@
+"""Approval-gate lifecycle tests (#244, ADR-0010): suspend on pending, resume
+on resolve, durable across a worker restart.
+
+Same harness discipline as the other kernel suites: real Valkey, the real
+substrate over a fake Kubernetes client, an in-process fake ACI runner. Only
+Slack, the model, and the approval API (a recording fake at the
+``ApprovalCreator`` seam) are faked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+from agentos_worker.approvals import ApprovalBackendError, ApprovalRequest, CreatedApproval
+from agentos_worker.sandbox.types import RouteState
+
+DONE = SessionStatus.DONE
+AWAITING = SessionStatus.AWAITING_APPROVAL
+
+
+class RecordingApprovals:
+    """An ApprovalCreator fake that records requests and mints stable ids."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.requests: list[ApprovalRequest] = []
+        self.fail = fail
+
+    async def create(self, request: ApprovalRequest) -> CreatedApproval:
+        if self.fail:
+            raise ApprovalBackendError("approval API unavailable")
+        self.requests.append(request)
+        return CreatedApproval(id=f"appr-{len(self.requests)}", status="pending")
+
+
+def _qevent(
+    text: str,
+    *,
+    thread: str = "th-appr",
+    event_id: str | None = None,
+    placeholder: str = "p-1",
+) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id or uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U1",
+        text=text,
+        reply_handle=ReplyHandle(channel="C1", placeholder=placeholder),
+        received_at="2026-07-14T00:00:00+00:00",
+    )
+
+
+def _awaiting_script(summary: str) -> list:
+    return [
+        TextDelta(text="Requesting sign-off"),
+        Final(text="Requesting sign-off", status=AWAITING, approval_summary=summary),
+    ]
+
+
+def test_awaiting_approval_creates_record_and_suspends(make_harness) -> None:
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script("Give ACME a 20% discount")
+            ev = _qevent("please discount", event_id="ev-appr-1")
+            await h.kernel.process_event(ev)
+
+            # The durable record was created with the turn's identity: the
+            # dedupe key is the event id and the reply handle rides along so a
+            # resolution can resume into the same placeholder.
+            assert len(approvals.requests) == 1
+            req = approvals.requests[0]
+            assert req.summary == "Give ACME a 20% discount"
+            assert req.dedupe_key == "ev-appr-1"
+            assert req.conversation_id == ev.conversation_id
+            assert req.reply_channel == "C1"
+            assert req.reply_placeholder == "p-1"
+            assert req.author == "U1"
+
+            # The sandbox was suspended and the route flipped to SUSPENDED.
+            modes = [s.operating_mode for s in h.fake_k8s.sandboxes.values()]
+            assert modes == ["Suspended"]
+            record = h.substrate._affinity.get(ev.conversation_id)
+            assert record is not None and record.state is RouteState.SUSPENDED
+
+            # The placeholder carries the pending notice with the record id,
+            # and the event is done (no retry loop).
+            assert h.sink.last_text is not None
+            assert "Awaiting approval (appr-1)" in h.sink.last_text
+            assert "Give ACME a 20% discount" in h.sink.last_text
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_pending_state_survives_worker_restart_and_resumes_on_resolve(
+    make_harness,
+) -> None:
+    """The epic's acceptance shape: suspend, replace every worker-side object
+    (a fresh harness over the same Valkey routes), then deliver the resolution
+    turn and watch the session resume and complete."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        thread = "th-restart"
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script("Refund order 42")
+            await h.kernel.process_event(_qevent("refund?", thread=thread))
+            record = h.substrate._affinity.get(thread)
+            assert record is not None and record.state is RouteState.SUSPENDED
+
+        # "Restart": a brand-new kernel/substrate/runner (nothing in-process
+        # survives) over the same Valkey affinity keys. The suspended route is
+        # still there because it lives in Valkey, not worker memory.
+        async with make_harness(approvals=approvals) as h2:
+            record = h2.substrate._affinity.get(thread)
+            assert record is not None and record.state is RouteState.SUSPENDED
+
+            # The resolution turn (what the API enqueues on resolve): the
+            # kernel must resume the suspended thread, boot a replacement
+            # sandbox WITH the bound boot env, and run the turn to done.
+            h2.runner.default_script = [
+                Final(text="Refund processed.", status=DONE)
+            ]
+            resume_turn = _qevent(
+                "[approval resolved] approved by U9", thread=thread, event_id="ev-resolve-1"
+            )
+            await h2.kernel.process_event(resume_turn)
+
+            # The suspended claim was retired and a fresh one created; the
+            # route is LIVE again and the reply landed.
+            record = h2.substrate._affinity.get(thread)
+            assert record is not None and record.state is RouteState.LIVE
+            assert h2.sink.last_text == "Refund processed."
+            assert h2.runner.opened == ["[approval resolved] approved by U9"]
+
+    asyncio.run(go())
+
+
+def test_resume_injects_boot_env_into_replacement_claim(make_harness) -> None:
+    """The dormant-path fix: a resume must boot the replacement sandbox with
+    the same bound env a fresh claim gets (bundle ref, budget), not a generic
+    env -- the suspended pod is gone (ADR-0003) and env is all a boot has."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(approvals=approvals) as h:
+            thread = "th-envmerge"
+            h.runner.default_script = _awaiting_script("Ship it")
+            await h.kernel.process_event(_qevent("ship?", thread=thread))
+
+            h.runner.default_script = [Final(text="Shipped.", status=DONE)]
+            boot_env = {
+                "AGENTOS_BUNDLE_REF": "bundles/agent-v7.tgz",
+                "AGENTOS_BUDGET": '{"max_output_tokens_per_run": 1, "max_usd_per_day": 1.0}',
+            }
+            handle = await h.kernel._claim_or_resume(thread, boot_env)
+            assert handle is not None
+
+            resumed_env = h.fake_k8s.claim_envs[-1]
+            assert resumed_env is not None
+            assert resumed_env["AGENTOS_BUNDLE_REF"] == "bundles/agent-v7.tgz"
+            assert "AGENTOS_BUDGET" in resumed_env
+            # The substrate still guarantees session identity and a fresh
+            # runner token on the replacement claim.
+            assert resumed_env.get("AGENTOS_SESSION_ID")
+            assert resumed_env.get("AGENTOS_RUNNER_TOKEN")
+
+    asyncio.run(go())
+
+
+def test_no_backend_escalates_instead_of_stranding(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness() as h:  # no approvals client wired
+            h.runner.default_script = _awaiting_script("Anything")
+            ev = _qevent("gate this")
+            await h.kernel.process_event(ev)
+
+            assert h.sink.last_text is not None
+            assert "no approval backend" in h.sink.last_text
+            # Not suspended: a pause nothing could resume would strand the thread.
+            modes = [s.operating_mode for s in h.fake_k8s.sandboxes.values()]
+            assert modes == ["Running"]
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_backend_failure_escalates_and_does_not_suspend(make_harness) -> None:
+    async def go() -> None:
+        approvals = RecordingApprovals(fail=True)
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script("Anything")
+            ev = _qevent("gate this")
+            await h.kernel.process_event(ev)
+
+            assert h.sink.last_text is not None
+            assert "could not be created" in h.sink.last_text
+            modes = [s.operating_mode for s in h.fake_k8s.sandboxes.values()]
+            assert modes == ["Running"]
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())

--- a/apps/worker/tests/sandbox/test_substrate.py
+++ b/apps/worker/tests/sandbox/test_substrate.py
@@ -344,3 +344,32 @@ def test_claim_handle_carries_env_runner_token(
 
     assert handle.token == "tok-19"
     assert fake_k8s.claims[handle.claim_name].env[RUNNER_TOKEN_ENV] == "tok-19"
+
+
+def test_resume_merges_caller_boot_env(
+    substrate: SandboxSubstrate, fake_k8s: FakeSandboxClient
+) -> None:
+    # The approval resume path (#244): a suspended pod is gone (ADR-0003), so
+    # the replacement must boot with the same bound env a fresh claim gets
+    # (bundle ref, budget) or it comes up generic. Session identity and the
+    # recorded history ref are preserved on top of the caller env.
+    substrate.claim("T1")
+    substrate.suspend("T1", history_ref="h-42")
+
+    boot_env = {
+        "AGENTOS_BUNDLE_REF": "bundles/agent-v7.tgz",
+        "AGENTOS_BUDGET": '{"max_output_tokens_per_run": 1, "max_usd_per_day": 1.0}',
+        RUNNER_TOKEN_ENV: "tok-fresh",
+    }
+    resumed = substrate.resume("T1", env=boot_env)
+
+    env = fake_k8s.claims[resumed.claim_name].env
+    assert env["AGENTOS_BUNDLE_REF"] == "bundles/agent-v7.tgz"
+    assert env["AGENTOS_BUDGET"] == boot_env["AGENTOS_BUDGET"]
+    # A caller-minted token is kept (binding.boot_env mints one per claim).
+    assert env[RUNNER_TOKEN_ENV] == "tok-fresh"
+    # Session identity and the recorded history ref are preserved.
+    assert env[SESSION_ENV] == resumed.session_id
+    assert env[HISTORY_ENV] == "h-42"
+    # The caller's mapping is not mutated.
+    assert SESSION_ENV not in boot_env

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -210,6 +210,7 @@ mod tests {
             version: PROTOCOL_VERSION.into(),
             text: text.into(),
             status,
+            approval_summary: None,
         }
     }
 

--- a/cli/src/ndjson.rs
+++ b/cli/src/ndjson.rs
@@ -80,6 +80,7 @@ mod tests {
                 version: PROTOCOL_VERSION.to_string(),
                 text: "done".to_string(),
                 status: SessionStatus::Done,
+                approval_summary: None,
             }
         );
     }

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -12,6 +12,7 @@ pub fn status_str(status: &SessionStatus) -> &'static str {
         SessionStatus::Done => "done",
         SessionStatus::IdleAwaitingInput => "idle-awaiting-input",
         SessionStatus::ClassifiedFailure => "classified-failure",
+        SessionStatus::AwaitingApproval => "awaiting-approval",
     }
 }
 
@@ -151,6 +152,7 @@ mod tests {
             version: v(),
             text: "all done".into(),
             status: SessionStatus::Done,
+            approval_summary: None,
         };
         // A delta routes to stdout as a raw token.
         assert!(matches!(printer.part_for(&delta), Some(TurnPart::Token(t)) if t == "all done"));
@@ -167,6 +169,7 @@ mod tests {
             version: v(),
             text: "quiet answer".into(),
             status: SessionStatus::IdleAwaitingInput,
+            approval_summary: None,
         };
         // The caller prints this token to stdout, then appends the status trailer.
         assert!(
@@ -181,6 +184,7 @@ mod tests {
             version: v(),
             text: String::new(),
             status: SessionStatus::Done,
+            approval_summary: None,
         };
         assert!(
             matches!(printer.part_for(&final_frame), Some(TurnPart::Status(s)) if s == "-- final (done)")

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -17,41 +17,51 @@ explicit user-list, platform-RBAC) behind that one server-side check.
 
 ## Current contract
 
-This seam does **not exist in code yet**; the contract below is the *intended* line from
-[ADR-0010](../../adr/0010-approval-gates-and-human-in-the-loop.md) and epic
-[#22](https://github.com/curie-eng/agentos/issues/22), stated so a future implementation
-builds to it. What exists today is only the negative space it must fill:
+The durable base of the seam landed with #244; the authorizer port itself is still ahead
+(#246). What exists in code now:
 
-- **The hardcoded posture the gate replaces.** The runner today builds session options with
-  `permission_mode="bypassPermissions"` (`runner/src/agentos_runner/adapter.py:82`) and has
-  no tool-permission callback. A permission gate must introduce a `canUseTool` callback that
-  replaces this hardcoded bypass, intercepting a model-initiated tool call so it can block
-  pending an approval.
-- **The frozen status enum the gate extends.** `SessionStatus` (`packages/aci-protocol/src/aci_protocol/events.py:28`)
-  today has exactly three values — `DONE = "done"`, `IDLE_AWAITING_INPUT = "idle-awaiting-input"`,
-  `CLASSIFIED_FAILURE = "classified-failure"` (lines 35–37). The intended contract adds a
-  fourth, `awaiting-approval`, as a backward-compatible frozen-contract change regenerated
-  across all three language targets (Pydantic source, JSON Schema, TypeScript, Rust).
-- **The durable record + resolve-once semantics.** A durable `Approval` record (Postgres)
-  with compare-and-set claim semantics is the intended backing store, so losers of the claim
-  race are told it was already resolved. The authorizer check runs server-side at resolution
-  time; self-approval is blocked.
+- **The durable record + resolve-once semantics (landed, #244).** The `Approval` table
+  (`apps/api/src/agentos_api/models.py`) with the resolve-once compare-and-set
+  (`crud.claim_approval_resolution`, a conditional `UPDATE ... WHERE status='pending'`) behind
+  `POST /approvals/{id}/resolve`; losers of the claim race get 409 naming who resolved it,
+  a past-SLA record flips to expired (410). Creation is idempotent on `dedupe_key` (the
+  triggering event id).
+- **The `awaiting-approval` status (landed, #244).** `SessionStatus.AWAITING_APPROVAL` plus
+  the optional `Final.approval_summary` field
+  (`packages/aci-protocol/src/aci_protocol/events.py`), regenerated across all three language
+  targets as a backward-compatible frozen-contract change (ADR-0010 authorized it).
+- **The lifecycle (landed, #244).** A skill raises a policy gate through the runner's
+  in-process `mcp__agentos__request_approval` tool (`runner/src/agentos_runner/approval.py`);
+  the turn ends `awaiting-approval`, the worker persists the record and suspends the sandbox
+  (`kernel._pause_for_approval` — the first live use of the dormant ADR-0003 suspend path);
+  resolution enqueues a resume turn onto the ordinary runs stream
+  (`apps/api/src/agentos_api/resumequeue.py`), and the kernel's claim path rehydrates the
+  thread with its bound boot env (`substrate.resume(env=...)`).
+- **The hardcoded posture the permission gate will replace (still ahead, #245).** The runner
+  still builds session options with `permission_mode="bypassPermissions"`
+  (`runner/src/agentos_runner/adapter.py`) and has no tool-permission callback. The
+  `canUseTool` permission gate (config marks a tool approval-required; the runner intercepts
+  the call) is #245 and composes with the landed record + lifecycle.
 
 ## Implementations today
 
-**None.** Zero authorizer implementations, no durable `Approval` record, no `awaiting-approval`
-status, and no `canUseTool` gate. The seam lands with epic #22. The suspend/resume path it
-relies on (ADR-0003) is built but dormant; an approval is its first intended production use.
+**Zero authorizer implementations** — resolution is currently authorized by the shared API
+key alone, like every other endpoint; WHO may resolve (channel membership first, then
+user-group, explicit user-list, platform-RBAC) and the self-approval block land with #246 at
+the resolve endpoint, which is deliberately where the decision point already sits. The
+durable record, the `awaiting-approval` status, the request tool, and the suspend/resume
+lifecycle are live (#244).
 
 ## Known leakage
 
-Nothing to leak yet — the file records a placement constraint, not existing code. The single
-constraint a future implementation must honor: the authorizer is **enforced server-side at
-resolution time**, not inside the sandbox or runner. The runtime `canUseTool` gate blocks the
-*tool call*, but the authorization decision (who may resolve a pending approval) must live on
-the server that owns the durable `Approval` record, so it cannot be spoofed from inside the
-agent's box. Policy gate points ship versioned in the bundle; route bindings (which channel,
-who may approve) are per-agent deployment config.
+The placement constraint held in the landed base and must keep holding: the authorizer is
+**enforced server-side at resolution time**, not inside the sandbox or runner. The runner
+only *raises* a request (its tool marks the turn; the record, the resolve CAS, and the
+resume enqueue all live with the API/worker), so a compromised sandbox cannot mint or
+resolve an approval. The runtime `canUseTool` gate (#245) will block the *tool call*, but
+the authorization decision (who may resolve a pending approval) stays on the server that
+owns the durable `Approval` record. Policy gate points ship versioned in the bundle; route
+bindings (which channel, who may approve) are per-agent deployment config (#247).
 
 ## Cross-links
 

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -171,6 +171,20 @@ mod tests {
             version: PROTOCOL_VERSION.to_string(),
             text: "hi".to_string(),
             status: SessionStatus::Done,
+            approval_summary: None,
+        };
+        let encoded = serde_json::to_string(&event).unwrap();
+        let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(event, decoded);
+    }
+
+    #[test]
+    fn awaiting_approval_final_roundtrips() {
+        let event = OutboundEvent::Final {
+            version: PROTOCOL_VERSION.to_string(),
+            text: "requesting sign-off".to_string(),
+            status: SessionStatus::AwaitingApproval,
+            approval_summary: Some("Give ACME a 20% discount".to_string()),
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -30,6 +30,8 @@ pub enum SessionStatus {
     IdleAwaitingInput,
     #[serde(rename = "classified-failure")]
     ClassifiedFailure,
+    #[serde(rename = "awaiting-approval")]
+    AwaitingApproval,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -137,6 +139,8 @@ pub enum OutboundEvent {
         text: String,
         #[serde(default)]
         status: SessionStatus,
+        #[serde(default)]
+        approval_summary: Option<String>,
     },
     #[serde(rename = "error")]
     ErrorEvent {

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -17,13 +17,14 @@ export type Text = string;
 export type Ts = string;
 export type Type1 = "message" | "job" | "eval_case";
 export type User = string;
+export type ApprovalSummary = string | null;
 /**
  * Terminal or awaiting status of a session, from the output contract.
  *
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  */
-export type SessionStatus = "done" | "idle-awaiting-input" | "classified-failure";
+export type SessionStatus = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = "0.1.0";
@@ -75,7 +76,7 @@ export type SessionId = string;
  * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
-export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure";
+export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 
 export interface ACIProtocolV010 {
   [k: string]: unknown;
@@ -122,10 +123,17 @@ export interface Event {
 /**
  * The terminal response event, carrying the session status.
  *
+ * ``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):
+ * the human-readable statement of what needs approval, captured from the
+ * run's approval request so the platform can persist it on the durable
+ * ``Approval`` record and show it to the approver. ``None`` on every other
+ * status.
+ *
  * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
+  approval_summary?: ApprovalSummary;
   status?: SessionStatus;
   text: Text1;
   type: Type2;

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -114,8 +114,20 @@
     },
     "Final": {
       "additionalProperties": false,
-      "description": "The terminal response event, carrying the session status.",
+      "description": "The terminal response event, carrying the session status.\n\n``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):\nthe human-readable statement of what needs approval, captured from the\nrun's approval request so the platform can persist it on the durable\n``Approval`` record and show it to the approver. ``None`` on every other\nstatus.",
       "properties": {
+        "approval_summary": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Approval Summary"
+        },
         "status": {
           "$ref": "#/$defs/SessionStatus",
           "default": "done"
@@ -388,7 +400,8 @@
       "enum": [
         "done",
         "idle-awaiting-input",
-        "classified-failure"
+        "classified-failure",
+        "awaiting-approval"
       ],
       "title": "SessionStatus",
       "type": "string"

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -35,6 +35,11 @@ class SessionStatus(StrEnum):
     DONE = "done"
     IDLE_AWAITING_INPUT = "idle-awaiting-input"
     CLASSIFIED_FAILURE = "classified-failure"
+    # The turn ended pending a human decision (ADR-0010, epic #22): the platform
+    # suspends the session on this status and resumes it when the durable
+    # approval record is resolved. Additive value; consumers that only handle
+    # the original three still parse every pre-existing payload.
+    AWAITING_APPROVAL = "awaiting-approval"
 
 
 # --- Inbound channel messages -------------------------------------------------
@@ -89,11 +94,19 @@ class ToolNote(_OutboundBase):
 
 
 class Final(_OutboundBase):
-    """The terminal response event, carrying the session status."""
+    """The terminal response event, carrying the session status.
+
+    ``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):
+    the human-readable statement of what needs approval, captured from the
+    run's approval request so the platform can persist it on the durable
+    ``Approval`` record and show it to the approver. ``None`` on every other
+    status.
+    """
 
     type: Literal["final"] = "final"
     text: str
     status: SessionStatus = SessionStatus.DONE
+    approval_summary: str | None = None
 
 
 class ErrorEvent(_OutboundBase):

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -217,6 +217,20 @@ mod tests {
             version: PROTOCOL_VERSION.to_string(),
             text: "hi".to_string(),
             status: SessionStatus::Done,
+            approval_summary: None,
+        };
+        let encoded = serde_json::to_string(&event).unwrap();
+        let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(event, decoded);
+    }
+
+    #[test]
+    fn awaiting_approval_final_roundtrips() {
+        let event = OutboundEvent::Final {
+            version: PROTOCOL_VERSION.to_string(),
+            text: "requesting sign-off".to_string(),
+            status: SessionStatus::AwaitingApproval,
+            approval_summary: Some("Give ACME a 20% discount".to_string()),
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();

--- a/packages/aci-protocol/tests/test_events.py
+++ b/packages/aci-protocol/tests/test_events.py
@@ -75,3 +75,24 @@ def test_models_reject_unknown_fields() -> None:
 def test_session_status_wire_values() -> None:
     assert SessionStatus.IDLE_AWAITING_INPUT.value == "idle-awaiting-input"
     assert SessionStatus.CLASSIFIED_FAILURE.value == "classified-failure"
+
+
+def test_awaiting_approval_wire_value_and_final_round_trip() -> None:
+    # ADR-0010 (#244): the fourth status and the optional summary field on
+    # final, round-tripped through the strict wire models.
+    assert SessionStatus.AWAITING_APPROVAL.value == "awaiting-approval"
+
+    final = Final(
+        text="Requesting sign-off",
+        status=SessionStatus.AWAITING_APPROVAL,
+        approval_summary="Give ACME a 20% discount",
+    )
+    wire = final.model_dump(mode="json")
+    assert wire["status"] == "awaiting-approval"
+    assert wire["approval_summary"] == "Give ACME a 20% discount"
+    assert Final.model_validate(wire) == final
+
+    # Pre-existing payloads (no approval fields) still parse, defaulting the
+    # summary to None -- the additive-change guarantee.
+    legacy = Final.model_validate({"type": "final", "text": "ok", "status": "done"})
+    assert legacy.approval_summary is None

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -16,6 +16,7 @@ import anyio
 from aiohttp import web
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
+from .approval import build_approval_server
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .history import (
@@ -103,6 +104,10 @@ def build_runner(
             task_budget_hint=config.session.budget.task_budget_hint,
             env=sdk_env or {},
             hooks=bundle_hooks,
+            # Every session carries the in-process approval-request tool, so a
+            # skill can raise a policy gate (ADR-0010) without the bundle
+            # shipping its own MCP server for it.
+            mcp_servers={"agentos": build_approval_server()},
         )
         return ClaudeAgentSession(options)
 

--- a/runner/src/agentos_runner/adapter.py
+++ b/runner/src/agentos_runner/adapter.py
@@ -25,6 +25,7 @@ from claude_agent_sdk import (
     SdkPluginConfig,
     TaskBudget,
 )
+from claude_agent_sdk.types import McpSdkServerConfig
 
 
 class ModelSession(Protocol):
@@ -62,6 +63,7 @@ def build_options(
     task_budget_hint: int | None = None,
     env: dict[str, str] | None = None,
     hooks: dict[str, list[HookMatcher]] | None = None,
+    mcp_servers: dict[str, McpSdkServerConfig] | None = None,
 ) -> ClaudeAgentOptions:
     """Assemble ClaudeAgentOptions for the session.
 
@@ -92,6 +94,8 @@ def build_options(
         # Empty/None means no bundle hooks; the SDK default applies. The event
         # keys are the SDK's HookEvent literals (we emit only "PreToolUse").
         hooks=cast("Any", hooks),
+        # In-process platform tools (the approval-request gate, ADR-0010).
+        mcp_servers=cast("Any", mcp_servers or {}),
     )
 
 

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -1,0 +1,80 @@
+"""The in-process approval-request tool: how a skill raises a policy gate.
+
+ADR-0010 (approval gates, epic #22) makes gates policy-triggered, never
+phase-hardcoded: the agent's own logic decides something needs a human
+decision and raises an approval request. This module is that primitive's
+runner half. It registers an in-process SDK MCP tool
+(``mcp__agentos__request_approval``) every session carries, so a skill
+instructs the model to call it with a one-line summary of what needs
+approval. The call itself executes no real-world action; it only marks the
+turn, and the session emits its terminal ``final`` with
+``status=awaiting-approval`` and the captured summary (see ``session.py``).
+
+The durable ``Approval`` record, the authorizer, and the resume trigger all
+live server-side with the worker/API (they must not be spoofable from inside
+the sandbox -- see docs/interfaces/approval/INTERFACE.md); the runner's only
+job is to end the turn in the awaiting-approval state.
+
+Detection is wire-level, not execution-level: ``translate.py`` captures the
+``ToolUseBlock`` naming this tool, so the fake-model path (a scripted
+``ToolUseBlock``, no tool execution, no network) exercises the identical seam
+as a real model call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from claude_agent_sdk import create_sdk_mcp_server, tool
+from claude_agent_sdk.types import McpSdkServerConfig
+
+# The server key under ClaudeAgentOptions.mcp_servers; the SDK prefixes tool
+# names as mcp__<server>__<tool>.
+APPROVAL_SERVER_NAME = "agentos"
+_TOOL_NAME = "request_approval"
+# The fully qualified tool identifier as it appears on ToolUseBlock.name.
+APPROVAL_TOOL_NAME = f"mcp__{APPROVAL_SERVER_NAME}__{_TOOL_NAME}"
+
+_TOOL_DESCRIPTION = (
+    "Request human approval before proceeding. Call this when your"
+    " instructions say a step needs sign-off (a discount, an invoice, a"
+    " remediation). Pass a one-line summary of exactly what needs approval."
+    " After calling it, end your turn and tell the user the request is"
+    " pending; the platform pauses the session and resumes it with the"
+    " decision once an authorized human resolves it."
+)
+
+
+@tool(_TOOL_NAME, _TOOL_DESCRIPTION, {"summary": str})
+async def _request_approval(args: dict[str, Any]) -> dict[str, Any]:
+    summary = str(args.get("summary") or "").strip()
+    if not summary:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Rejected: pass a non-empty summary of what needs approval.",
+                }
+            ],
+            "is_error": True,
+        }
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    "Approval requested. The session will pause awaiting a human"
+                    " decision; end your turn now and tell the user the request"
+                    " is pending."
+                ),
+            }
+        ]
+    }
+
+
+def build_approval_server() -> McpSdkServerConfig:
+    """The in-process MCP server carrying the approval-request tool."""
+
+    return create_sdk_mcp_server(
+        name=APPROVAL_SERVER_NAME, version="1.0.0", tools=[_request_approval]
+    )

--- a/runner/src/agentos_runner/fake.py
+++ b/runner/src/agentos_runner/fake.py
@@ -49,6 +49,31 @@ def default_turn() -> list[Any]:
     ]
 
 
+# Explicit test-only marker: a query containing it makes the fake's default
+# script raise an approval request (ADR-0010), so the awaiting-approval
+# lifecycle round-trips fully offline (CI, `agentos skill up --fake-model`, the
+# chart's sealed default pool). Everything after the marker on the same line is
+# the approval summary. Like all fake-model behavior: no model call, no network.
+APPROVAL_MARKER = "[fake:request-approval]"
+
+
+def approval_turn(summary: str) -> list[Any]:
+    """A turn that calls the platform approval-request tool, then ends."""
+
+    text = "This needs sign-off; requesting approval."
+    return [
+        _assistant(TextBlock(text=text)),
+        _assistant(
+            ToolUseBlock(
+                id="t1",
+                name="mcp__agentos__request_approval",
+                input={"summary": summary},
+            )
+        ),
+        _result(text=text, usage={"input_tokens": 20, "output_tokens": 8}),
+    ]
+
+
 class FakeModelSession:
     """A ModelSession that replays a fixed script of SDK messages per turn.
 
@@ -66,12 +91,26 @@ class FakeModelSession:
         *,
         truncate_on_interrupt: bool = True,
     ) -> None:
-        self._script_factory = script_factory or default_turn
+        self._script_factory = script_factory or self._default_script
         self._truncate_on_interrupt = truncate_on_interrupt
         self.connected = False
         self.queries: list[str] = []
         self.interrupts = 0
         self._interrupted = False
+
+    def _default_script(self) -> list[Any]:
+        """The default per-turn script, branching on the approval marker.
+
+        A custom ``script_factory`` bypasses this entirely, so existing tests
+        keep their exact scripts; only the no-factory default (the container
+        fake-model path) reacts to the marker.
+        """
+
+        last = self.queries[-1] if self.queries else ""
+        if APPROVAL_MARKER in last:
+            summary = last.split(APPROVAL_MARKER, 1)[1].strip() or "unspecified request"
+            return approval_turn(summary)
+        return default_turn()
 
     async def connect(self) -> None:
         self.connected = True

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -81,6 +81,25 @@ def _is_auth_rejection(message: object) -> bool:
     )
 
 
+def _apply_approval_override(final: Final, state: TurnState) -> Final:
+    """Flip a successful final to awaiting-approval when a gate fired (ADR-0010).
+
+    Only a DONE final is overridden: a failure, budget halt, or intentional
+    interrupt outranks a pending approval (the turn did not complete cleanly,
+    so suspending on it would strand a broken run behind a human decision).
+    The captured summary rides the final so the platform can persist it on the
+    durable Approval record.
+    """
+
+    if state.approval_summary and final.status is SessionStatus.DONE:
+        return Final(
+            text=final.text,
+            status=SessionStatus.AWAITING_APPROVAL,
+            approval_summary=state.approval_summary,
+        )
+    return final
+
+
 class SessionRunner:
     """Drives one model session, streaming ACI NDJSON for each inbound frame."""
 
@@ -374,7 +393,7 @@ class SessionRunner:
                         for line in self._budget_halt_lines():
                             yield line
                         return
-                    final = self._reclassify(outbound)
+                    final = _apply_approval_override(self._reclassify(outbound), state)
                     self._status = final.status
                     self._turn_open = False
                     # Capture the delivered reply so run_turn can persist the
@@ -400,9 +419,10 @@ class SessionRunner:
             if self._interrupt_requested
             else SessionStatus.DONE
         )
-        self._status = status
+        final = _apply_approval_override(Final(text="", status=status), state)
+        self._status = final.status
         self._turn_open = False
-        yield to_ndjson_line(Final(text="", status=status))
+        yield to_ndjson_line(final)
 
     def _budget_halt_lines(self) -> list[str]:
         """The error+final pair emitted whenever the output-token ceiling trips.

--- a/runner/src/agentos_runner/side_effects.py
+++ b/runner/src/agentos_runner/side_effects.py
@@ -20,6 +20,9 @@ from collections.abc import Iterable
 
 # Built-in Claude Code tools that only read state. Names match the SDK's tool
 # identifiers. Anything not listed here is treated as side-effecting.
+# The platform approval-request tool (ADR-0010) is explicitly allowlisted: it
+# executes no real-world action (it only marks the turn awaiting-approval), and
+# flagging it would block the no-retry rule for the very turns approvals pause.
 DEFAULT_IDEMPOTENT_TOOLS: frozenset[str] = frozenset(
     {
         "Read",
@@ -30,6 +33,7 @@ DEFAULT_IDEMPOTENT_TOOLS: frozenset[str] = frozenset(
         "WebFetch",
         "WebSearch",
         "TodoRead",
+        "mcp__agentos__request_approval",
     }
 )
 

--- a/runner/src/agentos_runner/translate.py
+++ b/runner/src/agentos_runner/translate.py
@@ -34,6 +34,7 @@ from claude_agent_sdk import (
     ToolUseBlock,
 )
 
+from .approval import APPROVAL_TOOL_NAME
 from .otel import _GenerationSpan
 from .side_effects import SideEffectClassifier
 
@@ -44,6 +45,10 @@ class TurnState:
 
     side_effect_emitted: bool = False
     error_classification: str | None = None
+    # The summary passed to the approval-request tool (ADR-0010), captured off
+    # the ToolUseBlock so the session can end the turn awaiting-approval. None
+    # when no approval was requested this turn.
+    approval_summary: str | None = None
     # Assistant text streamed during the turn, accumulated so a DONE result with
     # an empty ``result`` can still deliver the model's answer. Reasoning models
     # routed through OpenRouter (e.g. z-ai/glm-5.2) emit the answer as a TextBlock
@@ -110,6 +115,14 @@ def _translate_assistant(
             events.append(ToolNote(text=f"running tool {block.name}", tool=block.name))
             if gen is not None:
                 gen.tool_span(block.name)
+            if block.name == APPROVAL_TOOL_NAME:
+                # A policy gate fired (ADR-0010). Capture the summary at the
+                # wire level so the real path (executed in-process tool) and
+                # the fake path (scripted ToolUseBlock) exercise one seam.
+                raw = block.input.get("summary") if isinstance(block.input, dict) else None
+                summary = str(raw or "").strip()
+                if summary:
+                    state.approval_summary = summary
             if classifier.is_side_effecting(block.name) and not state.side_effect_emitted:
                 events.append(
                     SideEffectFlag(tool=block.name, detail="non-idempotent tool executed")

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -1,0 +1,178 @@
+"""Approval-request tests (#244, ADR-0010): the runner half of the gate.
+
+Covers the wire-level capture in translation (one seam for real and fake
+models), the session's awaiting-approval final override, its precedence rules
+(failure, interrupt, and budget outrank a pending approval), and the fake
+model's offline approval script.
+"""
+
+from __future__ import annotations
+
+import json
+
+import anyio
+from aci_protocol import Event, Final, SessionStatus
+from agentos_runner.approval import APPROVAL_TOOL_NAME, build_approval_server
+from agentos_runner.fake import (
+    APPROVAL_MARKER,
+    FakeModelSession,
+    approval_turn,
+    default_turn,
+)
+from agentos_runner.otel import RunTracer
+from agentos_runner.session import SessionRunner, _apply_approval_override
+from agentos_runner.side_effects import SideEffectClassifier
+from agentos_runner.translate import TurnState, translate_message
+from claude_agent_sdk import AssistantMessage, ToolUseBlock
+
+
+def _event(text: str = "hello") -> Event:
+    return Event(type="message", text=text, user="U1", ts="123.45")
+
+
+def _runner(session: FakeModelSession) -> SessionRunner:
+    return SessionRunner(
+        session_factory=lambda: session,
+        ceiling=10_000,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="test",
+        session_id="s-1",
+    )
+
+
+async def _drain(runner: SessionRunner, text: str) -> list[dict[str, object]]:
+    lines = [line async for line in runner.run_turn(_event(text))]
+    return [json.loads(line) for line in lines]
+
+
+# --- translation capture --------------------------------------------------------
+
+
+def test_translate_captures_approval_summary() -> None:
+    state = TurnState()
+    message = AssistantMessage(
+        content=[
+            ToolUseBlock(
+                id="t1", name=APPROVAL_TOOL_NAME, input={"summary": "Discount 20%"}
+            )
+        ],
+        model="m",
+    )
+    events = translate_message(message, state, SideEffectClassifier(), None)
+
+    assert state.approval_summary == "Discount 20%"
+    # The approval tool is allowlisted read-only: no side_effect_flag, and the
+    # tool call still surfaces as a tool note.
+    types = [type(e).__name__ for e in events]
+    assert types == ["ToolNote"]
+
+
+def test_translate_ignores_empty_summary() -> None:
+    state = TurnState()
+    message = AssistantMessage(
+        content=[ToolUseBlock(id="t1", name=APPROVAL_TOOL_NAME, input={"summary": "  "})],
+        model="m",
+    )
+    translate_message(message, state, SideEffectClassifier(), None)
+    assert state.approval_summary is None
+
+
+# --- session override ------------------------------------------------------------
+
+
+def test_approval_turn_ends_awaiting_approval() -> None:
+    async def go() -> None:
+        session = FakeModelSession(lambda: approval_turn("Discount 20% for ACME"))
+        runner = _runner(session)
+        await runner.start()
+        frames = await _drain(runner, "please discount")
+
+        final = frames[-1]
+        assert final["type"] == "final"
+        assert final["status"] == "awaiting-approval"
+        assert final["approval_summary"] == "Discount 20% for ACME"
+        assert runner.status is SessionStatus.AWAITING_APPROVAL
+        # No side_effect_flag anywhere in the stream: the request itself is
+        # not a real-world action.
+        assert all(f["type"] != "side_effect_flag" for f in frames)
+
+    anyio.run(go)
+
+
+def test_plain_turn_still_ends_done() -> None:
+    async def go() -> None:
+        session = FakeModelSession(default_turn)
+        runner = _runner(session)
+        await runner.start()
+        frames = await _drain(runner, "hello")
+        assert frames[-1]["status"] == "done"
+        assert frames[-1]["approval_summary"] is None
+
+    anyio.run(go)
+
+
+def test_budget_halt_outranks_approval() -> None:
+    async def go() -> None:
+        session = FakeModelSession(lambda: approval_turn("Anything"))
+        runner = SessionRunner(
+            session_factory=lambda: session,
+            ceiling=1,  # the approval turn reports 8 output tokens; the halt trips
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="test",
+            session_id="s-1",
+        )
+        await runner.start()
+        frames = await _drain(runner, "gate this")
+        final = frames[-1]
+        assert final["status"] == "classified-failure"
+
+    anyio.run(go)
+
+
+def test_only_a_done_final_is_overridden() -> None:
+    # Precedence: an interrupt-reclassified (idle) or failed final outranks a
+    # pending approval -- the turn did not complete cleanly, so suspending on
+    # it would strand a broken run behind a human decision.
+    state = TurnState(approval_summary="Anything")
+    idle = Final(text="run interrupted", status=SessionStatus.IDLE_AWAITING_INPUT)
+    assert _apply_approval_override(idle, state) == idle
+    failed = Final(text="run failed", status=SessionStatus.CLASSIFIED_FAILURE)
+    assert _apply_approval_override(failed, state) == failed
+    done = Final(text="ok", status=SessionStatus.DONE)
+    overridden = _apply_approval_override(done, state)
+    assert overridden.status is SessionStatus.AWAITING_APPROVAL
+    assert overridden.approval_summary == "Anything"
+
+
+# --- fake model marker path ------------------------------------------------------
+
+
+def test_fake_default_script_reacts_to_marker() -> None:
+    async def go() -> None:
+        session = FakeModelSession()
+        runner = _runner(session)
+        await runner.start()
+
+        frames = await _drain(runner, f"{APPROVAL_MARKER} Give ACME 20% off")
+        final = frames[-1]
+        assert final["status"] == "awaiting-approval"
+        assert final["approval_summary"] == "Give ACME 20% off"
+
+        # A plain query keeps the canned default turn.
+        frames = await _drain(runner, "hello again")
+        assert frames[-1]["status"] == "done"
+
+    anyio.run(go)
+
+
+# --- the in-process MCP server ----------------------------------------------------
+
+
+def test_approval_server_config_shape() -> None:
+    config = build_approval_server()
+    assert config["type"] == "sdk"
+    assert config["name"] == "agentos"
+    # The qualified tool name translation matches on.
+    assert APPROVAL_TOOL_NAME == "mcp__agentos__request_approval"

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,7 @@ name = "agentos-api"
 version = "0.0.0"
 source = { editable = "apps/api" }
 dependencies = [
+    { name = "aci-protocol" },
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "boto3" },
@@ -54,6 +55,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aci-protocol", editable = "packages/aci-protocol" },
     { name = "alembic", specifier = ">=1.14" },
     { name = "asyncpg", specifier = ">=0.30" },
     { name = "boto3", specifier = ">=1.35" },


### PR DESCRIPTION
Closes #244. Part of epic #22 (approval gates and human-in-the-loop, ADR-0010). Interface contract: `docs/interfaces/approval/INTERFACE.md` (updated in this PR to reflect the landed base).

## What this lands

The durable core of the approval primitive, CLI-verifiable without Slack: a skill raises a policy gate, the run ends `awaiting-approval`, the platform persists a durable `Approval` record and suspends the session -- the **first live use of the dormant ADR-0003 suspend/resume path** -- and resolving the record wakes the suspended session through the ordinary runs stream.

### Frozen contract (authorized by ADR-0010)

- `SessionStatus.AWAITING_APPROVAL` ("awaiting-approval") plus an optional `Final.approval_summary` field carrying the human-readable statement of what needs approval. Backward-compatible additive change; JSON Schema, TypeScript, and Rust regenerated via `scripts/check-contracts.sh` (gate green), and the CLI handles the new variant.

### Runner (the request half)

- Every session carries an in-process `mcp__agentos__request_approval` MCP tool, so a skill can raise a policy gate without shipping its own MCP server. Gates stay policy-triggered, never phase-hardcoded: nothing fires unless the agent's own logic calls the tool.
- Detection is wire-level in `translate.py` (the `ToolUseBlock` naming the tool), so the real-model path and the fake-model path exercise one seam. A clean DONE final flips to `awaiting-approval`; failure, budget, and interrupt outcomes outrank a pending approval. The tool is allowlisted read-only (it executes no real-world action).
- The fake model reacts to an explicit test-only `[fake:request-approval]` marker, so the whole lifecycle round-trips fully offline (no model call, no network -- the fake-model contract is preserved).

### API (the durable record)

- `Approval` table (migration `0008`) storing the conversation key, the reply handle, the author, the summary, and optional SLA expiry, so a resume needs nothing from memory.
- **Resolve-once claim semantics**: `POST /approvals/{id}/resolve` claims the record with a conditional `UPDATE ... WHERE status='pending'`; exactly one resolver wins, losers get `409` with "already resolved by X", a past-SLA record flips to expired and returns `410`.
- Creation is idempotent on `dedupe_key` (the triggering event id), absorbing the worker's at-least-once redelivery.
- Resolution enqueues a platform-authored resume turn onto `agentos:runs` as a normal `QueuedTurn` (deterministic `event_id`, so the worker's done-marker dedupes), reusing the identical consume -> claim -> reply path a Slack mention takes.

### Worker (the lifecycle)

- On an `awaiting-approval` final the kernel creates the record, suspends the sandbox, and leaves a pending notice on the placeholder. Record-before-suspend ordering guarantees there is never a suspended session without a record that can wake it; if the approval backend is unavailable the kernel escalates instead of stranding the thread.
- Dormant-path fix surfaced by first live use: `substrate.resume()` now merges the caller's bound boot env (bundle ref, budget, state refs) into the replacement claim. Previously a resumed sandbox booted with a generic env and without the agent's bundle. Session identity, the recorded history ref, and the fresh runner token semantics are preserved.

### Authorization scope

Resolution is authorized by the shared API key, like every router. WHO may resolve (channel membership, self-approval block) is the server-side authorizer of #246 and slots in at the resolve endpoint, which is deliberately where the decision point sits -- outside the sandbox, on the server that owns the record.

## Verification

- `uv run pytest -q`: 863 passed (new: contract round-trip; runner translation/override/fake-marker; API create/idempotency/CAS race under real thread concurrency/expiry; kernel suspend, worker-restart survival, resume env injection, backend-failure escalation -- all against real Postgres/Valkey per repo discipline).
- `uv run ruff check .` and `uv run mypy`: clean. `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (335): clean. `scripts/check-contracts.sh`: green (generated Rust and TS compile).
- Hands-on e2e (issue #244 acceptance shape, offline): rebuilt the runner image from this branch and drove its real ACI over HTTP -- a `[fake:request-approval]` turn streams `final {status: awaiting-approval, approval_summary: ...}` and `/status` reports `awaiting-approval`, while a plain turn still ends `done`. Booted the API from this branch against a scratch database (migration `0008` applied cleanly) with a test-isolated runs stream on the real compose Valkey, then drove the record lifecycle with curl: create `201`, dedupe replay `200` (same id), resolve `200` by `U_MANAGER`, second resolver `409 "already resolved by U_MANAGER (approved)"`, and the resume `QueuedTurn` (deterministic event id, original reply handle) observed on the stream via `XRANGE`. Worker-restart survival of the pending state is asserted by the kernel integration test, which replaces every worker-side object over the same Valkey routes.

The remaining epic slices build on this: #245 (canUseTool permission gate), #246 (Block Kit cards + server-side authorizer), #247 (policy manifest + route bindings + audit log).