### PR TITLE
Add canUseTool permission gate replacing the hardcoded bypass

### DIFF
--- a/apps/api/alembic/versions/0009_approval_required_tools.py
+++ b/apps/api/alembic/versions/0009_approval_required_tools.py
@@ -1,0 +1,31 @@
+"""add agents.approval_required_tools (per-agent permission gates, #245)
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-07-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0009"
+down_revision: str | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "agentos"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column("approval_required_tools", postgresql.JSONB(), nullable=True),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "approval_required_tools", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3,6 +3,20 @@
     "schemas": {
       "AgentCreate": {
         "properties": {
+          "approval_required_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Required Tools"
+          },
           "behavior_packs": {
             "anyOf": [
               {
@@ -53,6 +67,20 @@
       },
       "AgentOut": {
         "properties": {
+          "approval_required_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Required Tools"
+          },
           "behavior_packs": {
             "anyOf": [
               {
@@ -113,14 +141,29 @@
           "repo_full_name",
           "behavior_packs",
           "model",
+          "approval_required_tools",
           "created_at"
         ],
         "title": "AgentOut",
         "type": "object"
       },
       "AgentUpdate": {
-        "description": "Partial update of mutable agent fields. slack_channel and model are\nupdatable (name and repo binding are identity); an omitted field is left\nunchanged.",
+        "description": "Partial update of mutable agent fields. slack_channel, model, and\napproval_required_tools are updatable (name and repo binding are identity);\nan omitted field is left unchanged.",
         "properties": {
+          "approval_required_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Required Tools"
+          },
           "model": {
             "anyOf": [
               {

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -41,6 +41,7 @@ async def create_agent(session: AsyncSession, data: AgentCreate) -> Agent:
             if data.behavior_packs is not None
             else None
         ),
+        approval_required_tools=data.approval_required_tools,
     )
     session.add(agent)
     await session.commit()
@@ -96,6 +97,18 @@ async def update_agent_model(
     session: AsyncSession, agent: Agent, model: str | None
 ) -> Agent:
     agent.model = model
+    await session.commit()
+    await session.refresh(agent)
+    return agent
+
+
+async def update_agent_approval_tools(
+    session: AsyncSession, agent: Agent, tools: list[str]
+) -> Agent:
+    """Set the agent's permission gates (#245). An empty list clears them
+    (stored as NULL, the no-gates posture)."""
+
+    agent.approval_required_tools = tools or None
     await session.commit()
     await session.refresh(agent)
     return agent

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -64,6 +64,14 @@ class Agent(Base):
     behavior_packs: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB, default=None
     )
+    # Per-agent permission gates (#245, ADR-0010): tool names whose calls
+    # require human approval. Forwarded by the worker binding as
+    # AGENTOS_APPROVAL_REQUIRED_TOOLS at sandbox boot; the runner's
+    # can_use_tool callback blocks these calls and ends the turn
+    # awaiting-approval. NULL means no permission gates (the bypass posture).
+    approval_required_tools: Mapped[list[str] | None] = mapped_column(
+        JSONB, default=None
+    )
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 
     versions: Mapped[list["AgentVersion"]] = relationship(

--- a/apps/api/src/agentos_api/routers/agents.py
+++ b/apps/api/src/agentos_api/routers/agents.py
@@ -72,6 +72,11 @@ async def update_agent(
         agent = await crud.update_agent_channel(session, agent, data.slack_channel)
     if data.model is not None:
         agent = await crud.update_agent_model(session, agent, data.model)
+    if data.approval_required_tools is not None:
+        # Omitted leaves the gates unchanged; an explicit [] clears them (#245).
+        agent = await crud.update_agent_approval_tools(
+            session, agent, data.approval_required_tools
+        )
     return AgentOut.model_validate(agent)
 
 

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -120,6 +120,22 @@ class BehaviorPacksConfig(BaseModel):
     nav: NavPackConfig = NavPackConfig()
 
 
+def _validate_tool_names(value: list[str] | None) -> list[str] | None:
+    """Approval-required tool names (#245) must be non-empty, comma-free
+    strings: the worker forwards the list to the runner as a comma-separated
+    AGENTOS_APPROVAL_REQUIRED_TOOLS value, so a comma inside a name would
+    silently split into two wrong gates."""
+    if value is None:
+        return value
+    cleaned = [t.strip() for t in value]
+    if any(not t or "," in t for t in cleaned):
+        raise ValueError(
+            "approval_required_tools entries must be non-empty tool names "
+            "without commas (e.g. Bash, mcp__github__create_issue)"
+        )
+    return cleaned
+
+
 class AgentCreate(BaseModel):
     name: str
     slack_channel: str
@@ -128,24 +144,36 @@ class AgentCreate(BaseModel):
     # Per-agent model id, forwarded as AGENTOS_MODEL at boot (#254). None uses the
     # platform default model.
     model: str | None = None
+    # Per-agent permission gates (#245): tool names requiring human approval.
+    # None means no gates (the bypass posture).
+    approval_required_tools: list[str] | None = None
 
     _check_slack_channel = field_validator("slack_channel")(
         _validate_slack_channel_id
     )
+    _check_approval_tools = field_validator("approval_required_tools")(
+        _validate_tool_names
+    )
 
 
 class AgentUpdate(BaseModel):
-    """Partial update of mutable agent fields. slack_channel and model are
-    updatable (name and repo binding are identity); an omitted field is left
-    unchanged."""
+    """Partial update of mutable agent fields. slack_channel, model, and
+    approval_required_tools are updatable (name and repo binding are identity);
+    an omitted field is left unchanged."""
 
     slack_channel: str | None = None
     # New per-agent model id (#254). Omitted (None) leaves the current model
     # unchanged, matching the slack_channel convention.
     model: str | None = None
+    # New permission gates (#245). Omitted (None) leaves the current gates
+    # unchanged; an explicit empty list clears them.
+    approval_required_tools: list[str] | None = None
 
     _check_slack_channel = field_validator("slack_channel")(
         _validate_slack_channel_id
+    )
+    _check_approval_tools = field_validator("approval_required_tools")(
+        _validate_tool_names
     )
 
 
@@ -158,6 +186,7 @@ class AgentOut(BaseModel):
     repo_full_name: str | None
     behavior_packs: dict[str, Any] | None
     model: str | None
+    approval_required_tools: list[str] | None
     created_at: datetime
 
 

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -44,3 +44,66 @@ def test_duplicate_repo_is_409(
     )
     assert dup.status_code == 409, dup.text
     assert "repository" in dup.json()["detail"]
+
+
+def test_agent_approval_required_tools_round_trip(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Create with permission gates (#245); they come back on reads.
+    created = client.post(
+        "/agents",
+        json={
+            "name": "gated-agent",
+            "slack_channel": "C000000G01",
+            "approval_required_tools": ["Bash", "mcp__github__create_issue"],
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    body = created.json()
+    assert body["approval_required_tools"] == ["Bash", "mcp__github__create_issue"]
+
+    # PATCH replaces the set; an explicit empty list clears it (NULL posture).
+    patched = client.patch(
+        f"/agents/{body['id']}",
+        json={"approval_required_tools": ["WebFetch"]},
+        headers=auth_headers,
+    )
+    assert patched.status_code == 200
+    assert patched.json()["approval_required_tools"] == ["WebFetch"]
+
+    cleared = client.patch(
+        f"/agents/{body['id']}",
+        json={"approval_required_tools": []},
+        headers=auth_headers,
+    )
+    assert cleared.json()["approval_required_tools"] is None
+
+    # Omitting the field leaves the gates unchanged.
+    repatched = client.patch(
+        f"/agents/{body['id']}",
+        json={"approval_required_tools": ["Bash"]},
+        headers=auth_headers,
+    )
+    assert repatched.json()["approval_required_tools"] == ["Bash"]
+    untouched = client.patch(
+        f"/agents/{body['id']}", json={"model": "claude-sonnet-5"}, headers=auth_headers
+    )
+    assert untouched.json()["approval_required_tools"] == ["Bash"]
+
+
+def test_agent_approval_required_tools_rejects_bad_names(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # A comma inside a name would split into two wrong gates on the env wire.
+    for bad in (["Bash,Read"], [""], ["  "]):
+        resp = client.post(
+            "/agents",
+            json={
+                "name": f"bad-{bad[0].strip() or 'blank'}",
+                "slack_channel": "C000000G02",
+                "approval_required_tools": bad,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422, resp.text

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -71,6 +71,10 @@ MODEL_ENV = "AGENTOS_MODEL"
 # Per-claim bearer token the runner enforces on its ACI POST routes (issue #63).
 # Not a model credential, so apply_model_env never sees it; minted fresh per claim.
 RUNNER_TOKEN_ENV = "AGENTOS_RUNNER_TOKEN"
+# Per-agent permission gates (#245, ADR-0010): comma-separated tool names whose
+# calls the runner intercepts via can_use_tool and pauses awaiting approval.
+# A runner-local knob (not frozen ACI env), like AGENTOS_IDEMPOTENT_TOOLS.
+APPROVAL_REQUIRED_ENV = "AGENTOS_APPROVAL_REQUIRED_TOOLS"
 
 _RESOLVE_SQL = """
 SELECT a.id AS agent_id,
@@ -78,6 +82,7 @@ SELECT a.id AS agent_id,
        a.max_output_tokens_per_run AS max_output_tokens_per_run,
        a.behavior_packs AS behavior_packs,
        a.model AS model,
+       a.approval_required_tools AS approval_required_tools,
        v.id AS version_id,
        v.version_label AS version_label,
        v.bundle_ref AS bundle_ref
@@ -104,6 +109,9 @@ class ResolvedDeployment(BaseModel):
     # The agent's pinned model id (#254), forwarded as AGENTOS_MODEL at boot.
     # None falls back to the worker's configured default model.
     model: str | None = None
+    # The agent's permission gates (#245): tool names requiring human approval,
+    # forwarded as AGENTOS_APPROVAL_REQUIRED_TOOLS at boot. None means no gates.
+    approval_required_tools: list[str] | None = None
 
 
 class BindingResolver:
@@ -140,11 +148,14 @@ class BindingResolver:
             )
         data = dict(rows[0])
         # asyncpg returns JSONB as a str for a raw-text SELECT (no column type to
-        # trigger SQLAlchemy's json deserializer); decode it to the dict the model
-        # expects. A dict (or None) passes through untouched.
+        # trigger SQLAlchemy's json deserializer); decode it to the dict/list the
+        # model expects. A dict/list (or None) passes through untouched.
         packs = data.get("behavior_packs")
         if isinstance(packs, str):
             data["behavior_packs"] = json.loads(packs)
+        gates = data.get("approval_required_tools")
+        if isinstance(gates, str):
+            data["approval_required_tools"] = json.loads(gates)
         return ResolvedDeployment.model_validate(data)
 
     async def repo_full_name(self, agent_id: uuid.UUID) -> str | None:
@@ -192,6 +203,11 @@ class BindingResolver:
         }
         if resolved.bundle_ref is not None:
             env[BUNDLE_REF_ENV] = resolved.bundle_ref
+        # Deliver the agent's permission gates (#245): the runner intercepts
+        # these tool calls via can_use_tool and pauses awaiting approval.
+        # Names are comma-joined (validated comma-free at the API on write).
+        if resolved.approval_required_tools:
+            env[APPROVAL_REQUIRED_ENV] = ",".join(resolved.approval_required_tools)
         # Deliver the memory ref (#264): the agent's scoped namespace on the
         # durable state store (#23/#248). The runner dereferences it at boot to
         # load prior memory and to append learned records with provenance. The

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -11,6 +11,7 @@ import uuid
 
 import pytest
 from agentos_worker.binding import (
+    APPROVAL_REQUIRED_ENV,
     BASE_URL_ENV,
     CREDENTIALS_ENV,
     FAKE_MODEL_ENV,
@@ -275,3 +276,20 @@ def test_binding_boot_env_omits_history_token_without_api_key() -> None:
 
     env = resolver.boot_env(_resolved(), "t-1")
     assert HISTORY_TOKEN_ENV not in env
+
+
+def test_binding_boot_env_carries_approval_required_tools() -> None:
+    # Permission gates (#245): the agent's approval-required tool names travel
+    # to the runner as a comma-joined env var; absent config injects nothing.
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig()  # type: ignore[attr-defined]
+
+    gated = _resolved()
+    gated = gated.model_copy(
+        update={"approval_required_tools": ["Bash", "mcp__github__create_issue"]}
+    )
+    env = resolver.boot_env(gated, "thread-1")
+    assert env[APPROVAL_REQUIRED_ENV] == "Bash,mcp__github__create_issue"
+
+    env = resolver.boot_env(_resolved(), "thread-1")
+    assert APPROVAL_REQUIRED_ENV not in env

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -9,12 +9,14 @@ up afterwards.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import uuid
 
 import pytest
 from agentos_worker.binding import (
     AGENT_ID_ENV,
+    APPROVAL_REQUIRED_ENV,
     BUDGET_ENV,
     BUNDLE_REF_ENV,
     BindingResolver,
@@ -37,14 +39,17 @@ async def _seed_agent(
     name: str,
     max_usd: float | None,
     max_tokens: int | None,
+    approval_tools: list[str] | None = None,
 ) -> uuid.UUID:
     agent_id = uuid.uuid4()
     async with engine.begin() as conn:
         await conn.execute(
             text(
                 f"INSERT INTO {_SCHEMA}.agents "
-                "(id, name, slack_channel, max_usd_per_day, max_output_tokens_per_run) "
-                "VALUES (:id, :name, :channel, :usd, :tokens)"
+                "(id, name, slack_channel, max_usd_per_day, max_output_tokens_per_run, "
+                "approval_required_tools) "
+                "VALUES (:id, :name, :channel, :usd, :tokens, "
+                "CAST(:approval_tools AS jsonb))"
             ),
             {
                 "id": agent_id,
@@ -52,6 +57,9 @@ async def _seed_agent(
                 "channel": channel,
                 "usd": max_usd,
                 "tokens": max_tokens,
+                "approval_tools": (
+                    json.dumps(approval_tools) if approval_tools is not None else None
+                ),
             },
         )
     return agent_id
@@ -360,6 +368,48 @@ def test_unknown_channel_resolves_to_none() -> None:
                 pytest.skip(f"Postgres not reachable: {exc}")
             resolved = await _resolver(engine).resolve(f"C-nonexistent-{uuid.uuid4().hex}")
             assert resolved is None
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_resolves_approval_required_tools_into_boot_env() -> None:
+    # Permission gates (#245): a gated agent's tool list survives the SQL
+    # resolve (JSONB decode included) and lands comma-joined in the boot env.
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            try:
+                async with engine.connect():
+                    pass
+            except SQLAlchemyError as exc:
+                pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+
+            token = uuid.uuid4().hex[:8]
+            channel = f"C-{token}"
+            agent_id = await _seed_agent(
+                engine,
+                channel=channel,
+                name=f"agent-{token}",
+                max_usd=None,
+                max_tokens=None,
+                approval_tools=["Bash", "mcp__github__create_issue"],
+            )
+            await _seed_deployment(
+                engine, agent_id=agent_id, environment="prod", bundle_ref=f"bundles/{token}.zip"
+            )
+            try:
+                resolved = await _resolver(engine).resolve(channel)
+                assert resolved is not None
+                assert resolved.approval_required_tools == [
+                    "Bash",
+                    "mcp__github__create_issue",
+                ]
+                env = _resolver(engine).boot_env(resolved, "thread-1")
+                assert env[APPROVAL_REQUIRED_ENV] == "Bash,mcp__github__create_issue"
+            finally:
+                await _cleanup(engine, [agent_id])
         finally:
             await engine.dispose()
 

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -37,11 +37,17 @@ The durable base of the seam landed with #244; the authorizer port itself is sti
   resolution enqueues a resume turn onto the ordinary runs stream
   (`apps/api/src/agentos_api/resumequeue.py`), and the kernel's claim path rehydrates the
   thread with its bound boot env (`substrate.resume(env=...)`).
-- **The hardcoded posture the permission gate will replace (still ahead, #245).** The runner
-  still builds session options with `permission_mode="bypassPermissions"`
-  (`runner/src/agentos_runner/adapter.py`) and has no tool-permission callback. The
-  `canUseTool` permission gate (config marks a tool approval-required; the runner intercepts
-  the call) is #245 and composes with the landed record + lifecycle.
+- **The permission gate (landed, #245).** Per-agent config
+  (`agents.approval_required_tools`, forwarded as `AGENTOS_APPROVAL_REQUIRED_TOOLS` by the
+  worker binding) marks tools approval-required; the runner intercepts those calls
+  proactively through an SDK `can_use_tool` callback (`build_can_use_tool`,
+  `runner/src/agentos_runner/approval.py`) -- the call is denied before execution, and the
+  turn ends `awaiting-approval` on the same override the policy gate uses, so both trigger
+  types share one record/suspend/resume lifecycle. An agent with no configured gates keeps
+  the historical `bypassPermissions` posture verbatim (zero behavior change). Not yet built:
+  a grant mechanism for the resumed turn (an approved tool call is still gated on retry
+  after resume; a one-shot allowance delivered at boot composes with #247's policy
+  evaluation).
 
 ## Implementations today
 

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -16,7 +16,7 @@ import anyio
 from aiohttp import web
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
-from .approval import build_approval_server
+from .approval import ApprovalGate, build_approval_server, build_can_use_tool
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .history import (
@@ -85,6 +85,16 @@ def build_runner(
     # In-bundle PreToolUse guardrails declared in the manifest hooks field (#272),
     # translated into SDK HookMatcher callbacks. None when the bundle declares none.
     bundle_hooks = load_bundle_hooks(config.session.plugin_dir)
+    # The permission gate (#245): when the agent's config marks tools as
+    # approval-required, a can_use_tool callback replaces the hardcoded bypass
+    # and blocks those calls pending approval. The gate object is shared with
+    # the SessionRunner so a blocked call flips the turn's final to
+    # awaiting-approval. None (no configured tools) keeps the bypass posture.
+    approval_gate = (
+        ApprovalGate(required=frozenset(config.approval_required_tools))
+        if config.approval_required_tools
+        else None
+    )
 
     def factory() -> ModelSession:
         if fake_model:
@@ -108,6 +118,9 @@ def build_runner(
             # skill can raise a policy gate (ADR-0010) without the bundle
             # shipping its own MCP server for it.
             mcp_servers={"agentos": build_approval_server()},
+            can_use_tool=(
+                build_can_use_tool(approval_gate) if approval_gate is not None else None
+            ),
         )
         return ClaudeAgentSession(options)
 
@@ -126,6 +139,7 @@ def build_runner(
         model=config.model,
         memory_store=memory_store,
         history_store=history_store,
+        approval_gate=approval_gate,
     )
 
 

--- a/runner/src/agentos_runner/adapter.py
+++ b/runner/src/agentos_runner/adapter.py
@@ -25,7 +25,7 @@ from claude_agent_sdk import (
     SdkPluginConfig,
     TaskBudget,
 )
-from claude_agent_sdk.types import McpSdkServerConfig
+from claude_agent_sdk.types import CanUseTool, McpSdkServerConfig, PermissionMode
 
 
 class ModelSession(Protocol):
@@ -64,6 +64,7 @@ def build_options(
     env: dict[str, str] | None = None,
     hooks: dict[str, list[HookMatcher]] | None = None,
     mcp_servers: dict[str, McpSdkServerConfig] | None = None,
+    can_use_tool: CanUseTool | None = None,
 ) -> ClaudeAgentOptions:
     """Assemble ClaudeAgentOptions for the session.
 
@@ -80,6 +81,15 @@ def build_options(
     """
 
     task_budget = TaskBudget(total=task_budget_hint) if task_budget_hint else None
+    # The permission posture (#245, ADR-0010): with a can_use_tool callback the
+    # session runs in default permission mode and every tool call is decided by
+    # the callback (approval-required tools are denied and pause the run; all
+    # others are allowed, preserving the pre-gate behavior). Without one there
+    # is nothing to decide, so the historical bypassPermissions posture is kept
+    # verbatim -- an unconfigured agent sees zero behavior change.
+    permission_mode: PermissionMode = (
+        "default" if can_use_tool is not None else "bypassPermissions"
+    )
     return ClaudeAgentOptions(
         plugins=plugins,
         model=model,
@@ -88,7 +98,8 @@ def build_options(
         max_budget_usd=max_budget_usd,
         resume=resume,
         task_budget=task_budget,
-        permission_mode="bypassPermissions",
+        permission_mode=permission_mode,
+        can_use_tool=can_use_tool,
         env=env or {},
         # In-bundle PreToolUse guardrails from the manifest hooks field (#272).
         # Empty/None means no bundle hooks; the SDK default applies. The event

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -1,32 +1,47 @@
-"""The in-process approval-request tool: how a skill raises a policy gate.
+"""Approval gates in the runner: the policy-gate tool and the permission gate.
 
-ADR-0010 (approval gates, epic #22) makes gates policy-triggered, never
-phase-hardcoded: the agent's own logic decides something needs a human
-decision and raises an approval request. This module is that primitive's
-runner half. It registers an in-process SDK MCP tool
-(``mcp__agentos__request_approval``) every session carries, so a skill
-instructs the model to call it with a one-line summary of what needs
-approval. The call itself executes no real-world action; it only marks the
-turn, and the session emits its terminal ``final`` with
-``status=awaiting-approval`` and the captured summary (see ``session.py``).
+ADR-0010 (approval gates, epic #22) defines one approval primitive with two
+trigger types, and this module is the runner half of both:
+
+- **Policy gate** (#244): the agent's own logic decides something needs a
+  human decision. An in-process SDK MCP tool
+  (``mcp__agentos__request_approval``) is carried by every session, so a
+  skill instructs the model to call it with a one-line summary. The call
+  executes no real-world action; it only marks the turn, and the session
+  emits its terminal ``final`` with ``status=awaiting-approval``.
+- **Permission gate** (#245): configuration marks a tool as
+  approval-required, and the runner intercepts the model-initiated call
+  proactively through the SDK ``can_use_tool`` callback -- the replacement
+  for the previously hardcoded ``permission_mode="bypassPermissions"``. The
+  gated call is denied (never executed), the ``ApprovalGate`` records what
+  was blocked, and the turn ends ``awaiting-approval`` exactly like a policy
+  gate, so the durable-record/suspend/resume lifecycle (#244) is shared.
 
 The durable ``Approval`` record, the authorizer, and the resume trigger all
 live server-side with the worker/API (they must not be spoofable from inside
 the sandbox -- see docs/interfaces/approval/INTERFACE.md); the runner's only
 job is to end the turn in the awaiting-approval state.
 
-Detection is wire-level, not execution-level: ``translate.py`` captures the
-``ToolUseBlock`` naming this tool, so the fake-model path (a scripted
-``ToolUseBlock``, no tool execution, no network) exercises the identical seam
-as a real model call.
+Policy-gate detection is wire-level, not execution-level: ``translate.py``
+captures the ``ToolUseBlock`` naming the request tool, so the fake-model path
+(a scripted ``ToolUseBlock``, no tool execution, no network) exercises the
+identical seam as a real model call.
 """
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass, field
 from typing import Any
 
 from claude_agent_sdk import create_sdk_mcp_server, tool
-from claude_agent_sdk.types import McpSdkServerConfig
+from claude_agent_sdk.types import (
+    CanUseTool,
+    McpSdkServerConfig,
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
 
 # The server key under ClaudeAgentOptions.mcp_servers; the SDK prefixes tool
 # names as mcp__<server>__<tool>.
@@ -78,3 +93,87 @@ def build_approval_server() -> McpSdkServerConfig:
     return create_sdk_mcp_server(
         name=APPROVAL_SERVER_NAME, version="1.0.0", tools=[_request_approval]
     )
+
+
+# --- The permission gate (#245): canUseTool over approval-required tools --------
+
+# Longest tool-input rendering carried into an approval summary. The summary is
+# shown to a human approver and persisted on the Approval record; a multi-KB
+# tool input would drown both, so it is truncated with an ellipsis marker.
+_SUMMARY_INPUT_LIMIT = 300
+
+# What the denied model is told. It must steer the model to end the turn (so
+# the session can emit the awaiting-approval final and the platform can
+# suspend), and to not spin on retries -- a retried call is denied identically.
+_DENY_MESSAGE = (
+    "This tool call requires human approval and was NOT executed. An approval"
+    " request has been recorded; the session will pause for a human decision."
+    " Do not retry the tool. End your turn now and tell the user exactly what"
+    " is pending approval."
+)
+
+
+def summarize_tool_call(tool_name: str, tool_input: dict[str, Any]) -> str:
+    """A one-line, human-readable statement of the blocked call.
+
+    This becomes the ``approval_summary`` on the awaiting-approval final and
+    therefore the durable record's summary a human resolves against, so it
+    names the tool and a compact rendering of its input.
+    """
+
+    try:
+        rendered = json.dumps(tool_input, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        rendered = str(tool_input)
+    if len(rendered) > _SUMMARY_INPUT_LIMIT:
+        rendered = rendered[:_SUMMARY_INPUT_LIMIT] + "... (truncated)"
+    return f"Tool call awaiting approval: {tool_name} {rendered}"
+
+
+@dataclass
+class ApprovalGate:
+    """Shared state between the ``can_use_tool`` callback and the session loop.
+
+    ``required`` is the per-agent set of approval-required tool names
+    (AGENTOS_APPROVAL_REQUIRED_TOOLS). ``pending_summary`` is set by the
+    callback when it blocks a call and consumed by the session at turn end to
+    flip the final to awaiting-approval; ``reset()`` clears it at each turn
+    start so one turn's block never leaks into the next.
+
+    The first blocked call of a turn wins: a model that retries the denied
+    tool (against the deny message's instruction) does not overwrite the
+    summary the human will resolve against.
+    """
+
+    required: frozenset[str] = field(default_factory=frozenset)
+    pending_summary: str | None = None
+
+    def reset(self) -> None:
+        self.pending_summary = None
+
+    def block(self, tool_name: str, tool_input: dict[str, Any]) -> None:
+        if self.pending_summary is None:
+            self.pending_summary = summarize_tool_call(tool_name, tool_input)
+
+
+def build_can_use_tool(gate: ApprovalGate) -> CanUseTool:
+    """The SDK permission callback replacing the hardcoded bypass (#245).
+
+    Approval-required tools are denied (the call never executes) and recorded
+    on the gate; every other tool is allowed, preserving the pre-gate posture
+    for unconfigured tools. The decision is proactive -- the call is blocked
+    before execution -- unlike the reactive ``side_effect_flag`` classifier,
+    which only reports after the fact.
+    """
+
+    async def can_use_tool(
+        tool_name: str,
+        tool_input: dict[str, Any],
+        _context: ToolPermissionContext,
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        if tool_name in gate.required:
+            gate.block(tool_name, tool_input)
+            return PermissionResultDeny(message=_DENY_MESSAGE)
+        return PermissionResultAllow()
+
+    return can_use_tool

--- a/runner/src/agentos_runner/config.py
+++ b/runner/src/agentos_runner/config.py
@@ -24,6 +24,13 @@ class RunnerConfig:
     max_turns: int
     history_ref: str | None
     idempotent_tools: list[str] | None
+    # Tool names whose calls require human approval (#245, ADR-0010). The
+    # runner intercepts these proactively via the SDK can_use_tool callback
+    # and ends the turn awaiting-approval instead of executing. Injected
+    # per-agent by the worker binding as AGENTOS_APPROVAL_REQUIRED_TOOLS
+    # (comma separated); None/empty means no permission gates and the
+    # pre-gate bypass posture is preserved.
+    approval_required_tools: list[str] | None
     port: int
     runner_token: str | None
 
@@ -59,6 +66,12 @@ class RunnerConfig:
             if idempotent_raw
             else None
         )
+        approval_raw = env.get("AGENTOS_APPROVAL_REQUIRED_TOOLS")
+        approval_required = (
+            [t.strip() for t in approval_raw.split(",") if t.strip()]
+            if approval_raw
+            else None
+        )
         return cls(
             session=session,
             model=env.get("AGENTOS_MODEL"),
@@ -66,6 +79,7 @@ class RunnerConfig:
             max_turns=int(env.get("AGENTOS_MAX_TURNS", "20")),
             history_ref=env.get("AGENTOS_HISTORY_REF"),
             idempotent_tools=idempotent,
+            approval_required_tools=approval_required,
             port=int(env.get("AGENTOS_RUNNER_PORT", "8080")),
             runner_token=env.get("AGENTOS_RUNNER_TOKEN") or None,
         )

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -37,6 +37,7 @@ from aci_protocol import (
 from claude_agent_sdk import AssistantMessage, ResultMessage
 
 from .adapter import ModelSession
+from .approval import ApprovalGate
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .history import NullTranscriptStore, TranscriptStore, TurnRecord
 from .memory import (
@@ -115,6 +116,7 @@ class SessionRunner:
         model: str | None = None,
         memory_store: MemoryStore | None = None,
         history_store: TranscriptStore | None = None,
+        approval_gate: ApprovalGate | None = None,
     ) -> None:
         self._factory = session_factory
         self._ceiling = ceiling
@@ -132,6 +134,10 @@ class SessionRunner:
         # once per successful turn so a restarted sandbox rehydrates the thread.
         # NullTranscriptStore when no AGENTOS_HISTORY_REF.
         self._history: TranscriptStore = history_store or NullTranscriptStore()
+        # The permission gate (#245): the can_use_tool callback records a
+        # blocked approval-required call here, and the turn's final is flipped
+        # to awaiting-approval on the same override the policy gate uses.
+        self._approval_gate = approval_gate
 
         self._session: ModelSession | None = None
         self._turn_lock = anyio.Lock()
@@ -293,6 +299,10 @@ class SessionRunner:
             self._interrupt_requested = False
             self._turn_open = True
             state = TurnState()
+            # A permission-gate block belongs to exactly one turn: clear any
+            # prior turn's residue before the model runs (#245).
+            if self._approval_gate is not None:
+                self._approval_gate.reset()
             tracker = BudgetTracker(ceiling=self._ceiling)
 
             with self._tracer.run_span(
@@ -393,6 +403,7 @@ class SessionRunner:
                         for line in self._budget_halt_lines():
                             yield line
                         return
+                    self._merge_gate_block(state)
                     final = _apply_approval_override(self._reclassify(outbound), state)
                     self._status = final.status
                     self._turn_open = False
@@ -419,10 +430,28 @@ class SessionRunner:
             if self._interrupt_requested
             else SessionStatus.DONE
         )
+        self._merge_gate_block(state)
         final = _apply_approval_override(Final(text="", status=status), state)
         self._status = final.status
         self._turn_open = False
         yield to_ndjson_line(final)
+
+    def _merge_gate_block(self, state: TurnState) -> None:
+        """Fold a permission-gate block (#245) into the turn state.
+
+        The can_use_tool callback records a blocked call on the shared gate;
+        merging it here (only when no policy-gate summary was already raised)
+        lets ``_apply_approval_override`` treat both trigger types identically,
+        so the awaiting-approval final and the platform lifecycle behind it
+        are one shared path.
+        """
+
+        if (
+            self._approval_gate is not None
+            and self._approval_gate.pending_summary
+            and not state.approval_summary
+        ):
+            state.approval_summary = self._approval_gate.pending_summary
 
     def _budget_halt_lines(self) -> list[str]:
         """The error+final pair emitted whenever the output-token ceiling trips.

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -12,7 +12,15 @@ import json
 
 import anyio
 from aci_protocol import Event, Final, SessionStatus
-from agentos_runner.approval import APPROVAL_TOOL_NAME, build_approval_server
+from agentos_runner.adapter import build_options
+from agentos_runner.approval import (
+    APPROVAL_TOOL_NAME,
+    ApprovalGate,
+    build_approval_server,
+    build_can_use_tool,
+    summarize_tool_call,
+)
+from agentos_runner.config import RunnerConfig
 from agentos_runner.fake import (
     APPROVAL_MARKER,
     FakeModelSession,
@@ -24,6 +32,11 @@ from agentos_runner.session import SessionRunner, _apply_approval_override
 from agentos_runner.side_effects import SideEffectClassifier
 from agentos_runner.translate import TurnState, translate_message
 from claude_agent_sdk import AssistantMessage, ToolUseBlock
+from claude_agent_sdk.types import (
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
 
 
 def _event(text: str = "hello") -> Event:
@@ -176,3 +189,168 @@ def test_approval_server_config_shape() -> None:
     assert config["name"] == "agentos"
     # The qualified tool name translation matches on.
     assert APPROVAL_TOOL_NAME == "mcp__agentos__request_approval"
+
+
+# --- the permission gate (#245): canUseTool over approval-required tools --------
+
+
+def test_can_use_tool_denies_configured_tool_and_records_block() -> None:
+    async def go() -> None:
+        gate = ApprovalGate(required=frozenset({"Bash"}))
+        callback = build_can_use_tool(gate)
+
+        result = await callback(
+            "Bash", {"command": "rm -rf /tmp/x"}, ToolPermissionContext()
+        )
+        assert isinstance(result, PermissionResultDeny)
+        assert "requires human approval" in result.message
+        assert gate.pending_summary is not None
+        assert gate.pending_summary.startswith("Tool call awaiting approval: Bash")
+        assert "rm -rf /tmp/x" in gate.pending_summary
+
+    anyio.run(go)
+
+
+def test_can_use_tool_allows_unconfigured_tools() -> None:
+    async def go() -> None:
+        gate = ApprovalGate(required=frozenset({"Bash"}))
+        callback = build_can_use_tool(gate)
+
+        result = await callback("Read", {"file_path": "/etc/hosts"}, ToolPermissionContext())
+        assert isinstance(result, PermissionResultAllow)
+        assert gate.pending_summary is None
+
+    anyio.run(go)
+
+
+def test_first_blocked_call_wins_the_summary() -> None:
+    async def go() -> None:
+        gate = ApprovalGate(required=frozenset({"Bash"}))
+        callback = build_can_use_tool(gate)
+        await callback("Bash", {"command": "first"}, ToolPermissionContext())
+        await callback("Bash", {"command": "second retry"}, ToolPermissionContext())
+        assert gate.pending_summary is not None
+        assert "first" in gate.pending_summary
+        assert "second retry" not in gate.pending_summary
+
+    anyio.run(go)
+
+
+def test_summary_truncates_oversized_tool_input() -> None:
+    summary = summarize_tool_call("Bash", {"command": "x" * 5000})
+    assert len(summary) < 500
+    assert summary.endswith("... (truncated)")
+
+
+def test_gate_reset_clears_the_block() -> None:
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    gate.block("Bash", {"command": "x"})
+    assert gate.pending_summary is not None
+    gate.reset()
+    assert gate.pending_summary is None
+
+
+def test_blocked_turn_ends_awaiting_approval() -> None:
+    """The session half: a turn during which the callback blocked a call ends
+    awaiting-approval, carrying the blocked-call summary. The script factory
+    sets the gate as a side effect, standing in for the SDK invoking the
+    callback mid-turn."""
+
+    async def go() -> None:
+        gate = ApprovalGate(required=frozenset({"Bash"}))
+        turns = {"n": 0}
+
+        def factory() -> list:
+            # Only the first turn's script blocks a call, so the second turn
+            # also proves the per-turn reset (a stale block never leaks).
+            turns["n"] += 1
+            if turns["n"] == 1:
+                gate.block("Bash", {"command": "echo hi"})
+            return default_turn()
+
+        session = FakeModelSession(factory)
+        runner = SessionRunner(
+            session_factory=lambda: session,
+            ceiling=10_000,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="test",
+            session_id="s-1",
+            approval_gate=gate,
+        )
+        await runner.start()
+        frames = await _drain(runner, "run echo hi")
+
+        final = frames[-1]
+        assert final["status"] == "awaiting-approval"
+        assert final["approval_summary"] is not None
+        assert final["approval_summary"].startswith("Tool call awaiting approval: Bash")
+
+        # The block is per-turn: a clean next turn ends done again.
+        frames = await _drain(runner, "hello")
+        assert frames[-1]["status"] == "done"
+
+    anyio.run(go)
+
+
+def test_policy_gate_summary_outranks_gate_block() -> None:
+    """When the model explicitly called request_approval AND a permission gate
+    blocked a call in the same turn, the model-authored summary wins (it is
+    the intentional, richer statement of what needs approval)."""
+
+    async def go() -> None:
+        gate = ApprovalGate(required=frozenset({"Bash"}))
+
+        def factory() -> list:
+            gate.block("Bash", {"command": "x"})
+            return approval_turn("Explicit policy summary")
+
+        session = FakeModelSession(factory)
+        runner = SessionRunner(
+            session_factory=lambda: session,
+            ceiling=10_000,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="test",
+            session_id="s-1",
+            approval_gate=gate,
+        )
+        await runner.start()
+        frames = await _drain(runner, "gate this")
+        assert frames[-1]["status"] == "awaiting-approval"
+        assert frames[-1]["approval_summary"] == "Explicit policy summary"
+
+    anyio.run(go)
+
+
+def test_build_options_permission_posture() -> None:
+    # Without a callback the historical bypass posture is preserved verbatim;
+    # with one, the session runs in default mode and the callback decides.
+    plain = build_options(
+        plugins=[], model=None, system_prompt=None, max_turns=1,
+        max_budget_usd=None, resume=None,
+    )
+    assert plain.permission_mode == "bypassPermissions"
+    assert plain.can_use_tool is None
+
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    gated = build_options(
+        plugins=[], model=None, system_prompt=None, max_turns=1,
+        max_budget_usd=None, resume=None, can_use_tool=build_can_use_tool(gate),
+    )
+    assert gated.permission_mode == "default"
+    assert gated.can_use_tool is not None
+
+
+def test_runner_config_parses_approval_required_tools() -> None:
+    base = {
+        "AGENTOS_PLUGIN_DIR": "/plugin",
+        "AGENTOS_SESSION_ID": "s",
+        "AGENTOS_SANDBOX_ID": "b",
+        "AGENTOS_BUDGET": '{"max_output_tokens_per_run": 1, "max_usd_per_day": 1.0}',
+    }
+    config = RunnerConfig.from_env(
+        {**base, "AGENTOS_APPROVAL_REQUIRED_TOOLS": "Bash, mcp__github__create_issue ,"}
+    )
+    assert config.approval_required_tools == ["Bash", "mcp__github__create_issue"]
+    assert RunnerConfig.from_env(base).approval_required_tools is None

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -168,3 +168,65 @@ def test_live_openrouter_cache_reuse() -> None:
     assert int((usage or {}).get("cache_read_input_tokens") or 0) > 0, (
         "no prompt-cache reuse on turn 2 through the OpenRouter path"
     )
+
+
+@pytest.mark.skipif(
+    not _HAS_CRED,
+    reason="no live credential (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY) in env",
+)
+def test_live_permission_gate_pauses_awaiting_approval() -> None:
+    """The #245 acceptance criterion on a real model: a tool configured as
+    approval-required is intercepted by can_use_tool (never executed) and the
+    turn ends awaiting-approval with the blocked call in the summary."""
+
+    from agentos_runner.approval import ApprovalGate, build_can_use_tool
+
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    options = build_options(
+        plugins=[],
+        model=None,
+        system_prompt=(
+            "You are a terse test agent. When asked to run a command, use the"
+            " Bash tool."
+        ),
+        max_turns=4,
+        max_budget_usd=1.0,
+        resume=None,
+        can_use_tool=build_can_use_tool(gate),
+    )
+    runner = SessionRunner(
+        session_factory=lambda: ClaudeAgentSession(options),
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="live-permission-gate",
+        session_id="live-gate",
+        approval_gate=gate,
+    )
+
+    async def go() -> list[str]:
+        await runner.start()
+        lines = [
+            line
+            async for line in runner.run_turn(
+                Event(
+                    type="message",
+                    text="Run the shell command `echo agentos-gate-live` and report its output.",
+                    user="U-live",
+                    ts="1.0",
+                )
+            )
+        ]
+        await runner.close()
+        return lines
+
+    lines = anyio.run(go)
+    events = [parse_ndjson(line) for line in lines]
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status is SessionStatus.AWAITING_APPROVAL
+    assert final.approval_summary is not None
+    assert final.approval_summary.startswith("Tool call awaiting approval: Bash")
+    # The blocked command never executed and never produced output text
+    # claiming it ran; the summary records what WOULD have run.
+    assert "echo agentos-gate-live" in final.approval_summary


### PR DESCRIPTION
Closes #245. Part of epic #22 (approval gates and human-in-the-loop, ADR-0010). Builds directly on the durable record + awaiting-approval lifecycle landed by #244 (PR #406). Interface contract: `docs/interfaces/approval/INTERFACE.md` (updated).

## What this lands

The tool-level (permission) half of the approval primitive: configuration marks a tool as approval-required, and the runner intercepts the model-initiated call **proactively, before execution**, through an SDK `can_use_tool` callback -- the replacement for the hardcoded `permission_mode="bypassPermissions"`. The previously reactive posture (`side_effects.py` flags a mutating call after it ran) becomes a proactive gate for configured tools.

### Runner (the gate)

- `ApprovalGate` carries the configured tool-name set and is shared between the `can_use_tool` callback and the session loop. A gated call is **denied -- it never executes** -- with a message steering the model to end its turn and report what is pending; every other tool is allowed, preserving the pre-gate behavior for unconfigured tools.
- The blocked call is recorded as a one-line summary (`Tool call awaiting approval: <tool> <compact-input>`, truncated) and folded into the turn state at final time, so the turn ends `awaiting-approval` on the **same override the policy gate uses**. Both trigger types of ADR-0010 now share one lifecycle: the worker persists the durable `Approval` record, suspends the session, and resolution resumes it -- nothing in #244's plumbing changed.
- Precedence and hygiene: the first blocked call of a turn wins the summary (a model retrying the denied tool cannot overwrite what the human resolves against); an explicit `request_approval` policy summary outranks the gate's machine-generated one; the gate resets per turn so a block never leaks across turns; failure/budget/interrupt finals still outrank a pending approval.
- **Zero behavior change for unconfigured agents**: with no approval-required tools, `build_options` keeps the historical `bypassPermissions` posture verbatim -- the callback and default permission mode are only wired when gates are configured.

### Config path (per-agent, end to end)

- `AGENTOS_APPROVAL_REQUIRED_TOOLS` (comma separated) on `RunnerConfig`, mirroring the `AGENTOS_IDEMPOTENT_TOOLS` precedent (a runner-local knob, no frozen-contract change).
- `agents.approval_required_tools` (JSONB, migration `0009`) with create/PATCH support: omitted leaves gates unchanged, an explicit `[]` clears them. Names are validated non-empty and comma-free at the API, because the worker binding forwards them comma-joined.
- The binding resolves the column and injects the env var into every sandbox claim, so a gate config change is live from the next fresh mention -- the same seam budget and model pinning already use.

### Known follow-up (recorded in the interface doc)

The resumed turn has no grant mechanism yet: after a human approves, a model that retries the same tool call is gated again (a fresh approval round). Correct-by-ADR-0003 grants must be delivered at boot from outside the sandbox (a one-shot allowance on the resume claim), which composes with #247's policy-evaluation work; this PR deliberately does not invent that mechanism.

## Verification

- `uv run pytest -q`: 876 passed (13 new: callback allow/deny/first-block-wins/truncation units; session integration -- a blocked turn ends `awaiting-approval` with the summary, the next turn is clean, policy summary outranks the gate block; permission-posture assertions on `build_options`; env parsing; API create/PATCH round-trip and comma/empty-name rejection; binding SQL resolve + boot-env injection against a migrated scratch database).
- `uv run ruff check .` / `uv run mypy`: clean. `cargo fmt --check` / `clippy -D warnings` / `cargo test`: clean (no contract change; `scripts/check-contracts.sh` green).
- Migration `0009` developed and verified against a disposable database only; the shared compose DB was not touched.
- Hands-on smoke on a rebuilt runner image: a container booted with `AGENTOS_APPROVAL_REQUIRED_TOOLS=Bash,...` is healthy, a plain fake-model turn still ends `done`, and the #244 policy-gate marker still round-trips `awaiting-approval` alongside the configured permission gate.
- The **live acceptance test** for the issue's criterion (a real model asked to run a gated Bash command: the call is intercepted, never executes, and the turn ends `awaiting-approval` naming the blocked command) is committed in `runner/tests/test_live.py` and runs whenever `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` is present; this environment has no model credential, so it is skipped here -- flagging explicitly rather than claiming a live pass.

Remaining epic slices: #246 (Block Kit cards + server-side authorizer), #247 (policy manifest + route bindings + audit log).