### PR TITLE
Add Block Kit approval cards with server-side authorizer and click-to-resolve

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -415,8 +415,19 @@
         "type": "object"
       },
       "ApprovalResolve": {
-        "description": "One resolution attempt. Exactly one attempt wins (compare-and-set);\nthe identity here is caller-asserted for now -- the server-side authorizer\n(channel membership, self-approval block) lands with #246.",
+        "description": "One resolution attempt. Exactly one attempt wins (compare-and-set), and\nthe server-side authorizer (#246) decides first whether this actor may\nresolve at all: self-approval is blocked, and channel membership is proven\nby ``actor_channel`` -- the channel the resolution attempt was made from\n(the card click's channel, relayed by the dispatcher; asserted explicitly\nby API-key operators).",
         "properties": {
+          "actor_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor Channel"
+          },
           "decision": {
             "enum": [
               "approved",
@@ -4090,7 +4101,7 @@
     },
     "/approvals/{approval_id}/resolve": {
       "post": {
-        "description": "Claim the resolution (resolve-once) and wake the suspended session.\n\nExactly one resolver wins the conditional UPDATE; a loser gets 409 naming\nwho resolved it, and a past-SLA record flips to expired and returns 410.\nThe winner's response is sent only after the resume turn is enqueued.",
+        "description": "Claim the resolution (resolve-once) and wake the suspended session.\n\nThe authorizer runs first, server-side (#246): self-approval is blocked\nand channel membership is checked against the attempt's channel; a denied\nactor gets 403 with the reason. Then exactly one authorized resolver wins\nthe conditional UPDATE; a loser gets 409 naming who resolved it, and a\npast-SLA record flips to expired and returns 410. The winner's response is\nsent only after the resume turn is enqueued.",
         "operationId": "resolve_approval_approvals__approval_id__resolve_post",
         "parameters": [
           {

--- a/apps/api/src/agentos_api/authorizer.py
+++ b/apps/api/src/agentos_api/authorizer.py
@@ -1,0 +1,73 @@
+"""The approval authorizer: who may resolve a pending approval (#246, ADR-0010).
+
+This is the seam docs/interfaces/approval/INTERFACE.md calls the black line: a
+server-side decision, at resolution time, of whether a given actor is allowed
+to resolve a given pending approval. It runs HERE, on the server that owns the
+durable ``Approval`` record, so it cannot be spoofed from inside the agent's
+sandbox -- the runner and the bundle never participate in the decision.
+
+The ``Authorizer`` protocol is the swappable interface; implementations planned
+by the epic are channel membership (this module), user-group, explicit
+user-list, and platform RBAC. The first implementation's membership evidence is
+the card click itself: the worker routes the approval card into the approval's
+channel, Slack only renders (and accepts clicks on) that message for members of
+that channel, and the click reaches the platform over the dispatcher's
+authenticated Socket Mode connection. The dispatcher relays the click's channel
+as ``actor_channel``; matching it against the record's channel is therefore a
+channel-membership proof for Slack-originated resolutions. Callers that are not
+the dispatcher (an operator's curl, the CLI) authenticate with the platform API
+key and assert the channel explicitly.
+
+Self-approval is blocked unconditionally: the actor who authored the turn that
+raised the request may not resolve it, whatever channel they click from.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .models import Approval
+
+
+@dataclass(frozen=True)
+class AuthzDecision:
+    """The verdict plus the human-readable reason rendered to the clicker."""
+
+    allowed: bool
+    reason: str = ""
+
+
+class Authorizer(Protocol):
+    """Decide whether ``actor`` may resolve ``approval`` (server-side, at
+    resolution time). ``actor_channel`` is the channel the resolution attempt
+    was made from (the card click's channel), or None when the caller supplied
+    no channel evidence."""
+
+    def authorize(
+        self, approval: Approval, actor: str, actor_channel: str | None
+    ) -> AuthzDecision: ...
+
+
+class ChannelMembershipAuthorizer:
+    """First authorizer: the approval's channel members may resolve it.
+
+    Membership evidence is the click channel (see the module docstring): an
+    attempt is allowed only when it comes from the same channel the approval
+    card was routed to, and never from the requester themselves.
+    """
+
+    def authorize(
+        self, approval: Approval, actor: str, actor_channel: str | None
+    ) -> AuthzDecision:
+        if actor == approval.author:
+            return AuthzDecision(
+                allowed=False,
+                reason="self-approval is blocked: the requester cannot resolve their own request",
+            )
+        if actor_channel != approval.reply_channel:
+            return AuthzDecision(
+                allowed=False,
+                reason="you are not an approver: resolve this from the approval's channel",
+            )
+        return AuthzDecision(allowed=True)

--- a/apps/api/src/agentos_api/routers/approvals.py
+++ b/apps/api/src/agentos_api/routers/approvals.py
@@ -22,6 +22,7 @@ from sqlalchemy.exc import IntegrityError
 
 from .. import crud
 from ..auth import require_api_key
+from ..authorizer import Authorizer, ChannelMembershipAuthorizer
 from ..deps import ResumeQueueDep, SessionDep
 from ..models import Approval, ApprovalStatus
 from ..resumequeue import build_resume_turn
@@ -32,6 +33,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/approvals", tags=["approvals"], dependencies=[Depends(require_api_key)]
 )
+
+# The server-side authorizer (#246): channel membership is the first
+# implementation of the swappable Authorizer seam (user-group, user-list, and
+# platform-RBAC come later); it is module-level state because the decision is
+# pure over the record and the attempt.
+_AUTHORIZER: Authorizer = ChannelMembershipAuthorizer()
 
 
 def _expired(approval: Approval) -> bool:
@@ -104,14 +111,21 @@ async def resolve_approval(
 ) -> ApprovalOut:
     """Claim the resolution (resolve-once) and wake the suspended session.
 
-    Exactly one resolver wins the conditional UPDATE; a loser gets 409 naming
-    who resolved it, and a past-SLA record flips to expired and returns 410.
-    The winner's response is sent only after the resume turn is enqueued.
+    The authorizer runs first, server-side (#246): self-approval is blocked
+    and channel membership is checked against the attempt's channel; a denied
+    actor gets 403 with the reason. Then exactly one authorized resolver wins
+    the conditional UPDATE; a loser gets 409 naming who resolved it, and a
+    past-SLA record flips to expired and returns 410. The winner's response is
+    sent only after the resume turn is enqueued.
     """
 
     approval = await crud.get_approval(session, approval_id)
     if approval is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+
+    decision = _AUTHORIZER.authorize(approval, data.resolved_by, data.actor_channel)
+    if not decision.allowed:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, decision.reason)
 
     if approval.status == ApprovalStatus.pending and _expired(approval):
         expired = await crud.expire_approval(session, approval_id)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -297,13 +297,17 @@ class ApprovalCreate(BaseModel):
 
 
 class ApprovalResolve(BaseModel):
-    """One resolution attempt. Exactly one attempt wins (compare-and-set);
-    the identity here is caller-asserted for now -- the server-side authorizer
-    (channel membership, self-approval block) lands with #246."""
+    """One resolution attempt. Exactly one attempt wins (compare-and-set), and
+    the server-side authorizer (#246) decides first whether this actor may
+    resolve at all: self-approval is blocked, and channel membership is proven
+    by ``actor_channel`` -- the channel the resolution attempt was made from
+    (the card click's channel, relayed by the dispatcher; asserted explicitly
+    by API-key operators)."""
 
     decision: Literal["approved", "rejected"]
     resolved_by: str = Field(min_length=1)
     note: str | None = None
+    actor_channel: str | None = None
 
 
 class ApprovalOut(BaseModel):

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -125,7 +125,12 @@ def test_resolve_once_and_enqueue_resume_turn(
 
     resolved = approvals_client.post(
         f"/approvals/{created['id']}/resolve",
-        json={"decision": "approved", "resolved_by": "U9", "note": "ship it"},
+        json={
+            "decision": "approved",
+            "resolved_by": "U9",
+            "note": "ship it",
+            "actor_channel": "C1",
+        },
         headers=auth_headers,
     )
     assert resolved.status_code == 200, resolved.text
@@ -151,7 +156,7 @@ def test_resolve_once_and_enqueue_resume_turn(
     # The loser of the claim race is told who resolved it.
     second = approvals_client.post(
         f"/approvals/{created['id']}/resolve",
-        json={"decision": "rejected", "resolved_by": "U2"},
+        json={"decision": "rejected", "resolved_by": "U2", "actor_channel": "C1"},
         headers=auth_headers,
     )
     assert second.status_code == 409
@@ -174,13 +179,15 @@ def test_concurrent_resolvers_yield_exactly_one_winner(
     def attempt(actor: str) -> int:
         response = approvals_client.post(
             f"/approvals/{created['id']}/resolve",
-            json={"decision": "approved", "resolved_by": actor},
+            json={"decision": "approved", "resolved_by": actor, "actor_channel": "C1"},
             headers=auth_headers,
         )
         return response.status_code
 
+    # Actors distinct from the record's author (U1), so none is blocked as
+    # self-approval and the race is purely over the pending claim.
     with ThreadPoolExecutor(max_workers=4) as pool:
-        codes = list(pool.map(attempt, [f"U{i}" for i in range(4)]))
+        codes = list(pool.map(attempt, [f"U_race_{i}" for i in range(4)]))
 
     assert sorted(codes) == [200, 409, 409, 409]
     assert len(valkey.xrange(runs_stream)) == 1
@@ -201,7 +208,7 @@ def test_expired_approval_cannot_be_resolved(
 
     resolved = approvals_client.post(
         f"/approvals/{created['id']}/resolve",
-        json={"decision": "approved", "resolved_by": "U9"},
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
         headers=auth_headers,
     )
     assert resolved.status_code == 410
@@ -216,7 +223,7 @@ def test_unknown_approval_is_404(
 ) -> None:
     missing = approvals_client.post(
         f"/approvals/{uuid.uuid4()}/resolve",
-        json={"decision": "approved", "resolved_by": "U9"},
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
         headers=auth_headers,
     )
     assert missing.status_code == 404
@@ -227,3 +234,61 @@ def test_requires_api_key(
 ) -> None:
     denied = approvals_client.post("/approvals", json=_payload())
     assert denied.status_code in (401, 403)
+
+
+def test_authorizer_blocks_non_member_and_self_approval(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """The server-side authorizer (#246): channel membership is proven by the
+    attempt's channel, self-approval is blocked unconditionally, and a denied
+    attempt neither resolves the record nor enqueues a resume turn."""
+
+    created = approvals_client.post(
+        "/approvals", json=_payload(), headers=auth_headers
+    ).json()
+    resolve_url = f"/approvals/{created['id']}/resolve"
+
+    # Wrong channel: not an approver.
+    wrong_channel = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C_OTHER"},
+        headers=auth_headers,
+    )
+    assert wrong_channel.status_code == 403
+    assert "not an approver" in wrong_channel.json()["detail"]
+
+    # No channel evidence at all: not an approver.
+    no_channel = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U9"},
+        headers=auth_headers,
+    )
+    assert no_channel.status_code == 403
+
+    # Self-approval: blocked even from the right channel (the record's author
+    # is U1, see _payload).
+    self_approval = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U1", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert self_approval.status_code == 403
+    assert "self-approval" in self_approval.json()["detail"]
+
+    # The record is still pending and nothing was enqueued.
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
+
+    # An authorized member still resolves it afterwards.
+    ok = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert ok.status_code == 200
+    assert len(valkey.xrange(runs_stream)) == 1

--- a/apps/api/tests/test_authorizer.py
+++ b/apps/api/tests/test_authorizer.py
@@ -1,0 +1,34 @@
+"""ChannelMembershipAuthorizer unit tests (#246): pure decisions, no I/O."""
+
+from agentos_api.authorizer import ChannelMembershipAuthorizer
+from agentos_api.models import Approval
+
+
+def _approval(*, author: str = "U_AE", channel: str = "C_MGRS") -> Approval:
+    return Approval(
+        conversation_id="th-1",
+        author=author,
+        summary="Discount for ACME",
+        reply_channel=channel,
+        reply_placeholder="p-1",
+        dedupe_key="ev-1",
+    )
+
+
+def test_member_of_the_approval_channel_is_allowed() -> None:
+    decision = ChannelMembershipAuthorizer().authorize(_approval(), "U_MANAGER", "C_MGRS")
+    assert decision.allowed
+
+
+def test_wrong_or_missing_channel_is_denied() -> None:
+    authorizer = ChannelMembershipAuthorizer()
+    for channel in ("C_OTHER", None, ""):
+        decision = authorizer.authorize(_approval(), "U_MANAGER", channel)
+        assert not decision.allowed
+        assert "not an approver" in decision.reason
+
+
+def test_self_approval_is_denied_even_from_the_right_channel() -> None:
+    decision = ChannelMembershipAuthorizer().authorize(_approval(author="U_AE"), "U_AE", "C_MGRS")
+    assert not decision.allowed
+    assert "self-approval" in decision.reason

--- a/apps/dispatcher/pyproject.toml
+++ b/apps/dispatcher/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "redis>=5.2",
     "pydantic>=2.10",
     "pydantic-settings>=2.7",
+    "httpx>=0.28",
 ]
 
 [build-system]

--- a/apps/dispatcher/src/agentos_dispatcher/app.py
+++ b/apps/dispatcher/src/agentos_dispatcher/app.py
@@ -51,6 +51,7 @@ def build_app(
     clock: Clock | None = None,
     authorize: Callable[..., Any] | None = None,
     logger: logging.Logger | None = None,
+    resolver: Any | None = None,
 ) -> App:
     """Build a Bolt App with the dispatcher's handlers registered."""
     signing = config.slack_signing_secret or _SOCKET_MODE_SIGNING_PLACEHOLDER
@@ -76,6 +77,10 @@ def build_app(
     }
     if clock is not None:
         register_kwargs["clock"] = clock
+    if resolver is not None:
+        # The approvals API client (#246), injectable so tests keep the
+        # click-to-resolve path offline.
+        register_kwargs["resolver"] = resolver
     register_handlers(app, **register_kwargs)
     return app
 

--- a/apps/dispatcher/src/agentos_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/agentos_dispatcher/approval_actions.py
@@ -1,0 +1,233 @@
+"""The click-to-resolve flow for approval cards (#246, ADR-0010).
+
+The worker posts a Block Kit approval card whose Approve/Reject buttons carry
+these action ids; a click arrives here over the authenticated Socket Mode
+websocket and is forwarded to the platform API's resolve endpoint, where the
+authorizer decides server-side whether this actor may resolve (channel
+membership, self-approval block). The dispatcher never decides authorization
+itself -- it relays who clicked and from which channel, and renders the API's
+verdict back into Slack:
+
+- the winner's card is edited in place (buttons removed, verdict stamped);
+- a non-approver gets the ephemeral "you are not an approver" rejection;
+- a loser of the claim race gets the ephemeral "already resolved by X";
+- an expired record gets the ephemeral expiry notice.
+
+The action-id constants live here (not in the worker, which renders the card)
+because the worker already depends on this package for the queue seam; the
+card renderer imports them so the two sides cannot drift.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from slack_sdk.web import WebClient
+
+from .config import DispatcherConfig
+
+logger = logging.getLogger(__name__)
+
+# Block Kit action ids for the approval card's buttons. The button ``value``
+# carries the approval record id. process_action's catch-all must skip these
+# (Bolt runs every matching listener, so without the skip a click would ALSO
+# be normalized into an ordinary turn).
+APPROVE_ACTION_ID = "agentos-approval-approve"
+REJECT_ACTION_ID = "agentos-approval-reject"
+_APPROVAL_ACTION_IDS = frozenset({APPROVE_ACTION_ID, REJECT_ACTION_ID})
+
+
+def is_approval_action(action_id: str) -> bool:
+    """True when a Block Kit action id belongs to the approval card."""
+
+    return action_id in _APPROVAL_ACTION_IDS
+
+
+@dataclass(frozen=True)
+class ResolveOutcome:
+    """The API's verdict on one resolution attempt, normalized for rendering."""
+
+    status_code: int
+    detail: str = ""
+    resolved_by: str | None = None
+    decision: str | None = None
+
+
+class ApprovalResolveClient:
+    """Thin client for POST /approvals/{id}/resolve (shared API key auth)."""
+
+    def __init__(
+        self, *, api_base_url: str, api_key: str, client: httpx.Client | None = None
+    ) -> None:
+        self._base = api_base_url.rstrip("/")
+        self._headers = {"X-API-Key": api_key} if api_key else {}
+        self._client = client or httpx.Client(timeout=10.0)
+
+    def resolve(
+        self,
+        approval_id: str,
+        *,
+        decision: str,
+        resolved_by: str,
+        actor_channel: str,
+    ) -> ResolveOutcome:
+        try:
+            response = self._client.post(
+                f"{self._base}/approvals/{approval_id}/resolve",
+                json={
+                    "decision": decision,
+                    "resolved_by": resolved_by,
+                    "actor_channel": actor_channel,
+                },
+                headers=self._headers,
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("approval resolve call failed for %s: %s", approval_id, exc)
+            return ResolveOutcome(status_code=0, detail=str(exc))
+        detail = ""
+        resolved = None
+        decided = None
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                detail = str(body.get("detail", ""))
+                resolved = body.get("resolved_by")
+                decided = body.get("status")
+        except ValueError:
+            detail = response.text
+        return ResolveOutcome(
+            status_code=response.status_code,
+            detail=detail,
+            resolved_by=str(resolved) if resolved else None,
+            decision=str(decided) if decided else None,
+        )
+
+
+def _resolved_card_blocks(original: dict[str, Any], verdict: str) -> list[dict[str, Any]]:
+    """The clicked card with its buttons replaced by the verdict line.
+
+    Every non-actions block of the original message is kept (the summary stays
+    readable in place); the actions block is swapped for a context line naming
+    the decision and the resolver, so the card cannot be clicked twice.
+    """
+
+    blocks = [
+        b for b in original.get("blocks", []) if b.get("type") != "actions"
+    ]
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": verdict}],
+        }
+    )
+    return blocks
+
+
+def process_approval_action(
+    *,
+    body: dict[str, Any],
+    decision: str,
+    web_client: WebClient,
+    resolver: ApprovalResolveClient,
+    logger: logging.Logger | None = None,
+) -> ResolveOutcome | None:
+    """Resolve one card click and render the verdict back into Slack.
+
+    Returns the API outcome (for tests/logging), or None when the interaction
+    payload is not a resolvable card click (missing value/channel/message).
+    """
+
+    log = logger or logging.getLogger(__name__)
+
+    actions = body.get("actions") or []
+    approval_id = str(actions[0].get("value") or "") if actions else ""
+    channel = (body.get("channel") or {}).get("id") or ""
+    user = (body.get("user") or {}).get("id") or ""
+    message = body.get("message") or {}
+    card_ts = message.get("ts") or ""
+    if not approval_id or not channel or not user or not card_ts:
+        log.info("approval action without id/channel/user/message, skipping")
+        return None
+
+    outcome = resolver.resolve(
+        approval_id, decision=decision, resolved_by=user, actor_channel=channel
+    )
+
+    if outcome.status_code == 200:
+        verdict = f"{(outcome.decision or decision).capitalize()} by <@{user}>"
+        # Best-effort: the record is already resolved and the resume turn is
+        # enqueued; a failed card edit must not undo either.
+        try:
+            web_client.chat_update(
+                channel=channel,
+                ts=card_ts,
+                text=verdict,
+                blocks=_resolved_card_blocks(message, verdict),
+            )
+        except Exception as exc:  # noqa: BLE001 - render is best-effort
+            log.warning("approval card update failed for %s: %s", approval_id, exc)
+        log.info("approval %s %s by %s", approval_id, decision, user)
+        return outcome
+
+    if outcome.status_code == 403:
+        ephemeral = "You are not an approver for this request."
+    elif outcome.status_code == 409:
+        ephemeral = (
+            f"Already resolved by {outcome.resolved_by}."
+            if outcome.resolved_by
+            else (outcome.detail or "This request was already resolved.")
+        )
+        # Refresh a stale card so it stops offering buttons for a settled
+        # record (the winner's edit normally did this; a race can leave it).
+        _refresh_settled_card(
+            web_client, channel=channel, card_ts=card_ts, message=message,
+            detail=ephemeral, log=log,
+        )
+    elif outcome.status_code == 410:
+        ephemeral = "This approval expired and can no longer be resolved."
+    elif outcome.status_code == 404:
+        ephemeral = "This approval no longer exists."
+    else:
+        ephemeral = "Resolving failed; try again shortly."
+
+    try:
+        web_client.chat_postEphemeral(channel=channel, user=user, text=ephemeral)
+    except Exception as exc:  # noqa: BLE001 - the verdict stands regardless
+        log.warning("ephemeral notice failed for %s: %s", approval_id, exc)
+    log.info(
+        "approval %s click by %s rejected: HTTP %s %s",
+        approval_id,
+        user,
+        outcome.status_code,
+        outcome.detail,
+    )
+    return outcome
+
+
+def _refresh_settled_card(
+    web_client: WebClient,
+    *,
+    channel: str,
+    card_ts: str,
+    message: dict[str, Any],
+    detail: str,
+    log: logging.Logger,
+) -> None:
+    try:
+        web_client.chat_update(
+            channel=channel,
+            ts=card_ts,
+            text=detail,
+            blocks=_resolved_card_blocks(message, detail),
+        )
+    except Exception as exc:  # noqa: BLE001 - best-effort refresh
+        log.debug("settled-card refresh skipped: %s", exc)
+
+
+def build_resolver(config: DispatcherConfig) -> ApprovalResolveClient:
+    """The production resolver, from the dispatcher's API settings."""
+
+    return ApprovalResolveClient(
+        api_base_url=config.api_base_url, api_key=config.api_key
+    )

--- a/apps/dispatcher/src/agentos_dispatcher/config.py
+++ b/apps/dispatcher/src/agentos_dispatcher/config.py
@@ -118,6 +118,13 @@ class DispatcherConfig(BaseSettings):
         default=3600, validation_alias="AGENTOS_DEDUPE_TTL_SECONDS"
     )
 
+    # Platform API for the approval click-to-resolve flow (#246). Defaults match
+    # the API's dev stack, mirroring the worker's settings for the same seam.
+    api_base_url: str = Field(
+        default="http://localhost:8000", validation_alias="AGENTOS_API_BASE_URL"
+    )
+    api_key: str = Field(default="agentos-dev-key", validation_alias="AGENTOS_API_KEY")
+
     placeholder_text: str = Field(
         default="On it. Working on your request.",
         validation_alias="AGENTOS_PLACEHOLDER_TEXT",

--- a/apps/dispatcher/src/agentos_dispatcher/handlers.py
+++ b/apps/dispatcher/src/agentos_dispatcher/handlers.py
@@ -26,6 +26,14 @@ from aci_protocol import QueuedTurn, ReplyHandle
 from slack_bolt import App
 from slack_sdk.web import WebClient
 
+from .approval_actions import (
+    APPROVE_ACTION_ID,
+    REJECT_ACTION_ID,
+    ApprovalResolveClient,
+    build_resolver,
+    is_approval_action,
+    process_approval_action,
+)
 from .config import DispatcherConfig
 from .queue import claim_event, enqueue
 
@@ -142,6 +150,11 @@ def process_action(
     actions = body.get("actions") or []
     if not actions:
         return None
+    # Approval-card buttons (#246) resolve through the API, never become a
+    # turn. Bolt runs every matching listener, so this catch-all sees the
+    # click too and must yield to the dedicated approval listener.
+    if is_approval_action(str(actions[0].get("action_id", ""))):
+        return None
     command = action_command(actions[0])
     if not command:
         return None
@@ -200,8 +213,13 @@ def register_handlers(
     config: DispatcherConfig,
     clock: Clock = _utc_now_iso,
     logger: logging.Logger | None = None,
+    resolver: ApprovalResolveClient | None = None,
 ) -> None:
-    """Wire the app_mention, (direct-message) message, and block-action listeners."""
+    """Wire the app_mention, (direct-message) message, block-action, and
+    approval-card listeners. ``resolver`` (the approvals API client) is
+    injectable for tests; None builds the production client from config."""
+
+    approval_resolver = resolver if resolver is not None else build_resolver(config)
 
     @app.event("app_mention")
     def _on_app_mention(body: dict[str, Any], event: dict[str, Any]) -> None:
@@ -229,8 +247,34 @@ def register_handlers(
             logger=logger,
         )
 
-    # Any Block Kit button click (a reply's action) becomes a turn. The catch-all
-    # matches every action_id; ack first (Bolt's 3s budget), then normalize+enqueue.
+    # Approval-card clicks (#246): resolve through the API (which enforces the
+    # authorizer server-side) and render the verdict; never enqueue a turn.
+    @app.action(APPROVE_ACTION_ID)
+    def _on_approve(ack: Callable[..., None], body: dict[str, Any]) -> None:
+        ack()
+        process_approval_action(
+            body=body,
+            decision="approved",
+            web_client=web_client,
+            resolver=approval_resolver,
+            logger=logger,
+        )
+
+    @app.action(REJECT_ACTION_ID)
+    def _on_reject(ack: Callable[..., None], body: dict[str, Any]) -> None:
+        ack()
+        process_approval_action(
+            body=body,
+            decision="rejected",
+            web_client=web_client,
+            resolver=approval_resolver,
+            logger=logger,
+        )
+
+    # Any other Block Kit button click (a reply's action) becomes a turn. The
+    # catch-all matches every action_id (including the approval ids above --
+    # Bolt runs all matching listeners -- so process_action skips those); ack
+    # first (Bolt's 3s budget), then normalize+enqueue.
     @app.action(re.compile(r".+"))
     def _on_action(ack: Callable[..., None], body: dict[str, Any]) -> None:
         ack()

--- a/apps/dispatcher/tests/test_approval_actions.py
+++ b/apps/dispatcher/tests/test_approval_actions.py
@@ -1,0 +1,249 @@
+"""Click-to-resolve through the real Bolt Socket Mode handler, offline (#246).
+
+Same discipline as test_dispatch.py: the envelope is driven through Bolt's real
+``SocketModeHandler``; only the socket, the Web API client, and the platform
+API (a scripted ``ApprovalResolveClient`` stand-in) are faked. Asserts the
+acceptance behaviors: an authorized click resolves and stamps the card, a
+non-approver gets the ephemeral rejection, a claim-race loser gets "already
+resolved by X", and the ordinary-button catch-all never double-handles an
+approval click.
+"""
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import redis
+from agentos_dispatcher.app import build_app
+from agentos_dispatcher.approval_actions import (
+    APPROVE_ACTION_ID,
+    REJECT_ACTION_ID,
+    ResolveOutcome,
+)
+from agentos_dispatcher.config import DispatcherConfig
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+from slack_bolt.authorization import AuthorizeResult
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.web import WebClient
+
+APPROVAL_ID = "9a1e8a10-0000-0000-0000-000000000246"
+
+_CARD_MESSAGE = {
+    "ts": "1700.0042",
+    "thread_ts": "1700.0001",
+    "blocks": [
+        {"type": "header", "text": {"type": "plain_text", "text": "Approval required"}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": "Discount for ACME"}},
+        {"type": "actions", "elements": []},
+    ],
+}
+
+
+def _authorize(**_kwargs: Any) -> AuthorizeResult:
+    return AuthorizeResult(
+        enterprise_id=None,
+        team_id="T1",
+        bot_token="xoxb-test",
+        bot_id="B1",
+        bot_user_id="U0BOT",
+    )
+
+
+class FakeSocketClient:
+    def __init__(self) -> None:
+        self.logger = logging.getLogger("fake-socket")
+        self.acked_envelope_ids: list[str] = []
+
+    def send_socket_mode_response(self, response: Any) -> None:
+        self.acked_envelope_ids.append(response.envelope_id)
+
+
+class ScriptedResolver:
+    """Stands in for the platform API: returns a scripted outcome per call."""
+
+    def __init__(self, outcome: ResolveOutcome) -> None:
+        self.outcome = outcome
+        self.calls: list[dict[str, str]] = []
+
+    def resolve(
+        self, approval_id: str, *, decision: str, resolved_by: str, actor_channel: str
+    ) -> ResolveOutcome:
+        self.calls.append(
+            {
+                "approval_id": approval_id,
+                "decision": decision,
+                "resolved_by": resolved_by,
+                "actor_channel": actor_channel,
+            }
+        )
+        return self.outcome
+
+
+def _build(
+    config: DispatcherConfig, redis_client: redis.Redis, resolver: ScriptedResolver
+) -> tuple[App, WebClient]:
+    web_client = WebClient(token="xoxb-test")
+    web_client.chat_postMessage = MagicMock(return_value={"ts": "555.000"})  # type: ignore[method-assign]
+    web_client.chat_update = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+    web_client.chat_postEphemeral = MagicMock(return_value={"ok": True})  # type: ignore[method-assign]
+    app = build_app(
+        config,
+        web_client=web_client,
+        redis_client=redis_client,
+        authorize=_authorize,
+        resolver=resolver,
+    )
+    return app, web_client
+
+
+def _drain(app: App) -> None:
+    app.listener_runner.listener_executor.shutdown(wait=True)
+
+
+def _approval_click(
+    envelope_id: str, *, action_id: str, user: str = "U_MANAGER"
+) -> SocketModeRequest:
+    return SocketModeRequest(
+        type="interactive",
+        envelope_id=envelope_id,
+        payload={
+            "type": "block_actions",
+            "trigger_id": f"trig-{envelope_id}",
+            "team": {"id": "T1"},
+            "user": {"id": user},
+            "api_app_id": "A1",
+            "token": "verif",
+            "container": {"type": "message", "message_ts": _CARD_MESSAGE["ts"]},
+            "channel": {"id": "C_MGRS"},
+            "message": _CARD_MESSAGE,
+            "actions": [
+                {
+                    "type": "button",
+                    "action_id": action_id,
+                    "action_ts": "2.0",
+                    "value": APPROVAL_ID,
+                }
+            ],
+        },
+    )
+
+
+def test_authorized_click_resolves_and_stamps_the_card(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _approval_click("env-a1", action_id=APPROVE_ACTION_ID))
+    assert sock.acked_envelope_ids == ["env-a1"]
+    _drain(app)
+
+    # The API was asked to resolve with the clicker's identity and channel
+    # (the membership evidence the server-side authorizer checks).
+    assert resolver.calls == [
+        {
+            "approval_id": APPROVAL_ID,
+            "decision": "approved",
+            "resolved_by": "U_MANAGER",
+            "actor_channel": "C_MGRS",
+        }
+    ]
+
+    # The card was stamped in place: buttons gone, verdict context appended.
+    web_client.chat_update.assert_called_once()
+    kwargs = web_client.chat_update.call_args.kwargs
+    assert kwargs["channel"] == "C_MGRS" and kwargs["ts"] == _CARD_MESSAGE["ts"]
+    assert all(b["type"] != "actions" for b in kwargs["blocks"])
+    assert "Approved by <@U_MANAGER>" in kwargs["text"]
+
+    # No turn was enqueued and no placeholder posted: the catch-all skipped it.
+    web_client.chat_postMessage.assert_not_called()
+    web_client.chat_postEphemeral.assert_not_called()
+
+
+def test_reject_button_resolves_with_rejected_decision(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="rejected")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _approval_click("env-r1", action_id=REJECT_ACTION_ID))
+    _drain(app)
+
+    assert resolver.calls[0]["decision"] == "rejected"
+    assert "Rejected by <@U_MANAGER>" in web_client.chat_update.call_args.kwargs["text"]
+
+
+def test_non_approver_gets_ephemeral_rejection(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=403, detail="you are not an approver")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(
+        FakeSocketClient(),
+        _approval_click("env-f1", action_id=APPROVE_ACTION_ID, user="U_OUTSIDER"),
+    )
+    _drain(app)
+
+    web_client.chat_postEphemeral.assert_called_once()
+    kwargs = web_client.chat_postEphemeral.call_args.kwargs
+    assert kwargs["user"] == "U_OUTSIDER"
+    assert "not an approver" in kwargs["text"]
+    # The card is untouched and no turn was enqueued.
+    web_client.chat_update.assert_not_called()
+    web_client.chat_postMessage.assert_not_called()
+
+
+def test_claim_race_loser_sees_already_resolved_by_winner(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    resolver = ScriptedResolver(
+        ResolveOutcome(
+            status_code=409,
+            detail="already resolved by U_FIRST (approved)",
+            resolved_by=None,
+        )
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(
+        FakeSocketClient(),
+        _approval_click("env-l1", action_id=APPROVE_ACTION_ID, user="U_SECOND"),
+    )
+    _drain(app)
+
+    kwargs = web_client.chat_postEphemeral.call_args.kwargs
+    assert kwargs["user"] == "U_SECOND"
+    assert "already resolved by U_FIRST" in kwargs["text"]
+    # The stale card is refreshed so it stops offering buttons.
+    assert web_client.chat_update.call_count == 1
+    assert all(
+        b["type"] != "actions"
+        for b in web_client.chat_update.call_args.kwargs["blocks"]
+    )
+
+
+def test_expired_click_gets_ephemeral_expiry_notice(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    resolver = ScriptedResolver(ResolveOutcome(status_code=410, detail="expired"))
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(FakeSocketClient(), _approval_click("env-x1", action_id=APPROVE_ACTION_ID))
+    _drain(app)
+
+    assert "expired" in web_client.chat_postEphemeral.call_args.kwargs["text"]

--- a/apps/worker/src/agentos_worker/blocks.py
+++ b/apps/worker/src/agentos_worker/blocks.py
@@ -256,3 +256,62 @@ def render(text: str, nav: NavPack | None = None) -> tuple[str, list[dict[str, A
         prefix = text[:open_at].strip()
         return (to_mrkdwn(prefix) if prefix else "…", None)
     return (to_mrkdwn(text), None)
+
+
+# --- The approval card (#246, ADR-0010) ------------------------------------------
+
+# Slack caps a section's mrkdwn at 3000 chars; the summary is clamped well under
+# it so the card never bounces (the durable record keeps the full text).
+_APPROVAL_SUMMARY_MAX = 2900
+
+
+def approval_card(
+    *, approval_id: str, summary: str, requested_by: str
+) -> tuple[str, list[dict[str, Any]]]:
+    """The Block Kit approval card: what needs approval plus Approve/Reject.
+
+    The button action ids are the dispatcher's click-to-resolve contract
+    (``agentos_dispatcher.approval_actions``); each button's ``value`` carries
+    the durable record id, so a click resolves exactly this approval. Returns
+    ``(fallback_text, blocks)`` for ``chat.postMessage``.
+    """
+
+    # Imported here (not module top) to keep the module importable in isolation;
+    # the worker package already depends on the dispatcher for the queue seam.
+    from agentos_dispatcher.approval_actions import (
+        APPROVE_ACTION_ID,
+        REJECT_ACTION_ID,
+    )
+
+    clamped = _truncate(to_mrkdwn(summary), _APPROVAL_SUMMARY_MAX)
+    fallback = _truncate(f"Approval required: {summary}", _SLACK_TEXT_MAX)
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": _truncate("Approval required", _HEADER_MAX),
+                "emoji": True,
+            },
+        },
+        {"type": "section", "text": {"type": "mrkdwn", "text": clamped}},
+        _context_block(f"Requested by <@{requested_by}>"),
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    **_button_shell("Approve"),
+                    "style": "primary",
+                    "action_id": _truncate(APPROVE_ACTION_ID, _ACTION_ID_MAX),
+                    "value": approval_id,
+                },
+                {
+                    **_button_shell("Reject"),
+                    "style": "danger",
+                    "action_id": _truncate(REJECT_ACTION_ID, _ACTION_ID_MAX),
+                    "value": approval_id,
+                },
+            ],
+        },
+    ]
+    return fallback, blocks

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -53,6 +53,7 @@ from .behaviorpacks import (
     sample_tip,
 )
 from .binding import BindingResolver
+from .blocks import approval_card
 from .config import WorkerConfig
 from .killswitch import KillSwitch
 from .markers import Markers
@@ -648,6 +649,24 @@ class Kernel:
             text=f"{base}\n\n{notice}" if base else notice,
             endpoint=qevent.reply_handle.endpoint,
         )
+
+        # The Block Kit approval card (#246): Approve/Reject buttons routed to
+        # the approval's channel, in this thread; the dispatcher resolves a
+        # click through the API's server-side authorizer. Best-effort -- the
+        # record and the API resolve path stand with or without the card.
+        fallback, card_blocks = approval_card(
+            approval_id=created.id, summary=summary, requested_by=qevent.author
+        )
+        try:
+            await self._sink.post(
+                channel=qevent.reply_handle.channel,
+                text=fallback,
+                blocks=card_blocks,
+                thread_ts=thread,
+                endpoint=qevent.reply_handle.endpoint,
+            )
+        except Exception as exc:  # noqa: BLE001 - the pause stands without the card
+            logger.warning("approval card post failed for %s: %s", created.id, exc)
         logger.info(
             "thread %s suspended awaiting approval %s", thread, created.id
         )

--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -53,6 +53,22 @@ class SlackSink(Protocol):
         no-op when shimmering is off; best-effort so it never breaks a turn."""
         ...
 
+    async def post(
+        self,
+        *,
+        channel: str,
+        text: str,
+        blocks: list[dict[str, object]] | None = None,
+        thread_ts: str | None = None,
+        endpoint: str | None = None,
+    ) -> str | None:
+        """Post a NEW message (the approval card, #246), returning its ts.
+
+        Distinct from ``update``: the placeholder-edit reply model stays the
+        norm; posting is reserved for platform-owned messages like the
+        approval card. Raises on failure so the caller decides best-effort."""
+        ...
+
 
 class AsyncSlackSink:
     """A SlackSink backed by the Slack Web API (chat.update).
@@ -123,6 +139,38 @@ class AsyncSlackSink:
                 await client.chat_update(channel=channel, ts=ts, text=rendered_text)
         else:
             await client.chat_update(channel=channel, ts=ts, text=rendered_text)
+
+    async def post(
+        self,
+        *,
+        channel: str,
+        text: str,
+        blocks: list[dict[str, object]] | None = None,
+        thread_ts: str | None = None,
+        endpoint: str | None = None,
+    ) -> str | None:
+        # A rejected Block Kit payload falls back to text-only, mirroring
+        # ``update``: the card is the resolve UI, but a plain-text notice still
+        # beats losing the message (the API resolve path works regardless).
+        client = self._client_for(endpoint)
+        try:
+            if blocks is not None:
+                response = await client.chat_postMessage(
+                    channel=channel, text=text, blocks=blocks, thread_ts=thread_ts
+                )
+            else:
+                response = await client.chat_postMessage(
+                    channel=channel, text=text, thread_ts=thread_ts
+                )
+        except SlackApiError:
+            if blocks is None:
+                raise
+            logger.warning("chat_postMessage with blocks rejected; retrying text-only")
+            response = await client.chat_postMessage(
+                channel=channel, text=text, thread_ts=thread_ts
+            )
+        ts = response.get("ts")
+        return str(ts) if ts else None
 
     async def set_status(
         self, *, channel: str, thread_ts: str, status: str, endpoint: str | None = None

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -107,6 +107,11 @@ class FakeSink(SlackSink):
         self.update_endpoints: list[str | None] = []
         self.status_sets: list[tuple[str, str, str]] = []
         self.status_clears: list[tuple[str, str]] = []
+        # New messages posted by the kernel (the approval card, #246):
+        # (channel, text, blocks, thread_ts) per post.
+        self.posts: list[
+            tuple[str, str, list[dict[str, object]] | None, str | None]
+        ] = []
 
     async def update(
         self,
@@ -130,6 +135,18 @@ class FakeSink(SlackSink):
         self, *, channel: str, thread_ts: str, endpoint: str | None = None
     ) -> None:
         self.status_clears.append((channel, thread_ts))
+
+    async def post(
+        self,
+        *,
+        channel: str,
+        text: str,
+        blocks: list[dict[str, object]] | None = None,
+        thread_ts: str | None = None,
+        endpoint: str | None = None,
+    ) -> str | None:
+        self.posts.append((channel, text, blocks, thread_ts))
+        return f"posted-{len(self.posts)}"
 
     @property
     def last_text(self) -> str | None:

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -202,3 +202,37 @@ def test_backend_failure_escalates_and_does_not_suspend(make_harness) -> None:
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
+
+
+def test_pause_posts_the_approval_card(make_harness) -> None:
+    """#246: pausing posts a Block Kit card into the approval's thread whose
+    buttons carry the record id, alongside the placeholder notice."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script("Give ACME a 20% discount")
+            ev = _qevent("please discount", thread="th-card")
+            await h.kernel.process_event(ev)
+
+            assert len(h.sink.posts) == 1
+            channel, fallback, blocks, thread_ts = h.sink.posts[0]
+            assert channel == "C1"
+            assert thread_ts == "th-card"
+            assert "Give ACME a 20% discount" in fallback
+            assert blocks is not None
+            actions = blocks[-1]
+            assert actions["type"] == "actions"
+            assert [e["value"] for e in actions["elements"]] == ["appr-1", "appr-1"]
+
+    asyncio.run(go())
+
+
+def test_escalation_paths_post_no_card(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness() as h:  # no approvals backend wired
+            h.runner.default_script = _awaiting_script("Anything")
+            await h.kernel.process_event(_qevent("gate this"))
+            assert h.sink.posts == []
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -317,3 +317,41 @@ def test_render_bounds_fallback_text_for_oversized_body() -> None:
     rendered_text, blocks = render(text)
     assert blocks is not None
     assert len(rendered_text) <= 40000
+
+
+def test_approval_card_shape_and_click_contract() -> None:
+    # The card carries what needs approval, who asked, and two buttons whose
+    # action ids are the dispatcher's click contract with the record id as value.
+    from agentos_dispatcher.approval_actions import APPROVE_ACTION_ID, REJECT_ACTION_ID
+    from agentos_worker.blocks import approval_card
+
+    fallback, card = approval_card(
+        approval_id="appr-1",
+        summary="Give ACME a 20% discount",
+        requested_by="U_AE",
+    )
+    assert "Give ACME a 20% discount" in fallback
+    assert card[0]["type"] == "header"
+    assert "Give ACME a 20% discount" in card[1]["text"]["text"]
+    assert "<@U_AE>" in card[2]["elements"][0]["text"]
+
+    actions = card[-1]
+    assert actions["type"] == "actions"
+    approve, reject = actions["elements"]
+    assert approve["action_id"] == APPROVE_ACTION_ID
+    assert approve["value"] == "appr-1"
+    assert approve["style"] == "primary"
+    assert reject["action_id"] == REJECT_ACTION_ID
+    assert reject["value"] == "appr-1"
+    assert reject["style"] == "danger"
+
+
+def test_approval_card_clamps_oversized_summary() -> None:
+    from agentos_worker.blocks import approval_card
+
+    fallback, card = approval_card(
+        approval_id="appr-2", summary="x" * 10000, requested_by="U1"
+    )
+    # Section mrkdwn stays under Slack's 3000-char cap; fallback under 40k.
+    assert len(card[1]["text"]["text"]) <= 2900
+    assert len(fallback) <= 39000

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -1,7 +1,7 @@
 # INTERFACE: Approval / authorizer
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** NONE &nbsp;·&nbsp; **Implementations today:** 0 &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 (channel membership) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -51,12 +51,17 @@ The durable base of the seam landed with #244; the authorizer port itself is sti
 
 ## Implementations today
 
-**Zero authorizer implementations** — resolution is currently authorized by the shared API
-key alone, like every other endpoint; WHO may resolve (channel membership first, then
-user-group, explicit user-list, platform-RBAC) and the self-approval block land with #246 at
-the resolve endpoint, which is deliberately where the decision point already sits. The
-durable record, the `awaiting-approval` status, the request tool, and the suspend/resume
-lifecycle are live (#244).
+**One: `ChannelMembershipAuthorizer`** (`apps/api/src/agentos_api/authorizer.py`), behind
+the `Authorizer` Protocol at the resolve endpoint (#246). Self-approval is blocked
+unconditionally; channel membership is proven by the resolution attempt's channel — the
+worker routes the Block Kit approval card into the approval's channel, Slack only renders
+that message (and accepts clicks) for members of that channel, and the click reaches the
+platform over the dispatcher's authenticated Socket Mode connection, which relays the
+click's channel as `actor_channel`. Non-dispatcher callers (operator curl, CLI) authenticate
+with the platform API key and assert the channel explicitly. User-group, explicit
+user-list, and platform-RBAC implementations swap in behind the same Protocol later. The
+durable record, the `awaiting-approval` status, both gate trigger types, the card
+click-to-resolve flow, and the suspend/resume lifecycle are live (#244, #245, #246).
 
 ## Known leakage
 

--- a/uv.lock
+++ b/uv.lock
@@ -77,6 +77,7 @@ name = "agentos-dispatcher"
 version = "0.0.0"
 source = { editable = "apps/dispatcher" }
 dependencies = [
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "redis" },
@@ -85,6 +86,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.28" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "redis", specifier = ">=5.2" },


### PR DESCRIPTION
Closes #246. Part of epic #22 (approval gates and human-in-the-loop, ADR-0010). Builds on the durable record + awaiting-approval lifecycle (#244) and the canUseTool permission gate (#245). Interface contract: `docs/interfaces/approval/INTERFACE.md` (updated: the authorizer seam graduates from NONE to CLEAN with its first implementation).

## What this lands

The human-facing half of the approval primitive: **who sees a pending approval, how they resolve it, and who is allowed to** -- across all three services.

### Worker: the approval card

Pausing a session (#244) now also posts a Block Kit **approval card** into the approval's channel, in the requesting thread: a header, the summary of what needs approval, who requested it, and Approve/Reject buttons whose `value` carries the durable record id. Every Slack limit is clamped (section 3000 chars, header/label/action-id lengths) so the card never bounces; posting is best-effort -- the durable record and the API resolve path stand with or without it. `SlackSink` gains a `post()` verb beside the existing placeholder edit-in-place norm.

### Dispatcher: click-to-resolve

Dedicated Bolt listeners for the two approval action ids (`agentos-approval-approve` / `-reject`) forward a click to `POST /approvals/{id}/resolve` with the clicker's identity and **the click's channel**, then render the API's verdict back into Slack:

- the winner's card is stamped in place (buttons removed, "Approved/Rejected by @user" context line), so a settled card cannot be clicked again;
- a non-approver gets the **ephemeral "you are not an approver"** rejection;
- a claim-race loser gets the **ephemeral "already resolved by X"** plus a card refresh;
- an expired record gets the expiry notice.

The ordinary block-action catch-all now skips approval action ids -- Bolt runs every matching listener, so without the skip a card click would also be normalized into a turn.

### API: the Authorizer seam, server-side

`Authorizer` lands as a real Protocol enforced at the resolve endpoint -- on the server that owns the durable record, never inside the sandbox or runner (the placement constraint the interface doc has carried since #244). First implementation, `ChannelMembershipAuthorizer`:

- **self-approval is blocked unconditionally** (the requester cannot resolve their own request, whatever channel they click from);
- **channel membership** is proven by the resolution attempt's channel: the worker routes the card into the approval's channel, Slack only renders that message (and accepts clicks on it) for members of that channel, and the click's channel reaches the platform over the dispatcher's authenticated Socket Mode connection as `actor_channel`. Non-dispatcher callers (operator curl, the CLI) authenticate with the platform API key and assert the channel explicitly.

Denied attempts get `403` with the reason, and neither resolve the record nor enqueue a resume turn. User-group, explicit user-list, and platform-RBAC implementations swap in behind the same Protocol later, exactly as the epic sequences them.

## Verification

- `uv run pytest -q`: 889 passed (26 new). Highlights: authorizer units; API 403 paths (wrong channel / no channel evidence / self-approval) with the record still pending and nothing enqueued, then authorized-after-denial success; the genuine-concurrency claim race now runs entirely through the authorizer; card render shape, click contract, and clamping; kernel pause posts the card into the right channel/thread (and escalation paths do not); dispatcher click-to-resolve driven through the **real Bolt `SocketModeHandler` offline** (the repo's established discipline: only the socket, the Web client, and the platform API are faked) covering approve, reject, 403, 409, 410 verdict renderings and catch-all non-interference.
- `uv run ruff check .` / `uv run mypy`: clean. `cargo fmt --check` / `clippy -D warnings` / `cargo test`: clean; `scripts/check-contracts.sh` green (no frozen-contract change in this PR).
- Hands-on e2e against a real API process on a migrated scratch database (shared compose DB untouched), the deal-desk shape end to end: outsider from the wrong channel `403 "you are not an approver"`, the requester self-approving `403 "self-approval is blocked"`, a channel member `200 approved`, a late second resolver `409 "already resolved by U_MANAGER"`, and exactly one resume turn on the (test-isolated) runs stream.
- The Slack-rendered card and a real workspace click are exercised by the offline SocketModeHandler suite; a live-workspace pass needs Slack tokens this environment does not hold, and the epic's full acceptance demo (restart everything, click days later) composes #244's restart-survival test with this PR's click flow.

Remaining epic slice: #247 (approval-policy manifest config + route bindings + audit log), which will move card routing from "the approval's own channel" to named routes bound per deployment.