### PR TITLE
Add approval-policy routes and the platform audit log

### DIFF
--- a/apps/api/alembic/versions/0010_approval_routes_audit.py
+++ b/apps/api/alembic/versions/0010_approval_routes_audit.py
@@ -1,0 +1,73 @@
+"""approval routes + audit log (#247, ADR-0010)
+
+Adds agents.approval_routes (route-name -> workspace binding), the approval's
+route/card_channel columns, and the append-only approval_audit_entries table.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-07-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0010"
+down_revision: str | None = "0009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "agentos"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column("approval_routes", postgresql.JSONB(), nullable=True),
+        schema=SCHEMA,
+    )
+    op.add_column(
+        "approvals", sa.Column("route", sa.String(), nullable=True), schema=SCHEMA
+    )
+    op.add_column(
+        "approvals",
+        sa.Column("card_channel", sa.String(), nullable=True),
+        schema=SCHEMA,
+    )
+    op.create_table(
+        "approval_audit_entries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("approval_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("action", sa.String(), nullable=False),
+        sa.Column("actor", sa.String(), nullable=False),
+        sa.Column("actor_channel", sa.String(), nullable=True),
+        sa.Column("decision", sa.String(), nullable=False),
+        sa.Column("authorizer", sa.String(), nullable=False),
+        sa.Column("authorized", sa.Boolean(), nullable=False),
+        sa.Column("reason", sa.String(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["approval_id"], [f"{SCHEMA}.approvals.id"], ondelete="CASCADE"
+        ),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "ix_approval_audit_entries_approval_id",
+        "approval_audit_entries",
+        ["approval_id"],
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_approval_audit_entries_approval_id", "approval_audit_entries", schema=SCHEMA
+    )
+    op.drop_table("approval_audit_entries", schema=SCHEMA)
+    op.drop_column("approvals", "card_channel", schema=SCHEMA)
+    op.drop_column("approvals", "route", schema=SCHEMA)
+    op.drop_column("agents", "approval_routes", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -17,6 +17,20 @@
             ],
             "title": "Approval Required Tools"
           },
+          "approval_routes": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/ApprovalRouteBinding"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Routes"
+          },
           "behavior_packs": {
             "anyOf": [
               {
@@ -81,6 +95,18 @@
             ],
             "title": "Approval Required Tools"
           },
+          "approval_routes": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Routes"
+          },
           "behavior_packs": {
             "anyOf": [
               {
@@ -142,6 +168,7 @@
           "behavior_packs",
           "model",
           "approval_required_tools",
+          "approval_routes",
           "created_at"
         ],
         "title": "AgentOut",
@@ -163,6 +190,20 @@
               }
             ],
             "title": "Approval Required Tools"
+          },
+          "approval_routes": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/ApprovalRouteBinding"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Routes"
           },
           "model": {
             "anyOf": [
@@ -204,8 +245,84 @@
         "title": "AppConfig",
         "type": "object"
       },
+      "ApprovalAuditOut": {
+        "description": "One audit entry (#247): who attempted what, and the authorizer snapshot\nthat counted (or refused) them.",
+        "properties": {
+          "action": {
+            "title": "Action",
+            "type": "string"
+          },
+          "actor": {
+            "title": "Actor",
+            "type": "string"
+          },
+          "actor_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Actor Channel"
+          },
+          "approval_id": {
+            "format": "uuid",
+            "title": "Approval Id",
+            "type": "string"
+          },
+          "authorized": {
+            "title": "Authorized",
+            "type": "boolean"
+          },
+          "authorizer": {
+            "title": "Authorizer",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "decision": {
+            "title": "Decision",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          }
+        },
+        "required": [
+          "id",
+          "approval_id",
+          "action",
+          "actor",
+          "actor_channel",
+          "decision",
+          "authorizer",
+          "authorized",
+          "reason",
+          "created_at"
+        ],
+        "title": "ApprovalAuditOut",
+        "type": "object"
+      },
       "ApprovalCreate": {
-        "description": "A durable approval request (#244), created by the worker when a run ends\nawaiting-approval. ``dedupe_key`` is the triggering event id, so a\nredelivered turn adopts the existing record instead of forking a second one.",
+        "description": "A durable approval request (#244), created by the worker when a run ends\nawaiting-approval. ``dedupe_key`` is the triggering event id, so a\nredelivered turn adopts the existing record instead of forking a second one.\n``route``/``card_channel`` (#247) record the manifest route the request\nnamed and the channel the worker routed the card to after binding\nresolution; the authorizer proves membership against ``card_channel``.",
         "properties": {
           "agent_id": {
             "anyOf": [
@@ -223,6 +340,17 @@
             "minLength": 1,
             "title": "Author",
             "type": "string"
+          },
+          "card_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Card Channel"
           },
           "conversation_id": {
             "minLength": 1,
@@ -267,6 +395,17 @@
             "title": "Reply Placeholder",
             "type": "string"
           },
+          "route": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Route"
+          },
           "summary": {
             "minLength": 1,
             "title": "Summary",
@@ -301,6 +440,17 @@
           "author": {
             "title": "Author",
             "type": "string"
+          },
+          "card_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Card Channel"
           },
           "conversation_id": {
             "title": "Conversation Id",
@@ -385,6 +535,17 @@
             ],
             "title": "Resolved By"
           },
+          "route": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Route"
+          },
           "status": {
             "title": "Status",
             "type": "string"
@@ -404,6 +565,8 @@
           "reply_placeholder",
           "reply_endpoint",
           "dedupe_key",
+          "route",
+          "card_channel",
           "status",
           "expires_at",
           "resolved_by",
@@ -458,6 +621,20 @@
           "resolved_by"
         ],
         "title": "ApprovalResolve",
+        "type": "object"
+      },
+      "ApprovalRouteBinding": {
+        "description": "One workspace binding for a manifest-declared approval route (#247):\nthe Slack channel whose members are that route's approvers (under the\nchannel-membership authorizer).",
+        "properties": {
+          "channel": {
+            "title": "Channel",
+            "type": "string"
+          }
+        },
+        "required": [
+          "channel"
+        ],
+        "title": "ApprovalRouteBinding",
         "type": "object"
       },
       "BehaviorPacksConfig": {
@@ -4094,6 +4271,70 @@
           }
         },
         "summary": "Get Approval",
+        "tags": [
+          "approvals"
+        ]
+      }
+    },
+    "/approvals/{approval_id}/audit": {
+      "get": {
+        "description": "The approval's audit trail (#247), oldest first: every resolution\nattempt with the authorizer snapshot that counted or refused it.",
+        "operationId": "get_approval_audit_approvals__approval_id__audit_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "approval_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Approval Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ApprovalAuditOut"
+                  },
+                  "title": "Response Get Approval Audit Approvals  Approval Id  Audit Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Approval Audit",
         "tags": [
           "approvals"
         ]

--- a/apps/api/src/agentos_api/authorizer.py
+++ b/apps/api/src/agentos_api/authorizer.py
@@ -53,8 +53,10 @@ class ChannelMembershipAuthorizer:
     """First authorizer: the approval's channel members may resolve it.
 
     Membership evidence is the click channel (see the module docstring): an
-    attempt is allowed only when it comes from the same channel the approval
-    card was routed to, and never from the requester themselves.
+    attempt is allowed only when it comes from the channel the approval card
+    was routed to -- ``card_channel`` when a route binding placed the card
+    (#247), else the requesting channel -- and never from the requester
+    themselves.
     """
 
     def authorize(
@@ -65,7 +67,8 @@ class ChannelMembershipAuthorizer:
                 allowed=False,
                 reason="self-approval is blocked: the requester cannot resolve their own request",
             )
-        if actor_channel != approval.reply_channel:
+        approvers_channel = approval.card_channel or approval.reply_channel
+        if actor_channel != approvers_channel:
             return AuthzDecision(
                 allowed=False,
                 reason="you are not an approver: resolve this from the approval's channel",

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -7,7 +7,15 @@ from typing import Any
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import Agent, AgentVersion, Approval, ApprovalStatus, Deployment, Environment
+from .models import (
+    Agent,
+    AgentVersion,
+    Approval,
+    ApprovalAuditEntry,
+    ApprovalStatus,
+    Deployment,
+    Environment,
+)
 from .schemas import AgentCreate, ApprovalCreate, DeploymentCreate, VersionCreate
 
 
@@ -42,6 +50,11 @@ async def create_agent(session: AsyncSession, data: AgentCreate) -> Agent:
             else None
         ),
         approval_required_tools=data.approval_required_tools,
+        approval_routes=(
+            {name: b.model_dump() for name, b in data.approval_routes.items()}
+            if data.approval_routes is not None
+            else None
+        ),
     )
     session.add(agent)
     await session.commit()
@@ -109,6 +122,18 @@ async def update_agent_approval_tools(
     (stored as NULL, the no-gates posture)."""
 
     agent.approval_required_tools = tools or None
+    await session.commit()
+    await session.refresh(agent)
+    return agent
+
+
+async def update_agent_approval_routes(
+    session: AsyncSession, agent: Agent, routes: dict[str, Any]
+) -> Agent:
+    """Set the agent's approval route bindings (#247). An empty dict clears
+    them (stored as NULL: unbound routes fall back to the requesting channel)."""
+
+    agent.approval_routes = routes or None
     await session.commit()
     await session.refresh(agent)
     return agent
@@ -297,6 +322,8 @@ async def create_approval(session: AsyncSession, data: "ApprovalCreate") -> Appr
         reply_placeholder=data.reply_placeholder,
         reply_endpoint=data.reply_endpoint,
         dedupe_key=data.dedupe_key,
+        route=data.route,
+        card_channel=data.card_channel,
         expires_at=expires_at,
     )
     session.add(approval)
@@ -390,3 +417,44 @@ async def expire_approval(
     if claimed is None:
         return None
     return await session.get(Approval, approval_id)
+
+
+async def append_approval_audit(
+    session: AsyncSession,
+    *,
+    approval_id: uuid.UUID,
+    action: str,
+    actor: str,
+    actor_channel: str | None,
+    decision: str,
+    authorizer: str,
+    authorized: bool,
+    reason: str | None,
+) -> ApprovalAuditEntry:
+    """Append one audit row (#247). Append-only by design; never updated."""
+
+    entry = ApprovalAuditEntry(
+        approval_id=approval_id,
+        action=action,
+        actor=actor,
+        actor_channel=actor_channel,
+        decision=decision,
+        authorizer=authorizer,
+        authorized=authorized,
+        reason=reason,
+    )
+    session.add(entry)
+    await session.commit()
+    await session.refresh(entry)
+    return entry
+
+
+async def list_approval_audit(
+    session: AsyncSession, approval_id: uuid.UUID
+) -> list[ApprovalAuditEntry]:
+    result = await session.scalars(
+        select(ApprovalAuditEntry)
+        .where(ApprovalAuditEntry.approval_id == approval_id)
+        .order_by(ApprovalAuditEntry.created_at)
+    )
+    return list(result)

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -72,6 +72,17 @@ class Agent(Base):
     approval_required_tools: Mapped[list[str] | None] = mapped_column(
         JSONB, default=None
     )
+    # Per-agent approval route bindings (#247, ADR-0010): the workspace half of
+    # the split policy. The bundle manifest declares gate points and route
+    # NAMES (versioned with the agent); this maps each declared name to
+    # workspace specifics, today a Slack channel: {"managers": {"channel":
+    # "C0123..."}}. The worker resolves a raised route through this map to
+    # decide where the approval card goes (and therefore who the
+    # channel-membership authorizer counts as approvers). NULL means no
+    # bindings; an unbound route falls back to the requesting channel.
+    approval_routes: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, default=None
+    )
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 
     versions: Mapped[list["AgentVersion"]] = relationship(
@@ -163,6 +174,12 @@ class Approval(Base):
     reply_channel: Mapped[str]
     reply_placeholder: Mapped[str]
     reply_endpoint: Mapped[str | None] = mapped_column(default=None)
+    # The approval route the request named (#247), and the channel the card
+    # was actually routed to after binding resolution. The authorizer proves
+    # channel membership against card_channel (falling back to reply_channel
+    # when NULL, the pre-route behavior).
+    route: Mapped[str | None] = mapped_column(default=None)
+    card_channel: Mapped[str | None] = mapped_column(default=None)
     # Idempotency: the triggering event id. A reclaimed/redelivered turn that
     # re-requests the same approval adopts the existing row instead of forking.
     dedupe_key: Mapped[str] = mapped_column(unique=True)
@@ -174,6 +191,38 @@ class Approval(Base):
     resolution_note: Mapped[str | None] = mapped_column(default=None)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     resolved_at: Mapped[datetime | None] = mapped_column(default=None)
+
+
+class ApprovalAuditEntry(Base):
+    """The platform audit log for approvals (#247, ADR-0010).
+
+    One row per authorization-relevant event on an approval: a resolution that
+    won, a denied attempt, an expiry. Each row snapshots WHO acted, from where,
+    and the authorizer verdict that counted (or refused) them -- the answer to
+    "who resolved, and why they counted" that a black-box approval cannot give.
+    Append-only: rows are written by the resolve endpoint and never updated.
+    """
+
+    __tablename__ = "approval_audit_entries"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    approval_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(f"{SCHEMA}.approvals.id", ondelete="CASCADE"), index=True
+    )
+    # What happened: resolved / denied / race_lost / expired.
+    action: Mapped[str]
+    actor: Mapped[str]
+    actor_channel: Mapped[str | None] = mapped_column(default=None)
+    # The decision the actor attempted (approved/rejected).
+    decision: Mapped[str]
+    # The authorizer snapshot: which implementation decided, its verdict, and
+    # its stated reason at the time of the attempt.
+    authorizer: Mapped[str]
+    authorized: Mapped[bool]
+    reason: Mapped[str | None] = mapped_column(default=None)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 
 
 class WorkflowStateEntry(Base):

--- a/apps/api/src/agentos_api/routers/agents.py
+++ b/apps/api/src/agentos_api/routers/agents.py
@@ -77,6 +77,13 @@ async def update_agent(
         agent = await crud.update_agent_approval_tools(
             session, agent, data.approval_required_tools
         )
+    if data.approval_routes is not None:
+        # Omitted leaves the bindings unchanged; an explicit {} clears them (#247).
+        agent = await crud.update_agent_approval_routes(
+            session,
+            agent,
+            {name: b.model_dump() for name, b in data.approval_routes.items()},
+        )
     return AgentOut.model_validate(agent)
 
 

--- a/apps/api/src/agentos_api/routers/approvals.py
+++ b/apps/api/src/agentos_api/routers/approvals.py
@@ -26,7 +26,7 @@ from ..authorizer import Authorizer, ChannelMembershipAuthorizer
 from ..deps import ResumeQueueDep, SessionDep
 from ..models import Approval, ApprovalStatus
 from ..resumequeue import build_resume_turn
-from ..schemas import ApprovalCreate, ApprovalOut, ApprovalResolve
+from ..schemas import ApprovalAuditOut, ApprovalCreate, ApprovalOut, ApprovalResolve
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +102,20 @@ async def get_approval(approval_id: uuid.UUID, session: SessionDep) -> ApprovalO
     return ApprovalOut.model_validate(approval)
 
 
+@router.get("/{approval_id}/audit", response_model=list[ApprovalAuditOut])
+async def get_approval_audit(
+    approval_id: uuid.UUID, session: SessionDep
+) -> list[ApprovalAuditOut]:
+    """The approval's audit trail (#247), oldest first: every resolution
+    attempt with the authorizer snapshot that counted or refused it."""
+
+    approval = await crud.get_approval(session, approval_id)
+    if approval is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+    entries = await crud.list_approval_audit(session, approval_id)
+    return [ApprovalAuditOut.model_validate(e) for e in entries]
+
+
 @router.post("/{approval_id}/resolve", response_model=ApprovalOut)
 async def resolve_approval(
     approval_id: uuid.UUID,
@@ -123,8 +137,26 @@ async def resolve_approval(
     if approval is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
 
+    authorizer_name = type(_AUTHORIZER).__name__
     decision = _AUTHORIZER.authorize(approval, data.resolved_by, data.actor_channel)
+
+    async def _audit(action: str, *, authorized: bool, reason: str | None) -> None:
+        # The audit log (#247): every authorization-relevant event, with the
+        # authorizer snapshot that counted (or refused) the actor.
+        await crud.append_approval_audit(
+            session,
+            approval_id=approval_id,
+            action=action,
+            actor=data.resolved_by,
+            actor_channel=data.actor_channel,
+            decision=data.decision,
+            authorizer=authorizer_name,
+            authorized=authorized,
+            reason=reason,
+        )
+
     if not decision.allowed:
+        await _audit("denied", authorized=False, reason=decision.reason)
         raise HTTPException(status.HTTP_403_FORBIDDEN, decision.reason)
 
     if approval.status == ApprovalStatus.pending and _expired(approval):
@@ -132,6 +164,11 @@ async def resolve_approval(
         # None means a concurrent resolution won the CAS before the expiry did;
         # fall through to the claim below, which will lose and report the winner.
         if expired is not None:
+            await _audit(
+                "expired",
+                authorized=True,
+                reason=f"approval expired at {expired.expires_at}",
+            )
             raise HTTPException(
                 status.HTTP_410_GONE,
                 f"approval expired at {expired.expires_at} and can no longer be resolved",
@@ -153,10 +190,17 @@ async def resolve_approval(
                 status.HTTP_410_GONE,
                 "approval expired and can no longer be resolved",
             )
+        await _audit(
+            "race_lost",
+            authorized=True,
+            reason=f"already resolved by {current.resolved_by} ({current.status})",
+        )
         raise HTTPException(
             status.HTTP_409_CONFLICT,
             f"already resolved by {current.resolved_by} ({current.status})",
         )
+
+    await _audit("resolved", authorized=True, reason=decision.reason or None)
 
     # Wake the suspended session: the resume turn rides the normal runs stream,
     # so the kernel's ordinary consume -> claim path rehydrates the thread

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -136,6 +136,28 @@ def _validate_tool_names(value: list[str] | None) -> list[str] | None:
     return cleaned
 
 
+class ApprovalRouteBinding(BaseModel):
+    """One workspace binding for a manifest-declared approval route (#247):
+    the Slack channel whose members are that route's approvers (under the
+    channel-membership authorizer)."""
+
+    channel: str
+
+    _check_channel = field_validator("channel")(_validate_slack_channel_id)
+
+
+def _validate_route_names(
+    value: dict[str, ApprovalRouteBinding] | None,
+) -> dict[str, ApprovalRouteBinding] | None:
+    """Route names must be non-empty; they are matched verbatim against the
+    manifest's declared route names."""
+    if value is None:
+        return value
+    if any(not name.strip() for name in value):
+        raise ValueError("approval_routes keys must be non-empty route names")
+    return value
+
+
 class AgentCreate(BaseModel):
     name: str
     slack_channel: str
@@ -147,12 +169,19 @@ class AgentCreate(BaseModel):
     # Per-agent permission gates (#245): tool names requiring human approval.
     # None means no gates (the bypass posture).
     approval_required_tools: list[str] | None = None
+    # Per-agent approval route bindings (#247): manifest route name -> workspace
+    # channel. None means no bindings (unbound routes fall back to the
+    # requesting channel).
+    approval_routes: dict[str, ApprovalRouteBinding] | None = None
 
     _check_slack_channel = field_validator("slack_channel")(
         _validate_slack_channel_id
     )
     _check_approval_tools = field_validator("approval_required_tools")(
         _validate_tool_names
+    )
+    _check_approval_routes = field_validator("approval_routes")(
+        _validate_route_names
     )
 
 
@@ -168,12 +197,18 @@ class AgentUpdate(BaseModel):
     # New permission gates (#245). Omitted (None) leaves the current gates
     # unchanged; an explicit empty list clears them.
     approval_required_tools: list[str] | None = None
+    # New route bindings (#247). Omitted (None) leaves the current bindings
+    # unchanged; an explicit empty dict clears them.
+    approval_routes: dict[str, ApprovalRouteBinding] | None = None
 
     _check_slack_channel = field_validator("slack_channel")(
         _validate_slack_channel_id
     )
     _check_approval_tools = field_validator("approval_required_tools")(
         _validate_tool_names
+    )
+    _check_approval_routes = field_validator("approval_routes")(
+        _validate_route_names
     )
 
 
@@ -187,6 +222,7 @@ class AgentOut(BaseModel):
     behavior_packs: dict[str, Any] | None
     model: str | None
     approval_required_tools: list[str] | None
+    approval_routes: dict[str, Any] | None
     created_at: datetime
 
 
@@ -281,7 +317,10 @@ class DeploymentOut(BaseModel):
 class ApprovalCreate(BaseModel):
     """A durable approval request (#244), created by the worker when a run ends
     awaiting-approval. ``dedupe_key`` is the triggering event id, so a
-    redelivered turn adopts the existing record instead of forking a second one."""
+    redelivered turn adopts the existing record instead of forking a second one.
+    ``route``/``card_channel`` (#247) record the manifest route the request
+    named and the channel the worker routed the card to after binding
+    resolution; the authorizer proves membership against ``card_channel``."""
 
     agent_id: uuid.UUID | None = None
     conversation_id: str = Field(min_length=1)
@@ -291,6 +330,8 @@ class ApprovalCreate(BaseModel):
     reply_placeholder: str = Field(min_length=1)
     reply_endpoint: str | None = None
     dedupe_key: str = Field(min_length=1)
+    route: str | None = None
+    card_channel: str | None = None
     # Optional SLA: seconds from creation after which the record can only
     # expire, never be approved or rejected.
     expires_in_seconds: int | None = Field(default=None, gt=0)
@@ -322,12 +363,32 @@ class ApprovalOut(BaseModel):
     reply_placeholder: str
     reply_endpoint: str | None
     dedupe_key: str
+    route: str | None
+    card_channel: str | None
     status: str
     expires_at: datetime | None
     resolved_by: str | None
     resolution_note: str | None
     created_at: datetime
     resolved_at: datetime | None
+
+
+class ApprovalAuditOut(BaseModel):
+    """One audit entry (#247): who attempted what, and the authorizer snapshot
+    that counted (or refused) them."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    approval_id: uuid.UUID
+    action: str
+    actor: str
+    actor_channel: str | None
+    decision: str
+    authorizer: str
+    authorized: bool
+    reason: str | None
+    created_at: datetime
 
 
 class WebhookResult(BaseModel):

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -107,3 +107,53 @@ def test_agent_approval_required_tools_rejects_bad_names(
             headers=auth_headers,
         )
         assert resp.status_code == 422, resp.text
+
+
+def test_agent_approval_routes_round_trip(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    created = client.post(
+        "/agents",
+        json={
+            "name": "routed-agent",
+            "slack_channel": "C000000R01",
+            "approval_routes": {"managers": {"channel": "C000000R02"}},
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    body = created.json()
+    assert body["approval_routes"] == {"managers": {"channel": "C000000R02"}}
+
+    # PATCH replaces the map; an explicit empty dict clears it.
+    patched = client.patch(
+        f"/agents/{body['id']}",
+        json={"approval_routes": {"legal": {"channel": "C000000R03"}}},
+        headers=auth_headers,
+    )
+    assert patched.json()["approval_routes"] == {"legal": {"channel": "C000000R03"}}
+    cleared = client.patch(
+        f"/agents/{body['id']}", json={"approval_routes": {}}, headers=auth_headers
+    )
+    assert cleared.json()["approval_routes"] is None
+
+
+def test_agent_approval_routes_rejects_bad_bindings(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # A binding must carry a Slack channel ID, not a #name; route names must be
+    # non-empty.
+    for routes in (
+        {"managers": {"channel": "#managers"}},
+        {" ": {"channel": "C000000R04"}},
+    ):
+        resp = client.post(
+            "/agents",
+            json={
+                "name": f"bad-routes-{list(routes)[0].strip() or 'blank'}",
+                "slack_channel": "C000000R05",
+                "approval_routes": routes,
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422, resp.text

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -292,3 +292,104 @@ def test_authorizer_blocks_non_member_and_self_approval(
     )
     assert ok.status_code == 200
     assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_route_bound_approval_authorizes_against_card_channel(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """#247: when a route binding placed the card in another channel, THAT
+    channel's members are the approvers; the requesting channel no longer is."""
+
+    created = approvals_client.post(
+        "/approvals",
+        json=_payload(route="managers", card_channel="C_MGRS"),
+        headers=auth_headers,
+    ).json()
+    assert created["route"] == "managers"
+    assert created["card_channel"] == "C_MGRS"
+    resolve_url = f"/approvals/{created['id']}/resolve"
+
+    # The requesting channel (C1) is NOT the approvers' channel anymore.
+    from_requesting = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert from_requesting.status_code == 403
+
+    # A member of the route-bound channel resolves it.
+    ok = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C_MGRS"},
+        headers=auth_headers,
+    )
+    assert ok.status_code == 200
+    assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_audit_log_records_attempts_with_authorizer_snapshots(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """The #247 acceptance read-back: denied and resolved attempts each leave
+    an append-only audit entry naming the actor, the channel evidence, and the
+    authorizer snapshot that counted (or refused) them."""
+
+    created = approvals_client.post(
+        "/approvals", json=_payload(), headers=auth_headers
+    ).json()
+    resolve_url = f"/approvals/{created['id']}/resolve"
+
+    denied = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U_OUT", "actor_channel": "C_X"},
+        headers=auth_headers,
+    )
+    assert denied.status_code == 403
+    resolved = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert resolved.status_code == 200
+    late = approvals_client.post(
+        resolve_url,
+        json={"decision": "rejected", "resolved_by": "U_LATE", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert late.status_code == 409
+
+    audit = approvals_client.get(
+        f"/approvals/{created['id']}/audit", headers=auth_headers
+    )
+    assert audit.status_code == 200
+    entries = audit.json()
+    assert [e["action"] for e in entries] == ["denied", "resolved", "race_lost"]
+
+    denied_entry, resolved_entry, race_entry = entries
+    assert denied_entry["actor"] == "U_OUT"
+    assert denied_entry["actor_channel"] == "C_X"
+    assert denied_entry["authorized"] is False
+    assert denied_entry["authorizer"] == "ChannelMembershipAuthorizer"
+    assert "not an approver" in denied_entry["reason"]
+
+    assert resolved_entry["actor"] == "U9"
+    assert resolved_entry["authorized"] is True
+    assert resolved_entry["decision"] == "approved"
+    assert resolved_entry["authorizer"] == "ChannelMembershipAuthorizer"
+
+    assert race_entry["actor"] == "U_LATE"
+    assert "already resolved by U9" in race_entry["reason"]
+
+    # The audit endpoint 404s for an unknown approval.
+    missing = approvals_client.get(
+        f"/approvals/{uuid.uuid4()}/audit", headers=auth_headers
+    )
+    assert missing.status_code == 404

--- a/apps/worker/src/agentos_worker/approvals.py
+++ b/apps/worker/src/agentos_worker/approvals.py
@@ -34,6 +34,11 @@ class ApprovalRequest(BaseModel):
     reply_placeholder: str
     reply_endpoint: str | None = None
     dedupe_key: str
+    # The manifest route the request named and the channel the card was routed
+    # to after binding resolution (#247); the authorizer proves membership
+    # against card_channel.
+    route: str | None = None
+    card_channel: str | None = None
     expires_in_seconds: int | None = None
 
 

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -83,6 +83,7 @@ SELECT a.id AS agent_id,
        a.behavior_packs AS behavior_packs,
        a.model AS model,
        a.approval_required_tools AS approval_required_tools,
+       a.approval_routes AS approval_routes,
        v.id AS version_id,
        v.version_label AS version_label,
        v.bundle_ref AS bundle_ref
@@ -112,6 +113,10 @@ class ResolvedDeployment(BaseModel):
     # The agent's permission gates (#245): tool names requiring human approval,
     # forwarded as AGENTOS_APPROVAL_REQUIRED_TOOLS at boot. None means no gates.
     approval_required_tools: list[str] | None = None
+    # The agent's approval route bindings (#247): manifest route name ->
+    # workspace binding ({"channel": "C..."}), resolved by the kernel when a
+    # raised approval names a route. None means no bindings.
+    approval_routes: dict[str, Any] | None = None
 
 
 class BindingResolver:
@@ -156,6 +161,9 @@ class BindingResolver:
         gates = data.get("approval_required_tools")
         if isinstance(gates, str):
             data["approval_required_tools"] = json.loads(gates)
+        routes = data.get("approval_routes")
+        if isinstance(routes, str):
+            data["approval_routes"] = json.loads(routes)
         return ResolvedDeployment.model_validate(data)
 
     async def repo_full_name(self, agent_id: uuid.UUID) -> str | None:

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -29,6 +29,7 @@ import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import Any
 
 import aiohttp
 from aci_protocol import (
@@ -80,9 +81,11 @@ class TurnOutcome:
     text: str = ""
     status: SessionStatus | None = None
     steered: bool = False
-    # The approval summary off an awaiting-approval final (ADR-0010), persisted
-    # onto the durable record by the pause path. None on every other status.
+    # The approval summary and route off an awaiting-approval final (ADR-0010,
+    # #247), persisted onto the durable record by the pause path. None on
+    # every other status; route also None when the request named none.
     approval_summary: str | None = None
+    approval_route: str | None = None
 
 
 @dataclass
@@ -114,6 +117,7 @@ class _StreamAccumulator:
     status: SessionStatus | None = None
     final_text: str | None = None
     approval_summary: str | None = None
+    approval_route: str | None = None
 
     def rendered(self) -> str:
         return self.final_text if self.final_text is not None else "".join(self.text_parts)
@@ -272,6 +276,7 @@ class Kernel:
             agent_id: uuid.UUID | None = None
             nav: NavPack | None = None
             packs: BehaviorPacks | None = None
+            approval_routes: dict[str, Any] | None = None
             if self._binding is not None:
                 resolved = await self._binding.resolve(qevent.reply_handle.channel)
                 if resolved is None:
@@ -293,6 +298,9 @@ class Kernel:
                 # reuse: the nav pack is threaded to the final render, the same
                 # packs feed the shimmer below.
                 packs = self._binding.packs_for(resolved)
+                # getattr: binding doubles (tests, alternate resolvers) may not
+                # carry the routes attribute; absent means unbound (#247).
+                approval_routes = getattr(resolved, "approval_routes", None)
                 nav = packs.nav
                 # Personalize the shimmer: replace the dispatcher's generic status
                 # with this agent's sampled load line (+ tip). Best-effort and
@@ -311,7 +319,9 @@ class Kernel:
                     # A gate fired (ADR-0010): persist the durable record, then
                     # suspend the session until a human resolves it. The event
                     # is done -- the resolution arrives as its own queued turn.
-                    await self._pause_for_approval(qevent, outcome, agent_id)
+                    await self._pause_for_approval(
+                        qevent, outcome, agent_id, approval_routes
+                    )
                     await self._markers.mark_done(event_id)
                     return
 
@@ -585,7 +595,11 @@ class Kernel:
             return await asyncio.to_thread(self._substrate.resume, thread, env=boot_env)
 
     async def _pause_for_approval(
-        self, qevent: QueuedTurn, outcome: TurnOutcome, agent_id: uuid.UUID | None
+        self,
+        qevent: QueuedTurn,
+        outcome: TurnOutcome,
+        agent_id: uuid.UUID | None,
+        approval_routes: dict[str, Any] | None = None,
     ) -> None:
         """Persist the approval, suspend the session, and leave the pending notice.
 
@@ -594,10 +608,32 @@ class Kernel:
         can wake it. The converse crash (record created, suspend or notice
         lost) self-heals -- creation is idempotent on the event id, and the
         resume path cold-claims a fresh sandbox regardless (ADR-0003).
+
+        ``approval_routes`` is the agent's per-deployment route-binding map
+        (#247): when the request named a route bound to a channel, the card is
+        routed there and that channel's members become the approvers; a named
+        but unbound route logs a warning and falls back to the requesting
+        channel rather than dropping the request.
         """
 
         thread = qevent.conversation_id
         summary = outcome.approval_summary or outcome.text or "Approval requested"
+
+        # Resolve the manifest route (#247) to its workspace channel.
+        route = outcome.approval_route
+        card_channel = qevent.reply_handle.channel
+        if route:
+            binding = (approval_routes or {}).get(route)
+            bound = binding.get("channel") if isinstance(binding, dict) else None
+            if bound:
+                card_channel = str(bound)
+            else:
+                logger.warning(
+                    "approval route %r is not bound for agent %s; routing the "
+                    "card to the requesting channel",
+                    route,
+                    agent_id,
+                )
 
         if self._approvals is None:
             await self._escalate(
@@ -618,6 +654,8 @@ class Kernel:
                     reply_placeholder=qevent.reply_handle.placeholder,
                     reply_endpoint=qevent.reply_handle.endpoint,
                     dedupe_key=qevent.event_id,
+                    route=route,
+                    card_channel=card_channel,
                 )
             )
         except ApprovalBackendError as exc:
@@ -659,10 +697,12 @@ class Kernel:
         )
         try:
             await self._sink.post(
-                channel=qevent.reply_handle.channel,
+                channel=card_channel,
                 text=fallback,
                 blocks=card_blocks,
-                thread_ts=thread,
+                # In the requesting channel the card joins the thread; a
+                # route-bound channel has no such thread, so it posts top-level.
+                thread_ts=thread if card_channel == qevent.reply_handle.channel else None,
                 endpoint=qevent.reply_handle.endpoint,
             )
         except Exception as exc:  # noqa: BLE001 - the pause stands without the card
@@ -726,6 +766,7 @@ class Kernel:
             acc.status = frame.status
             acc.final_text = frame.text
             acc.approval_summary = frame.approval_summary
+            acc.approval_route = frame.approval_route
 
     async def _finish(self, acc: _StreamAccumulator, reply: _ThrottledReply) -> TurnOutcome:
         if acc.status in (SessionStatus.DONE, SessionStatus.IDLE_AWAITING_INPUT):
@@ -747,6 +788,7 @@ class Kernel:
                 text=acc.rendered(),
                 status=acc.status,
                 approval_summary=acc.approval_summary,
+                approval_route=acc.approval_route,
             )
         # classified-failure, or the stream ended with no final at all.
         return TurnOutcome(

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -40,6 +40,7 @@ async def _seed_agent(
     max_usd: float | None,
     max_tokens: int | None,
     approval_tools: list[str] | None = None,
+    approval_routes: dict | None = None,
 ) -> uuid.UUID:
     agent_id = uuid.uuid4()
     async with engine.begin() as conn:
@@ -47,9 +48,9 @@ async def _seed_agent(
             text(
                 f"INSERT INTO {_SCHEMA}.agents "
                 "(id, name, slack_channel, max_usd_per_day, max_output_tokens_per_run, "
-                "approval_required_tools) "
+                "approval_required_tools, approval_routes) "
                 "VALUES (:id, :name, :channel, :usd, :tokens, "
-                "CAST(:approval_tools AS jsonb))"
+                "CAST(:approval_tools AS jsonb), CAST(:approval_routes AS jsonb))"
             ),
             {
                 "id": agent_id,
@@ -59,6 +60,9 @@ async def _seed_agent(
                 "tokens": max_tokens,
                 "approval_tools": (
                     json.dumps(approval_tools) if approval_tools is not None else None
+                ),
+                "approval_routes": (
+                    json.dumps(approval_routes) if approval_routes is not None else None
                 ),
             },
         )
@@ -408,6 +412,43 @@ def test_resolves_approval_required_tools_into_boot_env() -> None:
                 ]
                 env = _resolver(engine).boot_env(resolved, "thread-1")
                 assert env[APPROVAL_REQUIRED_ENV] == "Bash,mcp__github__create_issue"
+            finally:
+                await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_resolves_approval_routes_from_the_agent_row() -> None:
+    # Route bindings (#247): the per-agent JSONB map survives the SQL resolve
+    # (decode included) so the kernel can route approval cards through it.
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            try:
+                async with engine.connect():
+                    pass
+            except SQLAlchemyError as exc:
+                pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+
+            token = uuid.uuid4().hex[:8]
+            channel = f"C-{token}"
+            agent_id = await _seed_agent(
+                engine,
+                channel=channel,
+                name=f"agent-{token}",
+                max_usd=None,
+                max_tokens=None,
+                approval_routes={"managers": {"channel": "C_MGRS"}},
+            )
+            await _seed_deployment(
+                engine, agent_id=agent_id, environment="prod", bundle_ref=f"b/{token}.zip"
+            )
+            try:
+                resolved = await _resolver(engine).resolve(channel)
+                assert resolved is not None
+                assert resolved.approval_routes == {"managers": {"channel": "C_MGRS"}}
             finally:
                 await _cleanup(engine, [agent_id])
         finally:

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -236,3 +236,107 @@ def test_escalation_paths_post_no_card(make_harness) -> None:
             assert h.sink.posts == []
 
     asyncio.run(go())
+
+
+def _awaiting_routed_script(summary: str, route: str) -> list:
+    return [
+        TextDelta(text="Requesting sign-off"),
+        Final(
+            text="Requesting sign-off",
+            status=AWAITING,
+            approval_summary=summary,
+            approval_route=route,
+        ),
+    ]
+
+
+class RoutedBinding:
+    """A minimal binding stand-in: one channel -> one agent with route bindings."""
+
+    def __init__(self, routes: dict | None) -> None:
+        self.routes = routes
+        self.agent_id = uuid.uuid4()
+
+    async def resolve(self, channel: str):  # noqa: ANN201
+        from agentos_worker.binding import ResolvedDeployment
+
+        return ResolvedDeployment(
+            agent_id=self.agent_id,
+            version_id=uuid.uuid4(),
+            version_label="v1",
+            bundle_ref=None,
+            max_usd_per_day=None,
+            max_output_tokens_per_run=None,
+            approval_routes=self.routes,
+        )
+
+    def packs_for(self, resolved):  # noqa: ANN001, ANN201
+        from agentos_worker.behaviorpacks import BehaviorPacks
+
+        return BehaviorPacks.from_config(None)
+
+    def budget_for(self, resolved):  # noqa: ANN001, ANN201
+        from aci_protocol import Budget
+
+        return Budget(max_output_tokens_per_run=1000, max_usd_per_day=1.0)
+
+    def boot_env(self, resolved, thread_key):  # noqa: ANN001, ANN201
+        return {"AGENTOS_SESSION_ID": f"s-{thread_key}"}
+
+
+def test_routed_approval_cards_go_to_the_bound_channel(make_harness) -> None:
+    """#247: the manifest route resolves through the agent's bindings; the card
+    lands in the bound channel (top-level, no foreign thread) and the record
+    carries route + card_channel so the authorizer counts THAT channel."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        binding = RoutedBinding({"managers": {"channel": "C_MGRS"}})
+        async with make_harness(approvals=approvals, binding=binding) as h:
+            h.runner.default_script = _awaiting_routed_script(
+                "Discount for ACME", "managers"
+            )
+            await h.kernel.process_event(_qevent("discount?", thread="th-routed"))
+
+            req = approvals.requests[0]
+            assert req.route == "managers"
+            assert req.card_channel == "C_MGRS"
+            # Card posted to the bound channel, top-level (no thread there).
+            channel, _fallback, blocks, thread_ts = h.sink.posts[0]
+            assert channel == "C_MGRS"
+            assert thread_ts is None
+            assert blocks is not None
+
+    asyncio.run(go())
+
+
+def test_unbound_route_falls_back_to_requesting_channel(make_harness) -> None:
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        binding = RoutedBinding(None)  # agent has no bindings at all
+        async with make_harness(approvals=approvals, binding=binding) as h:
+            h.runner.default_script = _awaiting_routed_script("Anything", "managers")
+            await h.kernel.process_event(_qevent("gate", thread="th-unbound"))
+
+            req = approvals.requests[0]
+            assert req.route == "managers"
+            assert req.card_channel == "C1"  # fell back to the requesting channel
+            channel, _f, _b, thread_ts = h.sink.posts[0]
+            assert channel == "C1"
+            assert thread_ts == "th-unbound"  # same channel keeps the thread
+
+    asyncio.run(go())
+
+
+def test_routeless_approval_keeps_prior_behavior(make_harness) -> None:
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script("Plain request")
+            await h.kernel.process_event(_qevent("gate", thread="th-plain"))
+
+            req = approvals.requests[0]
+            assert req.route is None
+            assert req.card_channel == "C1"
+
+    asyncio.run(go())

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -211,6 +211,7 @@ mod tests {
             text: text.into(),
             status,
             approval_summary: None,
+            approval_route: None,
         }
     }
 

--- a/cli/src/ndjson.rs
+++ b/cli/src/ndjson.rs
@@ -81,6 +81,7 @@ mod tests {
                 text: "done".to_string(),
                 status: SessionStatus::Done,
                 approval_summary: None,
+                approval_route: None,
             }
         );
     }

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -153,6 +153,7 @@ mod tests {
             text: "all done".into(),
             status: SessionStatus::Done,
             approval_summary: None,
+            approval_route: None,
         };
         // A delta routes to stdout as a raw token.
         assert!(matches!(printer.part_for(&delta), Some(TurnPart::Token(t)) if t == "all done"));
@@ -170,6 +171,7 @@ mod tests {
             text: "quiet answer".into(),
             status: SessionStatus::IdleAwaitingInput,
             approval_summary: None,
+            approval_route: None,
         };
         // The caller prints this token to stdout, then appends the status trailer.
         assert!(
@@ -185,6 +187,7 @@ mod tests {
             text: String::new(),
             status: SessionStatus::Done,
             approval_summary: None,
+            approval_route: None,
         };
         assert!(
             matches!(printer.part_for(&final_frame), Some(TurnPart::Status(s)) if s == "-- final (done)")

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -17,8 +17,9 @@ explicit user-list, platform-RBAC) behind that one server-side check.
 
 ## Current contract
 
-The durable base of the seam landed with #244; the authorizer port itself is still ahead
-(#246). What exists in code now:
+The durable base landed with #244, the gates with #245, the authorizer and cards with #246,
+and the policy/route/audit layer with #247 — the epic's full primitive is live. What exists
+in code now:
 
 - **The durable record + resolve-once semantics (landed, #244).** The `Approval` table
   (`apps/api/src/agentos_api/models.py`) with the resolve-once compare-and-set
@@ -46,8 +47,19 @@ The durable base of the seam landed with #244; the authorizer port itself is sti
   types share one record/suspend/resume lifecycle. An agent with no configured gates keeps
   the historical `bypassPermissions` posture verbatim (zero behavior change). Not yet built:
   a grant mechanism for the resumed turn (an approved tool call is still gated on retry
-  after resume; a one-shot allowance delivered at boot composes with #247's policy
-  evaluation).
+  after resume; a one-shot allowance delivered at boot remains open follow-up work).
+- **The policy/route/audit layer (landed, #247).** The bundle manifest's `approvalPolicy`
+  gates (schema + deploy validation from #273) are consumed at runner boot
+  (`load_approval_policy`): each `{gate, route}` pair adds the tool to the permission gate
+  and tags it with a route NAME, versioned with the agent. The policy-gate tool accepts an
+  optional `route` argument for skill-raised requests. Route names are bound to workspace
+  channels per agent (`agents.approval_routes`, deployment config, never in the bundle);
+  the worker resolves a raised route through the binding and posts the card into the bound
+  channel (`card_channel` on the record), whose members the authorizer then counts as the
+  approvers; an unbound route falls back to the requesting channel with a warning. Every
+  resolution attempt appends to the platform audit log (`approval_audit_entries`,
+  `GET /approvals/{id}/audit`): actor, channel evidence, decision, and the authorizer
+  snapshot -- who resolved, and why they counted (or were refused).
 
 ## Implementations today
 

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -141,6 +141,8 @@ pub enum OutboundEvent {
         status: SessionStatus,
         #[serde(default)]
         approval_summary: Option<String>,
+        #[serde(default)]
+        approval_route: Option<String>,
     },
     #[serde(rename = "error")]
     ErrorEvent {
@@ -172,6 +174,7 @@ mod tests {
             text: "hi".to_string(),
             status: SessionStatus::Done,
             approval_summary: None,
+            approval_route: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -185,6 +188,7 @@ mod tests {
             text: "requesting sign-off".to_string(),
             status: SessionStatus::AwaitingApproval,
             approval_summary: Some("Give ACME a 20% discount".to_string()),
+            approval_route: Some("managers".to_string()),
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -17,6 +17,7 @@ export type Text = string;
 export type Ts = string;
 export type Type1 = "message" | "job" | "eval_case";
 export type User = string;
+export type ApprovalRoute = string | null;
 export type ApprovalSummary = string | null;
 /**
  * Terminal or awaiting status of a session, from the output contract.
@@ -126,13 +127,18 @@ export interface Event {
  * ``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):
  * the human-readable statement of what needs approval, captured from the
  * run's approval request so the platform can persist it on the durable
- * ``Approval`` record and show it to the approver. ``None`` on every other
- * status.
+ * ``Approval`` record and show it to the approver. ``approval_route`` names
+ * the approval route the request targets (#247): declared in the bundle
+ * manifest's ``approvalPolicy`` (versioned with the agent), bound to a
+ * workspace channel per deployment by the worker. Both ``None`` on every
+ * other status; ``approval_route`` also ``None`` when the request named no
+ * route (the platform falls back to the requesting channel).
  *
  * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
+  approval_route?: ApprovalRoute;
   approval_summary?: ApprovalSummary;
   status?: SessionStatus;
   text: Text1;

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -114,8 +114,20 @@
     },
     "Final": {
       "additionalProperties": false,
-      "description": "The terminal response event, carrying the session status.\n\n``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):\nthe human-readable statement of what needs approval, captured from the\nrun's approval request so the platform can persist it on the durable\n``Approval`` record and show it to the approver. ``None`` on every other\nstatus.",
+      "description": "The terminal response event, carrying the session status.\n\n``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):\nthe human-readable statement of what needs approval, captured from the\nrun's approval request so the platform can persist it on the durable\n``Approval`` record and show it to the approver. ``approval_route`` names\nthe approval route the request targets (#247): declared in the bundle\nmanifest's ``approvalPolicy`` (versioned with the agent), bound to a\nworkspace channel per deployment by the worker. Both ``None`` on every\nother status; ``approval_route`` also ``None`` when the request named no\nroute (the platform falls back to the requesting channel).",
       "properties": {
+        "approval_route": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Approval Route"
+        },
         "approval_summary": {
           "anyOf": [
             {

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -99,14 +99,19 @@ class Final(_OutboundBase):
     ``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):
     the human-readable statement of what needs approval, captured from the
     run's approval request so the platform can persist it on the durable
-    ``Approval`` record and show it to the approver. ``None`` on every other
-    status.
+    ``Approval`` record and show it to the approver. ``approval_route`` names
+    the approval route the request targets (#247): declared in the bundle
+    manifest's ``approvalPolicy`` (versioned with the agent), bound to a
+    workspace channel per deployment by the worker. Both ``None`` on every
+    other status; ``approval_route`` also ``None`` when the request named no
+    route (the platform falls back to the requesting channel).
     """
 
     type: Literal["final"] = "final"
     text: str
     status: SessionStatus = SessionStatus.DONE
     approval_summary: str | None = None
+    approval_route: str | None = None
 
 
 class ErrorEvent(_OutboundBase):

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -218,6 +218,7 @@ mod tests {
             text: "hi".to_string(),
             status: SessionStatus::Done,
             approval_summary: None,
+            approval_route: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -231,6 +232,7 @@ mod tests {
             text: "requesting sign-off".to_string(),
             status: SessionStatus::AwaitingApproval,
             approval_summary: Some("Give ACME a 20% discount".to_string()),
+            approval_route: Some("managers".to_string()),
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -16,7 +16,12 @@ import anyio
 from aiohttp import web
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
-from .approval import ApprovalGate, build_approval_server, build_can_use_tool
+from .approval import (
+    ApprovalGate,
+    build_approval_server,
+    build_can_use_tool,
+    load_approval_policy,
+)
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .history import (
@@ -85,14 +90,21 @@ def build_runner(
     # In-bundle PreToolUse guardrails declared in the manifest hooks field (#272),
     # translated into SDK HookMatcher callbacks. None when the bundle declares none.
     bundle_hooks = load_bundle_hooks(config.session.plugin_dir)
-    # The permission gate (#245): when the agent's config marks tools as
-    # approval-required, a can_use_tool callback replaces the hardcoded bypass
-    # and blocks those calls pending approval. The gate object is shared with
-    # the SessionRunner so a blocked call flips the turn's final to
-    # awaiting-approval. None (no configured tools) keeps the bypass posture.
+    # The permission gate (#245/#247): approval-required tools come from the
+    # union of the bundle manifest's approvalPolicy gates (versioned with the
+    # agent, each carrying its route name) and the AGENTOS_APPROVAL_REQUIRED_TOOLS
+    # env override (operator/per-agent config, no route). When either names a
+    # tool, a can_use_tool callback replaces the hardcoded bypass and blocks
+    # those calls pending approval; the gate object is shared with the
+    # SessionRunner so a blocked call flips the turn's final to
+    # awaiting-approval. Neither configured keeps the bypass posture.
+    policy_routes = load_approval_policy(config.session.plugin_dir)
+    gated_tools = frozenset(config.approval_required_tools or ()) | frozenset(
+        policy_routes
+    )
     approval_gate = (
-        ApprovalGate(required=frozenset(config.approval_required_tools))
-        if config.approval_required_tools
+        ApprovalGate(required=gated_tools, route_by_tool=policy_routes)
+        if gated_tools
         else None
     )
 

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from claude_agent_sdk import create_sdk_mcp_server, tool
@@ -42,6 +43,7 @@ from claude_agent_sdk.types import (
     PermissionResultDeny,
     ToolPermissionContext,
 )
+from plugin_format import ApprovalPolicy, PluginManifest
 
 # The server key under ClaudeAgentOptions.mcp_servers; the SDK prefixes tool
 # names as mcp__<server>__<tool>.
@@ -53,14 +55,33 @@ APPROVAL_TOOL_NAME = f"mcp__{APPROVAL_SERVER_NAME}__{_TOOL_NAME}"
 _TOOL_DESCRIPTION = (
     "Request human approval before proceeding. Call this when your"
     " instructions say a step needs sign-off (a discount, an invoice, a"
-    " remediation). Pass a one-line summary of exactly what needs approval."
-    " After calling it, end your turn and tell the user the request is"
-    " pending; the platform pauses the session and resumes it with the"
-    " decision once an authorized human resolves it."
+    " remediation). Pass a one-line summary of exactly what needs approval,"
+    " and, when your instructions name an approval route for this kind of"
+    " decision, pass it as route (the platform delivers the request to that"
+    " route's channel). After calling it, end your turn and tell the user the"
+    " request is pending; the platform pauses the session and resumes it with"
+    " the decision once an authorized human resolves it."
 )
 
+# Full JSON schema (not the shorthand type map) so ``route`` is optional: a
+# request without a route falls back to the requesting channel.
+_TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "summary": {
+            "type": "string",
+            "description": "One line stating exactly what needs approval.",
+        },
+        "route": {
+            "type": "string",
+            "description": "Optional approval route name from your instructions.",
+        },
+    },
+    "required": ["summary"],
+}
 
-@tool(_TOOL_NAME, _TOOL_DESCRIPTION, {"summary": str})
+
+@tool(_TOOL_NAME, _TOOL_DESCRIPTION, _TOOL_SCHEMA)
 async def _request_approval(args: dict[str, Any]) -> dict[str, Any]:
     summary = str(args.get("summary") or "").strip()
     if not summary:
@@ -134,11 +155,15 @@ def summarize_tool_call(tool_name: str, tool_input: dict[str, Any]) -> str:
 class ApprovalGate:
     """Shared state between the ``can_use_tool`` callback and the session loop.
 
-    ``required`` is the per-agent set of approval-required tool names
-    (AGENTOS_APPROVAL_REQUIRED_TOOLS). ``pending_summary`` is set by the
-    callback when it blocks a call and consumed by the session at turn end to
-    flip the final to awaiting-approval; ``reset()`` clears it at each turn
-    start so one turn's block never leaks into the next.
+    ``required`` is the per-agent set of approval-required tool names: the
+    union of the bundle manifest's ``approvalPolicy`` gates (#247, versioned
+    with the agent) and the AGENTOS_APPROVAL_REQUIRED_TOOLS env override.
+    ``route_by_tool`` maps a manifest-gated tool to its declared route name,
+    so a blocked call carries the route the platform binds to a channel.
+    ``pending_summary``/``pending_route`` are set by the callback when it
+    blocks a call and consumed by the session at turn end to flip the final
+    to awaiting-approval; ``reset()`` clears them at each turn start so one
+    turn's block never leaks into the next.
 
     The first blocked call of a turn wins: a model that retries the denied
     tool (against the deny message's instruction) does not overwrite the
@@ -146,14 +171,18 @@ class ApprovalGate:
     """
 
     required: frozenset[str] = field(default_factory=frozenset)
+    route_by_tool: dict[str, str] = field(default_factory=dict)
     pending_summary: str | None = None
+    pending_route: str | None = None
 
     def reset(self) -> None:
         self.pending_summary = None
+        self.pending_route = None
 
     def block(self, tool_name: str, tool_input: dict[str, Any]) -> None:
         if self.pending_summary is None:
             self.pending_summary = summarize_tool_call(tool_name, tool_input)
+            self.pending_route = self.route_by_tool.get(tool_name)
 
 
 def build_can_use_tool(gate: ApprovalGate) -> CanUseTool:
@@ -177,3 +206,44 @@ def build_can_use_tool(gate: ApprovalGate) -> CanUseTool:
         return PermissionResultAllow()
 
     return can_use_tool
+
+
+# --- The manifest approval policy (#247): gates shipped in the bundle -----------
+
+_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
+
+
+def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
+    """The bundle manifest's ``approvalPolicy`` gates as ``{tool: route}``.
+
+    A gate's ``gate`` field names the tool the runner intercepts (the tool
+    class of the ADR-0010 permission gate); its ``route`` names the approval
+    route the platform binds to a channel per deployment. Declared in the
+    bundle so the policy is versioned and evaluable with the agent (#247);
+    validated at deploy by ``plugin_format.validate_bundle``. Best-effort,
+    mirroring the hooks/systemPrompt readers: no dir, no manifest, or no
+    policy yields {} and the authoritative parse gate stays load_plugins.
+    """
+
+    if not plugin_dir:
+        return {}
+    root = Path(plugin_dir)
+    manifest_path = next(
+        (root / loc for loc in _MANIFEST_LOCATIONS if (root / loc).is_file()), None
+    )
+    if manifest_path is None:
+        return {}
+    try:
+        manifest = PluginManifest.model_validate(
+            json.loads(manifest_path.read_text(encoding="utf-8"))
+        )
+        if manifest.approvalPolicy is None:
+            return {}
+        policy = ApprovalPolicy.model_validate(manifest.approvalPolicy)
+    except (json.JSONDecodeError, ValueError, OSError):
+        return {}
+    return {
+        gate.gate.strip(): gate.route.strip()
+        for gate in policy.gates
+        if gate.gate and gate.gate.strip() and gate.route and gate.route.strip()
+    }

--- a/runner/src/agentos_runner/fake.py
+++ b/runner/src/agentos_runner/fake.py
@@ -9,6 +9,7 @@ spawns the CLI or touches the network. ``aci-protocol`` is never mocked.
 
 from __future__ import annotations
 
+import re
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 
@@ -53,21 +54,27 @@ def default_turn() -> list[Any]:
 # script raise an approval request (ADR-0010), so the awaiting-approval
 # lifecycle round-trips fully offline (CI, `agentos skill up --fake-model`, the
 # chart's sealed default pool). Everything after the marker on the same line is
-# the approval summary. Like all fake-model behavior: no model call, no network.
+# the approval summary; the routed form ``[fake:request-approval:managers]``
+# additionally names an approval route (#247). Like all fake-model behavior:
+# no model call, no network.
 APPROVAL_MARKER = "[fake:request-approval]"
+_APPROVAL_MARKER_RE = re.compile(r"\[fake:request-approval(?::([A-Za-z0-9_-]+))?\]")
 
 
-def approval_turn(summary: str) -> list[Any]:
+def approval_turn(summary: str, route: str | None = None) -> list[Any]:
     """A turn that calls the platform approval-request tool, then ends."""
 
     text = "This needs sign-off; requesting approval."
+    payload: dict[str, Any] = {"summary": summary}
+    if route is not None:
+        payload["route"] = route
     return [
         _assistant(TextBlock(text=text)),
         _assistant(
             ToolUseBlock(
                 id="t1",
                 name="mcp__agentos__request_approval",
-                input={"summary": summary},
+                input=payload,
             )
         ),
         _result(text=text, usage={"input_tokens": 20, "output_tokens": 8}),
@@ -107,9 +114,10 @@ class FakeModelSession:
         """
 
         last = self.queries[-1] if self.queries else ""
-        if APPROVAL_MARKER in last:
-            summary = last.split(APPROVAL_MARKER, 1)[1].strip() or "unspecified request"
-            return approval_turn(summary)
+        match = _APPROVAL_MARKER_RE.search(last)
+        if match:
+            summary = last[match.end() :].strip() or "unspecified request"
+            return approval_turn(summary, route=match.group(1))
         return default_turn()
 
     async def connect(self) -> None:

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -97,6 +97,7 @@ def _apply_approval_override(final: Final, state: TurnState) -> Final:
             text=final.text,
             status=SessionStatus.AWAITING_APPROVAL,
             approval_summary=state.approval_summary,
+            approval_route=state.approval_route,
         )
     return final
 
@@ -452,6 +453,7 @@ class SessionRunner:
             and not state.approval_summary
         ):
             state.approval_summary = self._approval_gate.pending_summary
+            state.approval_route = self._approval_gate.pending_route
 
     def _budget_halt_lines(self) -> list[str]:
         """The error+final pair emitted whenever the output-token ceiling trips.

--- a/runner/src/agentos_runner/translate.py
+++ b/runner/src/agentos_runner/translate.py
@@ -49,6 +49,10 @@ class TurnState:
     # the ToolUseBlock so the session can end the turn awaiting-approval. None
     # when no approval was requested this turn.
     approval_summary: str | None = None
+    # The approval route the request named (#247): a manifest-declared route
+    # the platform binds to a channel per deployment. None routes to the
+    # requesting channel.
+    approval_route: str | None = None
     # Assistant text streamed during the turn, accumulated so a DONE result with
     # an empty ``result`` can still deliver the model's answer. Reasoning models
     # routed through OpenRouter (e.g. z-ai/glm-5.2) emit the answer as a TextBlock
@@ -116,13 +120,16 @@ def _translate_assistant(
             if gen is not None:
                 gen.tool_span(block.name)
             if block.name == APPROVAL_TOOL_NAME:
-                # A policy gate fired (ADR-0010). Capture the summary at the
-                # wire level so the real path (executed in-process tool) and
-                # the fake path (scripted ToolUseBlock) exercise one seam.
-                raw = block.input.get("summary") if isinstance(block.input, dict) else None
-                summary = str(raw or "").strip()
+                # A policy gate fired (ADR-0010). Capture the summary (and the
+                # optional route, #247) at the wire level so the real path
+                # (executed in-process tool) and the fake path (scripted
+                # ToolUseBlock) exercise one seam.
+                payload = block.input if isinstance(block.input, dict) else {}
+                summary = str(payload.get("summary") or "").strip()
                 if summary:
                     state.approval_summary = summary
+                    route = str(payload.get("route") or "").strip()
+                    state.approval_route = route or None
             if classifier.is_side_effecting(block.name) and not state.side_effect_emitted:
                 events.append(
                     SideEffectFlag(tool=block.name, detail="non-idempotent tool executed")

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -354,3 +354,112 @@ def test_runner_config_parses_approval_required_tools() -> None:
     )
     assert config.approval_required_tools == ["Bash", "mcp__github__create_issue"]
     assert RunnerConfig.from_env(base).approval_required_tools is None
+
+
+# --- the manifest approval policy + routes (#247) --------------------------------
+
+
+def test_load_approval_policy_reads_manifest_gates(tmp_path) -> None:
+    import json as _json
+
+    from agentos_runner.approval import load_approval_policy
+
+    plugin = tmp_path / ".claude-plugin"
+    plugin.mkdir()
+    (plugin / "plugin.json").write_text(
+        _json.dumps(
+            {
+                "name": "deal-desk",
+                "approvalPolicy": {
+                    "gates": [
+                        {"gate": "Bash", "route": "managers"},
+                        {"gate": "mcp__crm__send_contract", "route": "legal"},
+                    ]
+                },
+            }
+        )
+    )
+    assert load_approval_policy(str(tmp_path)) == {
+        "Bash": "managers",
+        "mcp__crm__send_contract": "legal",
+    }
+    # No dir / no manifest / no policy all yield the empty map.
+    assert load_approval_policy(None) == {}
+    assert load_approval_policy(str(tmp_path / "missing")) == {}
+
+
+def test_gate_block_records_the_declared_route() -> None:
+    gate = ApprovalGate(
+        required=frozenset({"Bash", "Read"}), route_by_tool={"Bash": "managers"}
+    )
+    gate.block("Bash", {"command": "x"})
+    assert gate.pending_route == "managers"
+    gate.reset()
+    # An env-configured tool with no manifest route carries no route.
+    gate.block("Read", {"file_path": "/x"})
+    assert gate.pending_route is None
+
+
+def test_blocked_turn_final_carries_the_route() -> None:
+    async def go() -> None:
+        gate = ApprovalGate(
+            required=frozenset({"Bash"}), route_by_tool={"Bash": "managers"}
+        )
+        turns = {"n": 0}
+
+        def factory() -> list:
+            turns["n"] += 1
+            if turns["n"] == 1:
+                gate.block("Bash", {"command": "echo hi"})
+            return default_turn()
+
+        session = FakeModelSession(factory)
+        runner = SessionRunner(
+            session_factory=lambda: session,
+            ceiling=10_000,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="test",
+            session_id="s-1",
+            approval_gate=gate,
+        )
+        await runner.start()
+        frames = await _drain(runner, "run echo hi")
+        assert frames[-1]["status"] == "awaiting-approval"
+        assert frames[-1]["approval_route"] == "managers"
+
+    anyio.run(go)
+
+
+def test_policy_tool_route_param_reaches_the_final() -> None:
+    async def go() -> None:
+        session = FakeModelSession(
+            lambda: approval_turn("Discount for ACME", route="managers")
+        )
+        runner = _runner(session)
+        await runner.start()
+        frames = await _drain(runner, "discount please")
+        final = frames[-1]
+        assert final["status"] == "awaiting-approval"
+        assert final["approval_route"] == "managers"
+
+    anyio.run(go)
+
+
+def test_fake_routed_marker_names_the_route() -> None:
+    async def go() -> None:
+        session = FakeModelSession()
+        runner = _runner(session)
+        await runner.start()
+        frames = await _drain(
+            runner, "[fake:request-approval:managers] Give ACME 20% off"
+        )
+        final = frames[-1]
+        assert final["status"] == "awaiting-approval"
+        assert final["approval_summary"] == "Give ACME 20% off"
+        assert final["approval_route"] == "managers"
+        # The un-routed marker still works, with no route.
+        frames = await _drain(runner, f"{APPROVAL_MARKER} plain request")
+        assert frames[-1]["approval_route"] is None
+
+    anyio.run(go)


### PR DESCRIPTION
Closes #247 — the final slice of epic #22 (approval gates and human-in-the-loop, ADR-0010). Consumes the manifest schema #273 landed; builds on the durable record (#244), the permission gate (#245), and the cards + authorizer (#246). Interface contract: `docs/interfaces/approval/INTERFACE.md` (updated: the epic's full primitive is now live).

## What this lands

The policy split ADR-0010 prescribed, made real end to end: **gate points and route NAMES ship versioned in the bundle manifest; workspace bindings (which channel, and therefore who approves) stay per-agent deployment config; and every resolution attempt leaves an audit entry with the authorizer snapshot.**

### Manifest policy, consumed at runtime (runner)

- `load_approval_policy` reads the bundle's `approvalPolicy` (`{gates: [{gate, route}]}`, deploy-validated by #273) at boot: each gate adds its tool to the #245 permission gate and tags it with the declared route, unioned with the `AGENTOS_APPROVAL_REQUIRED_TOOLS` env override (operator config, no route). Policy remains **in the bundle and versioned with the agent** — the platform never hardcodes when a gate fires.
- The `request_approval` policy tool accepts an optional `route` argument (input schema widened to a full JSON schema so `route` stays optional), so a skill can raise "this needs the managers route" explicitly. The route rides the `awaiting-approval` final through **both** trigger types on one new optional contract field (`Final.approval_route`, regenerated across all three language targets; the generated-crate test template and CLI construction sites updated in the same change — the #406 lesson, applied preemptively).
- The fake model's approval marker gains a routed form (`[fake:request-approval:managers]`), keeping the whole path exercisable offline.

### Route bindings (API + worker)

- `agents.approval_routes` (migration `0010`): route name -> `{channel}` (validated as real Slack channel IDs), settable at create and PATCH (omitted = unchanged, `{}` = clear). This is the workspace half of the split: rebinding a route is a deployment-config change, never a bundle change.
- The worker binding resolves the map; the kernel resolves a raised route through it and posts the approval card **into the bound channel** (top-level there — the requesting thread does not exist in a foreign channel; unrouted approvals keep the in-thread behavior). `route` + `card_channel` are persisted on the durable record. A named-but-unbound route falls back to the requesting channel with a warning rather than dropping the request.
- The channel-membership authorizer now proves membership against `card_channel` (falling back to `reply_channel`), so binding a route **moves the approver set** to the bound channel: after routing, the requesting channel's members are no longer approvers — verified explicitly.

### The platform audit log (API)

- Append-only `approval_audit_entries`: one row per authorization-relevant event — `denied`, `resolved`, `race_lost`, `expired` — each snapshotting the actor, the channel evidence, the attempted decision, the authorizer implementation, its verdict, and its stated reason. This is the "who resolved, and why they counted" answer a black-box approval cannot give, and the denied rows are the part worth auditing.
- `GET /approvals/{id}/audit` reads the trail back, oldest first.

## Verification

- `uv run pytest -q`: **902 passed** (13 new): manifest loader; gate route tagging (env-configured tools carry no route); routed finals through the permission gate, the policy tool, and the routed fake marker; API route-binding round-trip, channel-ID validation, the card_channel authorization flip (requesting channel loses approver status once routed), and the audit trail read-back (`denied -> resolved -> race_lost`, snapshots asserted); worker binding SQL resolve (JSONB decode) and kernel routing (bound channel top-level, unbound fallback in-thread, routeless unchanged).
- `ruff` / `mypy` clean; `cargo fmt --check` / `clippy -D warnings` / `cargo test` clean; generated-crate `cargo test --locked` green locally; `scripts/check-contracts.sh` green.
- Migration `0010` developed and verified against a disposable database only; the shared compose DB untouched.
- **Hands-on e2e, the issue's acceptance flow**, against a real API process on a migrated scratch database plus a rebuilt runner container: create the agent **binding `managers -> C_MGRS` at deploy**; a routed approval lands carrying `route`/`card_channel`; a resolve from the requesting channel is denied `403`; a member of the bound channel resolves `200`; `GET /approvals/{id}/audit` reads back both entries with `ChannelMembershipAuthorizer` snapshots (denied with reason, resolved with verdict); and the real container emits `"approval_route":"managers"` on the wire for a routed request.

## Epic #22 status

With this PR the epic's four slices are complete: #244 (durable record + suspend/resume), #245 (canUseTool permission gate), #246 (cards + server-side authorizer), #247 (policy routes + audit). Known follow-up carried in the interface doc: a one-shot grant mechanism for the resumed turn, and richer authorizer implementations (user-group, user-list, RBAC) behind the existing Protocol.