### PR TITLE
Scope the sandbox state credential (ADR-0033)

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -13,6 +13,15 @@ worker, Postgres, MinIO/S3, Langfuse, and GitHub.
   replace it eventually, but until that lands, do not add a second
   auth scheme for a new router without raising it in an issue/PR first --
   every router should share the one dependency.
+- **The `state` router authenticates differently, on purpose (ADR-0033, #410).**
+  `require_state_access` (`routers/state.py`) accepts EITHER the platform key OR a
+  scoped, path-`agent_id`-bound `state` token minted by the worker for the
+  sandbox, so a sandboxed agent can rehydrate its own memory/transcript without
+  holding a resolve-capable platform-wide key. Every OTHER router keeps
+  `require_api_key` (platform key only); a scoped token is rejected everywhere
+  else, including `/approvals/{id}/resolve`. Do not collapse the state router
+  back onto `require_api_key`, and do not extend scoped-token acceptance to
+  another router without a new ADR.
 - **The GitHub webhook is authenticated differently, on purpose.** `/github/webhook`
   verifies the HMAC signature GitHub sends (`x-hub-signature-256` against
   `settings.github_webhook_secret`), not the API key -- GitHub cannot send an

--- a/apps/api/src/agentos_api/auth.py
+++ b/apps/api/src/agentos_api/auth.py
@@ -14,11 +14,21 @@ from .config import get_settings
 API_KEY_HEADER = "X-API-Key"
 
 
+def verify_platform_key(x_api_key: str | None) -> bool:
+    """True when the header carries the shared platform API key (constant-time).
+
+    The single place that defines what 'the platform key' means, shared by
+    require_api_key (raise on fail) and the state router's require_state_access
+    (fall through to the scoped-token check)."""
+    if x_api_key is None:
+        return False
+    return hmac.compare_digest(x_api_key, get_settings().api_key)
+
+
 async def require_api_key(
     x_api_key: Annotated[str | None, Header()] = None,
 ) -> None:
-    expected = get_settings().api_key
-    if x_api_key is None or not hmac.compare_digest(x_api_key, expected):
+    if not verify_platform_key(x_api_key):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="missing or invalid API key",

--- a/apps/api/src/agentos_api/routers/state.py
+++ b/apps/api/src/agentos_api/routers/state.py
@@ -12,21 +12,41 @@ slice.
 
 import json
 import uuid
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .. import crud
-from ..auth import require_api_key
+from .. import crud, sandbox_token
+from ..auth import verify_platform_key
 from ..config import get_settings
 from ..deps import SessionDep
 from ..models import WorkflowStateEntry
 from ..schemas import StateAppendIn, StateEntryOut, StateEntryPut
 
+
+async def require_state_access(
+    agent_id: uuid.UUID,
+    x_api_key: Annotated[str | None, Header()] = None,
+) -> None:
+    """State-router auth (ADR-0033): the platform key (trusted callers) OR a
+    scoped ``state`` token bound to this path's ``agent_id`` (the sandbox). Every
+    other router keeps the platform-key-only ``require_api_key``."""
+
+    if verify_platform_key(x_api_key):
+        return
+    if x_api_key is not None and sandbox_token.verify(
+        x_api_key, get_settings().api_key, agent=str(agent_id), scope="state"
+    ):
+        return
+    raise HTTPException(
+        status.HTTP_401_UNAUTHORIZED, detail="missing or invalid credential"
+    )
+
+
 router = APIRouter(
-    prefix="/agents", tags=["state"], dependencies=[Depends(require_api_key)]
+    prefix="/agents", tags=["state"], dependencies=[Depends(require_state_access)]
 )
 
 

--- a/apps/api/src/agentos_api/sandbox_token.py
+++ b/apps/api/src/agentos_api/sandbox_token.py
@@ -1,0 +1,90 @@
+"""Scoped, least-privilege sandbox state token (ADR-0033, issue #410).
+
+The worker mints one of these per turn and forwards it into the sandbox in place
+of the raw platform API key, so the runner can rehydrate memory and transcript
+without holding a resolve-capable, platform-wide credential. The token is an
+HMAC-SHA256 signature over its own claims, keyed by the shared ``api_key``: it
+authenticates only against the state router, only for the one agent it names, and
+can never be presented as the platform key (it is never equal to ``api_key``).
+
+This module is duplicated byte-identically in ``apps/api`` and ``apps/worker``
+(they share no internal library and the contract packages are frozen); a
+committed byte-identical-source test keeps the two copies from drifting.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+_PREFIX = "sbx"
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(seg: str) -> bytes:
+    pad = "=" * (-len(seg) % 4)
+    return base64.urlsafe_b64decode(seg + pad)
+
+
+def _signature(api_key: str, signing_input: str) -> str:
+    digest = hmac.new(
+        api_key.encode(), signing_input.encode(), hashlib.sha256
+    ).digest()
+    return _b64url(digest)
+
+
+def mint(api_key: str, *, agent: str, scope: str, exp: int) -> str:
+    """Mint a signed token binding ``agent`` and ``scope`` with absolute expiry
+    ``exp`` (unix seconds). Deterministic: the caller supplies ``exp`` so the wire
+    form is a pure function of its inputs."""
+
+    payload = json.dumps(
+        {"agent": agent, "scope": scope, "exp": exp},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    payload_seg = _b64url(payload)
+    signing_input = f"{_PREFIX}.{payload_seg}"
+    return f"{signing_input}.{_signature(api_key, signing_input)}"
+
+
+def verify(
+    token: str, api_key: str, *, agent: str, scope: str, now: int | None = None
+) -> bool:
+    """True only when ``token`` is a well-formed token signed by ``api_key`` that
+    names exactly this ``agent`` and ``scope`` and has not expired. Returns False
+    (never raises) on any malformed, tampered, wrong-key, wrong-claim, or expired
+    input, so the caller can treat a failure as a plain 401."""
+
+    try:
+        prefix, payload_seg, sig_seg = token.split(".")
+    except (ValueError, AttributeError):
+        return False
+    if prefix != _PREFIX:
+        return False
+    expected_sig = _signature(api_key, f"{_PREFIX}.{payload_seg}")
+    try:
+        signature_ok = hmac.compare_digest(sig_seg, expected_sig)
+    except TypeError:
+        return False
+    if not signature_ok:
+        return False
+    try:
+        payload = json.loads(_b64url_decode(payload_seg))
+    except (ValueError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("agent") != agent or payload.get("scope") != scope:
+        return False
+    exp = payload.get("exp")
+    if not isinstance(exp, int) or isinstance(exp, bool):
+        return False
+    current = now if now is not None else int(time.time())
+    return exp > current

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -23,6 +23,7 @@ from aci_protocol import QueuedTurn
 from agentos_api.config import get_settings
 from agentos_api.main import create_app
 from agentos_api.models import Approval
+from agentos_api.sandbox_token import mint
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -402,6 +403,49 @@ def test_requires_api_key(
 ) -> None:
     denied = approvals_client.post("/approvals", json=_payload())
     assert denied.status_code in (401, 403)
+
+
+def test_scoped_state_token_cannot_resolve_an_approval(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """The core #410 security assertion: a scoped sandbox "state" token is a
+    least-privilege credential for the agent's own state namespace ONLY. It must
+    NOT authorize resolving an approval -- otherwise a sandboxed agent could
+    forward its own state token to /approvals/{id}/resolve and self-approve its
+    own gated tool call, defeating the server-side authorizer (ADR-0010)."""
+
+    created = approvals_client.post(
+        "/approvals", json=_payload(), headers=auth_headers
+    ).json()
+    resolve_url = f"/approvals/{created['id']}/resolve"
+
+    scoped = mint(
+        get_settings().api_key,
+        agent=str(uuid.uuid4()),
+        scope="state",
+        exp=4102444800,  # 2100-01-01, valid at test time
+    )
+    denied = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers={"X-API-Key": scoped},
+    )
+    assert denied.status_code == 401, denied.text
+    # The record is untouched by the rejected attempt.
+    record = approvals_client.get(
+        f"/approvals/{created['id']}", headers=auth_headers
+    )
+    assert record.json()["status"] == "pending"
+
+    # The platform key still resolves it (no regression).
+    ok = approvals_client.post(
+        resolve_url,
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert ok.status_code == 200, ok.text
 
 
 def test_authorizer_blocks_non_member_and_self_approval(

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -1,6 +1,10 @@
 """Auth and health-endpoint behavior."""
 
+import uuid
 from typing import Any
+
+from agentos_api.config import get_settings
+from agentos_api.sandbox_token import mint
 
 
 def test_health_is_open(client: Any) -> None:
@@ -20,3 +24,16 @@ def test_agents_accept_valid_key(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:
     assert client.get("/agents", headers=auth_headers).status_code == 200
+
+
+def test_scoped_state_token_is_rejected_on_a_crud_route(client: Any) -> None:
+    # A scoped sandbox "state" token authorizes the state namespace only; it must
+    # be rejected by the shared require_api_key guard on every other route, so the
+    # rejection is not special-cased to approvals (#410).
+    token = mint(
+        get_settings().api_key,
+        agent=str(uuid.uuid4()),
+        scope="state",
+        exp=4102444800,  # 2100-01-01, valid at test time
+    )
+    assert client.get("/agents", headers={"X-API-Key": token}).status_code == 401

--- a/apps/api/tests/test_sandbox_token.py
+++ b/apps/api/tests/test_sandbox_token.py
@@ -1,0 +1,150 @@
+"""Wire-format contract for the scoped sandbox token (#410, api copy).
+
+The token is a minimal HMAC-signed capability minted by the worker and verified
+by the api, so a sandboxed agent gets a token that authorizes ONLY its own state
+namespace and nothing else. The module lives byte-identical in both apps; the
+token-module test bodies below are identical to
+apps/worker/tests/binding/test_sandbox_token.py except the import line.
+
+Pure stdlib, nothing mocked. An independent reference reimplementation of the
+wire format pins the exact encoding so the two copies cannot silently drift into
+a shape that still round-trips against itself but not against the other app.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+from pathlib import Path
+
+from agentos_api.sandbox_token import mint, verify
+
+KEY = "agentos-dev-key"
+AGENT = "00000000-0000-0000-0000-000000000001"
+EXP = 1893456000  # 2030-01-01, the golden known-answer exp
+FAR_FUTURE = 4102444800  # 2100-01-01, comfortably valid at test time
+PAST = 1000000000  # 2001, comfortably expired at test time
+
+
+def _sign(api_key: str, payload_obj: object) -> str:
+    """Independent reimplementation of the signing wire format from scratch.
+
+    Deliberately does NOT call the module under test: it rebuilds the exact
+    payload-segment + HMAC-SHA256 signature encoding so a test can assert the
+    module produces this byte sequence, and can forge validly-signed tokens with
+    arbitrary (even malformed) payloads to probe verify's claim checks.
+    """
+    payload_json = json.dumps(
+        payload_obj, separators=(",", ":"), sort_keys=True
+    ).encode()
+    payload_seg = base64.urlsafe_b64encode(payload_json).rstrip(b"=").decode()
+    signing_input = f"sbx.{payload_seg}"
+    sig = hmac.new(api_key.encode(), signing_input.encode(), hashlib.sha256).digest()
+    sig_seg = base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+    return f"sbx.{payload_seg}.{sig_seg}"
+
+
+def _reference_token(api_key: str, agent: str, scope: str, exp: int) -> str:
+    return _sign(api_key, {"agent": agent, "scope": scope, "exp": exp})
+
+
+def test_roundtrip_true_for_matching_claims_and_future_exp() -> None:
+    token = mint(KEY, agent=AGENT, scope="state", exp=FAR_FUTURE)
+    assert verify(token, KEY, agent=AGENT, scope="state") is True
+
+
+def test_roundtrip_false_when_exp_is_in_the_past() -> None:
+    token = mint(KEY, agent=AGENT, scope="state", exp=PAST)
+    assert verify(token, KEY, agent=AGENT, scope="state") is False
+
+
+def test_mint_matches_independent_reference_wire_format() -> None:
+    # Golden known-answer: pins the exact deterministic encoding, so the two
+    # byte-identical copies cannot drift into a self-consistent-but-incompatible
+    # shape. mint takes no clock; the caller passes the absolute exp.
+    token = mint(KEY, agent=AGENT, scope="state", exp=EXP)
+    assert token == _reference_token(KEY, AGENT, "state", EXP)
+    assert token.startswith("sbx.")
+    assert len(token.split(".")) == 3
+
+
+def test_verify_rejection_matrix_returns_false_and_never_raises() -> None:
+    other_agent = "99999999-9999-9999-9999-999999999999"
+    valid = mint(KEY, agent=AGENT, scope="state", exp=FAR_FUTURE)
+    parts = valid.split(".")
+
+    # Expired exp.
+    expired = mint(KEY, agent=AGENT, scope="state", exp=PAST)
+    assert verify(expired, KEY, agent=AGENT, scope="state") is False
+
+    # Wrong agent claim: a token minted for AGENT does not verify for another.
+    assert verify(valid, KEY, agent=other_agent, scope="state") is False
+
+    # Scope that merely CONTAINS "state" must NOT satisfy an exact "state"
+    # requirement, and the reverse (both directions catch substring matching).
+    broad = mint(KEY, agent=AGENT, scope="state-admin", exp=FAR_FUTURE)
+    assert verify(broad, KEY, agent=AGENT, scope="state") is False
+    notstate = mint(KEY, agent=AGENT, scope="notstate", exp=FAR_FUTURE)
+    assert verify(notstate, KEY, agent=AGENT, scope="state") is False
+    assert verify(valid, KEY, agent=AGENT, scope="state-admin") is False
+
+    # Tampered signature: flip a char in the sig segment.
+    sig_seg = parts[2]
+    flipped_char = "A" if sig_seg[-1] != "A" else "B"
+    tampered_sig = f"{parts[0]}.{parts[1]}.{sig_seg[:-1]}{flipped_char}"
+    assert verify(tampered_sig, KEY, agent=AGENT, scope="state") is False
+
+    # Tampered payload: swap in a different payload but keep the old signature.
+    forged_payload = json.dumps(
+        {"agent": AGENT, "scope": "state", "exp": FAR_FUTURE + 1},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    forged_seg = base64.urlsafe_b64encode(forged_payload).rstrip(b"=").decode()
+    tampered_payload = f"{parts[0]}.{forged_seg}.{parts[2]}"
+    assert verify(tampered_payload, KEY, agent=AGENT, scope="state") is False
+
+    # Token signed with a DIFFERENT api_key.
+    wrong_key_token = mint("some-other-key", agent=AGENT, scope="state", exp=FAR_FUTURE)
+    assert verify(wrong_key_token, KEY, agent=AGENT, scope="state") is False
+
+    # Missing "exp": must fail closed, never be treated as never-expiring.
+    missing_exp = _sign(KEY, {"agent": AGENT, "scope": "state"})
+    assert verify(missing_exp, KEY, agent=AGENT, scope="state") is False
+
+    # Missing "agent".
+    missing_agent = _sign(KEY, {"scope": "state", "exp": FAR_FUTURE})
+    assert verify(missing_agent, KEY, agent=AGENT, scope="state") is False
+
+    # Missing "scope".
+    missing_scope = _sign(KEY, {"agent": AGENT, "exp": FAR_FUTURE})
+    assert verify(missing_scope, KEY, agent=AGENT, scope="state") is False
+
+    # Non-dict JSON payload (a signed array, and a signed number).
+    array_payload = _sign(KEY, [AGENT, "state", FAR_FUTURE])
+    assert verify(array_payload, KEY, agent=AGENT, scope="state") is False
+    number_payload = _sign(KEY, 42)
+    assert verify(number_payload, KEY, agent=AGENT, scope="state") is False
+
+    # Garbage / malformed strings: none may raise, all return False.
+    malformed = [
+        "",
+        "sbx.notbase64!.x",
+        "sbx.onlytwo",
+        "sbx.a.b.c",
+        "nope.abc.def",
+    ]
+    for token in malformed:
+        assert verify(token, KEY, agent=AGENT, scope="state") is False
+
+
+def test_the_two_module_copies_are_byte_identical() -> None:
+    # Anti-drift gate: the worker mints and the api verifies, so the two copies
+    # MUST agree on the wire format to the byte. Resolve both paths relative to
+    # this test file (parents[3] is the worktree root) rather than hardcoding.
+    root = Path(__file__).resolve().parents[3]
+    api_src = root / "apps" / "api" / "src" / "agentos_api" / "sandbox_token.py"
+    worker_src = (
+        root / "apps" / "worker" / "src" / "agentos_worker" / "sandbox_token.py"
+    )
+    assert api_src.read_bytes() == worker_src.read_bytes()

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -4,7 +4,15 @@ Nothing mocked -- exercises the API against the compose Postgres (the
 disposable-DB conftest provisions and migrates a throwaway database per run).
 """
 
+import uuid
 from typing import Any
+
+from agentos_api.config import get_settings
+from agentos_api.sandbox_token import mint
+
+# Scoped-sandbox-token auth matrix constants (#410).
+_FAR_FUTURE = 4102444800  # 2100-01-01, valid at test time
+_PAST = 1000000000  # 2001, expired at test time
 
 
 def _agent(client: Any, headers: dict[str, str]) -> str:
@@ -16,6 +24,108 @@ def _agent(client: Any, headers: dict[str, str]) -> str:
     assert resp.status_code == 201, resp.text
     agent_id: str = resp.json()["id"]
     return agent_id
+
+
+def test_state_router_accepts_a_scoped_token_for_the_path_agent(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # A scoped "state" token whose agent claim matches the path agent is a
+    # first-class credential on the state router: no regression for the
+    # platform key, and the sandboxed agent reaches its own namespace with a
+    # least-privilege token instead of the raw shared key (#410).
+    aid = _agent(client, auth_headers)
+    api_key = get_settings().api_key
+    token = mint(api_key, agent=aid, scope="state", exp=_FAR_FUTURE)
+    headers = {"X-API-Key": token}
+    url = f"/agents/{aid}/state/scoped/k"
+
+    put = client.put(url, json={"value": {"n": 1}}, headers=headers)
+    assert put.status_code == 200, put.text
+    assert put.json()["value"] == {"n": 1}
+
+    got = client.get(url, headers=headers)
+    assert got.status_code == 200
+    assert got.json()["value"] == {"n": 1}
+
+    # The platform key still works on the same endpoint (no regression).
+    assert client.get(url, headers=auth_headers).status_code == 200
+
+
+def test_state_router_rejects_scoped_token_for_a_different_agent(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    other = str(uuid.uuid4())
+    token = mint(get_settings().api_key, agent=other, scope="state", exp=_FAR_FUTURE)
+    r = client.put(
+        f"/agents/{aid}/state/scoped/k",
+        json={"value": {"n": 1}},
+        headers={"X-API-Key": token},
+    )
+    assert r.status_code == 401, r.text
+
+
+def test_state_router_rejects_expired_scoped_token(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    token = mint(get_settings().api_key, agent=aid, scope="state", exp=_PAST)
+    r = client.put(
+        f"/agents/{aid}/state/scoped/k",
+        json={"value": {"n": 1}},
+        headers={"X-API-Key": token},
+    )
+    assert r.status_code == 401, r.text
+
+
+def test_state_router_rejects_wrong_scope_token(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    token = mint(get_settings().api_key, agent=aid, scope="admin", exp=_FAR_FUTURE)
+    r = client.put(
+        f"/agents/{aid}/state/scoped/k",
+        json={"value": {"n": 1}},
+        headers={"X-API-Key": token},
+    )
+    assert r.status_code == 401, r.text
+
+
+def test_state_router_rejects_wrong_signing_key_token(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    # Correct agent + scope, but signed with a key that is not the platform key.
+    token = mint("not-the-platform-key", agent=aid, scope="state", exp=_FAR_FUTURE)
+    r = client.put(
+        f"/agents/{aid}/state/scoped/k",
+        json={"value": {"n": 1}},
+        headers={"X-API-Key": token},
+    )
+    assert r.status_code == 401, r.text
+
+
+def test_state_router_rejects_garbage_token_without_echoing_it(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    garbage = "sbx.xxx.yyy"
+    r = client.put(
+        f"/agents/{aid}/state/scoped/k",
+        json={"value": {"n": 1}},
+        headers={"X-API-Key": garbage},
+    )
+    assert r.status_code == 401, r.text
+    # A rejected credential is never echoed back in the error body.
+    assert garbage not in r.text
+
+
+def test_state_router_rejects_missing_api_key_header(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    aid = _agent(client, auth_headers)
+    r = client.put(f"/agents/{aid}/state/scoped/k", json={"value": {"n": 1}})
+    assert r.status_code == 401, r.text
 
 
 def test_put_get_list_delete_round_trip(

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import logging
 import secrets
+import time
 import uuid
 from typing import Any
 from urllib.parse import quote
@@ -39,6 +40,7 @@ from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from . import sandbox_token
 from .behaviorpacks import BehaviorPacks
 from .config import WorkerConfig
 
@@ -75,6 +77,8 @@ RUNNER_TOKEN_ENV = "AGENTOS_RUNNER_TOKEN"
 # calls the runner intercepts via can_use_tool and pauses awaiting approval.
 # A runner-local knob (not frozen ACI env), like AGENTOS_IDEMPOTENT_TOOLS.
 APPROVAL_REQUIRED_ENV = "AGENTOS_APPROVAL_REQUIRED_TOOLS"
+# the worker re-mints every turn; this only bounds a leaked-token window (ADR-0033)
+SANDBOX_TOKEN_TTL_SECONDS = 24 * 60 * 60
 
 _RESOLVE_SQL = """
 SELECT a.id AS agent_id,
@@ -219,12 +223,11 @@ class BindingResolver:
         # Deliver the memory ref (#264): the agent's scoped namespace on the
         # durable state store (#23/#248). The runner dereferences it at boot to
         # load prior memory and to append learned records with provenance. The
-        # API key is forwarded as the memory token; a scoped, least-privilege
-        # memory token is future work (the state API has one shared key today).
+        # runner now receives a scoped ``state`` token (ADR-0033, #410) bound to
+        # this agent, not the raw platform key, so a sandboxed agent cannot
+        # resolve approvals or reach another agent's namespace.
         base = self._config.api_base_url.rstrip("/")
         env[MEMORY_REF_ENV] = f"{base}/agents/{resolved.agent_id}/state/memory"
-        if self._config.api_key:
-            env[MEMORY_TOKEN_ENV] = self._config.api_key
         # Deliver the history ref (#20, ADR-0029): this thread's transcript key on
         # the same state store. It is deterministic per (agent, thread), so a
         # fresh, restarted, or resumed sandbox all boot with the same ref and the
@@ -235,8 +238,19 @@ class BindingResolver:
         env[HISTORY_REF_ENV] = (
             f"{base}/agents/{resolved.agent_id}/state/transcript/{thread_segment}"
         )
+        # Mint one scoped ``state`` token (ADR-0033, #410) for this agent and use
+        # it for both the memory and history tokens. When no platform key is
+        # configured (fake/local) there is nothing to sign with, so no token is
+        # minted and neither is set -- preserving the pre-#410 no-key path.
         if self._config.api_key:
-            env[HISTORY_TOKEN_ENV] = self._config.api_key
+            state_token = sandbox_token.mint(
+                self._config.api_key,
+                agent=str(resolved.agent_id),
+                scope="state",
+                exp=int(time.time()) + SANDBOX_TOKEN_TTL_SECONDS,
+            )
+            env[MEMORY_TOKEN_ENV] = state_token
+            env[HISTORY_TOKEN_ENV] = state_token
         # The agent's pinned model (#254) overrides the worker default; None
         # falls back to config.model inside apply_model_env.
         apply_model_env(env, self._config, model_override=resolved.model)

--- a/apps/worker/src/agentos_worker/sandbox_token.py
+++ b/apps/worker/src/agentos_worker/sandbox_token.py
@@ -1,0 +1,90 @@
+"""Scoped, least-privilege sandbox state token (ADR-0033, issue #410).
+
+The worker mints one of these per turn and forwards it into the sandbox in place
+of the raw platform API key, so the runner can rehydrate memory and transcript
+without holding a resolve-capable, platform-wide credential. The token is an
+HMAC-SHA256 signature over its own claims, keyed by the shared ``api_key``: it
+authenticates only against the state router, only for the one agent it names, and
+can never be presented as the platform key (it is never equal to ``api_key``).
+
+This module is duplicated byte-identically in ``apps/api`` and ``apps/worker``
+(they share no internal library and the contract packages are frozen); a
+committed byte-identical-source test keeps the two copies from drifting.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+_PREFIX = "sbx"
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(seg: str) -> bytes:
+    pad = "=" * (-len(seg) % 4)
+    return base64.urlsafe_b64decode(seg + pad)
+
+
+def _signature(api_key: str, signing_input: str) -> str:
+    digest = hmac.new(
+        api_key.encode(), signing_input.encode(), hashlib.sha256
+    ).digest()
+    return _b64url(digest)
+
+
+def mint(api_key: str, *, agent: str, scope: str, exp: int) -> str:
+    """Mint a signed token binding ``agent`` and ``scope`` with absolute expiry
+    ``exp`` (unix seconds). Deterministic: the caller supplies ``exp`` so the wire
+    form is a pure function of its inputs."""
+
+    payload = json.dumps(
+        {"agent": agent, "scope": scope, "exp": exp},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    payload_seg = _b64url(payload)
+    signing_input = f"{_PREFIX}.{payload_seg}"
+    return f"{signing_input}.{_signature(api_key, signing_input)}"
+
+
+def verify(
+    token: str, api_key: str, *, agent: str, scope: str, now: int | None = None
+) -> bool:
+    """True only when ``token`` is a well-formed token signed by ``api_key`` that
+    names exactly this ``agent`` and ``scope`` and has not expired. Returns False
+    (never raises) on any malformed, tampered, wrong-key, wrong-claim, or expired
+    input, so the caller can treat a failure as a plain 401."""
+
+    try:
+        prefix, payload_seg, sig_seg = token.split(".")
+    except (ValueError, AttributeError):
+        return False
+    if prefix != _PREFIX:
+        return False
+    expected_sig = _signature(api_key, f"{_PREFIX}.{payload_seg}")
+    try:
+        signature_ok = hmac.compare_digest(sig_seg, expected_sig)
+    except TypeError:
+        return False
+    if not signature_ok:
+        return False
+    try:
+        payload = json.loads(_b64url_decode(payload_seg))
+    except (ValueError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("agent") != agent or payload.get("scope") != scope:
+        return False
+    exp = payload.get("exp")
+    if not isinstance(exp, int) or isinstance(exp, bool):
+        return False
+    current = now if now is not None else int(time.time())
+    return exp > current

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -22,6 +22,7 @@ from agentos_worker.binding import (
 )
 from agentos_worker.config import WorkerConfig
 from agentos_worker.eval.stream import EvalStreamConsumer, EvalWorkItem
+from agentos_worker.sandbox_token import verify
 
 
 def _resolved(model: str | None = None) -> ResolvedDeployment:
@@ -244,8 +245,15 @@ def test_binding_boot_env_sets_per_thread_transcript_ref() -> None:
     assert env[HISTORY_REF_ENV] == (
         f"{base}/agents/{resolved.agent_id}/state/transcript/1720000000.000100"
     )
-    # The API key is forwarded as the history token (shared with memory today).
-    assert env[HISTORY_TOKEN_ENV] == config.api_key
+    # The history token is a scoped state token bound to this agent
+    # (ADR-0033, #410), never the raw platform key.
+    assert env[HISTORY_TOKEN_ENV] != config.api_key
+    assert verify(
+        env[HISTORY_TOKEN_ENV],
+        config.api_key,
+        agent=str(resolved.agent_id),
+        scope="state",
+    )
 
 
 def test_binding_boot_env_history_ref_is_deterministic_per_thread() -> None:

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -19,9 +19,13 @@ from agentos_worker.binding import (
     APPROVAL_REQUIRED_ENV,
     BUDGET_ENV,
     BUNDLE_REF_ENV,
+    HISTORY_TOKEN_ENV,
+    MEMORY_TOKEN_ENV,
     BindingResolver,
+    ResolvedDeployment,
 )
 from agentos_worker.config import WorkerConfig
+from agentos_worker.sandbox_token import verify
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
@@ -418,6 +422,91 @@ def test_resolves_approval_required_tools_into_boot_env() -> None:
             await engine.dispose()
 
     asyncio.run(go())
+
+
+def test_boot_env_forwards_scoped_state_tokens_not_the_raw_key() -> None:
+    # #410 whole-fix regression guard: the memory and history tokens injected
+    # into the sandbox must be scoped "state" tokens (agent-bound, expiring),
+    # NEVER the raw shared platform key. A scoped token verifies for THIS agent
+    # and only this agent.
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            try:
+                async with engine.connect():
+                    pass
+            except SQLAlchemyError as exc:
+                pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+
+            token = uuid.uuid4().hex[:8]
+            channel = f"C-{token}"
+            agent_id = await _seed_agent(
+                engine, channel=channel, name=f"agent-{token}", max_usd=None, max_tokens=None
+            )
+            await _seed_deployment(
+                engine, agent_id=agent_id, environment="prod", bundle_ref=f"bundles/{token}.zip"
+            )
+            try:
+                resolved = await _resolver(engine).resolve(channel)
+                assert resolved is not None
+                env = _resolver(engine).boot_env(resolved, "thread-1")
+
+                # The resolver was built with WorkerConfig(db_schema=_SCHEMA),
+                # whose api_key default is the platform signing key.
+                api_key = WorkerConfig(db_schema=_SCHEMA).api_key
+                assert env[MEMORY_TOKEN_ENV] != api_key
+                assert env[HISTORY_TOKEN_ENV] != api_key
+
+                # Both tokens verify as scoped "state" credentials for THIS agent.
+                assert verify(
+                    env[MEMORY_TOKEN_ENV],
+                    api_key,
+                    agent=str(resolved.agent_id),
+                    scope="state",
+                )
+                assert verify(
+                    env[HISTORY_TOKEN_ENV],
+                    api_key,
+                    agent=str(resolved.agent_id),
+                    scope="state",
+                )
+
+                # A different agent's identity does not verify against them.
+                assert not verify(
+                    env[MEMORY_TOKEN_ENV],
+                    api_key,
+                    agent=str(uuid.uuid4()),
+                    scope="state",
+                )
+            finally:
+                await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_boot_env_mints_no_token_when_the_signing_key_is_empty() -> None:
+    # Fake/local parity: with no platform key configured there is nothing to
+    # sign with, so no state token is minted (matching the pre-#410 behavior of
+    # forwarding no token). Shown without a DB by constructing the resolved
+    # deployment directly -- boot_env is pure and never touches the engine.
+    engine = create_async_engine(_DB_URL)
+    try:
+        resolver = BindingResolver(engine, WorkerConfig(db_schema=_SCHEMA, api_key=""))
+        resolved = ResolvedDeployment(
+            agent_id=uuid.uuid4(),
+            version_id=uuid.uuid4(),
+            version_label="v",
+            bundle_ref=None,
+            max_usd_per_day=None,
+            max_output_tokens_per_run=None,
+        )
+        env = resolver.boot_env(resolved, "thread-1")
+        assert MEMORY_TOKEN_ENV not in env
+        assert HISTORY_TOKEN_ENV not in env
+    finally:
+        asyncio.run(engine.dispose())
 
 
 def test_resolves_approval_routes_from_the_agent_row() -> None:

--- a/apps/worker/tests/binding/test_sandbox_token.py
+++ b/apps/worker/tests/binding/test_sandbox_token.py
@@ -1,0 +1,137 @@
+"""Wire-format contract for the scoped sandbox token (#410, worker copy).
+
+The token is a minimal HMAC-signed capability minted by the worker and verified
+by the api, so a sandboxed agent gets a token that authorizes ONLY its own state
+namespace and nothing else. The module lives byte-identical in both apps; the
+token-module test bodies below are identical to
+apps/api/tests/test_sandbox_token.py except the import line.
+
+Pure stdlib, nothing mocked. An independent reference reimplementation of the
+wire format pins the exact encoding so the two copies cannot silently drift into
+a shape that still round-trips against itself but not against the other app.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+
+from agentos_worker.sandbox_token import mint, verify
+
+KEY = "agentos-dev-key"
+AGENT = "00000000-0000-0000-0000-000000000001"
+EXP = 1893456000  # 2030-01-01, the golden known-answer exp
+FAR_FUTURE = 4102444800  # 2100-01-01, comfortably valid at test time
+PAST = 1000000000  # 2001, comfortably expired at test time
+
+
+def _sign(api_key: str, payload_obj: object) -> str:
+    """Independent reimplementation of the signing wire format from scratch.
+
+    Deliberately does NOT call the module under test: it rebuilds the exact
+    payload-segment + HMAC-SHA256 signature encoding so a test can assert the
+    module produces this byte sequence, and can forge validly-signed tokens with
+    arbitrary (even malformed) payloads to probe verify's claim checks.
+    """
+    payload_json = json.dumps(
+        payload_obj, separators=(",", ":"), sort_keys=True
+    ).encode()
+    payload_seg = base64.urlsafe_b64encode(payload_json).rstrip(b"=").decode()
+    signing_input = f"sbx.{payload_seg}"
+    sig = hmac.new(api_key.encode(), signing_input.encode(), hashlib.sha256).digest()
+    sig_seg = base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+    return f"sbx.{payload_seg}.{sig_seg}"
+
+
+def _reference_token(api_key: str, agent: str, scope: str, exp: int) -> str:
+    return _sign(api_key, {"agent": agent, "scope": scope, "exp": exp})
+
+
+def test_roundtrip_true_for_matching_claims_and_future_exp() -> None:
+    token = mint(KEY, agent=AGENT, scope="state", exp=FAR_FUTURE)
+    assert verify(token, KEY, agent=AGENT, scope="state") is True
+
+
+def test_roundtrip_false_when_exp_is_in_the_past() -> None:
+    token = mint(KEY, agent=AGENT, scope="state", exp=PAST)
+    assert verify(token, KEY, agent=AGENT, scope="state") is False
+
+
+def test_mint_matches_independent_reference_wire_format() -> None:
+    # Golden known-answer: pins the exact deterministic encoding, so the two
+    # byte-identical copies cannot drift into a self-consistent-but-incompatible
+    # shape. mint takes no clock; the caller passes the absolute exp.
+    token = mint(KEY, agent=AGENT, scope="state", exp=EXP)
+    assert token == _reference_token(KEY, AGENT, "state", EXP)
+    assert token.startswith("sbx.")
+    assert len(token.split(".")) == 3
+
+
+def test_verify_rejection_matrix_returns_false_and_never_raises() -> None:
+    other_agent = "99999999-9999-9999-9999-999999999999"
+    valid = mint(KEY, agent=AGENT, scope="state", exp=FAR_FUTURE)
+    parts = valid.split(".")
+
+    # Expired exp.
+    expired = mint(KEY, agent=AGENT, scope="state", exp=PAST)
+    assert verify(expired, KEY, agent=AGENT, scope="state") is False
+
+    # Wrong agent claim: a token minted for AGENT does not verify for another.
+    assert verify(valid, KEY, agent=other_agent, scope="state") is False
+
+    # Scope that merely CONTAINS "state" must NOT satisfy an exact "state"
+    # requirement, and the reverse (both directions catch substring matching).
+    broad = mint(KEY, agent=AGENT, scope="state-admin", exp=FAR_FUTURE)
+    assert verify(broad, KEY, agent=AGENT, scope="state") is False
+    notstate = mint(KEY, agent=AGENT, scope="notstate", exp=FAR_FUTURE)
+    assert verify(notstate, KEY, agent=AGENT, scope="state") is False
+    assert verify(valid, KEY, agent=AGENT, scope="state-admin") is False
+
+    # Tampered signature: flip a char in the sig segment.
+    sig_seg = parts[2]
+    flipped_char = "A" if sig_seg[-1] != "A" else "B"
+    tampered_sig = f"{parts[0]}.{parts[1]}.{sig_seg[:-1]}{flipped_char}"
+    assert verify(tampered_sig, KEY, agent=AGENT, scope="state") is False
+
+    # Tampered payload: swap in a different payload but keep the old signature.
+    forged_payload = json.dumps(
+        {"agent": AGENT, "scope": "state", "exp": FAR_FUTURE + 1},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    forged_seg = base64.urlsafe_b64encode(forged_payload).rstrip(b"=").decode()
+    tampered_payload = f"{parts[0]}.{forged_seg}.{parts[2]}"
+    assert verify(tampered_payload, KEY, agent=AGENT, scope="state") is False
+
+    # Token signed with a DIFFERENT api_key.
+    wrong_key_token = mint("some-other-key", agent=AGENT, scope="state", exp=FAR_FUTURE)
+    assert verify(wrong_key_token, KEY, agent=AGENT, scope="state") is False
+
+    # Missing "exp": must fail closed, never be treated as never-expiring.
+    missing_exp = _sign(KEY, {"agent": AGENT, "scope": "state"})
+    assert verify(missing_exp, KEY, agent=AGENT, scope="state") is False
+
+    # Missing "agent".
+    missing_agent = _sign(KEY, {"scope": "state", "exp": FAR_FUTURE})
+    assert verify(missing_agent, KEY, agent=AGENT, scope="state") is False
+
+    # Missing "scope".
+    missing_scope = _sign(KEY, {"agent": AGENT, "exp": FAR_FUTURE})
+    assert verify(missing_scope, KEY, agent=AGENT, scope="state") is False
+
+    # Non-dict JSON payload (a signed array, and a signed number).
+    array_payload = _sign(KEY, [AGENT, "state", FAR_FUTURE])
+    assert verify(array_payload, KEY, agent=AGENT, scope="state") is False
+    number_payload = _sign(KEY, 42)
+    assert verify(number_payload, KEY, agent=AGENT, scope="state") is False
+
+    # Garbage / malformed strings: none may raise, all return False.
+    malformed = [
+        "",
+        "sbx.notbase64!.x",
+        "sbx.onlytwo",
+        "sbx.a.b.c",
+        "nope.abc.def",
+    ]
+    for token in malformed:
+        assert verify(token, KEY, agent=AGENT, scope="state") is False

--- a/docs/adr/0033-scoped-sandbox-state-token.md
+++ b/docs/adr/0033-scoped-sandbox-state-token.md
@@ -1,0 +1,174 @@
+# 33. Scoped, least-privilege sandbox state token
+
+Date: 2026-07-15
+
+Status: Accepted
+
+Implements [#410](https://github.com/curie-eng/agentos/issues/410).
+
+## Context
+
+The worker forwards the one shared platform API key into every sandbox so the
+runner can rehydrate the agent's memory and transcript at boot.
+`binding.boot_env()` sets `AGENTOS_MEMORY_TOKEN` and `AGENTOS_HISTORY_TOKEN` to
+`self._config.api_key` (`apps/worker/src/agentos_worker/binding.py`), and the
+runner sends that value verbatim as the `X-API-Key` header on its calls to the
+durable state store (`runner/src/agentos_runner/memory.py`,
+`runner/src/agentos_runner/history.py`). The state store routes
+(`/agents/{id}/state/...`) and every other authenticated route, including
+`/approvals/{id}/resolve`, are guarded by the same `require_api_key` dependency
+(`apps/api/src/agentos_api/auth.py`), which compares the header against the
+single `Settings.api_key` with `hmac.compare_digest`.
+
+The composition of these separately merged decisions is a HIGH-severity hole.
+A sandboxed agent can read `AGENTOS_HISTORY_TOKEN` (the platform key) from its
+own environment and use it to:
+
+1. Resolve its own gated approval by POSTing `/approvals/{id}/resolve` with a
+   fabricated non-author `resolved_by` and an `actor_channel` equal to the card
+   channel. The `ChannelMembershipAuthorizer` trusts caller-asserted identity,
+   so the sandbox self-approves the very tool call the ADR-0010 permission gate
+   was meant to block.
+2. Read and write any other agent's memory and transcript namespace (cross-agent
+   isolation break).
+3. Resolve any pending approval platform-wide.
+
+The egress allowlist does not mitigate this: the sandbox must reach the API host
+for memory and transcript rehydration to work at all, so the credential it
+carries is exactly the credential that unlocks approvals. This directly
+contradicts ADR-0010 and the approval INTERFACE guarantee that resolution is
+"enforced server-side at resolution time, not inside the sandbox or runner"
+(`docs/interfaces/approval/INTERFACE.md`).
+
+The root problem is credential scope: the sandbox needs a token that can touch
+only its own state namespace and nothing else, yet it is handed a
+platform-wide, resolve-capable key. This ADR records the decision to replace
+that credential with a scoped, least-privilege token. It supersedes nothing; it
+references and restores ADR-0010's server-side-enforcement guarantee.
+
+## Decision
+
+Mint a **scoped sandbox token** per turn and forward it in place of the raw
+platform key. The token grants access to exactly one agent's state namespace and
+nothing else.
+
+**Signing.** The token is HMAC-SHA256 signed using the existing shared
+`api_key` as the signing key. No new shared secret and no new config plumbing is
+introduced: the worker and the API already both carry `api_key`
+(`WorkerConfig.api_key` / `Settings.api_key`), and the API's production boot gate
+already refuses the dev-default value (`test_config_prod_gate.py`), so the HMAC
+key inherits that protection for free.
+
+**Payload claims.** A compact, self-describing format
+`sbx.<b64url(json payload)>.<b64url(hmac)>` with claims:
+
+- `agent`: the agent UUID the token is scoped to.
+- `scope`: the permitted capability, `"state"` for the memory/transcript token.
+- `exp`: expiry as unix seconds.
+
+**Minting (worker).** `binding.boot_env()` mints a token for
+`resolved.agent_id` with scope `state` and a fixed TTL, signing with
+`self._config.api_key`, and forwards that token as both `AGENTOS_MEMORY_TOKEN`
+and `AGENTOS_HISTORY_TOKEN` instead of the raw key. Because `boot_env` is
+recomputed on every claim through the kernel consume path
+(`kernel.py` -> `boot_env` -> `substrate.claim/resume(env=...)`), a fresh token
+is minted every turn, including on resume. A generous fixed TTL (24 hours)
+safely covers a multi-day approval pause, since a paused thread is a cold
+rehydrate on the next mention, not a live process holding a stale token.
+
+**Verification (API).** The `state` router
+(`apps/api/src/agentos_api/routers/state.py`) gets a new auth dependency that
+accepts **either**:
+
+- the platform key (operators, CLI, and the worker keep full access, so there is
+  zero regression for existing callers), **or**
+- a valid scoped token whose signature verifies against `api_key`, whose `agent`
+  claim equals the path `{agent_id}`, whose `scope` equals `state`, and whose
+  `exp` is in the future.
+
+Every other router keeps `require_api_key` unchanged (platform key only): a
+scoped token is rejected at `/approvals/{id}/resolve`, `/agents` CRUD, memory
+management routes, and everywhere else.
+
+**Runner.** Unchanged. It already sends whatever token it is given verbatim as
+`X-API-Key` and does not care whether that value is the platform key or a scoped
+token.
+
+**Security properties (must hold).**
+
+- The scoped token is a signed derivative of `api_key`, never the key itself,
+  and the API (which already holds the key) is the only verifier, so there is no
+  online guessing oracle. The one residual cost of reusing `api_key` as the HMAC
+  key instead of a dedicated random secret: a token is an offline verification
+  oracle, so an attacker holding a token could brute-force a low-entropy
+  `api_key` offline. This is acceptable only because `api_key` is high-entropy
+  machine-generated (chart secret generation, #195) and the production boot gate
+  refuses the dev-default value; an operator who hand-sets a memorable `api_key`
+  would void this property.
+- Presenting the scoped token to `require_api_key` fails `compare_digest`
+  because the token string is not equal to `api_key`, so the sandbox cannot
+  resolve approvals or reach any platform-key-only route.
+- Verification binds the token's `agent` claim to the request path
+  `{agent_id}`, so a token minted for agent A cannot read or write agent B's
+  namespace: cross-agent isolation is restored.
+- `exp` bounds the exposure window of a leaked token.
+
+## Alternatives considered and rejected
+
+- **Keep the shared platform key in the sandbox (status quo).** Rejected: this
+  is the vulnerability. The sandbox holds a resolve-capable, platform-wide
+  credential, defeating ADR-0010 and the approval INTERFACE guarantee.
+
+- **Mint an opaque, DB-registered token.** Issue a random token and persist an
+  (agent, scope, expiry) row the API looks up on each request. Rejected: it
+  needs new shared mutable state and a lookup on the hot memory/transcript path,
+  plus issuance, revocation, and cleanup machinery. A signed derivative carries
+  its own claims and needs no storage, no lookup, and no new table for the same
+  security outcome.
+
+- **Introduce a brand-new dedicated signing secret.** A separate
+  `sandbox_token_secret` distinct from `api_key`. Rejected: it requires config
+  plumbing across the worker, the API, the Helm chart, and compose, plus a new
+  production-gate entry, for no security gain. Reusing `api_key` as the HMAC key
+  is sound because the token is a non-invertible derivative, the worker and API
+  already both hold `api_key`, and the prod boot gate already protects it.
+
+- **A shared package for the token module.** Place mint and verify in one
+  internal library imported by both apps. Rejected/deferred: the worker and API
+  are separate uv-workspace members with no shared internal lib between them
+  (worker depends on channel-protocol and the dispatcher; the frozen contract
+  packages aci-protocol and channel-protocol are off-theme for auth crypto), so
+  a shared package means new cross-app coupling against a deliberately decoupled
+  boundary. Instead the ~40-line pure-stdlib module (`hmac`/`base64`/`json`) is
+  duplicated in both apps, and a committed known-answer test vector (a hardcoded
+  key and payload producing an exact token string) is asserted by both test
+  suites so the two copies mechanically cannot drift. See Consequences for the
+  tradeoff.
+
+## Consequences
+
+- The sandbox can no longer resolve approvals or reach any agent's namespace but
+  its own. ADR-0010's server-side-enforcement guarantee holds again: a
+  model-initiated approval resolution is rejected at the API because the sandbox
+  does not hold a resolve-capable credential.
+
+- The token module is duplicated in `apps/worker` and `apps/api`. This is a
+  deliberate tradeoff: duplication of ~40 lines of pure-stdlib code, fenced by a
+  committed golden test vector asserted in both suites, is preferred over new
+  cross-app coupling against the frozen-contract boundary. If a shared internal
+  library is introduced later for another reason, the module should move into it
+  and the duplication removed.
+
+- No new configuration surface. The HMAC key is the existing `api_key`, already
+  present in both services and already covered by the production boot gate. The
+  chart and compose need no change.
+
+- The token carries a fixed 24-hour TTL. This is not per-turn-tight, but the
+  rehydration path is a cold boot per claim, so a fresh token is minted every
+  turn regardless; the TTL only bounds a leaked-token window and is generous
+  enough that a multi-day approval pause rehydrates without a special branch.
+
+- Operators, the CLI, and the worker's own control-plane calls are unaffected:
+  the platform key still authenticates everywhere, including the `state` router,
+  so this is a strict capability reduction for the sandbox only, with zero
+  regression for trusted callers.

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -81,7 +81,14 @@ The placement constraint held in the landed base and must keep holding: the auth
 **enforced server-side at resolution time**, not inside the sandbox or runner. The runner
 only *raises* a request (its tool marks the turn; the record, the resolve CAS, and the
 resume enqueue all live with the API/worker), so a compromised sandbox cannot mint or
-resolve an approval. The runtime `canUseTool` gate (#245) will block the *tool call*, but
+resolve an approval. That guarantee holds only while the sandbox does not carry a
+resolve-capable credential: earlier the worker forwarded the shared platform API key
+into the sandbox as the memory/transcript token, and because `POST /approvals/{id}/resolve`
+is guarded by the same platform key, a compromised sandbox could self-approve its own
+gated tool call. ADR-0033 (#410) closed that gap by minting a scoped, agent-bound `state`
+token for the sandbox that only the state router accepts; the resolve endpoint stays
+platform-key-only, so the sandbox credential can no longer resolve an approval. The
+runtime `canUseTool` gate (#245) will block the *tool call*, but
 the authorization decision (who may resolve a pending approval) stays on the server that
 owns the durable `Approval` record. Policy gate points ship versioned in the bundle; route
 bindings (which channel, who may approve) are per-agent deployment config (#247).

--- a/docs/interfaces/conversation-history/INTERFACE.md
+++ b/docs/interfaces/conversation-history/INTERFACE.md
@@ -53,16 +53,20 @@ JSONB). `load` GETs the key; `append` POSTs to the key's `/append` endpoint,
 inheriting durability and the per-value/per-namespace size caps.
 `NullTranscriptStore` is the no-ref sink. The worker (`binding.boot_env`)
 delivers the ref as `http(s)://api/agents/<id>/state/transcript/<thread_key>`
-(URL-encoded thread key) and forwards the API key as the history token. The ref
+(URL-encoded thread key) and forwards a scoped, agent-bound `state` token
+(ADR-0033, #410) as the history token rather than the raw platform key. The ref
 is **deterministic per (agent, thread)**, so a fresh, a restarted, and a resumed
 sandbox all boot with the same ref and rehydrate identically — the
 unplanned-restart case needs no special worker/kernel branch.
 
 ## Known leakage
 
-- **Shared API key as the history token.** Same as memory: the state API has one
-  shared key today, so forwarding it as `AGENTOS_HISTORY_TOKEN` grants that key's
-  scope. Scoped, least-privilege tokens are shared follow-up auth-hardening work.
+- **Scoped history token (was: shared API key).** Same as memory: earlier the
+  state API's one shared platform key was forwarded as `AGENTOS_HISTORY_TOKEN`,
+  granting that key's scope. ADR-0033 (#410) replaced it with a scoped,
+  agent-bound, HMAC-signed `state` token minted per turn, accepted only by the
+  state router and bound to this agent's namespace, so the sandbox credential can
+  no longer resolve approvals or reach another agent's state.
 - **Unbounded append log under the state-store size caps.** A very long thread
   will eventually hit the per-namespace/per-value cap on the stored transcript.
   Delivery-side windowing now bounds the *rehydrated preamble* to a tail window

--- a/docs/interfaces/memory/INTERFACE.md
+++ b/docs/interfaces/memory/INTERFACE.md
@@ -45,15 +45,20 @@ over the durable KV/document store landed for #23/#248
 `load` GETs the single log-shaped key; `append` POSTs to that key's `/append`
 endpoint (#248), inheriting durability and the per-value/per-namespace size caps.
 The worker (`binding.boot_env`) delivers the ref as
-`http(s)://api/agents/<id>/state/memory` and forwards the API key as the memory
-token. `NullMemoryStore` is the no-ref sink.
+`http(s)://api/agents/<id>/state/memory` and forwards a scoped, agent-bound
+`state` token (ADR-0033, #410) as the memory token rather than the raw platform
+key. `NullMemoryStore` is the no-ref sink.
 
 ## Known leakage
 
-- **Shared API key as the memory token.** The state API has one shared API key
-  today, so forwarding it into the sandbox as `AGENTOS_MEMORY_TOKEN` grants that
-  key's full scope. A scoped, least-privilege memory token is follow-up work
-  (ADR-0025, consequences).
+- **Scoped memory token (was: shared API key).** Earlier the state API's one
+  shared platform key was forwarded into the sandbox as `AGENTOS_MEMORY_TOKEN`,
+  granting that key's full scope. ADR-0033 (#410) closed that: the worker now
+  mints a scoped, agent-bound, HMAC-signed `state` token per turn, accepted only
+  by the state router and bound to this agent's namespace, so the sandbox
+  credential can no longer resolve approvals or reach another agent's state. The
+  platform key still authenticates the state router for operators, the CLI, and
+  the worker's own control-plane calls.
 - **Consolidation is an opt-in capability, not part of the port.** The core
   `MemoryStore` port stays `load`/`append` only. Consolidation (#265) adds a
   separate `SupportsReplace` capability (`replace(records)`) and the


### PR DESCRIPTION
## Summary

Closes #410. A sandboxed agent could resolve its own gated approval, defeating the ADR-0010 permission gate: the worker forwarded the one shared platform API key into every sandbox as `AGENTOS_MEMORY_TOKEN` / `AGENTOS_HISTORY_TOKEN`, and because the durable state store and `/approvals/{id}/resolve` share one `require_api_key`, the sandbox could read that key from its own env and self-approve, read or write any agent's state, and resolve any pending approval.

## Fix

Mint a scoped, HMAC-SHA256-signed token per turn (claims: `agent`, `scope`, `exp`; keyed by the existing `api_key`) and forward it in place of the raw key. A shared `verify_platform_key` predicate backs both `require_api_key` and the state router's new `require_state_access`, which accepts either the platform key (trusted callers, zero regression) or a scoped `state` token bound to the path `agent_id`. Every other router keeps `require_api_key`, so the scoped token cannot resolve approvals or reach another agent's namespace. The runner is unchanged.

- The token is a one-way signed derivative of `api_key`, never equal to it, so `require_api_key`'s `compare_digest` rejects it everywhere off the state router.
- The token module is duplicated byte-identically in `apps/api` and `apps/worker` (decoupled apps, no shared internal lib, frozen contract packages), gated by a golden known-answer vector and a byte-identical-source test.
- Decision recorded in ADR-0033. The `ChannelMembershipAuthorizer` caller-asserted-identity hardening remains a separate defense-in-depth follow-up (the credential is now incapable regardless).

## Verification

Full `pytest` (593 passed) + ruff + mypy green. Beyond CI, a live socket pass against the assembled API on the compose stack asserts the real outcomes: platform key still works on the state router; a scoped token works for its own agent; and self-resolve-approval, CRUD access, cross-agent access, expired, wrong-scope, and wrong-key all return 401 with no token echo.