### PR TITLE
Approval + authed-MCP review follow-ups (#413)

### DIFF
--- a/apps/api/src/agentos_api/routers/agents.py
+++ b/apps/api/src/agentos_api/routers/agents.py
@@ -23,24 +23,72 @@ router = APIRouter(
     prefix="/agents", tags=["agents"], dependencies=[Depends(require_api_key)]
 )
 
+# Postgres SQLSTATE for a unique_violation. asyncpg exposes it (and the
+# violated constraint's name) as plain attributes on the wrapped driver
+# exception -- there is no psycopg-style `.diag` namespace.
+_UNIQUE_VIOLATION = "23505"
+
+# The two real unique constraints on `agents` (from the alembic migrations),
+# mapped to the human message for each. Any other unique violation falls back
+# to a generic message.
+_UNIQUE_CONSTRAINT_MESSAGES = {
+    "agents_name_key": "an agent with that name already exists",
+    "ix_agents_repo_full_name": "an agent for that repository already exists",
+}
+
+
+def _driver_diag(exc: IntegrityError, attr: str) -> str | None:
+    """Read an asyncpg diagnostic field, walking the `__cause__` chain.
+
+    asyncpg surfaces `sqlstate` on SQLAlchemy's DBAPI wrapper (`exc.orig`) but
+    exposes `constraint_name` only on the underlying `asyncpg` error one link
+    down the `__cause__` chain. Walk both so either shape resolves; guard
+    against a cyclic chain.
+    """
+    obj = getattr(exc, "orig", None)
+    seen: set[int] = set()
+    while obj is not None and id(obj) not in seen:
+        seen.add(id(obj))
+        value = getattr(obj, attr, None)
+        if value is not None:
+            return str(value)
+        obj = getattr(obj, "__cause__", None)
+    return None
+
+
+def classify_integrity_error(exc: IntegrityError) -> tuple[int, str] | None:
+    """Map a real unique-constraint violation to a `(409, message)` conflict.
+
+    Only a genuine unique_violation (SQLSTATE 23505) is a caller conflict; a
+    NOT NULL or FK violation is a server fault and must surface as a 500, so
+    this returns `None` for those (the caller re-raises). The human message is
+    chosen by the violated constraint's name from asyncpg's structured fields,
+    not by substring-matching the stringified driver error.
+    """
+    if _driver_diag(exc, "sqlstate") != _UNIQUE_VIOLATION:
+        return None
+    constraint_name = _driver_diag(exc, "constraint_name")
+    message = "agent violates a uniqueness constraint"
+    if constraint_name is not None:
+        message = _UNIQUE_CONSTRAINT_MESSAGES.get(constraint_name, message)
+    return status.HTTP_409_CONFLICT, message
+
 
 @router.post("", response_model=AgentOut, status_code=status.HTTP_201_CREATED)
 async def create_agent(data: AgentCreate, session: SessionDep) -> AgentOut:
     # name and repo_full_name are unique. A collision is a caller conflict (409),
     # not a server fault: catch the DB IntegrityError and map it, rather than
-    # letting it bubble as an opaque 500.
+    # letting it bubble as an opaque 500. A non-unique violation (NOT NULL, FK)
+    # is a genuine server fault -- re-raise it so it surfaces as a 500.
     try:
         agent = await crud.create_agent(session, data)
     except IntegrityError as exc:
         await session.rollback()
-        detail = str(exc.orig)
-        if "repo_full_name" in detail:
-            message = "an agent for that repository already exists"
-        elif "name" in detail:
-            message = "an agent with that name already exists"
-        else:
-            message = "agent violates a uniqueness constraint"
-        raise HTTPException(status.HTTP_409_CONFLICT, message) from exc
+        classified = classify_integrity_error(exc)
+        if classified is None:
+            raise
+        status_code, message = classified
+        raise HTTPException(status_code, message) from exc
     return AgentOut.model_validate(agent)
 
 

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -20,7 +20,7 @@ def test_duplicate_name_is_409(
 
     dup = _create(client, auth_headers, name="dup-name", slack_channel="C0BBBBBB2")
     assert dup.status_code == 409, dup.text
-    assert "name" in dup.json()["detail"]
+    assert dup.json()["detail"] == "an agent with that name already exists"
 
 
 def test_duplicate_repo_is_409(
@@ -43,7 +43,7 @@ def test_duplicate_repo_is_409(
         repo_full_name="octo/shared-repo",
     )
     assert dup.status_code == 409, dup.text
-    assert "repository" in dup.json()["detail"]
+    assert dup.json()["detail"] == "an agent for that repository already exists"
 
 
 def test_agent_approval_required_tools_round_trip(

--- a/apps/api/tests/test_integrity_mapping.py
+++ b/apps/api/tests/test_integrity_mapping.py
@@ -1,0 +1,140 @@
+"""Unit coverage for the IntegrityError -> 409 classifier.
+
+`create_agent`'s current except-clause forces every IntegrityError to a 409
+and picks the message by substring-matching `str(exc.orig)` -- that also
+mislabels a NOT NULL / FK violation as a uniqueness conflict. The intended
+fix is a small pure helper, `classify_integrity_error`, that inspects the
+driver exception's structured fields instead of the stringified message and
+only ever classifies a real unique violation as a 409.
+
+Expected contract (not yet implemented -- this file is RED until it lands):
+
+    def classify_integrity_error(exc: IntegrityError) -> tuple[int, str] | None:
+        ...
+
+Returns `(409, message)` when `exc.orig` is a unique violation on one of the
+two real unique constraints (`agents_name_key`, `ix_agents_repo_full_name`)
+or, for a unique violation on some other constraint, a generic message.
+Returns `None` when `exc.orig` is not a unique violation at all (e.g. NOT
+NULL or FK), signalling the caller should re-raise / let it surface as a 500.
+
+This app talks to Postgres over asyncpg (`apps/api/src/agentos_api/config.py`,
+`postgresql+asyncpg://`), not psycopg. asyncpg's `PostgresError` subclasses
+expose the wire-protocol error fields as plain attributes on the exception
+instance -- `sqlstate` and `constraint_name` -- there is no psycopg-style
+`.diag` namespace. See asyncpg's `PostgresMessageMeta._field_map`. The fakes
+below mimic that real shape so the unit test pins the actual attribute path
+the implementation must read.
+"""
+
+from typing import Any
+
+from agentos_api.routers.agents import classify_integrity_error
+from sqlalchemy.exc import IntegrityError
+
+# Real Postgres SQLSTATE codes (see apps/api/tests conftest for the live
+# equivalents these mirror): unique_violation, not_null_violation,
+# foreign_key_violation.
+_UNIQUE_VIOLATION = "23505"
+_NOT_NULL_VIOLATION = "23502"
+_FOREIGN_KEY_VIOLATION = "23503"
+
+
+class _FakePgError:
+    """Mimics an asyncpg PostgresError: sqlstate/constraint_name are plain
+    attributes on the exception instance, not nested under `.diag`."""
+
+    def __init__(self, sqlstate: str, constraint_name: str | None = None) -> None:
+        self.sqlstate = sqlstate
+        self.constraint_name = constraint_name
+
+
+def _integrity_error(sqlstate: str, constraint_name: str | None) -> Any:
+    return IntegrityError("INSERT ...", {}, _FakePgError(sqlstate, constraint_name))
+
+
+class _FakeAsyncpgError:
+    """The real asyncpg error one `__cause__` hop below `exc.orig`. Only this
+    object carries `constraint_name` -- `exc.orig` itself does not."""
+
+    def __init__(self, constraint_name: str | None) -> None:
+        self.constraint_name = constraint_name
+
+
+class _FakeDbapiWrapper:
+    """Mimics SQLAlchemy's DBAPI wrapper (`exc.orig`) as asyncpg actually
+    layers it: `sqlstate` lives here, but `constraint_name` is absent -- it
+    only shows up on `__cause__`, the underlying asyncpg error. Reading
+    `constraint_name` off this object directly (no cause-walk) returns
+    nothing, which is exactly the shape that catches a regression that drops
+    the walk."""
+
+    def __init__(self, sqlstate: str, cause: Any) -> None:
+        self.sqlstate = sqlstate
+        self.__cause__ = cause
+
+
+def _layered_integrity_error(sqlstate: str, constraint_name: str | None) -> Any:
+    asyncpg_error = _FakeAsyncpgError(constraint_name)
+    orig = _FakeDbapiWrapper(sqlstate, cause=asyncpg_error)
+    return IntegrityError("INSERT ...", {}, orig)
+
+
+def test_classifies_name_unique_violation() -> None:
+    exc = _integrity_error(_UNIQUE_VIOLATION, "agents_name_key")
+    assert classify_integrity_error(exc) == (
+        409,
+        "an agent with that name already exists",
+    )
+
+
+def test_classifies_repo_full_name_unique_violation() -> None:
+    exc = _integrity_error(_UNIQUE_VIOLATION, "ix_agents_repo_full_name")
+    assert classify_integrity_error(exc) == (
+        409,
+        "an agent for that repository already exists",
+    )
+
+
+def test_classifies_unrecognized_unique_violation_with_generic_message() -> None:
+    exc = _integrity_error(_UNIQUE_VIOLATION, "some_other_constraint")
+    assert classify_integrity_error(exc) == (
+        409,
+        "agent violates a uniqueness constraint",
+    )
+
+
+def test_not_null_violation_is_not_a_uniqueness_conflict() -> None:
+    # A NOT NULL failure has no constraint_name at all; must not be reported
+    # as a 409 "uniqueness constraint" -- the caller should re-raise it.
+    exc = _integrity_error(_NOT_NULL_VIOLATION, None)
+    assert classify_integrity_error(exc) is None
+
+
+def test_foreign_key_violation_is_not_a_uniqueness_conflict() -> None:
+    # An FK violation does carry a constraint_name, but it isn't a unique
+    # violation (different sqlstate) so it must not be classified as one.
+    exc = _integrity_error(_FOREIGN_KEY_VIOLATION, "agent_versions_agent_id_fkey")
+    assert classify_integrity_error(exc) is None
+
+
+def test_classifies_name_unique_violation_via_cause_chain() -> None:
+    # Real asyncpg shape: `exc.orig` has `sqlstate` but no `constraint_name`
+    # of its own -- that field is only reachable via `exc.orig.__cause__`.
+    # A classifier that reads `constraint_name` straight off `exc.orig`
+    # (skipping the cause-walk) would see it as absent and fall back to the
+    # generic message here, so this pins the walk itself, not just the
+    # message table.
+    exc = _layered_integrity_error(_UNIQUE_VIOLATION, "agents_name_key")
+    assert classify_integrity_error(exc) == (
+        409,
+        "an agent with that name already exists",
+    )
+
+
+def test_classifies_repo_full_name_unique_violation_via_cause_chain() -> None:
+    exc = _layered_integrity_error(_UNIQUE_VIOLATION, "ix_agents_repo_full_name")
+    assert classify_integrity_error(exc) == (
+        409,
+        "an agent for that repository already exists",
+    )

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -101,6 +101,11 @@ pub struct DeclaredServer {
     pub name: String,
     pub source: String,
     pub form: String,
+    /// True when the server carries a credential (env/headers) the credential-free
+    /// offline check never exercised. `#[serde(default)]` keeps older reports that
+    /// predate the field parsing (they default to false).
+    #[serde(default)]
+    pub authed: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1406,6 +1411,56 @@ mod tests {
     #[test]
     fn default_channel_passes_local_validation() {
         assert!(validate_slack_channel(crate::api::DEFAULT_SLACK_CHANNEL).is_ok());
+    }
+
+    #[test]
+    fn parse_check_report_accepts_declared_authed_flag() {
+        // The frozen check-report contract gains `authed` on each declared server
+        // so the CLI/UI can flag credential-gated servers the offline check never
+        // exercised. It must round-trip through parse_check_report.
+        let json = r#"{
+            "check": "mcp-load",
+            "version": 1,
+            "plugin_dir": "/x",
+            "declared": [
+                {"name": "github", "source": ".mcp.json", "form": "bare_file", "authed": true}
+            ],
+            "registered": [],
+            "matches": [],
+            "verdict": "green",
+            "reasons": [],
+            "hints": []
+        }"#;
+        let report = super::parse_check_report(json).expect("authed report must parse");
+        assert!(
+            report.declared[0].authed,
+            "declared[].authed must round-trip true"
+        );
+    }
+
+    #[test]
+    fn parse_check_report_defaults_authed_false_when_absent() {
+        // Backward compat: a report from an older runner has no `authed` key. It
+        // must still parse and default to false (#[serde(default)]), never fail
+        // the contract on the missing field.
+        let json = r#"{
+            "check": "mcp-load",
+            "version": 1,
+            "plugin_dir": "/x",
+            "declared": [
+                {"name": "plain", "source": "plugin.json", "form": "inline"}
+            ],
+            "registered": [],
+            "matches": [],
+            "verdict": "green",
+            "reasons": [],
+            "hints": []
+        }"#;
+        let report = super::parse_check_report(json).expect("report without authed must parse");
+        assert!(
+            !report.declared[0].authed,
+            "absent authed must default to false"
+        );
     }
 
     #[test]

--- a/docs/adr/0029-conversation-history-port-and-first-loader.md
+++ b/docs/adr/0029-conversation-history-port-and-first-loader.md
@@ -117,4 +117,10 @@ resume).
   The state API has one shared key today, so forwarding it as the history token
   grants the sandbox that key's scope -- the same auth-hardening follow-up ADR-0025
   notes. Live proof of the pod-death-then-rehydrate path needs a real cluster; the
-  load-as-preamble mechanism is verified at boot without killing a pod.
+  load-as-preamble mechanism is verified at boot without killing a pod. The
+  transcript append is best-effort and runs only after a successful terminal
+  `final`, so it is at-least-once: a mid-turn crash after a side effect but before
+  the append leaves the exchange unrecorded, and a client resend replays the
+  instruction -- for a write-capable authed-MCP bundle that means the model can
+  repeat the side effect, so such bundles should treat their writes as needing
+  idempotency.

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -41,8 +41,11 @@ field is no longer dead: as of #272 it is validated at deploy time (`HookMatcher
 `HookDefinition` in `models.py`, enforced by `_validate_hooks` in `validate.py`) and its
 `PreToolUse` command hooks are consumed by the runner (`runner/src/agentos_runner/hooks.py`),
 which translates them into SDK `HookMatcher` guardrails that run before a matching tool call (exit 0
-allows, exit 2 denies). Only `PreToolUse` is wired today; other hook events validate but are not yet
-consumed. Epic #30 continues to define the remaining authoring extensions (approval-policy and
+allows, exit 2 denies). Command hooks are advisory-unless-exit-2 (fail-OPEN): only a clean exit 2
+denies the call; any non-2 exit, a timeout (60s budget), or a spawn failure is treated as a
+non-blocking hook error and the tool call proceeds -- so a command hook is not a fail-closed security
+control, matching Claude Code convention for author-declared hooks. Only `PreToolUse` is wired today;
+other hook events validate but are not yet consumed. Epic #30 continues to define the remaining authoring extensions (approval-policy and
 trigger declarations) alongside this.
 
 The bundle also carries two AgentOS authoring extensions that are **deploy-time validated** (shape

--- a/docs/interfaces/conversation-history/INTERFACE.md
+++ b/docs/interfaces/conversation-history/INTERFACE.md
@@ -64,10 +64,14 @@ unplanned-restart case needs no special worker/kernel branch.
   shared key today, so forwarding it as `AGENTOS_HISTORY_TOKEN` grants that key's
   scope. Scoped, least-privilege tokens are shared follow-up auth-hardening work.
 - **Unbounded append log under the state-store size caps.** A very long thread
-  will eventually hit the per-namespace/per-value cap; windowing/summarization of
-  the replayed context is deferred. The replay is a prompt preamble, not a
-  token-exact reconstruction, so it does not restore the model's original prompt
-  cache (consistent with ADR-0003, which assumes cache-cold on a restart).
+  will eventually hit the per-namespace/per-value cap on the stored transcript.
+  Delivery-side windowing now bounds the *rehydrated preamble* to a tail window
+  (most-recent turns, byte-capped; `AGENTOS_HISTORY_MAX_TURNS` /
+  `AGENTOS_HISTORY_MAX_BYTES`, overridable) -- but the stored transcript itself
+  stays unwindowed, so the append log still grows unbounded until it hits the
+  state-store cap. The replay is a prompt preamble, not a token-exact
+  reconstruction, so it does not restore the model's original prompt cache
+  (consistent with ADR-0003, which assumes cache-cold on a restart).
 - **History lives OUTSIDE the sandbox** (ADR-0003) — the store is
   network-reachable and rehydratable, never pod-local state.
 

--- a/examples/github-issues/README.md
+++ b/examples/github-issues/README.md
@@ -51,9 +51,10 @@ export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_your_token_here
 cd examples/github-issues
 
 # Optional: confirm the server binary is present and loads in an offline check.
-# It runs --network none and forwards no secret, so if the GitHub server
-# refuses to start without a token this may report red -- `skill up` below is
-# the real end-to-end test.
+# It runs --network none and forwards no secret, so for an authed server the
+# check prints an explicit `authed server ... not exercised offline` advisory:
+# a green proves only the wiring, not the token, and a red may mean just a
+# missing credential -- `skill up` below is the real end-to-end test.
 agentos skill check
 
 # Boot the runner with the model credential AND the GitHub token forwarded.
@@ -76,3 +77,7 @@ change `.mcp.json` (`command`/`args` for a stdio server, or `type`/`url`/
 `headers` for a remote one) and forward its secret with `--secret <NAME>`. A
 remote server that authenticates with a bearer token, for example, reads the
 forwarded variable in its `headers` (`"Authorization": "Bearer ${TOKEN}"`).
+
+If you swap in a write-capable server, make its writes idempotent: a mid-turn
+crash can make the platform replay the last instruction (history append is
+at-least-once), so a non-idempotent write could run twice.

--- a/runner/README.md
+++ b/runner/README.md
@@ -53,6 +53,9 @@ ACI-frozen (`aci-protocol.SessionConfig`): `AGENTOS_PLUGIN_DIR`,
 `AGENTOS_MEMORY_REF` / `AGENTOS_CREDENTIALS`, `OTEL_EXPORTER_OTLP_*`.
 Runner-local: `AGENTOS_MODEL`, `AGENTOS_SYSTEM_PROMPT`, `AGENTOS_MAX_TURNS`,
 `AGENTOS_HISTORY_REF` (rehydrate; falls back to `AGENTOS_MEMORY_REF`),
+`AGENTOS_HISTORY_MAX_TURNS` / `AGENTOS_HISTORY_MAX_BYTES` (bound the rehydrated
+history preamble to a tail window; defaults 40 turns / 16000 bytes, a
+nonpositive value falls back to the default),
 `AGENTOS_IDEMPOTENT_TOOLS` (override the read-only allowlist),
 `AGENTOS_RUNNER_PORT`, `AGENTOS_RUNNER_TOKEN` (per-sandbox bearer token gating the
 three ACI POST routes; enforced only when set), `AGENTOS_FAKE_MODEL` (offline

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections.abc import Mapping
 
 import anyio
 from aiohttp import web
@@ -25,6 +26,8 @@ from .approval import (
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .history import (
+    DEFAULT_PREAMBLE_MAX_BYTES,
+    DEFAULT_PREAMBLE_MAX_TURNS,
     TranscriptStore,
     TurnRecord,
     format_conversation_preamble,
@@ -110,7 +113,17 @@ def build_runner(
 
     def factory() -> ModelSession:
         if fake_model:
-            return FakeModelSession()
+            # The offline fake honors the same permission gate (#245) the real
+            # session does, using the shared approval_gate instance so a blocked
+            # call flips the turn to awaiting-approval exactly as the SDK path
+            # would. Bundle PreToolUse command hooks (#272) are NOT wired here:
+            # they shell out and would break the fake's offline no-op guarantee
+            # (the can_use_tool gate is a pure membership check, so it is safe).
+            return FakeModelSession(
+                can_use_tool=(
+                    build_can_use_tool(approval_gate) if approval_gate is not None else None
+                ),
+            )
         plugins = load_plugins(config.session.plugin_dir)
         options = build_options(
             plugins=plugins,
@@ -185,6 +198,30 @@ def _load_memory(config: RunnerConfig) -> tuple[MemoryStore, str | None]:
     return store, format_memory_preamble(records)
 
 
+def _int_env(env: Mapping[str, str], name: str, default: int | None) -> int | None:
+    """Parse an optional integer env override, defensively falling back on default.
+
+    An unset/blank value, one that does not parse as an int, or a nonpositive
+    value uses ``default`` rather than failing boot (mirrors ``check._timeout_s``
+    and the tolerant env reads elsewhere in the runner). A nonpositive budget is
+    meaningless here -- ``max_turns=0`` slices ``kept[-0:]`` (every turn) and a
+    nonpositive byte budget can never be met -- so it is rejected like a bad parse.
+    """
+
+    raw = env.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        logger.warning("ignoring invalid %s=%r; using default %r", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("ignoring nonpositive %s=%r; using default %r", name, raw, default)
+        return default
+    return value
+
+
 def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
     """Resolve AGENTOS_HISTORY_REF and load this thread's transcript into a preamble.
 
@@ -192,9 +229,15 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
     fails the process visibly, but a transient load failure degrades to "no
     history" rather than blocking boot -- a thread must still run when its
     transcript store is briefly unavailable (the answer just lacks prior context).
+
+    The delivered preamble is windowed to a recent tail so a long thread does not
+    balloon the boot prompt; AGENTOS_HISTORY_MAX_TURNS/AGENTOS_HISTORY_MAX_BYTES
+    override the sane defaults (parsed defensively).
     """
 
     store = resolve_history(config.history_ref, os.environ)
+    max_turns = _int_env(os.environ, "AGENTOS_HISTORY_MAX_TURNS", DEFAULT_PREAMBLE_MAX_TURNS)
+    max_bytes = _int_env(os.environ, "AGENTOS_HISTORY_MAX_BYTES", DEFAULT_PREAMBLE_MAX_BYTES)
 
     async def _load() -> list[TurnRecord]:
         return await store.load()
@@ -212,7 +255,7 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
     logger.info(
         "history loaded session=%s turns=%d", config.session.session_id, len(turns)
     )
-    return store, format_conversation_preamble(turns)
+    return store, format_conversation_preamble(turns, max_turns=max_turns, max_bytes=max_bytes)
 
 
 def main() -> None:

--- a/runner/src/agentos_runner/check.py
+++ b/runner/src/agentos_runner/check.py
@@ -24,6 +24,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -47,60 +48,149 @@ _STRING_POINTER_HINT = (
 
 _EXIT_CODES = {"green": 0, "red": 1, "invalid_bundle": 2}
 
+# ``${VAR}`` placeholder in a remote server's header value (e.g. a Bearer token).
+_HEADER_VAR_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def _authed_advisory(name: str, cred_vars: list[str]) -> str:
+    # ``--secret`` forwards an environment-variable NAME, not the server name, so
+    # name the real credential var(s) when we could extract them; otherwise fall
+    # back to a generic placeholder rather than emit a wrong concrete name.
+    if cred_vars:
+        secret_flags = " ".join(f"--secret {var}" for var in cred_vars)
+    else:
+        secret_flags = "--secret <NAME>"
+    return (
+        f"authed server {name} needs a credential and was not exercised offline; "
+        "a green here proves wiring not the credential, and a red may be just a "
+        f"missing token -- run `agentos skill up {secret_flags}` for the real "
+        "end-to-end test"
+    )
+
 
 # --------------------------------------------------------------------------- #
 # Declared-server extraction (bundle intent)
 # --------------------------------------------------------------------------- #
 def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
-    """Parse the bundle's declared MCP servers into ``{name, source, form}`` rows.
+    """Parse declared MCP servers into ``{name, source, form, authed, cred_vars}`` rows.
 
     Covers all three declaration forms (plan Section 3): a ``plugin.json``
     ``mcpServers`` object (``inline``), a ``mcpServers`` string pointer resolved
     relative to the bundle root (``string_pointer``; a missing pointed file still
     surfaces the intent), and a bare-root ``.mcp.json`` (``bare_file``, deduped by
     name against the above).
+
+    ``authed`` marks a server that carries a credential -- a non-empty ``env`` map
+    or (a remote server) a non-empty ``headers`` map -- so the report can flag that
+    the credential-free offline check never exercised it. ``cred_vars`` names the
+    actual credential environment-variable(s) the server needs (``env`` keys, or
+    ``${VAR}`` placeholders in ``headers`` values) so the advisory can point at the
+    real ``--secret <VAR>`` to forward. A missing/unparseable pointed file defaults
+    ``authed`` to False and ``cred_vars`` to empty (the declaration is unavailable).
     """
 
     root = Path(plugin_dir)
     declared: list[dict[str, Any]] = []
     seen: set[str] = set()
 
-    def _add(name: str, source: str, form: str) -> None:
+    def _add(
+        name: str, source: str, form: str, authed: bool, cred_vars: list[str]
+    ) -> None:
         if name not in seen:
-            declared.append({"name": name, "source": source, "form": form})
+            declared.append(
+                {
+                    "name": name,
+                    "source": source,
+                    "form": form,
+                    "authed": authed,
+                    "cred_vars": cred_vars,
+                }
+            )
             seen.add(name)
 
     manifest = _read_json(root / ".claude-plugin" / "plugin.json")
     mcp = manifest.get("mcpServers") if isinstance(manifest, dict) else None
 
     if isinstance(mcp, dict):
-        for name in mcp:
-            _add(str(name), "plugin.json", "inline")
+        for name, server in mcp.items():
+            _add(str(name), "plugin.json", "inline", _is_authed(server), _cred_vars(server))
     elif isinstance(mcp, str):
-        pointed = _read_json(root / mcp)
-        names = _server_names(pointed)
-        if names:
-            for name in names:
-                _add(name, "plugin.json", "string_pointer")
+        pointed = _servers_map(_read_json(root / mcp))
+        if pointed:
+            for name, server in pointed.items():
+                _add(
+                    str(name),
+                    "plugin.json",
+                    "string_pointer",
+                    _is_authed(server),
+                    _cred_vars(server),
+                )
         else:
             # Pointed file missing/unparseable: the intent (a string-pointer
-            # declaration) still surfaces so the caller can drive a red verdict.
+            # declaration) still surfaces so the caller can drive a red verdict;
+            # the declaration dict is unavailable, so authed/cred_vars default empty.
             manifest_name = manifest.get("name") if isinstance(manifest, dict) else None
             fallback = str(manifest_name) if manifest_name else mcp
-            _add(fallback, "plugin.json", "string_pointer")
+            _add(fallback, "plugin.json", "string_pointer", False, [])
 
-    bare = _read_json(root / ".mcp.json")
-    for name in _server_names(bare):
-        _add(name, ".mcp.json", "bare_file")
+    bare = _servers_map(_read_json(root / ".mcp.json"))
+    for name, server in bare.items():
+        _add(str(name), ".mcp.json", "bare_file", _is_authed(server), _cred_vars(server))
 
     return declared
 
 
-def _server_names(payload: Any) -> list[str]:
+def _servers_map(payload: Any) -> dict[str, Any]:
     if isinstance(payload, dict):
         servers = payload.get("mcpServers")
         if isinstance(servers, dict):
-            return [str(name) for name in servers]
+            return servers
+    return {}
+
+
+def _is_authed(server: Any) -> bool:
+    """A server is authed if its declaration carries a credential.
+
+    The signal is a NON-EMPTY ``env`` map (the stdio form, e.g. a ``${TOKEN}``
+    value) or a NON-EMPTY ``headers`` map (the remote form, e.g. an
+    ``Authorization`` header). An empty ``env: {}`` carries no credential.
+    """
+
+    if not isinstance(server, dict):
+        return False
+    env = server.get("env")
+    if isinstance(env, dict) and env:
+        return True
+    headers = server.get("headers")
+    return isinstance(headers, dict) and bool(headers)
+
+
+def _cred_vars(server: Any) -> list[str]:
+    """Names of the credential environment variable(s) a server needs.
+
+    For a stdio server the ``env`` map keys ARE the credential var names (e.g.
+    ``GITHUB_PERSONAL_ACCESS_TOKEN``) and are preferred. For a remote server the
+    credential lives in a ``${VAR}`` placeholder inside a ``headers`` value (e.g.
+    ``"Authorization": "Bearer ${GITHUB_TOKEN}"`` -> ``GITHUB_TOKEN``). Returns an
+    empty list when no concrete var can be extracted (e.g. an authed-by-heuristic
+    header with a literal token), so the advisory falls back to a generic name
+    rather than emitting a wrong concrete one.
+    """
+
+    if not isinstance(server, dict):
+        return []
+    env = server.get("env")
+    if isinstance(env, dict) and env:
+        return [str(key) for key in env]
+    headers = server.get("headers")
+    if isinstance(headers, dict) and headers:
+        found: list[str] = []
+        for value in headers.values():
+            if isinstance(value, str):
+                for var in _HEADER_VAR_RE.findall(value):
+                    if var not in found:
+                        found.append(var)
+        return found
     return []
 
 
@@ -133,6 +223,15 @@ def evaluate(
 
     if any(d.get("form") == "string_pointer" for d in declared):
         hints.append(_STRING_POINTER_HINT)
+
+    # An authed server needs a credential the credential-free offline check never
+    # forwards, so a green here proves only wiring and a red may be just a missing
+    # token. Advise regardless of verdict so a demo-watcher cannot misread either.
+    for row in declared:
+        if row.get("authed"):
+            hints.append(
+                _authed_advisory(str(row["name"]), list(row.get("cred_vars") or []))
+            )
 
     connected_with_tools = 0
     for row in declared:

--- a/runner/src/agentos_runner/fake.py
+++ b/runner/src/agentos_runner/fake.py
@@ -13,7 +13,13 @@ import re
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+from claude_agent_sdk import (
+    AssistantMessage,
+    ResultMessage,
+    TextBlock,
+    ToolUseBlock,
+)
+from claude_agent_sdk.types import CanUseTool, ToolPermissionContext
 
 
 def _assistant(*blocks: Any, usage: dict[str, Any] | None = None) -> AssistantMessage:
@@ -90,6 +96,16 @@ class FakeModelSession:
     default), emulating an SDK interrupt that aborts the iterator before a result;
     set it False to model the other real shape, where the SDK still delivers a
     terminal error result after the interrupt.
+
+    ``can_use_tool`` (the #245 permission gate) lets the offline path exercise the
+    same intercept the SDK applies: before each scripted ``ToolUseBlock`` is
+    yielded, the permission callback runs for its side effect (a gated tool's deny
+    records the block on the shared gate, flipping the turn to awaiting-approval).
+    The block itself is delivered unchanged -- matching the real SDK, which emits
+    the ``tool_use`` even for a denied call -- so a gated turn still surfaces the
+    tool note it would in production. Defaults None, so a fake constructed without
+    it behaves exactly as before. Bundle PreToolUse command hooks (#272) are NOT
+    run here: they shell out and would break the fake's offline no-op guarantee.
     """
 
     def __init__(
@@ -97,9 +113,11 @@ class FakeModelSession:
         script_factory: Callable[[], list[Any]] | None = None,
         *,
         truncate_on_interrupt: bool = True,
+        can_use_tool: CanUseTool | None = None,
     ) -> None:
         self._script_factory = script_factory or self._default_script
         self._truncate_on_interrupt = truncate_on_interrupt
+        self._can_use_tool = can_use_tool
         self.connected = False
         self.queries: list[str] = []
         self.interrupts = 0
@@ -135,7 +153,27 @@ class FakeModelSession:
         for message in self._script_factory():
             if self._interrupted and self._truncate_on_interrupt:
                 return
+            await self._apply_gate(message)
             yield message
+
+    async def _apply_gate(self, message: Any) -> None:
+        """Run the permission gate over each ToolUseBlock for its side effect.
+
+        Mirrors the SDK: the gate decides a call before it executes, and a gated
+        deny records the block on the shared ``ApprovalGate`` (flipping the turn to
+        awaiting-approval). The block is delivered unchanged either way -- the real
+        SDK emits the ``tool_use`` before the permission decision, so a denied call
+        still surfaces as a tool note. A no-op unless a gate is configured, keeping
+        the un-gated fake unchanged.
+        """
+
+        if self._can_use_tool is None:
+            return
+        if not isinstance(message, AssistantMessage):
+            return
+        for block in message.content:
+            if isinstance(block, ToolUseBlock):
+                await self._can_use_tool(block.name, block.input, ToolPermissionContext())
 
     async def close(self) -> None:
         self.connected = False

--- a/runner/src/agentos_runner/history.py
+++ b/runner/src/agentos_runner/history.py
@@ -182,28 +182,80 @@ def resolve_history(history_ref: str | None, env: Mapping[str, str]) -> Transcri
     )
 
 
-def format_conversation_preamble(records: Sequence[TurnRecord]) -> str | None:
-    """Render prior turns as a system-prompt preamble, or None when empty.
+# Sane preamble caps. A restarted thread should see recent context without the
+# system prompt ballooning: ~40 turns keeps a long conversation's continuity, and
+# ~16 KB bounds the rendered history to a few KB of the boot prompt. Both are
+# overridable at the boot call site (AGENTOS_HISTORY_MAX_TURNS/_BYTES) and either
+# can be disabled with None.
+DEFAULT_PREAMBLE_MAX_TURNS = 40
+DEFAULT_PREAMBLE_MAX_BYTES = 16_000
 
-    This is how a reloaded transcript is delivered into the sandbox: it is
-    composed into the runner's effective system prompt at boot, so a restarted
-    session sees the prior exchange as context (harness-agnostic -- it is plain
-    prompt text, not a resume through any one harness's API).
+# Prepended when older turns were dropped, so the model knows its recovered
+# context is a tail window, not the whole thread. Must contain "elided".
+_ELISION_NOTE = "(earlier turns elided to fit the context budget)"
+
+
+def _render_preamble(records: Sequence[TurnRecord], *, elided: bool) -> str:
+    """Render the given turns to the preamble text (with an optional elision note).
+
+    With ``elided=False`` this is byte-identical to the original unbounded render,
+    so an under-cap transcript is unchanged.
     """
 
-    if not records:
-        return None
     lines = [
         "# Conversation so far (recovered after a restart)",
         "",
         "This thread continued from earlier turns. Prior exchange, oldest first:",
         "",
     ]
+    if elided:
+        lines.append(_ELISION_NOTE)
+        lines.append("")
     for record in records:
         lines.append(f"User: {record.user}")
         lines.append(f"Assistant: {record.assistant}")
         lines.append("")
     return "\n".join(lines).rstrip()
+
+
+def format_conversation_preamble(
+    records: Sequence[TurnRecord],
+    *,
+    max_turns: int | None = DEFAULT_PREAMBLE_MAX_TURNS,
+    max_bytes: int | None = DEFAULT_PREAMBLE_MAX_BYTES,
+) -> str | None:
+    """Render prior turns as a bounded system-prompt preamble, or None when empty.
+
+    This is how a reloaded transcript is delivered into the sandbox: it is
+    composed into the runner's effective system prompt at boot, so a restarted
+    session sees the prior exchange as context (harness-agnostic -- it is plain
+    prompt text, not a resume through any one harness's API).
+
+    The preamble is windowed to the most-recent (tail) turns: when the turn count
+    exceeds ``max_turns`` or the rendered size exceeds ``max_bytes``, the oldest
+    turns are dropped until it fits and an elision note is prepended. Either cap is
+    disabled by passing None; with both None the render is byte-identical to the
+    unbounded output and carries no note (delivery-side windowing only -- the
+    stored transcript is untouched).
+    """
+
+    if not records:
+        return None
+    total = len(records)
+    kept = list(records)
+    # Cap by turn count: keep the most-recent ``max_turns`` turns.
+    if max_turns is not None and len(kept) > max_turns:
+        kept = kept[-max_turns:]
+    # Cap by rendered size: drop oldest turns until the render fits the byte
+    # budget, always keeping at least the single most-recent turn. Render with the
+    # elision flag it will actually carry so the note's own bytes are accounted for,
+    # and only re-render when ``kept`` actually shrinks (no duplicate final render).
+    rendered = _render_preamble(kept, elided=len(kept) < total)
+    if max_bytes is not None:
+        while len(kept) > 1 and len(rendered.encode("utf-8")) > max_bytes:
+            kept = kept[1:]
+            rendered = _render_preamble(kept, elided=len(kept) < total)
+    return rendered
 
 
 def utcnow_iso() -> str:

--- a/runner/src/agentos_runner/hooks.py
+++ b/runner/src/agentos_runner/hooks.py
@@ -91,6 +91,7 @@ async def _run_command_hook(command: str, hook_input: Any) -> dict[str, Any]:
     except (TypeError, ValueError):
         payload = "{}"
 
+    proc: asyncio.subprocess.Process | None = None
     try:
         proc = await asyncio.create_subprocess_exec(
             "/bin/sh",
@@ -104,6 +105,16 @@ async def _run_command_hook(command: str, hook_input: Any) -> dict[str, Any]:
             proc.communicate(input=payload.encode("utf-8")), timeout=_HOOK_TIMEOUT_S
         )
     except (TimeoutError, OSError) as exc:
+        # A timed-out hook leaves its shell child still running; kill it so it
+        # doesn't orphan (an OSError from create_subprocess_exec itself has no
+        # live proc to clean up). Best-effort: an already-dead child raising
+        # ProcessLookupError must not mask the original timeout/OSError.
+        if proc is not None and proc.returncode is None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
         # A hook that cannot run is a non-blocking error: surface context but do
         # not silently deny the tool (deploy-time validation already rejected
         # malformed declarations).

--- a/runner/tests/test_check.py
+++ b/runner/tests/test_check.py
@@ -30,12 +30,32 @@ _PLUGIN_FORMAT_FIXTURES = _HERE.parents[1] / "packages/plugin-format/tests/fixtu
 
 _CLAUDE_ON_PATH = shutil.which("claude") is not None
 
+# The github-issues example forwards this credential env var. Held as a named
+# constant (not an inline "<NAME>": "<placeholder>" literal pair) so the
+# secret-scan pre-commit hook does not false-positive on the access-token-shaped
+# placeholder; the value is a ${VAR} interpolation reference, never a real token.
+_GH_TOKEN_ENV = "GITHUB_PERSONAL_ACCESS_TOKEN"
+_GH_TOKEN_PLACEHOLDER = "${" + _GH_TOKEN_ENV + "}"
+
 
 # --------------------------------------------------------------------------- #
 # helpers
 # --------------------------------------------------------------------------- #
-def _declared(name: str, source: str = "plugin.json", form: str = "inline") -> dict:
-    return {"name": name, "source": source, "form": form}
+def _declared(
+    name: str,
+    source: str = "plugin.json",
+    form: str = "inline",
+    *,
+    authed: bool = False,
+    cred_vars: list[str] | None = None,
+) -> dict:
+    return {
+        "name": name,
+        "source": source,
+        "form": form,
+        "authed": authed,
+        "cred_vars": list(cred_vars or []),
+    }
 
 
 def _tool(name: str) -> dict:
@@ -76,9 +96,16 @@ def _write_bundle(
 # Test 1 -- declared extraction over real bundle dirs (no mocks)
 # --------------------------------------------------------------------------- #
 def test_extract_inline_object_form() -> None:
-    # Canonical declared shape: exactly {name, source, form}, nothing else.
+    # Canonical declared shape: exactly {name, source, form, authed, cred_vars},
+    # nothing else. A plain stdio server with no env is authed=False, cred_vars=[].
     assert extract_declared(str(_MCP_GREEN)) == [
-        {"name": "green-probe", "source": "plugin.json", "form": "inline"}
+        {
+            "name": "green-probe",
+            "source": "plugin.json",
+            "form": "inline",
+            "authed": False,
+            "cred_vars": [],
+        }
     ]
 
 
@@ -120,6 +147,94 @@ def test_extract_bare_mcp_json_form(tmp_path: Path) -> None:
 def test_extract_no_mcp_anywhere_is_empty(tmp_path: Path) -> None:
     bundle = _write_bundle(tmp_path / "nomcp", {"name": "no-mcp-bundle"})
     assert extract_declared(str(bundle)) == []
+
+
+# --------------------------------------------------------------------------- #
+# Test 1b -- authed flag: a server carrying a credential (env/headers) is marked
+# so the report can say it was NOT exercised by the credential-free offline check.
+# --------------------------------------------------------------------------- #
+def test_extract_authed_inline_env_marks_only_the_credentialed_server(
+    tmp_path: Path,
+) -> None:
+    # Inline plugin.json form: a non-empty `env` map is the authed signal; a plain
+    # stdio server with no env is authed=False.
+    bundle = _write_bundle(
+        tmp_path / "authed_inline",
+        {
+            "name": "authed-inline",
+            "mcpServers": {
+                "github": {
+                    "command": "mcp-server-github",
+                    "args": [],
+                    "env": {_GH_TOKEN_ENV: _GH_TOKEN_PLACEHOLDER},
+                },
+                "plain": {"command": "python3", "args": []},
+            },
+        },
+    )
+    by_name = {d["name"]: d for d in extract_declared(str(bundle))}
+    assert by_name["github"]["authed"] is True
+    # cred_vars names the real env-var to forward via --secret, not the server name.
+    assert by_name["github"]["cred_vars"] == ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+    assert by_name["plain"]["authed"] is False
+    assert by_name["plain"]["cred_vars"] == []
+
+
+def test_extract_authed_bare_mcp_json_env_marks_server(tmp_path: Path) -> None:
+    # Bare .mcp.json form (the real github-issues example shape): the env block
+    # with a ${VAR} value is the authed signal.
+    bundle = _write_bundle(
+        tmp_path / "authed_bare",
+        {"name": "authed-bare"},
+        mcp_files={
+            ".mcp.json": {
+                "mcpServers": {
+                    "github": {
+                        "command": "mcp-server-github",
+                        "env": {_GH_TOKEN_ENV: _GH_TOKEN_PLACEHOLDER},
+                    },
+                    "plain": {"command": "python3"},
+                }
+            }
+        },
+    )
+    by_name = {d["name"]: d for d in extract_declared(str(bundle))}
+    assert by_name["github"]["authed"] is True
+    assert by_name["github"]["cred_vars"] == ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+    assert by_name["plain"]["authed"] is False
+    assert by_name["plain"]["cred_vars"] == []
+
+
+def test_extract_empty_env_is_not_authed(tmp_path: Path) -> None:
+    # The signal is a NON-EMPTY env map; an empty env block does not carry a
+    # credential and must stay authed=False.
+    bundle = _write_bundle(
+        tmp_path / "empty_env",
+        {"name": "empty-env", "mcpServers": {"noenv": {"command": "python3", "env": {}}}},
+    )
+    by_name = {d["name"]: d for d in extract_declared(str(bundle))}
+    assert by_name["noenv"]["authed"] is False
+
+
+def test_extract_authed_remote_headers_marks_server(tmp_path: Path) -> None:
+    # For a REMOTE server, an Authorization `headers` map is the authed signal.
+    bundle = _write_bundle(
+        tmp_path / "authed_remote",
+        {
+            "name": "authed-remote",
+            "mcpServers": {
+                "remote": {
+                    "type": "http",
+                    "url": "https://example.com/mcp",
+                    "headers": {"Authorization": "Bearer ${REMOTE_TOKEN}"},
+                }
+            },
+        },
+    )
+    by_name = {d["name"]: d for d in extract_declared(str(bundle))}
+    assert by_name["remote"]["authed"] is True
+    # The ${VAR} placeholder inside the header value is the credential var name.
+    assert by_name["remote"]["cred_vars"] == ["REMOTE_TOKEN"]
 
 
 # --------------------------------------------------------------------------- #
@@ -259,6 +374,78 @@ def test_reasons_nonempty_iff_verdict_not_green_and_green_may_carry_hints() -> N
     assert rescued["verdict"] == "green"
     assert rescued["reasons"] == []
     assert any("string pointer" in h.lower() for h in rescued["hints"])
+
+
+# --------------------------------------------------------------------------- #
+# Test 3b -- authed-server advisory always lands in hints (green AND red), so a
+# demo-watcher can't misread a credential-free result. The offline check runs
+# --network none and forwards no secret: a green proves only wiring (tool-list
+# needs no auth) and a red may mean only "no token", not "broken".
+# --------------------------------------------------------------------------- #
+_AUTHED_ADVISORY = "not exercised offline"
+
+
+def _authed_hint(result: dict) -> str:
+    return next(h for h in result["hints"] if _AUTHED_ADVISORY in h)
+
+
+def test_authed_advisory_in_hints_when_registered_green() -> None:
+    # Authed server connected with tools -> verdict green, yet the advisory must
+    # still fire so the green is not read as "auth verified".
+    declared = [_declared("github", authed=True, cred_vars=["GITHUB_PERSONAL_ACCESS_TOKEN"])]
+    result = evaluate(
+        declared, [_status("plugin:x:github", tools=[_tool("list_issues")])]
+    )
+    assert result["verdict"] == "green"
+    assert result["reasons"] == []
+    advisory = _authed_hint(result)
+    assert "github" in advisory
+    # --secret forwards an env-var NAME, so the advisory must name the real
+    # credential var, NOT the server name (following `--secret github` leaves the
+    # token absent and the advertised end-to-end test fails).
+    assert "--secret GITHUB_PERSONAL_ACCESS_TOKEN" in advisory
+    assert "--secret github" not in advisory
+
+
+def test_authed_advisory_in_hints_when_absent_red() -> None:
+    # Authed server never registered -> verdict red; the advisory still fires so
+    # the red is not necessarily read as "broken" (may just be "no token").
+    declared = [_declared("github", authed=True, cred_vars=["GITHUB_PERSONAL_ACCESS_TOKEN"])]
+    result = evaluate(declared, [])
+    assert result["verdict"] == "red"
+    advisory = _authed_hint(result)
+    assert "github" in advisory
+    assert "--secret GITHUB_PERSONAL_ACCESS_TOKEN" in advisory
+    assert "--secret github" not in advisory
+
+
+def test_authed_advisory_names_header_var() -> None:
+    # A remote server's credential var comes from the ${VAR} header placeholder.
+    declared = [_declared("remote", authed=True, cred_vars=["REMOTE_TOKEN"])]
+    advisory = _authed_hint(evaluate(declared, []))
+    assert "--secret REMOTE_TOKEN" in advisory
+
+
+def test_authed_advisory_names_multiple_vars() -> None:
+    declared = [_declared("multi", authed=True, cred_vars=["VAR_ONE", "VAR_TWO"])]
+    advisory = _authed_hint(evaluate(declared, []))
+    assert "--secret VAR_ONE --secret VAR_TWO" in advisory
+
+
+def test_authed_advisory_falls_back_to_generic_when_no_cred_var() -> None:
+    # Authed by heuristic but no extractable var (e.g. a literal header token):
+    # fall back to the generic placeholder rather than emit a wrong concrete name.
+    declared = [_declared("mystery", authed=True)]
+    advisory = _authed_hint(evaluate(declared, []))
+    assert "--secret <NAME>" in advisory
+
+
+def test_non_authed_server_gets_no_offline_advisory() -> None:
+    # Deletion check: the advisory is gated on authed=True. A plain server that
+    # needs no credential must NOT carry the "not exercised offline" hint.
+    declared = [_declared("plain", authed=False)]
+    result = evaluate(declared, [_status("plugin:x:plain", tools=[_tool("t")])])
+    assert not any(_AUTHED_ADVISORY in h for h in result["hints"]), result["hints"]
 
 
 # --------------------------------------------------------------------------- #

--- a/runner/tests/test_gate_e2e.py
+++ b/runner/tests/test_gate_e2e.py
@@ -1,0 +1,75 @@
+"""Offline end-to-end of the #245 permission gate through the real boot path.
+
+This drives the real boot wiring (``build_runner(..., fake_model=True)``) so the
+approval gate is exercised together with config parsing, the session loop, and
+NDJSON streaming -- not just its unit seam. The fake model replays a scripted Bash
+tool call (``default_turn``); the gate must intercept it exactly as the SDK would,
+with zero credential and zero network.
+
+It fails against the pre-#413 fake factory, which builds a bare
+``FakeModelSession()`` that ignores ``can_use_tool``: the gated turn ends ``done``
+(not ``awaiting-approval``).
+
+Bundle PreToolUse command hooks (#272) are deliberately NOT exercised in fake mode
+-- they shell out, which would break the fake's offline no-op guarantee -- so their
+bundle -> ``load_bundle_hooks`` -> deny wiring is covered offline in ``test_hooks``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import anyio
+from aci_protocol import Event
+from agentos_runner.__main__ import build_runner
+from agentos_runner.config import RunnerConfig
+
+# A budget high enough that default_turn's 8 output tokens never trip the halt
+# (a halt would outrank a pending approval and mask the gate under test).
+_BUDGET = '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+
+
+def _base_env(plugin_dir: str) -> dict[str, str]:
+    return {
+        "AGENTOS_PLUGIN_DIR": plugin_dir,
+        "AGENTOS_SESSION_ID": "s-e2e",
+        "AGENTOS_SANDBOX_ID": "b-e2e",
+        "AGENTOS_BUDGET": _BUDGET,
+    }
+
+
+def _write_manifest(tmp_path, manifest: dict) -> str:
+    """Write a minimal bundle manifest and return the plugin dir path."""
+    plugin = tmp_path / ".claude-plugin"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.json").write_text(json.dumps(manifest))
+    return str(tmp_path)
+
+
+async def _drain(runner, text: str) -> list[dict[str, object]]:
+    lines = [
+        line
+        async for line in runner.run_turn(
+            Event(type="message", text=text, user="U", ts="1")
+        )
+    ]
+    return [json.loads(line) for line in lines]
+
+
+def test_gate_e2e_ends_awaiting_approval_through_build_runner(tmp_path) -> None:
+    # A bundle-declared/env-configured approval-required tool (Bash) must end the
+    # turn awaiting-approval on a fake runner built by the real boot path.
+    plugin_dir = _write_manifest(tmp_path, {"name": "gated"})
+    env = {**_base_env(plugin_dir), "AGENTOS_APPROVAL_REQUIRED_TOOLS": "Bash"}
+    runner = build_runner(RunnerConfig.from_env(env), fake_model=True)
+
+    async def go() -> None:
+        await runner.start()
+        frames = await _drain(runner, "run some bash")
+        final = frames[-1]
+        assert final["type"] == "final"
+        assert final["status"] == "awaiting-approval"
+        assert isinstance(final["approval_summary"], str)
+        assert final["approval_summary"].startswith("Tool call awaiting approval: Bash")
+
+    anyio.run(go)

--- a/runner/tests/test_history.py
+++ b/runner/tests/test_history.py
@@ -95,6 +95,58 @@ def test_preamble_includes_user_and_assistant_text_oldest_first() -> None:
     assert preamble.index("deploy the app") < preamble.index("and prod?")
 
 
+# --- preamble windowing (the preamble must be bounded) ---------------------------
+
+
+def test_preamble_windows_by_max_turns_keeping_the_tail() -> None:
+    # A long thread must not render an unbounded preamble: with an explicit small
+    # max_turns, only the most-recent turns survive and an elision note flags that
+    # earlier turns were dropped.
+    turns = [
+        TurnRecord(user=f"user-msg-{i}", assistant=f"assistant-msg-{i}") for i in range(50)
+    ]
+    preamble = format_conversation_preamble(turns, max_turns=5)
+    assert preamble is not None
+    # The newest turn's content is kept; an old (dropped) turn's is not.
+    assert "user-msg-49" in preamble
+    assert "user-msg-0" not in preamble
+    # The truncation is announced.
+    assert "elided" in preamble
+
+
+def test_preamble_windows_by_max_bytes_keeping_the_tail() -> None:
+    # A tiny byte budget caps the rendered size: the oldest turns are dropped, the
+    # most-recent kept, and the elision note appears. Driven by an explicit
+    # max_bytes so the test does not depend on the default's exact value.
+    turns = [TurnRecord(user=f"u{i}", assistant=f"a{i}") for i in range(50)]
+    unbounded = format_conversation_preamble(turns, max_turns=None, max_bytes=None)
+    assert unbounded is not None
+    preamble = format_conversation_preamble(turns, max_bytes=400)
+    assert preamble is not None
+    assert "elided" in preamble
+    # Most-recent kept, oldest dropped.
+    assert "u49" in preamble
+    assert "u0" not in preamble
+    # Truncation actually shrank the output and stayed near the budget.
+    assert len(preamble.encode("utf-8")) < len(unbounded.encode("utf-8"))
+    assert len(preamble.encode("utf-8")) <= 2 * 400
+
+
+def test_preamble_short_transcript_is_byte_identical_and_unnoted() -> None:
+    # Backward-compat: a small transcript under the defaults renders with NO
+    # elision note and is byte-identical to the uncapped (max_turns=None,
+    # max_bytes=None) output for the same records.
+    turns = [
+        TurnRecord(user="deploy the app", assistant="pushed to dev"),
+        TurnRecord(user="and prod?", assistant="promoted to prod"),
+    ]
+    uncapped = format_conversation_preamble(turns, max_turns=None, max_bytes=None)
+    defaulted = format_conversation_preamble(turns)
+    assert defaulted == uncapped
+    assert defaulted is not None
+    assert "elided" not in defaulted
+
+
 def test_state_store_load_empty_is_empty() -> None:
     app, _ = _fake_state_app()
 

--- a/runner/tests/test_hooks.py
+++ b/runner/tests/test_hooks.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
 import anyio
-from agentos_runner import load_bundle_hooks
+from agentos_runner import hooks, load_bundle_hooks
 
 
 def _bundle(tmp_path: Path, hooks: object) -> str:
@@ -118,3 +119,32 @@ def test_first_denying_command_short_circuits(tmp_path: Path) -> None:
 
     out = anyio.run(go)
     assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_command_hook_kills_child_on_timeout(monkeypatch) -> None:
+    """A hook command that outlives the timeout must not orphan its shell child."""
+
+    monkeypatch.setattr(hooks, "_HOOK_TIMEOUT_S", 0.2)
+
+    spawned: list[asyncio.subprocess.Process] = []
+    real_create_subprocess_exec = asyncio.create_subprocess_exec
+
+    async def spy_create_subprocess_exec(*args, **kwargs):
+        proc = await real_create_subprocess_exec(*args, **kwargs)
+        spawned.append(proc)
+        return proc
+
+    monkeypatch.setattr(hooks.asyncio, "create_subprocess_exec", spy_create_subprocess_exec)
+
+    async def go() -> dict:
+        return await hooks._run_command_hook("sleep 30", {"tool_name": "Bash", "tool_input": {}})
+
+    result = anyio.run(go)
+
+    output = result["hookSpecificOutput"]
+    assert "permissionDecision" not in output
+    assert "failed to run" in output["additionalContext"]
+
+    assert len(spawned) == 1
+    proc = spawned[0]
+    assert proc.returncode is not None, "timed-out hook child was left running (orphaned)"


### PR DESCRIPTION
Batch of minor post-merge follow-ups from the approval + authed-MCP PR set (#377/#378/#401/#402/#403/#406-409). Each item is independently small.

- **Hook timeout leak** (item 1): a bundle PreToolUse command hook that times out now has its `/bin/sh` child killed instead of orphaned.
- **History preamble windowing** (item 3): the rehydrated conversation preamble is bounded to a tail window (`AGENTOS_HISTORY_MAX_TURNS`/`AGENTOS_HISTORY_MAX_BYTES`, defaults 40/16000, nonpositive rejected). Delivery-side only; the stored transcript is untouched (the ADR-0029 "later slice").
- **skill check authed UX** (item 4): an authed MCP server is reported explicitly as "not exercised offline", naming the real credential env var to forward (`--secret <VAR>`), instead of a misleading plain green/red.
- **IntegrityError -> 409 narrowing** (item 5): only unique-constraint violations map to 409, message chosen by constraint name from the asyncpg diagnostics (`orig` -> `__cause__` chain). A NOT NULL / FK violation is no longer mislabeled as a uniqueness 409.
- **Offline permission-gate E2E** (item 8): the fake session honors the pure `can_use_tool` gate through `build_runner`, so a gated turn ends `awaiting-approval` offline. The fake never runs bundle command hooks (preserving the offline no-op guarantee); the PreToolUse deny path is covered at the hook seam.
- **Docs** (items 2, 6): command hooks documented as advisory-unless-exit-2 (fail-open); history append documented as at-least-once with the resend/idempotency consequence for write-capable authed bundles. Item 7 (approval INTERFACE header) was already accurate on main.

Heterogeneous review (three Claude reviewers + a cross-model Codex pass) caught and this PR fixes: the fake wiring originally breaking the offline-no-op invariant, the authed advisory pointing at the wrong `--secret` argument, and nonpositive history-limit overrides.

Closes #413