### PR TITLE
Backstop stranded approval resumes with a reconciler

### DIFF
--- a/apps/api/alembic/versions/0011_approval_resumed_at.py
+++ b/apps/api/alembic/versions/0011_approval_resumed_at.py
@@ -1,0 +1,69 @@
+"""approval resumed_at work-list marker (#411, ADR-0010)
+
+Adds approvals.resumed_at: set once the resume turn is enqueued onto the runs
+stream, NULL on a resolved record means the wake is still owed (the resume
+reconciler's work-list). Backfills pre-existing resolved rows so the first
+reconciler pass after deploy treats settled history as delivered, never
+re-waking long-finished threads whose worker done-marker has expired.
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-07-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011"
+down_revision: str | None = "0010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "agentos"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "approvals",
+        sa.Column("resumed_at", sa.DateTime(), nullable=True),
+        schema=SCHEMA,
+    )
+    # Windowed backfill: settle ONLY rows resolved longer ago than the worker's
+    # done-marker TTL window (24h). Rows resolved within the last 24h stay NULL so
+    # they remain recoverable -- within the live done-marker window a successful
+    # delivery still dedupes a reconciler re-enqueue, while a failed (stranded)
+    # delivery, the actual bug victim, is finally recovered by the reconciler. A
+    # blanket backfill would settle those stranded-just-before-deploy rows too and
+    # the reconciler could never recover them. Only ambiguous older-than-TTL
+    # history is settled, to avoid re-delivering into long-finished threads whose
+    # marker has already expired. The 24h literal mirrors the worker
+    # ``idempotency_ttl_s`` DEFAULT (86400s). A migration cannot read the worker's
+    # runtime env, so this is a known coupling: a deployment that overrides
+    # ``IDEMPOTENCY_TTL_S`` must adjust this window to match (a longer TTL would
+    # leave some safely-dedupable rows NULL for one redundant re-enqueue; a shorter
+    # TTL risks re-waking a thread whose marker expired between the window and the
+    # true TTL). Both are one-time, deploy-only effects; change the two together.
+    op.execute(
+        "UPDATE agentos.approvals SET resumed_at = resolved_at "
+        "WHERE status IN ('approved','rejected') AND resolved_at IS NOT NULL "
+        "AND resolved_at < now() - interval '24 hours'"
+    )
+    # Partial index for the reconciler's work-list query, which runs every
+    # interval and filters resumed_at IS NULL + resolved_at. In steady state
+    # nearly every historical row has resumed_at set, so a partial index keeps
+    # the sweep proportional to the handful of owed wakes rather than scanning
+    # all resolved history.
+    op.create_index(
+        "ix_approvals_resolved_unresumed",
+        "approvals",
+        ["resolved_at"],
+        schema=SCHEMA,
+        postgresql_where=sa.text("resumed_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_approvals_resolved_unresumed", "approvals", schema=SCHEMA)
+    op.drop_column("approvals", "resumed_at", schema=SCHEMA)

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -81,6 +81,27 @@ class Settings(BaseSettings):
     # Must match the worker's AGENTOS_STREAM (its consumer side).
     runs_stream: str = "agentos:runs"
 
+    # Resume reconciler (#411): the backstop that re-enqueues resume turns for
+    # resolved approvals whose inline enqueue failed. enabled is the off-switch
+    # for tests/deploys; batch_limit caps one pass's work-list.
+    #
+    # grace is LOAD-BEARING, not approximate. It MUST exceed the worker's maximum
+    # single-turn processing time (runner_total_timeout_s, default 600s in the
+    # worker) so the reconciler never re-enqueues while an inline-delivered resume
+    # turn is still live: the cross-thread turn lock would steer a duplicate into
+    # that live turn and it could re-run the approved action. The worker's
+    # done-marker only dedupes a re-enqueue once the turn has reached terminal, so
+    # the grace has to outlast the turn. Kept at 900s to stay above the 600s worker
+    # max with margin (analogous to the migration's 24h done-marker /
+    # idempotency_ttl_s coupling). Residual: worker retry loops (max_attempts,
+    # backoff) can extend total processing past a single turn, so a fully airtight
+    # guarantee needs a worker-side in-flight lease (follow-up); 900s covers the
+    # common single-attempt case with margin.
+    resume_reconciler_enabled: bool = True
+    resume_reconciler_interval_seconds: int = 30
+    resume_reconciler_grace_seconds: int = 900
+    resume_reconciler_batch_limit: int = 100
+
     # Observability (OB1). kube_config_path points the runner-logs proxy at a
     # cluster; when unset the API tries in-cluster config, and if neither is
     # available the logs endpoint degrades to 503 rather than crashing.

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -419,6 +419,84 @@ async def expire_approval(
     return await session.get(Approval, approval_id)
 
 
+async def mark_approval_resumed(session: AsyncSession, approval_id: uuid.UUID) -> None:
+    """Record that the resume turn made it onto the stream (#411).
+
+    Conditional UPDATE guarded on ``resumed_at IS NULL``, so a second call (a
+    reconciler racing the inline path, another replica) matches zero rows and is
+    a no-op. Mirrors the conditional-UPDATE style of ``claim_approval_resolution``.
+    """
+
+    await session.execute(
+        update(Approval)
+        .where(Approval.id == approval_id, Approval.resumed_at.is_(None))
+        .values(resumed_at=func.now())
+    )
+    await session.commit()
+
+
+# The statuses an owed-wake row can carry: a resolution that must still reach its
+# suspended session. ``expired``/``pending`` are never resumed. Shared by the
+# reconciler's candidate finder and its per-row claim so the two never desync.
+_RESUMABLE_STATUSES = (ApprovalStatus.approved, ApprovalStatus.rejected)
+
+
+async def claim_resume_row(
+    session: AsyncSession, approval_id: uuid.UUID
+) -> Approval | None:
+    """Atomically claim one owed-wake row for this reconcile pass (#411).
+
+    ``SELECT ... FOR UPDATE SKIP LOCKED`` locks the row for the caller's
+    transaction, or returns None if another replica already holds it OR it is
+    already resumed (or no longer resolved). This is the per-row claim that keeps
+    two API replicas' overlapping reconcile passes from both enqueuing the same
+    resume turn -- the worker's done-marker is written only post-terminal, so it
+    cannot dedupe a concurrent re-run; the row claim must. The caller owns the
+    transaction (this does NOT commit); marking ``resumed_at`` on the returned
+    ORM object and committing releases the lock.
+    """
+
+    approval: Approval | None = await session.scalar(
+        select(Approval)
+        .where(
+            Approval.id == approval_id,
+            Approval.resumed_at.is_(None),
+            Approval.status.in_(_RESUMABLE_STATUSES),
+        )
+        .with_for_update(skip_locked=True)
+    )
+    return approval
+
+
+async def list_resolved_unresumed(
+    session: AsyncSession, *, resolved_before: datetime, limit: int
+) -> list[uuid.UUID]:
+    """The reconciler's work-list: ids of resolved approvals whose wake is owed.
+
+    ``expired`` is deliberately excluded -- an expired record has ``resolved_at``
+    set but never had a resume turn enqueued, so it must never be woken.
+    ``resolved_before`` is naive UTC, matching the DateTime columns.
+
+    Returns ids only (the unlocked candidate finder): each id is then claimed
+    atomically by ``claim_resume_row`` in its own short transaction, which
+    re-reads the row under lock, so the reconciler never holds a row lock across
+    the Valkey enqueue of the batch and never needs the full row here.
+    """
+
+    result = await session.scalars(
+        select(Approval.id)
+        .where(
+            Approval.status.in_(_RESUMABLE_STATUSES),
+            Approval.resolved_at.is_not(None),
+            Approval.resumed_at.is_(None),
+            Approval.resolved_at <= resolved_before,
+        )
+        .order_by(Approval.resolved_at)
+        .limit(limit)
+    )
+    return list(result)
+
+
 async def append_approval_audit(
     session: AsyncSession,
     *,

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -4,6 +4,7 @@ The engine, sessionmaker, httpx client, and Langfuse client are created once at
 startup and stored on app.state; dependencies (deps.py) read them per request.
 """
 
+import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -19,6 +20,7 @@ from .k8s import build_lazy_pod_lister, build_lazy_pod_log_reader
 from .killswitch import KillSwitch
 from .langfuse import LangfuseClient
 from .resumequeue import ResumeQueue
+from .resumereconciler import ResumeReconciler
 from .routers import (
     agents,
     approvals,
@@ -64,9 +66,32 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         token=settings.github_token,
         context=settings.eval_check_context,
     )
+    # The resume reconciler (#411) backstops a failed inline resume enqueue by
+    # periodically re-enqueuing owed wakes. It enqueues via resume_queue (which
+    # uses the valkey client), so it is cancelled BEFORE valkey.aclose() below.
+    reconciler = ResumeReconciler(
+        app.state.sessionmaker,
+        app.state.resume_queue,
+        interval_seconds=settings.resume_reconciler_interval_seconds,
+        grace_seconds=settings.resume_reconciler_grace_seconds,
+        batch_limit=settings.resume_reconciler_batch_limit,
+    )
+    app.state.resume_reconciler = reconciler
+    app.state.resume_reconciler_task = (
+        asyncio.create_task(reconciler.run_forever())
+        if settings.resume_reconciler_enabled
+        else None
+    )
     try:
         yield
     finally:
+        task = getattr(app.state, "resume_reconciler_task", None)
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
         await valkey.aclose()
         await http_client.aclose()
         await engine.dispose()

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -191,6 +191,9 @@ class Approval(Base):
     resolution_note: Mapped[str | None] = mapped_column(default=None)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     resolved_at: Mapped[datetime | None] = mapped_column(default=None)
+    # Set once the resume turn is enqueued onto the runs stream (#411); NULL on a
+    # resolved record means the wake is still owed (the reconciler's work-list).
+    resumed_at: Mapped[datetime | None] = mapped_column(default=None)
 
 
 class ApprovalAuditEntry(Base):

--- a/apps/api/src/agentos_api/resumereconciler.py
+++ b/apps/api/src/agentos_api/resumereconciler.py
@@ -1,0 +1,137 @@
+"""Resume reconciler (#411): the backstop that re-enqueues owed wakes.
+
+The resolve endpoint commits the resolve-once CAS claim and audit row, then
+enqueues the resume turn. If that enqueue fails (a Valkey blip), the record is
+left ``resolved_at`` set but ``resumed_at`` NULL -- a stranded suspended
+session. ``ResumeReconciler`` sweeps those rows on an interval and re-enqueues
+the resume turn, setting ``resumed_at`` only AFTER a successful enqueue
+(enqueue-first-then-mark), so a failed enqueue is retried on the next pass
+rather than lost.
+
+Three qualifications shape the design:
+
+- **Grace window (load-bearing).** ``reconcile_once`` only considers records
+  resolved at least ``grace_seconds`` ago. This is NOT approximate: the grace
+  must exceed the worker's maximum single-turn processing time
+  (``runner_total_timeout_s``, 600s) so the reconciler never re-enqueues while an
+  inline-delivered resume turn is still live. The worker writes its done-marker
+  only post-terminal, so a duplicate landing mid-turn is steered into that live
+  turn and re-runs the approved action -- a too-small grace re-introduces exactly
+  that. The two clocks it compares (``resolved_at`` is the DB ``func.now()``,
+  ``resolved_before`` is this pod's clock) only add a small skew margin on top of
+  a large grace, not a correctness dependency.
+- **Absorption is TTL-bounded.** A duplicate enqueue is safe because the resume
+  turn's ``event_id`` is deterministic per approval and the worker's done-marker
+  dedupes it -- but only within ``idempotency_ttl_s`` (default 24h). In steady
+  state the reconciler retries on the interval (seconds), far inside that
+  window. The bound only bites for pre-fix historical rows, which the migration
+  0011 backfill (``resumed_at = resolved_at``) excludes from the work-list.
+- **Concurrency.** The done-marker CANNOT dedupe a concurrent double-enqueue
+  (it is written only post-terminal), so two overlapping copies steer into one
+  live turn. Two races, two guards: (1) *reconciler vs reconciler* (``api.replicas
+  > 1``) -- a per-row ``SELECT ... FOR UPDATE SKIP LOCKED`` claim locks each
+  candidate in its own short transaction, so two replicas never grab the same
+  row; (2) *inline resolver vs reconciler* -- the grace above outlasts the max
+  worker turn, so an inline-delivered turn is terminal (done-marked) before the
+  reconciler would re-enqueue. Residual, NOT unconditional exactly-once: a worker
+  retry loop can keep a turn live past the grace after an inline mark-failure; a
+  fully airtight guarantee needs a worker-side in-flight lease (follow-up). The
+  done-marker still dedupes strictly-sequential redeliveries within the 24h TTL.
+  No leader election.
+"""
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from . import crud
+from .resumequeue import ResumeQueue, build_resume_turn
+
+logger = logging.getLogger(__name__)
+
+
+class ResumeReconciler:
+    """Periodically re-enqueue resume turns for resolved-but-unresumed approvals."""
+
+    def __init__(
+        self,
+        sessionmaker: async_sessionmaker[AsyncSession],
+        resume_queue: ResumeQueue,
+        *,
+        interval_seconds: int,
+        grace_seconds: int,
+        batch_limit: int,
+    ) -> None:
+        self._sessionmaker = sessionmaker
+        self._resume_queue = resume_queue
+        self._interval_seconds = interval_seconds
+        self._grace_seconds = grace_seconds
+        self._batch_limit = batch_limit
+
+    async def reconcile_once(self) -> int:
+        """Re-enqueue every owed wake past the grace horizon; return the count.
+
+        Candidates are read once (unlocked) past the grace horizon; then each is
+        claimed atomically in its OWN short transaction via ``claim_resume_row``
+        (``SELECT ... FOR UPDATE SKIP LOCKED``). A row a concurrent replica
+        already holds is skipped this pass and retried next -- two replicas never
+        both enqueue one record. Per-record failure is isolated: the enqueue and
+        mark live inside ``session.begin()``, so a single-record Valkey blip
+        rolls that row's transaction back (``resumed_at`` stays NULL for the next
+        pass, preserving enqueue-first-then-mark durability) without aborting the
+        batch. The row lock is held only for that one record's brief enqueue+mark,
+        never across the whole batch.
+        """
+
+        resolved_before = datetime.now(UTC).replace(tzinfo=None) - timedelta(
+            seconds=self._grace_seconds
+        )
+        async with self._sessionmaker() as session:
+            candidate_ids = await crud.list_resolved_unresumed(
+                session, resolved_before=resolved_before, limit=self._batch_limit
+            )
+
+        count = 0
+        for approval_id in candidate_ids:
+            async with self._sessionmaker() as session:
+                try:
+                    async with session.begin():
+                        approval = await crud.claim_resume_row(session, approval_id)
+                        if approval is None:
+                            # Another replica holds it, or it is already resumed;
+                            # exit the txn block cleanly, releasing any lock.
+                            continue
+                        turn = build_resume_turn(approval)
+                        await self._resume_queue.enqueue(turn)
+                        approval.resumed_at = datetime.now(UTC).replace(tzinfo=None)
+                    # session.begin() committed here, releasing the row lock.
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "approval %s resume re-enqueue failed, will retry next pass",
+                        approval_id,
+                        exc_info=True,
+                    )
+                    continue
+                count += 1
+                logger.info("approval %s resume turn re-enqueued", approval_id)
+        return count
+
+    async def run_forever(self) -> None:
+        """Reconcile on the interval forever; never die from a reconcile error.
+
+        The loop sleeps before each pass (including the first): the inline path
+        handles the common case, so a just-started pod need not sweep instantly,
+        and delaying the first pass keeps the backstop from firing inside a
+        sub-interval process lifetime.
+        """
+
+        while True:
+            await asyncio.sleep(self._interval_seconds)
+            try:
+                await self.reconcile_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("resume reconciler pass failed")

--- a/apps/api/src/agentos_api/routers/approvals.py
+++ b/apps/api/src/agentos_api/routers/approvals.py
@@ -23,6 +23,7 @@ from sqlalchemy.exc import IntegrityError
 from .. import crud
 from ..auth import require_api_key
 from ..authorizer import Authorizer, ChannelMembershipAuthorizer
+from ..config import get_settings
 from ..deps import ResumeQueueDep, SessionDep
 from ..models import Approval, ApprovalStatus
 from ..resumequeue import build_resume_turn
@@ -206,7 +207,28 @@ async def resolve_approval(
     # so the kernel's ordinary consume -> claim path rehydrates the thread
     # (ADR-0003) and delivers the decision. The turn's event_id is deterministic
     # per approval, so the worker's done-marker absorbs a duplicate enqueue.
-    stream_id = await resume_queue.enqueue(build_resume_turn(claimed))
+    # If the enqueue fails (a Valkey blip), the resolution still committed (CAS
+    # won, audit written): return 200 and leave resumed_at NULL so the reconciler
+    # (#411) backstops the failed enqueue on its next pass. Raising here would
+    # dead-end the client into the 409-forever branch on retry.
+    # BUT the 200-and-defer contract is only safe when a reconciler will recover
+    # the owed wake. With resume_reconciler_enabled=false there is no backstop, so
+    # a 200 would silently strand the suspended session -- re-raise instead, so the
+    # failure surfaces as a 500 the caller can see (the CAS/audit already committed).
+    try:
+        stream_id = await resume_queue.enqueue(build_resume_turn(claimed))
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "approval %s %s by %s; resume enqueue failed, reconciler will retry",
+            approval_id,
+            claimed.status,
+            claimed.resolved_by,
+            exc_info=True,
+        )
+        if not get_settings().resume_reconciler_enabled:
+            raise
+        return ApprovalOut.model_validate(claimed)
+    await crud.mark_approval_resumed(session, approval_id)
     logger.info(
         "approval %s %s by %s; resume turn enqueued (%s)",
         approval_id,

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -7,12 +7,14 @@ concurrency), SLA expiry (410), and the resume turn enqueued onto a
 test-isolated runs stream as a valid frozen-contract QueuedTurn.
 """
 
+import asyncio
 import json
 import os
 import time
 import uuid
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from typing import Any
 
 import pytest
@@ -20,7 +22,9 @@ import redis
 from aci_protocol import QueuedTurn
 from agentos_api.config import get_settings
 from agentos_api.main import create_app
+from agentos_api.models import Approval
 from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 _VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
 _VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
@@ -77,6 +81,170 @@ def _payload(**overrides: Any) -> dict[str, Any]:
     }
     base.update(overrides)
     return base
+
+
+def _read_resumed_at(approval_id: str) -> datetime | None:
+    """Read ``Approval.resumed_at`` straight from the DB (it is not exposed on
+    ``ApprovalOut``). A fresh engine keeps this safe under ``asyncio.run`` from
+    the sync test body -- the app's engine is bound to the TestClient's portal
+    loop and cannot be reused across event loops."""
+
+    async def _run() -> datetime | None:
+        engine = create_async_engine(get_settings().database_url)
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            async with sessionmaker() as session:
+                approval = await session.get(Approval, uuid.UUID(approval_id))
+                return None if approval is None else approval.resumed_at
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
+def test_resolve_endpoint_stays_200_when_enqueue_fails(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#411: a Valkey blip on the resume enqueue must not dead-end the resolve.
+
+    The resolution itself committed (CAS won, audit written), so the endpoint
+    returns 200 with the resolved record, leaves ``resumed_at`` NULL for the
+    reconciler to retry, and enqueues nothing. A retry still 409s (CAS intact) --
+    the owed wake belongs to the reconciler, never to a client retry (which used
+    to 500 then 409-forever).
+    """
+
+    created = approvals_client.post(
+        "/approvals", json=_payload(), headers=auth_headers
+    ).json()
+
+    async def _boom(_turn: Any) -> str:
+        raise RuntimeError("valkey unreachable")
+
+    monkeypatch.setattr(approvals_client.app.state.resume_queue, "enqueue", _boom)
+
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert resolved.json()["status"] == "approved"
+
+    # No resume turn on the stream, and the record still owes its wake.
+    assert valkey.xrange(runs_stream) == []
+    assert _read_resumed_at(created["id"]) is None
+
+    # The CAS is untouched: a retry loses as a normal race, it does not re-enqueue.
+    retry = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved", "resolved_by": "U2", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert retry.status_code == 409
+    assert valkey.xrange(runs_stream) == []
+
+
+@pytest.fixture
+def reconciler_disabled_client(
+    _disposable_db: Any, runs_stream: str
+) -> Iterator[TestClient]:
+    """A TestClient built with the resume reconciler DISABLED, so a failed inline
+    enqueue has no backstop. ``raise_server_exceptions=False`` lets the resulting
+    500 be asserted as a response rather than re-raised into the test body."""
+
+    os.environ["RESUME_RECONCILER_ENABLED"] = "false"
+    get_settings.cache_clear()
+    try:
+        with TestClient(create_app(), raise_server_exceptions=False) as test_client:
+            yield test_client
+    finally:
+        os.environ.pop("RESUME_RECONCILER_ENABLED", None)
+        get_settings.cache_clear()
+
+
+def test_resolve_reraises_when_reconciler_disabled(
+    reconciler_disabled_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#411 hardening: returning 200 on a failed resume enqueue is only safe when a
+    reconciler will recover the owed wake. With ``resume_reconciler_enabled=false``
+    there is no backstop, so the endpoint must surface the enqueue failure (500)
+    rather than silently stranding the suspended session behind a 200.
+
+    The resolution CAS still committed (approved, audit written), leaving the record
+    resolved-but-unresumed with nothing on the stream -- exactly the state a
+    disabled deployment must not hide. (The default-enabled 200 path is pinned by
+    ``test_resolve_endpoint_stays_200_when_enqueue_fails``.)
+    """
+
+    created = reconciler_disabled_client.post(
+        "/approvals", json=_payload(), headers=auth_headers
+    ).json()
+
+    async def _boom(_turn: Any) -> str:
+        raise RuntimeError("valkey unreachable")
+
+    monkeypatch.setattr(
+        reconciler_disabled_client.app.state.resume_queue, "enqueue", _boom
+    )
+
+    resolved = reconciler_disabled_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert resolved.status_code == 500, resolved.text
+
+    # The CAS committed -- the record is resolved -- but its wake is unrecoverably
+    # owed (no reconciler) and nothing reached the stream.
+    record = reconciler_disabled_client.get(
+        f"/approvals/{created['id']}", headers=auth_headers
+    )
+    assert record.json()["status"] == "approved"
+    assert _read_resumed_at(created["id"]) is None
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_happy_path_resolve_marks_resumed(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """#411: the normal successful resolve now records the wake as delivered by
+    setting ``resumed_at``, so the reconciler's work-list excludes it. This adds
+    to the resolve-once coverage without weakening the existing assertions."""
+
+    created = approvals_client.post(
+        "/approvals", json=_payload(), headers=auth_headers
+    ).json()
+
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert resolved.status_code == 200, resolved.text
+
+    # The resume turn is on the stream (the existing #244 contract) ...
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{created['id']}-resolved"
+
+    # ... and the record is now marked resumed (the new #411 contract).
+    assert _read_resumed_at(created["id"]) is not None
 
 
 def test_create_get_list_round_trip(

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -1,0 +1,523 @@
+"""Resume reconciler (#411): the backstop that re-enqueues owed wakes.
+
+A resolved approval whose resume enqueue failed is left ``resolved_at`` set but
+``resumed_at`` NULL -- a stranded suspended session. ``ResumeReconciler`` sweeps
+those rows on an interval and re-enqueues the resume turn onto the runs stream,
+setting ``resumed_at`` only AFTER a successful enqueue (enqueue-first-then-mark),
+so a failed enqueue is retried on the next pass rather than lost.
+
+Real Postgres + real Valkey from the compose dev stack -- never mocked; the only
+injected failure is a wrapped ``enqueue`` that raises for a chosen record. Every
+assertion is on a real outcome: the deterministic ``event_id`` present/absent on
+the actual stream, the ``resumed_at`` NULL<->set transition read back from the
+DB, and ``reconcile_once()``'s return count.
+
+The ``runs_stream``/``valkey`` fixtures are duplicated from ``test_approvals.py``
+on purpose: pytest fixtures are module-local, and copying them keeps that file's
+definitions untouched (true verbatim reuse of behavior) without hoisting
+Valkey-specific setup into the shared conftest.
+"""
+
+import asyncio
+import json
+import os
+import uuid
+from collections.abc import Awaitable, Callable, Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import redis
+import redis.asyncio as aioredis
+from aci_protocol import QueuedTurn
+from agentos_api.config import get_settings
+from agentos_api.models import Approval, ApprovalStatus
+from agentos_api.resumequeue import ResumeQueue
+from agentos_api.resumereconciler import ResumeReconciler
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
+_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
+_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
+
+
+@pytest.fixture
+def runs_stream() -> Iterator[str]:
+    """A per-test runs stream so reconciler enqueues never feed the shared
+    compose worker's real ``agentos:runs`` consumer group."""
+
+    name = f"test:agentos:runs:{uuid.uuid4().hex}"
+    os.environ["RUNS_STREAM"] = name
+    get_settings.cache_clear()
+    yield name
+    os.environ.pop("RUNS_STREAM", None)
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def valkey(runs_stream: str) -> Iterator[redis.Redis]:
+    client = redis.Redis(
+        host=_VALKEY_HOST,
+        port=_VALKEY_PORT,
+        password=_VALKEY_PW or None,
+        decode_responses=True,
+    )
+    try:
+        client.ping()
+    except redis.exceptions.RedisError as exc:
+        pytest.skip(f"Valkey not reachable: {exc}")
+    yield client
+    client.delete(runs_stream)
+    client.close()
+
+
+def _naive(seconds_ago: float = 0.0) -> datetime:
+    """Naive UTC ``now - seconds_ago``, matching the DateTime columns."""
+
+    return datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=seconds_ago)
+
+
+def _run_async[T](
+    steps: Callable[[async_sessionmaker[AsyncSession], ResumeQueue], Awaitable[T]],
+    stream: str,
+) -> T:
+    """Drive an async ``steps(sessionmaker, queue)`` with fresh loop-bound
+    resources. A fresh engine + async Valkey client (not the app's, which are
+    bound to the TestClient portal loop) makes ``asyncio.run`` from the sync
+    test body safe -- the same pattern conftest's ``_truncate`` uses."""
+
+    async def _main() -> T:
+        engine = create_async_engine(get_settings().database_url)
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        client = aioredis.Redis(
+            host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW or None
+        )
+        queue = ResumeQueue(client, stream=stream)
+        try:
+            return await steps(sessionmaker, queue)
+        finally:
+            await client.aclose()
+            await engine.dispose()
+
+    return asyncio.run(_main())
+
+
+async def _insert_approval(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    status: str,
+    resolved_at: datetime | None,
+    resumed_at: datetime | None,
+    resolved_by: str | None = "U9",
+    reply_endpoint: str | None = None,
+) -> uuid.UUID:
+    """Insert an approval row in a chosen lifecycle state (bypassing the resolve
+    endpoint), so a test can construct the exact stranded/settled/expired shapes
+    the reconciler must include or exclude."""
+
+    async with sessionmaker() as session:
+        approval = Approval(
+            conversation_id=f"th-{uuid.uuid4().hex[:8]}",
+            author="U1",
+            summary="Give ACME a 20% discount",
+            reply_channel="C1",
+            reply_placeholder="p-1",
+            reply_endpoint=reply_endpoint,
+            dedupe_key=uuid.uuid4().hex,
+            status=status,
+            resolved_by=resolved_by,
+            resolved_at=resolved_at,
+            resumed_at=resumed_at,
+        )
+        session.add(approval)
+        await session.commit()
+        await session.refresh(approval)
+        return approval.id
+
+
+async def _resumed_at(
+    sessionmaker: async_sessionmaker[AsyncSession], approval_id: uuid.UUID
+) -> datetime | None:
+    async with sessionmaker() as session:
+        approval = await session.get(Approval, approval_id)
+        assert approval is not None
+        return approval.resumed_at
+
+
+def test_reconciler_reenqueues_stranded_resolved_record(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """A resolved, past-grace, unresumed record is re-enqueued exactly once and
+    marked resumed. This is the core AC1 outcome."""
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[uuid.UUID, int, datetime | None]:
+        approval_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(120),
+            resumed_at=None,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker,
+            queue,
+            interval_seconds=30,
+            grace_seconds=0,
+            batch_limit=100,
+        )
+        count = await reconciler.reconcile_once()
+        return approval_id, count, await _resumed_at(sessionmaker, approval_id)
+
+    approval_id, count, resumed_at = _run_async(steps, runs_stream)
+
+    assert count == 1
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{approval_id}-resolved"
+    assert resumed_at is not None
+
+
+def test_reconciler_skips_already_resumed_record(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """A record whose wake was already delivered (``resumed_at`` set) is off the
+    work-list -- no re-enqueue, no double wake."""
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[int, datetime | None]:
+        resolved = _naive(120)
+        approval_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=resolved,
+            resumed_at=resolved,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        count = await reconciler.reconcile_once()
+        return count, await _resumed_at(sessionmaker, approval_id)
+
+    count, resumed_at = _run_async(steps, runs_stream)
+
+    assert count == 0
+    assert valkey.xrange(runs_stream) == []
+    assert resumed_at is not None
+
+
+def test_reconciler_skips_expired_record(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """An expired record has ``resolved_at`` set but was never enqueued and must
+    never be woken -- this pins the expired-exclusion in
+    ``list_resolved_unresumed`` (out-of-scope expiry-stranding stays out)."""
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[int, datetime | None]:
+        approval_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.expired,
+            resolved_at=_naive(120),
+            resumed_at=None,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        count = await reconciler.reconcile_once()
+        return count, await _resumed_at(sessionmaker, approval_id)
+
+    count, resumed_at = _run_async(steps, runs_stream)
+
+    assert count == 0
+    assert valkey.xrange(runs_stream) == []
+    assert resumed_at is None
+
+
+def test_reconciler_skips_pending_record(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """A still-pending record (no ``resolved_at``) is never on the work-list."""
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> int:
+        await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.pending,
+            resolved_at=None,
+            resumed_at=None,
+            resolved_by=None,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        return await reconciler.reconcile_once()
+
+    count = _run_async(steps, runs_stream)
+
+    assert count == 0
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_reconciler_ignores_backfilled_historical_row(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """A pre-migration resolution is backfilled to ``resumed_at = resolved_at``;
+    the reconciler must treat it as settled and never auto-wake it after deploy.
+
+    This pins the Change 1 backfill contract: without it, the first pass after
+    deploy would re-deliver stale resume turns into long-finished threads (the
+    worker done-marker's 24h TTL means an old wake is re-delivered, not absorbed).
+    """
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> int:
+        resolved = _naive(7200)
+        await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=resolved,
+            resumed_at=resolved,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        return await reconciler.reconcile_once()
+
+    count = _run_async(steps, runs_stream)
+
+    assert count == 0
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_reconciler_respects_grace_window(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """A record resolved within the grace window is skipped (avoids racing the
+    inline enqueue path); the same record, once past grace, is picked up."""
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[int, int, datetime | None]:
+        approval_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(0),
+            resumed_at=None,
+        )
+        within = ResumeReconciler(
+            sessionmaker,
+            queue,
+            interval_seconds=30,
+            grace_seconds=3600,
+            batch_limit=100,
+        )
+        count_within = await within.reconcile_once()
+
+        # Backdate the resolution well past the grace horizon.
+        async with sessionmaker() as session:
+            await session.execute(
+                update(Approval)
+                .where(Approval.id == approval_id)
+                .values(resolved_at=_naive(7200))
+            )
+            await session.commit()
+
+        past = ResumeReconciler(
+            sessionmaker,
+            queue,
+            interval_seconds=30,
+            grace_seconds=3600,
+            batch_limit=100,
+        )
+        count_past = await past.reconcile_once()
+        return count_within, count_past, await _resumed_at(sessionmaker, approval_id)
+
+    count_within, count_past, resumed_at = _run_async(steps, runs_stream)
+
+    assert count_within == 0
+    assert count_past == 1
+    assert len(valkey.xrange(runs_stream)) == 1
+    assert resumed_at is not None
+
+
+def test_reconciler_is_idempotent_across_runs(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """After one successful pass marks a record resumed, a second pass finds
+    nothing to do and enqueues nothing new."""
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[int, int]:
+        await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(120),
+            resumed_at=None,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        first = await reconciler.reconcile_once()
+        second = await reconciler.reconcile_once()
+        return first, second
+
+    first, second = _run_async(steps, runs_stream)
+
+    assert first == 1
+    assert second == 0
+    assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_reconciler_isolates_per_record_failure(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """One record's enqueue failure must not abort the batch nor mark that
+    record resumed; the other record is still enqueued and marked.
+
+    Marking-before-enqueue would leave the failing record marked -- this asserts
+    the enqueue-first-then-mark ordering by requiring the failing record's
+    ``resumed_at`` to stay NULL for the next pass.
+    """
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[uuid.UUID, uuid.UUID, int, datetime | None, datetime | None]:
+        fail_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(120),
+            resumed_at=None,
+        )
+        ok_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(120),
+            resumed_at=None,
+        )
+
+        real_enqueue = queue.enqueue
+        fail_event = f"approval-{fail_id}-resolved"
+
+        async def flaky(turn: QueuedTurn) -> str:
+            if turn.event_id == fail_event:
+                raise RuntimeError("valkey blip for one record")
+            return await real_enqueue(turn)
+
+        queue.enqueue = flaky  # type: ignore[method-assign]
+
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        count = await reconciler.reconcile_once()
+        return (
+            fail_id,
+            ok_id,
+            count,
+            await _resumed_at(sessionmaker, fail_id),
+            await _resumed_at(sessionmaker, ok_id),
+        )
+
+    fail_id, ok_id, count, resumed_fail, resumed_ok = _run_async(steps, runs_stream)
+
+    assert count == 1
+    assert resumed_fail is None
+    assert resumed_ok is not None
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{ok_id}-resolved"
+
+
+def test_reconciler_skips_row_locked_by_concurrent_claim(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """A row a concurrent replica already holds under ``FOR UPDATE`` is skipped by
+    this pass's ``SELECT ... FOR UPDATE SKIP LOCKED`` claim -- never double-enqueued
+    -- and picked up on the next pass once the lock releases. Two API replicas'
+    overlapping reconcile passes therefore never both re-run one approved action.
+
+    The whole interleave runs on one event loop across two distinct engines (two
+    real Postgres connections that genuinely contend). A ``statement_timeout`` on
+    the reconciler's engine keeps the pre-fix path -- which selects the locked row
+    and then blocks forever on its post-enqueue ``mark_approval_resumed`` UPDATE
+    against the held lock -- from deadlocking the suite: today it surfaces the bug
+    as a non-zero locked count and a non-empty stream instead of hanging.
+    """
+
+    async def coro() -> tuple[uuid.UUID, int, int, int, datetime | None]:
+        engine = create_async_engine(
+            get_settings().database_url,
+            connect_args={"server_settings": {"statement_timeout": "3000"}},
+        )
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        lock_engine = create_async_engine(get_settings().database_url)
+        lock_sessionmaker = async_sessionmaker(lock_engine, expire_on_commit=False)
+        client = aioredis.Redis(
+            host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW or None
+        )
+        queue = ResumeQueue(client, stream=runs_stream)
+        try:
+            approval_id = await _insert_approval(
+                sessionmaker,
+                status=ApprovalStatus.approved,
+                resolved_at=_naive(120),
+                resumed_at=None,
+            )
+            reconciler = ResumeReconciler(
+                sessionmaker,
+                queue,
+                interval_seconds=30,
+                grace_seconds=0,
+                batch_limit=100,
+            )
+
+            # A concurrent replica holds the row under FOR UPDATE, uncommitted.
+            async with lock_sessionmaker() as holder:
+                await holder.execute(
+                    select(Approval)
+                    .where(Approval.id == approval_id)
+                    .with_for_update()
+                )
+                # This pass must skip the locked row (0, nothing enqueued).
+                try:
+                    count_locked = await reconciler.reconcile_once()
+                except Exception:  # noqa: BLE001
+                    # Pre-fix: the locked row is selected, enqueued, then the mark
+                    # UPDATE blocks on the held lock until statement_timeout fires.
+                    count_locked = -1
+                locked_len = len(await client.xrange(runs_stream))
+                await holder.rollback()
+
+            # Lock released: the next pass claims and enqueues it exactly once.
+            count_free = await reconciler.reconcile_once()
+            resumed_at = await _resumed_at(sessionmaker, approval_id)
+            return approval_id, count_locked, locked_len, count_free, resumed_at
+        finally:
+            await client.aclose()
+            await engine.dispose()
+            await lock_engine.dispose()
+
+    approval_id, count_locked, locked_len, count_free, resumed_at = asyncio.run(coro())
+
+    # While the row was locked, the pass skipped it: no work, nothing enqueued.
+    assert count_locked == 0
+    assert locked_len == 0
+
+    # Once the lock released, the same row is picked up exactly once and marked.
+    assert count_free == 1
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{approval_id}-resolved"
+    assert resumed_at is not None

--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -105,6 +105,17 @@ spec:
             # an operator override of bundleFetch.bucket keeps them in lockstep.
             - name: BUNDLE_BUCKET
               value: {{ .Values.agentSandbox.runner.bundleFetch.bucket | quote }}
+            # Resume reconciler (#411) knobs; see values.yaml api.resumeReconciler.
+            # ENABLED false also switches the resolve endpoint to fail-loud on
+            # enqueue failure (no backstop to defer to).
+            - name: RESUME_RECONCILER_ENABLED
+              value: {{ .Values.api.resumeReconciler.enabled | quote }}
+            - name: RESUME_RECONCILER_INTERVAL_SECONDS
+              value: {{ .Values.api.resumeReconciler.intervalSeconds | quote }}
+            - name: RESUME_RECONCILER_GRACE_SECONDS
+              value: {{ .Values.api.resumeReconciler.graceSeconds | quote }}
+            - name: RESUME_RECONCILER_BATCH_LIMIT
+              value: {{ .Values.api.resumeReconciler.batchLimit | quote }}
           ports:
             - name: http
               containerPort: 8000

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -425,6 +425,20 @@ api:
   # external migration step owns the DB.
   migrate:
     enabled: true
+  # Resume reconciler (#411): the background loop that re-enqueues resume turns
+  # for approvals whose inline enqueue failed, so a suspended session is never
+  # permanently stranded. `enabled` is the off-switch -- with it false the loop
+  # does not run AND the resolve endpoint fails loud (500) on an enqueue failure
+  # instead of returning 200 and deferring to the (now-absent) backstop.
+  # `graceSeconds` is load-bearing: it MUST exceed the worker's max single-turn
+  # time (the worker's runner_total_timeout_s, a Python default of 600s that is
+  # not currently Helm-configurable) so a re-enqueue never lands in a still-live
+  # resume turn (which would re-run the approved action).
+  resumeReconciler:
+    enabled: true
+    intervalSeconds: 30
+    graceSeconds: 900
+    batchLimit: 100
   resources:
     requests: { cpu: 100m, memory: 256Mi }
     limits: { cpu: "1", memory: 512Mi }


### PR DESCRIPTION
## What

The approval resolve endpoint committed the resolve-once CAS claim + audit row, then enqueued the resume turn. If that enqueue failed (a Valkey blip), the approval was resolved in Postgres but its suspended session was never woken, and retries dead-ended on the CAS-lost 409 -- a permanent strand.

Adds a durable marker + periodic backstop:

- **`approvals.resumed_at`** column (migration 0011), set only after a successful enqueue (enqueue-first-then-mark). The backfill is windowed to rows resolved > 24h ago so sessions stranded just before deploy stay recoverable while settled history is not re-woken; a partial index keeps the sweep proportional to owed wakes.
- **`ResumeReconciler`** sweeps resolved-but-unresumed rows past a grace horizon and re-enqueues the resume turn (lifespan task, cancelled before the Valkey client closes).
- The resolve endpoint returns **200 on enqueue failure** and defers the wake to the reconciler, instead of 500-then-409-forever.

## Concurrency

The worker's done-marker is written post-terminal, so it cannot dedupe a duplicate that lands in a still-live turn (which would re-run the approved action). Two guards close that: a per-row `SELECT ... FOR UPDATE SKIP LOCKED` claim (reconciler-vs-reconciler across replicas), and a grace that outlasts the worker's max single-turn time (inline-resolver-vs-reconciler). The remaining retry-extended window is documented as a **follow-up** needing a worker-side in-flight lease.

## Operability

`RESUME_RECONCILER_*` settings are wired into the API Helm chart; disabling the reconciler makes the resolve endpoint fail loud on enqueue failure rather than silently strand.

## Review notes

A cross-model (Codex) pass caught three defects the same-family reviewers missed -- concurrent-replica re-execution, the migration abandoning recently-stranded rows, and the disabled-mode silent strand -- all fixed here. Scope beyond the original API-side plan: the Helm wiring (to make the off-switch reachable). No new ADR -- this is a reliability fix within ADR-0010's suspend/resume decision.

Closes #411