### PR TITLE
Add approval SLA expiry sweeper and resolve-path resume

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4342,7 +4342,7 @@
     },
     "/approvals/{approval_id}/resolve": {
       "post": {
-        "description": "Claim the resolution (resolve-once) and wake the suspended session.\n\nThe authorizer runs first, server-side (#246): self-approval is blocked\nand channel membership is checked against the attempt's channel; a denied\nactor gets 403 with the reason. Then exactly one authorized resolver wins\nthe conditional UPDATE; a loser gets 409 naming who resolved it, and a\npast-SLA record flips to expired and returns 410. The winner's response is\nsent only after the resume turn is enqueued.",
+        "description": "Claim the resolution (resolve-once) and wake the suspended session.\n\nThe authorizer runs first, server-side (#246): self-approval is blocked\nand channel membership is checked against the attempt's channel; a denied\nactor gets 403 with the reason. Then exactly one authorized resolver wins\nthe conditional UPDATE; a loser gets 409 naming who resolved it, and a\npast-SLA record flips to expired and returns 410 while still enqueuing the\nexpiry resume turn so the suspended session wakes down its timeout branch.\nThe winner's response is sent only after the resume turn is enqueued.",
         "operationId": "resolve_approval_approvals__approval_id__resolve_post",
         "parameters": [
           {

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -81,6 +81,11 @@ class Settings(BaseSettings):
     # Must match the worker's AGENTOS_STREAM (its consumer side).
     runs_stream: str = "agentos:runs"
 
+    # How often the expiry sweeper scans for lapsed pending approvals (#412) and
+    # resumes their stranded sessions. Values <= 0 disable the sweeper (the
+    # operator kill lever and the fully-inert-app escape hatch for tests).
+    approval_sweep_interval_s: float = 30.0
+
     # Resume reconciler (#411): the backstop that re-enqueues resume turns for
     # resolved approvals whose inline enqueue failed. enabled is the off-switch
     # for tests/deploys; batch_limit caps one pass's work-list.

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -400,6 +400,31 @@ async def claim_approval_resolution(
     return approval
 
 
+async def list_expired_pending_approvals(
+    session: AsyncSession, *, now: datetime, limit: int = 100
+) -> list[Approval]:
+    """The pending approvals whose SLA has lapsed (#412), oldest-lapse-first.
+
+    ``now`` is naive UTC, matching the DateTime columns and the router's
+    ``_expired`` comparison. Ordering by ``expires_at`` drains the oldest
+    lapses first, so a backlog larger than ``limit`` clears across successive
+    sweep passes rather than starving the earliest-expired records. Records
+    with a NULL ``expires_at`` (no SLA) are never selected.
+    """
+
+    result = await session.scalars(
+        select(Approval)
+        .where(
+            Approval.status == ApprovalStatus.pending,
+            Approval.expires_at.is_not(None),
+            Approval.expires_at <= now,
+        )
+        .order_by(Approval.expires_at)
+        .limit(limit)
+    )
+    return list(result)
+
+
 async def expire_approval(
     session: AsyncSession, approval_id: uuid.UUID
 ) -> Approval | None:

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -36,6 +36,7 @@ from .routers import (
     state,
 )
 from .storage import BundleStore
+from .sweeper import run_expiry_sweeper
 
 
 @asynccontextmanager
@@ -82,15 +83,44 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         if settings.resume_reconciler_enabled
         else None
     )
+    # The expiry sweeper (#412) flips lapsed pending approvals and resumes their
+    # stranded sessions. It shares this lifecycle's resources (sessionmaker,
+    # resume_queue); interval <= 0 disables it (no task started).
+    sweeper_stop: asyncio.Event | None = None
+    if settings.approval_sweep_interval_s > 0:
+        sweeper_stop = asyncio.Event()
+        app.state.sweeper_task = asyncio.create_task(
+            run_expiry_sweeper(
+                app.state.sessionmaker,
+                app.state.resume_queue,
+                settings.approval_sweep_interval_s,
+                sweeper_stop,
+            )
+        )
+    else:
+        app.state.sweeper_task = None
     try:
         yield
     finally:
+        # Both background loops enqueue via resume_queue (which uses the valkey
+        # client) and read via the sessionmaker, so both are stopped BEFORE
+        # valkey.aclose()/engine.dispose() below.
         task = getattr(app.state, "resume_reconciler_task", None)
         if task is not None:
             task.cancel()
             try:
                 await task
             except asyncio.CancelledError:
+                pass
+        # Stop the sweeper BEFORE closing valkey/engine so an in-flight pass does
+        # not race the closed clients. The wait-first loop wakes immediately on
+        # stop.set(); wait_for already cancels on timeout, so suppressing
+        # TimeoutError/CancelledError is the whole teardown.
+        if sweeper_stop is not None:
+            sweeper_stop.set()
+            try:
+                await asyncio.wait_for(app.state.sweeper_task, 5.0)
+            except (TimeoutError, asyncio.CancelledError):
                 pass
         await valkey.aclose()
         await http_client.aclose()

--- a/apps/api/src/agentos_api/resumequeue.py
+++ b/apps/api/src/agentos_api/resumequeue.py
@@ -30,6 +30,26 @@ def resume_event_id(approval_id: object) -> str:
     return f"approval-{approval_id}-resolved"
 
 
+def _build_turn(approval: Approval, *, author: str, text: str) -> QueuedTurn:
+    """Assemble the resume turn shared by the resolve and expiry paths: same
+    deterministic event_id, conversation, reply handle, and timestamp; only the
+    author and platform-authored text differ.
+    """
+
+    return QueuedTurn(
+        event_id=resume_event_id(approval.id),
+        conversation_id=approval.conversation_id,
+        author=author,
+        text=text,
+        reply_handle=ReplyHandle(
+            channel=approval.reply_channel,
+            placeholder=approval.reply_placeholder,
+            endpoint=approval.reply_endpoint,
+        ),
+        received_at=datetime.now(UTC).isoformat(),
+    )
+
+
 def build_resume_turn(approval: Approval) -> QueuedTurn:
     """The turn that continues a suspended session with the human decision.
 
@@ -46,18 +66,35 @@ def build_resume_turn(approval: Approval) -> QueuedTurn:
         f"by {approval.resolved_by}.{note} Continue the task accordingly: proceed "
         "with the approved action, or acknowledge the rejection and stop."
     )
-    return QueuedTurn(
-        event_id=resume_event_id(approval.id),
-        conversation_id=approval.conversation_id,
-        author=approval.resolved_by or "approver",
-        text=text,
-        reply_handle=ReplyHandle(
-            channel=approval.reply_channel,
-            placeholder=approval.reply_placeholder,
-            endpoint=approval.reply_endpoint,
-        ),
-        received_at=datetime.now(UTC).isoformat(),
+    return _build_turn(approval, author=approval.resolved_by or "approver", text=text)
+
+
+def build_expiry_resume_turn(approval: Approval) -> QueuedTurn:
+    """The turn that continues a suspended session after its approval EXPIRED (#412).
+
+    Same shape as ``build_resume_turn`` but platform-authored for an SLA lapse
+    with no human decision: the text states the request timed out, that nobody
+    approved or rejected it, and that the agent must proceed down its timeout
+    branch WITHOUT performing the gated action. ``author`` is "system" because
+    no person acted (``resolved_by`` is None on expiry).
+
+    The ``event_id`` reuses ``resume_event_id`` -- the SAME deterministic key
+    the resolve path uses. This is by design, so a redelivery of an
+    ALREADY-FINISHED turn for this approval is recognized by the worker's
+    done-marker and not re-run; the ``-resolved`` suffix in the key is
+    historical and must NOT be forked, or that redelivery guard silently
+    breaks. This is not a mid-turn dedupe: the single-wakeup guarantee for the
+    expiry vs. resolve race comes from the CAS in ``crud.expire_approval``, not
+    from this shared key.
+    """
+
+    text = (
+        f"[approval expired] The request \"{approval.summary}\" was not approved "
+        "or rejected before its deadline and has expired. Do not perform the "
+        "gated action. Continue the task down its timeout path: acknowledge the "
+        "expiry and proceed or stop accordingly."
     )
+    return _build_turn(approval, author="system", text=text)
 
 
 class ResumeQueue:

--- a/apps/api/src/agentos_api/routers/approvals.py
+++ b/apps/api/src/agentos_api/routers/approvals.py
@@ -26,7 +26,7 @@ from ..authorizer import Authorizer, ChannelMembershipAuthorizer
 from ..config import get_settings
 from ..deps import ResumeQueueDep, SessionDep
 from ..models import Approval, ApprovalStatus
-from ..resumequeue import build_resume_turn
+from ..resumequeue import build_expiry_resume_turn, build_resume_turn
 from ..schemas import ApprovalAuditOut, ApprovalCreate, ApprovalOut, ApprovalResolve
 
 logger = logging.getLogger(__name__)
@@ -130,8 +130,9 @@ async def resolve_approval(
     and channel membership is checked against the attempt's channel; a denied
     actor gets 403 with the reason. Then exactly one authorized resolver wins
     the conditional UPDATE; a loser gets 409 naming who resolved it, and a
-    past-SLA record flips to expired and returns 410. The winner's response is
-    sent only after the resume turn is enqueued.
+    past-SLA record flips to expired and returns 410 while still enqueuing the
+    expiry resume turn so the suspended session wakes down its timeout branch.
+    The winner's response is sent only after the resume turn is enqueued.
     """
 
     approval = await crud.get_approval(session, approval_id)
@@ -170,6 +171,26 @@ async def resolve_approval(
                 authorized=True,
                 reason=f"approval expired at {expired.expires_at}",
             )
+            # This resolver lost the SLA (it still gets 410), but the session is
+            # suspended and must be woken down its timeout branch. This resolver
+            # won the expiry CAS (expire_approval returned non-None), so it is
+            # the only writer that enqueues for this approval; a sweeper racing
+            # the same flip gets None back and skips it. The shared
+            # resume_event_id via build_expiry_resume_turn only guards against a
+            # redelivery of an already-finished turn re-running; it is the CAS,
+            # not the shared key, that keeps this wakeup single.
+            try:
+                await resume_queue.enqueue(build_expiry_resume_turn(expired))
+            except Exception:
+                # A queue blip must not turn the 410 into a 500; the flip is
+                # already committed, so log the possibly-lost wakeup and still
+                # report the expiry. (A durable outbox to guarantee delivery is
+                # tracked as follow-up.)
+                logger.exception(
+                    "failed to enqueue expiry resume turn for approval %s on the "
+                    "resolve path; session wakeup may be lost",
+                    approval_id,
+                )
             raise HTTPException(
                 status.HTTP_410_GONE,
                 f"approval expired at {expired.expires_at} and can no longer be resolved",

--- a/apps/api/src/agentos_api/sweeper.py
+++ b/apps/api/src/agentos_api/sweeper.py
@@ -1,0 +1,146 @@
+"""Approval SLA expiry sweeper (#412): resume the session an expiry stranded.
+
+A pending approval whose ``expires_at`` lapses used to dead-end the suspended
+session. The only prior expiry path lived inside the resolve endpoint (#244,
+ADR-0010): a late resolver flipped the record to ``expired`` (410) and enqueued
+NOTHING, so if no resolver ever arrived the session waited forever. This module
+closes that gap with a periodic sweeper that (1) flips lapsed ``pending``
+approvals to ``expired`` via the existing compare-and-set, (2) appends an
+``expired`` audit row consistent with #247, and (3) enqueues a platform-authored
+resume turn onto the same runs stream the resolve path uses, so the suspended
+session resumes down its timeout branch (ADR-0003) and the channel placeholder
+updates.
+
+Concurrency and idempotency (why unattended sweeping is safe): the flip is
+``crud.expire_approval``'s conditional UPDATE guarded on ``status = pending``, so
+for one record exactly one writer wins -- one replica's sweeper, or a racing
+resolver -- and every loser gets None back and neither audits nor enqueues. This
+pending-guarded CAS is what guarantees a single wakeup: only the flip winner
+ever enqueues.
+
+Warning for anyone adding a re-enqueue path (retry, durable outbox, reconciler):
+the worker's done-marker (``markers.py``) only skips an event that was already
+handled to a TERMINAL point (streamed to a final, or escalated). It does NOT
+collapse a duplicate that lands while the resumed turn is still in flight --
+that duplicate would steer the live turn instead of being absorbed. The shared
+``resume_event_id`` (see ``resumequeue.build_expiry_resume_turn``) prevents a
+redelivery of an already-finished turn from re-running; it does not make a
+re-enqueue free, so do not rely on it as a mid-turn dedupe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from . import crud
+from .resumequeue import ResumeQueue, build_expiry_resume_turn
+
+logger = logging.getLogger(__name__)
+
+
+async def sweep_expired_approvals(
+    session: AsyncSession,
+    resume_queue: ResumeQueue,
+    *,
+    now: datetime | None = None,
+    limit: int = 100,
+) -> int:
+    """One sweep pass: expire every lapsed pending approval and wake its session.
+
+    ``now`` defaults to naive UTC (matching ``expires_at`` and the router's
+    ``_expired`` comparison); tests pass an explicit ``now`` to avoid real
+    sleeps. Returns the number of records this pass successfully flipped.
+
+    Per record, the order is flip -> audit -> enqueue, each guarded by a
+    per-record try/except so one poisoned record cannot block the rest of the
+    batch. Flip-first makes the DB the single arbiter of the flip/resolve race:
+    only a successful CAS (``expire_approval`` returning the record) audits and
+    enqueues; a None means a concurrent resolver or another replica's sweeper
+    already claimed it, so this pass skips it silently.
+    """
+
+    now = now or datetime.now(UTC).replace(tzinfo=None)
+    lapsed = await crud.list_expired_pending_approvals(session, now=now, limit=limit)
+    # Read the ids into plain values up front: the per-record rollback below
+    # expires every ORM instance in this shared session, so reading record.id
+    # lazily in a later iteration would trigger an implicit reload (MissingGreenlet
+    # under the async session).
+    approval_ids = [record.id for record in lapsed]
+
+    flipped = 0
+    for approval_id in approval_ids:
+        try:
+            expired = await crud.expire_approval(session, approval_id)
+            if expired is None:
+                # A concurrent resolver or another replica's sweeper won the CAS;
+                # the winner owns the audit and enqueue. No side effects here.
+                continue
+            await crud.append_approval_audit(
+                session,
+                approval_id=expired.id,
+                action="expired",
+                actor="system",
+                actor_channel=None,
+                decision="",
+                authorizer="ExpirySweeper",
+                authorized=True,
+                reason=f"approval expired at {expired.expires_at}",
+            )
+            stream_id = await resume_queue.enqueue(build_expiry_resume_turn(expired))
+            flipped += 1
+            logger.info(
+                "approval %s expired by sweeper; resume turn enqueued (%s)",
+                expired.id,
+                stream_id,
+            )
+        except Exception:
+            # Reset the shared session so a failed commit on this record cannot
+            # poison the rest of the batch (PendingRollbackError); mirrors the
+            # rollback-after-DB-error convention in the routers. If the flip
+            # already committed, the audit/enqueue loss means the wakeup may be
+            # dropped (documented durability gap; a durable outbox is future work).
+            await session.rollback()
+            logger.exception(
+                "expiry sweep failed for approval %s; wakeup may be lost", approval_id
+            )
+            continue
+    return flipped
+
+
+async def run_expiry_sweeper(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    resume_queue: ResumeQueue,
+    interval_s: float,
+    stop: asyncio.Event,
+) -> None:
+    """Periodic loop driving ``sweep_expired_approvals`` until ``stop`` is set.
+
+    Mirrors the worker heartbeat's sleep-or-stop shape (an
+    ``asyncio.wait_for(stop.wait(), timeout=interval_s)`` that wakes early on
+    shutdown) but INVERTS it to wait-FIRST: no sweep at t=0. That is deliberate,
+    both boot hygiene (no DB query racing app startup) and a test-safety
+    guarantee -- with a double-digit-second interval, no sweep fires inside any
+    integration test's window, so the sweeper cannot leak into the frozen
+    resolve-path expiry contract.
+
+    A maintenance loop must never take down the API, so each pass runs inside a
+    broad try/except: a failed pass (DB down, etc.) is logged and retried next
+    interval rather than crashing the process.
+    """
+
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=interval_s)
+        except TimeoutError:
+            pass
+        if stop.is_set():
+            break
+        try:
+            async with sessionmaker() as session:
+                await sweep_expired_approvals(session, resume_queue)
+        except Exception:
+            logger.exception("expiry sweep pass failed; retrying next interval")

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -12,18 +12,23 @@ import json
 import os
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
 import redis
+import redis.asyncio as aioredis
 from aci_protocol import QueuedTurn
+from agentos_api import crud
 from agentos_api.config import get_settings
 from agentos_api.main import create_app
 from agentos_api.models import Approval
+from agentos_api.resumequeue import ResumeQueue
 from agentos_api.sandbox_token import mint
+from agentos_api.sweeper import run_expiry_sweeper, sweep_expired_approvals
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -362,15 +367,16 @@ def test_concurrent_resolvers_yield_exactly_one_winner(
     assert len(valkey.xrange(runs_stream)) == 1
 
 
-def test_expired_approval_cannot_be_resolved(
+def test_expired_approval_resolve_returns_410_and_resumes(
     approvals_client: TestClient,
     auth_headers: dict[str, str],
     clean_db: None,
     valkey: redis.Redis,
     runs_stream: str,
 ) -> None:
+    payload = _payload(expires_in_seconds=1)
     created = approvals_client.post(
-        "/approvals", json=_payload(expires_in_seconds=1), headers=auth_headers
+        "/approvals", json=payload, headers=auth_headers
     ).json()
     assert created["expires_at"] is not None
     time.sleep(1.1)
@@ -383,8 +389,22 @@ def test_expired_approval_cannot_be_resolved(
     assert resolved.status_code == 410
     got = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
     assert got.json()["status"] == "expired"
-    # No resume turn for an expired record.
-    assert valkey.xrange(runs_stream) == []
+
+    # #412: a resolver landing after the SLA lapsed (but before the next
+    # sweep) must not strand the session. The late resolve still gets 410
+    # and the record still flips to expired, but it now enqueues the same
+    # deterministic expiry resume turn the sweeper would have produced, so
+    # the conversation resumes down its timeout branch instead of hanging.
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{created['id']}-resolved"
+    assert turn.conversation_id == payload["conversation_id"]
+    assert turn.author == "system"
+    assert turn.reply_handle.channel == "C1"
+    assert turn.reply_handle.placeholder == "p-1"
+    assert "expired" in turn.text
+    assert payload["summary"] in turn.text
 
 
 def test_unknown_approval_is_404(
@@ -605,3 +625,428 @@ def test_audit_log_records_attempts_with_authorizer_snapshots(
         f"/approvals/{uuid.uuid4()}/audit", headers=auth_headers
     )
     assert missing.status_code == 404
+
+
+# --- expiry sweeper (#412) ----------------------------------------------------
+#
+# These tests exercise the periodic sweeper that flips lapsed pending approvals
+# to `expired` and enqueues a platform-authored resume turn, so the suspended
+# session resumes down its timeout branch instead of stranding. Real Postgres +
+# real Valkey, no mocks. Because `sweep_expired_approvals` is async and asyncpg
+# connections are loop-bound, each test creates records via the SYNC HTTP client
+# (they land in the disposable DB regardless of loop), then runs ONE
+# `asyncio.run` scenario that builds its OWN async engine + sessionmaker + redis
+# client + ResumeQueue against the same DB/stream, and asserts DB state via the
+# sync HTTP client and stream contents via the sync `valkey` fixture. Real sleeps
+# are avoided by creating records with `expires_in_seconds=1` and sweeping with
+# an explicit `now` two seconds in the future (naive UTC, which also pins the
+# timezone edge case).
+
+
+def _naive_utc(seconds_ahead: float = 0.0) -> datetime:
+    """Naive-UTC clock matching the sweeper's `now`/`expires_at` comparison."""
+
+    return datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=seconds_ahead)
+
+
+@asynccontextmanager
+async def _sweeper_stack(
+    stream: str,
+) -> AsyncIterator[tuple[async_sessionmaker[Any], ResumeQueue, aioredis.Redis]]:
+    """A self-owned async engine + sessionmaker + resume queue on the test's DB
+    and isolated runs stream, disposed on exit. Built inside the running loop so
+    the asyncpg/redis pools bind to it, never to the TestClient's lifespan loop."""
+
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    async_client = aioredis.from_url(settings.valkey_dsn())
+    queue = ResumeQueue(async_client, stream=stream)
+    try:
+        yield sessionmaker, queue, async_client
+    finally:
+        await async_client.aclose()
+        await engine.dispose()
+
+
+def test_sweeper_expires_lapsed_pending_and_enqueues_resume_turn(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    payload = _payload(
+        expires_in_seconds=1, reply_endpoint="http://localhost:9999/api/"
+    )
+    created = approvals_client.post(
+        "/approvals", json=payload, headers=auth_headers
+    ).json()
+    assert created["expires_at"] is not None
+
+    now = _naive_utc(2)
+
+    async def _scenario() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, _client):
+            async with sessionmaker() as session:
+                return await sweep_expired_approvals(session, queue, now=now)
+
+    flipped = asyncio.run(_scenario())
+    assert flipped == 1
+
+    # DB state: flipped to expired by the platform, no human resolver recorded.
+    got = approvals_client.get(
+        f"/approvals/{created['id']}", headers=auth_headers
+    ).json()
+    assert got["status"] == "expired"
+    assert got["resolved_by"] is None
+    assert got["resolved_at"] is not None
+
+    # Exactly one resume turn, a valid frozen QueuedTurn addressed back to the
+    # requesting thread's placeholder and conveying the expiry.
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{created['id']}-resolved"
+    assert turn.conversation_id == payload["conversation_id"]
+    assert turn.author == "system"
+    assert turn.reply_handle.channel == "C1"
+    assert turn.reply_handle.placeholder == "p-1"
+    assert turn.reply_handle.endpoint == "http://localhost:9999/api/"
+    assert "expired" in turn.text
+    assert payload["summary"] in turn.text
+
+    # The autonomous flip is audited consistently with #247.
+    audit = approvals_client.get(
+        f"/approvals/{created['id']}/audit", headers=auth_headers
+    )
+    assert audit.status_code == 200
+    entries_audit = audit.json()
+    assert len(entries_audit) == 1
+    row = entries_audit[0]
+    assert row["action"] == "expired"
+    assert row["actor"] == "system"
+    assert row["authorizer"] == "ExpirySweeper"
+    assert row["authorized"] is True
+    assert row["decision"] == ""
+
+
+def test_sweeper_ignores_unexpired_and_unbounded_records(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    future = approvals_client.post(
+        "/approvals", json=_payload(expires_in_seconds=3600), headers=auth_headers
+    ).json()
+    unbounded = approvals_client.post(
+        "/approvals", json=_payload(), headers=auth_headers
+    ).json()
+    assert unbounded["expires_at"] is None
+
+    now = _naive_utc()
+
+    async def _scenario() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, _client):
+            async with sessionmaker() as session:
+                return await sweep_expired_approvals(session, queue, now=now)
+
+    flipped = asyncio.run(_scenario())
+    assert flipped == 0
+
+    for record in (future, unbounded):
+        got = approvals_client.get(
+            f"/approvals/{record['id']}", headers=auth_headers
+        ).json()
+        assert got["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_sweeper_second_pass_is_a_no_op(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals", json=_payload(expires_in_seconds=1), headers=auth_headers
+    ).json()
+
+    now = _naive_utc(2)
+
+    async def _scenario() -> tuple[int, int]:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, _client):
+            async with sessionmaker() as session:
+                first = await sweep_expired_approvals(session, queue, now=now)
+            async with sessionmaker() as session:
+                second = await sweep_expired_approvals(session, queue, now=now)
+            return first, second
+
+    first, second = asyncio.run(_scenario())
+    assert first == 1
+    assert second == 0
+
+    # No double-flip, no second turn, no second audit row.
+    assert len(valkey.xrange(runs_stream)) == 1
+    audit = approvals_client.get(
+        f"/approvals/{created['id']}/audit", headers=auth_headers
+    ).json()
+    assert [e["action"] for e in audit] == ["expired"]
+
+
+def test_sweeper_skips_already_resolved_records(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals", json=_payload(expires_in_seconds=1), headers=auth_headers
+    ).json()
+
+    # Resolve it via the normal path BEFORE the SLA lapses (approver from C1).
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert resolved.status_code == 200
+    assert len(valkey.xrange(runs_stream)) == 1  # the resolve turn
+
+    now = _naive_utc(2)
+
+    async def _scenario() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, _client):
+            async with sessionmaker() as session:
+                return await sweep_expired_approvals(session, queue, now=now)
+
+    flipped = asyncio.run(_scenario())
+    assert flipped == 0
+
+    got = approvals_client.get(
+        f"/approvals/{created['id']}", headers=auth_headers
+    ).json()
+    assert got["status"] == "approved"
+
+    # Exactly the one resolve turn, authored by the human resolver; no expiry
+    # turn was appended.
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.author == "U9"
+
+
+# --- fault injection (#412 hardening) -----------------------------------------
+#
+# Two defects an independent review surfaced, each pinned by driving a
+# Valkey enqueue failure at the exact seam that used to be unguarded:
+#   A. the resolve path 500s instead of 410 when the expiry resume enqueue fails;
+#   B. the sweeper must isolate a per-record enqueue failure so the batch
+#      continues (one poisoned record cannot strand the rest).
+
+
+def test_resolve_path_expiry_returns_410_even_if_enqueue_fails(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A late resolver on a lapsed approval must still get 410 when enqueuing the
+    expiry resume turn fails (a Valkey blip).
+
+    The flip to ``expired`` already committed (``expire_approval`` commits before
+    the enqueue), so the resolve path owes the caller a clean 410 conveying the
+    SLA outcome -- not a 500 that buries it behind an infra error. This pins the
+    #412 regression where the unguarded ``resume_queue.enqueue`` on the expiry
+    branch turns the 410 into an uncaught 500.
+    """
+
+    payload = _payload(expires_in_seconds=1)
+    created = approvals_client.post(
+        "/approvals", json=payload, headers=auth_headers
+    ).json()
+    assert created["expires_at"] is not None
+    time.sleep(1.1)
+
+    async def _boom(*a: Any, **k: Any) -> str:
+        raise RuntimeError("valkey down")
+
+    # The resolve endpoint reads request.app.state.resume_queue; make its enqueue
+    # fail so the expiry branch's enqueue raises.
+    monkeypatch.setattr(approvals_client.app.state.resume_queue, "enqueue", _boom)
+
+    # Observe the real 500 the error middleware returns in production, rather
+    # than letting TestClient (raise_server_exceptions=True) re-raise it -- the
+    # regression being pinned is precisely "500 leaks out where 410 is owed".
+    monkeypatch.setattr(
+        approvals_client._transport, "raise_server_exceptions", False
+    )
+
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    # RED today: the unguarded enqueue raises, so the endpoint 500s (or the
+    # RuntimeError propagates) instead of returning the 410 the SLA lapse owes.
+    assert resolved.status_code == 410, resolved.text
+
+    # The SLA flip still committed independently of the failed enqueue.
+    got = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert got.json()["status"] == "expired"
+
+    # The enqueue failed, so no resume turn reached the stream.
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_sweeper_isolates_a_failing_record(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Valkey enqueue failure on ONE lapsed record must not stop the sweeper
+    from flipping and resuming the others: the per-record try/except in
+    ``sweep_expired_approvals`` isolates the failure so the batch continues.
+
+    Ordering note (robust form): ``list_expired_pending_approvals`` orders by
+    ``expires_at``, so which of the two records the sweep processes first is not
+    asserted here. The flaky enqueue raises on its FIRST call regardless of which
+    record that is; the assertions only pin the isolation contract -- the sweep
+    flips BOTH records, returns 1 (exactly one enqueue succeeded), and lands
+    exactly one resume turn, belonging to whichever record was processed second.
+
+    This may already be GREEN: the per-record ``except`` exists today. Its job is
+    to lock the isolation contract so it cannot regress -- the accompanying #412
+    production fix also adds a ``session.rollback()`` in that ``except`` to guard
+    the rarer DB-commit-failure case, matching the convention in
+    routers/approvals.py and routers/agents.py.
+    """
+
+    first = approvals_client.post(
+        "/approvals", json=_payload(expires_in_seconds=1), headers=auth_headers
+    ).json()
+    second = approvals_client.post(
+        "/approvals", json=_payload(expires_in_seconds=1), headers=auth_headers
+    ).json()
+    assert first["expires_at"] is not None
+    assert second["expires_at"] is not None
+
+    ids = {first["id"], second["id"]}
+    # Map conversation_id -> record id so we can identify which record the single
+    # surviving turn belongs to, without assuming processing order.
+    conversation_to_id = {
+        first["conversation_id"]: first["id"],
+        second["conversation_id"]: second["id"],
+    }
+    now = _naive_utc(2)
+
+    async def _scenario() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, _client):
+            orig = queue.enqueue
+            calls = {"n": 0}
+
+            async def _flaky_enqueue(turn: QueuedTurn) -> str:
+                # Raise on the first record's enqueue (a Valkey blip), then let
+                # every later record enqueue for real.
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise RuntimeError("valkey down")
+                return await orig(turn)
+
+            monkeypatch.setattr(queue, "enqueue", _flaky_enqueue)
+            async with sessionmaker() as session:
+                return await sweep_expired_approvals(session, queue, now=now)
+
+    swept = asyncio.run(_scenario())
+    # One enqueue raised (record processed first), one succeeded (processed
+    # second): the poisoned record did not block the batch.
+    assert swept == 1
+
+    # Both flips committed -- expire_approval commits before the enqueue runs, so
+    # the record whose enqueue failed is still expired.
+    for record in (first, second):
+        got = approvals_client.get(
+            f"/approvals/{record['id']}", headers=auth_headers
+        ).json()
+        assert got["status"] == "expired"
+
+    # Exactly one resume turn on the stream, for whichever record was second.
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.conversation_id in conversation_to_id
+    resumed_id = conversation_to_id[turn.conversation_id]
+    assert resumed_id in ids
+    assert turn.event_id == f"approval-{resumed_id}-resolved"
+    assert turn.author == "system"
+
+
+def test_sweeper_disabled_when_interval_nonpositive(
+    _disposable_db: Any,
+) -> None:
+    prior = os.environ.get("APPROVAL_SWEEP_INTERVAL_S")
+    os.environ["APPROVAL_SWEEP_INTERVAL_S"] = "0"
+    get_settings.cache_clear()
+    try:
+        with TestClient(create_app()) as client:
+            # Disabled: no task started, and shutdown (the `with` exit) is
+            # unconditional-safe against the None state.
+            assert client.app.state.sweeper_task is None
+    finally:
+        if prior is None:
+            os.environ.pop("APPROVAL_SWEEP_INTERVAL_S", None)
+        else:
+            os.environ["APPROVAL_SWEEP_INTERVAL_S"] = prior
+        get_settings.cache_clear()
+
+
+def test_run_expiry_sweeper_loop_sweeps_and_stops(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals", json=_payload(expires_in_seconds=1), headers=auth_headers
+    ).json()
+    approval_id = uuid.UUID(created["id"])
+
+    async def _scenario() -> None:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, client):
+            stop = asyncio.Event()
+            task = asyncio.create_task(
+                run_expiry_sweeper(sessionmaker, queue, 0.05, stop)
+            )
+            try:
+                # Poll (bounded) until the loop observes the lapse and flips it.
+                deadline = asyncio.get_running_loop().time() + 5.0
+                status = created["status"]
+                while status != "expired":
+                    assert asyncio.get_running_loop().time() < deadline, (
+                        "sweeper loop never flipped the lapsed record"
+                    )
+                    await asyncio.sleep(0.1)
+                    async with sessionmaker() as session:
+                        record = await crud.get_approval(session, approval_id)
+                        assert record is not None
+                        status = record.status
+                # The loop also enqueued the expiry resume turn.
+                assert len(await client.xrange(runs_stream)) == 1
+            finally:
+                stop.set()
+                # Wait-first loop wakes immediately on stop; it must finish
+                # promptly, not hang.
+                await asyncio.wait_for(task, 2)
+            assert task.done()
+
+    asyncio.run(_scenario())

--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -116,6 +116,12 @@ spec:
               value: {{ .Values.api.resumeReconciler.graceSeconds | quote }}
             - name: RESUME_RECONCILER_BATCH_LIMIT
               value: {{ .Values.api.resumeReconciler.batchLimit | quote }}
+            # Expiry sweeper cadence (#412). Rendered unconditionally, not behind
+            # an optional-value guard, because the disable value 0 is falsy in Go
+            # templates and would be silently dropped, leaving the app default
+            # instead of disabling. <= 0 disables the sweeper.
+            - name: APPROVAL_SWEEP_INTERVAL_S
+              value: {{ .Values.api.approvalSweepIntervalSeconds | quote }}
           ports:
             - name: http
               containerPort: 8000

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -417,6 +417,10 @@ api:
   orgName: AgentOS
   # HMAC secret the GitHub git-flow webhook authenticates inbound events with.
   githubWebhookSecret: dev-webhook-secret
+  # How often (seconds) the API scans for lapsed pending approvals and resumes
+  # their stranded sessions (#412). Set to 0 (or any value <= 0) to disable the
+  # expiry sweeper entirely. Default matches the app's built-in 30s cadence.
+  approvalSweepIntervalSeconds: 30
   service:
     type: ClusterIP
     port: 8000

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -25,8 +25,9 @@ in code now:
   (`apps/api/src/agentos_api/models.py`) with the resolve-once compare-and-set
   (`crud.claim_approval_resolution`, a conditional `UPDATE ... WHERE status='pending'`) behind
   `POST /approvals/{id}/resolve`; losers of the claim race get 409 naming who resolved it,
-  a past-SLA record flips to expired (410). Creation is idempotent on `dedupe_key` (the
-  triggering event id).
+  a past-SLA record flips to expired (410) and now also enqueues the expiry resume turn
+  (#412, below) so the late resolver's dead end no longer strands the session. Creation is
+  idempotent on `dedupe_key` (the triggering event id).
 - **The `awaiting-approval` status (landed, #244).** `SessionStatus.AWAITING_APPROVAL` plus
   the optional `Final.approval_summary` field
   (`packages/aci-protocol/src/aci_protocol/events.py`), regenerated across all three language
@@ -38,6 +39,22 @@ in code now:
   resolution enqueues a resume turn onto the ordinary runs stream
   (`apps/api/src/agentos_api/resumequeue.py`), and the kernel's claim path rehydrates the
   thread with its bound boot env (`substrate.resume(env=...)`).
+- **Expiry resume (landed, #412).** A prior gap: an approval whose SLA lapsed with no
+  resolver stayed `pending` forever, since the only expiry path lived inside the resolve
+  endpoint. A periodic sweeper in the API lifespan (`apps/api/src/agentos_api/sweeper.py`,
+  `run_expiry_sweeper` driving `sweep_expired_approvals`) now flips lapsed `pending` records
+  to `expired` through the same `crud.expire_approval` compare-and-set, appends an `expired`
+  audit row (`authorizer="ExpirySweeper"`), and enqueues a platform-authored (`author="system"`)
+  resume turn so the suspended session resumes down its timeout branch (ADR-0003). The
+  single-wakeup guarantee comes from the pending-guarded compare-and-set in
+  `crud.expire_approval`: only the flip winner (the sweeper or a racing resolver) enqueues.
+  Both paths also reuse the deterministic `resume_event_id(approval.id)`, but that shared key
+  only keeps a redelivery of an already-terminally-handled turn from re-running; it does not
+  collapse a duplicate landing while the resumed turn is still in flight. Cadence is `approval_sweep_interval_s` (env
+  `APPROVAL_SWEEP_INTERVAL_S`, Helm `api.approvalSweepIntervalSeconds`, default 30s; `<= 0`
+  disables). Known gap: a failure after the flip but before the audit/enqueue (a Valkey blip,
+  a pod shutdown mid-batch) can still drop that one wakeup, since the flipped record is no
+  longer re-selected; a durable outbox to close this is tracked as follow-up.
 - **The permission gate (landed, #245).** Per-agent config
   (`agents.approval_required_tools`, forwarded as `AGENTOS_APPROVAL_REQUIRED_TOOLS` by the
   worker binding) marks tools approval-required; the runner intercepts those calls


### PR DESCRIPTION
## What

An approval whose SLA (`expires_in_seconds`) lapsed with no resolver stranded the suspended session forever: the record stayed `pending`, the Slack notice stayed on "Awaiting approval," and the session never proceeded or aborted. The only expiry path lived inside `POST /approvals/{id}/resolve` and enqueued nothing.

This closes both defects named in the issue title ("no expiry sweeper, no resume-on-expiry"):

- **Expiry sweeper** — a periodic wait-first loop in the API lifespan (`sweeper.py`) flips lapsed `pending` approvals to `expired` via the existing `status = pending` compare-and-set, appends an `expired` audit row (`authorizer="ExpirySweeper"`), and enqueues a platform-authored (`author="system"`) resume turn so the session resumes down its timeout branch (ADR-0003) and the channel notice updates.
- **Resolve-path resume** — the resolve endpoint's own past-SLA branch now also enqueues that expiry resume turn (still returning 410 to the late resolver), so a resolver arriving in the lapse-to-sweep window no longer dead-ends the session.

Both paths reuse the deterministic `resume_event_id(approval.id)`, so the worker's done-marker delivers at most one wakeup per approval regardless of which path wins the CAS. Concurrent API replicas and sweeper-vs-resolve races are all arbitrated by that same pending-guarded CAS.

## Operator control

`APPROVAL_SWEEP_INTERVAL_S` (config) / `api.approvalSweepIntervalSeconds` (Helm), default 30s; `<= 0` disables the sweeper. Rendered unconditionally in the chart so the disable value `0` is not swallowed by Go-template falsiness.

## Robustness

The sweeper never crashes the API (per-pass and per-record `try/except`); enqueue failures are logged and swept past (the resolve path keeps its 410 instead of 500ing on a queue blip); the sweeper rolls back its shared session per record so a failed commit cannot poison the rest of the batch.

## Scope note

The resolve-path resume was provisionally deferred as "F1" in planning, then scoped into this PR per the issue title's second defect ("no resume-on-expiry") and ADR-0010 ("expiry must also resume, not dead-end"). The frozen `test_expired_approval_cannot_be_resolved` was updated (and renamed) to assert the corrected contract.

## Relationship to the resume reconciler (#411 / PR #416)

PR #416 merged while this was in flight; this branch is rebased onto it and the two are complementary, not duplicates:

- The **reconciler** backstops lost wakeups for **resolved** (approved/rejected) approvals, re-enqueuing past a grace horizon. It deliberately excludes `expired` (`_RESUMABLE_STATUSES = (approved, rejected)`, "expired/pending are never resumed").
- This PR makes **expired** approvals resumable for the first time (sweeper + resolve-path expiry).

They coexist as two independently-gated lifespan loops. My expiry paths never touch `resumed_at`, and the reconciler never claims `expired` rows, so there is no double-enqueue between them.

## Known limitation / follow-up

Because the reconciler excludes `expired`, expiry wakeups have no backstop: a failure after the flip but before the enqueue (a Valkey blip, or a pod shutdown mid-batch) still drops that one wakeup, since the flipped record is no longer re-selected. A new user message still revives the session via the kernel's claim-or-resume. Closing this is now a small, well-scoped follow-up that reuses #411's machinery rather than a new outbox: add `expired` to `_RESUMABLE_STATUSES` and mark `resumed_at` on the two expiry enqueue paths (#418). That changes #411's deliberate design premise and its test contract, so it belongs in its own PR. An expiry-aware Slack card update is #419.

Note for future re-enqueue work: the worker's done-marker is written only post-terminal, so a duplicate landing mid-turn steers the live turn rather than being absorbed. The single-wakeup guarantee here is the `status = pending` CAS, not the shared `resume_event_id`.

Closes #412
