### PR TITLE
Backstop expiry wakeups in the resume reconciler

### DIFF
--- a/apps/api/alembic/versions/0012_settle_historical_expired.py
+++ b/apps/api/alembic/versions/0012_settle_historical_expired.py
@@ -1,0 +1,67 @@
+"""settle historical expired approvals (#418, ADR-0010)
+
+Data-only companion to 0011. #418 adds ``expired`` to the resume reconciler's
+work-list, which makes every pre-existing expired row a candidate for the first
+pass after deploy. This settles the ambiguous older-than-TTL ones, on the same
+window and for the same reason 0011 settled the resolved rows.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-07-15
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0012"
+down_revision: str | None = "0011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Every expired row predating #418 has resolved_at set (expire_approval
+    # stamps it in the same CAS) and resumed_at NULL, because nothing marked the
+    # expiry paths' enqueues until now. 0011 left them NULL harmlessly: under the
+    # #416 contract an expired row was never a reconciler candidate. Widening
+    # _RESUMABLE_STATUSES makes them all candidates at once, so without this
+    # backfill the first pass after deploy would enqueue an expiry wake for the
+    # whole history.
+    #
+    # Windowed, not blanket, exactly as in 0011: settle ONLY rows expired longer
+    # ago than the worker's done-marker TTL window (24h). Past that window the
+    # marker has expired, so a re-enqueued wake is NOT deduped -- it re-delivers
+    # into a long-finished thread and steers it down a timeout branch it already
+    # took. Rows expired within the last 24h stay NULL because they are the
+    # recoverable bug victims: if their enqueue succeeded the live done-marker
+    # absorbs the reconciler's one redundant re-enqueue, and if it failed (the
+    # #418 bug) the wake is finally delivered. A blanket settle would write off
+    # precisely those stranded-just-before-deploy sessions this fix exists to
+    # recover.
+    #
+    # The 24h literal mirrors the worker ``idempotency_ttl_s`` DEFAULT (86400s);
+    # see 0011's comment for the full statement of that coupling. A migration
+    # cannot read the worker's runtime env, so a deployment overriding
+    # ``IDEMPOTENCY_TTL_S`` must adjust both windows together.
+    #
+    # The ``resumed_at IS NULL`` guard (absent from 0011 only because 0011
+    # created the column in the same revision) makes this idempotent and keeps an
+    # out-of-band re-run from overwriting rows the new runtime paths marked.
+    op.execute(
+        "UPDATE agentos.approvals SET resumed_at = resolved_at "
+        "WHERE status = 'expired' AND resolved_at IS NOT NULL "
+        "AND resumed_at IS NULL "
+        "AND resolved_at < now() - interval '24 hours'"
+    )
+    # No index work: 0011's ix_approvals_resolved_unresumed is keyed on
+    # resolved_at with a resumed_at IS NULL predicate and is status-agnostic, so
+    # it already serves the widened status IN (...) work-list query.
+
+
+def downgrade() -> None:
+    # Deliberate no-op. There is no schema element to drop, and settled history
+    # cannot be selectively un-settled: this migration's writes are
+    # indistinguishable from the marks the runtime expiry paths make, so
+    # reverting them would misclassify genuinely-delivered wakes as owed.
+    pass

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -460,10 +460,18 @@ async def mark_approval_resumed(session: AsyncSession, approval_id: uuid.UUID) -
     await session.commit()
 
 
-# The statuses an owed-wake row can carry: a resolution that must still reach its
-# suspended session. ``expired``/``pending`` are never resumed. Shared by the
-# reconciler's candidate finder and its per-row claim so the two never desync.
-_RESUMABLE_STATUSES = (ApprovalStatus.approved, ApprovalStatus.rejected)
+# The statuses an owed-wake row can carry: a terminal outcome that must still
+# reach its suspended session. ``expired`` belongs here since #412 gave both
+# expiry paths (the sweeper and the resolve-path expiry branch) a resume turn of
+# their own, so an expired record owes a wake exactly as a decided one does
+# (#418). Only ``pending`` is excluded: it has neither been decided nor lapsed,
+# so nothing is owed yet. Shared by the reconciler's candidate finder and its
+# per-row claim so the two never desync.
+_RESUMABLE_STATUSES = (
+    ApprovalStatus.approved,
+    ApprovalStatus.rejected,
+    ApprovalStatus.expired,
+)
 
 
 async def claim_resume_row(
@@ -496,11 +504,17 @@ async def claim_resume_row(
 async def list_resolved_unresumed(
     session: AsyncSession, *, resolved_before: datetime, limit: int
 ) -> list[uuid.UUID]:
-    """The reconciler's work-list: ids of resolved approvals whose wake is owed.
+    """The reconciler's work-list: ids of settled approvals whose wake is owed.
 
-    ``expired`` is deliberately excluded -- an expired record has ``resolved_at``
-    set but never had a resume turn enqueued, so it must never be woken.
-    ``resolved_before`` is naive UTC, matching the DateTime columns.
+    A row in any ``_RESUMABLE_STATUSES`` with ``resolved_at`` set and
+    ``resumed_at`` NULL is an owed wake: every path that settles a record (the
+    resolve endpoint, the expiry sweeper, and the resolve-path expiry branch)
+    enqueues a resume turn and marks ``resumed_at`` only once that enqueue
+    succeeded, so NULL means the wake never reached the stream. That now includes
+    ``expired`` records (#418), whose expiry wake was previously unrecoverable
+    because a flipped record is no longer ``pending`` and so is never re-selected
+    by ``list_expired_pending_approvals``. ``resolved_before`` is naive UTC,
+    matching the DateTime columns.
 
     Returns ids only (the unlocked candidate finder): each id is then claimed
     atomically by ``claim_resume_row`` in its own short transaction, which

--- a/apps/api/src/agentos_api/resumequeue.py
+++ b/apps/api/src/agentos_api/resumequeue.py
@@ -18,7 +18,7 @@ from typing import Any
 import redis.asyncio as redis
 from aci_protocol import QueuedTurn, ReplyHandle
 
-from .models import Approval
+from .models import Approval, ApprovalStatus
 
 RUNS_STREAM = "agentos:runs"
 STREAM_PAYLOAD_FIELD = "payload"
@@ -95,6 +95,29 @@ def build_expiry_resume_turn(approval: Approval) -> QueuedTurn:
         "expiry and proceed or stop accordingly."
     )
     return _build_turn(approval, author="system", text=text)
+
+
+def resume_turn_for(approval: Approval) -> QueuedTurn:
+    """The resume turn owed for a resolved-or-expired approval, by status.
+
+    The single status -> builder mapping, kept beside the builders so a new
+    resumable status cannot be added without extending it, and so the one
+    status-agnostic caller (the reconciler, #418) stays mapping-free. Raises
+    ValueError for a status that owes no wake (pending), mirroring how
+    ``crud._RESUMABLE_STATUSES`` fences the reconciler's finder and its per-row
+    claim.
+
+    The three inline callers do NOT come through here: each just performed the
+    CAS that established its record's status, so it names its builder directly.
+    """
+
+    if approval.status == ApprovalStatus.expired:
+        return build_expiry_resume_turn(approval)
+    if approval.status in (ApprovalStatus.approved, ApprovalStatus.rejected):
+        return build_resume_turn(approval)
+    raise ValueError(
+        f"approval {approval.id} status {approval.status} owes no resume turn"
+    )
 
 
 class ResumeQueue:

--- a/apps/api/src/agentos_api/resumereconciler.py
+++ b/apps/api/src/agentos_api/resumereconciler.py
@@ -8,6 +8,14 @@ the resume turn, setting ``resumed_at`` only AFTER a successful enqueue
 (enqueue-first-then-mark), so a failed enqueue is retried on the next pass
 rather than lost.
 
+An ``expired`` record is an owed wake on the same terms (#418): since #412 both
+expiry paths enqueue a wake of their own, so a NULL ``resumed_at`` there means
+the same failed enqueue -- and, unlike a resolved record, the flipped row is no
+longer ``pending`` and so is never re-selected by the sweeper, which made an
+expiry wake the one permanently unrecoverable case. Which turn a candidate owes
+follows from its status, so the reconciler defers to ``resume_turn_for`` rather
+than carrying the mapping itself.
+
 Three qualifications shape the design:
 
 - **Grace window (load-bearing).** ``reconcile_once`` only considers records
@@ -25,7 +33,9 @@ Three qualifications shape the design:
   dedupes it -- but only within ``idempotency_ttl_s`` (default 24h). In steady
   state the reconciler retries on the interval (seconds), far inside that
   window. The bound only bites for pre-fix historical rows, which the migration
-  0011 backfill (``resumed_at = resolved_at``) excludes from the work-list.
+  backfills (``resumed_at = resolved_at``) exclude from the work-list: 0011 for
+  the resolved rows, 0012 for the expired rows that #418's widened work-list
+  first made candidates.
 - **Concurrency.** The done-marker CANNOT dedupe a concurrent double-enqueue
   (it is written only post-terminal), so two overlapping copies steer into one
   live turn. Two races, two guards: (1) *reconciler vs reconciler* (``api.replicas
@@ -47,7 +57,7 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from . import crud
-from .resumequeue import ResumeQueue, build_resume_turn
+from .resumequeue import ResumeQueue, resume_turn_for
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +113,7 @@ class ResumeReconciler:
                             # Another replica holds it, or it is already resumed;
                             # exit the txn block cleanly, releasing any lock.
                             continue
-                        turn = build_resume_turn(approval)
+                        turn = resume_turn_for(approval)
                         await self._resume_queue.enqueue(turn)
                         approval.resumed_at = datetime.now(UTC).replace(tzinfo=None)
                     # session.begin() committed here, releasing the row lock.

--- a/apps/api/src/agentos_api/routers/approvals.py
+++ b/apps/api/src/agentos_api/routers/approvals.py
@@ -166,10 +166,16 @@ async def resolve_approval(
         # None means a concurrent resolution won the CAS before the expiry did;
         # fall through to the claim below, which will lose and report the winner.
         if expired is not None:
+            # Read expires_at into a plain value up front: the except below now
+            # rolls back, which expires every ORM instance in this session, so
+            # reading it off the record afterwards for the 410 message would
+            # trigger an implicit reload (MissingGreenlet under the async
+            # session) and turn the owed 410 back into a 500.
+            expires_at = expired.expires_at
             await _audit(
                 "expired",
                 authorized=True,
-                reason=f"approval expired at {expired.expires_at}",
+                reason=f"approval expired at {expires_at}",
             )
             # This resolver lost the SLA (it still gets 410), but the session is
             # suspended and must be woken down its timeout branch. This resolver
@@ -181,19 +187,50 @@ async def resolve_approval(
             # not the shared key, that keeps this wakeup single.
             try:
                 await resume_queue.enqueue(build_expiry_resume_turn(expired))
+                # Enqueue-first-then-mark (#418): only a wake that reached the
+                # stream is written off, so a failure below leaves resumed_at
+                # NULL and the reconciler re-enqueues it past its grace horizon.
+                # This is the sole recovery path for an expiry wake -- a flipped
+                # record is no longer pending, so no later sweep re-selects it.
+                await crud.mark_approval_resumed(session, approval_id)
             except Exception:
+                # Reset the session before raising: the mark inside the try is a
+                # DB write, so its failure leaves this session in
+                # PendingRollbackError until dependency teardown. Nothing
+                # committed is discarded -- expire_approval and the audit each
+                # commit themselves above, so the rollback only clears the failed
+                # mark's aborted transaction. Mirrors the sweeper's except.
+                await session.rollback()
                 # A queue blip must not turn the 410 into a 500; the flip is
-                # already committed, so log the possibly-lost wakeup and still
-                # report the expiry. (A durable outbox to guarantee delivery is
-                # tracked as follow-up.)
+                # already committed, so report the expiry regardless. Unlike the
+                # resolve path below, this branch never re-raises when the
+                # reconciler is disabled: a 410 claims no delivery, it reports
+                # the true fact that the approval expired, and a 500 here would
+                # misinform the resolver about an outcome that did happen.
+                #
+                # The log must not name the enqueue as the failure: this except
+                # also catches a failed mark, in which case the wake DID reach
+                # the stream. An operator reads this line while deciding whether
+                # a session is stranded, so it states the uncertainty rather than
+                # guessing.
+                retry = (
+                    "the reconciler will re-enqueue it past its grace horizon "
+                    "(a redundant wake if it did land, which is the safe "
+                    "direction)"
+                    if get_settings().resume_reconciler_enabled
+                    else "nothing will retry it (resume reconciler disabled) "
+                    "and the session wakeup may be lost"
+                )
                 logger.exception(
-                    "failed to enqueue expiry resume turn for approval %s on the "
-                    "resolve path; session wakeup may be lost",
+                    "expiry wakeup incomplete for approval %s on the resolve "
+                    "path; the resume turn may or may not have reached the "
+                    "stream, so %s",
                     approval_id,
+                    retry,
                 )
             raise HTTPException(
                 status.HTTP_410_GONE,
-                f"approval expired at {expired.expires_at} and can no longer be resolved",
+                f"approval expired at {expires_at} and can no longer be resolved",
             )
 
     claimed = await crud.claim_approval_resolution(

--- a/apps/api/src/agentos_api/sweeper.py
+++ b/apps/api/src/agentos_api/sweeper.py
@@ -18,14 +18,24 @@ resolver -- and every loser gets None back and neither audits nor enqueues. This
 pending-guarded CAS is what guarantees a single wakeup: only the flip winner
 ever enqueues.
 
-Warning for anyone adding a re-enqueue path (retry, durable outbox, reconciler):
-the worker's done-marker (``markers.py``) only skips an event that was already
-handled to a TERMINAL point (streamed to a final, or escalated). It does NOT
-collapse a duplicate that lands while the resumed turn is still in flight --
-that duplicate would steer the live turn instead of being absorbed. The shared
-``resume_event_id`` (see ``resumequeue.build_expiry_resume_turn``) prevents a
-redelivery of an already-finished turn from re-running; it does not make a
-re-enqueue free, so do not rely on it as a mid-turn dedupe.
+A successful enqueue is recorded with ``crud.mark_approval_resumed`` (#418), the
+same enqueue-first-then-mark ordering the resolve path uses: a NULL
+``resumed_at`` on a flipped record means the wake never reached the stream, and
+the resume reconciler (#411) re-enqueues it past its grace horizon. That is the
+only recovery path for an expiry wake, because a flipped record is no longer
+``pending`` and so is never re-selected by a later sweep. Marking before the
+enqueue would write the wake off as delivered and strand the session for good.
+
+Warning for anyone adding a re-enqueue path (retry, durable outbox, another
+reconciler): the worker's done-marker (``markers.py``) only skips an event that
+was already handled to a TERMINAL point (streamed to a final, or escalated). It
+does NOT collapse a duplicate that lands while the resumed turn is still in
+flight -- that duplicate would steer the live turn instead of being absorbed.
+The shared ``resume_event_id`` (see ``resumequeue.build_expiry_resume_turn``)
+prevents a redelivery of an already-finished turn from re-running; it does not
+make a re-enqueue free, so do not rely on it as a mid-turn dedupe. What keeps
+the reconciler's re-enqueue safe is its grace horizon (longer than the worker's
+maximum turn), not the shared key.
 """
 
 from __future__ import annotations
@@ -37,6 +47,7 @@ from datetime import UTC, datetime
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from . import crud
+from .config import get_settings
 from .resumequeue import ResumeQueue, build_expiry_resume_turn
 
 logger = logging.getLogger(__name__)
@@ -53,7 +64,10 @@ async def sweep_expired_approvals(
 
     ``now`` defaults to naive UTC (matching ``expires_at`` and the router's
     ``_expired`` comparison); tests pass an explicit ``now`` to avoid real
-    sleeps. Returns the number of records this pass successfully flipped.
+    sleeps. Returns the number of records this pass flipped AND landed a resume
+    turn on the stream for. The count is taken at the enqueue rather than after
+    the mark below: at that point the wake is delivered, so a failed mark must
+    not subtract from a wake the session already got.
 
     Per record, the order is flip -> audit -> enqueue, each guarded by a
     per-record try/except so one poisoned record cannot block the rest of the
@@ -92,6 +106,10 @@ async def sweep_expired_approvals(
             )
             stream_id = await resume_queue.enqueue(build_expiry_resume_turn(expired))
             flipped += 1
+            # Enqueue-first-then-mark: only a wake that actually reached the
+            # stream is written off. The mark's ``resumed_at IS NULL`` guard
+            # makes a race with the reconciler a no-op rather than a conflict.
+            await crud.mark_approval_resumed(session, expired.id)
             logger.info(
                 "approval %s expired by sweeper; resume turn enqueued (%s)",
                 expired.id,
@@ -101,11 +119,27 @@ async def sweep_expired_approvals(
             # Reset the shared session so a failed commit on this record cannot
             # poison the rest of the batch (PendingRollbackError); mirrors the
             # rollback-after-DB-error convention in the routers. If the flip
-            # already committed, the audit/enqueue loss means the wakeup may be
-            # dropped (documented durability gap; a durable outbox is future work).
+            # already committed, this record is left expired with ``resumed_at``
+            # NULL, which is exactly the owed-wake shape the resume reconciler
+            # (#411) re-enqueues past its grace horizon -- so the wakeup is
+            # retried rather than dropped, provided that backstop is enabled.
             await session.rollback()
+            # The log must not name the enqueue as the failure: this except also
+            # catches a failed mark, in which case the wake DID reach the stream.
+            # An operator reads this line while deciding whether a session is
+            # stranded, so it states the uncertainty instead of guessing.
+            retry = (
+                "the reconciler will re-enqueue it past its grace horizon (a "
+                "redundant wake if it did land, which is the safe direction)"
+                if get_settings().resume_reconciler_enabled
+                else "nothing will retry it (resume reconciler disabled) and "
+                "the wakeup may be lost"
+            )
             logger.exception(
-                "expiry sweep failed for approval %s; wakeup may be lost", approval_id
+                "expiry sweep failed for approval %s after the flip; the resume "
+                "turn may or may not have reached the stream, so %s",
+                approval_id,
+                retry,
             )
             continue
     return flipped

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -27,6 +27,7 @@ from agentos_api.config import get_settings
 from agentos_api.main import create_app
 from agentos_api.models import Approval
 from agentos_api.resumequeue import ResumeQueue
+from agentos_api.resumereconciler import ResumeReconciler
 from agentos_api.sandbox_token import mint
 from agentos_api.sweeper import run_expiry_sweeper, sweep_expired_approvals
 from fastapi.testclient import TestClient
@@ -406,6 +407,11 @@ def test_expired_approval_resolve_returns_410_and_resumes(
     assert "expired" in turn.text
     assert payload["summary"] in turn.text
 
+    # #418: the wake made it onto the stream, so the record is marked resumed and
+    # the reconciler owes it nothing. Enqueue-first-then-mark, the same ordering
+    # the resolve path uses.
+    assert _read_resumed_at(created["id"]) is not None
+
 
 def test_unknown_approval_is_404(
     approvals_client: TestClient, auth_headers: dict[str, str], clean_db: None
@@ -730,6 +736,24 @@ def test_sweeper_expires_lapsed_pending_and_enqueues_resume_turn(
     assert row["authorized"] is True
     assert row["decision"] == ""
 
+    # #418: the wake reached the stream, so the sweeper marked the record resumed.
+    assert _read_resumed_at(created["id"]) is not None
+
+    # ...which is what keeps the reconciler off a healthy sweep. Now that expired
+    # rows are reconciler candidates, an unmarked one would be re-enqueued past
+    # the grace horizon and steer the resumed thread a second time. Run the
+    # backstop against the same DB with grace 0 (the worst case: every expired
+    # row is instantly past the horizon) and it must find nothing to do.
+    async def _reconcile() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, _client):
+            reconciler = ResumeReconciler(
+                sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+            )
+            return await reconciler.reconcile_once()
+
+    assert asyncio.run(_reconcile()) == 0
+    assert len(valkey.xrange(runs_stream)) == 1
+
 
 def test_sweeper_ignores_unexpired_and_unbounded_records(
     approvals_client: TestClient,
@@ -904,6 +928,91 @@ def test_resolve_path_expiry_returns_410_even_if_enqueue_fails(
     # The enqueue failed, so no resume turn reached the stream.
     assert valkey.xrange(runs_stream) == []
 
+    # #418: and because nothing was delivered, the record stays unmarked -- an
+    # owed wake the reconciler picks up past the grace horizon. Marking before
+    # enqueuing would write the wake off as delivered and strand the session
+    # permanently, since an expired record is never re-selected as pending.
+    assert _read_resumed_at(created["id"]) is None
+
+
+def test_resolve_path_expiry_returns_410_when_the_resumed_mark_fails(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A late resolver on a lapsed approval must still get 410 when the MARK
+    fails, not just when the enqueue does.
+
+    Distinct from ``test_resolve_path_expiry_returns_410_even_if_enqueue_fails``:
+    there the enqueue raises FIRST, so the mark never runs. Here the enqueue
+    SUCCEEDS and ``crud.mark_approval_resumed`` raises, which is the only ordering
+    that reaches the ``except``'s ``session.rollback()`` with a live ORM instance
+    still needed by the 410 message. That rollback expires every instance in the
+    session, so reading ``expired.expires_at`` off the record afterwards would
+    trigger an implicit reload and raise ``MissingGreenlet`` under the async
+    session, turning the owed 410 into a 500. The endpoint hoists ``expires_at``
+    into a local before the try to keep the deadline readable after the rollback;
+    this test pins that hoist.
+
+    ``resumed_at`` must stay NULL: the mark is what writes the wake off as
+    delivered, and it did not commit, so the reconciler still owns the retry past
+    its grace horizon (a redundant wake, the safe direction, since the turn did
+    reach the stream).
+    """
+
+    payload = _payload(expires_in_seconds=1)
+    created = approvals_client.post(
+        "/approvals", json=payload, headers=auth_headers
+    ).json()
+    assert created["expires_at"] is not None
+    time.sleep(1.1)
+
+    real_mark = crud.mark_approval_resumed
+
+    async def _failing_mark(session: Any, approval_id: uuid.UUID) -> Any:
+        # Wrap the real collaborator: only this record's mark fails (a DB blip),
+        # every other caller keeps the genuine implementation.
+        if str(approval_id) == created["id"]:
+            raise RuntimeError("postgres unreachable")
+        return await real_mark(session, approval_id)
+
+    monkeypatch.setattr(crud, "mark_approval_resumed", _failing_mark)
+
+    # Observe the real 500 the error middleware would return in production rather
+    # than letting TestClient re-raise it -- the regression pinned here is
+    # precisely "500 leaks out where 410 is owed".
+    monkeypatch.setattr(approvals_client._transport, "raise_server_exceptions", False)
+
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
+        headers=auth_headers,
+    )
+    assert resolved.status_code == 410, resolved.text
+
+    # The 410 still names the expiry deadline. This is what the hoist protects: a
+    # lazy reload after the rollback 500s before this body is ever built.
+    deadline = str(datetime.fromisoformat(created["expires_at"]))
+    assert deadline in resolved.json()["detail"]
+
+    # The SLA flip committed independently of the failed mark.
+    got = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert got.json()["status"] == "expired"
+
+    # The enqueue ran BEFORE the mark, so the wake did reach the stream -- this is
+    # the ordering the enqueue-failure test cannot reach.
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{created['id']}-resolved"
+    assert turn.author == "system"
+
+    # The mark did not commit, so the record still reads as owing its wake.
+    assert _read_resumed_at(created["id"]) is None
+
 
 def test_sweeper_isolates_a_failing_record(
     approvals_client: TestClient,
@@ -988,6 +1097,15 @@ def test_sweeper_isolates_a_failing_record(
     assert resumed_id in ids
     assert turn.event_id == f"approval-{resumed_id}-resolved"
     assert turn.author == "system"
+
+    # #418: enqueue-first-then-mark, per record. The record whose enqueue landed
+    # is marked; the poisoned one stays NULL so the reconciler re-enqueues it
+    # later. Marking before the enqueue would leave the failed record marked --
+    # its wake written off as delivered with nothing on the stream, which is the
+    # permanent strand this issue exists to close.
+    (stranded_id,) = ids - {resumed_id}
+    assert _read_resumed_at(resumed_id) is not None
+    assert _read_resumed_at(stranded_id) is None
 
 
 def test_sweeper_disabled_when_interval_nonpositive(

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -106,6 +106,29 @@ def _run_async[T](
     return asyncio.run(_main())
 
 
+def _detached_approval(status: str, *, resolved_by: str | None = "U9") -> Approval:
+    """An unpersisted ``Approval`` in a chosen status, for the pure-unit selector
+    test: the turn builders read the record's fields only, so no DB round-trip is
+    needed to exercise the status -> builder mapping.
+
+    Also the single construction site for ``_insert_approval`` below, so a new
+    non-nullable column on ``Approval`` is added once, and the record the unit
+    test exercises cannot drift from the one the DB tests insert.
+    """
+
+    return Approval(
+        id=uuid.uuid4(),
+        conversation_id=f"th-{uuid.uuid4().hex[:8]}",
+        author="U1",
+        summary="Give ACME a 20% discount",
+        reply_channel="C1",
+        reply_placeholder="p-1",
+        dedupe_key=uuid.uuid4().hex,
+        status=status,
+        resolved_by=resolved_by,
+    )
+
+
 async def _insert_approval(
     sessionmaker: async_sessionmaker[AsyncSession],
     *,
@@ -119,20 +142,12 @@ async def _insert_approval(
     endpoint), so a test can construct the exact stranded/settled/expired shapes
     the reconciler must include or exclude."""
 
+    approval = _detached_approval(status, resolved_by=resolved_by)
+    approval.reply_endpoint = reply_endpoint
+    approval.resolved_at = resolved_at
+    approval.resumed_at = resumed_at
+
     async with sessionmaker() as session:
-        approval = Approval(
-            conversation_id=f"th-{uuid.uuid4().hex[:8]}",
-            author="U1",
-            summary="Give ACME a 20% discount",
-            reply_channel="C1",
-            reply_placeholder="p-1",
-            reply_endpoint=reply_endpoint,
-            dedupe_key=uuid.uuid4().hex,
-            status=status,
-            resolved_by=resolved_by,
-            resolved_at=resolved_at,
-            resumed_at=resumed_at,
-        )
         session.add(approval)
         await session.commit()
         await session.refresh(approval)
@@ -212,33 +227,94 @@ def test_reconciler_skips_already_resumed_record(
     assert resumed_at is not None
 
 
-def test_reconciler_skips_expired_record(
+def test_reconciler_reenqueues_stranded_expired_record(
     clean_db: None, valkey: redis.Redis, runs_stream: str
 ) -> None:
-    """An expired record has ``resolved_at`` set but was never enqueued and must
-    never be woken -- this pins the expired-exclusion in
-    ``list_resolved_unresumed`` (out-of-scope expiry-stranding stays out)."""
+    """#418: an expired record whose expiry wake never reached the stream is an
+    owed wake, and the reconciler must deliver it -- with the EXPIRY turn.
+
+    Since #412 both expiry paths (the sweeper and the resolve-path expiry branch)
+    enqueue a wake, so ``status=expired, resolved_at`` set, ``resumed_at`` NULL
+    means the enqueue failed and the session is stranded. It gets the same
+    durable backstop a resolved record already had.
+
+    ``resolved_by`` is None because expiry records no human decision. That is
+    also why the builder choice is load-bearing rather than cosmetic: sending
+    this row through ``build_resume_turn`` would author the wake as "approver"
+    and tell the model the request "was expired by None". The text/author
+    assertions below are what prove the expiry builder was dispatched.
+    """
 
     async def steps(
         sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
-    ) -> tuple[int, datetime | None]:
+    ) -> tuple[uuid.UUID, int, datetime | None]:
         approval_id = await _insert_approval(
             sessionmaker,
             status=ApprovalStatus.expired,
             resolved_at=_naive(120),
             resumed_at=None,
+            resolved_by=None,
         )
         reconciler = ResumeReconciler(
             sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
         )
         count = await reconciler.reconcile_once()
-        return count, await _resumed_at(sessionmaker, approval_id)
+        return approval_id, count, await _resumed_at(sessionmaker, approval_id)
 
-    count, resumed_at = _run_async(steps, runs_stream)
+    approval_id, count, resumed_at = _run_async(steps, runs_stream)
 
-    assert count == 0
-    assert valkey.xrange(runs_stream) == []
-    assert resumed_at is None
+    assert count == 1
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+
+    # The shared deterministic key: the ``-resolved`` suffix is historical and
+    # must NOT fork per status, or the worker's done-marker stops recognizing a
+    # redelivery of the already-finished turn for this approval.
+    assert turn.event_id == f"approval-{approval_id}-resolved"
+
+    # The expiry turn, not the human-decision one.
+    assert turn.text.startswith("[approval expired]")
+    assert turn.author == "system"
+
+    assert resumed_at is not None
+
+
+def test_resume_turn_selector_domain_matches_resumable_statuses() -> None:
+    """The status -> turn-builder mapping is total over the resumable statuses,
+    and its domain cannot silently desync from ``crud._RESUMABLE_STATUSES``.
+
+    The selector lives beside the builders while the finder and the per-row claim
+    are fenced by crud's private tuple. Nothing in the type system ties the two
+    together, so a future status added to the tuple would reach the selector and
+    raise, or a status added to the selector would never be selected. The set
+    equality below is the executable form of that invariant.
+
+    Pure unit: no DB, no Valkey -- the selector is a function of the record.
+    """
+
+    from agentos_api import crud
+    from agentos_api.resumequeue import resume_turn_for
+
+    approved = resume_turn_for(_detached_approval(ApprovalStatus.approved))
+    assert "[approval resolved]" in approved.text
+
+    rejected = resume_turn_for(_detached_approval(ApprovalStatus.rejected))
+    assert "[approval resolved]" in rejected.text
+
+    expired = resume_turn_for(
+        _detached_approval(ApprovalStatus.expired, resolved_by=None)
+    )
+    assert "[approval expired]" in expired.text
+    assert expired.author == "system"
+
+    # A pending record owes no wake: it has not been decided and has not lapsed.
+    with pytest.raises(ValueError):
+        resume_turn_for(_detached_approval(ApprovalStatus.pending, resolved_by=None))
+
+    assert {s for s in ApprovalStatus if s is not ApprovalStatus.pending} == set(
+        crud._RESUMABLE_STATUSES
+    )
 
 
 def test_reconciler_skips_pending_record(
@@ -270,12 +346,22 @@ def test_reconciler_skips_pending_record(
 def test_reconciler_ignores_backfilled_historical_row(
     clean_db: None, valkey: redis.Redis, runs_stream: str
 ) -> None:
-    """A pre-migration resolution is backfilled to ``resumed_at = resolved_at``;
-    the reconciler must treat it as settled and never auto-wake it after deploy.
+    """Historical rows are backfilled to ``resumed_at = resolved_at``; the
+    reconciler must treat them as settled and never auto-wake them after deploy.
 
-    This pins the Change 1 backfill contract: without it, the first pass after
-    deploy would re-deliver stale resume turns into long-finished threads (the
-    worker done-marker's 24h TTL means an old wake is re-delivered, not absorbed).
+    This pins the reconciler-level steady-state contract only: a row that
+    already carries ``resumed_at`` -- whoever set it, migration 0011 (#411),
+    migration 0012 (#418), or the runtime -- is never re-woken, because
+    ``list_resolved_unresumed`` filters on ``resumed_at IS NULL``. That contract
+    is what makes settling history sufficient; without it, the first pass after
+    deploy would re-deliver stale wakes into long-finished threads (past the
+    worker done-marker's 24h TTL an old wake is re-delivered, not absorbed, so it
+    steers a thread that already moved on).
+
+    It does NOT verify either migration's WHERE clause: the rows here are
+    hand-inserted already carrying ``resumed_at``, so deleting a migration leaves
+    this test green. The 24h window is verified separately against a disposable
+    database.
     """
 
     async def steps(
@@ -288,6 +374,14 @@ def test_reconciler_ignores_backfilled_historical_row(
             resolved_at=resolved,
             resumed_at=resolved,
         )
+        # The exact shape migration 0012 produces for a historical expired row.
+        await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.expired,
+            resolved_at=resolved,
+            resumed_at=resolved,
+            resolved_by=None,
+        )
         reconciler = ResumeReconciler(
             sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
         )
@@ -297,6 +391,58 @@ def test_reconciler_ignores_backfilled_historical_row(
 
     assert count == 0
     assert valkey.xrange(runs_stream) == []
+
+
+def test_reconciler_grace_applies_to_expired_rows(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """The grace horizon guards expired rows exactly as it guards resolved ones.
+
+    Grace is what keeps the reconciler from racing an inline enqueue that is
+    still being consumed: it must exceed the worker's max turn duration. For an
+    expired row the horizon keys off the ``resolved_at`` the expiry CAS stamps at
+    flip time, so a freshly expired record whose sweeper-delivered wake is still
+    in flight is skipped, and only a genuinely stale one is re-enqueued. A
+    work-list that special-cased expired rows out of the grace filter would pass
+    every other test here and fail this one.
+    """
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[int, int, datetime | None]:
+        approval_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.expired,
+            resolved_at=_naive(0),
+            resumed_at=None,
+            resolved_by=None,
+        )
+        within = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=3600, batch_limit=100
+        )
+        count_within = await within.reconcile_once()
+
+        # Backdate the expiry well past the grace horizon.
+        async with sessionmaker() as session:
+            await session.execute(
+                update(Approval)
+                .where(Approval.id == approval_id)
+                .values(resolved_at=_naive(7200))
+            )
+            await session.commit()
+
+        past = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=3600, batch_limit=100
+        )
+        count_past = await past.reconcile_once()
+        return count_within, count_past, await _resumed_at(sessionmaker, approval_id)
+
+    count_within, count_past, resumed_at = _run_async(steps, runs_stream)
+
+    assert count_within == 0
+    assert count_past == 1
+    assert len(valkey.xrange(runs_stream)) == 1
+    assert resumed_at is not None
 
 
 def test_reconciler_respects_grace_window(


### PR DESCRIPTION
#412 made expired approvals resumable, but #411's resume reconciler still excluded `expired` from `_RESUMABLE_STATUSES`. That premise is now stale, and the consequence is asymmetric durability: a resolved wake whose enqueue fails is retried, while an expiry wake whose enqueue fails (a Valkey blip, or a pod shutdown between the flip and the enqueue) is dropped for good, since the flipped record is no longer re-selected by `list_expired_pending_approvals`.

## What changed

- `expired` joins `_RESUMABLE_STATUSES`, so the candidate finder and the `FOR UPDATE SKIP LOCKED` claim both cover it from the one shared tuple. Both guards carry over with no new code: the claim widens automatically, and the 900s grace applies unchanged because `expire_approval` stamps `resolved_at` at flip time, which is what the grace filter keys off.
- A `resume_turn_for` selector in `resumequeue.py` maps status to builder, so the reconciler cannot wake an expired row with the human-decision text. It lives beside the builders and the event-id invariant; the three inline call sites keep naming their builder directly, since each just performed the CAS that established its status.
- `resumed_at` is marked after a successful enqueue on both expiry paths (`sweeper.sweep_expired_approvals` and the resolve-path expiry branch), following the enqueue-first-then-mark convention so a failed enqueue is retried rather than lost. The 410 is never converted to a 500.
- Migration 0012 settles historical expired rows past the 24h done-marker window. Without it, widening the tuple would make every historical expired row a candidate and the first pass after deploy would mass-wake long-finished threads. The window mirrors 0011's reasoning: rows expired within 24h are the recoverable victims this fix exists to deliver.

The shared `resume_event_id` is not relied on for mid-turn dedupe anywhere, per the issue's gotcha.

## Verification

Migration 0012 was verified against a disposable Postgres (never the shared compose DB): rows past 24h settle, a 23h59m row stays recoverable, already-marked and non-expired rows are untouched, and the statement is idempotent on re-run.

Closes #418