### PR TITLE
Unfuse the approval approver set from the route's channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,18 @@ VALKEY_PASSWORD=valkeypass
 # the worker's Slack stub, then start the stack with `--profile full --profile
 # slack` (brings up the optional agentos-dispatcher). See README "Connect a real
 # Slack workspace".
+# Approval routes that name a user-group approver set also need SLACK_BOT_TOKEN
+# visible to the API service (compose forwards it to agentos-api), because the
+# API looks up the group's membership itself at resolve time instead of trusting
+# a caller-asserted claim. That lookup needs the `usergroups:read` bot scope, so
+# an existing Slack app must add the scope and be reinstalled to the workspace.
+# Without the token or the scope, a route with a declared approver group fails
+# closed (the click is rejected); channel and explicit-user-list approvers are
+# unaffected.
+# How long (seconds) the API reuses a group's fetched member set. Defaults to 60.
+# Within that window a member revoked from the group can still approve; set 0 to
+# look the group up on every resolve and close that lag, at the cost of Slack
+# Tier 2 rate-limit headroom (a rate limit then denies a legitimate approver).
+# Leave this unset rather than empty: the value is numeric and an empty string
+# stops the API from booting.
+# SLACK_USERGROUP_CACHE_TTL_S=60

--- a/apps/api/alembic/versions/0013_approval_audit_evidence.py
+++ b/apps/api/alembic/versions/0013_approval_audit_evidence.py
@@ -1,0 +1,38 @@
+"""approval audit membership evidence (#420, ADR-0010)
+
+Adds approval_audit_entries.evidence: the membership facts the authorizer
+decided on, so the trail answers "why did this actor count" and not merely
+"which implementation refused them". Nullable and additive: writers that make no
+membership decision (the expiry sweeper) leave it NULL, and rows written before
+this column read back as NULL rather than being backfilled with a verdict
+nobody actually made.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-07-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0013"
+down_revision: str | None = "0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "agentos"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "approval_audit_entries",
+        sa.Column("evidence", postgresql.JSONB(), nullable=True),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("approval_audit_entries", "evidence", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -245,6 +245,39 @@
         "title": "AppConfig",
         "type": "object"
       },
+      "ApprovalApprovers": {
+        "additionalProperties": false,
+        "description": "WHO may resolve a route's approvals (#420), as opposed to the binding's\n``channel``, which is only WHERE the card posts.\n\nDeclaring an approvers block is what lets a request sit in a broad channel\nwhere everyone can see it while only a narrow set may act on it. Omitting it\nkeeps the zero-setup default: the card channel's members are the approvers.",
+        "properties": {
+          "group": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group"
+          },
+          "users": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Users"
+          }
+        },
+        "title": "ApprovalApprovers",
+        "type": "object"
+      },
       "ApprovalAuditOut": {
         "description": "One audit entry (#247): who attempted what, and the authorizer snapshot\nthat counted (or refused) them.",
         "properties": {
@@ -289,6 +322,18 @@
             "title": "Decision",
             "type": "string"
           },
+          "evidence": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evidence"
+          },
           "id": {
             "format": "uuid",
             "title": "Id",
@@ -316,6 +361,7 @@
           "authorizer",
           "authorized",
           "reason",
+          "evidence",
           "created_at"
         ],
         "title": "ApprovalAuditOut",
@@ -624,8 +670,19 @@
         "type": "object"
       },
       "ApprovalRouteBinding": {
-        "description": "One workspace binding for a manifest-declared approval route (#247):\nthe Slack channel whose members are that route's approvers (under the\nchannel-membership authorizer).",
+        "additionalProperties": false,
+        "description": "One workspace binding for a manifest-declared approval route (#247):\nthe Slack channel whose members are that route's approvers (under the\nchannel-membership authorizer), and optionally the ``approvers`` block that\nnarrows WHO may act (#420), leaving ``channel`` to mean only WHERE the card\nposts.",
         "properties": {
+          "approvers": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ApprovalApprovers"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "channel": {
             "title": "Channel",
             "type": "string"
@@ -4342,7 +4399,7 @@
     },
     "/approvals/{approval_id}/resolve": {
       "post": {
-        "description": "Claim the resolution (resolve-once) and wake the suspended session.\n\nThe authorizer runs first, server-side (#246): self-approval is blocked\nand channel membership is checked against the attempt's channel; a denied\nactor gets 403 with the reason. Then exactly one authorized resolver wins\nthe conditional UPDATE; a loser gets 409 naming who resolved it, and a\npast-SLA record flips to expired and returns 410 while still enqueuing the\nexpiry resume turn so the suspended session wakes down its timeout branch.\nThe winner's response is sent only after the resume turn is enqueued.",
+        "description": "Claim the resolution (resolve-once) and wake the suspended session.\n\nThe authorizer runs first, server-side (#246): self-approval is blocked and\nthe route's approvers decide -- an explicit user list, a Slack user group,\nor (declaring none) the card channel's members (#420); a denied actor gets\n403 with the reason. Then exactly one authorized resolver wins\nthe conditional UPDATE; a loser gets 409 naming who resolved it, and a\npast-SLA record flips to expired and returns 410 while still enqueuing the\nexpiry resume turn so the suspended session wakes down its timeout branch.\nThe winner's response is sent only after the resume turn is enqueued.",
         "operationId": "resolve_approval_approvals__approval_id__resolve_post",
         "parameters": [
           {

--- a/apps/api/src/agentos_api/approvers.py
+++ b/apps/api/src/agentos_api/approvers.py
@@ -1,0 +1,162 @@
+"""The approver-set port: who counts as an approver (#420, ADR-0034).
+
+An ``ApproverSet`` answers exactly one question -- is this actor in the set --
+and gets no vote on anything else. That narrowness is the point. Self-approval
+(AC2) is the authorizer's rule, enforced once in ``authorize_approval`` before
+any set is consulted, so a set cannot skip it, forget it, or be safe only by
+accident. The predecessor of this port had three authorizers each promising in a
+docstring to re-check self-approval themselves; a promise is not a mechanism.
+
+Two axes decide an approval today, and they are not symmetrical:
+
+- A set may prove membership from what the caller already presented. Channel
+  membership does this: the click's channel IS the evidence, so it performs no
+  lookup. That is why ``contains`` takes ``actor_channel`` at all.
+- A set may go and find out. A user group does this, and it can fail.
+
+``MembershipVerdict.undetermined`` carries that second case. It is not
+``member=False``: "you are not in the set" and "we could not find out" are
+different facts, they deny for different reasons, and telling a clicker the
+first when the second is true sends them arguing with policy over an outage.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .models import Approval
+
+# The audit vocabulary is FROZEN, and each set pins its own ``audit_name`` to the
+# class name it had before ADR-0034 turned it from an authorizer into a set. The
+# strings therefore read oddly now ("...Authorizer" naming a set), and that is
+# the trade: `approval_audit.authorizer` is append-only history, rows already on
+# main carry these values, and renaming the vocabulary mid-stream would make
+# every old row lie about what decided. New vocabulary needs a new column, not a
+# redefinition of this one.
+
+
+@dataclass(frozen=True)
+class MembershipVerdict:
+    """A set's answer about one actor.
+
+    ``undetermined=True`` means the set could not establish membership at all;
+    ``member`` is then meaningless and the authorizer fails closed. ``reason``
+    is rendered to the clicker, so it is the set's job: only the set knows
+    whether it refused on a list, a group, or a channel. ``evidence`` is the
+    snapshot the audit row stores.
+    """
+
+    member: bool
+    undetermined: bool = False
+    reason: str = ""
+    evidence: dict[str, Any] | None = None
+
+
+class ApproverSet(Protocol):
+    """The set of actors permitted to resolve one approval.
+
+    ``audit_name`` is the string the audit row's ``authorizer`` column records.
+    ``contains`` is async because a set may perform its own lookup; the ones that
+    do not simply never await.
+    """
+
+    @property
+    def audit_name(self) -> str: ...
+
+    async def contains(
+        self, actor: str, actor_channel: str | None
+    ) -> MembershipVerdict: ...
+
+
+class ExplicitUsers:
+    """A literal allowlist of user IDs (#420): the only provider-neutral set.
+
+    Pure config, so it decides while every upstream is unreachable, and it can
+    never report ``undetermined``. The click channel plays no part -- that is the
+    whole point of unfusing authority from card location -- so a listed approver
+    may resolve from anywhere and an unlisted one may not, however deep in the
+    card's channel they are standing.
+    """
+
+    # Frozen; see the audit-vocabulary note above.
+    audit_name = "ExplicitUserListAuthorizer"
+
+    def __init__(self, users: Sequence[str]) -> None:
+        self._users = tuple(users)
+
+    async def contains(
+        self, actor: str, actor_channel: str | None
+    ) -> MembershipVerdict:
+        listed = actor in self._users
+        evidence: dict[str, Any] = {
+            "kind": "user_list",
+            "users": list(self._users),
+            "actor_listed": listed,
+        }
+        if not listed:
+            return MembershipVerdict(
+                member=False,
+                reason=(
+                    "you are not an approver: this approval's route is bound to "
+                    "an explicit list of approvers"
+                ),
+                evidence=evidence,
+            )
+        return MembershipVerdict(member=True, evidence=evidence)
+
+
+class InvalidApprovers:
+    """A declared approvers block the platform cannot read: a set admitting nobody.
+
+    Modelling this as a set rather than a special path is what keeps the
+    authorizer free of one. An unreadable block is not the absence of policy, it
+    is policy nothing can evaluate, so it can determine nothing and admits
+    nobody. That is exactly ``undetermined``, and the authorizer's existing
+    fail-closed rule then denies it without knowing this set exists.
+
+    Failing closed here is the point: falling back to channel membership would
+    widen the approver set to everyone in the card's channel, the opposite of
+    what the binding was trying to say.
+    """
+
+    # Frozen; see the audit-vocabulary note above. Never was a class name, but it
+    # ships in rows #420 wrote, so it is vocabulary all the same.
+    audit_name = "InvalidApproversSpec"
+
+    def __init__(self, error: str) -> None:
+        self._error = error
+
+    async def contains(
+        self, actor: str, actor_channel: str | None
+    ) -> MembershipVerdict:
+        return MembershipVerdict(
+            member=False,
+            undetermined=True,
+            reason=(
+                "could not verify approvers: this approval's route declares an "
+                "approvers block the platform cannot read"
+            ),
+            evidence={"kind": "approvers_config", "error": self._error},
+        )
+
+
+class ApproverSetSelector(Protocol):
+    """Pick the approver set an approval's route binding calls for.
+
+    Performs no I/O: a set that needs a lookup does it in ``contains``, which is
+    what lets the authorizer refuse a self-approval before anything is fetched.
+    Never raises -- an unreadable block is an ``InvalidApprovers`` set, not an
+    error, so every binding maps to a set and the authorizer has one code path.
+
+    Implementations are provider-aware by nature: selection reads the binding
+    schema, and that schema is the provider's shape. That is why they live on the
+    provider's side of this port and not with the authorizer.
+
+    ``binding`` is ``Any`` because it is a raw JSONB value read straight from the
+    route map: an implementation narrows it itself and fails a non-object closed
+    rather than trusting it to be a mapping.
+    """
+
+    def __call__(self, approval: Approval, binding: Any) -> ApproverSet: ...

--- a/apps/api/src/agentos_api/authorizer.py
+++ b/apps/api/src/agentos_api/authorizer.py
@@ -1,4 +1,4 @@
-"""The approval authorizer: who may resolve a pending approval (#246, ADR-0010).
+"""The approval authorizer: who may resolve a pending approval (#246, #420).
 
 This is the seam docs/interfaces/approval/INTERFACE.md calls the black line: a
 server-side decision, at resolution time, of whether a given actor is allowed
@@ -6,71 +6,93 @@ to resolve a given pending approval. It runs HERE, on the server that owns the
 durable ``Approval`` record, so it cannot be spoofed from inside the agent's
 sandbox -- the runner and the bundle never participate in the decision.
 
-The ``Authorizer`` protocol is the swappable interface; implementations planned
-by the epic are channel membership (this module), user-group, explicit
-user-list, and platform RBAC. The first implementation's membership evidence is
-the card click itself: the worker routes the approval card into the approval's
-channel, Slack only renders (and accepts clicks on) that message for members of
-that channel, and the click reaches the platform over the dispatcher's
-authenticated Socket Mode connection. The dispatcher relays the click's channel
-as ``actor_channel``; matching it against the record's channel is therefore a
-channel-membership proof for Slack-originated resolutions. Callers that are not
-the dispatcher (an operator's curl, the CLI) authenticate with the platform API
-key and assert the channel explicitly.
+This module is pure policy. It knows nothing about chat providers, route
+bindings, or how an approver set is chosen: it is handed an
+``approvers.ApproverSet``, which answers only "is this actor in the set", and it
+applies every rule that is not membership. There is ONE authorizer, and the
+swappable part is the set behind it (ADR-0034).
 
-Self-approval is blocked unconditionally: the actor who authored the turn that
-raised the request may not resolve it, whatever channel they click from.
+Self-approval is the rule that matters, and it is why the split is shaped this
+way. The actor who authored the turn that raised the request may not resolve it,
+whatever channel they click from, under every set, and a set is never asked. That
+makes AC2 structural: no set can skip the check, because no set participates in
+it. The predecessor of this design had three authorizers each promising in a
+docstring to re-check self-approval themselves, which is a convention, not a
+mechanism.
+
+Fail closed: a set that could not determine membership (a lookup that failed, a
+binding the platform cannot read) denies. That is the set reporting
+``undetermined``, and it stays distinct from reporting that the actor is not a
+member -- a config or infrastructure error must not be rendered to a clicker as
+policy, and must never widen an approver set an operator narrowed.
+
+Each decision carries the evidence that produced it, so the audit row records
+the authority that counted rather than only the actor. One honest limit on that
+evidence: it proves the ASSERTED identity satisfied policy at click time, not
+who actually clicked (the ADR-0033 residual, tracked separately).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any
 
+from .approvers import ApproverSet
 from .models import Approval
+
+# The one wording for a self-approval refusal, so the dispatcher's rendering of
+# it does not depend on which set the approval happened to be bound to.
+_SELF_APPROVAL_REASON = (
+    "self-approval is blocked: the requester cannot resolve their own request"
+)
 
 
 @dataclass(frozen=True)
 class AuthzDecision:
-    """The verdict plus the human-readable reason rendered to the clicker."""
+    """The verdict, the human-readable reason rendered to the clicker, and the
+    membership facts that decided it (#420), which the audit row stores so the
+    trail records the authority that counted rather than only the actor."""
 
     allowed: bool
     reason: str = ""
+    evidence: dict[str, Any] | None = None
 
 
-class Authorizer(Protocol):
-    """Decide whether ``actor`` may resolve ``approval`` (server-side, at
-    resolution time). ``actor_channel`` is the channel the resolution attempt
-    was made from (the card click's channel), or None when the caller supplied
-    no channel evidence."""
+async def authorize_approval(
+    approval: Approval,
+    actor: str,
+    actor_channel: str | None,
+    *,
+    approver_set: ApproverSet,
+) -> tuple[str, AuthzDecision]:
+    """Decide whether ``actor`` may resolve ``approval``, and name what decided
+    (for the audit row).
 
-    def authorize(
-        self, approval: Approval, actor: str, actor_channel: str | None
-    ) -> AuthzDecision: ...
+    ``approver_set`` is the set this approval's route binding calls for, already
+    chosen by an ``approvers.ApproverSetSelector``. Every binding maps to some
+    set, including one the platform could not read, so there is no second path
+    through here.
 
-
-class ChannelMembershipAuthorizer:
-    """First authorizer: the approval's channel members may resolve it.
-
-    Membership evidence is the click channel (see the module docstring): an
-    attempt is allowed only when it comes from the channel the approval card
-    was routed to -- ``card_channel`` when a route binding placed the card
-    (#247), else the requesting channel -- and never from the requester
-    themselves.
+    The order is the contract: refuse self-approval BEFORE asking the set. Since
+    selection does no I/O and a set only fetches inside ``contains``, that means a
+    self-attempt spends no rate-limit budget and cannot be used to probe who is in
+    a group.
     """
 
-    def authorize(
-        self, approval: Approval, actor: str, actor_channel: str | None
-    ) -> AuthzDecision:
-        if actor == approval.author:
-            return AuthzDecision(
-                allowed=False,
-                reason="self-approval is blocked: the requester cannot resolve their own request",
-            )
-        approvers_channel = approval.card_channel or approval.reply_channel
-        if actor_channel != approvers_channel:
-            return AuthzDecision(
-                allowed=False,
-                reason="you are not an approver: resolve this from the approval's channel",
-            )
-        return AuthzDecision(allowed=True)
+    name = approver_set.audit_name
+
+    if actor == approval.author:
+        # Named after the set that would have decided, but carrying no evidence:
+        # the set never ran, and recording its snapshot next to this denial would
+        # imply membership was what refused.
+        return name, AuthzDecision(allowed=False, reason=_SELF_APPROVAL_REASON)
+
+    verdict = await approver_set.contains(actor, actor_channel)
+    if verdict.undetermined or not verdict.member:
+        # Both refuse, and the set says why: it is the only one that knows
+        # whether it could not determine membership or the actor is genuinely
+        # outside the set.
+        return name, AuthzDecision(
+            allowed=False, reason=verdict.reason, evidence=verdict.evidence
+        )
+    return name, AuthzDecision(allowed=True, evidence=verdict.evidence)

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -107,6 +107,22 @@ class Settings(BaseSettings):
     resume_reconciler_grace_seconds: int = 900
     resume_reconciler_batch_limit: int = 100
 
+    # The Slack bot token the API uses for its OWN user-group lookups (#420),
+    # rather than trusting a caller's claim about who is in a group. The same
+    # token the dispatcher and worker already hold; empty is the normal state
+    # for a Slack-free install. Empty does NOT relax anything: a route that
+    # declares an approvers group then fails closed at resolve time, while
+    # channel and user-list authorizers are unaffected. Left out of the #57 prod
+    # boot gate deliberately -- Slack is optional, and that resolve-time denial
+    # is the enforcement.
+    slack_bot_token: str = ""
+    # How long a fetched user-group member set is reused (#420).
+    # usergroups.users.list is a Slack Tier 2 method (~20 req/min), so a fetch
+    # per click would let a busy approval channel hit the rate limit; 60s of
+    # revocation lag against an hours-to-days human flow is negligible. 0 is the
+    # operator lever for a per-resolve fetch, trading that headroom for no lag.
+    slack_usergroup_cache_ttl_s: float = 60.0
+
     # Observability (OB1). kube_config_path points the runner-logs proxy at a
     # cluster; when unset the API tries in-cluster config, and if neither is
     # available the logs endpoint degrades to 503 rather than crashing.

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -336,6 +336,37 @@ async def get_approval(session: AsyncSession, approval_id: uuid.UUID) -> Approva
     return await session.get(Approval, approval_id)
 
 
+async def get_approval_route_binding(
+    session: AsyncSession, approval: Approval
+) -> Any:
+    """The route binding governing ``approval``, read fresh at resolve time
+    (#420), or None when there is none to read.
+
+    Read fresh rather than snapshotted at creation: approvals pend for hours to
+    days, and evaluating against current policy means removing someone from the
+    approver group revokes them immediately instead of leaving them able to
+    resolve yesterday's stale request.
+
+    None covers every legitimate miss -- a generic approval with no agent
+    (``agent_id`` is nullable by design), an approval with no route, an agent
+    with no bindings, a route the map does not bind -- and each of them means
+    "no approvers declared", which is channel membership by design (AC4), not a
+    failure.
+
+    A present-but-non-dict value is NOT one of those misses, so it is returned
+    raw (the JSONB value can be anything) rather than coerced to None: the
+    selector fails a malformed binding closed, the same as a malformed
+    ``approvers`` block, instead of widening it to card-channel membership.
+    """
+
+    if approval.agent_id is None or not approval.route:
+        return None
+    agent = await get_agent(session, approval.agent_id)
+    if agent is None or not isinstance(agent.approval_routes, dict):
+        return None
+    return agent.approval_routes.get(approval.route)
+
+
 async def get_approval_by_dedupe_key(
     session: AsyncSession, dedupe_key: str
 ) -> Approval | None:
@@ -547,8 +578,13 @@ async def append_approval_audit(
     authorizer: str,
     authorized: bool,
     reason: str | None,
+    evidence: dict[str, Any] | None = None,
 ) -> ApprovalAuditEntry:
-    """Append one audit row (#247). Append-only by design; never updated."""
+    """Append one audit row (#247). Append-only by design; never updated.
+
+    ``evidence`` (#420) is the membership snapshot the authorizer decided on;
+    None for writers that made no membership decision.
+    """
 
     entry = ApprovalAuditEntry(
         approval_id=approval_id,
@@ -559,6 +595,7 @@ async def append_approval_audit(
         authorizer=authorizer,
         authorized=authorized,
         reason=reason,
+        evidence=evidence,
     )
     session.add(entry)
     await session.commit()

--- a/apps/api/src/agentos_api/deps.py
+++ b/apps/api/src/agentos_api/deps.py
@@ -6,6 +6,7 @@ from typing import Annotated
 from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from .approvers import ApproverSetSelector
 from .evalqueue import EvalQueue
 from .github_checks import GitHubStatusReporter
 from .k8s import PodLister, PodLogReader
@@ -61,6 +62,17 @@ def get_resume_queue(request: Request) -> ResumeQueue:
     return resume_queue
 
 
+def get_approver_sets(request: Request) -> ApproverSetSelector:
+    """Picks the approver set a route binding calls for (#420).
+
+    Always present: which provider's selector was wired is main's decision, and
+    a deployment with no bot token still selects sets, it just cannot resolve a
+    group's membership when one is asked for."""
+
+    selector: ApproverSetSelector = request.app.state.approver_sets
+    return selector
+
+
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 LangfuseDep = Annotated[LangfuseClient, Depends(get_langfuse)]
 StoreDep = Annotated[ObjectStore, Depends(get_store)]
@@ -70,3 +82,4 @@ KillSwitchDep = Annotated[KillSwitch, Depends(get_kill_switch)]
 EvalQueueDep = Annotated[EvalQueue, Depends(get_eval_queue)]
 GitHubReporterDep = Annotated[GitHubStatusReporter, Depends(get_github_reporter)]
 ResumeQueueDep = Annotated[ResumeQueue, Depends(get_resume_queue)]
+ApproverSetSelectorDep = Annotated[ApproverSetSelector, Depends(get_approver_sets)]

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -35,6 +35,8 @@ from .routers import (
     runs,
     state,
 )
+from .slack_approvers import SlackApproverSetSelector
+from .slack_usergroups import SlackUserGroupClient
 from .storage import BundleStore
 from .sweeper import run_expiry_sweeper
 
@@ -61,6 +63,23 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.kill_switch = KillSwitch(valkey)
     app.state.eval_queue = EvalQueue(valkey)
     app.state.resume_queue = ResumeQueue(valkey, stream=settings.runs_stream)
+    # The composition root for approvals (#420, ADR-0034): the only place that
+    # names Slack to build the approver-set selector, so the authorizer and the
+    # resolve endpoint depend on ports rather than on a provider. The usergroup
+    # client shares the app's httpx client and is None when no bot token is
+    # configured, which is the normal Slack-free deployment -- a route that
+    # declares an approvers group then fails closed at resolve time rather than
+    # silently widening.
+    usergroups = (
+        SlackUserGroupClient(
+            http_client,
+            token=settings.slack_bot_token,
+            ttl_s=settings.slack_usergroup_cache_ttl_s,
+        )
+        if settings.slack_bot_token
+        else None
+    )
+    app.state.approver_sets = SlackApproverSetSelector(usergroups)
     app.state.github_reporter = GitHubStatusReporter(
         http_client,
         api_url=settings.github_api_url,

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -225,6 +225,12 @@ class ApprovalAuditEntry(Base):
     authorizer: Mapped[str]
     authorized: Mapped[bool]
     reason: Mapped[str | None] = mapped_column(default=None)
+    # The membership facts the authorizer decided on (#420): the group ID and
+    # the actor's verdict, the allowlist that counted, or the channels compared.
+    # Nullable because writers that make no membership decision (the expiry
+    # sweeper) must leave it NULL rather than fabricate one, and because rows
+    # written before this column existed have none.
+    evidence: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
 
 

--- a/apps/api/src/agentos_api/routers/approvals.py
+++ b/apps/api/src/agentos_api/routers/approvals.py
@@ -22,9 +22,9 @@ from sqlalchemy.exc import IntegrityError
 
 from .. import crud
 from ..auth import require_api_key
-from ..authorizer import Authorizer, ChannelMembershipAuthorizer
+from ..authorizer import authorize_approval
 from ..config import get_settings
-from ..deps import ResumeQueueDep, SessionDep
+from ..deps import ApproverSetSelectorDep, ResumeQueueDep, SessionDep
 from ..models import Approval, ApprovalStatus
 from ..resumequeue import build_expiry_resume_turn, build_resume_turn
 from ..schemas import ApprovalAuditOut, ApprovalCreate, ApprovalOut, ApprovalResolve
@@ -34,12 +34,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/approvals", tags=["approvals"], dependencies=[Depends(require_api_key)]
 )
-
-# The server-side authorizer (#246): channel membership is the first
-# implementation of the swappable Authorizer seam (user-group, user-list, and
-# platform-RBAC come later); it is module-level state because the decision is
-# pure over the record and the attempt.
-_AUTHORIZER: Authorizer = ChannelMembershipAuthorizer()
 
 
 def _expired(approval: Approval) -> bool:
@@ -123,12 +117,14 @@ async def resolve_approval(
     data: ApprovalResolve,
     session: SessionDep,
     resume_queue: ResumeQueueDep,
+    approver_sets: ApproverSetSelectorDep,
 ) -> ApprovalOut:
     """Claim the resolution (resolve-once) and wake the suspended session.
 
-    The authorizer runs first, server-side (#246): self-approval is blocked
-    and channel membership is checked against the attempt's channel; a denied
-    actor gets 403 with the reason. Then exactly one authorized resolver wins
+    The authorizer runs first, server-side (#246): self-approval is blocked and
+    the route's approvers decide -- an explicit user list, a Slack user group,
+    or (declaring none) the card channel's members (#420); a denied actor gets
+    403 with the reason. Then exactly one authorized resolver wins
     the conditional UPDATE; a loser gets 409 naming who resolved it, and a
     past-SLA record flips to expired and returns 410 while still enqueuing the
     expiry resume turn so the suspended session wakes down its timeout branch.
@@ -139,12 +135,29 @@ async def resolve_approval(
     if approval is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
 
-    authorizer_name = type(_AUTHORIZER).__name__
-    decision = _AUTHORIZER.authorize(approval, data.resolved_by, data.actor_channel)
+    # The route binding is read fresh at resolve time (#420), so revoking an
+    # approver takes effect on the next click rather than at the next restart.
+    binding = await crud.get_approval_route_binding(session, approval)
+    approver_set = approver_sets(approval, binding)
+    # Release the pooled DB connection before the membership lookup. A
+    # group-bound set performs a Slack HTTP call (up to the client timeout), and
+    # holding the read transaction's connection across it lets a Slack outage
+    # plus concurrent clicks exhaust the pool and stall unrelated routes (#420).
+    # The reads above are complete; expire_on_commit is False (create_sessionmaker)
+    # so `approval` stays usable, and the CAS/audit below check out a fresh
+    # connection, each committing itself as they already do.
+    await session.commit()
+    authorizer_name, decision = await authorize_approval(
+        approval,
+        data.resolved_by,
+        data.actor_channel,
+        approver_set=approver_set,
+    )
 
     async def _audit(action: str, *, authorized: bool, reason: str | None) -> None:
         # The audit log (#247): every authorization-relevant event, with the
-        # authorizer snapshot that counted (or refused) the actor.
+        # authorizer snapshot that counted (or refused) the actor, and the
+        # membership evidence it decided on (#420).
         await crud.append_approval_audit(
             session,
             approval_id=approval_id,
@@ -155,6 +168,7 @@ async def resolve_approval(
             authorizer=authorizer_name,
             authorized=authorized,
             reason=reason,
+            evidence=decision.evidence,
         )
 
     if not decision.allowed:

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -5,7 +5,15 @@ import uuid
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializerFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 from .models import Environment
 
@@ -15,6 +23,12 @@ from .models import Environment
 # also rejects bare names ("general"), pasted URLs, and lowercase IDs -- none of
 # which the worker can route on.
 _SLACK_CHANNEL_ID = re.compile(r"^[CDG][A-Z0-9]{7,}$")
+# Slack user-group (subteam) IDs start with S; user IDs start with U, or W for
+# enterprise-grid users. Same allowlist discipline and same reason as channels:
+# a @handle or a bare name never resolves, and the S/C prefix is the whole
+# distinction between a user group and a channel.
+_SLACK_USERGROUP_ID = re.compile(r"^S[A-Z0-9]{7,}$")
+_SLACK_USER_ID = re.compile(r"^[UW][A-Z0-9]{7,}$")
 
 
 def _validate_slack_channel_id(value: str | None) -> str | None:
@@ -136,12 +150,113 @@ def _validate_tool_names(value: list[str] | None) -> list[str] | None:
     return cleaned
 
 
-class ApprovalRouteBinding(BaseModel):
+class _StoredWithoutNulls(BaseModel):
+    """Serializes to the stored-JSONB shape: unset keys are absent, not null.
+
+    Route bindings are dumped straight into ``agents.approval_routes`` by every
+    persist site, and a plain dump would rewrite every pre-#420 binding with an
+    ``approvers: null`` sibling (and every group-only approvers block with a
+    ``users: null`` one) on the next write. Making that an invariant of the
+    models themselves, rather than asking each caller for ``exclude_none=True``,
+    keeps the stored shape from depending on every writer remembering.
+
+    Tripwire for a future reader: subclasses are validation-side only today
+    (request bodies), which is why the committed ``openapi.json`` carries one
+    schema each. Using one in a RESPONSE model would make FastAPI split it into
+    ``-Input``/``-Output`` variants, because the wrap serializer above makes the
+    dumped shape differ from the validated one.
+    """
+
+    @model_serializer(mode="wrap")
+    def _dump_without_nulls(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> dict[str, Any]:
+        return {k: v for k, v in handler(self).items() if v is not None}
+
+
+class ApprovalApprovers(_StoredWithoutNulls):
+    """WHO may resolve a route's approvals (#420), as opposed to the binding's
+    ``channel``, which is only WHERE the card posts.
+
+    Declaring an approvers block is what lets a request sit in a broad channel
+    where everyone can see it while only a narrow set may act on it. Omitting it
+    keeps the zero-setup default: the card channel's members are the approvers.
+    """
+
+    # A typo in an optional key must not be ignored: silently dropping it would
+    # leave no approvers block at read time, falling the route back to channel
+    # membership and widening the approver set the operator meant to narrow.
+    model_config = ConfigDict(extra="forbid")
+
+    # A Slack user group whose current members are the approvers. Membership is
+    # resolved by the API against Slack at resolve time, never asserted by the
+    # caller. Ignored when ``users`` is set.
+    group: str | None = None
+    # An explicit allowlist of Slack user IDs. Takes precedence over ``group``
+    # (issue #420 settles the precedence rather than refusing the combination),
+    # and needs no Slack lookup at all.
+    users: list[str] | None = None
+
+    @field_validator("group")
+    @classmethod
+    def _check_group(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        if not _SLACK_USERGROUP_ID.match(value):
+            raise ValueError(
+                f"approvers group {value!r} is not a Slack user-group ID: pass "
+                "the ID (e.g. S0123ABCD), not a @handle or a name -- a handle "
+                "never resolves, and a C-prefixed value is a channel, not a "
+                "user group. Find it via the usergroups.list API."
+            )
+        return value
+
+    @field_validator("users")
+    @classmethod
+    def _check_users(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return value
+        if not value:
+            # Neither "unset" (omit the key) nor "nobody may approve": as silent
+            # config the latter is a footgun, since the approval could then only
+            # ever expire.
+            raise ValueError(
+                "approvers users, when present, must contain at least one user ID"
+            )
+        for user in value:
+            if not _SLACK_USER_ID.match(user):
+                raise ValueError(
+                    f"approvers user {user!r} is not a Slack user ID: pass the "
+                    "ID (e.g. U0123ABCD, or W0123ABCD on enterprise grid), not "
+                    "a @handle or a display name."
+                )
+        return value
+
+    @model_validator(mode="after")
+    def _check_not_empty(self) -> "ApprovalApprovers":
+        if self.group is None and self.users is None:
+            raise ValueError(
+                "approvers must declare at least one of group or users; omit "
+                "the approvers block entirely to keep channel membership"
+            )
+        return self
+
+
+class ApprovalRouteBinding(_StoredWithoutNulls):
     """One workspace binding for a manifest-declared approval route (#247):
     the Slack channel whose members are that route's approvers (under the
-    channel-membership authorizer)."""
+    channel-membership authorizer), and optionally the ``approvers`` block that
+    narrows WHO may act (#420), leaving ``channel`` to mean only WHERE the card
+    posts.
+    """
+
+    # Rejects a typo'd ``approver`` rather than storing a channel-only binding
+    # the operator believes narrows authority. Pre-#420 bindings are
+    # ``{"channel": ...}`` only, so forbidding extras does not reject them.
+    model_config = ConfigDict(extra="forbid")
 
     channel: str
+    approvers: ApprovalApprovers | None = None
 
     _check_channel = field_validator("channel")(_validate_slack_channel_id)
 
@@ -388,6 +503,11 @@ class ApprovalAuditOut(BaseModel):
     authorizer: str
     authorized: bool
     reason: str | None
+    # The membership facts that decided it (#420): the group and the actor's
+    # verdict, the allowlist that counted, or the channels compared. NULL for
+    # writers that made no membership decision (the expiry sweeper) and for rows
+    # written before the column existed.
+    evidence: dict[str, Any] | None
     created_at: datetime
 
 

--- a/apps/api/src/agentos_api/slack_approvers.py
+++ b/apps/api/src/agentos_api/slack_approvers.py
@@ -1,0 +1,220 @@
+"""Slack's two approver sets, and the selector that reads a binding (#420, ADR-0034).
+
+Both of Slack's ways of saying "who is authorized" live here: everyone in this
+room, and everyone on this list Slack maintains. They look like different kinds
+of thing -- one is where the card posted, the other is a real fetch -- but both
+are Slack expressing an approver set, which is why they are two implementations
+of one port rather than an authorizer each. ``approvers.ExplicitUsers`` is the
+only set that owes Slack nothing.
+
+Selection lives here too, and that is not an accident of layering. Reading a
+binding means parsing ``ApprovalApprovers``, whose schema validates ``S...``
+usergroup IDs and ``C...`` channel IDs: the binding format is Slack's shape, so
+the code that reads it is Slack-aware and belongs on this side of the port. That
+is what lets ``authorizer.py`` be pure policy with no Slack in it at all.
+
+The evidence asymmetry is deliberate and worth stating plainly. ``SlackChannelMembers``
+performs no lookup: the click's channel IS the proof, because Slack only renders
+a card (and only accepts clicks on it) for members of the channel it posted in,
+and the dispatcher relays that channel over its authenticated Socket Mode
+connection. ``SlackUserGroupMembers`` has no such free evidence and must ask
+Slack, so it is the only set here that can come back undetermined.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import ValidationError
+
+from .approvers import ApproverSet, ExplicitUsers, InvalidApprovers, MembershipVerdict
+from .models import Approval
+from .schemas import ApprovalApprovers
+from .usergroups import GroupMembershipSource, UserGroupLookupError
+
+
+class SlackChannelMembers:
+    """The card channel's members are the approvers (#246): the zero-setup default.
+
+    Membership is proven by the resolution attempt's channel -- ``card_channel``
+    when a route binding placed the card (#247), else the requesting channel.
+    Callers that are not the dispatcher (an operator's curl, the CLI) authenticate
+    with the platform API key and assert the channel explicitly.
+    """
+
+    # Frozen to the pre-port class name; see the audit-vocabulary note in
+    # authorizer.py.
+    audit_name = "ChannelMembershipAuthorizer"
+
+    def __init__(self, approvers_channel: str | None) -> None:
+        self._approvers_channel = approvers_channel
+
+    async def contains(
+        self, actor: str, actor_channel: str | None
+    ) -> MembershipVerdict:
+        evidence: dict[str, Any] = {
+            "kind": "channel_membership",
+            "approvers_channel": self._approvers_channel,
+            "actor_channel": actor_channel,
+        }
+        if actor_channel != self._approvers_channel:
+            return MembershipVerdict(
+                member=False,
+                reason="you are not an approver: resolve this from the approval's channel",
+                evidence=evidence,
+            )
+        return MembershipVerdict(member=True, evidence=evidence)
+
+
+class SlackUserGroupMembers:
+    """A Slack user group's members are the approvers (#420).
+
+    Owns its lookup: it holds the ``GroupMembershipSource`` port and fetches
+    inside ``contains``, rather than being handed a member set the caller already
+    resolved. ``source`` is None when no bot token is configured, which is a
+    normal Slack-free deployment and not an error -- it simply cannot determine
+    membership, so a route bound to a group fails closed.
+
+    Like the user list, the click channel plays no part.
+    """
+
+    # Frozen to the pre-port class name; see the audit-vocabulary note in
+    # authorizer.py.
+    audit_name = "UserGroupAuthorizer"
+
+    def __init__(self, group_id: str, source: GroupMembershipSource | None) -> None:
+        self._group_id = group_id
+        self._source = source
+
+    async def contains(
+        self, actor: str, actor_channel: str | None
+    ) -> MembershipVerdict:
+        if self._source is None:
+            return self._undetermined("no Slack bot token is configured for the API")
+        try:
+            membership = await self._source.members(self._group_id)
+        except UserGroupLookupError as exc:
+            # The class name, not the message: the message carries the group ID
+            # and upstream text, and this lands in an append-only table.
+            return self._undetermined(type(exc).__name__)
+        in_group = actor in membership.users
+        # The member list itself is deliberately not evidence: a 500-member group
+        # would bloat an append-only table on every click. The group, the actor's
+        # verdict, the size of the set that proved it, and the age of the fetch
+        # are the snapshot.
+        evidence: dict[str, Any] = {
+            "kind": "user_group",
+            "group": self._group_id,
+            "actor_in_group": in_group,
+            "member_count": len(membership.users),
+            "fetched_at": membership.fetched_at.isoformat(),
+            "cache_age_s": membership.cache_age_s,
+        }
+        if not in_group:
+            return MembershipVerdict(
+                member=False,
+                reason=(
+                    "you are not an approver: this approval's route is bound to "
+                    "a Slack user group you are not a member of"
+                ),
+                evidence=evidence,
+            )
+        return MembershipVerdict(member=True, evidence=evidence)
+
+    def _undetermined(self, error: str) -> MembershipVerdict:
+        """No member set, so no verdict: the authorizer fails closed on this.
+
+        Kept distinct from an empty group on purpose. Both refuse, but the
+        clicker needs to know the lookup, not the rule, is what stopped them.
+        """
+
+        return MembershipVerdict(
+            member=False,
+            undetermined=True,
+            reason=(
+                "could not verify approver group membership: this approval's "
+                "route is bound to a Slack user group and the membership "
+                "lookup failed"
+            ),
+            evidence={
+                "kind": "user_group",
+                "group": self._group_id,
+                "lookup_failed": True,
+                "error": error,
+            },
+        )
+
+
+class SlackApproverSetSelector:
+    """Reads a route binding and picks the set it calls for (``ApproverSetSelector``).
+
+    Holds the ``GroupMembershipSource`` so it can hand it to a user-group set;
+    None when no bot token is configured, which is a normal Slack-free deployment
+    (a route bound to a group then fails closed at resolve time).
+    """
+
+    def __init__(self, group_client: GroupMembershipSource | None) -> None:
+        self._group_client = group_client
+
+    def __call__(self, approval: Approval, binding: Any) -> ApproverSet:
+        """Precedence, exactly as issue #420 states it: ``users`` wins over
+        ``group``, which wins over channel membership. No I/O happens here."""
+
+        approvers, spec_error = _parse_approvers(binding)
+        if spec_error is not None:
+            # A spec that does not parse is a config error, not an absence of
+            # policy: falling back to channel membership here would widen the
+            # approver set to everyone in the card's channel -- the opposite of
+            # what the binding was trying to say.
+            return InvalidApprovers(spec_error)
+        if approvers is None:
+            # No approvers declared: the card channel's members are the approvers,
+            # exactly as before #420 (AC4).
+            return SlackChannelMembers(approval.card_channel or approval.reply_channel)
+        if approvers.users:
+            return ExplicitUsers(approvers.users)
+        group = approvers.group
+        if group is None:
+            # Unreachable via the schema, which rejects an approvers block
+            # declaring neither. Written as a branch rather than an assert so it
+            # stays a real refusal: an assert is stripped under `python -O`, and
+            # the line below would then bind a set to a group named None. A block
+            # the platform cannot make sense of denies, exactly as one that does
+            # not parse does.
+            return InvalidApprovers("approvers block declares neither users nor group")
+        return SlackUserGroupMembers(group, self._group_client)
+
+
+def _parse_approvers(
+    binding: Any,
+) -> tuple[ApprovalApprovers | None, str | None]:
+    """Read the binding's approvers block: ``(spec, None)`` when one is declared
+    and parses, ``(None, None)`` when none is declared, ``(None, error)`` when
+    one is declared but does not parse.
+
+    Re-validates the approvers block itself at read time, not the whole
+    binding: malformed approvers content fails closed here rather than becoming
+    an unenforceable binding. A typo'd sibling key (``approver`` for
+    ``approvers``) is caught at write time instead, by the model's
+    ``extra="forbid"``, which is sufficient because the API is the binding's
+    only writer. Absent and null are treated identically -- bindings written
+    before #420 have no key at all.
+
+    A binding that is present but not a JSON object (a hand-edited JSONB row, a
+    future writer bug) fails closed here, distinct from the absent None above: a
+    corrupted binding must not silently widen a route an operator bound to a
+    group down to card-channel membership.
+    """
+
+    if binding is None:
+        return None, None
+    if not isinstance(binding, Mapping):
+        return None, "route binding is not a JSON object"
+    spec = binding.get("approvers")
+    if spec is None:
+        return None, None
+    try:
+        return ApprovalApprovers.model_validate(spec), None
+    except ValidationError as exc:
+        return None, type(exc).__name__

--- a/apps/api/src/agentos_api/slack_usergroups.py
+++ b/apps/api/src/agentos_api/slack_usergroups.py
@@ -1,0 +1,181 @@
+"""The Slack adapter behind the group-membership port (#420, ADR-0010, ADR-0034).
+
+``usergroups.GroupMembershipSource`` is the port and states the contract; this is
+its one implementation, and the only place the API asks Slack who is in a group.
+
+The lookup is one GET against ``usergroups.users.list``, a Slack Tier 2 method
+(~20 requests per minute). A busy approval channel clicks far faster than that,
+so member sets are cached per group for ``ttl_s``; the cost is that a
+revocation takes up to that long to bite, which is negligible against a human
+approval flow measured in hours. The cache alone does not deliver that headroom:
+a burst of clicks on one group would all miss together and fan out one request
+each, so misses for a group are single-flighted: the first caller starts the
+fetch, later callers await that same in-flight fetch, and only one reaches Slack.
+Single-flighting the FETCH rather than the cache entry is what makes that true of
+failures too. Sharing only the cached result coalesces successes and leaves
+failures to run one after another behind the lock that was meant to help,
+turning a Slack outage into N sequential timeouts, which is worse than no
+coalescing at all. Failures are still deliberately NOT cached: caching one Slack
+blip would extend it into a TTL-long outage of every group-bound approval, and
+would keep the fail-closed denial sticky long after Slack came back. The
+in-flight entry is dropped the moment the fetch settles either way, so a later
+caller retries rather than replaying the failure.
+
+Every failure mode -- HTTP error, network error, ``ok: false``, a body without
+a member list -- raises the port's ``UserGroupLookupError``, which is the whole
+of what the port promises: none of them yields a member set, and a lookup that
+produced no member set must never be mistaken for a group with no members.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+import httpx
+
+from .usergroups import (
+    GroupMembershipSource,
+    UserGroupLookupError,
+    UserGroupMembership,
+)
+
+_USERGROUPS_USERS_LIST = "https://slack.com/api/usergroups.users.list"
+
+
+class SlackUserGroupClient:
+    """Reads Slack user-group membership, with a per-group TTL cache.
+
+    The ``httpx.AsyncClient`` is injected so the app can share one client and
+    tests can drive a ``MockTransport``; ``clock`` is injected so the TTL window
+    and the recorded ``fetched_at`` come from one source that tests can crank
+    without sleeping.
+    """
+
+    def __init__(
+        self,
+        http: httpx.AsyncClient,
+        *,
+        token: str,
+        ttl_s: float = 60.0,
+        clock: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        self._http = http
+        self._token = token
+        self._ttl_s = ttl_s
+        self._clock = clock
+        self._cache: dict[str, tuple[datetime, frozenset[str]]] = {}
+        # One in-flight fetch per group, not one global one: a slow lookup of
+        # one group must not stall an unrelated group's approvals behind it. The
+        # map holds only fetches that have not settled yet, so it is bounded by
+        # the number of groups being resolved at this instant.
+        self._inflight: dict[str, asyncio.Task[tuple[datetime, frozenset[str]]]] = {}
+
+    async def members(self, group_id: str) -> UserGroupMembership:
+        """The group's members, cached or freshly fetched.
+
+        Concurrent misses for one group share a single fetch, so a click storm
+        costs one request rather than one per click. That holds whether the
+        fetch succeeds or fails: sharers of a failed fetch all raise, so an
+        outage costs one request and one timeout, not one of each per caller.
+
+        Raises ``UserGroupLookupError`` on every failure mode.
+        """
+
+        cached = self._cached(group_id)
+        if cached is not None:
+            return cached
+        task = self._inflight.get(group_id)
+        # A done task is treated as absent: attaching to one would hand a later
+        # caller a settled result (or a settled cancellation) instead of the
+        # retry it is owed. The finally below pops the entry before the task
+        # settles, so this is belt-and-braces against a leak that would
+        # otherwise poison the group permanently rather than for one fetch.
+        if task is None or task.done():
+            task = asyncio.create_task(self._fetch_shared(group_id))
+            self._inflight[group_id] = task
+        # Shielded: a caller that gives up (its request was cancelled) must not
+        # cancel the fetch the other waiters are still counting on. Sharing an
+        # in-flight fetch is deduplication of one simultaneous request, not a
+        # cache hit, so it is correct under ttl_s <= 0 too: that lever asks for
+        # a fetch per resolve, and these resolves are all riding one fetch that
+        # is happening right now.
+        fetched_at, users = await asyncio.shield(task)
+        return UserGroupMembership(
+            group=group_id, users=users, fetched_at=fetched_at, cache_age_s=0.0
+        )
+
+    async def _fetch_shared(self, group_id: str) -> tuple[datetime, frozenset[str]]:
+        """The single fetch every concurrent caller for this group awaits."""
+
+        try:
+            users = await self._fetch(group_id)
+            # Stamped after Slack answers, not before the request: a stamp taken
+            # up front predates the answer by the request duration, which would
+            # open the TTL window early and overstate the freshness of the
+            # evidence the audit row records.
+            fetched_at = self._clock()
+            self._cache[group_id] = (fetched_at, users)
+            return fetched_at, users
+        finally:
+            # In the coroutine's own finally, not a done callback: this runs
+            # before the task settles, so there is no window in which a fresh
+            # caller could attach to an already-failed fetch and be handed the
+            # failure instead of retrying. Both paths drop the entry, so neither
+            # a success nor a failure leaks one.
+            self._inflight.pop(group_id, None)
+
+    def _cached(self, group_id: str) -> UserGroupMembership | None:
+        """The live cache entry for the group, or None to fetch."""
+
+        # ttl_s <= 0 is the documented per-resolve-fetch lever, so it bypasses
+        # the cache entirely rather than relying on an age comparison a frozen
+        # clock would defeat.
+        if self._ttl_s <= 0:
+            return None
+        entry = self._cache.get(group_id)
+        if entry is None:
+            return None
+        fetched_at, users = entry
+        age_s = (self._clock() - fetched_at).total_seconds()
+        if age_s >= self._ttl_s:
+            return None
+        return UserGroupMembership(
+            group=group_id, users=users, fetched_at=fetched_at, cache_age_s=age_s
+        )
+
+    async def _fetch(self, group_id: str) -> frozenset[str]:
+        try:
+            response = await self._http.get(
+                _USERGROUPS_USERS_LIST,
+                params={"usergroup": group_id},
+                headers={"Authorization": f"Bearer {self._token}"},
+            )
+            response.raise_for_status()
+            body = response.json()
+        except httpx.HTTPError as exc:
+            raise UserGroupLookupError(
+                f"usergroup {group_id} lookup failed: {exc}"
+            ) from exc
+        except ValueError as exc:  # a 200 that is not JSON at all
+            raise UserGroupLookupError(
+                f"usergroup {group_id} lookup returned a non-JSON body"
+            ) from exc
+        if not isinstance(body, dict) or not body.get("ok"):
+            error = body.get("error") if isinstance(body, dict) else None
+            raise UserGroupLookupError(
+                f"usergroup {group_id} lookup refused by Slack: {error or 'unknown error'}"
+            )
+        users = body.get("users")
+        if not isinstance(users, list) or not all(isinstance(u, str) for u in users):
+            raise UserGroupLookupError(
+                f"usergroup {group_id} lookup returned no member list"
+            )
+        return frozenset(users)
+
+
+# The port is a checked contract rather than a claim: a signature that drifts from
+# GroupMembershipSource fails type-checking here, at the adapter, rather than
+# type-checking clean and diverging silently from the resolver that depends on it.
+_CONFORMS: type[GroupMembershipSource] = SlackUserGroupClient

--- a/apps/api/src/agentos_api/usergroups.py
+++ b/apps/api/src/agentos_api/usergroups.py
@@ -1,0 +1,53 @@
+"""The group-membership port the approval authorizer decides on (#420, ADR-0034).
+
+The user-group authorizer needs to know who is in a group, and the platform must
+not take that answer from its caller: any platform-key holder could then assert
+their own membership, which is not authorization but a formality. So the API
+resolves membership ITSELF, through this port, and the authorizer decides on what
+an implementation returns.
+
+The port is what keeps that resolution a contained dependency. #420 is the first
+outbound call ``apps/api`` makes to a chat provider, and the authorizer -- the
+platform's decision -- must not be the thing holding the provider's client. There
+is one adapter today, and ``main`` is the only module that names it, because
+selecting an adapter is wiring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+
+class UserGroupLookupError(Exception):
+    """A usergroup lookup that did not produce a member set.
+
+    The authorizer maps this to a fail-closed denial, so it is raised for every
+    failure mode rather than returning an empty set: "nobody is in this group"
+    and "we could not find out" are different facts and must stay different.
+    """
+
+
+@dataclass(frozen=True)
+class UserGroupMembership:
+    """A group's member set plus the provenance the audit row records: when the
+    membership was fetched, and how stale the answer that decided is."""
+
+    group: str
+    users: frozenset[str]
+    fetched_at: datetime
+    cache_age_s: float
+
+
+class GroupMembershipSource(Protocol):
+    """Resolve a group's members, server-side, at resolution time.
+
+    An implementation raises ``UserGroupLookupError`` for EVERY mode that yields
+    no member set, and never stands an empty ``UserGroupMembership`` in for one:
+    the authorizer fails closed on the error and denies as a non-member on the
+    empty set, so conflating them would tell a clicker that policy refused them
+    when an outage did.
+    """
+
+    async def members(self, group_id: str) -> UserGroupMembership: ...

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -157,3 +157,218 @@ def test_agent_approval_routes_rejects_bad_bindings(
             headers=auth_headers,
         )
         assert resp.status_code == 422, resp.text
+
+
+# --- #420: the approvers block on a route binding ------------------------------
+#
+# `approvers` is the WHO, sitting alongside the binding's `channel` (the WHERE).
+# It is workspace deployment config, so it is validated on write with the same
+# allowlist-ID discipline #143 established for channels: real IDs, never
+# @handles or bare names, which never resolve and fail silently.
+
+
+def test_agent_approval_routes_with_approvers_round_trip(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """The extended binding shape survives create and PATCH verbatim.
+
+    The stored JSONB stays minimal: a group-only binding must NOT read back with
+    a `users: null` sibling, or every pre-#420 binding gets rewritten with null
+    padding on the next write.
+    """
+
+    created = client.post(
+        "/agents",
+        json={
+            "name": "approvers-agent",
+            "slack_channel": "C000000A01",
+            "approval_routes": {
+                "managers": {"channel": "C000000A02", "approvers": {"group": "S000000G1"}}
+            },
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    body = created.json()
+    assert body["approval_routes"] == {
+        "managers": {"channel": "C000000A02", "approvers": {"group": "S000000G1"}}
+    }
+
+    patched = client.patch(
+        f"/agents/{body['id']}",
+        json={
+            "approval_routes": {
+                "managers": {
+                    "channel": "C000000A02",
+                    "approvers": {"users": ["U000000U1", "W000000E1"]},
+                }
+            }
+        },
+        headers=auth_headers,
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["approval_routes"] == {
+        "managers": {
+            "channel": "C000000A02",
+            "approvers": {"users": ["U000000U1", "W000000E1"]},
+        }
+    }
+
+
+def test_agent_approval_routes_accepts_both_users_and_group(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """Both set is VALID, not an error: issue #420 settles the precedence
+    (`users` wins, `group` is ignored at read time) rather than refusing the
+    combination at write time."""
+
+    created = client.post(
+        "/agents",
+        json={
+            "name": "both-approvers-agent",
+            "slack_channel": "C000000B01",
+            "approval_routes": {
+                "managers": {
+                    "channel": "C000000B02",
+                    "approvers": {"group": "S000000G2", "users": ["U000000U2"]},
+                }
+            },
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    assert created.json()["approval_routes"]["managers"]["approvers"] == {
+        "group": "S000000G2",
+        "users": ["U000000U2"],
+    }
+
+
+def test_agent_approval_routes_rejects_bad_approvers(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """Every way an approvers block can be meaningless is a clear 422 on write,
+    never a silently-unenforceable binding:
+
+    - `{}`: declares an approvers block that restricts nothing.
+    - `users: []`: neither "unset" (omit the key) nor "nobody may approve" --
+      the latter as silent config is a footgun, since the approval could then
+      only ever expire.
+    - a `@handle` or bare name where an ID belongs: never resolves (#143).
+    - a channel ID where a usergroup ID belongs: the S-prefix is the whole
+      distinction, and a C-prefixed value would look plausible in a config file.
+    """
+
+    bad_approvers = [
+        {},
+        {"users": []},
+        {"group": "@managers"},
+        {"group": "managers"},
+        {"group": "C000000C9"},
+        {"group": ""},
+        {"users": ["not-a-user"]},
+        {"users": ["@brian"]},
+        {"users": ["U000000U3", "nope"]},
+        {"users": [""]},
+    ]
+    for index, approvers in enumerate(bad_approvers):
+        resp = client.post(
+            "/agents",
+            json={
+                "name": f"bad-approvers-{index}",
+                "slack_channel": "C000000C01",
+                "approval_routes": {
+                    "managers": {"channel": "C000000C02", "approvers": approvers}
+                },
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422, f"{approvers!r} was accepted: {resp.text}"
+
+
+def test_agent_approval_routes_rejects_unknown_keys(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """A typo in an optional key is a 422, not a silently narrower-looking
+    binding.
+
+    Ignoring the extra key is the one config error the fail-closed doctrine
+    would otherwise miss: nothing was "declared", so the route falls back to
+    channel membership and every member of the (deliberately broad) card channel
+    becomes an approver, while the operator believes they narrowed authority to
+    the users they listed.
+    """
+
+    bad_bindings = [
+        # `approver`, missing the `s`: the whole approvers block disappears.
+        {"channel": "C000000E02", "approver": {"users": ["U000000U1"]}},
+        # A typo inside the approvers block: `user` instead of `users` leaves a
+        # group-only spec, or nothing at all.
+        {"channel": "C000000E02", "approvers": {"user": ["U000000U1"]}},
+        {"channel": "C000000E02", "approvers": {"groups": "S000000G1"}},
+        {
+            "channel": "C000000E02",
+            "approvers": {"users": ["U000000U1"], "unknown": "x"},
+        },
+    ]
+    for index, binding in enumerate(bad_bindings):
+        resp = client.post(
+            "/agents",
+            json={
+                "name": f"unknown-key-{index}",
+                "slack_channel": "C000000E01",
+                "approval_routes": {"managers": binding},
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 422, f"{binding!r} was accepted: {resp.text}"
+
+
+def test_agent_approval_routes_patch_rejects_unknown_keys(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """#143's posture: create and PATCH validate identically, so a typo'd key
+    cannot be smuggled in through the update path either."""
+
+    created = client.post(
+        "/agents",
+        json={"name": "patch-unknown-key-agent", "slack_channel": "C000000F01"},
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+    agent_id = created.json()["id"]
+
+    for binding in (
+        {"channel": "C000000F02", "approver": {"users": ["U000000U1"]}},
+        {"channel": "C000000F02", "approvers": {"users": ["U000000U1"], "extra": 1}},
+    ):
+        patched = client.patch(
+            f"/agents/{agent_id}",
+            json={"approval_routes": {"managers": binding}},
+            headers=auth_headers,
+        )
+        assert patched.status_code == 422, f"{binding!r} was accepted: {patched.text}"
+
+
+def test_agent_approval_routes_patch_rejects_bad_approvers(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """#143's posture: create and PATCH validate identically, so a bad binding
+    cannot be smuggled in through the update path."""
+
+    created = client.post(
+        "/agents",
+        json={"name": "patch-approvers-agent", "slack_channel": "C000000D01"},
+        headers=auth_headers,
+    )
+    assert created.status_code == 201, created.text
+
+    patched = client.patch(
+        f"/agents/{created.json()['id']}",
+        json={
+            "approval_routes": {
+                "managers": {"channel": "C000000D02", "approvers": {"users": []}}
+            }
+        },
+        headers=auth_headers,
+    )
+    assert patched.status_code == 422, patched.text

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -18,17 +18,21 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import httpx
 import pytest
 import redis
 import redis.asyncio as aioredis
 from aci_protocol import QueuedTurn
 from agentos_api import crud
 from agentos_api.config import get_settings
+from agentos_api.deps import get_approver_sets
 from agentos_api.main import create_app
 from agentos_api.models import Approval
 from agentos_api.resumequeue import ResumeQueue
 from agentos_api.resumereconciler import ResumeReconciler
 from agentos_api.sandbox_token import mint
+from agentos_api.slack_approvers import SlackApproverSetSelector
+from agentos_api.slack_usergroups import SlackUserGroupClient
 from agentos_api.sweeper import run_expiry_sweeper, sweep_expired_approvals
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -1168,3 +1172,692 @@ def test_run_expiry_sweeper_loop_sweeps_and_stops(
             assert task.done()
 
     asyncio.run(_scenario())
+
+
+# --- #420: approver sets unfused from the card's channel -----------------------
+#
+# Setup shape throughout: an agent binds route "managers" to the BROAD channel
+# (where the card posts) and, optionally, an `approvers` block (who may act).
+# The approval then names that agent + route, with card_channel=C_BROAD -- the
+# exact shape the worker produces at kernel.py:626-627.
+#
+# Slack is the only faked service (a MockTransport behind the real
+# SlackUserGroupClient, injected through the API's own dependency). Postgres and
+# Valkey are real. `calls` records every request that reached the transport,
+# which is how the "this path does no I/O" contracts are proven rather than
+# assumed.
+
+_GROUP = "S0MGRS001"
+_APPROVER = "U0APPROV1"
+_LISTED = "U0LISTED1"
+_OTHER = "U0OTHER01"
+_BROAD = "C0BROAD01"
+_ELSEWHERE = "C0ELSE001"
+
+
+def _agent_with_routes(
+    client: TestClient, headers: dict[str, str], routes: dict[str, Any]
+) -> str:
+    created = client.post(
+        "/agents",
+        json={
+            "name": f"routed-{uuid.uuid4().hex[:8]}",
+            "slack_channel": "C0AGENT001",
+            "approval_routes": routes,
+        },
+        headers=headers,
+    )
+    assert created.status_code == 201, created.text
+    return str(created.json()["id"])
+
+
+def _routed_payload(agent_id: str | None, **overrides: Any) -> dict[str, Any]:
+    return _payload(
+        agent_id=agent_id, route="managers", card_channel=_BROAD, **overrides
+    )
+
+
+def _fake_slack(
+    client: TestClient,
+    members: list[str],
+    *,
+    calls: list[httpx.Request],
+    fail: bool = False,
+) -> None:
+    """Wire the API's usergroup client to a MockTransport-backed Slack."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if fail:
+            return httpx.Response(500, text="slack is down")
+        return httpx.Response(200, json={"ok": True, "users": members})
+
+    group_client = SlackUserGroupClient(
+        httpx.AsyncClient(transport=httpx.MockTransport(_handler)),
+        token="xoxb-test",
+    )
+    client.app.dependency_overrides[get_approver_sets] = lambda: (
+        SlackApproverSetSelector(group_client)
+    )
+
+
+def _no_slack_configured(client: TestClient) -> None:
+    """A deployment with no SLACK_BOT_TOKEN: the selector is still wired (main
+    always wires one), it just has no usergroup client behind it."""
+
+    client.app.dependency_overrides[get_approver_sets] = lambda: (
+        SlackApproverSetSelector(None)
+    )
+
+
+def _resolve(
+    client: TestClient,
+    headers: dict[str, str],
+    approval_id: str,
+    actor: str,
+    channel: str | None = _BROAD,
+) -> Any:
+    return client.post(
+        f"/approvals/{approval_id}/resolve",
+        json={"decision": "approved", "resolved_by": actor, "actor_channel": channel},
+        headers=headers,
+    )
+
+
+# --- AC1: a group binding narrows authority inside a broad channel -------------
+
+
+def test_group_bound_route_denies_non_group_member_even_in_card_channel(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC1, the headline of #420: the card sits in a BROAD channel so everyone
+    can SEE the request, but only the bound user group may act on it. U_OTHER
+    clicks from exactly the right channel -- under today's channel-membership
+    authorizer that is a 200 -- and must be refused: right room, no authority.
+    """
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [_APPROVER], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    denied = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
+    assert denied.status_code == 403, denied.text
+    assert "not an approver" in denied.json()["detail"]
+
+    # The refusal is total: no claim, no wake.
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
+    assert len(calls) == 1
+
+
+def test_group_member_resolves_and_session_resumes(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC1's other half: the group member's click resolves the record and wakes
+    the suspended session exactly once."""
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [_APPROVER], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+    )
+    payload = _routed_payload(agent_id)
+    created = approvals_client.post(
+        "/approvals", json=payload, headers=auth_headers
+    ).json()
+
+    ok = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["status"] == "approved"
+    assert ok.json()["resolved_by"] == _APPROVER
+
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{created['id']}-resolved"
+    assert turn.conversation_id == payload["conversation_id"]
+    assert turn.author == _APPROVER
+
+
+def test_user_list_bound_route_denies_an_unlisted_actor_without_calling_slack(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC1 for the explicit allowlist. The zero-transport-call assertion is the
+    substance: the user-list path is pure config, so it must not depend on Slack
+    being reachable at all."""
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [_OTHER], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"users": [_LISTED]}}},
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    denied = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
+    assert denied.status_code == 403, denied.text
+    assert "not an approver" in denied.json()["detail"]
+    assert calls == []
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_user_list_bound_route_resolves_for_a_listed_actor(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC1: the listed actor resolves and the session resumes, with Slack untouched."""
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"users": [_LISTED, _APPROVER]}}},
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    ok = _resolve(approvals_client, auth_headers, created["id"], _LISTED)
+    assert ok.status_code == 200, ok.text
+    assert len(valkey.xrange(runs_stream)) == 1
+    assert calls == []
+
+
+def test_explicit_user_list_wins_over_the_group_binding(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC1 precedence, exactly as the issue states it: with BOTH declared,
+    ``users`` decides and ``group`` is ignored. A genuine group member who is
+    not on the list is refused, and Slack is never consulted."""
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [_APPROVER], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {
+            "managers": {
+                "channel": _BROAD,
+                "approvers": {"group": _GROUP, "users": [_LISTED]},
+            }
+        },
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    denied = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
+    assert denied.status_code == 403, denied.text
+    assert "not an approver" in denied.json()["detail"]
+
+    ok = _resolve(approvals_client, auth_headers, created["id"], _LISTED)
+    assert ok.status_code == 200, ok.text
+    assert len(valkey.xrange(runs_stream)) == 1
+    assert calls == []
+
+
+# --- AC2: no self-approval under ANY authorizer --------------------------------
+
+
+def test_requester_cannot_self_approve_under_the_group_authorizer(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC2: the author IS a member of the approver group and still cannot resolve
+    their own request.
+
+    The zero-call assertion pins the guard's ORDERING, not just its verdict: the
+    self-approval check runs before any Slack fetch, so a self-attempt spends no
+    rate-limit budget and cannot be used to probe group membership.
+    """
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [_APPROVER], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+    )
+    created = approvals_client.post(
+        "/approvals",
+        json=_routed_payload(agent_id, author=_APPROVER),
+        headers=auth_headers,
+    ).json()
+
+    denied = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
+    assert denied.status_code == 403, denied.text
+    assert "self-approval" in denied.json()["detail"]
+    assert calls == []
+
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_requester_cannot_self_approve_under_the_user_list_authorizer(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC2: the author is on the explicit allowlist and still cannot resolve."""
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"users": [_LISTED, _APPROVER]}}},
+    )
+    created = approvals_client.post(
+        "/approvals",
+        json=_routed_payload(agent_id, author=_LISTED),
+        headers=auth_headers,
+    ).json()
+
+    denied = _resolve(approvals_client, auth_headers, created["id"], _LISTED)
+    assert denied.status_code == 403, denied.text
+    assert "self-approval" in denied.json()["detail"]
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_requester_cannot_self_approve_under_a_bound_channel_authorizer(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC2's third implementation. Distinct from the unbound-approval case that
+    ``test_authorizer_blocks_non_member_and_self_approval`` already pins: here a
+    route binding placed the card, so the resolver walks the binding path before
+    landing on channel membership. The self-approval block must survive that
+    route."""
+
+    agent_id = _agent_with_routes(
+        approvals_client, auth_headers, {"managers": {"channel": _BROAD}}
+    )
+    created = approvals_client.post(
+        "/approvals",
+        json=_routed_payload(agent_id, author=_APPROVER),
+        headers=auth_headers,
+    ).json()
+
+    denied = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
+    assert denied.status_code == 403, denied.text
+    assert "self-approval" in denied.json()["detail"]
+    assert valkey.xrange(runs_stream) == []
+
+
+# --- AC3: the audit names the authorizer AND the evidence that counted ---------
+
+
+def test_audit_names_authorizer_and_membership_evidence(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC3: after a group-denied then group-approved sequence, each audit row
+    names UserGroupAuthorizer and carries the membership evidence that decided
+    it -- the group, the actor's verdict, the size of the group that proved it,
+    and when that membership was fetched. The member list itself is deliberately
+    NOT stored (a 500-member group would bloat an append-only table per click).
+    """
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [_APPROVER, _LISTED], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    assert _resolve(approvals_client, auth_headers, created["id"], _OTHER).status_code == 403
+    assert _resolve(approvals_client, auth_headers, created["id"], _APPROVER).status_code == 200
+
+    entries = approvals_client.get(
+        f"/approvals/{created['id']}/audit", headers=auth_headers
+    ).json()
+    assert [e["action"] for e in entries] == ["denied", "resolved"]
+    denied_entry, resolved_entry = entries
+
+    assert denied_entry["authorizer"] == "UserGroupAuthorizer"
+    assert denied_entry["authorized"] is False
+    assert denied_entry["evidence"]["kind"] == "user_group"
+    assert denied_entry["evidence"]["group"] == _GROUP
+    assert denied_entry["evidence"]["actor_in_group"] is False
+    assert denied_entry["evidence"]["member_count"] == 2
+    assert datetime.fromisoformat(denied_entry["evidence"]["fetched_at"])
+    assert denied_entry["evidence"]["cache_age_s"] >= 0
+
+    assert resolved_entry["authorizer"] == "UserGroupAuthorizer"
+    assert resolved_entry["authorized"] is True
+    assert resolved_entry["evidence"]["actor_in_group"] is True
+    assert resolved_entry["evidence"]["group"] == _GROUP
+    # The list itself is not the snapshot; the verdict + count + timestamp are.
+    assert "users" not in resolved_entry["evidence"]
+
+
+def test_audit_evidence_for_a_user_list_decision(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC3: a user-list resolution records the allowlist that counted and the
+    actor's verdict against it."""
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"users": [_LISTED, _APPROVER]}}},
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    assert _resolve(approvals_client, auth_headers, created["id"], _OTHER).status_code == 403
+    assert _resolve(approvals_client, auth_headers, created["id"], _LISTED).status_code == 200
+
+    denied_entry, resolved_entry = approvals_client.get(
+        f"/approvals/{created['id']}/audit", headers=auth_headers
+    ).json()
+
+    assert denied_entry["authorizer"] == "ExplicitUserListAuthorizer"
+    assert denied_entry["evidence"]["kind"] == "user_list"
+    assert denied_entry["evidence"]["actor_listed"] is False
+    assert sorted(denied_entry["evidence"]["users"]) == sorted([_LISTED, _APPROVER])
+
+    assert resolved_entry["authorizer"] == "ExplicitUserListAuthorizer"
+    assert resolved_entry["evidence"]["actor_listed"] is True
+
+
+def test_audit_evidence_for_a_channel_decision(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC3 + AC4: the unchanged channel path gains evidence too, naming the
+    channel that held the authority and the channel the click came from."""
+
+    agent_id = _agent_with_routes(
+        approvals_client, auth_headers, {"managers": {"channel": _BROAD}}
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    denied = _resolve(approvals_client, auth_headers, created["id"], _OTHER, _ELSEWHERE)
+    assert denied.status_code == 403, denied.text
+    assert _resolve(approvals_client, auth_headers, created["id"], _OTHER).status_code == 200
+
+    denied_entry, resolved_entry = approvals_client.get(
+        f"/approvals/{created['id']}/audit", headers=auth_headers
+    ).json()
+
+    assert denied_entry["authorizer"] == "ChannelMembershipAuthorizer"
+    assert denied_entry["evidence"]["kind"] == "channel_membership"
+    assert denied_entry["evidence"]["approvers_channel"] == _BROAD
+    assert denied_entry["evidence"]["actor_channel"] == _ELSEWHERE
+
+    assert resolved_entry["evidence"]["approvers_channel"] == _BROAD
+    assert resolved_entry["evidence"]["actor_channel"] == _BROAD
+
+
+def test_expiry_sweeper_audit_rows_carry_no_evidence(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """Edge cases 11 and 13: ``evidence`` is a NULLABLE column on an append-only
+    table. Writers that made no membership decision -- the expiry sweeper -- must
+    leave it NULL rather than fabricate one, and old rows must still read back
+    through ApprovalAuditOut."""
+
+    created = approvals_client.post(
+        "/approvals", json=_payload(expires_in_seconds=1), headers=auth_headers
+    ).json()
+    now = _naive_utc(2)
+
+    async def _scenario() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, _client):
+            async with sessionmaker() as session:
+                return await sweep_expired_approvals(session, queue, now=now)
+
+    assert asyncio.run(_scenario()) == 1
+
+    entries = approvals_client.get(
+        f"/approvals/{created['id']}/audit", headers=auth_headers
+    ).json()
+    assert [e["action"] for e in entries] == ["expired"]
+    assert entries[0]["authorizer"] == "ExpirySweeper"
+    assert entries[0]["evidence"] is None
+
+
+# --- fail closed: a declared approvers spec never degrades to channel ----------
+
+
+def test_group_binding_without_a_bot_token_denies_instead_of_channel_fallback(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """Fail closed on config error. The deployment declared a group but wired no
+    SLACK_BOT_TOKEN, so membership is unverifiable. The actor below is standing
+    in the card channel -- a fallback to channel membership would ALLOW them,
+    silently widening the approver set the operator thought they had narrowed.
+    """
+
+    _no_slack_configured(approvals_client)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    denied = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
+    assert denied.status_code == 403, denied.text
+    assert "could not verify" in denied.json()["detail"]
+
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_group_lookup_failure_denies_and_audits_the_failure(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """Fail closed on lookup error, plus AC3 for the failure row. Slack is down;
+    the actor is in the card channel and must STILL be refused, and the audit
+    must record that infrastructure -- not policy -- refused them."""
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [_APPROVER], calls=calls, fail=True)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    denied = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
+    assert denied.status_code == 403, denied.text
+    assert "could not verify" in denied.json()["detail"]
+    assert calls != []
+
+    entries = approvals_client.get(
+        f"/approvals/{created['id']}/audit", headers=auth_headers
+    ).json()
+    assert [e["action"] for e in entries] == ["denied"]
+    row = entries[0]
+    assert row["authorized"] is False
+    assert row["authorizer"] != "ChannelMembershipAuthorizer"
+    assert row["evidence"]["kind"] == "user_group"
+    assert row["evidence"]["group"] == _GROUP
+    assert row["evidence"]["lookup_failed"] is True
+    assert row["evidence"]["error"]
+
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
+
+
+# --- AC4: no approvers declared keeps today's behavior exactly -----------------
+
+
+def test_binding_without_approvers_keeps_channel_membership(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC4: an existing deployment's bare ``{channel}`` binding keeps resolving
+    against ``card_channel`` -- anyone in the card channel, nobody outside it.
+    Zero-setup stays zero-setup."""
+
+    agent_id = _agent_with_routes(
+        approvals_client, auth_headers, {"managers": {"channel": _BROAD}}
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    outside = _resolve(approvals_client, auth_headers, created["id"], _OTHER, _ELSEWHERE)
+    assert outside.status_code == 403, outside.text
+    assert "not an approver" in outside.json()["detail"]
+
+    inside = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
+    assert inside.status_code == 200, inside.text
+    assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_agentless_approval_keeps_channel_membership(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC4 / edge case 7: ``agent_id`` is nullable by design (the generic/dev
+    path). With no agent there is no binding to read, so the record falls back to
+    channel membership on its card_channel -- today's behavior, unchanged."""
+
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(None, author=_APPROVER), headers=auth_headers
+    ).json()
+    assert created["agent_id"] is None
+    assert created["route"] == "managers"
+
+    outside = _resolve(approvals_client, auth_headers, created["id"], _OTHER, _ELSEWHERE)
+    assert outside.status_code == 403, outside.text
+
+    # AC2 survives the no-binding path: the author is refused from the card
+    # channel, where anyone else would be allowed.
+    author = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
+    assert author.status_code == 403, author.text
+    assert "self-approval" in author.json()["detail"]
+
+    inside = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
+    assert inside.status_code == 200, inside.text
+    assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_unbound_route_name_keeps_channel_membership(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """AC4 / edge case 8: the approval names a route the agent's map does not
+    bind (renamed or removed while pending). Fresh-read semantics say current
+    config wins, and current config declares no approvers for this route, so it
+    is channel membership -- mirroring the worker's unbound-route card fallback.
+    """
+
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"legal": {"channel": _ELSEWHERE, "approvers": {"users": [_LISTED]}}},
+    )
+    created = approvals_client.post(
+        "/approvals",
+        json=_routed_payload(agent_id, author=_APPROVER),
+        headers=auth_headers,
+    ).json()
+
+    # The OTHER route's allowlist must not leak onto this one.
+    listed_elsewhere = _resolve(
+        approvals_client, auth_headers, created["id"], _LISTED, _ELSEWHERE
+    )
+    assert listed_elsewhere.status_code == 403, listed_elsewhere.text
+
+    # AC2 survives the unbound-route path too.
+    author = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
+    assert author.status_code == 403, author.text
+    assert "self-approval" in author.json()["detail"]
+
+    inside = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
+    assert inside.status_code == 200, inside.text
+    assert len(valkey.xrange(runs_stream)) == 1

--- a/apps/api/tests/test_approvers_port.py
+++ b/apps/api/tests/test_approvers_port.py
@@ -1,0 +1,151 @@
+"""The approver-set port is a port, not a rename (#420, ADR-0034).
+
+Every other test drives the authorizer through Slack's sets, which cannot tell a
+real seam from a hardcoded one. These drive it through a set and a selector that
+Slack has nothing to do with, so the file importing no Slack module is the
+assertion: the authorizer needs no provider at all to work, and if it ever
+reaches for one again this stops compiling rather than quietly still passing.
+
+The self-approval case is the one that matters. A fake set can be written that
+happily reports the author as a member, which is exactly what a careless real
+implementation would do. The authorizer must still refuse. That is the proof AC2
+is structural -- a property of the authorizer that no set can opt out of -- rather
+than a promise each implementation makes in a docstring and might forget.
+"""
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from agentos_api.approvers import ApproverSet, ApproverSetSelector, MembershipVerdict
+from agentos_api.authorizer import AuthzDecision, authorize_approval
+from agentos_api.models import Approval
+
+_AUTHOR = "U0AUTHOR1"
+_APPROVER = "U0APPROV1"
+_OUTSIDER = "U0OTHER01"
+_CARD_CHANNEL = "C0BROAD01"
+
+
+class _EveryoneIsAMember:
+    """A set that admits anyone, including the author. No provider behind it."""
+
+    audit_name = "FakeApproverSet"
+
+    async def contains(
+        self, actor: str, actor_channel: str | None
+    ) -> MembershipVerdict:
+        return MembershipVerdict(member=True, evidence={"kind": "fake", "actor": actor})
+
+
+class _NobodyIsAMember:
+    audit_name = "FakeApproverSet"
+
+    async def contains(
+        self, actor: str, actor_channel: str | None
+    ) -> MembershipVerdict:
+        return MembershipVerdict(
+            member=False, reason="you are not an approver: fake set", evidence=None
+        )
+
+
+class _CannotTell:
+    """A set whose lookup yielded nothing: the port's undetermined case."""
+
+    audit_name = "FakeApproverSet"
+
+    async def contains(
+        self, actor: str, actor_channel: str | None
+    ) -> MembershipVerdict:
+        return MembershipVerdict(
+            member=False,
+            undetermined=True,
+            reason="could not verify: fake set could not tell",
+            evidence={"kind": "fake", "lookup_failed": True},
+        )
+
+
+class _FakeSelector:
+    """An ``ApproverSetSelector`` that reads no binding and knows no provider."""
+
+    def __init__(self, approver_set: ApproverSet) -> None:
+        self._approver_set = approver_set
+
+    def __call__(
+        self, approval: Approval, binding: Mapping[str, Any] | None
+    ) -> ApproverSet:
+        return self._approver_set
+
+
+def _approval(*, author: str = _AUTHOR) -> Approval:
+    return Approval(
+        conversation_id="th-420",
+        author=author,
+        summary="Discount for ACME",
+        reply_channel="C0REQ0001",
+        reply_placeholder="p-1",
+        dedupe_key="ev-420",
+        route="managers",
+        card_channel=_CARD_CHANNEL,
+    )
+
+
+def _authorize(approver_set: ApproverSet, actor: str) -> tuple[str, AuthzDecision]:
+    """The resolve endpoint's exact shape: select a set, then authorize on it."""
+
+    select: ApproverSetSelector = _FakeSelector(approver_set)
+    approval = _approval()
+    return asyncio.run(
+        authorize_approval(
+            approval,
+            actor,
+            _CARD_CHANNEL,
+            approver_set=select(approval, None),
+        )
+    )
+
+
+def test_a_member_of_any_set_is_allowed() -> None:
+    name, decision = _authorize(_EveryoneIsAMember(), _APPROVER)
+    assert name == "FakeApproverSet"
+    assert decision.allowed
+    assert decision.evidence == {"kind": "fake", "actor": _APPROVER}
+
+
+def test_a_non_member_of_any_set_is_denied_with_the_sets_reason() -> None:
+    _name, decision = _authorize(_NobodyIsAMember(), _APPROVER)
+    assert not decision.allowed
+    assert "not an approver" in decision.reason
+
+
+def test_an_undetermined_set_fails_closed() -> None:
+    """The fail-closed contract is owed to the PORT's undetermined verdict, not
+    to a Slack exception the authorizer happens to recognize."""
+
+    _name, decision = _authorize(_CannotTell(), _APPROVER)
+    assert not decision.allowed
+    assert "could not verify" in decision.reason
+    assert decision.evidence == {"kind": "fake", "lookup_failed": True}
+
+
+def test_the_author_is_denied_even_by_a_set_that_admits_them() -> None:
+    """AC2 is structural. The set says the author is a member; the authorizer
+    refuses anyway, because a set never gets a vote on self-approval."""
+
+    admitting = _EveryoneIsAMember()
+    assert asyncio.run(admitting.contains(_AUTHOR, _CARD_CHANNEL)).member
+
+    _name, decision = _authorize(admitting, _AUTHOR)
+    assert not decision.allowed
+    assert "self-approval" in decision.reason
+    # The set never ran, so its snapshot must not appear next to this denial.
+    assert decision.evidence is None
+
+
+def test_an_outsider_is_still_allowed_by_a_set_that_admits_everyone() -> None:
+    """Guards the test above from passing vacuously: the admitting set really
+    does allow a non-author, so the author's denial is the self-approval rule and
+    not a broken fake."""
+
+    _name, decision = _authorize(_EveryoneIsAMember(), _OUTSIDER)
+    assert decision.allowed

--- a/apps/api/tests/test_authorizer.py
+++ b/apps/api/tests/test_authorizer.py
@@ -1,7 +1,32 @@
-"""ChannelMembershipAuthorizer unit tests (#246): pure decisions, no I/O."""
+"""Authorizer and approver-set unit tests (#246, #420).
 
-from agentos_api.authorizer import ChannelMembershipAuthorizer
+The originals below pin the channel-membership behavior (#246), now driven
+through ``authorize_approval`` on an unbound approval, which is the path
+production takes to reach that set. Everything after the divider pins #420: the
+explicit-user-list and user-group sets that unfuse "who may approve" from "where
+the card posted", plus the authorizer that selects between them and owns every
+rule that is not membership. Slack is the only external service here and it is
+reached exclusively through a MockTransport-backed real client.
+
+Self-approval is deliberately NOT tested at the set level: a set is never asked
+about it (ADR-0034), so a set-level self-approval test would assert an invariant
+that does not live there. It is pinned on the authorizer, once per set, below.
+"""
+
+import asyncio
+from typing import Any
+
+import httpx
+from agentos_api.approvers import ApproverSet, ExplicitUsers, MembershipVerdict
+from agentos_api.authorizer import AuthzDecision, authorize_approval
 from agentos_api.models import Approval
+from agentos_api.slack_approvers import (
+    SlackApproverSetSelector,
+    SlackChannelMembers,
+    SlackUserGroupMembers,
+)
+from agentos_api.slack_usergroups import SlackUserGroupClient
+from agentos_api.usergroups import GroupMembershipSource
 
 
 def _approval(*, author: str = "U_AE", channel: str = "C_MGRS") -> Approval:
@@ -15,20 +40,551 @@ def _approval(*, author: str = "U_AE", channel: str = "C_MGRS") -> Approval:
     )
 
 
+def _authorize(
+    approval: Approval,
+    actor: str,
+    actor_channel: str | None,
+    *,
+    binding: Any = None,
+    group_client: GroupMembershipSource | None = None,
+) -> tuple[str, AuthzDecision]:
+    """The resolve endpoint's exact shape: select a set from the binding, then
+    authorize on it. Selection is real, so these stay end-to-end tests of the
+    binding-to-decision path rather than of the authorizer in isolation."""
+
+    select = SlackApproverSetSelector(group_client)
+    return asyncio.run(
+        authorize_approval(
+            approval, actor, actor_channel, approver_set=select(approval, binding)
+        )
+    )
+
+
+def _decide(approval: Approval, actor: str, channel: str | None) -> AuthzDecision:
+    """The unbound path: no binding, so the card channel is the approver set."""
+
+    _name, decision = _authorize(approval, actor, channel, binding=None)
+    return decision
+
+
 def test_member_of_the_approval_channel_is_allowed() -> None:
-    decision = ChannelMembershipAuthorizer().authorize(_approval(), "U_MANAGER", "C_MGRS")
-    assert decision.allowed
+    assert _decide(_approval(), "U_MANAGER", "C_MGRS").allowed
 
 
 def test_wrong_or_missing_channel_is_denied() -> None:
-    authorizer = ChannelMembershipAuthorizer()
     for channel in ("C_OTHER", None, ""):
-        decision = authorizer.authorize(_approval(), "U_MANAGER", channel)
+        decision = _decide(_approval(), "U_MANAGER", channel)
         assert not decision.allowed
         assert "not an approver" in decision.reason
 
 
 def test_self_approval_is_denied_even_from_the_right_channel() -> None:
-    decision = ChannelMembershipAuthorizer().authorize(_approval(author="U_AE"), "U_AE", "C_MGRS")
+    decision = _decide(_approval(author="U_AE"), "U_AE", "C_MGRS")
     assert not decision.allowed
     assert "self-approval" in decision.reason
+
+
+# --- #420: the user-list + user-group sets, and the authorizer over them -------
+
+_GROUP = "S0MGRS001"
+_AUTHOR = "U0AUTHOR1"
+_APPROVER = "U0APPROV1"
+_LISTED = "U0LISTED1"
+_OUTSIDER = "U0OTHER01"
+_CARD_CHANNEL = "C0BROAD01"
+_REQUEST_CHANNEL = "C0REQ0001"
+
+
+def _bound_approval(*, author: str = _AUTHOR, card_channel: str = _CARD_CHANNEL) -> Approval:
+    """An approval whose card a route binding placed in ``card_channel`` (#247).
+
+    Distinct from ``_approval`` above: the #420 story is about a card sitting in
+    a BROAD channel while authority lives elsewhere, so these tests need the
+    card/request channel split the route binding creates.
+    """
+
+    return Approval(
+        conversation_id="th-420",
+        author=author,
+        summary="Discount for ACME",
+        reply_channel=_REQUEST_CHANNEL,
+        reply_placeholder="p-1",
+        dedupe_key="ev-420",
+        route="managers",
+        card_channel=card_channel,
+    )
+
+
+def _slack(members: list[str], calls: list[httpx.Request] | None = None) -> SlackUserGroupClient:
+    """A real SlackUserGroupClient over a MockTransport.
+
+    Slack is an external service, so it is the one thing faked; the client, the
+    sets, and the authorizer under test are all real. ``calls`` records every
+    request that reached the transport, which is how the no-I/O contracts below
+    are proven rather than asserted by inspection.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if calls is not None:
+            calls.append(request)
+        return httpx.Response(200, json={"ok": True, "users": members})
+
+    return SlackUserGroupClient(
+        httpx.AsyncClient(transport=httpx.MockTransport(_handler)),
+        token="xoxb-test",
+    )
+
+
+def _contains(
+    approver_set: ApproverSet, actor: str, channel: str | None
+) -> MembershipVerdict:
+    return asyncio.run(approver_set.contains(actor, channel))
+
+
+# --- ExplicitUsers ------------------------------------------------------------
+
+
+def test_user_list_set_contains_a_listed_actor() -> None:
+    """AC1: the literal allowlist is the authority; no channel, no I/O."""
+
+    verdict = _contains(ExplicitUsers([_APPROVER, _LISTED]), _LISTED, _CARD_CHANNEL)
+    assert verdict.member
+
+
+def test_user_list_set_excludes_an_unlisted_actor() -> None:
+    """AC1: not on the list means no authority, even standing in the card channel."""
+
+    verdict = _contains(ExplicitUsers([_APPROVER]), _OUTSIDER, _CARD_CHANNEL)
+    assert not verdict.member
+    assert "not an approver" in verdict.reason
+
+
+def test_user_list_authorizer_denies_the_author_even_when_listed() -> None:
+    """AC2: self-approval is blocked independent of the membership check, so an
+    author who is also on the allowlist still cannot resolve their own request.
+
+    Pinned on the authorizer, not the set: the set reports the author as a member
+    (asserted here), and the refusal is the authorizer's alone."""
+
+    assert _contains(ExplicitUsers([_AUTHOR, _APPROVER]), _AUTHOR, _CARD_CHANNEL).member
+
+    _name, decision = _authorize(
+        _bound_approval(author=_AUTHOR),
+        _AUTHOR,
+        _CARD_CHANNEL,
+        binding={"channel": _CARD_CHANNEL, "approvers": {"users": [_AUTHOR, _APPROVER]}},
+    )
+    assert not decision.allowed
+    assert "self-approval" in decision.reason
+
+
+def test_user_list_set_ignores_the_actor_channel() -> None:
+    """AC1 (the unfusing): the allowlist decides and the click channel is not
+    part of the verdict -- proven in BOTH directions, so neither an
+    allow-everything nor a still-checking-the-channel implementation passes."""
+
+    approver_set = ExplicitUsers([_LISTED])
+
+    # Listed actor, deliberately wrong channel (and no channel at all): member.
+    assert _contains(approver_set, _LISTED, "C0WRONG01").member
+    assert _contains(approver_set, _LISTED, None).member
+
+    # Unlisted actor standing in exactly the card channel: still not a member.
+    in_card_channel = _contains(approver_set, _OUTSIDER, _CARD_CHANNEL)
+    assert not in_card_channel.member
+    assert "not an approver" in in_card_channel.reason
+
+
+def test_user_list_evidence_names_the_list_and_the_verdict() -> None:
+    """AC3: the decision carries the authority that counted, not just the actor."""
+
+    approver_set = ExplicitUsers([_APPROVER, _LISTED])
+
+    allowed = _contains(approver_set, _LISTED, _CARD_CHANNEL)
+    assert allowed.evidence is not None
+    assert allowed.evidence["kind"] == "user_list"
+    assert allowed.evidence["actor_listed"] is True
+    assert sorted(allowed.evidence["users"]) == sorted([_APPROVER, _LISTED])
+
+    denied = _contains(approver_set, _OUTSIDER, _CARD_CHANNEL)
+    assert denied.evidence is not None
+    assert denied.evidence["kind"] == "user_list"
+    assert denied.evidence["actor_listed"] is False
+
+
+# --- SlackUserGroupMembers ----------------------------------------------------
+
+
+def test_user_group_set_contains_a_member() -> None:
+    """AC1: membership in the bound Slack user group is the authority."""
+
+    approver_set = SlackUserGroupMembers(_GROUP, _slack([_APPROVER]))
+    assert _contains(approver_set, _APPROVER, _CARD_CHANNEL).member
+
+
+def test_user_group_set_excludes_a_non_member() -> None:
+    """AC1: standing in the card channel is not authority under a group binding."""
+
+    approver_set = SlackUserGroupMembers(_GROUP, _slack([_APPROVER]))
+    verdict = _contains(approver_set, _OUTSIDER, _CARD_CHANNEL)
+    assert not verdict.member
+    assert "not an approver" in verdict.reason
+
+
+def test_user_group_set_ignores_the_actor_channel() -> None:
+    """AC1 (the unfusing proof, unit level): authority is independent of card
+    location. Proven in both directions -- a genuine member is a member from a
+    deliberately wrong channel and with no channel evidence at all, while a
+    non-member standing in exactly the card channel is still excluded."""
+
+    approver_set = SlackUserGroupMembers(_GROUP, _slack([_APPROVER]))
+
+    assert _contains(approver_set, _APPROVER, "C0WRONG01").member
+    assert _contains(approver_set, _APPROVER, None).member
+
+    in_card_channel = _contains(approver_set, _OUTSIDER, _CARD_CHANNEL)
+    assert not in_card_channel.member
+    assert "not an approver" in in_card_channel.reason
+
+
+def test_user_group_authorizer_denies_the_author_even_when_a_member() -> None:
+    """AC2: an author who is in the approver group still cannot self-approve.
+
+    Pinned on the authorizer: the set would report the author as a member, and
+    the authorizer refuses before it is ever asked (proven by the empty
+    ``calls`` -- the group is not even fetched)."""
+
+    calls: list[httpx.Request] = []
+    _name, decision = _authorize(
+        _bound_approval(author=_AUTHOR),
+        _AUTHOR,
+        _CARD_CHANNEL,
+        binding={"channel": _CARD_CHANNEL, "approvers": {"group": _GROUP}},
+        group_client=_slack([_AUTHOR, _APPROVER], calls),
+    )
+    assert not decision.allowed
+    assert "self-approval" in decision.reason
+    assert calls == []
+
+
+def test_user_group_set_is_undetermined_when_the_lookup_failed() -> None:
+    """Fail closed: a failed lookup yields no member set, so the verdict is
+    undetermined -- never a member, and never quietly an empty group whose 'not
+    an approver' reason would mislead the clicker into thinking policy, rather
+    than infrastructure, refused them. Undetermined for every actor, including
+    the author: the set does not know what an author is."""
+
+    def _boom(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="upstream boom")
+
+    approver_set = SlackUserGroupMembers(
+        _GROUP,
+        SlackUserGroupClient(
+            httpx.AsyncClient(transport=httpx.MockTransport(_boom)),
+            token="xoxb-test",
+        ),
+    )
+    for actor in (_APPROVER, _OUTSIDER, _AUTHOR):
+        verdict = _contains(approver_set, actor, _CARD_CHANNEL)
+        assert verdict.undetermined
+        assert not verdict.member
+        assert "could not verify" in verdict.reason
+        assert verdict.evidence is not None
+        assert verdict.evidence["kind"] == "user_group"
+        assert verdict.evidence["group"] == _GROUP
+        assert verdict.evidence["lookup_failed"] is True
+
+
+def test_user_group_set_excludes_everyone_when_the_group_is_empty() -> None:
+    """Edge case 5: a valid lookup returning zero members is NOT a lookup
+    failure. Nobody is a member, so the actor is excluded as a non-approver."""
+
+    approver_set = SlackUserGroupMembers(_GROUP, _slack([]))
+    verdict = _contains(approver_set, _APPROVER, _CARD_CHANNEL)
+    assert not verdict.member
+    assert not verdict.undetermined
+    assert "not an approver" in verdict.reason
+    assert verdict.evidence is not None
+    assert verdict.evidence.get("lookup_failed") is not True
+    assert verdict.evidence["member_count"] == 0
+
+
+def test_user_group_evidence_names_the_group_and_the_verdict() -> None:
+    """AC3: the group ID, the actor's verdict, and the size of the group that
+    proved it. The member list itself is deliberately not carried."""
+
+    approver_set = SlackUserGroupMembers(_GROUP, _slack([_APPROVER, _LISTED]))
+
+    allowed = _contains(approver_set, _APPROVER, _CARD_CHANNEL)
+    assert allowed.evidence is not None
+    assert allowed.evidence["kind"] == "user_group"
+    assert allowed.evidence["group"] == _GROUP
+    assert allowed.evidence["actor_in_group"] is True
+    assert allowed.evidence["member_count"] == 2
+
+    denied = _contains(approver_set, _OUTSIDER, _CARD_CHANNEL)
+    assert denied.evidence is not None
+    assert denied.evidence["actor_in_group"] is False
+    assert denied.evidence["member_count"] == 2
+
+
+# --- SlackChannelMembers ------------------------------------------------------
+
+
+def test_channel_set_compares_the_click_channel_to_the_approvers_channel() -> None:
+    """The set's whole logic: the click's channel IS the membership evidence, so
+    it performs no lookup and can never be undetermined."""
+
+    approver_set = SlackChannelMembers(_CARD_CHANNEL)
+
+    inside = _contains(approver_set, _OUTSIDER, _CARD_CHANNEL)
+    assert inside.member
+    assert inside.evidence is not None
+    assert inside.evidence["kind"] == "channel_membership"
+    assert inside.evidence["approvers_channel"] == _CARD_CHANNEL
+    assert inside.evidence["actor_channel"] == _CARD_CHANNEL
+
+    outside = _contains(approver_set, _OUTSIDER, "C0WRONG01")
+    assert not outside.member
+    assert not outside.undetermined
+    assert "not an approver" in outside.reason
+    assert outside.evidence is not None
+    assert outside.evidence["actor_channel"] == "C0WRONG01"
+
+
+# --- the authorizer -----------------------------------------------------------
+
+
+def test_authorizer_prefers_the_explicit_user_list_over_the_group() -> None:
+    """AC1 precedence (issue-stated): ``users`` wins and ``group`` is ignored,
+    so a group member who is not on the list is denied and Slack is never asked."""
+
+    calls: list[httpx.Request] = []
+    binding = {
+        "channel": _CARD_CHANNEL,
+        "approvers": {"group": _GROUP, "users": [_LISTED]},
+    }
+    client = _slack([_APPROVER], calls)
+
+    name, group_member = _authorize(
+        _bound_approval(),
+        _APPROVER,
+        _CARD_CHANNEL,
+        binding=binding,
+        group_client=client,
+    )
+    assert name == "ExplicitUserListAuthorizer"
+    assert not group_member.allowed
+    assert "not an approver" in group_member.reason
+
+    _name, listed = _authorize(
+        _bound_approval(),
+        _LISTED,
+        _CARD_CHANNEL,
+        binding=binding,
+        group_client=client,
+    )
+    assert listed.allowed
+    assert calls == []
+
+
+def test_authorizer_selects_the_user_group_set_when_only_a_group_is_bound() -> None:
+    """AC1: a group-only binding resolves membership through Slack and decides
+    on it -- the card channel is not consulted."""
+
+    calls: list[httpx.Request] = []
+    binding = {"channel": _CARD_CHANNEL, "approvers": {"group": _GROUP}}
+    client = _slack([_APPROVER], calls)
+
+    name, decision = _authorize(
+        _bound_approval(),
+        _APPROVER,
+        _CARD_CHANNEL,
+        binding=binding,
+        group_client=client,
+    )
+    assert name == "UserGroupAuthorizer"
+    assert decision.allowed
+    assert decision.evidence is not None
+    assert decision.evidence["group"] == _GROUP
+    assert decision.evidence["actor_in_group"] is True
+    assert len(calls) == 1
+
+    _name, outsider = _authorize(
+        _bound_approval(),
+        _OUTSIDER,
+        _CARD_CHANNEL,
+        binding=binding,
+        group_client=client,
+    )
+    assert not outsider.allowed
+    assert "not an approver" in outsider.reason
+
+
+def test_authorizer_falls_back_to_channel_membership_without_approvers() -> None:
+    """AC4: a binding that declares no ``approvers`` keeps today's behavior --
+    the card channel's members are the approvers, nobody else is."""
+
+    binding = {"channel": _CARD_CHANNEL}
+
+    name, member = _authorize(
+        _bound_approval(), _OUTSIDER, _CARD_CHANNEL, binding=binding
+    )
+    assert name == "ChannelMembershipAuthorizer"
+    assert member.allowed
+    assert member.evidence is not None
+    assert member.evidence["kind"] == "channel_membership"
+    assert member.evidence["approvers_channel"] == _CARD_CHANNEL
+    assert member.evidence["actor_channel"] == _CARD_CHANNEL
+
+    _name, elsewhere = _authorize(
+        _bound_approval(), _OUTSIDER, "C0WRONG01", binding=binding
+    )
+    assert not elsewhere.allowed
+    assert "not an approver" in elsewhere.reason
+    assert elsewhere.evidence is not None
+    assert elsewhere.evidence["actor_channel"] == "C0WRONG01"
+
+
+def test_authorizer_falls_back_to_channel_membership_without_a_binding() -> None:
+    """AC4: no binding at all (an agentless or unbound-route approval) is the
+    zero-setup path and must keep resolving against the card channel."""
+
+    name, in_channel = _authorize(
+        _bound_approval(), _OUTSIDER, _CARD_CHANNEL, binding=None
+    )
+    assert name == "ChannelMembershipAuthorizer"
+    assert in_channel.allowed
+
+    _name, elsewhere = _authorize(
+        _bound_approval(), _OUTSIDER, "C0WRONG01", binding=None
+    )
+    assert not elsewhere.allowed
+    assert "not an approver" in elsewhere.reason
+
+
+def test_authorizer_denies_a_malformed_approvers_block_without_channel_fallback() -> None:
+    """Fail closed (edge case 3): an ``approvers`` block that does not parse (a
+    hand-edited JSONB row, a future writer bug) is a config error, not an
+    absence of policy. The actor here stands in the card channel, so a fallback
+    to channel membership would ALLOW them -- a config error must never widen
+    the approver set."""
+
+    for broken in ({"group": 123}, {"users": "U0LISTED1"}, {}, {"users": []}):
+        name, decision = _authorize(
+            _bound_approval(),
+            _OUTSIDER,
+            _CARD_CHANNEL,
+            binding={"channel": _CARD_CHANNEL, "approvers": broken},
+            group_client=_slack([_OUTSIDER]),
+        )
+        assert not decision.allowed, f"malformed approvers {broken!r} must not allow"
+        assert name != "ChannelMembershipAuthorizer", (
+            f"malformed approvers {broken!r} fell back to channel membership"
+        )
+
+
+def test_authorizer_fails_closed_on_a_malformed_stored_binding() -> None:
+    """Fail closed: the whole stored binding value (not just its ``approvers``
+    block) is corrupted to a non-object -- a hand-edited JSONB row, a future
+    writer bug. crud passes it through raw rather than coercing it to None, so a
+    route an operator bound to a group must NOT silently widen to card-channel
+    membership. The actor stands in the card channel, where a fallback would
+    allow them."""
+
+    for broken in ("C0CARD001", ["U0LISTED1"], 123, True):
+        name, decision = _authorize(
+            _bound_approval(),
+            _OUTSIDER,
+            _CARD_CHANNEL,
+            binding=broken,
+            group_client=_slack([_OUTSIDER]),
+        )
+        assert not decision.allowed, f"malformed binding {broken!r} must not allow"
+        assert name != "ChannelMembershipAuthorizer", (
+            f"malformed binding {broken!r} fell back to channel membership"
+        )
+        assert name == "InvalidApproversSpec"
+
+
+def test_self_approval_wins_over_a_malformed_block_but_the_audit_still_names_it() -> None:
+    """Ordering: self-approval is refused before the set is asked, so an author
+    self-clicking an unreadable block is told about the self-approval rather than
+    the spec. Both deny, so nothing is widened.
+
+    The audit row still records ``InvalidApproversSpec``, because the name comes
+    from the selected set: an operator reading the trail can still see the block
+    was unreadable, which is the fact the reason string no longer carries."""
+
+    name, decision = _authorize(
+        _bound_approval(author=_AUTHOR),
+        _AUTHOR,
+        _CARD_CHANNEL,
+        binding={"channel": _CARD_CHANNEL, "approvers": {"group": 123}},
+    )
+    assert name == "InvalidApproversSpec"
+    assert not decision.allowed
+    assert "self-approval" in decision.reason
+
+
+def test_authorizer_denies_self_approval_before_fetching_the_group() -> None:
+    """AC2 + the pre-fetch guard's no-I/O property: the author is refused
+    before any Slack call is made, so a self-attempt against a group-bound route
+    spends no rate-limit budget and cannot be used to probe the group."""
+
+    calls: list[httpx.Request] = []
+    _name, decision = _authorize(
+        _bound_approval(author=_AUTHOR),
+        _AUTHOR,
+        _CARD_CHANNEL,
+        binding={"channel": _CARD_CHANNEL, "approvers": {"group": _GROUP}},
+        group_client=_slack([_AUTHOR, _APPROVER], calls),
+    )
+    assert not decision.allowed
+    assert "self-approval" in decision.reason
+    assert calls == []
+
+
+def test_authorizer_fails_closed_when_no_slack_client_is_configured() -> None:
+    """Fail closed: a group binding with no bot token wired into the API cannot
+    be verified. It denies with the could-not-verify reason; it does not degrade
+    into channel membership (the actor below is in the card channel)."""
+
+    name, decision = _authorize(
+        _bound_approval(),
+        _OUTSIDER,
+        _CARD_CHANNEL,
+        binding={"channel": _CARD_CHANNEL, "approvers": {"group": _GROUP}},
+        group_client=None,
+    )
+    assert not decision.allowed
+    assert "could not verify" in decision.reason
+    assert name != "ChannelMembershipAuthorizer"
+
+
+def test_authorizer_fails_closed_when_the_slack_lookup_errors() -> None:
+    """Fail closed: Slack answering 500 denies and records the failure; it never
+    falls back to the card channel (which would allow this actor)."""
+
+    def _boom(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="upstream boom")
+
+    client = SlackUserGroupClient(
+        httpx.AsyncClient(transport=httpx.MockTransport(_boom)),
+        token="xoxb-test",
+    )
+    name, decision = _authorize(
+        _bound_approval(),
+        _OUTSIDER,
+        _CARD_CHANNEL,
+        binding={"channel": _CARD_CHANNEL, "approvers": {"group": _GROUP}},
+        group_client=client,
+    )
+    assert not decision.allowed
+    assert "could not verify" in decision.reason
+    assert name != "ChannelMembershipAuthorizer"
+    assert decision.evidence is not None
+    assert decision.evidence["kind"] == "user_group"
+    assert decision.evidence["group"] == _GROUP
+    assert decision.evidence["lookup_failed"] is True
+    assert decision.evidence["error"]

--- a/apps/api/tests/test_slack_usergroups.py
+++ b/apps/api/tests/test_slack_usergroups.py
@@ -1,0 +1,542 @@
+"""SlackUserGroupClient unit tests (#420): the Slack adapter's own lookup.
+
+The issue rejects dispatcher-asserted membership as caller-asserted (and
+therefore forgeable) authorization, so the API resolves Slack user-group
+membership itself. Slack is an external service and is the only thing faked
+here, via ``httpx.MockTransport``; the client under test is real.
+
+Time is injected rather than slept: the client takes a ``clock`` returning an
+aware UTC datetime, which the TTL window and the evidence's ``fetched_at`` /
+``cache_age_s`` are both computed from. Every TTL assertion below therefore
+runs instantly and deterministically.
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+from agentos_api.slack_usergroups import SlackUserGroupClient
+from agentos_api.usergroups import UserGroupLookupError, UserGroupMembership
+
+_GROUP = "S0MGRS001"
+_OTHER_GROUP = "S0LEGAL01"
+_TOKEN = "xoxb-fake"  # kept short of the secret scanner's length floor on purpose
+
+
+class _Clock:
+    """A hand-cranked UTC clock. ``advance`` moves it; nothing sleeps."""
+
+    def __init__(self) -> None:
+        self.now = datetime(2026, 7, 15, 12, 0, 0, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += timedelta(seconds=seconds)
+
+
+def _client(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    calls: list[httpx.Request],
+    clock: _Clock | None = None,
+    ttl_s: float = 60.0,
+) -> SlackUserGroupClient:
+    def _recording(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return handler(request)
+
+    return SlackUserGroupClient(
+        httpx.AsyncClient(transport=httpx.MockTransport(_recording)),
+        token=_TOKEN,
+        ttl_s=ttl_s,
+        clock=clock or _Clock(),
+    )
+
+
+def _async_client(
+    handler: Callable[[httpx.Request], Awaitable[httpx.Response]],
+    *,
+    calls: list[httpx.Request],
+    clock: _Clock | None = None,
+    ttl_s: float = 60.0,
+) -> SlackUserGroupClient:
+    """``_client`` for the concurrency tests: the handler is a coroutine, so a
+    lookup can be held in flight while other callers pile up behind it."""
+
+    async def _recording(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return await handler(request)
+
+    return SlackUserGroupClient(
+        httpx.AsyncClient(transport=httpx.MockTransport(_recording)),
+        token=_TOKEN,
+        ttl_s=ttl_s,
+        clock=clock or _Clock(),
+    )
+
+
+def _ok(users: list[str]) -> Callable[[httpx.Request], httpx.Response]:
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True, "users": users})
+
+    return _handler
+
+
+def test_members_parses_the_user_list_and_authenticates_with_the_bot_token() -> None:
+    """The happy path: GET usergroups.users.list for the requested group with a
+    Bearer bot token, and the response's ``users`` become the member set."""
+
+    calls: list[httpx.Request] = []
+    client = _client(_ok(["U0APPROV1", "U0LISTED1"]), calls=calls)
+
+    membership = asyncio.run(client.members(_GROUP))
+
+    assert membership.users == frozenset({"U0APPROV1", "U0LISTED1"})
+    assert membership.group == _GROUP
+    assert len(calls) == 1
+    request = calls[0]
+    assert request.url.path == "/api/usergroups.users.list"
+    assert request.url.host == "slack.com"
+    assert request.url.params["usergroup"] == _GROUP
+    assert request.headers["authorization"] == f"Bearer {_TOKEN}"
+
+
+def test_a_fresh_lookup_reports_zero_cache_age() -> None:
+    """``cache_age_s`` and ``fetched_at`` are the evidence the audit row carries
+    (AC3), so a fresh fetch must report itself as fresh and stamped now."""
+
+    calls: list[httpx.Request] = []
+    clock = _Clock()
+    client = _client(_ok(["U0APPROV1"]), calls=calls, clock=clock)
+
+    membership = asyncio.run(client.members(_GROUP))
+
+    assert membership.cache_age_s == 0.0
+    assert membership.fetched_at == clock.now
+
+
+def test_fetched_at_is_stamped_when_slack_answers_not_when_it_was_asked() -> None:
+    """The stamp must describe the answer, not the question. A stamp taken
+    before the request predates Slack's reply by the request duration, which
+    both overstates the freshness of the evidence the audit row carries (AC3)
+    and opens the TTL window early, pushing a revoked member's real ceiling out
+    to ttl_s + latency. The handler advances the clock to spend that latency."""
+
+    calls: list[httpx.Request] = []
+    clock = _Clock()
+    asked_at = clock.now
+
+    def _handler(_request: httpx.Request) -> httpx.Response:
+        clock.advance(5)  # Slack took five seconds to answer.
+        return httpx.Response(200, json={"ok": True, "users": ["U0APPROV1"]})
+
+    client = _client(_handler, calls=calls, clock=clock, ttl_s=60.0)
+
+    membership = asyncio.run(client.members(_GROUP))
+
+    assert membership.fetched_at == asked_at + timedelta(seconds=5)
+
+    # And the TTL window runs from that answer: 59s later the entry is still
+    # live, where a stamp of asked_at would have aged it to 64s and refetched.
+    clock.advance(59)
+    cached = asyncio.run(client.members(_GROUP))
+    assert len(calls) == 1
+    assert cached.cache_age_s == 59.0
+
+
+def test_second_lookup_within_the_ttl_is_served_from_cache() -> None:
+    """A busy approval channel must not fan out one Slack call per click:
+    usergroups.users.list is Tier 2 (~20/min). Within the TTL the cached member
+    set is reused, and it reports the age of the fetch that proved it rather
+    than pretending to be fresh."""
+
+    calls: list[httpx.Request] = []
+    clock = _Clock()
+    client = _client(_ok(["U0APPROV1"]), calls=calls, clock=clock, ttl_s=60.0)
+
+    first = asyncio.run(client.members(_GROUP))
+    clock.advance(30)
+    second = asyncio.run(client.members(_GROUP))
+
+    assert len(calls) == 1
+    assert second.users == first.users
+    assert second.fetched_at == first.fetched_at
+    assert second.cache_age_s == 30.0
+
+
+def test_lookup_after_the_ttl_expires_refetches() -> None:
+    """Past the TTL the client goes back to Slack, so a membership change
+    propagates. The refetched set is what the caller gets -- the point of
+    expiring is that the ANSWER changes, not merely that a call is made."""
+
+    calls: list[httpx.Request] = []
+    clock = _Clock()
+    responses = [_ok(["U0APPROV1", "U0LEAVER1"]), _ok(["U0APPROV1"])]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return responses[min(len(calls) - 1, len(responses) - 1)](request)
+
+    client = _client(_handler, calls=calls, clock=clock, ttl_s=60.0)
+
+    before = asyncio.run(client.members(_GROUP))
+    assert before.users == frozenset({"U0APPROV1", "U0LEAVER1"})
+
+    clock.advance(61)
+    after = asyncio.run(client.members(_GROUP))
+
+    assert len(calls) == 2
+    assert after.users == frozenset({"U0APPROV1"})
+    assert after.fetched_at == clock.now
+    assert after.cache_age_s == 0.0
+
+
+def test_zero_ttl_forces_a_lookup_on_every_call() -> None:
+    """``slack_usergroup_cache_ttl_s=0`` is the documented operator lever for
+    per-resolve fetch (trading rate-limit headroom for zero revocation lag). It
+    must actually bypass the cache, even with a frozen clock."""
+
+    calls: list[httpx.Request] = []
+    client = _client(_ok(["U0APPROV1"]), calls=calls, clock=_Clock(), ttl_s=0.0)
+
+    asyncio.run(client.members(_GROUP))
+    asyncio.run(client.members(_GROUP))
+
+    assert len(calls) == 2
+
+
+def test_distinct_groups_do_not_share_a_cache_entry() -> None:
+    """The cache is keyed by group ID. A single shared key would hand one route's
+    approver set to another route -- an authorization bug, not a caching one."""
+
+    calls: list[httpx.Request] = []
+    by_group = {_GROUP: ["U0APPROV1"], _OTHER_GROUP: ["U0LEGAL01"]}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        group = request.url.params["usergroup"]
+        return httpx.Response(200, json={"ok": True, "users": by_group[group]})
+
+    client = _client(_handler, calls=calls, ttl_s=60.0)
+
+    managers = asyncio.run(client.members(_GROUP))
+    legal = asyncio.run(client.members(_OTHER_GROUP))
+
+    assert managers.users == frozenset({"U0APPROV1"})
+    assert legal.users == frozenset({"U0LEGAL01"})
+    assert len(calls) == 2
+
+
+# --- concurrency: the headroom the cache exists for is a concurrent property --
+#
+# The TTL cache above only helps callers that arrive AFTER a fetch has landed.
+# The burst that actually threatens the Tier 2 limit (~20/min) is a click storm
+# on one group, where every caller misses at once. Those tests are sequential
+# and cannot see it, so these drive real concurrent callers.
+
+
+def test_concurrent_lookups_of_one_group_cost_a_single_slack_call() -> None:
+    """A click storm on one group must not fan out one request per click. Each
+    caller misses the cache (nothing has landed yet), so without single-flight
+    all of them fetch, and 25 concurrent resolutions burn 25 of the ~20/min
+    budget -- tripping the very limit the cache exists to stay under, which
+    under the fail-closed rule denies legitimate approvers."""
+
+    calls: list[httpx.Request] = []
+
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.05)  # Slack is in flight while the storm arrives.
+        return httpx.Response(200, json={"ok": True, "users": ["U0APPROV1"]})
+
+    client = _async_client(_handler, calls=calls, ttl_s=60.0)
+
+    async def _storm() -> list[UserGroupMembership]:
+        return await asyncio.gather(*(client.members(_GROUP) for _ in range(25)))
+
+    memberships = asyncio.run(_storm())
+
+    assert len(calls) == 1
+    # Sharing the fetch must mean sharing its ANSWER: nobody gets an empty set.
+    assert len(memberships) == 25
+    assert all(m.users == frozenset({"U0APPROV1"}) for m in memberships)
+
+
+def test_concurrent_lookups_of_distinct_groups_do_not_serialize() -> None:
+    """Single-flight must be per group. One global lock would also produce one
+    call per group, so counting calls cannot tell the two apart: instead both
+    handlers rendezvous at a barrier and neither answers until both are in
+    flight, which a shared lock makes impossible."""
+
+    calls: list[httpx.Request] = []
+    by_group = {_GROUP: ["U0APPROV1"], _OTHER_GROUP: ["U0LEGAL01"]}
+
+    async def _main() -> list[UserGroupMembership]:
+        both_in_flight = asyncio.Barrier(2)
+
+        async def _handler(request: httpx.Request) -> httpx.Response:
+            # Times out (rather than hanging the suite) if the groups serialize.
+            await asyncio.wait_for(both_in_flight.wait(), 5.0)
+            group = request.url.params["usergroup"]
+            return httpx.Response(200, json={"ok": True, "users": by_group[group]})
+
+        client = _async_client(_handler, calls=calls, ttl_s=60.0)
+        return await asyncio.gather(
+            client.members(_GROUP), client.members(_OTHER_GROUP)
+        )
+
+    managers, legal = asyncio.run(_main())
+
+    assert managers.users == frozenset({"U0APPROV1"})
+    assert legal.users == frozenset({"U0LEGAL01"})
+    assert len(calls) == 2
+
+
+def test_a_failed_lookup_fails_every_concurrent_caller_and_is_not_cached() -> None:
+    """Fail closed applies to sharers too. A caller that waited on a fetch which
+    then failed must get the error, never an empty or stale member set -- an
+    empty set would read as "you are not an approver" and silently deny."""
+
+    calls: list[httpx.Request] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.01)
+        return _server_error(request)
+
+    client = _async_client(_handler, calls=calls, ttl_s=3600.0)
+
+    async def _main() -> list[BaseException | UserGroupMembership]:
+        results = await asyncio.gather(
+            *(client.members(_GROUP) for _ in range(5)), return_exceptions=True
+        )
+        # Not cached, under a TTL that would have cached a success: the retry
+        # reaches the transport again rather than replaying the failure.
+        before = len(calls)
+        with pytest.raises(UserGroupLookupError):
+            await client.members(_GROUP)
+        assert len(calls) > before
+        return results
+
+    results = asyncio.run(_main())
+
+    assert len(results) == 5
+    assert all(isinstance(r, UserGroupLookupError) for r in results)
+
+
+def test_concurrent_failing_lookups_of_one_group_cost_a_single_slack_call() -> None:
+    """Single-flight must coalesce the FETCH, not merely its cached result.
+
+    Failures are not cached, so a design that shares only the cache entry
+    coalesces nothing when Slack is down: each waiter finds the cache still
+    empty and issues its own request, one after another. That is worse than no
+    coalescing, which would at least fail everyone in parallel. With the real
+    10s HTTP timeout, ten concurrent clicks would burn ten calls and leave the
+    last one waiting ~100s, and /approvals/{id}/resolve awaits this inline.
+
+    So: one call, and one delay's worth of wall clock rather than five.
+    """
+
+    calls: list[httpx.Request] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.05)  # Stands in for the HTTP timeout.
+        return _server_error(request)
+
+    client = _async_client(_handler, calls=calls, ttl_s=60.0)
+
+    async def _storm() -> tuple[list[Any], float]:
+        started = asyncio.get_running_loop().time()
+        results = await asyncio.gather(
+            *(client.members(_GROUP) for _ in range(5)), return_exceptions=True
+        )
+        return results, asyncio.get_running_loop().time() - started
+
+    results, elapsed = asyncio.run(_storm())
+
+    assert len(calls) == 1
+    assert all(isinstance(r, UserGroupLookupError) for r in results)
+    # Serialized failures would cost 5 * 0.05 = 0.25s; one shared fetch costs
+    # one 0.05s delay. The bound sits between the two, well clear of both.
+    assert elapsed < 0.15
+
+
+def test_a_failure_shared_by_concurrent_callers_is_not_cached() -> None:
+    """Sharing the in-flight fetch must not become caching the failure. The
+    entry is dropped the moment the fetch settles, so the next click after
+    Slack recovers resolves rather than replaying the storm's error."""
+
+    calls: list[httpx.Request] = []
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.01)
+        if len(calls) == 1:  # The storm's one shared fetch; Slack recovers after.
+            return _server_error(request)
+        return httpx.Response(200, json={"ok": True, "users": ["U0APPROV1"]})
+
+    client = _async_client(_handler, calls=calls, ttl_s=3600.0)
+
+    async def _main() -> UserGroupMembership:
+        results = await asyncio.gather(
+            *(client.members(_GROUP) for _ in range(5)), return_exceptions=True
+        )
+        assert all(isinstance(r, UserGroupLookupError) for r in results)
+        assert len(calls) == 1
+        return await client.members(_GROUP)
+
+    recovered = asyncio.run(_main())
+
+    assert recovered.users == frozenset({"U0APPROV1"})
+    assert len(calls) == 2
+
+
+def test_concurrent_failing_lookups_of_distinct_groups_do_not_serialize() -> None:
+    """The per-group property has to survive on the failure path too: one
+    group's Slack outage must not park an unrelated group's approvals behind it
+    for a timeout. As with the success case, counting calls cannot tell a global
+    in-flight entry from a per-group one, so both handlers rendezvous at a
+    barrier and neither fails until both are in flight."""
+
+    calls: list[httpx.Request] = []
+
+    async def _main() -> list[Any]:
+        both_in_flight = asyncio.Barrier(2)
+
+        async def _handler(request: httpx.Request) -> httpx.Response:
+            # Times out (rather than hanging the suite) if the groups serialize.
+            await asyncio.wait_for(both_in_flight.wait(), 5.0)
+            return _server_error(request)
+
+        client = _async_client(_handler, calls=calls, ttl_s=60.0)
+        return await asyncio.gather(
+            client.members(_GROUP),
+            client.members(_OTHER_GROUP),
+            return_exceptions=True,
+        )
+
+    results = asyncio.run(_main())
+
+    assert all(isinstance(r, UserGroupLookupError) for r in results)
+    assert len(calls) == 2
+
+
+def test_a_cancelled_caller_does_not_kill_the_fetch_its_peers_share() -> None:
+    """The shared fetch outlives any one caller. A click whose HTTP request is
+    cancelled mid-await (the client hung up) must not cancel the fetch the other
+    waiters are riding, which would fail them closed for someone else's dropped
+    connection."""
+
+    calls: list[httpx.Request] = []
+
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.05)
+        return httpx.Response(200, json={"ok": True, "users": ["U0APPROV1"]})
+
+    client = _async_client(_handler, calls=calls, ttl_s=60.0)
+
+    async def _main() -> UserGroupMembership:
+        quitter = asyncio.create_task(client.members(_GROUP))
+        stayer = asyncio.create_task(client.members(_GROUP))
+        await asyncio.sleep(0)  # Both are now awaiting the one shared fetch.
+        quitter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await quitter
+        return await stayer
+
+    membership = asyncio.run(_main())
+
+    assert membership.users == frozenset({"U0APPROV1"})
+    assert len(calls) == 1
+
+
+# --- failures: every mode is a lookup failure, and none of them are cached ----
+#
+# Caching a failure would extend one Slack blip into a TTL-long outage of every
+# group-bound approval, and (worse) would make the fail-closed denial sticky
+# long after Slack recovered. Each test below proves the retry actually reaches
+# the transport again, under a TTL that WOULD have cached a success.
+
+
+def _slack_error(_request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, json={"ok": False, "error": "no_such_subteam"})
+
+
+def _rate_limited(_request: httpx.Request) -> httpx.Response:
+    return httpx.Response(429, headers={"retry-after": "30"}, json={"ok": False})
+
+
+def _server_error(_request: httpx.Request) -> httpx.Response:
+    return httpx.Response(500, text="internal error")
+
+
+def _connect_error(request: httpx.Request) -> httpx.Response:
+    raise httpx.ConnectError("name resolution failed", request=request)
+
+
+def _malformed_body(_request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, json={"ok": True})
+
+
+@pytest.mark.parametrize(
+    "handler",
+    [_slack_error, _rate_limited, _server_error, _connect_error, _malformed_body],
+    ids=["ok_false", "http_429", "http_500", "connect_error", "malformed_body"],
+)
+def test_failed_lookups_raise_and_are_not_cached(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    calls: list[httpx.Request] = []
+    client = _client(handler, calls=calls, ttl_s=3600.0)
+
+    with pytest.raises(UserGroupLookupError):
+        asyncio.run(client.members(_GROUP))
+    assert len(calls) == 1
+
+    # Not cached: the retry hits Slack again rather than replaying the failure.
+    with pytest.raises(UserGroupLookupError):
+        asyncio.run(client.members(_GROUP))
+    assert len(calls) == 2
+
+
+def test_a_failed_lookup_does_not_poison_a_later_success() -> None:
+    """The consequence that matters operationally: once Slack recovers, the very
+    next click resolves. A cached failure would keep denying for the whole TTL."""
+
+    calls: list[httpx.Request] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if len(calls) == 1:
+            return _server_error(request)
+        return httpx.Response(200, json={"ok": True, "users": ["U0APPROV1"]})
+
+    client = _client(_handler, calls=calls, ttl_s=3600.0)
+
+    with pytest.raises(UserGroupLookupError):
+        asyncio.run(client.members(_GROUP))
+
+    membership = asyncio.run(client.members(_GROUP))
+    assert membership.users == frozenset({"U0APPROV1"})
+    assert len(calls) == 2
+
+
+def test_a_cached_success_is_not_disturbed_by_a_later_failure() -> None:
+    """The inverse: within the TTL a cached success keeps serving, so a blip
+    mid-window does not flip an established approver set to fail-closed."""
+
+    calls: list[httpx.Request] = []
+    clock = _Clock()
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if len(calls) == 1:
+            return httpx.Response(200, json={"ok": True, "users": ["U0APPROV1"]})
+        return _server_error(request)
+
+    client = _client(_handler, calls=calls, clock=clock, ttl_s=60.0)
+
+    asyncio.run(client.members(_GROUP))
+    clock.advance(10)
+    cached: Any = asyncio.run(client.members(_GROUP))
+
+    assert cached.users == frozenset({"U0APPROV1"})
+    assert len(calls) == 1

--- a/apps/dispatcher/slack-app-manifest.yaml
+++ b/apps/dispatcher/slack-app-manifest.yaml
@@ -31,6 +31,13 @@ oauth_config:
       # has no stable manifest key, so it is a one-click manual step. Harmless to
       # keep the scope even with shimmer off.
       - assistant:write
+      # Required only for approval user-group authorizers (#420): the API calls
+      # usergroups.users.list with this same bot token to resolve who is in a
+      # route's approver group. Not needed for channel-membership or
+      # explicit-user-list approvers. ADDING A SCOPE REQUIRES REINSTALLING THE
+      # APP to the workspace -- an existing installation keeps its old grant
+      # until then, and a route with a declared approver group fails closed.
+      - usergroups:read
 settings:
   socket_mode_enabled: true
   event_subscriptions:

--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -116,12 +116,31 @@ spec:
               value: {{ .Values.api.resumeReconciler.graceSeconds | quote }}
             - name: RESUME_RECONCILER_BATCH_LIMIT
               value: {{ .Values.api.resumeReconciler.batchLimit | quote }}
+            # Slack bot token for the approval user-group authorizer (#420): the
+            # API resolves usergroups.users.list itself rather than trusting a
+            # caller-asserted membership claim (ADR-0034). Same shared secret key
+            # the dispatcher and worker read, so no new secret material. Rendered
+            # unconditionally, mirroring worker.yaml's ref to the same key; a
+            # declared approver group with no token then fails closed at resolve
+            # time, which is the intended posture.
+            - name: SLACK_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "agentos.secretName" . }}
+                  key: slackBotToken
             # Expiry sweeper cadence (#412). Rendered unconditionally, not behind
             # an optional-value guard, because the disable value 0 is falsy in Go
             # templates and would be silently dropped, leaving the app default
             # instead of disabling. <= 0 disables the sweeper.
             - name: APPROVAL_SWEEP_INTERVAL_S
               value: {{ .Values.api.approvalSweepIntervalSeconds | quote }}
+            # How long a fetched user-group member set is reused (#420). Rendered
+            # unconditionally for the same reason as the sweeper above: 0 is the
+            # meaningful strict-mode value (fetch per resolve) and is falsy in Go
+            # templates, so an optional-value guard would silently drop exactly
+            # the setting an operator is trying to make.
+            - name: SLACK_USERGROUP_CACHE_TTL_S
+              value: {{ .Values.api.slackUsergroupCacheTtlSeconds | quote }}
           ports:
             - name: http
               containerPort: 8000

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -421,6 +421,15 @@ api:
   # their stranded sessions (#412). Set to 0 (or any value <= 0) to disable the
   # expiry sweeper entirely. Default matches the app's built-in 30s cadence.
   approvalSweepIntervalSeconds: 30
+  # How long (seconds) the API reuses a fetched Slack user-group member set when
+  # resolving a user-group approver (#420). Default matches the app's built-in
+  # 60s. The tradeoff: within the window a member revoked from the group can
+  # still approve. Set to 0 to force a fetch on every resolve and close that lag
+  # entirely, at the cost of Slack Tier 2 rate-limit headroom on
+  # usergroups.users.list (~20 req/min) -- under the fail-closed rule a rate
+  # limit becomes a false denial of a legitimate approver, so 0 suits low-volume
+  # or strict-revocation deployments.
+  slackUsergroupCacheTtlSeconds: 60
   service:
     type: ClusterIP
     port: 8000
@@ -475,7 +484,13 @@ dispatcher:
   # Slack credentials. Socket Mode means the process dials out (no ingress), so
   # there is no Service. Left empty the supervisor just backs off and retries, so
   # the pod stays up without them; fill them (or an existingSecret) to connect.
-  # slackBotToken is shared with the worker (it edits the Slack placeholder).
+  # slackBotToken is shared with the worker (it edits the Slack placeholder) and,
+  # when set, with the API, whose approval user-group authorizers look up
+  # usergroup membership themselves (#420, ADR-0034). That lookup needs the
+  # `usergroups:read` bot scope, which existing Slack apps get only by
+  # reinstalling the app to the workspace. Changing this token requires a pod
+  # rollout of the consumers, not just a `helm upgrade`: a secretKeyRef env
+  # resolves once at pod start.
   slack:
     appToken: ""
     botToken: ""

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -316,6 +316,18 @@ services:
       LANGFUSE_HOST: http://langfuse-web:3000
       LANGFUSE_PUBLIC_KEY: pk-lf-agentos-dev
       LANGFUSE_SECRET_KEY: sk-lf-agentos-dev
+      # Approval user-group authorizers (#420) look up Slack usergroup
+      # membership from the API itself, so the API reads the same bot token the
+      # worker and dispatcher use. Empty by default: the Slack-free local loop
+      # needs nothing here, and a route that declares an approver group without a
+      # token fails closed at resolve time rather than widening to channel
+      # membership. Needs the `usergroups:read` bot scope.
+      SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
+      # How long a fetched user-group member set is reused. The fallback repeats
+      # the app's own 60s default rather than being empty, because the setting is
+      # float-typed: an empty value fails validation and the API would not boot.
+      # Set SLACK_USERGROUP_CACHE_TTL_S=0 to fetch on every resolve.
+      SLACK_USERGROUP_CACHE_TTL_S: ${SLACK_USERGROUP_CACHE_TTL_S:-60}
     ports:
       - "28000:8000"
     healthcheck:

--- a/docs/adr/0034-approval-authorizers-resolve-membership-in-the-api.md
+++ b/docs/adr/0034-approval-authorizers-resolve-membership-in-the-api.md
@@ -1,0 +1,292 @@
+# 34. Approval authorizers resolve membership in the API
+
+Date: 2026-07-15
+
+Status: Accepted
+
+Implements [#420](https://github.com/curie-eng/agentos/issues/420). Supersedes
+ADR-0010's framing of the authorizer line: where ADR-0010 named channel
+membership, user-group, explicit user-list, and platform-RBAC as four
+`Authorizer` implementations, this decision makes them four APPROVER SETS behind
+a single authorizer. Platform-RBAC becomes the fourth set, not the fourth
+authorizer. Nothing else in ADR-0010 is reversed: the approval primitive, the
+server-side placement, and the sequence the line is built in all stand.
+
+## Context
+
+[ADR-0010](0010-approval-gates-and-human-in-the-loop.md) (Proposed) established
+the approval primitive and named the authorizer line it intended to build:
+channel membership first, then user-group, explicit user-list, and
+platform-RBAC, all behind one server-side check at resolution time. Only the
+first landed. This ADR extends that line with the next two, and reshapes what
+"implementation" means for all four (see the supersession note above).
+
+Today "who may approve" is fused to "where the card posts". The only
+implementation is `ChannelMembershipAuthorizer`
+(`apps/api/src/agentos_api/authorizer.py`), and the approver set is whoever can
+see the channel the worker routed the card into. That forces a choice no
+operator should have to make: post the card somewhere visible and accept a broad
+approver set, or narrow the approver set by hiding the conversation. Unfusing the
+two axes means the route binding keeps `channel` as the *where* and gains an
+optional `approvers` block as the *who*.
+
+The moment an approver set is a Slack user group rather than a channel, the
+platform must answer a question it has never had to answer: how does the server
+learn who is in that group? That question is cross-cutting. It decides whether
+the API grows an outbound dependency on the Slack Web API and a credential it
+has never held, and it decides whether the authorization decision stays
+trustworthy or quietly becomes something the caller asserts. It is not a
+detail of one endpoint.
+
+It is also a first. `apps/api` has never made an outbound call to Slack: the
+dispatcher and the worker hold that relationship, and the API's only Slack
+knowledge until now was the channel IDs it stored and handed back. So this
+change is not one more call added to an existing client -- it opens a door, and
+what comes through that door lands in whatever module is holding it.
+
+One framing correction underlies the shape below. It is tempting to read channel
+membership as the neutral baseline and the user group as the Slack feature bolted
+beside it. That is wrong. Both are Slack: they are two ways Slack expresses "who
+is in the authorized set" -- everyone in this room, and everyone on this list
+Slack maintains. Only the explicit user list owes Slack nothing. Reading the
+channel as neutral is what produced the fusion of *where* and *who* in the first
+place, and repeating it would have put Slack's two shapes on opposite sides of
+the abstraction.
+
+## Decision
+
+### 1. The API resolves user-group membership itself
+
+The API calls Slack's `usergroups.users.list` with its own bot token
+(`SLACK_BOT_TOKEN`, needing the `usergroups:read` scope) and caches the result
+in process. The decision is made from membership the server fetched, never from
+membership a caller supplied.
+
+### 2. The route binding is read fresh at resolve time
+
+The resolver reads `agents.approval_routes[<route>]` at the moment of the click,
+using the approval's `agent_id` and `route`. Nothing about the approver set is
+snapshotted onto the `Approval` record at creation time.
+
+### 3. Fail closed, precisely scoped
+
+When a binding read at resolve time DOES declare an `approvers` spec, every
+lookup and config error denies: no bot token configured, an HTTP error, a
+network error, an `ok: false` body, a malformed body, or malformed approvers
+JSON. Each denies with a could-not-verify reason and an audit row. None of them
+falls back to channel membership. Failures are never cached.
+
+This does NOT mean the absence of a declaration fails closed. A binding with no
+`approvers` spec means channel membership, by design: that is the zero-setup
+default and the behavior every existing deployment already has.
+
+### 4. One authorizer, four approver sets behind an async port
+
+`ApproverSet` (`approvers.py`) is the line this ADR draws:
+`async contains(actor, actor_channel) -> MembershipVerdict`, plus an
+`audit_name`. A set answers ONLY "is this actor in the set". There are four:
+`SlackChannelMembers` and `SlackUserGroupMembers` (`slack_approvers.py`),
+`ExplicitUsers` (`approvers.py`, the one that owes Slack nothing), and
+`InvalidApprovers` (`approvers.py`) for a declared block the platform cannot
+read. That last one is a set rather than a special path on purpose: an unreadable
+block is not the absence of policy, it is policy nothing can evaluate, so it
+admits nobody and determines nothing. Modelling it as a set means the authorizer
+has exactly one code path and never learns that config errors exist.
+
+Membership lookup sits behind a second, narrower port, `GroupMembershipSource`
+(`usergroups.py`): `async members(group_id) -> UserGroupMembership`, raising
+`UserGroupLookupError` for every mode that yields no member set.
+`SlackUserGroupClient` (`slack_usergroups.py`) implements it.
+
+Selection is `ApproverSetSelector` (`approvers.py`), implemented by
+`SlackApproverSetSelector` (`slack_approvers.py`). It lives on the Slack side
+deliberately: reading a binding means parsing `ApprovalApprovers`, whose schema
+validates `S...` usergroup IDs and `C...` channel IDs, so the code that reads a
+binding is Slack-aware by nature. Putting selection in the authorizer would have
+forced the authorization decision to import the provider's classes in order to
+choose between them, which is the coupling this decision exists to prevent.
+`main.py` is the composition root and the only module that names Slack to build
+the selector; `authorizer.py` contains no Slack at all.
+
+The two Slack sets are not symmetrical, and the port does not pretend otherwise.
+`SlackChannelMembers` performs no lookup: the click's channel IS the proof, which
+is why `contains` takes `actor_channel` at all. `SlackUserGroupMembers` must go
+and ask, so it is the only set that can come back `undetermined` -- a third state
+that is NOT `member=False`, because "you are not in the set" and "we could not
+find out" deny for different reasons and must stay distinct.
+
+**This reverses the synchronous-pure-port position** taken earlier in this ADR's
+own life. That argument was that lifting the fetch into the resolver keeps every
+implementation pure and the port unchanged. What changed the decision: a set that
+owns its own lookup deletes the resolver's fetch-then-post-attach-evidence dance.
+With a sync port the resolver had to fetch, construct the authorizer with a
+member set, catch the lookup error, and then splice `fetched_at`, `cache_age_s`,
+and `error` onto evidence the authorizer could not know -- a helper existed
+purely to paper over the seam being in the wrong place. Async moves the fetch to
+the only object that knows what it is fetching and lets each set report its own
+complete evidence. The purity the old argument protected is still there; it just
+lives in `ExplicitUsers`, which never awaits anything.
+
+### 5. Precedence, and self-approval as a structural invariant
+
+Explicit `users` wins over `group`, which wins over channel membership.
+
+Self-approval is enforced ONCE, in `authorize_approval`, after set selection and
+before the set is consulted. A set is never asked and cannot skip it. This
+replaces three implementations each promising in a docstring to re-check
+self-approval themselves, held together by nothing but that promise: an
+authorizer that forgot the check would have been silently unsafe and every test
+of it would still have passed. Now no set can be unsafe about self-approval,
+because no set participates in it. The check sitting before `contains` also keeps
+its old I/O property: a self-attempt spends no rate-limit budget and cannot be
+used to probe who is in a group.
+
+The check sits after set selection, because the audit row names the set that
+would have decided and that requires having selected one. Selection performs no
+I/O, so "after selection" and "before any lookup" are the same instant.
+
+One consequence, accepted: an author self-clicking a route whose approvers block
+is unreadable is now told "self-approval is blocked" rather than "could not
+verify approvers". Both deny, nothing is widened, and the audit row still records
+`InvalidApproversSpec`, so an operator reading the trail still sees the block was
+unreadable. Nothing in production can observe the change: `InvalidApproversSpec`
+is introduced by #420 and does not exist on main.
+
+### 6. Audit records the authority, not just the actor
+
+Audit rows gain a structured `evidence` object naming the basis of the decision:
+the channel pair for channel membership; the group ID, the actor's membership
+verdict, the member count, and the fetch time for a user group; the list and the
+actor's presence in it for a user list; the failure class for a lookup failure.
+The full member list is deliberately not stored: a 500-member group would bloat
+an append-only table on every click, and the group ID plus the verdict is the
+fact worth keeping.
+
+## Alternatives considered and rejected
+
+1. **The dispatcher resolves membership and passes it to the API as evidence.**
+   Rejected, and this is the door this ADR is mainly here to close. The
+   dispatcher already holds a bot token and could attach "this actor is in group
+   S123" to the resolve call. But the resolve endpoint authenticates with the
+   platform API key, so that field is asserted by whoever holds the key, not
+   proven. Any platform-key holder could forge group membership, which makes the
+   authorizer a formality rather than a control. An authorization port whose
+   input the caller controls is not an authorization port. The API must learn
+   membership from Slack directly, at the cost of a token and a scope it did not
+   previously need.
+
+2. **Snapshot the approvers spec onto the `Approval` row at creation time.**
+   Rejected. Approvals pend for hours to days. A snapshot lets a user removed
+   from the approver group yesterday resolve a stale pending approval today.
+   Evaluating against current policy at the decision point is the correct TOCTOU
+   direction for authorization. A snapshot would also need a new column, a worker
+   change to populate it, and an edit inside the kernel's pause path, none of
+   which the fresh read requires.
+
+3. **Keep a synchronous `Authorizer` port and lift the fetch into the resolver.**
+   Considered first and rejected on review; see decision 4 for what changed the
+   position. In short: it keeps the implementations pure at the cost of making
+   the resolver assemble evidence on their behalf, which is the seam being in the
+   wrong place rather than an absence of I/O.
+
+4. **Keep one authorizer per approver kind.** Rejected, and this is the change
+   review actually forced. Three `Authorizer` implementations each re-checking
+   self-approval means the invariant is a convention, not a mechanism; it also
+   put Slack's two shapes (a channel, a user group) on opposite sides of the
+   abstraction while pretending the channel was neutral. One authorizer over a
+   membership-only port makes self-approval unskippable and puts both Slack
+   shapes where they belong, next to each other and behind the port.
+
+5. **Fall back to channel membership when a group lookup fails.** Rejected. It
+   converts a Slack outage or a missing scope into a silent widening of the
+   approver set, which is the exact failure mode an approval gate exists to
+   prevent. Denying a legitimate approver during an outage is recoverable; a
+   silently widened approver set is not visible until after the fact.
+
+6. **Accept usergroup handles (`@deal-desk-approvers`) in bindings.** Rejected
+   here, following the channel-ID precedent: names never route, they fail
+   silently when renamed, and the binding schema takes IDs. Handle-to-ID
+   resolution is admin UX and is tracked separately.
+
+## Consequences
+
+- **The API gains an outbound Slack dependency and a credential.** The chart
+  reuses the existing shared `slackBotToken` secret key that the dispatcher and
+  worker already consume, so there is no new secret material, but the API now
+  reads it. Note the rollout gotcha: a `secretKeyRef` env resolves once at pod
+  start, so rotating the token needs a pod rollout of the API, not just a
+  `helm upgrade`. Slack-free installs set nothing and lose nothing.
+
+- **The ports relocate work; they do not shrink it.** Three ports and four set
+  classes across five modules replace three authorizer classes in one, and they
+  save nothing today: there is no second provider, and the binding schema is still
+  Slack-shaped (`schemas.py` validates `S...` usergroup IDs and `C...` channel
+  IDs), so a non-Slack provider would need a schema change as well as an adapter
+  and a selector. This narrows the coupling; it does not make the path
+  provider-neutral. What was bought is dependency direction -- keeping the
+  authorization decision free of a vendor client on the first call that could have
+  put one there -- and the AC2 invariant, which is now unskippable rather than
+  promised three times. Read as future savings it is oversold. Read as where Slack
+  is allowed to live and as what makes self-approval structural, it is the point.
+
+- **The audit vocabulary is frozen, and now reads oddly.** Each set's
+  `audit_name` pins the class name it had before this decision, so
+  `approval_audit.authorizer` still records `ChannelMembershipAuthorizer`,
+  `ExplicitUserListAuthorizer`, and `UserGroupAuthorizer` even though those are
+  now sets and no such classes exist. The column is append-only history: rows
+  already on main carry these values, and renaming the vocabulary mid-stream
+  would make every old row lie about what decided. The oddness is the cost of a
+  truthful trail, and it is the right trade. New vocabulary needs a new column,
+  not a redefinition of this one. `InvalidApproversSpec` and `ExpirySweeper` are
+  frozen for the same reason.
+
+- **`usergroups:read` requires reinstalling the Slack app.** An existing
+  installation keeps its old grant until the app is reinstalled to the
+  workspace. Until then a route declaring an approver group denies with the
+  could-not-verify reason, exactly as designed. Channel and user-list approvers
+  are unaffected.
+
+- **Unbinding a route mid-pend widens authority, and this is accepted.** Under
+  fresh-read semantics, deleting or renaming a binding that carried `approvers`
+  while an approval is pending widens the approver set from the declared group or
+  list to card-channel membership. The resolver cannot distinguish "never bound"
+  from "was bound, now unbound"; distinguishing them would require the snapshot
+  rejected above. This is intrinsic to the design, not a bug, and it is accepted
+  because: mutating `approval_routes` goes through the agent PATCH endpoint,
+  i.e. the same platform key that can already resolve any approval directly, so
+  no new escalation path exists; fail-closing unbound routes would reject
+  approvals that resolve fine today, breaking the guarantee that a deployment
+  declaring no approvers is unchanged; and the audit row records the widened
+  basis actually used, so the trail stays truthful.
+
+- **A 60s membership cache trades revocation lag for rate-limit headroom.**
+  `usergroups.users.list` is a Tier 2 Slack method (roughly 20 requests per
+  minute). An uncached per-click fetch would let a click storm or a busy
+  workspace hit that limit, and a rate limit under a fail-closed rule converts
+  into false denials of legitimate approvers, which is a worse outcome than the
+  lag it would remove. The cost is that a revoked member can still approve for up
+  to the TTL, and an added member waits up to the TTL. Against an hours-to-days
+  human flow, 60s is negligible. Failures are never cached, so an outage does not
+  stick. Operators who want strict semantics set `SLACK_USERGROUP_CACHE_TTL_S=0`
+  for a per-resolve fetch and accept the rate-limit exposure.
+
+- **Evidence proves policy, not identity, and this limit must stay written
+  down.** The audit evidence proves that the ASSERTED identity satisfied policy
+  at click time. It does not prove who clicked. Identity is dispatcher-verified
+  on the Slack path: the dispatcher populates the actor from Slack's
+  authenticated interaction payload
+  (`apps/dispatcher/src/agentos_dispatcher/approval_actions.py:146`). On the
+  platform-API-key path it remains caller-asserted, the named residual from
+  [ADR-0033](0033-scoped-sandbox-state-token.md) and a tracked follow-up. Richer
+  evidence makes a forged resolution look MORE legitimate in the trail than
+  today's thinner rows do, which is precisely why the limit belongs in the record
+  rather than left implicit. This change keeps the existing trust model; it does
+  not claim to fix it.
+
+- **One extra DB read per resolution.** The resolver loads the agent's route
+  bindings on each attempt. This is the cost of fresh-read semantics and is
+  bounded by the same request that already writes the audit row.
+
+- **Route bindings stay deployment config.** `approvers` lives on the per-agent
+  binding, never in the bundle manifest, preserving ADR-0010's split between
+  versioned gate points and workspace-bound routing.

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -1,7 +1,7 @@
 # INTERFACE: Approval / authorizer
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 (channel membership) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 3 approver sets behind one authorizer (Slack channel, Slack user group, explicit user list) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -80,17 +80,141 @@ in code now:
 
 ## Implementations today
 
-**One: `ChannelMembershipAuthorizer`** (`apps/api/src/agentos_api/authorizer.py`), behind
-the `Authorizer` Protocol at the resolve endpoint (#246). Self-approval is blocked
-unconditionally; channel membership is proven by the resolution attempt's channel — the
-worker routes the Block Kit approval card into the approval's channel, Slack only renders
-that message (and accepts clicks) for members of that channel, and the click reaches the
-platform over the dispatcher's authenticated Socket Mode connection, which relays the
-click's channel as `actor_channel`. Non-dispatcher callers (operator curl, CLI) authenticate
-with the platform API key and assert the channel explicitly. User-group, explicit
-user-list, and platform-RBAC implementations swap in behind the same Protocol later. The
-durable record, the `awaiting-approval` status, both gate trigger types, the card
-click-to-resolve flow, and the suspend/resume lifecycle are live (#244, #245, #246).
+**One authorizer** (`apps/api/src/agentos_api/authorizer.py`, pure policy with no Slack in
+it) over **three approver sets** behind the `ApproverSet` port (ADR-0034). A set answers
+only "is this actor in the set"; every rule that is not membership lives in the authorizer,
+applied identically whatever the set. Self-approval is the rule that matters:
+`authorize_approval` denies a self-attempt after the set is selected and before it is asked
+(so a self-click never spends a Slack lookup), and a set is never consulted, so none can
+skip it. The durable record, the
+`awaiting-approval` status, both gate trigger types, the card click-to-resolve flow, and the
+suspend/resume lifecycle are live (#244, #245, #246).
+
+Two of the three sets are Slack's, and that is the honest framing: a channel and a user
+group are two ways Slack says "who is in the authorized set", not a neutral baseline plus a
+Slack feature.
+
+- **`SlackChannelMembers`** (#246, `slack_approvers.py`), the zero-setup default. Channel
+  membership is proven by the resolution attempt's channel — the worker routes the Block Kit
+  approval card into the approval's channel, Slack only renders that message (and accepts
+  clicks) for members of that channel, and the click reaches the platform over the
+  dispatcher's authenticated Socket Mode connection, which relays the click's channel as
+  `actor_channel`. Non-dispatcher callers (operator curl, CLI) authenticate with the
+  platform API key and assert the channel explicitly. Performs no lookup.
+- **`SlackUserGroupMembers`** (#420, `slack_approvers.py`), a Slack user group as the
+  approver set. Owns its lookup, through the `GroupMembershipSource` port below. Membership
+  is never accepted from the caller: a dispatcher-asserted membership claim would be
+  forgeable by any platform-key holder, so ADR-0034 rejected it. The only set that can come
+  back undetermined.
+- **`ExplicitUsers`** (#420, `approvers.py`), a literal allowlist of user IDs. Pure, no I/O,
+  and the only set that owes Slack nothing.
+
+Platform-RBAC remains the epic's fourth set and is not built.
+
+**The audit vocabulary is frozen.** Each set's `audit_name` pins its pre-ADR-0034 class
+name, so `approval_audit.authorizer` still records `ChannelMembershipAuthorizer`,
+`ExplicitUserListAuthorizer`, and `UserGroupAuthorizer`. Those classes no longer exist. The
+column is append-only history and rows already on main carry those values, so renaming the
+vocabulary would make old rows lie about what decided.
+
+### Unfusing who from where
+
+The route binding keeps `channel` as *where the card posts* and gains an optional
+`approvers` block as *who may approve*, so a card can be visible in a broad channel while
+authority stays narrow:
+
+```
+approval_routes: {
+  "<route-name>": {
+    "channel": "C0123ABCD",                 # where the card posts (unchanged)
+    "approvers": {                          # optional; absent means channel membership
+      "group": "S0123ABCD",                 # Slack user-group ID
+      "users": ["U0123ABCD", "U0456EFGH"]   # explicit allowlist
+    }
+  }
+}
+```
+
+Both take IDs, never `@handles` or names, matching the channel-ID precedent (#143): names
+never route and fail silently. The group and user-list authorizers deliberately ignore
+`actor_channel` — the whole point is that authority does not depend on card location.
+
+**Precedence: `users` > `group` > channel membership.** When `users` is set, `group` is
+ignored and no Slack call is made. When neither is declared, channel membership decides.
+
+**Fail closed, precisely scoped.** When a binding DOES declare an `approvers` spec, every
+lookup and config error denies: no bot token configured, HTTP error, network error,
+`ok: false`, malformed body, malformed approvers JSON. All deny with a could-not-verify
+reason and an audit row; none falls back to channel membership. Failures are not cached.
+This does NOT mean the absence of a declaration fails closed: no `approvers` declared means
+channel membership, by design. A group that legitimately resolves to zero members is a
+successful lookup, not a failure: the actor is simply not a member and is denied as a
+non-approver.
+
+**The binding is read fresh at resolve time**, from `agents.approval_routes` via the
+approval's `agent_id` and `route`; nothing is snapshotted onto the record at creation. That
+is the correct TOCTOU direction for authorization: revocation takes effect at the decision
+point, and a user removed from the approver group yesterday cannot resolve a stale pending
+approval today. The accepted consequence: deleting or renaming a binding that carried
+`approvers` while an approval pends WIDENS authority from the declared group or list to
+card-channel membership, because the resolver cannot distinguish "never bound" from "was
+bound, now unbound" without the rejected snapshot. It is accepted because mutating
+`approval_routes` requires the agent PATCH endpoint (the same platform key that can already
+resolve any approval directly, so no new escalation path), because fail-closing unbound
+routes would reject approvals that resolve fine today, and because the audit row records
+the widened basis actually used. An approval with a NULL `agent_id`, or one naming a route
+absent from the map, likewise has no binding to read and keeps channel membership.
+
+### The three ports
+
+**`ApproverSet`** (`approvers.py`) is the black line #420 draws: `async contains(actor,
+actor_channel) -> MembershipVerdict`, plus an `audit_name` for the audit row. It is async
+because a set may own a lookup; `ExplicitUsers` simply never awaits. `MembershipVerdict`
+carries a third state beyond member/not-member: `undetermined`, meaning the set could not
+find out. The authorizer fails closed on it, and it is deliberately never collapsed into
+`member=False` — "you are not in the set" and "we could not check" deny for different
+reasons, and telling a clicker the first when the second is true sends them arguing with
+policy over an outage.
+
+The two Slack sets are asymmetrical and the port does not hide it. `contains` takes
+`actor_channel` precisely because channel membership proves membership from the click itself
+and performs no lookup, while the user group has no such free evidence and must ask.
+
+A fourth set, **`InvalidApprovers`** (`approvers.py`), covers a declared block the platform
+cannot read: it admits nobody and reports `undetermined`. Modelling that as a set rather
+than a special path is what lets the authorizer have exactly one code path and never learn
+that config errors exist.
+
+**`ApproverSetSelector`** (`approvers.py`) picks the set a binding calls for:
+`(approval, binding) -> ApproverSet`. It performs no I/O and never raises. Its
+implementation, `SlackApproverSetSelector` (`slack_approvers.py`), lives on the Slack side
+deliberately — reading a binding means parsing the Slack-shaped `approvers` schema, so
+selection is provider-aware by nature. That placement is what keeps `authorizer.py` free of
+Slack entirely.
+
+**`GroupMembershipSource`** (`usergroups.py`) is the narrowest port, behind
+`SlackUserGroupMembers`: `async members(group_id) -> UserGroupMembership`, raising
+`UserGroupLookupError` for every mode that yields no member set. Its one implementation is
+`SlackUserGroupClient` (`slack_usergroups.py`), which reads `usergroups.users.list` with the
+API's own bot token (`SLACK_BOT_TOKEN`, `usergroups:read` scope) and caches member sets in
+process for `slack_usergroup_cache_ttl_s` (env `SLACK_USERGROUP_CACHE_TTL_S`, default 60s;
+`0` forces a per-resolve fetch).
+
+**`main.py` is the composition root**: the only module that names Slack to build the
+selector, so the authorizer and the resolve endpoint depend on ports rather than a provider.
+
+This narrows the coupling; it does not make the path provider-neutral. **The binding schema
+is still Slack-shaped**: `schemas.py` validates usergroup IDs as `S...` and channel IDs as
+`C...`, so a non-Slack provider would need a schema change plus an adapter and a selector.
+What the ports buy is dependency direction — #420 is the first outbound Slack call
+`apps/api` makes, and the authorization decision must not be what holds that client — plus
+the structural self-approval invariant. There is no second provider today.
+
+**Audit records the authority, not just the actor.** Each attempt's audit row carries a
+structured `evidence` object naming the basis of the decision: the channel pair for channel
+membership; the group ID, the actor's membership verdict, the member count, and the fetch
+time for a user group; the list and the actor's presence in it for a user list; the failure
+class for a lookup failure. The full member list is deliberately not stored.
 
 ## Known leakage
 
@@ -110,8 +234,19 @@ the authorization decision (who may resolve a pending approval) stays on the ser
 owns the durable `Approval` record. Policy gate points ship versioned in the bundle; route
 bindings (which channel, who may approve) are per-agent deployment config (#247).
 
+One limit the audit trail must not be read as overstating (#420, ADR-0034): the evidence
+proves that the ASSERTED identity satisfied policy at click time; it does not prove who
+clicked. Identity is dispatcher-verified on the Slack path — the dispatcher populates the
+actor from Slack's authenticated interaction payload
+(`apps/dispatcher/src/agentos_dispatcher/approval_actions.py:146`) — and caller-asserted on
+the platform-API-key path, the named ADR-0033 residual tracked as a follow-up. Richer
+evidence makes a forged resolution look MORE legitimate in the trail than today's thinner
+rows do, which is exactly why this limit is written down rather than left implicit. The
+membership authorizers narrow *who counts as an approver*; they do not change *how the
+actor is established*.
+
 ## Cross-links
 
 - **Epic(s):** [#22](https://github.com/curie-eng/agentos/issues/22) — approval gates and human-in-the-loop; adds the durable record, `awaiting-approval` status, `canUseTool` gate, and the authorizer interface.
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — not one of the six graded jobs; a cross-cutting core lifecycle change, not separately graded.
-- **ADR(s):** [ADR-0010](../../adr/0010-approval-gates-and-human-in-the-loop.md) — Approval gates and human-in-the-loop (Proposed); grounds this intended line. Composes with [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) (stateless-first suspend/resume, the pause mechanism).
+- **ADR(s):** [ADR-0010](../../adr/0010-approval-gates-and-human-in-the-loop.md) — Approval gates and human-in-the-loop (Proposed); grounds this intended line, including the authorizer sequence (channel membership first, then user-group, explicit user-list, platform-RBAC). [ADR-0034](../../adr/0034-approval-authorizers-resolve-membership-in-the-api.md) — Approval authorizers resolve membership in the API (Accepted); adds the user-group and user-list sets, the API-resident membership lookup, the scoped fail-closed rule, and fresh-read binding resolution. Supersedes ADR-0010's framing of those four as `Authorizer` implementations: they are approver SETS behind one authorizer, and platform-RBAC becomes the fourth set. Composes with [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) (stateless-first suspend/resume, the pause mechanism).


### PR DESCRIPTION
Today "who can approve" is fused to the route's channel: `ChannelMembershipAuthorizer` was the only implementation and it was wired as a module-level global, so narrowing the approver set meant narrowing who could see the request, and on a public channel the approver set was the whole workspace.

A route binding may now declare an optional `approvers` block. `channel` still decides only **where the card posts**; the block decides **who may click**.

```jsonc
"managers": {
  "channel": "C0BROAD01",                 // where the card posts (unchanged)
  "approvers": { "group": "S0DEALDESK" }  // who may resolve (new, optional)
}
```

- `UserGroupAuthorizer` (Slack user group) and `ExplicitUserListAuthorizer` (literal allowlist) land behind the existing `Authorizer` port.
- The global is replaced by a per-approval resolver that reads the binding at resolve time. Precedence: `users` > `group` > channel membership.
- **Unchanged by default:** a deployment declaring no `approvers` keeps today's behavior exactly, including a bare `{"channel"}` binding, a null `agent_id`, and an unbound route name.

## The decisions worth reviewing

Recorded in **ADR-0034**, which extends (does not supersede) ADR-0010.

- **The API resolves group membership itself**, rather than accepting it from the dispatcher. The resolve endpoint authenticates with the platform key, so caller-supplied membership is asserted rather than proven, and an authorization port whose input the caller controls is not one. Cost: a new `usergroups:read` scope and the API reading the existing `slackBotToken`.
- **The binding is read fresh at resolve time**, not snapshotted at creation. Approvals pend for hours to days; a snapshot lets someone removed from the group yesterday resolve today. Requires no worker change (the kernel only ever reads `channel`).
- **Fail closed, precisely scoped.** Errors under a *declared* `approvers` block deny and never fall back to channel membership. The *absence* of a declaration is channel membership by design.
- **Accepted consequence, stated plainly:** unbinding a route mid-pend widens authority to card-channel membership, because fresh-read cannot distinguish "never bound" from "was bound, now unbound". Accepted because mutating bindings needs the same platform key that can already resolve directly, and the audit row records the widened basis actually used.
- **Evidence proves policy, not identity.** The audit row shows the asserted identity satisfied policy at click time; it does not prove who clicked. Identity stays caller-asserted on the API-key path, the known ADR-0033 residual, explicitly not fixed here.

## Notes for the reviewer

- Migration is **0013**, chained after #418's 0012, which landed mid-run.
- `usergroups:read` requires **reinstalling the Slack app**. Until then a group-bound route denies with could-not-verify, by design. Channel and user-list approvers are unaffected.
- The chart reuses the existing `slackBotToken` secret key (no new secret material), but a token change needs an API pod rollout: a `secretKeyRef` env resolves at pod start.

## Not verified here

The **real Slack usergroup lookup** is untested end to end: no bot token is available locally and `usergroups:read` needs the app reinstall above. Everything else is covered, including fail-closed-with-no-token and the full user-list path, which need no Slack at all.

## Follow-ups (not built here)

Platform-RBAC authorizer; caller-asserted `resolved_by` hardening (ADR-0033 residual); usergroup handle to ID resolution; async `Authorizer` port; a write-time 422 when both `users` and `group` are set (raised in review, declined here because #420 explicitly settles that precedence, so it belongs back on the issue rather than diverged in code); a per-agent default `approvers` for routeless approvals.

Closes #420
