### PR TITLE
Auto-mark prerelease GitHub Releases for -rc tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -346,3 +346,5 @@ jobs:
             dist/agentos-*
             dist/compose.release.yaml
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}


### PR DESCRIPTION
Drive the release step's `prerelease`/`make_latest` off the pushed tag name so releases are classified without a manual fixup.

- A semver **prerelease** tag (ref name contains a `-`, e.g. `v0.4.0-rc.1`) publishes the GitHub Release with `prerelease: true` and `make_latest: false` -- Pre-release, NOT Latest, so the prior stable release keeps the Latest badge.
- A stable `vX.Y.Z` tag is unchanged: normal release, marked Latest (`prerelease: false`, `make_latest: true`).
- Docker image build/push (all images, both arches) is untouched -- only the GitHub Release metadata changes.

Removes the manual `gh release edit <tag> --prerelease --latest=false` step after every RC build.

Validated with `actionlint` (clean). No unit test exercises a workflow YAML; the linter is the proportionate check.

Closes #426