### PR TITLE
Interactive TUI + keychain secrets: guided authed-MCP flow, with the github-issues example

### DIFF
--- a/examples/github-issues/README.md
+++ b/examples/github-issues/README.md
@@ -69,6 +69,23 @@ If the message reply cites real issue titles/numbers from the repo, the authed
 MCP path worked end to end: token forwarded → server authenticated → tools
 called → answer grounded in live data.
 
+## Evals
+
+`evals/cases.json` grades the agent the same way at every tier. With the runner
+up (`skill up --secret ...`), run:
+
+```bash
+agentos skill eval
+```
+
+The three cases are deliberately robust to changing issue data — they assert on
+things that do not churn: that the agent returns real issue numbers (`#\d+`),
+that it finds the stable `enhancement` label when grouping, and that it can read
+a specific **closed** historical issue (#7, whose title is about `aci-protocol`).
+If the repo is ever restructured so those anchors no longer hold, update the
+`expected` values here — a case that starts failing is the grader catching a real
+change, which is the point.
+
 ## Swapping in a different service
 
 The mechanism is service-agnostic. To point at another authed MCP server,

--- a/examples/github-issues/evals/cases.json
+++ b/examples/github-issues/evals/cases.json
@@ -1,0 +1,32 @@
+{
+  "name": "github-issues",
+  "cases": [
+    {
+      "id": "lists-real-issue-numbers",
+      "input": "List a few open issues in curie-eng/agentos. Show each with its issue number in the form #<number>.",
+      "grader": {
+        "kind": "regex",
+        "expected": "#\\d+",
+        "case_sensitive": false
+      }
+    },
+    {
+      "id": "groups-by-label",
+      "input": "Group the open issues in curie-eng/agentos by their labels and name the labels you find.",
+      "grader": {
+        "kind": "contains",
+        "expected": "enhancement",
+        "case_sensitive": false
+      }
+    },
+    {
+      "id": "reads-a-specific-issue",
+      "input": "In curie-eng/agentos, what is issue #7 about? Answer in one sentence.",
+      "grader": {
+        "kind": "contains",
+        "expected": "aci-protocol",
+        "case_sensitive": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Recovers and ships the interactive-terminal + secrets feature branch (its remote
had been deleted; this was unmerged and local-only). It turns `agentos` into a
guided, keyboard-driven surface for driving agents — including the authed-MCP
`github-issues` example — with credentials managed in the OS keychain instead of
ad-hoc env exports.

### Highlights
- **OS keychain secret store** (`cli/src/secrets.rs`): `agentos secrets
  save/list/remove`, backed by the OS credential store, with a vault
  consolidation + legacy-credential migration. Values are never printed.
- **Interactive TUI** (`cli/src/interactive.rs`, ratatui): a surface over the
  existing clap grammar — pick a target/action, preview the exact `agentos …`
  command, get prompted for values, and stay inside the alternate screen. Adds
  an **example browser** and an **in-TUI agent chat** seeded from each bundle's
  `starterPrompts`.
- **Keychain-resolved credentials for `skill up`**: both the model credential
  and `--secret` MCP secrets hydrate from the keychain when not in the env, so
  the whole flow runs with zero manual exports (and the preflight reports, masked,
  what will be forwarded).
- **`channel-protocol`** (`packages/channel-protocol`): a new frozen contract
  package (Pydantic → schema codegen) for the reusable terminal-interaction
  contract the TUI chat uses.
- **`starterPrompts`** authoring field in the plugin-format manifest, populated
  for all three examples.
- **`github-issues` example**: the authed off-the-shelf GitHub MCP agent, now
  with an **eval suite** (`evals/cases.json`) whose cases are robust to live
  issue-data churn.

## Validation

Exercised end to end on this branch against the live GitHub MCP server, using
keychain-stored `ANTHROPIC_API_KEY` + `GITHUB_PERSONAL_ACCESS_TOKEN`:
- `agentos skill up --secret GITHUB_PERSONAL_ACCESS_TOKEN` → both creds loaded
  from the keychain; runner healthy.
- `agentos skill message "…group issues by label"` → the agent called
  `mcp__plugin_github-issues_github__list_issues` and returned 53 real issues
  grouped by label.
- `agentos skill eval` → **3/3 pass** against live data.
- `cargo fmt --check`, `cargo clippy -- -D warnings` clean; command manifest
  current; `plugin_format.validate_bundle` + frozen `EvalSuite` validation pass.

## Notes for review
- Adds a **frozen contract package** (`channel-protocol`) — worth a close look at
  the schema/codegen per the frozen-contracts rule.
- Only the final commit (the `github-issues` eval suite) was authored in this
  session; the rest is the recovered feature branch.
- `local`/`cluster` tiers do **not** yet forward an arbitrary MCP secret into the
  worker sandbox, so the `github-issues` example is skill-tier only for now
  (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)