### PR TITLE
Docs: arm approval gates with the fully-namespaced tool name

### DIFF
--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -78,6 +78,27 @@ in code now:
   `GET /approvals/{id}/audit`): actor, channel evidence, decision, and the authorizer
   snapshot -- who resolved, and why they counted (or were refused).
 
+### Arming a gate: use the fully-namespaced tool name
+
+The permission gate (`agents.approval_required_tools`, the runner's `can_use_tool`
+callback) matches a configured tool name by exact string equality -- no
+normalization, no prefix matching. The name you arm must be the tool's LIVE,
+fully-namespaced name, not the bare tool name.
+
+For a bundle-declared MCP tool that live name is
+`mcp__plugin_<bundle>_<server>__<tool>`, where `<bundle>` is the
+`.claude-plugin/plugin.json` `name` and `<server>` is the `.mcp.json` server key,
+for example `mcp__plugin_github-issues_github__create_issue`. The bare form
+`mcp__<server>__<tool>` (e.g. `mcp__github__create_issue`) does NOT match: a gate
+armed with it silently never intercepts the call, and a destructive tool runs
+with no approval whatsoever.
+
+Confirm the exact live name before arming a gate rather than guessing it.
+`agentos skill check` prints a `match: <server> -> plugin:<bundle>:<server>`
+line; rewrite that `plugin:<bundle>:<server>` value into the
+`mcp__plugin_<bundle>_<server>__<tool>` prefix and append the tool name. A
+tool-call trace also shows the exact live name directly.
+
 ## Implementations today
 
 **One authorizer** (`apps/api/src/agentos_api/authorizer.py`, pure policy with no Slack in

--- a/examples/github-issues/README.md
+++ b/examples/github-issues/README.md
@@ -81,3 +81,28 @@ forwarded variable in its `headers` (`"Authorization": "Bearer ${TOKEN}"`).
 If you swap in a write-capable server, make its writes idempotent: a mid-turn
 crash can make the platform replay the last instruction (history append is
 at-least-once), so a non-idempotent write could run twice.
+
+## Gating a write behind approval
+
+To require human approval before this bundle's GitHub server performs a write
+(for example, creating an issue), arm the approval gate with the tool's
+fully-namespaced LIVE name, not the bare name. The permission gate matches by
+exact string equality, so a bare or guessed name silently fails to gate: the
+tool call runs uninterrupted, with no approval prompt.
+
+For this bundle, bundle `github-issues` (from `.claude-plugin/plugin.json`) and
+server `github` (from `.mcp.json`) give:
+
+```
+Correct: mcp__plugin_github-issues_github__create_issue
+Wrong:   mcp__github__create_issue
+```
+
+The wrong (bare) form does NOT match and does NOT gate the call.
+
+Confirm the exact live name before arming the gate: `agentos skill check`
+prints a `match: github -> plugin:github-issues:github` line, which rewrites to
+the correct prefix above; or read the name directly from a tool-call trace.
+
+See [../../docs/interfaces/approval/INTERFACE.md](../../docs/interfaces/approval/INTERFACE.md)
+for the general rule.


### PR DESCRIPTION
Documents that an approval gate must be armed with a bundle-declared MCP tool's LIVE, fully-namespaced name (`mcp__plugin_<bundle>_<server>__<tool>`), not the bare `mcp__<server>__<tool>`. The permission gate matches by exact string equality, so a bare name silently never intercepts the call and a destructive tool runs with no approval.

- `docs/interfaces/approval/INTERFACE.md`: new "Arming a gate" note with the live-name shape, the silent-non-gating warning, and how to confirm the exact name (`agentos skill check` `match:` line, or a tool-call trace).
- `examples/github-issues/README.md`: new "Gating a write behind approval" section showing the correct vs bare gated string for this bundle.

The `agentos guide` primer does not currently cover approvals, so no primer change (adding one would be scope creep).

Closes #432