### PR TITLE
Declare aci-protocol dep on the dispatcher and smoke-test its image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,3 +288,23 @@ jobs:
         run: docker build -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile .
       - name: Build the worker-local overlay (no push)
         run: docker build --build-arg BASE_TAG=ci-local -f compose/worker-local.Dockerfile compose
+
+  # The dispatcher image builds with `uv sync --no-editable`, so it installs
+  # only the package's DECLARED dependencies. aci-protocol is a uv workspace
+  # member imported by handlers.py/queue.py; if it is not declared in
+  # apps/dispatcher/pyproject.toml it stays importable from a source checkout
+  # but is absent from the isolated image venv, and the process crash-loops on
+  # startup (issue #428). The build-only `images` job above cannot catch this
+  # (it never runs the image). Build the real image and assert the entrypoint's
+  # imports resolve inside it -- the one place that gap is observable.
+  dispatcher-image-smoke:
+    name: Dispatcher image imports resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Build the dispatcher image locally
+        run: docker build -t agentos-dispatcher:ci-smoke -f apps/dispatcher/Dockerfile .
+      - name: Entrypoint imports resolve in the built image
+        run: docker run --rm --entrypoint python agentos-dispatcher:ci-smoke -c "import agentos_dispatcher; import aci_protocol"

--- a/apps/dispatcher/pyproject.toml
+++ b/apps/dispatcher/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 description = "AgentOS dispatcher (Slack Bolt for Python, Socket Mode): ack + enqueue to Valkey Streams"
 requires-python = ">=3.13"
 dependencies = [
+    "aci-protocol",
     "slack-bolt>=1.21",
     "redis>=5.2",
     "pydantic>=2.10",

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,7 @@ name = "agentos-dispatcher"
 version = "0.0.0"
 source = { editable = "apps/dispatcher" }
 dependencies = [
+    { name = "aci-protocol" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -98,6 +99,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aci-protocol", editable = "packages/aci-protocol" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.7" },


### PR DESCRIPTION
The published dispatcher image crash-loops on startup with `ModuleNotFoundError: No module named 'aci_protocol'`, disabling the entire Slack path (mention ingestion + the approval-button relay) in every released image since 0.3.0.

`apps/dispatcher/src/agentos_dispatcher/{handlers.py,queue.py}` import `aci_protocol`, but `apps/dispatcher/pyproject.toml` never declared the `aci-protocol` workspace dependency. The image builds with `uv sync --no-editable`, which installs only declared deps, so the workspace member was importable from a source checkout but absent from the isolated image venv. Nothing in CI ran the dispatcher image, so it shipped broken.

- Declare `aci-protocol` in `apps/dispatcher/pyproject.toml` (mirroring `apps/worker`) and re-lock. The lock delta is 2 lines; `aci-protocol` only needs `pydantic` (already declared), so no transitive drift.
- Add a `dispatcher-image-smoke` CI job that builds the real image and asserts `import agentos_dispatcher; import aci_protocol` resolves inside the isolated venv, so a workspace-dep-not-declared regression fails red instead of reshipping.

Verified locally: the pre-fix image import check exits 1 with the exact `ModuleNotFoundError`; the post-fix image exits 0 and `python -m agentos_dispatcher` runs through the import chain to the expected missing-`SLACK_BOT_TOKEN` stage. ruff, mypy (128 files), and `pytest apps/dispatcher` (50 passed) green.

Closes #428