### PR TITLE
plugin-format: secrets policy field (#429)

### DIFF
--- a/examples/github-issues/.claude-plugin/plugin.json
+++ b/examples/github-issues/.claude-plugin/plugin.json
@@ -4,6 +4,7 @@
   "description": "Example bundle: an agent that reads and triages GitHub issues through the off-the-shelf GitHub MCP server, authenticated with a personal access token forwarded into the sandbox.",
   "author": { "name": "CurieTech" },
   "keywords": ["example", "mcp", "authed", "github", "stdio"],
+  "secrets": ["GITHUB_PERSONAL_ACCESS_TOKEN"],
   "starterPrompts": [
     "List the open issues in curie-eng/agentos and group them by label.",
     "Summarize the most recently updated pull requests in curie-eng/agentos.",

--- a/packages/plugin-format/schema/plugin-format.schema.json
+++ b/packages/plugin-format/schema/plugin-format.schema.json
@@ -399,6 +399,21 @@
           "default": null,
           "title": "Repository"
         },
+        "secrets": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Secrets"
+        },
         "starterPrompts": {
           "anyOf": [
             {

--- a/packages/plugin-format/src/plugin_format/models.py
+++ b/packages/plugin-format/src/plugin_format/models.py
@@ -62,6 +62,12 @@ class PluginManifest(BaseModel):
     # Initial terminal/chat affordances. These are bundle-authored conversation
     # starters, not response actions; adapters discard them after the first turn.
     starterPrompts: list[str] | None = None
+    # AgentOS authoring extension (ADR-0009, #429): the named secrets this
+    # bundle's connectors need (e.g. an authed MCP server's API token). Policy
+    # only -- the NAMES, never values. Values are supplied per-agent at deploy
+    # time and delivered into the sandbox env, where ``.mcp.json`` ``${VAR}``
+    # expansion consumes them. Validated env-var-style by ``validate.py``.
+    secrets: list[str] | None = None
     # AgentOS authoring extensions (epic #30 / #29), validated at deploy time by
     # ``validate.py``. Kept loosely typed on the manifest (the models stay
     # lenient); the dedicated ``TriggerDeclaration`` / ``ApprovalPolicy`` models

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -82,6 +82,7 @@ def validate_bundle(path: str | Path) -> ValidationResult:
         _validate_hooks(root, manifest, c)
         _validate_triggers(manifest, c)
         _validate_approval_policy(manifest, c)
+        _validate_secrets(manifest, c)
         _validate_scripts(root, c)
 
     return c.result()
@@ -337,6 +338,37 @@ def _validate_approval_policy(manifest: PluginManifest, c: _Collector) -> None:
             c.error(
                 "approval_policy.incomplete",
                 "an approval gate must define a non-empty 'gate' and 'route'",
+                loc,
+            )
+
+
+_SECRET_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+
+def _validate_secrets(manifest: PluginManifest, c: _Collector) -> None:
+    """Validate the manifest ``secrets`` policy (deploy-time gate, ADR-0009 / #429).
+
+    ``secrets`` is a list of the named connector secrets the bundle needs (the
+    NAMES only, never values). Each must be an environment-variable-style name
+    (``^[A-Z_][A-Z0-9_]*$``) so it can be forwarded into the sandbox env and
+    consumed by ``.mcp.json`` ``${VAR}`` expansion; a malformed name is rejected
+    at deploy before an agent ships expecting a secret that can never bind.
+    """
+
+    declared = manifest.secrets
+    if declared is None:
+        return
+    if not isinstance(declared, list):
+        c.error("secrets.invalid", "secrets must be a list of names", "plugin.json")
+        return
+
+    for i, name in enumerate(declared):
+        loc = f"plugin.json (secrets[{i}])"
+        if not isinstance(name, str) or not _SECRET_NAME_RE.match(name):
+            c.error(
+                "secrets.name_invalid",
+                f"secret name {name!r} must be an env-var-style name "
+                "(uppercase letters, digits, underscore; not starting with a digit)",
                 loc,
             )
 

--- a/packages/plugin-format/tests/test_models.py
+++ b/packages/plugin-format/tests/test_models.py
@@ -57,6 +57,20 @@ def test_manifest_starter_prompts_round_trip() -> None:
     assert PluginManifest.model_validate({"name": "demo"}).starterPrompts is None
 
 
+def test_manifest_secrets_field() -> None:
+    """The AgentOS ``secrets`` policy extension round-trips (ADR-0009 / #429)."""
+    manifest = PluginManifest.model_validate(
+        {"name": "demo", "secrets": ["GITHUB_PERSONAL_ACCESS_TOKEN"]}
+    )
+    assert manifest.secrets == ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+    # Absent -> None (backward compatible; bundles without it still validate).
+    assert PluginManifest.model_validate({"name": "demo"}).secrets is None
+    # Serializes back under the verbatim key.
+    assert manifest.model_dump(exclude_none=True)["secrets"] == [
+        "GITHUB_PERSONAL_ACCESS_TOKEN"
+    ]
+
+
 def test_manifest_trigger_and_approval_policy_fields() -> None:
     """The AgentOS trigger + approval-policy authoring extensions parse (#273)."""
     manifest = PluginManifest.model_validate(

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -145,6 +145,25 @@ def test_trigger_entry_not_object_is_rejected(tmp_path: Path) -> None:
     assert "triggers.invalid" in _codes(bundle)
 
 
+def test_valid_secrets_policy_passes(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path, '{"name": "demo", "secrets": ["GITHUB_PERSONAL_ACCESS_TOKEN", "API_KEY"]}'
+    )
+    assert validate_bundle(bundle).valid
+
+
+def test_non_env_var_secret_name_is_rejected(tmp_path: Path) -> None:
+    # A lowercase/hyphenated name cannot be forwarded as an env var -> rejected.
+    bundle = _bundle(tmp_path, '{"name": "demo", "secrets": ["github-token"]}')
+    assert "secrets.name_invalid" in _codes(bundle)
+
+
+def test_malformed_secrets_shape_is_rejected(tmp_path: Path) -> None:
+    # A non-list secrets value is rejected.
+    bundle = _bundle(tmp_path, '{"name": "demo", "secrets": "nope"}')
+    assert not validate_bundle(bundle).valid
+
+
 def test_valid_approval_policy_passes(tmp_path: Path) -> None:
     bundle = _bundle(
         tmp_path,


### PR DESCRIPTION
Adds an optional `secrets: [NAME,…]` field to the plugin-format manifest — the versioned, evaluable list of named connector secrets a bundle needs (the **names only**, never values). First implementation PR for #429 / ADR-0009 (PR #435).

- `PluginManifest.secrets: list[str] | None` (lenient models, mirrors the `starterPrompts` extension).
- `_validate_secrets` rejects non-env-var-style names at deploy (`secrets.name_invalid`), wired into `validate_bundle`.
- Regenerated the committed `plugin-format.schema.json` (`scripts/check-contracts.sh` clean; no aci/rust/ts drift).
- Declared `GITHUB_PERSONAL_ACCESS_TOKEN` on the `github-issues` example.
- Tests: `test_manifest_secrets_field`, valid/invalid-name/malformed-shape validate cases.

Backward-compatible (absent → None), lands independently.

Ref #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)