### PR TITLE
cluster: per-agent connector-secret Secret + render assertions (#429)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -115,6 +115,14 @@ jobs:
           set -euo pipefail
           bash charts/agentos/ci/controller-rbac-assertions.sh
 
+      # Prove per-agent connector secrets (ADR-0009, #429) render as their own
+      # Secret, do not leak into the shared chart Secret, and are absent by
+      # default.
+      - name: helm render assertions (per-agent connector secrets)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/connector-secrets-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ oauth.env
 # this the chart is silently uninstallable (backing stores reference a Secret
 # that never gets committed).
 !charts/agentos/templates/secrets.yaml
+# Same exception for the per-agent connector-secret template + its render-
+# assertion script (ADR-0009, #429): Helm syntax / a test, not secret material.
+!charts/agentos/templates/agent-connector-secrets.yaml
+!charts/agentos/ci/connector-secrets-assertions.sh
 
 # Python
 __pycache__/

--- a/charts/agentos/ci/connector-secrets-assertions.sh
+++ b/charts/agentos/ci/connector-secrets-assertions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for per-agent connector secrets (ADR-0009, #429). Proves,
+# with `helm template` alone (no cluster), that:
+#
+#   1. Each `agentSandbox.connectorSecrets.<agent>` entry renders its OWN Opaque
+#      Secret named <fullname>-agent-<agent>-connector-secrets, labelled
+#      agentos.dev/agent=<agent>, carrying that agent's named values.
+#   2. Those values are NOT merged into the shared chart Secret
+#      (<fullname>) -- one agent's connector token must not be readable by every
+#      component.
+#   3. With no connectorSecrets (the default) NO connector Secret renders, so a
+#      stock install is unaffected (fail-closed / no surprise objects).
+#
+# Fails loudly, naming the assertion. Runnable locally and from CI.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+  echo "ASSERTION FAILED: $1" >&2
+  exit 1
+}
+
+# 1 + 2: a configured agent renders its own Secret with the value, and the shared
+# Secret does not carry it.
+rendered="$(helm template agentos "$CHART" \
+  --set 'agentSandbox.connectorSecrets.github-issues.GITHUB_PERSONAL_ACCESS_TOKEN=ghp_assert' 2>/dev/null)"
+
+per_agent="$(printf '%s' "$rendered" | awk '
+  /^# Source: agentos\/templates\/agent-connector-secrets.yaml/ {inblock=1}
+  /^# Source:/ && !/agent-connector-secrets/ {inblock=0}
+  inblock {print}
+')"
+
+printf '%s' "$per_agent" | grep -q "name: agentos-agent-github-issues-connector-secrets" \
+  || fail "per-agent Secret 'agentos-agent-github-issues-connector-secrets' did not render"
+printf '%s' "$per_agent" | grep -q 'agentos.dev/agent: "github-issues"' \
+  || fail "per-agent Secret missing the agentos.dev/agent label"
+printf '%s' "$per_agent" | grep -q 'GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_assert"' \
+  || fail "per-agent Secret missing the connector value"
+
+# The shared chart Secret (Source secrets.yaml) must NOT carry the connector key.
+shared="$(printf '%s' "$rendered" | awk '
+  /^# Source: agentos\/templates\/secrets.yaml/ {inblock=1}
+  /^# Source:/ && !/templates\/secrets.yaml/ {inblock=0}
+  inblock {print}
+')"
+if printf '%s' "$shared" | grep -q "GITHUB_PERSONAL_ACCESS_TOKEN"; then
+  fail "connector secret leaked into the shared chart Secret"
+fi
+
+# 3: no connectorSecrets -> no connector Secret object at all.
+default_render="$(helm template agentos "$CHART" 2>/dev/null)"
+if printf '%s' "$default_render" | grep -q "connector-secrets"; then
+  fail "a connector Secret rendered with no agentSandbox.connectorSecrets configured"
+fi
+
+echo "OK: per-agent connector-secret render assertions passed"

--- a/charts/agentos/templates/agent-connector-secrets.yaml
+++ b/charts/agentos/templates/agent-connector-secrets.yaml
@@ -1,0 +1,32 @@
+{{/*
+Per-agent connector-secret Secrets (ADR-0009, #429).
+
+Each agent that needs authed-MCP connector secrets gets its OWN Opaque Secret,
+named <fullname>-agent-<agentName>-connector-secrets, holding that agent's named
+secret VALUES. Deliberately separate from the shared chart Secret
+(`agentos.secretName`) so one agent's connector token is not readable by every
+component, and never placed on the value-only SandboxClaim CR: the runner
+sandbox reads a value via a per-agent SandboxTemplate `secretKeyRef` (that
+binding is cluster-verified and tracked separately, see ADR-0009). Rendered from
+`agentSandbox.connectorSecrets` (agent name -> {NAME: value}); nothing renders
+when the map is empty (the default), so a stock install is unaffected.
+*/}}
+{{- if .Values.agentSandbox.deploy }}
+{{- range $agent, $secrets := .Values.agentSandbox.connectorSecrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentos.fullname" $ }}-agent-{{ $agent }}-connector-secrets
+  labels:
+    {{- include "agentos.labels" $ | nindent 4 }}
+    agentos.dev/agent: {{ $agent | quote }}
+  annotations:
+    agentos.dev/purpose: per-agent-connector-secrets
+type: Opaque
+stringData:
+  {{- range $name, $value := $secrets }}
+  {{ $name }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -668,6 +668,19 @@ preflights:
 # ---------------------------------------------------------------------------
 agentSandbox:
   deploy: true
+  # Per-agent connector secrets (ADR-0009, #429): a map of agent name -> the
+  # named connector secret VALUES that agent's authed MCP servers need. Each
+  # entry renders as its OWN Kubernetes Secret
+  # (<fullname>-agent-<name>-connector-secrets), kept off the shared chart
+  # Secret and off the value-only SandboxClaim CR. The runner sandbox reads a
+  # value via a per-agent SandboxTemplate `secretKeyRef` (the binding half is
+  # cluster-verified, tracked separately). Empty by default; supply per agent,
+  # e.g.:
+  #   connectorSecrets:
+  #     github-issues:
+  #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+  # Prefer `--set-file`/a sealed values file over inlining a real token.
+  connectorSecrets: {}
   controller:
     # Installs the vendored kubernetes-sigs/agent-sandbox v0.5.0 controller
     # (namespace agent-sandbox-system, RBAC, webhook Service, Deployment with


### PR DESCRIPTION
The **storage half** of ADR-0009's cluster-tier per-agent secret plane (#429), fully offline-verifiable.

Each `agentSandbox.connectorSecrets.<agent>` entry renders its **own** Opaque Secret (`<fullname>-agent-<agent>-connector-secrets`), deliberately kept off the shared chart Secret (so one agent's token isn't readable by every component) and off the value-only `SandboxClaim` CR. Nothing renders by default, so a stock install is unaffected.

- `charts/agentos/templates/agent-connector-secrets.yaml` — the per-agent Secret.
- `charts/agentos/values.yaml` — `agentSandbox.connectorSecrets` (documented, `{}` default).
- `charts/agentos/ci/connector-secrets-assertions.sh` — `helm template` assertions (wired into `helm-ci`): the Secret renders with its value + `agentos.dev/agent` label, does **not** leak into the shared Secret, and is absent when unconfigured.
- `.gitignore` — negations so the template + test (which contain "secret") aren't caught by the `*secret*` rule (same precedent as `secrets.yaml`).

Verified: `bash charts/agentos/ci/connector-secrets-assertions.sh` passes; `helm lint` clean.

## Deliberately out of scope (the sacred / cluster-verified remainder)
The **delivery half** — binding this Secret into the sandbox via a per-agent SandboxTemplate `secretKeyRef` and routing the worker claim to that per-agent pool, plus the per-agent egress NetworkPolicy `podSelector` — changes the **sacred worker claim path** (`apps/worker/CLAUDE.md`: single-owner + adversarial review) and the shared warm-pool, and can only be truly verified on a live cluster. Confirmed the CRD supports `secretKeyRef` in the SandboxTemplate (the model credential already uses it). Tracked as a follow-up issue.

Ref #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)