### PR TITLE
TUI: guided "Deploy to Slack" workflow (local + cluster)

### DIFF
--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -336,9 +336,7 @@ fn run_recipe_in_tui(
             Workflow::ExploreExamples => explore_examples(terminal, app, &values)?,
             Workflow::ParityLadder => parity_ladder(terminal, app)?,
             Workflow::DeployToSlack => deploy_to_slack(terminal, app, SlackTier::Local)?,
-            Workflow::DeployToSlackCluster => {
-                deploy_to_slack(terminal, app, SlackTier::Cluster)?
-            }
+            Workflow::DeployToSlackCluster => deploy_to_slack(terminal, app, SlackTier::Cluster)?,
         }
         return Ok(format!("Finished: {}", recipe.title));
     }
@@ -2025,7 +2023,7 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 "local"
             };
             lines.push(Line::from(Span::styled(
-                "Deploy to Slack",
+                "How to deploy to Slack",
                 Style::default().fg(Color::Yellow).bold(),
             )));
             lines.push(Line::from(
@@ -2695,7 +2693,7 @@ fn recipes() -> Vec<Recipe> {
         },
         Recipe {
             target: "local",
-            title: "Deploy to Slack",
+            title: "How to deploy to Slack",
             description: "Deploy an agent to the local platform and connect it to a real Slack workspace.",
             kind: RecipeKind::Workflow(Workflow::DeployToSlack),
             args: vec![],
@@ -2708,7 +2706,7 @@ fn recipes() -> Vec<Recipe> {
         },
         Recipe {
             target: "cluster",
-            title: "Deploy to Slack",
+            title: "How to deploy to Slack",
             description: "Deploy an agent to the deployed cluster release and connect it to a real Slack workspace.",
             kind: RecipeKind::Workflow(Workflow::DeployToSlackCluster),
             args: vec![],
@@ -2960,13 +2958,13 @@ mod tests {
         let app = App::new();
         // Local-tier Deploy to Slack under the `local` tab.
         assert!(app.recipes.iter().any(|recipe| {
-            recipe.title == "Deploy to Slack"
+            recipe.title == "How to deploy to Slack"
                 && recipe.target == "local"
                 && matches!(recipe.kind, RecipeKind::Workflow(Workflow::DeployToSlack))
         }));
         // Cluster-tier Deploy to Slack under the `cluster` tab.
         assert!(app.recipes.iter().any(|recipe| {
-            recipe.title == "Deploy to Slack"
+            recipe.title == "How to deploy to Slack"
                 && recipe.target == "cluster"
                 && matches!(
                     recipe.kind,

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -823,6 +823,37 @@ fn deploy_to_slack(
     .filter(|dir| !dir.trim().is_empty())
     .unwrap_or_else(|| ".".to_string());
 
+    // Cluster targets a specific Helm release; prompt for its namespace/release
+    // so the workflow works for a release not named the default `agentos` (the
+    // API auto-discovery and `cluster comms` both key off these).
+    let (namespace, release) = if tier == SlackTier::Cluster {
+        let ns = prompt_text(
+            terminal,
+            app,
+            "Deploy to Slack",
+            "Kubernetes namespace",
+            Some("agentos"),
+            false,
+            true,
+        )?
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "agentos".to_string());
+        let rel = prompt_text(
+            terminal,
+            app,
+            "Deploy to Slack",
+            "Helm release name",
+            Some("agentos"),
+            false,
+            true,
+        )?
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "agentos".to_string());
+        (Some(ns), Some(rel))
+    } else {
+        (None, None)
+    };
+
     // 4. Forward the model credential + Slack tokens into the child processes.
     //    `<tier> comms --slack` reads SLACK_APP_TOKEN/SLACK_BOT_TOKEN from its env;
     //    a value already exported is inherited by the child, so only vault-stored
@@ -870,6 +901,16 @@ fn deploy_to_slack(
             deploy_argv.push("--api-url".to_string());
             deploy_argv.push("http://localhost:28000".to_string());
         }
+        // Cluster: target the named release (deploy auto-discovers the API from
+        // it, comms upgrades it).
+        if let (Some(ns), Some(rel)) = (&namespace, &release) {
+            deploy_argv.extend([
+                "--namespace".to_string(),
+                ns.clone(),
+                "--release".to_string(),
+                rel.clone(),
+            ]);
+        }
         run_agentos_in_tui_with_env(
             terminal,
             app,
@@ -879,10 +920,19 @@ fn deploy_to_slack(
             &secret_env,
         )?;
         // Wire the real Slack tokens and start the dispatcher.
+        let mut comms_argv = vec![verb.to_string(), "comms".to_string(), "--slack".to_string()];
+        if let (Some(ns), Some(rel)) = (&namespace, &release) {
+            comms_argv.extend([
+                "--namespace".to_string(),
+                ns.clone(),
+                "--release".to_string(),
+                rel.clone(),
+            ]);
+        }
         run_agentos_in_tui_with_env(
             terminal,
             app,
-            &[verb.to_string(), "comms".to_string(), "--slack".to_string()],
+            &comms_argv,
             &repo_root,
             &mut view,
             &secret_env,

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -75,6 +75,7 @@ enum TuiAction {
 enum Workflow {
     ExploreExamples,
     ParityLadder,
+    DeployToSlack,
 }
 
 #[derive(Clone, Debug)]
@@ -317,6 +318,7 @@ fn run_recipe_in_tui(
         match workflow {
             Workflow::ExploreExamples => explore_examples(terminal, app, &values)?,
             Workflow::ParityLadder => parity_ladder(terminal, app)?,
+            Workflow::DeployToSlack => deploy_to_slack(terminal, app, &values)?,
         }
         return Ok(format!("Finished: {}", recipe.title));
     }
@@ -719,6 +721,185 @@ fn explore_examples(
     Ok(())
 }
 
+/// Guided "Deploy to Slack" workflow (local tier): walk the operator through the
+/// one-time Slack-app creation (the part that can't be automated), collect the
+/// tokens + channel id into the secret vault, then run `local up` -> `local
+/// deploy` -> `local comms --slack` inside the TUI. Mirrors `explore_examples`.
+fn deploy_to_slack(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    _values: &BTreeMap<String, String>,
+) -> Result<()> {
+    // 1. The manual, browser-only part: create the Slack app and gather the two
+    //    tokens + the channel id. Pause until the operator has them.
+    let mut intro = RunView::new("Deploy to Slack — create your Slack app");
+    for line in [
+        "This connects a local AgentOS agent to a real Slack workspace through the",
+        "compose stack: local up -> local deploy -> local comms --slack.",
+        "",
+        "STEP 1 (one time, in your browser -- not automatable):",
+        "  1. Open https://api.slack.com/apps  ->  Create New App  ->  From a manifest",
+        "  2. Paste the manifest from this repo: apps/dispatcher/slack-app-manifest.yaml",
+        "  3. 'Basic Information' -> 'App-Level Tokens' -> Generate a token with the",
+        "     'connections:write' scope. Copy the xapp-... value  (SLACK_APP_TOKEN).",
+        "  4. 'Install App' -> 'Install to Workspace'. Copy the 'Bot User OAuth Token'",
+        "     (xoxb-...)  (SLACK_BOT_TOKEN).",
+        "  5. In Slack, invite the bot to a channel:  /invite @agentos",
+        "  6. Copy that channel's ID: channel name -> 'View channel details' -> the",
+        "     C0... id at the very bottom.",
+        "",
+        "Next you'll paste the two tokens (hidden) and the channel id.",
+        "Press Enter when you have all three.",
+    ] {
+        intro.push(line);
+    }
+    show_run_view(terminal, app, &mut intro)?;
+
+    // 2. Save the model credential + Slack tokens into the vault (hidden input).
+    crate::secrets::sync_secret_file()?;
+    ensure_model_credential_available(terminal, app)?;
+    ensure_secret_available(terminal, app, "SLACK_APP_TOKEN")?;
+    ensure_secret_available(terminal, app, "SLACK_BOT_TOKEN")?;
+
+    // 3. Channel id + bundle dir, prompted after the operator has completed step 1.
+    let Some(channel) = prompt_text(
+        terminal,
+        app,
+        "Deploy to Slack",
+        "Slack channel ID (C0...)",
+        None,
+        false,
+        false,
+    )?
+    else {
+        return Ok(());
+    };
+    let plugin_dir = prompt_text(
+        terminal,
+        app,
+        "Deploy to Slack",
+        "Agent bundle directory",
+        Some("."),
+        false,
+        true,
+    )?
+    .filter(|dir| !dir.trim().is_empty())
+    .unwrap_or_else(|| ".".to_string());
+
+    // 4. Forward the model credential + Slack tokens into the child processes.
+    //    `local comms --slack` reads SLACK_APP_TOKEN/SLACK_BOT_TOKEN from its env
+    //    and the compose worker reads the model credential the same way; a value
+    //    already exported is inherited by the child, so only vault-stored ones
+    //    are forwarded here.
+    let secret_env = slack_secret_env()?;
+
+    // Run from the repo root (compose files are repo-relative on a dev checkout);
+    // resolve the bundle dir to an absolute path so `--plugin-dir` finds it
+    // regardless of the run cwd.
+    let cwd = std::env::current_dir().context("reading current directory")?;
+    let plugin_abs = cwd.join(&plugin_dir);
+    if !plugin_abs.join(".claude-plugin/plugin.json").is_file() {
+        anyhow::bail!(
+            "no agent bundle at {} (expected a .claude-plugin/plugin.json there)",
+            plugin_abs.display()
+        );
+    }
+    let repo_root = find_repo_root(cwd.clone()).unwrap_or(cwd);
+    let api_url = "http://localhost:28000";
+
+    let mut view = RunView::new(&format!("Deploy to Slack — channel {channel}"));
+    let run_result = (|| -> Result<()> {
+        run_agentos_in_tui_with_env(
+            terminal,
+            app,
+            &["local".to_string(), "up".to_string()],
+            &repo_root,
+            &mut view,
+            &secret_env,
+        )?;
+        run_agentos_in_tui_with_env(
+            terminal,
+            app,
+            &[
+                "local".to_string(),
+                "deploy".to_string(),
+                "--plugin-dir".to_string(),
+                plugin_abs.display().to_string(),
+                "--slack-channel".to_string(),
+                channel.clone(),
+                "--api-url".to_string(),
+                api_url.to_string(),
+            ],
+            &repo_root,
+            &mut view,
+            &secret_env,
+        )?;
+        run_agentos_in_tui_with_env(
+            terminal,
+            app,
+            &[
+                "local".to_string(),
+                "comms".to_string(),
+                "--slack".to_string(),
+            ],
+            &repo_root,
+            &mut view,
+            &secret_env,
+        )
+    })();
+
+    if let Err(err) = run_result {
+        view.push("");
+        view.push(format!("ERROR: {err:#}"));
+        show_run_view(terminal, app, &mut view)?;
+        return Err(err);
+    }
+
+    let mut done = RunView::new("Deploy to Slack — connected");
+    for line in [
+        format!("Your agent is deployed and wired to Slack channel {channel}."),
+        String::new(),
+        "Try it: in Slack, @mention the bot in that channel (or DM it) and send a".to_string(),
+        "message -- the dispatcher routes it through the worker to your agent.".to_string(),
+        String::new(),
+        "Disconnect Slack:  agentos local comms --slack --disconnect".to_string(),
+        "Stop the stack:    agentos local down".to_string(),
+    ] {
+        done.push(line);
+    }
+    show_run_view(terminal, app, &mut done)?;
+    Ok(())
+}
+
+/// The env forwarded into the `local up`/`deploy`/`comms` children for the Slack
+/// deploy workflow: the first available model credential and the two Slack
+/// tokens, each pulled from the vault only when not already exported (an exported
+/// value is inherited by the child process directly).
+fn slack_secret_env() -> Result<Vec<(String, String)>> {
+    let mut env = Vec::new();
+    for name in [
+        "AGENTOS_CREDENTIALS",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ] {
+        if std::env::var_os(name).is_some() {
+            break;
+        }
+        if let Some(value) = crate::secrets::get_value(name)? {
+            env.push((name.to_string(), value));
+            break;
+        }
+    }
+    for name in ["SLACK_APP_TOKEN", "SLACK_BOT_TOKEN"] {
+        if std::env::var_os(name).is_none() {
+            if let Some(value) = crate::secrets::get_value(name)? {
+                env.push((name.to_string(), value));
+            }
+        }
+    }
+    Ok(env)
+}
+
 fn example_choices() -> Vec<ExampleChoice> {
     vec![
         ExampleChoice {
@@ -952,7 +1133,7 @@ fn secrets_status_lines() -> Vec<Line<'static>> {
 
 fn maybe_add_secret_status(lines: &mut Vec<Line<'static>>, workflow: Workflow) {
     match workflow {
-        Workflow::ExploreExamples => {
+        Workflow::ExploreExamples | Workflow::DeployToSlack => {
             lines.push(Line::from(Span::styled(
                 "Credential status",
                 Style::default().fg(Color::Yellow).bold(),
@@ -1743,6 +1924,24 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             ));
             lines.push(Line::from(""));
         }
+        RecipeKind::Workflow(Workflow::DeployToSlack) => {
+            lines.push(Line::from(Span::styled(
+                "Deploy to Slack",
+                Style::default().fg(Color::Yellow).bold(),
+            )));
+            lines.push(Line::from(
+                "1. Create a Slack app from the repo manifest (one time)",
+            ));
+            lines.push(Line::from(
+                "2. Save your app + bot tokens and the channel ID",
+            ));
+            lines.push(Line::from(
+                "3. local up -> local deploy -> local comms --slack",
+            ));
+            lines.push(Line::from("4. @mention the bot in Slack to test"));
+            lines.push(Line::from(""));
+            maybe_add_secret_status(&mut lines, Workflow::DeployToSlack);
+        }
     }
     if !recipe.fields.is_empty() {
         lines.push(Line::from(Span::styled(
@@ -2396,6 +2595,19 @@ fn recipes() -> Vec<Recipe> {
             ],
         },
         Recipe {
+            target: "local",
+            title: "Deploy to Slack",
+            description: "Deploy an agent to the local platform and connect it to a real Slack workspace.",
+            kind: RecipeKind::Workflow(Workflow::DeployToSlack),
+            args: vec![],
+            fields: vec![],
+            notes: &[
+                "Creating the Slack app is a one-time manual step; the workflow gives you the manifest path and links.",
+                "Requires a model credential plus your Slack app-level (xapp-) and bot (xoxb-) tokens, saved when prompted.",
+                "Runs local up -> local deploy -> local comms --slack; then @mention the bot in your channel to test.",
+            ],
+        },
+        Recipe {
             target: "secrets",
             title: "Save secret",
             description: "Store a local secret in AgentOS private storage with hidden input.",
@@ -2629,6 +2841,22 @@ mod tests {
         }
         // And they lead the recipe list (first recipe is on the platform tab).
         assert_eq!(app.recipes.first().map(|r| r.target), Some("platform"));
+    }
+
+    #[test]
+    fn deploy_to_slack_recipe_is_registered_under_local() {
+        let app = App::new();
+        let recipe = app
+            .recipes
+            .iter()
+            .find(|recipe| recipe.title == "Deploy to Slack")
+            .expect("Deploy to Slack recipe should be registered");
+        assert_eq!(recipe.target, "local");
+        assert!(matches!(
+            recipe.kind,
+            RecipeKind::Workflow(Workflow::DeployToSlack)
+        ));
+        assert!(app.targets.contains(&"local"));
     }
 
     #[test]

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -76,6 +76,23 @@ enum Workflow {
     ExploreExamples,
     ParityLadder,
     DeployToSlack,
+    DeployToSlackCluster,
+}
+
+/// Which platform tier a Deploy-to-Slack workflow drives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SlackTier {
+    Local,
+    Cluster,
+}
+
+impl SlackTier {
+    fn verb(self) -> &'static str {
+        match self {
+            SlackTier::Local => "local",
+            SlackTier::Cluster => "cluster",
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -318,7 +335,10 @@ fn run_recipe_in_tui(
         match workflow {
             Workflow::ExploreExamples => explore_examples(terminal, app, &values)?,
             Workflow::ParityLadder => parity_ladder(terminal, app)?,
-            Workflow::DeployToSlack => deploy_to_slack(terminal, app, &values)?,
+            Workflow::DeployToSlack => deploy_to_slack(terminal, app, SlackTier::Local)?,
+            Workflow::DeployToSlackCluster => {
+                deploy_to_slack(terminal, app, SlackTier::Cluster)?
+            }
         }
         return Ok(format!("Finished: {}", recipe.title));
     }
@@ -721,21 +741,34 @@ fn explore_examples(
     Ok(())
 }
 
-/// Guided "Deploy to Slack" workflow (local tier): walk the operator through the
-/// one-time Slack-app creation (the part that can't be automated), collect the
-/// tokens + channel id into the secret vault, then run `local up` -> `local
-/// deploy` -> `local comms --slack` inside the TUI. Mirrors `explore_examples`.
+/// Guided "Deploy to Slack" workflow: walk the operator through the one-time
+/// Slack-app creation (the part that can't be automated), collect the tokens +
+/// channel id into the secret vault, then run `<tier> deploy` -> `<tier> comms
+/// --slack` (local additionally brings the compose stack up first) inside the
+/// TUI. Mirrors `explore_examples`.
 fn deploy_to_slack(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &App,
-    _values: &BTreeMap<String, String>,
+    tier: SlackTier,
 ) -> Result<()> {
+    let verb = tier.verb();
+
     // 1. The manual, browser-only part: create the Slack app and gather the two
     //    tokens + the channel id. Pause until the operator has them.
     let mut intro = RunView::new("Deploy to Slack — create your Slack app");
+    let flow = match tier {
+        SlackTier::Local => "compose stack: local up -> local deploy -> local comms --slack.",
+        SlackTier::Cluster => "deployed release: cluster deploy -> cluster comms --slack.",
+    };
+    intro.push(format!(
+        "This connects an AgentOS agent to a real Slack workspace through the {flow}"
+    ));
+    if tier == SlackTier::Cluster {
+        intro.push("Requires an installed release (agentos cluster up) with a model credential.");
+        intro.push("One Slack app = one Socket Mode owner: do not also run a local dispatcher");
+        intro.push("on the same app token.");
+    }
     for line in [
-        "This connects a local AgentOS agent to a real Slack workspace through the",
-        "compose stack: local up -> local deploy -> local comms --slack.",
         "",
         "STEP 1 (one time, in your browser -- not automatable):",
         "  1. Open https://api.slack.com/apps  ->  Create New App  ->  From a manifest",
@@ -756,8 +789,12 @@ fn deploy_to_slack(
     show_run_view(terminal, app, &mut intro)?;
 
     // 2. Save the model credential + Slack tokens into the vault (hidden input).
+    //    On the cluster tier the model credential is configured on the release at
+    //    `cluster up` time (a chart Secret), so only the Slack tokens are gathered.
     crate::secrets::sync_secret_file()?;
-    ensure_model_credential_available(terminal, app)?;
+    if tier == SlackTier::Local {
+        ensure_model_credential_available(terminal, app)?;
+    }
     ensure_secret_available(terminal, app, "SLACK_APP_TOKEN")?;
     ensure_secret_available(terminal, app, "SLACK_BOT_TOKEN")?;
 
@@ -787,15 +824,14 @@ fn deploy_to_slack(
     .unwrap_or_else(|| ".".to_string());
 
     // 4. Forward the model credential + Slack tokens into the child processes.
-    //    `local comms --slack` reads SLACK_APP_TOKEN/SLACK_BOT_TOKEN from its env
-    //    and the compose worker reads the model credential the same way; a value
-    //    already exported is inherited by the child, so only vault-stored ones
-    //    are forwarded here.
+    //    `<tier> comms --slack` reads SLACK_APP_TOKEN/SLACK_BOT_TOKEN from its env;
+    //    a value already exported is inherited by the child, so only vault-stored
+    //    ones are forwarded here.
     let secret_env = slack_secret_env()?;
 
-    // Run from the repo root (compose files are repo-relative on a dev checkout);
-    // resolve the bundle dir to an absolute path so `--plugin-dir` finds it
-    // regardless of the run cwd.
+    // Run from the repo root (compose files / the chart are repo-relative on a dev
+    // checkout); resolve the bundle dir to an absolute path so `--plugin-dir` finds
+    // it regardless of the run cwd.
     let cwd = std::env::current_dir().context("reading current directory")?;
     let plugin_abs = cwd.join(&plugin_dir);
     if !plugin_abs.join(".claude-plugin/plugin.json").is_file() {
@@ -805,43 +841,48 @@ fn deploy_to_slack(
         );
     }
     let repo_root = find_repo_root(cwd.clone()).unwrap_or(cwd);
-    let api_url = "http://localhost:28000";
 
     let mut view = RunView::new(&format!("Deploy to Slack — channel {channel}"));
     let run_result = (|| -> Result<()> {
+        // Local brings the compose platform up first (idempotent); the cluster
+        // release is expected to already be installed.
+        if tier == SlackTier::Local {
+            run_agentos_in_tui_with_env(
+                terminal,
+                app,
+                &["local".to_string(), "up".to_string()],
+                &repo_root,
+                &mut view,
+                &secret_env,
+            )?;
+        }
+        // Ship the bundle and bind it to the Slack channel. Local targets the
+        // compose API on 28000; cluster auto-discovers the release's UI /api proxy.
+        let mut deploy_argv = vec![
+            verb.to_string(),
+            "deploy".to_string(),
+            "--plugin-dir".to_string(),
+            plugin_abs.display().to_string(),
+            "--slack-channel".to_string(),
+            channel.clone(),
+        ];
+        if tier == SlackTier::Local {
+            deploy_argv.push("--api-url".to_string());
+            deploy_argv.push("http://localhost:28000".to_string());
+        }
         run_agentos_in_tui_with_env(
             terminal,
             app,
-            &["local".to_string(), "up".to_string()],
+            &deploy_argv,
             &repo_root,
             &mut view,
             &secret_env,
         )?;
+        // Wire the real Slack tokens and start the dispatcher.
         run_agentos_in_tui_with_env(
             terminal,
             app,
-            &[
-                "local".to_string(),
-                "deploy".to_string(),
-                "--plugin-dir".to_string(),
-                plugin_abs.display().to_string(),
-                "--slack-channel".to_string(),
-                channel.clone(),
-                "--api-url".to_string(),
-                api_url.to_string(),
-            ],
-            &repo_root,
-            &mut view,
-            &secret_env,
-        )?;
-        run_agentos_in_tui_with_env(
-            terminal,
-            app,
-            &[
-                "local".to_string(),
-                "comms".to_string(),
-                "--slack".to_string(),
-            ],
+            &[verb.to_string(), "comms".to_string(), "--slack".to_string()],
             &repo_root,
             &mut view,
             &secret_env,
@@ -856,25 +897,28 @@ fn deploy_to_slack(
     }
 
     let mut done = RunView::new("Deploy to Slack — connected");
-    for line in [
-        format!("Your agent is deployed and wired to Slack channel {channel}."),
-        String::new(),
-        "Try it: in Slack, @mention the bot in that channel (or DM it) and send a".to_string(),
-        "message -- the dispatcher routes it through the worker to your agent.".to_string(),
-        String::new(),
-        "Disconnect Slack:  agentos local comms --slack --disconnect".to_string(),
-        "Stop the stack:    agentos local down".to_string(),
-    ] {
-        done.push(line);
+    done.push(format!(
+        "Your agent is deployed and wired to Slack channel {channel}."
+    ));
+    done.push("");
+    done.push("Try it: in Slack, @mention the bot in that channel (or DM it) and send a");
+    done.push("message -- the dispatcher routes it through the worker to your agent.");
+    done.push("");
+    done.push(format!(
+        "Disconnect Slack:  agentos {verb} comms --slack --disconnect"
+    ));
+    if tier == SlackTier::Local {
+        done.push("Stop the stack:    agentos local down".to_string());
     }
     show_run_view(terminal, app, &mut done)?;
     Ok(())
 }
 
-/// The env forwarded into the `local up`/`deploy`/`comms` children for the Slack
-/// deploy workflow: the first available model credential and the two Slack
-/// tokens, each pulled from the vault only when not already exported (an exported
-/// value is inherited by the child process directly).
+/// The env forwarded into the deploy/comms children for the Slack deploy
+/// workflow: the first available model credential and the two Slack tokens, each
+/// pulled from the vault only when not already exported (an exported value is
+/// inherited by the child process directly). The cluster tier ignores the model
+/// credential here (it lives on the chart Secret) but forwarding it is harmless.
 fn slack_secret_env() -> Result<Vec<(String, String)>> {
     let mut env = Vec::new();
     for name in [
@@ -1133,7 +1177,7 @@ fn secrets_status_lines() -> Vec<Line<'static>> {
 
 fn maybe_add_secret_status(lines: &mut Vec<Line<'static>>, workflow: Workflow) {
     match workflow {
-        Workflow::ExploreExamples | Workflow::DeployToSlack => {
+        Workflow::ExploreExamples | Workflow::DeployToSlack | Workflow::DeployToSlackCluster => {
             lines.push(Line::from(Span::styled(
                 "Credential status",
                 Style::default().fg(Color::Yellow).bold(),
@@ -1924,7 +1968,12 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             ));
             lines.push(Line::from(""));
         }
-        RecipeKind::Workflow(Workflow::DeployToSlack) => {
+        RecipeKind::Workflow(wf @ (Workflow::DeployToSlack | Workflow::DeployToSlackCluster)) => {
+            let tier = if matches!(wf, Workflow::DeployToSlackCluster) {
+                "cluster"
+            } else {
+                "local"
+            };
             lines.push(Line::from(Span::styled(
                 "Deploy to Slack",
                 Style::default().fg(Color::Yellow).bold(),
@@ -1935,12 +1984,12 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             lines.push(Line::from(
                 "2. Save your app + bot tokens and the channel ID",
             ));
-            lines.push(Line::from(
-                "3. local up -> local deploy -> local comms --slack",
-            ));
+            lines.push(Line::from(format!(
+                "3. {tier} deploy -> {tier} comms --slack"
+            )));
             lines.push(Line::from("4. @mention the bot in Slack to test"));
             lines.push(Line::from(""));
-            maybe_add_secret_status(&mut lines, Workflow::DeployToSlack);
+            maybe_add_secret_status(&mut lines, *wf);
         }
     }
     if !recipe.fields.is_empty() {
@@ -2608,6 +2657,19 @@ fn recipes() -> Vec<Recipe> {
             ],
         },
         Recipe {
+            target: "cluster",
+            title: "Deploy to Slack",
+            description: "Deploy an agent to the deployed cluster release and connect it to a real Slack workspace.",
+            kind: RecipeKind::Workflow(Workflow::DeployToSlackCluster),
+            args: vec![],
+            fields: vec![],
+            notes: &[
+                "Requires an installed release (agentos cluster up) with a model credential configured on the chart.",
+                "Creating the Slack app is a one-time manual step; the workflow gives you the manifest path and links.",
+                "Runs cluster deploy -> cluster comms --slack; one Slack app owns one Socket Mode dispatcher.",
+            ],
+        },
+        Recipe {
             target: "secrets",
             title: "Save secret",
             description: "Store a local secret in AgentOS private storage with hidden input.",
@@ -2844,19 +2906,24 @@ mod tests {
     }
 
     #[test]
-    fn deploy_to_slack_recipe_is_registered_under_local() {
+    fn deploy_to_slack_recipes_registered_for_both_tiers() {
         let app = App::new();
-        let recipe = app
-            .recipes
-            .iter()
-            .find(|recipe| recipe.title == "Deploy to Slack")
-            .expect("Deploy to Slack recipe should be registered");
-        assert_eq!(recipe.target, "local");
-        assert!(matches!(
-            recipe.kind,
-            RecipeKind::Workflow(Workflow::DeployToSlack)
-        ));
-        assert!(app.targets.contains(&"local"));
+        // Local-tier Deploy to Slack under the `local` tab.
+        assert!(app.recipes.iter().any(|recipe| {
+            recipe.title == "Deploy to Slack"
+                && recipe.target == "local"
+                && matches!(recipe.kind, RecipeKind::Workflow(Workflow::DeployToSlack))
+        }));
+        // Cluster-tier Deploy to Slack under the `cluster` tab.
+        assert!(app.recipes.iter().any(|recipe| {
+            recipe.title == "Deploy to Slack"
+                && recipe.target == "cluster"
+                && matches!(
+                    recipe.kind,
+                    RecipeKind::Workflow(Workflow::DeployToSlackCluster)
+                )
+        }));
+        assert!(app.targets.contains(&"local") && app.targets.contains(&"cluster"));
     }
 
     #[test]


### PR DESCRIPTION
Adds a guided **Deploy to Slack** workflow to the interactive TUI (`agentos`), so an agent can be taken end-to-end onto a real Slack workspace without memorizing the command sequence. Available on both the **`local`** and **`cluster`** tabs.

## What it does
A `Workflow::DeployToSlack` / `DeployToSlackCluster` recipe (one tier-parameterized function) that:
1. **Shows the one-time, browser-only Slack-app steps** it can't automate — create the app from `apps/dispatcher/slack-app-manifest.yaml`, generate the app-level (`xapp-`) token, install for the bot (`xoxb-`) token, `/invite` the bot, copy the channel id — and pauses.
2. **Collects credentials into the secret vault** via hidden prompts: `SLACK_APP_TOKEN` + `SLACK_BOT_TOKEN` (and, local only, the model credential), then the channel id + bundle dir.
3. **Runs the real flow inside the TUI**, forwarding the tokens into the child env (`comms` reads them from env):
   - **local**: `local up` → `local deploy --plugin-dir <bundle> --slack-channel <id> --api-url http://localhost:28000` → `local comms --slack`
   - **cluster**: `cluster deploy --plugin-dir <bundle> --slack-channel <id>` (auto-discovers the UI /api proxy) → `cluster comms --slack` (assumes an installed release; model credential lives on the chart Secret)
4. **Prints how to test** (@mention the bot) and how to tear down.

## Notes
- Mirrors the existing `explore_examples` workflow machinery (`ensure_secret_available`, `run_agentos_in_tui_with_env`, `show_run_view` pauses).
- **TUI-only** — no clap command surface change, so no `command-manifest.json` regeneration.
- Cluster intro notes the single-Socket-Mode-owner constraint (don't run local + cluster dispatchers on the same app token).
- Tests: `deploy_to_slack_recipes_registered_for_both_tiers`. `cargo fmt`/`clippy`/`test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)