### PR TITLE
Add `agentos update`: self-reinstall the CLI from the checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ discoverable surface beats a scatter of scripts. The script or tool call can
 stay the *implementation*; it just isn't the interface.
 
 - Building the runner image → `agentos build` (not a copy-pasted `docker build -f runner/Dockerfile ...`).
-- First-run dev bootstrap → `agentos install`.
+- First-run dev bootstrap → `agentos install` (or `./install.sh`, which also puts `agentos` on PATH the first time).
+- Refresh the on-PATH CLI after a code change → `agentos update` (rebuilds and `cargo install`s the CLI to `~/.cargo/bin`; `--image` also rebuilds the runner). The per-change loop, so you never re-run the bootstrap script.
 - Contributor/CI scripts (contract codegen, chart render-asserts, the e2e round-trip) → `agentos dev <...>`. The `dev` namespace fences off commands that need a **source checkout + dev toolchains**; they error clearly when run from a released binary.
 - Operator/product commands stay top-level: `init`, `build`, `skill`, `local`, `cluster`.
 

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1912,6 +1912,26 @@ export const commandManifest = {
       "name": "install"
     },
     {
+      "about": "Rebuild this CLI from the source checkout and reinstall it on PATH (source checkout only)",
+      "args": [
+        {
+          "global": false,
+          "help": "Also rebuild the local runner image (for runner/ changes)",
+          "id": "image",
+          "long": "image",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "long_about": "Rebuild this CLI from the source checkout and reinstall it on PATH (source checkout only).\n\nThe fast per-change refresh: runs `cargo install --path cli --force` from the repo root so a code change to the CLI is live on the next `agentos` invocation, without re-running the bootstrap script. Pass `--image` to also rebuild the local runner image (for `runner/` changes). A release binary cannot rebuild itself and errors clearly.",
+      "name": "update"
+    },
+    {
       "about": "Open the interactive terminal interface",
       "hidden": false,
       "long_about": "Open the interactive terminal interface.\n\nA keyboard-driven terminal UI for humans: browse targets and actions, preview exact commands, fill required values, and run workflows without memorizing the full command surface.",

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1909,6 +1909,26 @@
       "name": "install"
     },
     {
+      "about": "Rebuild this CLI from the source checkout and reinstall it on PATH (source checkout only)",
+      "args": [
+        {
+          "global": false,
+          "help": "Also rebuild the local runner image (for runner/ changes)",
+          "id": "image",
+          "long": "image",
+          "positional": false,
+          "possible_values": [
+            "true",
+            "false"
+          ],
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "long_about": "Rebuild this CLI from the source checkout and reinstall it on PATH (source checkout only).\n\nThe fast per-change refresh: runs `cargo install --path cli --force` from the repo root so a code change to the CLI is live on the next `agentos` invocation, without re-running the bootstrap script. Pass `--image` to also rebuild the local runner image (for `runner/` changes). A release binary cannot rebuild itself and errors clearly.",
+      "name": "update"
+    },
+    {
       "about": "Open the interactive terminal interface",
       "hidden": false,
       "long_about": "Open the interactive terminal interface.\n\nA keyboard-driven terminal UI for humans: browse targets and actions, preview exact commands, fill required values, and run workflows without memorizing the full command surface.",

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -384,10 +384,19 @@ pub async fn install(update: bool) -> Result<()> {
 /// and the next invocation is the freshly installed one.
 pub async fn update(image: bool) -> Result<()> {
     let ui = crate::ui::ui();
-    let root = find_repo_root().context(
-        "runner/Dockerfile not found here or in any parent directory. Run `agentos update` \
-         from an agentos source checkout -- a release binary cannot rebuild itself.",
-    )?;
+    // `update` rebuilds from a source checkout; a release-installed binary has no
+    // checkout to rebuild from. Point that user at the release assets instead of
+    // the generic install error, and be explicit that self-update-from-release is
+    // not built here (#443 review).
+    let root = find_repo_root().ok_or_else(|| {
+        crate::exit::usage(
+            "`agentos update` rebuilds the CLI from a source checkout, but this binary is not \
+             running inside one.\n  - From a git clone: run `agentos update` from the repo.\n  \
+             - Installed from a GitHub release: download the latest agentos-<target> asset from \
+             https://github.com/curie-eng/agentos/releases and replace this binary (updating a \
+             released binary from the latest release is not built yet).",
+        )
+    })?;
     require_tool("cargo", "cargo is not installed - https://rustup.rs/")?;
     run_step(
         &root,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -375,6 +375,34 @@ pub async fn install(update: bool) -> Result<()> {
     Ok(())
 }
 
+/// `agentos update`: rebuild the CLI from this source checkout and reinstall it
+/// on PATH (`cargo install --path cli --force` -> ~/.cargo/bin), so a code change
+/// is picked up on the next `agentos` invocation without re-running the bootstrap
+/// script. Optionally rebuilds the local runner image too. Source-checkout only,
+/// like `install` -- a release binary has no source to rebuild from. Replacing the
+/// running binary is safe: the current process keeps running from the old inode
+/// and the next invocation is the freshly installed one.
+pub async fn update(image: bool) -> Result<()> {
+    let ui = crate::ui::ui();
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `agentos update` \
+         from an agentos source checkout -- a release binary cannot rebuild itself.",
+    )?;
+    require_tool("cargo", "cargo is not installed - https://rustup.rs/")?;
+    run_step(
+        &root,
+        "cargo",
+        &["install", "--path", "cli", "--force"],
+        "cargo install (cli -> ~/.cargo/bin)",
+    )
+    .await?;
+    if image {
+        build("agentos-runner").await?;
+    }
+    ui.success("agentos updated. The new binary is live on your next `agentos` invocation.");
+    Ok(())
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum EnvSeed {
     Preserved,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -109,6 +109,7 @@ enum Command {
     /// `--update`, already-present heavyweight artifacts like the runner image
     /// are reused. A release binary has no source tree to install and errors
     /// clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.
+    #[command(alias = "i")]
     Install {
         /// Reuse already-present artifacts while refreshing dependencies and builds.
         #[arg(long)]
@@ -121,6 +122,7 @@ enum Command {
     /// invocation, without re-running the bootstrap script. Pass `--image` to
     /// also rebuild the local runner image (for `runner/` changes). A release
     /// binary cannot rebuild itself and errors clearly.
+    #[command(alias = "u")]
     Update {
         /// Also rebuild the local runner image (for runner/ changes).
         #[arg(long)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,6 +114,18 @@ enum Command {
         #[arg(long)]
         update: bool,
     },
+    /// Rebuild this CLI from the source checkout and reinstall it on PATH (source checkout only).
+    ///
+    /// The fast per-change refresh: runs `cargo install --path cli --force` from
+    /// the repo root so a code change to the CLI is live on the next `agentos`
+    /// invocation, without re-running the bootstrap script. Pass `--image` to
+    /// also rebuild the local runner image (for `runner/` changes). A release
+    /// binary cannot rebuild itself and errors clearly.
+    Update {
+        /// Also rebuild the local runner image (for runner/ changes).
+        #[arg(long)]
+        image: bool,
+    },
     /// Open the interactive terminal interface.
     ///
     /// A keyboard-driven terminal UI for humans: browse targets and actions,
@@ -924,6 +936,7 @@ async fn run(command: Option<Command>) -> Result<()> {
         }) => commands::init(name, dir, from_spec),
         Some(Command::Build { tag }) => commands::build(&tag).await,
         Some(Command::Install { update }) => commands::install(update).await,
+        Some(Command::Update { image }) => commands::update(image).await,
         Some(Command::Interactive) => agentos::interactive::run().await,
         Some(Command::Secrets { action }) => match action {
             SecretsAction::Set { name, from_env } => {
@@ -1577,6 +1590,21 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Command::Install { update: true })
+        ));
+    }
+
+    #[test]
+    fn update_parses_with_and_without_image() {
+        let bare = Cli::try_parse_from(["agentos", "update"]).expect("update should parse");
+        assert!(matches!(
+            bare.command,
+            Some(Command::Update { image: false })
+        ));
+        let with_image =
+            Cli::try_parse_from(["agentos", "update", "--image"]).expect("update should parse");
+        assert!(matches!(
+            with_image.command,
+            Some(Command::Update { image: true })
         ));
     }
 

--- a/install.sh
+++ b/install.sh
@@ -46,3 +46,7 @@ echo "==> agentos install ${UPDATE_ARGS[*]} (deps + runner image as needed)"
 echo
 echo "Done. If 'agentos' is not found in this shell, add ~/.cargo/bin to PATH"
 echo "(rustup writes ~/.cargo/env for this) and open a new shell."
+echo
+echo "For future changes you don't need this script -- run 'agentos update' to"
+echo "rebuild and reinstall the CLI on PATH ('agentos update --image' also rebuilds"
+echo "the runner image)."


### PR DESCRIPTION
## Why
After a CLI code change, the only way to refresh the on-PATH `agentos` was `./install.sh` (heavy: uv sync + pnpm + runner image) or a raw `cargo install --path cli --force`. `agentos install --update` didn't help — its build step is `cargo build` → `target/debug`, which never touches `~/.cargo/bin`.

## What
Adds **`agentos update`** — the fast per-change loop:
- runs `cargo install --path cli --force` from the repo root, so a CLI change is live on the next `agentos` invocation;
- `--image` also rebuilds the local runner image (for `runner/` changes);
- source-checkout only (a release binary errors clearly);
- safe self-replace: the running process keeps the old inode; the next invocation is the new binary.

Plus: `CLAUDE.md` documents it as the on-PATH refresh, and `install.sh` now points to it for future changes.

## Test
- `update_parses_with_and_without_image` unit test; command-manifest regenerated (drift check passes).
- Ran it for real: rebuilt + replaced `~/.cargo/bin/agentos` (v0.3.1 → v0.4.0-rc.2) in ~14s; the new command is live on PATH.
- `cargo fmt`/`clippy`/`test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)