### PR TITLE
Reject reserved AGENTOS_* connector-secret names

### DIFF
--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -167,6 +167,15 @@ def _validate_secret_map(value: dict[str, str] | None) -> dict[str, str] | None:
                 f"secret name {name!r} must be an env-var-style name "
                 "(uppercase letters, digits, underscore; not starting with a digit)"
             )
+        if name.startswith("AGENTOS_"):
+            # AGENTOS_* names are the platform's reserved sandbox boot-env keys
+            # (budget/session/credential/etc.). A connector secret named that way
+            # would either clobber a boot var or be silently dropped by the worker
+            # binding's reserved-key guard, so reject it on write.
+            raise ValueError(
+                f"secret name {name!r} is reserved: AGENTOS_* names are platform "
+                "boot-env keys and cannot be used for a connector secret"
+            )
         if not secret:
             raise ValueError(f"secret {name!r} has an empty value")
     return value

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -416,3 +416,19 @@ def test_agent_non_env_var_secret_name_is_422(
         headers=auth_headers,
     )
     assert bad.status_code == 422, bad.text
+
+
+def test_agent_reserved_secret_name_is_422(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # AGENTOS_* names are reserved platform boot-env keys; rejected on write.
+    bad = client.post(
+        "/agents",
+        json={
+            "name": "reserved-secret-agent",
+            "slack_channel": "C000000S03",
+            "secrets": {"AGENTOS_BUDGET": "x"},
+        },
+        headers=auth_headers,
+    )
+    assert bad.status_code == 422, bad.text

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -371,6 +371,16 @@ def _validate_secrets(manifest: PluginManifest, c: _Collector) -> None:
                 "(uppercase letters, digits, underscore; not starting with a digit)",
                 loc,
             )
+        elif name.startswith("AGENTOS_"):
+            # AGENTOS_* names are the platform's reserved sandbox boot-env keys;
+            # a connector secret must not declare one (it would clobber or be
+            # dropped by the worker binding at delivery time).
+            c.error(
+                "secrets.name_reserved",
+                f"secret name {name!r} is reserved: AGENTOS_* names are platform "
+                "boot-env keys and cannot be used for a connector secret",
+                loc,
+            )
 
 
 def _validate_scripts(root: Path, c: _Collector) -> None:

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -158,6 +158,12 @@ def test_non_env_var_secret_name_is_rejected(tmp_path: Path) -> None:
     assert "secrets.name_invalid" in _codes(bundle)
 
 
+def test_reserved_agentos_secret_name_is_rejected(tmp_path: Path) -> None:
+    # AGENTOS_* names are reserved platform boot-env keys.
+    bundle = _bundle(tmp_path, '{"name": "demo", "secrets": ["AGENTOS_BUDGET"]}')
+    assert "secrets.name_reserved" in _codes(bundle)
+
+
 def test_malformed_secrets_shape_is_rejected(tmp_path: Path) -> None:
     # A non-list secrets value is rejected.
     bundle = _bundle(tmp_path, '{"name": "demo", "secrets": "nope"}')


### PR DESCRIPTION
## Why
Found during a bug scan of the #429 secret work. A connector secret named `AGENTOS_*` would collide with the platform's reserved sandbox boot-env keys (budget/session/credential/…): the worker binding's reserved-key guard would either drop it silently or a marker/boot var would clobber it. The env-var-style name check (`^[A-Z_][A-Z0-9_]*$`) accepted these names.

## Fix
Reject `AGENTOS_*` secret names in both gates:
- **API** `schemas._validate_secret_map` — `AgentCreate`/`AgentUpdate` write path → 422.
- **plugin-format** `validate._validate_secrets` — bundle `secrets` policy → `secrets.name_reserved`.

Runtime validators only — no JSON-schema/openapi change (confirmed no drift). Tests added on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)