### PR TITLE
TUI: lead with a "Platform" tab of the primary product functions

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -896,6 +896,333 @@ export const commandManifest = {
           ],
           "hidden": false,
           "name": "deploy"
+        },
+        {
+          "about": "List an agent's immutable versions (`GET /agents/{id}/versions`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "versions"
+        },
+        {
+          "about": "Show what an agent has learned (its memory log; `GET /agents/{id}/memory`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "memory"
+        },
+        {
+          "about": "View or set the tools whose calls require human approval (`PATCH /agents/{id}`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
+              "id": "gate",
+              "long": "gate",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear all approval gates on the agent",
+              "id": "clear",
+              "long": "clear",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "approvals"
+        },
+        {
+          "about": "Open the local observability surfaces (AgentOS Console + Langfuse traces/cost)",
+          "hidden": false,
+          "name": "observability"
+        },
+        {
+          "about": "Set an agent's daily budget (`PUT /agents/{id}/budget`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Daily spend cap in USD. Must be > 0",
+              "id": "limit",
+              "long": "limit",
+              "positional": false,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "budget"
+        },
+        {
+          "about": "Kill an agent (stop its runs; `POST /agents/{id}/kill`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the action",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "kill"
+        },
+        {
+          "about": "Resume a killed agent (`POST /agents/{id}/resume`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "resume"
         }
       ]
     },
@@ -1869,6 +2196,167 @@ export const commandManifest = {
           ],
           "hidden": false,
           "name": "delete"
+        },
+        {
+          "about": "List an agent's immutable versions (`GET /agents/{id}/versions`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "versions"
+        },
+        {
+          "about": "Show what an agent has learned (its memory log; `GET /agents/{id}/memory`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "memory"
+        },
+        {
+          "about": "View or set the tools whose calls require human approval (`PATCH /agents/{id}`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
+              "id": "gate",
+              "long": "gate",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear all approval gates on the agent",
+              "id": "clear",
+              "long": "clear",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "approvals"
         }
       ]
     },

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -893,6 +893,333 @@
           ],
           "hidden": false,
           "name": "deploy"
+        },
+        {
+          "about": "List an agent's immutable versions (`GET /agents/{id}/versions`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "versions"
+        },
+        {
+          "about": "Show what an agent has learned (its memory log; `GET /agents/{id}/memory`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "memory"
+        },
+        {
+          "about": "View or set the tools whose calls require human approval (`PATCH /agents/{id}`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
+              "id": "gate",
+              "long": "gate",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear all approval gates on the agent",
+              "id": "clear",
+              "long": "clear",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "approvals"
+        },
+        {
+          "about": "Open the local observability surfaces (AgentOS Console + Langfuse traces/cost)",
+          "hidden": false,
+          "name": "observability"
+        },
+        {
+          "about": "Set an agent's daily budget (`PUT /agents/{id}/budget`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Daily spend cap in USD. Must be > 0",
+              "id": "limit",
+              "long": "limit",
+              "positional": false,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "budget"
+        },
+        {
+          "about": "Kill an agent (stop its runs; `POST /agents/{id}/kill`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the action",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "kill"
+        },
+        {
+          "about": "Resume a killed agent (`POST /agents/{id}/resume`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "resume"
         }
       ]
     },
@@ -1866,6 +2193,167 @@
           ],
           "hidden": false,
           "name": "delete"
+        },
+        {
+          "about": "List an agent's immutable versions (`GET /agents/{id}/versions`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "versions"
+        },
+        {
+          "about": "Show what an agent has learned (its memory log; `GET /agents/{id}/memory`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "memory"
+        },
+        {
+          "about": "View or set the tools whose calls require human approval (`PATCH /agents/{id}`)",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
+              "id": "gate",
+              "long": "gate",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear all approval gates on the agent",
+              "id": "clear",
+              "long": "clear",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "default_values": [
+                "http://localhost:8000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "approvals"
         }
       ]
     },

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -26,6 +26,10 @@ pub struct Agent {
     pub id: String,
     pub name: String,
     pub slack_channel: String,
+    /// Tool names gated behind human approval (#245). Present on `AgentOut`;
+    /// `#[serde(default)]` keeps older/leaner responses parsing to None.
+    #[serde(default)]
+    pub approval_required_tools: Option<Vec<String>>,
 }
 
 /// What a deploy did with the agent's Slack channel, for the summary printout.
@@ -45,6 +49,23 @@ pub enum ChannelOutcome {
 pub struct Version {
     pub id: String,
     pub version_label: String,
+    // Extra VersionOut fields for the `versions` listing verb; `#[serde(default)]`
+    // keeps the deploy path (which only reads id/version_label) tolerant of a
+    // leaner response.
+    #[serde(default)]
+    pub commit_sha: Option<String>,
+    #[serde(default)]
+    pub created_by: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+}
+
+/// One learned memory entry (`MemoryEntryOut`) for the `memory` listing verb.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MemoryEntry {
+    pub index: u64,
+    pub content: String,
+    pub version: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -450,6 +471,57 @@ impl ApiClient {
             .json()
             .await
             .context("decoding budget")
+    }
+
+    /// List an agent's immutable versions, newest first: `GET /agents/{id}/versions`.
+    pub async fn list_versions(&self, agent_id: &str) -> Result<Vec<Version>> {
+        let resp = self
+            .http
+            .get(format!("{}/agents/{agent_id}/versions", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("GET /agents/{id}/versions")?;
+        Self::expect_ok(resp, "listing versions")
+            .await?
+            .json()
+            .await
+            .context("decoding version list")
+    }
+
+    /// List an agent's learned memory, oldest first: `GET /agents/{id}/memory`.
+    pub async fn list_memory(&self, agent_id: &str) -> Result<Vec<MemoryEntry>> {
+        let resp = self
+            .http
+            .get(format!("{}/agents/{agent_id}/memory", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("GET /agents/{id}/memory")?;
+        Self::expect_ok(resp, "listing memory")
+            .await?
+            .json()
+            .await
+            .context("decoding memory list")
+    }
+
+    /// Set the agent's approval-required tool gates: `PATCH /agents/{id}` with
+    /// `approval_required_tools` (an empty list clears them). Returns the updated
+    /// agent so the caller can echo the effective gates.
+    pub async fn set_approval_tools(&self, agent_id: &str, tools: &[String]) -> Result<Agent> {
+        let resp = self
+            .http
+            .patch(format!("{}/agents/{agent_id}", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .json(&json!({ "approval_required_tools": tools }))
+            .send()
+            .await
+            .context("PATCH /agents/{id} (approval gates)")?;
+        Self::expect_ok(resp, "updating approval gates")
+            .await?
+            .json()
+            .await
+            .context("decoding updated agent")
     }
 
     /// Delete the agent: `DELETE /agents/{id}` (204 No Content on success).

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1422,6 +1422,160 @@ pub async fn delete(opts: AgentActionOpts, yes: bool) -> Result<()> {
     Ok(())
 }
 
+/// `<tier> versions <agent>`: list the agent's immutable versions (newest first).
+pub async fn versions(opts: AgentActionOpts) -> Result<()> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        ui.payload_plain(&format!(
+            "GET {}/agents/<id>/versions  (would resolve agent {:?} first)",
+            opts.api_url, opts.agent
+        ));
+        return Ok(());
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let agent = client.find_agent(&opts.agent).await?;
+    let versions = client.list_versions(&agent.id).await?;
+    if versions.is_empty() {
+        ui.payload(&format!(
+            "{} has no versions yet (deploy it first)",
+            agent.name
+        ));
+        return Ok(());
+    }
+    ui.payload(&format!(
+        "{} — {} version(s), newest first:",
+        agent.name,
+        versions.len()
+    ));
+    for v in versions.iter().rev() {
+        let commit = v.commit_sha.as_deref().unwrap_or("-");
+        let by = v.created_by.as_deref().unwrap_or("-");
+        let at = v.created_at.as_deref().unwrap_or("-");
+        ui.kv(
+            &v.version_label,
+            &format!("commit {commit}  by {by}  at {at}"),
+        );
+    }
+    Ok(())
+}
+
+/// `<tier> memory <agent>`: show what the agent has learned (its memory log).
+pub async fn memory(opts: AgentActionOpts) -> Result<()> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        ui.payload_plain(&format!(
+            "GET {}/agents/<id>/memory  (would resolve agent {:?} first)",
+            opts.api_url, opts.agent
+        ));
+        return Ok(());
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let agent = client.find_agent(&opts.agent).await?;
+    let entries = client.list_memory(&agent.id).await?;
+    if entries.is_empty() {
+        ui.payload(&format!("{} has no learned memory yet", agent.name));
+        return Ok(());
+    }
+    ui.payload(&format!(
+        "{} — {} memory entr(ies):",
+        agent.name,
+        entries.len()
+    ));
+    for e in &entries {
+        ui.kv(&format!("#{}", e.index), &e.content);
+    }
+    Ok(())
+}
+
+/// `<tier> approvals <agent> [--gate TOOL]... [--clear]`: view or set the tool
+/// names whose calls pause for human approval. No flags => show current gates.
+pub async fn approvals(opts: AgentActionOpts, gate: Vec<String>, clear: bool) -> Result<()> {
+    let ui = crate::ui::ui();
+    if clear && !gate.is_empty() {
+        return Err(crate::exit::usage(
+            "--clear cannot be combined with --gate (clear removes all gates)",
+        ));
+    }
+    let setting = clear || !gate.is_empty();
+    if opts.dry_run {
+        let action = if setting {
+            format!(
+                "PATCH {}/agents/<id> approval_required_tools={:?}",
+                opts.api_url, gate
+            )
+        } else {
+            format!("GET {}/agents/<id> (show current gates)", opts.api_url)
+        };
+        ui.payload_plain(&format!(
+            "{action}  (would resolve agent {:?} first)",
+            opts.agent
+        ));
+        return Ok(());
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let agent = client.find_agent(&opts.agent).await?;
+    let gates = if setting {
+        let cl = ui.checklist();
+        let step = cl.step(&format!("updating approval gates for {}", agent.name));
+        match client.set_approval_tools(&agent.id, &gate).await {
+            Ok(updated) => {
+                step.done("updated");
+                updated.approval_required_tools.unwrap_or_default()
+            }
+            Err(err) => {
+                step.fail("failed");
+                return Err(err);
+            }
+        }
+    } else {
+        agent.approval_required_tools.clone().unwrap_or_default()
+    };
+    if gates.is_empty() {
+        ui.payload(&format!(
+            "{}: no tools are gated (calls run without approval)",
+            agent.name
+        ));
+    } else {
+        ui.payload(&format!("{} — {} gated tool(s):", agent.name, gates.len()));
+        for tool in &gates {
+            ui.kv("gated", tool);
+        }
+    }
+    Ok(())
+}
+
+/// `local observability`: open (and print) the local platform's observability
+/// surfaces -- the AgentOS Console and the Langfuse UI. Best-effort browser open
+/// so it degrades to just the URLs on a headless host.
+pub async fn observability() -> Result<()> {
+    let ui = crate::ui::ui();
+    let urls = [
+        ("AgentOS Console", "http://localhost:28080/?api=1"),
+        (
+            "Langfuse UI (traces / cost / evals)",
+            "http://localhost:23000",
+        ),
+    ];
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    for (name, url) in urls {
+        ui.kv(name, url);
+        // Fire-and-forget: a missing opener (headless/CI) is not an error -- the
+        // URL is already printed above.
+        let _ = tokio::process::Command::new(opener)
+            .arg(url)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await;
+    }
+    ui.payload("opened the local observability surfaces (start them with `agentos local up`)");
+    Ok(())
+}
+
 /// Reject a Slack channel value that is a `#name` rather than a channel ID.
 ///
 /// Real Slack events carry the channel **ID** (e.g. `C0123ABCD`), and the

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -74,6 +74,7 @@ enum TuiAction {
 #[derive(Clone, Copy, Debug)]
 enum Workflow {
     ExploreExamples,
+    ParityLadder,
 }
 
 #[derive(Clone, Debug)]
@@ -146,7 +147,12 @@ impl App {
         let recipes = recipes();
         App {
             recipes,
-            targets: vec!["all", "skill", "secrets", "local", "cluster", "dev"],
+            // "platform" leads (it is the default landing tab, target_idx 0): the
+            // primary product functions -- parity/evals/observe/version/budget/
+            // approve/remember -- come before the per-tier operator verbs.
+            targets: vec![
+                "platform", "all", "skill", "secrets", "local", "cluster", "dev",
+            ],
             target_idx: 0,
             selected: 0,
             message: "Select an action. Enter runs it; q exits.".into(),
@@ -307,8 +313,11 @@ fn run_recipe_in_tui(
     let Some(values) = prompt_recipe_fields(terminal, app, recipe)? else {
         return Ok(format!("Canceled: {}", recipe.title));
     };
-    if matches!(recipe.kind, RecipeKind::Workflow(Workflow::ExploreExamples)) {
-        explore_examples(terminal, app, &values)?;
+    if let RecipeKind::Workflow(workflow) = &recipe.kind {
+        match workflow {
+            Workflow::ExploreExamples => explore_examples(terminal, app, &values)?,
+            Workflow::ParityLadder => parity_ladder(terminal, app)?,
+        }
         return Ok(format!("Finished: {}", recipe.title));
     }
     let mut view = RunView::new(recipe.title);
@@ -588,6 +597,37 @@ fn prompt_text(
             _ => {}
         }
     }
+}
+
+/// Print-only "parity ladder" explainer: the framing for the whole Platform tab
+/// -- what agentos is (one bundle + one eval suite across skill/local/cluster) and
+/// how to climb it. Mirrors the show_run_view pause used by the other workflows.
+fn parity_ladder(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &App) -> Result<()> {
+    let mut view = RunView::new("The parity ladder");
+    for line in [
+        "agentos runs ONE immutable bundle and ONE evals/cases.json identically",
+        "across three tiers, so 'works on my laptop' and 'works deployed' are the",
+        "same artifact -- not a hope.",
+        "",
+        "  skill    runner only, on your Docker. Fastest loop; no platform/queue.",
+        "           -> agentos skill up / skill message / skill eval",
+        "  local    the full platform via docker compose (API, queue, worker,",
+        "           sandbox, Langfuse). The real product loop, zero Slack/K8s.",
+        "           -> agentos local up / local deploy / local message",
+        "  cluster  the same platform on Kubernetes (a Helm release).",
+        "           -> agentos cluster deploy / cluster message",
+        "",
+        "Climb it: iterate at skill, promote to local, then cluster. Run the SAME",
+        "evals at each tier -- a tier-to-tier divergence is the harness catching a",
+        "deployment bug, not a flaky test.",
+        "",
+        "The other Platform actions (evals, observability, versions, budget,",
+        "approvals, memory) let you evaluate, observe, and govern a deployed agent.",
+    ] {
+        view.push(line);
+    }
+    show_run_view(terminal, app, &mut view)?;
+    Ok(())
 }
 
 fn explore_examples(
@@ -920,6 +960,8 @@ fn maybe_add_secret_status(lines: &mut Vec<Line<'static>>, workflow: Workflow) {
             lines.extend(secrets_status_lines());
             lines.push(Line::from(""));
         }
+        // The parity-ladder explainer needs no credential status.
+        Workflow::ParityLadder => {}
     }
 }
 
@@ -1683,6 +1725,24 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
             lines.push(Line::from(""));
             maybe_add_secret_status(&mut lines, Workflow::ExploreExamples);
         }
+        RecipeKind::Workflow(Workflow::ParityLadder) => {
+            lines.push(Line::from(Span::styled(
+                "The parity ladder",
+                Style::default().fg(Color::Yellow).bold(),
+            )));
+            lines.push(Line::from("What agentos is: one immutable bundle + one"));
+            lines.push(Line::from(
+                "evals/cases.json, run identically across tiers.",
+            ));
+            lines.push(Line::from(
+                "skill (runner only) -> local (full platform) ->",
+            ));
+            lines.push(Line::from("cluster (Kubernetes). A tier-to-tier eval"));
+            lines.push(Line::from(
+                "divergence is the harness catching a deploy bug.",
+            ));
+            lines.push(Line::from(""));
+        }
     }
     if !recipe.fields.is_empty() {
         lines.push(Line::from(Span::styled(
@@ -2087,6 +2147,167 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
 
 fn recipes() -> Vec<Recipe> {
     vec![
+        // --- Platform: the primary product functions, leading the TUI ---
+        Recipe {
+            target: "platform",
+            title: "Parity ladder (what agentos is)",
+            description: "One bundle + one eval suite across skill -> local -> cluster.",
+            kind: RecipeKind::Workflow(Workflow::ParityLadder),
+            args: vec![],
+            fields: vec![],
+            notes: &[
+                "Read this first: the platform is about running the SAME artifact everywhere and evaluating/observing/governing it.",
+            ],
+        },
+        Recipe {
+            target: "platform",
+            title: "Run evals (parity gate)",
+            description: "Grade the bundle's evals/cases.json against the running skill runner.",
+            kind: RecipeKind::Command,
+            args: vec![ArgPart::Literal("skill"), ArgPart::Literal("eval")],
+            fields: vec![],
+            notes: &["Requires a runner up (Start runner / skill up) with the bundle's evals/cases.json."],
+        },
+        Recipe {
+            target: "platform",
+            title: "Open observability (Console + Langfuse)",
+            description: "Open the local AgentOS Console and Langfuse traces/cost UIs.",
+            kind: RecipeKind::Command,
+            args: vec![ArgPart::Literal("local"), ArgPart::Literal("observability")],
+            fields: vec![],
+            notes: &["Start the platform first with `agentos local up`."],
+        },
+        Recipe {
+            target: "platform",
+            title: "List versions",
+            description: "Show an agent's immutable deployed versions (newest first).",
+            kind: RecipeKind::Command,
+            args: vec![
+                ArgPart::Literal("local"),
+                ArgPart::Literal("versions"),
+                ArgPart::Field("agent"),
+            ],
+            fields: vec![Field {
+                key: "agent",
+                label: "Agent name",
+                default: None,
+                required: true,
+            }],
+            notes: &["Every deploy pins a new immutable version; a thread keeps the one it booted with."],
+        },
+        Recipe {
+            target: "platform",
+            title: "Set budget",
+            description: "Set an agent's daily USD spend cap (enforced per run).",
+            kind: RecipeKind::Command,
+            args: vec![
+                ArgPart::Literal("local"),
+                ArgPart::Literal("budget"),
+                ArgPart::Field("agent"),
+                ArgPart::Literal("--limit"),
+                ArgPart::Field("limit"),
+            ],
+            fields: vec![
+                Field {
+                    key: "agent",
+                    label: "Agent name",
+                    default: None,
+                    required: true,
+                },
+                Field {
+                    key: "limit",
+                    label: "Daily cap in USD (e.g. 5)",
+                    default: None,
+                    required: true,
+                },
+            ],
+            notes: &[],
+        },
+        Recipe {
+            target: "platform",
+            title: "Gate a tool (approvals)",
+            description: "Require human approval before an agent may call a named tool.",
+            kind: RecipeKind::Command,
+            args: vec![
+                ArgPart::Literal("local"),
+                ArgPart::Literal("approvals"),
+                ArgPart::Field("agent"),
+                ArgPart::OptionalFlag {
+                    flag: "--gate",
+                    field: "tool",
+                },
+            ],
+            fields: vec![
+                Field {
+                    key: "agent",
+                    label: "Agent name",
+                    default: None,
+                    required: true,
+                },
+                Field {
+                    key: "tool",
+                    label: "Tool to gate (blank = show current gates)",
+                    default: None,
+                    required: false,
+                },
+            ],
+            notes: &["e.g. gate mcp__plugin_github-issues_github__create_issue so a write pauses for approval."],
+        },
+        Recipe {
+            target: "platform",
+            title: "Inspect memory",
+            description: "Show what an agent has learned (its memory log).",
+            kind: RecipeKind::Command,
+            args: vec![
+                ArgPart::Literal("local"),
+                ArgPart::Literal("memory"),
+                ArgPart::Field("agent"),
+            ],
+            fields: vec![Field {
+                key: "agent",
+                label: "Agent name",
+                default: None,
+                required: true,
+            }],
+            notes: &[],
+        },
+        Recipe {
+            target: "platform",
+            title: "Kill an agent",
+            description: "Stop an agent's runs (the kill switch).",
+            kind: RecipeKind::Command,
+            args: vec![
+                ArgPart::Literal("local"),
+                ArgPart::Literal("kill"),
+                ArgPart::Field("agent"),
+                ArgPart::Literal("--yes"),
+            ],
+            fields: vec![Field {
+                key: "agent",
+                label: "Agent name",
+                default: None,
+                required: true,
+            }],
+            notes: &["Resume it later with the 'Resume an agent' action."],
+        },
+        Recipe {
+            target: "platform",
+            title: "Resume an agent",
+            description: "Bring a killed agent back online.",
+            kind: RecipeKind::Command,
+            args: vec![
+                ArgPart::Literal("local"),
+                ArgPart::Literal("resume"),
+                ArgPart::Field("agent"),
+            ],
+            fields: vec![Field {
+                key: "agent",
+                label: "Agent name",
+                default: None,
+                required: true,
+            }],
+            notes: &[],
+        },
         Recipe {
             target: "skill",
             title: "Start runner",
@@ -2372,6 +2593,42 @@ mod tests {
     fn render_command_quotes_shell_specials() {
         let argv = vec!["skill".into(), "message".into(), "hello world".into()];
         assert_eq!(render_command(&argv), "agentos skill message 'hello world'");
+    }
+
+    #[test]
+    fn platform_tab_leads_and_carries_the_primary_functions() {
+        let app = App::new();
+        // "platform" is the first tab, so it is the default landing view.
+        assert_eq!(
+            app.targets.first().copied(),
+            Some("platform"),
+            "platform must lead the tabs"
+        );
+        // The primary functions are present under it.
+        let platform_titles: Vec<&str> = app
+            .recipes
+            .iter()
+            .filter(|r| r.target == "platform")
+            .map(|r| r.title)
+            .collect();
+        for expected in [
+            "Parity ladder (what agentos is)",
+            "Run evals (parity gate)",
+            "Open observability (Console + Langfuse)",
+            "List versions",
+            "Set budget",
+            "Gate a tool (approvals)",
+            "Inspect memory",
+            "Kill an agent",
+            "Resume an agent",
+        ] {
+            assert!(
+                platform_titles.contains(&expected),
+                "missing platform recipe: {expected}"
+            );
+        }
+        // And they lead the recipe list (first recipe is on the platform tab).
+        assert_eq!(app.recipes.first().map(|r| r.target), Some("platform"));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2255,12 +2255,22 @@ mod tests {
     #[test]
     fn approvals_parses_repeatable_gate_and_clear() {
         let cli = Cli::try_parse_from([
-            "agentos", "local", "approvals", "gh", "--gate", "Bash", "--gate", "mcp__x__y",
+            "agentos",
+            "local",
+            "approvals",
+            "gh",
+            "--gate",
+            "Bash",
+            "--gate",
+            "mcp__x__y",
         ])
         .expect("local approvals should parse");
         match cli.command {
             Some(Command::Local {
-                action: LocalAction::Approvals { agent, gate, clear, .. },
+                action:
+                    LocalAction::Approvals {
+                        agent, gate, clear, ..
+                    },
             }) => {
                 assert_eq!(agent, "gh");
                 assert_eq!(gate, vec!["Bash".to_string(), "mcp__x__y".to_string()]);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -508,6 +508,110 @@ enum LocalAction {
         #[arg(long = "secret", value_name = "NAME")]
         secret: Vec<String>,
     },
+    /// List an agent's immutable versions (`GET /agents/{id}/versions`).
+    Versions {
+        /// Agent name or id.
+        agent: String,
+        #[arg(
+            long,
+            default_value = "http://localhost:28000",
+            env = "AGENTOS_API_URL"
+        )]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show what an agent has learned (its memory log; `GET /agents/{id}/memory`).
+    Memory {
+        /// Agent name or id.
+        agent: String,
+        #[arg(
+            long,
+            default_value = "http://localhost:28000",
+            env = "AGENTOS_API_URL"
+        )]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// View or set the tools whose calls require human approval (`PATCH /agents/{id}`).
+    Approvals {
+        /// Agent name or id.
+        agent: String,
+        /// Tool name to gate behind approval (repeatable). Omit to show current gates.
+        #[arg(long = "gate", value_name = "TOOL")]
+        gate: Vec<String>,
+        /// Clear all approval gates on the agent.
+        #[arg(long)]
+        clear: bool,
+        #[arg(
+            long,
+            default_value = "http://localhost:28000",
+            env = "AGENTOS_API_URL"
+        )]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Open the local observability surfaces (AgentOS Console + Langfuse traces/cost).
+    Observability,
+    /// Set an agent's daily budget (`PUT /agents/{id}/budget`).
+    Budget {
+        /// Agent name or id.
+        agent: String,
+        /// Daily spend cap in USD. Must be > 0.
+        #[arg(long)]
+        limit: f64,
+        #[arg(
+            long,
+            default_value = "http://localhost:28000",
+            env = "AGENTOS_API_URL"
+        )]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Kill an agent (stop its runs; `POST /agents/{id}/kill`).
+    Kill {
+        /// Agent name or id.
+        agent: String,
+        #[arg(
+            long,
+            default_value = "http://localhost:28000",
+            env = "AGENTOS_API_URL"
+        )]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        /// Confirm the action.
+        #[arg(long)]
+        yes: bool,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Resume a killed agent (`POST /agents/{id}/resume`).
+    Resume {
+        /// Agent name or id.
+        agent: String,
+        #[arg(
+            long,
+            default_value = "http://localhost:28000",
+            env = "AGENTOS_API_URL"
+        )]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -868,6 +972,45 @@ enum ClusterAction {
         #[arg(long)]
         dry_run: bool,
     },
+    /// List an agent's immutable versions (`GET /agents/{id}/versions`).
+    Versions {
+        /// Agent name or id.
+        agent: String,
+        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show what an agent has learned (its memory log; `GET /agents/{id}/memory`).
+    Memory {
+        /// Agent name or id.
+        agent: String,
+        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// View or set the tools whose calls require human approval (`PATCH /agents/{id}`).
+    Approvals {
+        /// Agent name or id.
+        agent: String,
+        /// Tool name to gate behind approval (repeatable). Omit to show current gates.
+        #[arg(long = "gate", value_name = "TOOL")]
+        gate: Vec<String>,
+        /// Clear all approval gates on the agent.
+        #[arg(long)]
+        clear: bool,
+        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        api_key: String,
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 async fn resolve_compose_file(file: Option<String>, dry_run: bool) -> Result<String> {
@@ -1197,6 +1340,105 @@ async fn run(command: Option<Command>) -> Result<()> {
                     label,
                     secret,
                     connect_hint,
+                })
+                .await
+            }
+            LocalAction::Versions {
+                agent,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::versions(AgentActionOpts {
+                    api_url,
+                    api_key,
+                    agent,
+                    dry_run,
+                })
+                .await
+            }
+            LocalAction::Memory {
+                agent,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::memory(AgentActionOpts {
+                    api_url,
+                    api_key,
+                    agent,
+                    dry_run,
+                })
+                .await
+            }
+            LocalAction::Approvals {
+                agent,
+                gate,
+                clear,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::approvals(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
+                    gate,
+                    clear,
+                )
+                .await
+            }
+            LocalAction::Observability => commands::observability().await,
+            LocalAction::Budget {
+                agent,
+                limit,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::budget(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
+                    limit,
+                )
+                .await
+            }
+            LocalAction::Kill {
+                agent,
+                api_url,
+                api_key,
+                yes,
+                dry_run,
+            } => {
+                commands::kill(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
+                    yes,
+                )
+                .await
+            }
+            LocalAction::Resume {
+                agent,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::resume(AgentActionOpts {
+                    api_url,
+                    api_key,
+                    agent,
+                    dry_run,
                 })
                 .await
             }
@@ -1532,6 +1774,54 @@ async fn run(command: Option<Command>) -> Result<()> {
                         dry_run,
                     },
                     yes,
+                )
+                .await
+            }
+            ClusterAction::Versions {
+                agent,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::versions(AgentActionOpts {
+                    api_url,
+                    api_key,
+                    agent,
+                    dry_run,
+                })
+                .await
+            }
+            ClusterAction::Memory {
+                agent,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::memory(AgentActionOpts {
+                    api_url,
+                    api_key,
+                    agent,
+                    dry_run,
+                })
+                .await
+            }
+            ClusterAction::Approvals {
+                agent,
+                gate,
+                clear,
+                api_url,
+                api_key,
+                dry_run,
+            } => {
+                commands::approvals(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
+                    gate,
+                    clear,
                 )
                 .await
             }
@@ -1928,6 +2218,58 @@ mod tests {
             }
             _ => panic!("expected cluster budget command"),
         }
+    }
+
+    #[test]
+    fn local_platform_verbs_parse() {
+        // The inspection/governance verbs mirrored onto the local tier.
+        assert!(matches!(
+            Cli::try_parse_from(["agentos", "local", "versions", "gh"])
+                .expect("local versions")
+                .command,
+            Some(Command::Local {
+                action: LocalAction::Versions { .. }
+            })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["agentos", "local", "memory", "gh"])
+                .expect("local memory")
+                .command,
+            Some(Command::Local {
+                action: LocalAction::Memory { .. }
+            })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["agentos", "local", "observability"])
+                .expect("local observability")
+                .command,
+            Some(Command::Local {
+                action: LocalAction::Observability
+            })
+        ));
+        // local budget/kill/resume are the mirrored lifecycle verbs.
+        assert!(Cli::try_parse_from(["agentos", "local", "budget", "gh", "--limit", "1"]).is_ok());
+        assert!(Cli::try_parse_from(["agentos", "local", "kill", "gh", "--yes"]).is_ok());
+    }
+
+    #[test]
+    fn approvals_parses_repeatable_gate_and_clear() {
+        let cli = Cli::try_parse_from([
+            "agentos", "local", "approvals", "gh", "--gate", "Bash", "--gate", "mcp__x__y",
+        ])
+        .expect("local approvals should parse");
+        match cli.command {
+            Some(Command::Local {
+                action: LocalAction::Approvals { agent, gate, clear, .. },
+            }) => {
+                assert_eq!(agent, "gh");
+                assert_eq!(gate, vec!["Bash".to_string(), "mcp__x__y".to_string()]);
+                assert!(!clear);
+            }
+            _ => panic!("expected local approvals command"),
+        }
+        // --clear parses on both tiers.
+        assert!(Cli::try_parse_from(["agentos", "cluster", "approvals", "gh", "--clear"]).is_ok());
     }
 
     #[test]

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1016,6 +1016,7 @@ mod tests {
             id: format!("id-{name}"),
             name: name.to_string(),
             slack_channel: channel.to_string(),
+            approval_required_tools: None,
         }
     }
 


### PR DESCRIPTION
Makes the TUI open on what agentos **is** — a parity-ladder platform you evaluate, observe, and govern — instead of per-tier operator verbs and a Slack walkthrough. PR 2 of 2 (**stacked on #446**, whose verbs these recipes shell — merge #446 first).

## What
A new **`platform` tab, first in the list so it's the default landing view**, leading with:
- **Parity ladder** — a print-only explainer (one immutable bundle + one `evals/cases.json` across skill → local → cluster) via `Workflow::ParityLadder`
- **Run evals** (`skill eval`, the parity gate)
- **Open observability** (`local observability` → Console + Langfuse)
- **List versions** · **Set budget** · **Gate a tool (approvals)** · **Inspect memory** · **Kill** · **Resume** — Command recipes shelling the #446 verbs, each prompting for the agent name (+ limit/tool where relevant)

Recipes lead the `recipes()` vec so they render first. The existing tier tabs (skill/local/cluster/secrets/dev) are unchanged after it.

## Test
`platform_tab_leads_and_carries_the_primary_functions` (platform is first + carries all 9 functions + leads the list). `cargo fmt`/`clippy`/`test` green. Also fixes a `message.rs` test `Agent` literal for #446's new `approval_required_tools` field.

## Note
Independently modifies `interactive.rs` alongside the unmerged Deploy-to-Slack PR (#441); both add a `Workflow` variant + recipes, so a trivial keep-both conflict is expected when the second lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)