### PR TITLE
Share model resolution between local up and local comms

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -436,14 +436,18 @@ suffix). `local message` composes with `--channel`, `--thread`, and
 `--timeout-secs` and rejects the cluster only flags (`--namespace`,
 `--release`, `--force-wire`, ...)
 with a clear error. The compose worker runs the fake model by default (a canned
-reply, no credentials); export a credential in your shell and `local up` goes
-live automatically for a real model.
+reply, no credentials); export a credential in your shell and `local up` or
+`local comms` goes live automatically for a real model. Set
+`AGENTOS_FAKE_MODEL=1` to force the fake model regardless of a credential
+being present.
 
 Use `agentos local comms --slack` when you want the same compose stack to talk
 to a real Slack workspace. Connect reads `SLACK_APP_TOKEN` and
 `SLACK_BOT_TOKEN`, masks them in printed commands, starts the dispatcher, and
-points the worker at real Slack. `--disconnect` stops the dispatcher and
-restores the local stub. `--dry-run` prints the compose command only.
+points the worker at real Slack, resolving the model the same way as `local up`
+(live when a credential is present, fake otherwise). `--disconnect` stops the
+dispatcher and restores the local stub. `--dry-run` prints the compose command
+only.
 
 Use `--continue` to reuse the last successful `local message` context from
 `.agentos/last-turn.json` in the current working directory, so only the new text

--- a/cli/src/comms.rs
+++ b/cli/src/comms.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{bail, Result};
 
+use crate::local::{fake_model_env_override, ModelMode};
 use crate::ops::{plain, require_on_path, run_step, secret_set, CommonOpts, OpsCommand};
 
 /// The worker's Slack stub sink URL (compose default); restored on disconnect.
@@ -26,6 +27,11 @@ pub struct LocalCommsOpts {
     pub app_token: String,
     pub bot_token: String,
     pub disconnect: bool,
+    /// Model mode resolved from the shell (skill/`local up` parity, issue
+    /// #450): the worker-restarting commands below apply the same
+    /// `fake_model_env_override` as `up_command` so `local comms` never
+    /// silently downgrades a live stack back to the fake model.
+    pub model_mode: ModelMode,
 }
 
 pub fn connect_commands(opts: &CommsOpts) -> Vec<OpsCommand> {
@@ -67,6 +73,8 @@ pub fn disconnect_commands(opts: &CommsOpts) -> Vec<OpsCommand> {
 }
 
 pub fn local_connect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
+    let mut env = vec![("SLACK_API_BASE_URL".into(), String::new())];
+    env.extend(fake_model_env_override(o.model_mode));
     vec![OpsCommand::new(
         "docker",
         vec![
@@ -84,7 +92,7 @@ pub fn local_connect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
             plain("agentos-dispatcher"),
         ],
     )
-    .with_env(vec![("SLACK_API_BASE_URL".into(), String::new())])
+    .with_env(env)
     .with_secret_env(vec![
         ("SLACK_APP_TOKEN".into(), o.app_token.clone()),
         ("SLACK_BOT_TOKEN".into(), o.bot_token.clone()),
@@ -92,6 +100,11 @@ pub fn local_connect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
 }
 
 pub fn local_disconnect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
+    let mut worker_env = vec![
+        ("SLACK_API_BASE_URL".into(), LOCAL_SLACK_STUB_URL.into()),
+        ("SLACK_BOT_TOKEN".into(), LOCAL_SLACK_STUB_BOT_TOKEN.into()),
+    ];
+    worker_env.extend(fake_model_env_override(o.model_mode));
     vec![
         OpsCommand::new(
             "docker",
@@ -121,10 +134,7 @@ pub fn local_disconnect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
                 plain("agentos-worker"),
             ],
         )
-        .with_env(vec![
-            ("SLACK_API_BASE_URL".into(), LOCAL_SLACK_STUB_URL.into()),
-            ("SLACK_BOT_TOKEN".into(), LOCAL_SLACK_STUB_BOT_TOKEN.into()),
-        ]),
+        .with_env(worker_env),
     ]
 }
 
@@ -276,6 +286,11 @@ pub async fn local_comms(opts: LocalCommsOpts) -> Result<()> {
         return Ok(());
     }
 
+    if opts.model_mode == ModelMode::FakePinnedDespiteCredential {
+        ui.warn(
+            "Running the FAKE model despite a credential in your shell: AGENTOS_FAKE_MODEL is pinned on. Unset it or set AGENTOS_FAKE_MODEL=0 to go live.",
+        );
+    }
     require_on_path("docker")?;
     let cl = ui.checklist();
     let label = if opts.disconnect {
@@ -443,6 +458,25 @@ mod tests {
         assert!(!line.contains("xoxb-"), "{line}");
     }
 
+    fn local_comms_opts(disconnect: bool, mode: ModelMode) -> LocalCommsOpts {
+        LocalCommsOpts {
+            file: "compose.dev.yaml".into(),
+            dry_run: false,
+            app_token: if disconnect {
+                String::new()
+            } else {
+                "xapp-1".into()
+            },
+            bot_token: if disconnect {
+                String::new()
+            } else {
+                "xoxb-1".into()
+            },
+            disconnect,
+            model_mode: mode,
+        }
+    }
+
     #[test]
     fn local_connect_command_wires_dispatcher_and_unwires_stub() {
         let cmds = local_connect_commands(&LocalCommsOpts {
@@ -451,6 +485,7 @@ mod tests {
             app_token: "xapp-1-secretsecret".into(),
             bot_token: "xoxb-1-secretsecret".into(),
             disconnect: false,
+            model_mode: ModelMode::DefaultFake,
         });
         assert_eq!(cmds.len(), 1);
         let line = cmds[0].display();
@@ -466,13 +501,7 @@ mod tests {
 
     #[test]
     fn local_disconnect_commands_stop_dispatcher_and_restub_worker() {
-        let cmds = local_disconnect_commands(&LocalCommsOpts {
-            file: "compose.dev.yaml".into(),
-            dry_run: false,
-            app_token: String::new(),
-            bot_token: String::new(),
-            disconnect: true,
-        });
+        let cmds = local_disconnect_commands(&local_comms_opts(true, ModelMode::DefaultFake));
         assert_eq!(cmds.len(), 2);
         assert_eq!(
             cmds[0].display(),
@@ -489,5 +518,174 @@ mod tests {
             !second.contains("agentos-dispatcher"),
             "disconnect worker restart must not mention dispatcher: {second}"
         );
+    }
+
+    /// Issue #450: `local comms --slack` restarted the worker on compose's fake
+    /// default even when a real model credential was present in the shell. With
+    /// a credential (`LiveFromCredential`), connect must inject
+    /// `AGENTOS_FAKE_MODEL=0` exactly once, and the pre-existing
+    /// `SLACK_API_BASE_URL` clear must survive alongside it (env is REPLACED,
+    /// not appended, by `with_env`, so building the full vec once is load-bearing).
+    #[test]
+    fn local_connect_live_from_credential_injects_fake_zero_once() {
+        let cmds = local_connect_commands(&local_comms_opts(false, ModelMode::LiveFromCredential));
+        let cmd = &cmds[0];
+        assert_eq!(
+            cmd.env
+                .iter()
+                .filter(|(k, _)| k == "AGENTOS_FAKE_MODEL")
+                .count(),
+            1,
+            "exactly one AGENTOS_FAKE_MODEL; env={:?}",
+            cmd.env
+        );
+        assert!(cmd
+            .env
+            .contains(&("AGENTOS_FAKE_MODEL".to_string(), "0".to_string())));
+        assert!(
+            cmd.env
+                .contains(&("SLACK_API_BASE_URL".to_string(), String::new())),
+            "SLACK_API_BASE_URL clear must survive the env rebuild; env={:?}",
+            cmd.env
+        );
+    }
+
+    /// `DefaultFake` and `FakePinnedDespiteCredential` must inject no
+    /// `AGENTOS_FAKE_MODEL` at all, leaving compose's `${AGENTOS_FAKE_MODEL:-1}`
+    /// default (or the operator's pin) alone.
+    #[test]
+    fn local_connect_non_live_modes_inject_nothing() {
+        for mode in [
+            ModelMode::DefaultFake,
+            ModelMode::FakePinnedDespiteCredential,
+        ] {
+            let cmds = local_connect_commands(&local_comms_opts(false, mode));
+            assert!(
+                !cmds[0].env.iter().any(|(k, _)| k == "AGENTOS_FAKE_MODEL"),
+                "{mode:?} must not inject AGENTOS_FAKE_MODEL; env={:?}",
+                cmds[0].env
+            );
+        }
+    }
+
+    /// Same bug, same fix, on the worker-restarting leg of disconnect: it also
+    /// silently reverted to the fake model. The stub `SLACK_API_BASE_URL` /
+    /// `SLACK_BOT_TOKEN` entries must survive the env rebuild alongside the
+    /// injected override.
+    #[test]
+    fn local_disconnect_live_from_credential_injects_fake_zero_and_keeps_stub_env() {
+        let cmds =
+            local_disconnect_commands(&local_comms_opts(true, ModelMode::LiveFromCredential));
+        let worker_cmd = &cmds[1];
+        assert_eq!(
+            worker_cmd
+                .env
+                .iter()
+                .filter(|(k, _)| k == "AGENTOS_FAKE_MODEL")
+                .count(),
+            1,
+            "exactly one AGENTOS_FAKE_MODEL; env={:?}",
+            worker_cmd.env
+        );
+        assert!(worker_cmd
+            .env
+            .contains(&("AGENTOS_FAKE_MODEL".to_string(), "0".to_string())));
+        assert!(worker_cmd.env.contains(&(
+            "SLACK_API_BASE_URL".to_string(),
+            LOCAL_SLACK_STUB_URL.to_string(),
+        )));
+        assert!(worker_cmd.env.contains(&(
+            "SLACK_BOT_TOKEN".to_string(),
+            LOCAL_SLACK_STUB_BOT_TOKEN.to_string(),
+        )));
+    }
+
+    #[test]
+    fn local_disconnect_non_live_modes_inject_nothing() {
+        for mode in [
+            ModelMode::DefaultFake,
+            ModelMode::FakePinnedDespiteCredential,
+        ] {
+            let cmds = local_disconnect_commands(&local_comms_opts(true, mode));
+            let worker_cmd = &cmds[1];
+            assert!(
+                !worker_cmd
+                    .env
+                    .iter()
+                    .any(|(k, _)| k == "AGENTOS_FAKE_MODEL"),
+                "{mode:?} must not inject AGENTOS_FAKE_MODEL; env={:?}",
+                worker_cmd.env
+            );
+        }
+    }
+
+    /// Anti-drift guard (issue #450): `local up` and `local comms` connect must
+    /// agree on whether/how they inject `AGENTOS_FAKE_MODEL`, for every
+    /// `ModelMode`. Compares `up_command` (with `local_model: None`, since that
+    /// path is its own independent live route) against `local_connect_commands`.
+    #[test]
+    fn up_and_local_connect_agree_on_fake_model_override_for_every_mode() {
+        for mode in [
+            ModelMode::LiveFromCredential,
+            ModelMode::FakePinnedDespiteCredential,
+            ModelMode::DefaultFake,
+        ] {
+            let up_env = crate::local::up_command(&crate::local::LocalOpts {
+                file: "compose.dev.yaml".into(),
+                dry_run: false,
+                minimal: false,
+                local_model: None,
+                slack: false,
+                model_mode: mode,
+            })
+            .env;
+            let connect_env = local_connect_commands(&local_comms_opts(false, mode))[0]
+                .env
+                .clone();
+            let up_override: Option<&(String, String)> =
+                up_env.iter().find(|(k, _)| k == "AGENTOS_FAKE_MODEL");
+            let connect_override: Option<&(String, String)> =
+                connect_env.iter().find(|(k, _)| k == "AGENTOS_FAKE_MODEL");
+            assert_eq!(
+                up_override, connect_override,
+                "{mode:?}: up_command and local_connect_commands disagree on \
+                 AGENTOS_FAKE_MODEL; up={up_env:?} connect={connect_env:?}"
+            );
+        }
+    }
+
+    /// Same anti-drift guard (issue #450) for the DISCONNECT leg: `local up`
+    /// and `local comms --disconnect`'s worker-restarting command must agree
+    /// on whether/how they inject `AGENTOS_FAKE_MODEL`, for every `ModelMode`.
+    #[test]
+    fn up_and_local_disconnect_agree_on_fake_model_override_for_every_mode() {
+        for mode in [
+            ModelMode::LiveFromCredential,
+            ModelMode::FakePinnedDespiteCredential,
+            ModelMode::DefaultFake,
+        ] {
+            let up_env = crate::local::up_command(&crate::local::LocalOpts {
+                file: "compose.dev.yaml".into(),
+                dry_run: false,
+                minimal: false,
+                local_model: None,
+                slack: false,
+                model_mode: mode,
+            })
+            .env;
+            let disconnect_env = local_disconnect_commands(&local_comms_opts(true, mode))[1]
+                .env
+                .clone();
+            let up_override: Option<&(String, String)> =
+                up_env.iter().find(|(k, _)| k == "AGENTOS_FAKE_MODEL");
+            let disconnect_override: Option<&(String, String)> = disconnect_env
+                .iter()
+                .find(|(k, _)| k == "AGENTOS_FAKE_MODEL");
+            assert_eq!(
+                up_override, disconnect_override,
+                "{mode:?}: up_command and local_disconnect_commands disagree on \
+                 AGENTOS_FAKE_MODEL; up={up_env:?} disconnect={disconnect_env:?}"
+            );
+        }
     }
 }

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -79,6 +79,21 @@ pub fn resolve_model_mode(explicit_fake_model: Option<&str>, has_credential: boo
     }
 }
 
+/// The single injection step every worker-restarting command shares: flip
+/// compose's fake default to live when (and only when) a credential is present
+/// and fake is not explicitly pinned. `FakePinnedDespiteCredential` and
+/// `DefaultFake` return `None` so compose's `${AGENTOS_FAKE_MODEL:-1}` default
+/// stands. This is the one place that decision is made -- `up_command` and
+/// `local comms`'s connect/disconnect commands all call it instead of each
+/// re-deriving the pair inline, which is what let `local comms` drift out of
+/// parity with `local up` (issue #450).
+pub fn fake_model_env_override(mode: ModelMode) -> Option<(String, String)> {
+    match mode {
+        ModelMode::LiveFromCredential => Some(("AGENTOS_FAKE_MODEL".into(), "0".into())),
+        ModelMode::FakePinnedDespiteCredential | ModelMode::DefaultFake => None,
+    }
+}
+
 /// Snapshot the shell for the parity decision. An empty AGENTOS_FAKE_MODEL is
 /// treated as unset (matches compose's `${AGENTOS_FAKE_MODEL:-1}` and the
 /// empty-string-is-not-a-credential rule); a credential is any non-empty
@@ -164,13 +179,13 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
             // (which is what compose otherwise derives the project name from).
             ("COMPOSE_PROJECT_NAME".into(), "agentos".into()),
         ]
-    } else if o.model_mode == ModelMode::LiveFromCredential {
-        // A credential is present: flip compose's fake default to live, matching
-        // `skill up`. (FakePinnedDespiteCredential/DefaultFake inject nothing so
-        // compose's `${AGENTOS_FAKE_MODEL:-1}` default stands.)
-        vec![("AGENTOS_FAKE_MODEL".into(), "0".into())]
     } else {
-        Vec::new()
+        // Delegate to `fake_model_env_override`, which discriminates on
+        // `o.model_mode`: LiveFromCredential injects AGENTOS_FAKE_MODEL=0 so
+        // compose goes live, matching `skill up`. FakePinnedDespiteCredential
+        // and DefaultFake inject nothing, so compose's
+        // `${AGENTOS_FAKE_MODEL:-1}` default stands for those two modes.
+        fake_model_env_override(o.model_mode).into_iter().collect()
     };
     if !env.is_empty() {
         cmd = cmd.with_env(env);
@@ -474,6 +489,19 @@ mod tests {
                 "pin {pin:?} should stay live"
             );
         }
+    }
+
+    #[test]
+    fn fake_model_env_override_maps_all_three_modes() {
+        assert_eq!(
+            fake_model_env_override(ModelMode::LiveFromCredential),
+            Some(("AGENTOS_FAKE_MODEL".to_string(), "0".to_string()))
+        );
+        assert_eq!(
+            fake_model_env_override(ModelMode::FakePinnedDespiteCredential),
+            None
+        );
+        assert_eq!(fake_model_env_override(ModelMode::DefaultFake), None);
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1224,6 +1224,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     app_token,
                     bot_token,
                     disconnect,
+                    model_mode: local::model_mode_from_env(),
                 })
                 .await
             }


### PR DESCRIPTION
`agentos local comms` restarted the worker from compose's `${AGENTOS_FAKE_MODEL:-1}` default, so wiring up Slack silently downgraded the stack to the offline fake model even with a real credential present. `local up` already resolved this correctly. The failure presents as a broken approval gate rather than as a fake model: the fake model never calls the gated tool, so the whole flow no-ops.

## What changed

- `fake_model_env_override` in `local.rs` is now the single place that decides whether to inject `AGENTOS_FAKE_MODEL=0`. `up_command` was building that pair inline, which is the step that drifted; it now calls the helper.
- `local comms` resolves the model mode from the shell exactly like `local up`, on both the connect and the `--disconnect` legs. Disconnect is included because it also restarts `agentos-worker` and carried the identical bug.
- Two anti-drift tests assert `local up` and both `local comms` legs agree on the `AGENTOS_FAKE_MODEL` decision for every `ModelMode`, so AC3 is a mechanical gate rather than a promise.
- `cli/README.md` documented the credential-driven live resolution as `local up`-only; updated to cover both commands.

## Acceptance criteria

- [x] With a credential present, `local comms --slack` leaves the worker on the live model
- [x] `AGENTOS_FAKE_MODEL=1` still forces the fake model for both commands
- [x] Model resolution is shared between `local up` and `local comms` (one code path)

## Out-of-scope note

The `ui.warn` for the credential-present-but-fake-pinned case is intentionally included: it mirrors the existing warn in `local.rs::up` so the "both commands" half of AC2 is observably true rather than silent.

Closes #450
