### PR TITLE
Post route-bound approval cards over the default transport

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -714,10 +714,16 @@ class Kernel:
                 channel=card_channel,
                 text=fallback,
                 blocks=card_blocks,
-                # In the requesting channel the card joins the thread; a
-                # route-bound channel has no such thread, so it posts top-level.
+                # In the requesting channel the card joins the thread and rides
+                # the trigger's transport; a route-bound channel has no such
+                # thread and is policy, not a per-turn reply, so it posts
+                # top-level over the worker's default Slack transport.
                 thread_ts=thread if card_channel == qevent.reply_handle.channel else None,
-                endpoint=qevent.reply_handle.endpoint,
+                endpoint=(
+                    qevent.reply_handle.endpoint
+                    if card_channel == qevent.reply_handle.channel
+                    else None
+                ),
             )
         except Exception as exc:  # noqa: BLE001 - the pause stands without the card
             logger.warning("approval card post failed for %s: %s", created.id, exc)

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -108,9 +108,11 @@ class FakeSink(SlackSink):
         self.status_sets: list[tuple[str, str, str]] = []
         self.status_clears: list[tuple[str, str]] = []
         # New messages posted by the kernel (the approval card, #246):
-        # (channel, text, blocks, thread_ts) per post.
+        # (channel, text, blocks, thread_ts, endpoint) per post. The endpoint is
+        # the transport the post is delivered through (#451): None means the
+        # worker's default Slack transport.
         self.posts: list[
-            tuple[str, str, list[dict[str, object]] | None, str | None]
+            tuple[str, str, list[dict[str, object]] | None, str | None, str | None]
         ] = []
 
     async def update(
@@ -145,7 +147,7 @@ class FakeSink(SlackSink):
         thread_ts: str | None = None,
         endpoint: str | None = None,
     ) -> str | None:
-        self.posts.append((channel, text, blocks, thread_ts))
+        self.posts.append((channel, text, blocks, thread_ts, endpoint))
         return f"posted-{len(self.posts)}"
 
     @property

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -40,13 +40,16 @@ def _qevent(
     thread: str = "th-appr",
     event_id: str | None = None,
     placeholder: str = "p-1",
+    endpoint: str | None = None,
 ) -> QueuedTurn:
     return QueuedTurn(
         event_id=event_id or uuid.uuid4().hex,
         conversation_id=thread,
         author="U1",
         text=text,
-        reply_handle=ReplyHandle(channel="C1", placeholder=placeholder),
+        reply_handle=ReplyHandle(
+            channel="C1", placeholder=placeholder, endpoint=endpoint
+        ),
         received_at="2026-07-14T00:00:00+00:00",
     )
 
@@ -297,7 +300,7 @@ def test_pause_posts_the_approval_card(make_harness) -> None:
             await h.kernel.process_event(ev)
 
             assert len(h.sink.posts) == 1
-            channel, fallback, blocks, thread_ts = h.sink.posts[0]
+            channel, fallback, blocks, thread_ts, _endpoint = h.sink.posts[0]
             assert channel == "C1"
             assert thread_ts == "th-card"
             assert "Give ACME a 20% discount" in fallback
@@ -368,7 +371,9 @@ class RoutedBinding:
 def test_routed_approval_cards_go_to_the_bound_channel(make_harness) -> None:
     """#247: the manifest route resolves through the agent's bindings; the card
     lands in the bound channel (top-level, no foreign thread) and the record
-    carries route + card_channel so the authorizer counts THAT channel."""
+    carries route + card_channel so the authorizer counts THAT channel. #451:
+    the triggering turn has no per-turn endpoint (a Slack-triggered turn), so
+    the card also rides the worker's default Slack transport (``None``)."""
 
     async def go() -> None:
         approvals = RecordingApprovals()
@@ -383,10 +388,11 @@ def test_routed_approval_cards_go_to_the_bound_channel(make_harness) -> None:
             assert req.route == "managers"
             assert req.card_channel == "C_MGRS"
             # Card posted to the bound channel, top-level (no thread there).
-            channel, _fallback, blocks, thread_ts = h.sink.posts[0]
+            channel, _fallback, blocks, thread_ts, endpoint = h.sink.posts[0]
             assert channel == "C_MGRS"
             assert thread_ts is None
             assert blocks is not None
+            assert endpoint is None
 
     asyncio.run(go())
 
@@ -402,7 +408,7 @@ def test_unbound_route_falls_back_to_requesting_channel(make_harness) -> None:
             req = approvals.requests[0]
             assert req.route == "managers"
             assert req.card_channel == "C1"  # fell back to the requesting channel
-            channel, _f, _b, thread_ts = h.sink.posts[0]
+            channel, _f, _b, thread_ts, _endpoint = h.sink.posts[0]
             assert channel == "C1"
             assert thread_ts == "th-unbound"  # same channel keeps the thread
 
@@ -419,5 +425,61 @@ def test_routeless_approval_keeps_prior_behavior(make_harness) -> None:
             req = approvals.requests[0]
             assert req.route is None
             assert req.card_channel == "C1"
+
+    asyncio.run(go())
+
+
+# --- Card transport follows the card's channel, not the trigger (#451) --------
+
+_CLI_STUB = "http://localhost:8155"
+
+
+def test_routed_card_ignores_the_triggering_turns_endpoint(make_harness) -> None:
+    """#451: the card's channel is policy (the manifest route binding), so its
+    transport must be too. A CLI-triggered turn carries a local stub endpoint;
+    delivering a route-bound card through it posts the card at the stub instead
+    of the real Slack workspace, so the bound channel never sees it. ``None``
+    means the worker's default Slack transport."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        binding = RoutedBinding({"managers": {"channel": "C_MGRS"}})
+        async with make_harness(approvals=approvals, binding=binding) as h:
+            h.runner.default_script = _awaiting_routed_script(
+                "Discount for ACME", "managers"
+            )
+            await h.kernel.process_event(
+                _qevent("discount?", thread="th-cli-routed", endpoint=_CLI_STUB)
+            )
+
+            channel, _f, _b, thread_ts, endpoint = h.sink.posts[0]
+            assert channel == "C_MGRS"
+            assert thread_ts is None
+            assert endpoint is None
+
+    asyncio.run(go())
+
+
+def test_card_routed_to_requesting_channel_keeps_the_trigger_endpoint(
+    make_harness,
+) -> None:
+    """The inverse of the routed case: when the route binds back to the channel
+    that asked, the card belongs to that conversation -- it threads under it and
+    rides the same transport the trigger arrived on, so a CLI-stub turn's card
+    stays at the stub."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        binding = RoutedBinding({"managers": {"channel": "C1"}})  # the requesting channel
+        async with make_harness(approvals=approvals, binding=binding) as h:
+            h.runner.default_script = _awaiting_routed_script("Ship it", "managers")
+            await h.kernel.process_event(
+                _qevent("ship?", thread="th-self-routed", endpoint=_CLI_STUB)
+            )
+
+            channel, _f, _b, thread_ts, endpoint = h.sink.posts[0]
+            assert channel == "C1"
+            assert thread_ts == "th-self-routed"
+            assert endpoint == _CLI_STUB
 
     asyncio.run(go())

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -99,7 +99,13 @@ in code now:
   channels per agent (`agents.approval_routes`, deployment config, never in the bundle);
   the worker resolves a raised route through the binding and posts the card into the bound
   channel (`card_channel` on the record), whose members the authorizer then counts as the
-  approvers; an unbound route falls back to the requesting channel with a warning. Every
+  approvers; an unbound route falls back to the requesting channel with a warning. The
+  card's transport follows the same split (#451): a bound channel that differs from the
+  requesting channel is deployment policy, not part of the triggering conversation, so the
+  card posts top-level over the worker's default Slack transport rather than the trigger's
+  per-turn endpoint (this is what lets a non-Slack-triggered turn, e.g. CLI or API, still
+  deliver a real Slack card); the requesting-channel case (including the unbound fallback)
+  keeps the trigger's endpoint and threads under the conversation as before. Every
   resolution attempt appends to the platform audit log (`approval_audit_entries`,
   `GET /approvals/{id}/audit`): actor, channel evidence, decision, and the authorizer
   snapshot -- who resolved, and why they counted (or were refused).


### PR DESCRIPTION
The approval card's channel is route-bound policy, but its transport still
inherited the triggering turn's per-turn endpoint. A turn triggered from
anything other than Slack posted its card to the correct channel name through
the wrong transport: for a CLI turn (`local message`) that is the local stub on
`localhost:8155`, so the card never reached Slack. Cron, scheduled, and
proactive agents (#268) have no triggering Slack event to inherit a transport
from at all, so a gated action needing human approval in Slack was broken by
construction.

The fix mirrors the condition the adjacent `thread_ts` line already uses: a card
routed to a bound channel that is not the requesting channel is a workspace
destination, not part of the triggering conversation, so it posts over the
worker's default Slack transport. Slack-triggered behavior is unchanged (its
endpoint is already `None`).

## Verification

`kernel.py` is a sacred module, so this ran the full adversarial roster:
spec-vs-impl, side-effects-detective, scope-creep, code-reviewer, and a
cross-model Codex pass. All approved with zero blocking findings.

Test quality was checked by mutation rather than inspection: reverting the gate
fails the AC1 test, and over-correcting to an unconditional `endpoint=None`
fails the AC3 test, so the gate is pinned from both sides. Full worker suite is
355 passed / 1 skipped; ruff and mypy clean.

## Notes for the reviewer

- **Not verified live against real Slack.** The ACs are proven at code level and
  by mutation, but no hands-on deployed pass ran. Compose points the default
  transport at the CLI stub and `cluster message --wire` does the same, so AC1
  only validates on an unwired cluster with a real Slack token.
- **Follow-up, pre-existing:** the card post dials the default transport inside
  the pause path with no bounded timeout, and `slack_sink` retries text-only on
  any failure when that retry exists for Block Kit rejection alone. This already
  affects every Slack-triggered card today (the dispatcher never sets an
  endpoint), so it is out of scope here; worth its own issue.
- `docs/interfaces/approval/INTERFACE.md` documented the card's channel but not
  its transport; the transport split is now stated there.

Closes #451
