### PR TITLE
Wire the dispatcher to the platform API and gate boot on it

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -123,6 +123,15 @@ jobs:
           set -euo pipefail
           bash charts/agentos/ci/connector-secrets-assertions.sh
 
+      # Prove the dispatcher is told where the platform API is and how to
+      # authenticate to it (issue #442). Unwired, it falls back to its code
+      # default http://localhost:8000 -- itself -- and every Slack Approve click
+      # dead-ends with only a warning.
+      - name: helm render assertions (dispatcher API wiring)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/dispatcher-api-wiring-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -75,6 +75,31 @@ Read from the environment by `DispatcherConfig()` (a `pydantic_settings.BaseSett
 | `AGENTOS_BACKOFF_INITIAL_SECONDS` | `1.0` | first reconnect backoff |
 | `AGENTOS_BACKOFF_MAX_SECONDS` | `30.0` | backoff cap |
 | `AGENTOS_BACKOFF_MULTIPLIER` | `2.0` | backoff growth factor |
+| `AGENTOS_API_BASE_URL` | `http://localhost:8000` | platform API used to resolve approval clicks (compose: `http://agentos-api:8000`) |
+| `AGENTOS_API_KEY` | `agentos-dev-key` | shared API key sent as `X-API-Key` on the resolve call |
+| `AGENTOS_API_PREFLIGHT_TIMEOUT_SECONDS` | `30.0` | deadline for the boot gate below; must be positive |
+
+### Boot gate on the platform API
+
+Before any Slack wiring, `main()` polls `GET {AGENTOS_API_BASE_URL}/health` until
+it answers 200 or `AGENTOS_API_PREFLIGHT_TIMEOUT_SECONDS` elapses, reusing the
+`AGENTOS_BACKOFF_*` tunables for the poll interval. On success it logs the
+resolved URL once at INFO. On the deadline it logs an error naming that URL and
+the time actually spent, and
+exits non-zero, so a misconfigured base URL is dead on arrival instead of
+dead-ending every Slack Approve click much later (the previous behavior was a
+single warning at click time). It retries rather than probing once so a
+slow-starting API does not fail a healthy stack; in Kubernetes the restart
+backoff is the outer retry loop and `CrashLoopBackOff` is the operator signal.
+
+The gate runs once at boot only. It is not a liveness monitor: an API restart
+later does not kill the dispatcher (the heartbeat probes own liveness, and the
+resolve call degrades per-call on its own). There is no off switch: the gate is
+the point, so a non-positive timeout is rejected as a config error at boot.
+
+**Known limit: the gate proves reachability, not credentials.** `/health` is
+unauthenticated, so a wrong `AGENTOS_API_KEY` still passes the gate and fails at
+click time. This check catches the base-URL class of misconfiguration only.
 
 The two Slack tokens are the only secrets. When a workspace exists they come from
 the app's install (App-Level Token with `connections:write` for `SLACK_APP_TOKEN`;

--- a/apps/dispatcher/src/agentos_dispatcher/config.py
+++ b/apps/dispatcher/src/agentos_dispatcher/config.py
@@ -23,6 +23,9 @@ Env mapping:
     AGENTOS_BACKOFF_INITIAL_SECONDS -> backoff_initial_seconds
     AGENTOS_BACKOFF_MAX_SECONDS     -> backoff_max_seconds
     AGENTOS_BACKOFF_MULTIPLIER      -> backoff_multiplier
+    AGENTOS_API_BASE_URL       -> api_base_url
+    AGENTOS_API_KEY            -> api_key
+    AGENTOS_API_PREFLIGHT_TIMEOUT_SECONDS -> api_preflight_timeout_s
     AGENTOS_HEARTBEAT_FILE             -> heartbeat_file
     AGENTOS_HEARTBEAT_INTERVAL_SECONDS -> heartbeat_interval_s
 """
@@ -124,6 +127,19 @@ class DispatcherConfig(BaseSettings):
         default="http://localhost:8000", validation_alias="AGENTOS_API_BASE_URL"
     )
     api_key: str = Field(default="agentos-dev-key", validation_alias="AGENTOS_API_KEY")
+    # Deadline for the boot-time gate on that wiring (see preflight.py). Long
+    # enough to absorb the API's own startup. Must be positive: the gate is the
+    # AC2 requirement, so a non-positive value is a config error at boot rather
+    # than a silent way to turn it off. Non-finite is rejected for the same
+    # reason: `inf` passes `gt=0` but hangs the boot gate forever, so the pod
+    # never exits, never crash-loops, and the operator never gets the signal the
+    # gate exists to produce.
+    api_preflight_timeout_s: float = Field(
+        default=30.0,
+        gt=0,
+        allow_inf_nan=False,
+        validation_alias="AGENTOS_API_PREFLIGHT_TIMEOUT_SECONDS",
+    )
 
     placeholder_text: str = Field(
         default="On it. Working on your request.",

--- a/apps/dispatcher/src/agentos_dispatcher/preflight.py
+++ b/apps/dispatcher/src/agentos_dispatcher/preflight.py
@@ -1,0 +1,129 @@
+"""Boot-time gate on the platform API wiring (#442, AC2).
+
+The dispatcher resolves Slack approval clicks by calling the platform API. When
+``AGENTOS_API_BASE_URL`` points somewhere unreachable, the only symptom today is
+a warning at click time and a dead-ended button: ``ApprovalResolveClient.resolve``
+catches the ``httpx.HTTPError`` and returns ``ResolveOutcome(status_code=0)``.
+This gate turns that silent misconfiguration into a loud boot failure naming the
+URL it could not reach.
+
+The gate is bounded retry, not a single probe: one probe at t=0 races the API's
+own startup, and in Kubernetes pod start order is not ordered at all, so
+fail-immediately would crash-loop a healthy stack. Restart backoff is the outer
+retry loop there, and a CrashLoopBackOff with the named URL in the log is the
+operator signal.
+
+It is a wiring gate, not a liveness monitor: one shot at boot only. The heartbeat
+probes own liveness and ``ApprovalResolveClient`` owns per-call degradation, so an
+API restart hours later must not kill the dispatcher.
+
+``/health`` is unauthenticated by design, so this gate proves reachability only: a
+wrong ``AGENTOS_API_KEY`` still passes it and surfaces as a 401 at the first
+approval click.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+from .config import DispatcherConfig
+from .supervisor import BackoffPolicy
+
+# Cap on any single probe, so one hung connect cannot eat the whole deadline and
+# collapse bounded retry into the single probe the design rejected. A black-holed
+# address (a DROP'd rule, an unroutable IP) hangs until this fires rather than
+# refusing fast like a closed port does.
+_MAX_PROBE_TIMEOUT_S = 5.0
+
+
+class ApiUnreachableError(RuntimeError):
+    """The platform API did not answer ``GET /health`` before the deadline."""
+
+
+def _safe_for_log(url: str) -> str:
+    """Drop any userinfo from a URL so credentials cannot reach the logs.
+
+    AC2 requires naming the resolved URL, so the URL itself must survive; only
+    the ``user:pass@`` part is removed. ``httpx`` accepts userinfo, so a BYO
+    ``dispatcher.apiBaseUrl`` could otherwise write it into pod logs and any log
+    shipper downstream.
+    """
+    parts = urlsplit(url)
+    if not (parts.username or parts.password):
+        return url
+    host = parts.hostname or ""
+    netloc = f"{host}:{parts.port}" if parts.port else host
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+def check_api_reachable(
+    config: DispatcherConfig,
+    *,
+    logger: logging.Logger,
+    client: httpx.Client | None = None,
+) -> None:
+    """Poll ``GET {api_base_url}/health`` until it answers 200 or the deadline passes.
+
+    Raises ``ApiUnreachableError`` naming the resolved base URL when the deadline
+    expires.
+    """
+    # The resolve path rstrips its base too; without this a perfectly reasonable
+    # "http://agentos-api:8000/" would probe "//health" and fail a wired stack.
+    base = config.api_base_url.rstrip("/")
+    logged_base = _safe_for_log(base)
+    timeout_s = config.api_preflight_timeout_s
+
+    backoff = BackoffPolicy(
+        initial_seconds=config.backoff_initial_seconds,
+        max_seconds=config.backoff_max_seconds,
+        multiplier=config.backoff_multiplier,
+    )
+    http = client or httpx.Client(timeout=min(_MAX_PROBE_TIMEOUT_S, timeout_s))
+    owned = client is None
+    start = time.monotonic()
+    deadline = start + timeout_s
+    attempt = 0
+    last_error = ""
+    try:
+        while True:
+            # Bound each probe to what is left of the budget, so the loop cannot
+            # start a request it has no time for and then block past the deadline
+            # on that request's own timeout. Without this a 30s deadline takes
+            # ~35s and a short one nearly doubles.
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                response = http.get(
+                    f"{base}/health", timeout=min(_MAX_PROBE_TIMEOUT_S, remaining)
+                )
+                if response.status_code == 200:
+                    logger.info("platform API reachable at %s", logged_base)
+                    return
+                last_error = f"HTTP {response.status_code}"
+            except httpx.HTTPError as exc:
+                last_error = str(exc)
+
+            delay = backoff.delay(attempt)
+            attempt += 1
+            # Clamp to the remaining budget rather than breaking when the next
+            # delay would overshoot it: with the shipped defaults (backoff_max
+            # 30.0 vs a 30.0s deadline) breaking abandons half the budget, and
+            # raising the deadline then buys the operator nothing.
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(delay, remaining))
+    finally:
+        if owned:
+            http.close()
+
+    elapsed = time.monotonic() - start
+    raise ApiUnreachableError(
+        f"cannot reach the platform API at {logged_base} after {elapsed:.1f}s "
+        f"({attempt} attempts, last error: {last_error}); check AGENTOS_API_BASE_URL"
+    )

--- a/apps/dispatcher/src/agentos_dispatcher/run.py
+++ b/apps/dispatcher/src/agentos_dispatcher/run.py
@@ -12,6 +12,7 @@ import signal
 from .app import SocketModeConnection, build_app, build_redis, build_web_client
 from .config import DispatcherConfig
 from .heartbeat import start_heartbeat
+from .preflight import ApiUnreachableError, check_api_reachable
 from .supervisor import BackoffPolicy, Supervisor
 
 
@@ -36,6 +37,14 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger("agentos_dispatcher")
     config = DispatcherConfig()
+
+    # Gate on the platform API wiring before touching Slack: a dispatcher that
+    # cannot reach the API dead-ends every approval click (#442).
+    try:
+        check_api_reachable(config, logger=logger)
+    except ApiUnreachableError as exc:
+        logger.error("%s", exc)
+        raise SystemExit(1) from exc
 
     supervisor = build_supervisor(config, logger=logger)
     hb_stop = start_heartbeat(config.heartbeat_file, config.heartbeat_interval_s)

--- a/apps/dispatcher/tests/test_config.py
+++ b/apps/dispatcher/tests/test_config.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import pytest
 from agentos_dispatcher.config import DispatcherConfig
+from pydantic import ValidationError
 
 
 def _clear_all_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -153,6 +154,91 @@ def test_overrides_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None
         assert type(actual) is type(expected), (
             f"{env_var} -> {field}: type {type(actual)} != {type(expected)}"
         )
+
+
+# --- Platform API wiring (#442) ---------------------------------------------
+#
+# #442 proposed changing api_base_url's default off localhost. It was rejected:
+# the default is correct for its only real audience (a dispatcher run bare on a
+# laptop against a local API), and every containerized context has a manifest
+# whose whole job is to declare the wiring. The obvious "fix"
+# (http://agentos-api:8000) hardcodes a compose service name into application
+# code -- wrong in the chart, wrong on a laptop, wrong for any BYO deployment.
+# The default also deliberately mirrors the worker's for the same seam (#246).
+# These lock that decision, and cover the setting the boot gate reads.
+
+
+def test_api_base_url_default_stays_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The code default is unchanged: the fix is manifest wiring, not a new default.
+
+    A dispatcher run bare on a laptop against a local API must keep working with
+    no env set at all.
+    """
+    _clear_all_config_env(monkeypatch)
+
+    assert DispatcherConfig().api_base_url == "http://localhost:8000"
+
+
+def test_api_preflight_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The boot gate's deadline defaults to 30s: long enough to absorb API startup."""
+    _clear_all_config_env(monkeypatch)
+
+    assert DispatcherConfig().api_preflight_timeout_s == 30.0
+
+
+def test_api_preflight_timeout_reads_its_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The deadline is tunable via AGENTOS_API_PREFLIGHT_TIMEOUT_SECONDS, and float-coerced."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_API_PREFLIGHT_TIMEOUT_SECONDS", "5.5")
+
+    config = DispatcherConfig()
+
+    assert config.api_preflight_timeout_s == 5.5
+    assert type(config.api_preflight_timeout_s) is float
+
+
+def test_api_preflight_timeout_ignores_bare_field_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The new aliased field follows the house rule: alias only, no bare-name fallback."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("API_PREFLIGHT_TIMEOUT_S", "99.0")
+
+    assert DispatcherConfig().api_preflight_timeout_s == 30.0
+
+
+def test_api_preflight_timeout_rejects_non_positive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-positive deadline is a config error, not a way to switch the gate off.
+
+    The gate is the AC2 requirement, so `0` must fail loudly at boot rather than
+    silently skip the probe and hand the operator back the dead-ended Approve
+    button the gate exists to prevent.
+    """
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_API_PREFLIGHT_TIMEOUT_SECONDS", "0")
+
+    with pytest.raises(ValidationError):
+        DispatcherConfig()
+
+
+@pytest.mark.parametrize("token", ["inf", "Infinity", "-inf", "nan"])
+def test_api_preflight_timeout_rejects_non_finite(
+    monkeypatch: pytest.MonkeyPatch, token: str
+) -> None:
+    """A non-finite deadline defeats the gate as thoroughly as switching it off.
+
+    `gt=0` catches `-inf` and `nan` on its own but passes `inf`, which makes the
+    boot probe wait forever: the pod never exits, so it never CrashLoopBackOffs,
+    so the operator never sees the misconfiguration. That is the exact silent
+    failure AC2 exists to eliminate, so the value is rejected at boot instead.
+    """
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_API_PREFLIGHT_TIMEOUT_SECONDS", token)
+
+    with pytest.raises(ValidationError):
+        DispatcherConfig()
 
 
 # --- Per-service bool divergence (review #178) -------------------------------

--- a/apps/dispatcher/tests/test_preflight.py
+++ b/apps/dispatcher/tests/test_preflight.py
@@ -1,0 +1,354 @@
+"""Boot-time platform-API wiring gate (#442, AC2).
+
+The dispatcher resolves Slack approval clicks by calling the platform API. When
+it is wired to the wrong place the only symptom today is a warning at click time
+and a dead-ended button (``ApprovalResolveClient.resolve`` catches the
+``httpx.HTTPError`` and returns ``ResolveOutcome(status_code=0)``). This gate
+turns that silent misconfiguration into a loud boot failure naming the URL it
+could not reach.
+
+The gate is bounded-retry-then-fail, not fail-immediately: a single probe at t=0
+races the API's own startup, and in k8s pod start order is not ordered at all, so
+fail-immediately would crash-loop a healthy stack. Test 3 is the guard on that
+decision.
+
+Only the API is faked, at the ``client=`` seam, with ``httpx.MockTransport`` --
+the same "fake the platform API, drive the real code" discipline as
+test_approval_actions.py's scripted resolver. The retry loop, the deadline, and
+the URL construction are all real. Tests stay fast by configuring tiny backoff
+values (real settings, not a patched clock), so the poll loop under test is the
+one that ships.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import httpx
+import pytest
+from agentos_dispatcher.config import DispatcherConfig
+from agentos_dispatcher.preflight import ApiUnreachableError, check_api_reachable
+
+API_URL = "http://agentos-api:8000"
+
+
+def _config(**overrides: object) -> DispatcherConfig:
+    """A config whose poll loop runs to its deadline in a fraction of a second.
+
+    The backoff knobs are the real ``config.backoff_*`` settings the preflight
+    reuses; shrinking them keeps the suite fast without patching time, so the
+    loop exercised here is the shipped one.
+    """
+    defaults: dict[str, object] = {
+        "api_base_url": API_URL,
+        "api_preflight_timeout_s": 0.2,
+        "backoff_initial_seconds": 0.01,
+        "backoff_max_seconds": 0.02,
+        "backoff_multiplier": 2.0,
+    }
+    defaults.update(overrides)
+    return DispatcherConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _client(handler) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _refusing(request: httpx.Request) -> httpx.Response:
+    """A fake handler that always refuses the connection."""
+    raise httpx.ConnectError("connection refused", request=request)
+
+
+def _ok(request: httpx.Request) -> httpx.Response:
+    """A fake handler that always answers a healthy 200."""
+    return httpx.Response(200, json={"status": "ok"})
+
+
+def test_healthy_api_returns_and_logs_the_url(caplog: pytest.LogCaptureFixture) -> None:
+    """A reachable API returns cleanly and records where it looked.
+
+    The happy path. A gutted implementation (a bare `return`) also passes this
+    one, which is why it is not the contract -- tests 2 and 3 are.
+    """
+    requested: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(str(request.url))
+        return httpx.Response(200, json={"status": "ok"})
+
+    logger = logging.getLogger("test-preflight-healthy")
+    with caplog.at_level(logging.INFO, logger="test-preflight-healthy"):
+        check_api_reachable(_config(), logger=logger, client=_client(handler))
+
+    assert requested == [f"{API_URL}/health"]
+    assert any(API_URL in record.getMessage() for record in caplog.records), (
+        "the preflight logged nothing naming the API URL it reached; the "
+        "resolved wiring must be visible in the boot logs"
+    )
+
+
+def test_unreachable_api_raises_naming_the_url() -> None:
+    """AC2: an unreachable API fails loudly, naming the URL that was tried.
+
+    This is the whole point of the gate. Deleting the implementation fails this.
+    Naming the URL is the load-bearing part: "cannot reach the API" without the
+    resolved address does not tell an operator that it is pointed at itself.
+    """
+
+    with pytest.raises(ApiUnreachableError) as excinfo:
+        check_api_reachable(
+            _config(api_preflight_timeout_s=0.05),
+            logger=logging.getLogger("test-preflight"),
+            client=_client(_refusing),
+        )
+
+    assert API_URL in str(excinfo.value), (
+        f"the error must name the configured api_base_url; got {str(excinfo.value)!r}"
+    )
+
+
+def test_transient_failure_then_success_does_not_raise() -> None:
+    """Bounded RETRY, not fail-immediately: a slow-starting API is not a failure.
+
+    The crash-loop guard, and the test that pins the design decision. A naive
+    single-probe implementation fails here: in compose and k8s the API is
+    routinely not yet accepting connections when the dispatcher boots.
+    """
+    attempts: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise httpx.ConnectError("connection refused", request=request)
+        return httpx.Response(200, json={"status": "ok"})
+
+    check_api_reachable(
+        _config(), logger=logging.getLogger("test-preflight"), client=_client(handler)
+    )
+
+    assert len(attempts) == 3, (
+        f"expected the preflight to keep polling until the API answered "
+        f"(3 attempts); it made {len(attempts)}"
+    )
+
+
+def test_non_200_health_is_treated_as_unreachable() -> None:
+    """A responding-but-unhealthy endpoint is not "reachable".
+
+    Guards against ignoring status_code. A 404 here is the realistic case: the
+    URL points at some other service that answers HTTP but is not the API.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    with pytest.raises(ApiUnreachableError):
+        check_api_reachable(
+            _config(api_preflight_timeout_s=0.05),
+            logger=logging.getLogger("test-preflight"),
+            client=_client(handler),
+        )
+
+
+def test_health_url_tolerates_a_trailing_slash() -> None:
+    """A base URL with a trailing slash must not yield `//health`.
+
+    ``ApprovalResolveClient`` already rstrips its base; the preflight builds its
+    own URL and must do the same or a perfectly reasonable
+    `http://agentos-api:8000/` fails the gate on a correctly wired stack.
+    """
+    requested: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(request.url.path)
+        return httpx.Response(200, json={"status": "ok"})
+
+    check_api_reachable(
+        _config(api_base_url=f"{API_URL}/"),
+        logger=logging.getLogger("test-preflight"),
+        client=_client(handler),
+    )
+
+    assert requested == ["/health"]
+
+
+def test_the_loop_spends_its_whole_budget_with_production_backoff_ratios() -> None:
+    """The gate must poll until its deadline, and report what it really spent.
+
+    The other cases run `backoff_max << timeout`, where the growing delay never
+    approaches the deadline. The shipped defaults are the opposite ratio
+    (`backoff_max` 30.0 against a 30.0s deadline), so the delays 1, 2, 4, 8, 16
+    reach t=15s and the next 16s delay overshoots. An implementation that breaks
+    on the overshoot instead of clamping to the remaining budget abandons half
+    its deadline and then reports the configured 30.0s it never spent. This
+    config is those defaults scaled by 100.
+    """
+
+    config = _config(
+        api_preflight_timeout_s=0.3,
+        backoff_initial_seconds=0.01,
+        backoff_max_seconds=0.3,
+        backoff_multiplier=2.0,
+    )
+    start = time.monotonic()
+    with pytest.raises(ApiUnreachableError) as excinfo:
+        check_api_reachable(
+            config, logger=logging.getLogger("test-preflight"), client=_client(_refusing)
+        )
+    elapsed = time.monotonic() - start
+
+    assert elapsed >= 0.27, (
+        f"the preflight gave up after {elapsed:.3f}s of its 0.3s budget; the "
+        f"delay must be clamped to the remaining time, not abandoned when it "
+        f"would overshoot"
+    )
+    # 0.15s is the pre-fix elapsed: the message must never claim time it did not spend.
+    assert "after 0.3s" in str(excinfo.value), (
+        f"the error must report the time actually elapsed, not the configured "
+        f"deadline; got {str(excinfo.value)!r}"
+    )
+
+
+@contextmanager
+def _black_hole_api() -> Iterator[str]:
+    """A real port that completes the TCP handshake and then never answers.
+
+    The counterpart to `_refusing`: a refused connection fails instantly, so it
+    can never show a probe running past the deadline. This one hangs until some
+    timeout fires, which is exactly the case where an unbounded probe overshoots.
+    Nothing accepts the socket; the kernel's listen backlog completes the
+    handshake, so `connect` succeeds and the read blocks.
+    """
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    try:
+        yield f"http://127.0.0.1:{sock.getsockname()[1]}"
+    finally:
+        sock.close()
+
+
+def test_the_loop_does_not_probe_past_its_deadline() -> None:
+    """The upper bound: the gate must spend its budget and then stop.
+
+    The sibling test above pins the lower bound (never abandon the budget early).
+    This pins the other side, which that fix left open: the loop could still
+    enter a probe with little or no budget left, and the probe's own timeout then
+    ran past the deadline -- measured at 0.249s elapsed against a 0.2s deadline,
+    with the error still claiming "after 0.2s". A boot gate that overshoots its
+    configured deadline delays the CrashLoopBackOff signal it exists to produce.
+
+    The injected client carries the 5.0s default the preflight builds for itself,
+    so an unbounded probe against a black hole burns 5s of a 0.3s budget.
+    """
+    with _black_hole_api() as url:
+        config = _config(api_base_url=url, api_preflight_timeout_s=0.3)
+        start = time.monotonic()
+        with pytest.raises(ApiUnreachableError) as excinfo:
+            check_api_reachable(
+                config,
+                logger=logging.getLogger("test-preflight"),
+                client=httpx.Client(timeout=5.0),
+            )
+        elapsed = time.monotonic() - start
+
+    assert elapsed < 0.6, (
+        f"the preflight took {elapsed:.3f}s against a 0.3s deadline; each probe "
+        f"must be bounded by the time remaining, not by the probe timeout"
+    )
+    assert elapsed >= 0.27, (
+        f"the preflight gave up after {elapsed:.3f}s of its 0.3s budget; bounding "
+        f"the probe must not turn into abandoning the deadline early"
+    )
+    assert "after 0.3s" in str(excinfo.value), (
+        f"the error must report the time actually elapsed; got {str(excinfo.value)!r}"
+    )
+
+
+def test_userinfo_in_the_base_url_is_kept_out_of_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A credential-bearing base URL must not write its password to the logs.
+
+    AC2 requires naming the resolved URL, so stripping userinfo beats dropping
+    the URL. `httpx` accepts `http://user:pass@host`, so a BYO `apiBaseUrl` would
+    otherwise put `pass` in the pod logs and every shipper downstream.
+    """
+
+    logger = logging.getLogger("test-preflight-userinfo")
+    with caplog.at_level(logging.INFO, logger="test-preflight-userinfo"):
+        check_api_reachable(
+            _config(api_base_url="http://user:hunter2@agentos-api:8000"),
+            logger=logger,
+            client=_client(_ok),
+        )
+
+    logged = " ".join(record.getMessage() for record in caplog.records)
+    assert "hunter2" not in logged and "user" not in logged, (
+        f"the preflight logged the URL's userinfo: {logged!r}"
+    )
+    assert "agentos-api:8000" in logged, (
+        f"AC2 still requires the log to name the resolved URL; got {logged!r}"
+    )
+
+
+def test_userinfo_is_stripped_from_the_error_too() -> None:
+    """The failure path names the URL as well, so it needs the same scrub."""
+
+    with pytest.raises(ApiUnreachableError) as excinfo:
+        check_api_reachable(
+            _config(
+                api_base_url="http://user:hunter2@agentos-api:8000",
+                api_preflight_timeout_s=0.05,
+            ),
+            logger=logging.getLogger("test-preflight"),
+            client=_client(_refusing),
+        )
+
+    assert "hunter2" not in str(excinfo.value)
+    assert "agentos-api:8000" in str(excinfo.value)
+
+
+def test_run_main_gates_before_connecting_slack(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ordering contract: the wiring gate precedes any Slack wiring.
+
+    Driven through the real ``run.main()`` so it survives an internal rename of
+    ``check_api_reachable``. ``build_supervisor`` -- the boundary that builds the
+    Valkey client, the Slack Web client, and the Socket Mode connection factory --
+    is replaced with a recorder; reaching it at all means the gate did not fire
+    first. The API is a genuinely dead port, so nothing is stubbed on the path
+    under test.
+    """
+    from agentos_dispatcher import run
+
+    reached_slack: list[str] = []
+
+    def _recording_build_supervisor(*args: object, **kwargs: object) -> object:
+        reached_slack.append("build_supervisor")
+        raise AssertionError(
+            "build_supervisor was called with an unreachable API: the dispatcher "
+            "wired up Slack before (or instead of) gating on the platform API"
+        )
+
+    monkeypatch.setattr(run, "build_supervisor", _recording_build_supervisor)
+    for name, field in DispatcherConfig.model_fields.items():
+        alias = field.validation_alias
+        monkeypatch.delenv(alias if isinstance(alias, str) else name.upper(), raising=False)
+    # Port 1 is reserved and never listening: a real, immediate connection refusal.
+    monkeypatch.setenv("AGENTOS_API_BASE_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("AGENTOS_API_PREFLIGHT_TIMEOUT_SECONDS", "0.2")
+    monkeypatch.setenv("AGENTOS_BACKOFF_INITIAL_SECONDS", "0.01")
+    monkeypatch.setenv("AGENTOS_BACKOFF_MAX_SECONDS", "0.02")
+
+    with pytest.raises(SystemExit) as excinfo:
+        run.main()
+
+    assert excinfo.value.code not in (0, None), (
+        f"the dispatcher must exit non-zero on an unreachable API so a "
+        f"CrashLoopBackOff surfaces it; exited {excinfo.value.code!r}"
+    )
+    assert reached_slack == []

--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -64,6 +64,31 @@ the containerd handler on every node first, or add `--set security.gvisor.mode=o
 (or `-f charts/agentos/values-e2e-nogvisor.yaml`) to run real code without kernel
 isolation knowingly.
 
+The dispatcher also needs to reach the platform API: a Slack Approve click is
+relayed to the API as an approval resolve. By default it is wired to the in-chart
+API Service (`http://<fullname>-api:<api.service.port>`, derived, so an overridden
+`api.service.port` tracks automatically) and authenticates with the chart Secret's
+`apiKey` by reference. Point it at an API this chart did not deploy with
+`dispatcher.apiBaseUrl`:
+
+```bash
+helm upgrade agentos charts/agentos -n agentos --reuse-values \
+  --set dispatcher.apiBaseUrl=https://your-api.example
+```
+
+| Value | Default | Meaning |
+| --- | --- | --- |
+| `dispatcher.apiBaseUrl` | `""` | Empty derives the in-chart API Service. A set value is used verbatim (BYO), and is **required** when `api.deploy: false`, where no in-chart Service exists to derive from. |
+
+Two limits worth knowing. With `api.deploy: false` and an empty
+`dispatcher.apiBaseUrl` the dispatcher is pointed at a Service that does not
+exist; its boot preflight fails and the pod CrashLoopBackOffs naming the
+unreachable URL. That is intentional (a loud boot failure beats a silent
+dead-end at click time) and the fix is to set `dispatcher.apiBaseUrl`. And
+because the API's `/health` is unauthenticated, that preflight proves only
+reachability, not that the key is right: a BYO API expecting a different key
+still passes boot and fails at click time. Match `apiKey` to the API you point at.
+
 **Cluster variants:**
 
 - **Cluster already runs the agent-sandbox controller** (cluster-scoped, one per

--- a/charts/agentos/ci/dispatcher-api-wiring-assertions.sh
+++ b/charts/agentos/ci/dispatcher-api-wiring-assertions.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for the dispatcher's platform-API wiring (#442). Proves,
+# with `helm template` alone (no cluster), that the dispatcher Deployment is told
+# where the API is and how to authenticate to it. Unwired, the dispatcher falls
+# back to its code default http://localhost:8000, which inside its own pod is the
+# dispatcher itself, and every Slack Approve click dead-ends with only a warning.
+#
+#   1. Default install renders AGENTOS_API_BASE_URL as the in-chart API Service
+#      (http://<fullname>-api:<api.service.port>), asserted as a VALUE.
+#   2. The port tracks .Values.api.service.port and is not hardcoded.
+#   3. dispatcher.apiBaseUrl overrides verbatim (the BYO / api.deploy=false path).
+#   4. AGENTOS_API_KEY arrives by secretKeyRef to the chart Secret's `apiKey`
+#      key, never as an inline literal (which would land the credential in
+#      `helm get manifest` and in any rendered artifact CI uploads).
+#   5. A token-less install still renders no dispatcher at all (unchanged gate).
+#
+# NOTE ON `--output-dir`: the sibling scripts in this directory capture
+# `helm template` through command substitution. Do NOT copy that here, and do not
+# "fix" this script back to a pipe. In this environment `helm template` into a
+# stdout pipe has been observed to truncate silently at ~41 lines while still
+# exiting 0, which turns a rendered-fine env var into a reported-absent FALSE
+# NEGATIVE (and could equally report one present by luck). Rendering to a
+# directory and reading the written file is the only trustworthy form here.
+#
+# Fails loudly, naming the assertion. Runnable locally and from CI.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "ASSERTION FAILED: $1" >&2
+  exit 1
+}
+
+# The dispatcher template is gated on both Slack tokens being set
+# (agentos.dispatcher.enabled), so every render that expects a dispatcher must
+# supply them.
+TOKENS=(
+  --set dispatcher.slack.appToken=xapp-assert
+  --set dispatcher.slack.botToken=xoxb-assert
+)
+
+# Render to a directory and echo the path of the dispatcher Deployment manifest.
+render_dispatcher() {
+  local name="$1"
+  shift
+  local out="$TMP/$name"
+  mkdir -p "$out"
+  helm template agentos "$CHART" --output-dir "$out" "$@" >/dev/null
+  local manifest="$out/agentos/templates/dispatcher.yaml"
+  [ -f "$manifest" ] || fail "$name: dispatcher.yaml did not render at all"
+  echo "$manifest"
+}
+
+# Read one env entry out of the rendered dispatcher container structurally, via
+# PyYAML -- the same convention as read_key() in render-assertions.sh and the
+# ASSERT_PY pass in controller-rbac-assertions.sh. Deliberately NOT grep/awk over
+# the text: a line-oriented state machine silently mis-reads a requoted value, a
+# reordered key, or a `valueFrom` that renders before `value`, and it fails as a
+# FALSE PASS -- exactly the class this script's header warns about.
+#
+#   env_value  <manifest> <name>   -> the entry's `value`, empty if absent
+#   env_field  <manifest> <name> <dotted-path>
+#                                  -> a nested field (e.g. valueFrom.secretKeyRef.key)
+#   env_has    <manifest> <name> <dotted-path>
+#                                  -> exit 0 if the path exists, 1 if not
+ENV_PY="$TMP/env.py"
+cat > "$ENV_PY" <<'PY'
+import sys, yaml
+
+manifest, name = sys.argv[1], sys.argv[2]
+path = sys.argv[3] if len(sys.argv) > 3 else "value"
+
+with open(manifest) as f:
+    docs = [d for d in yaml.safe_load_all(f) if d]
+
+entries = [
+    e
+    for d in docs
+    if d.get("kind") == "Deployment"
+    for c in ((d.get("spec") or {}).get("template") or {}).get("spec", {}).get("containers") or []
+    for e in (c.get("env") or [])
+    if e.get("name") == name
+]
+if not entries:
+    sys.exit(1)
+if len(entries) > 1:
+    sys.stderr.write("env %r appears %d times in the dispatcher\n" % (name, len(entries)))
+    sys.exit(2)
+
+node = entries[0]
+for part in path.split("."):
+    if not isinstance(node, dict) or part not in node:
+        sys.exit(1)
+    node = node[part]
+sys.stdout.write(str(node))
+PY
+
+env_value() { python3 "$ENV_PY" "$1" "$2" || true; }
+env_field() { python3 "$ENV_PY" "$1" "$2" "$3" || true; }
+env_has() { python3 "$ENV_PY" "$1" "$2" "$3" >/dev/null; }
+
+# 1: default install renders the in-chart API Service name and port as a value.
+# This render is reused by assertion 4 below (identical arguments), so it is
+# deliberately kept in its own variable rather than re-rendered.
+default_manifest="$(render_dispatcher default "${TOKENS[@]}")"
+actual="$(env_value "$default_manifest" AGENTOS_API_BASE_URL)"
+[ -n "$actual" ] \
+  || fail "default install: dispatcher has no AGENTOS_API_BASE_URL env value; it will fall back to http://localhost:8000 (itself) and Slack approval clicks will dead-end"
+[ "$actual" = "http://agentos-api:8000" ] \
+  || fail "default install: AGENTOS_API_BASE_URL is '$actual', expected 'http://agentos-api:8000' (the in-chart API Service)"
+
+# 2: the port comes from .Values.api.service.port, not a hardcoded 8000.
+manifest="$(render_dispatcher port --set api.service.port=9999 "${TOKENS[@]}")"
+actual="$(env_value "$manifest" AGENTOS_API_BASE_URL)"
+[ "$actual" = "http://agentos-api:9999" ] \
+  || fail "api.service.port=9999: AGENTOS_API_BASE_URL is '$actual', expected 'http://agentos-api:9999' (the port is hardcoded in the template instead of read from .Values.api.service.port)"
+
+# 3: BYO override renders verbatim (the api.deploy=false answer).
+manifest="$(render_dispatcher byo --set dispatcher.apiBaseUrl=http://byo-api.example:8080 "${TOKENS[@]}")"
+actual="$(env_value "$manifest" AGENTOS_API_BASE_URL)"
+[ "$actual" = "http://byo-api.example:8080" ] \
+  || fail "dispatcher.apiBaseUrl override: AGENTOS_API_BASE_URL is '$actual', expected the verbatim override 'http://byo-api.example:8080'"
+
+# 4: the API key arrives by reference to the chart Secret, never inline. Reuses
+# assertion 1's default render -- the arguments are identical, so a second render
+# would only pay another full chart template for the same bytes.
+env_has "$default_manifest" AGENTOS_API_KEY name \
+  || fail "default install: dispatcher has no AGENTOS_API_KEY env; approval resolve calls will be rejected by the API"
+env_has "$default_manifest" AGENTOS_API_KEY valueFrom.secretKeyRef \
+  || fail "AGENTOS_API_KEY is not a secretKeyRef; an inline value would put the shared API key into 'helm get manifest' output"
+actual="$(env_field "$default_manifest" AGENTOS_API_KEY valueFrom.secretKeyRef.name)"
+[ "$actual" = "agentos-secrets" ] \
+  || fail "AGENTOS_API_KEY secretKeyRef names Secret '$actual', expected the chart Secret 'agentos-secrets'"
+actual="$(env_field "$default_manifest" AGENTOS_API_KEY valueFrom.secretKeyRef.key)"
+[ "$actual" = "apiKey" ] \
+  || fail "AGENTOS_API_KEY secretKeyRef uses key '$actual', expected the chart Secret's existing 'apiKey' key (the same key api.yaml consumes as API_KEY; a new key would let the two sides drift)"
+if env_has "$default_manifest" AGENTOS_API_KEY value; then
+  fail "AGENTOS_API_KEY renders an inline literal value; the credential must come from the Secret by reference only"
+fi
+
+# 5: unchanged gate -- no Slack tokens, no dispatcher.
+out="$TMP/tokenless"
+mkdir -p "$out"
+helm template agentos "$CHART" --output-dir "$out" >/dev/null
+if [ -f "$out/agentos/templates/dispatcher.yaml" ]; then
+  fail "a token-less default install rendered a dispatcher Deployment; the agentos.dispatcher.enabled gate regressed"
+fi
+
+echo "OK: dispatcher platform-API wiring render assertions passed"

--- a/charts/agentos/templates/NOTES.txt
+++ b/charts/agentos/templates/NOTES.txt
@@ -37,6 +37,19 @@ App services:
 {{- else }}
   - dispatcher: NOT deployed (no Slack tokens set) -- see "Enable a real model and a Slack workspace" below
 {{- end }}
+{{- if and (include "agentos.dispatcher.enabled" .) (not .Values.api.deploy) (not .Values.dispatcher.apiBaseUrl) }}
+  - !! The dispatcher resolves Slack approval clicks against the platform API,
+       but api.deploy is false and dispatcher.apiBaseUrl is empty, so it is
+       pointed at an in-chart API Service this release does not deploy. Its boot
+       preflight will fail and the pod will CrashLoopBackOff by design, naming
+       the unreachable URL in its logs. Set dispatcher.apiBaseUrl to the base URL
+       of the API you run, and pair it with api.apiKey set to a key that API
+       accepts -- the preflight only checks the unauthenticated /health endpoint,
+       so a mismatched key still passes boot and 401s at click time instead:
+         helm upgrade {{ .Release.Name }} charts/agentos -n {{ .Release.Namespace }} --reuse-values \
+           --set dispatcher.apiBaseUrl=https://your-api.example \
+           --set api.apiKey=<key that API accepts>
+{{- end }}
 {{- if .Values.worker.deploy }}
   - worker ({{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }})
 {{- end }}

--- a/charts/agentos/templates/_helpers.tpl
+++ b/charts/agentos/templates/_helpers.tpl
@@ -217,6 +217,42 @@ app.kubernetes.io/component: {{ .component }}
       key: valkeyPassword
 {{- end -}}
 
+{{/* Platform-API connection env for the first-party services that CALL the API
+     (today the dispatcher; the chart worker's identical gap is a tracked
+     follow-up). Exists as a helper for the same reason agentos.env.postgres and
+     agentos.env.valkey do: AGENTOS_API_BASE_URL has now been forgotten three
+     times on new callers, while the store envs never recurred, because those had
+     a helper to include and this did not. Wire a new API caller by including
+     this rather than re-deriving the URL inline.
+
+     The BYO override is .Values.dispatcher.apiBaseUrl. Note the deliberate
+     absence of a `required` call for the api.deploy=false case that the sibling
+     `X.host` helpers use: an empty override with api.deploy=false yields a
+     CrashLoopBackOff by design (documented in NOTES.txt and the README), not a
+     render-time failure. Include with `nindent 12` to land at a container's env
+     column. */}}
+{{- define "agentos.env.api" -}}
+# Where the platform API lives. The dispatcher POSTs an approval
+# resolve here when someone clicks Approve in Slack, so an unwired
+# value means the click dead-ends: the code default
+# http://localhost:8000 is, inside this pod, the dispatcher itself.
+# Empty dispatcher.apiBaseUrl (the default) derives the in-chart API
+# Service; a set value renders verbatim and is the BYO answer, and
+# the only correct one when api.deploy is false. The port comes from
+# api.service.port so the two sides cannot drift.
+- name: AGENTOS_API_BASE_URL
+  value: {{ .Values.dispatcher.apiBaseUrl | default (printf "http://%s-api:%v" (include "agentos.fullname" .) .Values.api.service.port) | quote }}
+# The same chart Secret key api.yaml consumes as API_KEY, so the
+# caller and the API cannot drift apart. By reference only: an inline
+# value would put the shared platform key into `helm get manifest`
+# output and into any rendered artifact CI uploads.
+- name: AGENTOS_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "agentos.secretName" . }}
+      key: apiKey
+{{- end -}}
+
 {{/* Heartbeat exec probes for the worker and dispatcher. Neither has an HTTP
      port, so an exec probe checks AGENTOS_HEARTBEAT_FILE freshness (< 30s)
      instead of hitting a port. Each Deployment sets its own heartbeat path via

--- a/charts/agentos/templates/dispatcher.yaml
+++ b/charts/agentos/templates/dispatcher.yaml
@@ -54,6 +54,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentos.secretName" . }}
                   key: slackSigningSecret
+            {{- include "agentos.env.api" . | nindent 12 }}
             # Heartbeat file a background daemon thread in the dispatcher touches
             # each tick; the exec probes below read this same path so template and
             # app cannot drift.

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -473,6 +473,16 @@ api:
 dispatcher:
   deploy: true
   replicas: 1
+  # Platform API the dispatcher resolves Slack approval clicks against. Empty
+  # (the default) derives the in-chart API Service,
+  # http://<fullname>-api:<api.service.port>. Set it to a full base URL to point
+  # at an API this chart did not deploy; that BYO value renders verbatim and is
+  # required when api.deploy is false, where no in-chart Service exists to derive.
+  # Pair it with api.apiKey set to a key the BYO API accepts -- the chart Secret's
+  # own generated apiKey still resolves otherwise, and the boot preflight cannot
+  # catch the mismatch since /health is unauthenticated and proves reachability
+  # only, not that the key is right.
+  apiBaseUrl: ""
   image:
     repository: ghcr.io/curie-eng/agentos-dispatcher
     # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -470,6 +470,8 @@ services:
     depends_on:
       valkey:
         condition: service_healthy
+      agentos-api:
+        condition: service_healthy
     environment:
       VALKEY_HOST: valkey
       VALKEY_PORT: "6379"
@@ -477,6 +479,12 @@ services:
       SLACK_APP_TOKEN: ${SLACK_APP_TOKEN:-}
       SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
       SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:-}
+      # In-network form, matching the UI's AGENTOS_API_TARGET above. The
+      # published host port is unreachable from this bridge-network container.
+      AGENTOS_API_BASE_URL: http://agentos-api:8000
+      # Mirrors agentos-api's API_KEY so resolve calls authenticate. Wired
+      # explicitly rather than relying on the two defaults happening to match.
+      AGENTOS_API_KEY: agentos-dev-key
     restart: unless-stopped
 
 volumes:

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -194,6 +194,126 @@ def test_cli_default_version_is_latest():
     assert all(tag == "latest" for tag in tags)
 
 
+# --- Dispatcher <-> API wiring (#442) ---------------------------------------
+#
+# The dispatcher resolves Slack approval clicks by calling the platform API. It
+# must therefore be told where the API is. Unwired, it falls back to its code
+# default http://localhost:8000, which inside its own bridge-network container
+# is the dispatcher itself, and every Approve click dead-ends.
+#
+# These assert the resolved VALUE, not the presence of a key: both "absent" and
+# "wired to the wrong host" must fail. They run against the dev document (the
+# source of truth) and the generated release document (the shipped asset), since
+# the generator copies env through untouched and a guard on only one of the two
+# leaves the other free to drift.
+
+
+def env_map(spec):
+    """Service `environment:` as a dict, normalizing compose's two forms.
+
+    The dispatcher and API use map form (`KEY: value`); the worker uses list
+    form (`- KEY=value`). Both are valid compose and both appear in this file.
+    """
+    env = spec.get("environment", {})
+    if isinstance(env, dict):
+        return {key: "" if value is None else str(value) for key, value in env.items()}
+    out = {}
+    for item in env:
+        key, sep, value = str(item).partition("=")
+        out[key] = value if sep else ""
+    return out
+
+
+def compose_docs():
+    """The dev document and the generated release document, parsed and labelled."""
+    generate = load_generate()
+    return [
+        ("compose.dev.yaml", yaml.safe_load(DEV_TEXT)),
+        ("compose.release.yaml", yaml.safe_load(generate(DEV_TEXT, OTEL_TEXT, version="9.9.9"))),
+    ]
+
+
+def test_dispatcher_api_base_url_is_in_network():
+    """The dispatcher points at the API by compose service name, not localhost.
+
+    `http://agentos-api:8000` is the in-network form the UI already uses
+    (`AGENTOS_API_TARGET`). The published host port (28000) is correct only for
+    the host-networked worker and is unreachable from the dispatcher's bridge
+    network.
+    """
+    for label, doc in compose_docs():
+        env = env_map(doc["services"]["agentos-dispatcher"])
+        assert env.get("AGENTOS_API_BASE_URL") == "http://agentos-api:8000", (
+            f"{label}: agentos-dispatcher AGENTOS_API_BASE_URL is "
+            f"{env.get('AGENTOS_API_BASE_URL')!r}; the dispatcher cannot reach the "
+            f"API and Slack approval clicks dead-end"
+        )
+
+
+def test_dispatcher_api_key_matches_the_api():
+    """The dispatcher authenticates with the key the API actually accepts.
+
+    Asserted as a relationship between the two services rather than against the
+    literal dev key, so rotating the key on one side without the other fails
+    here instead of at click time with a 401.
+    """
+    for label, doc in compose_docs():
+        dispatcher = env_map(doc["services"]["agentos-dispatcher"])
+        api = env_map(doc["services"]["agentos-api"])
+
+        assert "AGENTOS_API_KEY" in dispatcher, (
+            f"{label}: agentos-dispatcher has no AGENTOS_API_KEY; its auth to the "
+            f"API is an accident of two defaults agreeing"
+        )
+        assert dispatcher["AGENTOS_API_KEY"] == api["API_KEY"], (
+            f"{label}: agentos-dispatcher AGENTOS_API_KEY "
+            f"{dispatcher['AGENTOS_API_KEY']!r} != agentos-api API_KEY "
+            f"{api['API_KEY']!r}; approval resolve calls will be rejected"
+        )
+
+
+def test_dispatcher_depends_on_api_healthy():
+    """The dispatcher waits for the API to be healthy before it starts.
+
+    The API block already publishes a healthcheck (the UI depends on it the same
+    way), so this is the ordering guarantee that keeps the dispatcher's boot
+    preflight a backstop rather than a race.
+    """
+    for label, doc in compose_docs():
+        depends = doc["services"]["agentos-dispatcher"].get("depends_on", {})
+        assert isinstance(depends, dict), (
+            f"{label}: agentos-dispatcher depends_on is list form, which carries "
+            f"no condition; the API dependency needs service_healthy"
+        )
+        entry = depends.get("agentos-api")
+        assert isinstance(entry, dict) and entry.get("condition") == "service_healthy", (
+            f"{label}: agentos-dispatcher does not depend on agentos-api with "
+            f"condition service_healthy (got {entry!r})"
+        )
+
+
+def test_worker_api_base_url_stays_host_local():
+    """Regression guard: the worker's localhost:28000 is CORRECT. Do not "fix" it.
+
+    #442 names the worker's `AGENTOS_API_BASE_URL=http://localhost:28000` as the
+    defect. It is not. The worker runs `network_mode: host`, so the published
+    host port is exactly right for it, and rewriting this line to the in-network
+    form breaks the worker. This test passes today and must keep passing.
+    """
+    for label, doc in compose_docs():
+        worker = doc["services"]["agentos-worker"]
+        assert worker.get("network_mode") == "host", (
+            f"{label}: agentos-worker is no longer host-networked; the premise of "
+            f"its localhost:28000 API URL has changed"
+        )
+        env = env_map(worker)
+        assert env.get("AGENTOS_API_BASE_URL") == "http://localhost:28000", (
+            f"{label}: agentos-worker AGENTOS_API_BASE_URL is "
+            f"{env.get('AGENTOS_API_BASE_URL')!r}, expected http://localhost:28000 "
+            f"(host-networked: the published port is the correct form here)"
+        )
+
+
 def assert_init_containers_adopted(compose_text, label):
     """Assert every one-shot init container is adopted via
     `service_completed_successfully` in every profile combo `agentos local up`


### PR DESCRIPTION
## What

The released compose stack and the Helm chart never set `AGENTOS_API_BASE_URL`
on the `agentos-dispatcher`, so it fell back to the code default
`http://localhost:8000`. Inside a container that address is the dispatcher
itself, so it could not reach the platform API to `POST /approvals/{id}/resolve`
and every Slack approval click dead-ended out of the box.

Note the issue misattributed the bad line: the `localhost:28000` in the
generated release compose belongs to `agentos-worker`, which runs on the host
network where that value is correct. The real defect was that the dispatcher
wired no API address at all, in both compose and the chart. A regression test
now guards the worker's value.

## Changes

- Compose dispatcher points at the in-network API (`http://agentos-api:8000`)
  and gains `depends_on: agentos-api: service_healthy`.
- Chart dispatcher wires the API through a new shared `agentos.env.api` helper:
  a derived `<release>-api:<port>` URL, a `dispatcher.apiBaseUrl` BYO override,
  and the API key via `secretKeyRef`. The identical chart omission left the
  cluster Slack path broken the same way.
- New dispatcher boot preflight polls `GET /health` with bounded retry and
  exits with a clear error naming the unreachable URL, so a misconfigured
  address surfaces at startup instead of silently at click time.
- The chart wiring assertions are now registered in helm CI.

The chart worker has the same `AGENTOS_API_BASE_URL` gap for eval reporting;
that is left as a follow-up.

## Verification

- `uv run pytest -q`: 1102 passed. Ruff and mypy clean; `helm lint` clean.
- Live container-network check on the compose bridge: `localhost:8000` refuses
  (reproducing the bug), `agentos-api:8000` returns `{"status":"ok"}` 200
  (the fix and the preflight target).

Closes #442
