### PR TITLE
Close two approval-seam defects: silent fail-open gates and collapsed 403 reasons

### DIFF
--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -1712,6 +1712,7 @@ def test_group_binding_without_a_bot_token_denies_instead_of_channel_fallback(
     denied = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
     assert denied.status_code == 403, denied.text
     assert "could not verify" in denied.json()["detail"]
+    assert "not an approver" not in denied.json()["detail"]
 
     record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
     assert record.json()["status"] == "pending"
@@ -1743,6 +1744,7 @@ def test_group_lookup_failure_denies_and_audits_the_failure(
     denied = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
     assert denied.status_code == 403, denied.text
     assert "could not verify" in denied.json()["detail"]
+    assert "not an approver" not in denied.json()["detail"]
     assert calls != []
 
     entries = approvals_client.get(

--- a/apps/dispatcher/src/agentos_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/agentos_dispatcher/approval_actions.py
@@ -95,7 +95,11 @@ class ApprovalResolveClient:
                 resolved = body.get("resolved_by")
                 decided = body.get("status")
         except ValueError:
-            detail = response.text
+            # A non-JSON body (e.g. from an ingress/proxy/WAF intermediary)
+            # may carry an internal hostname or request id. Do not surface
+            # that raw text to the Slack clicker; fall back to empty so the
+            # caller's class-neutral fallback applies instead (#453 LOW-1).
+            detail = ""
         return ResolveOutcome(
             status_code=response.status_code,
             detail=detail,
@@ -171,7 +175,15 @@ def process_approval_action(
         return outcome
 
     if outcome.status_code == 403:
-        ephemeral = "You are not an approver for this request."
+        # Render the API's reason verbatim: it already knows which class of
+        # refusal this is (non-membership, self-approval, or could-not-verify)
+        # and words each one distinctly. When the detail is empty or missing,
+        # the dispatcher cannot know the class, so the fallback must stay
+        # class-neutral rather than guessing at a policy denial (#453 AC5).
+        ephemeral = (
+            outcome.detail.strip()
+            or "This click was refused and the platform gave no reason."
+        )
     elif outcome.status_code == 409:
         ephemeral = (
             f"Already resolved by {outcome.resolved_by}."

--- a/apps/dispatcher/tests/test_approval_actions.py
+++ b/apps/dispatcher/tests/test_approval_actions.py
@@ -18,6 +18,7 @@ from agentos_dispatcher.app import build_app
 from agentos_dispatcher.approval_actions import (
     APPROVE_ACTION_ID,
     REJECT_ACTION_ID,
+    ApprovalResolveClient,
     ResolveOutcome,
 )
 from agentos_dispatcher.config import DispatcherConfig
@@ -38,6 +39,23 @@ _CARD_MESSAGE = {
         {"type": "actions", "elements": []},
     ],
 }
+
+# Real API reason strings, copied verbatim (not imported -- the dispatcher
+# does not depend on apps/api). Sources: apps/api/src/agentos_api/authorizer.py
+# (_SELF_APPROVAL_REASON) and apps/api/src/agentos_api/slack_approvers.py (the
+# channel non-membership reason and the group-lookup could-not-verify reason).
+# The API side pins its own half of this contract in
+# apps/api/tests/test_approvers_port.py and apps/api/tests/test_approvals.py.
+_CHANNEL_NON_APPROVER_REASON = (
+    "you are not an approver: resolve this from the approval's channel"
+)
+_SELF_APPROVAL_REASON = (
+    "self-approval is blocked: the requester cannot resolve their own request"
+)
+_COULD_NOT_VERIFY_GROUP_REASON = (
+    "could not verify approver group membership: this approval's route is "
+    "bound to a Slack user group and the membership lookup failed"
+)
 
 
 def _authorize(**_kwargs: Any) -> AuthorizeResult:
@@ -182,11 +200,19 @@ def test_reject_button_resolves_with_rejected_decision(
     assert "Rejected by <@U_MANAGER>" in web_client.chat_update.call_args.kwargs["text"]
 
 
-def test_non_approver_gets_ephemeral_rejection(
+def test_non_approver_rejection_renders_the_api_reason(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:
+    """Strengthened from the original #246 test. The old assertion
+    (``"not an approver" in kwargs["text"]``) also passes against the
+    hardcoded fixed string, so it would pass unchanged even for a
+    self-approval 403. Asserting the SPECIFIC channel reason from
+    ``outcome.detail`` is the only way to prove the rendering is not a
+    hardcoded literal (#453 AC4).
+    """
+
     resolver = ScriptedResolver(
-        ResolveOutcome(status_code=403, detail="you are not an approver")
+        ResolveOutcome(status_code=403, detail=_CHANNEL_NON_APPROVER_REASON)
     )
     app, web_client = _build(config, redis_client, resolver)
     handler = SocketModeHandler(app, app_token="xapp-test")
@@ -200,10 +226,109 @@ def test_non_approver_gets_ephemeral_rejection(
     web_client.chat_postEphemeral.assert_called_once()
     kwargs = web_client.chat_postEphemeral.call_args.kwargs
     assert kwargs["user"] == "U_OUTSIDER"
-    assert "not an approver" in kwargs["text"]
+    # The specific reason, not just the generic "not an approver" phrase a
+    # hardcoded string could also satisfy.
+    assert "resolve this from the approval's channel" in kwargs["text"]
     # The card is untouched and no turn was enqueued.
     web_client.chat_update.assert_not_called()
     web_client.chat_postMessage.assert_not_called()
+
+
+def test_self_approval_rejection_is_distinguishable(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """AC4: a self-approval 403 must not read like a non-membership 403."""
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=403, detail=_SELF_APPROVAL_REASON)
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(
+        FakeSocketClient(),
+        _approval_click("env-f2", action_id=APPROVE_ACTION_ID, user="U_AUTHOR"),
+    )
+    _drain(app)
+
+    kwargs = web_client.chat_postEphemeral.call_args.kwargs
+    assert "self-approval is blocked" in kwargs["text"]
+    assert "not an approver" not in kwargs["text"]
+
+
+def test_could_not_verify_is_not_worded_as_a_policy_denial(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """AC5: an infrastructure/config failure must not be rendered as a policy
+    denial. A clicker reading this must not be told they lack permission."""
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=403, detail=_COULD_NOT_VERIFY_GROUP_REASON)
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(
+        FakeSocketClient(),
+        _approval_click("env-f3", action_id=APPROVE_ACTION_ID, user="U_OUTSIDER"),
+    )
+    _drain(app)
+
+    kwargs = web_client.chat_postEphemeral.call_args.kwargs
+    assert "could not verify" in kwargs["text"]
+    assert "not an approver" not in kwargs["text"]
+
+
+def test_the_three_refusal_classes_render_distinctly(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """AC4: non-membership, self-approval, and could-not-verify are
+    distinguishable to the clicker. A hardcoded fixed string can never
+    satisfy this, since all three would collapse to one rendered string."""
+
+    rendered: list[str] = []
+    for i, detail in enumerate(
+        (
+            _CHANNEL_NON_APPROVER_REASON,
+            _SELF_APPROVAL_REASON,
+            _COULD_NOT_VERIFY_GROUP_REASON,
+        )
+    ):
+        resolver = ScriptedResolver(ResolveOutcome(status_code=403, detail=detail))
+        app, web_client = _build(config, redis_client, resolver)
+        handler = SocketModeHandler(app, app_token="xapp-test")
+        handler.handle(
+            FakeSocketClient(),
+            _approval_click(
+                f"env-distinct-{i}", action_id=APPROVE_ACTION_ID, user="U_OUTSIDER"
+            ),
+        )
+        _drain(app)
+        rendered.append(web_client.chat_postEphemeral.call_args.kwargs["text"])
+
+    assert len(set(rendered)) == 3
+
+
+def test_403_with_empty_detail_does_not_assert_policy(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """Edge case: when the API's detail is empty (an infrastructure failure
+    with no body), the fallback must stay class-neutral rather than guessing
+    at "you are not an approver" (AC5)."""
+
+    resolver = ScriptedResolver(ResolveOutcome(status_code=403, detail=""))
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+
+    handler.handle(
+        FakeSocketClient(),
+        _approval_click("env-f5", action_id=APPROVE_ACTION_ID, user="U_OUTSIDER"),
+    )
+    _drain(app)
+
+    kwargs = web_client.chat_postEphemeral.call_args.kwargs
+    assert kwargs["text"]
+    assert "not an approver" not in kwargs["text"]
 
 
 def test_claim_race_loser_sees_already_resolved_by_winner(
@@ -247,3 +372,53 @@ def test_expired_click_gets_ephemeral_expiry_notice(
     _drain(app)
 
     assert "expired" in web_client.chat_postEphemeral.call_args.kwargs["text"]
+
+
+class _FakeHttpResponse:
+    """A non-JSON HTTP response body, as an intermediary (ingress/WAF) in
+    front of the API might return instead of FastAPI's own JSON 403."""
+
+    def __init__(self, *, status_code: int, text: str) -> None:
+        self.status_code = status_code
+        self.text = text
+
+    def json(self) -> Any:
+        raise ValueError("not json")
+
+
+class _FakeHttpClient:
+    """Stands in for httpx.Client: the only external boundary resolve() calls."""
+
+    def __init__(self, response: _FakeHttpResponse) -> None:
+        self._response = response
+
+    def post(
+        self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+    ) -> _FakeHttpResponse:
+        return self._response
+
+
+def test_non_json_403_body_is_not_captured_as_detail() -> None:
+    """LOW-1 (security review of #453): a non-JSON 403 body must not be
+    captured into ResolveOutcome.detail. FastAPI's own 403s are always JSON,
+    but an intermediary (ingress/WAF) in front of the API can return a
+    non-JSON body -- an HTML block page that may embed an internal hostname
+    or request id. Before this PR the 403 branch showed a hardcoded string,
+    so this raw text never reached the clicker; now
+    process_approval_action renders outcome.detail verbatim (#453 AC4/AC5),
+    so a non-JSON body reaching resolve() must not become a renderable
+    reason in the first place.
+    """
+
+    raw_body = "<html>403 Forbidden - waf-node-7.internal</html>"
+    fake_client = _FakeHttpClient(_FakeHttpResponse(status_code=403, text=raw_body))
+    resolver = ApprovalResolveClient(
+        api_base_url="https://api.internal", api_key="k", client=fake_client
+    )
+
+    outcome = resolver.resolve(
+        APPROVAL_ID, decision="approved", resolved_by="U_MANAGER", actor_channel="C_MGRS"
+    )
+
+    assert outcome.status_code == 403
+    assert raw_body not in outcome.detail

--- a/packages/plugin-format/README.md
+++ b/packages/plugin-format/README.md
@@ -56,8 +56,16 @@ Pydantic models mirroring the Claude Code shapes:
 - `ApprovalPolicy` / `ApprovalGate` (the manifest `approvalPolicy` field, #273):
   `{gates: [{gate, route}]}` — each gate names a pause point and the approval
   route that decides it; both are required. **Deploy-time validation** rejects a
-  malformed policy or a gate missing `gate`/`route`. Runtime approval routing is
-  a separate not-yet-built seam, so this is validation only today.
+  malformed policy or a gate missing `gate`/`route`. It also rejects a gate whose
+  (whitespace-stripped) name starts with `mcp__` but is not a live,
+  fully-namespaced tool name for a server the bundle declares
+  (`mcp__plugin_<bundle>_<server>__<tool>`, non-empty tool suffix) — the runner
+  matches gates by exact string equality, so a mis-namespaced `mcp__` gate
+  previously validated green but silently never armed (#453). Built-in gates
+  (no `mcp__` prefix, e.g. `Bash`) are unaffected. The error message names the
+  expected form; to arm a live tool name the bundle does not declare, use the
+  per-agent `AGENTOS_APPROVAL_REQUIRED_TOOLS` env knob instead. Runtime approval
+  routing is a separate not-yet-built seam, so this is validation only today.
 - `scripts/` is a directory convention (no manifest schema of its own).
 
 `validate_bundle(path) -> ValidationResult` is the entry point the bundle pipeline calls. It
@@ -78,7 +86,8 @@ Error codes include `bundle.missing`, `manifest.missing`,
 `hooks.invalid`, `hooks.command_missing`, `triggers.invalid`,
 `triggers.unknown_type`, `triggers.cron_missing_schedule`,
 `triggers.webhook_missing_path`, `approval_policy.invalid`,
-`approval_policy.incomplete`, `scripts.not_a_directory`.
+`approval_policy.incomplete`, `approval_policy.gate_not_namespaced`,
+`scripts.not_a_directory`.
 
 ## Frozen-interface rule
 

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -78,10 +78,10 @@ def validate_bundle(path: str | Path) -> ValidationResult:
     manifest = _validate_manifest(root, c)
     if manifest is not None:
         _validate_skills(root, c)
-        _validate_mcp(root, manifest, c)
+        mcp_servers = _validate_mcp(root, manifest, c)
         _validate_hooks(root, manifest, c)
         _validate_triggers(manifest, c)
-        _validate_approval_policy(manifest, c)
+        _validate_approval_policy(manifest, mcp_servers, c)
         _validate_secrets(manifest, c)
         _validate_scripts(root, c)
 
@@ -146,23 +146,40 @@ def _validate_skills(root: Path, c: _Collector) -> None:
                 c.error("skill.frontmatter_invalid", issue, rel)
 
 
-def _validate_mcp(root: Path, manifest: PluginManifest, c: _Collector) -> None:
+def _validate_mcp(root: Path, manifest: PluginManifest, c: _Collector) -> set[str] | None:
     """Validate every MCP declaration: the manifest field and root .mcp.json.
 
     The manifest ``mcpServers`` may be an inline object or a path to a config
     file; either form is a supported declaration that must be checked, not only
     the conventional root ``.mcp.json``.
+
+    Returns the set of declared server names across every declaration it read, so
+    the approval-policy check can compare a gate name against them. ``None`` means
+    a declaration existed but could not be read (invalid JSON, a missing declared
+    path, or a config that failed to validate); it poisons the union, because a
+    single unreadable source makes the declared-server set unknowable. An empty
+    set is a different fact: a declaration was read and named no servers.
     """
 
     validated_files: set[Path] = set()
     declared = manifest.mcpServers
+    servers: set[str] = set()
+    unreadable = False
 
     if isinstance(declared, dict):
-        _validate_mcp_object(declared, "plugin.json (mcpServers)", c)
+        result = _validate_mcp_object(declared, "plugin.json (mcpServers)", c)
+        if result is None:
+            unreadable = True
+        else:
+            servers |= result
     elif isinstance(declared, str):
         declared_path = root / declared
         if declared_path.is_file():
-            _validate_mcp_file(declared_path, str(Path(declared)), c)
+            result = _validate_mcp_file(declared_path, str(Path(declared)), c)
+            if result is None:
+                unreadable = True
+            else:
+                servers |= result
             validated_files.add(declared_path.resolve())
         else:
             c.error(
@@ -170,22 +187,31 @@ def _validate_mcp(root: Path, manifest: PluginManifest, c: _Collector) -> None:
                 f"manifest mcpServers path {declared!r} was not found",
                 "plugin.json",
             )
+            unreadable = True
 
     root_mcp = root / ".mcp.json"
     if root_mcp.is_file() and root_mcp.resolve() not in validated_files:
-        _validate_mcp_file(root_mcp, ".mcp.json", c)
+        result = _validate_mcp_file(root_mcp, ".mcp.json", c)
+        if result is None:
+            unreadable = True
+        else:
+            servers |= result
+
+    if unreadable:
+        return None
+    return servers
 
 
-def _validate_mcp_file(path: Path, location: str, c: _Collector) -> None:
+def _validate_mcp_file(path: Path, location: str, c: _Collector) -> set[str] | None:
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         c.error("mcp.invalid_json", f"{location} is not valid JSON: {exc}", location)
-        return
-    _validate_mcp_object(data, location, c)
+        return None
+    return _validate_mcp_object(data, location, c)
 
 
-def _validate_mcp_object(obj: object, location: str, c: _Collector) -> None:
+def _validate_mcp_object(obj: object, location: str, c: _Collector) -> set[str] | None:
     # Accept both a full config object ({"mcpServers": {...}}) and a bare servers
     # map ({name: server}), which is how the manifest carries an inline value.
     payload = obj if isinstance(obj, dict) and "mcpServers" in obj else {"mcpServers": obj}
@@ -194,7 +220,7 @@ def _validate_mcp_object(obj: object, location: str, c: _Collector) -> None:
     except ValidationError as exc:
         for issue in _explain(exc):
             c.error("mcp.invalid", issue, location)
-        return
+        return None
 
     for name, server in config.mcpServers.items():
         if server.command is None and server.url is None:
@@ -203,6 +229,8 @@ def _validate_mcp_object(obj: object, location: str, c: _Collector) -> None:
                 f"mcp server {name!r} must define either 'command' (stdio) or 'url' (remote)",
                 location,
             )
+
+    return set(config.mcpServers)
 
 
 def _validate_hooks(root: Path, manifest: PluginManifest, c: _Collector) -> None:
@@ -306,12 +334,23 @@ def _validate_triggers(manifest: PluginManifest, c: _Collector) -> None:
             )
 
 
-def _validate_approval_policy(manifest: PluginManifest, c: _Collector) -> None:
+def _validate_approval_policy(
+    manifest: PluginManifest, mcp_servers: set[str] | None, c: _Collector
+) -> None:
     """Validate the manifest ``approvalPolicy`` declaration (deploy-time, #273).
 
     Shape ``{gates: [{gate, route}]}``: each gate names a pause point and the
     route that decides. A malformed policy or a gate missing its ``gate``/``route``
     is rejected at deploy.
+
+    ``mcp_servers`` is the set of MCP server names the bundle declares (from
+    ``_validate_mcp``). A gate that carries the ``mcp__`` prefix must be a live,
+    fully-namespaced tool name (``mcp__plugin_<bundle>_<server>__<tool>``); the
+    runner matches a gate by exact string equality, so the natural
+    ``mcp__<server>__<tool>`` shape arms nothing and silently never fires. We
+    reject it here. ``None`` means the MCP declaration could not be read, so the
+    cross-check stays silent rather than stacking a misleading error on top of the
+    MCP error that already fired.
     """
 
     declared = manifest.approvalPolicy
@@ -332,6 +371,16 @@ def _validate_approval_policy(manifest: PluginManifest, c: _Collector) -> None:
             c.error("approval_policy.invalid", issue, "plugin.json (approvalPolicy)")
         return
 
+    # Construct the valid prefixes from what the bundle declares rather than
+    # parsing the gate to extract a server name: a bundle name cannot contain '_'
+    # (_NAME_RE) but a server key can, so parsing mcp__plugin_a_b_c__t is
+    # ambiguous. Constructing and testing startswith sidesteps that entirely.
+    expected_prefixes: set[str] | None = (
+        {f"mcp__plugin_{manifest.name}_{s}__" for s in mcp_servers}
+        if mcp_servers is not None
+        else None
+    )
+
     for i, gate in enumerate(policy.gates):
         loc = f"plugin.json (approvalPolicy.gates[{i}])"
         if not (gate.gate and gate.gate.strip()) or not (gate.route and gate.route.strip()):
@@ -340,6 +389,47 @@ def _validate_approval_policy(manifest: PluginManifest, c: _Collector) -> None:
                 "an approval gate must define a non-empty 'gate' and 'route'",
                 loc,
             )
+            continue
+
+        # A gate without the mcp__ prefix names a built-in tool (Bash, Write,
+        # PreToolUse); it is armed by raw name and never touched here. Evaluate
+        # the STRIPPED value: the runner strips the gate before matching
+        # (approval.py load_approval_policy), so a leading-space "mcp__..." that
+        # looks built-in on the raw string would arm a mis-namespaced tool at
+        # runtime and silently never fire (#453).
+        stripped_gate = gate.gate.strip()
+        if expected_prefixes is None or not stripped_gate.startswith("mcp__"):
+            continue
+
+        # A live tool name needs a non-empty tool suffix after the matched
+        # prefix; the bare "mcp__plugin_<bundle>_<server>__" arms nothing (#453).
+        if not any(
+            stripped_gate.startswith(prefix) and len(stripped_gate) > len(prefix)
+            for prefix in expected_prefixes
+        ):
+            c.error(
+                "approval_policy.gate_not_namespaced",
+                _gate_not_namespaced_message(stripped_gate, manifest.name, mcp_servers or set()),
+                loc,
+            )
+
+
+def _gate_not_namespaced_message(gate: str, bundle: str, mcp_servers: set[str]) -> str:
+    """Actionable message for a gate whose mcp__ name is not a live tool name."""
+
+    if mcp_servers:
+        declared = "Expected one of: " + ", ".join(
+            sorted(f"mcp__plugin_{bundle}_{s}__<tool>" for s in mcp_servers)
+        )
+    else:
+        declared = "This bundle declares no MCP servers"
+    return (
+        f"approval gate {gate!r} is not a live MCP tool name. A bundle-declared "
+        f"MCP tool's live name is mcp__plugin_{bundle}_<server>__<tool>. "
+        f"{declared}. A built-in tool gate (e.g. Bash) carries no mcp__ prefix. "
+        "To arm a live tool name this bundle does not declare, add it to the "
+        "per-agent AGENTOS_APPROVAL_REQUIRED_TOOLS env knob."
+    )
 
 
 _SECRET_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -204,3 +204,311 @@ def test_malformed_approval_policy_shape_is_rejected(tmp_path: Path) -> None:
 def test_approval_policy_gates_wrong_type_is_rejected(tmp_path: Path) -> None:
     bundle = _bundle(tmp_path, '{"name": "demo", "approvalPolicy": {"gates": "nope"}}')
     assert "approval_policy.invalid" in _codes(bundle)
+
+
+# --- approval gate names must be the live, fully-namespaced MCP tool name ------
+#
+# A bundle-declared MCP tool's live name is mcp__plugin_<bundle>_<server>__<tool>.
+# The runner matches a gate by exact string equality, so an author who writes the
+# obvious mcp__<server>__<tool> arms nothing: the gate silently never fires. These
+# cases pin the deploy-time rejection of that shape.
+
+_GATE_CODE = "approval_policy.gate_not_namespaced"
+
+
+def _write_mcp(bundle: Path, text: str, name: str = ".mcp.json") -> Path:
+    """Write an MCP declaration file into an existing bundle."""
+    path = bundle / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _gate_errors(bundle: Path) -> list[str]:
+    return [i.message for i in validate_bundle(bundle).errors if i.code == _GATE_CODE]
+
+
+def test_bare_mcp_gate_for_declared_server_is_rejected(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__crm__send_contract", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
+
+    result = validate_bundle(bundle)
+    assert not result.valid
+    messages = [i.message for i in result.errors if i.code == _GATE_CODE]
+    assert len(messages) == 1, result.errors
+    message = messages[0]
+    # Actionable: it must name the offending gate and the live form to use.
+    assert "mcp__crm__send_contract" in message
+    assert "mcp__plugin_demo_crm__" in message
+    # And it must point at the escape hatch for a live name the bundle
+    # does not declare, rather than dead-ending the author.
+    assert "AGENTOS_APPROVAL_REQUIRED_TOOLS" in message
+
+
+def test_builtin_tool_gate_passes(tmp_path: Path) -> None:
+    # A gate with no mcp__ prefix names a built-in tool and is never touched,
+    # even when the bundle also declares an MCP server.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "Bash", "route": "legal"}, '
+        '{"gate": "PreToolUse", "route": "manager-approval"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+    assert not [i for i in result.errors if i.code.startswith("approval_policy.")]
+
+
+def test_correctly_namespaced_gate_passes_without_asserting_the_tool(tmp_path: Path) -> None:
+    # send_contract is a tool nothing declares and nothing could know without
+    # running the server. The prefix is correct, so the gate passes: the suffix
+    # is never inspected.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__plugin_demo_crm__send_contract", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+
+
+def test_gate_naming_an_undeclared_server_is_rejected(tmp_path: Path) -> None:
+    # Correct prefix shape, but 'ghost' is not a server this bundle declares.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__plugin_demo_ghost__x", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
+
+    assert _GATE_CODE in _codes(bundle)
+
+
+def test_gate_for_inline_manifest_mcp_servers_is_resolved(tmp_path: Path) -> None:
+    # The manifest mcpServers field carries an inline dict rather than a path.
+    good_dir = tmp_path / "good"
+    good_dir.mkdir()
+    good = _bundle(
+        good_dir,
+        '{"name": "demo", "mcpServers": {"crm": {"command": "crm-server"}}, '
+        '"approvalPolicy": {"gates": ['
+        '{"gate": "mcp__plugin_demo_crm__send_contract", "route": "legal"}]}}',
+    )
+    assert validate_bundle(good).valid, validate_bundle(good).errors
+
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    bad = _bundle(
+        bad_dir,
+        '{"name": "demo", "mcpServers": {"crm": {"command": "crm-server"}}, '
+        '"approvalPolicy": {"gates": ['
+        '{"gate": "mcp__crm__send_contract", "route": "legal"}]}}',
+    )
+    assert _GATE_CODE in _codes(bad)
+
+
+def test_gate_resolved_across_both_inline_and_root_mcp_json(tmp_path: Path) -> None:
+    # A bundle with an inline dict AND a distinct root .mcp.json declares BOTH
+    # sets of servers; gates for either must pass.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "mcpServers": {"alpha": {"command": "alpha-server"}}, '
+        '"approvalPolicy": {"gates": ['
+        '{"gate": "mcp__plugin_demo_alpha__x", "route": "legal"}, '
+        '{"gate": "mcp__plugin_demo_beta__y", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"beta": {"command": "beta-server"}}}')
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+
+
+def test_gate_for_string_pointer_mcp_declaration_is_resolved(tmp_path: Path) -> None:
+    # The manifest mcpServers field points at a config file rather than the
+    # conventional root .mcp.json.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "mcpServers": "config/servers.json", '
+        '"approvalPolicy": {"gates": ['
+        '{"gate": "mcp__plugin_demo_crm__send_contract", "route": "legal"}]}}',
+    )
+    _write_mcp(
+        bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}', "config/servers.json"
+    )
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+
+
+def test_mcp_gate_rejected_when_bundle_declares_no_servers(tmp_path: Path) -> None:
+    # An approvalPolicy with an mcp__ gate but no MCP declaration anywhere.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__crm__send_contract", "route": "legal"}]}}',
+    )
+
+    messages = _gate_errors(bundle)
+    assert len(messages) == 1, messages
+    # The message must state the bundle declares none rather than print an
+    # empty list at the author.
+    assert "no MCP servers" in messages[0]
+
+
+def test_invalid_json_mcp_declaration_does_not_add_a_gate_error(tmp_path: Path) -> None:
+    # An unreadable declaration is not an empty one: the bundle already fails on
+    # the MCP error, and stacking a misleading gate error on top would send the
+    # author chasing the wrong fix.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__crm__send_contract", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, "{not json")
+
+    codes = _codes(bundle)
+    assert "mcp.invalid_json" in codes
+    assert _GATE_CODE not in codes
+
+
+def test_invalid_mcp_config_does_not_add_a_gate_error(tmp_path: Path) -> None:
+    # Valid JSON that fails McpConfig validation. This is the layer where
+    # conflating "could not read" with "read, and it was empty" is the tempting
+    # shortcut: an empty set here would report every mcp__ gate as naming an
+    # undeclared server, on top of the real mcp.invalid error.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__crm__send_contract", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": []}')
+
+    codes = _codes(bundle)
+    assert "mcp.invalid" in codes
+    assert _GATE_CODE not in codes
+
+
+def test_declared_missing_mcp_path_does_not_add_a_gate_error(tmp_path: Path) -> None:
+    # A manifest mcpServers path that was not found is also unreadable.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "mcpServers": "config/servers.json", '
+        '"approvalPolicy": {"gates": ['
+        '{"gate": "mcp__crm__send_contract", "route": "legal"}]}}',
+    )
+
+    codes = _codes(bundle)
+    assert "mcp.declared_missing" in codes
+    assert _GATE_CODE not in codes
+
+
+def test_bundle_declaring_zero_mcp_servers_still_rejects_an_mcp_gate(tmp_path: Path) -> None:
+    # The other side of the unreadable cases: a READABLE declaration that
+    # declares no servers. Same empty prefix set, opposite verdict. This pair is
+    # what makes empty and unreadable provably distinct facts.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__crm__send_contract", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {}}')
+
+    codes = _codes(bundle)
+    assert "mcp.invalid" not in codes
+    assert "mcp.invalid_json" not in codes
+    assert _GATE_CODE in codes
+
+
+def test_hyphenated_bundle_and_underscored_server_names_resolve(tmp_path: Path) -> None:
+    # Live names are not mangled: a bundle name keeps its hyphens and a server
+    # key keeps its underscores. This is why the rule constructs the expected
+    # prefix from what the bundle declares instead of parsing the gate string.
+    manifest = (
+        '{{"name": "github-issues", '
+        '"mcpServers": {{"local_tools": {{"command": "tools-server"}}}}, '
+        '"approvalPolicy": {{"gates": [{{"gate": "{gate}", "route": "legal"}}]}}}}'
+    )
+    good_dir = tmp_path / "good"
+    good_dir.mkdir()
+    good = _bundle(
+        good_dir, manifest.format(gate="mcp__plugin_github-issues_local_tools__x")
+    )
+    assert validate_bundle(good).valid, validate_bundle(good).errors
+
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    bad = _bundle(bad_dir, manifest.format(gate="mcp__local_tools__x"))
+    bad_messages = _gate_errors(bad)
+    assert len(bad_messages) == 1, bad_messages
+    assert "mcp__plugin_github-issues_local_tools__" in bad_messages[0]
+
+
+def test_malformed_mcp_gate_is_rejected(tmp_path: Path) -> None:
+    # A gate that is bare 'mcp__' or otherwise matches no expected prefix falls
+    # to the general rule; no special case exists for it.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
+
+    assert _GATE_CODE in _codes(bundle)
+
+
+def test_gate_with_leading_whitespace_is_rejected(tmp_path: Path) -> None:
+    # Leading whitespace hides the mcp__ prefix from a naive startswith check,
+    # so the gate looks like a built-in tool and passes green. But the runner
+    # strips the value before matching, leaving the bare mcp__crm__send_contract
+    # that never equals the live mcp__plugin_demo_crm__send_contract -- the gate
+    # arms nothing. The validator must inspect the stripped value, like runtime.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": " mcp__crm__send_contract", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
+
+    assert _GATE_CODE in _codes(bundle)
+
+
+def test_mcp_gate_with_empty_tool_suffix_is_rejected(tmp_path: Path) -> None:
+    # The prefix is correct but there is no tool name after it, so the gate can
+    # never equal a real tool like mcp__plugin_demo_crm__send_contract. The
+    # startswith check alone passes it green; the validator must require at least
+    # one character after the matched prefix.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__plugin_demo_crm__", "route": "legal"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
+
+    assert _GATE_CODE in _codes(bundle)
+
+
+def test_each_offending_gate_is_reported_at_its_own_location(tmp_path: Path) -> None:
+    # Gates are checked independently at gates[i]; no dedupe.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "mcp__crm__send_contract", "route": "legal"}, '
+        '{"gate": "mcp__crm__send_contract", "route": "finance"}]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}')
+
+    locations = [
+        i.location for i in validate_bundle(bundle).errors if i.code == _GATE_CODE
+    ]
+    # Both entries are reported, each anchored to its own gates[i].
+    assert len(locations) == 2, locations
+    assert any("gates[0]" in loc for loc in locations)
+    assert any("gates[1]" in loc for loc in locations)


### PR DESCRIPTION
An interface review of the approval seam found two defects on either side of the ADR-0034 authorizer split, both letting a correct server-side decision reach the human as something other than what it was. Closes #453.

## What changed

**1. A gate could validate green and silently never arm (plugin-format).**
The runner matches gate names against the live tool name by exact string equality, but a bundle-declared MCP tool's live name is `mcp__plugin_<bundle>_<server>__<tool>`. The natural authoring mistake `mcp__<server>__<tool>` armed nothing at runtime yet passed validation. `validate_bundle` now rejects a gate whose whitespace-stripped name starts with `mcp__` but is not the correctly-namespaced form for a declared server (empty tool suffix included), with an actionable error that names the expected form and the `AGENTOS_APPROVAL_REQUIRED_TOOLS` escape hatch. Built-in gates (no `mcp__` prefix, e.g. `Bash`) are unaffected. Declared-server discovery threads through `_validate_mcp` as a `set[str] | None` that None-poisons when an mcp declaration is unreadable, so the cross-check stays silent rather than stacking a misleading error.

**2. The dispatcher rendered every refusal as a policy denial.**
A denied Slack click now renders the API's own reason, so non-membership, self-approval, and could-not-verify are distinguishable, and a could-not-verify refusal is no longer worded as a policy denial (the ADR-0034 distinction, preserved to the only surface a human sees). A non-JSON 403 body from an intermediary proxy or WAF is dropped rather than surfaced, so it cannot leak internal detail to the clicker.

## Scope

The API is unchanged: its 403 reason strings are already self-describing, so no discriminator field was needed. The approval-card Block Kit bypass (ADR-0020) is out of scope per the ticket (tracked in #451). AC5 is pinned at the producer with negative assertions in `apps/api/tests/test_approvals.py` so a future API rewording cannot silently break it.

## Follow-ups (not in this PR)

- A shared `normalize_gate` helper so the validator and the runner's `load_approval_policy` cannot drift on gate normalization (this PR duplicates the `.strip()` deliberately; the shared point touches the `runner` package).
- A shared constructor + conformance test for the `mcp__plugin_<bundle>_<server>__` prefix, whose format is owned by the harness and re-encoded in a few places.
- Server-key charset beyond hyphen/underscore is untested against the live harness naming (security review LOW-3); pin once the harness mapping is confirmed.

## Testing

Full workspace suite green (1101 passed, 5 skipped); ruff, mypy, and the frozen-contract drift check all clean. Reviewed by code, scope-creep, security, and spec-vs-impl reviewers plus two Codex execution passes; Codex's runtime probes caught the leading-whitespace and empty-suffix fail-opens, which are fixed and pinned.