### PR TITLE
Adopt semver for the ACI, true the version to 0.2.0, and enforce compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,17 @@ jobs:
       - name: Migrate the shared database
         working-directory: apps/api
         run: uv run alembic upgrade head
+      # The committed-lock test only proves the lock matches the current wire; it
+      # passes even if the lock was regenerated without a version bump. Compare
+      # against the BASE branch's lock so an unbumped wire change actually fails
+      # CI. The shallow checkout has no base ref, so fetch it depth=1; a missing
+      # or empty base lock (base predates the lock) skips cleanly (exit 0), and
+      # only a genuine unbumped wire change vs an existing base lock exits 1.
+      - name: ACI wire-lock base gate
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref || 'main' }}" || true
+          git show "origin/${{ github.base_ref || 'main' }}:packages/aci-protocol/schema/wire.lock" > /tmp/base-wire.lock 2>/dev/null || true
+          uv run python -m aci_protocol.wire_lock --check-base /tmp/base-wire.lock
       - name: Pytest
         run: uv run pytest -q
       - name: Dump dev stack logs on failure
@@ -135,7 +146,7 @@ jobs:
         run: |
           npx --yes json-schema-to-typescript@15.0.4 \
             packages/aci-protocol/schema/aci-protocol.schema.json \
-            --unreachableDefinitions --no-additionalProperties=false \
+            --unreachableDefinitions \
             -o packages/aci-protocol/generated/ts/aci-protocol.ts
           git diff --exit-code -- packages/aci-protocol/generated/ts/aci-protocol.ts
       - name: tsc --noEmit on generated ACI types

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,15 @@ stack runs on the baked defaults without one). Load-bearing facts:
 `packages/aci-protocol` (the ACI session protocol + NDJSON events) and
 `packages/plugin-format` (the Claude Code plugin shape, verbatim) are **frozen
 interfaces**. Every lane compiles against them across three languages (Pydantic
-source of truth -> committed JSON Schema -> generated TS + Rust), and the
-schema-compat CI test fails any non-backwards-compatible change.
+source of truth -> committed JSON Schema -> generated TS + Rust). Two CI gates
+guard the ACI, and neither infers backward compatibility on its own: the
+schema-compat test catches **artifact-sync drift** (a model change that was not
+regenerated into the committed schema/TS/Rust), and the **wire-lock gate**
+(`packages/aci-protocol/schema/wire.lock`) fails a wire change that did not bump
+`PROTOCOL_VERSION`, telling you which bump to make. Backward compatibility itself
+is a **policy** the semver table in `packages/CLAUDE.md` defines and a human
+applies per change class -- CI enforces that you version the change, not that the
+change is safe.
 
 If your task needs a change to either package: **stop, do not work around it, and
 open a GitHub issue or raise it in your PR** -- a contract change must land as

--- a/apps/dispatcher/src/agentos_dispatcher/queue.py
+++ b/apps/dispatcher/src/agentos_dispatcher/queue.py
@@ -24,7 +24,7 @@ does not require scanning the Stream.
 
 from typing import Any, Protocol, cast, runtime_checkable
 
-from aci_protocol import QueuedTurn
+from aci_protocol import QueuedTurn, parse_queued_turn
 
 from .config import DispatcherConfig
 
@@ -60,7 +60,7 @@ def to_stream_fields(turn: QueuedTurn) -> dict[str, str]:
 
 def from_stream_fields(fields: dict[str, str]) -> QueuedTurn:
     """Reconstruct a turn from a Stream entry's field map (the worker's entry point)."""
-    return QueuedTurn.model_validate_json(fields[STREAM_PAYLOAD_FIELD])
+    return parse_queued_turn(fields[STREAM_PAYLOAD_FIELD])
 
 
 def claim_event(redis_client: "StreamPublisher", config: "DispatcherConfig", event_id: str) -> bool:

--- a/apps/dispatcher/tests/test_queue.py
+++ b/apps/dispatcher/tests/test_queue.py
@@ -1,5 +1,6 @@
 """Queue seam + dedupe against real Valkey."""
 
+import json
 from pathlib import Path
 
 import redis
@@ -38,6 +39,18 @@ def test_queued_turn_stream_fields_roundtrip() -> None:
     fields = to_stream_fields(event)
     # The worker (F1) consumes a single JSON payload field.
     assert set(fields) == {"payload"}
+    assert from_stream_fields(fields) == event
+
+
+def test_from_stream_fields_tolerates_unknown_payload_field() -> None:
+    # A payload written by a newer producer (image skew across the queue boundary)
+    # carries a field this build does not model. The consumer must decode it
+    # tolerantly rather than raising, so a mid-deploy skew does not drop turns.
+    event = _event()
+    payload = json.loads(event.model_dump_json())
+    payload["future_field"] = "from a newer image"
+    fields = {"payload": json.dumps(payload)}
+
     assert from_stream_fields(fields) == event
 
 

--- a/docs/adr/0036-aci-semver-and-reader-policy.md
+++ b/docs/adr/0036-aci-semver-and-reader-policy.md
@@ -1,0 +1,140 @@
+# 36. ACI semver, reader-policy asymmetry, and a wire-lock gate that enforces it
+
+Date: 2026-07-16
+
+Status: Accepted
+
+Implements [#455](https://github.com/curie-eng/agentos/issues/455).
+
+## Context
+
+The ACI (`packages/aci-protocol`) is the strongest seam in the system: every
+lane (runner, worker, CLI, UI) compiles against it in three languages, and it is
+the wire a second harness must satisfy. ADR-0005 declared it a **frozen,
+versioned contract with a compat CI test** and stopped there. In practice
+"frozen" was neither expressed nor enforced:
+
+- `PROTOCOL_VERSION` stayed `0.1.0` while four wire-visible changes shipped with
+  no bump: `SessionStatus.AWAITING_APPROVAL` + `Final.approval_summary`,
+  `Final.approval_route`, the `QueuedTurn`/`ReplyHandle` promotion (#7), and
+  `ReplyHandle.endpoint` (#19).
+- Every model was `extra="forbid"` and the decoder gated on exact string
+  equality (`version != PROTOCOL_VERSION`), with `ProtocolVersionLiteral`
+  pinning the version as a schema `const`. Under that reader policy a new
+  optional field breaks an old consumer exactly as hard as a rename, so there is
+  **no such thing as a compatible minor** -- semver on top of strict readers is
+  decoration.
+- The one gate, `test_schema_compat.py`, asserts `render_schema() == committed`.
+  Because a model change is regenerated and committed together, it always goes
+  green. It pins artifact *sync*; it never pinned *compatibility*.
+- `AGENTS.md` told every agent the schema-compat test "fails any
+  non-backwards-compatible change." That was false, and a rule that promises a
+  protection which does not exist is why four changes walked through without
+  anyone reaching for the version.
+
+This ADR **amends the frozen-ACI posture of ADR-0005**. ADR-0005 remains the
+decision to make the ACI a frozen, versioned contract; it is not superseded.
+What changes is *how* frozen is expressed and enforced: the reader policy, the
+version's type, the compatibility rule, and the gate. The four un-bumped changes
+were breaking under the readers in force at the time, so the honest number is a
+minor bump to `0.2.0`, not a retro-fitted compatibility claim.
+
+## Decision
+
+**1. Semver, independent of the AgentOS release, with a written change-class
+table.** The protocol version tracks the wire contract's compatibility, not the
+product's cadence. The bump class for each change:
+
+| Change class | 0.x today | Post-1.0 |
+|---|---|---|
+| New optional field (consumer ignores it) | patch | minor |
+| New required field | minor (breaking) | major |
+| New enum value | minor (breaking) | major |
+| Field removal | minor (breaking) | major |
+| Field rename | minor (breaking) | major |
+| Type change | minor (breaking) | major |
+| Doc/description only (no wire change) | none | none |
+
+Compatibility rule a consumer applies: accept a wire version with the same
+`major.minor` under 0.x (the same `major` after 1.0); reject otherwise, with a
+message naming both versions. Under 0.x only a **new optional field is
+compatible** (patch): tolerant consumers ignore it. Every other class breaks an
+old consumer, so it bumps the minor (the breaking axis before 1.0). A
+same-major-minor **patch** difference is explicitly *not* an error.
+
+**2. Strict producers, tolerant consumers -- the classic asymmetry.**
+Constructing an event with an unknown field stays an error (producer mistakes
+caught at the source). A decoder reading the wire **ignores fields it does not
+model**, so a new optional field is genuinely backward compatible and a minor
+bump means something. The version gate becomes compatibility-aware
+(`major.minor` match under 0.x), not exact-match; this requires the `version`
+field to stop being a `Literal` const, since a const cannot express a range.
+
+**3. Unknown enum values REJECT; they do not degrade.** `SessionStatus` is
+**control-bearing, not informational**: `awaiting-approval` drives suspend-and-wait
+(ADR-0010), `done` drives finalize, `classified-failure` drives escalate. A
+consumer that degraded an unknown status to a fallback would take a **wrong
+control action silently** -- degrading a future approval-like status to `done`
+would finalize a turn that is actually pending a human decision, dropping the
+approval on the floor. That is strictly worse than a loud failure. The rule
+composes with the version policy: a new enum value is classified breaking, so it
+bumps the minor, so an old consumer rejects the payload at the version gate
+(with both versions named) before it ever meets the unknown token. The asymmetry
+with unknown *fields* is principled: an unknown field is information the consumer
+was never using; an unknown enum value is a control instruction it cannot follow.
+
+**4. A wire-lock gate that normalizes the version out.** A committed
+`schema/wire.lock` pins `{protocol_version, wire_sha256}`. The fingerprint is
+taken over the built schema **with the version normalized out** (drop `title`
+and `protocolVersion`, replace any residual version-const value with a fixed
+placeholder), so the hash reflects the wire shape alone. Gate logic: hash
+unchanged -> pass (a gratuitous version-only bump is legal); hash changed and
+version unchanged -> **fail** with a message naming the semver table and the
+bump to make; hash changed and version changed -> pass, and the lock is
+regenerated. The regenerator refuses to write a lock whose hash changed while
+the version did not, closing the escape hatch of regenerating the lock without
+bumping. Without version normalization every bump would change the hash and the
+gate would degenerate into the same regenerate-and-diff tautology it replaces.
+
+## Alternatives considered
+
+- **Prune unknown keys on read (keep `extra="forbid"`, strip extras before
+  validating).** Rejected. It would tolerate unknown fields at the reader, but
+  it does **not** change the emitted JSON Schema -- the committed schema would
+  keep advertising `additionalProperties: false` while the real reader tolerated
+  extras. That re-creates exactly the "the rule promises a protection that does
+  not exist" defect this issue exists to kill: the committed schema would be
+  lying. The chosen approach (tolerant config plus a reader-context validator)
+  makes the schema tell the truth as a byproduct, and pydantic propagates the
+  reader context into nested models for free, where pruning would need
+  hand-written recursion per nesting site.
+- **Degrade unknown enum values to a fallback.** Rejected for the fail-closed
+  reasoning in decision 3: a silent wrong control action on the approval path is
+  worse than a loud reject.
+- **Hash the raw schema without normalizing the version.** Rejected: the version
+  is embedded in the schema in three places, so every bump would move the hash
+  and the gate could never distinguish "the wire changed" from "someone bumped."
+
+## Consequences
+
+- `additionalProperties: false` disappears from the generated JSON Schema and
+  `deny_unknown_fields` from the generated Rust (both were byproducts of the
+  strict read path, which is the path being loosened); TypeScript interfaces gain
+  an index signature and become tolerant. Producers stay strict by construction.
+- `PROTOCOL_VERSION` is `0.2.0`, with every committed artifact regenerated in the
+  same change.
+- Published images lagging `main` is a normal condition here. Post-change, a
+  `0.2.x` consumer meeting a `0.1.0` producer rejects loudly and correctly with
+  both versions named -- the intended outcome, not a defect. There is no in-band
+  version negotiation and none is planned.
+- **Security note (narrow):** the tolerant reader sits on the runner->worker
+  boundary that carries approval control state. Dropping an unmodelled field is
+  safe today, but the "new optional field -> patch" classification must be
+  applied with care to any future field that carries authorization scope -- such
+  a field being silently ignored by an old consumer is a compatibility question
+  with a security edge. The enum-reject rule (decision 3) is the fail-closed
+  backstop on that same path.
+- **Out of scope, tracked separately (per #455):** the unfrozen env contract
+  that shadows `SessionConfig` (the approval/history vars the worker injects and
+  depends on), and conformance's failure to exercise the approval path. Both are
+  real gaps in what "frozen" covers.

--- a/docs/interfaces/aci-producer/INTERFACE.md
+++ b/docs/interfaces/aci-producer/INTERFACE.md
@@ -11,8 +11,9 @@ The frozen, cross-process ACI (Agent Container Interface) protocol — the stron
 system. It makes the whole **harness** swappable: anything inside the sandbox that speaks this
 wire contract (session setup env + NDJSON event union + steer/interrupt endpoints) can replace the
 default claude-agent-sdk runner without the worker, CLI, or UI changing. What stays opinionated
-core is the protocol itself: the event shapes, the `AGENTOS_*` env contract, and the strict
-`version` gate. A second harness produces the same bytes; it does not get to redefine them.
+core is the protocol itself: the event shapes, the `AGENTOS_*` env contract, and the
+compatibility-checked `version` gate. A second harness produces the same bytes; it does not get to
+redefine them.
 
 ## Current contract
 
@@ -22,7 +23,8 @@ live turn (409 if none running), `POST /v1/interrupt` hard-stops it. It streams 
 NDJSON discriminated union `OutboundEvent` (`packages/aci-protocol/src/aci_protocol/events.py:119`):
 `TextDelta` (`text_delta`, :76), `ToolNote` (`tool_note`, :83), `Final` (`final` + `status`, :91),
 `ErrorEvent` (`error` + `classification`, :99), `SideEffectFlag` (`side_effect_flag`, :107). Every
-outbound event carries `version` equal to `PROTOCOL_VERSION` and inbound frames are the
+outbound event carries `version` equal to the producer's exact build `PROTOCOL_VERSION`; a consumer
+accepts any `major.minor`-compatible version under 0.x (`major` after 1.0). Inbound frames are the
 `InboundMessage` union `Event | Interrupt` on the `kind` tag
 (`packages/aci-protocol/src/aci_protocol/events.py:64`, `:43`, `:55`). Setup is read from the
 environment via `SessionConfig.from_env` (`packages/aci-protocol/src/aci_protocol/session.py:96`),
@@ -42,8 +44,9 @@ CI-guarded by `packages/aci-protocol/tests/test_schema_compat.py`.
 Plugin-format entanglement: the ACI server must interpret Claude Code plugin bundles mounted at
 `AGENTOS_PLUGIN_DIR` (see the [bundle-format seam](../bundle-format/INTERFACE.md)), so a genuinely
 foreign harness inherits that shape too — the A- is docked for exactly this and for the
-SDK-shaped resume. Otherwise the line is clean and frozen: unknown wire versions raise
-`ProtocolVersionError`, and `extra="forbid"` rejects stray keys at construction.
+SDK-shaped resume. Otherwise the line is clean and frozen: a producer constructs strictly (stray
+keys are rejected at construction), while a consumer tolerates unknown fields and rejects only an
+**incompatible** wire version, raising `ProtocolVersionError` naming both versions (see ADR-0036).
 
 ## Cross-links
 

--- a/docs/interfaces/aci-producer/implementing-an-aci-server.md
+++ b/docs/interfaces/aci-producer/implementing-an-aci-server.md
@@ -55,11 +55,18 @@ Import everything from `aci_protocol`; do not hand-roll JSON.
 - `ErrorEvent` → `error` `{version, message, classification?}`
 - `SideEffectFlag` → `side_effect_flag` `{version, tool?, detail?}`
 
-**Version gate (strict).** Every outbound event's `version` must equal
-`PROTOCOL_VERSION` (currently `0.1.0`). The decoder raises `ProtocolVersionError`
-on a missing or mismatched version — this is deliberate and is one of the
-conformance checks. Because the models set `version` as a `const` literal, you get
-this for free by constructing the models rather than emitting raw dicts.
+**Version gate (strict producer, tolerant consumer).** Your producer emits its
+**exact build `PROTOCOL_VERSION`** (currently `0.2.0`) on every outbound event and
+constructs strictly -- an unknown field is an error at construction, catching your
+mistakes at the source. A **consumer** decoding the wire is tolerant the other way:
+it accepts any version compatible with its own build (`major.minor` match under
+0.x, `major` after 1.0) and ignores unknown fields it does not model, so a new
+optional field is backward compatible. The decoder raises `ProtocolVersionError`
+on a missing version or an **incompatible** one, with a message naming both
+versions -- a same-`major.minor` patch difference is not an error. Constructing the
+frozen models and calling `to_ndjson_line` gives you the right version and wire
+shape for free, so you never assemble version strings by hand. (Policy and
+rationale: ADR-0036.)
 
 ## Step 1 — model your turn as a producer
 
@@ -113,7 +120,7 @@ The suite runs five checks (the last only when you pass a producer):
 | --- | --- |
 | `outbound_roundtrip` | Every outbound event type survives encode→decode (library-level; always runs). |
 | `inbound_roundtrip` | Every inbound frame survives encode→decode (always runs). |
-| `reject_unknown_version` | A `9.9.9` line is rejected with `ProtocolVersionError`. |
+| `reject_unknown_version` | An **incompatible** `9.9.9` line is rejected with `ProtocolVersionError` naming both versions (a same-`major.minor` patch line is accepted). |
 | `reject_missing_version` | A version-less line is rejected. |
 | `producer_stream` | **Your** producer emits a well-formed stream for every inbound case. |
 
@@ -123,7 +130,8 @@ inbound cases** — `event:message`, `event:job`, `event:eval_case`, and
 
 1. the producer emits **at least one** event (no empty stream);
 2. the stream **ends in a `final`** event;
-3. **every** event carries `version == PROTOCOL_VERSION`.
+3. **every** event carries a `version` -- your producer's exact build
+   `PROTOCOL_VERSION`.
 
 A harness that handles ordinary messages but drops `interrupt` or a batch `job`
 will fail here — that is the point. A concrete failing example: a producer that

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -18,8 +18,35 @@ lanes proceed.
 
 ## When a change is genuinely approved
 
-1. Bump the relevant version constant (`aci_protocol.version.PROTOCOL_VERSION`
-   for the ACI; the plugin-format schema has no separate version today).
+1. Bump `aci_protocol.version.PROTOCOL_VERSION` to the class the change earns
+   (the plugin-format schema has no separate version today). The ACI is
+   versioned as **semver, independent of the AgentOS release**: the number
+   tracks the wire contract's compatibility, not the product's cadence.
+   **Backward compatibility is the default expectation.** A consumer accepts a
+   wire version with the same `major.minor` under 0.x (the same `major` after
+   1.0) and rejects anything else, loudly, naming both versions. Pick the bump
+   from the change class:
+
+   | Change class | 0.x today | Post-1.0 |
+   |---|---|---|
+   | New optional field (consumer ignores it) | patch | minor |
+   | New required field | minor (breaking) | major |
+   | New enum value | minor (breaking) | major |
+   | Field removal | minor (breaking) | major |
+   | Field rename | minor (breaking) | major |
+   | Type change | minor (breaking) | major |
+   | Doc/description only (no wire change) | none | none |
+
+   Only a **new optional field is compatible** while we are in 0.x: tolerant
+   consumers ignore it, so it is a patch and old consumers keep decoding. Every
+   other row breaks an old consumer, so under 0.x it bumps the **minor** (the
+   breaking axis before 1.0) and old consumers reject it at the version gate
+   with both versions named. A new **enum value** counts as breaking even though
+   it looks additive: `SessionStatus` is control-bearing, so an unknown value is
+   rejected, never degraded (see ADR-0036). When a change cannot be made
+   backward compatible, do not force it into a patch to keep the gate quiet:
+   bump the breaking class, and if two versions must coexist on the wire, ship
+   and name both explicitly rather than pretending one is compatible.
 2. Regenerate every committed artifact and check for drift:
    ```bash
    ./scripts/check-contracts.sh
@@ -42,12 +69,17 @@ lanes proceed.
 
 ## Model conventions specific to these packages
 
-- **`aci-protocol` is strict.** The wire contract rejects unknown fields
-  (`deny_unknown_fields` equivalent in both Python and generated Rust) and
-  rejects any `version` other than the exact `PROTOCOL_VERSION` (no
-  same-major looseness in the 0.x line). If you are tempted to loosen this
-  for a consumer's convenience, that is a version-policy change -- raise it in
-  an issue/PR first, do not quietly relax a model.
+- **`aci-protocol` is strict producers, tolerant consumers** (conservative in
+  what it sends, liberal in what it accepts). Constructing an event with an
+  unknown field is still an error -- that is where the value of strictness
+  lives, catching producer mistakes at the source. But a **consumer decoding
+  the wire ignores fields it does not model**, so a new optional field is
+  genuinely backward compatible and a minor bump means something. The version
+  gate is **compatibility-aware, not exact-match**: it accepts any wire version
+  that matches the build's `major.minor` under 0.x (`major` after 1.0) and
+  rejects across an incompatible boundary, naming both versions. Loosening the
+  gate further (accepting an incompatible version) is a version-policy change --
+  raise it in an issue/PR first, do not quietly relax a model.
 - **`plugin-format` is lenient by design.** Its models use `extra="allow"`
   because real Claude Code plugin bundles carry keys this MVP does not model;
   rejecting them would reject valid bundles. Do not add strict validation

--- a/packages/aci-protocol/README.md
+++ b/packages/aci-protocol/README.md
@@ -12,18 +12,21 @@ models are the source of truth, and the committed JSON Schema, generated
 TypeScript, and generated Rust are derived from them. The runner, worker, CLI,
 and UI all depend on it, so it never changes from a dependent lane; a needed
 change stops the task and lands as its own reviewed change (see the
-frozen-interface rule below). The wire contract is strict: the decoder accepts
-only events whose `version` equals `PROTOCOL_VERSION` (currently `0.1.0`) and
-raises `ProtocolVersionError` on anything else, with `version` typed as a
-`const` literal so an off-version value is rejected at construction. The 0.x
-line has no same-major looseness, so any protocol change is a `PROTOCOL_VERSION`
-bump and a hard break signaled by `ProtocolVersionError`; a looser same-major
-policy is planned for 1.0, and the schema-compat gate
-(`tests/test_schema_compat.py`) fails on any drift.
+frozen-interface rule below). The wire contract is **strict producers, tolerant
+consumers**: constructing an event with an unknown field is an error, but a
+consumer decoding the wire ignores fields it does not model, so a new optional
+field is genuinely backward compatible. The version is **semver**: the decoder
+accepts any wire version compatible with this build's `PROTOCOL_VERSION` (same
+`major.minor` under 0.x, same `major` from 1.0 on) and raises
+`ProtocolVersionError` on an incompatible or malformed one, naming both
+versions. The `version` field is a semver-pattern string, not a `const`, so the
+compatibility range means something. Artifact sync is enforced by the
+schema-compat gate (`tests/test_schema_compat.py`); an unbumped wire change is
+caught by the wire-lock gate (`tests/test_wire_lock.py`).
 
-## Contract surface (v0.1.0)
+## Contract surface (v0.2.0)
 
-`PROTOCOL_VERSION = "0.1.0"` is embedded in the schema and in every outbound
+`PROTOCOL_VERSION = "0.2.0"` is embedded in the schema and in every outbound
 event.
 
 **Session setup** (`SessionConfig`, with `to_env()` / `from_env()`):
@@ -108,21 +111,23 @@ compiles the generated Rust (`cargo test`) and TypeScript (`tsc --noEmit`).
   failure surfaces as an `error` event plus a `final` with
   `status=classified-failure`. Wire tokens use hyphens (`idle-awaiting-input`,
   `classified-failure`) as spelled in section 0.
-- **Version policy is exact match for the 0.x line.** The decoder accepts only
-  events whose `version` equals `PROTOCOL_VERSION` and rejects anything else
-  with `ProtocolVersionError`. The `version` field is typed as the literal
-  `"0.1.0"`, so the models reject an off-version value at construction and the
-  JSON Schema and TypeScript express it as a `const`, not just any string. This
-  is the "reject unknown versions gracefully" requirement; a looser same-major
-  policy can come with 1.0.
+- **Version policy is semver compatibility, not exact match.** The decoder
+  accepts any wire version compatible with `PROTOCOL_VERSION` (same `major.minor`
+  under 0.x, same `major` from 1.0 on) via `is_compatible`, and rejects an
+  incompatible or malformed one with `ProtocolVersionError` naming both versions.
+  The `version` field is a semver-pattern string (not a `const`), so the JSON
+  Schema and TypeScript express the range while still requiring the field. See
+  `packages/CLAUDE.md` for the change-class table and `docs/adr/0036-*` for the
+  rationale.
 - **Whole-frame union types are exported.** The committed schema and generated
   TypeScript include `InboundMessage` (`Event | Interrupt`) and `OutboundEvent`
   (the five response events) as discriminated unions, so a consumer can type a
   full channel frame, not only the concrete variants. The generated Rust models
-  these as internally-tagged enums that enforce the same strictness as Python:
-  `deny_unknown_fields` on both structs and the tagged enums rejects extra keys,
-  and the `version` field decodes through a guard that rejects any value other
-  than `PROTOCOL_VERSION`.
+  these as internally-tagged enums whose read path matches Python: extra unknown
+  keys are tolerated (no `deny_unknown_fields`, since a consumer ignores fields
+  it does not model, while a Rust producer stays strict by construction), and
+  the `version` field decodes through `require_compatible_protocol_version`,
+  which rejects any value not compatible with `PROTOCOL_VERSION`.
 
 ## What consumers need to know
 

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,14 +6,44 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.1.0";
+pub const PROTOCOL_VERSION: &str = "0.2.0";
 
-fn require_protocol_version<'de, D>(deserializer: D) -> Result<String, D::Error>
+fn parse_semver(value: &str) -> Option<(u64, u64)> {
+    let mut parts = value.split('.');
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let minor = parts.next()?.parse::<u64>().ok()?;
+    let patch = parts.next()?;
+    if patch.is_empty() || !patch.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor))
+}
+
+fn is_compatible_protocol_version(wire: &str) -> bool {
+    let (w_major, w_minor) = match parse_semver(wire) {
+        Some(parsed) => parsed,
+        None => return false,
+    };
+    let (b_major, b_minor) = match parse_semver(PROTOCOL_VERSION) {
+        Some(parsed) => parsed,
+        None => return false,
+    };
+    if b_major == 0 {
+        w_major == 0 && w_minor == b_minor
+    } else {
+        w_major == b_major
+    }
+}
+
+fn require_compatible_protocol_version<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let value = String::deserialize(deserializer)?;
-    if value != PROTOCOL_VERSION {
+    if !is_compatible_protocol_version(&value) {
         return Err(serde::de::Error::custom(format!(
             "unsupported protocol version {value:?}; this build speaks {PROTOCOL_VERSION:?}"
         )));
@@ -45,7 +75,6 @@ pub enum EventType {
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Budget {
     pub max_output_tokens_per_run: i64,
     #[serde(default)]
@@ -54,7 +83,6 @@ pub struct Budget {
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct OtelConfig {
     #[serde(default)]
     pub endpoint: Option<String>,
@@ -65,7 +93,6 @@ pub struct OtelConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct SessionConfig {
     pub plugin_dir: String,
     pub session_id: String,
@@ -80,7 +107,6 @@ pub struct SessionConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ReplyHandle {
     pub channel: String,
     pub placeholder: String,
@@ -89,7 +115,6 @@ pub struct ReplyHandle {
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct QueuedTurn {
     pub event_id: String,
     pub conversation_id: String,
@@ -100,7 +125,7 @@ pub struct QueuedTurn {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "kind", deny_unknown_fields)]
+#[serde(tag = "kind")]
 pub enum InboundMessage {
     #[serde(rename = "event")]
     Event {
@@ -116,17 +141,17 @@ pub enum InboundMessage {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", deny_unknown_fields)]
+#[serde(tag = "type")]
 pub enum OutboundEvent {
     #[serde(rename = "text_delta")]
     TextDelta {
-        #[serde(deserialize_with = "require_protocol_version")]
+        #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
         text: String,
     },
     #[serde(rename = "tool_note")]
     ToolNote {
-        #[serde(deserialize_with = "require_protocol_version")]
+        #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
         text: String,
         #[serde(default)]
@@ -134,7 +159,7 @@ pub enum OutboundEvent {
     },
     #[serde(rename = "final")]
     Final {
-        #[serde(deserialize_with = "require_protocol_version")]
+        #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
         text: String,
         #[serde(default)]
@@ -146,7 +171,7 @@ pub enum OutboundEvent {
     },
     #[serde(rename = "error")]
     ErrorEvent {
-        #[serde(deserialize_with = "require_protocol_version")]
+        #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
         message: String,
         #[serde(default)]
@@ -154,7 +179,7 @@ pub enum OutboundEvent {
     },
     #[serde(rename = "side_effect_flag")]
     SideEffectFlag {
-        #[serde(deserialize_with = "require_protocol_version")]
+        #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
         #[serde(default)]
         tool: Option<String>,
@@ -209,14 +234,26 @@ mod tests {
     }
 
     #[test]
-    fn rejects_off_version_event() {
+    fn rejects_incompatible_version_event() {
         let raw = r#"{"type":"final","version":"9.9.9","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
     }
 
     #[test]
-    fn rejects_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.1.0","text":"x","status":"done","extra":1}"#;
+    fn rejects_incompatible_minor() {
+        let raw = r#"{"type":"final","version":"0.3.0","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
+    }
+
+    #[test]
+    fn accepts_compatible_patch() {
+        let raw = r#"{"type":"final","version":"0.2.7","text":"x","status":"done"}"#;
+        assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
+    }
+
+    #[test]
+    fn accepts_unknown_fields() {
+        let raw = r#"{"type":"final","version":"0.2.0","text":"x","status":"done","extra":1}"#;
+        assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 }

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -11,7 +11,7 @@ export type TaskBudgetHint = number | null;
 export type Classification = string | null;
 export type Message = string;
 export type Type = "error";
-export type Version = "0.1.0";
+export type Version = string;
 export type Kind = "event";
 export type Text = string;
 export type Ts = string;
@@ -28,9 +28,9 @@ export type ApprovalSummary = string | null;
 export type SessionStatus = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 export type Text1 = string;
 export type Type2 = "final";
-export type Version1 = "0.1.0";
+export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
@@ -40,21 +40,21 @@ export type Endpoint = string | null;
 export type Headers = string | null;
 export type Protocol = string | null;
 /**
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
 export type Text2 = string;
 export type Type3 = "text_delta";
-export type Version2 = "0.1.0";
+export type Version2 = string;
 export type Text3 = string;
 export type Tool = string | null;
 export type Type4 = "tool_note";
-export type Version3 = "0.1.0";
+export type Version3 = string;
 export type Detail = string | null;
 export type Tool1 = string | null;
 export type Type5 = "side_effect_flag";
-export type Version4 = "0.1.0";
+export type Version4 = string;
 export type Author = string;
 export type ConversationId = string;
 export type EventId = string;
@@ -74,12 +74,12 @@ export type SessionId = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 
-export interface ACIProtocolV010 {
+export interface ACIProtocolV020 {
   [k: string]: unknown;
 }
 /**
@@ -88,18 +88,19 @@ export interface ACIProtocolV010 {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
   max_output_tokens_per_run: MaxOutputTokensPerRun;
   max_usd_per_day: MaxUsdPerDay;
   task_budget_hint?: TaskBudgetHint;
+  [k: string]: unknown;
 }
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -107,11 +108,12 @@ export interface ErrorEvent {
   message: Message;
   type: Type;
   version: Version;
+  [k: string]: unknown;
 }
 /**
  * An inbound event delivered into a live session (initial or follow-up).
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -120,6 +122,7 @@ export interface Event {
   ts: Ts;
   type: Type1;
   user: User;
+  [k: string]: unknown;
 }
 /**
  * The terminal response event, carrying the session status.
@@ -134,7 +137,7 @@ export interface Event {
  * other status; ``approval_route`` also ``None`` when the request named no
  * route (the platform falls back to the requesting channel).
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
@@ -144,16 +147,18 @@ export interface Final {
   text: Text1;
   type: Type2;
   version: Version1;
+  [k: string]: unknown;
 }
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
   kind: Kind1;
   reason: Reason;
+  [k: string]: unknown;
 }
 /**
  * The OTEL_EXPORTER_OTLP_* subset the runner needs to export traces.
@@ -162,29 +167,31 @@ export interface Interrupt {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
   endpoint?: Endpoint;
   headers?: Headers;
   protocol?: Protocol;
+  [k: string]: unknown;
 }
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
   text: Text2;
   type: Type3;
   version: Version2;
+  [k: string]: unknown;
 }
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -192,6 +199,7 @@ export interface ToolNote {
   tool?: Tool;
   type: Type4;
   version: Version3;
+  [k: string]: unknown;
 }
 /**
  * Marks that a non-idempotent tool call executed during the run.
@@ -199,7 +207,7 @@ export interface ToolNote {
  * Its presence gates the no-retry-after-side-effects rule (section 2b): a
  * failed run carrying this flag escalates to a human instead of retrying.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
@@ -207,6 +215,7 @@ export interface SideEffectFlag {
   tool?: Tool1;
   type: Type5;
   version: Version4;
+  [k: string]: unknown;
 }
 /**
  * A normalized inbound turn ready for the worker to route and run.
@@ -216,7 +225,7 @@ export interface SideEffectFlag {
  * stream-encoding helpers live with the producer (the dispatcher), not on this
  * frozen model, so the contract stays transport-agnostic.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -226,6 +235,7 @@ export interface QueuedTurn {
   received_at: ReceivedAt;
   reply_handle: ReplyHandle;
   text: Text4;
+  [k: string]: unknown;
 }
 /**
  * Channel-neutral coordinates for where a turn's reply is delivered.
@@ -244,13 +254,14 @@ export interface QueuedTurn {
  * (its ``slack_api_base_url``, i.e. real Slack), so a producer that does not set
  * it keeps the pre-#19 behavior.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {
   channel: Channel;
   endpoint?: Endpoint1;
   placeholder: Placeholder;
+  [k: string]: unknown;
 }
 /**
  * The typed session setup contract.
@@ -259,7 +270,7 @@ export interface ReplyHandle {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV010`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV020`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -270,4 +281,5 @@ export interface SessionConfig {
   plugin_dir: PluginDir;
   sandbox_id: SandboxId;
   session_id: SessionId;
+  [k: string]: unknown;
 }

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -1,7 +1,6 @@
 {
   "$defs": {
     "Budget": {
-      "additionalProperties": false,
       "description": "Per-agent budget spec, carried as JSON in AGENTOS_BUDGET.\n\n``task_budget_hint`` is the optional hint passed through to the model so it\nself paces (section 6b); it is not a hard ceiling.",
       "properties": {
         "max_output_tokens_per_run": {
@@ -33,7 +32,6 @@
       "type": "object"
     },
     "ErrorEvent": {
-      "additionalProperties": false,
       "description": "A classified failure surfaced to the platform.",
       "properties": {
         "classification": {
@@ -58,7 +56,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
           "title": "Version",
           "type": "string"
         }
@@ -72,7 +70,6 @@
       "type": "object"
     },
     "Event": {
-      "additionalProperties": false,
       "description": "An inbound event delivered into a live session (initial or follow-up).",
       "properties": {
         "kind": {
@@ -113,7 +110,6 @@
       "type": "object"
     },
     "Final": {
-      "additionalProperties": false,
       "description": "The terminal response event, carrying the session status.\n\n``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):\nthe human-readable statement of what needs approval, captured from the\nrun's approval request so the platform can persist it on the durable\n``Approval`` record and show it to the approver. ``approval_route`` names\nthe approval route the request targets (#247): declared in the bundle\nmanifest's ``approvalPolicy`` (versioned with the agent), bound to a\nworkspace channel per deployment by the worker. Both ``None`` on every\nother status; ``approval_route`` also ``None`` when the request named no\nroute (the platform falls back to the requesting channel).",
       "properties": {
         "approval_route": {
@@ -154,7 +150,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
           "title": "Version",
           "type": "string"
         }
@@ -186,7 +182,6 @@
       "title": "InboundMessage"
     },
     "Interrupt": {
-      "additionalProperties": false,
       "description": "A hard stop delivered on the control channel, distinct from a steer.",
       "properties": {
         "kind": {
@@ -207,7 +202,6 @@
       "type": "object"
     },
     "OtelConfig": {
-      "additionalProperties": false,
       "description": "The OTEL_EXPORTER_OTLP_* subset the runner needs to export traces.\n\nSection 0 lists OTEL_EXPORTER_OTLP_* as a wildcard. We capture the standard\nfields the prototype used (endpoint, headers, protocol); any others pass\nthrough as raw env vars untouched and are out of scope for this typed view.",
       "properties": {
         "endpoint": {
@@ -281,7 +275,6 @@
       "title": "OutboundEvent"
     },
     "QueuedTurn": {
-      "additionalProperties": false,
       "description": "A normalized inbound turn ready for the worker to route and run.\n\nThe channel-neutral promotion of the dispatcher's former ``QueuedSlackEvent``.\nThe Valkey Stream carries this model as a single ``payload`` JSON field; the\nstream-encoding helpers live with the producer (the dispatcher), not on this\nfrozen model, so the contract stays transport-agnostic.",
       "properties": {
         "author": {
@@ -320,7 +313,6 @@
       "type": "object"
     },
     "ReplyHandle": {
-      "additionalProperties": false,
       "description": "Channel-neutral coordinates for where a turn's reply is delivered.\n\nThe reply model is edit-in-place: the ingress adapter pre-posts a placeholder\nmessage and the worker edits it as the answer streams. For the Slack adapter\ntoday, ``channel`` is the Slack channel id (also the key the deployment\nbinding matches an agent on) and ``placeholder`` is the ts of the pre-posted\nplaceholder message.\n\n``endpoint`` is the per-turn reply target: the base URL of the channel API the\nworker delivers this turn's reply through. It routes the reply back to the\ningress that enqueued the turn instead of a worker-global setting, so two\ningress paths (a real Slack workspace and a no-Slack CLI stub) can coexist on\none worker (issue #19). ``None`` means \"use the worker's configured default\"\n(its ``slack_api_base_url``, i.e. real Slack), so a producer that does not set\nit keeps the pre-#19 behavior.",
       "properties": {
         "channel": {
@@ -352,7 +344,6 @@
       "type": "object"
     },
     "SessionConfig": {
-      "additionalProperties": false,
       "description": "The typed session setup contract.\n\n``credentials_ref`` is a reference to injected secrets (AGENTOS_CREDENTIALS);\nsection 0 describes these as per-tool secrets via K8s Secret refs, so the\ncontract carries the reference, not the secret material itself.",
       "properties": {
         "budget": {
@@ -419,7 +410,6 @@
       "type": "string"
     },
     "SideEffectFlag": {
-      "additionalProperties": false,
       "description": "Marks that a non-idempotent tool call executed during the run.\n\nIts presence gates the no-retry-after-side-effects rule (section 2b): a\nfailed run carrying this flag escalates to a human instead of retrying.",
       "properties": {
         "detail": {
@@ -452,7 +442,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
           "title": "Version",
           "type": "string"
         }
@@ -465,7 +455,6 @@
       "type": "object"
     },
     "TextDelta": {
-      "additionalProperties": false,
       "description": "A streamed chunk of assistant text.",
       "properties": {
         "text": {
@@ -478,7 +467,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
           "title": "Version",
           "type": "string"
         }
@@ -492,7 +481,6 @@
       "type": "object"
     },
     "ToolNote": {
-      "additionalProperties": false,
       "description": "A human readable note about a tool call the harness is making.",
       "properties": {
         "text": {
@@ -517,7 +505,7 @@
           "type": "string"
         },
         "version": {
-          "const": "0.1.0",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
           "title": "Version",
           "type": "string"
         }
@@ -533,6 +521,6 @@
   },
   "$id": "https://curie.tech/agentos/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.1.0",
-  "title": "ACI Protocol v0.1.0"
+  "protocolVersion": "0.2.0",
+  "title": "ACI Protocol v0.2.0"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,0 +1,4 @@
+{
+  "protocol_version": "0.2.0",
+  "wire_sha256": "231e2923a1b8b1924958735540e1a45d099f9cce40fc56eefd431847dbd39b86"
+}

--- a/packages/aci-protocol/src/aci_protocol/__init__.py
+++ b/packages/aci-protocol/src/aci_protocol/__init__.py
@@ -1,11 +1,14 @@
-"""Frozen ACI session protocol and NDJSON event types.
+"""The ACI session protocol and NDJSON event types.
 
 This package is the single source of truth for the Agent Container Interface
-(ACI) contract v0.1 (docs/reference/detailed-architecture.md section 0). It is a
-frozen interface: every lane compiles against it across three languages
-(Pydantic here, generated TypeScript and Rust from the committed JSON Schema). A
-change stops the current task and escalates to the orchestrator, and must bump
-PROTOCOL_VERSION and regenerate the committed schema and types.
+(ACI) contract (docs/reference/detailed-architecture.md section 0). Every lane
+compiles against it across three languages (Pydantic here, generated TypeScript
+and Rust from the committed JSON Schema). The wire is strict producers, tolerant
+consumers: constructing an event with an unknown field is an error, but a
+consumer decoding the wire ignores fields it does not model. The version is
+semver; a consumer accepts a compatible wire version (same major.minor under 0.x)
+via ``is_compatible``. A contract change bumps PROTOCOL_VERSION per the change
+class and regenerates the committed schema and types.
 """
 
 from .conformance import ConformanceReport, Producer, run_conformance
@@ -29,18 +32,20 @@ from .ndjson import (
     parse_inbound,
     parse_ndjson,
     parse_ndjson_line,
+    parse_queued_turn,
     to_inbound_json,
     to_ndjson_line,
 )
 from .reference import reference_producer
 from .session import Budget, OtelConfig, SessionConfig
 from .turn import QueuedTurn, ReplyHandle
-from .version import PROTOCOL_VERSION
+from .version import PROTOCOL_VERSION, is_compatible
 
 __version__ = "0.0.0"
 
 __all__ = [
     "PROTOCOL_VERSION",
+    "is_compatible",
     "__version__",
     # session setup
     "SessionConfig",
@@ -70,6 +75,7 @@ __all__ = [
     "iter_ndjson",
     "parse_inbound",
     "to_inbound_json",
+    "parse_queued_turn",
     "ProtocolVersionError",
     # conformance
     "run_conformance",

--- a/packages/aci-protocol/src/aci_protocol/conformance.py
+++ b/packages/aci-protocol/src/aci_protocol/conformance.py
@@ -35,7 +35,7 @@ from .ndjson import (
     to_inbound_json,
     to_ndjson_line,
 )
-from .version import PROTOCOL_VERSION
+from .version import PROTOCOL_VERSION, is_compatible
 
 # A producer maps an inbound message to the NDJSON lines a runner emits for it.
 Producer = Callable[[Event | Interrupt], Iterable[str]]
@@ -102,8 +102,39 @@ def _reject_unknown_version() -> str:
     try:
         parse_ndjson_line(bad)
     except ProtocolVersionError:
-        return "unknown version rejected with ProtocolVersionError"
+        return "incompatible version rejected with ProtocolVersionError"
     raise AssertionError("a 9.9.9 version line was accepted; it must be rejected")
+
+
+def _accept_compatible_patch_version() -> str:
+    # A same-major-minor patch difference is not an error: a consumer speaking
+    # PROTOCOL_VERSION accepts a producer one patch ahead.
+    major, minor, patch = (int(p) for p in PROTOCOL_VERSION.split("."))
+    ahead = f"{major}.{minor}.{patch + 1}"
+    if not is_compatible(ahead, PROTOCOL_VERSION):  # pragma: no cover - guards the sample
+        raise AssertionError(f"{ahead} should be compatible with {PROTOCOL_VERSION}")
+    line = json.dumps({"type": "final", "version": ahead, "text": "x", "status": "done"})
+    decoded = parse_ndjson_line(line)
+    if decoded.version != ahead:
+        raise AssertionError(f"a compatible {ahead} line did not round-trip its version")
+    return f"compatible patch version {ahead} accepted"
+
+
+def _tolerate_unknown_field() -> str:
+    # Consumers accept and ignore unknown fields they do not model.
+    line = json.dumps(
+        {
+            "type": "final",
+            "version": PROTOCOL_VERSION,
+            "text": "x",
+            "status": "done",
+            "future_field": 1,
+        }
+    )
+    decoded = parse_ndjson_line(line)
+    if not isinstance(decoded, Final) or decoded.text != "x":
+        raise AssertionError("an unknown field was not tolerated on read")
+    return "unknown field tolerated on read"
 
 
 def _reject_missing_version() -> str:
@@ -130,7 +161,7 @@ def _producer_stream(producer: Producer) -> str:
                 f"ended in {events[-1].type!r}"
             )
         for event in events:
-            if event.version != PROTOCOL_VERSION:
+            if not is_compatible(event.version, PROTOCOL_VERSION):
                 raise AssertionError(f"producer emitted version {event.version!r} for {label}")
     return f"producer streams for {len(_INBOUND_SAMPLES)} inbound cases are well formed"
 
@@ -148,6 +179,8 @@ def run_conformance(producer: Producer | None = None) -> ConformanceReport:
         _check("inbound_roundtrip", _roundtrip_inbound),
         _check("reject_unknown_version", _reject_unknown_version),
         _check("reject_missing_version", _reject_missing_version),
+        _check("accept_compatible_patch_version", _accept_compatible_patch_version),
+        _check("tolerate_unknown_field", _tolerate_unknown_field),
     ]
     if producer is not None:
         checks.append(_check("producer_stream", lambda: _producer_stream(producer)))

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -14,15 +14,49 @@ outbound event carries a ``version`` equal to PROTOCOL_VERSION.
 """
 
 from enum import StrEnum
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
 
-from .version import PROTOCOL_VERSION, ProtocolVersionLiteral
+from .version import PROTOCOL_VERSION, SEMVER_PATTERN
 
-# Wire contract: unknown keys are a hard error. Every lane compiles against these
-# exact shapes, so a stray field means a producer and consumer disagree.
-_STRICT = ConfigDict(extra="forbid")
+# Reader-context flag. The decoder passes ``context={_READER_CONTEXT_KEY: True}``
+# so a consumer decoding the wire tolerates unknown fields; direct construction
+# does not, so a producer building a model with a stray field is rejected. It
+# lives here (not in a new module) because every wire model shares it and the
+# tests import it from ``aci_protocol.events``.
+_READER_CONTEXT_KEY = "aci_reader"
+
+
+class _AciModel(BaseModel):
+    """Base for every ACI wire model: strict producers, tolerant consumers.
+
+    ``extra="ignore"`` drops unknown keys, but the before-validator rejects them
+    on construction UNLESS the caller passes the reader context flag. So a
+    producer that builds an event with a field the contract does not define is
+    caught at the source, while a consumer decoding a newer producer's payload
+    ignores fields it does not model. Pydantic propagates the validation context
+    into nested models, so a nested model (``ReplyHandle`` inside ``QueuedTurn``)
+    gets the same tolerant read without threading the flag by hand.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_unknown_keys_on_construction(cls, data: Any, info: ValidationInfo) -> Any:
+        # Aliases are not used anywhere in aci-protocol, so comparing raw keys
+        # against ``model_fields`` is exact. If an alias is ever added here, this
+        # would need to compare against alias-aware keys instead.
+        if isinstance(data, dict) and not (info.context or {}).get(_READER_CONTEXT_KEY):
+            unknown = data.keys() - cls.model_fields.keys()
+            if unknown:
+                raise ValueError(
+                    f"unexpected field(s) {sorted(unknown)}; the ACI wire is strict on "
+                    "construction (a consumer decoding the wire tolerates them, a producer "
+                    "does not)"
+                )
+        return data
 
 
 class SessionStatus(StrEnum):
@@ -45,10 +79,8 @@ class SessionStatus(StrEnum):
 # --- Inbound channel messages -------------------------------------------------
 
 
-class Event(BaseModel):
+class Event(_AciModel):
     """An inbound event delivered into a live session (initial or follow-up)."""
-
-    model_config = _STRICT
 
     kind: Literal["event"] = "event"
     type: Literal["message", "job", "eval_case"]
@@ -57,10 +89,8 @@ class Event(BaseModel):
     ts: str
 
 
-class Interrupt(BaseModel):
+class Interrupt(_AciModel):
     """A hard stop delivered on the control channel, distinct from a steer."""
-
-    model_config = _STRICT
 
     kind: Literal["interrupt"] = "interrupt"
     reason: str
@@ -72,10 +102,12 @@ InboundMessage = Annotated[Event | Interrupt, Field(discriminator="kind")]
 # --- Outbound NDJSON response events ------------------------------------------
 
 
-class _OutboundBase(BaseModel):
-    model_config = _STRICT
-
-    version: ProtocolVersionLiteral = PROTOCOL_VERSION
+class _OutboundBase(_AciModel):
+    # ``version`` is a semver-constrained string (not a Literal const): the wire
+    # accepts any compatible version, so pinning it to one value would defeat the
+    # compatibility range. The NDJSON decoder enforces compatibility; the pattern
+    # here rejects a structurally malformed value on construction.
+    version: str = Field(default=PROTOCOL_VERSION, pattern=SEMVER_PATTERN)
 
 
 class TextDelta(_OutboundBase):

--- a/packages/aci-protocol/src/aci_protocol/ndjson.py
+++ b/packages/aci-protocol/src/aci_protocol/ndjson.py
@@ -1,10 +1,19 @@
-"""NDJSON serialization for the outbound response stream.
+"""NDJSON serialization for the outbound response stream and the queued-turn payload.
 
 The response channel is newline-delimited JSON: one outbound event per line.
 These helpers are the single sanctioned encoder and decoder. The decoder
-enforces the protocol version: an event whose ``version`` is missing or does not
-match PROTOCOL_VERSION is rejected with ProtocolVersionError rather than being
-silently accepted, so a runner speaking a different version fails loudly.
+enforces protocol-version compatibility: an event whose ``version`` is missing,
+malformed, or not compatible with this build's PROTOCOL_VERSION is rejected with
+ProtocolVersionError (naming both versions) rather than being silently accepted,
+so a runner speaking an incompatible version fails loudly. Compatibility is same
+``major.minor`` under 0.x (see ``version.is_compatible``); a same-major-minor
+patch difference is accepted. The decoder threads a reader context so consumers
+tolerate unknown fields while producers stay strict on construction.
+
+This module also owns the sanctioned tolerant decode of the queued-turn payload
+(``parse_queued_turn``), which crosses the dispatcher->worker queue boundary and
+carries no ``version`` field, so it is a pure tolerant field decode with no
+version gate -- the same reader-context policy as the NDJSON decoders.
 """
 
 import json
@@ -14,6 +23,7 @@ from typing import Any
 from pydantic import TypeAdapter
 
 from .events import (
+    _READER_CONTEXT_KEY,
     ErrorEvent,
     Final,
     InboundMessage,
@@ -22,7 +32,10 @@ from .events import (
     TextDelta,
     ToolNote,
 )
-from .version import PROTOCOL_VERSION
+from .turn import QueuedTurn
+from .version import PROTOCOL_VERSION, is_compatible
+
+_READER_CONTEXT = {_READER_CONTEXT_KEY: True}
 
 OutboundEventModel = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag
 
@@ -31,7 +44,7 @@ _INBOUND_ADAPTER: TypeAdapter[Any] = TypeAdapter(InboundMessage)
 
 
 class ProtocolVersionError(ValueError):
-    """Raised when a decoded event declares an incompatible protocol version."""
+    """Raised when a decoded event declares an incompatible or malformed version."""
 
 
 def to_ndjson_line(event: OutboundEventModel) -> str:
@@ -49,20 +62,22 @@ def dump_ndjson(events: Iterable[OutboundEventModel]) -> str:
 def parse_ndjson_line(line: str) -> OutboundEventModel:
     """Decode one NDJSON line into a validated outbound event.
 
-    Raises ProtocolVersionError if the line omits ``version`` or declares a
-    version other than PROTOCOL_VERSION. Raises pydantic ValidationError for a
-    structurally invalid event.
+    Raises ProtocolVersionError if the line omits ``version``, carries a
+    malformed version, or declares a version incompatible with this build's
+    PROTOCOL_VERSION. Unknown extra fields are tolerated (the reader context
+    loosens the strict-on-construction models). Raises pydantic ValidationError
+    for a structurally invalid event.
     """
 
     raw = json.loads(line)
     if not isinstance(raw, dict):
         raise ProtocolVersionError(f"expected a JSON object per line, got {type(raw).__name__}")
-    version = raw.get("version")
-    if version != PROTOCOL_VERSION:
+    version: Any = raw.get("version")
+    if not is_compatible(version, PROTOCOL_VERSION):
         raise ProtocolVersionError(
             f"unsupported protocol version {version!r}; this build speaks {PROTOCOL_VERSION!r}"
         )
-    return _OUTBOUND_ADAPTER.validate_python(raw)
+    return _OUTBOUND_ADAPTER.validate_python(raw, context=_READER_CONTEXT)
 
 
 def parse_ndjson(text: str) -> list[OutboundEventModel]:
@@ -83,13 +98,27 @@ def parse_inbound(raw: str | dict[str, Any]) -> Any:
     """Decode an inbound channel message (event or interrupt) from JSON."""
 
     data = json.loads(raw) if isinstance(raw, str) else raw
-    return _INBOUND_ADAPTER.validate_python(data)
+    return _INBOUND_ADAPTER.validate_python(data, context=_READER_CONTEXT)
 
 
 def to_inbound_json(message: Any) -> str:
     """Encode an inbound channel message to a JSON string."""
 
     return _INBOUND_ADAPTER.dump_json(message).decode("utf-8")
+
+
+def parse_queued_turn(raw: str | bytes) -> QueuedTurn:
+    """Decode a queued-turn payload tolerantly (the sanctioned consumer decode).
+
+    This is the queue-boundary counterpart to the NDJSON decoders: it threads the
+    same reader context so an unknown field on the turn (or its nested reply
+    handle) is tolerated rather than rejected, matching the tolerant-consumer
+    policy. QueuedTurn carries no ``version`` field, so there is no version gate
+    here -- it is a pure tolerant field decode. Producers stay strict: they
+    construct the model directly, where an unknown field is still an error.
+    """
+
+    return QueuedTurn.model_validate_json(raw, context=_READER_CONTEXT)
 
 
 __all__ = [
@@ -102,4 +131,5 @@ __all__ = [
     "iter_ndjson",
     "parse_inbound",
     "to_inbound_json",
+    "parse_queued_turn",
 ]

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -29,7 +29,7 @@ from .events import (
 )
 from .session import Budget, OtelConfig, SessionConfig
 from .turn import QueuedTurn, ReplyHandle
-from .version import PROTOCOL_VERSION
+from .version import PROTOCOL_VERSION, WIRE_VERSION_FIELD
 
 _NONE = type(None)
 _SCALARS: dict[type, str] = {str: "String", int: "i64", float: "f64", bool: "bool"}
@@ -38,9 +38,6 @@ _SCALARS: dict[type, str] = {str: "String", int: "i64", float: "f64", bool: "boo
 # exists today; an unrecognized literal raises so the generator stays honest.
 _EVENT_TYPE_ARGS = get_args(Event.model_fields["type"].annotation)
 
-# Tagged enums cannot use deny_unknown_fields (serde does not support it with
-# internally tagged enums), so the wire-strictness of extra="forbid" is enforced
-# on the plain structs, which do carry deny_unknown_fields.
 _ENUM_DERIVES = "#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]"
 _STRUCT_DERIVES = "#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]"
 
@@ -73,19 +70,6 @@ _RUST_KEYWORDS = {
 
 def _rust_field(name: str) -> str:
     return f"r#{name}" if name in _RUST_KEYWORDS else name
-
-
-def _is_wire_const(annotation: Any) -> bool:
-    """True for a single-valued string literal (the version const).
-
-    Such fields have a Python default but are mandatory on the wire, so Rust must
-    require them rather than defaulting them, matching the JSON Schema.
-    """
-
-    if get_origin(annotation) is Literal:
-        args = get_args(annotation)
-        return len(args) == 1 and isinstance(args[0], str)
-    return False
 
 
 def crate_dir() -> Path:
@@ -125,8 +109,9 @@ def _rust_bare_type(annotation: Any) -> str:
         if args == _EVENT_TYPE_ARGS:
             return "EventType"
         if len(args) == 1 and isinstance(args[0], str):
-            # A single-valued string literal (the version const) is a plain
-            # String on the Rust side; the NDJSON decoder enforces the value.
+            # A single-valued string literal maps to a plain Rust String. The
+            # version field is no longer a Literal, so this branch is a defensive
+            # fallback for any future single-valued literal field.
             return "String"
         raise TypeError(f"unexpected literal field {annotation!r}")
     if isinstance(annotation, type) and issubclass(annotation, BaseModel):
@@ -157,10 +142,14 @@ def _struct_fields(model: type[BaseModel], skip: set[str], public: bool) -> list
         if field_name in skip:
             continue
         rust = _rust_type(field.annotation)
-        if _is_wire_const(field.annotation):
-            # A wire constant (version) is mandatory and value-checked on decode,
-            # matching the NDJSON decoder's exact-match version policy.
-            out.append('    #[serde(deserialize_with = "require_protocol_version")]')
+        if field_name == WIRE_VERSION_FIELD:
+            # The version field is mandatory and compatibility-checked on decode,
+            # matching the NDJSON decoder. Detected by name (WIRE_VERSION_FIELD),
+            # not by type, so dropping the old Literal does not silently remove
+            # the guard and let #[serde(default)] make version optional.
+            out.append(
+                '    #[serde(deserialize_with = "require_compatible_protocol_version")]'
+            )
         elif not field.is_required():
             # Any other field with a Pydantic default is omittable on the wire,
             # so Rust accepts it missing too.
@@ -170,7 +159,11 @@ def _struct_fields(model: type[BaseModel], skip: set[str], public: bool) -> list
 
 
 def _struct(model: type[BaseModel]) -> str:
-    lines = [_STRUCT_DERIVES, "#[serde(deny_unknown_fields)]", f"pub struct {model.__name__} {{"]
+    # No deny_unknown_fields: the reader path is deliberately tolerant of unknown
+    # fields (strict producers, tolerant consumers). A Rust producer stays strict
+    # by construction -- a struct cannot serialize a field it does not have -- so
+    # dropping it only loosens the read path we mean to loosen.
+    lines = [_STRUCT_DERIVES, f"pub struct {model.__name__} {{"]
     lines.extend(_struct_fields(model, skip=set(), public=True))
     lines.append("}")
     return "\n".join(lines)
@@ -179,7 +172,7 @@ def _struct(model: type[BaseModel]) -> str:
 def _tagged_enum(name: str, tag: str, variants: tuple[type[BaseModel], ...]) -> str:
     lines = [
         _ENUM_DERIVES,
-        f'#[serde(tag = "{tag}", deny_unknown_fields)]',
+        f'#[serde(tag = "{tag}")]',
         f"pub enum {name} {{",
     ]
     for model in variants:
@@ -193,12 +186,42 @@ def _tagged_enum(name: str, tag: str, variants: tuple[type[BaseModel], ...]) -> 
     return "\n".join(lines)
 
 
-_VERSION_GUARD = """fn require_protocol_version<'de, D>(deserializer: D) -> Result<String, D::Error>
+_VERSION_GUARD = """fn parse_semver(value: &str) -> Option<(u64, u64)> {
+    let mut parts = value.split('.');
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let minor = parts.next()?.parse::<u64>().ok()?;
+    let patch = parts.next()?;
+    if patch.is_empty() || !patch.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor))
+}
+
+fn is_compatible_protocol_version(wire: &str) -> bool {
+    let (w_major, w_minor) = match parse_semver(wire) {
+        Some(parsed) => parsed,
+        None => return false,
+    };
+    let (b_major, b_minor) = match parse_semver(PROTOCOL_VERSION) {
+        Some(parsed) => parsed,
+        None => return false,
+    };
+    if b_major == 0 {
+        w_major == 0 && w_minor == b_minor
+    } else {
+        w_major == b_major
+    }
+}
+
+fn require_compatible_protocol_version<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let value = String::deserialize(deserializer)?;
-    if value != PROTOCOL_VERSION {
+    if !is_compatible_protocol_version(&value) {
         return Err(serde::de::Error::custom(format!(
             "unsupported protocol version {value:?}; this build speaks {PROTOCOL_VERSION:?}"
         )));
@@ -253,15 +276,27 @@ mod tests {
     }
 
     #[test]
-    fn rejects_off_version_event() {
+    fn rejects_incompatible_version_event() {
         let raw = r#"{"type":"final","version":"9.9.9","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
     }
 
     #[test]
-    fn rejects_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.1.0","text":"x","status":"done","extra":1}"#;
+    fn rejects_incompatible_minor() {
+        let raw = r#"{"type":"final","version":"0.3.0","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_err());
+    }
+
+    #[test]
+    fn accepts_compatible_patch() {
+        let raw = r#"{"type":"final","version":"0.2.7","text":"x","status":"done"}"#;
+        assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
+    }
+
+    #[test]
+    fn accepts_unknown_fields() {
+        let raw = r#"{"type":"final","version":"0.2.0","text":"x","status":"done","extra":1}"#;
+        assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 }
 """

--- a/packages/aci-protocol/src/aci_protocol/schema_export.py
+++ b/packages/aci-protocol/src/aci_protocol/schema_export.py
@@ -28,7 +28,7 @@ from .events import InboundMessage as InboundMessageUnion
 from .events import OutboundEvent as OutboundEventUnion
 from .session import Budget, OtelConfig, SessionConfig
 from .turn import QueuedTurn, ReplyHandle
-from .version import PROTOCOL_VERSION
+from .version import PROTOCOL_VERSION, WIRE_VERSION_FIELD
 
 
 # RootModel envelopes so the committed schema and generated TypeScript expose the
@@ -69,15 +69,21 @@ def schema_path() -> Path:
     return Path(__file__).resolve().parents[2] / "schema" / "aci-protocol.schema.json"
 
 
-def _require_const_props(defs: dict[str, Any]) -> None:
-    """Make fixed wire tokens required and drop their misleading defaults.
+def _require_wire_mandatory_props(defs: dict[str, Any]) -> None:
+    """Make mandatory wire tokens required and drop their misleading defaults.
 
     The discriminator and version fields carry a Python default for ergonomic
     construction, which pydantic renders as non-required with a default. On the
     wire they are mandatory (the NDJSON decoder rejects a missing version, and
-    the union discriminator selects the variant), so any property with a
-    ``const`` is marked required and its default removed. This keeps the schema
-    and generated TypeScript consistent with the Python decoder for every lane.
+    the union discriminator selects the variant), so they are marked required and
+    their default removed.
+
+    The discriminator fields are detected by their ``const`` (a single-valued
+    Literal). The version field is no longer a Literal -- it is a semver-pattern
+    string -- so it is special-cased **by name** (WIRE_VERSION_FIELD). Keying off
+    the name rather than a ``const`` is deliberate: it is what keeps ``version``
+    required-with-a-pattern once the Literal is gone, instead of silently
+    becoming optional-with-a-default and lying to every consumer.
     """
 
     for schema in defs.values():
@@ -86,7 +92,9 @@ def _require_const_props(defs: dict[str, Any]) -> None:
             continue
         required = set(schema.get("required", []))
         for name, prop in props.items():
-            if isinstance(prop, dict) and "const" in prop:
+            if not isinstance(prop, dict):
+                continue
+            if "const" in prop or name == WIRE_VERSION_FIELD:
                 required.add(name)
                 prop.pop("default", None)
         if required:
@@ -101,7 +109,7 @@ def build_schema() -> dict[str, Any]:
         ref_template="#/$defs/{model}",
     )
     if isinstance(top.get("$defs"), dict):
-        _require_const_props(top["$defs"])
+        _require_wire_mandatory_props(top["$defs"])
     doc: dict[str, Any] = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$id": SCHEMA_ID,

--- a/packages/aci-protocol/src/aci_protocol/session.py
+++ b/packages/aci-protocol/src/aci_protocol/session.py
@@ -17,26 +17,24 @@ Env mapping:
 
 from collections.abc import Mapping
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import Field
 
-_STRICT = ConfigDict(extra="forbid")
+from .events import _AciModel
 
 
-class Budget(BaseModel):
+class Budget(_AciModel):
     """Per-agent budget spec, carried as JSON in AGENTOS_BUDGET.
 
     ``task_budget_hint`` is the optional hint passed through to the model so it
     self paces (section 6b); it is not a hard ceiling.
     """
 
-    model_config = _STRICT
-
     max_output_tokens_per_run: int
     task_budget_hint: int | None = None
     max_usd_per_day: float
 
 
-class OtelConfig(BaseModel):
+class OtelConfig(_AciModel):
     """The OTEL_EXPORTER_OTLP_* subset the runner needs to export traces.
 
     Section 0 lists OTEL_EXPORTER_OTLP_* as a wildcard. We capture the standard
@@ -44,22 +42,18 @@ class OtelConfig(BaseModel):
     through as raw env vars untouched and are out of scope for this typed view.
     """
 
-    model_config = _STRICT
-
     endpoint: str | None = None
     headers: str | None = None
     protocol: str | None = None
 
 
-class SessionConfig(BaseModel):
+class SessionConfig(_AciModel):
     """The typed session setup contract.
 
     ``credentials_ref`` is a reference to injected secrets (AGENTOS_CREDENTIALS);
     section 0 describes these as per-tool secrets via K8s Secret refs, so the
     contract carries the reference, not the secret material itself.
     """
-
-    model_config = _STRICT
 
     plugin_dir: str
     session_id: str

--- a/packages/aci-protocol/src/aci_protocol/turn.py
+++ b/packages/aci-protocol/src/aci_protocol/turn.py
@@ -25,12 +25,10 @@ single ``payload`` field holding this model's JSON) is a transport detail and
 stays outside this package, in the dispatcher's queue module.
 """
 
-from pydantic import BaseModel, ConfigDict
-
-_STRICT = ConfigDict(extra="forbid")
+from .events import _AciModel
 
 
-class ReplyHandle(BaseModel):
+class ReplyHandle(_AciModel):
     """Channel-neutral coordinates for where a turn's reply is delivered.
 
     The reply model is edit-in-place: the ingress adapter pre-posts a placeholder
@@ -48,14 +46,12 @@ class ReplyHandle(BaseModel):
     it keeps the pre-#19 behavior.
     """
 
-    model_config = _STRICT
-
     channel: str
     placeholder: str
     endpoint: str | None = None
 
 
-class QueuedTurn(BaseModel):
+class QueuedTurn(_AciModel):
     """A normalized inbound turn ready for the worker to route and run.
 
     The channel-neutral promotion of the dispatcher's former ``QueuedSlackEvent``.
@@ -63,8 +59,6 @@ class QueuedTurn(BaseModel):
     stream-encoding helpers live with the producer (the dispatcher), not on this
     frozen model, so the contract stays transport-agnostic.
     """
-
-    model_config = _STRICT
 
     event_id: str
     conversation_id: str

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -1,18 +1,63 @@
-"""The ACI protocol version constant.
+"""The ACI protocol version and its semver compatibility policy.
 
 This is the single source of truth for the wire version embedded in every
-outbound event and in the exported JSON Schema. The frozen interface rule
-(see the package README) requires bumping this whenever any model changes,
-and regenerating the committed schemas and generated types in the same commit.
+outbound event and in the exported JSON Schema. The ACI is versioned as semver,
+independent of the AgentOS release: the number tracks the wire contract's
+compatibility, not the product's cadence.
 
-``ProtocolVersionLiteral`` types the ``version`` field on outbound events so the
-exact value is enforced by the models, the JSON Schema (a ``const``), and the
-generated TypeScript, not just by the NDJSON decoder. Keep the two in lockstep;
-``tests/test_events.py`` asserts the literal equals PROTOCOL_VERSION.
+The compatibility rule a consumer applies is same ``major.minor`` under 0.x
+(same ``major`` from 1.0 on). A new optional field is a patch (tolerant
+consumers ignore it); every breaking change (new required field, new enum value,
+removal, rename, type change) bumps the minor under 0.x. See ``packages/CLAUDE.md``
+for the change-class table and ``docs/adr/0036-*`` for the rationale.
+
+``WIRE_VERSION_FIELD`` names the wire field carrying the version. The exporters
+special-case it by name (required, semver-constrained, version-guarded) rather
+than introspecting a type, so removing the old ``Literal`` does not silently gut
+the guard.
 """
 
-from typing import Final, Literal
+import re
+from typing import Final
 
-PROTOCOL_VERSION: Final = "0.1.0"
+PROTOCOL_VERSION: Final = "0.2.0"
 
-ProtocolVersionLiteral = Literal["0.1.0"]
+# The wire field carrying the protocol version on every outbound event. Both
+# exporters special-case this field by name; do not rename without updating them.
+WIRE_VERSION_FIELD: Final = "version"
+
+# A strict three-component numeric semver (major.minor.patch). Prerelease and
+# build metadata are deliberately not accepted: the 0.x line does not ship them,
+# and a malformed version is rejected rather than ordered. Each component is
+# ASCII with no leading zeros; ``[0-9]`` (not ``\d``) so the pattern means the
+# same thing in Python and in the ECMA-262 ``pattern`` emitted into the JSON
+# Schema, where the Rust lane parses ASCII-only. The ``^...$`` anchors stay
+# because JSON Schema/ECMA does not support ``\A\Z``; the trailing-newline slack
+# they leave in Python is closed by matching with ``fullmatch`` below.
+SEMVER_PATTERN: Final = r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$"
+
+_SEMVER_RE = re.compile(SEMVER_PATTERN)
+
+
+def is_compatible(wire: str, build: str) -> bool:
+    """Return whether a consumer speaking ``build`` accepts a ``wire`` version.
+
+    Compatibility is same ``major.minor`` under 0.x, same ``major`` from 1.0 on.
+    Returns ``False`` (never raises) for any malformed input -- ``None``, ``""``,
+    a non-semver string, a two-component ``"0.2"``, a prerelease/build string, a
+    leading-zero component (``"0.02.0"``), a Unicode-digit string, or a trailing
+    newline (``"0.2.0\n"``) -- so the NDJSON decoder can turn a bad version into
+    ``ProtocolVersionError`` instead of a stray ``ValueError``/``IndexError``
+    escaping its contract. ``fullmatch`` (not ``match``) is what rejects the
+    trailing newline the ``$`` anchor would otherwise tolerate in Python.
+    """
+
+    if not isinstance(wire, str) or not isinstance(build, str):
+        return False
+    if not _SEMVER_RE.fullmatch(wire) or not _SEMVER_RE.fullmatch(build):
+        return False
+    w_major, w_minor, _ = (int(part) for part in wire.split("."))
+    b_major, b_minor, _ = (int(part) for part in build.split("."))
+    if b_major == 0:
+        return w_major == 0 and w_minor == b_minor
+    return w_major == b_major

--- a/packages/aci-protocol/src/aci_protocol/wire_lock.py
+++ b/packages/aci-protocol/src/aci_protocol/wire_lock.py
@@ -1,0 +1,207 @@
+"""The wire-lock gate: a version gate that actually gates.
+
+The committed compat test pins artifact *sync* -- it fails if the models drift
+from the generated files. It cannot tell "the wire changed" from "someone bumped
+the version", because both move the generated schema together. This module adds
+the missing half: a fingerprint of the wire shape that is *invariant* under a
+version bump, and a gate that fails a wire change which was not accompanied by a
+bump -- with a message saying which to do.
+
+The fingerprint is built from the *shipped* wire shape, not the raw pydantic
+output: the same ``schema_export._require_wire_mandatory_props`` postprocess that
+the exported schema goes through is applied first, so an exporter-only change
+(e.g. that helper no longer marking ``version`` required) moves the hash too.
+The version *values* are then normalized out (decision 4 of the plan) -- the
+``protocolVersion`` key that embeds ``PROTOCOL_VERSION`` and any
+``const``/``default`` on the version field are placeholdered -- and every
+``title``/``description`` key is stripped, because documentation is not
+wire-compatibility surface (a doc-only edit must not force a version bump). Field
+names, types, ``required``, enums, and structure remain, so the fingerprint still
+moves when a field is added or the version field is retyped -- only a pure
+version-number bump or a pure doc edit leaves it unchanged.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic.json_schema import models_json_schema
+
+from . import schema_export
+from .version import PROTOCOL_VERSION, WIRE_VERSION_FIELD
+
+_VERSION_PLACEHOLDER = "<version>"
+
+_LOCK_NAME = "wire.lock"
+
+
+class WireLockError(Exception):
+    """Raised when the wire changed but PROTOCOL_VERSION was not bumped."""
+
+
+def _placeholder_version_values(node: Any) -> None:
+    """Replace version const/default *values* in place, leaving shape intact.
+
+    Normalizes only the version-number values so a pure version bump does not
+    move the fingerprint. The version field's presence, type, and pattern are
+    deliberately untouched -- retyping the field must still change the hash.
+    """
+
+    if isinstance(node, dict):
+        props = node.get("properties")
+        if isinstance(props, dict):
+            version_prop = props.get(WIRE_VERSION_FIELD)
+            if isinstance(version_prop, dict):
+                for key in ("const", "default"):
+                    if key in version_prop:
+                        version_prop[key] = _VERSION_PLACEHOLDER
+        for value in node.values():
+            _placeholder_version_values(value)
+    elif isinstance(node, list):
+        for item in node:
+            _placeholder_version_values(item)
+
+
+def _strip_doc_keys(node: Any) -> None:
+    """Remove every ``title``/``description`` key in place.
+
+    Documentation is not wire-compatibility surface: a class docstring or a new
+    ``Field(description=...)`` renders into the schema as ``title``/``description``
+    text but changes nothing a consumer decodes off the wire. Stripping them keeps
+    a doc-only edit from moving the fingerprint (the change-class table's
+    "Doc/description only -> none"), while field names, types, ``required``,
+    enums, and structure -- the real wire surface -- remain and still move it.
+    """
+
+    if isinstance(node, dict):
+        node.pop("title", None)
+        node.pop("description", None)
+        for value in node.values():
+            _strip_doc_keys(value)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_doc_keys(item)
+
+
+def wire_fingerprint(models: tuple[type[BaseModel], ...] | None = None) -> str:
+    """Fingerprint the shipped wire shape of ``models`` (defaults to the set).
+
+    The same ``_require_wire_mandatory_props`` postprocess the exported schema
+    goes through is applied first (so an exporter-only change to the shipped wire
+    moves the hash), version values are normalized out (invariant under a version
+    bump), and ``title``/``description`` are stripped (invariant under a doc-only
+    edit). The hash still changes when a field is added, removed, retyped, or
+    renamed.
+    """
+
+    if models is None:
+        models = schema_export._MODELS
+    _, top = models_json_schema(
+        [(model, "validation") for model in models],
+        ref_template="#/$defs/{model}",
+    )
+    # ``top`` is a fresh models_json_schema result owned by this call, so it is
+    # normalized in place rather than copied.
+    normalized = top
+    if isinstance(normalized.get("$defs"), dict):
+        schema_export._require_wire_mandatory_props(normalized["$defs"])
+    normalized.pop("protocolVersion", None)
+    _strip_doc_keys(normalized)
+    _placeholder_version_values(normalized)
+    canonical = json.dumps(normalized, indent=2, sort_keys=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def check_wire_lock(
+    *, fingerprint: str, version: str, lock: dict[str, str]
+) -> None:
+    """Fail an unbumped wire change; pass a version-only bump or an unchanged wire.
+
+    Truth table (plan decision 4):
+    - fingerprint == lock hash -> pass (a gratuitous version-only bump is legal).
+    - fingerprint != lock hash and version == lock version -> fail (the escape
+      hatch): the wire moved without a bump.
+    - fingerprint != lock hash and version != lock version -> pass; the caller
+      must regenerate and commit the lock.
+    """
+
+    if fingerprint == lock["wire_sha256"]:
+        return
+    if version != lock["protocol_version"]:
+        return
+    raise WireLockError(
+        "The ACI wire changed but PROTOCOL_VERSION was not bumped "
+        f"(still {version!r}). Bump PROTOCOL_VERSION to the class the change "
+        "earns per the semver table in packages/CLAUDE.md, then regenerate the "
+        "lock with scripts/check-contracts.sh and commit it."
+    )
+
+
+def check_against_base(base_lock: dict[str, str] | None) -> None:
+    """Fail an unbumped wire change measured against the base branch's lock.
+
+    ``test_committed_lock_matches_the_current_wire`` only proves the lock matches
+    the *current* wire -- it passes even if an author regenerated or hand-forged
+    the lock without bumping. This compares the current wire against the BASE
+    (origin/main) lock instead, so a wire change at the same version as base
+    raises :class:`WireLockError`. A ``None`` base lock (the base predates the
+    lock, true for this PR and all pre-lock history) is not a failure and returns
+    quietly.
+    """
+
+    if base_lock is None:
+        return
+    check_wire_lock(
+        fingerprint=wire_fingerprint(), version=PROTOCOL_VERSION, lock=base_lock
+    )
+
+
+def _lock_path() -> Path:
+    return schema_export.schema_path().parent / _LOCK_NAME
+
+
+def write_lock(models: tuple[type[BaseModel], ...] | None = None) -> Path:
+    """Rewrite the committed wire.lock, refusing an unbumped wire change.
+
+    Enforces the same rule as :func:`check_wire_lock` before touching disk, so an
+    author cannot silently rewrite the lock without a bump. The refusal fires
+    *before* the file is written, keeping the tree clean.
+    """
+
+    fingerprint = wire_fingerprint(models)
+    version = PROTOCOL_VERSION
+    path = _lock_path()
+    if path.exists():
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        check_wire_lock(fingerprint=fingerprint, version=version, lock=existing)
+    payload = {"protocol_version": version, "wire_sha256": fingerprint}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) >= 3 and sys.argv[1] == "--check-base":
+        # CI base gate: compare the current wire against the base branch's lock.
+        # A missing or empty base lock (no lock on base yet) is treated as None
+        # and skips cleanly -- only a genuine unbumped wire change vs an existing
+        # base lock exits non-zero.
+        base_path = Path(sys.argv[2])
+        base_lock: dict[str, str] | None = None
+        if base_path.exists():
+            raw = base_path.read_text(encoding="utf-8").strip()
+            if raw:
+                base_lock = json.loads(raw)
+        try:
+            check_against_base(base_lock)
+        except WireLockError as exc:
+            print(str(exc), file=sys.stderr)
+            sys.exit(1)
+        print("wire-lock base gate: ok")
+    else:
+        written = write_lock()
+        print(f"wrote {written}")

--- a/packages/aci-protocol/tests/test_conformance.py
+++ b/packages/aci-protocol/tests/test_conformance.py
@@ -23,7 +23,7 @@ def test_library_checks_run_without_a_producer() -> None:
 
 def test_a_broken_producer_fails_the_stream_check() -> None:
     def broken(_message: Event | Interrupt) -> Iterable[str]:
-        return ['{"type": "text_delta", "version": "0.1.0", "text": "no final"}\n']
+        return ['{"type": "text_delta", "version": "0.2.0", "text": "no final"}\n']
 
     report = run_conformance(broken)
     assert not report.passed

--- a/packages/aci-protocol/tests/test_events.py
+++ b/packages/aci-protocol/tests/test_events.py
@@ -33,16 +33,20 @@ def test_final_defaults_to_done_status() -> None:
     assert Final(text="ok").status is SessionStatus.DONE
 
 
-def test_outbound_version_field_rejects_wrong_value() -> None:
-    # The version literal is enforced at the model level, not only by the NDJSON
-    # decoder, so a producer cannot construct an off-version event.
+def test_unknown_session_status_is_rejected() -> None:
+    # Decision 3: an unknown SessionStatus is a hard decode error, never
+    # degraded to a fallback. Status is control-bearing (awaiting-approval drives
+    # suspend-and-wait); silently defaulting a future value to "done" would
+    # finalize a turn that is actually pending a human decision.
     with pytest.raises(ValidationError):
-        Final(text="ok", version="9.9.9")  # type: ignore[arg-type]
-
-
-def test_protocol_version_literal_matches_constant() -> None:
-    # Guards the one duplicated literal in version.py against PROTOCOL_VERSION.
-    assert Final(text="ok").version == PROTOCOL_VERSION
+        _OUTBOUND.validate_python(
+            {
+                "type": "final",
+                "version": PROTOCOL_VERSION,
+                "text": "x",
+                "status": "invented-future-status",
+            }
+        )
 
 
 def test_outbound_union_discriminates_on_type() -> None:

--- a/packages/aci-protocol/tests/test_exporters.py
+++ b/packages/aci-protocol/tests/test_exporters.py
@@ -1,0 +1,34 @@
+"""Exporter regressions: the version guard must survive the Literal removal.
+
+Decision 5 -- the highest-risk silent failure in this change. Both exporters
+detect the version field by introspecting the single-valued Literal. Once
+``version`` becomes a plain ``str``, that introspection stops matching and the
+guard vanishes green: the schema quietly makes ``version`` optional, and the Rust
+reader quietly stops checking it. These tests assert the rendered artifacts, not
+the private helpers, because the rendered artifact is the real contract.
+"""
+
+from aci_protocol.rust_export import render_rust
+from aci_protocol.schema_export import build_schema
+
+
+def test_version_field_is_required_in_the_exported_schema() -> None:
+    final = build_schema()["$defs"]["Final"]
+    assert "version" in final["required"]
+    # It is no longer a const; it is a semver-pattern string. A const value would
+    # re-pin the exact version and defeat the whole compatibility range.
+    assert "const" not in final["properties"]["version"]
+
+
+def test_generated_rust_guards_the_version() -> None:
+    rust = render_rust()
+    lines = rust.splitlines()
+    version_fields = [i for i, line in enumerate(lines) if line.strip() == "version: String,"]
+    assert version_fields, "no version field found in the generated Rust"
+    for i in version_fields:
+        preceding = lines[i - 1].strip()
+        # The compatibility deserializer must decorate every version field, and
+        # #[serde(default)] must NOT -- a defaulted version is the silent gutting.
+        assert preceding == '#[serde(deserialize_with = "require_compatible_protocol_version")]', (
+            f"version field is not guarded; preceding line was {preceding!r}"
+        )

--- a/packages/aci-protocol/tests/test_ndjson.py
+++ b/packages/aci-protocol/tests/test_ndjson.py
@@ -18,6 +18,7 @@ from aci_protocol import (
     to_inbound_json,
     to_ndjson_line,
 )
+from pydantic import ValidationError
 
 
 def test_ndjson_line_has_trailing_newline() -> None:
@@ -66,3 +67,109 @@ def test_inbound_roundtrip() -> None:
         Interrupt(reason="stop"),
     ):
         assert parse_inbound(to_inbound_json(message)) == message
+
+
+# --- Reader policy: tolerant consumers, strict producers ----------------------
+
+
+def test_unknown_field_is_ignored_on_read() -> None:
+    # AC: consumers accept and ignore unknown fields they do not model. The
+    # decoder threads a reader context that loosens the strict model on read.
+    line = json.dumps(
+        {
+            "type": "final",
+            "version": PROTOCOL_VERSION,
+            "text": "x",
+            "status": "done",
+            "future_field": 1,
+        }
+    )
+    assert parse_ndjson_line(line) == Final(text="x")
+
+
+def test_unknown_field_is_rejected_on_construction() -> None:
+    # AC: producers reject unknown fields on construction. This is the guard that
+    # stops a lazy extra="ignore" from silently satisfying the reader-side test.
+    with pytest.raises(ValidationError):
+        Final(text="x", future_field=1)  # type: ignore[call-arg]
+
+
+def test_unknown_field_is_ignored_on_inbound_read() -> None:
+    # Edge 7: the reader context must reach parse_inbound as well as
+    # parse_ndjson_line, or the runner's inbound decode stays strict cross-process.
+    raw = json.dumps(
+        {
+            "kind": "event",
+            "type": "message",
+            "text": "hi",
+            "user": "U1",
+            "ts": "1.0",
+            "future_field": 1,
+        }
+    )
+    msg = parse_inbound(raw)
+    assert isinstance(msg, Event)
+    assert msg.text == "hi"
+
+
+# --- Version compatibility (semver, major.minor under 0.x) --------------------
+
+
+def test_compatible_patch_version_is_accepted() -> None:
+    # AC: a same-major-minor patch difference is not an error. Build speaks
+    # 0.2.0; a 0.2.7 line decodes fine.
+    line = json.dumps(
+        {"type": "final", "version": "0.2.7", "text": "x", "status": "done"}
+    )
+    decoded = parse_ndjson_line(line)
+    assert isinstance(decoded, Final)
+    assert decoded.text == "x"
+
+
+def test_incompatible_minor_is_rejected_naming_both_versions() -> None:
+    # AC: rejects an incompatible version with a message naming both versions.
+    # The assertion is on the message content, not just the exception type.
+    line = json.dumps(
+        {"type": "final", "version": "0.3.0", "text": "x", "status": "done"}
+    )
+    with pytest.raises(ProtocolVersionError) as excinfo:
+        parse_ndjson_line(line)
+    message = str(excinfo.value)
+    assert "0.3.0" in message
+    assert PROTOCOL_VERSION in message
+
+
+def test_incompatible_major_is_rejected() -> None:
+    line = json.dumps(
+        {"type": "final", "version": "1.0.0", "text": "x", "status": "done"}
+    )
+    with pytest.raises(ProtocolVersionError):
+        parse_ndjson_line(line)
+
+
+@pytest.mark.parametrize(
+    "bad_version",
+    [
+        "abc",
+        "",
+        "0.2",
+        "0.2.0-rc.1",
+        "0.2.0+build",
+        # ASCII semver refinements (change 3): no leading zeros, no trailing
+        # newline (the ``$`` anchor tolerates it in Python, ``fullmatch`` rejects
+        # it), and no Unicode digits (``[0-9]`` not ``\d``). The generated Rust
+        # parses ASCII-only, so accepting any of these would split the lanes.
+        "0.02.0",
+        "0.2.0\n",
+        "０.２.０",  # fullwidth digits for 0.2.0
+    ],
+)
+def test_malformed_version_is_rejected_via_the_decoder_contract(bad_version: str) -> None:
+    # Edge 5: a malformed version must reject through the decoder's own error
+    # contract (ProtocolVersionError), never escape as an IndexError/ValueError
+    # out of a bare .split(".").
+    line = json.dumps(
+        {"type": "final", "version": bad_version, "text": "x", "status": "done"}
+    )
+    with pytest.raises(ProtocolVersionError):
+        parse_ndjson_line(line)

--- a/packages/aci-protocol/tests/test_schema_compat.py
+++ b/packages/aci-protocol/tests/test_schema_compat.py
@@ -1,9 +1,12 @@
-"""The compat gate: committed schema and generated Rust must match the models.
+"""The artifact-sync gate: committed schema and generated Rust match the models.
 
-If a model changes without regenerating the committed artifacts, these tests
-fail, which is the drift detection the frozen contract relies on. Regenerate
-with ``scripts/check-contracts.sh`` (or the two module entry points) and commit
-the result, bumping PROTOCOL_VERSION per the frozen-interface rule.
+These tests check *artifact sync* only: if a model changes without regenerating
+the committed schema or Rust, they fail. Regenerate with
+``scripts/check-contracts.sh`` (or the two module entry points) and commit the
+result. They do not, and cannot, judge backward compatibility -- a model change
+regenerates both sides and stays green. Compatibility is a policy defined by the
+semver change-class table (packages/CLAUDE.md); an *unbumped* wire change is
+caught separately by the wire-lock gate in ``tests/test_wire_lock.py``.
 
 The generated TypeScript compiles under tsc in CI (it needs a Node toolchain, so
 it is not regenerated here); its input is the same committed schema this gate

--- a/packages/aci-protocol/tests/test_turn.py
+++ b/packages/aci-protocol/tests/test_turn.py
@@ -1,0 +1,73 @@
+"""Reader-context propagation into nested models on the queued-turn payload.
+
+``QueuedTurn`` crosses the Valkey Stream boundary between the dispatcher and the
+worker, carrying a nested ``ReplyHandle``. The tolerant-read policy must reach
+that nested model, not just the top-level one -- pydantic propagates validation
+context into nested models, but decision 1 says assert it, do not assume it.
+"""
+
+import json
+
+import pytest
+from aci_protocol import QueuedTurn, ReplyHandle, parse_queued_turn
+from aci_protocol.events import _READER_CONTEXT_KEY
+from pydantic import ValidationError
+
+
+def _turn_payload_with_unknown_fields() -> dict[str, object]:
+    return {
+        "event_id": "e1",
+        "conversation_id": "c1",
+        "author": "u1",
+        "text": "hi",
+        "received_at": "2026-01-01T00:00:00Z",
+        "future_top": 1,
+        "reply_handle": {
+            "channel": "C1",
+            "placeholder": "1.0",
+            "future_nested": 2,
+        },
+    }
+
+
+def test_reader_context_reaches_nested_reply_handle() -> None:
+    # With the reader context, an unknown field on the TOP-LEVEL turn and an
+    # unknown field on the NESTED reply handle are both ignored -- proving the
+    # context propagated into ReplyHandle.
+    turn = QueuedTurn.model_validate(
+        _turn_payload_with_unknown_fields(),
+        context={_READER_CONTEXT_KEY: True},
+    )
+    assert turn.event_id == "e1"
+    assert turn.reply_handle.channel == "C1"
+
+
+def test_nested_reply_handle_is_strict_without_reader_context() -> None:
+    # Producers stay strict: without the reader context, the unknown nested field
+    # is rejected on construction/validation.
+    with pytest.raises(ValidationError):
+        QueuedTurn.model_validate(_turn_payload_with_unknown_fields())
+
+
+def test_parse_queued_turn_tolerates_unknown_top_level_and_nested_fields() -> None:
+    # The sanctioned consumer decode threads the reader context, so an unknown
+    # field on the TOP-LEVEL turn and an unknown field on the NESTED reply handle
+    # are both tolerated (the queue-boundary counterpart to the NDJSON decoders).
+    turn = parse_queued_turn(json.dumps(_turn_payload_with_unknown_fields()))
+    assert turn.event_id == "e1"
+    assert turn.reply_handle.channel == "C1"
+
+
+def test_constructing_queued_turn_with_unknown_field_is_strict() -> None:
+    # Tolerance is read-only: producers construct the model directly, where an
+    # unknown field is still rejected.
+    with pytest.raises(ValidationError):
+        QueuedTurn(
+            event_id="e1",
+            conversation_id="c1",
+            author="u1",
+            text="hi",
+            reply_handle=ReplyHandle(channel="C1", placeholder="1.0"),
+            received_at="2026-01-01T00:00:00Z",
+            bogus=1,
+        )

--- a/packages/aci-protocol/tests/test_wire_lock.py
+++ b/packages/aci-protocol/tests/test_wire_lock.py
@@ -1,0 +1,138 @@
+"""The wire-lock gate: a version gate that actually gates.
+
+The gate must distinguish "the wire changed" from "someone bumped the version".
+Its fingerprint therefore normalizes the version out of the schema, and it fails
+a wire change that is not accompanied by a version bump -- with a message saying
+which to do. Every model mutation here is done IN MEMORY (a mutated ``_MODELS``
+tuple via ``pydantic.create_model``); no file is touched, so the repo stays clean.
+"""
+
+import json
+
+import pytest
+from aci_protocol import PROTOCOL_VERSION, schema_export
+from aci_protocol.schema_export import _MODELS
+from aci_protocol.session import SessionConfig
+from aci_protocol.wire_lock import (
+    WireLockError,
+    check_against_base,
+    check_wire_lock,
+    wire_fingerprint,
+    write_lock,
+)
+from pydantic import Field, create_model
+
+# A model set that differs from the shipped one by exactly one added model, so a
+# correct fingerprint changes while the version does not.
+_MUTATED_MODELS = _MODELS + (create_model("Injected", x=(str, ...)),)
+
+# A model set identical on the wire to the shipped one but carrying a different
+# docstring and a new field ``description`` -- a doc-only edit. ``create_model``
+# (not a subclass) keeps the ``$defs`` key "SessionConfig" so the sole schema
+# delta is documentation. SessionConfig is a pure root (no other model in the set
+# $refs it), so replacing it introduces no name collision.
+_DOC_ONLY_MODELS = tuple(
+    create_model(
+        "SessionConfig",
+        __base__=SessionConfig,
+        __doc__="A deliberately different docstring: documentation only.",
+        plugin_dir=(str, Field(description="where the plugin bundle is mounted")),
+    )
+    if model is SessionConfig
+    else model
+    for model in _MODELS
+)
+
+
+def test_gate_fires_when_wire_changes_without_a_bump() -> None:
+    # AC: CI fails a wire change that does not bump the version, with a message
+    # saying which to do.
+    h_real = wire_fingerprint()
+    h_mutated = wire_fingerprint(_MUTATED_MODELS)
+    assert h_mutated != h_real  # precondition: the mutation is observable
+    lock = {"protocol_version": "0.2.0", "wire_sha256": h_real}
+    with pytest.raises(WireLockError) as excinfo:
+        check_wire_lock(fingerprint=h_mutated, version="0.2.0", lock=lock)
+    message = str(excinfo.value)
+    assert "bump" in message.lower()
+    assert "version" in message.lower()
+
+
+def test_gate_passes_when_wire_changes_with_a_bump() -> None:
+    h_real = wire_fingerprint()
+    h_mutated = wire_fingerprint(_MUTATED_MODELS)
+    lock = {"protocol_version": "0.2.0", "wire_sha256": h_real}
+    # A bumped version legitimizes the wire change; no raise.
+    check_wire_lock(fingerprint=h_mutated, version="0.3.0", lock=lock)
+
+
+def test_gate_passes_on_a_version_only_bump() -> None:
+    # AC: CI still passes when only the version is bumped (wire unchanged).
+    h_real = wire_fingerprint()
+    lock = {"protocol_version": "0.2.0", "wire_sha256": h_real}
+    check_wire_lock(fingerprint=h_real, version="0.2.1", lock=lock)
+
+
+def test_fingerprint_is_invariant_under_a_version_bump(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Decision 4's whole point: the fingerprint normalizes the version out, so a
+    # version-only bump does not move the hash. Without this the gate is a
+    # tautology and nobody would notice.
+    baseline = wire_fingerprint()
+    monkeypatch.setattr(schema_export, "PROTOCOL_VERSION", "0.9.9")
+    monkeypatch.setattr("aci_protocol.version.PROTOCOL_VERSION", "0.9.9")
+    assert wire_fingerprint() == baseline
+
+
+def test_fingerprint_changes_when_a_field_is_added() -> None:
+    # The inverse guard: a fingerprint that normalizes too aggressively would be
+    # blind to a real wire change. Also kills wire_fingerprint -> return "".
+    assert wire_fingerprint(_MUTATED_MODELS) != wire_fingerprint()
+
+
+def test_fingerprint_is_invariant_under_a_doc_only_change() -> None:
+    # Change 2b: documentation is not wire-compatibility surface. A new docstring
+    # or Field(description=...) renders into the schema as title/description keys
+    # but changes nothing a consumer decodes, so it must not move the hash (the
+    # change-class table's "Doc/description only -> none"). Without the recursive
+    # title/description strip this would force a spurious version bump.
+    assert wire_fingerprint(_DOC_ONLY_MODELS) == wire_fingerprint()
+
+
+def test_check_against_base_skips_a_missing_base_lock() -> None:
+    # The base predates the lock (this PR and all pre-lock history): a None base
+    # lock is not a failure, it returns quietly.
+    check_against_base(None)
+
+
+def test_check_against_base_fails_a_wire_move_at_the_same_base_version() -> None:
+    # The gate the committed-lock test cannot express: the current wire differs
+    # from the base lock's hash at the SAME version, i.e. a wire change was landed
+    # without a bump relative to base.
+    stale = {"protocol_version": PROTOCOL_VERSION, "wire_sha256": "0" * 64}
+    with pytest.raises(WireLockError):
+        check_against_base(stale)
+
+
+def test_check_against_base_passes_when_base_matches_current_wire() -> None:
+    # An unchanged wire against a base lock that already records it: no raise.
+    base = {"protocol_version": PROTOCOL_VERSION, "wire_sha256": wire_fingerprint()}
+    check_against_base(base)
+
+
+def test_write_lock_refuses_an_unbumped_wire_change() -> None:
+    # Closes the escape hatch (decision 4): the regenerator enforces the same
+    # rule as the gate, so an author cannot silently rewrite the lock without a
+    # bump. Driven with a mutated model set so nothing is written to disk.
+    with pytest.raises(WireLockError):
+        write_lock(_MUTATED_MODELS)
+
+
+def test_committed_lock_matches_the_current_wire() -> None:
+    # The live CI assertion, wiring the real fingerprint against the committed
+    # wire.lock.
+    lock_path = schema_export.schema_path().parent / "wire.lock"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert lock["protocol_version"] == PROTOCOL_VERSION
+    assert lock["wire_sha256"] == wire_fingerprint()

--- a/scripts/check-contracts.sh
+++ b/scripts/check-contracts.sh
@@ -10,6 +10,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 aci_schema="packages/aci-protocol/schema/aci-protocol.schema.json"
+aci_wire_lock="packages/aci-protocol/schema/wire.lock"
 channel_schema="packages/channel-protocol/schema/channel-protocol.schema.json"
 plugin_schema="packages/plugin-format/schema/plugin-format.schema.json"
 eval_schema="apps/worker/schema/eval-cases.schema.json"
@@ -25,9 +26,12 @@ uv run python -m agentos_worker.eval.schema_export
 echo "== regenerating Rust types =="
 uv run python -m aci_protocol.rust_export
 
+echo "== regenerating the ACI wire lock =="
+uv run python -m aci_protocol.wire_lock
+
 echo "== regenerating TypeScript types =="
 npx --yes json-schema-to-typescript@15 "$aci_schema" \
-  --unreachableDefinitions --no-additionalProperties=false -o "$ts_out"
+  --unreachableDefinitions -o "$ts_out"
 
 echo "== compiling generated Rust =="
 cargo check --manifest-path "$rust_crate/Cargo.toml"
@@ -37,7 +41,7 @@ npx --yes -p typescript@5 tsc --noEmit -p packages/aci-protocol/generated/ts/tsc
 
 echo "== checking for drift =="
 if ! git diff --exit-code -- \
-  "$aci_schema" "$channel_schema" "$plugin_schema" "$eval_schema" "$ts_out" "$rust_crate/src/lib.rs"; then
+  "$aci_schema" "$aci_wire_lock" "$channel_schema" "$plugin_schema" "$eval_schema" "$ts_out" "$rust_crate/src/lib.rs"; then
   echo "ERROR: committed contract artifacts drifted from the models." >&2
   echo "The files above were regenerated and differ. Review, then commit them." >&2
   exit 1


### PR DESCRIPTION
Adopts semver for the ACI wire contract and makes the version gate actually enforce compatibility, closing the gap where four wire-visible changes shipped under `0.1.0` with nothing watching.

## What changed

- **Reader policy asymmetry.** Producers stay strict on construction (an unknown field is an error at the source); consumers ignore fields they do not model. One `_AciModel` base with a reader-context before-validator, so tolerance propagates into nested models and a new optional field is genuinely backward compatible.
- **Compatibility-aware version gate.** The `version` field is a semver-pattern string rather than a `Literal` const. The decoder accepts a same-`major.minor` wire under 0.x (a patch difference is not an error) and rejects an incompatible version naming both versions. Unknown `SessionStatus` values reject rather than degrade, since the enum is control-bearing.
- **The exporters can't silently gut the guard.** They mark the version field by name, so the schema keeps it required and the generated Rust keeps its compatibility deserializer once the `Literal` is gone.
- **A wire-lock that makes the bump impossible to skip.** `schema/wire.lock` fingerprints the version-normalized, doc-stripped wire. The regenerator refuses an unbumped wire change, and CI compares against the base lock so a wire change without a bump fails with an actionable message. `PROTOCOL_VERSION` is now `0.2.0` with every derivative regenerated.
- **Tolerant reads reach the boundary that matters.** The dispatcher to worker Valkey queue consumer decodes `QueuedTurn` tolerantly, so an old worker survives a newer producer's optional fields across published-image skew.
- **Docs.** ADR-0036 records the policy and amends ADR-0005's frozen posture; the false `AGENTS.md` compat-gate claim is corrected; `packages/CLAUDE.md` carries the change-class table; the aci-producer interface docs match the new behavior.

## Notes

- Deliberately out of scope per the issue: the unfrozen env contract shadowing `SessionConfig`, and conformance not exercising the approval path.
- Follow-up (not blocking): `apps/ui/src/fixtures/traces.ts` still shows sample ACI events at `version: "0.1.0"`; harmless (no runtime validator) but worth truing up. The CI base-gate could also move behind an `agentos dev` subcommand rather than a raw CI shell step.

Closes #455
