### PR TITLE
Document macOS Gatekeeper workaround for the release binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ agentos cluster up
 agentos local up
 ```
 
+> **macOS: "unidentified developer"?** The release binaries are not yet
+> notarized by Apple, so a copy downloaded through a browser is quarantined and
+> Gatekeeper blocks it on first launch. The `curl -L` command above avoids this
+> entirely (curl does not set the quarantine flag). If you already downloaded it
+> in a browser, clear the flag once with
+> `xattr -d com.apple.quarantine ./agentos-aarch64-apple-darwin`, or right-click
+> the binary in Finder and choose Open to approve it a single time.
+
 A release binary needs no repo checkout for `agentos cluster up` or `agentos local up`.
 It pulls the pinned chart release asset and the pinned `compose.release.yaml`
 matching the binary version, then caches them under `~/.cache/agentos/`. For


### PR DESCRIPTION
The macOS release binary is built unsigned, so a copy downloaded through a browser is quarantined and Gatekeeper blocks it as an unidentified developer (issue #447).

Full relief needs Apple notarization (Developer ID cert + notarytool), which requires a paid Apple Developer Program account and repo secrets. As an immediate, zero-cost fix this adds a Quickstart note that:

- steers macOS users to the `curl -L` install path, which does not set the quarantine flag
- gives the one-time bypass for an already browser-downloaded binary (`xattr -d com.apple.quarantine ...`, or right-click > Open)

Docs-only change; notarization tracked as follow-up.

Closes #447