### PR TITLE
Renumber observability ADR 0037 -> 0038 (collision with model-routing ADR)

### DIFF
--- a/docs/adr/0038-observability-cli-helper-for-the-agent-dev-loop.md
+++ b/docs/adr/0038-observability-cli-helper-for-the-agent-dev-loop.md
@@ -1,4 +1,4 @@
-# 37. An observability CLI helper for the agent-dev loop
+# 38. An observability CLI helper for the agent-dev loop
 
 Date: 2026-07-16
 Status: Proposed


### PR DESCRIPTION
Two PRs concurrently claimed **ADR-0037**, both cut from a base where 0036 was the latest, and both merged:

- #480 (`ADR-0037: opt-in binding hook and Pareto model routing`, epic #473, stones #475-478)
- #479 (`ADR-0037: agent-facing observability CLI helper`, #461)

`main` ended up with two `docs/adr/0037-*.md`, breaking the sequential-numbering invariant. The model-routing ADR is the referenced anchor (epic + stones + issue links), so this renumbers the observability ADR to **0038** and leaves the model-routing one as 0037.

Pure file rename plus the header number line; no content change.

Refs #461