### PR TITLE
Correct the drifted interface catalog and gate it against re-rot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,12 @@ jobs:
         run: uv run ruff check .
       - name: Mypy
         run: uv run mypy
+      # Regenerate the interface-catalog seam table and per-doc headers from
+      # each seam's front-matter, fail on drift, then lint every citation under
+      # docs/ (excluding docs/adr/). A cheap, cluster-free gate, so it runs
+      # right after ruff/mypy and before the dev stack boots.
+      - name: Interface catalog docs (generate + drift + citation lint)
+        run: bash scripts/check-docs.sh
       # Integration tests dial the real dev stack (Postgres 25432, Valkey 26379,
       # MinIO 29000, Langfuse 23000 + ClickHouse + OTel Collector). Boot it after
       # ruff/mypy so cheap failures stay fast. The first up starts the one-shot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,14 @@ The app is a real Vite + React + TS project -- see `apps/ui/CLAUDE.md`. The
 top-level CI workflow's `ui` job runs the full pnpm lint, vitest, build, and
 stackless Playwright suite; run `pnpm test`/`pnpm e2e` locally to match it.
 
+**Docs (interface catalog):** `agentos dev docs-lint` regenerates the seam index
+(`docs/interfaces.md`) and each `INTERFACE.md` header from the per-seam YAML
+front-matter, then checks that no doc under `docs/` (excluding `docs/adr/`) carries a
+line-number citation and that every cited path and Python symbol resolves. Run it after
+editing any interface-catalog doc and commit the regenerated files; CI runs the same
+check (`scripts/check-docs.sh`) in the `python` job. To exempt a genuinely illustrative
+example path, put `<!-- doclint:ignore-line -->` on that line (or the line before it).
+
 Test discipline: test-first for behavior-bearing code; mock ONLY external
 services (Slack, Anthropic, GitHub); NEVER mock Postgres/Valkey/Langfuse -- run
 integration tests against the dev stack below. A change that only makes tests

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,7 +140,7 @@ The worker reaches Slack only through a base URL
 `agentos local message` path starts a local Slack Web API stub
 ([`cli/src/chat.rs`](cli/src/chat.rs)), prints the `SLACK_API_BASE_URL` to point
 the worker at it ([`cli/src/chat.rs:269`](cli/src/chat.rs)), enqueues a synthetic
-`QueuedSlackEvent` onto the very same `agentos:runs` stream the dispatcher uses,
+`QueuedTurn` onto the very same `agentos:runs` stream the dispatcher uses,
 and waits for the worker to finalize the turn by calling the stub's Slack API
 back. The worker cannot distinguish the stub from Slack: same queue payload, same
 `chat.update` call. This is what lets D1/F1/I1 and most of E1 be verified with no
@@ -167,7 +167,7 @@ sequenceDiagram
     D->>V: SET dedupe:<event_id> NX EX ttl
     Note over D: retried delivery finds the key set, is dropped (still acked, never re-posted)
     D->>U: post placeholder ("On it...")
-    D->>V: XADD agentos:runs {QueuedSlackEvent}
+    D->>V: XADD agentos:runs {QueuedTurn}
 
     W->>V: XREADGROUP (consumer group)
     W->>V: SET NX PX thread lock (routing CAS)
@@ -191,7 +191,7 @@ sequenceDiagram
 
 The pieces, cited:
 
-- **Dedupe + placeholder + enqueue** live in the dispatcher: dedupe SET NX at [`apps/dispatcher/src/agentos_dispatcher/queue.py:73`](apps/dispatcher/src/agentos_dispatcher/queue.py), placeholder post at [`apps/dispatcher/src/agentos_dispatcher/handlers.py:83`](apps/dispatcher/src/agentos_dispatcher/handlers.py), `XADD agentos:runs` at [`apps/dispatcher/src/agentos_dispatcher/queue.py:87`](apps/dispatcher/src/agentos_dispatcher/queue.py). Socket Mode handler at [`apps/dispatcher/src/agentos_dispatcher/app.py:99`](apps/dispatcher/src/agentos_dispatcher/app.py). The stream name and payload model (`QueuedSlackEvent`) are defined at [`apps/dispatcher/src/agentos_dispatcher/queue.py:48`](apps/dispatcher/src/agentos_dispatcher/queue.py) and [`config.py:46`](apps/dispatcher/src/agentos_dispatcher/config.py).
+- **Dedupe + placeholder + enqueue** live in the dispatcher: dedupe SET NX at [`apps/dispatcher/src/agentos_dispatcher/queue.py::claim_event`](apps/dispatcher/src/agentos_dispatcher/queue.py), placeholder post at [`apps/dispatcher/src/agentos_dispatcher/handlers.py:83`](apps/dispatcher/src/agentos_dispatcher/handlers.py), `XADD agentos:runs` at [`apps/dispatcher/src/agentos_dispatcher/queue.py::enqueue`](apps/dispatcher/src/agentos_dispatcher/queue.py). Socket Mode handler at [`apps/dispatcher/src/agentos_dispatcher/app.py:99`](apps/dispatcher/src/agentos_dispatcher/app.py). The stream name is configured on [`apps/dispatcher/src/agentos_dispatcher/config.py::DispatcherConfig`](apps/dispatcher/src/agentos_dispatcher/config.py) (default `agentos:runs`) and the payload model is the channel-neutral [`packages/aci-protocol/src/aci_protocol/turn.py::QueuedTurn`](packages/aci-protocol/src/aci_protocol/turn.py).
 - **The kernel** consumes at [`apps/worker/src/agentos_worker/consumer.py:104`](apps/worker/src/agentos_worker/consumer.py) and processes at [`kernel.py:169`](apps/worker/src/agentos_worker/kernel.py). It talks to the runner over `POST /v1/event`, `/v1/steer`, `/v1/interrupt` ([`apps/worker/src/agentos_worker/runner_client.py:76`](apps/worker/src/agentos_worker/runner_client.py)) — the same routes the runner serves at [`runner/src/agentos_runner/server.py:46`](runner/src/agentos_runner/server.py).
 - **Deployment binding**: a run resolves its agent, version, and `bundle_ref` by exact-match on `slack_channel` against the active deployment ([`apps/worker/src/agentos_worker/binding.py:49`](apps/worker/src/agentos_worker/binding.py)). This is how one worker serves many agents: the channel selects the bundle.
 

--- a/apps/dispatcher/CLAUDE.md
+++ b/apps/dispatcher/CLAUDE.md
@@ -11,11 +11,15 @@ summary.
   the worker (`apps/worker`). If you find yourself adding any
   decision about *how* a message gets answered, that decision belongs one
   layer up -- stop and move it, don't grow the dispatcher's scope.
-- **The dispatcher owns the `QueuedSlackEvent` shape.** It is defined in
-  `dispatcher.queue.QueuedSlackEvent` because the dispatcher is the producer.
-  Do not move this model into `packages/` unilaterally -- if it needs to
-  become a shared type, raise it in an issue/PR first rather than moving it
-  from a dispatcher change.
+- **The queued-turn shape is the frozen `QueuedTurn` contract in `packages/`.**
+  The dispatcher is the producer, but the payload it enqueues was promoted out
+  of the dispatcher into the channel-neutral `aci_protocol.QueuedTurn` (issue
+  #7). That shared contract is the Pydantic source of truth guarded by the
+  schema-compat gate, so the Python producer and the Rust/TS consumers compile
+  against one shape instead of a hand-mirrored dispatcher-local model. Do not
+  reintroduce a dispatcher-owned payload model. The producer-owns-the-shape
+  principle still governs any *new* dispatcher-only field: land a contract
+  change in `packages/aci-protocol` via an issue/PR first, exactly as #7 did.
 - **Idempotency key is the Slack event id, not the message content.** Dedupe
   is `SET <dedupe_prefix><event_id> 1 NX EX <ttl>` in Valkey -- O(1), TTL-bounded,
   no scan. Order is always claim -> post placeholder -> `XADD`, so a
@@ -23,7 +27,7 @@ summary.
   these three steps.
 - **The queue seam is one `payload` field, not a multi-field Stream entry.**
   Each Stream entry carries a single `payload` field holding the
-  `QueuedSlackEvent` JSON. This lets fields be added to the payload without
+  `QueuedTurn` JSON. This lets fields be added to the payload without
   reshaping the Stream schema itself -- do not add a second top-level Stream
   field for a new piece of data; put it inside the JSON payload.
 - **Reconnects are the supervisor's job, not the Slack client's.** The Bolt

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -13,24 +13,25 @@ run orchestration are the worker's job, not the dispatcher's.
 
 The dispatcher `XADD`s onto a Valkey Stream (`AGENTOS_STREAM`, default
 `agentos:runs`). Each entry carries one field, `payload`, holding the JSON of a
-`QueuedSlackEvent` (`dispatcher.queue.QueuedSlackEvent`):
+`QueuedTurn` (from `aci_protocol`). Its fields are channel-neutral; the
+parenthetical is what the Slack adapter maps onto each one:
 
 | field | meaning |
 |---|---|
-| `slack_event_id` | Slack's per-delivery event id; the idempotency key |
-| `thread_ts` | canonical thread key (root message ts of the thread) |
-| `channel` | Slack channel id |
-| `user` | Slack user id that authored the message |
+| `event_id` | idempotency key for the delivery (the Slack event id) |
+| `conversation_id` | canonical thread/conversation key (the thread ts) |
+| `author` | who authored the message (the Slack user id) |
 | `text` | message text |
-| `placeholder_ts` | ts of the placeholder reply already posted; the worker edits this message in place with the real response |
-| `received_at` | ISO-8601 UTC timestamp the dispatcher received it |
+| `reply_handle` | where the reply is delivered: a `ReplyHandle` of `channel`, `placeholder` (ts of the already-posted placeholder the worker edits in place), and an optional per-turn `endpoint` |
+| `received_at` | ISO-8601 UTC timestamp the adapter received it |
 
-The worker reconstructs it with `QueuedSlackEvent.from_stream_fields(fields)` (import from
-`agentos_dispatcher`, or mirror the model). The model is defined inside the
-dispatcher because the dispatcher is the producer and owns the shape; if it later
-deserves promotion into a shared package, the maintainers make that call (the
-dispatcher does not touch `packages/`). The single-`payload`-field encoding keeps
-the seam explicit and lets fields be added without reshaping the Stream schema.
+The worker reconstructs it with `from_stream_fields(fields)`, a module-level
+helper in `agentos_dispatcher.queue`. The model lives in the frozen `aci_protocol`
+package (promoted out of the dispatcher in issue #7) so the producer and the
+Rust/TS consumers share one schema-gated contract instead of a hand-mirrored copy;
+the dispatcher's queue module owns only the Stream transport of it. The
+single-`payload`-field encoding keeps the seam explicit and lets fields be added
+without reshaping the Stream schema.
 
 ## Dedupe (idempotency)
 

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2493,6 +2493,11 @@ export const commandManifest = {
           "about": "Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`)",
           "hidden": false,
           "name": "e2e"
+        },
+        {
+          "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
+          "hidden": false,
+          "name": "docs-lint"
         }
       ]
     },

--- a/apps/worker/CLAUDE.md
+++ b/apps/worker/CLAUDE.md
@@ -1,9 +1,10 @@
 # CLAUDE.md - apps/worker
 
-The concurrency kernel plus the Agent Sandbox substrate. The eval runner is not
-yet built. Full behavior spec lives in `apps/worker/README.md`; this file is the
-enforceable-rule summary. Read `../../ARCHITECTURE.md`'s message-flow diagram
-before changing `kernel.py`.
+The concurrency kernel plus the Agent Sandbox substrate, and the F3 eval-stream
+runner (`agentos_worker.eval`), which runs eval suites off the `agentos:evals`
+stream against the frozen eval-case format (#8, ADR-0019). Full behavior spec
+lives in `apps/worker/README.md`; this file is the enforceable-rule summary. Read
+`../../ARCHITECTURE.md`'s message-flow diagram before changing `kernel.py`.
 
 ## The kernel is sacred: single owner, adversarial review
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -140,14 +140,14 @@ end-to-end (no `target_url`) that boots via the substrate and releases in a fina
 
 ## The concurrency kernel (`agentos_worker.kernel` + `agentos_worker.consumer`)
 
-The kernel closes the loop: it consumes `QueuedSlackEvent` entries the dispatcher
+The kernel closes the loop: it consumes `QueuedTurn` entries the dispatcher
 puts on the `agentos:runs` Valkey stream, routes each to a runner turn in a
 claimed sandbox, streams the NDJSON reply back into the Slack thread by editing
 the placeholder in place, and gets every failure mode right.
 
 ```
 XREADGROUP agentos:runs        Consumer (consumer group; XAUTOCLAIM reclaims a
-   -> QueuedSlackEvent            dead consumer's pending entries after an idle
+   -> QueuedTurn                  dead consumer's pending entries after an idle
    -> Kernel.process_event        timeout, then reprocesses them idempotently)
         -> SlackSink     chat.update placeholder to booting text (best effort)
         -> substrate.lookup/claim/resume   (sandbox substrate)
@@ -235,11 +235,14 @@ Contract notes the kernel must know:
   to `Suspended` (the pod is deleted) and records the caller-supplied history
   ref. `resume()` retires the old claim and creates a new one whose per-claim
   env injects `AGENTOS_HISTORY_REF` (+ the original `AGENTOS_SESSION_ID`); the
-  runner passes that ref to the SDK as its `resume` session id. Never assume
-  process or prompt-cache warmth across a suspend.
-- **Producing the history ref is the caller's job.** The frozen ACI `final`
-  frame does not carry the SDK session id today; if the kernel needs it surfaced from
-  the runner, that is a contract change to escalate, not to work around.
+  runner resolves that ref to the thread's transcript on the durable state store
+  and replays the prior turns as a boot-time system-prompt preamble (ADR-0029),
+  not an SDK-native resume id. Never assume process or prompt-cache warmth across
+  a suspend.
+- **Producing the history ref is the caller's job.** The ref is a deterministic
+  state-store URL (`.../state/transcript/<thread_key>`), so there is nothing to
+  capture off the ACI `final` frame and no frozen-contract change (ADR-0029); do
+  not reintroduce a frame-captured resume id.
 - **Reaping.** `release()` deletes the claim (the claim owns its sandbox and
   pod). Routes that expire in Valkey leave orphaned claims; `reap_orphans()`
   lists claims labeled `agentos.dev/managed-by=agentos-sandbox-substrate` and

--- a/apps/worker/src/agentos_worker/sandbox/substrate.py
+++ b/apps/worker/src/agentos_worker/sandbox/substrate.py
@@ -13,8 +13,11 @@ caller-supplied history ref on the route; ``resume()`` retires the suspended
 claim and creates a NEW claim whose per-claim env injects
 ``AGENTOS_HISTORY_REF`` (and the original ``AGENTOS_SESSION_ID``), so the
 replacement runner boots rehydrating from stored history rather than assuming
-process or cache warmth. The runner accepts the ref as an SDK resume id
-(runner/config.py); producing the ref (an SDK session id) is the caller's job.
+process or cache warmth. The runner resolves the ref to the thread's transcript
+namespace on the durable state store and replays the prior turns as a boot-time
+system-prompt preamble; the ref is a harness-agnostic state-store URL, not an SDK
+resume id (ADR-0029 superseded that framing). Producing the ref -- the thread's
+transcript key -- is the caller's job.
 """
 
 from __future__ import annotations

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2490,6 +2490,11 @@
           "about": "Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`)",
           "hidden": false,
           "name": "e2e"
+        },
+        {
+          "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
+          "hidden": false,
+          "name": "docs-lint"
         }
       ]
     },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -174,6 +174,8 @@ enum DevAction {
     ChartCheck,
     /// Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`).
     E2e,
+    /// Lint the interface catalog docs (`bash scripts/check-docs.sh`).
+    DocsLint,
 }
 
 #[derive(Subcommand)]
@@ -1096,6 +1098,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 commands::dev_script("charts/agentos/ci/render-assertions.sh").await
             }
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
+            DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh").await,
         },
         Some(Command::Skill { action }) => match action {
             SkillAction::Up {
@@ -1981,6 +1984,14 @@ mod tests {
             cli.command,
             Some(Command::Dev {
                 action: DevAction::E2e
+            })
+        ));
+        let cli = Cli::try_parse_from(["agentos", "dev", "docs-lint"])
+            .expect("dev docs-lint should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::DocsLint
             })
         ));
     }

--- a/docs/adr/0038-generated-interface-catalog-and-doc-lint-gate.md
+++ b/docs/adr/0038-generated-interface-catalog-and-doc-lint-gate.md
@@ -1,0 +1,119 @@
+# 38. The interface catalog is generated from declared front-matter and gated in CI
+
+Date: 2026-07-16
+
+Status: Accepted
+
+Implements [#452](https://github.com/curie-eng/agentos/issues/452).
+
+## Context
+
+The swappable-seam catalog in `docs/interfaces/` rotted. A review of all 17 seams
+found it could not be trusted in either direction without re-reading the source,
+which is the whole job it exists to do: `harness-modelsession/INTERFACE.md`
+overstated cleanliness (claiming a refactor that had not merged), `channel-ingress`
+and `queue-stream` understated it (describing a `QueuedSlackEvent` payload that #7
+had already promoted to the channel-neutral `QueuedTurn`), and `docs/interfaces.md`
+contradicted itself (listing Workflow state as `NONE | 0 impls` while adjacent rows
+credited loaders built on that exact store).
+
+The corrections matter, but they are not the durable point. The catalog rotted for
+one structural reason: **the same fact is written in two places and checked in
+zero.** The index (`docs/interfaces.md`) restates the Kind / Impls / Grade that each
+seam doc already declares, and nothing compares them. Line-number citations
+(`file.py:NN`) rot because they encode a coordinate that every insertion above them
+invalidates. Both are the same defect, an unverified duplicate. Written once and
+left alone, any hand-correction rots back to the same state within a fortnight.
+
+The repo already answers this defect class for its typed contracts: one declared
+source of truth, a generator, and a regenerate-and-diff check in CI
+(`scripts/check-contracts.sh`, the `contracts-ts` job, the UI `gen:manifest` diff).
+The ask is to apply that same pattern to the catalog.
+
+## Decision
+
+**Make the interface catalog machine-checkable by generating it from a single
+declared source per seam and gating it in CI.** Three parts:
+
+- **YAML front-matter on each `INTERFACE.md` is the single declared source.** Each
+  seam doc carries a front-matter block declaring `seam`, `kind`, `impls`, `grade`,
+  `epics`, `order`, and an optional `epic_note`. This is the one place the seam's
+  catalog facts are stated. Front-matter is chosen because it is unambiguous to
+  parse, invisible in the renderers GitHub uses, and separates the declared fact
+  from the prose that explains it. The audit found the premise that these fields
+  already existed to be false: sixteen docs carried the facts only in a prose
+  blockquote, one carried a different blockquote shape entirely, and the index's
+  Epic(s) column lived nowhere in the docs and silently disagreed with them. Writing
+  the front-matter forces each of those contradictions to be resolved by a human,
+  once. That reconciliation is the ticket's real value.
+
+- **A generator emits the derived views from that source.** `agentos dev docs-lint`
+  regenerates the seam table in `docs/interfaces.md` and each doc's header
+  blockquote from the front-matter, replacing only the region between explicit
+  `<!-- BEGIN/END GENERATED -->` markers so hand-written prose and generated content
+  coexist in one file. The blockquote becomes generated output, not hand prose, so
+  the index can no longer disagree with the docs it summarizes.
+
+- **A CI doc-lint gates the catalog.** The same `agentos dev docs-lint` command
+  (wrapped by `scripts/check-docs.sh`, mirroring `check-contracts.sh`: regenerate,
+  then `git diff --exit-code`) runs in the existing `python` job and fails on: any
+  line-number citation under the linted root (every recognized extension, and the
+  GitHub `#L` spelling); any cited file path that does not exist; any cited Python
+  symbol that does not resolve (by a static `ast` parse, never an import); and an
+  index table that does not match what the seam docs' front-matter declares.
+  Citations become symbol-form (`authorizer.py::authorize_approval`), which survives
+  refactors where a line number rots on the next insertion above it.
+
+The tool is Python in a `tools/doclint` uv workspace member, behind a thin
+`agentos dev docs-lint` clap wrapper that shells the script exactly like its
+`dev contracts` / `dev chart-check` siblings.
+
+## Alternatives considered
+
+- **Regex over the existing prose blockquote** (no front-matter). Rejected: it
+  encodes the current prose wording as a grammar and breaks on the next reword,
+  which is the exact rot this ADR exists to stop. It also has no source at all for
+  three of the index's columns, which are not in the blockquote.
+- **A Rust implementation under `agentos dev`.** Rejected: the resolver must parse
+  Python to resolve cited symbols, and Python's `ast` module is the correct, free
+  tool. A Rust reimplementation of Python symbol resolution is a real bug surface
+  for zero user-facing benefit, and the `dev` namespace's own siblings are thin
+  shell-outs to repo scripts, not Rust implementations.
+- **A bare `scripts/*.sh` with no CLI surface.** Rejected: root `CLAUDE.md` is
+  explicit that a loose script should be the exception with a reason. The discoverable
+  `agentos dev` surface is the convention; the script stays the implementation.
+- **Generating the Swap-readiness grade table too** (the `docs/interfaces.md` <->
+  `docs/architecture-vision.md` verbatim duplicate). Deferred, not adopted this run:
+  the grade table's source is a prose narrative with no per-seam home, so inventing
+  one is a second architecture change riding a docs PR. Named as a follow-up.
+
+## Consequences
+
+- The index cannot silently disagree with the seam docs: it is regenerated from
+  their declared front-matter and CI diffs the result. A cited path that is deleted
+  or a symbol that is renamed fails CI on the renaming PR, dragging the stale prose
+  in front of a human instead of letting it rot silently. This is the gate working,
+  and the first few unrelated PRs after it lands should expect to hit it.
+- **Accepted limit: the gate coordinate-checks and index-consistency-checks; it does
+  NOT verify prose truth.** A doc can cite a real path and a resolving symbol while
+  the sentence around them is false, and every seam correction in #452 is exactly
+  that class of defect, meaning the gate this ADR builds would not have caught the
+  bugs it is fixing. Checking prose against code is a reviewer, not a lint, and
+  pretending otherwise is how the catalog earned its reputation. The gate's claim is
+  narrow and exact: it makes a false claim harder to write accidentally and
+  impossible to keep silently. It converts silent rot into a build failure; it does
+  not convert prose into proof. A green `docs-lint` badge means the catalog is
+  coordinate-checked and index-consistent, not that its prose is verified.
+- **`docs/adr/` is excluded from the linted root.** ADRs are immutable once
+  Accepted (root `CLAUDE.md`); an ADR's line citation is a record of what its author
+  was looking at on that date, not a claim about today's code, and rewriting it to
+  satisfy a lint would corrupt the historical record. The exclusion is a constant in
+  the tool, covered by a test, so the decision is visible in code rather than in a
+  forgotten conversation. This means the issue's "no line-number citations remain
+  under `docs/`" is met for every path except `docs/adr/`, a deliberate and
+  documented deviation.
+- Symbol resolution is Python-only this run; a `::symbol` on a non-Python path is a
+  hard error (not a silent pass), and Rust/TS resolvers are named follow-up work.
+- The catalog now has a maintenance contract: a new seam is picked up by globbing
+  `docs/interfaces/*/INTERFACE.md`, so a seam added without front-matter fails the
+  gate rather than entering the catalog ungated.

--- a/docs/architecture-vision.md
+++ b/docs/architecture-vision.md
@@ -63,10 +63,13 @@ does not change. The runner's conformance suite
 format. `packages/plugin-format` is the Claude Code plugin shape verbatim (a
 deliberate distribution wedge), so a non-Claude harness must interpret Claude
 Code plugin bundles or translate them into its own configuration; "implement
-the ACI server" understates that work. Resume also assumes SDK-like history
-rehydration: `AGENTOS_HISTORY_REF` becomes the SDK `resume` session id
-(`adapter.py::build_options`); a harness without an equivalent must build its
-own history store.
+the ACI server" understates that work. Resume, by contrast, is harness-agnostic:
+the boot path passes `resume=None`, and `AGENTOS_HISTORY_REF` is a durable
+state-store URL for the thread's transcript that the runner loads and replays as a
+boot-time system-prompt preamble
+(`runner/src/agentos_runner/history.py::format_conversation_preamble`), not an
+SDK-native resume identifier (ADR-0029). A second harness rehydrates the same way
+by reusing that state-store contract.
 
 ### 2. Observability / OTel store (Langfuse today)
 
@@ -103,12 +106,12 @@ into the URL namespace even though the payloads are ours.
 **Port:** our own eval plane defines the schema; Langfuse is storage behind
 it. The write path is the `agentos:evals` Valkey stream carrying an
 `EvalWorkItem`, consumed by `apps/worker/src/agentos_worker/eval/stream.py`,
-with results shaped by our models (`eval/models.py`). The UI-facing read path
+with results shaped by our models (`apps/worker/src/agentos_worker/eval/models.py`). The UI-facing read path
 is our API's matrix endpoint (`apps/api/src/agentos_api/routers/evals.py`)
 returning our `EvalMatrix` schema, and the PR gate is our `/evals/report`
 endpoint turning a rollup into a GitHub commit status.
 
-**Current adapter:** `eval/recorder.py` posts one Langfuse trace plus an
+**Current adapter:** `apps/worker/src/agentos_worker/eval/recorder.py` posts one Langfuse trace plus an
 `eval_pass` score per case via the public ingestion API, tagged
 `version:<v>` / `suite:<s>`; the matrix endpoint reads the grid back by those
 tags through the same `LangfuseClient`.
@@ -122,9 +125,9 @@ convention, not a frozen contract.
 
 **Leakage:** the eval-case format is now converged and frozen
 ([issue #8](https://github.com/curie-eng/agentos/issues/8), ADR-0019): the CLI
-reads `evals/cases.json` as a suite object `{name, cases:[{id, input, grader}]}`
+reads the bundle's evals/cases.json as a suite object `{name, cases:[{id, input, grader}]}`
 (`cli/src/evals.rs`) and the platform's bundle loader validates the same shape
-(`eval/stream.py`), both building to one committed schema
+(`apps/worker/src/agentos_worker/eval/stream.py`), both building to one committed schema
 (`apps/worker/schema/eval-cases.schema.json`) kept honest by a drift gate.
 
 ### 4. Blob storage (MinIO today)
@@ -164,23 +167,26 @@ change, and that is the realistic swap. A different SQL engine is a small
 refactor, not a rewrite.
 
 **Leakage:** two Postgres-isms are in the models: the
-`sqlalchemy.dialects.postgresql.UUID` column type (`models.py`) and
-schema-qualified tables plus a schema-scoped native enum
-(`db.py::SCHEMA`, the `Environment` enum). Both have portable SQLAlchemy
-equivalents if a non-Postgres target ever materializes.
+`sqlalchemy.dialects.postgresql.UUID` column type
+(`apps/api/src/agentos_api/models.py`) and schema-qualified tables plus a
+schema-scoped native enum (`apps/api/src/agentos_api/db.py::SCHEMA`, the
+`Environment` enum). Both have portable SQLAlchemy equivalents if a
+non-Postgres target ever materializes.
 
 ### 6. Communication channel (Slack today)
 
-**Port:** this is the least clean seam, and saying so is the point. The
-ingress contract is `QueuedSlackEvent`
-(`apps/dispatcher/src/agentos_dispatcher/queue.py`), Slack-shaped by name and
-semantics: `slack_event_id` as the idempotency key, `thread_ts` as the
-conversation key, `placeholder_ts` encoding Slack's edit-in-place reply
-model. The egress contract is the worker's `SlackSink` protocol
+**Port:** the ingress half of this seam is now clean; the egress half is where
+it stays least clean. The ingress contract was promoted out of the dispatcher
+into the channel-neutral `QueuedTurn`
+(`packages/aci-protocol/src/aci_protocol/turn.py::QueuedTurn`, issue #7): a
+generic `event_id` idempotency key, a `conversation_id` conversation key, and a
+`ReplyHandle` (`packages/aci-protocol/src/aci_protocol/turn.py::ReplyHandle`)
+carrying the channel and placeholder, so the Slack-shaped field names are gone
+from the core contract. The egress contract is the worker's `SlackSink` protocol
 (`apps/worker/src/agentos_worker/slack_sink.py`), a single
 `update(channel, ts, text)` built on `chat.update`. The mrkdwn dialect is
 correctly confined to the sink (`mrkdwn.py`), but the kernel does assume the
-edit-a-placeholder reply shape.
+edit-a-placeholder reply shape, which is the remaining Slack coupling.
 
 **Current adapter:** `apps/dispatcher` (Bolt, Socket Mode) on ingress,
 `AsyncSlackSink` on egress.
@@ -188,21 +194,23 @@ edit-a-placeholder reply shape.
 **Evidence the channel is already semi-swappable:** `agentos local message` and
 `agentos cluster message` (`cli/src/chat.rs`, `cli/src/message.rs`) drive the entire
 deployed system with zero Slack contact by minting the exact
-`QueuedSlackEvent` wire payload (`cli/src/queue.rs`) and standing in as the
-Slack Web API. The Slack service swaps; the Slack protocol does not yet.
+`QueuedTurn` wire payload (`cli/src/queue.rs`) and standing in as the
+Slack Web API. The Slack service swaps; the ingress payload is already
+channel-neutral, and the remaining Slack coupling is the egress reply shape.
 
-**What a channel-neutral port looks like:** an ingress event of
-`{event_id, conversation_id, author, text, reply_handle, received_at}` and a
-`ReplySink` with post/update semantics per channel adapter. The reshaping
-cost is bounded: the queue payload (which
-[issue #7](https://github.com/curie-eng/agentos/issues/7) already wants promoted
-into `packages/aci-protocol`), the CLI's mirrored struct, the
-kernel's thread-lock and marker keys, and the channel-based deployment
-binding (`apps/worker/src/agentos_worker/binding.py`). Doing the promotion
-and the rename in one motion turns two contract debts into one change. A
-separate gap: the reply base URL is worker-global (`worker.slackApiBaseUrl`),
-so two ingress paths cannot coexist on one deployment until replies are
-routed per turn ([issue #19](https://github.com/curie-eng/agentos/issues/19)).
+**What a channel-neutral port looks like:** the ingress half already matches this
+target — `QueuedTurn` carries `{event_id, conversation_id, author, text,
+reply_handle, received_at}` ([issue #7](https://github.com/curie-eng/agentos/issues/7),
+landed). What remains is a `ReplySink` with post/update semantics per channel
+adapter. The remaining reshaping cost is bounded: the CLI's mirrored struct already
+tracks the promoted contract, while the kernel's thread-lock and marker keys and the
+channel-based deployment binding (`apps/worker/src/agentos_worker/binding.py`) still
+assume Slack. Reply routing, by contrast, already landed per turn
+([issue #19](https://github.com/curie-eng/agentos/issues/19)): a turn's
+`ReplyHandle.endpoint` (`packages/aci-protocol/src/aci_protocol/turn.py::ReplyHandle`)
+is the reply target, so a real Slack workspace and a no-Slack CLI stub can coexist on
+one deployment; the worker-global base URL (`worker.slackApiBaseUrl`) is now only the
+fallback used when a turn sets no endpoint.
 
 ADR-0020 fixes the target shape for this seam: a rendering-free port (required
 core plus queryable capabilities plus semantic interaction intents) rendered
@@ -256,7 +264,7 @@ flowchart TB
         PG["Postgres (today) or managed SQL"]
     end
 
-    Slack -- "QueuedSlackEvent" --> Dispatcher
+    Slack -- "QueuedTurn" --> Dispatcher
     CLIStub -- "same wire payload" --> Queue
     Runner -- "frozen ACI protocol" --> SDK
     Runner -- "OTLP HTTP" --> Collector
@@ -273,11 +281,11 @@ flowchart TB
 | Job | Port contract | Current adapter | Grade | Cheapest next step |
 |---|---|---|---|---|
 | Harness / runtime | Frozen ACI protocol (`packages/aci-protocol`), tri-language, CI-guarded | claude-agent-sdk runner | A-: strongest seam in the system; docked for the plugin-format entanglement and SDK-shaped resume | Write the "implement an ACI server" guide from the conformance suite so the port is documented, not just enforced |
-| Observability | OTLP to collector (write), API DTOs (read) | Langfuse behind `langfuse.py` | B+: write side clean but for one vendor span attribute; read side isolated in one module | Rename `langfuse.trace.name` to a neutral attribute mapped in the collector; rename the `/langfuse/*` API routes |
-| Evals | Our stream schema + `EvalMatrix` DTO; store behind recorder | Langfuse traces + `eval_pass` scores | B: schema is ours, but the case format is duplicated and the tag convention is unfrozen | Converge the two `cases.json` definitions into one frozen schema ([issue #8](https://github.com/curie-eng/agentos/issues/8)) |
+| Observability | OTLP to collector (write), API DTOs (read) | Langfuse behind `langfuse.py` | B+: write side clean but for three vendor span attributes (`langfuse.trace.name`, `langfuse.session.id`, `langfuse.user.id`); read side spans several API modules plus routers | Map the three `langfuse.*` attributes to neutral names in the collector; rename the `/langfuse/*` API routes |
+| Evals | Our stream schema + `EvalMatrix` DTO; store behind recorder | Langfuse traces + `eval_pass` scores | B: schema is ours; the case format converged into one frozen, drift-gated schema (#8, ADR-0019), leaving the `version:`/`suite:` tag convention as the unfrozen part | Freeze the tag convention into the schema, or record it as a deliberate soft contract |
 | Blob storage | S3 protocol (boto3 + mc, path-style, endpoint-configurable) | MinIO | B+: config-only within S3-compatible stores; three hand-aligned client sites; no interface for non-S3 | None needed until a non-S3 demand exists; document the three client sites as one seam |
 | Relational DB | SQLAlchemy 2.0 + alembic | Postgres | A-: managed-Postgres swap is a DSN change; two Postgres-isms in models | Leave as is; note the `postgresql.UUID` and schema-scoped enum as the two things a non-Postgres target would touch |
-| Communication | `QueuedSlackEvent` + `SlackSink` | Slack (Bolt + chat.update) | C: Slack-shaped names and edit-in-place semantics in the core's contract; service swappable (CLI stub), protocol not | Promote the queue payload into `aci-protocol` with channel-neutral field names in the same change |
+| Communication | `QueuedTurn` (channel-neutral, in `aci-protocol`) + `SlackSink` | Slack (Bolt + chat.update) | C: the ingress payload is now the channel-neutral `QueuedTurn` (#7), but egress still assumes Slack's edit-in-place `chat.update` reply shape; service swappable (CLI stub), egress protocol not | Route replies per turn (#19) and define a channel-neutral `ReplySink` post/update port so a second channel can coexist |
 
 ## What we deliberately do not abstract yet
 

--- a/docs/behavior-packs.md
+++ b/docs/behavior-packs.md
@@ -42,7 +42,7 @@ The substrate, end to end, minus the kernel call sites:
   (migration `0005`), validated by `schemas.BehaviorPacksConfig`, accepted on
   `POST /agents`, and read/written via `GET|PUT /agents/{id}/behavior-packs`
   (mirrors the budget control endpoints). NULL reads as all-off.
-- **Logic** (`apps/worker/behaviorpacks.py`): `sample_load(packs, seed)`,
+- **Logic** (`apps/worker/src/agentos_worker/behaviorpacks.py::sample_load`): `sample_load(packs, seed)`,
   `sample_tip(packs, seed)`, `match_greeting(packs, text)`,
   `match_help(packs, text)`, plus the settings pack's `coerce_setting(setting,
   raw)` and `resolve_settings(packs, overrides)`. Pure stdlib, fully unit-tested.
@@ -53,7 +53,7 @@ The substrate, end to end, minus the kernel call sites:
   report") returns `None` and falls through to the model. `resolve_settings`
   layers a validated override over each declared default and ignores
   unknown/invalid keys, so a stale store can never break resolution.
-- **Binding** (`apps/worker/binding.py`, not the sacred kernel): the resolver
+- **Binding** (`apps/worker/src/agentos_worker/binding.py::BindingResolver`, not the sacred kernel): the resolver
   now selects `behavior_packs`, carries it on `ResolvedDeployment`, and exposes
   `BindingResolver.packs_for(resolved) -> BehaviorPacks`.
 
@@ -73,7 +73,7 @@ additive and touches neither the kernel nor a frozen contract.
 
 ### The kernel wiring for tips/greeting/help (needs F1 review)
 
-These touches fire from inside `apps/worker/kernel.py`, which is the F1 "sacred"
+These touches fire from inside `apps/worker/src/agentos_worker/kernel.py::Kernel`, which is the F1 "sacred"
 module: any change needs the escalated adversarial review (spec-vs-impl +
 side-effects-detective) per `apps/worker/CLAUDE.md`. The greeting short-circuit
 also brushes against kernel rule 3 ("the kernel never keyword-guesses intent"),
@@ -138,7 +138,7 @@ pack.
 | Greeting detection | **Pack** (`greeting`) | Data (phrases + reply), deterministic pre-model matcher. Shipped. |
 | Help / "what can you do" | **Pack** (`help`) | Same shape as greeting; the niceties battery's help half. Shipped. |
 | Runtime settings / knobs | **Pack** (`settings`, schema) | The editable-settings allowlist is declarative; shipped with platform-owned validation (`coerce_setting`/`resolve_settings`). The durable override store + edit UI are a deferred runtime. |
-| Kill switch / control | **Already native** | AgentOS has it: `apps/worker/killswitch.py` + `Kernel` kill gate + the `/agents/{id}/kill` control endpoint. A pack would duplicate it. |
+| Kill switch / control | **Already native** | AgentOS has it: `apps/worker/src/agentos_worker/killswitch.py::KillSwitch` + `Kernel` kill gate + the `/agents/{id}/kill` control endpoint. A pack would duplicate it. |
 | Activity log | **Already native (observability)** | Post-model observation is Langfuse tracing; the Slack "activity" ring buffer is stateful UI code, not declarative data. |
 | Logging setup | **Not per-agent** | Pure infra, identical for every agent; belongs to the platform, not a pack. |
 | Block Kit rendering | **Not applicable** | AgentOS streams text + `chat_update` mrkdwn; there is no structured `Reply` object to render. Would need a Block Kit reply model first. |

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -9,25 +9,27 @@ is documentation of where the code already draws the line, not a new abstraction
 
 ## The seams
 
+<!-- BEGIN GENERATED: seam-table (agentos dev docs-lint) -->
 | Seam | Kind | Impls | Grade | Epic(s) | INTERFACE.md |
 |---|---|---|---|---|---|
-| Substrate / SandboxClient | CLEAN | 2 (k8s, docker) | not separately graded | #86, #44 | [interfaces/substrate/INTERFACE.md](interfaces/substrate/INTERFACE.md) |
-| Harness in-proc / ModelSession | CLEAN | 1 + fake | A- | (folds into #25) | [interfaces/harness-modelsession/INTERFACE.md](interfaces/harness-modelsession/INTERFACE.md) |
-| ACI producer (frozen protocol) | CLEAN, frozen | 1 + reference | A- | #25, #47 | [interfaces/aci-producer/INTERFACE.md](interfaces/aci-producer/INTERFACE.md) |
-| Channel / ingress (Slack) | SOFT | 1 | C | #7, #19, #27, #38 | [interfaces/channel-ingress/INTERFACE.md](interfaces/channel-ingress/INTERFACE.md) |
-| Channel interaction message | CLEAN | 2 renderers (Slack, terminal) | not separately graded | ADR-0020 | [interfaces/channel-interaction/INTERFACE.md](interfaces/channel-interaction/INTERFACE.md) |
-| Model provider / credentials | SOFT | 1 (Anthropic) | not separately graded | #24, #46 | [interfaces/model-provider/INTERFACE.md](interfaces/model-provider/INTERFACE.md) |
-| Telemetry / OTEL | SOFT | 1 | B+ | #47 | [interfaces/telemetry-otel/INTERFACE.md](interfaces/telemetry-otel/INTERFACE.md) |
-| Evals (case + scorer) | SOFT | 1 grader family | B | #8, #26 | [interfaces/evals/INTERFACE.md](interfaces/evals/INTERFACE.md) |
-| Blob storage (S3/MinIO) | CLEAN | 1 backend behind the ObjectStore port | A- | #83 | [interfaces/blob-storage/INTERFACE.md](interfaces/blob-storage/INTERFACE.md) |
-| Relational DB (Postgres) | SOFT | 1 | A- | #84 | [interfaces/relational-db/INTERFACE.md](interfaces/relational-db/INTERFACE.md) |
-| Queue / stream (Valkey) | CLEAN | 1 (redis-py) behind the broker port | not separately graded | #85, #7 | [interfaces/queue-stream/INTERFACE.md](interfaces/queue-stream/INTERFACE.md) |
-| Bundle format | CLEAN, frozen | 1 | not separately graded | #30 | [interfaces/bundle-format/INTERFACE.md](interfaces/bundle-format/INTERFACE.md) |
-| Approval / authorizer | NONE | 0 | not separately graded | #22 | [interfaces/approval/INTERFACE.md](interfaces/approval/INTERFACE.md) |
-| Workflow state store | NONE | 0 (concrete AffinityStore) | not separately graded | #23 | [interfaces/workflow-state/INTERFACE.md](interfaces/workflow-state/INTERFACE.md) |
-| Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [interfaces/memory/INTERFACE.md](interfaces/memory/INTERFACE.md) |
-| Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [interfaces/conversation-history/INTERFACE.md](interfaces/conversation-history/INTERFACE.md) |
-| Triggers | SOFT | 2 hardcoded (Slack, GH push) | not separately graded | #29 | [interfaces/triggers/INTERFACE.md](interfaces/triggers/INTERFACE.md) |
+| Substrate / SandboxClient | CLEAN | 2 (k8s, docker) | not separately graded | #86, #44 | [Substrate / SandboxClient](interfaces/substrate/INTERFACE.md) |
+| Harness in-proc / ModelSession | CLEAN | 1 + fake | A- | (folds into #25) | [Harness in-proc / ModelSession](interfaces/harness-modelsession/INTERFACE.md) |
+| ACI producer (frozen protocol) | CLEAN, frozen | 1 + reference | A- | #25, #47 | [ACI producer (frozen protocol)](interfaces/aci-producer/INTERFACE.md) |
+| Channel / ingress (Slack) | SOFT | 1 | C | #7, #19, #27, #38 | [Channel / ingress (Slack)](interfaces/channel-ingress/INTERFACE.md) |
+| Channel interaction message | CLEAN | 2 renderers (Slack, terminal) | not separately graded | ADR-0020 | [Channel interaction message](interfaces/channel-interaction/INTERFACE.md) |
+| Model provider / credentials | SOFT | 2 prefix-routed (Anthropic, OpenRouter) + base-URL-selected provider-native endpoints (Zhipu, Moonshot, DeepSeek, Ollama) | not separately graded | #24, #46 | [Model provider / credentials](interfaces/model-provider/INTERFACE.md) |
+| Telemetry / OTEL | SOFT | 1 | B+ | #47 | [Telemetry / OTEL](interfaces/telemetry-otel/INTERFACE.md) |
+| Evals (case + scorer) | SOFT | 2 scorers (grader family + trajectory matcher) | B | #8, #26 | [Evals (case + scorer)](interfaces/evals/INTERFACE.md) |
+| Blob storage (S3/MinIO) | CLEAN | 1 backend (S3/MinIO) behind the ObjectStore port | A- | #83 | [Blob storage (S3/MinIO)](interfaces/blob-storage/INTERFACE.md) |
+| Relational DB (Postgres) | SOFT | 1 | A- | #84 | [Relational DB (Postgres)](interfaces/relational-db/INTERFACE.md) |
+| Queue / stream (Valkey) | CLEAN | 1 (redis-py) behind the broker port | not separately graded | #85, #7 | [Queue / stream (Valkey)](interfaces/queue-stream/INTERFACE.md) |
+| Bundle format | CLEAN, frozen | 1 | not separately graded | #30 | [Bundle format](interfaces/bundle-format/INTERFACE.md) |
+| Approval / authorizer | CLEAN | 3 approver sets behind one authorizer (Slack channel, Slack user group, explicit user list) | not separately graded | #22 | [Approval / authorizer](interfaces/approval/INTERFACE.md) |
+| Workflow state store | SOFT | 1 (API state router) | not separately graded | #23, #248 | [Workflow state store](interfaces/workflow-state/INTERFACE.md) |
+| Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [Memory](interfaces/memory/INTERFACE.md) |
+| Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [Conversation history](interfaces/conversation-history/INTERFACE.md) |
+| Triggers | SOFT | 2 hardcoded (Slack, GH push) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
+<!-- END GENERATED: seam-table -->
 
 ## Kind legend
 
@@ -49,8 +51,8 @@ graded here.
 | Job | Port contract | Current adapter | Grade | Cheapest next step |
 |---|---|---|---|---|
 | Harness / runtime | Frozen ACI protocol (`packages/aci-protocol`), tri-language, CI-guarded | claude-agent-sdk runner | A-: strongest seam in the system; docked for the plugin-format entanglement and SDK-shaped resume | Write the "implement an ACI server" guide from the conformance suite so the port is documented, not just enforced |
-| Observability | OTLP to collector (write), API DTOs (read) | Langfuse behind `langfuse.py` | B+: write side clean but for one vendor span attribute; read side isolated in one module | Rename `langfuse.trace.name` to a neutral attribute mapped in the collector; rename the `/langfuse/*` API routes |
-| Evals | Our stream schema + `EvalMatrix` DTO; store behind recorder | Langfuse traces + `eval_pass` scores | B: schema is ours, but the case format is duplicated and the tag convention is unfrozen | Converge the two `cases.json` definitions into one frozen schema ([issue #8](https://github.com/curie-eng/agentos/issues/8)) |
+| Observability | OTLP to collector (write), API DTOs (read) | Langfuse behind `langfuse.py` | B+: write side clean but for three vendor span attributes (`langfuse.trace.name`, `langfuse.session.id`, `langfuse.user.id`); read side spans several API modules plus routers | Map the three `langfuse.*` attributes to neutral names in the collector; rename the `/langfuse/*` API routes |
+| Evals | Our stream schema + `EvalMatrix` DTO; store behind recorder | Langfuse traces + `eval_pass` scores | B: schema is ours; the case format converged into one frozen, drift-gated schema (#8, ADR-0019), leaving the `version:`/`suite:` tag convention as the unfrozen part | Freeze the tag convention into the schema, or record it as a deliberate soft contract |
 | Blob storage | S3 protocol (boto3 + mc, path-style, endpoint-configurable) | MinIO | B+: config-only within S3-compatible stores; three hand-aligned client sites; no interface for non-S3 | None needed until a non-S3 demand exists; document the three client sites as one seam |
 | Relational DB | SQLAlchemy 2.0 + alembic | Postgres | A-: managed-Postgres swap is a DSN change; two Postgres-isms in models | Leave as is; note the `postgresql.UUID` and schema-scoped enum as the two things a non-Postgres target would touch |
-| Communication | `QueuedSlackEvent` + `SlackSink` | Slack (Bolt + chat.update) | C: Slack-shaped names and edit-in-place semantics in the core's contract; service swappable (CLI stub), protocol not | Promote the queue payload into `aci-protocol` with channel-neutral field names in the same change |
+| Communication | `QueuedTurn` (channel-neutral, in `aci-protocol`) + `SlackSink` | Slack (Bolt + chat.update) | C: the ingress payload is now the channel-neutral `QueuedTurn` (#7), but egress still assumes Slack's edit-in-place `chat.update` reply shape; service swappable (CLI stub), egress protocol not | Route replies per turn (#19) and define a channel-neutral `ReplySink` post/update port so a second channel can coexist |

--- a/docs/interfaces/aci-producer/INTERFACE.md
+++ b/docs/interfaces/aci-producer/INTERFACE.md
@@ -1,7 +1,21 @@
+---
+seam: ACI producer (frozen protocol)
+kind: CLEAN, frozen
+impls: 1 + reference
+grade: A-
+epics:
+  - "#25"
+  - "#47"
+order: 3
+---
+
 # INTERFACE: ACI producer (frozen protocol)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 + reference &nbsp;·&nbsp; **Swap-readiness grade:** A-
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** CLEAN, frozen &nbsp;·&nbsp; **Implementations today:** 1 + reference &nbsp;·&nbsp; **Swap-readiness grade:** A-
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -18,18 +32,23 @@ redefine them.
 ## Current contract
 
 A second implementation is an **ACI server** — an HTTP process that accepts the three endpoints
-(`docs/diagrams/aci.md:20`): `POST /v1/event` opens a turn, `POST /v1/steer` injects into the
+(`docs/diagrams/aci.md`): `POST /v1/event` opens a turn, `POST /v1/steer` injects into the
 live turn (409 if none running), `POST /v1/interrupt` hard-stops it. It streams the outbound
-NDJSON discriminated union `OutboundEvent` (`packages/aci-protocol/src/aci_protocol/events.py:119`):
-`TextDelta` (`text_delta`, :76), `ToolNote` (`tool_note`, :83), `Final` (`final` + `status`, :91),
-`ErrorEvent` (`error` + `classification`, :99), `SideEffectFlag` (`side_effect_flag`, :107). Every
+NDJSON discriminated union `OutboundEvent` (`packages/aci-protocol/src/aci_protocol/events.py::OutboundEvent`):
+`TextDelta` (`packages/aci-protocol/src/aci_protocol/events.py::TextDelta`, `text_delta`),
+`ToolNote` (`packages/aci-protocol/src/aci_protocol/events.py::ToolNote`, `tool_note`),
+`Final` (`packages/aci-protocol/src/aci_protocol/events.py::Final`, `final` + `status`),
+`ErrorEvent` (`packages/aci-protocol/src/aci_protocol/events.py::ErrorEvent`, `error` + `classification`),
+`SideEffectFlag` (`packages/aci-protocol/src/aci_protocol/events.py::SideEffectFlag`, `side_effect_flag`). Every
 outbound event carries `version` equal to the producer's exact build `PROTOCOL_VERSION`; a consumer
 accepts any `major.minor`-compatible version under 0.x (`major` after 1.0). Inbound frames are the
-`InboundMessage` union `Event | Interrupt` on the `kind` tag
-(`packages/aci-protocol/src/aci_protocol/events.py:64`, `:43`, `:55`). Setup is read from the
-environment via `SessionConfig.from_env` (`packages/aci-protocol/src/aci_protocol/session.py:96`),
-honoring the `AGENTOS_*` mapping in `to_env` (`:72`). Conformance is proven by
-`run_conformance(<your producer>)`, which must return `passed=True`.
+`InboundMessage` union (`packages/aci-protocol/src/aci_protocol/events.py::InboundMessage`) of
+`Event` (`packages/aci-protocol/src/aci_protocol/events.py::Event`) and
+`Interrupt` (`packages/aci-protocol/src/aci_protocol/events.py::Interrupt`) on the `kind` tag.
+Setup is read from the environment via `SessionConfig.from_env`
+(`packages/aci-protocol/src/aci_protocol/session.py::SessionConfig.from_env`), honoring the
+`AGENTOS_*` mapping in `to_env` (`packages/aci-protocol/src/aci_protocol/session.py::SessionConfig.to_env`).
+Conformance is proven by `run_conformance(<your producer>)`, which must return `passed=True`.
 
 ## Implementations today
 

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -1,7 +1,20 @@
+---
+seam: Approval / authorizer
+kind: CLEAN
+impls: 3 approver sets behind one authorizer (Slack channel, Slack user group, explicit user list)
+grade: not separately graded
+epics:
+  - "#22"
+order: 13
+---
+
 # INTERFACE: Approval / authorizer
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
 > **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 3 approver sets behind one authorizer (Slack channel, Slack user group, explicit user list) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -119,7 +132,7 @@ fully-namespaced name, not the bare tool name.
 
 For a bundle-declared MCP tool that live name is
 `mcp__plugin_<bundle>_<server>__<tool>`, where `<bundle>` is the
-`.claude-plugin/plugin.json` `name` and `<server>` is the `.mcp.json` server key,
+.claude-plugin/plugin.json `name` and `<server>` is the `.mcp.json` server key,
 for example `mcp__plugin_github-issues_github__create_issue`. The bare form
 `mcp__<server>__<tool>` (e.g. `mcp__github__create_issue`) does NOT match: a gate
 armed with it silently never intercepts the call, and a destructive tool runs
@@ -159,8 +172,11 @@ Slack feature.
   is never accepted from the caller: a dispatcher-asserted membership claim would be
   forgeable by any platform-key holder, so ADR-0034 rejected it. The only set that can come
   back undetermined.
-- **`ExplicitUsers`** (#420, `approvers.py`), a literal allowlist of user IDs. Pure, no I/O,
-  and the only set that owes Slack nothing.
+- **`ExplicitUsers`** (#420, `approvers.py`), a literal allowlist of user IDs. Pure, no I/O.
+  It owes Slack no *lookup*, but it can still only be **configured with Slack-validated user
+  IDs**: the binding schema rejects anything that is not a Slack `U`/`W`-prefixed ID
+  (`apps/api/src/agentos_api/schemas.py::_SLACK_USER_ID`), never a handle or a name, so even this
+  "Slack-free" set is expressed in Slack-shaped identifiers.
 
 Platform-RBAC remains the epic's fourth set and is not built.
 
@@ -291,8 +307,12 @@ One limit the audit trail must not be read as overstating (#420, ADR-0034): the 
 proves that the ASSERTED identity satisfied policy at click time; it does not prove who
 clicked. Identity is dispatcher-verified on the Slack path — the dispatcher populates the
 actor from Slack's authenticated interaction payload
-(`apps/dispatcher/src/agentos_dispatcher/approval_actions.py:146`) — and caller-asserted on
-the platform-API-key path, the named ADR-0033 residual tracked as a follow-up. Richer
+(`apps/dispatcher/src/agentos_dispatcher/approval_actions.py::process_approval_action`) — and
+caller-asserted on the platform-API-key path, the named ADR-0033 residual tracked as a follow-up.
+**The channel evidence is asserted on the same footing:** `actor_channel` on the platform-key
+path is caller-supplied and unvalidated too, so the residual is not identity-only — a
+platform-key caller asserts both *who* acted and *from which channel*, and the channel-membership
+set trusts that asserted channel exactly as the authorizer trusts the asserted actor. Richer
 evidence makes a forged resolution look MORE legitimate in the trail than today's thinner
 rows do, which is exactly why this limit is written down rather than left implicit. The
 membership authorizers narrow *who counts as an approver*; they do not change *how the

--- a/docs/interfaces/blob-storage/INTERFACE.md
+++ b/docs/interfaces/blob-storage/INTERFACE.md
@@ -1,14 +1,27 @@
+---
+seam: Blob storage (S3/MinIO)
+kind: CLEAN
+impls: 1 backend (S3/MinIO) behind the ObjectStore port
+grade: A-
+epics:
+  - "#83"
+order: 9
+---
+
 # INTERFACE: Blob storage (S3/MinIO)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 backend (S3/MinIO) behind the `ObjectStore` port &nbsp;·&nbsp; **Swap-readiness grade:** A-
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 backend (S3/MinIO) behind the ObjectStore port &nbsp;·&nbsp; **Swap-readiness grade:** A-
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
 ## The black line
 
 Immutable plugin bundles are addressed by a deterministic `(agent, version)` key in
-an object store, behind the **`ObjectStore` port** (`apps/api/.../storage.py`,
+an object store, behind the **`ObjectStore` port** (`apps/api/src/agentos_api/storage.py`,
 #282 / ADR-0026): `ensure_bucket` / `exists` / `put` / `get`, with the
 write-once/no-mutation key discipline promoted from convention **into the port's
 contract**. The one backing today is S3/MinIO (`BundleStore`); a future non-S3
@@ -19,16 +32,20 @@ second implementation.
 
 ## Current contract
 
-A second implementation must speak the boto3 S3 API with **path-style addressing**,
-configured entirely through env/settings — no code changes:
+The **`ObjectStore` port itself does not require S3**: its docstring
+(`apps/api/src/agentos_api/storage.py::ObjectStore`) states a second backend (GCS-native,
+Azure Blob) satisfies the Protocol without being boto3/S3. What speaks boto3 S3 is the one
+backing today, and a config-only swap that stays *within* the S3-compatible family (AWS S3,
+Cloudflare R2, MinIO) needs no code, only env/settings:
 
-- **Env/settings** (`apps/api/src/agentos_api/config.py:36-40`): `s3_endpoint_url`,
+- **Env/settings** (`apps/api/src/agentos_api/config.py::Settings`): `s3_endpoint_url`,
   `s3_access_key`, `s3_secret_key`, `s3_region`, `bundle_bucket` (env vars
   `S3_ENDPOINT_URL`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_REGION`, `BUNDLE_BUCKET`).
-- **Client construction** (`apps/api/src/agentos_api/storage.py:25-32`): `boto3.client("s3", endpoint_url=..., config=BotoConfig(s3={"addressing_style": "path"}))`.
-- **Operations used** (`storage.py:39-66`): `head_bucket`, `create_bucket`,
+- **Client construction** (`apps/api/src/agentos_api/storage.py::build_s3_client`): `boto3.client("s3", endpoint_url=..., config=BotoConfig(s3={"addressing_style": "path"}))`.
+- **Operations used** (`apps/api/src/agentos_api/storage.py::BundleStore`): `head_bucket`, `create_bucket`,
   `head_object`, `put_object` (with `Body`, `ContentType`), `get_object` (reads
-  `obj["Body"].read()`). The backend must support exactly these five calls, path-style.
+  `obj["Body"].read()`). The current S3 backing uses exactly these five calls, path-style;
+  a non-S3 backend instead honors the port's five method contract, not these wire calls.
 
 ## Implementations today
 
@@ -37,9 +54,9 @@ One backend (S3/MinIO) behind the port, plus the chart's `mc` init:
 - **`ObjectStore` port** — `apps/api/src/agentos_api/storage.py` (`Protocol`: the
   five ops + the write-once contract). Consumers (`deps`/`gitflow`/`deploy`) type
   against it, so a second backend is a drop-in.
-- **API writer** — `apps/api/.../storage.py` `BundleStore`, the S3/MinIO backing
+- **API writer** — `apps/api/src/agentos_api/storage.py::BundleStore`, the S3/MinIO backing
   (async-offloaded boto3); client built by the shared `build_s3_client` factory.
-- **Worker reader** — `apps/worker/.../bundle_store.py`: a local `BundleReader`
+- **Worker reader** — `apps/worker/src/agentos_worker/bundle_store.py::BundleReader`: a local `BundleReader`
   Protocol (the read-only slice of the port; the worker does not import the API
   package) with `BundleStore` as its S3/MinIO backing.
 - **Chart bundle-fetch init** — `charts/agentos/templates/agent-sandbox.yaml`
@@ -53,6 +70,13 @@ The port now names the contract, but two physically separate S3 clients remain
 which point the adapter is a drop-in `ObjectStore`/`BundleReader` rather than a
 three-site sweep. Building that adapter ahead of a real non-S3 customer is still
 out of scope (ADR-0007, ADR-0026).
+
+A second non-S3 backend is **two adapters, not one**: the API owns the full **async**
+`ObjectStore` port (`apps/api/src/agentos_api/storage.py::ObjectStore`, `async` methods),
+while the worker reads through a separate **sync** `BundleReader` slice
+(`apps/worker/src/agentos_worker/bundle_store.py::BundleReader`, a plain `get`) because it
+deliberately does not import the API package. A GCS/Azure backend must therefore supply
+both an async and a sync implementation.
 
 ## Cross-links
 

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -1,7 +1,20 @@
+---
+seam: Bundle format
+kind: CLEAN, frozen
+impls: "1"
+grade: not separately graded
+epics:
+  - "#30"
+order: 12
+---
+
 # INTERFACE: Bundle format
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** CLEAN, frozen &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -9,30 +22,40 @@
 
 The frozen bundle/plugin manifest format: the **Claude Code plugin shape verbatim**, a deliberate
 distribution wedge. What is swappable is the harness that consumes a bundle; what stays fixed is
-the shape a bundle must have to be accepted. The package does not invent format extensions —
-compatibility with real Claude Code bundles is the whole point, so the models are lenient
-(`extra="allow"`) rather than strict, and any bundle written for Claude Code validates unchanged.
+the shape a bundle must have to be accepted. The base is the Claude Code plugin shape, and the
+models are lenient (`extra="allow"`) rather than strict so any bundle written for Claude Code
+validates unchanged. On top of that base the package **does add five AgentOS authoring
+extensions** — `systemPrompt`, `starterPrompts`, `secrets`, `triggers`, `approvalPolicy` on
+`packages/plugin-format/src/plugin_format/models.py::PluginManifest`, optional fields Claude Code
+does not define. Leniency is what lets the Claude Code base and these extensions coexist; the
+earlier "does not invent format extensions" framing was wrong.
 
 ## Current contract
 
 `validate_bundle(path) -> ValidationResult` is the single entry point every deploy path calls
-(`packages/plugin-format/src/plugin_format/validate.py:55`). It returns path-qualified issues
-(codes like `manifest.missing`, `manifest.name_invalid`, `mcp.server_incomplete`) instead of
+(`packages/plugin-format/src/plugin_format/validate.py::validate_bundle`). It returns path-qualified
+issues (codes like `manifest.missing`, `manifest.name_invalid`, `mcp.server_incomplete`) instead of
 raising. The shapes it checks (`packages/plugin-format/src/plugin_format/models.py`):
-`PluginManifest` (`.claude-plugin/plugin.json`, `:35`) with `name` required and optional
-`version`, `description`, `author`, `commands`, `agents`, `hooks` (`:55`), `mcpServers` (`:56`);
-`SkillFrontmatter` (`skills/**/SKILL.md`, `:59`) with `name`/`description` required and
-`allowed_tools` aliased to the verbatim `allowed-tools` key (`:71`); `McpServer`/`McpConfig`
-(`.mcp.json`, `:74`, `:94`) where the validator enforces each server define `command` (stdio) or
-`url` (remote). A second consumer must accept exactly these shapes.
+`PluginManifest` (`packages/plugin-format/src/plugin_format/models.py::PluginManifest`, the
+`plugin.json` manifest) with `name` required and optional `version`, `description`, `author`,
+`commands`, `agents`, `hooks`, `mcpServers`; `SkillFrontmatter`
+(`packages/plugin-format/src/plugin_format/models.py::SkillFrontmatter`, a `SKILL.md` frontmatter)
+with `name`/`description` required and `allowed_tools` aliased to the verbatim `allowed-tools` key;
+`McpServer`/`McpConfig` (`packages/plugin-format/src/plugin_format/models.py::McpConfig`, the
+`.mcp.json` file) where the validator enforces each server define `command` (stdio) or `url`
+(remote). A second consumer must accept exactly these shapes.
 
 ## Implementations today
 
-One: the `plugin_format` package. Like `aci-protocol` it is tri-language and frozen — Pydantic
-source of truth, committed JSON Schema, generated types — CI-guarded by
-`packages/plugin-format/tests/test_schema_compat.py`. Unlike `aci-protocol` it carries no
-`PROTOCOL_VERSION`; the format is pinned to the Claude Code shape and the models are lenient by
-design so future Claude Code keys still validate.
+One: the `plugin_format` package. **Unlike `aci-protocol`, it is NOT tri-language with generated
+types.** The Pydantic models are the source of truth and a committed JSON Schema
+(`packages/plugin-format/schema/plugin-format.schema.json`) is regenerated and drift-checked by
+`packages/plugin-format/tests/test_schema_compat.py`, but there is **no generated Rust or TS** in
+the package (contrast `packages/aci-protocol/generated/`): the Rust (CLI) and TypeScript (UI)
+consumers of this format are **hand-written mirrors with no drift gate**, so a manifest field added
+here does not fail CI if those mirrors fall behind. It also carries no `PROTOCOL_VERSION`; the
+format is pinned to the Claude Code shape and the models are lenient by design so future Claude
+Code keys still validate.
 
 ## Known leakage
 
@@ -48,13 +71,19 @@ control, matching Claude Code convention for author-declared hooks. Only `PreToo
 other hook events validate but are not yet consumed. Epic #30 continues to define the remaining authoring extensions (approval-policy and
 trigger declarations) alongside this.
 
-The bundle also carries two AgentOS authoring extensions that are **deploy-time validated** (shape
-enforced, malformed declarations rejected) but whose **runtime consumption is a separate not-yet-built
-seam**: `triggers` (a list of `cron`/`webhook` declarations for waking the agent beyond chat, #273/#270
-— see the [triggers seam](../triggers/INTERFACE.md)) and `approvalPolicy` (`{gates: [{gate, route}]}`
-approval declarations, #273). Their validators live alongside the others in `validate.py`
-(`triggers.*` / `approval_policy.*` error codes); a future kernel/ingress consumer reads these same
-declarations.
+Two of those AgentOS authoring extensions are **deploy-time validated** (shape enforced, malformed
+declarations rejected), but they differ in whether the runtime acts on them yet:
+
+- `approvalPolicy` (`{gates: [{gate, route}]}` approval declarations, #273) is **consumed at
+  runtime**, not merely validated: the runner reads the gates at boot (`load_approval_policy`,
+  #247 / ADR-0010) and arms each `{gate, route}` on the permission gate — so calling this
+  "not-yet-built" is stale (see the [approval seam](../approval/INTERFACE.md)).
+- `triggers` (a list of `cron`/`webhook` declarations for waking the agent beyond chat, #273/#270 —
+  see the [triggers seam](../triggers/INTERFACE.md)) is still **declaration-only**: its validator
+  runs at deploy, but no runtime scheduler/ingress consumes a declared trigger yet (Epic #29).
+
+Their validators live alongside the others in `validate.py` (`triggers.*` / `approval_policy.*`
+error codes).
 
 ## Cross-links
 

--- a/docs/interfaces/bundle-format/workflow-agent-conversion.md
+++ b/docs/interfaces/bundle-format/workflow-agent-conversion.md
@@ -33,13 +33,13 @@ maps this cleanly — you do **not** turn the pipeline into a prompt.
 
 | Workflow agent piece | Bundle home | Why |
 | --- | --- | --- |
-| The agent's job + when to act + how to answer | `skills/deal-desk/SKILL.md` | The skill is the model-facing contract: trigger + procedure + hard rules. |
+| The agent's job + when to act + how to answer | skills/deal-desk/SKILL.md | The skill is the model-facing contract: trigger + procedure + hard rules. |
 | LLM edges (parse the ask, phrase the answer) | Prose steps in `SKILL.md` | These *are* the model's work; they live as instructions, not code. |
 | Deterministic pipeline (pricing rules, totals, thresholds) | An MCP tool server in `.mcp.json`, or a `scripts/` helper the skill calls | Keeps determinism out of the prompt; the model *calls* it, never re-derives it. |
 | External systems (pricing DB, CRM) | MCP servers in `.mcp.json` | Wire, don't inline; credentials come from env. |
-| One-time setup (build the pricing index) | `scripts/setup.sh` | Directory convention; no schema of its own. |
-| Regression cases | `evals/cases.json` | Feeds `agentos skill eval`. |
-| Name, version, description | `.claude-plugin/plugin.json` | The manifest; `name` is the only required field. |
+| One-time setup (build the pricing index) | scripts/setup.sh | Directory convention; no schema of its own. |
+| Regression cases | evals/cases.json | Feeds `agentos skill eval`. |
+| Name, version, description | .claude-plugin/plugin.json | The manifest; `name` is the only required field. |
 
 ## Step 0 — scaffold the skeleton
 
@@ -64,6 +64,7 @@ validator and the scaffolder enforce.
 
 ## Step 1 — the manifest
 
+<!-- doclint:ignore-line -->
 `.claude-plugin/plugin.json`. `name` is required; `version`, `description`, and the
 other Claude Code keys (`author`, `homepage`, `repository`, `license`, `keywords`,
 `commands`, `agents`, `hooks`, `mcpServers`) are optional and preserved if present.
@@ -81,6 +82,7 @@ carries over unchanged.
 
 ## Step 2 — write the skill (the LLM edges)
 
+<!-- doclint:ignore-line -->
 `skills/deal-desk/SKILL.md`. The frontmatter needs `name` and `description`;
 `allowed-tools` is optional but is how you scope what the model may call. Use the
 **real** field name `allowed-tools` (not `tools`).
@@ -159,7 +161,7 @@ Credentials come from env, never inlined. If your pipeline is a handful of pure
 functions rather than a service, the smallest MCP server that exposes `quote` as a
 tool is enough — the goal is that the model calls it, so the numbers never live in
 the prompt. One-time preparation (building the pricing index) goes in
-`scripts/setup.sh` (a directory convention with no schema of its own).
+`scripts/setup.sh` (a directory convention with no schema of its own). <!-- doclint:ignore-line -->
 
 ### Porting checklist for the pipeline
 - Every deterministic step → a tool (or an argument of one), never a prompt
@@ -208,7 +210,7 @@ compose services.
 ## Step 6 — pin behavior with eval cases
 
 Turn the workflow's known inputs/outputs into regression cases in
-`evals/cases.json` (a suite `{name, cases: [{id, input, grader}]}`), then:
+`evals/cases.json` (a suite `{name, cases: [{id, input, grader}]}`), then: <!-- doclint:ignore-line -->
 
 ```bash
 agentos skill eval          # defaults to evals/cases.json, runs through the runner
@@ -235,6 +237,7 @@ contract, and you have already met it.
   `allowed-tools`; the other name silently does nothing.
 - **Inlined credentials.** Reference env (`${VAR}`) in `.mcp.json`; never commit a
   token.
+<!-- doclint:ignore-line -->
 - **Manifest in the wrong place.** Canonical is `.claude-plugin/plugin.json`; a bare
   root `plugin.json` is accepted as a fallback but prefer the canonical location.
 

--- a/docs/interfaces/channel-ingress/INTERFACE.md
+++ b/docs/interfaces/channel-ingress/INTERFACE.md
@@ -1,66 +1,100 @@
+---
+seam: Channel / ingress (Slack)
+kind: SOFT
+impls: 1
+grade: C
+epics:
+  - "#7"
+  - "#19"
+  - "#27"
+  - "#38"
+order: 4
+---
 # INTERFACE: Channel / ingress (Slack)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
 > **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** C
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
 ## The black line
 
 The line that makes the communication channel swappable is the pair of contracts at
-the two ends of the run: the ingress payload the dispatcher enqueues
-(`QueuedSlackEvent`) and the egress port the kernel writes replies through
-(`SlackSink`). Everything between them — routing, concurrency, sandboxing — is
-opinionated core and channel-agnostic. This is the least-clean of the AgentOS seams:
-both ends are Slack-shaped by name and by semantics, so a second channel does not
-drop in behind a stable interface today. One implementation today; the port is the
-wire + Protocol contract, not a channel-neutral code interface — extracted only when a
-second channel demands it ("the second implementation teaches the interface").
+the two ends of the run: the ingress payload the dispatcher enqueues (`QueuedTurn`) and
+the egress port the kernel writes replies through (`SlackSink`). Everything between them —
+routing, concurrency, sandboxing — is opinionated core and channel-agnostic. Since #7 and
+#19 the ingress payload and the per-turn reply routing are channel-neutral, so this is no
+longer the least-clean seam by its wire contract; the remaining vendor shape is on the
+egress semantics (edit-in-place) and on the Slack-typed binding surface. One implementation
+today; the port is the wire + Protocol contract, extracted further only when a second
+channel demands it ("the second implementation teaches the interface").
 
 ## Current contract
 
 A second channel must produce the ingress payload and satisfy the egress Protocol:
 
-- **Ingress** — `QueuedSlackEvent` (`apps/dispatcher/src/agentos_dispatcher/queue.py:34`),
-  a Pydantic model with Slack-named fields: `slack_event_id` (idempotency key,
-  line 48), `thread_ts` (conversation key, line 49), `channel` (line 50), `user`,
-  `text`, and `placeholder_ts` (the pre-posted reply the worker edits in place,
-  line 53). It serializes to a single Stream field via `to_stream_fields`
-  (`queue.py:56`), keyed by `STREAM_PAYLOAD_FIELD = "payload"` (`queue.py:31`).
-- **Egress** — the `SlackSink` Protocol (`apps/worker/src/agentos_worker/slack_sink.py:21`),
+- **Ingress** — `QueuedTurn` (`packages/aci-protocol/src/aci_protocol/turn.py::QueuedTurn`),
+  a Pydantic model in the frozen ACI package with channel-neutral fields: `event_id`
+  (idempotency key), `conversation_id` (the conversation/thread key routing keeps one live
+  session per), `author`, `text`, `received_at`, and `reply_handle` — a `ReplyHandle`
+  (`packages/aci-protocol/src/aci_protocol/turn.py::ReplyHandle`) carrying `channel`,
+  `placeholder` (the pre-posted reply the worker edits in place), and an optional per-turn
+  `endpoint`. The dispatcher serializes it to a single Stream field via `to_stream_fields`
+  (`apps/dispatcher/src/agentos_dispatcher/queue.py::to_stream_fields`), keyed by
+  `STREAM_PAYLOAD_FIELD = "payload"` (`apps/dispatcher/src/agentos_dispatcher/queue.py::STREAM_PAYLOAD_FIELD`).
+  For the Slack adapter, `event_id` is the Slack event id, `conversation_id` is the thread
+  ts, `author` is the Slack user id, and `reply_handle` carries the Slack channel plus the
+  placeholder ts.
+- **Egress** — the `SlackSink` Protocol (`apps/worker/src/agentos_worker/slack_sink.py::SlackSink`),
   whose core method is `async def update(self, *, channel: str, ts: str, text: str)`
-  (`slack_sink.py:24`) — an edit-in-place on Slack's `chat.update`, plus best-effort
+  (`apps/worker/src/agentos_worker/slack_sink.py::SlackSink.update`) — an edit-in-place on Slack's `chat.update`, plus best-effort
   `set_status`/`clear_status`. The mrkdwn dialect is confined behind the sink in
-  `to_mrkdwn` (`apps/worker/src/agentos_worker/mrkdwn.py:45`).
+  `to_mrkdwn` (`apps/worker/src/agentos_worker/mrkdwn.py::to_mrkdwn`).
 - **Binding** — a channel resolves to a deployment by `agents.slack_channel`
-  equality in `BindingResolver.resolve` (`apps/worker/src/agentos_worker/binding.py:94`).
+  equality in `BindingResolver.resolve` (`apps/worker/src/agentos_worker/binding.py::BindingResolver.resolve`).
 
 ## Implementations today
 
 One: Slack. Ingress is `apps/dispatcher` (Bolt / Socket Mode); egress is
-`AsyncSlackSink` (`slack_sink.py:37`) on the Slack Web API. The swap proof that the
+`AsyncSlackSink` (`apps/worker/src/agentos_worker/slack_sink.py::AsyncSlackSink`) on the Slack Web API. The swap proof that the
 protocol (not just the service) is the seam: the Rust CLI mints the exact
-`QueuedSlackEvent` wire payload — `struct QueuedSlackEvent` with the same seven fields
-(`cli/src/queue.rs:35`) — and drives the whole deployed system with zero Slack contact
+`QueuedTurn` wire payload with the same channel-neutral fields
+(`cli/src/queue.rs`) and drives the whole deployed system with zero Slack contact
 via `agentos local message` / `cluster message` (`cli/src/chat.rs`, `cli/src/message.rs`).
 
 ## Known leakage
 
-The line leaks the vendor through the core contract in three ways. (1) The ingress
-field names are Slack's: `slack_event_id`, `thread_ts`, `placeholder_ts`. (2) The
-egress semantics are edit-a-placeholder — `update(channel, ts, text)` on `chat.update`,
-not post-a-message — so any channel without in-place edit must emulate it. (3) The
-reply base URL is worker-global: `WorkerConfig.slack_api_base_url`
-(`apps/worker/src/agentos_worker/config.py:40`), fed to `AsyncSlackSink(base_url=...)`
-(`slack_sink.py:45`), so two ingress paths cannot coexist on one deployment until
-replies route per turn. The restraint is deliberate: no multi-channel adapter framework
-is built (#27) — the channel-neutral rename comes with the second real channel.
+Two ends were cleaned and one Slack surface is newly documented.
+
+- **Fixed (#7).** The ingress field names were Slack's (`slack_event_id`, `thread_ts`,
+  `placeholder_ts`); the payload was promoted into `packages/aci-protocol` as `QueuedTurn`
+  with channel-neutral names.
+- **Fixed (#19).** The reply base URL was worker-global; per-turn reply routing now rides
+  `ReplyHandle.endpoint`, so a real Slack workspace and a no-Slack CLI stub can coexist on
+  one deployment. `WorkerConfig.slack_api_base_url` (`apps/worker/src/agentos_worker/config.py::WorkerConfig`)
+  is now only the default when a turn sets no `endpoint`, fed to `AsyncSlackSink`
+  (`apps/worker/src/agentos_worker/slack_sink.py::AsyncSlackSink.__init__`).
+- **Still leaks — egress semantics.** The reply model is edit-a-placeholder —
+  `update(channel, ts, text)` on `chat.update`, not post-a-message — so any channel without
+  in-place edit must emulate it.
+- **Still leaks — the Slack-typed binding surface, undocumented until now.** The agents table
+  carries a `slack_channel` column (`apps/api/src/agentos_api/models.py::Agent`), and agent
+  create/update validate it as a Slack channel id via `_validate_slack_channel_id`
+  (`apps/api/src/agentos_api/schemas.py::_validate_slack_channel_id`) wired onto
+  `apps/api/src/agentos_api/schemas.py::AgentCreate` and
+  `apps/api/src/agentos_api/schemas.py::AgentUpdate`. This is the largest remaining Slack
+  surface and appears in no other seam doc: the binding key and its validators are
+  Slack-shaped in the control plane, not just at the channel edges. The restraint is
+  deliberate: no multi-channel adapter framework is built (#27) — the channel-neutral
+  binding rename comes with the second real channel.
 
 ## Cross-links
 
 - **Epic(s):** #7 — promote the queue payload into `packages/aci-protocol` with
-  channel-neutral field names
-- **Epic(s):** #19 — per-turn reply routing (the reply base URL is worker-global today)
+  channel-neutral field names (landed)
+- **Epic(s):** #19 — per-turn reply routing (landed)
 - **Epic(s):** #27 — deliberately defers a pluggable multi-channel framework
 - **Epic(s):** #38 — channel-seam hardening / follow-up
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 6 (Communication channel), grade C

--- a/docs/interfaces/channel-interaction/INTERFACE.md
+++ b/docs/interfaces/channel-interaction/INTERFACE.md
@@ -1,6 +1,22 @@
+---
+seam: Channel interaction message
+kind: CLEAN
+impls: 2 renderers (Slack, terminal)
+grade: not separately graded
+epics:
+  - "ADR-0020"
+order: 5
+---
+
 # INTERFACE: Channel interaction
 
-> Part of the AgentOS swappable-seam catalog. **Kind:** CLEAN. **Version:** 1.0.
+> Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 2 renderers (Slack, terminal) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
+
+**Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
 ## The black line
 

--- a/docs/interfaces/conversation-history/INTERFACE.md
+++ b/docs/interfaces/conversation-history/INTERFACE.md
@@ -1,7 +1,20 @@
+---
+seam: Conversation history
+kind: CLEAN
+impls: 1 loader (StateApiTranscriptStore)
+grade: not separately graded
+epics:
+  - "#20"
+order: 16
+---
+
 # INTERFACE: Conversation history
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 loader (`StateApiTranscriptStore`) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 loader (StateApiTranscriptStore) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 

--- a/docs/interfaces/evals/INTERFACE.md
+++ b/docs/interfaces/evals/INTERFACE.md
@@ -1,9 +1,23 @@
+---
+seam: Evals (case + scorer)
+kind: SOFT
+impls: 2 scorers (grader family + trajectory matcher)
+grade: B
+epics:
+  - "#8"
+  - "#26"
+order: 8
+---
 # INTERFACE: Evals (case + scorer)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** SOFT (scorer slot now a typed `Scorer` Protocol) &nbsp;·&nbsp; **Implementations today:** 2 scorers (grader family + deterministic trajectory matcher) &nbsp;·&nbsp; **Swap-readiness grade:** B
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 scorers (grader family + trajectory matcher) &nbsp;·&nbsp; **Swap-readiness grade:** B
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
+
+The scorer slot is now a typed `Scorer` Protocol above the port; the seam overall is still SOFT because the request-in / results-out contracts are wire shapes, not a code interface.
 
 ## The black line
 
@@ -11,17 +25,17 @@ The eval seam is defined by two wire contracts, not a code interface: the `agent
 
 ## Current contract
 
-Request side — one stream field `payload` (`STREAM_PAYLOAD_FIELD`, `apps/worker/src/agentos_worker/eval/stream.py:72`) holding an `EvalWorkItem` JSON (`stream.py:76`): `agent_id`, `version_id`, `sha`, `suite`, `bundle_ref`, `target_url`, `requested_at`. Consumer group `agentos-eval-workers` reads it (`stream.py:6`, `stream.py:181`).
+Request side — one stream field `payload` (`STREAM_PAYLOAD_FIELD`, `apps/worker/src/agentos_worker/eval/stream.py::STREAM_PAYLOAD_FIELD`) holding an `EvalWorkItem` JSON (`apps/worker/src/agentos_worker/eval/stream.py::EvalWorkItem`): `agent_id`, `version_id`, `sha`, `suite`, `bundle_ref`, `target_url`, `requested_at`. Consumer group `agentos-eval-workers` is created and read by the eval stream consumer (`apps/worker/src/agentos_worker/eval/stream.py::EvalStreamConsumer.ensure_group`, `apps/worker/src/agentos_worker/eval/stream.py::EvalStreamConsumer._read_loop`).
 
-Case + grader models — `EvalCase` is `{id, input, grader}` (`eval/models.py:53`); `Grader` is `{kind: GraderKind, expected, case_sensitive}` (`models.py:26`) where `GraderKind` is the enum-dispatched family `EXACT | CONTAINS | REGEX` (`models.py:18`), applied by `Grader.grade(output)` (`models.py:39`). This is the single "grader family" — deny-by-default, string-shaped only.
+Case + grader models — `EvalCase` is `{id, input, grader}` (`apps/worker/src/agentos_worker/eval/models.py::EvalCase`); `Grader` is `{kind: GraderKind, expected, case_sensitive}` (`apps/worker/src/agentos_worker/eval/models.py::Grader`) where `GraderKind` is the enum-dispatched family `EXACT | CONTAINS | REGEX` (`apps/worker/src/agentos_worker/eval/models.py::GraderKind`), applied by `Grader.grade(output)` (`apps/worker/src/agentos_worker/eval/models.py::Grader.grade`). This is the single "grader family" — deny-by-default, string-shaped only.
 
-Scorer seam — the pass/fail decision is now a swappable `Scorer` Protocol above the port (`eval/scorer.py`): `score(case, output, trajectory) -> ScoreResult`. `EvalRunner` captures both the answer text and the tool-call `trajectory` (the ordered `tool` field of each `tool_note` frame) and delegates to an injected scorer, defaulting to `GraderScorer` (the frozen grader over the text — behavior-preserving). The second, tier-1 scorer is `TrajectoryScorer`: a deterministic matcher over the tool-call sequence with modes `EXACT | IN_ORDER | ANY_ORDER | PRECISION | RECALL`, configured above the port via a `case_id -> TrajectorySpec` mapping the run layer supplies (NOT a field on the frozen case — a per-case trajectory expectation would change the frozen eval-case schema, deliberately out of scope). LLM-judge and hosted-eval-API scorers are the later, costlier tiers; they conform to the same Protocol but are not built.
+Scorer seam — the pass/fail decision is now a swappable `Scorer` Protocol above the port (`apps/worker/src/agentos_worker/eval/scorer.py::Scorer`): `score(case, output, trajectory) -> ScoreResult`. `EvalRunner` captures both the answer text and the tool-call `trajectory` (the ordered `tool` field of each `tool_note` frame) and delegates to an injected scorer, defaulting to `GraderScorer` (the frozen grader over the text — behavior-preserving). The second, tier-1 scorer is `TrajectoryScorer`: a deterministic matcher over the tool-call sequence with modes `EXACT | IN_ORDER | ANY_ORDER | PRECISION | RECALL`, configured above the port via a `case_id -> TrajectorySpec` mapping the run layer supplies (NOT a field on the frozen case — a per-case trajectory expectation would change the frozen eval-case schema, deliberately out of scope). LLM-judge and hosted-eval-API scorers are the later, costlier tiers; they conform to the same Protocol but are not built.
 
-Result side — `LangfuseEvalRecorder.record()` (`eval/recorder.py:47`) posts, per case, a trace tagged `["eval", f"version:{run.version}", f"suite:{run.suite}"]` (`recorder.py:82`) plus an `eval_pass` numeric score `1.0/0.0` (`SCORE_NAME`, `recorder.py:25`; `_score_event`, `recorder.py:96`). The read path is `GET /matrix` returning `EvalMatrix`, querying traces by those tags (`apps/api/src/agentos_api/routers/evals.py:16`; `list_traces_by_tags(["eval", f"suite:{suite}"])` at `evals.py:23`).
+Result side — `LangfuseEvalRecorder.record()` (`apps/worker/src/agentos_worker/eval/recorder.py::LangfuseEvalRecorder.record`) posts, per case, a trace tagged `["eval", f"version:{run.version}", f"suite:{run.suite}"]` (`apps/worker/src/agentos_worker/eval/recorder.py::LangfuseEvalRecorder._trace_event`) plus an `eval_pass` numeric score `1.0/0.0` (`SCORE_NAME`, `apps/worker/src/agentos_worker/eval/recorder.py::SCORE_NAME`; `_score_event`, `apps/worker/src/agentos_worker/eval/recorder.py::LangfuseEvalRecorder._score_event`). The read path is `GET /matrix` returning `EvalMatrix`, querying traces by those tags (`apps/api/src/agentos_api/routers/evals.py::eval_matrix`, which calls `list_traces_by_tags(["eval", f"suite:{suite}"])`).
 
 Model dimension (issue #255, BYO-model epic #24) — additive, same convention as `version:`/`suite:`. A run carries the model id it ran under on `EvalRunResult.model`, which the recorder emits as a `model:<name>` tag plus a `metadata.model` field (and a per-case `metadata.cost_usd` when available). `build_matrix` reads them back (`_model_of`/`_cost_of`) into `EvalCell.model` and a per-model `EvalModelSummary` rollup (pass-rate + summed cost) on `EvalMatrix.model_summaries`, so a suite is sliceable by model for pass-rate/cost comparison. Runs with no resolved model (the `target_url` shortcut) record no `model:` tag and fall into the unlabelled column. **UI surfacing of `model_summaries` (a model column/toggle on the matrix grid) is not built here — the API DTO carries it; the console has yet to render it.** The recorder does not yet compute `cost_usd` from live usage (the ACI wire carries no usage block), so cost is present-but-`None` until a usage/pricing source is threaded — a deliberate follow-up.
 
-Prompt-cache observability (issue #255) — `_GenerationSpan.record_usage` (`runner/src/agentos_runner/otel.py`) now also stamps `cache_read_input_tokens`/`cache_creation_input_tokens` on the generation span, and `agentos_runner.cache` classifies a turn's usage as a warm cache hit. The prompt-cache smoke test (`runner/tests/test_prompt_cache.py`) drives a two-turn warm thread through the real `SessionRunner` and fails loudly if the second turn does not report cache reads — the signal a translating gateway silently broke caching.
+Prompt-cache observability (issue #255) — `_GenerationSpan.record_usage` (`runner/src/agentos_runner/otel.py::_GenerationSpan.record_usage`) now also stamps `cache_read_input_tokens`/`cache_creation_input_tokens` on the generation span, and `agentos_runner.cache` classifies a turn's usage as a warm cache hit. The prompt-cache smoke test (`runner/tests/test_prompt_cache.py`) drives a two-turn warm thread through the real `SessionRunner` and fails loudly if the second turn does not report cache reads — the signal a translating gateway silently broke caching.
 
 ## Implementations today
 
@@ -29,10 +43,10 @@ Two scorers through the `Scorer` seam — the three-variant deterministic grader
 
 ## Known leakage
 
-One seam still bleeds through. The eval-case format is now converged and frozen (issue #8, ADR-0019): both the CLI scaffold/loader (`cli/src/evals.rs`) and the worker's `load_suite_from_bundle` (`stream.py:143`) build to one schema, `apps/worker/schema/eval-cases.schema.json`, generated from the Pydantic `EvalSuite`/`EvalCase`/`Grader` models (`models.py`) and guarded by the same regenerate-and-diff drift gate as the frozen packages. The CLI hand-mirrors the schema in Rust and is kept honest by a byte-level conformance test against the shared committed fixture. Still open: the `version:`/`suite:` trace-tag convention is an unfrozen string contract hand-aligned between the recorder (`recorder.py:82`) and the matrix reader (`evals.py:23`) — a rename on one side silently breaks the grid.
+One seam still bleeds through. The eval-case format is now converged and frozen (issue #8, ADR-0019): both the CLI scaffold/loader (`cli/src/evals.rs`) and the worker's `load_suite_from_bundle` (`apps/worker/src/agentos_worker/eval/stream.py::load_suite_from_bundle`) build to one schema, `apps/worker/schema/eval-cases.schema.json`, generated from the Pydantic `EvalSuite`/`EvalCase`/`Grader` models (`apps/worker/src/agentos_worker/eval/models.py`) and guarded by the same regenerate-and-diff drift gate as the frozen packages. The CLI hand-mirrors the schema in Rust and is kept honest by a byte-level conformance test against the shared committed fixture. Still open: the `version:`/`suite:` trace-tag convention is an unfrozen string contract hand-aligned between the recorder (`apps/worker/src/agentos_worker/eval/recorder.py::LangfuseEvalRecorder._trace_event`) and the matrix reader (`apps/api/src/agentos_api/routers/evals.py::eval_matrix`) — a rename on one side silently breaks the grid.
 
 ## Cross-links
 
-- **Epic(s):** #8 — converge and freeze the duplicated `cases.json` case format into one schema; #26 — scorer swappability (grader family beyond the deterministic three)
+- **Epic(s):** #8 — converge and freeze the duplicated `cases.json` case format into one schema (landed via ADR-0019); #26 — scorer swappability (grader family beyond the deterministic three)
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 3 (Evals), grade B
-- **ADR(s):** [ADR-0004](../../adr/0004-langfuse-observability-and-eval-backbone.md) — Langfuse as the single observability + eval backbone
+- **ADR(s):** [ADR-0004](../../adr/0004-langfuse-observability-and-eval-backbone.md) — Langfuse as the single observability + eval backbone; [ADR-0019](../../adr/0019-freeze-eval-case-format.md) — converge and freeze the eval-case format

--- a/docs/interfaces/harness-modelsession/INTERFACE.md
+++ b/docs/interfaces/harness-modelsession/INTERFACE.md
@@ -1,7 +1,19 @@
+---
+seam: Harness in-proc / ModelSession
+kind: CLEAN
+impls: 1 + fake
+grade: A-
+epics:
+  - "#25"
+order: 2
+epic_note: folds into
+---
 # INTERFACE: Harness in-process (`ModelSession`)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 + fake &nbsp;·&nbsp; **Swap-readiness grade:** A- (the harness / ACI seam)
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 + fake &nbsp;·&nbsp; **Swap-readiness grade:** A-
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -9,56 +21,68 @@
 
 Inside the runner the model harness is reached through one in-process port: the
 `ModelSession` Protocol. Everything above it (ACI translation, budget, side-effect
-flagging, NDJSON, the HTTP layer) is written against the Protocol, so the concrete
-`claude-agent-sdk` driver is the only SDK-coupled code. What stays opinionated core
-is the frozen ACI wire contract the runner serves; the port is how a harness plugs
-into that runner. Steer and interrupt are first-class Protocol operations, not
-emulated.
+flagging, NDJSON, the HTTP layer) is written against the Protocol. The port itself is
+CLEAN, but the SDK is not yet confined to one module: eight runner modules still import
+`claude_agent_sdk` today (`check.py`, `session.py`, `hooks.py`, `adapter.py`, `fake.py`,
+`approval.py`, `translate.py`, `plugin.py`), and the value that crosses the port is
+currently the raw SDK message union rather than a runner-owned neutral type. The
+runner-owned `TurnEvent` model that would draw that line is pending (#307/#315, both
+open); until it lands, a second harness must emit objects the SDK-shaped translation
+step accepts. What stays opinionated core is the frozen ACI wire contract the runner
+serves; the port is how a harness plugs into that runner. Steer and interrupt are
+first-class Protocol operations, not emulated.
 
 ## Current contract
 
 A second harness must supply an object satisfying `ModelSession`
-(`runner/src/agentos_runner/adapter.py:24`), a five-method `Protocol`:
+(`runner/src/agentos_runner/adapter.py::ModelSession`), a five-method `Protocol`:
 
-- `async def connect(self) -> None` (`adapter.py:27`) — start/attach the harness,
+- `async def connect(self) -> None` (`runner/src/agentos_runner/adapter.py::ModelSession.connect`) — start/attach the harness,
   rehydrating if a resume ref is configured.
-- `async def query(self, text: str) -> None` (`adapter.py:31`) — push a user message;
+- `async def query(self, text: str) -> None` (`runner/src/agentos_runner/adapter.py::ModelSession.query`) — push a user message;
   a `query` issued while a turn is live is the mid-run **steer**.
-- `def receive_turn(self) -> AsyncIterator[Any]` (`adapter.py:35`) — yield the harness
+- `def receive_turn(self) -> AsyncIterator[Any]` (`runner/src/agentos_runner/adapter.py::ModelSession.receive_turn`) — yield the harness
   messages for the current turn, ending at its terminal result.
-- `async def interrupt(self) -> None` (`adapter.py:39`) — native hard stop at the next
+- `async def interrupt(self) -> None` (`runner/src/agentos_runner/adapter.py::ModelSession.interrupt`) — native hard stop at the next
   safe boundary.
-- `async def close(self) -> None` (`adapter.py:43`) — tear down.
+- `async def close(self) -> None` (`runner/src/agentos_runner/adapter.py::ModelSession.close`) — tear down.
 
 The messages a `receive_turn` iterator yields must be mappable by
-`translate_message` (`runner/src/agentos_runner/translate.py:55`) into the ACI
+`translate_message` (`runner/src/agentos_runner/translate.py::translate_message`) into the ACI
 outbound union (`TextDelta` / `ToolNote` / `SideEffectFlag` / `ErrorEvent` /
-`Final`). Session options are assembled by `build_options`
-(`adapter.py:48`), which pins `permission_mode="bypassPermissions"`
-(`adapter.py:82`).
+`Final`). Today those messages are the concrete `claude_agent_sdk` dataclasses; the
+neutral `TurnEvent` payload that would decouple the port from the SDK shape is #307/#315,
+not yet shipped. Session options are assembled by `build_options`
+(`runner/src/agentos_runner/adapter.py::build_options`). Since #245 / ADR-0010 the permission
+posture is conditional, not pinned: with an approval `can_use_tool` callback the session
+runs in `permission_mode="default"` so each tool call is gated, and only an unconfigured
+agent (no callback) keeps the historical `"bypassPermissions"` verbatim
+(`runner/src/agentos_runner/adapter.py::build_options`).
 
 ## Implementations today
 
 Two, both in `runner/src/agentos_runner/`:
 
-- **Real:** `ClaudeAgentSession` (`adapter.py:87`), wrapping `ClaudeSDKClient` in
+- **Real:** `ClaudeAgentSession` (`runner/src/agentos_runner/adapter.py::ClaudeAgentSession`), wrapping `ClaudeSDKClient` in
   streaming-input mode; `receive_turn` delegates to `self._client.receive_response()`
-  (`adapter.py:100`) and `interrupt` to `self._client.interrupt()` (`adapter.py:103`).
-- **Fake:** `FakeModelSession` (`runner/src/agentos_runner/fake.py:52`), a scripted
+  (`runner/src/agentos_runner/adapter.py::ClaudeAgentSession.receive_turn`) and `interrupt` to `self._client.interrupt()`
+  (`runner/src/agentos_runner/adapter.py::ClaudeAgentSession.interrupt`).
+- **Fake:** `FakeModelSession` (`runner/src/agentos_runner/fake.py::FakeModelSession`), a scripted
   replayer that constructs real SDK message dataclasses. It is the reusable acceptance
-  harness: `conformance_producer` (`runner/src/agentos_runner/conformance.py:33`) drives
-  a real `SessionRunner` over the fake (`conformance.py:24`), so the ACI conformance gate
+  harness: `conformance_producer` (`runner/src/agentos_runner/conformance.py::conformance_producer`) drives
+  a real `SessionRunner` over the fake (`runner/src/agentos_runner/conformance.py::_build_runner`), so the ACI conformance gate
   validates the actual translation/final plumbing, not a canned stream.
 
 ## Known leakage
 
-The port is CLEAN as a code interface but leaks harness shape in two places, both
-called out in vision-doc Job 1:
+The port is CLEAN as a code interface but leaks harness shape where the SDK is not yet
+walled off, called out in vision-doc Job 1:
 
-- **SDK-shaped resume.** `AGENTOS_HISTORY_REF` is read verbatim into `history_ref`
-  (`runner/src/agentos_runner/config.py:64`) and passed as the SDK `resume` session id
-  by `build_options` (`adapter.py:64`, `:80`). A harness without an equivalent
-  resume/session-store concept must build its own history store.
+- **SDK-shaped message payload.** The value crossing the port is the concrete
+  `claude_agent_sdk` message union, and `claude_agent_sdk` is imported across eight
+  runner modules rather than one adapter. The runner-owned `TurnEvent` model that draws
+  the neutral line is #307/#315 (open); until it merges, a second harness emits SDK-shaped
+  dataclasses that `translate_message` understands.
 - **Plugin-format entanglement.** `packages/plugin-format` is the Claude Code plugin
   shape verbatim, so a non-Claude harness must interpret Claude Code plugin bundles or
   translate them; "implement the ACI server" understates that work.
@@ -67,4 +91,4 @@ called out in vision-doc Job 1:
 
 - **Epic(s):** — no standalone epic; folds into #25 (ACI producer / second-harness work).
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 1 (Harness / runtime), grade A-.
-- **ADR(s):** [ADR-0005](../../adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md) — claude-agent-sdk adapter behind a frozen ACI session contract; [ADR-0011](../../adr/0011-opencode-second-harness.md) — OpenCode as the second harness behind the ACI.
+- **ADR(s):** [ADR-0005](../../adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md) — claude-agent-sdk adapter behind a frozen ACI session contract; [ADR-0010](../../adr/0010-approval-gates-and-human-in-the-loop.md) — approval gates make `permission_mode` conditional on a `can_use_tool` callback; [ADR-0011](../../adr/0011-opencode-second-harness.md) — OpenCode as the second harness behind the ACI.

--- a/docs/interfaces/memory/INTERFACE.md
+++ b/docs/interfaces/memory/INTERFACE.md
@@ -1,7 +1,20 @@
+---
+seam: Memory
+kind: CLEAN
+impls: 1 loader (StateApiMemoryStore)
+grade: not separately graded
+epics:
+  - "#28"
+order: 15
+---
+
 # INTERFACE: Memory
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 loader (`StateApiMemoryStore`) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 loader (StateApiMemoryStore) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -19,7 +32,7 @@ class MemoryStore(Protocol):
 A `MemoryRecord` is `content: str` plus a `Provenance`
 (`learned_from_session_id`, `source_trace_ids`, `recorded_at`) — the
 entry→source-traces link. `SessionConfig.memory_ref`
-(`packages/aci-protocol/src/aci_protocol/session.py:68`, `AGENTOS_MEMORY_REF`) is
+(`packages/aci-protocol/src/aci_protocol/session.py::SessionConfig`, `AGENTOS_MEMORY_REF`) is
 resolved to a concrete `MemoryStore` at runner boot by `resolve_memory`. The
 frozen ACI field is unchanged; the state-API bearer is a runner-local knob
 (`AGENTOS_MEMORY_TOKEN`), not part of the frozen env.

--- a/docs/interfaces/model-provider/INTERFACE.md
+++ b/docs/interfaces/model-provider/INTERFACE.md
@@ -1,7 +1,21 @@
+---
+seam: Model provider / credentials
+kind: SOFT
+impls: 2 prefix-routed (Anthropic, OpenRouter) + base-URL-selected provider-native endpoints (Zhipu, Moonshot, DeepSeek, Ollama)
+grade: not separately graded
+epics:
+  - "#24"
+  - "#46"
+order: 6
+---
+
 # INTERFACE: Model provider / credentials
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
 > **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 prefix-routed (Anthropic, OpenRouter) + base-URL-selected provider-native endpoints (Zhipu, Moonshot, DeepSeek, Ollama) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -19,21 +33,21 @@ the Anthropic wire format (kept even for OpenRouter, so prompt caching survives)
 Resolution lives in `runner/src/agentos_runner/sdk_auth.py`. A provider is defined by
 three things:
 
-- **Credential**, delivered as `AGENTOS_CREDENTIALS` (`sdk_auth.py:31`).
-  `resolve_model_credential` (`sdk_auth.py:82`) routes it by prefix
-  (`sdk_auth.py:94`): `sk-ant-oat...` → `CLAUDE_CODE_OAUTH_TOKEN`; other `sk-ant-...`
+- **Credential**, delivered as `AGENTOS_CREDENTIALS` (`runner/src/agentos_runner/sdk_auth.py::CREDENTIALS_ENV`).
+  `resolve_model_credential` (`runner/src/agentos_runner/sdk_auth.py::resolve_model_credential`) routes it by
+  prefix: `sk-ant-oat...` → `CLAUDE_CODE_OAUTH_TOKEN`; other `sk-ant-...`
   → `ANTHROPIC_API_KEY`; `sk-or-...` (OpenRouter) → base-URL override; a bare `sk-...`
-  raises `UnsupportedCredentialError` (`sdk_auth.py:47`, `:116`). An SDK credential
-  already in the env wins (`sdk_auth.py:89`).
+  raises `UnsupportedCredentialError` (`runner/src/agentos_runner/sdk_auth.py::UnsupportedCredentialError`). An SDK credential
+  already in the env wins.
 - **Base URL**, `ANTHROPIC_BASE_URL`, or its `AGENTOS_`-namespaced alias
   `AGENTOS_MODEL_BASE_URL` (the raw var wins when both are set).
-  `resolve_base_url_override` builds the override env when either is set, and
-  `resolve_sdk_env` is the entry point that decides override-vs-plain.
+  `resolve_base_url_override` (`runner/src/agentos_runner/sdk_auth.py::resolve_base_url_override`) builds the override env when either is set, and
+  `resolve_sdk_env` (`runner/src/agentos_runner/sdk_auth.py::resolve_sdk_env`) is the entry point that decides override-vs-plain.
 - **Model id**, `AGENTOS_MODEL`, read by `RunnerConfig.from_env`
-  (`runner/src/agentos_runner/config.py:62`).
+  (`runner/src/agentos_runner/config.py::RunnerConfig.from_env`).
 
 The override deliberately blanks `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_AUTH_TOKEN`
-to `""` (`sdk_auth.py:76`) so an inherited token cannot take precedence or leak to a
+to `""` (`runner/src/agentos_runner/sdk_auth.py::resolve_base_url_override`) so an inherited token cannot take precedence or leak to a
 third-party endpoint.
 
 ## Implementations today
@@ -69,9 +83,9 @@ gateway. A minimal config: `AGENTOS_MODEL_BASE_URL=https://api.deepseek.com/anth
 
 The gotcha the seam encodes rather than a bleed-through: base-URL override mode must
 carry a **non-empty** placeholder key, `NO_OP_API_KEY = "not-needed"`
-(`sdk_auth.py:44`). The bundled Claude CLI treats an empty `ANTHROPIC_API_KEY` as
+(`runner/src/agentos_runner/sdk_auth.py::NO_OP_API_KEY`). The bundled Claude CLI treats an empty `ANTHROPIC_API_KEY` as
 "not logged in" and refuses to dial the overridden endpoint (empirically verified
-2026-07-07, `sdk_auth.py:58`), so an empty string is not viable — a deliberately
+2026-07-07, `runner/src/agentos_runner/sdk_auth.py::resolve_base_url_override`), so an empty string is not viable — a deliberately
 non-`sk-` placeholder passes the auth gate without being mistakable for a credential.
 The credential value is never logged.
 

--- a/docs/interfaces/queue-stream/INTERFACE.md
+++ b/docs/interfaces/queue-stream/INTERFACE.md
@@ -1,7 +1,19 @@
+---
+seam: Queue / stream (Valkey)
+kind: CLEAN
+impls: 1 (redis-py) behind the broker port
+grade: not separately graded
+epics:
+  - "#85"
+  - "#7"
+order: 11
+---
 # INTERFACE: Queue / stream (Valkey)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
 > **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 1 (redis-py) behind the broker port &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -10,9 +22,9 @@
 The seam is the Valkey Stream wire contract between the dispatcher (producer) and the
 worker (consumer): a named stream carrying a frozen one-field payload. As of #284 /
 ADR-0027 the stream verbs are drawn behind a thin **broker port** at the two non-sacred
-seams — a `StreamPublisher` `Protocol` on the producer (`apps/dispatcher/.../queue.py`:
+seams — a `StreamPublisher` `Protocol` on the producer (`apps/dispatcher/src/agentos_dispatcher/queue.py::StreamPublisher`:
 `xadd` + the `SET NX EX` dedupe-claim) and a `StreamBroker` `Protocol` on the consumer
-transport (`apps/worker/.../broker.py`: `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`).
+transport (`apps/worker/src/agentos_worker/broker.py::StreamBroker`: `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`).
 The routing, consumer-group concurrency, dedupe, and reclaim rules stay opinionated
 **core**. `redis.Redis` / `redis.asyncio.Redis` structurally satisfy the ports, so
 redis-py is the one backing today with no adapter; a redis-compatible backend (Valkey,
@@ -26,25 +38,28 @@ exists (ADR-0007); only the port is extracted.
 A second broker must honor the stream key, the payload encoding, and the Stream verbs:
 
 - **Stream key** — `"agentos:runs"`, defaulted identically on both ends:
-  `DispatcherConfig.stream` (`apps/dispatcher/src/agentos_dispatcher/config.py:47`,
+  `DispatcherConfig.stream` (`apps/dispatcher/src/agentos_dispatcher/config.py::DispatcherConfig`,
   env `AGENTOS_STREAM`) and `WorkerConfig.stream`
-  (`apps/worker/src/agentos_worker/config.py:72`).
+  (`apps/worker/src/agentos_worker/config.py::WorkerConfig`).
 - **Payload encoding** — one Stream field, `STREAM_PAYLOAD_FIELD = "payload"`
-  (`queue.py:31`), holding `model_dump_json()`. Produced by `enqueue` via
-  `redis_client.xadd(config.stream, fields)`
-  (`apps/dispatcher/src/agentos_dispatcher/queue.py:82`) and reconstructed by
-  `QueuedSlackEvent.from_stream_fields` (`queue.py:60`).
+  (`apps/dispatcher/src/agentos_dispatcher/queue.py::STREAM_PAYLOAD_FIELD`),
+  holding `model_dump_json()`. Produced by `enqueue` via `redis_client.xadd(config.stream, fields)`
+  (`apps/dispatcher/src/agentos_dispatcher/queue.py::enqueue`) and reconstructed by
+  `from_stream_fields` (`apps/dispatcher/src/agentos_dispatcher/queue.py::from_stream_fields`)
+  into a `QueuedTurn`.
 - **Consumer verbs** — the worker reads with `xreadgroup` over a consumer group
-  (`apps/worker/src/agentos_worker/consumer.py:104`), rebuilds the model at
-  `consumer.py:143`, and acknowledges with `xack` (`consumer.py:160`). The group is
-  `"agentos-workers"` (`WorkerConfig.consumer_group`, `config.py:73`).
+  (`apps/worker/src/agentos_worker/consumer.py::Consumer._read_loop`), rebuilds the model at
+  `apps/worker/src/agentos_worker/consumer.py::Consumer._handle`, and acknowledges with `xack`
+  (`apps/worker/src/agentos_worker/consumer.py::Consumer._ack`). The group is
+  `"agentos-workers"` (`WorkerConfig.consumer_group`, `apps/worker/src/agentos_worker/config.py::WorkerConfig`).
 
 Idempotency lives beside the stream, not in it: `claim_event` does a
-`SET <dedupe_key> 1 NX EX <ttl>` before `XADD` (`queue.py:66`).
+`SET <dedupe_key> 1 NX EX <ttl>` before `XADD` (`apps/dispatcher/src/agentos_dispatcher/queue.py::claim_event`).
 
 ## Implementations today
 
-One, redis-py against Valkey. The dispatcher `XADD`s (`queue.py:82`); the worker runs
+One, redis-py against Valkey. The dispatcher `XADD`s
+(`apps/dispatcher/src/agentos_dispatcher/queue.py::enqueue`); the worker runs
 a consumer group with `XREADGROUP`/`XACK` and crash-recovery `XAUTOCLAIM`
 (`apps/worker/src/agentos_worker/consumer.py`). A second, sibling stream
 `"agentos:evals"` uses the same one-field `payload` convention
@@ -54,13 +69,15 @@ real contract.
 ## The port (as of #284 / ADR-0027)
 
 Drawn only at the **non-sacred** seams; the sacred concurrency kernel
-(`kernel.py`/`consumer.py`/`threadlock.py`/`markers.py`) is not touched:
+(`apps/worker/src/agentos_worker/kernel.py` / `apps/worker/src/agentos_worker/consumer.py` /
+`apps/worker/src/agentos_worker/threadlock.py` / `apps/worker/src/agentos_worker/markers.py`)
+is not touched:
 
-- **Producer** — `StreamPublisher` (`apps/dispatcher/.../queue.py`): `xadd` and the
+- **Producer** — `StreamPublisher` (`apps/dispatcher/src/agentos_dispatcher/queue.py::StreamPublisher`): `xadd` and the
   `SET NX EX` dedupe-claim. `enqueue`/`claim_event` type against it.
-- **Consumer transport** — `StreamBroker` (`apps/worker/.../broker.py`):
+- **Consumer transport** — `StreamBroker` (`apps/worker/src/agentos_worker/broker.py::StreamBroker`):
   `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`. The non-sacred `StreamConsumer`
-  base (`stream_consumer.py`) holds a `StreamBroker`; the sacred `consumer.py` subclass
+  base (`apps/worker/src/agentos_worker/stream_consumer.py`) holds a `StreamBroker`; the sacred `consumer.py` subclass
   inherits it unchanged (its `XAUTOCLAIM` reclaim now targets the port by inheritance).
 
 The verbs return a bare `Awaitable`/value matching redis-py's own typing, so
@@ -69,22 +86,30 @@ The verbs return a bare `Awaitable`/value matching redis-py's own typing, so
 ## Known leakage
 
 - **Reclaim + composition root still touch redis directly.** `consumer.py`'s
-  `XAUTOCLAIM` call (sacred file, by rule) and `run.py`'s client construction (the
-  composition root, by design) reference redis directly; the API's `main.py` redis is
-  the kill-switch / eval-queue, not the runs stream, and is out of scope. Fully unifying
-  these is left for when a real second broker lands (ADR-0007, ADR-0027).
-- The payload carried on this stream is `QueuedSlackEvent` — Slack-shaped by name
-(`slack_event_id`, `thread_ts`, `placeholder_ts`). That vendor leakage is not the queue
-seam's own; it belongs to the [channel / ingress seam](../channel-ingress/INTERFACE.md),
-and #7 promotes the payload into `packages/aci-protocol` with channel-neutral names,
-cleaning both seams at once. The queue seam's own constraint is narrower: the contract
-assumes redis Stream semantics (ordered entries, consumer groups, pending-entry
-reclaim), so a swap that stays redis-compatible is a URL change while a non-redis broker
-rewrites the wire and the consumer verbs.
+  `XAUTOCLAIM` call (sacred file, by rule) and the client construction in
+  `apps/worker/src/agentos_worker/run.py` (the composition root, by design) reference
+  redis directly.
+- **The API writes the runs stream outside the broker port.** Correcting an earlier claim
+  that the API's redis only backs the kill-switch / eval-queue: the approval-resume path
+  enqueues resume turns directly onto the same `agentos:runs` stream via `ResumeQueue`
+  (`apps/api/src/agentos_api/resumequeue.py::ResumeQueue`) and the expiry sweeper, an `xadd`
+  that bypasses the dispatcher's `StreamPublisher` port entirely. A second broker must
+  account for this third producer (the API) that does not go through the port today.
+- **The redis-py exception surface leaks.** The ports type the verbs but not the error
+  contract: `redis.exceptions` propagate through the callers unabstracted, so a non-redis
+  broker must either raise redis-py-compatible exceptions or the call sites must learn its
+  error types.
+- **Payload vendor-neutrality (now closed on this seam).** The payload was once Slack-shaped
+  by name; #7 promoted it into `packages/aci-protocol` as the channel-neutral
+  `QueuedTurn`, so the queue seam no longer carries Slack-shaped field names. The queue
+  seam's own remaining constraint is narrower: the contract assumes redis Stream semantics
+  (ordered entries, consumer groups, pending-entry reclaim), so a swap that stays
+  redis-compatible is a URL change while a non-redis broker rewrites the wire and the
+  consumer verbs.
 
 ## Cross-links
 
 - **Epic(s):** #85 — vision: make the broker itself swappable behind the stream contract
-- **Epic(s):** #7 — payload promotion into `packages/aci-protocol` (overlaps the channel seam)
+- **Epic(s):** #7 — payload promotion into `packages/aci-protocol` (overlaps the channel seam, landed)
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — opinionated core (`agentos:runs` stream), not one of the six swap jobs
 - **ADR(s):** [ADR-0027](../../adr/0027-thin-broker-port-defer-second-broker.md) — the broker port at the non-sacred seams; [ADR-0007](../../adr/0007-adopt-not-build-boundaries.md) — adopt-not-build (Valkey adopted; second broker deferred)

--- a/docs/interfaces/relational-db/INTERFACE.md
+++ b/docs/interfaces/relational-db/INTERFACE.md
@@ -1,7 +1,20 @@
+---
+seam: Relational DB (Postgres)
+kind: SOFT
+impls: "1"
+grade: A-
+epics:
+  - "#84"
+order: 10
+---
+
 # INTERFACE: Relational DB (Postgres)
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
 > **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** A-
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -21,28 +34,29 @@ store is ever demanded.
 A second implementation must be a Postgres speaking the async `asyncpg` dialect and
 honoring the models/migrations verbatim:
 
-- **DSN + schema** (`apps/api/src/agentos_api/db.py:21,29`): `SCHEMA = get_settings().db_schema` (default `"agentos"`, `config.py:21`); the engine is built from `database_url` (env `DATABASE_URL`, `config.py:18`) via `create_async_engine(..., pool_pre_ping=True)`.
-- **Schema-scoped metadata** (`db.py:24-25`): `Base.metadata = MetaData(schema=SCHEMA)` — every table is qualified into the `agentos` schema.
-- **Models** (`apps/api/src/agentos_api/models.py`): `Agent` (`agents`, line 25), `AgentVersion` (`agent_versions`, line 58), `Deployment` (`deployments`, line 79), plus the `Environment` StrEnum (`models.py:20`).
+- **DSN + schema** (`apps/api/src/agentos_api/db.py::SCHEMA`, `apps/api/src/agentos_api/db.py::create_engine`): `SCHEMA = get_settings().db_schema` (default `"agentos"`, `apps/api/src/agentos_api/config.py::Settings`); the engine is built from `database_url` (env `DATABASE_URL`) via `create_async_engine(..., pool_pre_ping=True)`.
+- **Schema-scoped metadata** (`apps/api/src/agentos_api/db.py::Base`): `Base.metadata = MetaData(schema=SCHEMA)` — every table is qualified into the `agentos` schema.
+- **Models** (`apps/api/src/agentos_api/models.py`): `apps/api/src/agentos_api/models.py::Agent` (table `agents`), `apps/api/src/agentos_api/models.py::AgentVersion` (table `agent_versions`), `apps/api/src/agentos_api/models.py::Deployment` (table `deployments`), plus the `apps/api/src/agentos_api/models.py::Environment` StrEnum.
 - **Migrations**: 5 Alembic revisions in `apps/api/alembic/versions/` (`0001_initial` → `0005_behavior_packs`); the target DB must apply this chain.
 
 ## Implementations today
 
 One: the compose/dev Postgres, reached through the single SQLAlchemy async engine in
-`apps/api/src/agentos_api/db.py:28-33`. Tests point the same engine at the compose
+`apps/api/src/agentos_api/db.py::create_engine`. Tests point the same engine at the compose
 Postgres by overriding `database_url` (per the module docstring).
 
 ## Known leakage
 
 Two Postgres-isms make the "just change the DSN" story leak for a non-Postgres store:
 
-1. **`postgresql.UUID` column type** — `models.py:14` imports `UUID` from
-   `sqlalchemy.dialects.postgresql`, used as `UUID(as_uuid=True)` on every primary
-   and foreign key (e.g. `models.py:29, 62, 82`). This is a dialect-specific type.
+1. **`postgresql.UUID` column type** — `apps/api/src/agentos_api/models.py::UUID` is imported
+   from `sqlalchemy.dialects.postgresql` and used as `UUID(as_uuid=True)` on every primary
+   and foreign key (e.g. `apps/api/src/agentos_api/models.py::Agent`). This is a dialect-specific type.
 2. **Schema-qualified tables + a schema-scoped native enum** — foreign keys are
-   written as `f"{SCHEMA}.agents.id"` (`models.py:65, 88-89`) and the `environment`
+   written as `f"{SCHEMA}.agents.id"` (`apps/api/src/agentos_api/models.py::AgentVersion`,
+   `apps/api/src/agentos_api/models.py::Deployment`) and the `environment`
    column is a native Postgres `Enum(Environment, name="environment", schema=SCHEMA)`
-   (`models.py:91-92`), which materializes as a `CREATE TYPE` in the `agentos` schema.
+   (`apps/api/src/agentos_api/models.py::Deployment`), which materializes as a `CREATE TYPE` in the `agentos` schema.
 
 Both are cheap within the Postgres family (the A- grade) but would need rework for a
 different RDBMS — the marker that a real port should be extracted first.

--- a/docs/interfaces/substrate/INTERFACE.md
+++ b/docs/interfaces/substrate/INTERFACE.md
@@ -1,7 +1,19 @@
+---
+seam: Substrate / SandboxClient
+kind: CLEAN
+impls: 2 (k8s, docker)
+grade: not separately graded
+epics:
+  - "#86"
+  - "#44"
+order: 1
+---
 # INTERFACE: Substrate / SandboxClient
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 2 (Kubernetes, Docker) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded (core substrate)
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 2 (k8s, docker) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -11,27 +23,27 @@ The substrate is where a conversation thread claims, dials, suspends, and reaps 
 
 ## Current contract
 
-A second implementation must satisfy the `SandboxClient` `Protocol` at `apps/worker/src/agentos_worker/sandbox/k8s.py:50`, six methods:
+A second implementation must satisfy the `SandboxClient` `Protocol` at `apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient`, six methods:
 
-- `create_claim(name, *, pool, env=None, labels=None) -> None` (`k8s.py:53`)
-- `get_claim(name) -> ClaimView | None` (`k8s.py:62`)
-- `delete_claim(name) -> None` (`k8s.py:64`)
-- `list_claims(*, label_selector) -> list[ClaimView]` (`k8s.py:66`)
-- `get_sandbox(name) -> SandboxView | None` (`k8s.py:68`)
-- `set_sandbox_mode(name, mode: OperatingMode) -> None` (`k8s.py:70`)
+- `create_claim(name, *, pool, env=None, labels=None) -> None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.create_claim`)
+- `get_claim(name) -> ClaimView | None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.get_claim`)
+- `delete_claim(name) -> None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.delete_claim`)
+- `list_claims(*, label_selector) -> list[ClaimView]` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.list_claims`)
+- `get_sandbox(name) -> SandboxView | None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.get_sandbox`)
+- `set_sandbox_mode(name, mode: OperatingMode) -> None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.set_sandbox_mode`)
 
-The exchanged value types are `ClaimView` (`sandbox/types.py:110`: `name`, `ready`, `sandbox_name`, `labels`) and `SandboxView` (`sandbox/types.py:120`: `name`, `ready`, `service_fqdn`, `operating_mode`, `port`). `operating_mode` must report `"Running"` for a claim to be handed back (`substrate.py:75`), and `OperatingMode` is `Literal["Running", "Suspended"]` (`k8s.py:30`). The selector reads `AGENTOS_SANDBOX_SUBSTRATE` (default `"kubernetes"`, else `"docker"`) in `_sandbox_client()` at `apps/worker/src/agentos_worker/run.py:81` (branch at `run.py:98`).
+The exchanged value types are `ClaimView` (`apps/worker/src/agentos_worker/sandbox/types.py::ClaimView`: `name`, `ready`, `sandbox_name`, `labels`) and `SandboxView` (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxView`: `name`, `ready`, `service_fqdn`, `operating_mode`, `port`). `operating_mode` must report `"Running"` for a claim to be handed back (`apps/worker/src/agentos_worker/sandbox/substrate.py::SandboxSubstrate.claim`), and `OperatingMode` is `Literal["Running", "Suspended"]` (`apps/worker/src/agentos_worker/sandbox/k8s.py::OperatingMode`). The selector reads `AGENTOS_SANDBOX_SUBSTRATE` (default `"kubernetes"`, else `"docker"`) in `_sandbox_client()` at `apps/worker/src/agentos_worker/run.py::_sandbox_client`, which branches on the value inside that same function.
 
 ## Implementations today
 
 Two, both under `apps/worker/src/agentos_worker/sandbox/`:
 
-- `KubernetesSandboxClient` (`k8s.py:101`) — drives agent-sandbox CRDs (`Sandbox` in `agents.x-k8s.io`, `SandboxClaim` in `extensions.agents.x-k8s.io`) via `CustomObjectsApi`.
-- `DockerSandboxClient` (`docker.py:94`) — boots runner containers on the local Docker daemon for middle mode (a laptop, no cluster).
+- `KubernetesSandboxClient` (`apps/worker/src/agentos_worker/sandbox/k8s.py::KubernetesSandboxClient`) — drives agent-sandbox CRDs (`Sandbox` in `agents.x-k8s.io`, `SandboxClaim` in `extensions.agents.x-k8s.io`) via `CustomObjectsApi`.
+- `DockerSandboxClient` (`apps/worker/src/agentos_worker/sandbox/docker.py::DockerSandboxClient`) — boots runner containers on the local Docker daemon for middle mode (a laptop, no cluster).
 
 ## Known leakage
 
-The `SandboxView.port` field (`types.py:134`) exists only because the Docker path publishes each runner on its own loopback host port, while the Kubernetes path uses one fleet-wide `runner_port`; `None` means "fall back to `SubstrateConfig.runner_port`". Credential handling also differs across the line: the k8s client strips `AGENTOS_CREDENTIALS` from per-claim env so it is never persisted in plaintext on the claim (`k8s.py:47`, `k8s.py:139`), relying on the chart Secret's `secretKeyRef`; the Docker client has no Secret and forwards exactly one model credential by name -- an explicit AGENTOS_CREDENTIALS alone (never an ambient CLAUDE_CODE_OAUTH_TOKEN/ANTHROPIC_API_KEY that would shadow it), and none at all for a fake-model or local base-URL-override run that resolves none. These are runtime-shaped asymmetries the `Protocol` does not fully hide.
+The `SandboxView.port` field (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxView`) exists only because the Docker path publishes each runner on its own loopback host port, while the Kubernetes path uses one fleet-wide `runner_port`; `None` means "fall back to `SubstrateConfig.runner_port`". Credential handling also differs across the line: the k8s client strips `AGENTOS_CREDENTIALS` (`apps/worker/src/agentos_worker/sandbox/k8s.py::CREDENTIALS_ENV`) from per-claim env so it is never persisted in plaintext on the claim (`apps/worker/src/agentos_worker/sandbox/k8s.py::KubernetesSandboxClient.create_claim`), relying on the chart Secret's `secretKeyRef`; the Docker client has no Secret and forwards exactly one model credential by name -- an explicit AGENTOS_CREDENTIALS alone (never an ambient CLAUDE_CODE_OAUTH_TOKEN/ANTHROPIC_API_KEY that would shadow it), and none at all for a fake-model or local base-URL-override run that resolves none. These are runtime-shaped asymmetries the `Protocol` does not fully hide.
 
 ## Cross-links
 

--- a/docs/interfaces/telemetry-otel/INTERFACE.md
+++ b/docs/interfaces/telemetry-otel/INTERFACE.md
@@ -1,7 +1,18 @@
+---
+seam: Telemetry / OTEL
+kind: SOFT
+impls: 1
+grade: B+
+epics:
+  - "#47"
+order: 7
+---
 # INTERFACE: Telemetry / OTEL
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
 > **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** B+
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -20,34 +31,35 @@ attributes on it.
 A second backend must ingest the OTLP-HTTP export produced in
 `runner/src/agentos_runner/otel.py`:
 
-- `build_tracer_provider` (`otel.py:36`) returns a `TracerProvider` wired with an
-  argument-free `OTLPSpanExporter()` over a `SimpleSpanProcessor` (`otel.py:62`), or
-  `None` when unconfigured (`otel.py:48`, so offline runs neither export nor fail).
+- `build_tracer_provider` (`runner/src/agentos_runner/otel.py::build_tracer_provider`) returns a `TracerProvider` wired with an
+  argument-free `OTLPSpanExporter()` over a `SimpleSpanProcessor`, or
+  `None` when unconfigured (so offline runs neither export nor fail).
 - Endpoint/headers come from the standard `OTEL_EXPORTER_OTLP_*` env vars, read by the
-  opentelemetry SDK itself (`otel.py:59`); `SessionConfig.otel` is the typed view of
+  opentelemetry SDK itself inside `build_tracer_provider`; `SessionConfig.otel` is the typed view of
   the same vars.
-- `RunTracer.run_span` (`otel.py:80`) opens the root `agent.run` (`SpanKind.SERVER`,
-  `otel.py:98`) and a child `llm.generation` span. `_GenerationSpan.record_model`
-  stamps `gen_ai.request.model` (`otel.py:141`), `record_usage` stamps
-  `gen_ai.usage.input_tokens` / `output_tokens` (`otel.py:153`), and `tool_span` emits
+- `RunTracer.run_span` (`runner/src/agentos_runner/otel.py::RunTracer.run_span`) opens the root `agent.run` (`SpanKind.SERVER`)
+  and a child `llm.generation` span. `_GenerationSpan.record_model`
+  stamps `gen_ai.request.model` (`runner/src/agentos_runner/otel.py::_GenerationSpan.record_model`), `record_usage` stamps
+  `gen_ai.usage.input_tokens` / `output_tokens` (`runner/src/agentos_runner/otel.py::_GenerationSpan.record_usage`), and `tool_span` emits
   an `execute_tool` child carrying `gen_ai.tool.name` and `gen_ai.operation.name`
-  (`otel.py:159`).
+  (`runner/src/agentos_runner/otel.py::_GenerationSpan.tool_span`).
 
 ## Implementations today
 
 One: Langfuse, reached through the OTel Collector (which authenticates and forwards,
 since Langfuse OTLP ingest is HTTP-only). The runner does not know it is Langfuse — it
-only knows OTLP. The read side (trace list, tree reconstruction) is a separate adapter
-in the API and out of scope for this write-side seam.
+only knows OTLP. The read side (trace list, tree reconstruction) is a separate concern in
+the API — Langfuse's query model spans several API modules plus routers, not one isolated
+module — and is out of scope for this write-side seam.
 
 ## Known leakage
 
-The write path is clean but for one vendor attribute: the root span carries
-`langfuse.trace.name` (`otel.py:99`), a Langfuse-named attribute on an otherwise
-neutral OTLP path. `run_span` similarly stamps `langfuse.session.id` (`otel.py:101`)
-and `langfuse.user.id` (`otel.py:103`) so Langfuse maps them to its Sessions/Users
-features. A clean seam would emit a neutral attribute the collector maps to the
-vendor name; today the vendor name is set at the source.
+The write path is clean but for three vendor-named attributes, all set at the source on
+the root span rather than mapped in the collector. `RunTracer.run_span` stamps
+`langfuse.trace.name`, `langfuse.session.id`, and `langfuse.user.id`
+(`runner/src/agentos_runner/otel.py::RunTracer.run_span`) so Langfuse maps them to its
+name/Sessions/Users features. A clean seam would emit neutral attributes the collector
+maps to the vendor names; today all three vendor names are set at the source.
 
 ## Cross-links
 

--- a/docs/interfaces/triggers/INTERFACE.md
+++ b/docs/interfaces/triggers/INTERFACE.md
@@ -1,7 +1,20 @@
+---
+seam: Triggers
+kind: SOFT
+impls: 2 hardcoded (Slack, GH push)
+grade: not separately graded
+epics:
+  - "#29"
+order: 17
+---
+
 # INTERFACE: Triggers
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 2 hardcoded (Slack, GH push) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
@@ -21,17 +34,33 @@ assert a port that does not exist.
 There is no cross-trigger contract to satisfy — a new trigger today means adding
 another hardcoded handler. The two that exist:
 
-- **Slack mention** — `apps/dispatcher/src/agentos_dispatcher/handlers.py:196`:
-  `@app.event("app_mention")` on the Slack Bolt app, which calls `process_event(...)`
-  to enqueue a run. (An adjacent `@app.event("message")` DM handler sits at
-  `handlers.py:208`, gated to `channel_type == "im"`.)
-- **GitHub push** — `apps/api/src/agentos_api/routers/github.py:20-21`:
+- **Slack mention** — `apps/dispatcher/src/agentos_dispatcher/handlers.py::process_event`:
+  the `@app.event("app_mention")` listener (wired in
+  `apps/dispatcher/src/agentos_dispatcher/handlers.py::register_handlers`) calls
+  `process_event(...)` to enqueue a run. (An adjacent `@app.event("message")` DM handler
+  in the same `register_handlers`, gated to `channel_type == "im"`, shares the path.)
+- **GitHub push** — `apps/api/src/agentos_api/routers/github.py::github_webhook`:
   `@router.post("/webhook")` verifies the HMAC signature, then branches on
-  `x_github_event`; a `"push"` event (`github.py:38`) is handed to `process_push(...)`,
+  `x_github_event`; a `"push"` event is handed to `process_push(...)`,
   everything else is `"ignored"`.
 
 The two share no abstraction: one is a Slack Bolt event listener, the other a FastAPI
 route with GitHub HMAC auth. They converge only downstream (both end up enqueuing work).
+
+**Two further wake paths the inventory omitted.** Beyond the two external triggers, two
+platform-internal paths also turn an event into a run on the same `agentos:runs` stream,
+and a truthful inventory names them:
+
+- **Slack block-action (button click)** —
+  `apps/dispatcher/src/agentos_dispatcher/handlers.py::process_action` normalizes a Block
+  Kit button click into a `QueuedTurn` (dedupe, in-thread placeholder, enqueue) so a click
+  is answered exactly as if the user had typed the button's command. Approval-card clicks
+  are excluded here and resolve through the API instead.
+- **Approval-resume** — resolving or expiring a durable approval enqueues a
+  platform-authored resume turn onto the runs stream via
+  `apps/api/src/agentos_api/resumequeue.py::ResumeQueue.enqueue`, so a suspended session
+  wakes down the identical consumer/kernel/claim path a Slack mention takes (see the
+  [approval seam](../approval/INTERFACE.md)).
 
 **Declaration vs. consumption (#273/#270).** The bundle manifest now carries deploy-time-validated
 `triggers` declarations (`cron` with a `schedule`, `webhook` with a `path`; `TriggerDeclaration` in
@@ -43,10 +72,14 @@ shape; it does not yet wire a live wake-up.
 
 ## Implementations today
 
-Two, both hardcoded, in two different processes:
+Two external triggers, both hardcoded, in two different processes:
 
-1. Slack `app_mention` in the dispatcher (`handlers.py:196`).
-2. GitHub `push` webhook in the API (`routers/github.py:20`).
+1. Slack `app_mention` in the dispatcher (`apps/dispatcher/src/agentos_dispatcher/handlers.py::process_event`).
+2. GitHub `push` webhook in the API (`apps/api/src/agentos_api/routers/github.py::github_webhook`).
+
+Plus two platform-internal wake paths that also enqueue a run: the Slack block-action
+handler (`apps/dispatcher/src/agentos_dispatcher/handlers.py::process_action`) and the
+approval-resume enqueue (`apps/api/src/agentos_api/resumequeue.py::ResumeQueue.enqueue`).
 
 ## Known leakage
 

--- a/docs/interfaces/workflow-state/INTERFACE.md
+++ b/docs/interfaces/workflow-state/INTERFACE.md
@@ -1,38 +1,83 @@
+---
+seam: Workflow state store
+kind: SOFT
+impls: 1 (API state router)
+grade: not separately graded
+epics:
+  - "#23"
+  - "#248"
+order: 14
+---
 # INTERFACE: Workflow state store
 
 > Part of the AgentOS swappable-seam catalog — see the [seam index](../../interfaces.md).
-> **Kind:** NONE &nbsp;·&nbsp; **Implementations today:** 0 abstracted (a concrete `AffinityStore` exists) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 (API state router) &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+<!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
 
 ## The black line
 
-There is no workflow-state port yet — only a concrete, single-purpose route store. Today's `AffinityStore` records exactly one thing: the `thread_key -> sandbox route` binding on Valkey, with atomic acquire and TTL expiry. A general workflow state store (durable get / compare-and-swap put / list / delete / append for agent run state, checkpoints, and history) is unbuilt. The intended line, when extracted, is a small typed port the kernel writes state through, with Valkey (or Postgres) behind it — but per "the second implementation teaches the interface," the port lands only when a real second consumer demands it.
+The durable workflow-state store is built. It shipped (#248, under epic #23) as the API
+state router: a scoped KV/document store on Postgres JSONB exposing exactly the five verbs
+this doc once said did not exist — get / put-with-CAS / list / delete / append. The swap
+axis here is the state backend, and it is a SOFT seam: the store is reached over the HTTP
+state API, not a typed in-process port, so a second backend is a persistence change behind
+that API rather than a `Protocol` swap. A separate concrete route store, `AffinityStore`,
+records one narrow thing (the `thread_key -> sandbox route` binding on Valkey, with atomic
+acquire and TTL expiry) and is not the general store. The typed in-process port the kernel
+would write arbitrary run state through (#23) is still unextracted, per "the second
+implementation teaches the interface."
 
 ## Current contract
 
-No port class exists. The concrete `AffinityStore` at `apps/worker/src/agentos_worker/sandbox/affinity.py:31` is what exists today, and its methods are the closest thing to a state contract:
+The state API is the store today. The five verbs live in
+`apps/api/src/agentos_api/routers/state.py`:
 
-- `get(thread_key) -> RouteRecord | None` (`affinity.py:42`)
-- `put_if_absent(thread_key, record, ttl_seconds) -> bool` — atomic acquire, the CAS-shaped primitive (`affinity.py:49`, `SET ... nx=True`)
-- `replace(thread_key, record, ttl_seconds) -> None` (`affinity.py:59`)
-- `touch(thread_key, ttl_seconds) -> bool` (`affinity.py:64`)
-- `delete_if_claim(thread_key, claim_name) -> bool` — guarded delete via a Lua `_DELETE_IF_CLAIM` script (`affinity.py:69`, script at `affinity.py:18`)
-- `live_claim_names(...) -> set[str]` (`affinity.py:74`)
-- `mark_suspended(thread_key, history_ref, ttl_seconds) -> RouteRecord` (`affinity.py:96`)
+- `get_state` (`apps/api/src/agentos_api/routers/state.py::get_state`)
+- `put_state` — put with compare-and-swap (`apps/api/src/agentos_api/routers/state.py::put_state`)
+- `list_state` (`apps/api/src/agentos_api/routers/state.py::list_state`)
+- `delete_state` (`apps/api/src/agentos_api/routers/state.py::delete_state`)
+- `append_state` (`apps/api/src/agentos_api/routers/state.py::append_state`)
 
-The stored value is a `RouteRecord` (`sandbox/types.py:54`) JSON-serialized. This is route affinity, not general workflow state — the get/put-CAS/list/delete/append surface epic #23 specifies does not exist here.
+Memory and Conversation history are the CLEAN loaders already built over this store
+(`StateApiMemoryStore`, `StateApiTranscriptStore`).
+
+The worker-side route store is separate. `AffinityStore` at
+`apps/worker/src/agentos_worker/sandbox/affinity.py::AffinityStore` records the
+`thread_key -> sandbox route` binding, and its methods are the closest thing to a
+route-state contract:
+
+- `get(thread_key) -> RouteRecord | None` (`apps/worker/src/agentos_worker/sandbox/affinity.py::AffinityStore.get`)
+- `put_if_absent(thread_key, record, ttl_seconds) -> bool` — atomic acquire, the CAS-shaped primitive (`apps/worker/src/agentos_worker/sandbox/affinity.py::AffinityStore.put_if_absent`, `SET ... nx=True`)
+- `replace(thread_key, record, ttl_seconds) -> None` (`apps/worker/src/agentos_worker/sandbox/affinity.py::AffinityStore.replace`)
+- `touch(thread_key, ttl_seconds) -> bool` (`apps/worker/src/agentos_worker/sandbox/affinity.py::AffinityStore.touch`)
+- `delete_if_claim(thread_key, claim_name) -> bool` — guarded delete via a Lua script (`apps/worker/src/agentos_worker/sandbox/affinity.py::AffinityStore.delete_if_claim`, script at `apps/worker/src/agentos_worker/sandbox/affinity.py::_DELETE_IF_CLAIM`)
+- `live_claim_names(...) -> set[str]` (`apps/worker/src/agentos_worker/sandbox/affinity.py::AffinityStore.live_claim_names`)
+- `mark_suspended(thread_key, history_ref, ttl_seconds) -> RouteRecord` (`apps/worker/src/agentos_worker/sandbox/affinity.py::AffinityStore.mark_suspended`)
+
+The stored value is a `RouteRecord` (`apps/worker/src/agentos_worker/sandbox/types.py::RouteRecord`) JSON-serialized. This is route affinity, not general workflow state.
 
 ## Implementations today
 
-Zero abstracted implementations. One concrete class, `AffinityStore` (`affinity.py:31`), bound directly to `redis.Redis` and to the sandbox-routing use case.
+One general store (the API state router over Postgres JSONB) plus one narrow concrete
+route store: `AffinityStore` (`apps/worker/src/agentos_worker/sandbox/affinity.py::AffinityStore`), bound directly to `redis.Redis` and to the sandbox-routing use case. Neither is abstracted behind a typed workflow-state port yet.
 
 ## Known leakage
 
-The port does not exist yet, so there is nothing to leak through — but the placement constraint the future store must honor is already visible: it is stateless-first. Per ADR-0003, a suspend/resume is a cold pod restart (the live process never survives), so resume rehydrates from a caller-supplied `history_ref` injected as `AGENTOS_HISTORY_REF` rather than assuming any in-process or cache warmth (`sandbox/substrate.py:99`–`139`). A future workflow-state port must not assume process affinity or cache continuity across a suspend; state that must survive has to be written durably, keyed by thread/session, and rehydratable from cold.
+The placement constraint the future in-process port must honor is already visible in two
+shapes. First, it is stateless-first: per ADR-0003 a suspend/resume is a cold pod restart
+(the live process never survives), so resume rehydrates from a caller-supplied `history_ref`
+injected as `AGENTOS_HISTORY_REF` rather than assuming any in-process or cache warmth
+(`apps/worker/src/agentos_worker/sandbox/substrate.py::SandboxSubstrate.resume`). Second,
+the route store leans on Valkey TTL-expiry as garbage collection: an idle route record
+simply expires, and the reaper protocol depends on that automatic expiry. A durable
+(non-TTL) backend for a future workflow-state port would have to add its own sweeper to
+reclaim abandoned state, because it cannot inherit Valkey's expiry-as-GC for free.
 
 ## Cross-links
 
-- **Epic(s):** #23 — full workflow state store API spec (get / put-CAS / list / delete / append); the extracted port lands with this epic, and its interface AC is the gold standard for this seam
+- **Epic(s):** #23 — full workflow state store API spec (get / put-CAS / list / delete / append); the store shipped as the API state router via #248, and the extracted in-process port lands under this epic
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — not one of the six graded jobs
 - **ADR(s):** [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) — stateless-first sessions; rehydrate on resume; no cross-hibernation cache assumption

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -76,9 +76,9 @@ agentos skill down
 ```
 
 `agentos init` scaffolds a generic starter bundle: a Claude Code plugin
-(`.claude-plugin/plugin.json`, a starter `skills/<name>/SKILL.md`, `.mcp.json`,
-and an `evals/cases.json` smoke seed) plus a root `AGENTS.md` and
-`.claude/skills/using-agentos/SKILL.md`, the harness primer. The scaffolded eval
+(`.claude-plugin/plugin.json`, a starter `skills/<name>/SKILL.md`, `.mcp.json`, <!-- doclint:ignore-line -->
+and an `evals/cases.json` smoke seed) plus a root `AGENTS.md` and <!-- doclint:ignore-line -->
+`.claude/skills/using-agentos/SKILL.md`, the harness primer. The scaffolded eval <!-- doclint:ignore-line -->
 is a smoke test that passes out of the box; replace it with real graders as you
 build. `--fake-model` gives scripted replies with no
 Anthropic key, so this proves the loop offline. Drop `--fake-model` and export a
@@ -86,7 +86,7 @@ credential, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, or
 `AGENTOS_CREDENTIALS`, for a real model.
 
 The reply streams to `stdout` as `NDJSON`. Abort a live turn with `Ctrl-C`.
-`agentos skill eval` runs the bundle's `evals/cases.json` the same way.
+`agentos skill eval` runs the bundle's `evals/cases.json` the same way. <!-- doclint:ignore-line -->
 
 ## Step 2: The Real Product Loop With `local`
 
@@ -120,7 +120,7 @@ agentos local message "what changed in the last deploy?"
   is optional then.
 - For multi turn work, `local message` prints a `continue this conversation:`
   line. Use `agentos local message --continue "follow up"` to reuse the last
-  turn's channel and thread from `.agentos/last-turn.json`. Send only the new
+  turn's channel and thread from `.agentos/last-turn.json`. Send only the new <!-- doclint:ignore-line -->
   text. `--continue` reads the API key again from `$AGENTOS_API_KEY` and does not
   replay transport flags like `--listen-port`, so pass those again if you used
   custom values.

--- a/docs/spikes/0001-plugin-bundle-translator.md
+++ b/docs/spikes/0001-plugin-bundle-translator.md
@@ -30,7 +30,7 @@ carry unmodeled keys the platform preserves.
 
 | Bundle element | Source location | Shape |
 |---|---|---|
-| Manifest | `.claude-plugin/plugin.json` (fallback: bare `plugin.json`) | `PluginManifest`: `name` required; optional `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, `commands`, `agents`, `hooks`, `mcpServers` |
+| Manifest | .claude-plugin/plugin.json (fallback: bare `plugin.json`) | `PluginManifest`: `name` required; optional `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, `commands`, `agents`, `hooks`, `mcpServers` |
 | Skills | `skills/**/SKILL.md` | YAML frontmatter (`name`, `description`, optional `allowed-tools`) + markdown body |
 | MCP servers | `.mcp.json` and/or manifest `mcpServers` (inline object or path) | `McpServer`: stdio (`command`,`args?`,`env?`) or remote (`type`,`url`,`headers?`) |
 | Scripts | `scripts/` | directory convention, no schema |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ members = [
     "apps/dispatcher",
     "apps/worker",
     "runner",
+    "tools/doclint",
 ]
 
 [tool.uv.sources]
@@ -35,9 +36,11 @@ agentos-api = { workspace = true }
 agentos-dispatcher = { workspace = true }
 agentos-worker = { workspace = true }
 agentos-runner = { workspace = true }
+agentos-doclint = { workspace = true }
 
 [dependency-groups]
 dev = [
+    "agentos-doclint",
     "pytest>=8.3",
     "ruff>=0.15.21",
     "mypy>=2.2.0",
@@ -58,6 +61,7 @@ testpaths = [
     "runner/tests",
     "compose/tests",
     "examples/tests",
+    "tools/doclint/tests",
 ]
 
 [tool.ruff]
@@ -67,6 +71,13 @@ extend-exclude = ["prototypes"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B"]
+
+[tool.ruff.lint.per-file-ignores]
+# The committed doclint test suite is frozen (issue #452) and groups its imports
+# with an extra blank line before the first section comment, which ruff's isort
+# would collapse. The implementation under tools/doclint/src stays fully linted,
+# I001 included; only the frozen tests are exempt from import-block formatting.
+"tools/doclint/tests/**" = ["I001"]
 
 [tool.mypy]
 python_version = "3.13"
@@ -81,6 +92,7 @@ mypy_path = [
     "apps/dispatcher/src",
     "apps/worker/src",
     "runner/src",
+    "tools/doclint/src",
 ]
 files = [
     "packages/aci-protocol/src",
@@ -90,6 +102,7 @@ files = [
     "apps/dispatcher/src",
     "apps/worker/src",
     "runner/src",
+    "tools/doclint/src",
 ]
 
 # The official kubernetes client ships no type stubs; keep its boundary typed

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Regenerate the generated regions of the interface catalog from each seam's
+# front-matter, fail if anything drifted, then lint every citation under the
+# linted root. This is the local mirror of the CI docs gate and the exact shape
+# of scripts/check-contracts.sh: regenerate, diff, then check. Run it after any
+# intended catalog change, then commit the regenerated docs.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+generated_docs=(docs/interfaces.md docs/interfaces)
+
+echo "== regenerating the seam table and per-doc headers =="
+uv run python -m agentos_doclint --repo-root "$repo_root" --write
+
+echo "== checking for drift =="
+if ! git diff --exit-code -- "${generated_docs[@]}"; then
+  echo "ERROR: generated catalog regions drifted from the seam front-matter." >&2
+  echo "The files above were regenerated and differ. Review, then commit them." >&2
+  exit 1
+fi
+
+echo "== linting citations under the linted root =="
+uv run python -m agentos_doclint --repo-root "$repo_root"
+
+echo "OK: the interface catalog is generated, drift-free, and every citation resolves."

--- a/tools/doclint/pyproject.toml
+++ b/tools/doclint/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "agentos-doclint"
+version = "0.0.0"
+description = "The interface-catalog citation linter and index/header generator (issue #452)"
+requires-python = ">=3.13"
+dependencies = [
+    "markdown-it-py>=3.0",
+    "pyyaml>=6.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentos_doclint"]

--- a/tools/doclint/src/agentos_doclint/__init__.py
+++ b/tools/doclint/src/agentos_doclint/__init__.py
@@ -1,0 +1,349 @@
+"""The interface-catalog citation linter and index/header generator (#452).
+
+Two phases run over the linted root (``docs/`` excluding ``docs/adr/``):
+
+1. Generate: regenerate the seam table in ``docs/interfaces.md`` and each seam
+   doc's header blockquote from front-matter, comparing to what is on disk.
+2. Lint: walk every citation, assert no line coordinates, every path exists,
+   every Python symbol resolves.
+
+``main`` is a pure check by default (drift is a finding, nothing is written);
+``main --write`` rewrites the generated regions so ``scripts/check-docs.sh`` can
+diff them, mirroring ``scripts/check-contracts.sh``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from .citation import (
+    SOURCE_EXTENSIONS,
+    Classification,
+    CodeSpan,
+    classify,
+    find_code_spans,
+    is_line_suppressed,
+    path_exists,
+    scan_raw_line_ban,
+)
+from .finding import Finding
+from .frontmatter import SeamMeta, parse_and_validate
+from .generate import (
+    INDEX_REL,
+    OrderTieError,
+    extract_region,
+    iter_seam_docs,
+    render_header_block,
+    render_index_table,
+    render_table,
+    replace_region,
+    seam_link,
+)
+from .symbols import SymbolCache, SymbolSyntaxError, resolve_symbol
+
+__all__ = [
+    "SOURCE_EXTENSIONS",
+    "Finding",
+    "lint",
+    "main",
+    "render_index_table",
+]
+
+_ADR_REL = "docs/adr"
+
+
+def _git_top_level() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def lint(repo_root: Path) -> list[Finding]:
+    """Run the generate + lint phases in memory and return the findings."""
+    findings, _ = _lint_and_count(repo_root)
+    return findings
+
+
+def _lint_and_count(repo_root: Path) -> tuple[list[Finding], int]:
+    """Return the findings plus the count of lines silenced by the escape hatch."""
+    cache = SymbolCache()
+    findings: list[Finding] = []
+    findings.extend(_check_generation(repo_root))
+    doc_findings, ignored = _check_docs(repo_root, cache)
+    findings.extend(doc_findings)
+    return findings, ignored
+
+
+def _collect_seam_rows(
+    repo_root: Path,
+) -> tuple[list[tuple[Path, str, str, SeamMeta]], list[Finding]]:
+    """Parse every seam doc's front-matter once.
+
+    Returns the docs that parsed cleanly, each as ``(doc, rel, text, meta)``,
+    plus findings for any doc whose front-matter failed to parse. Shared by
+    the check phase and the write phase so their seam-row loops cannot drift
+    out of sync with each other.
+    """
+    findings: list[Finding] = []
+    seam_docs: list[tuple[Path, str, str, SeamMeta]] = []
+
+    for doc in iter_seam_docs(repo_root):
+        rel = doc.relative_to(repo_root).as_posix()
+        text = doc.read_text(encoding="utf-8")
+        meta, errors = parse_and_validate(text)
+        if meta is None:
+            findings.extend(Finding(rel, err.field, err.reason) for err in errors)
+            continue
+        seam_docs.append((doc, rel, text, meta))
+
+    return seam_docs, findings
+
+
+def _render_table_or_finding(
+    rows: list[tuple[str, SeamMeta]],
+) -> tuple[str | None, Finding | None]:
+    """Render the seam table, converting an ``OrderTieError`` into a Finding.
+
+    Returns ``(table, None)`` on success or ``(None, finding)`` on a tie, so
+    the check phase and the write phase report a tie identically.
+    """
+    try:
+        return render_table(rows), None
+    except OrderTieError as exc:
+        return None, Finding(INDEX_REL, "seam-table", f"order tie: {exc}")
+
+
+def _check_generation(repo_root: Path) -> list[Finding]:
+    seam_docs, findings = _collect_seam_rows(repo_root)
+    rows: list[tuple[str, SeamMeta]] = []
+
+    for doc, rel, text, meta in seam_docs:
+        rows.append((seam_link(doc, repo_root), meta))
+        findings.extend(_check_header_region(rel, text, meta))
+
+    findings.extend(_check_index_region(repo_root, rows))
+    return findings
+
+
+def _check_header_region(rel: str, text: str, meta: SeamMeta) -> list[Finding]:
+    region = extract_region(text, "header")
+    if region.missing:
+        return [
+            Finding(rel, "header", "generated header marker block is missing or unpaired")
+        ]
+    if region.content.strip() != render_header_block(meta).strip():
+        return [Finding(rel, "header", "generated header block is out of date; regenerate")]
+    return []
+
+
+def _check_index_region(repo_root: Path, rows: list[tuple[str, SeamMeta]]) -> list[Finding]:
+    index_path = repo_root / INDEX_REL
+    if not index_path.is_file():
+        return []
+    text = index_path.read_text(encoding="utf-8")
+    region = extract_region(text, "seam-table")
+    if region.missing:
+        return [Finding(INDEX_REL, "seam-table", "generated marker block is missing or unpaired")]
+    expected, tie_finding = _render_table_or_finding(rows)
+    if tie_finding is not None:
+        return [tie_finding]
+    if expected is not None and region.content.strip() != expected.strip():
+        return [Finding(INDEX_REL, "seam-table", "index seam-table is out of date; regenerate")]
+    return []
+
+
+def _check_docs(repo_root: Path, cache: SymbolCache) -> tuple[list[Finding], int]:
+    findings: list[Finding] = []
+    ignored = 0
+    docs_root = repo_root / "docs"
+    if not docs_root.is_dir():
+        return findings, ignored
+    adr_root = repo_root / _ADR_REL
+
+    for md in sorted(docs_root.rglob("*.md")):
+        if _is_under(md, adr_root):
+            continue
+        rel = md.relative_to(repo_root).as_posix()
+        text = md.read_text(encoding="utf-8")
+        doc_findings, doc_ignored = _lint_doc(repo_root, rel, text, cache)
+        findings.extend(doc_findings)
+        ignored += doc_ignored
+
+    return findings, ignored
+
+
+def _lint_doc(
+    repo_root: Path, rel: str, text: str, cache: SymbolCache
+) -> tuple[list[Finding], int]:
+    """Lint one doc, then apply the per-line escape hatch uniformly.
+
+    Every finding type (line-ban, path, symbol, shorthand) is produced first,
+    then a finding whose line is silenced by ``<!-- doclint:ignore-line -->``
+    (on the preceding line, or inline at the end of that same line) is dropped.
+    The count is of distinct suppressed physical lines, so the summary reflects
+    genuinely-silenced findings, not bare comments.
+    """
+    lines = text.splitlines()
+    raw: list[Finding] = []
+
+    for hit in scan_raw_line_ban(text):
+        raw.append(
+            Finding(
+                rel,
+                hit.coordinate,
+                "line-number coordinate citation is banned; cite a symbol instead",
+                line=hit.line,
+            )
+        )
+
+    for span in find_code_spans(text):
+        raw.extend(_check_span(repo_root, rel, span, cache))
+
+    kept: list[Finding] = []
+    suppressed_lines: set[int] = set()
+    for finding in raw:
+        if finding.line is not None and is_line_suppressed(lines, finding.line):
+            suppressed_lines.add(finding.line)
+        else:
+            kept.append(finding)
+
+    return kept, len(suppressed_lines)
+
+
+def _check_span(repo_root: Path, rel: str, span: CodeSpan, cache: SymbolCache) -> list[Finding]:
+    classification = classify(span.content)
+    if classification.kind == "not_a_citation":
+        return []
+    if classification.kind == "shorthand_error":
+        return [
+            Finding(
+                rel,
+                span.content,
+                "shorthand citation has a symbol but no path; write the full "
+                "repo-relative path (citations resolve from the repo root, "
+                "never relative to the doc)",
+                line=span.line,
+            )
+        ]
+    return _check_citation(repo_root, rel, span, classification, cache)
+
+
+def _check_citation(
+    repo_root: Path,
+    rel: str,
+    span: CodeSpan,
+    classification: Classification,
+    cache: SymbolCache,
+) -> list[Finding]:
+    if not path_exists(repo_root, classification.path):
+        return [Finding(rel, span.content, "cited path does not exist", line=span.line)]
+    if not classification.symbol:
+        return []
+
+    extension = classification.path.rsplit(".", 1)[-1]
+    if extension != "py":
+        return [
+            Finding(
+                rel,
+                span.content,
+                f"symbol resolution is not supported for .{extension}; cite the file only",
+                line=span.line,
+            )
+        ]
+
+    try:
+        resolved = resolve_symbol(repo_root / classification.path, classification.symbol, cache)
+    except SymbolSyntaxError:
+        return [Finding(rel, span.content, "cited file has a syntax error", line=span.line)]
+    if not resolved:
+        return [
+            Finding(
+                rel,
+                span.content,
+                f"symbol '{classification.symbol}' does not resolve",
+                line=span.line,
+            )
+        ]
+    return []
+
+
+def _is_under(path: Path, ancestor: Path) -> bool:
+    try:
+        path.relative_to(ancestor)
+    except ValueError:
+        return False
+    return True
+
+
+def _write_generated(repo_root: Path) -> list[Finding]:
+    """Rewrite the generated regions in place; return blocking findings."""
+    seam_docs, findings = _collect_seam_rows(repo_root)
+    rows: list[tuple[str, SeamMeta]] = []
+
+    for doc, rel, text, meta in seam_docs:
+        rows.append((seam_link(doc, repo_root), meta))
+        region = extract_region(text, "header")
+        if region.missing:
+            findings.append(
+                Finding(rel, "header", "generated header marker block is missing or unpaired")
+            )
+            continue
+        rewritten = replace_region(text, "header", render_header_block(meta))
+        if rewritten != text:
+            doc.write_text(rewritten, encoding="utf-8")
+
+    index_path = repo_root / INDEX_REL
+    if index_path.is_file():
+        text = index_path.read_text(encoding="utf-8")
+        region = extract_region(text, "seam-table")
+        if region.missing:
+            findings.append(
+                Finding(INDEX_REL, "seam-table", "generated marker block is missing or unpaired")
+            )
+        else:
+            table, tie_finding = _render_table_or_finding(rows)
+            if tie_finding is not None:
+                findings.append(tie_finding)
+            elif table is not None:
+                rewritten = replace_region(text, "seam-table", table)
+                if rewritten != text:
+                    index_path.write_text(rewritten, encoding="utf-8")
+
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="agentos_doclint")
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root to lint; defaults to the git top-level.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Rewrite the generated regions in place instead of checking drift.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else _git_top_level()
+
+    if args.write:
+        findings = _write_generated(repo_root)
+        ignored = 0
+    else:
+        findings, ignored = _lint_and_count(repo_root)
+
+    for finding in findings:
+        print(finding.render())
+
+    if ignored:
+        print(f"doclint: {ignored} line(s) suppressed by the ignore-line escape hatch")
+
+    return 0 if not findings else 1

--- a/tools/doclint/src/agentos_doclint/__main__.py
+++ b/tools/doclint/src/agentos_doclint/__main__.py
@@ -1,0 +1,10 @@
+"""CLI entry: ``python -m agentos_doclint``."""
+
+from __future__ import annotations
+
+import sys
+
+from . import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/doclint/src/agentos_doclint/citation.py
+++ b/tools/doclint/src/agentos_doclint/citation.py
@@ -1,0 +1,236 @@
+"""Citation discovery, the three-bucket classifier, and the raw line-ban rule.
+
+Discovery is by markdown parse, not raw regex, so fenced and indented code
+blocks are structurally excluded from path/symbol checking rather than
+heuristically skipped. Only inline-code spans are candidate citations.
+
+The raw line-ban rule is the one deliberate exception: it scans the raw file
+text (including fenced blocks and prose) because the goal is that the rotten
+coordinate form does not appear at all.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from markdown_it import MarkdownIt
+
+# The single recognized extension list, shared by the path rule and the raw
+# line-ban rule. Two lists would drift, which is the whole subject of #452.
+SOURCE_EXTENSIONS: tuple[str, ...] = (
+    "py",
+    "rs",
+    "ts",
+    "tsx",
+    "yaml",
+    "yml",
+    "json",
+    "sh",
+    "toml",
+    "md",
+)
+
+# The unified raw line-citation ban: every recognized extension followed by
+# either the ``:NN`` or the GitHub ``#LNN`` spelling of a line coordinate. The
+# leading character class captures the path prefix so the reported match names
+# the full coordinate (e.g. ``pkg/x.rs:12``).
+_LINE_BAN = re.compile(
+    r"[A-Za-z0-9_./#-]*\.(?:" + "|".join(SOURCE_EXTENSIONS) + r")(?::\d+|#L\d+)"
+)
+
+_IGNORE_LINE = "<!-- doclint:ignore-line -->"
+
+# Reused across calls: MarkdownIt is safe to construct once and parse many
+# times, and construction is not free enough to redo on every doc.
+_MD = MarkdownIt("commonmark")
+
+
+@dataclass(frozen=True)
+class CodeSpan:
+    content: str
+    line: int | None
+
+
+@dataclass(frozen=True)
+class LineBanHit:
+    coordinate: str
+    line: int
+
+
+def _has_source_extension(text: str) -> bool:
+    return any(text.endswith("." + ext) for ext in SOURCE_EXTENSIONS)
+
+
+def _locate_span(block_text: str, content: str, cursor: int) -> tuple[int, int]:
+    """Return ``(line_offset, next_cursor)`` for a span's content in a block.
+
+    ``code_inline`` tokens carry no reliable own map, so the span's true source
+    line is recovered by finding its backtick content within the inline block's
+    raw source (the lines from ``token.map[0]`` to ``token.map[1]``). ``cursor``
+    is the char offset to search from, advanced past each match so repeated
+    identical spans map to successive physical lines instead of all collapsing
+    onto the block's first line. ``line_offset`` is the count of newlines before
+    the match, i.e. how many lines into the block the span sits.
+
+    Falls back to the cursor position when the content is not found verbatim
+    (e.g. a span whose source wraps a line break, which markdown collapses to a
+    space); the reported line is then the block-relative cursor line.
+    """
+    index = block_text.find(content, cursor)
+    if index < 0:
+        index = cursor
+    line_offset = block_text.count("\n", 0, index)
+    return line_offset, index + max(len(content), 1)
+
+
+def find_code_spans(text: str) -> list[CodeSpan]:
+    """Return every inline-code span, excluding fenced/indented code blocks.
+
+    ``code_inline`` tokens appear only as children of ``inline`` tokens, never
+    inside a ``fence`` or ``code_block`` leaf, so collecting them naturally
+    excludes fenced and indented content.
+
+    Each span's ``line`` is its true physical source line, not the inline
+    container's start line. A multi-line paragraph holds one ``inline`` token
+    whose ``map`` spans the whole paragraph, so stamping every span with
+    ``map[0]`` would report each on the paragraph's first line; that is what let
+    a single escape-hatch comment silence findings paragraph-wide. Instead each
+    span is located within the block's source text (see ``_locate_span``) so the
+    reported line is where the backticks actually are.
+
+    A ``code_inline`` inside a markdown link is validated like any other span,
+    with one exception: a self-referential relative link whose visible text is
+    identical to its own destination (e.g. `` [`diagrams/x.md`](diagrams/x.md) ``)
+    is navigation, not a citation. The label and the target are the same string,
+    so nothing is being cited, only linked; such spans are skipped. A decorated
+    citation whose destination differs from its text (e.g.
+    `` [`apps/api/x.py`](../../apps/api/x.py) ``) is still classified and checked,
+    which closes the blind spot where a real repo-root citation escaped the gate
+    merely by being written as a link. CommonMark disallows nested links, so at
+    most one link is ever open at a time; that is tracked as a single optional
+    href rather than a stack.
+    """
+    source_lines = text.split("\n")
+    spans: list[CodeSpan] = []
+    for token in _MD.parse(text):
+        if token.type != "inline" or token.children is None:
+            continue
+        if token.map is not None:
+            start_line = token.map[0]
+            block_text = "\n".join(source_lines[token.map[0] : token.map[1]])
+        else:
+            start_line = None
+            block_text = ""
+        cursor = 0
+        current_href: str | None = None
+        for child in token.children:
+            if child.type == "link_open":
+                current_href = str(child.attrGet("href") or "")
+            elif child.type == "link_close":
+                current_href = None
+            elif child.type == "code_inline":
+                line_offset, cursor = _locate_span(block_text, child.content, cursor)
+                if current_href is not None and child.content.strip() == current_href.strip():
+                    continue
+                line = start_line + 1 + line_offset if start_line is not None else None
+                spans.append(CodeSpan(content=child.content, line=line))
+    return spans
+
+
+@dataclass(frozen=True)
+class Classification:
+    """The bucket a code span falls into, with the parts a citation carries."""
+
+    kind: str  # "citation" | "shorthand_error" | "not_a_citation"
+    path: str = ""
+    symbol: str = ""
+
+
+def _is_doc_relative(path: str) -> bool:
+    """A ``..``/``.``-anchored path is doc-relative navigation, not a citation.
+
+    The gate resolves every citation repo-root-relative (see ``path_exists``),
+    so a path beginning ``../`` or ``./`` cannot be a repo-root citation by the
+    spec's own rule. It is a doc-relative link, a link checker's concern.
+    """
+    return path.startswith("../") or path.startswith("./")
+
+
+def _is_glob_or_placeholder(path: str) -> bool:
+    """A path part carrying ``*``, ``<``, or ``>`` is a pattern/template.
+
+    Examples: ``skills/**/SKILL.md``, ``skills/<name>/SKILL.md``. These name a
+    shape, not a concrete file, so they are not checkable citations.
+    """
+    return any(ch in path for ch in ("*", "<", ">"))
+
+
+def classify(content: str) -> Classification:
+    """Sort a code span into exactly one of the three buckets.
+
+    The path portion is the part before ``::`` when present, otherwise the
+    whole span; that portion is normalized once (doc-relative/glob exclusion,
+    then the path-with-extension citation check) so the ``::`` and no-``::``
+    forms cannot drift out of sync with each other.
+    """
+    path_part, sep, symbol_part = content.partition("::")
+    if _is_doc_relative(path_part) or _is_glob_or_placeholder(path_part):
+        return Classification("not_a_citation")
+    if "/" in path_part and _has_source_extension(path_part):
+        return Classification("citation", path=path_part, symbol=symbol_part)
+    if sep and _has_source_extension(path_part):
+        # Symbol form with no path: invisible to the gate, so a hard error.
+        return Classification("shorthand_error")
+    return Classification("not_a_citation")
+
+
+def scan_raw_line_ban(text: str) -> Iterator[LineBanHit]:
+    """Yield every banned line coordinate in ``text`` (before suppression).
+
+    Scans the raw file text, including fenced blocks and prose, because the
+    goal is that the rotten coordinate form does not appear at all. The
+    per-line escape hatch is applied by the caller through
+    ``is_line_suppressed`` so that suppression and its accounting live in one
+    place across every finding type (line-ban, path, symbol, shorthand).
+    """
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        for match in _LINE_BAN.finditer(line):
+            yield LineBanHit(coordinate=match.group(0), line=index + 1)
+
+
+def _is_standalone_ignore(line: str) -> bool:
+    """True when ``line`` is a ``doclint:ignore-line`` comment and nothing else."""
+    return _IGNORE_LINE in line and not line.replace(_IGNORE_LINE, "").strip()
+
+
+def is_line_suppressed(lines: list[str], line_no: int) -> bool:
+    """True when a finding on 1-based ``line_no`` is silenced by the hatch.
+
+    Two forms, and each silences exactly one physical line:
+
+    * inline form: a ``<!-- doclint:ignore-line -->`` at the end of a physical
+      line that also carries content suppresses findings on that same line;
+    * preceding-line form: a standalone comment (the marker alone on its own
+      line) suppresses findings on the next line.
+
+    The two are mutually exclusive by construction: a marker sharing a line with
+    content is inline and cannot double as a preceding-line comment for the line
+    below, so an inline suppression never bleeds onto the following line. There
+    is no file-level, paragraph-level, or directory-level ignore, by design.
+    ``lines`` is the file's ``splitlines()`` output.
+    """
+    if line_no < 1 or line_no > len(lines):
+        return False
+    same = lines[line_no - 1]
+    if _IGNORE_LINE in same and not _is_standalone_ignore(same):
+        return True
+    return line_no >= 2 and _is_standalone_ignore(lines[line_no - 2])
+
+
+def path_exists(repo_root: Path, rel_path: str) -> bool:
+    """Repo-root-relative existence check. Never doc-relative."""
+    return (repo_root / rel_path).is_file()

--- a/tools/doclint/src/agentos_doclint/finding.py
+++ b/tools/doclint/src/agentos_doclint/finding.py
@@ -1,0 +1,33 @@
+"""The one finding type the linter emits.
+
+A ``Finding`` carries at least the repo-relative doc path, the offending
+citation or field, and a human reason, per the public contract. The printed
+line combines all three so the test suite (which reads exit code and message
+text only) can assert on any of them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single lint failure.
+
+    ``doc`` is the repo-relative path of the file the failure was found in.
+    ``citation`` is the offending token: a citation string, a front-matter
+    field name, a kind value, a coordinate, or a generated-marker name.
+    ``reason`` explains the failure. ``line`` is the 1-based line number when
+    known, else ``None``.
+    """
+
+    doc: str
+    citation: str
+    reason: str
+    line: int | None = None
+
+    def render(self) -> str:
+        """One printable line naming the doc, the citation, and the reason."""
+        location = self.doc if self.line is None else f"{self.doc}:{self.line}"
+        return f"{location}: {self.citation}: {self.reason}"

--- a/tools/doclint/src/agentos_doclint/frontmatter.py
+++ b/tools/doclint/src/agentos_doclint/frontmatter.py
@@ -1,0 +1,112 @@
+"""Front-matter parse and validation.
+
+Front-matter is the single declared source of truth for a seam's index row and
+its generated header blockquote. An unvalidated contract is prose, so every
+field is checked here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import yaml
+
+_REQUIRED_FIELDS = ("seam", "kind", "impls", "grade", "epics", "order")
+_VALID_KINDS = ("CLEAN", "SOFT", "NONE")
+
+
+@dataclass(frozen=True)
+class SeamMeta:
+    seam: str
+    kind: str
+    impls: str
+    grade: str
+    epics: list[str]
+    order: int
+    epic_note: str | None
+
+
+@dataclass(frozen=True)
+class FieldError:
+    field: str
+    reason: str
+
+
+def split_front_matter(text: str) -> str | None:
+    """Return the raw YAML front-matter block, or None if absent.
+
+    The block is delimited by a leading ``---`` line and the next ``---`` line.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            return "\n".join(lines[1:index])
+    return None
+
+
+def parse_and_validate(text: str) -> tuple[SeamMeta | None, list[FieldError]]:
+    """Parse and validate a doc's front-matter.
+
+    Returns ``(meta, [])`` when valid, ``(None, errors)`` otherwise. A missing
+    block is reported as a missing ``front-matter`` field.
+    """
+    block = split_front_matter(text)
+    if block is None:
+        return None, [FieldError("front-matter", "missing front-matter block")]
+
+    try:
+        loaded = yaml.safe_load(block)
+    except yaml.YAMLError as exc:
+        return None, [FieldError("front-matter", f"invalid YAML: {exc}")]
+    if not isinstance(loaded, dict):
+        return None, [FieldError("front-matter", "front-matter is not a mapping")]
+
+    errors: list[FieldError] = []
+    for field in _REQUIRED_FIELDS:
+        if field not in loaded or loaded[field] is None:
+            errors.append(FieldError(field, "front-matter field is required"))
+
+    kind_ok = True
+    if "kind" in loaded and loaded["kind"] is not None:
+        kind_value = str(loaded["kind"])
+        base_kind = kind_value.split(",", 1)[0].strip()
+        if base_kind not in _VALID_KINDS:
+            kind_ok = False
+            errors.append(
+                FieldError(
+                    kind_value,
+                    "invalid kind; expected CLEAN, SOFT, or NONE",
+                )
+            )
+
+    order_value = 0
+    if "order" in loaded and loaded["order"] is not None:
+        try:
+            order_value = int(loaded["order"])
+        except (TypeError, ValueError):
+            errors.append(FieldError("order", "front-matter field must be an integer"))
+
+    epics: list[str] = []
+    if "epics" in loaded and loaded["epics"] is not None:
+        raw_epics = loaded["epics"]
+        if not isinstance(raw_epics, list):
+            errors.append(FieldError("epics", "front-matter field must be a list"))
+        else:
+            epics = [str(item) for item in raw_epics]
+
+    if errors or not kind_ok:
+        return None, errors
+
+    epic_note_raw = loaded.get("epic_note")
+    meta = SeamMeta(
+        seam=str(loaded["seam"]),
+        kind=str(loaded["kind"]),
+        impls=str(loaded["impls"]),
+        grade=str(loaded["grade"]),
+        epics=epics,
+        order=order_value,
+        epic_note=None if epic_note_raw is None else str(epic_note_raw),
+    )
+    return meta, []

--- a/tools/doclint/src/agentos_doclint/generate.py
+++ b/tools/doclint/src/agentos_doclint/generate.py
@@ -1,0 +1,132 @@
+"""The seam-table and per-doc header generator, plus marker handling.
+
+The generator owns two generated regions, each delimited by HTML comment
+markers so hand prose and generated content coexist in one file:
+
+- the seam table in ``docs/interfaces.md``,
+- the header blockquote at the top of each ``INTERFACE.md``.
+
+Rows are ordered by the front-matter ``order`` field; a tie is a hard error,
+never a silent tiebreak, so output is byte-stable across runs and machines.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .frontmatter import SeamMeta, parse_and_validate
+
+INDEX_REL = "docs/interfaces.md"
+SEAM_GLOB = "docs/interfaces/*/INTERFACE.md"
+
+_TABLE_HEADER = "| Seam | Kind | Impls | Grade | Epic(s) | INTERFACE.md |"
+_TABLE_SEPARATOR = "|---|---|---|---|---|---|"
+
+
+class OrderTieError(Exception):
+    """Raised when two seams declare the same ``order`` value."""
+
+
+def iter_seam_docs(repo_root: Path) -> list[Path]:
+    """Every seam INTERFACE.md, found by glob (never a hardcoded list)."""
+    return sorted(repo_root.glob(SEAM_GLOB))
+
+
+def seam_link(doc: Path, repo_root: Path) -> str:
+    """The index link path for a seam doc, relative to ``docs/``."""
+    return doc.relative_to(repo_root / "docs").as_posix()
+
+
+def _epics_cell(meta: SeamMeta) -> str:
+    joined = ", ".join(meta.epics)
+    if meta.epic_note:
+        return f"({meta.epic_note} {joined})"
+    return joined
+
+
+def render_row(meta: SeamMeta, link: str) -> str:
+    return (
+        f"| {meta.seam} | {meta.kind} | {meta.impls} | {meta.grade} "
+        f"| {_epics_cell(meta)} | [{meta.seam}]({link}) |"
+    )
+
+
+def render_table(rows: list[tuple[str, SeamMeta]]) -> str:
+    """Render the seam table from ``(link, meta)`` pairs, ordered by ``order``.
+
+    A repeated ``order`` value is a hard error.
+    """
+    seen: dict[int, str] = {}
+    for _, meta in rows:
+        if meta.order in seen:
+            raise OrderTieError(
+                f"order {meta.order} is declared by both "
+                f"{seen[meta.order]} and {meta.seam}"
+            )
+        seen[meta.order] = meta.seam
+
+    ordered = sorted(rows, key=lambda pair: pair[1].order)
+    lines = [_TABLE_HEADER, _TABLE_SEPARATOR]
+    lines.extend(render_row(meta, link) for link, meta in ordered)
+    return "\n".join(lines)
+
+
+def render_index_table(repo_root: Path) -> str:
+    """Public generator surface: the ``docs/interfaces.md`` seam-table block.
+
+    Byte-stable across runs and machines; globs the interfaces dir.
+    """
+    rows: list[tuple[str, SeamMeta]] = []
+    for doc in iter_seam_docs(repo_root):
+        meta, errors = parse_and_validate(doc.read_text(encoding="utf-8"))
+        if meta is None:
+            raise ValueError(f"{doc}: invalid front-matter: {errors}")
+        rows.append((seam_link(doc, repo_root), meta))
+    return render_table(rows)
+
+
+def render_header_block(meta: SeamMeta) -> str:
+    """The generated header blockquote for a seam doc."""
+    return (
+        f"> **Kind:** {meta.kind} &nbsp;·&nbsp; "
+        f"**Implementations today:** {meta.impls} &nbsp;·&nbsp; "
+        f"**Swap-readiness grade:** {meta.grade}"
+    )
+
+
+@dataclass(frozen=True)
+class RegionResult:
+    missing: bool
+    content: str = ""
+
+
+def _begin_prefix(name: str) -> str:
+    return f"<!-- BEGIN GENERATED: {name}"
+
+
+def _end_marker(name: str) -> str:
+    return f"<!-- END GENERATED: {name} -->"
+
+
+def extract_region(text: str, name: str) -> RegionResult:
+    """Return the content between the named markers, or missing/unpaired."""
+    begin = text.find(_begin_prefix(name))
+    if begin == -1:
+        return RegionResult(missing=True)
+    begin_close = text.find("-->", begin)
+    if begin_close == -1:
+        return RegionResult(missing=True)
+    content_start = begin_close + len("-->")
+    end = text.find(_end_marker(name), content_start)
+    if end == -1:
+        return RegionResult(missing=True)
+    return RegionResult(missing=False, content=text[content_start:end])
+
+
+def replace_region(text: str, name: str, new_content: str) -> str:
+    """Rewrite the content between the named markers, preserving the markers."""
+    begin = text.find(_begin_prefix(name))
+    begin_close = text.find("-->", begin) + len("-->")
+    end = text.find(_end_marker(name), begin_close)
+    return f"{text[:begin_close]}\n{new_content}\n{text[end:]}"

--- a/tools/doclint/src/agentos_doclint/symbols.py
+++ b/tools/doclint/src/agentos_doclint/symbols.py
@@ -1,0 +1,110 @@
+"""ast-based symbol resolution.
+
+The resolver parses a cited ``.py`` file with ``ast`` and never imports or
+executes it: importing app modules to lint a doc would run module-level code,
+need the full dependency graph installed, and could fire side effects. A static
+parse is correct here and cannot.
+
+Resolution forms:
+
+- ``name`` matches a top-level function, class, or assignment target (a
+  module-level constant), or a name bound by a plain ``from x import name``.
+- ``Class.method`` matches a function in the body of the named class; deeper
+  nesting (``A.B.c``) walks successive class bodies.
+- A star-import (``from x import *``) binds nothing resolvable: a symbol that
+  would resolve only via a star-import does NOT resolve.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+class SymbolSyntaxError(Exception):
+    """Raised when the cited file does not parse; a clean lint failure."""
+
+
+def _parse(file_path: Path) -> ast.Module:
+    try:
+        return ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
+    except SyntaxError as exc:
+        raise SymbolSyntaxError(str(exc)) from exc
+
+
+class SymbolCache:
+    """Per-lint-run cache of parsed ASTs, keyed by absolute file path.
+
+    A doc that cites the same file for several symbols would otherwise re-read
+    and re-parse it once per citation. Create one instance fresh at the start
+    of each ``lint()`` invocation and thread it through; deliberately not a
+    module-level ``functools.lru_cache``, which would persist across separate
+    lint runs in the same process (e.g. across tests) and could serve a stale
+    parse after a file on disk changes between runs.
+    """
+
+    def __init__(self) -> None:
+        self._parsed: dict[Path, ast.Module] = {}
+
+    def parse(self, file_path: Path) -> ast.Module:
+        cached = self._parsed.get(file_path)
+        if cached is not None:
+            return cached
+        tree = _parse(file_path)
+        self._parsed[file_path] = tree
+        return tree
+
+
+def resolve_symbol(file_path: Path, dotted: str, cache: SymbolCache | None = None) -> bool:
+    """Return True if ``dotted`` resolves in ``file_path`` by static parse.
+
+    Raises ``SymbolSyntaxError`` if the file cannot be parsed, so the caller
+    reports a clean finding rather than crashing. When ``cache`` is given, a
+    repeated citation of the same file within one lint run reuses the parse
+    instead of re-reading and re-parsing the file.
+    """
+    tree = cache.parse(file_path) if cache is not None else _parse(file_path)
+    parts = dotted.split(".")
+    return _resolve_in_body(tree.body, parts)
+
+
+def _resolve_in_body(body: list[ast.stmt], parts: list[str]) -> bool:
+    head, rest = parts[0], parts[1:]
+
+    if not rest:
+        return _name_bound_in_body(body, head)
+
+    # A dotted remainder means head must name a class we can descend into.
+    for node in body:
+        if isinstance(node, ast.ClassDef) and node.name == head:
+            return _resolve_in_body(node.body, rest)
+    return False
+
+
+def _name_bound_in_body(body: list[ast.stmt], name: str) -> bool:
+    for node in body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            if node.name == name:
+                return True
+        elif isinstance(node, ast.Assign):
+            if any(_target_binds(target, name) for target in node.targets):
+                return True
+        elif isinstance(node, ast.AnnAssign):
+            if _target_binds(node.target, name):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "*":
+                    continue  # star-import binds nothing resolvable
+                bound = alias.asname or alias.name
+                if bound == name:
+                    return True
+    return False
+
+
+def _target_binds(target: ast.expr, name: str) -> bool:
+    if isinstance(target, ast.Name):
+        return target.id == name
+    if isinstance(target, ast.Tuple | ast.List):
+        return any(_target_binds(elt, name) for elt in target.elts)
+    return False

--- a/tools/doclint/tests/CONTRACT.md
+++ b/tools/doclint/tests/CONTRACT.md
@@ -1,0 +1,70 @@
+# doclint public API contract (assumed by the test suite)
+
+The tests in this directory were written first, against the public surface
+below. The Implementer builds `agentos_doclint` to satisfy exactly this. Tests
+assert through the CLI exit code and message text, never internal helpers, so
+private module/function names are free to change.
+
+## Package
+
+`import agentos_doclint`
+
+## Entrypoint
+
+`agentos_doclint.main(argv: list[str]) -> int`
+- Accepts `["--repo-root", "<path>"]`; `--repo-root` defaults to the git
+  top-level when omitted.
+- Returns `0` when the linted tree is clean, non-zero otherwise.
+- Prints one line per finding (to stdout or stderr; the suite reads both).
+
+## Findings API (documented, not asserted directly)
+
+`agentos_doclint.lint(repo_root: Path) -> list[Finding]` runs the generate +
+lint phases in memory and returns the findings `main` prints. A `Finding`
+carries at least the repo-relative doc path, the offending citation/field, and
+a human reason. Tests exercise this through `main`.
+
+## Generator surface
+
+`agentos_doclint.render_index_table(repo_root: Path) -> str`
+- Renders the `docs/interfaces.md` seam-table block from front-matter, ordered
+  by the `order` field (ties are a hard error). Byte-stable across runs and
+  machines. Globs `docs/interfaces/*/INTERFACE.md` (no hardcoded seam list).
+
+## Constants
+
+`agentos_doclint.SOURCE_EXTENSIONS: tuple[str, ...]` — the single recognized
+extension list, shared by the path rule and the raw line-ban rule. The test
+list parametrizes over this constant so it cannot drift from the tool. Must
+include at least: `py rs ts tsx yaml yml json sh toml md`.
+
+## Linted root
+
+`docs/` EXCLUDING `docs/adr/` (E2). ADR docs are never path/symbol/line
+checked.
+
+## Expected message fragments (the reason the suite asserts)
+
+- Nonexistent path: names the doc, the citation, and contains `does not exist`.
+- Unresolvable symbol: names the citation/symbol and contains `does not resolve`.
+- Shorthand `::` with no path (rule 2): names the citation and contains
+  `full repo-relative path`.
+- Line-number / `#L` citation: names the doc and the offending coordinate.
+- Missing/unpaired generated marker: contains `marker`.
+- Front-matter missing required field: contains the field name and `required`.
+- Invalid `kind`: contains `kind` and the offending value.
+- Syntax error in a cited `.py` file: names the file and contains `syntax`.
+
+## Front-matter schema (per `INTERFACE.md`)
+
+Required: `seam`, `kind` (`CLEAN` / `SOFT` / `NONE`, optional `, qualifier`),
+`impls`, `grade`, `epics` (list of `"#N"` / `"ADR-XXXX"`), `order` (int).
+Optional: `epic_note`.
+
+## Generated regions (marker-delimited)
+
+- Index seam-table: `<!-- BEGIN GENERATED: seam-table (agentos dev docs-lint) -->`
+  ... `<!-- END GENERATED: seam-table -->`, rows
+  `| Seam | Kind | Impls | Grade | Epic(s) | INTERFACE.md |`.
+- Per-doc header blockquote: `<!-- BEGIN GENERATED: header ... -->` ...
+  `<!-- END GENERATED: header -->`.

--- a/tools/doclint/tests/conftest.py
+++ b/tools/doclint/tests/conftest.py
@@ -1,0 +1,59 @@
+"""Shared fixtures for the doclint suite.
+
+Nothing is mocked. Every test that is not the one end-to-end case copies the
+miniature ``fixtures/clean_repo`` tree into a tmp dir, optionally mutates it,
+and runs the real linter over it: a genuine filesystem walk and a genuine
+``ast`` parse over a small tree. Only ``test_real_repo_docs_are_clean`` points
+at the real repo.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from agentos_doclint import main
+
+FIXTURES = Path(__file__).parent / "fixtures"
+CLEAN_REPO = FIXTURES / "clean_repo"
+
+# The worktree root: tests/ -> doclint/ -> tools/ -> repo root.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Type of the run_lint callable: takes a repo root, returns (exit_code, output).
+RunLint = Callable[[Path], tuple[int, str]]
+
+
+@pytest.fixture
+def clean_repo(tmp_path: Path) -> Path:
+    """A fresh, writable copy of the clean fixture tree per test."""
+    dest = tmp_path / "repo"
+    shutil.copytree(CLEAN_REPO, dest)
+    return dest
+
+
+@pytest.fixture
+def run_lint(capsys: pytest.CaptureFixture[str]) -> RunLint:
+    """Drive the public CLI entrypoint and return (exit_code, combined output).
+
+    Tests assert through the exit code and message text only, never internal
+    function names, so renaming a helper does not break the suite.
+    """
+
+    def _run(root: Path) -> tuple[int, str]:
+        code = main(["--repo-root", str(root)])
+        captured = capsys.readouterr()
+        return code, captured.out + captured.err
+
+    return _run
+
+
+def write(root: Path, rel: str, content: str) -> Path:
+    """Write a file under the repo, creating parent dirs."""
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path

--- a/tools/doclint/tests/fixtures/clean_repo/cli/src/queue.rs
+++ b/tools/doclint/tests/fixtures/clean_repo/cli/src/queue.rs
@@ -1,0 +1,5 @@
+// Fixture Rust file. Paths are checked for every recognized extension, but
+// ::symbol resolution is Python-only this run, so this file is only ever
+// cited file-only in the clean tree.
+
+pub fn enqueue() {}

--- a/tools/doclint/tests/fixtures/clean_repo/docs/adr/0001-example.md
+++ b/tools/doclint/tests/fixtures/clean_repo/docs/adr/0001-example.md
@@ -1,0 +1,8 @@
+# ADR-0001: Example (fixture)
+
+Status: Accepted
+
+ADRs are immutable once Accepted, so their historical citations are NOT linted.
+This line deliberately carries a rotten coordinate `queue.py:60` and a
+nonexistent path `apps/ghost/does_not_exist.py`, and the clean tree must still
+pass because `docs/adr/` is excluded from the linted root.

--- a/tools/doclint/tests/fixtures/clean_repo/docs/interfaces.md
+++ b/tools/doclint/tests/fixtures/clean_repo/docs/interfaces.md
@@ -1,0 +1,12 @@
+# Interface catalog (fixture)
+
+Hand-written intro prose that the generator never touches.
+
+<!-- BEGIN GENERATED: seam-table (agentos dev docs-lint) -->
+| Seam | Kind | Impls | Grade | Epic(s) | INTERFACE.md |
+|---|---|---|---|---|---|
+| Substrate | CLEAN | 2 | A | #86 | [Substrate](interfaces/substrate/INTERFACE.md) |
+| Approval | SOFT | 1 + fake | B+ | #430, ADR-0035 | [Approval](interfaces/approval/INTERFACE.md) |
+<!-- END GENERATED: seam-table -->
+
+Hand-written legend prose that also stays put.

--- a/tools/doclint/tests/fixtures/clean_repo/docs/interfaces/approval/INTERFACE.md
+++ b/tools/doclint/tests/fixtures/clean_repo/docs/interfaces/approval/INTERFACE.md
@@ -1,0 +1,22 @@
+---
+seam: Approval
+kind: SOFT
+impls: 1 + fake
+grade: B+
+epics:
+  - "#430"
+  - "ADR-0035"
+order: 2
+---
+
+# Approval
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 + fake &nbsp;·&nbsp; **Swap-readiness grade:** B+
+<!-- END GENERATED: header -->
+
+Current contract: the gate is `runner/src/agentos_runner/approval.py::authorize_approval`,
+built on `runner/src/agentos_runner/approval.py::ApprovalGate` and its
+`runner/src/agentos_runner/approval.py::ApprovalGate.consume_grant` method. The
+option builder is re-exported here as
+`runner/src/agentos_runner/approval.py::build_options`.

--- a/tools/doclint/tests/fixtures/clean_repo/docs/interfaces/substrate/INTERFACE.md
+++ b/tools/doclint/tests/fixtures/clean_repo/docs/interfaces/substrate/INTERFACE.md
@@ -1,0 +1,18 @@
+---
+seam: Substrate
+kind: CLEAN
+impls: 2
+grade: A
+epics:
+  - "#86"
+order: 1
+---
+
+# Substrate
+
+<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 2 &nbsp;·&nbsp; **Swap-readiness grade:** A
+<!-- END GENERATED: header -->
+
+The black line runs through `runner/src/agentos_runner/approval.py` and the
+Rust queue at `cli/src/queue.rs`. Both are file-only citations that resolve.

--- a/tools/doclint/tests/fixtures/clean_repo/runner/src/agentos_runner/approval.py
+++ b/tools/doclint/tests/fixtures/clean_repo/runner/src/agentos_runner/approval.py
@@ -1,0 +1,25 @@
+"""Fixture module with a known, stable set of resolvable symbols.
+
+The doclint symbol resolver parses this file with ``ast`` (never imports it),
+so the bindings below are the ground truth the resolution tests cite against.
+"""
+
+from ._helpers import build_options  # ImportFrom-bound name, resolvable at this site
+
+GRANT_PREFIX = "agentos:grant"  # module-level constant (assignment target)
+
+
+def authorize_approval(actor: str) -> bool:
+    """Module-level function symbol."""
+    return bool(actor)
+
+
+class ApprovalGate:
+    """Class symbol."""
+
+    def consume_grant(self, tool: str) -> None:
+        """Method symbol, cited as ``ApprovalGate.consume_grant``."""
+        _ = tool
+
+
+__all__ = ["authorize_approval", "ApprovalGate", "GRANT_PREFIX", "build_options"]

--- a/tools/doclint/tests/test_citation.py
+++ b/tools/doclint/tests/test_citation.py
@@ -1,0 +1,160 @@
+"""Citation discovery, classification, and the raw line-ban rule.
+
+All tests drive the public CLI over a copied fixture tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentos_doclint import SOURCE_EXTENSIONS
+
+from .conftest import RunLint, write
+
+
+# --- Test 1: a cited path that does not exist ------------------------------
+
+
+def test_nonexistent_path_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    write(
+        clean_repo,
+        "docs/ghost.md",
+        "The gate lives in `apps/api/src/agentos_api/ghost.py`.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "docs/ghost.md" in out  # names the offending doc
+    assert "apps/api/src/agentos_api/ghost.py" in out  # names the citation
+    assert "does not exist" in out.lower()  # names the reason
+
+
+# --- Test 3: the unified line-citation ban ---------------------------------
+
+
+def test_line_number_citation_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    write(clean_repo, "docs/line.md", "See `queue.py:60` for the detail.\n")
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "docs/line.md" in out
+    assert "queue.py:60" in out
+
+
+@pytest.mark.parametrize("ext", SOURCE_EXTENSIONS)
+def test_line_ban_covers_every_recognized_extension(
+    clean_repo: Path, run_lint: RunLint, ext: str
+) -> None:
+    # Parametrized over the tool's own extension constant so the test list
+    # cannot drift from the tool. The .rs and .md cases mirror live
+    # violations; the rest are the forward-looking half.
+    write(clean_repo, "docs/ext.md", f"Coordinate `pkg/x.{ext}:12` is rotten.\n")
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert f"pkg/x.{ext}:12" in out
+
+
+def test_line_ban_covers_github_hash_L_form(clean_repo: Path, run_lint: RunLint) -> None:
+    # Zero instances exist today; this is purely preventive. Both spellings of
+    # the same rotten coordinate must fail.
+    write(
+        clean_repo,
+        "docs/hashl.md",
+        "GitHub links `path.py#L60` and `cli/src/queue.rs#L35` are banned too.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "path.py#L60" in out
+    assert "cli/src/queue.rs#L35" in out
+
+
+# --- Test 6: shorthand ::symbol with no path is a hard error ---------------
+
+
+def test_shorthand_symbol_citation_without_path_is_hard_error(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    write(clean_repo, "docs/short.md", "The builder is `adapter.py::build_options`.\n")
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "adapter.py::build_options" in out  # names the citation
+    assert "full repo-relative path" in out.lower()  # instructs the fix
+
+
+def test_shorthand_partner_full_path_passes(clean_repo: Path, run_lint: RunLint) -> None:
+    write(
+        clean_repo,
+        "docs/full.md",
+        "The builder is `runner/src/agentos_runner/approval.py::build_options`.\n",
+    )
+    code, _ = run_lint(clean_repo)
+    assert code == 0
+
+
+def test_shorthand_partner_prose_spans_pass(clean_repo: Path, run_lint: RunLint) -> None:
+    write(clean_repo, "docs/prose.md", "Fields `payload` and `ok: false` are fine.\n")
+    code, _ = run_lint(clean_repo)
+    assert code == 0
+
+
+def test_shorthand_partner_bare_filename_is_not_an_error(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Extension, no ::, no / -> prose shorthand, not a false claim of being
+    # gated. Only the :: makes it masquerade as checked.
+    write(clean_repo, "docs/bare.md", "Look in `adapter.py` for the builder.\n")
+    code, _ = run_lint(clean_repo)
+    assert code == 0
+
+
+# --- Test 8: fenced blocks ------------------------------------------------
+
+
+def test_fenced_code_block_line_citation_is_not_a_citation_but_still_fails_raw_rule(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # A path inside a fenced block is NOT path-checked: a fictional,
+    # nonexistent path in an example must not fail.
+    write(
+        clean_repo,
+        "docs/fenced_ok.md",
+        "Example:\n\n```\ncite `apps/ghost/imaginary.py` like this\n```\n",
+    )
+    code, _ = run_lint(clean_repo)
+    assert code == 0
+
+    # But a line coordinate anywhere, fenced or not, DOES fail the raw rule.
+    write(
+        clean_repo,
+        "docs/fenced_bad.md",
+        "Example:\n\n```\nsee queue.py:60 here\n```\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "queue.py:60" in out
+
+
+# --- Test 9: ordinary prose spans are not citations ------------------------
+
+
+def test_prose_code_span_is_not_a_citation(clean_repo: Path, run_lint: RunLint) -> None:
+    write(
+        clean_repo,
+        "docs/spans.md",
+        "Spans `payload`, `ok: false`, `SET NX`, `bundle-format` are not citations.\n",
+    )
+    code, _ = run_lint(clean_repo)
+    assert code == 0
+
+
+# --- Test 10: docs/adr/ is excluded from the linted root -------------------
+
+
+def test_adr_directory_is_not_linted(clean_repo: Path, run_lint: RunLint) -> None:
+    write(
+        clean_repo,
+        "docs/adr/0099-historical.md",
+        "Historical `queue.py:60` and `apps/gone/missing.py` stay untouched.\n",
+    )
+    code, _ = run_lint(clean_repo)
+    assert code == 0

--- a/tools/doclint/tests/test_discovery_refinements.py
+++ b/tools/doclint/tests/test_discovery_refinements.py
@@ -1,0 +1,157 @@
+"""Discovery-grammar refinements for the whole-tree docs-lint gate (#452).
+
+Additive coverage for the three principled exclusions (markdown link text,
+doc-relative paths, glob/placeholder patterns) and the escape-hatch extension
+to path/symbol findings. Every test drives the public CLI over a copied fixture
+tree, like the frozen suite. The partner tests prove the refinements did not
+blunt the gate: a genuinely rotten concrete citation still fails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .conftest import RunLint, write
+
+
+# --- Refinement 1: markdown link text is not a citation candidate ----------
+
+
+def test_link_text_relative_path_is_not_a_citation(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # The reported false positive: a nav link whose text is a code span. The
+    # destination is a link checker's job, never this gate's.
+    write(
+        clean_repo,
+        "docs/nav.md",
+        "See [`../ARCHITECTURE.md`](../ARCHITECTURE.md) for the map.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_link_text_concrete_missing_path_is_not_a_citation(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Link-text exclusion holds even when the text looks like a concrete,
+    # nonexistent repo path: it is link text, checked by a link checker.
+    write(
+        clean_repo,
+        "docs/navc.md",
+        "Jump to [`apps/ghost/imaginary.py`](apps/ghost/imaginary.py) here.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_bare_span_beside_a_link_still_checked(clean_repo: Path, run_lint: RunLint) -> None:
+    # The exclusion is scoped to link text only: a bare rotten span on the same
+    # line, outside the link, must still fail. Proves link tracking is not a
+    # blanket line skip.
+    write(
+        clean_repo,
+        "docs/mixed.md",
+        "Link [`docs/README.md`](README.md) but bare `apps/ghost/rot.py` fails.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "apps/ghost/rot.py" in out
+    assert "does not exist" in out.lower()
+
+
+# --- Refinement 2: doc-relative paths are not repo-root citations ----------
+
+
+def test_doc_relative_bare_spans_are_not_citations(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Citations resolve repo-root-relative, so a ".."/"."-anchored path is by
+    # definition not one. Neither the ".." nor the "." form may fail on
+    # nonexistence.
+    write(
+        clean_repo,
+        "docs/rel.md",
+        "Paths `../foo.py` and `./bar.py` are doc-relative, not citations.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_doc_relative_symbol_form_is_not_a_citation(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # A doc-relative path in the ``::`` shorthand is navigation too, not a
+    # shorthand error.
+    write(clean_repo, "docs/relsym.md", "The builder `../adapter.py::build` is relative.\n")
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+# --- Refinement 3: glob / placeholder patterns are not citations -----------
+
+
+def test_glob_and_placeholder_spans_are_not_citations(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # A path part carrying "*", "<", or ">" names a shape, not a concrete file.
+    write(
+        clean_repo,
+        "docs/glob.md",
+        "Patterns `skills/<name>/SKILL.md` and `x/**/y.py` are templates.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+# --- Escape hatch extension: ignore-line covers path/symbol findings --------
+
+
+def test_ignore_line_suppresses_a_nonexistent_path_and_counts_it(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # A genuinely-illustrative example path (a bundle-internal walkthrough) can
+    # be silenced per-line. The suppression is visible in the counted summary.
+    write(
+        clean_repo,
+        "docs/hatch.md",
+        "Example bundle path:\n\n"
+        "<!-- doclint:ignore-line -->\n"
+        "The plugin lives at `apps/ghost/example.py` inside the bundle.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+    assert "suppressed by the ignore-line escape hatch" in out
+
+
+def test_same_path_without_ignore_line_still_fails(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Partner to the hatch test: it is the comment, not the path shape, doing
+    # the suppression. Without it the identical citation fails.
+    write(
+        clean_repo,
+        "docs/nohatch.md",
+        "The plugin lives at `apps/ghost/example.py` inside the bundle.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "apps/ghost/example.py" in out
+    assert "does not exist" in out.lower()
+
+
+# --- Partner: a real rotten citation still fails after all refinements ------
+
+
+def test_real_rotten_citation_still_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    # Concrete path, not a link, not relative, not a pattern, not ignored: the
+    # refinements must not have blunted the gate for the case it exists to catch.
+    write(
+        clean_repo,
+        "docs/rot.md",
+        "The gate lives in `apps/api/src/agentos_api/ghost.py`.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "apps/api/src/agentos_api/ghost.py" in out
+    assert "does not exist" in out.lower()

--- a/tools/doclint/tests/test_end_to_end.py
+++ b/tools/doclint/tests/test_end_to_end.py
@@ -1,0 +1,26 @@
+"""The clean-tree floor and the one real-repo end-to-end test."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .conftest import REPO_ROOT, RunLint
+
+
+# --- Test 5: the correct fixture tree passes -------------------------------
+
+
+def test_clean_tree_passes(clean_repo: Path, run_lint: RunLint) -> None:
+    # The test that stops a linter that just always fails.
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+# --- Test 15: the real repo docs are clean ---------------------------------
+
+
+def test_real_repo_docs_are_clean(run_lint: RunLint) -> None:
+    # The only test that points at the real docs/ tree. Green only once Streams
+    # B and C are done; this is the test that proves the ticket.
+    code, out = run_lint(REPO_ROOT)
+    assert code == 0, out

--- a/tools/doclint/tests/test_frontmatter.py
+++ b/tools/doclint/tests/test_frontmatter.py
@@ -1,0 +1,86 @@
+"""Front-matter is a contract; an unvalidated contract is prose.
+
+Also pins that the generator globs ``docs/interfaces/*/INTERFACE.md`` rather
+than iterating a hardcoded list of seams.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .conftest import RunLint, write
+
+# A minimal seam body reused below. The generated header intentionally matches
+# a CLEAN/2/A front-matter so that only the front-matter defect under test is
+# the reason a run fails.
+_HEADER = (
+    "<!-- BEGIN GENERATED: header (agentos dev docs-lint) -->\n"
+    "> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 2"
+    " &nbsp;·&nbsp; **Swap-readiness grade:** A\n"
+    "<!-- END GENERATED: header -->\n"
+)
+
+
+def _seam(front_matter: str) -> str:
+    return f"{front_matter}\n# Seam\n\n{_HEADER}\nProse.\n"
+
+
+# --- Test 12: front-matter validation --------------------------------------
+
+
+def test_frontmatter_missing_required_field_fails(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # substrate front-matter with no `grade`.
+    fm = (
+        "---\n"
+        "seam: Substrate\n"
+        "kind: CLEAN\n"
+        "impls: 2\n"
+        "epics:\n"
+        '  - "#86"\n'
+        "order: 1\n"
+        "---\n"
+    )
+    write(clean_repo, "docs/interfaces/substrate/INTERFACE.md", _seam(fm))
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "grade" in out.lower()
+    assert "required" in out.lower()
+
+
+def test_frontmatter_invalid_kind_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    fm = (
+        "---\n"
+        "seam: Substrate\n"
+        "kind: MAYBE\n"
+        "impls: 2\n"
+        "grade: A\n"
+        "epics:\n"
+        '  - "#86"\n'
+        "order: 1\n"
+        "---\n"
+    )
+    write(clean_repo, "docs/interfaces/substrate/INTERFACE.md", _seam(fm))
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "kind" in out.lower()
+    assert "MAYBE" in out
+
+
+# --- Test 7: a seam doc without front-matter is a hard error ---------------
+
+
+def test_seam_doc_without_frontmatter_is_hard_error(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Pins that the generator globs the interfaces dir: a new seam with no
+    # front-matter must be caught, not silently skipped.
+    write(
+        clean_repo,
+        "docs/interfaces/newseam/INTERFACE.md",
+        "# New seam\n\nNo front-matter block at all.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "docs/interfaces/newseam/INTERFACE.md" in out

--- a/tools/doclint/tests/test_gate_integrity.py
+++ b/tools/doclint/tests/test_gate_integrity.py
@@ -1,0 +1,110 @@
+"""Gate-integrity regressions for the whole-tree docs-lint gate (#452).
+
+Defect 1: a code span that is the text of a markdown link used to escape
+path/symbol validation entirely, so a real repo-root citation written as a link
+could rot silently. The fix runs the ordinary classifier on link text and skips
+only self-referential relative links (visible text identical to the link's own
+destination), which is navigation, not a citation.
+
+Every test drives the public CLI over a copied fixture tree, like the frozen
+suite, asserting through exit code and message text only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .conftest import RunLint, write
+
+
+def test_link_text_repo_path_to_missing_file_fails(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # The blind spot: a real repo-root citation decorated as a link (its
+    # destination differs from its text) must be validated like any other
+    # citation. A nonexistent path fails; renaming or deleting the file can no
+    # longer hide behind the link syntax.
+    write(
+        clean_repo,
+        "docs/blind.md",
+        "The gate lives in "
+        "[`apps/api/src/agentos_api/ghost.py`](../apps/api/src/agentos_api/ghost.py).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "apps/api/src/agentos_api/ghost.py" in out
+    assert "does not exist" in out.lower()
+
+
+def test_nav_self_link_to_missing_path_still_passes(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Partner to the blind-spot test: a self-referential relative nav link (text
+    # identical to its own destination) is navigation, not a citation, even when
+    # the path does not resolve at the repo root. This is what keeps the real
+    # tree's `[`diagrams/x.md`](diagrams/x.md)` links quiet.
+    write(
+        clean_repo,
+        "docs/nav.md",
+        "See [`../ARCHITECTURE.md`](../ARCHITECTURE.md) and "
+        "[`diagrams/message-flow.md`](diagrams/message-flow.md).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_inline_ignore_suppresses_only_its_own_line(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Per-line-granularity proof: two citations to missing paths sit on adjacent
+    # physical lines of ONE paragraph. An inline `<!-- doclint:ignore-line -->`
+    # at the end of the first line silences only that line; the bare citation on
+    # the next line of the same paragraph still fails. The old paragraph-wide
+    # behavior stamped both spans on the paragraph's first line, so one comment
+    # would have masked both -- exactly the gate hole this change closes.
+    write(
+        clean_repo,
+        "docs/perline.md",
+        "The scaffold writes `pkg/ghost/first.py` here <!-- doclint:ignore-line -->\n"
+        "and also writes `pkg/ghost/second.py` there.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "pkg/ghost/second.py" in out
+    assert "pkg/ghost/first.py" not in out
+
+
+def test_finding_line_is_true_physical_line_in_paragraph(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # A citation on the third line of a multi-line paragraph must be reported on
+    # that physical line, not the inline container's start line. This is what
+    # makes a per-line escape hatch meaningful: the reported line is where the
+    # backticks actually are.
+    write(
+        clean_repo,
+        "docs/lines.md",
+        "First line of the paragraph with no citation.\n"
+        "Second line also clean, still no citation here.\n"
+        "Third line cites `pkg/ghost/third.py` which is missing.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "docs/lines.md:3:" in out
+    assert "pkg/ghost/third.py" in out
+
+
+def test_link_text_repo_path_to_real_file_passes(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # A decorated citation whose destination differs from its text and whose
+    # repo-root path exists must pass: the fix validates it, it does not flag it.
+    write(
+        clean_repo,
+        "docs/good.md",
+        "The gate lives in "
+        "[`runner/src/agentos_runner/approval.py`]"
+        "(../runner/src/agentos_runner/approval.py).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out

--- a/tools/doclint/tests/test_generate.py
+++ b/tools/doclint/tests/test_generate.py
@@ -1,0 +1,94 @@
+"""Generation: drift detection, markers, and stable order.
+
+Uses the public ``render_index_table`` generator surface plus the CLI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos_doclint import render_index_table
+
+from .conftest import RunLint, write
+
+_BEGIN = "<!-- BEGIN GENERATED: seam-table (agentos dev docs-lint) -->"
+_END = "<!-- END GENERATED: seam-table -->"
+
+
+def _between_markers(text: str) -> str:
+    return text.split(_BEGIN, 1)[1].split(_END, 1)[0]
+
+
+# --- Test 4: a drifted index fails; the generator round-trips --------------
+
+
+def test_drifted_index_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    index = clean_repo / "docs" / "interfaces.md"
+    text = index.read_text(encoding="utf-8")
+    # The seam doc declares CLEAN | 2; drift the on-disk row to NONE | 0.
+    drifted = text.replace(
+        "| Substrate | CLEAN | 2 | A |",
+        "| Substrate | NONE | 0 | A |",
+    )
+    assert drifted != text
+    index.write_text(drifted, encoding="utf-8")
+    code, _ = run_lint(clean_repo)
+    assert code != 0
+
+
+def test_regenerated_index_matches_frontmatter(clean_repo: Path) -> None:
+    # The generator round-trips the clean fixture to the bytes already on disk.
+    on_disk = _between_markers(
+        (clean_repo / "docs" / "interfaces.md").read_text(encoding="utf-8")
+    )
+    rendered = render_index_table(clean_repo)
+    assert rendered.strip() == on_disk.strip()
+
+
+# --- Test 7 partner: a new seam dir appears in the generated table ---------
+
+
+def test_new_seam_dir_appears_in_generated_table(clean_repo: Path) -> None:
+    fm = (
+        "---\n"
+        "seam: New Seam\n"
+        "kind: CLEAN\n"
+        "impls: 1\n"
+        "grade: C\n"
+        "epics:\n"
+        '  - "#999"\n'
+        "order: 3\n"
+        "---\n"
+        "\n# New seam\n\nProse.\n"
+    )
+    write(clean_repo, "docs/interfaces/newseam/INTERFACE.md", fm)
+    rendered = render_index_table(clean_repo)
+    # The glob is live: no code change, and the new dir shows up as a row.
+    assert "New Seam" in rendered
+    assert "interfaces/newseam/INTERFACE.md" in rendered
+
+
+# --- Test 11: a missing/unpaired marker is a hard error --------------------
+
+
+def test_missing_marker_is_a_hard_error(clean_repo: Path, run_lint: RunLint) -> None:
+    index = clean_repo / "docs" / "interfaces.md"
+    text = index.read_text(encoding="utf-8")
+    # Remove the END marker, leaving BEGIN unpaired.
+    index.write_text(text.replace(_END + "\n", ""), encoding="utf-8")
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "marker" in out.lower()
+
+
+# --- Test 13: stable order, declared order beats filesystem/alpha order -----
+
+
+def test_table_row_order_is_stable(clean_repo: Path) -> None:
+    first = render_index_table(clean_repo)
+    second = render_index_table(clean_repo)
+    assert first == second  # byte-identical across runs
+
+    # "approval" sorts before "substrate" on disk, but substrate declares
+    # order 1 and approval order 2, so the declared order must win.
+    assert first.index("Substrate") < first.index("Approval")

--- a/tools/doclint/tests/test_symbols.py
+++ b/tools/doclint/tests/test_symbols.py
@@ -1,0 +1,70 @@
+"""ast-based symbol resolution: the four resolution forms, and syntax errors.
+
+Nothing is imported or executed; the resolver parses the cited file with ast.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .conftest import RunLint, write
+
+APPROVAL = "runner/src/agentos_runner/approval.py"
+
+
+# --- Test 2: unresolvable symbol fails -------------------------------------
+
+
+def test_unresolvable_symbol_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    write(clean_repo, "docs/miss.md", f"See `{APPROVAL}::no_such_function`.\n")
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "no_such_function" in out  # names the symbol
+    assert "does not resolve" in out.lower()  # names the reason
+
+
+# --- Test 2 partner: all four resolution forms pass ------------------------
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    [
+        "authorize_approval",  # module-level function
+        "ApprovalGate",  # class
+        "ApprovalGate.consume_grant",  # method
+        "build_options",  # ImportFrom-bound name
+    ],
+)
+def test_resolvable_symbol_passes(
+    clean_repo: Path, run_lint: RunLint, symbol: str
+) -> None:
+    # Without this positive partner, a linter that fails everything would pass
+    # the negative test above.
+    write(clean_repo, "docs/hit.md", f"See `{APPROVAL}::{symbol}`.\n")
+    code, _ = run_lint(clean_repo)
+    assert code == 0
+
+
+# --- Test 14: a syntax error in a cited file is a clean lint failure -------
+
+
+def test_syntax_error_in_cited_file_reports_cleanly(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    write(
+        clean_repo,
+        "runner/src/agentos_runner/broken.py",
+        "def oops(:\n    pass\n",  # deliberate syntax error
+    )
+    write(
+        clean_repo,
+        "docs/broken_cite.md",
+        "See `runner/src/agentos_runner/broken.py::oops`.\n",
+    )
+    # Must not raise an unhandled SyntaxError; must fail naming the file.
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "broken.py" in out
+    assert "syntax" in out.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "agentos-api",
     "agentos-channel-protocol",
     "agentos-dispatcher",
+    "agentos-doclint",
     "agentos-runner",
     "agentos-worker",
     "agentos-workspace",
@@ -108,6 +109,21 @@ requires-dist = [
 ]
 
 [[package]]
+name = "agentos-doclint"
+version = "0.0.0"
+source = { editable = "tools/doclint" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "markdown-it-py", specifier = ">=3.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+
+[[package]]
 name = "agentos-runner"
 version = "0.0.0"
 source = { editable = "runner" }
@@ -185,6 +201,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "agentos-doclint" },
     { name = "mypy" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
@@ -206,6 +223,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "agentos-doclint", editable = "tools/doclint" },
     { name = "mypy", specifier = ">=2.2.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29" },
     { name = "opentelemetry-sdk", specifier = ">=1.29" },
@@ -1079,6 +1097,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1153,6 +1183,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The swappable-seam catalog in `docs/interfaces/` had drifted in every direction at once (overstating cleanliness, understating it, and contradicting its own index), so this corrects it and adds the CI gate that keeps it honest.

## The gate

New `agentos_doclint` tool, surfaced as `agentos dev docs-lint` and run in the `python` CI job through `scripts/check-docs.sh` (the same regenerate-then-`git diff --exit-code` pattern as `check-contracts.sh`):

- Generates `docs/interfaces.md`'s seam table and each `INTERFACE.md` header from per-seam YAML front-matter, the single declared source, and fails on drift.
- Bans line-number citations under `docs/` and checks every cited path exists and every cited Python symbol resolves (via `ast`, never import).
- A per-line `<!-- doclint:ignore-line -->` escape hatch (counted, no file or directory scope) for genuinely illustrative example paths.

## Corrections

Every in-scope line citation is converted to symbol-or-full-path form, front-matter is added to all 17 seam docs, and the enumerated false claims are corrected across harness-modelsession, channel-ingress, queue-stream, workflow-state, approval, bundle-format, evals, telemetry-otel, blob-storage, substrate, and triggers. The instruction files that named the dead `QueuedSlackEvent` model now name the channel-neutral `QueuedTurn`; the worker's eval-runner claim is corrected; and the superseded resume rationale is dropped from `substrate.py`'s docstring. The decision is recorded in ADR-0038.

## What this gate does and does not claim

The catalog is now coordinate-checked and index-consistent; its prose is exactly as true as the last human who read it. The gate makes a false claim harder to write accidentally and impossible to keep silently: a symbol citation forces the author to name something real, and a renamed symbol fails CI on the renaming PR, dragging the stale prose in front of a human. It does not verify that the sentence around a resolving citation is true. Read a green `docs-lint` as coordinate-checked, not as a verified catalog.

## Decisions worth a look

- **`docs/adr/` is excluded from the lint.** ADRs are immutable once Accepted and record what the author saw on that date, not a claim about today, so their 29 line citations are left intact. AC-1 is therefore met for the living catalog, not literally for `docs/adr/`.
- **The index is generated from YAML front-matter, not from the existing headers.** The issue assumed the seam docs already declared Kind/Impls/Grade uniformly; they did not (one had a different header shape, and the Epic(s) column lived in prose that already disagreed with the index). Front-matter is the single source that resolves those contradictions once.
- **Enabling the gate surfaced pre-existing rot in general docs.** `docs/behavior-packs.md` cited `apps/worker/*.py` paths that moved under `src/agentos_worker/` long ago; those are fixed. Genuinely illustrative bundle-internal paths in the onboarding, spike, and bundle-walkthrough docs are marked with the escape hatch. Both are the unavoidable cost of turning the gate green, not scope creep.

## Out of scope

Per the issue, this changes docs, generation, and the gate only; the code-level leaks the audit found are untouched. One test-file comment (`runner/tests/test_session.py`) still uses the old resume phrasing; test files are outside the issue's docstring-sweep scope and the ADR-0029 numbering there is a separate upstream matter.

Closes #452
