### PR TITLE
Reserve model-credential env names for connector secrets

### DIFF
--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
+from plugin_format import is_reserved_boot_env_name
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -167,14 +168,16 @@ def _validate_secret_map(value: dict[str, str] | None) -> dict[str, str] | None:
                 f"secret name {name!r} must be an env-var-style name "
                 "(uppercase letters, digits, underscore; not starting with a digit)"
             )
-        if name.startswith("AGENTOS_"):
-            # AGENTOS_* names are the platform's reserved sandbox boot-env keys
-            # (budget/session/credential/etc.). A connector secret named that way
-            # would either clobber a boot var or be silently dropped by the worker
-            # binding's reserved-key guard, so reject it on write.
+        if is_reserved_boot_env_name(name):
+            # Reserved names are either AGENTOS_*-prefixed platform sandbox
+            # boot-env keys (budget/session/credential/etc.) or one of the
+            # fixed model-credential keys (ANTHROPIC_API_KEY, etc.). A
+            # connector secret named that way would either clobber a boot var
+            # or be silently dropped by the worker binding's reserved-key
+            # guard, so reject it on write.
             raise ValueError(
-                f"secret name {name!r} is reserved: AGENTOS_* names are platform "
-                "boot-env keys and cannot be used for a connector secret"
+                f"secret name {name!r} is reserved: it is a platform boot-env "
+                "or model-credential key and cannot be used for a connector secret"
             )
         if not secret:
             raise ValueError(f"secret {name!r} has an empty value")

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -7,6 +7,8 @@ collision must surface as a caller conflict, not an opaque server error.
 
 from typing import Any
 
+import pytest
+
 
 def _create(client: Any, headers: dict[str, str], **fields: Any) -> Any:
     return client.post("/agents", json=fields, headers=headers)
@@ -432,3 +434,47 @@ def test_agent_reserved_secret_name_is_422(
         headers=auth_headers,
     )
     assert bad.status_code == 422, bad.text
+
+
+# The four runner-owned credential keys are NOT AGENTOS_-prefixed, so #445's
+# prefix fence never caught them; a connector secret named `ANTHROPIC_BASE_URL`
+# would silently redirect the model. #457 rejects them at the write seam too.
+_RESERVED_CREDENTIAL_KEYS = [
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_AUTH_TOKEN",
+]
+
+
+@pytest.mark.parametrize("name", _RESERVED_CREDENTIAL_KEYS)
+def test_agent_reserved_credential_secret_name_is_422(
+    client: Any, auth_headers: dict[str, str], clean_db: None, name: str
+) -> None:
+    bad = client.post(
+        "/agents",
+        json={
+            "name": "cred-secret-agent",
+            "slack_channel": "C000000S04",
+            "secrets": {name: "x"},
+        },
+        headers=auth_headers,
+    )
+    assert bad.status_code == 422, bad.text
+
+
+def test_agent_legitimate_secret_name_still_creates(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Negative control: a real connector token name is unaffected by the fence.
+    ok = client.post(
+        "/agents",
+        json={
+            "name": "ok-secret-agent",
+            "slack_channel": "C000000S05",
+            "secrets": {"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_x"},
+        },
+        headers=auth_headers,
+    )
+    assert ok.status_code == 201, ok.text
+    assert ok.json()["secrets"] == ["GITHUB_PERSONAL_ACCESS_TOKEN"]

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -37,6 +37,7 @@ from typing import Any
 from urllib.parse import quote
 
 from aci_protocol import Budget
+from plugin_format import is_reserved_boot_env_name
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -366,17 +367,13 @@ class BindingResolver:
         # values the bundle's authed MCP servers read from the sandbox env, where
         # `.mcp.json` `${VAR}` expansion consumes them. Injected by value; the
         # docker substrate forwards them as `-e KEY=VALUE`, while the k8s
-        # substrate strips them off its plaintext claim CR by the marker below
-        # (their secretKeyRef delivery is #440). A reserved boot-env key is never
-        # overwritten, so a misnamed secret cannot clobber the ACI contract env or
-        # the model credential.
-        injected_secret_keys: list[str] = []
-        for name, value in (resolved.secrets or {}).items():
-            if name not in env:
-                env[name] = value
-                injected_secret_keys.append(name)
-        if injected_secret_keys:
-            env[CONNECTOR_SECRET_KEYS_ENV] = ",".join(sorted(injected_secret_keys))
+        # substrate strips them off its plaintext claim CR by the marker
+        # AGENTOS_CONNECTOR_SECRET_KEYS (their secretKeyRef delivery is #440).
+        # Reserved boot-env names are filtered out order-independently -- see the
+        # inject_connector_secrets docstring for the #457 rationale.
+        inject_connector_secrets(
+            env, resolved.secrets, agent_label=resolved.agent_id
+        )
         # The agent's pinned model (#254) overrides the worker default; None
         # falls back to config.model inside apply_model_env.
         apply_model_env(env, self._config, model_override=resolved.model)
@@ -407,3 +404,39 @@ def apply_model_env(
     model = model_override if model_override is not None else config.model
     if model:
         env[MODEL_ENV] = model
+
+
+def inject_connector_secrets(
+    env: dict[str, str],
+    secrets: dict[str, str] | None,
+    *,
+    agent_label: object,
+) -> None:
+    """Inject per-agent connector secrets, dropping reserved boot-env names
+    (order-independent, #457). Sets the AGENTOS_CONNECTOR_SECRET_KEYS marker
+    for the keys actually injected. Shared by the runs binding and the eval
+    consumer so both write sites stay hardened identically.
+
+    Every connector secret is filtered against the shared reserved-name policy
+    (``is_reserved_boot_env_name``) regardless of env ordering, so a secret named
+    after an ACI contract env key or a model credential (e.g. ``ANTHROPIC_BASE_URL``)
+    can never clobber it -- even on the default path where ``apply_model_env`` does
+    not itself set the base URL after the caller runs this. Drop-and-log rather than
+    raise (raising would crash a live claim); a dropped key never carries its value
+    and is kept out of the marker. The log names the key and ``agent_label`` only,
+    never the value.
+    """
+    injected_secret_keys: list[str] = []
+    for name, value in (secrets or {}).items():
+        if is_reserved_boot_env_name(name):
+            logger.warning(
+                "Dropping connector secret with reserved boot-env name %s "
+                "for agent %s (never injected, never marked)",
+                name,
+                agent_label,
+            )
+            continue
+        env[name] = value
+        injected_secret_keys.append(name)
+    if injected_secret_keys:
+        env[CONNECTOR_SECRET_KEYS_ENV] = ",".join(sorted(injected_secret_keys))

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -43,11 +43,11 @@ from redis.asyncio import Redis
 from ..binding import (
     BUDGET_ENV,
     BUNDLE_REF_ENV,
-    CONNECTOR_SECRET_KEYS_ENV,
     PLUGIN_DIR_ENV,
     RUNNER_TOKEN_ENV,
     SESSION_ID_ENV,
     apply_model_env,
+    inject_connector_secrets,
 )
 from ..bundle_store import BundleReader
 from ..config import WorkerConfig
@@ -366,16 +366,12 @@ class EvalStreamConsumer(StreamConsumer):
             env[BUNDLE_REF_ENV] = item.bundle_ref
         # Deliver the agent's connector secrets (#429) so an authed-MCP bundle
         # authenticates during eval exactly as it does on a bound run -- otherwise
-        # its tool calls fail auth and the eval measures the wrong thing. A
-        # reserved boot-env key is never overwritten. The values are resolved by
-        # the async caller (they need a DB lookup) and passed in.
-        injected_secret_keys: list[str] = []
-        for name, value in (connector_secrets or {}).items():
-            if name not in env:
-                env[name] = value
-                injected_secret_keys.append(name)
-        if injected_secret_keys:
-            env[CONNECTOR_SECRET_KEYS_ENV] = ",".join(sorted(injected_secret_keys))
+        # its tool calls fail auth and the eval measures the wrong thing. The
+        # shared helper drops reserved boot-env names (#457) so a secret named after
+        # a runner-owned env key or model credential can never clobber it, keeping
+        # this write site hardened identically to binding.boot_env. The values are
+        # resolved by the async caller (they need a DB lookup) and passed in.
+        inject_connector_secrets(env, connector_secrets, agent_label=item.agent_id)
         apply_model_env(env, self._config)
         return env
 

--- a/apps/worker/tests/binding/test_reserved_boot_env_pin.py
+++ b/apps/worker/tests/binding/test_reserved_boot_env_pin.py
@@ -1,0 +1,137 @@
+"""Completeness + cross-language drift pin for the reserved boot-env policy (#457).
+
+Three guards, all checked at import time (no Postgres, no fixtures):
+
+(a) Every credential-key literal the runner's ``sdk_auth`` owns is caught by
+    ``is_reserved_boot_env_name``. If a new model credential is added to
+    ``sdk_auth`` but not to ``RESERVED_BOOT_ENV``, this fails -- the exact
+    class of gap #457 closes.  ``AGENTOS_MODEL_BASE_URL`` / ``AGENTOS_CREDENTIALS``
+    are already safe via the prefix rule, but the pin asserts them anyway so the
+    sdk_auth inventory is covered exhaustively.
+(b) Every ``agentos_worker.binding`` ``*_ENV`` literal that starts with
+    ``AGENTOS_`` is caught. This passes today via the prefix rule; it is a
+    tripwire against the predicate silently regressing.
+(c) Cross-language parity: the Helm ``_helpers.tpl`` reserved list is an
+    unavoidable second copy (Helm cannot import Python). Its
+    ``agentos.reservedConnectorSecretNames`` define MUST list exactly the
+    non-``AGENTOS_`` members of ``RESERVED_BOOT_ENV`` (the prefix rule covers
+    ``AGENTOS_*`` on both sides). Fails CI if the two lists drift.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import agentos_runner.sdk_auth as sdk_auth
+import agentos_worker.binding as binding
+from plugin_format import RESERVED_BOOT_ENV, is_reserved_boot_env_name
+
+# --- (a) sdk_auth credential-key literals ------------------------------------
+
+# An env-var-name string: uppercase alnum, underscore-separated (ANTHROPIC_BASE_URL,
+# AGENTOS_MODEL_BASE_URL, ...). Discriminates a credential-key literal from a base
+# URL like "https://openrouter.ai/api" or a tuple constant.
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$")
+
+
+def _sdk_auth_credential_env_literals() -> dict[str, str]:
+    """Discover the credential/base-url env-var literals sdk_auth owns.
+
+    Every module-level ``*_ENV`` name in ``agentos_runner.sdk_auth`` whose value
+    is an env-var-name string. Reading the module: all of them
+    (``CLAUDE_CODE_OAUTH_TOKEN``, ``ANTHROPIC_API_KEY``, ``ANTHROPIC_BASE_URL``,
+    ``ANTHROPIC_AUTH_TOKEN``, ``AGENTOS_MODEL_BASE_URL``, ``AGENTOS_CREDENTIALS``)
+    are credential/base-url keys that MUST be reserved -- there is no runner-local
+    ``*_ENV`` knob here to exclude. The tuple alias ``_SDK_CREDENTIAL_ENV`` is
+    skipped by the string check. Dynamic (not a hardcoded list) so a NEW credential
+    ``*_ENV`` constant added to sdk_auth is caught even if nobody updates the pin.
+    """
+    out: dict[str, str] = {}
+    for attr in dir(sdk_auth):
+        if not attr.endswith("_ENV"):
+            continue
+        value = getattr(sdk_auth, attr)
+        if isinstance(value, str) and _ENV_VAR_NAME_RE.match(value):
+            out[attr] = value
+    return out
+
+
+def test_every_sdk_auth_credential_key_is_reserved() -> None:
+    literals = _sdk_auth_credential_env_literals()
+    # Sanity floor: discovery is not vacuous, and the four non-AGENTOS_ credential
+    # keys plus the AGENTOS_ base-url alias are all present (guards the predicate
+    # silently narrowing and skipping the exact gap #457 closes).
+    assert {
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "ANTHROPIC_AUTH_TOKEN",
+        "AGENTOS_MODEL_BASE_URL",
+    } <= set(literals.values()), literals
+    for attr, value in literals.items():
+        assert is_reserved_boot_env_name(value), (
+            f"sdk_auth.{attr} == {value!r} is not caught by the reserved policy"
+        )
+
+
+# --- (b) binding AGENTOS_* *_ENV literals ------------------------------------
+
+
+def _binding_agentos_env_literals() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for attr in dir(binding):
+        if not attr.endswith("_ENV"):
+            continue
+        value = getattr(binding, attr)
+        if isinstance(value, str) and value.startswith("AGENTOS_"):
+            out[attr] = value
+    return out
+
+
+def test_every_binding_agentos_env_literal_is_reserved() -> None:
+    literals = _binding_agentos_env_literals()
+    # Sanity: the introspection actually found the boot keys (guards against a
+    # rename making this test vacuously pass).
+    assert literals, "found no AGENTOS_* *_ENV literals in agentos_worker.binding"
+    for attr, value in literals.items():
+        assert is_reserved_boot_env_name(value), (
+            f"binding.{attr} == {value!r} is not caught by the reserved policy"
+        )
+
+
+# --- (c) Helm cross-language drift gate --------------------------------------
+
+_HELPERS_TPL = (
+    Path(__file__).resolve().parents[4]
+    / "charts"
+    / "agentos"
+    / "templates"
+    / "_helpers.tpl"
+)
+
+# An env-name token: uppercase, at least one underscore (ANTHROPIC_BASE_URL etc).
+_ENV_NAME_RE = re.compile(r"[A-Z0-9]+(?:_[A-Z0-9]+)+")
+
+
+def _reserved_names_from_helpers() -> set[str]:
+    text = _HELPERS_TPL.read_text(encoding="utf-8")
+    # Extract the body of the reservedConnectorSecretNames define, tolerantly.
+    match = re.search(
+        r'define\s+"agentos\.reservedConnectorSecretNames"\s*(?:-?}})?(?P<body>.*?){{-?\s*end',
+        text,
+        re.DOTALL,
+    )
+    assert match, (
+        "no `agentos.reservedConnectorSecretNames` define found in "
+        f"{_HELPERS_TPL} -- the Helm reserved-name drift gate has no source"
+    )
+    tokens = set(_ENV_NAME_RE.findall(match.group("body")))
+    # The prefix rule covers AGENTOS_* on both sides; only the explicitly
+    # enumerated credential keys need list-parity.
+    return {t for t in tokens if not t.startswith("AGENTOS_")}
+
+
+def test_helm_reserved_list_matches_non_prefixed_members() -> None:
+    expected = {n for n in RESERVED_BOOT_ENV if not n.startswith("AGENTOS_")}
+    assert _reserved_names_from_helpers() == expected

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -19,6 +19,7 @@ from agentos_worker.binding import (
     APPROVAL_REQUIRED_ENV,
     BUDGET_ENV,
     BUNDLE_REF_ENV,
+    CONNECTOR_SECRET_KEYS_ENV,
     HISTORY_TOKEN_ENV,
     MEMORY_TOKEN_ENV,
     BindingResolver,
@@ -585,6 +586,63 @@ def test_resolves_connector_secrets_into_boot_env() -> None:
                 # secrets_for resolves the same map by agent_id (the eval lane).
                 by_id = await resolver.secrets_for(agent_id)
                 assert by_id == {"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_seeded"}
+            finally:
+                await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_reserved_connector_secret_is_dropped_order_independently() -> None:
+    # #457 order-independence regression. A connector secret named
+    # ANTHROPIC_BASE_URL redirects the model credential. The old `if name not in
+    # env` guard did NOT stop it on the DEFAULT path (model_base_url unset),
+    # because apply_model_env sets ANTHROPIC_BASE_URL AFTER the injection loop,
+    # so the reserved name was absent from env at loop time and survived. The
+    # fix must filter by the reserved SET, not by env state. This test MUST run
+    # the default path (_resolver builds WorkerConfig with model_base_url unset)
+    # or the bug does not reproduce.
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            try:
+                async with engine.connect():
+                    pass
+            except SQLAlchemyError as exc:
+                pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+
+            token = uuid.uuid4().hex[:8]
+            channel = f"C-{token}"
+            agent_id = await _seed_agent(
+                engine,
+                channel=channel,
+                name=f"agent-{token}",
+                max_usd=None,
+                max_tokens=None,
+                secrets={
+                    "ANTHROPIC_BASE_URL": "http://evil",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_ok",
+                },
+            )
+            await _seed_deployment(
+                engine, agent_id=agent_id, environment="prod", bundle_ref=f"b/{token}.zip"
+            )
+            try:
+                resolver = _resolver(engine)
+                resolved = await resolver.resolve(channel)
+                assert resolved is not None
+                env = resolver.boot_env(resolved, thread_key="t1")
+
+                # The injected reserved value must never land in the boot env.
+                assert env.get("ANTHROPIC_BASE_URL") != "http://evil"
+                # Negative control: the legitimate connector secret is delivered.
+                assert env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "ghp_ok"
+                # The dropped reserved key is excluded from the marker; only the
+                # legitimately injected key is listed.
+                keys = env[CONNECTOR_SECRET_KEYS_ENV].split(",")
+                assert keys == ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+                assert "ANTHROPIC_BASE_URL" not in keys
             finally:
                 await _cleanup(engine, [agent_id])
         finally:

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -704,6 +704,42 @@ def test_eval_boot_env_mints_runner_token() -> None:
     assert env.get(RUNNER_TOKEN_ENV), "_boot_env must mint a non-empty runner token"
 
 
+def test_eval_boot_env_drops_reserved_connector_secret() -> None:
+    """#457 eval-path parity: the eval consumer's connector-secret injection must
+    honor the reserved-boot-env policy exactly like binding.boot_env does. A secret
+    named after a runner-owned model credential (ANTHROPIC_BASE_URL) must never
+    survive into the eval boot env -- even on the DEFAULT path where apply_model_env
+    does not itself set the base URL, so nothing overwrites the injected value after
+    the loop. Order-independent: the reserved key is dropped and never marked; a
+    legitimate connector secret is injected and is the only key marked.
+
+    RED until the eval path's _boot_env is hardened (it currently injects any name
+    not already in env, so the reserved key leaks through on the default path)."""
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(),  # default path: model_base_url unset
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.zip", target_url=None)
+    env = consumer._boot_env(
+        item,
+        {
+            "ANTHROPIC_BASE_URL": "http://evil",
+            "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_ok",
+        },
+    )
+    # The reserved model-credential key never carries the injected value.
+    assert env.get("ANTHROPIC_BASE_URL") != "http://evil"
+    # The legitimate connector secret is injected...
+    assert env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "ghp_ok"
+    # ...and is the ONLY key marked as a delivered connector secret.
+    assert env.get("AGENTOS_CONNECTOR_SECRET_KEYS") == "GITHUB_PERSONAL_ACCESS_TOKEN"
+
+
 def test_eval_threads_claim_token_into_run_eval_suite(monkeypatch) -> None:
     # The token surfaced from the provisioned handle must be threaded into the
     # eval turn driver so a token-enforcing sandbox does not 401 the eval. The

--- a/charts/agentos/ci/connector-secrets-assertions.sh
+++ b/charts/agentos/ci/connector-secrets-assertions.sh
@@ -57,4 +57,36 @@ if printf '%s' "$default_render" | grep -q "connector-secrets"; then
   fail "a connector Secret rendered with no agentSandbox.connectorSecrets configured"
 fi
 
+# 4 (#457): a reserved boot-env name as the inner connector-secret key must fail
+# the render fail-closed. The four runner-owned credential keys are NOT
+# AGENTOS_-prefixed, so #445's prefix fence never saw them; plus one AGENTOS_*
+# key to prove the prefix rule is still enforced at the Helm seam. `helm
+# template` must exit non-zero and the error must name the reservation.
+assert_reserved_render_fails() {
+  local key="$1"
+  local out
+  if out="$(helm template agentos "$CHART" \
+    --set "agentSandbox.connectorSecrets.demo.${key}=x" 2>&1)"; then
+    fail "reserved connector-secret name '${key}' rendered instead of failing"
+  fi
+  printf '%s' "$out" | grep -qi "reserved" \
+    || fail "reserved '${key}' render failed but the error did not mention 'reserved': ${out}"
+}
+
+for key in \
+  ANTHROPIC_BASE_URL \
+  ANTHROPIC_API_KEY \
+  CLAUDE_CODE_OAUTH_TOKEN \
+  ANTHROPIC_AUTH_TOKEN \
+  AGENTOS_BUDGET; do
+  assert_reserved_render_fails "$key"
+done
+
+# Negative control: the legitimate GITHUB_PERSONAL_ACCESS_TOKEN render still
+# succeeds (proven above in assertion 1, re-asserted here as the paired control).
+if ! helm template agentos "$CHART" \
+  --set 'agentSandbox.connectorSecrets.demo.GITHUB_PERSONAL_ACCESS_TOKEN=ghp_ok' >/dev/null 2>&1; then
+  fail "legitimate connector-secret name GITHUB_PERSONAL_ACCESS_TOKEN failed to render"
+fi
+
 echo "OK: per-agent connector-secret render assertions passed"

--- a/charts/agentos/templates/_helpers.tpl
+++ b/charts/agentos/templates/_helpers.tpl
@@ -48,6 +48,24 @@ app.kubernetes.io/component: {{ .component }}
 {{- printf "%s-secrets" (include "agentos.fullname" .) -}}
 {{- end -}}
 
+{{/* ---- Reserved connector-secret boot-env names (#457, ADR-0009) ----
+     The non-AGENTOS_-prefixed runner credential keys a per-agent connector
+     secret must never declare, kept in list-parity with the Python source of
+     truth in packages/plugin-format (module reserved_env). This is the
+     unavoidable second copy -- Helm cannot import Python -- so the completeness
+     pin apps/worker/tests/binding/test_reserved_boot_env_pin.py parses THIS
+     define's body and fails CI if the two lists drift.
+
+     IMPORTANT: the pin scans this body for env-name-shaped uppercase tokens, so
+     the body must contain EXACTLY these four keys and no other stray ones (this
+     comment lives OUTSIDE the define so it is never scanned). The whole
+     AGENTOS_ namespace is fenced separately by the hasPrefix rule in the
+     connector-secret guard, so it is intentionally absent here. Emitted
+     space-separated for consumption via `splitList " "`. */}}
+{{- define "agentos.reservedConnectorSecretNames" -}}
+ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKEN
+{{- end -}}
+
 {{/* ---- Backing-store hosts (in-cluster Service name, or BYO host) ---- */}}
 
 {{- define "agentos.postgres.host" -}}

--- a/charts/agentos/templates/agent-connector-secrets.yaml
+++ b/charts/agentos/templates/agent-connector-secrets.yaml
@@ -25,7 +25,20 @@ metadata:
     agentos.dev/purpose: per-agent-connector-secrets
 type: Opaque
 stringData:
+  {{- /* Reserved boot-env guard (#457, ADR-0009). Each connector-secret KEY
+       ($name, the inner uppercase env name -- NOT the camelCase agent map key
+       $agent) must not shadow a runner-owned model credential or an AGENTOS_*
+       boot key, which the sandbox boot injects and a connector secret could
+       otherwise silently redirect. Reserved iff AGENTOS_-prefixed OR one of the
+       four non-prefixed credential keys enumerated in
+       `agentos.reservedConnectorSecretNames`. A reserved name aborts the ENTIRE
+       render fail-closed (edge case 7) -- intended: a bad name must never reach
+       a cluster, and `fail` is the only render-time stop Helm offers. */}}
+  {{- $reserved := splitList " " (trim (include "agentos.reservedConnectorSecretNames" $)) }}
   {{- range $name, $value := $secrets }}
+  {{- if or (hasPrefix "AGENTOS_" $name) (has $name $reserved) }}
+  {{- fail (printf "agentSandbox.connectorSecrets.%s.%s uses a reserved boot-env name (%q); a connector secret must not shadow a runner-owned model credential or an AGENTOS_* boot key" $agent $name $name) }}
+  {{- end }}
   {{ $name }}: {{ $value | quote }}
   {{- end }}
 {{- end }}

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -19,12 +19,15 @@ from .models import (
     SkillFrontmatter,
     TriggerDeclaration,
 )
+from .reserved_env import RESERVED_BOOT_ENV, is_reserved_boot_env_name
 from .validate import ValidationIssue, ValidationResult, validate_bundle
 
 __version__ = "0.0.0"
 
 __all__ = [
     "__version__",
+    "RESERVED_BOOT_ENV",
+    "is_reserved_boot_env_name",
     "PluginManifest",
     "Author",
     "SkillFrontmatter",

--- a/packages/plugin-format/src/plugin_format/reserved_env.py
+++ b/packages/plugin-format/src/plugin_format/reserved_env.py
@@ -1,0 +1,83 @@
+"""Reserved sandbox boot-env name policy for connector secrets (#457, #445, ADR-0009).
+
+Single source of truth for the names a per-agent connector secret must never
+declare, consulted by every write seam so a connector secret cannot shadow a
+runner-owned model credential or a platform boot-env key:
+
+- API validator ``agentos_api.schemas._validate_secret_map``,
+- bundle validator ``plugin_format.validate._validate_secrets``,
+- worker injection loop ``agentos_worker.binding``,
+- Helm guard ``charts/agentos/templates/agent-connector-secrets.yaml``.
+
+#445 fenced only the ``AGENTOS_`` prefix, which structurally cannot see the four
+non-prefixed credential keys the runner's ``sdk_auth`` owns
+(``ANTHROPIC_BASE_URL``, ``ANTHROPIC_API_KEY``, ``CLAUDE_CODE_OAUTH_TOKEN``,
+``ANTHROPIC_AUTH_TOKEN``). A connector secret named ``ANTHROPIC_BASE_URL`` would
+silently redirect the Claude session to an arbitrary endpoint and hand it the
+resolved model credential. #457 closes that gap by naming those keys explicitly
+while keeping the whole ``AGENTOS_`` namespace fenced for forward safety.
+
+The real owners of these names are ``runner/src/agentos_runner/sdk_auth.py`` (the
+credential keys) and ``apps/worker/src/agentos_worker/binding.py`` (the
+``AGENTOS_*`` boot keys). This module re-enumerates them so the policy is
+greppable from one place; ``apps/worker/tests/binding/test_reserved_boot_env_pin.py``
+is the completeness + cross-language drift pin that fails CI if a boot or
+credential key is added there but not covered here (or if the Helm list drifts).
+"""
+
+from __future__ import annotations
+
+# The four runner ``sdk_auth`` credential keys that are NOT ``AGENTOS_``-prefixed.
+# These are the exact gap #457 closes -- and, per the drift pin, the ONLY
+# non-prefixed members allowed in the set (the Helm ``_helpers.tpl`` reserved
+# list must equal this subset).
+_CREDENTIAL_KEYS = frozenset(
+    {
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "ANTHROPIC_AUTH_TOKEN",
+    }
+)
+
+# The ``AGENTOS_``-prefixed boot/config keys the worker and runner own. Every one
+# is already caught by the prefix rule in ``is_reserved_boot_env_name``; they are
+# enumerated here for greppability and to make the completeness pin
+# membership-based. Cross-checked against ``binding.py`` (``*_ENV`` constants) and
+# ``sdk_auth.MODEL_BASE_URL_ENV``.
+_AGENTOS_BOOT_KEYS = frozenset(
+    {
+        "AGENTOS_MODEL_BASE_URL",
+        "AGENTOS_CREDENTIALS",
+        "AGENTOS_MODEL",
+        "AGENTOS_FAKE_MODEL",
+        "AGENTOS_BUDGET",
+        "AGENTOS_SESSION_ID",
+        "AGENTOS_AGENT_ID",
+        "AGENTOS_BUNDLE_REF",
+        "AGENTOS_PLUGIN_DIR",
+        "AGENTOS_MEMORY_REF",
+        "AGENTOS_MEMORY_TOKEN",
+        "AGENTOS_HISTORY_REF",
+        "AGENTOS_HISTORY_TOKEN",
+        "AGENTOS_RUNNER_TOKEN",
+        "AGENTOS_APPROVAL_REQUIRED_TOOLS",
+        "AGENTOS_CONNECTOR_SECRET_KEYS",
+        "AGENTOS_APPROVAL_GRANT_TOOL",
+        "AGENTOS_SANDBOX_ID",
+        "AGENTOS_RUNNER_PORT",
+    }
+)
+
+RESERVED_BOOT_ENV: frozenset[str] = _CREDENTIAL_KEYS | _AGENTOS_BOOT_KEYS
+
+
+def is_reserved_boot_env_name(name: str) -> bool:
+    """Whether ``name`` is a reserved sandbox boot-env / model-credential key.
+
+    ``True`` for any explicitly enumerated key in ``RESERVED_BOOT_ENV`` and for
+    the whole ``AGENTOS_`` namespace (the forward-safe catch-all covering future
+    boot keys nobody remembers to enumerate). Connector secrets must not declare
+    such a name.
+    """
+    return name in RESERVED_BOOT_ENV or name.startswith("AGENTOS_")

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -22,6 +22,7 @@ from .models import (
     SkillFrontmatter,
     TriggerDeclaration,
 )
+from .reserved_env import is_reserved_boot_env_name
 
 # The hooks field is a mapping of event name -> list of matcher entries. Reused
 # to validate both the inline object and a declared hooks file.
@@ -461,14 +462,16 @@ def _validate_secrets(manifest: PluginManifest, c: _Collector) -> None:
                 "(uppercase letters, digits, underscore; not starting with a digit)",
                 loc,
             )
-        elif name.startswith("AGENTOS_"):
-            # AGENTOS_* names are the platform's reserved sandbox boot-env keys;
-            # a connector secret must not declare one (it would clobber or be
-            # dropped by the worker binding at delivery time).
+        elif is_reserved_boot_env_name(name):
+            # Reserved sandbox boot-env / model-credential keys (#457, #445):
+            # the whole AGENTOS_* namespace plus the runner's non-prefixed
+            # credential keys (ANTHROPIC_BASE_URL etc). A connector secret must
+            # not declare one -- it would clobber or be dropped by the worker
+            # binding at delivery time, or silently redirect the model session.
             c.error(
                 "secrets.name_reserved",
-                f"secret name {name!r} is reserved: AGENTOS_* names are platform "
-                "boot-env keys and cannot be used for a connector secret",
+                f"secret name {name!r} is reserved: it is a platform boot-env or "
+                "model-credential key and cannot be used for a connector secret",
                 loc,
             )
 

--- a/packages/plugin-format/tests/test_reserved_env.py
+++ b/packages/plugin-format/tests/test_reserved_env.py
@@ -1,0 +1,49 @@
+"""Unit pin for the shared reserved boot-env name policy (#457).
+
+`RESERVED_BOOT_ENV` + `is_reserved_boot_env_name` are the single source of truth
+that every write seam (API validator, bundle validator, worker injection loop,
+Helm guard) consults so a connector secret cannot shadow a runner-owned model
+credential. #445 fenced only the `AGENTOS_` prefix; the four non-prefixed
+credential keys the runner's `sdk_auth` owns slipped through, which is exactly
+the redirect this predicate closes.
+"""
+
+from __future__ import annotations
+
+import pytest
+from plugin_format import RESERVED_BOOT_ENV, is_reserved_boot_env_name
+
+# The four credential keys the runner's sdk_auth owns that are NOT AGENTOS_-
+# prefixed -- the gap #457 exists to close.
+_CREDENTIAL_KEYS = [
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_AUTH_TOKEN",
+]
+
+
+@pytest.mark.parametrize("name", _CREDENTIAL_KEYS)
+def test_credential_keys_are_reserved(name: str) -> None:
+    assert is_reserved_boot_env_name(name) is True
+
+
+@pytest.mark.parametrize("name", _CREDENTIAL_KEYS)
+def test_credential_keys_are_members_of_the_set(name: str) -> None:
+    assert name in RESERVED_BOOT_ENV
+
+
+def test_model_base_url_alias_is_reserved() -> None:
+    # sdk_auth's AGENTOS_-prefixed alias of the base-URL seam.
+    assert is_reserved_boot_env_name("AGENTOS_MODEL_BASE_URL") is True
+
+
+def test_agentos_prefix_is_the_catch_all() -> None:
+    # An arbitrary AGENTOS_* name nobody enumerated is still fenced by the
+    # prefix rule (the forward-safe half of the predicate).
+    assert is_reserved_boot_env_name("AGENTOS_FOO") is True
+
+
+def test_legitimate_connector_name_is_not_reserved() -> None:
+    # Negative control: a real connector token name must still be allowed.
+    assert is_reserved_boot_env_name("GITHUB_PERSONAL_ACCESS_TOKEN") is False

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from plugin_format import validate_bundle
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -162,6 +163,31 @@ def test_reserved_agentos_secret_name_is_rejected(tmp_path: Path) -> None:
     # AGENTOS_* names are reserved platform boot-env keys.
     bundle = _bundle(tmp_path, '{"name": "demo", "secrets": ["AGENTOS_BUDGET"]}')
     assert "secrets.name_reserved" in _codes(bundle)
+
+
+# The four runner-owned credential keys are NOT AGENTOS_-prefixed, so the #445
+# prefix fence never saw them: a bundle could declare `ANTHROPIC_BASE_URL` and
+# silently redirect the model. #457 rejects them at the same deploy gate.
+_RESERVED_CREDENTIAL_KEYS = [
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_AUTH_TOKEN",
+]
+
+
+@pytest.mark.parametrize("name", _RESERVED_CREDENTIAL_KEYS)
+def test_reserved_credential_secret_name_is_rejected(tmp_path: Path, name: str) -> None:
+    bundle = _bundle(tmp_path, f'{{"name": "demo", "secrets": ["{name}"]}}')
+    assert "secrets.name_reserved" in _codes(bundle)
+
+
+def test_legitimate_connector_secret_name_is_not_reserved(tmp_path: Path) -> None:
+    # Negative control: a real connector token name still validates clean.
+    bundle = _bundle(
+        tmp_path, '{"name": "demo", "secrets": ["GITHUB_PERSONAL_ACCESS_TOKEN"]}'
+    )
+    assert "secrets.name_reserved" not in _codes(bundle)
 
 
 def test_malformed_secrets_shape_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
Connector-secret names were fenced only by the `AGENTOS_` prefix, so a secret named `ANTHROPIC_BASE_URL` passed every write gate and was injected into the sandbox boot env, silently redirecting the model session to an arbitrary endpoint and handing it the `AGENTOS_CREDENTIALS` model credential. The worker guard was also ordering-dependent (`if name not in env`), and `apply_model_env` sets `ANTHROPIC_BASE_URL` *after* the injection loop, so on the default path the injected value survived.

## What changed

- **One canonical policy** in `packages/plugin-format` (`RESERVED_BOOT_ENV` + `is_reserved_boot_env_name`), the only package the API, worker, and bundle validator all import. It adds the four non-prefixed `sdk_auth` credential keys: `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_AUTH_TOKEN`.
- **Enforced at every write seam**: API validator, bundle validator, and the Helm path, which validated nothing before and now fails closed.
- **Order-independent worker filter**: `inject_connector_secrets` is one shared helper for both worker write sites (runs binding and the eval consumer). A reserved name is dropped and logged without its value, and never enters the `AGENTOS_CONNECTOR_SECRET_KEYS` marker.
- **Self-defending drift gate**: the pin test discovers `sdk_auth`/`binding` env constants dynamically and asserts parity with the Helm list, so the policy fails CI on drift instead of relying on memory.
- Corrects the false comment claiming a reserved key could never be clobbered.

## Deliberate deviation from acceptance criterion 1

AC 1 says "replace" the `AGENTOS_` prefix test with the explicit set. This keeps **both**: `is_reserved_boot_env_name` is `name in RESERVED_BOOT_ENV or name.startswith("AGENTOS_")`. The explicit set carries the actual fix (the four non-prefixed credential keys); retaining the prefix preserves #445's whole-namespace fence and its tests. Dropping it would have re-opened that hole, so this is a superset of both #445's behavior and this issue's requirement rather than a shortfall.

## Review notes

Review surfaced a second vulnerable write site the issue did not name: `EvalStreamConsumer._boot_env` carried the identical pre-fix loop and leaked the same way. That is fixed here, and is why the injection is now one shared helper rather than two parallel loops that can diverge.

Deferred to a follow-up: reserving proxy and TLS-trust redirect env (`HTTPS_PROXY`, `NODE_EXTRA_CA_CERTS`, `ANTHROPIC_CUSTOM_HEADERS`), which reach the same end state through a different class of name. That is broader than this issue's "keys the worker or the runner's `sdk_auth` owns" scope, and is mitigated in-cluster by fail-closed egress.

Closes #457
