### PR TITLE
Emit structured JSON under --json for every agent-facing verb

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,22 @@ just that unit tests pass.
   non-interactive (a `--yes`/`--force` path, never blocking on stdin), and errors
   as `{"error","fix"}` recovery instructions. Exit-code scheme: see
   `cli/README.md`.
+- **The agent-facing read and result verbs emit one JSON object to stdout under
+  `--json` -- never empty stdout (issue #456).** That covers the read/query verbs
+  (`versions`, `memory`, `approvals`, `observability`), the lifecycle result
+  verbs (`kill`, `resume`, `budget`, `delete`), and every verb's `--dry-run`
+  plan. Silent empty-stdout-exit-0 is the worst failure for an agent consumer: it
+  reads as success while carrying no data. To apply: a new or refactored verb
+  returns a `CliOutput` (a typed output object, or `DryRunPlan` for a `--dry-run`
+  plan) and routes it through `Ui::emit`, which is the single place the
+  json-vs-human decision is made -- handlers do not call stdout emitters
+  (`payload`/`kv`/`payload_plain`) directly. Two tracked exceptions: the
+  schema-gated ADR-0021 builders (`skill status`/`skill eval`, `skill check`,
+  `local message`/`cluster message`, `secrets list`, the error path, `guide`)
+  inline the same `if json` decision themselves, sanctioned and tracked for
+  migration onto `Ui::emit` in #474; and the operator verbs (`up`, `down`,
+  `status`, `comms`), `deploy`, and `skill message` have real-path success output
+  that is not yet structured under `--json`, tracked in #485.
 - **Console/CLI parity is a two-sided invariant (epic #145):** any CLI
   command-surface change regenerates the committed manifest (`cli/CLAUDE.md`),
   and every wired console action maps to a real command or an explicit

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -12,6 +12,25 @@ release with `up`, `status`, `down`, `comms`, `message`, and `deploy`. Full comm
 
 ## Load-bearing invariants
 
+- **Under `--json`, the agent-facing read and result verbs emit one JSON object
+  to stdout -- never empty stdout (issue #456).** That covers the read/query
+  verbs (`versions`, `memory`, `approvals`, `observability`), the lifecycle
+  result verbs (`kill`, `resume`, `budget`, `delete`), and every verb's
+  `--dry-run` plan. Silent empty-stdout-exit-0 is the worst failure mode for an
+  agent consumer: it looks like success but carries no data. The json-vs-human
+  decision lives in exactly one place, `Ui::emit` (the success-path mirror of
+  `main.rs`'s centralized error emit). A new or refactored verb returns a
+  `CliOutput` -- a typed output object (e.g. `VersionsOutput`, `KillOutput`), or
+  `DryRunPlan { lines }` for a `--dry-run` plan -- and routes it through
+  `Ui::emit`; handlers must not call the stdout emitters
+  (`payload`/`payload_plain`/`kv`) directly, since those suppress under `--json`.
+  Two tracked exceptions: the schema-gated ADR-0021 builders (`skill
+  status`/`skill eval`, `skill check`, `local message`/`cluster message`,
+  `secrets list`, the error path, `guide`) still inline their own `if json()`
+  branch, sanctioned and tracked for migration onto `Ui::emit` in #474; and the
+  operator verbs (`up`, `down`, `status`, `comms`), `deploy`, and `skill message`
+  have real-path success output that is not yet structured under `--json`,
+  tracked in #485.
 - **The command manifest is a committed artifact; regenerate it in the same
   change as any command-surface edit (console/CLI parity, epic #145).** Any
   change to a clap `Command`/subcommand or an `*Action` enum — a renamed verb,

--- a/cli/README.md
+++ b/cli/README.md
@@ -463,23 +463,30 @@ original turn used a non-default value.
 The CLI's primary consumer is a coding agent (ADR-0021), so its output and
 control flow are machine-first.
 
-**`--json`** (global) switches the read/report commands `agentos skill status`
-and `agentos skill eval` to a single machine-readable JSON object on **stdout**;
-it also switches `agentos local message` and `agentos cluster message` to emit
-one structured line per terminal state on stdout: a completed turn emits
-`{"reply": ..., "thread": ..., "finalized": ...}` (the model's reply, which is
-null on a no-edit completion, plus the thread the turn ran under); a **timeout**
-emits `{"reply": null, "finalized": false, "timed_out": true}` before exiting 3
-(transient); and `--json --dry-run` emits a planned-action descriptor
-`{"dry_run": true, "target": "local"|"cluster", "stream": ..., "channel": ...,
-"reply_endpoint": ...}` (`channel` is null when it would be resolved from the sole
-deployed agent). The three shapes are the `oneOf` in `cli/schema/message.schema.json`.
-All human and
-log text (progress, notes, warnings) goes to **stderr**, so a plain
-`... --json | jq` yields clean data. On failure under `--json`, the error
-is emitted to stdout as `{"error": "<message>", "fix": "<hint>"|null}` instead of
-a prose message, so an agent can recover without parsing prose. `NO_COLOR`,
-`CLICOLOR`, and `--color=never` are honored on every command.
+**`--json`** (global) makes every agent-facing verb emit a single
+machine-readable JSON object on **stdout** instead of empty output: the
+read/query verbs (`versions`, `memory`, `approvals`, `observability`), the
+lifecycle result verbs (`kill`, `resume`, `budget`, `delete`), and every verb's
+`--dry-run` plan (uniform shape `{"dry_run": true, "plan": [<lines>]}`) all
+route through one centralized emitter. The `message` verbs keep their own,
+more specific shapes: `agentos local message` and `agentos cluster message`
+emit one structured line per terminal state on stdout -- a completed turn
+emits `{"reply": ..., "thread": ..., "finalized": ...}` (the model's reply,
+which is null on a no-edit completion, plus the thread the turn ran under); a
+**timeout** emits `{"reply": null, "finalized": false, "timed_out": true}`
+before exiting 3 (transient); and `--json --dry-run` emits a planned-action
+descriptor `{"dry_run": true, "target": "local"|"cluster", "stream": ...,
+"channel": ..., "reply_endpoint": ...}` (`channel` is null when it would be
+resolved from the sole deployed agent). The three shapes are the `oneOf` in
+`cli/schema/message.schema.json`. Two verbs lag this contract on their
+real-path success output: `agentos skill message`, and the operator verbs
+(`up`, `down`, `status`, `comms`) plus `deploy`, still print human text rather
+than JSON on success (tracked in #485). All human and log text (progress,
+notes, warnings) goes to **stderr**, so a plain `... --json | jq` yields clean
+data. On failure under `--json`, the error is emitted to stdout as
+`{"error": "<message>", "fix": "<hint>"|null}` instead of a prose message, so
+an agent can recover without parsing prose. `NO_COLOR`, `CLICOLOR`, and
+`--color=never` are honored on every command.
 
 **Semantic exit codes** let an agent branch on *why* a command failed without
 parsing output:

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -473,7 +473,9 @@ impl ApiClient {
             .context("decoding budget")
     }
 
-    /// List an agent's immutable versions, newest first: `GET /agents/{id}/versions`.
+    /// List an agent's immutable versions, ascending by `created_at` (oldest
+    /// first): `GET /agents/{id}/versions`. `commands::versions` reverses
+    /// this to newest-first before display/JSON output.
     pub async fn list_versions(&self, agent_id: &str) -> Result<Vec<Version>> {
         let resp = self
             .http

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1265,18 +1265,49 @@ pub struct AgentActionOpts {
     pub dry_run: bool,
 }
 
+/// Output of `<tier> kill <agent>`: the dry-run plan, or the resulting kill
+/// state. Owns its data (agent name) so `to_json` / `render` outlive the
+/// `ApiClient`. The json-vs-human choice is made once, in `Ui::emit` (#456).
+#[derive(Debug)]
+pub enum KillOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Done { agent: String, killed: bool },
+}
+
+impl crate::ui::CliOutput for KillOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            KillOutput::DryRun(plan) => plan.to_json(),
+            KillOutput::Done { agent, killed } => {
+                serde_json::json!({"agent": agent, "killed": killed})
+            }
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            KillOutput::DryRun(plan) => plan.render(ui),
+            KillOutput::Done { agent, killed } => {
+                ui.payload(&format!("agent {agent} killed (killed={killed})"));
+                ui.note("Run `agentos cluster resume <agent>` to bring it back.");
+            }
+        }
+    }
+}
+
 /// `agentos cluster kill <agent> --yes`: flip the agent kill switch on
 /// (`POST /agents/{id}/kill`). Destructive (it stops the agent's runs), so it
-/// refuses without `--yes`, mirroring `cluster down`. `--dry-run` prints the
+/// refuses without `--yes`, mirroring `cluster down`. `--dry-run` returns the
 /// plan and makes no request.
-pub async fn kill(opts: AgentActionOpts, yes: bool) -> Result<()> {
+pub async fn kill(opts: AgentActionOpts, yes: bool) -> Result<KillOutput> {
     let ui = crate::ui::ui();
     if opts.dry_run {
-        ui.payload_plain(&format!(
-            "POST {}/agents/<id>/kill  (would resolve agent {:?} first)",
-            opts.api_url, opts.agent
-        ));
-        return Ok(());
+        return Ok(KillOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!(
+                "POST {}/agents/<id>/kill  (would resolve agent {:?} first)",
+                opts.api_url, opts.agent
+            )],
+        }));
     }
     if !yes {
         return Err(crate::exit::CliError::usage(format!(
@@ -1300,25 +1331,52 @@ pub async fn kill(opts: AgentActionOpts, yes: bool) -> Result<()> {
             return Err(err);
         }
     };
-    ui.payload(&format!(
-        "agent {} killed (killed={})",
-        agent.name, state.killed
-    ));
-    ui.note("Run `agentos cluster resume <agent>` to bring it back.");
-    Ok(())
+    Ok(KillOutput::Done {
+        agent: agent.name,
+        killed: state.killed,
+    })
+}
+
+/// Output of `<tier> resume <agent>`: the dry-run plan, or the resulting kill
+/// state. Owns its data so it outlives the `ApiClient`.
+#[derive(Debug)]
+pub enum ResumeOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Done { agent: String, killed: bool },
+}
+
+impl crate::ui::CliOutput for ResumeOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            ResumeOutput::DryRun(plan) => plan.to_json(),
+            ResumeOutput::Done { agent, killed } => {
+                serde_json::json!({"agent": agent, "killed": killed})
+            }
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            ResumeOutput::DryRun(plan) => plan.render(ui),
+            ResumeOutput::Done { agent, killed } => {
+                ui.payload(&format!("agent {agent} resumed (killed={killed})"));
+            }
+        }
+    }
 }
 
 /// `agentos cluster resume <agent>`: flip the agent kill switch off
 /// (`POST /agents/{id}/resume`). Non-destructive, so no `--yes` gate.
-/// `--dry-run` prints the plan and makes no request.
-pub async fn resume(opts: AgentActionOpts) -> Result<()> {
+/// `--dry-run` returns the plan and makes no request.
+pub async fn resume(opts: AgentActionOpts) -> Result<ResumeOutput> {
     let ui = crate::ui::ui();
     if opts.dry_run {
-        ui.payload_plain(&format!(
-            "POST {}/agents/<id>/resume  (would resolve agent {:?} first)",
-            opts.api_url, opts.agent
-        ));
-        return Ok(());
+        return Ok(ResumeOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!(
+                "POST {}/agents/<id>/resume  (would resolve agent {:?} first)",
+                opts.api_url, opts.agent
+            )],
+        }));
     }
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     let agent = client.find_agent(&opts.agent).await?;
@@ -1334,26 +1392,65 @@ pub async fn resume(opts: AgentActionOpts) -> Result<()> {
             return Err(err);
         }
     };
-    ui.payload(&format!(
-        "agent {} resumed (killed={})",
-        agent.name, state.killed
-    ));
-    Ok(())
+    Ok(ResumeOutput::Done {
+        agent: agent.name,
+        killed: state.killed,
+    })
+}
+
+/// Output of `<tier> budget <agent>`: the dry-run plan, or the saved budget.
+/// `max_usd_per_day` is `None` when the platform default applies. Owns its data
+/// so it outlives the `ApiClient`.
+#[derive(Debug)]
+pub enum BudgetOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Done {
+        agent: String,
+        max_usd_per_day: Option<f64>,
+    },
+}
+
+impl crate::ui::CliOutput for BudgetOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            BudgetOutput::DryRun(plan) => plan.to_json(),
+            BudgetOutput::Done {
+                agent,
+                max_usd_per_day,
+            } => serde_json::json!({"agent": agent, "max_usd_per_day": max_usd_per_day}),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            BudgetOutput::DryRun(plan) => plan.render(ui),
+            BudgetOutput::Done {
+                agent,
+                max_usd_per_day,
+            } => {
+                let usd = max_usd_per_day
+                    .map(|v| format!("${v}/day"))
+                    .unwrap_or_else(|| "platform default".to_string());
+                ui.payload(&format!("budget for {agent} set: max $/day {usd}"));
+            }
+        }
+    }
 }
 
 /// `agentos cluster budget <agent> --limit <n>`: set the agent budget
 /// (`PUT /agents/{id}/budget`). `--limit` sets the daily spend cap
 /// (`max_usd_per_day`, the primary `BudgetConfig` field the console surfaces as
 /// "Max $/day"); the per-run token cap is left at the platform default.
-/// `--dry-run` prints the plan and makes no request.
-pub async fn budget(opts: AgentActionOpts, limit: f64) -> Result<()> {
+/// `--dry-run` returns the plan and makes no request.
+pub async fn budget(opts: AgentActionOpts, limit: f64) -> Result<BudgetOutput> {
     let ui = crate::ui::ui();
     if opts.dry_run {
-        ui.payload_plain(&format!(
-            "PUT {}/agents/<id>/budget  {{\"max_usd_per_day\":{limit}}}  (would resolve agent {:?} first)",
-            opts.api_url, opts.agent
-        ));
-        return Ok(());
+        return Ok(BudgetOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!(
+                "PUT {}/agents/<id>/budget  {{\"max_usd_per_day\":{limit}}}  (would resolve agent {:?} first)",
+                opts.api_url, opts.agent
+            )],
+        }));
     }
     if !limit.is_finite() || limit <= 0.0 {
         return Err(crate::exit::usage(format!(
@@ -1378,26 +1475,49 @@ pub async fn budget(opts: AgentActionOpts, limit: f64) -> Result<()> {
             return Err(err);
         }
     };
-    let usd = saved
-        .max_usd_per_day
-        .map(|v| format!("${v}/day"))
-        .unwrap_or_else(|| "platform default".to_string());
-    ui.payload(&format!("budget for {} set: max $/day {usd}", agent.name));
-    Ok(())
+    Ok(BudgetOutput::Done {
+        agent: agent.name,
+        max_usd_per_day: saved.max_usd_per_day,
+    })
+}
+
+/// Output of `<tier> delete <agent>`: the dry-run plan, or the deleted agent's
+/// name. Owns its data so it outlives the `ApiClient`.
+#[derive(Debug)]
+pub enum DeleteOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Done { agent: String },
+}
+
+impl crate::ui::CliOutput for DeleteOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            DeleteOutput::DryRun(plan) => plan.to_json(),
+            DeleteOutput::Done { agent } => serde_json::json!({"agent": agent, "deleted": true}),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            DeleteOutput::DryRun(plan) => plan.render(ui),
+            DeleteOutput::Done { agent } => ui.payload(&format!("agent {agent} deleted")),
+        }
+    }
 }
 
 /// `agentos cluster delete <agent> --yes`: delete the agent
 /// (`DELETE /agents/{id}`). Destructive and irreversible, so it refuses without
-/// `--yes`, mirroring `cluster down`. `--dry-run` prints the plan and makes no
+/// `--yes`, mirroring `cluster down`. `--dry-run` returns the plan and makes no
 /// request.
-pub async fn delete(opts: AgentActionOpts, yes: bool) -> Result<()> {
+pub async fn delete(opts: AgentActionOpts, yes: bool) -> Result<DeleteOutput> {
     let ui = crate::ui::ui();
     if opts.dry_run {
-        ui.payload_plain(&format!(
-            "DELETE {}/agents/<id>  (would resolve agent {:?} first)",
-            opts.api_url, opts.agent
-        ));
-        return Ok(());
+        return Ok(DeleteOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!(
+                "DELETE {}/agents/<id>  (would resolve agent {:?} first)",
+                opts.api_url, opts.agent
+            )],
+        }));
     }
     if !yes {
         return Err(crate::exit::CliError::usage(format!(
@@ -1418,79 +1538,215 @@ pub async fn delete(opts: AgentActionOpts, yes: bool) -> Result<()> {
             return Err(err);
         }
     }
-    ui.payload(&format!("agent {} deleted", agent.name));
-    Ok(())
+    Ok(DeleteOutput::Done { agent: agent.name })
+}
+
+/// Output of `<tier> versions <agent>`: the dry-run plan, the empty case, or the
+/// version list. Owns its data (agent name + cloned versions) so `to_json` /
+/// `render` outlive the `ApiClient`. The json-vs-human choice is made once, in
+/// `Ui::emit` (issue #456).
+pub enum VersionsOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Empty {
+        agent: String,
+    },
+    /// `versions` is held **newest-first**, normalized once by the `versions`
+    /// handler (the API returns them oldest-first). Both `to_json` and `render`
+    /// iterate it plainly, so any future constructor must preserve that order or
+    /// the two paths silently diverge.
+    List {
+        agent: String,
+        versions: Vec<crate::api::Version>,
+    },
+}
+
+impl crate::ui::CliOutput for VersionsOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            VersionsOutput::DryRun(plan) => plan.to_json(),
+            VersionsOutput::Empty { agent } => {
+                serde_json::json!({"agent": agent, "versions": []})
+            }
+            VersionsOutput::List { agent, versions } => {
+                let versions: Vec<serde_json::Value> = versions
+                    .iter()
+                    .map(|v| {
+                        serde_json::json!({
+                            "version_label": v.version_label,
+                            "commit_sha": v.commit_sha,
+                            "created_by": v.created_by,
+                            "created_at": v.created_at,
+                        })
+                    })
+                    .collect();
+                serde_json::json!({"agent": agent, "versions": versions})
+            }
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            VersionsOutput::DryRun(plan) => plan.render(ui),
+            VersionsOutput::Empty { agent } => {
+                ui.payload(&format!("{agent} has no versions yet (deploy it first)"));
+            }
+            VersionsOutput::List { agent, versions } => {
+                ui.payload(&format!(
+                    "{agent} — {} version(s), newest first:",
+                    versions.len()
+                ));
+                for v in versions.iter() {
+                    let commit = v.commit_sha.as_deref().unwrap_or("-");
+                    let by = v.created_by.as_deref().unwrap_or("-");
+                    let at = v.created_at.as_deref().unwrap_or("-");
+                    ui.kv(
+                        &v.version_label,
+                        &format!("commit {commit}  by {by}  at {at}"),
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// `<tier> versions <agent>`: list the agent's immutable versions (newest first).
-pub async fn versions(opts: AgentActionOpts) -> Result<()> {
-    let ui = crate::ui::ui();
+pub async fn versions(opts: AgentActionOpts) -> Result<VersionsOutput> {
     if opts.dry_run {
-        ui.payload_plain(&format!(
-            "GET {}/agents/<id>/versions  (would resolve agent {:?} first)",
-            opts.api_url, opts.agent
-        ));
-        return Ok(());
+        return Ok(VersionsOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!(
+                "GET {}/agents/<id>/versions  (would resolve agent {:?} first)",
+                opts.api_url, opts.agent
+            )],
+        }));
     }
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     let agent = client.find_agent(&opts.agent).await?;
     let versions = client.list_versions(&agent.id).await?;
     if versions.is_empty() {
-        ui.payload(&format!(
-            "{} has no versions yet (deploy it first)",
-            agent.name
-        ));
-        return Ok(());
+        return Ok(VersionsOutput::Empty { agent: agent.name });
     }
-    ui.payload(&format!(
-        "{} — {} version(s), newest first:",
-        agent.name,
-        versions.len()
-    ));
-    for v in versions.iter().rev() {
-        let commit = v.commit_sha.as_deref().unwrap_or("-");
-        let by = v.created_by.as_deref().unwrap_or("-");
-        let at = v.created_at.as_deref().unwrap_or("-");
-        ui.kv(
-            &v.version_label,
-            &format!("commit {commit}  by {by}  at {at}"),
-        );
+    // The API returns versions oldest-first; normalize to the documented
+    // newest-first order HERE, once, so the json and human paths cannot diverge.
+    Ok(VersionsOutput::List {
+        agent: agent.name,
+        versions: versions.into_iter().rev().collect(),
+    })
+}
+
+/// Output of `<tier> memory <agent>`: the dry-run plan, the empty case, or the
+/// learned-memory list. Owns its data so it outlives the `ApiClient`.
+pub enum MemoryOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Empty {
+        agent: String,
+    },
+    List {
+        agent: String,
+        entries: Vec<crate::api::MemoryEntry>,
+    },
+}
+
+impl crate::ui::CliOutput for MemoryOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            MemoryOutput::DryRun(plan) => plan.to_json(),
+            MemoryOutput::Empty { agent } => {
+                serde_json::json!({"agent": agent, "entries": []})
+            }
+            MemoryOutput::List { agent, entries } => {
+                let entries: Vec<serde_json::Value> = entries
+                    .iter()
+                    .map(|e| serde_json::json!({"index": e.index, "content": e.content}))
+                    .collect();
+                serde_json::json!({"agent": agent, "entries": entries})
+            }
+        }
     }
-    Ok(())
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            MemoryOutput::DryRun(plan) => plan.render(ui),
+            MemoryOutput::Empty { agent } => {
+                ui.payload(&format!("{agent} has no learned memory yet"));
+            }
+            MemoryOutput::List { agent, entries } => {
+                ui.payload(&format!("{agent} — {} memory entr(ies):", entries.len()));
+                for e in entries {
+                    ui.kv(&format!("#{}", e.index), &e.content);
+                }
+            }
+        }
+    }
 }
 
 /// `<tier> memory <agent>`: show what the agent has learned (its memory log).
-pub async fn memory(opts: AgentActionOpts) -> Result<()> {
-    let ui = crate::ui::ui();
+pub async fn memory(opts: AgentActionOpts) -> Result<MemoryOutput> {
     if opts.dry_run {
-        ui.payload_plain(&format!(
-            "GET {}/agents/<id>/memory  (would resolve agent {:?} first)",
-            opts.api_url, opts.agent
-        ));
-        return Ok(());
+        return Ok(MemoryOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!(
+                "GET {}/agents/<id>/memory  (would resolve agent {:?} first)",
+                opts.api_url, opts.agent
+            )],
+        }));
     }
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     let agent = client.find_agent(&opts.agent).await?;
     let entries = client.list_memory(&agent.id).await?;
     if entries.is_empty() {
-        ui.payload(&format!("{} has no learned memory yet", agent.name));
-        return Ok(());
+        return Ok(MemoryOutput::Empty { agent: agent.name });
     }
-    ui.payload(&format!(
-        "{} — {} memory entr(ies):",
-        agent.name,
-        entries.len()
-    ));
-    for e in &entries {
-        ui.kv(&format!("#{}", e.index), &e.content);
+    Ok(MemoryOutput::List {
+        agent: agent.name,
+        entries,
+    })
+}
+
+/// Output of `<tier> approvals <agent>`: the dry-run plan, or the gate list
+/// (empty vec == "no tools gated"). Owns its data so it outlives the `ApiClient`.
+pub enum ApprovalsOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Gates {
+        agent: String,
+        gated_tools: Vec<String>,
+    },
+}
+
+impl crate::ui::CliOutput for ApprovalsOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            ApprovalsOutput::DryRun(plan) => plan.to_json(),
+            ApprovalsOutput::Gates { agent, gated_tools } => {
+                serde_json::json!({"agent": agent, "gated_tools": gated_tools})
+            }
+        }
     }
-    Ok(())
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            ApprovalsOutput::DryRun(plan) => plan.render(ui),
+            ApprovalsOutput::Gates { agent, gated_tools } => {
+                if gated_tools.is_empty() {
+                    ui.payload(&format!(
+                        "{agent}: no tools are gated (calls run without approval)"
+                    ));
+                } else {
+                    ui.payload(&format!("{agent} — {} gated tool(s):", gated_tools.len()));
+                    for tool in gated_tools {
+                        ui.kv("gated", tool);
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// `<tier> approvals <agent> [--gate TOOL]... [--clear]`: view or set the tool
 /// names whose calls pause for human approval. No flags => show current gates.
-pub async fn approvals(opts: AgentActionOpts, gate: Vec<String>, clear: bool) -> Result<()> {
-    let ui = crate::ui::ui();
+pub async fn approvals(
+    opts: AgentActionOpts,
+    gate: Vec<String>,
+    clear: bool,
+) -> Result<ApprovalsOutput> {
     if clear && !gate.is_empty() {
         return Err(crate::exit::usage(
             "--clear cannot be combined with --gate (clear removes all gates)",
@@ -1506,12 +1762,14 @@ pub async fn approvals(opts: AgentActionOpts, gate: Vec<String>, clear: bool) ->
         } else {
             format!("GET {}/agents/<id> (show current gates)", opts.api_url)
         };
-        ui.payload_plain(&format!(
-            "{action}  (would resolve agent {:?} first)",
-            opts.agent
-        ));
-        return Ok(());
+        return Ok(ApprovalsOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!(
+                "{action}  (would resolve agent {:?} first)",
+                opts.agent
+            )],
+        }));
     }
+    let ui = crate::ui::ui();
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     let agent = client.find_agent(&opts.agent).await?;
     let gates = if setting {
@@ -1530,25 +1788,43 @@ pub async fn approvals(opts: AgentActionOpts, gate: Vec<String>, clear: bool) ->
     } else {
         agent.approval_required_tools.clone().unwrap_or_default()
     };
-    if gates.is_empty() {
-        ui.payload(&format!(
-            "{}: no tools are gated (calls run without approval)",
-            agent.name
-        ));
-    } else {
-        ui.payload(&format!("{} — {} gated tool(s):", agent.name, gates.len()));
-        for tool in &gates {
-            ui.kv("gated", tool);
-        }
+    Ok(ApprovalsOutput::Gates {
+        agent: agent.name,
+        gated_tools: gates,
+    })
+}
+
+/// Output of `local observability`: the observability surfaces (name, url) to
+/// print. The browser-open side effect happens in the handler; this type only
+/// carries what `emit` renders.
+pub struct ObservabilityOutput {
+    pub surfaces: Vec<(String, String)>,
+}
+
+impl crate::ui::CliOutput for ObservabilityOutput {
+    fn to_json(&self) -> serde_json::Value {
+        let surfaces: Vec<serde_json::Value> = self
+            .surfaces
+            .iter()
+            .map(|(name, url)| serde_json::json!({"name": name, "url": url}))
+            .collect();
+        serde_json::json!({"surfaces": surfaces})
     }
-    Ok(())
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        for (name, url) in &self.surfaces {
+            ui.kv(name, url);
+        }
+        ui.payload("opened the local observability surfaces (start them with `agentos local up`)");
+    }
 }
 
 /// `local observability`: open (and print) the local platform's observability
 /// surfaces -- the AgentOS Console and the Langfuse UI. Best-effort browser open
-/// so it degrades to just the URLs on a headless host.
-pub async fn observability() -> Result<()> {
-    let ui = crate::ui::ui();
+/// so it degrades to just the URLs on a headless host. Under `--json` the
+/// consumer is a machine, so the browser-open side effect is skipped entirely
+/// (it would spawn tabs an agent never sees, and makes tests non-hermetic).
+pub async fn observability() -> Result<ObservabilityOutput> {
     let urls = [
         ("AgentOS Console", "http://localhost:28080/?api=1"),
         (
@@ -1561,19 +1837,22 @@ pub async fn observability() -> Result<()> {
     } else {
         "xdg-open"
     };
+    let open_browser = !crate::ui::ui().json();
+    let mut surfaces = Vec::with_capacity(urls.len());
     for (name, url) in urls {
-        ui.kv(name, url);
-        // Fire-and-forget: a missing opener (headless/CI) is not an error -- the
-        // URL is already printed above.
-        let _ = tokio::process::Command::new(opener)
-            .arg(url)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .await;
+        if open_browser {
+            // Fire-and-forget: a missing opener (headless/CI) is not an error --
+            // the URL is printed by `render` either way.
+            let _ = tokio::process::Command::new(opener)
+                .arg(url)
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .await;
+        }
+        surfaces.push((name.to_string(), url.to_string()));
     }
-    ui.payload("opened the local observability surfaces (start them with `agentos local up`)");
-    Ok(())
+    Ok(ObservabilityOutput { surfaces })
 }
 
 /// Reject a Slack channel value that is a `#name` rather than a channel ID.

--- a/cli/src/comms.rs
+++ b/cli/src/comms.rs
@@ -230,12 +230,13 @@ pub async fn comms(opts: CommsOpts) -> Result<()> {
     );
 
     if opts.common.dry_run {
-        for cmd in &cmds {
-            ui.payload_plain(&cmd.display());
-        }
-        for cmd in &rollout {
-            ui.payload_plain(&cmd.display());
-        }
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: cmds
+                .iter()
+                .chain(rollout.iter())
+                .map(|cmd| cmd.display())
+                .collect(),
+        });
         return Ok(());
     }
 
@@ -280,9 +281,9 @@ pub async fn local_comms(opts: LocalCommsOpts) -> Result<()> {
     };
 
     if opts.dry_run {
-        for cmd in &cmds {
-            ui.payload_plain(&cmd.display());
-        }
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: cmds.iter().map(|cmd| cmd.display()).collect(),
+        });
         return Ok(());
     }
 

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -233,7 +233,9 @@ pub async fn up(o: LocalOpts) -> Result<()> {
     let ui = crate::ui::ui();
     let cmd = up_command(&o);
     if o.dry_run {
-        ui.payload_plain(&cmd.display());
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: vec![cmd.display()],
+        });
         return Ok(());
     }
     require_on_path("docker")?;
@@ -276,7 +278,9 @@ pub async fn status(o: LocalOpts) -> Result<()> {
     let ui = crate::ui::ui();
     let cmd = status_command(&o);
     if o.dry_run {
-        ui.payload_plain(&cmd.display());
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: vec![cmd.display()],
+        });
         return Ok(());
     }
     require_on_path("docker")?;
@@ -305,11 +309,15 @@ pub async fn down(o: LocalDownOpts) -> Result<()> {
     let ui = crate::ui::ui();
     let cmd = down_command(&o);
     if o.common.dry_run {
-        ui.payload_plain(&cmd.display());
-        ui.payload_plain(&format!(
-            "docker rm -f $(docker ps -a --filter label={} -q)",
-            docker::SANDBOX_LABEL
-        ));
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: vec![
+                cmd.display(),
+                format!(
+                    "docker rm -f $(docker ps -a --filter label={} -q)",
+                    docker::SANDBOX_LABEL
+                ),
+            ],
+        });
         return Ok(());
     }
     if o.wipe {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1067,6 +1067,15 @@ async fn main() {
     }
 }
 
+/// Route a handler's structured output through the one success-path emit
+/// (`Ui::emit`), mirroring the centralized error emit in `main`. The read verbs
+/// return a `CliOutput` instead of touching stdout themselves, so the
+/// json-vs-human decision is made in exactly one place (issue #456).
+fn emit<T: agentos::ui::CliOutput>(out: T) -> Result<()> {
+    ui::ui().emit(&out);
+    Ok(())
+}
+
 /// Dispatch one parsed command. No subcommand opens the interactive terminal,
 /// matching `agentos interactive` / `agentos ui`. Returns the command's
 /// `Result`; `main`
@@ -1349,29 +1358,29 @@ async fn run(command: Option<Command>) -> Result<()> {
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::versions(AgentActionOpts {
                     api_url,
                     api_key,
                     agent,
                     dry_run,
                 })
-                .await
-            }
+                .await?,
+            ),
             LocalAction::Memory {
                 agent,
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::memory(AgentActionOpts {
                     api_url,
                     api_key,
                     agent,
                     dry_run,
                 })
-                .await
-            }
+                .await?,
+            ),
             LocalAction::Approvals {
                 agent,
                 gate,
@@ -1379,7 +1388,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::approvals(
                     AgentActionOpts {
                         api_url,
@@ -1390,16 +1399,16 @@ async fn run(command: Option<Command>) -> Result<()> {
                     gate,
                     clear,
                 )
-                .await
-            }
-            LocalAction::Observability => commands::observability().await,
+                .await?,
+            ),
+            LocalAction::Observability => emit(commands::observability().await?),
             LocalAction::Budget {
                 agent,
                 limit,
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::budget(
                     AgentActionOpts {
                         api_url,
@@ -1409,15 +1418,15 @@ async fn run(command: Option<Command>) -> Result<()> {
                     },
                     limit,
                 )
-                .await
-            }
+                .await?,
+            ),
             LocalAction::Kill {
                 agent,
                 api_url,
                 api_key,
                 yes,
                 dry_run,
-            } => {
+            } => emit(
                 commands::kill(
                     AgentActionOpts {
                         api_url,
@@ -1427,22 +1436,22 @@ async fn run(command: Option<Command>) -> Result<()> {
                     },
                     yes,
                 )
-                .await
-            }
+                .await?,
+            ),
             LocalAction::Resume {
                 agent,
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::resume(AgentActionOpts {
                     api_url,
                     api_key,
                     agent,
                     dry_run,
                 })
-                .await
-            }
+                .await?,
+            ),
         },
         Some(Command::Cluster { action }) => match action {
             ClusterAction::Up {
@@ -1716,7 +1725,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 api_key,
                 yes,
                 dry_run,
-            } => {
+            } => emit(
                 commands::kill(
                     AgentActionOpts {
                         api_url,
@@ -1726,29 +1735,29 @@ async fn run(command: Option<Command>) -> Result<()> {
                     },
                     yes,
                 )
-                .await
-            }
+                .await?,
+            ),
             ClusterAction::Resume {
                 agent,
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::resume(AgentActionOpts {
                     api_url,
                     api_key,
                     agent,
                     dry_run,
                 })
-                .await
-            }
+                .await?,
+            ),
             ClusterAction::Budget {
                 agent,
                 limit,
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::budget(
                     AgentActionOpts {
                         api_url,
@@ -1758,15 +1767,15 @@ async fn run(command: Option<Command>) -> Result<()> {
                     },
                     limit,
                 )
-                .await
-            }
+                .await?,
+            ),
             ClusterAction::Delete {
                 agent,
                 api_url,
                 api_key,
                 yes,
                 dry_run,
-            } => {
+            } => emit(
                 commands::delete(
                     AgentActionOpts {
                         api_url,
@@ -1776,36 +1785,36 @@ async fn run(command: Option<Command>) -> Result<()> {
                     },
                     yes,
                 )
-                .await
-            }
+                .await?,
+            ),
             ClusterAction::Versions {
                 agent,
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::versions(AgentActionOpts {
                     api_url,
                     api_key,
                     agent,
                     dry_run,
                 })
-                .await
-            }
+                .await?,
+            ),
             ClusterAction::Memory {
                 agent,
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::memory(AgentActionOpts {
                     api_url,
                     api_key,
                     agent,
                     dry_run,
                 })
-                .await
-            }
+                .await?,
+            ),
             ClusterAction::Approvals {
                 agent,
                 gate,
@@ -1813,7 +1822,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 api_url,
                 api_key,
                 dry_run,
-            } => {
+            } => emit(
                 commands::approvals(
                     AgentActionOpts {
                         api_url,
@@ -1824,8 +1833,8 @@ async fn run(command: Option<Command>) -> Result<()> {
                     gate,
                     clear,
                 )
-                .await
-            }
+                .await?,
+            ),
         },
         Some(Command::Schema) => {
             use clap::CommandFactory;

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -907,9 +907,9 @@ async fn eval_local(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
     let api_base = local_api_base(opts.api_url.as_deref());
 
     if opts.dry_run {
-        for line in eval_dry_run_lines(&opts, &suite.name, suite.cases.len()) {
-            ui.payload_plain(&line);
-        }
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: eval_dry_run_lines(&opts, &suite.name, suite.cases.len()),
+        });
         return Ok(());
     }
 
@@ -940,9 +940,9 @@ async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
     let ui = crate::ui::ui();
 
     if opts.dry_run {
-        for line in eval_dry_run_lines(&opts, &suite.name, suite.cases.len()) {
-            ui.payload_plain(&line);
-        }
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: eval_dry_run_lines(&opts, &suite.name, suite.cases.len()),
+        });
         return Ok(());
     }
 

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1229,9 +1229,9 @@ pub async fn up(mut opts: UpOpts) -> Result<()> {
         ));
     }
     if opts.common.dry_run {
-        for cmd in &cmds {
-            ui.payload_plain(&cmd.display());
-        }
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: cmds.iter().map(|cmd| cmd.display()).collect(),
+        });
         return Ok(());
     }
     require_on_path("helm")?;
@@ -1248,9 +1248,12 @@ pub async fn up(mut opts: UpOpts) -> Result<()> {
 pub async fn status(opts: CommonOpts) -> Result<()> {
     let ui = crate::ui::ui();
     if opts.dry_run {
-        for cmd in status_commands(&opts) {
-            ui.payload_plain(&cmd.display());
-        }
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: status_commands(&opts)
+                .iter()
+                .map(|cmd| cmd.display())
+                .collect(),
+        });
         return Ok(());
     }
     require_on_path("helm")?;
@@ -1324,9 +1327,9 @@ pub async fn down(opts: DownOpts) -> Result<()> {
     let ui = crate::ui::ui();
     let cmds = down_commands(&opts.common);
     if opts.common.dry_run {
-        for cmd in &cmds {
-            ui.payload_plain(&cmd.display());
-        }
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: cmds.iter().map(|cmd| cmd.display()).collect(),
+        });
         return Ok(());
     }
     ui.warn(&format!(

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -177,6 +177,19 @@ impl Ui {
         }
     }
 
+    /// The one success-path decision point (mirror of the centralized error emit
+    /// in `main.rs`): under `--json` emit the value's single JSON object to
+    /// stdout, otherwise render the human view. Handlers hand `emit` a
+    /// `CliOutput` and stop deciding how to render, so no verb can silently emit
+    /// empty stdout under `--json` (issue #456, ADR-0021).
+    pub fn emit(&self, out: &dyn CliOutput) {
+        if self.json {
+            self.emit_json(&out.to_json());
+        } else {
+            out.render(self);
+        }
+    }
+
     // -- styling helpers ---------------------------------------------------
 
     /// Wrap `s` in `style`'s ANSI codes when stdout color is on, else raw.
@@ -446,6 +459,43 @@ impl Ui {
             " ".repeat(pad + 1),
             self.paint_err(self.dim(), elapsed)
         )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CliOutput: the success-path emit contract
+// ---------------------------------------------------------------------------
+
+/// A command result that knows both how to serialize to one JSON object (for
+/// `--json`) and how to render itself for humans. `Ui::emit` picks between them,
+/// so the json-vs-human decision lives in exactly one place. Implement this for
+/// any verb's output rather than calling a stdout emitter directly.
+pub trait CliOutput {
+    /// The single JSON object emitted under `--json`.
+    fn to_json(&self) -> serde_json::Value;
+    /// The human render (stdout payload lines) when not under `--json`.
+    fn render(&self, ui: &Ui);
+}
+
+/// A generic `--dry-run` plan: the shell command lines a verb WOULD run. Its
+/// JSON is `{"dry_run":true,"plan":[lines]}`; its human render is the same lines
+/// verbatim (so operator dry-run output is byte-identical to before). The lines
+/// come straight from `OpsCommand::display()` (already credential-masked), so
+/// this type never re-derives argv or reads a raw secret.
+#[derive(Debug)]
+pub struct DryRunPlan {
+    pub lines: Vec<String>,
+}
+
+impl CliOutput for DryRunPlan {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({ "dry_run": true, "plan": self.lines })
+    }
+
+    fn render(&self, ui: &Ui) {
+        for line in &self.lines {
+            ui.payload_plain(line);
+        }
     }
 }
 

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -1,0 +1,746 @@
+//! Integration: the `--json` emit contract (issue #456, ADR-0021). Under
+//! `--json`, EVERY agent-facing verb must emit exactly one JSON object to
+//! stdout -- never empty stdout. Today the read verbs and the whole `--dry-run`
+//! surface go through `ui.payload`/`ui.kv`/`ui.payload_plain`, which suppress
+//! under `--json`, so those verbs emit empty stdout + exit 0 (the bug). These
+//! tests are RED now (empty stdout, no JSON object) and GREEN once the handlers
+//! route their payload through a `--json` sink that always emits an object.
+//!
+//! The dry-run coverage is manifest-driven on purpose: it walks the committed
+//! `command-manifest.json`, so a verb added later with a `--dry-run` arg is
+//! auto-covered without touching this test. Exit codes are deliberately ignored
+//! (comms/eval legitimately exit non-zero with a JSON *error* object); the bug
+//! under test is empty stdout, not a nonzero code.
+
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentos")
+}
+
+fn manifest() -> serde_json::Value {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/command-manifest.json");
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("committed manifest {path} must exist: {e}"));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("manifest {path} must be valid JSON: {e}"))
+}
+
+/// Placeholder value for a required arg. `--limit` parses as an f64, so a
+/// non-numeric placeholder would be a clap parse error (empty stdout -> false
+/// failure); everything else is a plain string.
+fn placeholder(id: &str) -> &'static str {
+    match id {
+        "limit" => "1",
+        _ => "x",
+    }
+}
+
+/// Every LEAF verb path (e.g. `["cluster", "kill"]`) whose `args` include an arg
+/// with `"id": "dry_run"`, paired with the argv fragment of its required-arg
+/// placeholders (positional value, or `--<long>` + value for a required flag).
+fn dry_run_verbs() -> Vec<(Vec<String>, Vec<String>)> {
+    let mut out = Vec::new();
+    fn args_of(node: &serde_json::Value) -> &[serde_json::Value] {
+        node.get("args")
+            .and_then(|a| a.as_array())
+            .map_or(&[], |a| a.as_slice())
+    }
+    fn walk(
+        node: &serde_json::Value,
+        path: Vec<String>,
+        out: &mut Vec<(Vec<String>, Vec<String>)>,
+    ) {
+        let subs = node
+            .get("subcommands")
+            .and_then(|s| s.as_array())
+            .filter(|s| !s.is_empty());
+        match subs {
+            Some(subs) => {
+                for sub in subs {
+                    let name = sub
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .expect("subcommand has a name")
+                        .to_string();
+                    let mut child = path.clone();
+                    child.push(name);
+                    walk(sub, child, out);
+                }
+            }
+            None => {
+                // Leaf verb: collect it only if it carries a --dry-run arg.
+                let args = args_of(node);
+                let has_dry = args
+                    .iter()
+                    .any(|a| a.get("id").and_then(|i| i.as_str()) == Some("dry_run"));
+                if !has_dry {
+                    return;
+                }
+                let mut required = Vec::new();
+                for a in args {
+                    if a.get("required").and_then(|r| r.as_bool()) != Some(true) {
+                        continue;
+                    }
+                    let id = a.get("id").and_then(|i| i.as_str()).unwrap_or("");
+                    if a.get("positional").and_then(|p| p.as_bool()) == Some(true) {
+                        required.push(placeholder(id).to_string());
+                    } else {
+                        let long = a
+                            .get("long")
+                            .and_then(|l| l.as_str())
+                            .expect("required non-positional arg has a --long");
+                        required.push(format!("--{long}"));
+                        required.push(placeholder(id).to_string());
+                    }
+                }
+                out.push((path, required));
+            }
+        }
+    }
+    walk(&manifest(), Vec::new(), &mut out);
+    out
+}
+
+#[test]
+fn every_dry_run_verb_emits_json_object() {
+    let verbs = dry_run_verbs();
+    // Guard against a vacuously-passing empty walk, and against a manifest that
+    // silently drops verbs: ~24 carry --dry-run today, so a loose floor of 20.
+    assert!(
+        verbs.len() >= 20,
+        "expected >= 20 --dry-run verbs in the manifest, found {} ({:?}); \
+         a vacuous or shrunken walk must fail loudly",
+        verbs.len(),
+        verbs.iter().map(|(p, _)| p.join(" ")).collect::<Vec<_>>()
+    );
+
+    for (path, required) in &verbs {
+        let mut argv: Vec<String> = path.clone();
+        argv.extend(required.iter().cloned());
+        argv.push("--dry-run".to_string());
+        argv.push("--json".to_string());
+
+        // cargo runs integration tests with cwd = `cli/`, where `charts/agentos`
+        // and the compose file don't resolve -- so the cluster/local operator
+        // verbs (`up`/`down`/`status`) would error on chart resolution and never
+        // reach their real dry-run branch, satisfying "non-empty JSON" via the
+        // centralized *error* path instead of the *plan* path (a gate hole).
+        // Run from the worktree root so those verbs hit their true dry-run
+        // branch; pre-fix that path emits exit 0 + empty stdout (the RED we want).
+        let root = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
+        let output = Command::new(bin())
+            .current_dir(root)
+            .args(&argv)
+            .output()
+            .unwrap_or_else(|e| panic!("run agentos {}: {e}", argv.join(" ")));
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(
+            !stdout.trim().is_empty(),
+            "`agentos {}` under --json must not emit empty stdout\nstderr: {}",
+            argv.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+                panic!(
+                    "`agentos {}` under --json must emit parseable JSON: {e}\nstdout: {stdout}",
+                    argv.join(" ")
+                )
+            });
+        assert!(
+            parsed.is_object(),
+            "`agentos {}` under --json must emit a JSON object, got: {stdout}",
+            argv.join(" ")
+        );
+    }
+}
+
+#[test]
+fn observability_emits_json_object() {
+    // AC1: `local observability` has no --dry-run, so the manifest walk misses
+    // it. It is network-free (prints two URLs + best-effort browser open; the
+    // opener failure is swallowed on a headless host, so xdg-open failing is
+    // fine and must not be fought). Today it emits empty stdout under --json.
+    let output = Command::new(bin())
+        .args(["local", "observability", "--json"])
+        .output()
+        .expect("run agentos local observability --json");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.trim().is_empty(),
+        "`agentos local observability --json` must not emit empty stdout\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("must emit parseable JSON: {e}\nstdout: {stdout}"));
+    assert!(
+        parsed.is_object(),
+        "`agentos local observability --json` must emit a JSON object, got: {stdout}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "observability is hermetic and must exit 0\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn dry_run_json_masks_credentials() {
+    // SECURITY: the new JSON sink must carry the ALREADY-MASKED plan string, not
+    // a raw secret. The non-json dry-run masks the model credential via
+    // `CmdArg::SecretSet` (first 8 chars + "***"), so `sk-ant-SECRETSENTINEL9999`
+    // prints as `sk-ant-S***` and the raw sentinel never appears. The --json
+    // output must preserve exactly that masking. RED now = empty stdout.
+    //
+    // `--chart` is required: a dev build with no `charts/agentos` in the test
+    // binary's cwd (the `cli/` package dir) errors before building the plan, so
+    // point it at the committed chart at the worktree root (one level up from
+    // CARGO_MANIFEST_DIR). `--dry-run` never fetches or stats it.
+    let chart = concat!(env!("CARGO_MANIFEST_DIR"), "/../charts/agentos");
+    let output = Command::new(bin())
+        .args(["cluster", "up", "--chart", chart, "--dry-run", "--json"])
+        .env("AGENTOS_MODEL_CREDENTIALS", "sk-ant-SECRETSENTINEL9999")
+        .output()
+        .expect("run agentos cluster up --dry-run --json");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.trim().is_empty(),
+        "`agentos cluster up --dry-run --json` must not emit empty stdout\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("must emit parseable JSON: {e}\nstdout: {stdout}"));
+    assert!(
+        parsed.is_object(),
+        "`agentos cluster up --dry-run --json` must emit a JSON object, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("sk-ant-S***"),
+        "the JSON plan must carry the masked credential marker `sk-ant-S***`: {stdout}"
+    );
+    assert!(
+        !stdout.contains("SECRETSENTINEL9999"),
+        "the raw model credential must NEVER appear in the JSON output: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The `eval --dry-run` PLAN path (not the error path)
+// ---------------------------------------------------------------------------
+
+/// The manifest-driven gate above drives every `--dry-run` verb with NO required
+/// args beyond placeholders, so `eval` fails cases-resolution and satisfies the
+/// "emits an object" assertion via the CENTRALIZED ERROR-JSON path -- it never
+/// reaches its dry-run PLAN branch, which is the branch that was actually broken.
+/// This drives `eval` with a real `--cases` file so the plan branch is exercised,
+/// and asserts the payload is the PLAN (no `error` key), so an error-path
+/// regression cannot green this test. `--dry-run` touches no network.
+fn assert_eval_dry_run_plan(tier: &str) {
+    let output = Command::new(bin())
+        .args([
+            tier,
+            "eval",
+            "--cases",
+            "examples/weather/evals/cases.json",
+            "--dry-run",
+            "--json",
+        ])
+        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+        .output()
+        .unwrap_or_else(|e| panic!("run agentos {tier} eval --dry-run --json: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "`agentos {tier} eval --dry-run --json` is hermetic and must exit 0\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stdout.trim().is_empty(),
+        "`agentos {tier} eval --dry-run --json` must not emit empty stdout\nstderr: {stderr}"
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("must emit parseable JSON: {e}\nstdout: {stdout}"));
+    assert!(
+        parsed.is_object(),
+        "`agentos {tier} eval --dry-run --json` must emit a JSON object, got: {stdout}"
+    );
+    assert!(
+        parsed.get("error").is_none(),
+        "must be the dry-run PLAN, not an error object -- the false-green this gap was about: {stdout}"
+    );
+    assert_eq!(
+        parsed.get("dry_run"),
+        Some(&serde_json::Value::Bool(true)),
+        "the plan object must carry `dry_run: true`: {stdout}"
+    );
+    let plan = parsed
+        .get("plan")
+        .and_then(|p| p.as_array())
+        .unwrap_or_else(|| panic!("`plan` must be an array: {stdout}"));
+    assert!(
+        !plan.is_empty(),
+        "`plan` must be a NON-empty array of the lines eval would run: {stdout}"
+    );
+    let first = plan[0].as_str().unwrap_or_default();
+    assert!(
+        first.contains("weather"),
+        "the first plan line must name the resolved suite (`weather`), proving cases resolved: {first:?}"
+    );
+}
+
+#[test]
+fn local_eval_dry_run_emits_plan_not_error() {
+    assert_eval_dry_run_plan("local");
+}
+
+#[test]
+fn cluster_eval_dry_run_emits_plan_not_error() {
+    assert_eval_dry_run_plan("cluster");
+}
+
+// ---------------------------------------------------------------------------
+// The `comms --dry-run` PLAN path (not the error path)
+// ---------------------------------------------------------------------------
+
+/// Sentinel Slack tokens. Distinctive enough that a raw leak anywhere in stdout
+/// is unambiguous, and long enough to survive the `xapp-SEN***` masking prefix.
+const SENTINEL_APP_TOKEN: &str = "xapp-SENTINELAPP1234";
+const SENTINEL_BOT_TOKEN: &str = "xoxb-SENTINELBOT5678";
+
+/// Drives a `<tier> comms` variant with `--dry-run --json` and asserts the
+/// payload is the PLAN, returning it for the caller's tier-specific checks.
+///
+/// The manifest-driven gate above supplies NO provider flags, so `comms` fails
+/// its `require_provider`/`require_connect_tokens` check and satisfies the
+/// "emits an object" assertion via the CENTRALIZED ERROR-JSON path -- it never
+/// reaches its dry-run PLAN branch, which is the branch that was actually
+/// broken. These drive real connect/disconnect inputs so the plan branch is
+/// exercised, and the `no error key` assertion means an error-path regression
+/// cannot green them. Both tiers emit the plan and return BEFORE their
+/// `require_on_path("helm"/"kubectl"/"docker")` calls, so this is hermetic:
+/// no network, no cluster, no tooling on PATH.
+fn assert_comms_dry_run_plan(tier: &str, extra: &[&str]) -> serde_json::Value {
+    let mut args = vec![tier, "comms", "--slack"];
+    args.extend_from_slice(extra);
+    args.extend_from_slice(&["--dry-run", "--json"]);
+    let output = Command::new(bin())
+        .args(&args)
+        // The token flags default from these; remove them so an ambient shell
+        // value can never influence the plan under test.
+        .env_remove("SLACK_APP_TOKEN")
+        .env_remove("SLACK_BOT_TOKEN")
+        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+        .output()
+        .unwrap_or_else(|e| panic!("run agentos {args:?}: {e}"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "`agentos {args:?}` is hermetic and must exit 0\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stdout.trim().is_empty(),
+        "`agentos {args:?}` must not emit empty stdout\nstderr: {stderr}"
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("must emit parseable JSON: {e}\nstdout: {stdout}"));
+    assert!(
+        parsed.is_object(),
+        "`agentos {args:?}` must emit a JSON object, got: {stdout}"
+    );
+    assert!(
+        parsed.get("error").is_none(),
+        "must be the dry-run PLAN, not an error object -- the false-green this gap was about: {stdout}"
+    );
+    assert_eq!(
+        parsed.get("dry_run"),
+        Some(&serde_json::Value::Bool(true)),
+        "the plan object must carry `dry_run: true`: {stdout}"
+    );
+    let plan = parsed
+        .get("plan")
+        .and_then(|p| p.as_array())
+        .unwrap_or_else(|| panic!("`plan` must be an array: {stdout}"));
+    assert!(
+        !plan.is_empty(),
+        "`plan` must be a NON-empty array of the lines comms would run: {stdout}"
+    );
+    parsed
+}
+
+/// Reinforces the masking contract: comms tokens go through `CmdArg::SecretSet`,
+/// so `cmd.display()` renders them as a `xapp-SEN***` prefix. A regression that
+/// swapped `SecretSet` for a plain arg would spill the raw token into the plan
+/// -- and into any agent's logs that captured this `--json` payload.
+fn assert_tokens_masked(stdout: &str) {
+    assert!(
+        !stdout.contains(SENTINEL_APP_TOKEN),
+        "the raw app token must NEVER appear in the plan: {stdout}"
+    );
+    assert!(
+        !stdout.contains(SENTINEL_BOT_TOKEN),
+        "the raw bot token must NEVER appear in the plan: {stdout}"
+    );
+    assert!(
+        stdout.contains("xapp-SEN***"),
+        "the app token must appear MASKED (`xapp-SEN***`), proving it was carried as a secret rather than dropped: {stdout}"
+    );
+    assert!(
+        stdout.contains("xoxb-SEN***"),
+        "the bot token must appear MASKED (`xoxb-SEN***`): {stdout}"
+    );
+}
+
+#[test]
+fn local_comms_dry_run_emits_plan_not_error() {
+    let parsed = assert_comms_dry_run_plan(
+        "local",
+        &[
+            "--app-token",
+            SENTINEL_APP_TOKEN,
+            "--bot-token",
+            SENTINEL_BOT_TOKEN,
+        ],
+    );
+    let stdout = parsed.to_string();
+    assert_tokens_masked(&stdout);
+    let first = parsed["plan"][0].as_str().unwrap_or_default();
+    assert!(
+        first.contains("docker compose") && first.contains("agentos-dispatcher"),
+        "the local plan must be the compose connect command that brings up the dispatcher: {first:?}"
+    );
+}
+
+#[test]
+fn cluster_comms_dry_run_emits_plan_not_error() {
+    let parsed = assert_comms_dry_run_plan(
+        "cluster",
+        &[
+            "--app-token",
+            SENTINEL_APP_TOKEN,
+            "--bot-token",
+            SENTINEL_BOT_TOKEN,
+        ],
+    );
+    let stdout = parsed.to_string();
+    assert_tokens_masked(&stdout);
+    let first = parsed["plan"][0].as_str().unwrap_or_default();
+    assert!(
+        first.contains("helm upgrade") && first.contains("dispatcher.slack.appToken"),
+        "the cluster plan must be the helm upgrade that sets the dispatcher's Slack tokens: {first:?}"
+    );
+}
+
+/// `--disconnect` needs no tokens (`require_connect_tokens` short-circuits), so
+/// it reaches the plan branch on both tiers and is worth pinning: it is the
+/// variant an agent runs to tear Slack back down.
+#[test]
+fn local_comms_disconnect_dry_run_emits_plan_not_error() {
+    let parsed = assert_comms_dry_run_plan("local", &["--disconnect"]);
+    let plan = parsed["plan"].as_array().expect("plan array");
+    assert!(
+        plan.iter().any(|l| l
+            .as_str()
+            .unwrap_or_default()
+            .contains("stop agentos-dispatcher")),
+        "the local disconnect plan must stop the dispatcher: {parsed}"
+    );
+}
+
+#[test]
+fn cluster_comms_disconnect_dry_run_emits_plan_not_error() {
+    let parsed = assert_comms_dry_run_plan("cluster", &["--disconnect"]);
+    let first = parsed["plan"][0].as_str().unwrap_or_default();
+    assert!(
+        first.contains("helm upgrade") && first.contains("dispatcher.slack.appToken="),
+        "the cluster disconnect plan must clear the dispatcher's Slack tokens: {first:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// `to_json` key-shape pins
+// ---------------------------------------------------------------------------
+//
+// The read verbs' real (`List`) path needs a live server, so the binary-driven
+// tests above cannot reach it -- and they only assert `is_object()`, which a
+// dropped or renamed key still satisfies. These unit-test `to_json` directly and
+// compare against an EXACT literal, so renaming, dropping, OR adding a key fails.
+// This is the only coverage of the agent-facing key contract.
+
+use agentos::api::{MemoryEntry, Version};
+use agentos::commands::{
+    ApprovalsOutput, BudgetOutput, DeleteOutput, KillOutput, MemoryOutput, ObservabilityOutput,
+    ResumeOutput, VersionsOutput,
+};
+use agentos::ui::{CliOutput, DryRunPlan};
+use serde_json::json;
+
+fn plan(lines: &[&str]) -> DryRunPlan {
+    DryRunPlan {
+        lines: lines.iter().map(|l| l.to_string()).collect(),
+    }
+}
+
+#[test]
+fn dry_run_plan_json_shape_is_pinned() {
+    assert_eq!(
+        plan(&["helm upgrade --install agentos", "kubectl rollout status"]).to_json(),
+        json!({
+            "dry_run": true,
+            "plan": ["helm upgrade --install agentos", "kubectl rollout status"],
+        })
+    );
+    // An empty plan still emits the `plan` key as an array, never null/absent.
+    assert_eq!(plan(&[]).to_json(), json!({"dry_run": true, "plan": []}));
+}
+
+#[test]
+fn versions_output_json_shape_is_pinned() {
+    assert_eq!(
+        VersionsOutput::DryRun(plan(&["GET <api>/agents/<id>/versions"])).to_json(),
+        json!({"dry_run": true, "plan": ["GET <api>/agents/<id>/versions"]})
+    );
+    assert_eq!(
+        VersionsOutput::Empty {
+            agent: "weather".to_string(),
+        }
+        .to_json(),
+        json!({"agent": "weather", "versions": []})
+    );
+    // Two versions, one with every optional field `None` and one with them all
+    // `Some`, so the null-vs-value rendering of each optional is pinned. `id` is
+    // deliberately NOT emitted; adding it would fail this exact-match.
+    assert_eq!(
+        VersionsOutput::List {
+            agent: "weather".to_string(),
+            versions: vec![
+                Version {
+                    id: "ver_1".to_string(),
+                    version_label: "v1".to_string(),
+                    commit_sha: None,
+                    created_by: None,
+                    created_at: None,
+                },
+                Version {
+                    id: "ver_2".to_string(),
+                    version_label: "v2".to_string(),
+                    commit_sha: Some("abc1234".to_string()),
+                    created_by: Some("bconn".to_string()),
+                    created_at: Some("2026-07-16T00:00:00Z".to_string()),
+                },
+            ],
+        }
+        .to_json(),
+        json!({
+            "agent": "weather",
+            "versions": [
+                {
+                    "version_label": "v1",
+                    "commit_sha": null,
+                    "created_by": null,
+                    "created_at": null,
+                },
+                {
+                    "version_label": "v2",
+                    "commit_sha": "abc1234",
+                    "created_by": "bconn",
+                    "created_at": "2026-07-16T00:00:00Z",
+                },
+            ],
+        })
+    );
+}
+
+#[test]
+fn memory_output_json_shape_is_pinned() {
+    assert_eq!(
+        MemoryOutput::DryRun(plan(&["GET <api>/agents/<id>/memory"])).to_json(),
+        json!({"dry_run": true, "plan": ["GET <api>/agents/<id>/memory"]})
+    );
+    assert_eq!(
+        MemoryOutput::Empty {
+            agent: "weather".to_string(),
+        }
+        .to_json(),
+        json!({"agent": "weather", "entries": []})
+    );
+    // `MemoryEntry::version` is deliberately NOT emitted; this exact-match pins
+    // that (surfacing it later would fail here and force a contract decision).
+    assert_eq!(
+        MemoryOutput::List {
+            agent: "weather".to_string(),
+            entries: vec![
+                MemoryEntry {
+                    index: 0,
+                    content: "user prefers celsius".to_string(),
+                    version: 3,
+                },
+                MemoryEntry {
+                    index: 1,
+                    content: "home airport is BOS".to_string(),
+                    version: 3,
+                },
+            ],
+        }
+        .to_json(),
+        json!({
+            "agent": "weather",
+            "entries": [
+                {"index": 0, "content": "user prefers celsius"},
+                {"index": 1, "content": "home airport is BOS"},
+            ],
+        })
+    );
+}
+
+#[test]
+fn approvals_output_json_shape_is_pinned() {
+    assert_eq!(
+        ApprovalsOutput::DryRun(plan(&["GET <api>/agents/<id>"])).to_json(),
+        json!({"dry_run": true, "plan": ["GET <api>/agents/<id>"]})
+    );
+    // No gates: `gated_tools` must still be an empty array, never null/absent --
+    // an agent consumer branches on the array, not on key presence.
+    assert_eq!(
+        ApprovalsOutput::Gates {
+            agent: "weather".to_string(),
+            gated_tools: vec![],
+        }
+        .to_json(),
+        json!({"agent": "weather", "gated_tools": []})
+    );
+    assert_eq!(
+        ApprovalsOutput::Gates {
+            agent: "weather".to_string(),
+            gated_tools: vec!["Bash".to_string(), "mcp__weather__forecast".to_string()],
+        }
+        .to_json(),
+        json!({
+            "agent": "weather",
+            "gated_tools": ["Bash", "mcp__weather__forecast"],
+        })
+    );
+}
+
+#[test]
+fn observability_output_json_shape_is_pinned() {
+    assert_eq!(
+        ObservabilityOutput {
+            surfaces: vec![
+                (
+                    "AgentOS Console".to_string(),
+                    "http://localhost:28080/?api=1".to_string()
+                ),
+                (
+                    "Langfuse UI".to_string(),
+                    "http://localhost:23000".to_string()
+                ),
+            ],
+        }
+        .to_json(),
+        json!({
+            "surfaces": [
+                {"name": "AgentOS Console", "url": "http://localhost:28080/?api=1"},
+                {"name": "Langfuse UI", "url": "http://localhost:23000"},
+            ],
+        })
+    );
+}
+
+#[test]
+fn kill_output_json_shape_is_pinned() {
+    assert_eq!(
+        KillOutput::DryRun(plan(&["POST <api>/agents/<id>/kill"])).to_json(),
+        json!({"dry_run": true, "plan": ["POST <api>/agents/<id>/kill"]})
+    );
+    assert_eq!(
+        KillOutput::Done {
+            agent: "weather".to_string(),
+            killed: true,
+        }
+        .to_json(),
+        json!({"agent": "weather", "killed": true})
+    );
+    // The false case must emit `killed: false`, not omit the key.
+    assert_eq!(
+        KillOutput::Done {
+            agent: "weather".to_string(),
+            killed: false,
+        }
+        .to_json(),
+        json!({"agent": "weather", "killed": false})
+    );
+}
+
+#[test]
+fn resume_output_json_shape_is_pinned() {
+    assert_eq!(
+        ResumeOutput::DryRun(plan(&["POST <api>/agents/<id>/resume"])).to_json(),
+        json!({"dry_run": true, "plan": ["POST <api>/agents/<id>/resume"]})
+    );
+    assert_eq!(
+        ResumeOutput::Done {
+            agent: "weather".to_string(),
+            killed: false,
+        }
+        .to_json(),
+        json!({"agent": "weather", "killed": false})
+    );
+    assert_eq!(
+        ResumeOutput::Done {
+            agent: "weather".to_string(),
+            killed: true,
+        }
+        .to_json(),
+        json!({"agent": "weather", "killed": true})
+    );
+}
+
+#[test]
+fn budget_output_json_shape_is_pinned() {
+    assert_eq!(
+        BudgetOutput::DryRun(plan(&["PATCH <api>/agents/<id>"])).to_json(),
+        json!({"dry_run": true, "plan": ["PATCH <api>/agents/<id>"]})
+    );
+    assert_eq!(
+        BudgetOutput::Done {
+            agent: "weather".to_string(),
+            max_usd_per_day: Some(12.5),
+        }
+        .to_json(),
+        json!({"agent": "weather", "max_usd_per_day": 12.5})
+    );
+    // `None` means "platform default" and must serialize as an explicit null --
+    // omitting the key would read to an agent as "no budget field at all".
+    assert_eq!(
+        BudgetOutput::Done {
+            agent: "weather".to_string(),
+            max_usd_per_day: None,
+        }
+        .to_json(),
+        json!({"agent": "weather", "max_usd_per_day": null})
+    );
+}
+
+#[test]
+fn delete_output_json_shape_is_pinned() {
+    assert_eq!(
+        DeleteOutput::DryRun(plan(&["DELETE <api>/agents/<id>"])).to_json(),
+        json!({"dry_run": true, "plan": ["DELETE <api>/agents/<id>"]})
+    );
+    assert_eq!(
+        DeleteOutput::Done {
+            agent: "weather".to_string(),
+        }
+        .to_json(),
+        json!({"agent": "weather", "deleted": true})
+    );
+}


### PR DESCRIPTION
## What

Under `--json`, six verbs (`local|cluster versions|memory|approvals`, `local observability`) and the entire `--dry-run` surface emitted **empty stdout, exit 0** — the worst failure shape for an agent consumer, since it looks like success. Their handlers wrote only through `ui.payload`/`kv`/`payload_plain`, which suppress under `--json`, and none called `emit_json`. The error path was already compliant because it is centralized in `main.rs`; this mirrors that centralization on the success path.

## How

- A `CliOutput` trait + `Ui::emit` become the single success-path json-vs-human decision point, plus a `DryRunPlan` type for `--dry-run` plans.
- The read/query verbs (`versions`, `memory`, `approvals`, `observability`) and the lifecycle result verbs (`kill`, `resume`, `budget`, `delete`) return typed output routed through one dispatch shim; operator and `eval` `--dry-run` branches emit their already-masked plan lines through `DryRunPlan`.
- Version ordering is normalized once in the handler so the JSON matches the documented newest-first promise and the human output (the two had diverged).
- `observability` skips the browser-open under `--json`.

## Testing

- A **manifest-driven gate** drives every `--dry-run` verb under `--json` and asserts non-empty JSON, so future dry-run verbs are covered automatically.
- **Exact-key shape tests** pin every output type / enum arm (a renamed, dropped, or added key fails).
- Dedicated tests drive `eval` and `comms` into their real plan branch (not the error path), and assert credential masking survives the JSON sink.
- Full suite green (428); human (non-`--json`) output is byte-identical.

## Scope

The invariant is recorded in `AGENTS.md`, `cli/CLAUDE.md`, and `cli/README.md`. Two classes are deliberately deferred with tracked follow-ups so the documented invariant is true of the binary: the schema-gated ADR-0021 inline builders (#474) and the operator/`deploy`/`skill message` real-path success output (#485).

Closes #456
