### PR TITLE
Enforce plugin manifest secrets policy at deploy time

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -18,7 +18,7 @@ use crate::docker::{self, CheckSpec, StartSpec};
 use crate::evals::{load_suite, turn_passes};
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
-use crate::scaffold::{read_manifest, scaffold, scaffold_from_spec};
+use crate::scaffold::{read_declared_secrets, read_manifest, scaffold, scaffold_from_spec};
 use crate::state::{self, RunnerState};
 
 pub const DEFAULT_PORT: u16 = 7245; // the design canon's local bot port
@@ -1124,11 +1124,41 @@ pub struct DeployOpts {
     /// to the platform API, which stores it on the agent for the worker to
     /// forward into the sandbox. From `deploy --secret <NAME>`.
     pub secret: Vec<String>,
+    /// Whether this tier offers `--secret` binding, gating the declared-secrets
+    /// policy check (#464): true for tiers that can bind a declared secret
+    /// (local), false where secret delivery is not yet wired (cluster, until
+    /// #440 flips it). When false the gate is skipped -- otherwise every
+    /// secrets-declaring bundle would hard-fail with a `--secret <NAME>`
+    /// remediation that does not exist on that tier.
+    pub secret_binding_supported: bool,
     /// Actionable remediation line printed when the platform API connection
     /// fails (e.g. the kubectl port-forward command for cluster, or
     /// `agentos local up` for local). Naming the fix turns a raw
     /// "Connection refused" into something the operator can act on.
     pub connect_hint: String,
+}
+
+/// The declared connector-secret NAMES not present in the operator's bound
+/// `--secret` set (#464). A non-empty result is a deploy-time gap: the bundle
+/// expects a secret nothing will bind, which would surface at runtime as an
+/// auth failure (#429).
+///
+/// Only WELL-FORMED, bindable names count as a gap: a declared name is diffed
+/// only when it passes `crate::secrets::validate_name`, the same env-var-syntax
+/// check (`^[A-Z_][A-Z0-9_]*$`) used for `agentos secrets set`. Malformed or
+/// reserved names are the plugin-format validator's responsibility (server-side
+/// on upload); the gate excludes them so it never preempts that real validation
+/// error with a misleading "bind `--secret <NAME>`" message. The reserved-name
+/// list is deliberately NOT mirrored into Rust (drift risk) -- the regex filter
+/// is the intended scope.
+fn unbound_declared_secrets(declared: &[String], bound: &[String]) -> Vec<String> {
+    declared
+        .iter()
+        .filter(|name| {
+            crate::secrets::validate_name(name).is_ok() && !bound.iter().any(|b| b == *name)
+        })
+        .cloned()
+        .collect()
 }
 
 pub async fn deploy(opts: DeployOpts) -> Result<()> {
@@ -1141,6 +1171,32 @@ pub async fn deploy(opts: DeployOpts) -> Result<()> {
         .label
         .unwrap_or_else(|| format!("{manifest_version}-{}", unix_now()));
     let created_by = std::env::var("USER").unwrap_or_else(|_| "agentos-cli".to_string());
+
+    // Deploy-time secrets-policy gate (#464 / ADR-0009): every NAME the bundle's
+    // manifest `secrets` policy declares must be in the operator's bound
+    // `--secret` set, else deploy FAILS naming the gap. Decision is fail-loud per
+    // the ticket -- a missing binding otherwise surfaces later as a runtime auth
+    // failure (#429). This runs in the shared deploy() path, pre-network, so it
+    // covers BOTH `local deploy` and `cluster deploy`. It is gated on
+    // `secret_binding_supported` (AC2): cluster deploy cannot bind a `--secret`
+    // until #440 wires delivery, so enforcing there would hard-fail every
+    // secrets-declaring bundle with a remediation the tier cannot satisfy. It
+    // runs first, before the archive is even packed: the check is a pure
+    // name-set diff on `opts.secret` (the bound NAME set) and needs no packed
+    // bundle or resolved values, so a declared-but-unbound policy fails fast
+    // without doing any of that work.
+    if opts.secret_binding_supported {
+        let declared = read_declared_secrets(&plugin_dir)?;
+        let unbound = unbound_declared_secrets(&declared, &opts.secret);
+        if !unbound.is_empty() {
+            return Err(crate::exit::usage(format!(
+                "{plugin_name} declares connector secret(s) that were not bound on deploy: {}. \
+                 Bind each with `--secret <NAME>` (value read from the environment or from \
+                 `agentos secrets set <NAME>`).",
+                unbound.join(", ")
+            )));
+        }
+    }
 
     let ui = crate::ui::ui();
     if let Some(channel) = opts.slack_channel.as_deref() {
@@ -1911,7 +1967,23 @@ mod tests {
         merge_secret_env, resolve_cases_path, seed_env_if_missing, select_passthrough_env,
         validate_slack_channel, EnvSeed,
     };
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+
+    /// Scaffold a bundle at `dir` under `name`, then overwrite its manifest's
+    /// `secrets` policy with `secrets`. Shared setup for tests exercising the
+    /// declared-secrets gate in `deploy()`.
+    fn scaffold_with_secrets(dir: &Path, name: &str, secrets: &[&str]) {
+        crate::scaffold::scaffold(dir, name).unwrap();
+        let manifest_path = dir.join(".claude-plugin/plugin.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        manifest["secrets"] = serde_json::json!(secrets);
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
 
     #[test]
     fn default_channel_passes_local_validation() {
@@ -2144,6 +2216,7 @@ mod tests {
             env: super::DeployEnv::Dev,
             label: Some("v0".to_string()),
             secret: vec![],
+            secret_binding_supported: true,
             connect_hint: hint.to_string(),
         };
         let err = super::deploy(opts).await.unwrap_err();
@@ -2151,6 +2224,113 @@ mod tests {
         assert!(
             rendered.contains(hint),
             "hint missing from error: {rendered}"
+        );
+    }
+
+    #[test]
+    fn unbound_declared_secrets_diffs_declared_against_bound() {
+        // All declared names bound -> nothing unbound.
+        assert!(super::unbound_declared_secrets(
+            &["GH_TOKEN".to_string()],
+            &["GH_TOKEN".to_string()]
+        )
+        .is_empty());
+        // A declared name not in the bound set is returned.
+        assert_eq!(
+            super::unbound_declared_secrets(
+                &["GH_TOKEN".to_string(), "SLACK".to_string()],
+                &["GH_TOKEN".to_string()]
+            ),
+            vec!["SLACK".to_string()]
+        );
+        // Nothing declared -> nothing unbound (even with bound extras).
+        assert!(super::unbound_declared_secrets(&[], &["GH_TOKEN".to_string()]).is_empty());
+        // The #464 mismatch: declared the connector name, bound a different one.
+        assert_eq!(
+            super::unbound_declared_secrets(
+                &["GITHUB_PERSONAL_ACCESS_TOKEN".to_string()],
+                &["GH_TOKEN".to_string()]
+            ),
+            vec!["GITHUB_PERSONAL_ACCESS_TOKEN".to_string()]
+        );
+        // A MALFORMED declared name (not env-var syntax) is excluded from the
+        // gap: it is the plugin-format validator's job to reject it server-side,
+        // so the gate must not preempt that with a misleading `--secret` message.
+        assert!(super::unbound_declared_secrets(&["github-token".to_string()], &[]).is_empty());
+        // A well-formed unbound name alongside a malformed one: only the
+        // well-formed one is a gap.
+        assert_eq!(
+            super::unbound_declared_secrets(
+                &["github-token".to_string(), "GITHUB_TOKEN".to_string()],
+                &[]
+            ),
+            vec!["GITHUB_TOKEN".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn deploy_fails_when_declared_secret_is_not_bound() {
+        // AC3: a declared secret NAME with no matching --secret binding fails the
+        // deploy BEFORE any network attempt -- a true deploy-time error, not a
+        // runtime/connection failure.
+        let dir = tempfile::tempdir().unwrap();
+        // Declares a NAME we will bind under the wrong key.
+        scaffold_with_secrets(dir.path(), "test-agent", &["GITHUB_PERSONAL_ACCESS_TOKEN"]);
+
+        let opts = super::DeployOpts {
+            plugin_dir: dir.path().to_path_buf(),
+            api_url: "http://127.0.0.1:1".to_string(),
+            api_key: "k".to_string(),
+            slack_channel: None,
+            env: super::DeployEnv::Dev,
+            label: Some("v0".to_string()),
+            secret: vec!["GH_TOKEN".to_string()],
+            secret_binding_supported: true,
+            connect_hint: "UNREACHABLE-HINT-SENTINEL".to_string(),
+        };
+        let err = super::deploy(opts).await.unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("GITHUB_PERSONAL_ACCESS_TOKEN"),
+            "error must name the missing secret: {rendered}"
+        );
+        assert!(
+            !rendered.contains("UNREACHABLE-HINT-SENTINEL"),
+            "gate must fire before any network attempt (no connect hint): {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deploy_skips_secrets_gate_when_binding_unsupported() {
+        // AC2: the cluster tier cannot bind a `--secret` until #440, so the
+        // declared-secrets gate is SKIPPED there. A secrets-declaring bundle must
+        // NOT be preempted by the gate; deploy proceeds to the network and fails
+        // on the connect path instead (naming the connect hint, never the secret).
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_with_secrets(dir.path(), "test-agent", &["GITHUB_PERSONAL_ACCESS_TOKEN"]);
+
+        let opts = super::DeployOpts {
+            plugin_dir: dir.path().to_path_buf(),
+            // port 1 is reserved/closed -> deterministic connection refused
+            api_url: "http://127.0.0.1:1".to_string(),
+            api_key: "k".to_string(),
+            slack_channel: None,
+            env: super::DeployEnv::Dev,
+            label: Some("v0".to_string()),
+            secret: vec![],
+            secret_binding_supported: false,
+            connect_hint: "UNREACHABLE-HINT-SENTINEL".to_string(),
+        };
+        let err = super::deploy(opts).await.unwrap_err();
+        let rendered = format!("{err:#}");
+        // The error is the network/connect path, not the secrets gate.
+        assert!(
+            rendered.contains("UNREACHABLE-HINT-SENTINEL"),
+            "gate should be skipped, so deploy reaches the network: {rendered}"
+        );
+        assert!(
+            !rendered.contains("GITHUB_PERSONAL_ACCESS_TOKEN"),
+            "the skipped gate must not name the declared secret: {rendered}"
         );
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1352,6 +1352,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                     env,
                     label,
                     secret,
+                    // `local deploy` offers `--secret`, so enforce the
+                    // declared-secrets policy gate (#464).
+                    secret_binding_supported: true,
                     connect_hint,
                 })
                 .await
@@ -1718,6 +1721,11 @@ async fn run(command: Option<Command>) -> Result<()> {
                     // Cluster connector-secret delivery is deferred to #440; no
                     // `--secret` flag on `cluster deploy` (see the note above).
                     secret: Vec::new(),
+                    // Secret binding is not wired on cluster until #440, so the
+                    // declared-secrets policy gate (#464) is skipped here: it
+                    // would otherwise hard-fail every secrets-declaring bundle
+                    // with a `--secret <NAME>` remediation this tier lacks.
+                    secret_binding_supported: false,
                     connect_hint,
                 })
                 .await

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -234,8 +234,13 @@ pub fn scaffold_from_spec(dir: &Path, spec: &AgentSpec) -> Result<Vec<PathBuf>> 
     write_bundle(dir, files)
 }
 
-/// Read the plugin name and version from a bundle's manifest.
-pub fn read_manifest(dir: &Path) -> Result<(String, String)> {
+/// Locate and parse a bundle's manifest JSON, trying
+/// `.claude-plugin/plugin.json` then `plugin.json`. Shared by `read_manifest`
+/// and `read_declared_secrets` so the path-resolution/read/parse steps (and
+/// their error messages) live in one place. Returns the resolved manifest path
+/// alongside the parsed value so callers can keep referencing it (e.g. `name`)
+/// in their own error messages.
+fn load_manifest_json(dir: &Path) -> Result<(std::path::PathBuf, serde_json::Value)> {
     let path = [".claude-plugin/plugin.json", "plugin.json"]
         .iter()
         .map(|rel| dir.join(rel))
@@ -245,6 +250,12 @@ pub fn read_manifest(dir: &Path) -> Result<(String, String)> {
         std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
     let value: serde_json::Value = serde_json::from_str(&body)
         .with_context(|| format!("{} is not valid JSON", path.display()))?;
+    Ok((path, value))
+}
+
+/// Read the plugin name and version from a bundle's manifest.
+pub fn read_manifest(dir: &Path) -> Result<(String, String)> {
+    let (path, value) = load_manifest_json(dir)?;
     let name = value
         .get("name")
         .and_then(|v| v.as_str())
@@ -256,6 +267,26 @@ pub fn read_manifest(dir: &Path) -> Result<(String, String)> {
         .unwrap_or("0.0.0")
         .to_string();
     Ok((name, version))
+}
+
+/// Read the bundle's declared connector-secret NAMES (#464 / ADR-0009).
+/// The manifest `secrets` policy lists NAMES only (never values). Returns an
+/// empty vec when the field is absent or null. Uses the same manifest-path
+/// resolution as `read_manifest`.
+pub fn read_declared_secrets(dir: &Path) -> Result<Vec<String>> {
+    let (_path, value) = load_manifest_json(dir)?;
+    // Missing/null -> no declared secrets. Non-string entries are ignored
+    // defensively; the plugin-format validator already rejects malformed names.
+    let names = value
+        .get("secrets")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(names)
 }
 
 #[cfg(test)]
@@ -425,5 +456,32 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         assert!(scaffold(dir.path(), "Bad_Name").is_err());
         assert!(std::fs::read_dir(dir.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn read_declared_secrets_absent_field_is_empty_and_present_array_is_the_names() {
+        // Absent `secrets` field -> empty (the scaffold seeds no secrets policy).
+        let dir = tempfile::tempdir().unwrap();
+        scaffold(dir.path(), "deal-desk").unwrap();
+        assert!(read_declared_secrets(dir.path()).unwrap().is_empty());
+
+        // Present array -> the declared NAMES, in order.
+        let manifest_path = dir.path().join(".claude-plugin/plugin.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        manifest["secrets"] =
+            serde_json::json!(["GITHUB_PERSONAL_ACCESS_TOKEN", "SLACK_APP_TOKEN"]);
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            read_declared_secrets(dir.path()).unwrap(),
+            vec![
+                "GITHUB_PERSONAL_ACCESS_TOKEN".to_string(),
+                "SLACK_APP_TOKEN".to_string(),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Implements the missing consumer for the plugin manifest `secrets` policy (ADR-0009). The policy declares the connector-secret NAMES a bundle needs, but nothing checked those names against what the operator actually binds, so a mismatch (bundle declares `GITHUB_PERSONAL_ACCESS_TOKEN`, operator binds `GH_TOKEN`) only surfaced at runtime as an auth failure (#429).

Adds a deploy-time gate in the shared `deploy()` path: every declared secret name must be present in the operator's `--secret` bound set, else deploy fails naming the missing secret(s).

- **Fail-loud** (deploy-time error, not a warning) per the ticket's AC3, which mandates a deploy-time error naming the missing secret.
- **Shared path** covers both `local deploy` and, once #440 wires cluster `--secret` delivery, `cluster deploy`. Tier-gated via `secret_binding_supported` so it does not prematurely block `cluster deploy`, which has no `--secret` flag yet.
- **Well-formed names only** are diffed (reusing `secrets::validate_name`); malformed or reserved names stay the server-side plugin-format validator's authority, so the gate never preempts that real validation error.

Tests: unit coverage for the name diff plus integration tests asserting a declared-but-unbound secret produces a pre-network deploy-time error naming it, and that the cluster tier is not prematurely blocked.

Closes #464
