### PR TITLE
Add ADR-0040: adopt ACP as an edge projection

### DIFF
--- a/docs/adr/0040-adopt-acp-as-an-edge-projection.md
+++ b/docs/adr/0040-adopt-acp-as-an-edge-projection.md
@@ -1,0 +1,130 @@
+# 40. Adopt the Agent Client Protocol as an edge projection
+
+Date: 2026-07-16
+
+Status: Proposed
+
+## Context
+
+The Agent Client Protocol (ACP) is an open standard created by Zed Industries,
+released August 2025 under Apache-2.0, speaking JSON-RPC 2.0 over stdio (an
+HTTP/WebSocket transport for remote agents is upstream work in progress). Its
+pitch is "LSP for coding agents": decouple any editor from any agent, reusing
+MCP's JSON representations where they fit and adding the agentic-UX types MCP
+lacks (diffs, permission requests, session updates). Spec at
+agentclientprotocol.com; reference implementation at
+github.com/agentclientprotocol/agent-client-protocol.
+
+Adoption is far enough along to matter to us. The ACP agent registry lists
+roughly fifty agents, Claude Code and Codex among them, and OpenCode ships
+native ACP support. On the client side Zed and the JetBrains IDEs are native,
+with Neovim and Emacs carried by the community. The decisive fact is that
+**both** harnesses AgentOS wraps (ADR-0005's claude-agent-sdk adapter, ADR-0011's
+OpenCode second harness) are already ACP-aware, so this is not swimming upstream.
+
+AgentOS has no editor-embedding story at all. Its clients are the CLI, the Slack
+dispatcher, and the UI, and each new client surface re-implements turn rendering
+and approval prompting from scratch. ADR-0020 pushed rendering out of the channel
+interface, but it did not give the outside world a contract to render against.
+
+Two existing decisions bound the shape of any answer. ADR-0031 decided that **the
+runner owns its message model**: the SDK dataclasses leaving `ModelSession.receive_turn`
+become a runner-owned `TurnEvent` union (`AssistantText | ToolCall | RateLimit |
+TurnResult`), with the Claude adapter mapping SDK to TurnEvent and other harnesses
+emitting TurnEvent directly. That union exists for one purpose ADR-0031 states
+plainly: it is the one extraction that shrinks per-harness work, because it
+normalizes across heterogeneous harnesses. ADR-0034 and ADR-0035 fix the approval
+model: a gated tool call is denied at the runner's `can_use_tool`, the turn ends
+`awaiting-approval`, the worker persists a durable `Approval` and suspends, the
+API resolves who may approve **server-side** behind a single authorizer over four
+approver sets, and a resume turn carries a one-shot allowance so the approved call
+can complete exactly once.
+
+Prior art was reviewed. xAI's Grok Build uses the ACP `SessionUpdate` enum as its
+single canonical turn type across TUI, headless, and IDE surfaces, and its ACP
+`request_permission` reverse-request is precisely the human-in-the-loop shape
+AgentOS already implements durably. That is a real signal about the protocol's
+fitness, and also a warning about how much of Grok's approach transfers.
+
+## Decision
+
+**1. Adopt ACP as an edge projection, not as a replacement for TurnEvent.** Add a
+`TurnEvent -> acp::SessionUpdate` projector at the runner edge. TurnEvent stays the
+internal canonical type because it does a job ACP does not do: normalize across
+heterogeneous harnesses. Grok can make "ACP `SessionUpdate` is the one true type"
+work only because it is a single self-contained harness with nothing to normalize.
+AgentOS is not that, per ADR-0031, and collapsing the internal type into the wire
+type would put the cross-harness normalization back in every consumer.
+
+**2. Ship an ACP server entry point (stdio first).** A dedicated `agentos runner acp`
+subcommand speaks ACP over stdio and projects turns through decision 1. Remote
+transports stay out of scope until upstream stabilizes them. This buys embedding in
+Zed, the JetBrains IDEs, Neovim, and Emacs against an open standard rather than four
+bespoke integrations.
+
+**3. Project the gated-tool approval as ACP `request_permission`.** AgentOS already
+owns the hard half: the durable `Approval`, the suspend, and the reconciler-driven
+resume (ADR-0034, ADR-0035). ACP supplies the wire contract for the easy half, so any
+ACP client can render an approval and carry a human's answer back without per-client
+work.
+
+**4. The authorizer remains the sole authority; ACP is a rendering and transport
+contract, not a trust boundary.** A client answering `request_permission` is not
+authority, it is input. Membership resolution stays server-side in the API per
+ADR-0034, and the one-shot allowance semantics of ADR-0035 are unchanged: the answer
+travels to the API, the authorizer decides, and only then does a resume turn carry a
+grant. Any design in which an ACP client's answer is trusted directly by the runner
+is explicitly rejected, because it re-creates the caller-asserted-actor defect
+ADR-0033 and ADR-0034 exist to close.
+
+**5. Do not adopt ACP's or Grok's session-persistence model.** File-per-session JSONL
+is a single-user local-workstation assumption and is wrong for AgentOS's concurrent
+multi-tenant reality (ADR-0008, ADR-0013). Durable state stays exactly as it is; the
+projector is stateless.
+
+**6. Pin and negotiate the ACP protocol version, with a reader policy mirroring
+ADR-0036.** ADR-0036 settled this argument once for the ACI: a version number on top
+of readers that cannot express a compatibility range is decoration, and unknown
+control-bearing tokens reject rather than degrade. The ACP edge inherits that posture.
+Negotiate the version at initialize, accept the compatible range, and **fail loud with
+both versions named** on an incompatible peer rather than silently degrading. An ACP
+permission request is control-bearing in the ADR-0036 sense, so a token we cannot
+model is a loud error, not a fallback.
+
+## Alternatives considered
+
+- **Replace TurnEvent with `acp::SessionUpdate` outright (Grok's approach).**
+  Rejected. It discards the cross-harness normalization that is ADR-0031's entire
+  reason for existing, and it couples the core's message model to an external crate's
+  enum evolution, so every upstream ACP release becomes a core refactor.
+- **Bespoke per-editor integrations.** Rejected: N integrations, no standard, and each
+  one re-implements turn rendering and approval prompting, which is the cost this ADR
+  is trying to stop paying.
+- **Do nothing.** No editor embedding at all, and every new client surface keeps
+  re-implementing turn rendering and approval prompting. Viable only if editor
+  embedding is never a goal.
+
+## Consequences
+
+- IDE embedding and an open standard for roughly the cost of one projector plus one
+  entry point. Nothing in the worker, the API, or the approval plane moves.
+- The projector is a pure function of TurnEvent, which makes it cheap to test and
+  keeps ADR-0031's safety net intact: `run_conformance`
+  (`packages/aci-protocol/src/aci_protocol/conformance.py`, exercised by
+  `runner/tests/test_conformance.py`) must stay green for the Claude, fake, and
+  OpenCode sessions with the projector in the tree.
+- ACP's remote transport is upstream work in progress, so stdio-only initially
+  constrains the embedding story to local subprocess clients. Remote embedding waits
+  on upstream.
+- A new external dependency (the `agent-client-protocol` crate) enters the runner
+  edge. Version skew is handled by decision 6, and containment to the edge is what
+  decision 1 buys.
+- The honest tradeoff: **ACP's permission model is client-mediated by design**, which
+  is a weaker posture than AgentOS's API-side authorizer. Decision 4 is what
+  reconciles them, and it has a visible cost: AgentOS will not implement
+  `request_permission` the way the spec naively reads. The client renders and relays;
+  it does not decide. Clients whose UX assumes local authority over the answer will
+  see a round trip and, sometimes, a denial.
+- TurnEvent itself is still ADR-0031's proposed decision and is not yet in the tree.
+  This ADR is a decision about where ACP sits relative to that seam, and the projector
+  cannot be built before the seam it projects from exists.


### PR DESCRIPTION
Proposes adopting the Agent Client Protocol (ACP) as an edge projection over the runner-owned `TurnEvent` seam, rather than as a replacement for it.

ACP is an open standard (Zed Industries, August 2025, Apache-2.0, JSON-RPC 2.0 over stdio). Both harnesses AgentOS wraps are already ACP-aware: Claude Code and Codex are in the ACP agent registry, and OpenCode ships native support. Client side, Zed and the JetBrains IDEs are native, with Neovim and Emacs community-carried.

The decision keeps `TurnEvent` internal (it normalizes across heterogeneous harnesses, which ACP does not do), adds a `TurnEvent -> acp::SessionUpdate` projector plus a stdio entry point, and models the gated-tool approval as ACP `request_permission` while keeping the API-side authorizer as the sole authority per ADR-0034.

Two honest constraints are recorded in Consequences: ACP's permission model is client-mediated by design and is deliberately not implemented the way the spec naively reads, and the projector depends on the `TurnEvent` seam from ADR-0031, which is still Proposed and not yet in the tree.

Prior art reviewed: xAI's Grok Build, which uses ACP `SessionUpdate` as its single canonical turn type. That works only because it is a single self-contained harness; the ADR explains why AgentOS cannot follow it there.