### PR TITLE
Share one AgentTarget args struct across local and cluster tiers

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1002,26 +1002,6 @@ export const commandManifest = {
               "required": true
             },
             {
-              "global": false,
-              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
-              "id": "gate",
-              "long": "gate",
-              "positional": false,
-              "required": false
-            },
-            {
-              "global": false,
-              "help": "Clear all approval gates on the agent",
-              "id": "clear",
-              "long": "clear",
-              "positional": false,
-              "possible_values": [
-                "true",
-                "false"
-              ],
-              "required": false
-            },
-            {
               "default_values": [
                 "http://localhost:28000"
               ],
@@ -1047,6 +1027,26 @@ export const commandManifest = {
               "global": false,
               "id": "dry_run",
               "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
+              "id": "gate",
+              "long": "gate",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear all approval gates on the agent",
+              "id": "clear",
+              "long": "clear",
               "positional": false,
               "possible_values": [
                 "true",
@@ -2302,26 +2302,6 @@ export const commandManifest = {
               "required": true
             },
             {
-              "global": false,
-              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
-              "id": "gate",
-              "long": "gate",
-              "positional": false,
-              "required": false
-            },
-            {
-              "global": false,
-              "help": "Clear all approval gates on the agent",
-              "id": "clear",
-              "long": "clear",
-              "positional": false,
-              "possible_values": [
-                "true",
-                "false"
-              ],
-              "required": false
-            },
-            {
               "default_values": [
                 "http://localhost:8000"
               ],
@@ -2347,6 +2327,26 @@ export const commandManifest = {
               "global": false,
               "id": "dry_run",
               "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
+              "id": "gate",
+              "long": "gate",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear all approval gates on the agent",
+              "id": "clear",
+              "long": "clear",
               "positional": false,
               "possible_values": [
                 "true",

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -999,26 +999,6 @@
               "required": true
             },
             {
-              "global": false,
-              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
-              "id": "gate",
-              "long": "gate",
-              "positional": false,
-              "required": false
-            },
-            {
-              "global": false,
-              "help": "Clear all approval gates on the agent",
-              "id": "clear",
-              "long": "clear",
-              "positional": false,
-              "possible_values": [
-                "true",
-                "false"
-              ],
-              "required": false
-            },
-            {
               "default_values": [
                 "http://localhost:28000"
               ],
@@ -1044,6 +1024,26 @@
               "global": false,
               "id": "dry_run",
               "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
+              "id": "gate",
+              "long": "gate",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear all approval gates on the agent",
+              "id": "clear",
+              "long": "clear",
               "positional": false,
               "possible_values": [
                 "true",
@@ -2299,26 +2299,6 @@
               "required": true
             },
             {
-              "global": false,
-              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
-              "id": "gate",
-              "long": "gate",
-              "positional": false,
-              "required": false
-            },
-            {
-              "global": false,
-              "help": "Clear all approval gates on the agent",
-              "id": "clear",
-              "long": "clear",
-              "positional": false,
-              "possible_values": [
-                "true",
-                "false"
-              ],
-              "required": false
-            },
-            {
               "default_values": [
                 "http://localhost:8000"
               ],
@@ -2344,6 +2324,26 @@
               "global": false,
               "id": "dry_run",
               "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Tool name to gate behind approval (repeatable). Omit to show current gates",
+              "id": "gate",
+              "long": "gate",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Clear all approval gates on the agent",
+              "id": "clear",
+              "long": "clear",
               "positional": false,
               "possible_values": [
                 "true",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,7 +18,56 @@ use agentos::secrets;
 use agentos::state::{apply_continue, load_turn, CliTurnArgs, TurnVerb};
 use agentos::ui::{self, ColorFlag, Ui};
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
+
+/// Per-tier defaults for the flags shared by the agent-target verbs. The only
+/// thing that differs between `local` and `cluster` is where the platform API
+/// listens, so that is the single const each tier supplies.
+trait TierDefaults: Clone + Send + Sync + std::fmt::Debug + 'static {
+    const API_URL: &'static str;
+}
+
+#[derive(Clone, Debug)]
+struct LocalTier;
+
+impl TierDefaults for LocalTier {
+    const API_URL: &'static str = "http://localhost:28000";
+}
+
+#[derive(Clone, Debug)]
+struct ClusterTier;
+
+impl TierDefaults for ClusterTier {
+    const API_URL: &'static str = "http://localhost:8000";
+}
+
+/// The flags every agent-target verb (`versions`, `memory`, `approvals`) takes,
+/// flattened into both tiers so a flag added here cannot be added to one tier
+/// and forgotten on the other (issue #466).
+#[derive(Args, Debug, Clone)]
+struct AgentTarget<T: TierDefaults> {
+    /// Agent name or id.
+    agent: String,
+    #[arg(long, default_value = T::API_URL, env = "AGENTOS_API_URL")]
+    api_url: String,
+    #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+    api_key: String,
+    #[arg(long)]
+    dry_run: bool,
+    #[arg(skip)]
+    _tier: std::marker::PhantomData<T>,
+}
+
+impl<T: TierDefaults> From<AgentTarget<T>> for AgentActionOpts {
+    fn from(target: AgentTarget<T>) -> Self {
+        AgentActionOpts {
+            api_url: target.api_url,
+            api_key: target.api_key,
+            agent: target.agent,
+            dry_run: target.dry_run,
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(
@@ -512,54 +561,24 @@ enum LocalAction {
     },
     /// List an agent's immutable versions (`GET /agents/{id}/versions`).
     Versions {
-        /// Agent name or id.
-        agent: String,
-        #[arg(
-            long,
-            default_value = "http://localhost:28000",
-            env = "AGENTOS_API_URL"
-        )]
-        api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
-        api_key: String,
-        #[arg(long)]
-        dry_run: bool,
+        #[command(flatten)]
+        target: AgentTarget<LocalTier>,
     },
     /// Show what an agent has learned (its memory log; `GET /agents/{id}/memory`).
     Memory {
-        /// Agent name or id.
-        agent: String,
-        #[arg(
-            long,
-            default_value = "http://localhost:28000",
-            env = "AGENTOS_API_URL"
-        )]
-        api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
-        api_key: String,
-        #[arg(long)]
-        dry_run: bool,
+        #[command(flatten)]
+        target: AgentTarget<LocalTier>,
     },
     /// View or set the tools whose calls require human approval (`PATCH /agents/{id}`).
     Approvals {
-        /// Agent name or id.
-        agent: String,
+        #[command(flatten)]
+        target: AgentTarget<LocalTier>,
         /// Tool name to gate behind approval (repeatable). Omit to show current gates.
         #[arg(long = "gate", value_name = "TOOL")]
         gate: Vec<String>,
         /// Clear all approval gates on the agent.
         #[arg(long)]
         clear: bool,
-        #[arg(
-            long,
-            default_value = "http://localhost:28000",
-            env = "AGENTOS_API_URL"
-        )]
-        api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
-        api_key: String,
-        #[arg(long)]
-        dry_run: bool,
     },
     /// Open the local observability surfaces (AgentOS Console + Langfuse traces/cost).
     Observability,
@@ -976,42 +995,24 @@ enum ClusterAction {
     },
     /// List an agent's immutable versions (`GET /agents/{id}/versions`).
     Versions {
-        /// Agent name or id.
-        agent: String,
-        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
-        api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
-        api_key: String,
-        #[arg(long)]
-        dry_run: bool,
+        #[command(flatten)]
+        target: AgentTarget<ClusterTier>,
     },
     /// Show what an agent has learned (its memory log; `GET /agents/{id}/memory`).
     Memory {
-        /// Agent name or id.
-        agent: String,
-        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
-        api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
-        api_key: String,
-        #[arg(long)]
-        dry_run: bool,
+        #[command(flatten)]
+        target: AgentTarget<ClusterTier>,
     },
     /// View or set the tools whose calls require human approval (`PATCH /agents/{id}`).
     Approvals {
-        /// Agent name or id.
-        agent: String,
+        #[command(flatten)]
+        target: AgentTarget<ClusterTier>,
         /// Tool name to gate behind approval (repeatable). Omit to show current gates.
         #[arg(long = "gate", value_name = "TOOL")]
         gate: Vec<String>,
         /// Clear all approval gates on the agent.
         #[arg(long)]
         clear: bool,
-        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
-        api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
-        api_key: String,
-        #[arg(long)]
-        dry_run: bool,
     },
 }
 
@@ -1356,54 +1357,13 @@ async fn run(command: Option<Command>) -> Result<()> {
                 })
                 .await
             }
-            LocalAction::Versions {
-                agent,
-                api_url,
-                api_key,
-                dry_run,
-            } => emit(
-                commands::versions(AgentActionOpts {
-                    api_url,
-                    api_key,
-                    agent,
-                    dry_run,
-                })
-                .await?,
-            ),
-            LocalAction::Memory {
-                agent,
-                api_url,
-                api_key,
-                dry_run,
-            } => emit(
-                commands::memory(AgentActionOpts {
-                    api_url,
-                    api_key,
-                    agent,
-                    dry_run,
-                })
-                .await?,
-            ),
+            LocalAction::Versions { target } => emit(commands::versions(target.into()).await?),
+            LocalAction::Memory { target } => emit(commands::memory(target.into()).await?),
             LocalAction::Approvals {
-                agent,
+                target,
                 gate,
                 clear,
-                api_url,
-                api_key,
-                dry_run,
-            } => emit(
-                commands::approvals(
-                    AgentActionOpts {
-                        api_url,
-                        api_key,
-                        agent,
-                        dry_run,
-                    },
-                    gate,
-                    clear,
-                )
-                .await?,
-            ),
+            } => emit(commands::approvals(target.into(), gate, clear).await?),
             LocalAction::Observability => emit(commands::observability().await?),
             LocalAction::Budget {
                 agent,
@@ -1790,54 +1750,13 @@ async fn run(command: Option<Command>) -> Result<()> {
                 )
                 .await?,
             ),
-            ClusterAction::Versions {
-                agent,
-                api_url,
-                api_key,
-                dry_run,
-            } => emit(
-                commands::versions(AgentActionOpts {
-                    api_url,
-                    api_key,
-                    agent,
-                    dry_run,
-                })
-                .await?,
-            ),
-            ClusterAction::Memory {
-                agent,
-                api_url,
-                api_key,
-                dry_run,
-            } => emit(
-                commands::memory(AgentActionOpts {
-                    api_url,
-                    api_key,
-                    agent,
-                    dry_run,
-                })
-                .await?,
-            ),
+            ClusterAction::Versions { target } => emit(commands::versions(target.into()).await?),
+            ClusterAction::Memory { target } => emit(commands::memory(target.into()).await?),
             ClusterAction::Approvals {
-                agent,
+                target,
                 gate,
                 clear,
-                api_url,
-                api_key,
-                dry_run,
-            } => emit(
-                commands::approvals(
-                    AgentActionOpts {
-                        api_url,
-                        api_key,
-                        agent,
-                        dry_run,
-                    },
-                    gate,
-                    clear,
-                )
-                .await?,
-            ),
+            } => emit(commands::approvals(target.into(), gate, clear).await?),
         },
         Some(Command::Schema) => {
             use clap::CommandFactory;
@@ -2290,10 +2209,12 @@ mod tests {
             Some(Command::Local {
                 action:
                     LocalAction::Approvals {
-                        agent, gate, clear, ..
+                        target,
+                        gate,
+                        clear,
                     },
             }) => {
-                assert_eq!(agent, "gh");
+                assert_eq!(target.agent, "gh");
                 assert_eq!(gate, vec!["Bash".to_string(), "mcp__x__y".to_string()]);
                 assert!(!clear);
             }

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -194,6 +194,61 @@ fn dump_commands_alias_emits_same_manifest() {
     assert_eq!(schema.stdout, alias.stdout);
 }
 
+/// Collect every long flag (`--foo`) the command's help exposes.
+fn help_flags(args: &[&str]) -> std::collections::BTreeSet<String> {
+    let output = run_help(args);
+    assert!(
+        output.status.success(),
+        "expected success for {:?}\n{}",
+        args,
+        output_text(&output)
+    );
+    output_text(&output)
+        .split_whitespace()
+        .filter(|token| token.starts_with("--") && token.len() > 2)
+        .map(|token| token.trim_end_matches(',').to_string())
+        .collect()
+}
+
+/// The agent-target verbs share one `AgentTarget<T>` whose only per-tier
+/// difference is where the platform API listens. Lock both defaults so the
+/// shared struct cannot silently collapse them onto one port (issue #466).
+///
+/// Assert the full bracketed clap default string, not a bare port number:
+/// `8000` is a substring of `28000`, so a bare-port assertion for `cluster`
+/// would still pass even if `cluster` silently inherited `local`'s default.
+#[test]
+fn agent_target_verbs_keep_their_per_tier_api_url_default() {
+    for verb in ["versions", "memory", "approvals"] {
+        let local = output_text(&run_help(&["local", verb]));
+        assert!(
+            local.contains("[default: http://localhost:28000]"),
+            "local {verb} lost its api-url default\n{local}"
+        );
+
+        let cluster = output_text(&run_help(&["cluster", verb]));
+        assert!(
+            cluster.contains("[default: http://localhost:8000]"),
+            "cluster {verb} lost its api-url default\n{cluster}"
+        );
+    }
+}
+
+/// Tier parity gate: the shared `AgentTarget<T>` means a flag added to `local
+/// versions` is structurally impossible to forget on `cluster versions`. This
+/// test fails if the two tiers ever drift apart again (issue #466).
+#[test]
+fn agent_target_verbs_expose_the_same_flags_on_both_tiers() {
+    for verb in ["versions", "memory", "approvals"] {
+        let local = help_flags(&["local", verb]);
+        let cluster = help_flags(&["cluster", verb]);
+        assert_eq!(
+            local, cluster,
+            "local {verb} and cluster {verb} expose different flags"
+        );
+    }
+}
+
 fn to_argv(parts: &[&str]) -> Vec<String> {
     parts.iter().map(|part| (*part).to_string()).collect()
 }


### PR DESCRIPTION
The `local` and `cluster` clap variants for `versions`, `memory`, and `approvals` were byte-identical except the api_url port default, and nothing connected them. A flag added to one tier and forgotten on the other was invisible: no test, no gate, no type error. That is the bug class this removes.

## What changed

- The six variants now share one generic `AgentTarget<T: TierDefaults>` flattened into both tiers via `#[command(flatten)]`.
- The api_url port default is supplied per tier through a trait const (`LocalTier` = 28000, `ClusterTier` = 8000). This was chosen over the alternative the issue also sanctioned (`Option<String>` resolved at dispatch) because it keeps the `--help` output and displayed defaults verbatim, where the dispatch-resolved form would have dropped the `[default: ...]` line from help.
- The six duplicated dispatch arms collapse to one-liners through `From<AgentTarget<T>> for AgentActionOpts`. The handler seam itself is unchanged.
- Both committed manifests regenerated by their generators.

## Verification

The only grammar change is display order: `approvals` now prints `gate`/`clear` after the shared flags. Normalizing the manifest by sorting args at every node shows it deep-equal to `main` across the whole file, which mechanically proves no flag, default, env var, or help text was dropped in any of the six variants. `versions` and `memory` have zero manifest churn.

A new tier-parity test asserts the two tiers expose identical flag sets, so future drift fails the suite rather than passing silently.

## Notes

- The issue estimated roughly 340 deleted lines from `main.rs`; the real figure is ~146 net (227 changed lines, with the shared struct costing back ~48). Nothing was padded to chase the estimate.
- The same duplication still exists on other verbs (`budget` and friends); out of scope here, but a natural follow-up now that the pattern exists.
- Advisory, not addressed: the parity gate parses `--help` prose, so a `hide = true` flag would escape it, and the verb list is hardcoded. Gating on the manifest would fix both. The flatten already enforces parity at the type level, so this is belt-and-braces.

Closes #466