### PR TITLE
Make the TUI Platform tab governance recipes tier-aware (#463)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -91,7 +91,10 @@ same `agentos ...` subcommands documented here. It opens a full-screen TUI with
 target navigation, action selection, command previews, and guarded execution:
 when an action needs values (for example message text or a channel id), the TUI
 temporarily leaves the alternate screen, prompts for the values, runs the exact
-previewed command, then returns to the interface.
+previewed command, then returns to the interface. Some actions also require a
+tier (local or cluster); the TUI asks which tier before prompting for the
+other values, and the command preview shows `<local|cluster>` in the tier's
+position until that question is answered.
 
 ```bash
 agentos

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -32,7 +32,7 @@ use ratatui::{Frame, Terminal};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::channel::{parse_terminal_message, TerminalAction, REPLY_FENCE};
-use crate::recipes::{build_argv, recipes, Recipe, RecipeKind, TuiAction, Workflow};
+use crate::recipes::{build_argv, recipes, ArgPart, Recipe, RecipeKind, Tier, TuiAction, Workflow};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum SecretNameChoice {
@@ -47,22 +47,6 @@ struct SelectChoice<T> {
     value: T,
 }
 
-/// Which platform tier a Deploy-to-Slack workflow drives.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum SlackTier {
-    Local,
-    Cluster,
-}
-
-impl SlackTier {
-    fn verb(self) -> &'static str {
-        match self {
-            SlackTier::Local => "local",
-            SlackTier::Cluster => "cluster",
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
 struct ExampleChoice {
     id: &'static str,
@@ -70,6 +54,14 @@ struct ExampleChoice {
     description: &'static str,
     directory: &'static str,
     secrets: &'static [&'static str],
+}
+
+/// What the recipe prompt collected: the answered tier (`None` when the recipe
+/// is not tier-bearing) and the answered field values.
+#[derive(Clone, Debug)]
+struct RecipeAnswers {
+    tier: Option<Tier>,
+    values: BTreeMap<String, String>,
 }
 
 #[derive(Debug)]
@@ -242,12 +234,50 @@ impl Drop for TerminalSession {
     }
 }
 
+/// The one tier prompt: which platform tier a tier-bearing recipe or workflow
+/// drives. Shared by the governance recipes and the Deploy-to-Slack workflow so
+/// the two surfaces cannot drift apart.
+fn prompt_tier(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    title: &str,
+) -> Result<Option<Tier>> {
+    prompt_select(
+        terminal,
+        app,
+        title,
+        "Which tier?",
+        vec![
+            SelectChoice {
+                label: "local (compose)".to_string(),
+                description: "The full platform on your machine via docker compose.".to_string(),
+                value: Tier::Local,
+            },
+            SelectChoice {
+                label: "cluster (Kubernetes)".to_string(),
+                description: "A deployed Helm release (must already be up); needs AGENTOS_API_URL and AGENTOS_API_KEY set for that release."
+                    .to_string(),
+                value: Tier::Cluster,
+            },
+        ],
+    )
+}
+
 fn prompt_recipe_fields(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &App,
     recipe: &Recipe,
-) -> Result<Option<BTreeMap<String, String>>> {
+) -> Result<Option<RecipeAnswers>> {
     let mut values = BTreeMap::new();
+    // The tier leads the per-field prompts so the steps read in argv order. A
+    // recipe that is not tier-bearing answers no tier at all.
+    let mut chosen_tier = None;
+    if recipe.args.contains(&ArgPart::Tier) {
+        let Some(tier) = prompt_tier(terminal, app, recipe.title)? else {
+            return Ok(None);
+        };
+        chosen_tier = Some(tier);
+    }
     for (idx, field) in recipe.fields.iter().enumerate() {
         let title = format!(
             "{} · Step {} of {}",
@@ -272,7 +302,10 @@ fn prompt_recipe_fields(
         }
         values.insert(field.key.to_string(), value);
     }
-    Ok(Some(values))
+    Ok(Some(RecipeAnswers {
+        tier: chosen_tier,
+        values,
+    }))
 }
 
 fn run_recipe_in_tui(
@@ -280,7 +313,7 @@ fn run_recipe_in_tui(
     app: &App,
     recipe: &Recipe,
 ) -> Result<String> {
-    let Some(values) = prompt_recipe_fields(terminal, app, recipe)? else {
+    let Some(RecipeAnswers { tier, values }) = prompt_recipe_fields(terminal, app, recipe)? else {
         return Ok(format!("Canceled: {}", recipe.title));
     };
     if let RecipeKind::Workflow(workflow) = &recipe.kind {
@@ -294,7 +327,7 @@ fn run_recipe_in_tui(
     let mut view = RunView::new(recipe.title);
     let run_result = match &recipe.kind {
         RecipeKind::Command => {
-            let argv = build_argv(recipe, &values);
+            let argv = build_argv(recipe, tier, &values);
             run_agentos_in_tui(terminal, app, &argv, Path::new("."), &mut view)
         }
         RecipeKind::Tui(_) => Ok(()),
@@ -698,25 +731,7 @@ fn explore_examples(
 fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &App) -> Result<()> {
     // One recipe, both tiers: ask which platform to target rather than listing a
     // near-duplicate recipe per tier.
-    let Some(tier) = prompt_select(
-        terminal,
-        app,
-        "Deploy to Slack",
-        "Which tier to deploy to?",
-        vec![
-            SelectChoice {
-                label: "local (compose)".to_string(),
-                description: "The full platform on your machine via docker compose.".to_string(),
-                value: SlackTier::Local,
-            },
-            SelectChoice {
-                label: "cluster (Kubernetes)".to_string(),
-                description: "A deployed Helm release (must already be up).".to_string(),
-                value: SlackTier::Cluster,
-            },
-        ],
-    )?
-    else {
+    let Some(tier) = prompt_tier(terminal, app, "Deploy to Slack")? else {
         return Ok(());
     };
     let verb = tier.verb();
@@ -725,13 +740,13 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     //    tokens + the channel id. Pause until the operator has them.
     let mut intro = RunView::new("Deploy to Slack — create your Slack app");
     let flow = match tier {
-        SlackTier::Local => "compose stack: local up -> local deploy -> local comms --slack.",
-        SlackTier::Cluster => "deployed release: cluster deploy -> cluster comms --slack.",
+        Tier::Local => "compose stack: local up -> local deploy -> local comms --slack.",
+        Tier::Cluster => "deployed release: cluster deploy -> cluster comms --slack.",
     };
     intro.push(format!(
         "This connects an AgentOS agent to a real Slack workspace through the {flow}"
     ));
-    if tier == SlackTier::Cluster {
+    if tier == Tier::Cluster {
         intro.push("Requires an installed release (agentos cluster up) with a model credential.");
         intro.push("One Slack app = one Socket Mode owner: do not also run a local dispatcher");
         intro.push("on the same app token.");
@@ -760,7 +775,7 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     //    On the cluster tier the model credential is configured on the release at
     //    `cluster up` time (a chart Secret), so only the Slack tokens are gathered.
     crate::secrets::sync_secret_file()?;
-    if tier == SlackTier::Local {
+    if tier == Tier::Local {
         ensure_model_credential_available(terminal, app)?;
     }
     ensure_secret_available(terminal, app, "SLACK_APP_TOKEN")?;
@@ -794,7 +809,7 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     // Cluster targets a specific Helm release; prompt for its namespace/release
     // so the workflow works for a release not named the default `agentos` (the
     // API auto-discovery and `cluster comms` both key off these).
-    let (namespace, release) = if tier == SlackTier::Cluster {
+    let (namespace, release) = if tier == Tier::Cluster {
         let ns = prompt_text(
             terminal,
             app,
@@ -846,7 +861,7 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     let run_result = (|| -> Result<()> {
         // Local brings the compose platform up first (idempotent); the cluster
         // release is expected to already be installed.
-        if tier == SlackTier::Local {
+        if tier == Tier::Local {
             run_agentos_in_tui_with_env(
                 terminal,
                 app,
@@ -866,7 +881,7 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
             "--slack-channel".to_string(),
             channel.clone(),
         ];
-        if tier == SlackTier::Local {
+        if tier == Tier::Local {
             deploy_argv.push("--api-url".to_string());
             deploy_argv.push("http://localhost:28000".to_string());
         }
@@ -926,7 +941,7 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     done.push(format!(
         "Disconnect Slack:  agentos {verb} comms --slack --disconnect"
     ));
-    if tier == SlackTier::Local {
+    if tier == Tier::Local {
         done.push("Stop the stack:    agentos local down".to_string());
     }
     show_run_view(terminal, app, &mut done)?;
@@ -1884,7 +1899,7 @@ fn draw_detail(frame: &mut Frame<'_>, area: Rect, app: &App) {
     ];
     match &recipe.kind {
         RecipeKind::Command => {
-            let preview = build_argv(recipe, &values);
+            let preview = build_argv(recipe, None, &values);
             lines.push(Line::from(Span::styled(
                 "Command preview",
                 Style::default().fg(Color::Yellow).bold(),

--- a/cli/src/recipes.rs
+++ b/cli/src/recipes.rs
@@ -38,9 +38,28 @@ pub(crate) enum Workflow {
     DeployToSlack,
 }
 
+/// Which platform tier a tier-bearing recipe or workflow drives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Tier {
+    Local,
+    Cluster,
+}
+
+impl Tier {
+    pub(crate) fn verb(self) -> &'static str {
+        match self {
+            Tier::Local => "local",
+            Tier::Cluster => "cluster",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ArgPart {
     Literal(&'static str),
+    /// The tier verb (`local` / `cluster`), resolved from `build_argv`'s
+    /// explicit `tier` argument.
+    Tier,
     Field(&'static str),
     OptionalFlag {
         flag: &'static str,
@@ -56,11 +75,22 @@ pub(crate) struct Field {
     pub(crate) required: bool,
 }
 
-pub(crate) fn build_argv(recipe: &Recipe, values: &BTreeMap<String, String>) -> Vec<String> {
+pub(crate) fn build_argv(
+    recipe: &Recipe,
+    tier: Option<Tier>,
+    values: &BTreeMap<String, String>,
+) -> Vec<String> {
     let mut argv = Vec::new();
     for part in &recipe.args {
         match part {
             ArgPart::Literal(value) => argv.push((*value).to_string()),
+            // `None` means no tier answered yet, which today is only the
+            // read-only detail-pane preview: render the placeholder so the argv
+            // is visibly non-executable rather than a plausible but wrong tier.
+            ArgPart::Tier => argv.push(match tier {
+                Some(tier) => tier.verb().to_string(),
+                None => "<local|cluster>".to_string(),
+            }),
             ArgPart::Field(field) => {
                 if let Some(value) = values.get(*field) {
                     if !value.is_empty() {
@@ -84,23 +114,32 @@ pub(crate) fn build_argv(recipe: &Recipe, values: &BTreeMap<String, String>) -> 
 /// Placeholder-filled argv for every `Command` recipe -- the seam the CLI/TUI
 /// recipe parity gate test consumes to compare the TUI surface against the clap
 /// grammar without exposing the whole `Recipe` type surface.
+///
+/// A tier-bearing recipe expands into one entry per tier, so the gate execs the
+/// cluster path too instead of only ever proving the local one.
 #[doc(hidden)]
 pub fn command_recipe_argvs() -> Vec<(&'static str, Vec<String>)> {
-    recipes()
+    let mut entries = Vec::new();
+    for recipe in recipes()
         .into_iter()
         .filter(|recipe| matches!(recipe.kind, RecipeKind::Command))
-        .map(|recipe| {
-            let mut values = BTreeMap::new();
-            for field in &recipe.fields {
-                values.insert(
-                    field.key.to_string(),
-                    field.default.unwrap_or("1").to_string(),
-                );
+    {
+        let mut values = BTreeMap::new();
+        for field in &recipe.fields {
+            values.insert(
+                field.key.to_string(),
+                field.default.unwrap_or("1").to_string(),
+            );
+        }
+        if recipe.args.contains(&ArgPart::Tier) {
+            for tier in [Tier::Local, Tier::Cluster] {
+                entries.push((recipe.title, build_argv(&recipe, Some(tier), &values)));
             }
-            let argv = build_argv(&recipe, &values);
-            (recipe.title, argv)
-        })
-        .collect()
+        } else {
+            entries.push((recipe.title, build_argv(&recipe, None, &values)));
+        }
+    }
+    entries
 }
 
 pub(crate) fn recipes() -> Vec<Recipe> {
@@ -131,6 +170,8 @@ pub(crate) fn recipes() -> Vec<Recipe> {
             title: "Open observability (Console + Langfuse)",
             description: "Open the local AgentOS Console and Langfuse traces/cost UIs.",
             kind: RecipeKind::Command,
+            // Local-only on purpose: there is no `cluster observability` verb in
+            // the clap grammar yet (the cluster twin is tracked as issue #460).
             args: vec![ArgPart::Literal("local"), ArgPart::Literal("observability")],
             fields: vec![],
             notes: &["Start the platform first with `agentos local up`."],
@@ -141,7 +182,7 @@ pub(crate) fn recipes() -> Vec<Recipe> {
             description: "Show an agent's immutable deployed versions (newest first).",
             kind: RecipeKind::Command,
             args: vec![
-                ArgPart::Literal("local"),
+                ArgPart::Tier,
                 ArgPart::Literal("versions"),
                 ArgPart::Field("agent"),
             ],
@@ -159,7 +200,7 @@ pub(crate) fn recipes() -> Vec<Recipe> {
             description: "Set an agent's daily USD spend cap (enforced per run).",
             kind: RecipeKind::Command,
             args: vec![
-                ArgPart::Literal("local"),
+                ArgPart::Tier,
                 ArgPart::Literal("budget"),
                 ArgPart::Field("agent"),
                 ArgPart::Literal("--limit"),
@@ -187,7 +228,7 @@ pub(crate) fn recipes() -> Vec<Recipe> {
             description: "Require human approval before an agent may call a named tool.",
             kind: RecipeKind::Command,
             args: vec![
-                ArgPart::Literal("local"),
+                ArgPart::Tier,
                 ArgPart::Literal("approvals"),
                 ArgPart::Field("agent"),
                 ArgPart::OptionalFlag {
@@ -217,7 +258,7 @@ pub(crate) fn recipes() -> Vec<Recipe> {
             description: "Show what an agent has learned (its memory log).",
             kind: RecipeKind::Command,
             args: vec![
-                ArgPart::Literal("local"),
+                ArgPart::Tier,
                 ArgPart::Literal("memory"),
                 ArgPart::Field("agent"),
             ],
@@ -235,7 +276,7 @@ pub(crate) fn recipes() -> Vec<Recipe> {
             description: "Stop an agent's runs (the kill switch).",
             kind: RecipeKind::Command,
             args: vec![
-                ArgPart::Literal("local"),
+                ArgPart::Tier,
                 ArgPart::Literal("kill"),
                 ArgPart::Field("agent"),
                 ArgPart::Literal("--yes"),
@@ -254,7 +295,7 @@ pub(crate) fn recipes() -> Vec<Recipe> {
             description: "Bring a killed agent back online.",
             kind: RecipeKind::Command,
             args: vec![
-                ArgPart::Literal("local"),
+                ArgPart::Tier,
                 ArgPart::Literal("resume"),
                 ArgPart::Field("agent"),
             ],
@@ -533,6 +574,122 @@ pub(crate) fn recipes() -> Vec<Recipe> {
 mod tests {
     use super::*;
 
+    /// The platform governance recipes that must work on BOTH tiers (#463).
+    /// Observability is deliberately absent: see the local-only test below.
+    const TIERED_PLATFORM_RECIPES: [&str; 6] = [
+        "List versions",
+        "Set budget",
+        "Gate a tool (approvals)",
+        "Inspect memory",
+        "Kill an agent",
+        "Resume an agent",
+    ];
+
+    fn recipe_named(title: &str) -> Recipe {
+        recipes()
+            .into_iter()
+            .find(|recipe| recipe.title == title)
+            .unwrap_or_else(|| panic!("no such recipe: {title}"))
+    }
+
+    /// argv for a recipe at an explicit tier, with the given field values.
+    fn argv_at_tier(title: &str, tier: Tier, fields: &[(&str, &str)]) -> Vec<String> {
+        let recipe = recipe_named(title);
+        let mut values = BTreeMap::new();
+        for (key, value) in fields {
+            values.insert((*key).to_string(), (*value).to_string());
+        }
+        build_argv(&recipe, Some(tier), &values)
+    }
+
+    /// #463: every governance recipe carries a resolvable tier instead of a
+    /// hardcoded `local`, which is what made the cluster tier unreachable.
+    #[test]
+    fn platform_governance_recipes_are_tier_bearing_not_hardcoded_local() {
+        for title in TIERED_PLATFORM_RECIPES {
+            let recipe = recipe_named(title);
+            assert!(
+                recipe.args.contains(&ArgPart::Tier),
+                "recipe {title:?} must lead with ArgPart::Tier so it can run on cluster"
+            );
+            assert!(
+                !recipe.args.contains(&ArgPart::Literal("local")),
+                "recipe {title:?} still pins the `local` literal, so the cluster tier is unreachable"
+            );
+        }
+    }
+
+    /// The tier resolves out of `build_argv`'s explicit tier argument and
+    /// produces a real argv on both tiers -- reachability, not a title string.
+    #[test]
+    fn build_argv_resolves_the_tier_part_on_both_tiers() {
+        for (tier, verb) in [(Tier::Local, "local"), (Tier::Cluster, "cluster")] {
+            assert_eq!(
+                argv_at_tier("List versions", tier, &[("agent", "demo")]),
+                vec![verb, "versions", "demo"]
+            );
+            assert_eq!(
+                argv_at_tier("Kill an agent", tier, &[("agent", "demo")]),
+                vec![verb, "kill", "demo", "--yes"]
+            );
+            assert_eq!(
+                argv_at_tier("Set budget", tier, &[("agent", "demo"), ("limit", "5")]),
+                vec![verb, "budget", "demo", "--limit", "5"]
+            );
+        }
+    }
+
+    /// Observability is the ONE platform recipe that stays local-only: there is
+    /// no `cluster observability` verb in the clap grammar yet (tracked as
+    /// issue #460). Pinning it here keeps a future tier sweep from making the
+    /// Platform tab offer a verb that does not exist.
+    #[test]
+    fn observability_stays_local_only_until_cluster_gains_the_verb() {
+        let recipe = recipe_named("Open observability (Console + Langfuse)");
+        assert!(
+            !recipe.args.contains(&ArgPart::Tier),
+            "observability has no cluster verb (#460); it must not become tier-bearing"
+        );
+        assert_eq!(
+            build_argv(&recipe, None, &BTreeMap::new()),
+            vec!["local", "observability"]
+        );
+    }
+
+    /// The parity gate consumes `command_recipe_argvs`, so a tier-bearing
+    /// recipe has to expand into BOTH tier variants there. Otherwise the gate
+    /// only ever execs the local path and cluster drift ships unnoticed.
+    #[test]
+    fn command_recipe_argvs_expands_a_tiered_recipe_into_both_tiers() {
+        let argvs = command_recipe_argvs();
+        let versions: Vec<&Vec<String>> = argvs
+            .iter()
+            .filter(|(title, _)| *title == "List versions")
+            .map(|(_, argv)| argv)
+            .collect();
+
+        assert_eq!(
+            versions.len(),
+            2,
+            "expected one local and one cluster argv for List versions, got {versions:?}"
+        );
+        for tier in ["local", "cluster"] {
+            assert!(
+                versions
+                    .iter()
+                    .any(|argv| argv.first().map(String::as_str) == Some(tier)),
+                "no {tier} argv for List versions: {versions:?}"
+            );
+        }
+        for argv in &versions {
+            assert_eq!(
+                argv.get(1).map(String::as_str),
+                Some("versions"),
+                "expanded argv lost its verb: {argv:?}"
+            );
+        }
+    }
+
     #[test]
     fn build_argv_omits_empty_optional_flags() {
         let recipe = Recipe {
@@ -556,7 +713,7 @@ mod tests {
         values.insert("text".to_string(), "hello world".to_string());
         values.insert("channel".to_string(), String::new());
         assert_eq!(
-            build_argv(&recipe, &values),
+            build_argv(&recipe, None, &values),
             vec!["skill", "message", "hello world"]
         );
     }

--- a/cli/tests/tui_parity.rs
+++ b/cli/tests/tui_parity.rs
@@ -62,6 +62,45 @@ fn every_command_recipe_resolves_to_a_real_verb() {
     eprintln!("tui_parity: exercised {} command recipes", recipes.len());
 }
 
+/// The cluster tier must be REACHABLE from the TUI catalog, not just claimed
+/// by the Platform tab's tier explainer (#463). The catalog has to expand its
+/// tier-bearing recipes into cluster argv, and every one of those argvs has to
+/// resolve against the real grammar -- the same `<argv> --help` exec the
+/// catalog-wide gate uses, so a cluster verb that does not exist fails here.
+#[test]
+fn cluster_tier_recipes_are_expanded_and_resolve() {
+    let recipes = command_recipe_argvs();
+    let cluster: Vec<&(&str, Vec<String>)> = recipes
+        .iter()
+        .filter(|(_, argv)| argv.first().map(String::as_str) == Some("cluster"))
+        .collect();
+
+    assert!(
+        !cluster.is_empty(),
+        "no cluster argv in the TUI catalog: the cluster tier is unreachable"
+    );
+
+    // Governance, not just the pre-existing cluster status/message recipes:
+    // a tier-bearing platform recipe must actually reach the cluster tier.
+    assert!(
+        cluster
+            .iter()
+            .any(|(_, argv)| argv.get(1).map(String::as_str) == Some("versions")),
+        "no `cluster versions` argv: the platform governance recipes are still local-only"
+    );
+
+    for (title, argv) in &cluster {
+        let output = run_help(argv);
+        assert!(
+            output.status.success(),
+            "cluster recipe {title:?} does not resolve: argv {argv:?}\n{}",
+            output_text(&output)
+        );
+    }
+
+    eprintln!("tui_parity: exercised {} cluster recipes", cluster.len());
+}
+
 /// Negative control: proves the gate mechanism actually rejects drift rather
 /// than always passing regardless of argv.
 #[test]


### PR DESCRIPTION
The Platform tab's explainer claims AgentOS runs one immutable bundle across three tiers, while every governance recipe under it was pinned to the `local` literal. So a tab whose thesis is tier parity offered no way to inspect versions, set a budget, gate a tool, or kill an agent on cluster. The parity claim was print-only.

## What changed

- `SlackTier` (the right idea, scoped to one workflow) is promoted to a first-class `recipes::Tier`, plus an `ArgPart::Tier` the whole catalog shares. The local vs cluster axis is now declared once, not per recipe.
- One shared `prompt_tier()` resolves it, used by both the governance recipes and the Deploy-to-Slack workflow, so the two surfaces cannot drift apart again.
- `build_argv` takes the answered tier as an explicit `Option<Tier>` parameter. An unanswered tier is a compile-time question rather than a silent `local` default, which is the same bug class this ticket exists to kill.
- `command_recipe_argvs()` expands a tier-bearing recipe into both tiers, so the parity gate added in #462 execs the cluster argv against the real grammar rather than only the local one.

`versions`, `budget`, `approvals`, `memory`, `kill`, and `resume` all reach cluster from the Platform tab. They are flag-identical across tiers in the clap grammar, so this needed no per-verb special casing.

## Deliberate exceptions

- **`observability` stays local-only.** `cluster observability` does not exist in the grammar; #460 tracks the twin. A test pins this so the recipe cannot silently start lying.
- **The cluster choice states that it needs `AGENTOS_API_URL` and `AGENTOS_API_KEY`.** Every cluster governance verb defaults to `http://localhost:8000` and `agentos-dev-key`, so it cannot reach a real release without them. That is a pre-existing CLI gap (those defaults shipped with the verbs in `2facaa0`, and a plain `agentos cluster versions demo` hits it today), now filed as #524. Naming the requirement in the prompt is the honest stopgap; real discovery changes CLI semantics for every caller, not just the TUI.

## Verification

Tests assert the cluster path is reachable and produces valid argv, never that a title string exists. The parity gate execs each expanded cluster argv against the real binary.

Driving the built TUI in a pty (Platform tab, List versions, tier prompt, cluster, agent `demo`) executed `agentos cluster versions demo` for real, reaching `http://localhost:8000/agents` and failing connection-refused. That confirms both the reachability this ticket wanted and the pre-existing gap now tracked in #524.

440 tests pass, `cargo fmt --check` clean, clippy fingerprint identical to `origin/main`.

Closes #463
