### PR TITLE
Accept ADR-0022 and rewrite it to match the code as a build spec

### DIFF
--- a/docs/adr/0022-eval-completeness-tier-parity-and-trace-promotion.md
+++ b/docs/adr/0022-eval-completeness-tier-parity-and-trace-promotion.md
@@ -1,7 +1,7 @@
 # 22. Eval completeness: run the same evals at every tier, grade what actually happened, and promote real traces into cases
 
 Date: 2026-07-13
-Status: Proposed
+Status: Accepted (2026-07-16)
 
 Gives the scattered eval work one decision spine. Extends
 [ADR-0004](0004-langfuse-observability-and-eval-backbone.md) (Langfuse as the
@@ -37,12 +37,16 @@ on the fake-model CI path the same suite greens without a single tool call
 even less. Closing the gap between what a green eval *appears* to prove and what it
 *actually* proves is the whole purpose of this ADR.
 
-**1. You cannot actually run the same evals at every tier.** The CLI exposes
-`skill eval` only (`cli/src/main.rs`, dispatched to `commands::eval`); there is no
+**1. You cannot actually run the same evals at every tier.** *(Status at acceptance:
+closed. `local eval` and `cluster eval` landed via
+[#344](https://github.com/curie-eng/agentos/issues/344) on 2026-07-13, hours after
+this ADR was drafted. The analysis below is the state that motivated the decision
+and is retained as the record; Phase 1's tier-parity half is done.)* The CLI exposed
+`skill eval` only (`cli/src/main.rs`, dispatched to `commands::eval`); there was no
 `local eval` or `cluster eval` verb. The platform runs suites as fanned-out Jobs
-per version, but a developer at the CLI can grade a bundle in the in-process runner
-and nowhere else. The "same evals everywhere" promise has one of its three rungs
-missing ([#344](https://github.com/curie-eng/agentos/issues/344)). The grading
+per version, but a developer at the CLI could grade a bundle in the in-process runner
+and nowhere else. The "same evals everywhere" promise had one of its three rungs
+missing. The grading
 *discipline* is already shared — the platform runner and the CLI both apply the
 `Done`-gate and classified-failure gate before grading
 (`apps/worker/src/agentos_worker/eval/runner.py`, mirrored by the CLI's
@@ -58,11 +62,17 @@ that string was ever **called**, or that it returned a **structured result**. Th
 is not hypothetical. In a cold-start dogfood (run 2, a "release-radar" agent on
 GLM-5.2), the agent had to *invent* a tamper-proof "proof token" that its engine
 emitted and then grep the final text for it — a pure workaround for the absence of
-a "a tool was called / a structured result is present" grader. Worse, the fake
-model greens every text grader without calling a single tool
-([#337](https://github.com/curie-eng/agentos/issues/337)), so a
-green-on-fake result is false confidence: it proves the harness plumbing, not the
-agent. The trajectory is *already on the ACI wire* — the runner emits a
+a "a tool was called / a structured result is present" grader.
+
+A green-on-fake result is likewise false confidence: it proves the harness
+plumbing, not the agent
+([#337](https://github.com/curie-eng/agentos/issues/337)). **Note (2026-07-16, at
+acceptance): #337 has since closed, and its fix changes this ADR's reasoning —
+see the correction in Phase 1 below.** The fake model's `default_turn` now emits a
+scripted `ToolUseBlock` (`runner/src/agentos_runner/fake.py`), so the fake does
+call a (scripted) tool. That fixes the MCP-tool-loading gap #337 was filed for, but
+it means a tool-call grader no longer distinguishes the fake from a real model.
+The trajectory is *already on the ACI wire* — the runner emits a
 `tool_note` (carrying the tool name) and a `side_effect_flag` for every tool use
 (`runner/src/agentos_runner/translate.py`) — but the eval runner discards those
 frames and forwards only `final.text` to the grader. We are grading a keyhole view
@@ -130,11 +140,13 @@ eval needs to protect, and the model — not the code — is what this ADR fixes
 
 - **Text matchers** (`exact | contains | regex`) — unchanged, still on final text.
 - **Tool-call assertion** — a named tool was invoked during the turn (e.g. the
-  bundle's deterministic engine ran). This directly closes the dogfood workaround
-  and the #337 fake-model false-green: a tool-call grader **fails on the fake
-  model**, which is the correct signal, because the fake never calls a tool. The
-  raw material already exists (`tool_note` carries the tool name); the eval runner
-  must capture those frames into the graded record instead of dropping them.
+  bundle's deterministic engine ran). This directly closes the dogfood workaround.
+  The raw material already exists (`tool_note` carries the tool name); the eval
+  runner must capture those frames into the graded record instead of dropping them.
+  It does **not**, on its own, close the green-on-fake false confidence: since
+  #337's fix the fake emits a scripted `ToolUseBlock`, so a tool-call grader can
+  green on the fake exactly as a text grader does. Fake-model false-green needs a
+  separate mechanism — see Phase 1.
 - **Structured-result assertion** — a tool returned a result matching a shape
   (present / non-empty / JSON-path predicate). This is what the dogfood's
   hand-rolled "proof token" was faking. It requires the tool result to reach the
@@ -221,7 +233,15 @@ trajectory grader.
   place to add a **model** dimension so the same suite grades across BYO models and
   the results compare side by side. This is an orthogonal axis to grading and
   **deferred**: it is a reporting/fan-out concern that composes cleanly with
-  everything above once tier-parity execution and the richer taxonomy exist. It also
+  everything above once tier-parity execution and the richer taxonomy exist.
+
+  *Status at acceptance (2026-07-16): #255 is closed, but its acceptance criterion
+  ("the eval matrix reports pass-rate + cost per model") is only half true. The model
+  dimension records and slices; the cost axis has no producer, so every per-model
+  `cost_usd` reads `None` ([#390](https://github.com/curie-eng/agentos/issues/390)),
+  and there is no way to select a model at eval time or sweep a suite across models
+  ([#526](https://github.com/curie-eng/agentos/issues/526)). The deferral stands, but
+  the matrix should be treated as unbuilt for planning purposes, not done.* It also
   connects to the cross-harness parity evals
   ([#313](https://github.com/curie-eng/agentos/issues/313)) and the harness eval
   delta ([#326](https://github.com/curie-eng/agentos/issues/326)), both of which are
@@ -234,11 +254,24 @@ reference. Phases are sequenced by leverage-over-risk, not by which is most
 interesting.
 
 - **Phase 1 — Tier parity + tool-call grader (the credibility floor).** Ship
-  `local eval` and `cluster eval` (#344) and the **tool-call assertion** grader
-  kind. Together these close the two failures the dogfood proved: evals that only
-  run at one tier, and green-on-fake false confidence (#337, because a tool-call
-  grader fails the fake model). Lowest new-contract surface — `tool_note` already
-  carries the signal. This is the phase that makes the parity claim true.
+  `local eval` and `cluster eval` (#344, **landed 2026-07-13**) and the **tool-call
+  assertion** grader kind (outstanding). Lowest new-contract surface — `tool_note`
+  already carries the signal. This is the phase that makes the parity claim true.
+
+  **Correction at acceptance (2026-07-16).** As drafted, this phase claimed to close
+  *two* failures: single-tier evals, and green-on-fake false confidence "because a
+  tool-call grader fails the fake model." The second half no longer holds. #337's fix
+  gave the fake's `default_turn` a scripted `ToolUseBlock`, so the fake now calls a
+  tool and a tool-call grader greens on it. The tool-call grader is still the right
+  Phase 1 work — it closes the dogfood proof-token workaround and raises every
+  grader's signal — but **fake-model false-green is now an open problem this ADR does
+  not solve.** Candidate mechanisms, to be decided in the phase that builds it:
+  refuse to record eval results from a fake-model run at all (the fake is a plumbing
+  fixture, not a subject under test); or an evidence check on the trajectory's
+  provenance rather than its shape (the family of
+  [#517](https://github.com/curie-eng/agentos/issues/517)). Whichever is chosen, the
+  constraint decided here is: **a fake-model run must not be able to produce a green
+  that reads as an agent-quality signal.**
 - **Phase 2 — Trace → eval promotion (the headline capability).** `agentos eval
   add-from-trace` capturing input + trajectory + a curated assertion, with trace-id
   provenance (epic #26, #266). Depends on Phase 1's tool-call/trajectory capture so
@@ -252,7 +285,21 @@ interesting.
   pluggable scorer seam (#261), and the BYO-model matrix dimension (#255, feeding
   #313 and #326). These make eval results *trustworthy over noise* and *comparable
   across models* — most valuable once there is a rich trajectory grader to run *k*
-  times and across models.
+  times and across models. At acceptance this phase carries the reachability debt
+  from the closed issues that shipped inert: wiring the scorer seam into a runnable
+  path (#389), a producer for the cost axis (#390), and eval-time model selection /
+  sweep (#526).
+
+**Cross-cutting: the cases themselves.** Every phase above improves the *harness*.
+None of them improves the *suites* the harness runs, and the committed examples are
+currently unfalsifiable — `examples/weather/evals/cases.json` passes on
+`contains: "weather"` for an input that contains the word "weather"
+([#527](https://github.com/curie-eng/agentos/issues/527)). Because `init` seeds new
+bundles from these examples, a vacuous case is not one bad file; it is the pattern
+every new agent inherits. The standard this ADR sets for a case is the same one it
+sets for a grader: **could a plausibly-broken agent pass it?** If yes, it is not an
+eval. Rewriting the seeds tracks alongside Phase 1, since the tool-call grader is
+what several of them need to become falsifiable.
 
 ## Alternatives considered
 
@@ -287,8 +334,12 @@ interesting.
   command a developer or coding agent can run, and a tier divergence is a real,
   reproducible environment-bug signal.
 - **A green eval starts meaning "the agent did the work," not "a string appeared."**
-  Tool-call and trajectory assertions make the fake-model path fail honestly (#337),
-  which removes a class of false confidence rather than papering over it.
+  Tool-call and trajectory assertions grade the run rather than its last sentence,
+  which removes a class of false confidence rather than papering over it. This does
+  *not* extend to the fake-model path: since #337's fix the fake calls a scripted
+  tool, so it greens a tool-call grader too. Keeping a fake-model green from reading
+  as an agent-quality signal is an open problem (Phase 1 correction), and until it is
+  closed, a green on the fake-model CI path proves plumbing only.
 - **New contract surface is incurred deliberately and in order.** Server-side
   grading and structured-result assertions touch the frozen ACI/eval contract; each
   is an escalate-first change (ADR-0005/0017), scoped to the phase that needs it, not

--- a/docs/adr/0022-eval-completeness-tier-parity-and-trace-promotion.md
+++ b/docs/adr/0022-eval-completeness-tier-parity-and-trace-promotion.md
@@ -1,7 +1,7 @@
 # 22. Eval completeness: run the same evals at every tier, grade what actually happened, and promote real traces into cases
 
 Date: 2026-07-13
-Status: Accepted (2026-07-16)
+Status: Accepted
 
 Gives the scattered eval work one decision spine. Extends
 [ADR-0004](0004-langfuse-observability-and-eval-backbone.md) (Langfuse as the
@@ -12,87 +12,77 @@ and the eval issues under it. Read
 [ADR-0021](0021-agentos-is-a-harness-for-coding-agents.md) first: evals are the
 contract the harness's parity promise is measured against.
 
+[ADR-0029](0029-llm-as-a-verifier-grader-and-progress-signal.md) extends this ADR
+with the **semantic** grader (`GraderKind.verifier`) and supersedes one point of it:
+this ADR's rejection of an LLM judge inside the frozen enum. The two divide by case
+type — deterministic graders here assert what a trajectory makes checkable (a tool
+was called, a gate fired); ADR-0029's verifier judges correctness where no string
+match exists. ADR-0029 depends on the trajectory-forwarding decided here, so this
+ADR's Phase 1 is its prerequisite. Everything else below stands.
+
 ## Context
 
 The parity thesis (ADR-0021) is that **the same bundle plus the same
-`evals/cases.json` stay green from `skill` to `local` to `cluster`**. Evals are
-the contract that proves parity: a tier-to-tier divergence is the harness catching
-a real environment bug, not the agent's skill logic. For that contract to mean
-anything, two things must be true, and today neither fully is.
+`evals/cases.json` stay green from `skill` to `local` to `cluster`**. Evals are the
+contract that proves parity: a tier-to-tier divergence is the harness catching a
+real environment bug, not the agent's skill logic.
 
-**Put plainly: as a parity contract, the eval system is broken today — it does not
-prove what AgentOS advertises it proves.** The cold-start dogfood (run 2) makes this
-concrete and is worth stating outright. That agent *did* drive the same bundle to
-5/5 green at all three tiers — but the green was **hand-assembled around the eval
-system, not produced by it.** To assert the deterministic engine actually ran, the
-agent had to invent a tamper-proof "proof token" and grep the final text for it,
-because no grader can check that a tool was ever called (axis 2 below). To "run the
-same evals" at `local` and `cluster`, it had to hand-drive every case through
-`message` and grep the reply itself, because those tiers have no `eval` verb (axis 1
-below). A reader who sees "5/5 parity at every tier" concludes the contract works;
-in fact a skilled agent manually reconstructed what the eval system could not do on
-its own. The green proves the **runner's** parity, not the **eval system's** — and
-on the fake-model CI path the same suite greens without a single tool call
-([#337](https://github.com/curie-eng/agentos/issues/337)), so a green there proves
-even less. Closing the gap between what a green eval *appears* to prove and what it
-*actually* proves is the whole purpose of this ADR.
+**As a parity contract, the eval system does not yet prove what AgentOS advertises
+it proves.** The execution surface is in place — the same suite does run at all
+three tiers — but what a green eval *asserts* is still "a string appeared in the
+final sentence," not "the agent did the work." A cold-start dogfood made this
+concrete: to assert its deterministic engine had actually run, the agent had to
+invent a tamper-proof "proof token" that the engine emitted and then grep the final
+text for it, because no grader can check that a tool was ever called. Closing the
+gap between what a green eval *appears* to prove and what it *actually* proves is
+the purpose of this ADR.
 
-**1. You cannot actually run the same evals at every tier.** *(Status at acceptance:
-closed. `local eval` and `cluster eval` landed via
-[#344](https://github.com/curie-eng/agentos/issues/344) on 2026-07-13, hours after
-this ADR was drafted. The analysis below is the state that motivated the decision
-and is retained as the record; Phase 1's tier-parity half is done.)* The CLI exposed
-`skill eval` only (`cli/src/main.rs`, dispatched to `commands::eval`); there was no
-`local eval` or `cluster eval` verb. The platform runs suites as fanned-out Jobs
-per version, but a developer at the CLI could grade a bundle in the in-process runner
-and nowhere else. The "same evals everywhere" promise had one of its three rungs
-missing. The grading
-*discipline* is already shared — the platform runner and the CLI both apply the
-`Done`-gate and classified-failure gate before grading
-(`apps/worker/src/agentos_worker/eval/runner.py`, mirrored by the CLI's
-`turn_passes`) — so the foundation for identical grading exists; the execution
-surface does not.
+Three axes are incomplete. Each is stated below as the code stands today.
 
-**2. The graders cannot assert what actually matters.** The frozen grader
-taxonomy is `exact | contains | regex`, and all three run against the turn's
-**final answer text** only (`apps/worker/src/agentos_worker/eval/models.py`,
-`GraderKind`). A grader can confirm a version-shaped string appears in the reply;
-it cannot confirm the deterministic engine or tool that was *supposed* to produce
-that string was ever **called**, or that it returned a **structured result**. This
-is not hypothetical. In a cold-start dogfood (run 2, a "release-radar" agent on
-GLM-5.2), the agent had to *invent* a tamper-proof "proof token" that its engine
-emitted and then grep the final text for it — a pure workaround for the absence of
-a "a tool was called / a structured result is present" grader.
+**1. Grading sees only the final sentence.** The frozen grader taxonomy is
+`exact | contains | regex`, and all three run against the turn's final answer text
+(`apps/worker/src/agentos_worker/eval/models.py`, `GraderKind`). A grader can
+confirm a version-shaped string appears in the reply; it cannot confirm the tool or
+deterministic engine that was *supposed* to produce that string was ever **called**,
+or that it returned a **structured result**. The trajectory is *already on the ACI
+wire* — the runner emits a `tool_note` (carrying the tool name) and a
+`side_effect_flag` for every tool use (`runner/src/agentos_runner/translate.py`) —
+and the eval runner already captures those frames into a `trajectory` list
+(`eval/runner.py`). Nothing in the frozen case format can assert against it. We are
+grading a keyhole view of a run we can already see in full.
 
-A green-on-fake result is likewise false confidence: it proves the harness
-plumbing, not the agent
-([#337](https://github.com/curie-eng/agentos/issues/337)). **Note (2026-07-16, at
-acceptance): #337 has since closed, and its fix changes this ADR's reasoning —
-see the correction in Phase 1 below.** The fake model's `default_turn` now emits a
-scripted `ToolUseBlock` (`runner/src/agentos_runner/fake.py`), so the fake does
-call a (scripted) tool. That fixes the MCP-tool-loading gap #337 was filed for, but
-it means a tool-call grader no longer distinguishes the fake from a real model.
-The trajectory is *already on the ACI wire* — the runner emits a
-`tool_note` (carrying the tool name) and a `side_effect_flag` for every tool use
-(`runner/src/agentos_runner/translate.py`) — but the eval runner discards those
-frames and forwards only `final.text` to the grader. We are grading a keyhole view
-of a run we can already see in full.
+**2. A fake-model green is indistinguishable from a real one.** The fake model's
+`default_turn` emits a scripted `ToolUseBlock(name="Bash")`
+(`runner/src/agentos_runner/fake.py`), so on the fake-model CI path a text grader
+greens without a model call — and a tool-call grader, once built, would green too.
+The fake is a plumbing fixture, not a subject under test, but nothing in the eval
+system says so. A green there proves the harness works, not the agent.
 
-**3. There is no path from a real run to a committed eval.** The single most
-valuable eval cases are the ones reality writes: a production thread someone liked,
-or one that caught a regression. Today, turning such a Langfuse trace into a
-committed `evals/cases.json` case is entirely manual — read the trace, retype the
-input, guess a `contains` string. Epic #26 names this the headline capability
-("from traces to test suites") and it does not exist. This is the future
-requirement that most shapes the design: it must be *easy* — ideally one command —
-to promote an observed run into a curated, committed case.
+**3. Promotion captures the input but throws away the behavior.** `POST
+/traces/{trace_id}/eval-case` (`apps/api/src/agentos_api/routers/runs.py`) reads a
+Langfuse trace, extracts and anonymizes the conversation, and emits a case in the
+frozen shape. But it grades with
+`GraderOut(kind="contains", expected=_expected_snippet(anon_output))` — a `contains`
+against a capped snippet of the output the run happened to produce
+(`apps/api/src/agentos_api/evalcase.py`). It never looks at the trajectory, so a
+promoted case asserts the agent says something similar, not that it does the same
+work. There is no CLI verb, and provenance exists only as an `id` naming convention
+(`promoted-<trace_id>`), not a field. The most valuable cases are the ones reality
+writes; today promotion turns them into the weakest grader we have.
 
-This ADR is not new machinery invented from scratch. ADR-0004 already chose
-Langfuse as the trace + eval store and flagged per-run version reproducibility as
-"lands with the eval lane" — this is that lane. ADR-0019 already froze the case
-*format* and deliberately left the door open ("pluggable scorers via `GraderKind`,
-per-model matrices") — this ADR walks through that door. What has been missing is a
-single decision that says how the pieces fit and in what order they land.
+A fourth issue is not a harness gap but sets the standard the harness serves: **the
+committed example suites are unfalsifiable.** `examples/weather/evals/cases.json`
+passes on `contains: "weather"` for an input containing the word "weather"
+([#527](https://github.com/curie-eng/agentos/issues/527)). Because `init` seeds new
+bundles from these examples, a vacuous case is not one bad file; it is the pattern
+every new agent inherits.
+
+This ADR is not new machinery invented from scratch. ADR-0004 already chose Langfuse
+as the trace + eval store and flagged per-run version reproducibility as "lands with
+the eval lane" — this is that lane. ADR-0019 already froze the case *format* and
+deliberately left the door open ("pluggable scorers via `GraderKind`, per-model
+matrices") — this ADR walks through that door. What has been missing is a single
+decision that says how the pieces fit and in what order they land.
 
 ## Decision
 
@@ -103,55 +93,48 @@ and we sequence the work so the highest-leverage, lowest-risk pieces land first.
 ### 1. Tier-parity execution: one suite, one grader, three rungs
 
 The same `evals/cases.json` runs at `skill`, `local`, and `cluster` through **one
-shared grader implementation**, invoked identically at every tier. Add the two
-missing CLI verbs, `local eval` and `cluster eval`
-([#344](https://github.com/curie-eng/agentos/issues/344)), as thin drivers that
-target, respectively, the compose stack's runner and a deployed release's runner —
-mirroring how `message` already exists at all three tiers. A case grades identically
-everywhere or the harness has a bug.
+shared grader implementation**, invoked identically at every tier. A case grades
+identically everywhere or the harness has a bug.
 
-The grader is authored **once, in Python**, as the source of truth
-([ADR-0017](0017-tri-language-contract-codegen.md)): the CLI does not
-re-implement grading logic in Rust. Two mechanisms are on the table and the choice
-is deferred to the phase that builds it, but the *constraint* is decided now — a
-case must never grade differently at two tiers:
+The three verbs exist (`cli/src/main.rs`), and the grading *discipline* is already
+shared: the platform runner and the CLI both apply the `Done`-gate and
+classified-failure gate before grading (`eval/runner.py`, mirrored by the CLI's
+`turn_passes`), so a turn that ends idle or errors never grades green on matching
+text. What is **not** settled is where the grader lives. Today it is
+hand-mirrored — Python in the platform, Rust in the CLI — held together by
+ADR-0019's byte-level conformance fixture. That is the **fallback** mechanism, and it
+means every new grader kind is a second implementation to keep in lockstep.
 
-- **Preferred: grade server-side, at the runner.** The runner already owns the
-  trajectory (it emits the `tool_note`/`side_effect_flag`/`final` frames). Move
-  grading behind the `eval_case` ACI channel so the runner returns a graded result,
-  and every tier's CLI verb becomes a dumb "submit case, print verdict" client.
-  This makes cross-tier drift structurally impossible because there is exactly one
-  grader. It requires the `eval_case` result frame to carry the graded outcome and
-  the trajectory it graded — an ACI/frozen-contract change that stops and escalates
-  per ADR-0005/0017, not a side channel.
-- **Fallback: keep the CLI's hand-mirrored grader**, extended to the new taxonomy,
-  and hold it honest with the existing byte-level conformance fixture (ADR-0019's
-  mechanism). Cheaper, but every new grader kind is a second implementation to keep
-  in lockstep.
+The **preferred** end state is to grade server-side, at the runner: the runner
+already owns the trajectory, so moving grading behind the `eval_case` ACI channel
+makes every tier's CLI verb a dumb "submit case, print verdict" client and makes
+cross-tier drift structurally impossible. It requires the `eval_case` result frame
+to carry the graded outcome and the trajectory it graded — an ACI/frozen-contract
+change that stops and escalates per ADR-0005/0017, not a side channel.
 
-Whichever is chosen, the invariant is: **the grader that decides pass/fail is
-defined in one place and the tiers differ only in where the runner runs.** The
-`Done`-gate/classified-failure parity already established stays as-is.
+The choice between them is deferred to the phase that adds the first non-text
+grader, because that is the phase that pays the mirroring cost. The **constraint** is
+decided now: **the grader that decides pass/fail is defined in one place and the
+tiers differ only in where the runner runs.** The grader is authored once, in
+Python, as the source of truth ([ADR-0017](0017-tri-language-contract-codegen.md));
+the CLI never grows an independently-authored grader.
 
 ### 2. Grader taxonomy: assert the trajectory, not just the last sentence
 
 Extend `GraderKind` beyond text matchers. The taxonomy grows to cover what a real
-eval needs to protect, and the model — not the code — is what this ADR fixes:
+eval needs to protect:
 
 - **Text matchers** (`exact | contains | regex`) — unchanged, still on final text.
 - **Tool-call assertion** — a named tool was invoked during the turn (e.g. the
-  bundle's deterministic engine ran). This directly closes the dogfood workaround.
-  The raw material already exists (`tool_note` carries the tool name); the eval
-  runner must capture those frames into the graded record instead of dropping them.
-  It does **not**, on its own, close the green-on-fake false confidence: since
-  #337's fix the fake emits a scripted `ToolUseBlock`, so a tool-call grader can
-  green on the fake exactly as a text grader does. Fake-model false-green needs a
-  separate mechanism — see Phase 1.
+  bundle's deterministic engine ran). This closes the dogfood proof-token
+  workaround. The raw material exists: `tool_note` carries the tool name and
+  `eval/runner.py` already accumulates the `trajectory` list; what is missing is a
+  grader kind that can assert against it and a case format that can express it.
 - **Structured-result assertion** — a tool returned a result matching a shape
   (present / non-empty / JSON-path predicate). This is what the dogfood's
-  hand-rolled "proof token" was faking. It requires the tool result to reach the
-  graded record, which is a larger contract touch than tool-call and is scoped to a
-  later phase.
+  hand-rolled proof token was faking. It requires the tool *result* to reach the
+  graded record — a larger contract touch than tool-call, since only the tool
+  *name* is on the wire today — and is scoped to a later phase.
 - **Trajectory / turn matcher** — an ordered or unordered set of tool calls
   occurred, and specifically **an approval gate was requested**
   ([#262](https://github.com/curie-eng/agentos/issues/262)). Gate-exercising evals
@@ -173,181 +156,230 @@ that never inspects the trajectory. The assertion is about *what the run did*, r
 from the observed trajectory frames, **not** about what the final text says the run
 did. That distinction is the whole point of this axis.
 
-### 3. Trace → eval promotion: reality writes the best cases
+### 3. Fake-model runs must not produce an agent-quality green
 
-A single blessed command promotes an observed run into a committed case:
+The fake calls a scripted tool, so no grader kind can distinguish it from a real
+model by inspecting the trajectory's *shape*. Since a richer taxonomy cannot fix
+this, it is decided separately here: **a fake-model run must not be able to produce
+a green that reads as an agent-quality signal.** The mechanism is chosen in the
+phase that builds it; the two candidates are to refuse to record eval results from a
+fake-model run at all (the fake is a plumbing fixture, and its green belongs to the
+harness's own test suite, not to an agent's eval history), or an evidence check on
+the trajectory's provenance rather than its shape (the family of
+[#517](https://github.com/curie-eng/agentos/issues/517)). The first is cheaper and
+is the default unless the phase finds a reason otherwise.
+
+### 4. Trace to eval promotion: reality writes the best cases
+
+Promotion must capture **behavior, not just words**. Extend the existing endpoint and
+give it a CLI front door:
 
 ```
 agentos eval add-from-trace <trace-id> [--assert tool:<name>] [--assert contains:<text>]
 ```
 
-It reads the Langfuse trace (ADR-0004's store, addressed by trace id), and
-**captures**:
+It reads the Langfuse trace (ADR-0004's store, addressed by trace id) and captures:
 
 - **the input** — the user turn(s) that opened the run, verbatim, so the case
-  replays the real prompt rather than a paraphrase;
+  replays the real prompt rather than a paraphrase. *(Built: `extract_io` + `redact`
+  in `evalcase.py`.)*
 - **the trajectory** — the ordered tool calls and any approval gates the run
-  exercised, so the promoted case can assert on behavior, not just the final text;
+  exercised, so the promoted case can assert on behavior. *(Not built: the endpoint
+  reads observations but discards tool structure.)*
 - **a graded assertion** — proposed from the trajectory (e.g. "tool `X` was called
-  and the final text contains `Y`"), which the human **curates** before commit. The
-  command writes a case into `evals/cases.json` in the frozen ADR-0019 shape; it
-  does not silently commit — the developer (or their coding agent, per ADR-0021)
-  reviews and edits the assertion, because a captured trajectory is a *candidate*,
-  not a truth.
+  and the final text contains `Y`"), which the human **curates** before commit.
+  *(Not built: today it emits a `contains` on a capped output snippet, which is the
+  weak-grader default this ADR exists to move off.)* The command writes a case into
+  `evals/cases.json` in the frozen ADR-0019 shape; it does not silently commit — the
+  developer (or their coding agent, per ADR-0021) reviews and edits the assertion,
+  because a captured trajectory is a *candidate*, not a truth.
 
-Provenance is recorded on the promoted case: the originating trace id is stamped so
-a case can be traced back to the run it came from
-([#266](https://github.com/curie-eng/agentos/issues/266)). A guided,
-interview-style variant of this flow — walking a human through which assertions to
-keep — is [#260](https://github.com/curie-eng/agentos/issues/260) and layers on top
-of the same capture pipeline; per ADR-0021 that interview is agent-conducted, and
-the CLI stays the non-interactive `add-from-trace` mechanism underneath. This
-promotion pipeline is the spine of epic #26.
+Provenance is recorded as a **field** on the promoted case, not inferred from the
+`id` string: the originating trace id is stamped so a case can be traced back to the
+run it came from. A guided, interview-style variant of this flow is
+[#260](https://github.com/curie-eng/agentos/issues/260) and layers on top of the same
+capture pipeline; per ADR-0021 that interview is agent-conducted, and the CLI stays
+the non-interactive `add-from-trace` mechanism underneath. This promotion pipeline is
+the spine of epic #26.
 
-### 4. Multi-sample / variance-aware grading
+### 5. Multi-sample / variance-aware grading
 
 Real model runs are non-deterministic; a single sample is a coin flip reported as a
 fact. Grading gains an optional sample count and a pass rule
 ([#332](https://github.com/curie-eng/agentos/issues/332)): run a case *k* times and
 pass on a threshold (majority, or pass@k / all-of-k for a flake-intolerant gate).
 The default stays **1** so today's suites and the fake-model CI path are unchanged
-and cheap; multi-sample is opt-in per case or per run, because it multiplies cost
-and latency. The per-case result rollup (`EvalRunResult`) already records per-case
-rows; variance grading extends it to carry the sample distribution, not just a
-boolean. This axis is decided in principle here and scheduled after the taxonomy,
-since a variance gate over a text-only grader is far less useful than one over a
-trajectory grader.
+and cheap; multi-sample is opt-in per case or per run, because it multiplies cost and
+latency. `EvalRunResult` already records per-case rows; variance grading extends it
+to carry the sample distribution, not just a boolean. This axis is scheduled after
+the taxonomy, since a variance gate over a text-only grader is far less useful than
+one over a trajectory grader.
 
-### 5. Pluggable scorer seam and BYO-model matrix
+### 6. Pluggable scorer seam and BYO-model matrix
 
-- **Pluggable scorer seam** ([#261](https://github.com/curie-eng/agentos/issues/261)):
-  the grader taxonomy above is deliberately a *closed, deterministic* enum, because
-  reproducibility is the point of eval-as-CI (ADR-0004, ADR-0019). The extension
-  point for open-ended scorers (an LLM-judge, a custom Python scorer) is a **named
-  seam above the frozen grader port**, not a new `GraderKind` value. A scorer plugs
-  in by name; the frozen case schema stays closed and reproducible. This keeps the
-  ADR-0019 freeze intact while giving #261 a home. Concrete scorer implementations
-  are out of scope for this ADR.
-- **BYO-model eval matrix** ([#255](https://github.com/curie-eng/agentos/issues/255)):
-  the run-result types are already keyed by `version`; the eval matrix is the natural
-  place to add a **model** dimension so the same suite grades across BYO models and
-  the results compare side by side. This is an orthogonal axis to grading and
-  **deferred**: it is a reporting/fan-out concern that composes cleanly with
-  everything above once tier-parity execution and the richer taxonomy exist.
+- **Pluggable scorer seam**: the grader taxonomy above is deliberately a *closed,
+  deterministic* enum, because reproducibility is the point of eval-as-CI (ADR-0004,
+  ADR-0019). The extension point for open-ended scorers (an LLM judge, a custom
+  Python scorer) is a **named seam above the frozen grader port**, not a new
+  `GraderKind` value. A scorer plugs in by name; the frozen case schema stays closed
+  and reproducible. The seam itself is built (`eval/scorer.py`: the `Scorer`
+  protocol, `GraderScorer` as the default, and the `scorer=` parameter on
+  `EvalRunner`), and a `TrajectoryScorer` with five match modes is built and
+  unit-tested — but **nothing injects it**: no CLI flag and no Job config supplies
+  the `case_id -> TrajectorySpec` map it needs, so it cannot be run end to end
+  ([#389](https://github.com/curie-eng/agentos/issues/389)).
 
-  *Status at acceptance (2026-07-16): #255 is closed, but its acceptance criterion
-  ("the eval matrix reports pass-rate + cost per model") is only half true. The model
-  dimension records and slices; the cost axis has no producer, so every per-model
-  `cost_usd` reads `None` ([#390](https://github.com/curie-eng/agentos/issues/390)),
-  and there is no way to select a model at eval time or sweep a suite across models
-  ([#526](https://github.com/curie-eng/agentos/issues/526)). The deferral stands, but
-  the matrix should be treated as unbuilt for planning purposes, not done.* It also
-  connects to the cross-harness parity evals
+  **Semantic grading is out of scope here and governed by
+  [ADR-0029](0029-llm-as-a-verifier-grader-and-progress-signal.md).** This ADR
+  originally rejected an LLM judge inside the frozen enum on reproducibility
+  grounds; ADR-0029 supersedes that specific rejection with a `GraderKind.verifier`
+  whose continuous scoring and `K` repeated evaluations answer the objection on the
+  evidence (Kwok et al., arXiv:2607.05391). The division of labor is by **case
+  type, not by preference**: deterministic graders assert the mechanical facts a
+  trajectory makes checkable (a tool was called, a gate fired, a result has a
+  shape) — cheap, zero-variance, and what the parity contract rests on; the
+  verifier grades semantic correctness where no string match exists. An LLM judge
+  is the wrong instrument for "was this tool called," which is a set-membership
+  check over structured wire data. Note that neither addresses run-to-run variance,
+  which is the model's non-determinism and is answered only by multi-sample (axis
+  5, #332).
+- **BYO-model eval matrix**: the run-result types are already keyed by `version`; the
+  matrix is the natural place for a **model** dimension so the same suite grades
+  across models and results compare side by side. The dimension is built
+  (`EvalRunResult.model` -> a Langfuse `model:` tag -> `GET /evals/matrix`), but two
+  pieces are missing: `EvalCaseResult.cost_usd` is declared and read by the matrix
+  yet **never populated**, so every per-model cost rollup reads `None`
+  ([#390](https://github.com/curie-eng/agentos/issues/390)); and no eval verb accepts
+  a model, so there is no way to select one at eval time or sweep a suite across
+  several ([#526](https://github.com/curie-eng/agentos/issues/526)). This axis is a
+  reporting/fan-out concern that composes cleanly once the taxonomy is richer, and it
+  feeds the cross-harness parity evals
   ([#313](https://github.com/curie-eng/agentos/issues/313)) and the harness eval
-  delta ([#326](https://github.com/curie-eng/agentos/issues/326)), both of which are
-  matrix consumers, not new grading machinery.
+  delta ([#326](https://github.com/curie-eng/agentos/issues/326)), both matrix
+  consumers rather than new grading machinery.
 
-### 6. Phased plan
+## What is built, and what this ADR asks for
 
-Each phase maps to the issues it closes or advances, so this ADR is their ordering
-reference. Phases are sequenced by leverage-over-risk, not by which is most
-interesting.
+Verified against the tree at acceptance. "Inert" means the code exists and is
+unit-tested but no runnable path reaches it.
 
-- **Phase 1 — Tier parity + tool-call grader (the credibility floor).** Ship
-  `local eval` and `cluster eval` (#344, **landed 2026-07-13**) and the **tool-call
-  assertion** grader kind (outstanding). Lowest new-contract surface — `tool_note`
-  already carries the signal. This is the phase that makes the parity claim true.
+| Capability | State | Issue |
+|---|---|---|
+| `skill` / `local` / `cluster eval` verbs | **built** | #344 |
+| Shared `Done`-gate + classified-failure gate across tiers | **built** | — |
+| Grader source of truth (server-side vs hand-mirrored) | **undecided** — hand-mirrored today | — |
+| Text graders (`exact`/`contains`/`regex`) on final text | **built** | ADR-0019 |
+| Trajectory captured by the eval runner | **built** (captured, ungradeable) | — |
+| Tool-call assertion grader kind | **not built** | — |
+| Structured-result assertion grader kind | **not built** | — |
+| Approval-gate / trajectory matcher grader kind | **not built** | #262 |
+| Fake-model run cannot yield an agent-quality green | **not built** | #517 |
+| Scorer seam above the frozen port | **built** | #261 |
+| `TrajectoryScorer` (5 modes) | **built but inert** | #389 |
+| Semantic grader (`GraderKind.verifier`) | **not built** — see ADR-0029 | #478 |
+| Trace promotion: input capture + anonymization | **built** | #259 |
+| Trace promotion: trajectory capture + curated assertion | **not built** | #26 |
+| Trace promotion: trace-id provenance as a field | **not built** (id convention only) | #26 |
+| Trace promotion: CLI `eval add-from-trace` | **not built** | #26 |
+| Guided eval-generation interview (`skill eval-init`) | **built** | #260 |
+| Multi-sample / pass@k grading | **not built** | #332 |
+| Matrix model dimension | **built** | #255 |
+| Matrix per-model cost | **built but dead** (no producer) | #390 |
+| Model selection / sweep at eval time | **not built** | #526 |
+| Falsifiable committed example suites | **not built** | #527 |
 
-  **Correction at acceptance (2026-07-16).** As drafted, this phase claimed to close
-  *two* failures: single-tier evals, and green-on-fake false confidence "because a
-  tool-call grader fails the fake model." The second half no longer holds. #337's fix
-  gave the fake's `default_turn` a scripted `ToolUseBlock`, so the fake now calls a
-  tool and a tool-call grader greens on it. The tool-call grader is still the right
-  Phase 1 work — it closes the dogfood proof-token workaround and raises every
-  grader's signal — but **fake-model false-green is now an open problem this ADR does
-  not solve.** Candidate mechanisms, to be decided in the phase that builds it:
-  refuse to record eval results from a fake-model run at all (the fake is a plumbing
-  fixture, not a subject under test); or an evidence check on the trajectory's
-  provenance rather than its shape (the family of
-  [#517](https://github.com/curie-eng/agentos/issues/517)). Whichever is chosen, the
-  constraint decided here is: **a fake-model run must not be able to produce a green
-  that reads as an agent-quality signal.**
-- **Phase 2 — Trace → eval promotion (the headline capability).** `agentos eval
+## Phased plan
+
+Phases are sequenced by leverage-over-risk, not by which is most interesting.
+
+- **Phase 1 — The credibility floor.** The **tool-call assertion** grader kind, and
+  the fake-model decision from axis 3. Together these make a green mean "the agent
+  did the work": the grader closes the dogfood proof-token workaround, and the
+  fake-model rule stops the CI path from minting greens that read as agent quality.
+  Lowest new-contract surface — `tool_note` already carries the signal and the runner
+  already captures it. Tier parity (#344) is already done, so this is what remains of
+  the floor. Settle the grader-source question (axis 1) here, since this is the first
+  grader kind that would otherwise be hand-mirrored twice.
+- **Phase 2 — Trace to eval promotion (the headline capability).** `agentos eval
   add-from-trace` capturing input + trajectory + a curated assertion, with trace-id
-  provenance (epic #26, #266). Depends on Phase 1's tool-call/trajectory capture so
-  a promoted case can assert on behavior. This is the flow that turns production
-  reality into a growing test suite.
-- **Phase 3 — Trajectory + structured-result + gate assertions.** The approval-gate
-  matcher (#262) and structured-result assertions, plus the guided interview on top
-  of promotion (#260). This is where the taxonomy becomes complete; it carries the
-  larger contract touch (tool results into the graded record).
-- **Phase 4 — Variance and matrix.** Multi-sample / pass@k grading (#332), the
-  pluggable scorer seam (#261), and the BYO-model matrix dimension (#255, feeding
-  #313 and #326). These make eval results *trustworthy over noise* and *comparable
-  across models* — most valuable once there is a rich trajectory grader to run *k*
-  times and across models. At acceptance this phase carries the reachability debt
-  from the closed issues that shipped inert: wiring the scorer seam into a runnable
-  path (#389), a producer for the cost axis (#390), and eval-time model selection /
-  sweep (#526).
-
-**Cross-cutting: the cases themselves.** Every phase above improves the *harness*.
-None of them improves the *suites* the harness runs, and the committed examples are
-currently unfalsifiable — `examples/weather/evals/cases.json` passes on
-`contains: "weather"` for an input that contains the word "weather"
-([#527](https://github.com/curie-eng/agentos/issues/527)). Because `init` seeds new
-bundles from these examples, a vacuous case is not one bad file; it is the pattern
-every new agent inherits. The standard this ADR sets for a case is the same one it
-sets for a grader: **could a plausibly-broken agent pass it?** If yes, it is not an
-eval. Rewriting the seeds tracks alongside Phase 1, since the tool-call grader is
-what several of them need to become falsifiable.
+  provenance as a field, extending the existing endpoint rather than replacing it
+  (epic #26). Depends on Phase 1's tool-call grader so a promoted case can assert on
+  behavior instead of defaulting to a `contains` snippet. This is the flow that turns
+  production reality into a growing test suite.
+- **Phase 3 — The rest of the taxonomy.** The approval-gate matcher (#262) and
+  structured-result assertions, plus the guided interview layered on promotion
+  (#260, whose starter-suite generator already exists). This carries the larger
+  contract touch: tool *results* must reach the graded record, where only tool names
+  are on the wire today.
+- **Phase 4 — Variance, reach, and matrix.** Multi-sample / pass@k grading (#332);
+  wiring the built-but-inert `TrajectoryScorer` into a runnable path (#389); a
+  producer for the cost axis (#390); and eval-time model selection / sweep (#526),
+  feeding #313 and #326. These make eval results *trustworthy over noise* and
+  *comparable across models* — most valuable once there is a rich trajectory grader
+  to run *k* times and across models.
+- **Cross-cutting — the cases themselves (#527).** Every phase above improves the
+  *harness*; none improves the *suites* it runs. Rewrite the committed examples so
+  each case is falsifiable, tracking alongside Phase 1 since the tool-call grader is
+  what several of them need. The standard for a case is the same one this ADR sets
+  for a grader: **could a plausibly-broken agent pass it?** If yes, it is not an eval.
 
 ## Alternatives considered
 
 - **Leave grading at final-text and tell authors to emit proof tokens.** Rejected:
   this is exactly the dogfood workaround, and it is a tax on every bundle author to
   reinvent a "was I called" signal the runtime already has on the wire. It also
-  cannot express approval-gate or structured-result assertions at all, and it keeps
-  the fake-model false-green (#337) unfixed.
+  cannot express approval-gate or structured-result assertions at all.
 - **A second, richer grader implementation in the CLI, independent of the platform.**
   Rejected: it reintroduces exactly the cross-language drift ADR-0017 and ADR-0019
   exist to prevent. One grader source of truth, generated or conformance-gated
   mirror — never two hand-authored graders that can disagree about pass/fail.
-- **Add an `llm-judge` value to the frozen `GraderKind` enum now.** Rejected: an
-  LLM-judge is non-deterministic and belongs above the frozen, reproducible grader
-  port as a named scorer (#261), not inside the closed enum that eval-as-CI's
-  reproducibility depends on. Adding it to `GraderKind` would erode the ADR-0019
-  freeze's core property.
+- **Add an `llm-judge` value to the frozen `GraderKind` enum now.** Originally
+  rejected on the grounds that an LLM judge is non-deterministic and belongs above
+  the frozen grader port as a named scorer, not inside the closed enum that
+  eval-as-CI's reproducibility depends on. **Superseded by ADR-0029 on this point.**
+  That rejection treated the judge's non-determinism as disqualifying; ADR-0029
+  shows it is a knob rather than a property — a continuous reward computed as the
+  expectation over the scoring-token distribution, averaged over `K` repeated
+  evaluations (variance `O(1/K)`) and `C` criteria, is reproducible enough to gate
+  on. The rest of this ADR is unaffected: ADR-0029 extends it and depends on the
+  trajectory-forwarding decided in axis 2.
+- **Fix fake-model false-green with a tool-call grader.** Rejected on the facts: the
+  fake emits a scripted `ToolUseBlock`, so it greens a tool-call grader exactly as it
+  greens a text grader. No grader kind can separate a scripted trajectory from a real
+  one by shape, which is why axis 3 decides it separately.
 - **Auto-commit promoted trace cases.** Rejected: a captured trajectory is a
   candidate assertion, not a verified one. A production run can be a run someone
-  *liked*, but "liked" is not "correct forever"; a human (or their coding agent)
-  must curate the assertion before it becomes a gate. `add-from-trace` proposes and
-  writes to the working tree; commit stays a reviewed act.
-- **Build the BYO-model matrix (#255) first, since parity across models is
-  compelling.** Rejected as a sequencing choice: a matrix over a text-only grader
-  multiplies a weak signal across more models. The taxonomy and tier-parity work
-  raise the signal quality that the matrix then amplifies, so the matrix lands last.
+  *liked*, but "liked" is not "correct forever"; a human (or their coding agent) must
+  curate the assertion before it becomes a gate. `add-from-trace` proposes and writes
+  to the working tree; commit stays a reviewed act.
+- **Build the BYO-model matrix first, since parity across models is compelling.**
+  Rejected as a sequencing choice: a matrix over a text-only grader multiplies a weak
+  signal across more models. The taxonomy work raises the signal quality that the
+  matrix then amplifies, so the matrix lands last.
 
 ## Consequences
 
-- **The parity claim becomes testable at all three tiers**, not just asserted. Once
-  Phase 1 ships, "the same evals stay green skill → local → cluster" (ADR-0021) is a
-  command a developer or coding agent can run, and a tier divergence is a real,
-  reproducible environment-bug signal.
 - **A green eval starts meaning "the agent did the work," not "a string appeared."**
   Tool-call and trajectory assertions grade the run rather than its last sentence,
-  which removes a class of false confidence rather than papering over it. This does
-  *not* extend to the fake-model path: since #337's fix the fake calls a scripted
-  tool, so it greens a tool-call grader too. Keeping a fake-model green from reading
-  as an agent-quality signal is an open problem (Phase 1 correction), and until it is
-  closed, a green on the fake-model CI path proves plumbing only.
+  which removes a class of false confidence rather than papering over it.
+- **The fake-model CI path stops minting agent-quality greens.** Axis 3 makes the
+  fake honest about what it is: a plumbing fixture whose green belongs to the
+  harness's test suite, not to an agent's eval history.
 - **New contract surface is incurred deliberately and in order.** Server-side
   grading and structured-result assertions touch the frozen ACI/eval contract; each
   is an escalate-first change (ADR-0005/0017), scoped to the phase that needs it, not
   smuggled in as a side channel. Phase 1 is chosen specifically because it adds the
   least contract surface.
-- **The eval suite becomes a living asset fed by production.** Trace → eval
+- **The eval suite becomes a living asset fed by production.** Trace to eval
   promotion means the highest-value cases accumulate from real runs, with provenance
-  back to the trace (#266) — the compounding loop epic #26 is aimed at.
+  back to the trace — the compounding loop epic #26 is aimed at. It also upgrades
+  promotion from its current weak default rather than leaving it as a `contains`
+  snippet generator.
+- **Built-but-unreachable code is treated as unbuilt.** The scorer seam's
+  `TrajectoryScorer` (#389) and the matrix's cost axis (#390) both shipped structurally
+  complete and functionally inert. This ADR counts a capability as done when a
+  runnable path reaches it, which is why both sit in Phase 4 rather than in the
+  built column.
 - **ADR-0019 stays intact.** The case *format* freeze holds: new grader kinds extend
   the enum through the same drift-gated schema mechanism, open-ended scorers plug in
   above the frozen port rather than inside it, and deny-by-default is preserved. This


### PR DESCRIPTION
Accepts ADR-0022 (eval completeness) and rewrites it so it can be handed to an implementer as-is. Every claim is verified against the tree rather than against the ADR's own prose.

## Why this is a rewrite and not a status flip

ADR-0022 was drafted 2026-07-13 and two of the issues it cites as broken closed the same day, hours later. Reviewing it against code turned up a load-bearing false premise, and since ADRs are immutable once Accepted, the correction had to land before the flip.

**Phase 1 no longer claims to close fake-model false-green.** The ADR argued a tool-call grader fixes it "because the fake never calls a tool." Since #337's fix, the fake's `default_turn` emits a scripted `ToolUseBlock(name="Bash")` (`runner/src/agentos_runner/fake.py`), so it greens a tool-call grader exactly as it greens a text grader. No grader kind can separate a scripted trajectory from a real one by shape. Fake-model honesty is now its own decided axis with a named default: don't record eval results from fake-model runs at all, since the fake is a plumbing fixture whose green belongs to the harness's test suite, not an agent's eval history.

## Other corrections

- Tier parity (#344) landed, so Phase 1 is now just the tool-call grader plus the fake-model rule.
- #255 closed with its "reports pass-rate + cost per model" AC only half met: the cost axis has no producer (#390) and no eval verb takes a model (#526).
- Trace promotion (#259) captures input + anonymization but grades with a `contains` on a capped output snippet and discards the trajectory, which is the weak-grader default this ADR exists to move off.
- Adds a **built / inert / not-built** table. Built-but-unreachable counts as unbuilt: #389's `TrajectoryScorer` and #390's cost axis are both structurally complete and functionally dead, and a reader seeing "closed" would skip them.
- Folds in the case-quality standard (#527) and eval-time model selection (#526).

## Relationship to ADR-0029

ADR-0029 supersedes **one paragraph** of this ADR: the rejection of an LLM judge inside the frozen `GraderKind` enum. It does not override tier parity, tool-call graders, trace promotion, or the fake-model axis, and it depends on the trajectory-forwarding decided here, so this ADR's Phase 1 is ADR-0029's prerequisite. Both ADRs now state the split by case type: deterministic graders assert what a trajectory makes checkable, ADR-0029's verifier judges semantic correctness, and multi-sample (#332) is what addresses run variance since that is the model's non-determinism rather than the grader's.

Note ADR-0029 is still `Proposed`. An implementer following the pointer from this ADR lands on an unratified decision.

Ref #26