### PR TITLE
Bound stream delivery with a cap and a dead-letter graveyard

### DIFF
--- a/apps/worker/CLAUDE.md
+++ b/apps/worker/CLAUDE.md
@@ -36,6 +36,41 @@ stop -- that is scope creep on the sacred module.
    still escalates on reclaim. Flag-clean failures retry by classification
    (`rate-limit`/`runner-error` transient, everything else escalates).
 
+## Delivery is bounded (ADR-0039, #505)
+
+The reclaim loop is **not** infinite. An entry already delivered `max_delivery`
+times (`AGENTOS_MAX_DELIVERY`, default 5, floor 2) is dead-lettered to
+`<stream>:dead` and acked off the group instead of re-dispatched. Unbounded
+reclaim let one permanently-failing entry starve the whole consumer group -- a
+silent total stall. Removing or bypassing the cap is that regression, not a
+simplification.
+
+- **The delivery count is read from the PEL every pass, never tracked in
+  process memory.** A process-local counter resets on restart, so a
+  crash-looping worker would retry poison forever -- the exact stall shape.
+- **Read the count with `XPENDING` *before* `XAUTOCLAIM`**, which bumps it on
+  claim; the pre-claim value is the budget already spent. Cap at `>=`. Keep the
+  `IDLE` filter equal to `XAUTOCLAIM`'s `min_idle_time`, and keep the
+  `_inflight_ids` skip ahead of the cap check.
+- **`XADD` before `XACK`, never the reverse.** A crash between them costs a
+  duplicate graveyard row; the reverse costs the entry.
+- **`max_delivery` is not `max_attempts`.** The latter is the kernel's
+  flag-clean retry *classification* inside one delivery. Do not conflate them.
+- **Transient failure is unchanged**: a mid-turn crash still reclaims, retries,
+  and acks. Only an exhausted budget dead-letters.
+- **The graveyard has no consumer group, but it IS bounded** by an approximate
+  `MAXLEN` (`AGENTOS_DEAD_LETTER_MAXLEN`, default 10000) on every `XADD`. The
+  unparseable path dead-letters per inbound entry, so an unbounded graveyard hands
+  a wire-DTO drift a full-ingest-rate OOM against the same Valkey that holds the
+  kernel's locks and markers. Rows are therefore **best-effort**: under a flood the
+  oldest are evicted. Do not treat the graveyard as a complete audit log, and do
+  not add a consumer group, a retention policy, or replay tooling as a passenger
+  on another change.
+- **A dead-letter stream equal to the source stream is rejected at config
+  validation.** `XADD` precedes `XACK`, so a self-targeting graveyard re-queues
+  failures onto the stream they came from and hot-loops. Do not soften that
+  validator into a warning.
+
 ## The sandbox substrate (`agentos_worker.sandbox`)
 
 - **The kernel talks in `thread_key` and `SandboxHandle` only.** Everything

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -182,11 +182,96 @@ Rules (detailed-architecture 2b), each with an integration test that provokes it
   a redelivered or reclaimed entry that already finished is skipped.
   `XAUTOCLAIM` reclaims entries a dead consumer took but never acked and
   reprocesses them; the markers make that safe.
+- **Bounded delivery + a dead-letter graveyard** (ADR-0039, #505). Reclaim is
+  capped, not infinite. An entry already delivered `max_delivery` times
+  (`AGENTOS_MAX_DELIVERY`, default 5, floor 2) and still failing is moved to a
+  dead-letter stream and acked off the group instead of re-dispatched, so it can
+  never be reclaimed again. Without the cap one permanently-failing entry -- for
+  example a turn whose reply endpoint died with the process that created it --
+  is reclaimed forever, starves the shared consumer group, and silently stalls
+  every later turn. **Transient failures are unaffected:** a worker that crashes
+  mid-turn still has its entry reclaimed, retried, and acked exactly as before;
+  only an exhausted delivery budget dead-letters.
+
+### The dead-letter graveyard
+
+The dead-letter stream is `AGENTOS_DEAD_LETTER_STREAM`, or `<stream>:dead`
+(`agentos:runs:dead`) when that is unset. Setting it **equal to** `AGENTOS_STREAM`
+is rejected at startup: the worker XADDs to the graveyard before it XACKs, so a
+self-targeting graveyard would re-queue every failure onto the stream it was
+consumed from and hot-loop on an unparseable one. The derived default can never
+collide, so only an explicit override trips this.
+
+The first `XADD` creates the stream; nothing pre-creates it. It is a sink, **not**
+a second processing lane: it has no consumer group, and nothing reads it
+automatically. Replay, if an operator wants it, is `XRANGE` plus a re-`XADD` onto
+the main stream.
+
+**The graveyard is bounded, and its rows are best-effort.** Every `XADD` passes an
+approximate `MAXLEN` of `AGENTOS_DEAD_LETTER_MAXLEN` (default `10000`, minimum
+`1`), so under a flood the oldest rows are evicted and those failures are lost.
+That loss is deliberate: the unparseable path dead-letters per **inbound** entry,
+so a wire-format drift would otherwise grow the graveyard at full ingest rate on
+the same Valkey that holds the kernel's per-thread locks and side-effect markers,
+i.e. a platform-wide OOM. Bounded record loss is traded against that. Do not treat
+the graveyard as a durable audit log. Because the trim is approximate (Valkey trims
+on node boundaries), the stream is bounded at *at least* the configured length, not
+exactly it. Below the cap it holds every dead-lettered entry, and its length reads
+the system's poison rate, saturating rather than growing once the bound is hit.
+
+Each graveyard row carries the original entry's fields verbatim plus namespaced
+failure metadata, so a human or a replay tool can inspect exactly what died and
+why:
+
+| Field | Meaning |
+|---|---|
+| `dl_original_id` | the entry's id on the source stream |
+| `dl_delivery_count` | deliveries made before it was given up on |
+| `dl_reason` | `max delivery exceeded`, or `unparseable` |
+| `dl_dead_lettered_at` | UTC ISO-8601 timestamp |
+
+The `dl_` prefix keeps the metadata namespaced, but the unparseable path stores
+an arbitrary, malformed field map verbatim, so an original field could itself be
+named `dl_something` and collide with one of the four keys above.
+`Consumer._dead_letter` escapes any original key already starting with `dl_`
+by doubling the prefix (`dl_reason` in the original becomes `dl_dl_reason` in
+the row) before writing the metadata last. The escape is injective: an escaped key
+always starts with `dl_dl_`, so it can never collide with the metadata, and
+un-escaping strips exactly one leading `dl_`. Nothing reads the graveyard
+today, so this costs nothing yet, but anything that later does (replay
+tooling, a dashboard, alerting) must strip one leading `dl_` to recover an
+original field whose name collided, or it will silently misread it.
+
+An entry that is pending while its message has been trimmed off the source
+stream produces a metadata-only row and is still acked. Every dead-letter
+emits a loud error log naming the entry, its delivery count, the reason, and
+the target stream.
+
+Two behaviors worth knowing before changing this path. The delivery count is read
+from Valkey's pending-entries list on every pass rather than tracked in worker
+memory, so a restarted or replacement worker still sees the accumulated count and
+still caps; a process-local counter would reset on restart and let a crash-looping
+worker retry poison forever. And the `XADD` to the graveyard happens before the
+`XACK`, so a crash between the two costs a duplicate graveyard row rather than a
+lost entry. Two replicas racing the same over-cap entry produce the same
+acceptable duplicate.
+
+**Unparseable entries take the same route** (`dl_reason="unparseable"`) instead of
+being silently acked away, so poison is observable rather than vanishing.
+
+**`AGENTOS_MAX_DELIVERY` is not `AGENTOS_MAX_ATTEMPTS`.** The delivery cap bounds
+how many times a stream entry may be handed to a handler; `max_attempts` governs
+the kernel's flag-clean per-turn retry classification *inside* a single delivery.
+The floor of 2 is enforced because `max_delivery=1` would dead-letter every
+ordinary worker crash on its first reclaim; values below 3 undermine the crash
+recovery of ADR-0013.
 
 Config surface (`WorkerConfig`): `VALKEY_*`, `SLACK_BOT_TOKEN`,
 `AGENTOS_STREAM` / `AGENTOS_CONSUMER_GROUP` / `AGENTOS_CONSUMER_NAME`,
-`AGENTOS_MAX_ATTEMPTS`, plus `AGENTOS_NAMESPACE` / `AGENTOS_WARM_POOL` /
-`AGENTOS_RUNNER_PORT` for the substrate. Run with `python -m agentos_worker`.
+`AGENTOS_MAX_ATTEMPTS`, `AGENTOS_MAX_DELIVERY` / `AGENTOS_DEAD_LETTER_STREAM` /
+`AGENTOS_DEAD_LETTER_MAXLEN` (approximate graveyard cap, default `10000`, minimum
+`1`), plus `AGENTOS_NAMESPACE` / `AGENTOS_WARM_POOL` / `AGENTOS_RUNNER_PORT` for
+the substrate. Run with `python -m agentos_worker`.
 
 Tests: `uv run pytest apps/worker/tests/kernel -q` runs against the real Valkey
 from `compose.dev.yaml`, the real sandbox substrate with a fake Kubernetes client whose

--- a/apps/worker/src/agentos_worker/broker.py
+++ b/apps/worker/src/agentos_worker/broker.py
@@ -39,9 +39,12 @@ class StreamBroker(Protocol):
     """The consumer-side stream contract: group semantics + crash recovery.
 
     A second broker must honor: an ordered stream, consumer groups
-    (``xgroup_create`` / ``xreadgroup``), per-entry ack (``xack``), and
-    pending-entry reclaim for crash recovery (``xautoclaim``). Dedupe lives on the
-    producer side (``StreamPublisher``), beside the stream, not in these verbs.
+    (``xgroup_create`` / ``xreadgroup``), per-entry ack (``xack``), pending-entry
+    reclaim for crash recovery (``xautoclaim``), and — since the delivery cap
+    (#505) — inspection of the pending list's delivery counts
+    (``xpending_range``), entry lookup (``xrange``), and append (``xadd``) to move
+    an over-cap entry to the dead-letter stream. Dedupe lives on the producer side
+    (``StreamPublisher``), beside the stream, not in these verbs.
 
     The verbs are declared to return a bare ``Awaitable`` (not ``async def``) to
     match how ``redis.asyncio.Redis`` types them, so the real client structurally
@@ -80,4 +83,41 @@ class StreamBroker(Protocol):
         justid: bool = ...,
     ) -> Awaitable[Any]:
         """Reclaim entries pending past ``min_idle_time`` from a dead consumer."""
+        ...
+
+    def xpending_range(
+        self,
+        name: Any,
+        groupname: Any,
+        min: Any,
+        max: Any,
+        count: Any,
+        consumername: Any = ...,
+        idle: Any = ...,
+    ) -> Awaitable[Any]:
+        """Pending entries with their delivery counts — the delivery cap's input."""
+        ...
+
+    def xrange(
+        self, name: Any, min: Any = ..., max: Any = ..., count: Any = ...
+    ) -> Awaitable[Any]:
+        """Read entries by id range; fetches an over-cap entry's original fields."""
+        ...
+
+    def xadd(
+        self,
+        name: Any,
+        fields: Any,
+        id: Any = ...,
+        maxlen: Any = ...,
+        approximate: bool = ...,
+    ) -> Awaitable[Any]:
+        """Append an entry — the dead-letter stream's write verb.
+
+        ``maxlen``/``approximate`` are part of the contract, not an optimization:
+        the dead-letter write is bounded (#505) so a flood of unparseable entries
+        cannot grow the graveyard without limit on the same Valkey the kernel's
+        locks and markers live on. A second broker must honor a bounded append
+        (exact trimming is allowed; ``approximate`` only permits trimming late).
+        """
         ...

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -19,7 +19,7 @@ import os
 import socket
 from typing import Annotated
 
-from pydantic import BeforeValidator, Field
+from pydantic import BeforeValidator, Field, model_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic_settings.sources import (
@@ -168,6 +168,68 @@ class WorkerConfig(BaseSettings):
         validation_alias="AGENTOS_CONSUMER_NAME",
     )
 
+    # Delivery cap + dead-letter graveyard (#505). ``max_delivery`` is the maximum
+    # number of times a stream entry may be DELIVERED to a handler before it is
+    # moved to the dead-letter stream and acked off the group. It is NOT
+    # ``max_attempts`` below: that governs the kernel's flag-clean per-turn retry
+    # *classification* (a completely different mechanism operating inside a single
+    # delivery). Conflating the two silently changes kernel retry behavior.
+    #
+    # The count is read from Valkey's pending-entries list, so it is durable: a
+    # restarted worker sees the accumulated count and still caps. The floor is 2
+    # because ``max_delivery=1`` would dead-letter every ordinary worker crash on
+    # its first reclaim, and values below 3 undermine ADR-0013 crash recovery
+    # (which relies on a reclaim actually retrying the entry).
+    #
+    # Leave headroom above what a HEALTHY turn can legitimately burn. A single
+    # delivery may span up to ``max_attempts * runner_total_timeout_s`` (~1800s
+    # at defaults, see the retry knobs below), which exceeds
+    # ``reclaim_min_idle_ms`` (900s), so another replica can reclaim a turn that
+    # is still working and bump its delivery count. A healthy long turn can
+    # therefore accrue roughly
+    # ``(max_attempts * runner_total_timeout_s) / reclaim_min_idle_ms`` (~2 at
+    # defaults) deliveries on its own. ``max_delivery`` must stay comfortably
+    # above that: at the ``ge=2`` floor a slow but healthy turn could be
+    # dead-lettered while it is still making progress.
+    max_delivery: int = Field(default=5, ge=2, validation_alias="AGENTOS_MAX_DELIVERY")
+    # Empty means "derive ``<stream>:dead``" at the use site; a static Field
+    # default cannot reference ``self.stream``. An explicit override equal to
+    # ``stream`` is rejected outright -- see ``_reject_self_targeting_graveyard``.
+    dead_letter_stream: str = Field(
+        default="", validation_alias="AGENTOS_DEAD_LETTER_STREAM"
+    )
+    # The graveyard is capped with an approximate MAXLEN on every XADD. The
+    # unparseable-poison path dead-letters per INBOUND entry, so a wire-format
+    # drift that makes entries unparseable en masse would otherwise grow the
+    # graveyard at full ingest rate -- on the same Valkey that holds the kernel's
+    # per-thread locks and side-effect markers, i.e. a platform-wide OOM. The
+    # trade is deliberate and lossy: under a flood the oldest dead-letter rows are
+    # evicted, so graveyard records are best-effort, not a durable audit log.
+    dead_letter_maxlen: int = Field(
+        default=10000, ge=1, validation_alias="AGENTOS_DEAD_LETTER_MAXLEN"
+    )
+
+    @model_validator(mode="after")
+    def _reject_self_targeting_graveyard(self) -> WorkerConfig:
+        """Fail at construction if the graveyard points back at the source stream.
+
+        ``_dead_letter`` XADDs the original payload to the dead-letter stream and
+        only then XACKs it. If that target IS the source stream, the payload is
+        re-queued to the very stream it was consumed from: a valid failure gets
+        re-consumed under a fresh entry id, and an unparseable one forms a hot
+        loop that re-creates the permanent stall the delivery cap exists to
+        prevent. Rejecting at config/startup means an operator learns at boot
+        rather than during an incident; the derived ``<stream>:dead`` default can
+        never collide, so only an explicit override trips this.
+        """
+        if self.dead_letter_stream and self.dead_letter_stream == self.stream:
+            raise ValueError(
+                "AGENTOS_DEAD_LETTER_STREAM must not equal AGENTOS_STREAM "
+                f"({self.stream!r}): dead-lettering onto the source stream "
+                "re-queues failures forever"
+            )
+        return self
+
     # Read loop
     read_count: int = 16
     read_block_ms: int = 5000
@@ -194,11 +256,20 @@ class WorkerConfig(BaseSettings):
     idempotency_ttl_s: int = 86400
 
     # Crash recovery: reclaim stream entries pending longer than this, and run
-    # the orphan-claim reaper, on this cadence. The idle threshold must exceed the
-    # longest legitimate in-flight time (a turn can stream up to
-    # runner_total_timeout_s, 600s) so the reaper never reclaims an entry a live
-    # turn is still processing; the consumer additionally skips its own in-flight
-    # entry ids as a second guard.
+    # the orphan-claim reaper, on this cadence.
+    #
+    # This window does NOT cover the longest legitimate in-flight time. One
+    # delivery is not one runner call: the kernel may retry a flag-clean failure
+    # up to max_attempts (3) times WITHIN a single delivery, each bounded by
+    # runner_total_timeout_s (600s), so a healthy delivery can legitimately span
+    # up to ~max_attempts * runner_total_timeout_s = ~1800s -- twice this 900s
+    # idle threshold. A long healthy turn can therefore be reclaimed by another
+    # replica and accrue delivery count (see max_delivery's headroom note above).
+    # The consumer skips its OWN in-flight entry ids, so this only bites across
+    # replicas; that cross-replica dup-dispatch is pre-existing and tracked
+    # separately. Raising this threshold past
+    # max_attempts * runner_total_timeout_s would close it at the cost of slower
+    # crash recovery.
     reclaim_min_idle_ms: int = 900000
     reclaim_interval_s: float = 30.0
 
@@ -281,3 +352,13 @@ class WorkerConfig(BaseSettings):
 
     def lock_key(self, thread_key: str) -> str:
         return f"{self.key_prefix}:lock:{thread_key}"
+
+    def dead_letter_stream_name(self) -> str:
+        """The graveyard stream: the explicit override, else derived ``<stream>:dead``.
+
+        ``dead_letter_stream``'s Field default cannot reference ``self.stream``,
+        so the derivation lives here rather than at the use site -- next to the
+        other derived names, and next to ``_reject_self_targeting_graveyard``,
+        which reasons about the same name.
+        """
+        return self.dead_letter_stream or f"{self.stream}:dead"

--- a/apps/worker/src/agentos_worker/consumer.py
+++ b/apps/worker/src/agentos_worker/consumer.py
@@ -9,14 +9,36 @@ marker) and the side-effect marker blocks auto-retry of a half-run action.
 
 Entries are dispatched concurrently across threads (bounded by a semaphore); the
 kernel serializes within a thread. A successfully handled entry is acked; an
-entry that raises is left pending for the next reclaim; an unparseable entry is
-acked (a poison message must not be reclaimed forever).
+entry that raises is left pending for the next reclaim.
+
+Delivery is **bounded** (#505). Reclaim-and-retry is not infinite: an entry that
+has already been delivered ``max_delivery`` times and still failed is moved to a
+dead-letter stream (``<stream>:dead`` by default) with its original fields plus
+``dl_*`` failure metadata, then acked off the group. Without that cap a
+permanently-failing entry (the motivating case: a reply POST to a CLI stub URL
+that was persisted into a durable approval and is now a dead port) is reclaimed
+and re-dispatched forever, silently stalling the whole consumer group. An
+unparseable entry takes the same route (``reason="unparseable"``) so poison is
+observable instead of being silently acked into the void.
+
+The graveyard itself is capped (approximate ``MAXLEN``, ``dead_letter_maxlen``):
+the unparseable path fires per INBOUND entry, so an unbounded graveyard would
+grow at full ingest rate on the Valkey the kernel's locks and markers live on.
+Dead-letter rows are therefore best-effort -- bounded loss traded against a
+platform-wide OOM.
+
+The delivery count is read from Valkey's pending-entries list on every pass and
+is NEVER tracked in a process-local dict: the PEL counter is durable, so a
+restarted or replacement worker still sees the accumulated count and still caps.
+A process-local counter would reset on restart and let a crash-looping worker
+retry a poison entry forever -- the exact stall this cap exists to end.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 from typing import cast
 
 from agentos_dispatcher.queue import from_stream_fields
@@ -31,6 +53,15 @@ logger = logging.getLogger(__name__)
 # Pause before retrying the blocking stream read after a transient transport
 # error, so a briefly-unreachable Valkey does not spin the read loop hot.
 _READ_ERROR_BACKOFF_S = 0.5
+
+# XPENDING page size for the over-cap scan in ``_dead_letter_over_cap``.
+# Deliberately NOT ``read_count``: that knob bounds how many entries the READ
+# loop dispatches concurrently, whereas this scan dispatches nothing -- it is a
+# pure metadata read that discards every under-cap row. Paging it at dispatch
+# granularity costs one sequential round-trip per ``read_count`` entries, so a
+# large backlog pages for no reason. A healthy tick is unaffected either way:
+# the IDLE filter plus the empty-page early-out make it a single round-trip.
+_CAP_SCAN_PAGE = 1000
 
 
 class Consumer(StreamConsumer):
@@ -113,8 +144,13 @@ class Consumer(StreamConsumer):
             try:
                 qevent = from_stream_fields(fields)
             except Exception:
-                logger.exception("unparseable stream entry %s; acking as poison", entry_id)
-                await self._ack(entry_id)
+                logger.exception("unparseable stream entry %s; dead-lettering", entry_id)
+                await self._dead_letter(
+                    entry_id,
+                    fields,
+                    reason="unparseable",
+                    delivery_count=await self._pending_delivery_count(entry_id),
+                )
                 return
             try:
                 await self._kernel.process_event(qevent)
@@ -130,6 +166,104 @@ class Consumer(StreamConsumer):
     async def _ack(self, entry_id: str) -> None:
         await self._xack(self._config.stream, self._config.consumer_group, entry_id)
 
+    async def _pending_delivery_count(self, entry_id: str) -> int:
+        """This entry's CURRENT delivery count, read from the PEL.
+
+        The unparseable path reaches here from the read loop OR from a reclaim:
+        an entry can be delivered, have its worker crash before it ever parses,
+        and be reclaimed -- so its count is 2+ by the time it is dead-lettered.
+        Hardcoding 1 would fabricate the graveyard's ``dl_delivery_count``
+        precisely during crash recovery, when the evidence matters most. Read
+        from the PEL, never a process-local counter, for the same durability
+        reason the cap does. Falls back to 1 only if the row has vanished (it was
+        delivered to us at least once), which is the honest floor rather than a
+        guess.
+        """
+        rows = await self._redis.xpending_range(
+            self._config.stream,
+            self._config.consumer_group,
+            min=entry_id,
+            max=entry_id,
+            count=1,
+        )
+        return int(rows[0]["times_delivered"]) if rows else 1
+
+    # -- dead letter ----------------------------------------------------------
+
+    @property
+    def _dead_letter_stream(self) -> str:
+        return self._config.dead_letter_stream_name()
+
+    async def _dead_letter(
+        self,
+        entry_id: str,
+        fields: dict[str, str] | None,
+        *,
+        reason: str,
+        delivery_count: int,
+    ) -> None:
+        """Move an entry to the graveyard and ack it off the main group.
+
+        ``fields`` are the original entry's fields, kept verbatim so a human or a
+        replay tool can inspect them; ``None`` writes a metadata-only row (the
+        entry was pending but its message had been trimmed off the stream).
+
+        The ``dl_`` prefix is a CONVENTION, not a guarantee: the unparseable path
+        accepts arbitrary malformed field maps, so an entry may already carry its
+        own ``dl_original_id``. A plain copy-then-update would let the payload
+        forge (or be silently clobbered by) the graveyard's own metadata. Original
+        keys already starting with ``dl_`` are therefore escaped by doubling the
+        prefix (``dl_reason`` -> ``dl_dl_reason``) before the metadata is written
+        last. The escape is injective -- escaped keys always start with ``dl_dl_``
+        and so can never equal a metadata key, and un-escaping strips exactly one
+        ``dl_`` -- so the metadata always wins AND the original is fully
+        recoverable.
+
+        XADD before XACK, deliberately: a crash between the two leaves the entry
+        pending, so it is re-reclaimed and re-dead-lettered -- a duplicate
+        graveyard row, which is strictly safer than the XACK-first ordering's
+        failure mode (a lost entry). Two replicas racing the same over-cap entry
+        produce the same acceptable duplicate.
+
+        The XADD is bounded by an approximate ``dead_letter_maxlen``, so
+        graveyard rows are BEST-EFFORT: under a flood the oldest rows are evicted
+        and those failures are lost. That loss is deliberate. The unparseable
+        path dead-letters per inbound entry, so a wire-format drift would grow an
+        unbounded graveyard at full ingest rate on the same Valkey that holds the
+        kernel's locks and side-effect markers -- bounded record loss is traded
+        against a platform-wide OOM. ``approximate=True`` lets Valkey trim on
+        node boundaries, so the stream is bounded at *at least* the configured
+        length, not exactly it.
+        """
+        target = self._dead_letter_stream
+        # Escape the original's own ``dl_*`` keys (see above) so the metadata
+        # written last always wins and the original stays recoverable.
+        payload: dict[str, str] = {
+            (f"dl_{k}" if k.startswith("dl_") else k): v for k, v in (fields or {}).items()
+        }
+        payload.update(
+            {
+                "dl_original_id": entry_id,
+                "dl_delivery_count": str(delivery_count),
+                "dl_reason": reason,
+                "dl_dead_lettered_at": datetime.now(UTC).isoformat(),
+            }
+        )
+        await self._redis.xadd(
+            target,
+            payload,
+            maxlen=self._config.dead_letter_maxlen,
+            approximate=True,
+        )
+        logger.error(
+            "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
+            entry_id,
+            delivery_count,
+            reason,
+            target,
+        )
+        await self._ack(entry_id)
+
     # -- maintenance loop -----------------------------------------------------
 
     async def _maintenance_loop(self) -> None:
@@ -142,7 +276,15 @@ class Consumer(StreamConsumer):
             await self._sleep_or_stop(self._config.reclaim_interval_s)
 
     async def _reclaim_once(self) -> int:
-        """Reclaim entries pending too long from any (dead) consumer and retry."""
+        """Reclaim entries pending too long from any (dead) consumer and retry.
+
+        Entries that have already exhausted their delivery budget are
+        dead-lettered first, so they are never claimed or re-dispatched again.
+        XAUTOCLAIM still claims an over-cap entry whose dead-letter failed (it is
+        still pending), so the ids it reports are skipped rather than dispatched:
+        the cap binds even when the graveyard is unwritable.
+        """
+        over_cap = await self._dead_letter_over_cap()
         reclaimed = 0
         cursor: str = "0-0"
         while not self._stop.is_set():
@@ -159,8 +301,88 @@ class Consumer(StreamConsumer):
             for entry_id, fields in entries:
                 if entry_id in self._inflight_ids:
                     continue  # still being processed here; not an orphan
+                if entry_id in over_cap:
+                    continue  # budget spent; never dispatch it again
                 reclaimed += 1
                 await self._dispatch(entry_id, fields)
             if cursor in ("0-0", "0"):
                 break
         return reclaimed
+
+    async def _dead_letter_over_cap(self) -> set[str]:
+        """Dead-letter pending entries that have exhausted their delivery budget.
+
+        Returns every over-cap id seen this pass -- including ones whose
+        dead-letter failed -- so the caller never re-dispatches them.
+
+        Read the delivery count with XPENDING *before* XAUTOCLAIM rather than
+        after, because XAUTOCLAIM increments the counter as it claims: the
+        pre-claim value is the number of deliveries ALREADY made, so an entry at
+        ``>= max_delivery`` has had its full budget and must not be claimed
+        again. Reading post-claim would fold in the current claim's own bump and
+        kill the entry one delivery early.
+
+        The scan PAGES THROUGH THE WHOLE pending list (``min`` advanced past the
+        last id seen), because XAUTOCLAIM below pages through all of it too: a
+        single ``COUNT _CAP_SCAN_PAGE`` page would cap-check only the head of the
+        list while XAUTOCLAIM happily claimed and dispatched the over-cap tail,
+        so the bound would silently not hold at backlog scale.
+
+        The IDLE filter matches XAUTOCLAIM's ``min_idle_time`` so both see the
+        same candidate set and an entry that is not yet reclaim-eligible is never
+        prematurely dead-lettered.
+
+        A failure to dead-letter ONE entry is logged and isolated: it must not
+        stop the other entries being cap-checked, nor XAUTOCLAIM, nor
+        ``reap_orphans``. This is the first await of the maintenance tick, and an
+        unguarded raise here would kill crash recovery for the whole group on
+        every tick -- #505's own stall class.
+        """
+        over_cap: set[str] = set()
+        page_size = _CAP_SCAN_PAGE
+        cursor = "-"
+        while True:
+            pending = await self._redis.xpending_range(
+                self._config.stream,
+                self._config.consumer_group,
+                min=cursor,
+                max="+",
+                count=page_size,
+                idle=self._config.reclaim_min_idle_ms,
+            )
+            if not pending:
+                break
+            for row in pending:
+                entry_id = str(row["message_id"])
+                # An entry in flight on THIS consumer is not an orphan: it is
+                # being worked right now, and its count must not be judged. This
+                # guard stays ahead of the cap check.
+                if entry_id in self._inflight_ids:
+                    continue
+                delivered = int(row["times_delivered"])
+                if delivered < self._config.max_delivery:
+                    continue
+                over_cap.add(entry_id)
+                try:
+                    await self._dead_letter_over_cap_entry(entry_id, delivered)
+                except Exception:
+                    logger.exception(
+                        "dead-lettering entry %s failed; left pending, not dispatched",
+                        entry_id,
+                    )
+            if len(pending) < page_size:
+                break
+            # Exclusive lower bound: resume after the last id of this page.
+            cursor = f"({pending[-1]['message_id']}"
+        return over_cap
+
+    async def _dead_letter_over_cap_entry(self, entry_id: str, delivered: int) -> None:
+        # XPENDING returns no fields; fetch the original payload. The id can be
+        # pending while its message was trimmed off the stream, in which case
+        # XRANGE comes back empty -> a metadata-only graveyard row, and the XACK
+        # still happens (skipping it would leave the stall in place).
+        found = await self._redis.xrange(self._config.stream, min=entry_id, max=entry_id)
+        fields = cast("list[StreamEntry]", found)[0][1] if found else None
+        await self._dead_letter(
+            entry_id, fields, reason="max delivery exceeded", delivery_count=delivered
+        )

--- a/apps/worker/tests/kernel/test_consumer_dead_letter.py
+++ b/apps/worker/tests/kernel/test_consumer_dead_letter.py
@@ -1,0 +1,821 @@
+"""Dead-letter tests: a permanently-failing entry is bounded by a delivery cap
+instead of being reclaimed and re-dispatched forever (#505).
+
+Against the real Valkey stream + consumer group, like ``test_consumer.py``.
+
+Valkey delivery-count semantics, pinned empirically against the live Valkey
+(localhost:26379) before these tests were written -- the Implementer MUST build
+to the same understanding:
+
+  * ``XADD`` alone puts nothing in the PEL; ``times_delivered`` does not exist
+    until an entry is delivered to a consumer.
+  * The FIRST ``XREADGROUP ... >`` delivery creates the PEL entry with
+    ``times_delivered == 1``. So the counter is a count of deliveries ALREADY
+    MADE, not of retries remaining.
+  * Every ``XAUTOCLAIM`` (and ``XREADGROUP ... 0`` pending-replay) INCREMENTS
+    ``times_delivered`` by exactly 1, and ``XPENDING`` reports the POST-claim
+    value. Observed: XREADGROUP -> 1, XAUTOCLAIM -> 2, -> 3, -> 4.
+
+The consequence for the cap: reading ``times_delivered`` via ``XPENDING``
+*before* the claim yields the number of deliveries already made, so the cap
+check is ``times_delivered >= max_delivery`` -> dead-letter without claiming.
+Reading it *after* an ``XAUTOCLAIM`` would already include the current claim's
+bump and needs ``>``. These tests are written against the XPENDING-first shape
+the plan recommends, but they assert only on the OBSERVABLE contract -- the
+number of times the handler is invoked -- so either implementation shape passes
+as long as the boundary is right.
+
+The contract these tests pin: ``max_delivery`` is the maximum number of times an
+entry may be DELIVERED to a handler. Once an entry has been delivered
+``max_delivery`` times and still failed, the next reclaim dead-letters it
+instead of re-dispatching.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import Any
+
+import agentos_worker.consumer as consumer_module
+import pytest
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus
+from agentos_dispatcher.queue import to_stream_fields
+from agentos_worker.config import WorkerConfig
+from agentos_worker.consumer import Consumer
+from pydantic import ValidationError
+
+DONE = SessionStatus.DONE
+
+
+def _qevent(text: str, *, thread: str, event_id: str) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id,
+        conversation_id=thread,
+        author="U1",
+        text=text,
+        # The #505 shape: a reply endpoint that is durably persisted but dead.
+        reply_handle=ReplyHandle(channel="C1", placeholder="p-1", endpoint="http://localhost:8155/api/"),
+        received_at="2026-07-05T00:00:00+00:00",
+    )
+
+
+def _dead_stream(config: WorkerConfig) -> str:
+    """The graveyard name, asked of the config rather than re-derived here.
+
+    Re-deriving ``<stream>:dead`` in the test would mirror the implementation, so
+    a change to the derivation would move both sides together and the suite would
+    never notice. Calling the same helper the consumer calls means these tests
+    fail loudly if the name changes.
+    """
+    return config.dead_letter_stream_name()
+
+
+async def _deliver_new(consumer: Consumer, h) -> int:
+    """Take initial delivery as THIS consumer and dispatch, exactly as the read
+    loop does -- so every delivery corresponds to one handler invocation.
+
+    Driving the read loop by hand (rather than ``consumer.run()``) keeps the
+    reclaim count deterministic: ``run()``'s maintenance loop would reclaim on
+    its own timer and race the assertions.
+    """
+    delivered = await h.async_redis.xreadgroup(
+        h.config.consumer_group,
+        h.config.consumer_name,
+        {h.config.stream: ">"},
+        count=10,
+    )
+    n = 0
+    for _stream, entries in delivered or []:
+        for entry_id, fields in entries:
+            await consumer._dispatch(entry_id, fields)
+            n += 1
+    await asyncio.gather(*list(consumer._inflight))
+    return n
+
+
+async def _reclaim_and_settle(consumer: Consumer) -> None:
+    await consumer._reclaim_once()
+    await asyncio.gather(*list(consumer._inflight))
+
+
+async def _pending_rows(h) -> dict[str, int]:
+    """Every pending entry id -> its current ``times_delivered``."""
+    rows = await h.async_redis.xpending_range(
+        h.config.stream,
+        h.config.consumer_group,
+        min="-",
+        max="+",
+        count=50,
+    )
+    return {row["message_id"]: int(row["times_delivered"]) for row in rows}
+
+
+async def _pending_ids(h) -> set[str]:
+    return set(await _pending_rows(h))
+
+
+async def _dead_rows(h) -> list[tuple[str, dict[str, str]]]:
+    return await h.async_redis.xrange(_dead_stream(h.config))
+
+
+def test_permanently_failing_entry_is_dead_lettered_at_the_cap_and_group_progresses(
+    make_harness,
+) -> None:
+    """A poison entry is dead-lettered after exactly ``max_delivery`` handler
+    invocations, and a healthy entry alongside it still completes (the
+    head-of-line proof: the poison never stalls the group).
+    """
+
+    async def go() -> None:
+        async with make_harness(max_delivery=3, reclaim_min_idle_ms=0) as h:
+            h.runner.default_script = [Final(text="answer", status=DONE)]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            # The controllable-failure seam: process_event raises forever for the
+            # poison event (the #505 dead-endpoint shape -- the reply POST to the
+            # long-gone CLI stub raises out of the kernel), and delegates to the
+            # real kernel for the healthy one.
+            real_process = h.kernel.process_event
+            calls: dict[str, int] = {"poison": 0, "healthy": 0}
+
+            async def counting(qevent: QueuedTurn) -> None:
+                calls[qevent.event_id] += 1
+                if qevent.event_id == "poison":
+                    raise RuntimeError("simulated dead reply endpoint")
+                await real_process(qevent)
+
+            h.kernel.process_event = counting  # type: ignore[method-assign,assignment]
+
+            poison = _qevent("poison turn", thread="tdl-poison", event_id="poison")
+            healthy = _qevent("healthy turn", thread="tdl-healthy", event_id="healthy")
+            poison_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(poison))
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(healthy))
+
+            try:
+                # Delivery #1 for both: the healthy entry succeeds and acks; the
+                # poison entry raises and is left pending.
+                assert await _deliver_new(consumer, h) == 2
+
+                # Reclaim until the poison entry leaves the main group's PEL --
+                # bounded well above the cap so a missing cap fails the test by
+                # assertion, not by hanging forever.
+                for _ in range(12):
+                    if poison_id not in await _pending_ids(h):
+                        break
+                    await _reclaim_and_settle(consumer)
+
+                # AC-1: the poison entry is on the graveyard, with the original
+                # payload preserved verbatim plus namespaced failure metadata.
+                rows = await _dead_rows(h)
+                assert len(rows) == 1, f"expected exactly one dead-letter row, got {rows}"
+                _dl_id, dl = rows[0]
+                assert dl["dl_original_id"] == poison_id
+                assert dl["dl_delivery_count"] == "3"
+                assert dl["dl_reason"]
+                assert dl["dl_dead_lettered_at"]
+                # The original entry fields survive so a human can inspect/replay.
+                # The frozen #7 wire encoding is a single JSON blob under
+                # "payload" (agentos_dispatcher.queue.to_stream_fields), not
+                # flat top-level fields, so decode it before asserting.
+                payload = json.loads(dl["payload"])
+                assert payload["event_id"] == "poison"
+                assert payload["text"] == "poison turn"
+
+                # AC-1: and it is gone from the main group's PEL, so it is never
+                # reclaimed again.
+                assert poison_id not in await _pending_ids(h)
+
+                # AC-5 / the exact boundary: the handler ran exactly max_delivery
+                # times -- not one fewer (dying early would break crash recovery),
+                # not one more (an off-by-one in the cap).
+                assert calls["poison"] == 3
+
+                # AC-2, the head-of-line proof and the issue's core severity: the
+                # healthy entry enqueued alongside the poison one was processed to
+                # completion, and the group's PEL is now empty -- forward progress,
+                # no stall.
+                assert h.runner.opened == ["healthy turn"]
+                assert h.sink.last_text == "answer"
+                assert calls["healthy"] == 1
+                summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+                assert summary["pending"] == 0
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_transient_failure_reclaims_and_acks_without_dead_lettering(
+    make_harness,
+) -> None:
+    """The cap must not break ADR-0013 crash recovery: a failure that stops
+    failing is retried by reclaim and eventually acked, never dead-lettered.
+
+    Deliberately set at the boundary (``max_delivery=3``, succeeding on delivery
+    #3) so this pins the cap from the opposite side to test 1: the LAST permitted
+    delivery must still happen. An implementation that reads the delivery count
+    AFTER ``XAUTOCLAIM``'s own bump and still compares ``>=`` would kill the entry
+    one delivery early and fail here, while test 1 (which catches a cap that runs
+    one delivery too long) would still pass. Together they nail the off-by-one.
+    """
+
+    async def go() -> None:
+        async with make_harness(max_delivery=3, reclaim_min_idle_ms=0) as h:
+            h.runner.default_script = [Final(text="recovered", status=DONE)]
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            # Fails the first two deliveries (a worker crash / transient blip),
+            # then the real kernel handles it on delivery #3 -- the last delivery
+            # max_delivery=3 permits.
+            real_process = h.kernel.process_event
+            calls = {"n": 0}
+
+            async def flaky(qevent: QueuedTurn) -> None:
+                calls["n"] += 1
+                if calls["n"] <= 2:
+                    raise RuntimeError("simulated transient failure")
+                await real_process(qevent)
+
+            h.kernel.process_event = flaky  # type: ignore[method-assign,assignment]
+
+            qe = _qevent("orphan", thread="tdl-transient", event_id="transient")
+            entry_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+
+            try:
+                assert await _deliver_new(consumer, h) == 1  # delivery #1: fails
+
+                for _ in range(8):
+                    if entry_id not in await _pending_ids(h):
+                        break
+                    await _reclaim_and_settle(consumer)
+
+                # It got there on the third delivery, by reclaim -- exactly the
+                # crash-recovery behavior the module exists for.
+                assert calls["n"] == 3
+                assert h.runner.opened == ["orphan"]
+                assert h.sink.last_text == "recovered"
+
+                # Acked off the main stream...
+                summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+                assert summary["pending"] == 0
+                # ...and NOT dead-lettered. A cap that fired here would have
+                # thrown away a turn that was going to succeed.
+                assert await _dead_rows(h) == []
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_unparseable_entry_is_dead_lettered_not_silently_dropped(
+    make_harness,
+) -> None:
+    """An entry the frozen queue contract cannot parse goes to the graveyard so
+    it is observable, instead of being silently acked into the void.
+    """
+
+    async def go() -> None:
+        async with make_harness(reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            token = uuid.uuid4().hex[:8]
+            entry_id = await h.async_redis.xadd(
+                h.config.stream, {"garbage": "x", "trace": token}
+            )
+
+            try:
+                assert await _deliver_new(consumer, h) == 1
+
+                rows = await _dead_rows(h)
+                assert len(rows) == 1, f"unparseable entry never reached the graveyard: {rows}"
+                _dl_id, dl = rows[0]
+                assert dl["dl_original_id"] == entry_id
+                assert "unparseable" in dl["dl_reason"]
+                assert dl["dl_dead_lettered_at"]
+                # The raw fields are kept verbatim -- the whole point is that a
+                # human can see WHAT failed to parse.
+                assert dl["garbage"] == "x"
+                assert dl["trace"] == token
+
+                # Acked off the main group: a poison entry must not be reclaimed
+                # forever either.
+                summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+                assert summary["pending"] == 0
+                # And the kernel never saw it.
+                assert h.runner.opened == []
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_cap_binds_beyond_the_first_pending_page(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every reclaim candidate is cap-checked, not just the first XPENDING page.
+
+    ``XAUTOCLAIM`` pages through the ENTIRE pending list via its cursor, so a
+    cap check that inspects only one ``COUNT _CAP_SCAN_PAGE`` page lets every
+    entry past the head of the list be claimed and re-dispatched over its budget
+    -- the bounded-delivery guarantee silently not holding at backlog scale.
+
+    The scan's page size is a module constant (1000), not a config knob, so it is
+    pinned to 1 here: three poison entries then span three pages and the paging
+    is actually exercised. Without this the backlog would fit in one page and the
+    test would pass against a single-page scan -- i.e. prove nothing.
+    """
+    monkeypatch.setattr(consumer_module, "_CAP_SCAN_PAGE", 1)
+
+    async def go() -> None:
+        async with make_harness(max_delivery=2, reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            calls: dict[str, int] = {"p0": 0, "p1": 0, "p2": 0}
+
+            async def always_fails(qevent: QueuedTurn) -> None:
+                calls[qevent.event_id] += 1
+                raise RuntimeError("simulated dead reply endpoint")
+
+            h.kernel.process_event = always_fails  # type: ignore[method-assign,assignment]
+
+            ids: dict[str, str] = {}
+            for name in ("p0", "p1", "p2"):
+                qe = _qevent(f"{name} turn", thread=f"tdl-page-{name}", event_id=name)
+                ids[name] = await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+
+            try:
+                # Delivery #1 for all three; every one fails and stays pending.
+                assert await _deliver_new(consumer, h) == 3
+                # Reclaim #1: all are at 1 < max_delivery=2, so all are claimed
+                # and re-dispatched -- delivery #2, the last one permitted.
+                await _reclaim_and_settle(consumer)
+                assert calls == {"p0": 2, "p1": 2, "p2": 2}
+
+                # Reclaim #2: all three are now over cap. Every one must be
+                # dead-lettered; none may be dispatched a third time. Against the
+                # single-page scan only p0 (the first page) is cap-checked, while
+                # XAUTOCLAIM's own paging still claims and dispatches p1 and p2.
+                await _reclaim_and_settle(consumer)
+
+                assert calls == {"p0": 2, "p1": 2, "p2": 2}, (
+                    "an entry beyond the first pending page was dispatched over the cap"
+                )
+                rows = await _dead_rows(h)
+                dead_originals = {dl["dl_original_id"] for _dl_id, dl in rows}
+                assert dead_originals == set(ids.values()), (
+                    f"not every over-cap entry reached the graveyard: {rows}"
+                )
+                for _dl_id, dl in rows:
+                    assert dl["dl_delivery_count"] == "2"
+                # ...and the whole group's PEL is drained: no stall left behind.
+                summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+                assert summary["pending"] == 0
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_a_failing_dead_letter_does_not_kill_the_rest_of_the_tick(
+    make_harness,
+    caplog: Any,
+) -> None:
+    """A graveyard XADD that fails for ONE entry is isolated.
+
+    ``_dead_letter_over_cap`` is the first, unguarded await of the maintenance
+    tick. If a single entry's XADD raises (an unwritable dead stream, a
+    WRONGTYPE key), an unisolated failure propagates out of ``_reclaim_once`` --
+    so XAUTOCLAIM never runs and ``reap_orphans`` never runs, on EVERY tick.
+    That is #505's own stall class: one bad entry silently killing crash
+    recovery for the whole group.
+    """
+
+    async def go() -> None:
+        async with make_harness(max_delivery=2, reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            calls: dict[str, int] = {"bad": 0, "good": 0}
+
+            async def always_fails(qevent: QueuedTurn) -> None:
+                calls[qevent.event_id] += 1
+                raise RuntimeError("simulated dead reply endpoint")
+
+            h.kernel.process_event = always_fails  # type: ignore[method-assign,assignment]
+
+            reaped = {"n": 0}
+            real_reap = h.kernel.reap_orphans
+
+            async def counting_reap() -> None:
+                reaped["n"] += 1
+                await real_reap()
+
+            h.kernel.reap_orphans = counting_reap  # type: ignore[method-assign,assignment]
+
+            # "bad" is XADDed first, so it is the first over-cap id the scan
+            # reaches: an unisolated raise there never gets to "good".
+            bad_id = await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("bad turn", thread="tdl-iso-bad", event_id="bad")),
+            )
+            good_id = await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("good turn", thread="tdl-iso-good", event_id="good")),
+            )
+
+            # The graveyard is unwritable for exactly one entry.
+            dead = _dead_stream(h.config)
+            real_xadd = h.async_redis.xadd
+
+            async def failing_xadd(name: str, fields: dict[str, str], **kw: Any) -> Any:
+                if name == dead and fields.get("dl_original_id") == bad_id:
+                    raise RuntimeError("graveyard unwritable")
+                return await real_xadd(name, fields, **kw)
+
+            consumer._redis.xadd = failing_xadd  # type: ignore[method-assign,assignment]
+
+            try:
+                assert await _deliver_new(consumer, h) == 2  # delivery #1: both fail
+                await _reclaim_and_settle(consumer)  # delivery #2: both fail
+                assert calls == {"bad": 2, "good": 2}
+
+                # The tick, exactly as _maintenance_loop runs it. Pre-fix, the
+                # raise from bad's XADD escapes _reclaim_once and reap never runs.
+                with caplog.at_level(logging.ERROR):
+                    await _reclaim_and_settle(consumer)
+                    await h.kernel.reap_orphans()
+
+                # The failure is loud, and names the entry and the cause.
+                assert any(
+                    bad_id in r.getMessage() and r.exc_info for r in caplog.records
+                ), "the failed dead-letter was not logged with the entry id"
+
+                # The OTHER entry was still cap-checked and dead-lettered.
+                rows = await _dead_rows(h)
+                assert [dl["dl_original_id"] for _dl_id, dl in rows] == [good_id]
+
+                # XAUTOCLAIM still ran on that same tick: it claimed the still-
+                # pending bad entry, bumping its PEL delivery count to 3...
+                assert (await _pending_rows(h)).get(bad_id) == 3
+                # ...but the cap still binds -- it was never dispatched again.
+                assert calls == {"bad": 2, "good": 2}
+                # ...and reap_orphans still ran.
+                assert reaped["n"] == 1
+            finally:
+                consumer._redis.xadd = real_xadd  # type: ignore[method-assign]
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_graveyard_is_bounded_by_dead_letter_maxlen(
+    make_harness,
+) -> None:
+    """The graveyard XADD is capped, so poison at ingest rate cannot OOM Valkey.
+
+    The unparseable path dead-letters per INBOUND entry, so a wire-format drift
+    that makes entries unparseable en masse grows the graveyard as fast as the
+    dispatcher produces -- on the same Valkey that holds the kernel's per-thread
+    locks and side-effect markers. This drives a flood well past a tiny
+    ``dead_letter_maxlen`` and asserts the graveyard LENGTH actually stays
+    bounded; an implementation that merely reads the knob and still XADDs
+    unbounded ends at ``flood`` rows and fails.
+
+    ``approximate=True`` lets Valkey trim on whole-node boundaries, so the bound
+    is "at least maxlen", not exactly it -- hence a generous ceiling rather than
+    an exact count (observed: 44 rows for this flood). The signal is
+    bounded-vs-linear growth, not the precise trim point.
+    """
+
+    flood = 400
+    # Comfortably above the observed trimmed length yet far below the unbounded
+    # one, so the assertion distinguishes the two without pinning Valkey's
+    # internal node size.
+    ceiling = 200
+
+    async def go() -> None:
+        async with make_harness(dead_letter_maxlen=1, reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            for i in range(flood):
+                # Unparseable: the per-inbound-entry dead-letter path.
+                await h.async_redis.xadd(h.config.stream, {"garbage": str(i)})
+
+            try:
+                # _deliver_new reads a bounded page, so drain to empty.
+                total = 0
+                while (n := await _deliver_new(consumer, h)) > 0:
+                    total += n
+                assert total == flood
+
+                dead_len = await h.async_redis.xlen(_dead_stream(h.config))
+                assert dead_len < flood, (
+                    f"graveyard grew unbounded: {dead_len} rows from {flood} "
+                    "dead-letters -- the maxlen bound is not applied"
+                )
+                assert dead_len <= ceiling, (
+                    f"graveyard length {dead_len} exceeds the expected bound for "
+                    f"dead_letter_maxlen=1 after {flood} dead-letters"
+                )
+
+                # The bound must not cost the ack: every entry is still off the
+                # group, even the ones whose graveyard row was evicted.
+                summary = await h.async_redis.xpending(
+                    h.config.stream, h.config.consumer_group
+                )
+                assert summary["pending"] == 0
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_unparseable_entry_records_its_real_reclaimed_delivery_count(
+    make_harness,
+) -> None:
+    """An unparseable entry reclaimed after a crash records its ACTUAL count.
+
+    An entry can be delivered, have its worker die before it ever parses, and be
+    reclaimed -- so by the time it is dead-lettered the PEL says 2+, not 1. A
+    hardcoded 1 fabricates ``dl_delivery_count`` precisely during crash recovery,
+    which is when the graveyard's operational evidence matters most. Here the
+    first delivery is taken WITHOUT dispatching (the crashed worker), so the
+    reclaim that follows is delivery #2.
+    """
+
+    async def go() -> None:
+        async with make_harness(reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            entry_id = await h.async_redis.xadd(h.config.stream, {"garbage": "x"})
+
+            try:
+                # Delivery #1, taken and then "crashed": claimed into the PEL but
+                # never dispatched, so it was never parsed and never acked.
+                await h.async_redis.xreadgroup(
+                    h.config.consumer_group,
+                    h.config.consumer_name,
+                    {h.config.stream: ">"},
+                    count=10,
+                )
+                assert (await _pending_rows(h))[entry_id] == 1
+
+                # Delivery #2, by reclaim: now it parses, fails, and dead-letters.
+                await _reclaim_and_settle(consumer)
+
+                rows = await _dead_rows(h)
+                assert len(rows) == 1, f"expected one dead-letter row, got {rows}"
+                _dl_id, dl = rows[0]
+                assert dl["dl_original_id"] == entry_id
+                assert "unparseable" in dl["dl_reason"]
+                # The real reclaimed count, not a fabricated 1.
+                assert dl["dl_delivery_count"] == "2", (
+                    "the graveyard fabricated the delivery count of a reclaimed "
+                    "unparseable entry instead of reading the PEL"
+                )
+                summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+                assert summary["pending"] == 0
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_unparseable_entry_cannot_clobber_or_forge_its_own_dl_metadata(
+    make_harness,
+) -> None:
+    """The graveyard's ``dl_*`` metadata is the consumer's, never the payload's.
+
+    The unparseable path stores an ARBITRARY malformed field map, so the ``dl_``
+    prefix is a convention the payload is under no obligation to respect. An
+    entry carrying its own ``dl_original_id`` must not be able to overwrite the
+    real one (forging the record) nor have its own value silently destroyed (the
+    graveyard then no longer preserves the original verbatim). The metadata wins;
+    the original survives under a doubled prefix.
+    """
+
+    async def go() -> None:
+        async with make_harness(reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            entry_id = await h.async_redis.xadd(
+                h.config.stream,
+                {
+                    "dl_original_id": "forged-id",
+                    "dl_reason": "forged-reason",
+                    "dl_delivery_count": "999",
+                    "dl_dead_lettered_at": "forged-time",
+                    "garbage": "x",
+                },
+            )
+
+            try:
+                assert await _deliver_new(consumer, h) == 1
+
+                rows = await _dead_rows(h)
+                assert len(rows) == 1, f"expected one dead-letter row, got {rows}"
+                _dl_id, dl = rows[0]
+
+                # The consumer's metadata wins outright -- the payload cannot forge it.
+                assert dl["dl_original_id"] == entry_id
+                assert "unparseable" in dl["dl_reason"]
+                assert dl["dl_delivery_count"] == "1"
+                assert dl["dl_dead_lettered_at"] != "forged-time"
+
+                # ...and the original is still preserved verbatim, recoverable by
+                # stripping exactly one "dl_" from the escaped key.
+                assert dl["dl_dl_original_id"] == "forged-id"
+                assert dl["dl_dl_reason"] == "forged-reason"
+                assert dl["dl_dl_delivery_count"] == "999"
+                assert dl["dl_dl_dead_lettered_at"] == "forged-time"
+                # Non-colliding fields are untouched.
+                assert dl["garbage"] == "x"
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_over_cap_entry_whose_message_was_trimmed_is_dead_lettered_and_acked(
+    make_harness,
+) -> None:
+    """An id can sit in the PEL while its message is gone from the stream.
+
+    A trim (MAXLEN) or an XDEL removes the message but NOT the pending entry, so
+    the over-cap path's XRANGE comes back empty. It must still write a
+    metadata-only graveyard row and -- the load-bearing half -- still XACK. Skip
+    the XACK and the id stays pending forever: exactly the #505 stall the cap
+    exists to end, now permanent because it can never be dispatched again either.
+
+    ``_dead_letter_over_cap`` is driven directly rather than via
+    ``_reclaim_once`` so the assertion sees the XACK and nothing else: a later
+    XAUTOCLAIM purges PEL ids whose messages were deleted, which would mask a
+    missing XACK entirely.
+    """
+
+    async def go() -> None:
+        async with make_harness(max_delivery=2, reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            calls = {"n": 0}
+
+            async def always_fails(qevent: QueuedTurn) -> None:
+                calls["n"] += 1
+                raise RuntimeError("simulated dead reply endpoint")
+
+            h.kernel.process_event = always_fails  # type: ignore[method-assign,assignment]
+
+            qe = _qevent("trimmed turn", thread="tdl-trimmed", event_id="trimmed")
+            entry_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+
+            try:
+                assert await _deliver_new(consumer, h) == 1  # delivery #1: fails
+                await _reclaim_and_settle(consumer)  # delivery #2: fails, at cap
+                assert calls["n"] == 2
+
+                # The message is trimmed off the stream while its id stays pending.
+                assert await h.async_redis.xdel(h.config.stream, entry_id) == 1
+                assert await h.async_redis.xrange(h.config.stream, min=entry_id, max=entry_id) == []
+                assert entry_id in await _pending_ids(h)
+
+                over_cap = await consumer._dead_letter_over_cap()
+                assert over_cap == {entry_id}
+
+                # A metadata-only row: everything the operator can still know.
+                rows = await _dead_rows(h)
+                assert len(rows) == 1, (
+                    f"the trimmed over-cap entry never reached the graveyard: {rows}"
+                )
+                _dl_id, dl = rows[0]
+                assert dl["dl_original_id"] == entry_id
+                assert dl["dl_delivery_count"] == "2"
+                assert dl["dl_reason"]
+                assert dl["dl_dead_lettered_at"]
+                # Metadata-ONLY: there is no original payload left to preserve.
+                assert set(dl) == {
+                    "dl_original_id",
+                    "dl_delivery_count",
+                    "dl_reason",
+                    "dl_dead_lettered_at",
+                }
+
+                # The XACK happened: the PEL is drained, so the stall is gone.
+                assert entry_id not in await _pending_ids(h)
+                summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+                assert summary["pending"] == 0
+                # ...and it was never dispatched again on the way out.
+                assert calls["n"] == 2
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_dead_letter_is_logged_loudly_with_the_operational_facts(
+    make_harness,
+    caplog: Any,
+) -> None:
+    """Dead-lettering is silent data loss unless it is loud.
+
+    The row itself is best-effort (the graveyard is MAXLEN-bounded and has no
+    consumer group), so the ERROR log is the only durable trace an operator is
+    guaranteed to see. It must carry the entry id, the delivery count, the
+    reason, and where the row went.
+    """
+
+    async def go() -> None:
+        async with make_harness(max_delivery=2, reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            async def always_fails(qevent: QueuedTurn) -> None:
+                raise RuntimeError("simulated dead reply endpoint")
+
+            h.kernel.process_event = always_fails  # type: ignore[method-assign,assignment]
+
+            qe = _qevent("poison turn", thread="tdl-log", event_id="poison")
+            entry_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+
+            try:
+                assert await _deliver_new(consumer, h) == 1  # delivery #1: fails
+                await _reclaim_and_settle(consumer)  # delivery #2: fails, at cap
+
+                with caplog.at_level(logging.ERROR):
+                    await _reclaim_and_settle(consumer)  # dead-letters
+
+                dead = _dead_stream(h.config)
+                # ONE record must carry every fact -- an operator reading a single
+                # line has to be able to act on it, not correlate across lines.
+                # (The per-delivery "left pending" ERRORs are also captured here;
+                # none of them is this record.)
+                messages = [
+                    r.getMessage() for r in caplog.records if r.levelno == logging.ERROR
+                ]
+                assert any(
+                    entry_id in m
+                    and "2" in m
+                    and "max delivery exceeded" in m
+                    and dead in m
+                    for m in messages
+                ), (
+                    "no single ERROR log carried the entry id, delivery count, "
+                    f"reason and target stream; got: {messages}"
+                )
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_max_delivery_below_the_floor_is_rejected() -> None:
+    """``max_delivery=1`` dead-letters every ordinary worker crash on its first
+    reclaim -- ADR-0013 crash recovery relies on a reclaim actually retrying.
+
+    The ``ge=2`` floor is the only thing standing between a config typo and a
+    consumer that throws away every recoverable turn, so pin it: a future edit
+    dropping the constraint fails here instead of shipping.
+    """
+    with pytest.raises(ValidationError):
+        WorkerConfig(stream="agentos:runs", max_delivery=1)
+    with pytest.raises(ValidationError):
+        WorkerConfig(stream="agentos:runs", max_delivery=0)
+
+    # The floor itself, and the default above it, stay valid.
+    assert WorkerConfig(stream="agentos:runs", max_delivery=2).max_delivery == 2
+    assert WorkerConfig(stream="agentos:runs").max_delivery >= 2
+
+
+def test_dead_letter_stream_equal_to_source_stream_is_rejected() -> None:
+    """A graveyard pointed at its own source stream is a config error, not a
+    runtime surprise.
+
+    ``_dead_letter`` XADDs the payload to the target and only then XACKs it, so
+    target == source re-queues every failure onto the stream it came from: a
+    valid failure is re-consumed under a fresh id, and an unparseable one spins a
+    hot loop -- the exact permanent stall the delivery cap exists to prevent.
+    Rejecting at construction means an operator learns at boot, not mid-incident.
+    """
+    with pytest.raises(ValidationError, match="must not equal AGENTOS_STREAM"):
+        WorkerConfig(stream="agentos:runs", dead_letter_stream="agentos:runs")
+
+    # The derived default can never collide, so it stays valid...
+    assert WorkerConfig(stream="agentos:runs").dead_letter_stream == ""
+    # ...and so does any genuinely distinct override.
+    assert (
+        WorkerConfig(
+            stream="agentos:runs", dead_letter_stream="agentos:runs:dead"
+        ).dead_letter_stream
+        == "agentos:runs:dead"
+    )

--- a/apps/worker/tests/test_broker_port.py
+++ b/apps/worker/tests/test_broker_port.py
@@ -1,8 +1,11 @@
 """The consumer-side broker port: redis.asyncio.Redis satisfies StreamBroker.
 
 Structural-conformance only -- no Valkey behavior is mocked (the real consume /
-ack / reclaim behavior is covered against real Valkey in the kernel + consumer
-suites). This pins that the one backing today is a drop-in for the port.
+ack / reclaim / delivery-cap behavior is covered against real Valkey in the
+kernel + consumer suites). This pins that the one backing today is a drop-in
+for the full 7-verb port: xgroup_create, xreadgroup, xack, xautoclaim (group
+semantics + crash recovery) plus xpending_range, xrange, xadd (#505 delivery
+cap / dead-letter).
 """
 
 from agentos_worker.broker import StreamBroker
@@ -29,6 +32,17 @@ def test_stream_consumer_accepts_any_broker() -> None:
 
         async def xautoclaim(self, *args, **kwargs):  # noqa: ANN002, ANN003, ANN201
             return ("0-0", [])
+
+        async def xpending_range(  # noqa: ANN201
+            self, name, groupname, min, max, count, consumername=None, idle=None  # noqa: ANN001, A002
+        ):
+            return []
+
+        async def xrange(self, name, min="-", max="+", count=None):  # noqa: ANN001, ANN201, A002
+            return []
+
+        async def xadd(self, name, fields):  # noqa: ANN001, ANN201
+            return "0-1"
 
     broker = FakeBroker()
     assert isinstance(broker, StreamBroker)

--- a/docs/adr/0039-bounded-delivery-and-a-dead-letter-graveyard.md
+++ b/docs/adr/0039-bounded-delivery-and-a-dead-letter-graveyard.md
@@ -1,0 +1,243 @@
+# 39. Bounded delivery: a delivery cap and a dead-letter graveyard
+
+Date: 2026-07-16
+
+Status: Accepted
+
+Implements [#505](https://github.com/curie-eng/agentos/issues/505).
+
+**Amends ADR-0013** ("Concurrency and delivery: at-least-once streams with an
+idempotent, side-effect-aware kernel"). ADRs are immutable once Accepted, so this
+is a new ADR that **supersedes in part** exactly one clause of 0013's Decision:
+"Crash recovery without backlog replay: pending entries are reclaimed with
+`XAUTOCLAIM`", which as built meant *reclaimed forever, with no cap*. Everything
+else in 0013 stands unchanged: at-least-once transport, the idempotent kernel,
+dispatcher-side dedupe, the thread-lock routing CAS, the finish race, the
+escalate-instead-of-retry rule after a side-effect flag, create-at-`$` so a cold
+worker never replays backlog, and the four sacred kernel invariants. This ADR
+bounds *how many times* the reclaim clause may fire, and nothing else.
+
+## Context
+
+ADR-0013 chose at-least-once transport plus an idempotent kernel, and made
+`XAUTOCLAIM` reclaim the crash-recovery mechanism: an entry a dead consumer took
+but never acked is reclaimed after an idle timeout and reprocessed. That loop was
+**unbounded** by design. Nothing in the model gave a permanently-failing entry a
+terminal state.
+
+Issue #505 is what that costs. `agentos local message` starts an ephemeral reply
+stub on `localhost:8155` and hands its URL to the turn. When the turn hits an
+approval gate, that URL is persisted into a durable `Approval` record and outlives
+the CLI process that served it. On resume the worker POSTs the reply to a port
+that no longer has a listener, the reply raises a connection error, the error
+propagates out of the escalation path, the entry stays pending, and every reclaim
+tick re-dispatches it into the same guaranteed failure. The entry never leaves the
+pending list. It consumes reclaim budget on every pass forever, and the shared
+`agentos-workers` consumer group stops making progress on later turns. The failure
+is silent: no crash, no alert, just a worker that has quietly stopped working.
+
+The dead CLI stub is only the cause that surfaced first. Any permanently-failing
+entry has the same shape: a malformed payload the kernel can never parse, a reply
+endpoint that has been decommissioned, a dependency that is gone for good. The
+severity does not come from the cause. It comes from the delivery model having no
+answer to "what if this never succeeds."
+
+Two adjacent facts frame the fix. First, Valkey's pending-entries list already
+tracks a per-entry delivery count in Valkey itself, so the information needed to
+bound the loop exists and is durable. Second, the existing unparseable-entry
+branch already acknowledged the problem in miniature: it acked poison away
+**silently**, because a poison message must not be reclaimed forever. That was the
+right instinct with the wrong terminal state, and it deleted the evidence.
+
+## Decision
+
+**Delivery is bounded.** An entry that has already been delivered `max_delivery`
+times and still failed is moved to a dead-letter stream and acked off the main
+group, rather than reclaimed and re-dispatched again.
+
+- **The cap.** `WorkerConfig.max_delivery` (env `AGENTOS_MAX_DELIVERY`, default
+  `5`, floor `ge=2`). The floor is a hard constraint, not a suggestion:
+  `max_delivery=1` would dead-letter every ordinary worker crash on its first
+  reclaim, which is precisely the crash recovery ADR-0013 exists to provide.
+  Values below 3 undermine that recovery and the field docstring says so.
+  `max_delivery` is deliberately **not** `max_attempts`: that existing knob
+  governs the kernel's flag-clean per-turn retry *classification* inside a single
+  delivery. Conflating the two would silently change kernel retry behavior.
+- **The graveyard.** `WorkerConfig.dead_letter_stream` (env
+  `AGENTOS_DEAD_LETTER_STREAM`), empty by default, which derives `<stream>:dead`
+  at the use site. A static field default cannot reference `self.stream`, so the
+  derivation lives in the consumer's `_dead_letter_stream` property. The first
+  `XADD` creates the stream; nothing pre-creates it.
+- **The row.** A dead-lettered entry is `XADD`ed with its original fields kept
+  verbatim plus namespaced failure metadata: `dl_original_id`,
+  `dl_delivery_count`, `dl_reason`, `dl_dead_lettered_at`. The `dl_` prefix means
+  the metadata can never collide with a field of the original payload. One
+  scheme, no JSON nesting alternative. An id can be pending while its message was
+  trimmed off the source stream, in which case the row is metadata-only and the
+  `XACK` still happens; skipping it would leave the stall in place.
+- **The ordering.** `XADD` precedes `XACK`, deliberately. A crash between the two
+  leaves the entry pending, so it is re-reclaimed and re-dead-lettered: a
+  duplicate graveyard row. The reverse ordering's failure mode is a lost entry.
+  A duplicate row is strictly the cheaper loss. Two replicas racing the same
+  over-cap entry produce the same acceptable duplicate, and we do not add locking
+  to prevent it.
+- **The count comes from the pending-entries list, never from process memory.**
+  It is read fresh from Valkey on every reclaim pass. This is load-bearing: a
+  process-local counter resets on restart, so a crash-looping worker would rearm
+  the budget on every restart and retry poison forever, which is the exact stall
+  shape the cap exists to end. A durable counter means a restarted or replacement
+  worker sees the accumulated count and still caps.
+- **Read the count before the claim, not after.** `XAUTOCLAIM` increments the
+  counter as it claims, so the pre-claim value is the number of deliveries
+  *already made*. An entry at `>= max_delivery` has had its full budget and must
+  not be claimed again. The `IDLE` filter matches `XAUTOCLAIM`'s `min_idle_time`
+  so both see the same candidate set and an entry that is not yet
+  reclaim-eligible is never dead-lettered early. An entry in flight on this
+  consumer is skipped ahead of the cap check: it is being worked right now, not
+  orphaned.
+- **The unparseable path routes to the same graveyard**, with
+  `dl_reason="unparseable"`, replacing the silent ack. Poison becomes observable
+  instead of vanishing.
+- **Transient failure is unchanged.** A worker that crashes mid-turn still has its
+  entry reclaimed and retried, exactly as ADR-0013 specifies. Only an entry that
+  has burned its whole budget is dead-lettered.
+- **The graveyard has no consumer group, but it IS bounded.** It is a sink, not a
+  second processing lane. Replay, if an operator ever needs it, is `XRANGE` plus a
+  re-`XADD` onto the main stream. Every `XADD` passes an approximate `MAXLEN` of
+  `WorkerConfig.dead_letter_maxlen` (env `AGENTOS_DEAD_LETTER_MAXLEN`, default
+  `10000`, floor `ge=1`). The bound is not optional polish: the unparseable path
+  dead-letters **per inbound entry**, so a wire-DTO drift that made entries
+  unparseable en masse would grow the graveyard at full ingest rate, on the same
+  Valkey that holds the kernel's per-thread locks and side-effect markers. An
+  unbounded graveyard would therefore introduce a platform-wide OOM vector that
+  did not exist before this change (previously an unparseable entry was acked and
+  dropped for free). `approximate=True` lets Valkey trim on node boundaries, so
+  the stream is bounded at *at least* the configured length, not exactly it.
+- **A self-targeting graveyard is rejected at config validation.**
+  `WorkerConfig._reject_self_targeting_graveyard` fails construction when an
+  explicit `dead_letter_stream` equals `stream`. Because `_dead_letter` XADDs
+  before it XACKs, a graveyard pointing at the source stream re-queues every
+  failure onto the stream it was consumed from, and an unparseable entry hot-loops
+  there, recreating the exact permanent stall the cap exists to end. The derived
+  `<stream>:dead` default can never collide, so only an explicit override trips
+  this. An operator learns at boot rather than during an incident.
+
+**Three verbs are added to the consumer's `StreamBroker` port**
+(`xpending_range`, `xrange`, `xadd`), taking it from four to seven. This is
+consistent with ADR-0027, not an exception to it: the split that ADR draws is
+about **dedupe placement** living on the producer side, not a rule that consumers
+never write. A dead-letter append is consumer-group lifecycle, the same family as
+`xack` and `xautoclaim`. Declaring `xadd` on the port is what makes the contract
+honest; hiding the write behind a cast would let a second broker ship structurally
+satisfying the port while being silently unable to dead-letter, which is the
+failure the port exists to prevent.
+
+## Alternatives considered
+
+- **Retry forever (the status quo this closes off).** ADR-0013 chose an unbounded
+  reclaim loop for a real reason: crash recovery must not lose an entry, and any
+  cap is a decision to eventually stop trying. That reasoning holds for the
+  transient case and we keep it there. It is wrong for the permanent case. A
+  permanently-failing entry, such as one whose reply endpoint died with the CLI
+  process that created it, never converges. Under an unbounded loop it starves the
+  shared consumer group and silently stalls every later turn (#505). "Never lose
+  an entry" was traded against "never stall the group," and the ADR-0013 model
+  only priced the first. Bounded delivery keeps the entry (in the graveyard) and
+  ends the stall.
+- **Fix only the CLI stub lifecycle (Option 1).** Make `local message` detect the
+  approval-gated case and warn that its reply stub is ephemeral. Rejected as the
+  fix: it reduces how often *this one cause* fires and does nothing for any other
+  permanently-failing entry. The group can still stall. Deferred as
+  [#529](https://github.com/curie-eng/agentos/issues/529), a needed follow-up and
+  not a substitute.
+- **Fix only the resume transport fallback (Option 2).** Fall back to the worker's
+  configured default transport when a per-turn reply endpoint is unreachable.
+  Rejected as the fix for the same reason, plus it risks mis-delivering a reply to
+  the wrong workspace and needs its own design. Deferred as
+  [#530](https://github.com/curie-eng/agentos/issues/530), a needed follow-up and
+  not a substitute. Neither #529 nor #530 replaces the cap: they reduce how often
+  the CLI-stub case fires and do nothing for the general poison case.
+- **Track the delivery count in the worker process.** Rejected: a process-local
+  counter resets on restart, so a crash-looping worker would never reach the cap.
+  It would produce exactly the silent stall the cap exists to end, while looking
+  like it had a cap.
+- **Build a dead-letter consumer or replay tool now.** Rejected: no operator has
+  needed one. The graveyard's value is that the entry is durable and observable;
+  a processing lane on top of it is a separate decision to make when there is
+  demand to verify against.
+- **Leave the graveyard unbounded.** Rejected. The `MAXLEN` is not a retention
+  policy bolted on as a passenger; it is the containment for a vector this change
+  itself introduces. Routing the per-inbound-entry unparseable path into a durable
+  stream converts a free drop into a write, so an unbounded graveyard hands a
+  wire-DTO drift a full-ingest-rate OOM against the Valkey the kernel's own
+  correctness depends on. A retention *policy* (age-based expiry, tiering, replay
+  tooling) remains undecided and is not a passenger on this change.
+- **Exempt side-effect-flagged entries from the cap.** Considered and rejected. It
+  is tempting to say an entry whose work already happened must never be given up
+  on. But the motivating #505 shape, a resume turn POSTing to a dead reply
+  endpoint, can itself carry the side-effect flag, so the exemption would apply to
+  exactly the entry that can never succeed and would resurrect the infinite loop
+  the cap exists to end. The side-effect marker survives in Valkey either way.
+
+## Consequences
+
+- **The honest trade: an entry that is dead-lettered may never deliver its reply,
+  and its side effects may already have happened.** In the #505 case the resumed
+  turn did its work; only the reply POST fails. Dead-lettering means that work is
+  done and the reply is lost, and the user is not notified. This is a deliberate
+  severity reduction, not an elimination: from a **silent total stall of the
+  worker group** to a **single-turn loss** with a graveyard row and a loud error
+  log naming the entry, its delivery count, and the reason. It is also exactly why
+  #529 and #530 remain needed follow-ups rather than discarded alternatives. They
+  attack the frequency of the loss this change makes survivable.
+- **"Observable" is only half earned today.** A dead-letter emits an ERROR log and
+  writes a graveyard row, so the evidence exists and a human who goes looking will
+  find it. But **no alarm, no metric, and no consumer watches `<stream>:dead`**.
+  Nothing pages, and nothing surfaces the row to anyone who is not already
+  looking. The severity trade above is therefore "silent total stall" against
+  "logged single loss," which is a real improvement and still short of observable
+  in the operational sense. Closing that gap is
+  [#531](https://github.com/curie-eng/agentos/issues/531).
+- **A dead-lettered RESUME turn strands its approval.** `ResumeQueue.enqueue`
+  (`apps/api/src/agentos_api/resumequeue.py`) sets `resumed_at` once the XADD
+  succeeds, and the resume reconciler
+  (`apps/api/src/agentos_api/resumereconciler.py`, over `list_resolved_unresumed`
+  in `apps/api/src/agentos_api/crud.py`) is gated on `resumed_at IS NULL`. A turn
+  that reached the stream and then died is therefore marked resumed and has no
+  backstop: approved in Postgres, sandbox never wakes, nothing retries it. This is
+  **not a regression**. Before this change the same turn was reclaimed forever
+  against a dead endpoint, never resumed either, and stalled the whole group while
+  failing. Bounding delivery does not create the stranding; it makes a
+  pre-existing gap visible and localizes it to one turn. Closing it is
+  [#532](https://github.com/curie-eng/agentos/issues/532).
+- **A cap is now a load-bearing invariant, and removing it is a regression, not a
+  simplification.** This inherits ADR-0013's warning about the retry loop: a
+  future change that drops the cap, raises it to infinity, or moves the count into
+  process memory reintroduces #505's silent stall and will pass unit tests while
+  doing it. The floor of `ge=2` is a config-level guard against the opposite
+  mistake.
+- **`kernel.py`, `threadlock.py`, and `markers.py` are untouched.** The cap lives
+  at the delivery layer in `consumer.py`. Rule 4 (no auto-retry after side
+  effects) holds *within* every delivery: the persisted side-effect flag makes
+  each reclaim escalate rather than retry, and an entry only reaches the cap when
+  escalation **itself** keeps failing. Dead-lettering after N failed escalations
+  is that path's correct terminal state, not a violation of it: the only
+  alternative is infinite failed escalations, which is the stall. A cap exemption
+  for side-effect-flagged entries was considered and rejected, because the
+  motivating #505 shape can itself carry the flag and exempting it would resurrect
+  that exact infinite loop. The side-effect marker survives in Valkey regardless
+  of the cap. A dead-letter never dispatches, never acquires the semaphore, and
+  never touches the thread lock.
+- **Graveyard records are best-effort, not a durable audit log.** The approximate
+  `MAXLEN` evicts the oldest rows under a flood, which means the failures most
+  worth reading (the first ones, at the onset of an incident) are the first
+  evicted once the cap is reached. Bounded record loss is deliberately traded
+  against a platform-wide OOM: losing some dead-letter rows costs evidence, while
+  an unbounded graveyard costs the Valkey the kernel's locks and markers live in,
+  and with it the whole platform. Do not build anything that treats the graveyard
+  as complete. Below the cap it holds every dead-lettered entry, and its length
+  remains a read on the system's poison rate, saturating rather than growing once
+  the bound is hit.
+- **`StreamBroker` is a seven-verb port.** A second broker must implement the
+  dead-letter verbs to drop in. ADR-0027's remaining coupling note still applies;
+  this widens the contract without widening the coupling.

--- a/docs/interfaces/queue-stream/INTERFACE.md
+++ b/docs/interfaces/queue-stream/INTERFACE.md
@@ -24,7 +24,8 @@ worker (consumer): a named stream carrying a frozen one-field payload. As of #28
 ADR-0027 the stream verbs are drawn behind a thin **broker port** at the two non-sacred
 seams — a `StreamPublisher` `Protocol` on the producer (`apps/dispatcher/src/agentos_dispatcher/queue.py::StreamPublisher`:
 `xadd` + the `SET NX EX` dedupe-claim) and a `StreamBroker` `Protocol` on the consumer
-transport (`apps/worker/src/agentos_worker/broker.py::StreamBroker`: `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`).
+transport (`apps/worker/src/agentos_worker/broker.py::StreamBroker`:
+`xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`/`xpending_range`/`xrange`/`xadd`).
 The routing, consumer-group concurrency, dedupe, and reclaim rules stay opinionated
 **core**. `redis.Redis` / `redis.asyncio.Redis` structurally satisfy the ports, so
 redis-py is the one backing today with no adapter; a redis-compatible backend (Valkey,
@@ -52,6 +53,19 @@ A second broker must honor the stream key, the payload encoding, and the Stream 
   `apps/worker/src/agentos_worker/consumer.py::Consumer._handle`, and acknowledges with `xack`
   (`apps/worker/src/agentos_worker/consumer.py::Consumer._ack`). The group is
   `"agentos-workers"` (`WorkerConfig.consumer_group`, `apps/worker/src/agentos_worker/config.py::WorkerConfig`).
+- **Delivery cap and dead-letter graveyard** (#505, ADR-0039) — an entry already
+  delivered `WorkerConfig.max_delivery` times (default 5, floor 2) is dead-lettered
+  instead of reclaimed again. `Consumer._dead_letter_over_cap`
+  (`apps/worker/src/agentos_worker/consumer.py::Consumer._dead_letter_over_cap`) reads
+  the pending list's delivery counts with `xpending_range` before the reclaim's
+  `xautoclaim` bumps them; an over-cap entry's original fields are fetched with
+  `xrange` in `Consumer._dead_letter_over_cap_entry`
+  (`apps/worker/src/agentos_worker/consumer.py::Consumer._dead_letter_over_cap_entry`)
+  and moved with `xadd` in `Consumer._dead_letter`
+  (`apps/worker/src/agentos_worker/consumer.py::Consumer._dead_letter`), then acked off
+  the group. The target stream is `WorkerConfig.dead_letter_stream`
+  (`apps/worker/src/agentos_worker/config.py::WorkerConfig`), defaulting to
+  `"<stream>:dead"`.
 
 Idempotency lives beside the stream, not in it: `claim_event` does a
 `SET <dedupe_key> 1 NX EX <ttl>` before `XADD` (`apps/dispatcher/src/agentos_dispatcher/queue.py::claim_event`).
@@ -60,7 +74,8 @@ Idempotency lives beside the stream, not in it: `claim_event` does a
 
 One, redis-py against Valkey. The dispatcher `XADD`s
 (`apps/dispatcher/src/agentos_dispatcher/queue.py::enqueue`); the worker runs
-a consumer group with `XREADGROUP`/`XACK` and crash-recovery `XAUTOCLAIM`
+a consumer group with `XREADGROUP`/`XACK`, crash-recovery `XAUTOCLAIM`, and the
+delivery-cap dead-letter path's `XPENDING`/`XRANGE`/`XADD`
 (`apps/worker/src/agentos_worker/consumer.py`). A second, sibling stream
 `"agentos:evals"` uses the same one-field `payload` convention
 (`apps/worker/src/agentos_worker/eval/stream.py`), reinforcing the wire shape as the
@@ -76,7 +91,8 @@ is not touched:
 - **Producer** — `StreamPublisher` (`apps/dispatcher/src/agentos_dispatcher/queue.py::StreamPublisher`): `xadd` and the
   `SET NX EX` dedupe-claim. `enqueue`/`claim_event` type against it.
 - **Consumer transport** — `StreamBroker` (`apps/worker/src/agentos_worker/broker.py::StreamBroker`):
-  `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`. The non-sacred `StreamConsumer`
+  `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`, plus — since the bounded-delivery
+  dead-letter path (#505, ADR-0039) — `xpending_range`/`xrange`/`xadd`. The non-sacred `StreamConsumer`
   base (`apps/worker/src/agentos_worker/stream_consumer.py`) holds a `StreamBroker`; the sacred `consumer.py` subclass
   inherits it unchanged (its `XAUTOCLAIM` reclaim now targets the port by inheritance).
 
@@ -112,4 +128,4 @@ The verbs return a bare `Awaitable`/value matching redis-py's own typing, so
 - **Epic(s):** #85 — vision: make the broker itself swappable behind the stream contract
 - **Epic(s):** #7 — payload promotion into `packages/aci-protocol` (overlaps the channel seam, landed)
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — opinionated core (`agentos:runs` stream), not one of the six swap jobs
-- **ADR(s):** [ADR-0027](../../adr/0027-thin-broker-port-defer-second-broker.md) — the broker port at the non-sacred seams; [ADR-0007](../../adr/0007-adopt-not-build-boundaries.md) — adopt-not-build (Valkey adopted; second broker deferred)
+- **ADR(s):** [ADR-0027](../../adr/0027-thin-broker-port-defer-second-broker.md) — the broker port at the non-sacred seams; [ADR-0007](../../adr/0007-adopt-not-build-boundaries.md) — adopt-not-build (Valkey adopted; second broker deferred); [ADR-0039](../../adr/0039-bounded-delivery-and-a-dead-letter-graveyard.md) — the delivery cap and dead-letter graveyard that added `xpending_range`/`xrange`/`xadd` to the port


### PR DESCRIPTION
Closes #505

`agentos local message` starts a throwaway reply stub on `localhost:8155` and injects it as the turn's reply endpoint. When the turn is approval-gated, that URL is persisted on the durable `Approval` and the stub dies the moment the CLI exits. On resume the worker POSTs to the dead stub, the entry is left pending, and the reclaim loop re-dispatches it forever. The permanently-failing entry then starves the `agentos-workers` group and every later turn silently stops.

This fixes it at the delivery model (the issue's option 3), because that bounds the stall for **every** permanently-failing cause rather than only the endpoint that motivated it. Options 1 and 2 are filed as follow-ups: they reduce how often the stub case fires but do nothing for the general poison case.

## What changed

- Cap deliveries at `max_delivery` (default 5, floor 2). An entry at the cap moves to a `<stream>:dead` graveyard and is acked off, so it can never block the group again. Every reclaim candidate is cap-checked, not just the first pending page.
- The count is read from the pending list (durable in Valkey), never process memory, so a crash-looping worker still converges on the cap.
- XADD before XACK: a crash between them costs a duplicate graveyard row, never a lost entry.
- Each dead-letter is isolated, so one unwritable entry cannot take reclaim and orphan reaping down with it. An entry whose dead-letter fails stays pending but is never dispatched again, so the cap binds regardless.
- The graveyard is bounded by an approximate maxlen. The unparseable path writes per inbound entry, so a payload-shape drift could otherwise grow it at full ingest rate on the same Valkey that holds the locks and markers the kernel depends on.
- Unparseable entries now land in the graveyard instead of being acked away silently, and a dead-letter target equal to its source stream is rejected at startup.
- `StreamBroker` declares the three verbs the cap needs, so a second broker cannot ship unable to dead-letter.

ADR-0039 records the decision, what it closes off (unbounded retry), and what it costs.

## The trade, stated plainly

Dead-lettering means a turn whose side effects already happened may never deliver its reply: severity drops from a silent total stall to a single localized loss. Today that loss is *observable* only in the sense that it emits an ERROR log and writes a row. Nothing watches `<stream>:dead` yet (#531). A dead-lettered resume also strands its approval (#532) - not a regression, since that turn previously retried forever and never resumed either, while also stalling the group, but it is the gap this change makes visible.

A cap exemption for side-effect-flagged entries was considered and rejected: the motivating shape here can itself carry the flag, so exempting it would resurrect the exact infinite loop.

## Verification

Verified end-to-end against a real dead HTTP port, driving a real `aiohttp.ClientConnectorError` through the real sink: the poison handler ran exactly `max_delivery` times, produced one graveyard row (`dl_reason=max delivery exceeded`, `dl_delivery_count=3`), the healthy entry alongside it completed, and the group's pending list drained to 0. Kernel suite 77 passed against real Valkey; the boundary and each hardening path were pinned by mutation rather than trusting green. The 19 `tests/binding/` failures on this branch are pre-existing on the base (unmigrated test Postgres).

## Follow-ups filed

#529 (CLI warns its reply stub is ephemeral), #530 (resume transport fallback, needs design), #531 (alert on dead-letter), #532 (dead-lettered resume backstop), #535 (the eval lane has the same uncapped shape, where each retry costs a sandbox and an LLM run).
