### PR TITLE
Gate outbound Claude Code plugin compatibility in CI

### DIFF
--- a/.github/workflows/plugin-compat.yaml
+++ b/.github/workflows/plugin-compat.yaml
@@ -1,0 +1,48 @@
+name: Plugin compat
+
+# The bundle format is the Claude Code plugin shape verbatim, so outbound
+# compatibility (an AgentOS bundle validates unmodified as a Claude Code plugin)
+# is a contract we owe, not a claim we make. This gate defends it.
+#
+# Both triggers are deliberate, because there are two independent drift vectors:
+#   - pull_request (path-filtered): catches OUR drift, when we touch the example
+#     bundles, the plugin-format models, or this gate itself.
+#   - schedule (nightly): catches THEIR drift, when Claude Code changes the
+#     format under us with no PR of ours involved. No per-PR trigger can see
+#     this, since the cadence is external to the repo.
+# The job is a checkout plus one npm install, so running both is cheap.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - "packages/plugin-format/**"
+      - ".github/workflows/plugin-compat.yaml"
+      - "scripts/check-plugin-compat.sh"
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-compat:
+    name: Bundles validate as Claude Code plugins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Install the Claude Code CLI
+        run: npm install --global @anthropic-ai/claude-code
+      - name: Validate every examples/ bundle
+        run: bash scripts/check-plugin-compat.sh

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2498,6 +2498,11 @@ export const commandManifest = {
           "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
           "hidden": false,
           "name": "docs-lint"
+        },
+        {
+          "about": "Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`)",
+          "hidden": false,
+          "name": "plugin-compat"
         }
       ]
     },

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2495,6 +2495,11 @@
           "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
           "hidden": false,
           "name": "docs-lint"
+        },
+        {
+          "about": "Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`)",
+          "hidden": false,
+          "name": "plugin-compat"
         }
       ]
     },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -225,6 +225,8 @@ enum DevAction {
     E2e,
     /// Lint the interface catalog docs (`bash scripts/check-docs.sh`).
     DocsLint,
+    /// Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`).
+    PluginCompat,
 }
 
 #[derive(Subcommand)]
@@ -1109,6 +1111,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             }
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh").await,
+            DevAction::PluginCompat => commands::dev_script("scripts/check-plugin-compat.sh").await,
         },
         Some(Command::Skill { action }) => match action {
             SkillAction::Up {

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -150,6 +150,25 @@ fn process_help_top_level_lists_new_surface_and_hides_retired_verbs() {
     }
 }
 
+/// `agentos dev plugin-compat` is the operator-facing name of the outbound
+/// Claude-Code-compatibility gate (see the bundle-format seam doc). If the verb
+/// stops being reachable, the gate is still in CI but nobody can run it locally
+/// before pushing.
+#[test]
+fn process_dev_help_lists_the_plugin_compat_gate() {
+    let output = run_help(&["dev"]);
+    assert!(
+        output.status.success(),
+        "expected success for dev help\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        help_lists_subcommand(&text, "plugin-compat"),
+        "missing plugin-compat\n{text}"
+    );
+}
+
 /// The checked-in manifest must equal what `agentos schema` emits from the live
 /// clap grammar. This is the generated-artifact + CI drift gate (mirroring the
 /// schema-export discipline for `packages/aci-protocol` / `packages/plugin-format`):

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -45,6 +45,20 @@ with `name`/`description` required and `allowed_tools` aliased to the verbatim `
 `.mcp.json` file) where the validator enforces each server define `command` (stdio) or `url`
 (remote). A second consumer must accept exactly these shapes.
 
+The seam is bidirectional, and both directions are contracts. **Inbound**, leniency means any
+bundle written for Claude Code validates here unchanged. **Outbound**, an AgentOS bundle must
+validate unmodified as a Claude Code plugin — that direction is what makes the shape a
+distribution wedge rather than a lookalike. The gate that defends it is
+`scripts/check-plugin-compat.sh` (run it as `agentos dev plugin-compat`), which discovers every
+bundle under `examples/` and asserts `claude plugin validate` exits 0 for each. CI runs the same
+script from `.github/workflows/plugin-compat.yaml` on two triggers, because drift arrives from two
+directions: a path-filtered `pull_request` trigger catches our own drift when we touch the bundles
+or the format models, and a nightly `schedule` catches Claude Code changing the format under us,
+which no PR of ours would ever surface. The check is deliberately not `--strict`: strict mode
+promotes unknown-field warnings to errors, and the five AgentOS authoring extensions are
+unknown-to-Claude-Code by design, so warnings are the expected steady state and only a non-zero
+exit is a failure.
+
 ## Implementations today
 
 One: the `plugin_format` package. **Unlike `aci-protocol`, it is NOT tri-language with generated
@@ -59,7 +73,15 @@ Code keys still validate.
 
 ## Known leakage
 
-By intent, the entire format is Claude-Code-shaped — that is the wedge, not a leak. The `hooks`
+By intent, the entire format is Claude-Code-shaped — that is the wedge, not a leak. What the wedge
+costs is asymmetric fidelity: a bundle loaded by Claude Code **validates but degrades**. All five
+AgentOS authoring extensions — `systemPrompt`, `starterPrompts`, `secrets`, `triggers`,
+`approvalPolicy` — are unknown fields to Claude Code, which warns about each and then silently
+ignores it at load time. The manifest is accepted and the commands, agents, hooks, and MCP servers
+work; the agent's persona, its suggested openers, its secret declarations, its wake-up triggers,
+and its approval gates do not travel. That degradation is by design (there is nowhere in the Claude
+Code shape to put them), but it is silent from the operator's side, so it is documented here rather
+than discovered. The `hooks`
 field is no longer dead: as of #272 it is validated at deploy time (`HookMatcherConfig` /
 `HookDefinition` in `models.py`, enforced by `_validate_hooks` in `validate.py`) and its
 `PreToolUse` command hooks are consumed by the runner (`runner/src/agentos_runner/hooks.py`),

--- a/scripts/check-plugin-compat.sh
+++ b/scripts/check-plugin-compat.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Assert every bundle under examples/ still validates as a Claude Code plugin.
+# The bundle format is the Claude Code plugin shape verbatim (the distribution
+# wedge), so outbound compatibility is a contract, not a claim: this is the
+# local mirror of the CI plugin-compat gate. Plain `claude plugin validate`, no
+# --strict: our five authoring extensions (systemPrompt, starterPrompts,
+# secrets, triggers, approvalPolicy) are unknown-to-Claude-Code by design, and
+# --strict would promote those unknown-field warnings to errors. Warnings are
+# expected and allowed; a non-zero exit is the failure signal.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "ERROR: the 'claude' CLI is not on PATH, so outbound compatibility cannot be checked." >&2
+  echo "Install it (npm i -g @anthropic-ai/claude-code) and re-run." >&2
+  exit 1
+fi
+
+echo "== discovering bundles under examples/ =="
+bundles=()
+while IFS= read -r manifest; do
+  bundles+=("$(dirname "$(dirname "$manifest")")")
+done < <(find examples -mindepth 3 -maxdepth 3 -path '*/.claude-plugin/plugin.json' | sort)
+
+if [ "${#bundles[@]}" -eq 0 ]; then
+  echo "ERROR: no bundles found under examples/ (looked for */.claude-plugin/plugin.json)." >&2
+  echo "An empty match would pass this gate vacuously, which defeats its purpose." >&2
+  exit 1
+fi
+echo "found ${#bundles[@]} bundle(s): ${bundles[*]}"
+
+echo "== validating each bundle against Claude Code =="
+failed=()
+for bundle in "${bundles[@]}"; do
+  echo "-- $bundle --"
+  if ! claude plugin validate "$bundle"; then
+    failed+=("$bundle")
+  fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo "ERROR: Claude Code rejected ${#failed[@]} bundle(s): ${failed[*]}" >&2
+  echo "The bundle format is the Claude Code plugin shape verbatim. Either the bundle" >&2
+  echo "drifted, or Claude Code changed the format under us. Fix the bundle or update" >&2
+  echo "docs/interfaces/bundle-format/INTERFACE.md to record the new contract." >&2
+  exit 1
+fi
+
+echo "OK: all ${#bundles[@]} bundle(s) validate as Claude Code plugins."


### PR DESCRIPTION
The bundle-format seam is frozen against an external moving target, and nothing defended the claim that an AgentOS bundle is a real Claude Code plugin verbatim. The property held when checked by hand; the next regression would have been silent. This makes it a gate.

- `scripts/check-plugin-compat.sh` discovers every bundle under `examples/` and asserts `claude plugin validate` exits 0 for each. It fails loudly when it finds zero bundles (a vacuously-passing empty glob is the exact false-green this gate exists to prevent) and when the `claude` CLI is absent.
- Wired as `agentos dev plugin-compat`, per the one-entry-point convention.
- Not `--strict`: strict mode promotes unknown-field warnings to errors, and the five AgentOS authoring extensions are unknown-to-Claude-Code by design. Warnings are the expected steady state; only a non-zero exit is a failure.
- `docs/interfaces/bundle-format/INTERFACE.md` now records the outbound direction as an explicit contract, names the gate defending it, and documents the five fields Claude Code silently drops (`systemPrompt`, `starterPrompts`, `secrets`, `triggers`, `approvalPolicy`).

**Nightly and per-PR, both.** Two independent drift vectors, neither trigger covering the other: the path-filtered `pull_request` trigger catches our own drift when we touch the bundles or the format models; the nightly `schedule` catches Claude Code changing the format under us, which no PR of ours would ever surface. The job is a checkout plus one npm install.

Verified live: all three bundles pass the real validator, exit 0.

**Known gap, deliberately not fixed here.** The doc names five dropped fields, but `examples/` only exercises two (`starterPrompts`, `secrets`). `systemPrompt`, `triggers`, and `approvalPolicy` appear in no bundle, so the gate cannot see Claude Code start typing them. Filed as a follow-up rather than padding a user-facing example with fields it does not need.

Closes #533