### PR TITLE
install: put the CLI on PATH (cargo install, not cargo build)

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2396,7 +2396,7 @@ export const commandManifest = {
         }
       ],
       "hidden": false,
-      "long_about": "Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo build` in `cli`, then builds the runner image. With `--update`, already-present heavyweight artifacts like the runner image are reused. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
+      "long_about": "Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo install --path cli` (builds AND puts `agentos` on PATH, so re-running install refreshes the live CLI), then builds the runner image. With `--update`, already-present heavyweight artifacts like the runner image are reused. `agentos update` is the fast CLI-only subset. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
       "name": "install"
     },
     {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2393,7 +2393,7 @@
         }
       ],
       "hidden": false,
-      "long_about": "Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo build` in `cli`, then builds the runner image. With `--update`, already-present heavyweight artifacts like the runner image are reused. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
+      "long_about": "Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only).\n\nFrom the repo root, runs (each idempotent, streaming output): copy `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in `apps/ui`, `cargo install --path cli` (builds AND puts `agentos` on PATH, so re-running install refreshes the live CLI), then builds the runner image. With `--update`, already-present heavyweight artifacts like the runner image are reused. `agentos update` is the fast CLI-only subset. A release binary has no source tree to install and errors clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.",
       "name": "install"
     },
     {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -356,9 +356,19 @@ pub async fn install(update: bool) -> Result<()> {
     )
     .await?;
 
-    // 4. cargo build in cli.
+    // 4. cargo install the CLI onto PATH (~/.cargo/bin), not just `cargo build`
+    // into target/debug. `install` should make the CLI it builds LIVE -- like
+    // `npm i` reconciling to the manifest -- so re-running it after a code change
+    // refreshes what the user actually runs, instead of silently leaving a stale
+    // on-PATH binary. `agentos update` is the fast CLI-only subset of this.
     require_tool("cargo", "cargo is not installed - https://rustup.rs/")?;
-    run_step(&root.join("cli"), "cargo", &["build"], "cargo build (cli)").await?;
+    run_step(
+        &root,
+        "cargo",
+        &["install", "--path", "cli", "--force"],
+        "cargo install (cli -> ~/.cargo/bin)",
+    )
+    .await?;
 
     // 5. Build the runner image via the existing `build` handler. Update mode
     // keeps reruns quick when the image is already present locally.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -105,10 +105,12 @@ enum Command {
     ///
     /// From the repo root, runs (each idempotent, streaming output): copy
     /// `.env.example` to `.env` if missing, `uv sync`, `pnpm install` in
-    /// `apps/ui`, `cargo build` in `cli`, then builds the runner image. With
-    /// `--update`, already-present heavyweight artifacts like the runner image
-    /// are reused. A release binary has no source tree to install and errors
-    /// clearly; a missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.
+    /// `apps/ui`, `cargo install --path cli` (builds AND puts `agentos` on PATH,
+    /// so re-running install refreshes the live CLI), then builds the runner
+    /// image. With `--update`, already-present heavyweight artifacts like the
+    /// runner image are reused. `agentos update` is the fast CLI-only subset. A
+    /// release binary has no source tree to install and errors clearly; a
+    /// missing tool (uv/pnpm/cargo/docker) prints a pointer and stops.
     #[command(alias = "i")]
     Install {
         /// Reuse already-present artifacts while refreshing dependencies and builds.


### PR DESCRIPTION
## Problem
`agentos install` (and `agentos i`) ran `cargo build` → `cli/target/debug/agentos`, which is **not** the `~/.cargo/bin/agentos` your shell runs. So after a CLI code change, `agentos i` *looked* like it updated the CLI but silently left the on-PATH binary stale — you'd test old code. That's the opposite of `npm i`, which reconciles the install to the manifest.

## Fix
`install`'s cargo step becomes **`cargo install --path cli --force`** — same as `update` — so `install` makes the CLI it builds **live on PATH**. Result:
- `agentos i` → full bootstrap that actually installs the CLI + deps + runner image (npm-i-like: reconcile everything to source)
- `agentos u` → the fast CLI-only subset (skip deps/image)

Both refresh PATH; they no longer diverge post-install.

## Safety
Nothing consumed the old `target/debug` output — `cli/scripts/e2e.sh` and CI build their own `target/release` binary. Regenerated the command manifest for the updated help text. `fmt`/`clippy`/drift-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)