### PR TITLE
#527: make committed example eval cases falsifiable

### DIFF
--- a/apps/worker/schema/eval-cases.example.json
+++ b/apps/worker/schema/eval-cases.example.json
@@ -3,7 +3,7 @@
     {
       "grader": {
         "case_sensitive": false,
-        "expected": "",
+        "expected": "example",
         "kind": "contains"
       },
       "id": "example-smoke",

--- a/apps/worker/tests/eval/test_models.py
+++ b/apps/worker/tests/eval/test_models.py
@@ -87,18 +87,20 @@ def test_valid_regex_grader_constructs_and_grades() -> None:
 
 
 def test_committed_fixture_parses_and_grades(eval_cases_example_path: Path) -> None:
-    """The committed cross-language fixture loads as an EvalSuite and its single
-    smoke grader (contains "") grades any completed turn's text True, proving the
-    scaffold output is platform-loadable (the latent bug in issue #8)."""
+    """The committed cross-language fixture loads as an EvalSuite, proving the
+    scaffold output is platform-loadable (the latent bug in issue #8). Its smoke
+    grader now asserts the agent named itself (#527), so it is falsifiable: an
+    empty/off-topic turn fails, an introduction naming the agent passes."""
     suite = EvalSuite.model_validate_json(
         eval_cases_example_path.read_text(encoding="utf-8")
     )
     assert len(suite.cases) == 1
     grader = suite.cases[0].grader
     assert grader.kind == GraderKind.CONTAINS
-    assert grader.expected == ""
-    assert grader.grade("anything at all") is True
-    assert grader.grade("") is True
+    assert grader.expected == "example"
+    assert grader.grade("I am the example agent.") is True
+    assert grader.grade("literally anything") is False
+    assert grader.grade("") is False
 
 
 def test_old_array_form_is_rejected() -> None:

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -819,7 +819,8 @@ def test_committed_fixture_loads_from_bundle_with_name_override(
 ) -> None:
     """A tar bundle carrying the committed cross-language fixture bytes at
     evals/cases.json loads through load_suite_from_bundle: the payload suite-name
-    override wins over the file's name, and the smoke grader grades any text True.
+    override wins over the file's name, and the falsifiable smoke grader (#527)
+    passes a turn naming the agent while failing off-topic text.
     Proves the scaffold output is platform-loadable (the latent bug in issue #8).
     """
     fixture_bytes = eval_cases_example_path.read_bytes()
@@ -836,4 +837,5 @@ def test_committed_fixture_loads_from_bundle_with_name_override(
     assert suite is not None
     assert suite.name == "override-suite-name"  # payload override at stream.py:160
     assert len(suite.cases) == 1
-    assert suite.cases[0].grader.grade("literally anything") is True
+    assert suite.cases[0].grader.grade("I am the example agent.") is True
+    assert suite.cases[0].grader.grade("literally anything") is False

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -329,9 +329,11 @@ mod tests {
         let suite = load_suite(&path).unwrap();
         assert_eq!(suite.cases.len(), 1);
         let case = &suite.cases[0];
-        assert_eq!(case.id, "weather-answers");
-        assert_eq!(case.grader.kind, GraderKind::Contains);
-        assert_eq!(case.grader.expected, "weather");
+        // Falsifiable case (#527): a real answer must carry a temperature figure,
+        // and the loader ignores the documentation-only `note` key on the case.
+        assert_eq!(case.id, "reports-a-temperature");
+        assert_eq!(case.grader.kind, GraderKind::Regex);
+        assert_eq!(case.grader.expected, "\\d+\\s*°");
     }
 
     #[test]

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -61,9 +61,15 @@ fn eval_cases(name: &str) -> String {
             {
                 "id": format!("{name}-smoke"),
                 "input": format!("In one short sentence, introduce yourself as the {name} agent."),
+                // Assert the agent NAMED itself, not `contains: ""` (which passed
+                // on any output, even an empty or errored turn). A broken agent
+                // that produces no reply -- or an off-topic one -- fails this,
+                // while a correct introduction contains the name the input asked
+                // for. Replace with a real domain grader as the first authoring
+                // step (see the scaffolded AGENTS.md).
                 "grader": {
                     "kind": "contains",
-                    "expected": "",
+                    "expected": name,
                     "case_sensitive": false,
                 },
             }
@@ -78,7 +84,7 @@ fn eval_cases(name: &str) -> String {
 /// full primer.
 fn agents_md(name: &str) -> String {
     format!(
-        "# Agent instructions: {name}\n\nThis is an AgentOS bundle (a Claude Code plugin shape). The full harness\nprimer is one command away and is the source of truth:\n\n    agentos guide\n\n## The loop\n\n1. `agentos skill up --fake-model` -- boot the runner offline, no credential.\n2. Edit `skills/{name}/SKILL.md` (behavior) and `evals/cases.json` (the contract).\n3. `agentos skill eval` -- must be green before any deploy. Merging to main promotes.\n4. `agentos skill down` when finished.\n\n## Rules\n\n- Verify before running: `agentos schema` lists every real command; never\n  invoke one you have not confirmed.\n- The eval file is the promotion gate and never changes across tiers\n  (skill/local/cluster). Never deploy on red.\n- Landmines: run `agentos guide` (or read\n  `.claude/skills/using-agentos/SKILL.md`) for the full, current list. The most\n  common: skill frontmatter uses `allowed-tools`, not `tools` (the wrong key\n  parses but silently grants no tools).\n- The scaffolded eval is a smoke test (passes on any completed turn).\n  Replace it with real graders as the first authoring step.\n"
+        "# Agent instructions: {name}\n\nThis is an AgentOS bundle (a Claude Code plugin shape). The full harness\nprimer is one command away and is the source of truth:\n\n    agentos guide\n\n## The loop\n\n1. `agentos skill up --fake-model` -- boot the runner offline, no credential.\n2. Edit `skills/{name}/SKILL.md` (behavior) and `evals/cases.json` (the contract).\n3. `agentos skill eval` -- must be green before any deploy. Merging to main promotes.\n4. `agentos skill down` when finished.\n\n## Rules\n\n- Verify before running: `agentos schema` lists every real command; never\n  invoke one you have not confirmed.\n- The eval file is the promotion gate and never changes across tiers\n  (skill/local/cluster). Never deploy on red.\n- Landmines: run `agentos guide` (or read\n  `.claude/skills/using-agentos/SKILL.md`) for the full, current list. The most\n  common: skill frontmatter uses `allowed-tools`, not `tools` (the wrong key\n  parses but silently grants no tools).\n- The scaffolded eval is a starter smoke test: it only checks the agent named\n  itself, so it fails on an empty/errored turn but proves nothing about the\n  real work. Replace it with a FALSIFIABLE grader -- one a plausibly-broken\n  agent would fail -- as the first authoring step (ADR-0022).\n"
     )
 }
 
@@ -316,7 +322,9 @@ mod tests {
         assert_eq!(case_list.len(), 1);
         assert_eq!(case_list[0]["id"], "deal-desk-smoke");
         assert_eq!(case_list[0]["grader"]["kind"], "contains");
-        assert_eq!(case_list[0]["grader"]["expected"], "");
+        // The seed asserts the agent named itself, not `contains: ""` (#527):
+        // an empty/errored turn fails, so the starter case is not vacuously green.
+        assert_eq!(case_list[0]["grader"]["expected"], "deal-desk");
         assert_eq!(case_list[0]["grader"]["case_sensitive"], false);
 
         // AGENTS.md teaches the developer's coding agent the harness.

--- a/examples/github-issues/README.md
+++ b/examples/github-issues/README.md
@@ -79,13 +79,15 @@ up (`skill up --secret ...`), run:
 agentos skill eval
 ```
 
-The three cases are deliberately robust to changing issue data — they assert on
-things that do not churn: that the agent returns real issue numbers (`#\d+`),
-that it finds the stable `enhancement` label when grouping, and that it can read
-a specific **closed** historical issue (#7, whose title is about `aci-protocol`).
-If the repo is ever restructured so those anchors no longer hold, update the
-`expected` values here — a case that starts failing is the grader catching a real
-change, which is the point.
+The cases are written to be **falsifiable** (a broken agent fails them) and
+robust to changing issue data by anchoring on a **closed** issue whose facts do
+not churn (#7 — title about `aci-protocol`, state closed): one case reads its
+content, one reads its state. A third case asserts the agent returns real
+issue-number-shaped output (`#\d+`); its `note` field flags that a fake-model
+agent inventing a number would still pass, which only the tool-call grader
+(ADR-0022 Phase 1) fully closes. If the repo is ever restructured so an anchor no
+longer holds, update the `expected` here — a case that starts failing is the
+grader catching a real change, which is the point.
 
 ## Swapping in a different service
 

--- a/examples/github-issues/evals/cases.json
+++ b/examples/github-issues/evals/cases.json
@@ -2,31 +2,34 @@
   "name": "github-issues",
   "cases": [
     {
+      "id": "reads-a-specific-issue-content",
+      "input": "In curie-eng/agentos, what is issue #7 about? Answer in one sentence.",
+      "grader": {
+        "kind": "contains",
+        "expected": "aci-protocol",
+        "case_sensitive": false
+      },
+      "note": "Falsifiable: issue #7's title is about promoting the queue payload into aci-protocol; an agent that does not read the issue cannot produce the distinctive term 'aci-protocol'. Anchored on a CLOSED issue so the fact is stable."
+    },
+    {
+      "id": "reads-a-specific-issue-state",
+      "input": "In curie-eng/agentos, is issue #7 open or closed? Answer with one word.",
+      "grader": {
+        "kind": "contains",
+        "expected": "closed",
+        "case_sensitive": false
+      },
+      "note": "Falsifiable: #7 is closed; an agent that does not query the issue state will guess wrong or hedge. Stable (a closed issue stays closed)."
+    },
+    {
       "id": "lists-real-issue-numbers",
       "input": "List a few open issues in curie-eng/agentos. Show each with its issue number in the form #<number>.",
       "grader": {
         "kind": "regex",
         "expected": "#\\d+",
         "case_sensitive": false
-      }
-    },
-    {
-      "id": "groups-by-label",
-      "input": "Group the open issues in curie-eng/agentos by their labels and name the labels you find.",
-      "grader": {
-        "kind": "contains",
-        "expected": "enhancement",
-        "case_sensitive": false
-      }
-    },
-    {
-      "id": "reads-a-specific-issue",
-      "input": "In curie-eng/agentos, what is issue #7 about? Answer in one sentence.",
-      "grader": {
-        "kind": "contains",
-        "expected": "aci-protocol",
-        "case_sensitive": false
-      }
+      },
+      "note": "Partly falsifiable: an agent that returns no issue-number-shaped text fails. LIMIT: a fake-model agent that INVENTS a '#5' still passes; proving the numbers came from an actual GitHub query needs the tool-call grader (ADR-0022 Phase 1). The two #7 cases above are the fully-falsifiable anchors."
     }
   ]
 }

--- a/examples/weather/evals/cases.json
+++ b/examples/weather/evals/cases.json
@@ -2,13 +2,14 @@
   "name": "weather",
   "cases": [
     {
-      "id": "weather-answers",
-      "input": "What's the weather in San Francisco?",
+      "id": "reports-a-temperature",
+      "input": "What's the weather in San Francisco today? Give the high in Fahrenheit.",
       "grader": {
-        "kind": "contains",
-        "expected": "weather",
+        "kind": "regex",
+        "expected": "\\d+\\s*°",
         "case_sensitive": false
-      }
+      },
+      "note": "Falsifiable: an agent that cannot fetch a matching forecast follows the SKILL rule and refuses ('I could not confirm a current forecast') with no temperature figure, which fails this grader -- unlike the old `contains: weather`, which the input itself guaranteed. LIMIT: a fake-model agent that INVENTS a plausible temperature still passes; proving the agent actually fetched a source needs the tool-call grader (ADR-0022 Phase 1)."
     }
   ]
 }


### PR DESCRIPTION
Closes #527.

The committed example suites (and the `agentos init` seed) were **vacuously green** — they passed on output the input itself guaranteed, so a plausibly-broken agent passed. ADR-0022's whole thesis is that a green eval means "the agent did the work."

## Changes
- **`examples/weather`** — `contains: "weather"` (the input all but guaranteed it) → a temperature-figure regex `\d+\s*°`. An agent that can't fetch a matching forecast follows the SKILL rule and refuses with no temperature → fails. A `note` documents the residual limit: a fake-model agent inventing a plausible number still passes; the ADR-0022 Phase 1 tool-call grader closes that.
- **`examples/github-issues`** — anchor on the **closed** issue #7 (content → `aci-protocol`, state → `closed`), both stable and falsifiable; keep the `#\d+` list case but annotate its limit; **drop** the vacuous `contains: "enhancement"` grouping case the issue flagged.
- **scaffold seed (`agentos init`)** — `contains: ""` (passed on *any* output, even empty) → assert the agent named itself. Updated the byte-equality fixture (`apps/worker/schema/eval-cases.example.json`), the scaffolded AGENTS.md guidance, and the `scaffold`/`evals` tests.

Every committed case is now **falsifiable** or carries a `note` (ignored by the frozen loader, so it doesn't affect grading) stating what fuller falsifiability waits on.

## Test
Both example suites load through the worker `EvalSuite` and the CLI `load_suite` (the `note` key is ignored); bundles validate; scaffold byte-equality + `evals` tests updated and green; `fmt`/`clippy` clean.

Ref ADR-0022, #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)