### PR TITLE
#526: skill eval --model + one-command model sweep (skill tier)

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -335,6 +335,30 @@ export const commandManifest = {
               "long": "url",
               "positional": false,
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Run the suite against this model in a throwaway runner instead of the already-running one. Repeatable: pass it N times to sweep N models and report pass-rate per model (#526). Needs a model credential + Docker",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Forward a connector secret BY NAME into each sweep runner (as `skill up --secret`), so an authed-MCP bundle can run under `--model`",
+              "id": "secret",
+              "long": "secret",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Runner image for the sweep runners. Defaults to the same image resolution as `skill up`",
+              "id": "image",
+              "long": "image",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -332,6 +332,30 @@
               "long": "url",
               "positional": false,
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Run the suite against this model in a throwaway runner instead of the already-running one. Repeatable: pass it N times to sweep N models and report pass-rate per model (#526). Needs a model credential + Docker",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Forward a connector secret BY NAME into each sweep runner (as `skill up --secret`), so an authed-MCP bundle can run under `--model`",
+              "id": "secret",
+              "long": "secret",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Runner image for the sweep runners. Defaults to the same image resolution as `skill up`",
+              "id": "image",
+              "long": "image",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
 use crate::bundle::pack_tar_gz;
 use crate::docker::{self, CheckSpec, StartSpec};
-use crate::evals::{load_suite, turn_passes};
+use crate::evals::{load_suite, turn_passes, EvalSuite};
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
 use crate::scaffold::{read_manifest, scaffold, scaffold_from_spec};
@@ -1008,30 +1008,210 @@ pub async fn send(
     Ok(())
 }
 
-pub async fn eval(cases_path: Option<PathBuf>, url: Option<String>) -> Result<()> {
+pub async fn eval(
+    cases_path: Option<PathBuf>,
+    url: Option<String>,
+    models: Vec<String>,
+    secrets: Vec<String>,
+    image: String,
+) -> Result<()> {
     let state_plugin_dir = state::load(Path::new("."))?.map(|s| PathBuf::from(s.plugin_dir));
     let cases_path = resolve_cases_path(cases_path, Path::new("."), state_plugin_dir.as_deref())?;
     let suite = load_suite(&cases_path)?;
+
+    // Model selection (#526): with `--model`, boot a transient runner per model,
+    // run the suite against each, and report pass-rate per model -- the one
+    // command a "can we move to a cheaper model" decision needs, instead of a
+    // manual `skill up --model X` + `skill eval` loop per model. Without it, the
+    // default path drives the already-running runner (whatever model it booted).
+    if !models.is_empty() {
+        return eval_sweep(
+            &suite,
+            &models,
+            &secrets,
+            &image,
+            state_plugin_dir.as_deref(),
+        )
+        .await;
+    }
+
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
     let ui = crate::ui::ui();
+    let bar = ui.progress_bar(suite.cases.len() as u64, "running evals");
+    let results = run_suite_cases(&client, &suite, |_| bar.inc(1)).await?;
+    bar.finish();
 
-    let total = suite.cases.len();
-    // (id, passed, seconds) rows, rendered as one table once the run finishes.
-    let mut results: Vec<(String, bool, f64)> = Vec::with_capacity(total);
-    let bar = ui.progress_bar(total as u64, "running evals");
-    for case in &suite.cases {
+    report_eval(&results)
+}
+
+/// Run every case in `suite` against a runner, returning `(id, passed, seconds)`
+/// rows. `on_case` is called once per completed case (progress). Shared by the
+/// single-runner path and the per-model sweep so both grade identically.
+async fn run_suite_cases(
+    client: &RunnerClient,
+    suite: &EvalSuite,
+    mut on_case: impl FnMut(usize),
+) -> Result<Vec<(String, bool, f64)>> {
+    let mut results = Vec::with_capacity(suite.cases.len());
+    for (i, case) in suite.cases.iter().enumerate() {
         let started = Instant::now();
         let events = client
             .send_event(EventType::EvalCase, &case.input, "U-eval", |_| {})
             .await?;
         let elapsed = started.elapsed().as_secs_f64();
         results.push((case.id.clone(), turn_passes(case, &events), elapsed));
-        bar.inc(1);
+        on_case(i);
     }
-    bar.finish();
+    Ok(results)
+}
 
-    report_eval(&results)
+/// Boot a throwaway runner for one model on `port`, forwarding the model
+/// credential and any `--secret` from the env or the host vault exactly like
+/// `skill up` (never in argv). Returns its base URL; the caller removes the
+/// container when done. Does NOT touch `.agentos/runner.json`, so a sweep never
+/// clobbers a persistent `skill up` runner's recorded state.
+async fn boot_eval_runner(
+    plugin_dir: &Path,
+    image: &str,
+    port: u16,
+    name: &str,
+    model: &str,
+    secrets: &[String],
+) -> Result<String> {
+    // Real-model run: forward the model credential (env or vault) and the
+    // bundle's --secret connector secrets, mirroring `start`'s resolution.
+    let mut docker_env = load_model_credentials_from_secret_store()?;
+    let byo_credential = std::env::var("AGENTOS_CREDENTIALS").ok().or_else(|| {
+        stored_env_contains(&docker_env, "AGENTOS_CREDENTIALS").then_some("stored".to_string())
+    });
+    for secret in secrets {
+        if std::env::var_os(secret).is_none() && !stored_env_contains(&docker_env, secret) {
+            if let Some(pair) = secret_store_env(secret)? {
+                docker_env.push(pair);
+            }
+        }
+    }
+    let passthrough_env = merge_secret_env(
+        select_passthrough_env(false, byo_credential.as_deref()),
+        secrets,
+    );
+    let spec = StartSpec {
+        image: image.to_string(),
+        container_name: name.to_string(),
+        host_port: port,
+        plugin_dir: plugin_dir.to_path_buf(),
+        session_id: format!("eval-{}", unix_now()),
+        sandbox_id: "local".into(),
+        budget_json: DEFAULT_BUDGET.to_string(),
+        fake_model: false,
+        network: None,
+        otel_endpoint: None,
+        model_base_url: None,
+        model: Some(model.to_string()),
+        passthrough_env,
+        docker_env,
+    };
+    docker::docker_with_env(&spec.run_args(), &spec.docker_env)
+        .await
+        .with_context(|| format!("booting eval runner for model {model}"))?;
+    let url = format!("http://localhost:{port}");
+    if let Err(err) = RunnerClient::new(&url)?
+        .wait_healthy(Duration::from_secs(60))
+        .await
+    {
+        let logs = docker::container_logs(name, 40).await;
+        let _ = docker::remove_container(name).await;
+        bail!("eval runner for model {model} failed to become healthy: {err}\n{logs}");
+    }
+    Ok(url)
+}
+
+/// Run the suite once per model in a fresh runner and report pass-rate per model.
+async fn eval_sweep(
+    suite: &EvalSuite,
+    models: &[String],
+    secrets: &[String],
+    image: &str,
+    state_plugin_dir: Option<&Path>,
+) -> Result<()> {
+    let ui = crate::ui::ui();
+    // Mount the recorded runner's bundle dir if one is known, else the cwd.
+    let plugin_dir = state_plugin_dir
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .canonicalize()
+        .context("resolving the bundle directory for the model sweep")?;
+    ui.note(&format!(
+        "model sweep: {} model(s) x {} case(s)",
+        models.len(),
+        suite.cases.len()
+    ));
+    let cl = ui.checklist();
+    let mut rows: Vec<(String, usize, usize)> = Vec::with_capacity(models.len());
+    for (i, model) in models.iter().enumerate() {
+        let name = format!("agentos-eval-sweep-{i}");
+        let port = DEFAULT_PORT + 100 + i as u16;
+        let step = cl.step(&format!("model {model}"));
+        let url = match boot_eval_runner(&plugin_dir, image, port, &name, model, secrets).await {
+            Ok(url) => url,
+            Err(err) => {
+                step.fail("boot failed");
+                return Err(err);
+            }
+        };
+        let client = RunnerClient::new(&url)?;
+        let run = run_suite_cases(&client, suite, |_| {}).await;
+        let _ = docker::remove_container(&name).await;
+        let results = run?;
+        let passed = results.iter().filter(|(_, ok, _)| *ok).count();
+        step.done(&format!("{passed}/{}", suite.cases.len()));
+        rows.push((model.clone(), passed, suite.cases.len()));
+    }
+    report_sweep(&rows)
+}
+
+/// Render a model-sweep roll-up: pass-rate per model. Under `--json` the whole
+/// comparison is one payload; otherwise a table. A sweep is a comparison, not a
+/// gate, so it never exits non-zero on a model that scored below 100%.
+pub fn report_sweep(rows: &[(String, usize, usize)]) -> Result<()> {
+    let ui = crate::ui::ui();
+    if ui.json() {
+        let models: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|(model, passed, total)| {
+                serde_json::json!({
+                    "model": model,
+                    "passed": passed,
+                    "total": total,
+                    "pass_rate": if *total > 0 { *passed as f64 / *total as f64 } else { 0.0 },
+                })
+            })
+            .collect();
+        ui.emit_json(&serde_json::json!({ "sweep": models }));
+        return Ok(());
+    }
+    let table: Vec<Vec<String>> = rows
+        .iter()
+        .map(|(model, passed, total)| {
+            let rate = if *total > 0 {
+                *passed as f64 / *total as f64 * 100.0
+            } else {
+                0.0
+            };
+            vec![
+                model.clone(),
+                format!("{passed}/{total}"),
+                format!("{rate:.0}%"),
+            ]
+        })
+        .collect();
+    ui.payload_plain(&crate::ui::table(
+        &["model", "passed", "pass rate"],
+        &table,
+        &[1, 2],
+    ));
+    Ok(())
 }
 
 /// Render a finished eval run identically for every tier (`skill`, `local`,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -287,6 +287,19 @@ enum SkillAction {
         /// Runner base URL (defaults to the started runner, then localhost).
         #[arg(long)]
         url: Option<String>,
+        /// Run the suite against this model in a throwaway runner instead of the
+        /// already-running one. Repeatable: pass it N times to sweep N models and
+        /// report pass-rate per model (#526). Needs a model credential + Docker.
+        #[arg(long = "model", value_name = "MODEL")]
+        model: Vec<String>,
+        /// Forward a connector secret BY NAME into each sweep runner (as
+        /// `skill up --secret`), so an authed-MCP bundle can run under `--model`.
+        #[arg(long = "secret", value_name = "NAME")]
+        secret: Vec<String>,
+        /// Runner image for the sweep runners. Defaults to the same image
+        /// resolution as `skill up`.
+        #[arg(long)]
+        image: Option<String>,
     },
     /// Interview to generate a starter `evals/cases.json` (guided eval generation).
     EvalInit {
@@ -1151,7 +1164,20 @@ async fn run(command: Option<Command>) -> Result<()> {
                 event_type,
                 url,
             } => commands::send(&text, &user, event_type.into(), url).await,
-            SkillAction::Eval { cases, url } => commands::eval(cases, url).await,
+            SkillAction::Eval {
+                cases,
+                url,
+                model,
+                secret,
+                image,
+            } => {
+                let image = artifacts::resolve_image(
+                    image.as_deref(),
+                    artifacts::Channel::current(),
+                    artifacts::version(),
+                );
+                commands::eval(cases, url, model, secret, image).await
+            }
             SkillAction::EvalInit { out, force } => {
                 agentos::eval_init::run(agentos::eval_init::EvalInitOpts { out, force })
             }
@@ -1883,6 +1909,38 @@ mod tests {
             cli.command,
             Some(Command::Install { update: true })
         ));
+    }
+
+    #[test]
+    fn skill_eval_model_is_repeatable_for_a_sweep() {
+        // No --model -> drive the running runner (empty models vec).
+        match Cli::try_parse_from(["agentos", "skill", "eval"])
+            .expect("skill eval should parse")
+            .command
+        {
+            Some(Command::Skill {
+                action: SkillAction::Eval { model, .. },
+            }) => assert!(model.is_empty()),
+            _ => panic!("expected skill eval"),
+        }
+        // Repeated --model collects into the sweep list.
+        match Cli::try_parse_from([
+            "agentos",
+            "skill",
+            "eval",
+            "--model",
+            "claude-haiku-4-5",
+            "--model",
+            "claude-sonnet-5",
+        ])
+        .expect("skill eval sweep should parse")
+        .command
+        {
+            Some(Command::Skill {
+                action: SkillAction::Eval { model, .. },
+            }) => assert_eq!(model, vec!["claude-haiku-4-5", "claude-sonnet-5"]),
+            _ => panic!("expected skill eval sweep"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
First slice of #526 — model selection on eval, at the **skill** tier.

## What
- **`agentos skill eval --model M`** runs the suite against `M` in a throwaway runner instead of the already-running one (the model is a boot-time property, so `--model` boots).
- **Repeatable** — `--model A --model B …` runs the suite across N models in one command and reports **pass-rate per model**. That's the "can we move this skill to a cheaper model" decision without a manual `skill up --model X` + `skill eval` loop.
- `--secret` forwards connector secrets into each sweep runner (so an authed-MCP bundle like `github-issues` can be swept), `--image` overrides the runner image.

## How
- `boot_eval_runner` boots a transient per-model runner (unique name/port, forwards the model credential + secrets from env/vault exactly like `skill up`) **without** writing `.agentos/runner.json` — a sweep never clobbers a persistent `skill up` runner's recorded state.
- `run_suite_cases` is shared by the single-runner path and the sweep so both grade identically. `report_sweep` renders pass-rate per model (table, or one payload under `--json`). A model that won't boot **fails loudly**.

## Scope / follow-ups
Skill tier only. `local`/`cluster eval --model` and writing the sweep through the recorder into `GET /evals/matrix` (sliced by model) are the platform-side pieces (worker eval-stream + API) — larger, tracked on #526.

## Test
Parse test for the repeatable `--model`; existing eval load/report tests green; command-manifest regenerated (drift check passes); `fmt`/`clippy` clean. Full sweep behavior needs Docker + a model credential (manual e2e).

Ref #255, #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)