### PR TITLE
Shrink the guide by making the product reject what it used to accept

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -138,8 +138,14 @@ pub fn check_outcome(report: &CheckReport) -> std::result::Result<(), crate::exi
             fix: None,
             class: crate::exit::ExitClass::Failure,
         }
+        // A structurally bad bundle is `invalid_bundle` (the runner's `run_check`
+        // rejects it at step 1), so every remaining red cause is a runtime one:
+        // a declared server that never registered or failed to start, one that
+        // registered zero tools, one that needs a credential the offline check
+        // never forwards, or MCP init exceeding the deadline. The printed
+        // `reason:` lines say which, so point at them rather than guess.
         .with_fix(
-            "declare MCP servers as an inline object in .claude-plugin/plugin.json (or a bare .mcp.json); run agentos skill check again",
+            "read the printed reason(s): fix the server's command/args, forward its credential with agentos skill up --secret <NAME>, or raise --timeout if MCP init ran long",
         )),
         "invalid_bundle" => {
             // An invalid bundle is a deterministic input error (exit 2, Usage),
@@ -565,8 +571,18 @@ fn merge_secret_env(mut passthrough: Vec<String>, secrets: &[String]) -> Vec<Str
     passthrough
 }
 
+/// Is `name` exported with a usable value?
+///
+/// An empty-string credential is absent, not supplied (issue #540): `var_os`
+/// alone reports `NAME=""` as present, which would suppress the vault fallback
+/// and forward nothing usable. Mirrors `ops.rs::resolve_up_credentials` and
+/// `interactive.rs::env_credential_present`.
+fn env_credential_present(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| !value.is_empty())
+}
+
 fn secret_store_env(name: &str) -> Result<Option<(String, String)>> {
-    if std::env::var_os(name).is_some() {
+    if env_credential_present(name) {
         return Ok(None);
     }
     if !crate::secrets::is_saved(name)? {
@@ -692,15 +708,18 @@ pub async fn start(opts: StartOpts) -> Result<()> {
     if !suppress_credential {
         docker_env.extend(load_model_credentials_from_secret_store()?);
     }
-    let byo_credential = std::env::var("AGENTOS_CREDENTIALS").ok().or_else(|| {
-        stored_env_contains(&docker_env, "AGENTOS_CREDENTIALS").then_some("stored".to_string())
-    });
+    let byo_credential = std::env::var("AGENTOS_CREDENTIALS")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            stored_env_contains(&docker_env, "AGENTOS_CREDENTIALS").then_some("stored".to_string())
+        });
     // Hydrate `--secret NAME` from AgentOS private storage when it is not
     // already present in the process env. The docker argv still forwards only
     // the NAME (`-e NAME`); the value is supplied only to the Docker CLI child
     // process so Docker can copy it into the runner container.
     for name in &opts.secret {
-        if std::env::var_os(name).is_none() && !stored_env_contains(&docker_env, name) {
+        if !env_credential_present(name) && !stored_env_contains(&docker_env, name) {
             match secret_store_env(name)? {
                 Some(pair) => docker_env.push(pair),
                 None => {

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -183,20 +183,8 @@ pub fn primer() -> Primer {
         ],
         landmines: vec![
             Landmine {
-                title: "Skill frontmatter uses `allowed-tools`, not `tools`",
-                detail: "The wrong key parses but silently grants no tools.",
-            },
-            Landmine {
-                title: "MCP servers must be inline objects in .mcp.json",
-                detail: "A string-pointer declaration silently fails to load; use the bare inline object form. Run `agentos skill check` to catch this offline before deploy.",
-            },
-            Landmine {
                 title: "Fake vs live model is symmetric across skill and local",
                 detail: "`agentos skill up` and `agentos local up` both run the real model when a credential is present and the fake model otherwise; `agentos skill up --fake-model` or AGENTOS_FAKE_MODEL=1 forces the offline fake at either tier.",
-            },
-            Landmine {
-                title: "In-cluster sandboxes need dnsPolicy ClusterFirst",
-                detail: "Otherwise the bound bundle fetch cannot resolve the in-cluster object store.",
             },
             Landmine {
                 title: "A real model in-cluster needs its provider's egress opened",
@@ -210,19 +198,11 @@ pub fn primer() -> Primer {
                 title: "A real-model `cluster up` fails closed without a gVisor runtime",
                 detail: "On a cluster with no `runsc` RuntimeClass, the default `security.gvisor.mode=auto` renders a blocking enforcement preflight for a real (non-fake) model, so `agentos cluster up` fails closed instead of running runner pods on the host kernel. Install anyway with `agentos cluster up --set security.gvisor.mode=off` (no kernel isolation, knowingly), use `--fake-model` (the sealed path skips the preflight), or install runsc on the nodes. This is the security posture, not a bug.",
             },
-            Landmine {
-                title: "An empty-string API key is not \"unset\"",
-                detail: "It trips the CLI auth gate. Omit the flag or env entirely to fall back, rather than passing an empty value.",
-            },
         ],
         recovery: vec![
             Recovery {
                 symptom: "\"platform API ... unreachable\" on a local deploy or message",
                 fix: "The stack is down. Run `agentos local up`, then retry.",
-            },
-            Recovery {
-                symptom: "authentication_failed from a live model",
-                fix: "A real credential is empty or being overridden. Unset the empty one; set AGENTOS_MODEL_CREDENTIALS for `agentos cluster up`.",
             },
             Recovery {
                 symptom: "`agentos cluster up` hangs ~2 min then dies with `job agentos-preflight-gvisor failed: DeadlineExceeded`",

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -948,6 +948,16 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     Ok(())
 }
 
+/// Is `name` exported with a usable value?
+///
+/// An empty-string credential is absent, not supplied (issue #540): `var_os`
+/// alone reports `NAME=""` as present, which would report a credential as
+/// available and suppress the vault fallback while forwarding nothing usable.
+/// Mirrors `local.rs::model_mode_from_env` and `ops.rs::resolve_up_credentials`.
+fn env_credential_present(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| !value.is_empty())
+}
+
 /// The env forwarded into the deploy/comms children for the Slack deploy
 /// workflow: the first available model credential and the two Slack tokens, each
 /// pulled from the vault only when not already exported (an exported value is
@@ -960,7 +970,7 @@ fn slack_secret_env() -> Result<Vec<(String, String)>> {
         "ANTHROPIC_API_KEY",
         "CLAUDE_CODE_OAUTH_TOKEN",
     ] {
-        if std::env::var_os(name).is_some() {
+        if env_credential_present(name) {
             break;
         }
         if let Some(value) = crate::secrets::get_value(name)? {
@@ -1032,7 +1042,7 @@ fn example_secret_env(extra_secrets: &[&str]) -> Result<Vec<(String, String)>> {
         "CLAUDE_CODE_OAUTH_TOKEN",
     ]
     .iter()
-    .any(|name| std::env::var_os(name).is_some())
+    .any(|name| env_credential_present(name))
     {
         for name in [
             "AGENTOS_CREDENTIALS",
@@ -1109,7 +1119,7 @@ fn ensure_model_credential_available(
         "CLAUDE_CODE_OAUTH_TOKEN",
     ];
     for name in NAMES {
-        if std::env::var_os(name).is_some() {
+        if env_credential_present(name) {
             return Ok(());
         }
     }
@@ -1175,7 +1185,7 @@ fn model_credential_status(
         "ANTHROPIC_API_KEY",
         "CLAUDE_CODE_OAUTH_TOKEN",
     ] {
-        if std::env::var_os(name).is_some() || saved_names.contains(name) {
+        if env_credential_present(name) || saved_names.contains(name) {
             return "available";
         }
         if legacy_names.contains(name) {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -50,7 +50,7 @@ struct AgentTarget<T: TierDefaults> {
     agent: String,
     #[arg(long, default_value = T::API_URL, env = "AGENTOS_API_URL")]
     api_url: String,
-    #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+    #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
     api_key: String,
     #[arg(long)]
     dry_run: bool,
@@ -486,7 +486,7 @@ enum LocalAction {
         #[arg(long)]
         api_url: Option<String>,
         /// Platform API key for the default-channel lookup.
-        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY)]
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Synthetic Slack user id for the enqueued event.
         #[arg(long, default_value = message::DEFAULT_USER)]
@@ -527,7 +527,7 @@ enum LocalAction {
         #[arg(long)]
         api_url: Option<String>,
         /// Platform API key for the default-channel lookup.
-        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY)]
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Synthetic Slack user id for the enqueued events.
         #[arg(long, default_value = message::DEFAULT_USER)]
@@ -555,7 +555,7 @@ enum LocalAction {
         )]
         api_url: String,
         /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
         api_key: String,
         /// Slack channel to bind the agent to. On first create it defaults to
         /// C0LOCALDEV; on redeploy it is only moved when you pass this flag, so
@@ -618,7 +618,7 @@ enum LocalAction {
             env = "AGENTOS_API_URL"
         )]
         api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
         api_key: String,
         #[arg(long)]
         dry_run: bool,
@@ -633,7 +633,7 @@ enum LocalAction {
             env = "AGENTOS_API_URL"
         )]
         api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
         api_key: String,
         /// Confirm the action.
         #[arg(long)]
@@ -651,7 +651,7 @@ enum LocalAction {
             env = "AGENTOS_API_URL"
         )]
         api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
         api_key: String,
         #[arg(long)]
         dry_run: bool,
@@ -849,7 +849,7 @@ enum ClusterAction {
         #[arg(long, default_value_t = message::DEFAULT_API_LOCAL_PORT)]
         api_local_port: u16,
         /// Platform API key for the default-channel lookup.
-        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY)]
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Synthetic Slack user id for the enqueued event.
         #[arg(long, default_value = message::DEFAULT_USER)]
@@ -911,7 +911,7 @@ enum ClusterAction {
         #[arg(long, default_value_t = message::DEFAULT_API_LOCAL_PORT)]
         api_local_port: u16,
         /// Platform API key for the default-channel lookup.
-        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY)]
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Synthetic Slack user id for the enqueued events.
         #[arg(long, default_value = message::DEFAULT_USER)]
@@ -944,7 +944,7 @@ enum ClusterAction {
         #[arg(long, default_value = "agentos")]
         release: String,
         /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
         api_key: String,
         /// Slack channel to bind the agent to. On first create it defaults to
         /// C0LOCALDEV; on redeploy it is only moved when you pass this flag, so
@@ -976,7 +976,7 @@ enum ClusterAction {
         #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
         api_url: String,
         /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
         api_key: String,
         /// Confirm this destructive action (required; it stops the agent's runs).
         #[arg(long)]
@@ -993,7 +993,7 @@ enum ClusterAction {
         #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
         api_url: String,
         /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
         api_key: String,
         /// Print what would be done and exit without making a request.
         #[arg(long)]
@@ -1010,7 +1010,7 @@ enum ClusterAction {
         #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
         api_url: String,
         /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
         api_key: String,
         /// Print what would be done and exit without making a request.
         #[arg(long)]
@@ -1024,7 +1024,7 @@ enum ClusterAction {
         #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
         api_url: String,
         /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY")]
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
         api_key: String,
         /// Confirm this destructive action (required; it permanently deletes the agent).
         #[arg(long)]
@@ -1332,7 +1332,11 @@ async fn run(command: Option<Command>) -> Result<()> {
                         api_key,
                     },
                     state,
-                    std::env::var("AGENTOS_API_KEY").ok(),
+                    // Empty is unset (#540), so the recorded-env bail below still
+                    // fires when $AGENTOS_API_KEY is exported blank.
+                    std::env::var("AGENTOS_API_KEY")
+                        .ok()
+                        .filter(|v| !v.is_empty()),
                 )?;
                 message::message(MessageOpts {
                     text,
@@ -1653,7 +1657,11 @@ async fn run(command: Option<Command>) -> Result<()> {
                         api_key,
                     },
                     state,
-                    std::env::var("AGENTOS_API_KEY").ok(),
+                    // Empty is unset (#540), so the recorded-env bail below still
+                    // fires when $AGENTOS_API_KEY is exported blank.
+                    std::env::var("AGENTOS_API_KEY")
+                        .ok()
+                        .filter(|v| !v.is_empty()),
                 )?;
                 let resolved_chart = artifacts::resolve_chart(
                     resolved.chart.as_deref(),

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -55,6 +55,42 @@ pub const DEFAULT_VALKEY_PASSWORD: &str = "valkeypass";
 /// The chart's default platform API key (values.yaml `api.apiKey`).
 pub const DEFAULT_API_KEY: &str = "agentos-dev-key";
 
+/// clap `value_parser` for every `--api-key` / `$AGENTOS_API_KEY` declaration.
+///
+/// An empty-string credential is absent, not "explicitly supplied" (issue #540).
+/// clap reports an env var set to `""` as PRESENT, so without this an empty
+/// value reaches [`crate::state::apply_continue`] as a user-supplied key,
+/// defeats its sentinel comparison against [`DEFAULT_API_KEY`], and silently
+/// sends a blank key onward instead of falling back. Normalizing at the parser
+/// -- the one seam every `--api-key` declaration shares -- is what makes the
+/// rule hold on the `--continue` and non-`--continue` paths alike, rather than
+/// only where a sentinel happens to be compared.
+///
+/// An explicit `--api-key ""` must behave exactly as an omitted flag, which is
+/// why the env source is consulted HERE rather than left to clap: clap resolves
+/// an explicit flag ahead of `env`, so by the time the parser runs the env
+/// source is already out of the running. Without this, `--api-key ""` under a
+/// real `$AGENTOS_API_KEY` would send the well-known dev sentinel instead of the
+/// operator's key.
+///
+/// Mirrors the rule already settled in `ops.rs::resolve_up_credentials`,
+/// `local.rs::model_mode_from_env`, and `secrets.rs::save_value`.
+pub fn api_key_or_default(raw: &str) -> Result<String, String> {
+    Ok(resolve_api_key(raw, env::var("AGENTOS_API_KEY").ok()))
+}
+
+/// The pure core of [`api_key_or_default`], with the env source passed in so the
+/// resolution is unit-testable without mutating this process's environment.
+/// Same shape as `ops.rs::resolve_up_credentials`.
+fn resolve_api_key(raw: &str, env_value: Option<String>) -> String {
+    if !raw.is_empty() {
+        return raw.to_string();
+    }
+    env_value
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_API_KEY.to_string())
+}
+
 /// Local mode (`--local`): the compose Valkey's published host port
 /// (`compose.dev.yaml`), where the CLI enqueues and the compose worker consumes.
 pub const DEFAULT_LOCAL_VALKEY_PORT: u16 = 26379;
@@ -112,7 +148,9 @@ fn persist_and_hint(opts: &MessageOpts, verb: TurnVerb, channel: &str, thread_ts
         verb,
         channel,
         thread_ts,
-        env::var("AGENTOS_API_KEY").ok(),
+        // Empty is unset (#540): otherwise this records an `api_key_env` that
+        // resolves to nothing on the next `--continue`.
+        env::var("AGENTOS_API_KEY").ok().filter(|v| !v.is_empty()),
     );
 
     match env::current_dir().context("resolving the current working directory") {
@@ -1041,6 +1079,40 @@ mod tests {
             local: false,
             api_url: None,
         }
+    }
+
+    /// The full `--api-key` x `$AGENTOS_API_KEY` truth table. The load-bearing
+    /// row is `--api-key ""` under a real env key: an empty flag is an ABSENT
+    /// flag, so it must resolve to the env key, never to the dev sentinel.
+    #[test]
+    fn resolve_api_key_treats_an_empty_flag_exactly_as_an_omitted_one() {
+        let real = || Some("sk-real-from-env".to_string());
+
+        // Flag omitted: clap hands the parser its `default_value`, which must
+        // survive untouched whatever the env holds.
+        assert_eq!(resolve_api_key(DEFAULT_API_KEY, None), DEFAULT_API_KEY);
+        assert_eq!(
+            resolve_api_key(DEFAULT_API_KEY, Some(String::new())),
+            DEFAULT_API_KEY
+        );
+        assert_eq!(resolve_api_key(DEFAULT_API_KEY, real()), DEFAULT_API_KEY);
+
+        // Env-sourced (clap passes the env value through the parser): empty is
+        // absent and falls back to the sentinel, non-empty passes through.
+        assert_eq!(resolve_api_key("", Some(String::new())), DEFAULT_API_KEY);
+
+        // The bug: an explicitly empty flag must reconsider the env source,
+        // because clap already resolved the flag ahead of `env` and will not.
+        assert_eq!(resolve_api_key("", real()), "sk-real-from-env");
+        // ...and with no env source at all it lands on the sentinel.
+        assert_eq!(resolve_api_key("", None), DEFAULT_API_KEY);
+
+        // An explicit non-empty flag still wins over the env source, and a real
+        // credential survives byte-for-byte: normalize the empty case ONLY.
+        assert_eq!(resolve_api_key("sk-explicit", real()), "sk-explicit");
+        assert_eq!(resolve_api_key("sk-real-key-123", None), "sk-real-key-123");
+        // Including a key that happens to look like whitespace-padded input.
+        assert_eq!(resolve_api_key(" ", real()), " ");
     }
 
     #[test]

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -80,11 +80,11 @@ fn eval_cases(name: &str) -> String {
 
 /// The root `AGENTS.md`: the cross-agent auto-scanned standard carrying the
 /// non-discoverable operating rules (the authoring loop, eval-as-promotion-gate,
-/// verify-first, the top landmines) and a pointer to `agentos guide` for the
-/// full primer.
+/// verify-first) and a pointer to `agentos guide` for the full primer and the
+/// current landmine list.
 fn agents_md(name: &str) -> String {
     format!(
-        "# Agent instructions: {name}\n\nThis is an AgentOS bundle (a Claude Code plugin shape). The full harness\nprimer is one command away and is the source of truth:\n\n    agentos guide\n\n## The loop\n\n1. `agentos skill up --fake-model` -- boot the runner offline, no credential.\n2. Edit `skills/{name}/SKILL.md` (behavior) and `evals/cases.json` (the contract).\n3. `agentos skill eval` -- must be green before any deploy. Merging to main promotes.\n4. `agentos skill down` when finished.\n\n## Rules\n\n- Verify before running: `agentos schema` lists every real command; never\n  invoke one you have not confirmed.\n- The eval file is the promotion gate and never changes across tiers\n  (skill/local/cluster). Never deploy on red.\n- Landmines: run `agentos guide` (or read\n  `.claude/skills/using-agentos/SKILL.md`) for the full, current list. The most\n  common: skill frontmatter uses `allowed-tools`, not `tools` (the wrong key\n  parses but silently grants no tools).\n- The scaffolded eval is a starter smoke test: it only checks the agent named\n  itself, so it fails on an empty/errored turn but proves nothing about the\n  real work. Replace it with a FALSIFIABLE grader -- one a plausibly-broken\n  agent would fail -- as the first authoring step (ADR-0022).\n"
+        "# Agent instructions: {name}\n\nThis is an AgentOS bundle (a Claude Code plugin shape). The full harness\nprimer is one command away and is the source of truth:\n\n    agentos guide\n\n## The loop\n\n1. `agentos skill up --fake-model` -- boot the runner offline, no credential.\n2. Edit `skills/{name}/SKILL.md` (behavior) and `evals/cases.json` (the contract).\n3. `agentos skill eval` -- must be green before any deploy. Merging to main promotes.\n4. `agentos skill down` when finished.\n\n## Rules\n\n- Verify before running: `agentos schema` lists every real command; never\n  invoke one you have not confirmed.\n- The eval file is the promotion gate and never changes across tiers\n  (skill/local/cluster). Never deploy on red.\n- Landmines: run `agentos guide` (or read\n  `.claude/skills/using-agentos/SKILL.md`) for the full, current list.\n- The scaffolded eval is a starter smoke test: it only checks the agent named\n  itself, so it fails on an empty/errored turn but proves nothing about the\n  real work. Replace it with a FALSIFIABLE grader -- one a plausibly-broken\n  agent would fail -- as the first authoring step (ADR-0022).\n"
     )
 }
 
@@ -362,7 +362,11 @@ mod tests {
         let agents = std::fs::read_to_string(dir.path().join("AGENTS.md")).unwrap();
         assert!(agents.contains("agentos guide"));
         assert!(agents.contains("agentos skill eval"));
-        assert!(agents.contains("allowed-tools"));
+        // AGENTS.md defers the landmine list to `agentos guide` rather than
+        // naming any specific landmine: no drift gate covers this hand-written
+        // prose, so a copy here goes stale silently. The `allowed-tools`
+        // teaching lives in the correct-by-example scaffolded SKILL.md above.
+        assert!(!agents.contains("allowed-tools"));
 
         // The installable harness primer skill, discovered by Claude Code.
         let harness_skill =

--- a/cli/tests/credential_resolution.rs
+++ b/cli/tests/credential_resolution.rs
@@ -1,0 +1,357 @@
+//! Empty-string credentials are absent, not "explicitly supplied" (issue #540, AC6).
+//!
+//! `AGENTOS_API_KEY=""` must resolve identically to the variable being unset, on
+//! every path. The rule is already settled in three places -- `ops.rs`'s
+//! `resolve_up_credentials` filters empty, `secrets.rs`'s `save_value` refuses to
+//! store an empty secret, and `local.rs`'s `model_mode_from_env` calls it out by
+//! name ("Empty counts as unset (the empty-string-is-not-a-credential rule)").
+//! The `--api-key` clap seam missed it: clap treats an env var set to `""` as
+//! present, so `""` reaches `state::apply_continue` as a user-supplied key,
+//! defeats the sentinel-default comparison against `DEFAULT_API_KEY`, and never
+//! falls back.
+//!
+//! These tests observe the resolution OUTCOME rather than any internal shape, so
+//! they hold wherever the normalization lands (a `value_parser` on the four
+//! `#[arg]` sites, or another single seam). The outcome they read is issue #112's
+//! contract, which is what an empty key silently defeats today: a turn recorded
+//! with `api_key_env = AGENTOS_API_KEY` must hard-error on `--continue` when that
+//! env source is no longer set, instead of quietly sending a blank key onward.
+//!
+//! Env is set on the CHILD process (`Command::env`), never on the test process --
+//! matching `json_emit_contract.rs`. `std::env::set_var` would race the other
+//! tests sharing this process's environment under cargo's parallel threads.
+
+use std::io::{BufRead, Write};
+use std::process::{Command, Output};
+use std::sync::{Mutex, MutexGuard};
+
+use agentos::state::{save_turn, TurnContext, TurnVerb};
+
+/// Serializes the binary spawns in this file.
+///
+/// While a case is RED the CLI runs past the bail and binds its Slack stub on
+/// `message::DEFAULT_LISTEN_PORT` (8155). That port is not configurable on this
+/// path -- `local message` exposes no `--listen-port` (only the `cluster` arms
+/// do, `main.rs:818`/`:880`) because `main.rs:1317` hardcodes
+/// `message::DEFAULT_LISTEN_PORT`. So two cases on cargo's parallel threads race
+/// to bind it and one dies with "Address already in use", masking the assertion
+/// under an environmental error. Taking the lock keeps every failure here
+/// attributable to the credential logic alone.
+///
+/// Once the fix lands the bail fires before the stub binds, so only the
+/// non-empty case binds at all -- but the lock stays: it is what makes a RED run
+/// (this suite's whole purpose before the fix, and again on any regression)
+/// report the real assertion instead of a port collision.
+static SPAWN_LOCK: Mutex<()> = Mutex::new(());
+
+/// A failing assertion panics while holding the lock, which poisons it. The data
+/// is `()`, so there is nothing to corrupt: recover the guard and carry on,
+/// otherwise the first red case would cascade into bogus `PoisonError` failures
+/// in the others.
+fn spawn_lock() -> MutexGuard<'static, ()> {
+    SPAWN_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentos")
+}
+
+fn err_str(o: &Output) -> String {
+    String::from_utf8_lossy(&o.stderr).into_owned()
+}
+
+/// The `apply_continue` bail that fires when a turn's recorded api-key env
+/// source is gone. Reaching it is the observable proof that the key resolved as
+/// "absent"; not reaching it proves it resolved as "supplied".
+const UNSET_ENV_BAIL: &str = "which is not set now";
+
+/// A project dir holding a `.agentos/last-turn.json` whose api key came from
+/// `$AGENTOS_API_KEY`, built through the real state types rather than a hand-written
+/// JSON literal so the fixture cannot drift from the shape the CLI loads.
+fn project_with_recorded_env_key() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    save_turn(
+        dir.path(),
+        &TurnContext {
+            verb: TurnVerb::Local,
+            channel: "C-recorded".into(),
+            thread_ts: "9.9".into(),
+            namespace: "agentos".into(),
+            release: "agentos".into(),
+            chart: "charts/agentos".into(),
+            listen_host: None,
+            timeout_secs: 1,
+            api_url: None,
+            api_key_env: Some("AGENTOS_API_KEY".into()),
+        },
+    )
+    .expect("save turn");
+    dir
+}
+
+/// Continue that recorded turn with `extra_args` and a controlled environment.
+/// `--timeout-secs 1` bounds the currently-broken path: today an empty key sails
+/// past the bail and enqueues, and without the bound this would block on a reply.
+///
+/// Every spawn goes through here, so taking [`SPAWN_LOCK`] here (rather than in
+/// each test) is what guarantees no case can bind the stub port concurrently.
+fn continue_turn(
+    dir: &tempfile::TempDir,
+    api_key_env: Option<&str>,
+    extra_args: &[&str],
+) -> Output {
+    let _guard = spawn_lock();
+    let mut cmd = Command::new(bin());
+    cmd.current_dir(dir.path())
+        .args(["local", "message", "--continue", "--timeout-secs", "1"])
+        .args(extra_args)
+        .arg("probe");
+    match api_key_env {
+        Some(value) => cmd.env("AGENTOS_API_KEY", value),
+        None => cmd.env_remove("AGENTOS_API_KEY"),
+    };
+    cmd.output().expect("run agentos local message")
+}
+
+/// The baseline the other cases are measured against: a genuinely unset
+/// `AGENTOS_API_KEY` hard-errors, per issue #112. Every "treated identically to
+/// unset" claim below means "produces exactly this".
+#[test]
+fn unset_agentos_api_key_hard_errors_on_continue() {
+    let dir = project_with_recorded_env_key();
+    let out = continue_turn(&dir, None, &[]);
+
+    assert!(
+        !out.status.success(),
+        "an unset recorded api-key env source must fail the turn, got success"
+    );
+    assert!(
+        err_str(&out).contains(UNSET_ENV_BAIL),
+        "expected the unset-env bail, got stderr: {}",
+        err_str(&out)
+    );
+}
+
+/// AC6: `AGENTOS_API_KEY=""` is unset. Today clap reports `""` as an explicitly
+/// supplied key, so the sentinel comparison in `state.rs` takes it as the user's
+/// choice, the #112 bail never fires, and a blank key is sent onward.
+#[test]
+fn empty_agentos_api_key_is_treated_as_unset_on_continue() {
+    let dir = project_with_recorded_env_key();
+    let out = continue_turn(&dir, Some(""), &[]);
+
+    assert!(
+        !out.status.success(),
+        "an empty AGENTOS_API_KEY must fail the turn exactly as an unset one does, got success"
+    );
+    assert!(
+        err_str(&out).contains(UNSET_ENV_BAIL),
+        "an empty AGENTOS_API_KEY must resolve as absent and hit the unset-env bail; got stderr: {}",
+        err_str(&out)
+    );
+}
+
+/// The same rule at the flag, not just the env var: an explicitly empty
+/// `--api-key ""` is an absent key. Pinned separately so a fix that special-cases
+/// only the env source cannot pass.
+#[test]
+fn empty_api_key_flag_is_treated_as_unset_on_continue() {
+    let dir = project_with_recorded_env_key();
+    let out = continue_turn(&dir, None, &["--api-key", ""]);
+
+    assert!(
+        !out.status.success(),
+        "an empty --api-key must fail the turn exactly as an unset one does, got success"
+    );
+    assert!(
+        err_str(&out).contains(UNSET_ENV_BAIL),
+        "an empty --api-key must resolve as absent and hit the unset-env bail; got stderr: {}",
+        err_str(&out)
+    );
+}
+
+/// The guard against over-normalizing: only EMPTY is absent. A real key must
+/// still resolve as supplied, so the bail must NOT fire. Without this, a fix that
+/// mapped every value to the sentinel would pass the three tests above.
+#[test]
+fn non_empty_agentos_api_key_is_still_an_explicit_key() {
+    let dir = project_with_recorded_env_key();
+    let out = continue_turn(&dir, Some("sk-real-key"), &[]);
+
+    assert!(
+        !err_str(&out).contains(UNSET_ENV_BAIL),
+        "a non-empty AGENTOS_API_KEY is an explicit key and must not be normalized to absent; got stderr: {}",
+        err_str(&out)
+    );
+}
+
+/// An explicitly empty `--api-key ""` must resolve to `$AGENTOS_API_KEY`, exactly
+/// as an OMITTED flag does.
+///
+/// clap resolves an explicit flag ahead of its `env` source, so the env value is
+/// already out of the running by the time the `value_parser` sees `""`. Before
+/// the fix the parser mapped `""` straight to the `agentos-dev-key` sentinel,
+/// which means `--api-key ""` silently sent the well-known dev key on the wire
+/// while the operator's real key sat unused in the environment.
+///
+/// Observed at the WIRE (the outgoing `X-API-Key`) rather than at any internal
+/// shape, so the test holds wherever the normalization lands. `local versions`
+/// is the cheapest verb that authenticates against a plain HTTP peer.
+#[test]
+fn empty_api_key_flag_falls_back_to_the_env_key_exactly_as_an_omitted_flag_does() {
+    let omitted = api_key_on_the_wire(&[]);
+    let empty = api_key_on_the_wire(&["--api-key", ""]);
+
+    assert_eq!(
+        omitted,
+        Some("sk-real-from-env".to_string()),
+        "baseline: an omitted --api-key must send $AGENTOS_API_KEY"
+    );
+    assert_eq!(
+        empty, omitted,
+        "an empty --api-key must send exactly what an omitted one sends ($AGENTOS_API_KEY), \
+         not the {DEFAULT_API_KEY_SENTINEL} sentinel"
+    );
+}
+
+/// The over-normalizing guard for the flag: an explicit NON-empty `--api-key`
+/// still beats the env source. Without this, "always prefer the env" would pass
+/// the case above.
+#[test]
+fn a_non_empty_api_key_flag_still_wins_over_the_env_key() {
+    assert_eq!(
+        api_key_on_the_wire(&["--api-key", "sk-explicit"]),
+        Some("sk-explicit".to_string()),
+        "an explicit non-empty --api-key must win over $AGENTOS_API_KEY"
+    );
+}
+
+/// The dev sentinel `--api-key` falls back to when no env source is available.
+const DEFAULT_API_KEY_SENTINEL: &str = "agentos-dev-key";
+
+/// Run `local versions` against a throwaway HTTP peer with
+/// `AGENTOS_API_KEY=sk-real-from-env` on the CHILD, and report the `X-API-Key`
+/// the CLI actually sent. `None` means the CLI never reached the peer.
+fn api_key_on_the_wire(extra_args: &[&str]) -> Option<String> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe listener");
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let probe = std::thread::spawn(move || {
+        let (stream, _) = listener.accept().ok()?;
+        let mut reader = std::io::BufReader::new(stream);
+        let mut key = None;
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).ok()? == 0 {
+                break;
+            }
+            let line = line.trim_end();
+            if line.is_empty() {
+                break;
+            }
+            // HTTP header names are case-insensitive and reqwest lowercases them.
+            if let Some((name, value)) = line.split_once(':') {
+                if name.eq_ignore_ascii_case("x-api-key") {
+                    key = Some(value.trim().to_string());
+                }
+            }
+        }
+        let stream = reader.get_mut();
+        let _ = stream.write_all(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n[]",
+        );
+        key
+    });
+
+    Command::new(bin())
+        .args(["local", "versions", "demo", "--api-url", &url])
+        .args(extra_args)
+        .env("AGENTOS_API_KEY", "sk-real-from-env")
+        .output()
+        .expect("run agentos local versions");
+
+    probe.join().expect("probe thread")
+}
+
+/// AC6 on the `skill up` path: `ANTHROPIC_API_KEY=""` exported must NOT suppress
+/// the AgentOS vault fallback.
+///
+/// `secret_store_env` gated on `var_os(name).is_some()`, which is TRUE for
+/// `NAME=""` -- so an empty export shadowed a real saved key and forwarded the
+/// empty value to the runner. The observable is the note `skill up` prints when
+/// it hydrates a credential from the vault, which it emits BEFORE it ever
+/// contacts Docker; the run failing at the container step afterwards is expected
+/// and irrelevant to the assertion.
+#[test]
+fn empty_anthropic_api_key_does_not_suppress_the_vault_fallback() {
+    let fixture = vault_with_saved_anthropic_key();
+    let out = skill_up(&fixture, Some(""));
+
+    assert!(
+        err_str(&out).contains(VAULT_HYDRATION_NOTE),
+        "an empty ANTHROPIC_API_KEY is absent, so the saved key must still be loaded from the vault; \
+         got stderr: {}",
+        err_str(&out)
+    );
+}
+
+/// The over-normalizing guard for the vault gate: a REAL exported credential is
+/// present and must still shadow the vault (the child inherits the export
+/// directly). Without this, "always read the vault" would pass the case above.
+#[test]
+fn a_non_empty_anthropic_api_key_still_shadows_the_vault() {
+    let fixture = vault_with_saved_anthropic_key();
+    let out = skill_up(&fixture, Some("sk-exported-real"));
+
+    assert!(
+        !err_str(&out).contains(VAULT_HYDRATION_NOTE),
+        "a non-empty exported ANTHROPIC_API_KEY is supplied and must shadow the vault; \
+         got stderr: {}",
+        err_str(&out)
+    );
+}
+
+/// The note `skill up` prints when it hydrates a credential from the vault.
+/// Reaching it is the observable proof the env value resolved as "absent".
+const VAULT_HYDRATION_NOTE: &str = "ANTHROPIC_API_KEY: loaded from AgentOS private storage";
+
+/// A private AgentOS config dir holding a saved `ANTHROPIC_API_KEY`, plus a real
+/// scaffolded bundle for `skill up` to read. Both are built by driving the real
+/// `secrets set` and `init` verbs rather than hand-writing a vault file or a
+/// manifest, so neither fixture can drift from the shapes the CLI loads.
+fn vault_with_saved_anthropic_key() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let seed = Command::new(bin())
+        .args(["secrets", "set", "ANTHROPIC_API_KEY", "--from-env", "SEED"])
+        .env("AGENTOS_CONFIG_DIR", dir.path().join("cfg"))
+        .env("SEED", "sk-vault-real")
+        .output()
+        .expect("run agentos secrets set");
+    assert!(seed.status.success(), "seed vault: {}", err_str(&seed));
+
+    let init = Command::new(bin())
+        .args(["init", "demo-agent", "--dir"])
+        .arg(dir.path().join("bundle"))
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run agentos init");
+    assert!(init.status.success(), "scaffold bundle: {}", err_str(&init));
+    dir
+}
+
+/// `skill up` in that fixture's bundle, with a controlled `ANTHROPIC_API_KEY` on
+/// the CHILD process. Each fixture owns its own config dir, so these spawns share
+/// no state and need no [`SPAWN_LOCK`] (they bind no fixed port either).
+fn skill_up(fixture: &tempfile::TempDir, anthropic_key: Option<&str>) -> Output {
+    let mut cmd = Command::new(bin());
+    cmd.current_dir(fixture.path().join("bundle"))
+        .args(["skill", "up"])
+        .env("AGENTOS_CONFIG_DIR", fixture.path().join("cfg"));
+    match anthropic_key {
+        Some(value) => cmd.env("ANTHROPIC_API_KEY", value),
+        None => cmd.env_remove("ANTHROPIC_API_KEY"),
+    };
+    // Never let an ambient BYO credential pre-empt the ANTHROPIC_API_KEY probe.
+    cmd.env_remove("AGENTOS_CREDENTIALS")
+        .env_remove("CLAUDE_CODE_OAUTH_TOKEN");
+    cmd.output().expect("run agentos skill up")
+}

--- a/cli/tests/guide.rs
+++ b/cli/tests/guide.rs
@@ -138,7 +138,7 @@ fn guide_prints_primer_to_stdout() {
         "cluster",
         "eval",
         "parity",
-        "allowed-tools",
+        "secretKeyRef",
     ] {
         assert!(text.contains(needle), "primer missing `{needle}`\n{text}");
     }

--- a/docs/interfaces/bundle-format/workflow-agent-conversion.md
+++ b/docs/interfaces/bundle-format/workflow-agent-conversion.md
@@ -234,7 +234,9 @@ contract, and you have already met it.
   call. If the model is doing arithmetic or applying discount rules from prose,
   you've lost the determinism the workflow guaranteed.
 - **`tools:` instead of `allowed-tools:`.** The verbatim Claude Code field is
-  `allowed-tools`; the other name silently does nothing.
+  `allowed-tools`; `validate_bundle` hard-rejects `tools`/`allowed_tools`/`allowedTools`
+  when `allowed-tools` is absent (`skill.tools_confusable`), so this is caught at
+  validate time rather than silently granting no tools.
 - **Inlined credentials.** Reference env (`${VAR}`) in `.mcp.json`; never commit a
   token.
 <!-- doclint:ignore-line -->

--- a/packages/plugin-format/README.md
+++ b/packages/plugin-format/README.md
@@ -81,8 +81,9 @@ if not result.valid:
 
 Error codes include `bundle.missing`, `manifest.missing`,
 `manifest.invalid_json`, `manifest.invalid`, `manifest.name_invalid`,
-`skill.frontmatter_missing`, `skill.frontmatter_invalid`, `mcp.invalid_json`,
-`mcp.server_incomplete`, `hooks.declared_missing`, `hooks.invalid_json`,
+`skill.frontmatter_missing`, `skill.frontmatter_invalid`,
+`skill.tools_confusable`, `mcp.invalid_json`, `mcp.server_incomplete`,
+`mcp.declared_pointer`, `hooks.declared_missing`, `hooks.invalid_json`,
 `hooks.invalid`, `hooks.command_missing`, `triggers.invalid`,
 `triggers.unknown_type`, `triggers.cron_missing_schedule`,
 `triggers.webhook_missing_path`, `approval_policy.invalid`,

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -140,6 +140,7 @@ def _validate_skills(root: Path, c: _Collector) -> None:
         frontmatter = _read_frontmatter(skill_file, rel, c)
         if frontmatter is None:
             continue
+        _check_tools_confusable(frontmatter, rel, c)
         try:
             SkillFrontmatter.model_validate(frontmatter)
         except ValidationError as exc:
@@ -147,12 +148,35 @@ def _validate_skills(root: Path, c: _Collector) -> None:
                 c.error("skill.frontmatter_invalid", issue, rel)
 
 
+# Keys an author reaches for instead of the verbatim Claude Code ``allowed-tools``.
+# ``tools`` is silently dropped by ``extra="allow"``; ``allowed_tools`` populates
+# the field via ``populate_by_name`` but will not survive a round-trip through
+# real Claude Code. Both are rejected, but only when ``allowed-tools`` is absent:
+# an author who already has the right key is not confused, whatever else the
+# frontmatter carries.
+_CONFUSABLE_TOOLS_KEYS = ("tools", "allowed_tools", "allowedTools")
+
+
+def _check_tools_confusable(frontmatter: dict[str, Any], rel: str, c: _Collector) -> None:
+    if "allowed-tools" in frontmatter:
+        return
+    for key in _CONFUSABLE_TOOLS_KEYS:
+        if key in frontmatter:
+            c.error(
+                "skill.tools_confusable",
+                f"skill frontmatter key {key!r} is not the Claude Code key: use "
+                "'allowed-tools'. As written the skill declares no tools.",
+                rel,
+            )
+            return
+
+
 def _validate_mcp(root: Path, manifest: PluginManifest, c: _Collector) -> set[str] | None:
     """Validate every MCP declaration: the manifest field and root .mcp.json.
 
-    The manifest ``mcpServers`` may be an inline object or a path to a config
-    file; either form is a supported declaration that must be checked, not only
-    the conventional root ``.mcp.json``.
+    The manifest ``mcpServers`` must be an inline object. The path-string form
+    parses but the real loader ignores it, so the servers never register; it is
+    rejected outright rather than validating a file that never loads (#540).
 
     Returns the set of declared server names across every declaration it read, so
     the approval-policy check can compare a gate name against them. ``None`` means
@@ -162,7 +186,6 @@ def _validate_mcp(root: Path, manifest: PluginManifest, c: _Collector) -> set[st
     set is a different fact: a declaration was read and named no servers.
     """
 
-    validated_files: set[Path] = set()
     declared = manifest.mcpServers
     servers: set[str] = set()
     unreadable = False
@@ -174,24 +197,20 @@ def _validate_mcp(root: Path, manifest: PluginManifest, c: _Collector) -> set[st
         else:
             servers |= result
     elif isinstance(declared, str):
-        declared_path = root / declared
-        if declared_path.is_file():
-            result = _validate_mcp_file(declared_path, str(Path(declared)), c)
-            if result is None:
-                unreadable = True
-            else:
-                servers |= result
-            validated_files.add(declared_path.resolve())
-        else:
-            c.error(
-                "mcp.declared_missing",
-                f"manifest mcpServers path {declared!r} was not found",
-                "plugin.json",
-            )
-            unreadable = True
+        c.error(
+            "mcp.declared_pointer",
+            f"manifest mcpServers is the path {declared!r}, a form the loader "
+            "ignores: the servers never register. Declare them as an inline "
+            'object instead: "mcpServers": {"<name>": {"command": "..."}}.',
+            "plugin.json",
+        )
+        # An unreadable declaration, not an empty one: poison the set so the
+        # approval-gate cross-check stays silent instead of stacking a
+        # misleading "gate names an undeclared server" error on top of this.
+        unreadable = True
 
     root_mcp = root / ".mcp.json"
-    if root_mcp.is_file() and root_mcp.resolve() not in validated_files:
+    if root_mcp.is_file():
         result = _validate_mcp_file(root_mcp, ".mcp.json", c)
         if result is None:
             unreadable = True

--- a/packages/plugin-format/tests/fixtures/valid_bundle/.claude-plugin/plugin.json
+++ b/packages/plugin-format/tests/fixtures/valid_bundle/.claude-plugin/plugin.json
@@ -3,6 +3,5 @@
   "version": "0.1.0",
   "description": "A demo plugin bundle used as a plugin-format fixture.",
   "author": { "name": "CurieTech" },
-  "keywords": ["demo", "fixture"],
-  "mcpServers": ".mcp.json"
+  "keywords": ["demo", "fixture"]
 }

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -5,6 +5,16 @@ from plugin_format import validate_bundle
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
+# The bundle whose manifest carries the string-pointer mcpServers form the real
+# Claude Code loader silently ignores (#336). Owned by runner/, read-only here:
+# it exists to be rejected, and #540 makes plugin_format a second, static gate on
+# it so `agentos skill check` (which boots a container to observe it) is no longer
+# the only one.
+_RED_POINTER = Path(__file__).parents[3] / "runner" / "tests" / "fixtures" / "mcp_red_pointer"
+
+_POINTER_CODE = "mcp.declared_pointer"
+_CONFUSABLE_CODE = "skill.tools_confusable"
+
 
 def _codes(path: Path) -> set[str]:
     return {issue.code for issue in validate_bundle(path).errors}
@@ -48,6 +58,15 @@ def test_skill_missing_description_is_reported() -> None:
 
 def test_mcp_server_without_command_or_url_is_reported() -> None:
     assert "mcp.server_incomplete" in _codes(FIXTURES / "bad_mcp")
+
+
+def test_inline_object_mcp_declaration_stays_valid(tmp_path: Path) -> None:
+    # The fix the string-pointer error names. It must keep validating clean.
+    bundle = _bundle(
+        tmp_path, '{"name": "demo", "mcpServers": {"crm": {"command": "crm-server"}}}'
+    )
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
 
 
 def test_inline_manifest_mcp_server_is_validated() -> None:
@@ -357,9 +376,12 @@ def test_gate_resolved_across_both_inline_and_root_mcp_json(tmp_path: Path) -> N
     assert result.valid, result.errors
 
 
-def test_gate_for_string_pointer_mcp_declaration_is_resolved(tmp_path: Path) -> None:
-    # The manifest mcpServers field points at a config file rather than the
-    # conventional root .mcp.json.
+def test_string_pointer_mcp_declaration_does_not_add_a_gate_error(tmp_path: Path) -> None:
+    # Inverted from test_gate_for_string_pointer_mcp_declaration_is_resolved: the
+    # string-pointer form is now rejected outright, so the file it points at is
+    # never read and the declared-server set is unknowable. The gate cross-check
+    # must stay silent rather than telling the author their correctly-namespaced
+    # gate names a server they did not declare -- the wrong fix.
     bundle = _bundle(
         tmp_path,
         '{"name": "demo", "mcpServers": "config/servers.json", '
@@ -370,8 +392,9 @@ def test_gate_for_string_pointer_mcp_declaration_is_resolved(tmp_path: Path) -> 
         bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}', "config/servers.json"
     )
 
-    result = validate_bundle(bundle)
-    assert result.valid, result.errors
+    codes = _codes(bundle)
+    assert _POINTER_CODE in codes
+    assert _GATE_CODE not in codes
 
 
 def test_mcp_gate_rejected_when_bundle_declares_no_servers(tmp_path: Path) -> None:
@@ -422,8 +445,11 @@ def test_invalid_mcp_config_does_not_add_a_gate_error(tmp_path: Path) -> None:
     assert _GATE_CODE not in codes
 
 
-def test_declared_missing_mcp_path_does_not_add_a_gate_error(tmp_path: Path) -> None:
-    # A manifest mcpServers path that was not found is also unreadable.
+def test_missing_string_pointer_mcp_path_does_not_add_a_gate_error(tmp_path: Path) -> None:
+    # Re-pointed from test_declared_missing_mcp_path_does_not_add_a_gate_error:
+    # whether the pointed-at file exists no longer matters, because the form
+    # itself is the error. Either way the declaration is unreadable and the gate
+    # cross-check stays silent.
     bundle = _bundle(
         tmp_path,
         '{"name": "demo", "mcpServers": "config/servers.json", '
@@ -432,7 +458,7 @@ def test_declared_missing_mcp_path_does_not_add_a_gate_error(tmp_path: Path) -> 
     )
 
     codes = _codes(bundle)
-    assert "mcp.declared_missing" in codes
+    assert _POINTER_CODE in codes
     assert _GATE_CODE not in codes
 
 
@@ -538,3 +564,116 @@ def test_each_offending_gate_is_reported_at_its_own_location(tmp_path: Path) -> 
     assert len(locations) == 2, locations
     assert any("gates[0]" in loc for loc in locations)
     assert any("gates[1]" in loc for loc in locations)
+
+
+# --- the string-pointer mcpServers form is rejected at validate ---------------
+#
+# `"mcpServers": "config/mcp.json"` parses clean and the pointed-at file even
+# validates, but the real loader ignores the form entirely: the servers never
+# register. Validating the file it points at is validating something that never
+# loads. The form itself is the error (#540, ref #336).
+
+
+def test_string_pointer_mcp_declaration_is_rejected(tmp_path: Path) -> None:
+    # File present AND itself valid -- the case that validates clean today.
+    bundle = _bundle(tmp_path, '{"name": "demo", "mcpServers": "config/servers.json"}')
+    _write_mcp(
+        bundle, '{"mcpServers": {"crm": {"command": "crm-server"}}}', "config/servers.json"
+    )
+
+    result = validate_bundle(bundle)
+    assert not result.valid
+    messages = [i.message for i in result.errors if i.code == _POINTER_CODE]
+    assert len(messages) == 1, result.errors
+    # Actionable: it must name the inline-object fix, not just say "no".
+    assert "mcpServers" in messages[0]
+    assert "inline" in messages[0]
+
+
+def test_red_pointer_fixture_is_rejected_without_booting_a_container() -> None:
+    # The #336 fixture, caught statically from one JSON field.
+    result = validate_bundle(_RED_POINTER)
+    assert not result.valid
+    assert _POINTER_CODE in {i.code for i in result.errors}
+
+
+# --- the tools / allowed-tools confusable ------------------------------------
+#
+# `extra="allow"` lets `tools:` parse clean while allowed_tools stays None, so
+# the skill silently gets no tools. A targeted confusable check rejects it by
+# name. A blanket extra="forbid" is forbidden (packages/CLAUDE.md:83-88): real
+# Claude Code bundles carry keys this MVP does not model.
+
+_CONFUSABLE_KEYS = ["tools", "allowed_tools", "allowedTools"]
+
+
+def _write_skill(bundle: Path, frontmatter: str) -> Path:
+    """Write a skills/demo/SKILL.md carrying the given frontmatter body."""
+    skill = bundle / "skills" / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text(
+        f"---\nname: demo\ndescription: A demo skill.\n{frontmatter}---\n\n# Demo\n",
+        encoding="utf-8",
+    )
+    return skill
+
+
+@pytest.mark.parametrize("key", _CONFUSABLE_KEYS)
+def test_confusable_tools_key_without_allowed_tools_is_rejected(
+    tmp_path: Path, key: str
+) -> None:
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_skill(bundle, f"{key}:\n  - Bash\n")
+
+    result = validate_bundle(bundle)
+    assert not result.valid
+    messages = [i.message for i in result.errors if i.code == _CONFUSABLE_CODE]
+    assert len(messages) == 1, result.errors
+    # It must name the offending key AND the correct one -- telling the author
+    # the right key is the entire point.
+    assert key in messages[0]
+    assert "allowed-tools" in messages[0]
+
+
+def test_correct_allowed_tools_key_validates_clean(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_skill(bundle, "allowed-tools:\n  - Bash\n")
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+
+
+def test_unknown_non_confusable_frontmatter_key_validates_clean(tmp_path: Path) -> None:
+    # The leniency guardrail (packages/CLAUDE.md:83-88). This test is what a
+    # blanket extra="forbid" would break, and it is why the check is targeted.
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_skill(bundle, "allowed-tools:\n  - Bash\nsome-future-claude-key: x\n")
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+
+
+def test_unknown_key_without_allowed_tools_validates_clean(tmp_path: Path) -> None:
+    # Same leniency guardrail, but on the path where _check_tools_confusable
+    # actually runs its loop: no 'allowed-tools' key, so the early return above
+    # does not short-circuit before the unknown key is checked against the
+    # confusable allowlist. Proves the check is a targeted three-key allowlist,
+    # not a de-facto extra="forbid" over all unrecognized keys.
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_skill(bundle, "some-future-claude-key: x\n")
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+
+
+@pytest.mark.parametrize("key", _CONFUSABLE_KEYS)
+def test_confusable_key_alongside_allowed_tools_validates_clean(
+    tmp_path: Path, key: str
+) -> None:
+    # An author who already has the right key is not confused, whatever else the
+    # bundle carries. Erroring here would reject real Claude Code bundles.
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_skill(bundle, f"allowed-tools:\n  - Bash\n{key}:\n  - Read\n")
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors

--- a/runner/README.md
+++ b/runner/README.md
@@ -104,7 +104,10 @@ and exits with the verdict code:
 
 The JSON shape (frozen contract) is `{check, version, plugin_dir, declared,
 registered, matches, verdict, reasons, hints}`; `reasons` is non-empty iff the
-verdict is not green, and the #336 string-pointer fingerprint surfaces in `hints`.
+verdict is not green. A manifest `mcpServers` string pointer is now rejected by
+`plugin_format` validation (step 1, `invalid_bundle`) before this check ever runs,
+so the #336 string-pointer hint fires only when `extract_declared`/`evaluate` are
+exercised directly (e.g. in tests), not through this entrypoint.
 The `agentos skill check` CLI verb wraps this as a one-shot container.
 
 ## Verify (from repo root)

--- a/runner/tests/test_check.py
+++ b/runner/tests/test_check.py
@@ -507,16 +507,16 @@ def test_run_check_green_bundle_registers_tools(
     assert result["reasons"] == []
 
 
-@pytest.mark.skipif(
-    not _CLAUDE_ON_PATH,
-    reason="requires the real `claude` CLI on PATH to spawn MCP servers",
-)
-def test_run_check_red_pointer_bundle_is_red(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+def test_run_check_red_pointer_bundle_is_invalid_bundle() -> None:
+    # The `.mcp.json` string-pointer form is rejected statically by `load_plugins`
+    # at run_check's step 1, so this never reaches `red`: a genuinely malformed
+    # bundle is `invalid_bundle`. Detection is static -- no container boot and no
+    # MCP server spawn -- so this needs no real `claude` CLI and stays unskipped.
     result = anyio.run(run_check, str(_MCP_RED_POINTER))
-    assert result["verdict"] == "red", result
-    assert result["reasons"]
+    assert result["verdict"] == "invalid_bundle", result
+    assert result["reasons"], result
+    joined = " ".join(result["reasons"])
+    # Prove it was rejected for THIS reason (the pointer form), not some other
+    # bundle error: the stable diagnostic code plus the offending path.
+    assert "[mcp.declared_pointer]" in joined, joined
+    assert "config/mcp.json" in joined, joined


### PR DESCRIPTION
Four `agentos guide` landmines existed only because the product silently accepted a wrong input and failed a tier or two from its cause. Each is deleted now that the product catches the mistake where it happens. The primer drops 114 -> 99 lines, and `agentos init` shrinks with it.

Closes #540

## What changed

- **`tools` / `allowed-tools` confusable** — declaring `tools:`, `allowed_tools:`, or `allowedTools:` without `allowed-tools:` is now a hard error naming the right key. The check is deliberately targeted at those three keys, so unknown-but-not-confusable keys still validate clean and plugin-format stays lenient by design (`packages/CLAUDE.md` forbids a blanket `extra="forbid"`, and a test pins that constraint on the path where the check actually runs).
- **`.mcp.json` string-pointer** — rejected at validation with no container boot, naming the inline-object fix. The rejection marks the declaration unreadable so the declared-server set still None-poisons, preserving the fix from `55f07fe9` that stops a bad MCP declaration stacking a misleading approval-gate error. The now-unreachable `mcp.declared_missing` is deleted (`hooks.declared_missing` is untouched).
- **Empty-string credentials** — an empty API key resolves as unset everywhere. An empty `--api-key` now falls back to the env source exactly as an omitted flag does, and an empty exported credential no longer suppresses the vault fallback.
- **`dnsPolicy: ClusterFirst`** — already fixed in the chart before this issue; the landmine only ever documented a bug that no longer exists. The chart is untouched and the BYO caveat stays in the values comment.

`models.py` is deliberately untouched: it drives the committed JSON Schema plus generated Rust/TS behind a drift gate, so both checks live in `validate.py` instead.

## Two things worth a reviewer's attention

**1. AC5 divergence — `skill check` on `mcp_red_pointer` now reports `invalid_bundle` (exit 2), not `red` (exit 1).**

AC5's letter says it must "still return RED" and that `test_check.py:514` stays green. It does not, and I judged that AC4 and AC5 are **mutually unsatisfiable as written**: `run_check` validates via `load_plugins` at step 1 and returns `invalid_bundle` on `PluginBundleError`; `red` is only reachable further down from `_connect_and_poll`. Once AC4's "reject with no container boot" holds, `red` is structurally unreachable for this input, and forcing it would mean special-casing `run_check` around plugin-format — contradicting its own documented contract.

AC5's intent is met: still caught, still non-zero, caught earlier and more precisely. The test was re-pointed and is now **stronger** — it pins the `[mcp.declared_pointer]` code and the offending path (the old one passed for any red cause), and it dropped its `skipif(not _CLAUDE_ON_PATH)` gate, so it runs unconditionally in CI instead of being skipped. **Reviewers split on this** (Codex and the scope reviewer flagged the letter; the code reviewer judged it legitimate and strengthening), so it is called out for an explicit decision rather than settled silently.

**2. Exit class moves 1 -> 2 for that bundle.** Both non-zero, so `if ! agentos skill check` gates are unaffected, and exit 2 (Usage, a deterministic input error) is arguably the more correct class per ADR-0021.

## Follow-up, not fixed here

With `ANTHROPIC_API_KEY=""` exported and **no** vault key saved, the blank var is still inherited by the child. That needs env scrubbing rather than credential resolution, and it fails closed either way, so it is out of scope for this PR.

## Verification

`cargo test` 480 passed; `pytest packages/ runner/` 375 passed; ruff, mypy, `cargo fmt`, clippy clean; `agentos dev chart-check` and `agentos dev docs-lint` pass. The `--api-key` fix was verified live against a stub server capturing the outgoing header, not just by unit test.
