### PR TITLE
Trace the deployed local tier by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ API + worker). Every backend integration test and UI E2E runs against `full`.
 
 ```bash
 docker compose --profile full -f compose.dev.yaml up -d   # full stack
-docker compose --profile core -f compose.dev.yaml up -d   # 7-service minimal stack (no Langfuse/ClickHouse/OTel/UI)
+OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d   # 7-service minimal stack (no Langfuse/ClickHouse/OTel/UI); blank endpoint avoids a DNS retry against the absent otel-collector
 docker compose -f compose.dev.yaml ps        # check health
 docker compose -f compose.dev.yaml down      # stop, KEEP volumes (fast restart)
 docker compose -f compose.dev.yaml down -v   # stop and WIPE volumes (throwaway)

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -550,6 +550,18 @@ export const commandManifest = {
               "required": false
             },
             {
+              "global": false,
+              "help": "The stack runs only the 7 core services (skip Langfuse/ClickHouse/OTel/UI). Must match how `local up` brought it up",
+              "id": "minimal",
+              "long": "minimal",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
               "default_values": [
                 ""
               ],

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -547,6 +547,18 @@
               "required": false
             },
             {
+              "global": false,
+              "help": "The stack runs only the 7 core services (skip Langfuse/ClickHouse/OTel/UI). Must match how `local up` brought it up",
+              "id": "minimal",
+              "long": "minimal",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
               "default_values": [
                 ""
               ],

--- a/cli/src/comms.rs
+++ b/cli/src/comms.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{bail, Result};
 
-use crate::local::{fake_model_env_override, ModelMode};
+use crate::local::{fake_model_env_override, otel_endpoint_env_override, ModelMode};
 use crate::ops::{plain, require_on_path, run_step, secret_set, CommonOpts, OpsCommand};
 
 /// The worker's Slack stub sink URL (compose default); restored on disconnect.
@@ -32,6 +32,12 @@ pub struct LocalCommsOpts {
     /// `fake_model_env_override` as `up_command` so `local comms` never
     /// silently downgrades a live stack back to the fake model.
     pub model_mode: ModelMode,
+    /// Whether the stack was brought up with `local up --minimal` (the `core`
+    /// profile, no otel-collector). Same parity obligation as `model_mode`: the
+    /// worker-restarting commands below apply the same
+    /// `otel_endpoint_env_override` as `up_command` so `local comms` never
+    /// re-points a collector-less stack at a collector that is not running.
+    pub minimal: bool,
 }
 
 pub fn connect_commands(opts: &CommsOpts) -> Vec<OpsCommand> {
@@ -75,6 +81,7 @@ pub fn disconnect_commands(opts: &CommsOpts) -> Vec<OpsCommand> {
 pub fn local_connect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
     let mut env = vec![("SLACK_API_BASE_URL".into(), String::new())];
     env.extend(fake_model_env_override(o.model_mode));
+    env.extend(otel_endpoint_env_override(o.minimal));
     vec![OpsCommand::new(
         "docker",
         vec![
@@ -105,6 +112,7 @@ pub fn local_disconnect_commands(o: &LocalCommsOpts) -> Vec<OpsCommand> {
         ("SLACK_BOT_TOKEN".into(), LOCAL_SLACK_STUB_BOT_TOKEN.into()),
     ];
     worker_env.extend(fake_model_env_override(o.model_mode));
+    worker_env.extend(otel_endpoint_env_override(o.minimal));
     vec![
         OpsCommand::new(
             "docker",
@@ -460,6 +468,10 @@ mod tests {
     }
 
     fn local_comms_opts(disconnect: bool, mode: ModelMode) -> LocalCommsOpts {
+        local_comms_opts_with(disconnect, mode, false)
+    }
+
+    fn local_comms_opts_with(disconnect: bool, mode: ModelMode, minimal: bool) -> LocalCommsOpts {
         LocalCommsOpts {
             file: "compose.dev.yaml".into(),
             dry_run: false,
@@ -475,6 +487,7 @@ mod tests {
             },
             disconnect,
             model_mode: mode,
+            minimal,
         }
     }
 
@@ -487,6 +500,7 @@ mod tests {
             bot_token: "xoxb-1-secretsecret".into(),
             disconnect: false,
             model_mode: ModelMode::DefaultFake,
+            minimal: false,
         });
         assert_eq!(cmds.len(), 1);
         let line = cmds[0].display();
@@ -686,6 +700,80 @@ mod tests {
                 up_override, disconnect_override,
                 "{mode:?}: up_command and local_disconnect_commands disagree on \
                  AGENTOS_FAKE_MODEL; up={up_env:?} disconnect={disconnect_env:?}"
+            );
+        }
+    }
+
+    /// Anti-drift guard (issue #545): `local up` and `local comms` connect must
+    /// agree on whether/how they suppress `OTEL_EXPORTER_OTLP_ENDPOINT`, for
+    /// both `minimal` values. `local comms` recreates the worker, so a dropped
+    /// override here re-resolves compose's collector default onto a `core`-only
+    /// stack that never started one, and every span pays a synchronous DNS retry.
+    #[test]
+    fn up_and_local_connect_agree_on_otel_endpoint_override_for_every_minimal() {
+        for minimal in [false, true] {
+            let up_env = crate::local::up_command(&crate::local::LocalOpts {
+                file: "compose.dev.yaml".into(),
+                dry_run: false,
+                minimal,
+                local_model: None,
+                slack: false,
+                model_mode: ModelMode::DefaultFake,
+            })
+            .env;
+            let connect_env = local_connect_commands(&local_comms_opts_with(
+                false,
+                ModelMode::DefaultFake,
+                minimal,
+            ))[0]
+                .env
+                .clone();
+            let up_override: Option<&(String, String)> = up_env
+                .iter()
+                .find(|(k, _)| k == "OTEL_EXPORTER_OTLP_ENDPOINT");
+            let connect_override: Option<&(String, String)> = connect_env
+                .iter()
+                .find(|(k, _)| k == "OTEL_EXPORTER_OTLP_ENDPOINT");
+            assert_eq!(
+                up_override, connect_override,
+                "minimal={minimal}: up_command and local_connect_commands disagree on \
+                 OTEL_EXPORTER_OTLP_ENDPOINT; up={up_env:?} connect={connect_env:?}"
+            );
+        }
+    }
+
+    /// Same anti-drift guard (issue #545) for the DISCONNECT leg: its
+    /// worker-restarting command must agree with `local up` on
+    /// `OTEL_EXPORTER_OTLP_ENDPOINT`, for both `minimal` values.
+    #[test]
+    fn up_and_local_disconnect_agree_on_otel_endpoint_override_for_every_minimal() {
+        for minimal in [false, true] {
+            let up_env = crate::local::up_command(&crate::local::LocalOpts {
+                file: "compose.dev.yaml".into(),
+                dry_run: false,
+                minimal,
+                local_model: None,
+                slack: false,
+                model_mode: ModelMode::DefaultFake,
+            })
+            .env;
+            let disconnect_env = local_disconnect_commands(&local_comms_opts_with(
+                true,
+                ModelMode::DefaultFake,
+                minimal,
+            ))[1]
+                .env
+                .clone();
+            let up_override: Option<&(String, String)> = up_env
+                .iter()
+                .find(|(k, _)| k == "OTEL_EXPORTER_OTLP_ENDPOINT");
+            let disconnect_override: Option<&(String, String)> = disconnect_env
+                .iter()
+                .find(|(k, _)| k == "OTEL_EXPORTER_OTLP_ENDPOINT");
+            assert_eq!(
+                up_override, disconnect_override,
+                "minimal={minimal}: up_command and local_disconnect_commands disagree on \
+                 OTEL_EXPORTER_OTLP_ENDPOINT; up={up_env:?} disconnect={disconnect_env:?}"
             );
         }
     }

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -105,6 +105,27 @@ pub fn fake_model_env_override(mode: ModelMode) -> Option<(String, String)> {
     }
 }
 
+/// The other injection step every worker-restarting command shares: suppress
+/// the OTel endpoint on a `core`-only stack. `otel-collector` is a `full`-profile
+/// service, so a `--minimal` stack has no collector to export to, and every span
+/// the runner emits would pay a synchronous DNS retry against a name that cannot
+/// resolve. An empty value (not an absent one) is what does it: compose writes
+/// the endpoint as `${OTEL_EXPORTER_OTLP_ENDPOINT-...}`, whose `-` (unset-only)
+/// form substitutes its default only when the var is UNSET, so exporting it
+/// empty resolves to empty and the runner exports nothing. `false` returns
+/// `None` so compose's shipped collector default stands. This is the one place
+/// that decision is made -- `up_command` and `local comms`'s connect/disconnect
+/// commands all call it instead of each re-deriving the pair inline, the same
+/// drift that let `local comms` fall out of parity with `local up` on the fake
+/// model (issue #450).
+pub fn otel_endpoint_env_override(minimal: bool) -> Option<(String, String)> {
+    if minimal {
+        Some(("OTEL_EXPORTER_OTLP_ENDPOINT".into(), String::new()))
+    } else {
+        None
+    }
+}
+
 /// Snapshot the shell for the parity decision. An empty AGENTOS_FAKE_MODEL is
 /// treated as unset (matches compose's `${AGENTOS_FAKE_MODEL:-1}` and the
 /// empty-string-is-not-a-credential rule); a credential is any non-empty
@@ -176,7 +197,7 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
     // credential-driven live injection are mutually exclusive: local-model
     // carries its own live env (AGENTOS_FAKE_MODEL=0 + the ollama routing), so
     // the parity injection only applies when no local model is requested.
-    let env: Vec<(String, String)> = if let Some(model) = &o.local_model {
+    let mut env: Vec<(String, String)> = if let Some(model) = &o.local_model {
         vec![
             ("AGENTOS_FAKE_MODEL".into(), "0".into()),
             (
@@ -198,6 +219,11 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
         // `${AGENTOS_FAKE_MODEL:-1}` default stands for those two modes.
         fake_model_env_override(o.model_mode).into_iter().collect()
     };
+    // Delegate to `otel_endpoint_env_override`, the single source of truth for
+    // the `core`-profile collector suppression. This sits AFTER the branch
+    // above, not inside it, because the `--local-model` arm does not fall
+    // through to the else: `--minimal --local-model` needs suppressing too.
+    env.extend(otel_endpoint_env_override(o.minimal));
     if !env.is_empty() {
         cmd = cmd.with_env(env);
     }
@@ -476,6 +502,64 @@ mod tests {
         )));
     }
 
+    /// `--minimal` starts the `core` profile, which has no otel-collector, so
+    /// `up` must hand compose an EMPTY endpoint. Compose's `${VAR-default}` form
+    /// substitutes only when the var is unset, so the empty value suppresses the
+    /// default instead of pointing every spawned runner at a host that never
+    /// resolves (each span then eats ~7s of synchronous export retry).
+    #[test]
+    fn up_minimal_suppresses_otel_endpoint() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.minimal = true;
+        let cmd = up_command(&o);
+        assert!(
+            cmd.env
+                .contains(&(String::from("OTEL_EXPORTER_OTLP_ENDPOINT"), String::new(),)),
+            "--minimal must pass an empty OTEL_EXPORTER_OTLP_ENDPOINT; env={:?}",
+            cmd.env
+        );
+    }
+
+    /// The `--local-model` arm of `up_command`'s env build does not fall through
+    /// to the else, so the suppression has to sit outside both arms. This is the
+    /// combination that regresses if it ever moves back inside one.
+    #[test]
+    fn up_minimal_suppresses_otel_endpoint_with_local_model() {
+        let mut o = opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b");
+        o.minimal = true;
+        let cmd = up_command(&o);
+        assert!(
+            cmd.env
+                .contains(&(String::from("OTEL_EXPORTER_OTLP_ENDPOINT"), String::new(),)),
+            "--minimal --local-model must pass an empty OTEL_EXPORTER_OTLP_ENDPOINT; env={:?}",
+            cmd.env
+        );
+        // The local-model wiring must survive the suppression.
+        assert!(cmd
+            .env
+            .contains(&(String::from("AGENTOS_MODEL"), String::from("qwen3:4b"))));
+    }
+
+    /// The default (full-profile) `up` starts otel-collector, so it must NOT
+    /// suppress: leaving the var unset is what lets compose's default resolve to
+    /// `http://otel-collector:4318`.
+    #[test]
+    fn up_default_does_not_suppress_otel_endpoint() {
+        for o in [
+            opts(DEFAULT_COMPOSE_FILE),
+            opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b"),
+        ] {
+            let cmd = up_command(&o);
+            assert!(
+                !cmd.env
+                    .iter()
+                    .any(|(k, _)| k == "OTEL_EXPORTER_OTLP_ENDPOINT"),
+                "a non-minimal up must leave compose's endpoint default alone; env={:?}",
+                cmd.env
+            );
+        }
+    }
+
     #[test]
     fn resolve_model_mode_truth_table() {
         // No credential -> DefaultFake regardless of any pin.
@@ -627,9 +711,11 @@ mod tests {
         let mut o = opts(DEFAULT_COMPOSE_FILE);
         o.minimal = true;
         let cmd = up_command(&o);
+        // The empty endpoint is `--minimal`'s collector suppression (the `core`
+        // profile starts no collector); `display` renders env before the program.
         assert_eq!(
             cmd.display(),
-            "docker compose --profile core -f compose.dev.yaml up -d --wait"
+            "OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d --wait"
         );
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -416,6 +416,9 @@ enum LocalAction {
         /// Clear Slack from the local stack instead of connecting it.
         #[arg(long)]
         disconnect: bool,
+        /// The stack runs only the 7 core services (skip Langfuse/ClickHouse/OTel/UI). Must match how `local up` brought it up.
+        #[arg(long)]
+        minimal: bool,
         /// Slack app token. Defaults from SLACK_APP_TOKEN.
         #[arg(
             long,
@@ -1250,6 +1253,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             LocalAction::Comms {
                 slack,
                 disconnect,
+                minimal,
                 app_token,
                 bot_token,
                 file,
@@ -1264,6 +1268,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     bot_token,
                     disconnect,
                     model_mode: local::model_mode_from_env(),
+                    minimal,
                 })
                 .await
             }

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -6,7 +6,9 @@
 # (same components, same pinned versions).
 #
 # Bring up full:  docker compose --profile full -f compose.dev.yaml up -d
-# Bring up core:  docker compose --profile core -f compose.dev.yaml up -d
+# Bring up core:  OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d
+# otel-collector is full-profile only; a core-only stack must blank the endpoint
+# or every span pays a synchronous DNS retry against an absent collector.
 # core = postgres, valkey, minio, minio-init, agentos-migrate, agentos-api, agentos-worker
 # full = core + clickhouse, langfuse-web, langfuse-worker, otel-collector, agentos-ui
 # The CLI `agentos local up` wraps these compose profile invocations.
@@ -438,14 +440,25 @@ services:
       - ANTHROPIC_API_KEY
       - CLAUDE_CODE_OAUTH_TOKEN
       - AGENTOS_CREDENTIALS
-      # Local-model demo enablement:
-      # agentos local up --local-model
-      # AGENTOS_DOCKER_NETWORK=agentos_default puts spawned runner containers on
-      # the compose network so they resolve ollama by name, same as the
-      # otel-collector trace path.
+      # By default, the worker joins spawned sandbox containers to the compose
+      # network (AGENTOS_DOCKER_NETWORK=agentos_default) and points them at the
+      # shipped collector (OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318),
+      # so a plain `agentos local up` traces with no manual flags. The network
+      # join is also what lets --local-model resolve ollama by name. Both are
+      # overridable from the shell.
+      #
+      # The endpoint default is what a full-profile `local up` gets. It uses the
+      # `${VAR-default}` form (substitute only when UNSET), not `${VAR:-default}`
+      # (substitute when unset OR empty), so an explicit empty value means "no
+      # endpoint". That is what lets `agentos local up --minimal` suppress it:
+      # --minimal selects the `core` profile, which does not start otel-collector,
+      # and a runner pointed at a host that never resolves stalls on synchronous
+      # export retries per span. AGENTOS_DOCKER_NETWORK stays on `:-` because the
+      # network join is correct under `core` too.
       - AGENTOS_MODEL_BASE_URL=${AGENTOS_MODEL_BASE_URL:-}
       - AGENTOS_MODEL=${AGENTOS_MODEL:-}
-      - AGENTOS_DOCKER_NETWORK=${AGENTOS_DOCKER_NETWORK:-}
+      - AGENTOS_DOCKER_NETWORK=${AGENTOS_DOCKER_NETWORK:-agentos_default}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
     restart: unless-stopped
 
   # Optional real Slack ingress for local development.

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -224,6 +224,34 @@ def env_map(spec):
     return out
 
 
+SHELL_DEFAULT_RE = re.compile(r"^\$\{[A-Za-z_][A-Za-z0-9_]*:?-(.*)\}$")
+
+
+def resolve_shell_default(value):
+    """Resolve compose's `${VAR:-default}` / `${VAR-default}` forms to the default
+    an operator gets with nothing exported in their shell.
+
+    `env_map` returns the raw literal from compose.dev.yaml, so a var written as
+    `${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}` comes back as
+    that literal string, not the resolved endpoint. The acceptance criterion
+    here is about what a plain `agentos local up` does with no shell overrides,
+    so the default inside the wrapper is the value under test, not the wrapper. A
+    plain literal (no `${...}` wrapper) passes through untouched.
+
+    Both forms appear on purpose and resolve identically for THIS helper's
+    question (nothing exported), so both are accepted: `:-` substitutes the
+    default when the var is unset OR empty, while `-` substitutes only when it is
+    UNSET. The endpoint uses the `-` form specifically so `agentos local up
+    --minimal` can suppress it with an explicit empty override; under `:-` an
+    empty value could never mean "no endpoint". Still intentionally narrow: no
+    `${VAR}`, `${VAR:?err}`, or nested forms.
+    """
+    if value is None:
+        return None
+    match = SHELL_DEFAULT_RE.match(value)
+    return match.group(1) if match else value
+
+
 def compose_docs():
     """The dev document and the generated release document, parsed and labelled."""
     generate = load_generate()
@@ -311,6 +339,55 @@ def test_worker_api_base_url_stays_host_local():
             f"{label}: agentos-worker AGENTOS_API_BASE_URL is "
             f"{env.get('AGENTOS_API_BASE_URL')!r}, expected http://localhost:28000 "
             f"(host-networked: the published port is the correct form here)"
+        )
+
+
+def collector_http_port():
+    """The port the shipped collector actually listens on for OTLP/HTTP.
+
+    Read from the collector's own config rather than hardcoded, so moving the
+    receiver port without repointing the worker fails here instead of shipping a
+    worker aimed at a closed port. The collector serves OTLP over both gRPC
+    (4317) and HTTP (4318); the worker's endpoint is an `http://` URL, so the
+    http receiver is the one it must match.
+    """
+    protocols = yaml.safe_load(OTEL_TEXT)["receivers"]["otlp"]["protocols"]
+    return protocols["http"]["endpoint"].rsplit(":", 1)[1]
+
+
+def test_worker_traces_to_shipped_collector_by_default():
+    """The worker exports traces to the collector this file ships, by default.
+
+    #545: `agentos local up` boots otel-collector + Langfuse, but the deployed
+    local tier exported ZERO traces because agentos-worker was never given
+    OTEL_EXPORTER_OTLP_ENDPOINT, and AGENTOS_DOCKER_NETWORK defaulted to empty
+    so spawned sandbox containers could not resolve otel-collector by name.
+    Both must default to values that work with no manual flags, matching the
+    documented manual recipe (README.md).
+
+    This pins the DEFAULT (full-profile) `agentos local up`. `--minimal` selects
+    the `core` profile, which starts no collector, and suppresses the endpoint by
+    exporting it empty -- see `up_minimal_suppresses_otel_endpoint` in
+    cli/src/local.rs, which is where the profile choice lives.
+    """
+    expected = f"http://otel-collector:{collector_http_port()}"
+    for label, doc in compose_docs():
+        assert "otel-collector" in doc["services"], (
+            f"{label}: otel-collector service not found in the compose document"
+        )
+        env = env_map(doc["services"]["agentos-worker"])
+        otel_endpoint = resolve_shell_default(env.get("OTEL_EXPORTER_OTLP_ENDPOINT"))
+        assert otel_endpoint == expected, (
+            f"{label}: agentos-worker OTEL_EXPORTER_OTLP_ENDPOINT resolves to "
+            f"{otel_endpoint!r}, expected {expected!r} (the collector's own "
+            f"OTLP/HTTP receiver); traces from spawned sandbox containers have "
+            f"nowhere to go"
+        )
+        docker_network = resolve_shell_default(env.get("AGENTOS_DOCKER_NETWORK"))
+        assert docker_network == "agentos_default", (
+            f"{label}: agentos-worker AGENTOS_DOCKER_NETWORK resolves to "
+            f"{docker_network!r}, expected agentos_default so spawned sandbox "
+            f"containers can resolve otel-collector by name"
         )
 
 


### PR DESCRIPTION
`agentos local up` started otel-collector and the full Langfuse stack and then sent them nothing: the worker never got `OTEL_EXPORTER_OTLP_ENDPOINT`, and `AGENTOS_DOCKER_NETWORK` defaulted to empty so a spawned sandbox could not resolve the collector by name even had the endpoint been set. The mechanism shipped; the wiring did not.

`compose.release.yaml` is generated from `compose.dev.yaml`, so fixing the source of truth carries the fix into the released asset.

## What changed

- The worker now defaults to the collector the same file ships and to the pinned project network, both still overridable from the shell.
- The endpoint is suppressed where no collector runs. `otel-collector` is full-profile only, so a core-only stack would leave the runner's synchronous span exporter paying a DNS retry per span (measured ~36s of dead wait on a real 5-span turn, against 0s before this change). The endpoint uses the unset-only `${VAR-default}` form so an empty override means "no endpoint", and `local up --minimal` sends exactly that.
- That decision lives in one `otel_endpoint_env_override` helper beside `fake_model_env_override`, called by all three worker-restarting commands, so `local comms` cannot re-resolve the default and quietly undo it. This is the same drift #450 already fixed once for the fake-model flag.
- `local comms` gained a `--minimal` flag so it can mirror how the stack was brought up.
- The compose header and `AGENTS.md:93` document the raw core invocation, which this change would otherwise leave advertising a command that stalls.

## Verification

Resolution checked against real `docker compose config` rather than inferred: unset resolves to `http://otel-collector:4318`, an empty override resolves to `""`, an explicit override passes through. Every `up`/`comms`/`disconnect` permutation was driven through the built binary. Gates: pytest, ruff, mypy, `cargo fmt`, 476 Rust tests, ESLint, 123 UI tests.

## Out-of-scope annotation

`collector_http_port()` in the compose test derives the assertion's port from the collector's own receiver config instead of hardcoding `4318`. The scope reviewer flagged this as broader than the ticket's fault (which was zero OTEL vars, not a wrong port); it is kept deliberately because AC 3 asks for a test that wires the worker "to the collector it ships", and the code reviewer confirmed a port-drift mutation survives the hardcoded version. Flagging it explicitly rather than burying it.

## Known follow-up (not addressed here)

`--minimal` on `comms` must be remembered, and mismatching it degrades silently in both directions (forget it and the stall returns; add it against a full stack and traces are lost). The sibling obligation this is modeled on, `model_mode`, auto-detects from the shell; `minimal` is not shell-derivable. Deriving it (probing the collector, or persisting the profile at `up` time) would break the CLI's pure-builder seam, so it is a design change rather than part of this fix. Happy to file an issue if you want it tracked.

Closes #545
