### PR TITLE
#526: model selection + sweep at the local/cluster eval tiers

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1283,6 +1283,17 @@
             "title": "Agent Id",
             "type": "string"
           },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
           "suite": {
             "anyOf": [
               {
@@ -1342,6 +1353,17 @@
               }
             ],
             "title": "Bundle Ref"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
           },
           "sha": {
             "title": "Sha",

--- a/apps/api/src/agentos_api/evalqueue.py
+++ b/apps/api/src/agentos_api/evalqueue.py
@@ -23,7 +23,13 @@ STREAM_PAYLOAD_FIELD = "payload"
 
 
 class EvalJobRequest(BaseModel):
-    """One eval job: run ``suite`` against the version built from ``sha``."""
+    """One eval job: run ``suite`` against the version built from ``sha``.
+
+    ``model`` is the model the worker should boot the eval sandbox with and tag
+    the run's matrix cell by (#526); None keeps the worker default. Adding it is
+    the intended forward-compatible evolution of the single-``payload`` seam -- an
+    older consumer ignores the field, a newer one honours it.
+    """
 
     agent_id: uuid.UUID
     version_id: uuid.UUID
@@ -31,6 +37,7 @@ class EvalJobRequest(BaseModel):
     suite: str
     bundle_ref: str | None
     target_url: str | None = None
+    model: str | None = None
     requested_at: str
 
     def to_stream_fields(self) -> dict[str, str]:

--- a/apps/api/src/agentos_api/evals.py
+++ b/apps/api/src/agentos_api/evals.py
@@ -63,6 +63,12 @@ def build_matrix(
 ) -> EvalMatrix:
     # Latest trace per (version, case) so a re-run supersedes an older result.
     latest: dict[tuple[str, str], dict[str, Any]] = {}
+    # The model dimension needs a model-aware key: a sweep runs the SAME suite +
+    # version under several models, so those traces share (version, case) and would
+    # collapse to one in `latest` -- the per-model rollup must keep the latest per
+    # (version, case, MODEL) instead, or a same-version sweep shows only one model
+    # (#526). The displayed grid stays (version, case): one cell, newest wins.
+    latest_by_model: dict[tuple[str, str, str | None], dict[str, Any]] = {}
     version_last_seen: dict[str, str] = {}
     for trace in traces:
         version = _version_of(trace)
@@ -73,6 +79,11 @@ def build_matrix(
         key = (version, case_id)
         if key not in latest or ts >= str(latest[key].get("timestamp") or ""):
             latest[key] = trace
+        model_key = (version, case_id, _model_of(trace))
+        if model_key not in latest_by_model or ts >= str(
+            latest_by_model[model_key].get("timestamp") or ""
+        ):
+            latest_by_model[model_key] = trace
         if ts >= version_last_seen.get(version, ""):
             version_last_seen[version] = ts
 
@@ -108,7 +119,7 @@ def build_matrix(
         )
         for case in cases
     ]
-    summaries = _model_summaries(latest, version_set)
+    summaries = _model_summaries(latest_by_model, version_set)
     return EvalMatrix(
         suite=suite,
         versions=versions,
@@ -120,23 +131,23 @@ def build_matrix(
 
 
 def _model_summaries(
-    latest: dict[tuple[str, str], dict[str, Any]],
+    latest_by_model: dict[tuple[str, str, str | None], dict[str, Any]],
     version_set: set[str],
 ) -> list[EvalModelSummary]:
-    """Roll the shown grid up per model: pass-rate + summed cost.
+    """Roll the shown versions up per model: pass-rate + summed cost.
 
-    Aggregates over exactly the cells that back the displayed grid (latest trace
-    per (version, case), scoped to the shown version columns), so the model
-    dimension and the version grid never disagree about a result. Cost sums only
+    Aggregates over the latest trace per (version, case, MODEL), scoped to the
+    shown version columns. Keying on the model (not just (version, case) like the
+    displayed grid) is what lets a same-version sweep across N models keep all N
+    rows instead of collapsing to whichever recorded last (#526). Cost sums only
     the cases that reported one; a model with no cost anywhere stays ``None``.
     """
     passed: dict[str | None, int] = {}
     total: dict[str | None, int] = {}
     cost: dict[str | None, float | None] = {}
-    for (version, _case), trace in latest.items():
+    for (version, _case, model), trace in latest_by_model.items():
         if version not in version_set:
             continue
-        model = _model_of(trace)
         meta_passed = (trace.get("metadata") or {}).get("passed")
         if meta_passed is None:
             continue

--- a/apps/api/src/agentos_api/routers/evals.py
+++ b/apps/api/src/agentos_api/routers/evals.py
@@ -85,6 +85,7 @@ async def trigger_eval(
             suite=suite,
             bundle_ref=version.bundle_ref,
             target_url=body.target_url,
+            model=body.model,
             requested_at=now_iso(),
         )
     )
@@ -95,6 +96,7 @@ async def trigger_eval(
         sha=sha,
         suite=suite,
         bundle_ref=version.bundle_ref,
+        model=body.model,
     )
 
 

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -709,6 +709,10 @@ class EvalTriggerRequest(BaseModel):
     version_id: uuid.UUID | None = None
     suite: str | None = None
     target_url: str | None = None
+    # The model to evaluate under (#526): booted into the eval sandbox and used as
+    # the run's matrix model dimension. None uses the worker default. A sweep posts
+    # one trigger per model, then reads GET /evals/matrix sliced by model back.
+    model: str | None = None
 
 
 class EvalTriggerResult(BaseModel):
@@ -720,6 +724,9 @@ class EvalTriggerResult(BaseModel):
     sha: str
     suite: str
     bundle_ref: str | None
+    # Echoes the requested model (#526) so a sweep caller can key each enqueued
+    # job to the model it will land under in the matrix; None = worker default.
+    model: str | None = None
 
 
 class EvalReport(BaseModel):

--- a/apps/api/tests/test_evalqueue_integration.py
+++ b/apps/api/tests/test_evalqueue_integration.py
@@ -62,6 +62,7 @@ def test_enqueue_lands_with_exact_shape() -> None:
             "suite": "default",
             "bundle_ref": "bundles/x/y.tar.gz",
             "target_url": None,
+            "model": None,
             "requested_at": request.requested_at,
         }
     finally:

--- a/apps/api/tests/test_evals_trigger_integration.py
+++ b/apps/api/tests/test_evals_trigger_integration.py
@@ -141,6 +141,29 @@ def test_trigger_enqueues_for_active_dev_deployment(
     assert req.suite == get_settings().eval_default_suite
     assert req.bundle_ref == seeded["bundle_ref"]
     assert req.target_url is None
+    assert req.model is None  # no model requested -> worker default
+
+
+def test_trigger_threads_requested_model_onto_the_job(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """#526: a requested model is echoed in the result AND carried on the enqueued
+    EvalJobRequest, so the worker boots+tags that model and a sweep's rows land in
+    the matrix's model column (one trigger per model)."""
+    agent = _create_agent(client, auth_headers, "trigger-model")
+    _seed(agent["id"])
+
+    resp = client.post(
+        "/evals/trigger",
+        json={"agent_id": agent["id"], "model": "claude-sweep-x"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["model"] == "claude-sweep-x"
+
+    payload = _payload_for_stream_id(resp.json()["stream_id"])
+    assert payload is not None
+    assert EvalJobRequest.model_validate(payload).model == "claude-sweep-x"
 
 
 def test_trigger_requires_api_key(client: Any) -> None:

--- a/apps/api/tests/test_evals_unit.py
+++ b/apps/api/tests/test_evals_unit.py
@@ -102,6 +102,31 @@ def test_model_dimension_rolls_up_pass_rate_and_cost_per_model() -> None:
     assert abs(summaries["sonnet"].cost_usd - 0.01) < 1e-9
 
 
+def test_same_version_sweep_keeps_every_model() -> None:
+    """A sweep (#526) runs the SAME suite + version across N models, so those
+    traces collide on (version, case) and would collapse to one in the grid dedup.
+    The per-model rollup keys on the model too, so all N models survive with their
+    own pass-rate -- the read surface a `local/cluster eval --model` sweep polls."""
+    traces = [
+        _mtrace("o1", "shaA", "c1", "2026-07-01T00:00:00Z", True, "opus", 0.02),
+        _mtrace("o2", "shaA", "c2", "2026-07-01T00:00:01Z", True, "opus", 0.01),
+        # sonnet ran the same version+cases slightly later (higher ts).
+        _mtrace("s1", "shaA", "c1", "2026-07-01T00:01:00Z", True, "sonnet", 0.006),
+        _mtrace("s2", "shaA", "c2", "2026-07-01T00:01:01Z", False, "sonnet", 0.004),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    # One version column, but BOTH models present in the rollup (not collapsed).
+    assert matrix.versions == ["shaA"]
+    summaries = {m.model: m for m in matrix.model_summaries}
+    assert set(summaries) == {"opus", "sonnet"}
+    assert summaries["opus"].passed == 2 and summaries["opus"].total == 2
+    assert summaries["sonnet"].passed == 1 and summaries["sonnet"].total == 2
+    # The displayed grid still shows one cell per (version, case): newest wins.
+    cell_models = {cell.model for row in matrix.rows for cell in row.cells}
+    assert cell_models == {"sonnet"}  # sonnet recorded last
+
+
 def test_cells_carry_model_and_unlabelled_runs_sort_last() -> None:
     traces = [
         _mtrace("m1", "shaA", "c1", "2026-07-01T00:00:00Z", True, "opus"),

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -886,6 +886,14 @@ export const commandManifest = {
             },
             {
               "global": false,
+              "help": "Evaluate under this model instead of the deployed one; repeat to sweep several models in one run (#526). A sweep triggers a platform eval per model and reports the per-model pass-rate from `GET /evals/matrix`",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Print the plan that a real run would produce, and exit",
               "id": "dry_run",
               "long": "dry-run",
@@ -2005,6 +2013,14 @@ export const commandManifest = {
               "help": "How long to wait for each case's reply. Default: 300 seconds",
               "id": "timeout_secs",
               "long": "timeout-secs",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Evaluate under this model instead of the deployed one; repeat to sweep several models in one run (#526). A sweep triggers a platform eval per model and reports the per-model pass-rate from `GET /evals/matrix`",
+              "id": "model",
+              "long": "model",
               "positional": false,
               "required": false
             },

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -67,7 +67,15 @@ STREAM_PAYLOAD_FIELD = "payload"
 
 
 class EvalWorkItem(BaseModel):
-    """One eval request from the agentos:evals stream (the K1-API seam)."""
+    """One eval request from the agentos:evals stream (the K1-API seam).
+
+    ``model`` is the model this run should be evaluated under (#526): when set it
+    is booted into the provisioned eval sandbox (winning over the worker's default
+    ``config.model``) AND becomes the run's model dimension, so a caller can sweep
+    one suite across several models and read the comparison back off
+    ``GET /evals/matrix``. None keeps the legacy behaviour (the worker default),
+    and the ``target_url`` shortcut still evals whatever that runner already booted.
+    """
 
     agent_id: uuid.UUID
     version_id: uuid.UUID
@@ -75,6 +83,7 @@ class EvalWorkItem(BaseModel):
     suite: str
     bundle_ref: str | None = None
     target_url: str | None = None
+    model: str | None = None
     requested_at: str
 
     @classmethod
@@ -341,10 +350,15 @@ class EvalStreamConsumer(StreamConsumer):
         return handle.base_url, release_key, handle.token or None
 
     def _eval_model(self, item: EvalWorkItem) -> str | None:
-        """The model dimension for this run: the model the eval's runner is booted
-        with (``config.model``, the same value ``apply_model_env`` forwards as
-        ``AGENTOS_MODEL``). The dev/test ``target_url`` shortcut evals a runner we
-        did not boot, so its model is unknown and left unlabelled."""
+        """The model dimension for this run: the caller-requested ``item.model``
+        when set (#526, a sweep pins each run to a distinct model), else the model
+        the eval's runner is booted with (``config.model``, the same value
+        ``apply_model_env`` forwards as ``AGENTOS_MODEL``). A requested model is
+        always the label, so a sweep run is never silently unlabelled. The dev/test
+        ``target_url`` shortcut evals a runner we did not boot, so unless the caller
+        named a model its model is unknown and left unlabelled."""
+        if item.model is not None:
+            return item.model
         if item.target_url is not None:
             return None
         return self._config.model or None
@@ -372,7 +386,11 @@ class EvalStreamConsumer(StreamConsumer):
         # this write site hardened identically to binding.boot_env. The values are
         # resolved by the async caller (they need a DB lookup) and passed in.
         inject_connector_secrets(env, connector_secrets, agent_label=item.agent_id)
-        apply_model_env(env, self._config)
+        # A caller-requested model (#526) wins over the worker default so the
+        # provisioned sandbox actually runs the model this sweep row is measuring;
+        # _eval_model tags the same value, keeping the boot and the matrix label
+        # in lock-step. None falls back to config.model exactly as before.
+        apply_model_env(env, self._config, model_override=item.model)
         return env
 
     async def _report_failed(

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -27,7 +27,7 @@ from typing import Any, cast
 
 import httpx
 import redis
-from agentos_worker.binding import BUDGET_ENV, BUNDLE_REF_ENV
+from agentos_worker.binding import BUDGET_ENV, BUNDLE_REF_ENV, MODEL_ENV
 from agentos_worker.bundle_store import BundleStore
 from agentos_worker.config import WorkerConfig
 from agentos_worker.eval import (
@@ -167,7 +167,12 @@ def _cfg(stream: str, group: str, **overrides: object) -> WorkerConfig:
 
 
 def _item(
-    *, suite: str, sha: str, bundle_ref: str | None, target_url: str | None
+    *,
+    suite: str,
+    sha: str,
+    bundle_ref: str | None,
+    target_url: str | None,
+    model: str | None = None,
 ) -> EvalWorkItem:
     return EvalWorkItem(
         agent_id=uuid.uuid4(),
@@ -176,6 +181,7 @@ def _item(
         suite=suite,
         bundle_ref=bundle_ref,
         target_url=target_url,
+        model=model,
         requested_at="2026-07-05T00:00:00+00:00",
     )
 
@@ -702,6 +708,54 @@ def test_eval_boot_env_mints_runner_token() -> None:
     item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.zip", target_url=None)
     env = consumer._boot_env(item)
     assert env.get(RUNNER_TOKEN_ENV), "_boot_env must mint a non-empty runner token"
+
+
+def test_eval_requested_model_boots_and_tags_that_model() -> None:
+    """#526: a work item's ``model`` is booted into the provisioned sandbox
+    (AGENTOS_MODEL wins over the worker default) AND becomes the run's model
+    dimension, so a sweep row is measured under, and labelled with, the model it
+    asked for -- never the worker default and never the unlabelled column."""
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(model="worker-default"),
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    item = _item(
+        suite="s", sha="deadbeef", bundle_ref="bundles/x.zip", target_url=None, model="claude-x"
+    )
+    env = consumer._boot_env(item)
+    assert env[MODEL_ENV] == "claude-x"  # requested model wins over worker default
+    assert consumer._eval_model(item) == "claude-x"  # ...and is the matrix label
+
+    # No requested model: the worker default is booted and tagged, as before.
+    default_item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.zip", target_url=None)
+    assert consumer._boot_env(default_item)[MODEL_ENV] == "worker-default"
+    assert consumer._eval_model(default_item) == "worker-default"
+
+
+def test_eval_requested_model_labels_even_a_target_url_run() -> None:
+    """A requested model is authoritative even on the ``target_url`` shortcut: the
+    caller asserts which model that runner is serving, so the run is labelled with
+    it rather than silently dropped into the matrix's unlabelled column (#526)."""
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(),
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    labelled = _item(
+        suite="s", sha="d", bundle_ref=None, target_url="http://runner", model="claude-y"
+    )
+    assert consumer._eval_model(labelled) == "claude-y"
+    unlabelled = _item(suite="s", sha="d", bundle_ref=None, target_url="http://runner")
+    assert consumer._eval_model(unlabelled) is None
 
 
 def test_eval_boot_env_drops_reserved_connector_secret() -> None:

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -883,6 +883,14 @@
             },
             {
               "global": false,
+              "help": "Evaluate under this model instead of the deployed one; repeat to sweep several models in one run (#526). A sweep triggers a platform eval per model and reports the per-model pass-rate from `GET /evals/matrix`",
+              "id": "model",
+              "long": "model",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
               "help": "Print the plan that a real run would produce, and exit",
               "id": "dry_run",
               "long": "dry-run",
@@ -2002,6 +2010,14 @@
               "help": "How long to wait for each case's reply. Default: 300 seconds",
               "id": "timeout_secs",
               "long": "timeout-secs",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Evaluate under this model instead of the deployed one; repeat to sweep several models in one run (#526). A sweep triggers a platform eval per model and reports the per-model pass-rate from `GET /evals/matrix`",
+              "id": "model",
+              "long": "model",
               "positional": false,
               "required": false
             },

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -89,6 +89,42 @@ pub struct KillState {
     pub killed: bool,
 }
 
+/// The enqueued eval job's identity (`EvalTriggerResult` in openapi.json): the
+/// response of `POST /evals/trigger`. `sha` keys the run's matrix column and
+/// `model` echoes the requested model (#526) so a sweep can pair each job to the
+/// row it will produce.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalTriggerResult {
+    pub stream_id: String,
+    pub sha: String,
+    pub suite: String,
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+/// One per-model rollup of the eval matrix (`EvalModelSummary` in openapi.json):
+/// pass-rate and summed cost for a suite run under one model (#255/#526). `model`
+/// is `None` for the matrix's unlabelled column (a run with no resolved model).
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalModelSummary {
+    #[serde(default)]
+    pub model: Option<String>,
+    pub passed: u64,
+    pub total: u64,
+    #[serde(default)]
+    pub cost_usd: Option<f64>,
+}
+
+/// The eval matrix grid (`EvalMatrix` in openapi.json): `GET /evals/matrix`. The
+/// sweep reads only `model_summaries` (the model dimension); the version grid is
+/// carried but unused here.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EvalMatrix {
+    pub suite: String,
+    #[serde(default)]
+    pub model_summaries: Vec<EvalModelSummary>,
+}
+
 /// The per-agent budget (`BudgetConfig` in openapi.json): the request and
 /// response body of `PUT /agents/{id}/budget`. Both fields are optional; an
 /// omitted field means "platform default" server-side, so we only serialize the
@@ -524,6 +560,56 @@ impl ApiClient {
             .json()
             .await
             .context("decoding updated agent")
+    }
+
+    /// Enqueue an on-demand platform eval run: `POST /evals/trigger`. With no
+    /// `version_id` the agent's active dev deployment is evaluated. `model` (#526)
+    /// pins the run's model dimension so a sweep posts one trigger per model and
+    /// reads the comparison back off the matrix. Returns the enqueued job identity.
+    pub async fn trigger_eval(
+        &self,
+        agent_id: &str,
+        suite: Option<&str>,
+        model: Option<&str>,
+    ) -> Result<EvalTriggerResult> {
+        let mut body = json!({ "agent_id": agent_id });
+        if let Some(suite) = suite {
+            body["suite"] = json!(suite);
+        }
+        if let Some(model) = model {
+            body["model"] = json!(model);
+        }
+        let resp = self
+            .http
+            .post(format!("{}/evals/trigger", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .context("POST /evals/trigger")?;
+        Self::expect_ok(resp, "triggering the eval")
+            .await?
+            .json()
+            .await
+            .context("decoding eval trigger result")
+    }
+
+    /// Read the eval matrix for a suite: `GET /evals/matrix?suite=..&versions=..`.
+    /// The sweep polls this for the per-model pass-rate rollup the recorder writes.
+    pub async fn eval_matrix(&self, suite: &str, versions: u32) -> Result<EvalMatrix> {
+        let resp = self
+            .http
+            .get(format!("{}/evals/matrix", self.base_url))
+            .query(&[("suite", suite), ("versions", &versions.to_string())])
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("GET /evals/matrix")?;
+        Self::expect_ok(resp, "reading the eval matrix")
+            .await?
+            .json()
+            .await
+            .context("decoding eval matrix")
     }
 
     /// Delete the agent: `DELETE /agents/{id}` (204 No Content on success).

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -570,6 +570,11 @@ enum LocalAction {
         /// How long to wait for each case's reply. Default: 300 seconds.
         #[arg(long, default_value_t = message::DEFAULT_TIMEOUT_SECS)]
         timeout_secs: u64,
+        /// Evaluate under this model instead of the deployed one; repeat to sweep
+        /// several models in one run (#526). A sweep triggers a platform eval per
+        /// model and reports the per-model pass-rate from `GET /evals/matrix`.
+        #[arg(long = "model")]
+        model: Vec<String>,
         /// Print the plan that a real run would produce, and exit.
         #[arg(long)]
         dry_run: bool,
@@ -954,6 +959,11 @@ enum ClusterAction {
         /// How long to wait for each case's reply. Default: 300 seconds.
         #[arg(long, default_value_t = message::DEFAULT_TIMEOUT_SECS)]
         timeout_secs: u64,
+        /// Evaluate under this model instead of the deployed one; repeat to sweep
+        /// several models in one run (#526). A sweep triggers a platform eval per
+        /// model and reports the per-model pass-rate from `GET /evals/matrix`.
+        #[arg(long = "model")]
+        model: Vec<String>,
         /// Print the kubectl commands, stub URL, and enqueue description that a
         /// real run would produce, and exit without executing anything.
         #[arg(long)]
@@ -1412,6 +1422,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 user,
                 stream,
                 timeout_secs,
+                model,
                 dry_run,
             } => {
                 message::eval(message::EvalOpts {
@@ -1431,6 +1442,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     dry_run,
                     local: true,
                     api_url,
+                    models: model,
                 })
                 .await
             }
@@ -1750,6 +1762,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 user,
                 stream,
                 timeout_secs,
+                model,
                 dry_run,
             } => {
                 message::eval(message::EvalOpts {
@@ -1769,6 +1782,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                     dry_run,
                     local: false,
                     api_url: None,
+                    models: model,
                 })
                 .await
             }
@@ -1975,6 +1989,42 @@ mod tests {
                 action: SkillAction::Eval { model, .. },
             }) => assert_eq!(model, vec!["claude-haiku-4-5", "claude-sonnet-5"]),
             _ => panic!("expected skill eval sweep"),
+        }
+    }
+
+    #[test]
+    fn local_and_cluster_eval_model_are_repeatable_for_a_sweep() {
+        // local eval --model repeats into the sweep list (#526).
+        match Cli::try_parse_from([
+            "agentos", "local", "eval", "--model", "opus", "--model", "sonnet",
+        ])
+        .expect("local eval sweep should parse")
+        .command
+        {
+            Some(Command::Local {
+                action: LocalAction::Eval { model, .. },
+            }) => assert_eq!(model, vec!["opus", "sonnet"]),
+            _ => panic!("expected local eval sweep"),
+        }
+        // Bare local eval -> no models (the in-CLI parity gate).
+        match Cli::try_parse_from(["agentos", "local", "eval"])
+            .expect("local eval should parse")
+            .command
+        {
+            Some(Command::Local {
+                action: LocalAction::Eval { model, .. },
+            }) => assert!(model.is_empty()),
+            _ => panic!("expected local eval"),
+        }
+        // cluster eval --model likewise.
+        match Cli::try_parse_from(["agentos", "cluster", "eval", "--model", "opus"])
+            .expect("cluster eval sweep should parse")
+            .command
+        {
+            Some(Command::Cluster {
+                action: ClusterAction::Eval { model, .. },
+            }) => assert_eq!(model, vec!["opus"]),
+            _ => panic!("expected cluster eval sweep"),
         }
     }
 

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -793,6 +793,11 @@ pub struct EvalOpts {
     pub local: bool,
     /// Local mode only: platform API base URL for the channel lookup.
     pub api_url: Option<String>,
+    /// Models to sweep (#526). Empty = the default parity-gate run (grade the
+    /// deployed model in-CLI). Non-empty switches to the platform eval plane: one
+    /// `POST /evals/trigger` per model, then poll `GET /evals/matrix` for the
+    /// per-model pass-rate so the run lands in the matrix sliced by model.
+    pub models: Vec<String>,
 }
 
 /// Grade one tier turn's reply with the SAME grader `skill eval` uses. A turn
@@ -814,6 +819,36 @@ pub fn reply_passes(case: &EvalCase, outcome: &Outcome) -> bool {
 /// rendering is unit-testable with no stack or cluster (mirrors `dry_run_lines`).
 pub fn eval_dry_run_lines(opts: &EvalOpts, suite_name: &str, case_count: usize) -> Vec<String> {
     let tier = if opts.local { "local" } else { "cluster" };
+    // A `--model` sweep (#526) is the platform eval plane, so its plan is the
+    // trigger-per-model + matrix-poll shape, not the message enqueue path.
+    if !opts.models.is_empty() {
+        let api_base = if opts.local {
+            local_api_base(opts.api_url.as_deref())
+        } else {
+            format!(
+                "http://localhost:{} (via api port-forward)",
+                opts.api_local_port
+            )
+        };
+        let mut lines = vec![format!(
+            "sweep {} model(s) over suite {suite_name:?} ({case_count} case(s)) on the {tier} \
+             platform eval plane",
+            opts.models.len()
+        )];
+        let target = match opts.channel.as_deref() {
+            Some(channel) => format!("channel {channel}"),
+            None => "the sole deployed agent".to_string(),
+        };
+        for model in &opts.models {
+            lines.push(format!(
+                "POST {api_base}/evals/trigger {{agent: {target}, suite: {suite_name:?}, model: {model:?}}}"
+            ));
+        }
+        lines.push(format!(
+            "then poll {api_base}/evals/matrix?suite={suite_name} for per-model pass-rate"
+        ));
+        return lines;
+    }
     let mut lines = vec![format!(
         "grade {case_count} case(s) from suite {suite_name:?} against the {tier} tier"
     )];
@@ -932,10 +967,157 @@ async fn run_eval_turns(
 /// `cluster` (issue #344, the per-tier parity gate).
 pub async fn eval(opts: EvalOpts) -> Result<()> {
     let suite = resolve_suite(opts.cases.clone())?;
+    // A `--model` sweep (#526) is the platform eval plane, not the in-CLI parity
+    // gate: it triggers a matrix-producing run per model and reads the comparison
+    // back off GET /evals/matrix. It is orthogonal to the tier's message path.
+    if !opts.models.is_empty() {
+        return eval_sweep(opts, suite).await;
+    }
     if opts.local {
         eval_local(opts, suite).await
     } else {
         eval_cluster(opts, suite).await
+    }
+}
+
+/// Poll interval and cap while waiting for triggered eval jobs to land in the
+/// matrix. The cap scales with model count because the eval consumer handles
+/// entries sequentially (`count=1`), so N models run one after another.
+const SWEEP_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Resolve the target agent's id for the trigger plane. Mirrors `select_channel`
+/// (explicit `--channel` matches an agent's `slack_channel`, else the sole
+/// deployed agent), but returns the agent id the trigger endpoint keys on.
+pub fn select_agent_id(agents: &[Agent], channel: Option<&str>) -> Result<String> {
+    if let Some(channel) = channel {
+        return agents
+            .iter()
+            .find(|a| a.slack_channel == channel)
+            .map(|a| a.id.clone())
+            .ok_or_else(|| anyhow::anyhow!("no deployed agent has slack_channel {channel:?}"));
+    }
+    match agents {
+        [] => bail!(
+            "no agents are deployed on the platform API; deploy one with `agentos local deploy` \
+             or `agentos cluster deploy`, or pass --channel <id>"
+        ),
+        [only] => Ok(only.id.clone()),
+        many => {
+            let listed = many
+                .iter()
+                .map(|a| format!("{} -> {}", a.name, a.slack_channel))
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!("multiple agents are deployed; pass --channel <id> to pick one ({listed})")
+        }
+    }
+}
+
+/// The `--model` sweep at the local/cluster tier: enqueue one platform eval per
+/// model against the agent's active dev version, then poll the matrix for the
+/// per-model pass-rate the recorder writes (#526). Unlike the skill sweep (which
+/// boots throwaway runners and grades in-CLI), this drives the platform eval
+/// plane so results are sliceable by model in `GET /evals/matrix`.
+async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: eval_dry_run_lines(&opts, &suite.name, suite.cases.len()),
+        });
+        return Ok(());
+    }
+
+    // The trigger + matrix reads go over the platform API. Local reaches it
+    // directly; cluster tunnels an api port-forward kept alive for the whole poll.
+    let (api, _api_pf) = if opts.local {
+        let base = local_api_base(opts.api_url.as_deref());
+        (ApiClient::new(&base, &opts.api_key)?, None)
+    } else {
+        require_on_path("kubectl")?;
+        let pf = start_port_forward(
+            &port_forward_command(
+                &opts.namespace,
+                &opts.release,
+                "api",
+                opts.api_local_port,
+                API_REMOTE_PORT,
+            ),
+            opts.api_local_port,
+            "api",
+        )
+        .await?;
+        let base = format!("http://localhost:{}", opts.api_local_port);
+        (ApiClient::new(&base, &opts.api_key)?, Some(pf))
+    };
+
+    let agents = api
+        .list_agents()
+        .await
+        .context("listing agents to resolve the eval target")?;
+    let agent_id = select_agent_id(&agents, opts.channel.as_deref())?;
+
+    ui.note(&format!(
+        "model sweep: {} model(s) x {} case(s) via the platform eval plane",
+        opts.models.len(),
+        suite.cases.len()
+    ));
+    let cl = ui.checklist();
+    for model in &opts.models {
+        let step = cl.step(&format!("enqueue {model}"));
+        let res = api
+            .trigger_eval(&agent_id, Some(&suite.name), Some(model))
+            .await
+            .with_context(|| format!("triggering eval for model {model}"))?;
+        step.done(&format!(
+            "{} @ {}",
+            res.stream_id,
+            &res.sha[..res.sha.len().min(8)]
+        ));
+    }
+
+    let want: std::collections::BTreeSet<&str> = opts.models.iter().map(String::as_str).collect();
+    let deadline = Instant::now() + SWEEP_POLL_INTERVAL * (opts.models.len() as u32 + 1) * 20;
+    ui.note("waiting for the eval jobs to land in the matrix (Ctrl-C to stop; jobs keep running)");
+    loop {
+        let matrix = api
+            .eval_matrix(&suite.name, 5)
+            .await
+            .context("reading the eval matrix")?;
+        let rows: Vec<(String, usize, usize)> = matrix
+            .model_summaries
+            .iter()
+            .filter_map(|s| {
+                let m = s.model.as_deref()?;
+                want.contains(m)
+                    .then(|| (m.to_string(), s.passed as usize, s.total as usize))
+            })
+            .filter(|(_, _, total)| *total > 0)
+            .collect();
+        let ready: std::collections::BTreeSet<&str> =
+            rows.iter().map(|(m, _, _)| m.as_str()).collect();
+        if want.iter().all(|m| ready.contains(m)) {
+            return crate::commands::report_sweep(&rows);
+        }
+        if Instant::now() >= deadline {
+            let missing = want
+                .iter()
+                .filter(|m| !ready.contains(**m))
+                .copied()
+                .collect::<Vec<_>>()
+                .join(", ");
+            if rows.is_empty() {
+                bail!(
+                    "timed out waiting for eval results in the matrix; no requested model \
+                     landed (still pending: {missing}). Check the worker eval consumer is \
+                     running, or raise --timeout-secs."
+                );
+            }
+            ui.warn(&format!(
+                "timed out waiting on some models ({missing}); reporting what landed so far"
+            ));
+            return crate::commands::report_sweep(&rows);
+        }
+        tokio::time::sleep(SWEEP_POLL_INTERVAL).await;
     }
 }
 
@@ -1334,6 +1516,7 @@ mod tests {
             dry_run: true,
             local,
             api_url: None,
+            models: Vec::new(),
         }
     }
 
@@ -1431,5 +1614,88 @@ mod tests {
                 .any(|l| l.starts_with("stub advertised at http://")),
             "{lines:?}"
         );
+    }
+
+    fn sweep_opts(local: bool, channel: Option<&str>, models: &[&str]) -> EvalOpts {
+        let mut opts = eval_opts(local, channel);
+        opts.models = models.iter().map(|m| m.to_string()).collect();
+        opts
+    }
+
+    #[test]
+    fn model_sweep_dry_run_plans_a_trigger_per_model_and_a_matrix_poll() {
+        // A `--model` sweep prints the platform-eval-plane plan (one trigger per
+        // model + a matrix poll), NOT the message enqueue path (#526).
+        let lines = eval_dry_run_lines(
+            &sweep_opts(true, Some("C7"), &["opus", "sonnet"]),
+            "smoke",
+            2,
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("sweep 2 model(s) over suite \"smoke\"")),
+            "{lines:?}"
+        );
+        // One trigger line per model, naming the model and the explicit channel.
+        for model in ["opus", "sonnet"] {
+            assert!(
+                lines.iter().any(|l| l.contains("/evals/trigger")
+                    && l.contains(&format!("{model:?}"))
+                    && l.contains("channel C7")),
+                "a trigger line for {model}: {lines:?}"
+            );
+        }
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("/evals/matrix?suite=smoke")),
+            "a matrix poll line: {lines:?}"
+        );
+        // The sweep plan does NOT walk the synthetic-turn enqueue path.
+        assert!(
+            !lines.iter().any(|l| l.contains("synthetic QueuedTurn")),
+            "sweep is the eval plane, not the message path: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn cluster_model_sweep_dry_run_reaches_the_api_via_port_forward() {
+        let lines = eval_dry_run_lines(&sweep_opts(false, None, &["opus"]), "smoke", 1);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("api port-forward") && l.contains("/evals/trigger")),
+            "cluster sweep triggers through the api port-forward: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn select_agent_id_resolves_by_channel_then_falls_back_to_sole_agent() {
+        let agents = vec![
+            Agent {
+                id: "a1".into(),
+                name: "one".into(),
+                slack_channel: "C1".into(),
+                approval_required_tools: None,
+            },
+            Agent {
+                id: "a2".into(),
+                name: "two".into(),
+                slack_channel: "C2".into(),
+                approval_required_tools: None,
+            },
+        ];
+        // Explicit channel picks the matching agent's id.
+        assert_eq!(select_agent_id(&agents, Some("C2")).unwrap(), "a2");
+        // An unknown channel errors, naming the channel.
+        assert!(select_agent_id(&agents, Some("C9"))
+            .unwrap_err()
+            .to_string()
+            .contains("C9"));
+        // Many agents + no channel is ambiguous.
+        assert!(select_agent_id(&agents, None).is_err());
+        // A sole agent + no channel resolves without a flag.
+        assert_eq!(select_agent_id(&agents[..1], None).unwrap(), "a1");
     }
 }

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -70,6 +70,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0038 | [An observability CLI helper for the agent-dev loop](0038-observability-cli-helper-for-the-agent-dev-loop.md) | Accepted |
 | 0039 | [Bounded delivery: a delivery cap and a dead-letter graveyard](0039-bounded-delivery-and-a-dead-letter-graveyard.md) | Accepted |
 | 0040 | [Adopt the Agent Client Protocol as an edge projection](0040-adopt-acp-as-an-edge-projection.md) | Proposed |
+| 0041 | [Every verb is answered at every tier](0041-every-verb-is-answered-at-every-tier.md) | Accepted |
 | 0042 | [Adopt LLM-as-a-Verifier: a continuous-score semantic grader and a live progress signal](0042-llm-as-a-verifier-grader-and-progress-signal.md) | Proposed |
 | 0043 | [The interface catalog is generated from declared front-matter and gated in CI](0043-generated-interface-catalog-and-doc-lint-gate.md) | Accepted |
 | 0044 | [Workflow-controlled agents run on AgentOS as a callable substrate first, a unified plane only on demand](0044-workflow-controlled-agents-callable-substrate.md) | Proposed |


### PR DESCRIPTION
Extends #526 down the parity ladder. `skill eval --model` (the skill-tier sweep) merged in #554; this brings model selection + a one-command sweep to `local`/`cluster eval`, and — the acceptance the skill tier can't meet — makes results **land in `GET /evals/matrix` sliced by model** via the existing recorder.

## The plane, made model-aware
The matrix's model dimension was only ever fed by the platform eval plane (`POST /evals/trigger` → `agentos:evals` → F3 `EvalStreamConsumer` → `LangfuseEvalRecorder`), and that consumer always ran under the worker's global `config.model` — so the model column had no real producer. Now:

- **Worker** (`eval/stream.py`): `EvalWorkItem` carries an optional `model`; `_boot_env` boots the provisioned sandbox with it (`apply_model_env` override) and `_eval_model` tags the run's matrix cell by it. A sweep row is measured under, and labelled with, the model it asked for — never the worker default, never the unlabelled column.
- **API** (`evalqueue.py`, `routers/evals.py`, `schemas.py`): `POST /evals/trigger` accepts + echoes `model`; `EvalJobRequest` carries it.
- **API** (`evals.py` `build_matrix`): the per-model rollup now keys on `(version, case, model)`. Without this, a sweep running the **same** suite+version under N models collides on `(version, case)` and collapses to whichever recorded last. The displayed grid is unchanged (one cell per `(version, case)`, newest wins).

## CLI
`local`/`cluster eval` gain `--model` (repeatable). When present, the verb switches from the in-CLI parity-gate (message-stream, fixed deployed model) to the **platform eval plane**: it triggers one eval per model against the agent's active dev version, then **polls the matrix** for the per-model pass-rate and prints the same table `skill eval` does (shared `report_sweep`). Bare `eval` is unchanged. `api.rs` gains `trigger_eval` + `eval_matrix`. Command manifest + UI manifest regenerated.

## Acceptance (#526)
- [x] `skill|local|cluster eval` can target a named model (skill in #554; local/cluster here)
- [x] one command sweeps N models, reports pass-rate per model
- [x] results land in `GET /evals/matrix` sliced by model, via the existing recorder
- [x] a requested model is always the matrix label (never the silent unlabelled column)

## Tests
- Worker: requested model boots + tags (incl. `target_url` labelling); fixtures updated.
- API: trigger threads/echoes model; `build_matrix` keeps every model on a same-version sweep; exact-shape + openapi drift updated.
- CLI: `--model` repeatable at both tiers; sweep dry-run plans a trigger-per-model + matrix poll (not the message path); `select_agent_id` resolution.

Note: 4 F3 `test_stream.py` seam tests + some queue integration tests require real MinIO/Langfuse/runner + a live Valkey and are environment-gated (pre-existing); all unit/pure tests pass.

Ref CUR-1612
Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)