### PR TITLE
Unify shell_quote + duplicated CLI helpers

### DIFF
--- a/cli/src/artifacts.rs
+++ b/cli/src/artifacts.rs
@@ -126,8 +126,13 @@ pub fn resolve_image(override_: Option<&str>, channel: Channel, version: &str) -
     }
 
     match channel {
-        Channel::Release => format!("ghcr.io/curie-eng/agentos-runner:{version}"),
-        Channel::Dev => "agentos-runner".to_string(),
+        Channel::Release => {
+            format!(
+                "ghcr.io/curie-eng/{}:{version}",
+                crate::docker::RUNNER_IMAGE
+            )
+        }
+        Channel::Dev => crate::docker::RUNNER_IMAGE.to_string(),
     }
 }
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -378,7 +378,7 @@ pub async fn install(update: bool) -> Result<()> {
 
     // 5. Build the runner image via the existing `build` handler. Update mode
     // keeps reruns quick when the image is already present locally.
-    let runner_image = "agentos-runner";
+    let runner_image = docker::RUNNER_IMAGE;
     if update && docker_image_exists(runner_image).await? {
         ui.note(&format!(
             "=== runner image '{runner_image}' already exists; skipping rebuild for --update ==="
@@ -422,7 +422,7 @@ pub async fn update(image: bool) -> Result<()> {
     )
     .await?;
     if image {
-        build("agentos-runner").await?;
+        build(docker::RUNNER_IMAGE).await?;
     }
     ui.success("agentos updated. The new binary is live on your next `agentos` invocation.");
     Ok(())

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -325,6 +325,15 @@ fn count_removed(rm_stdout: &str) -> usize {
 /// The label that worker-local stamps on every runner container it spawns.
 pub const SANDBOX_LABEL: &str = "agentos.dev/managed-by=agentos-sandbox-substrate";
 
+/// The runner image's short name (the dev/local tag, and the base of the GHCR
+/// release ref). One definition (#497) instead of the literal scattered across
+/// the artifact resolver, the boot path, and the clap defaults.
+pub const RUNNER_IMAGE: &str = "agentos-runner";
+
+/// The fixed container name for the single local/skill runner (`skill up` /
+/// `local` boot it, `skill down` reaps it). One definition (#497).
+pub const RUNNER_CONTAINER_LOCAL: &str = "agentos-runner-local";
+
 /// The last log lines of a container, for boot-failure diagnostics.
 pub async fn container_logs(name_or_id: &str, tail: u32) -> String {
     let args: Vec<String> = vec![

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -1779,20 +1779,9 @@ fn show_run_view(
 
 fn render_command(argv: &[String]) -> String {
     std::iter::once("agentos".to_string())
-        .chain(argv.iter().map(|arg| shell_quote(arg)))
+        .chain(argv.iter().map(|arg| crate::ops::shell_quote(arg)))
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-fn shell_quote(arg: &str) -> String {
-    if arg
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || "-_./:=@".contains(c))
-    {
-        arg.to_string()
-    } else {
-        format!("'{}'", arg.replace('\'', "'\\''"))
-    }
 }
 
 fn draw(frame: &mut Frame<'_>, app: &App) {
@@ -2414,6 +2403,15 @@ mod tests {
     fn render_command_quotes_shell_specials() {
         let argv = vec!["skill".into(), "message".into(), "hello world".into()];
         assert_eq!(render_command(&argv), "agentos skill message 'hello world'");
+    }
+
+    #[test]
+    fn render_command_shows_an_empty_field_as_a_quoted_empty_string() {
+        // #497: the old interactive shell_quote let an empty arg vanish (vacuous
+        // all() over an empty iterator). The canonical ops::shell_quote renders it
+        // as '' so the copy-pasteable command keeps the empty positional visible.
+        let argv = vec!["skill".into(), "message".into(), "".into()];
+        assert_eq!(render_command(&argv), "agentos skill message ''");
     }
 
     #[test]

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -6,7 +6,7 @@
 //! (or the `--dry-run` printer) consumes it, so argv construction stays
 //! unit-testable with no Docker daemon.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 
 use crate::commands::OLLAMA_PORT;
 use crate::docker;
@@ -362,7 +362,12 @@ pub async fn down(o: LocalDownOpts) -> Result<()> {
             "this destroys all volumes for the '{}' dev stack (Postgres, ClickHouse, MinIO, Valkey data)",
             o.common.file
         ));
-        if !o.yes && !confirm_wipe(&o.common.file)? {
+        if !o.yes
+            && !crate::ops::confirm(&format!(
+                "This destroys all volumes for the '{}' dev stack (Postgres, ClickHouse, MinIO, Valkey data). Continue? [y/N] ",
+                o.common.file
+            ))?
+        {
             ui.note("aborted");
             return Ok(());
         }
@@ -386,29 +391,6 @@ pub async fn down(o: LocalDownOpts) -> Result<()> {
         ui.note("volumes kept (fast restart with `agentos local up`)");
     }
     Ok(())
-}
-
-/// Read a y/N confirmation from stderr/stdin before `--wipe` destroys volumes.
-fn confirm_wipe(file: &str) -> Result<bool> {
-    use std::io::{IsTerminal, Write};
-    // An agent (or any piped stdin) can never answer this prompt; refuse instead
-    // of blocking on a read that will never complete. `--yes` is the non-interactive path.
-    if !std::io::stdin().is_terminal() {
-        return Err(crate::exit::CliError::usage(
-            "refusing to prompt for confirmation in a non-interactive session; re-run with --yes to proceed",
-        )
-        .with_fix("pass --yes")
-        .into());
-    }
-    eprint!(
-        "This destroys all volumes for the '{file}' dev stack (Postgres, ClickHouse, MinIO, Valkey data). Continue? [y/N] "
-    );
-    std::io::stderr().flush().ok();
-    let mut line = String::new();
-    std::io::stdin()
-        .read_line(&mut line)
-        .context("reading confirmation from stdin")?;
-    Ok(matches!(line.trim(), "y" | "Y" | "yes" | "Yes"))
 }
 
 #[cfg(test)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,6 +11,7 @@ use agentos::commands::{
     self, AgentActionOpts, DeployEnv, DeployOpts, SendType, StartOpts, DEFAULT_PORT,
 };
 use agentos::comms::{self, CommsOpts, LocalCommsOpts};
+use agentos::docker;
 use agentos::local::{self, LocalDownOpts, LocalOpts};
 use agentos::message::{self, MessageOpts};
 use agentos::ops::{self, CommonOpts, DownOpts, UpOpts};
@@ -149,7 +150,7 @@ enum Command {
     /// repo checkout.
     Build {
         /// Image tag to build.
-        #[arg(long, default_value = "agentos-runner")]
+        #[arg(long, default_value = docker::RUNNER_IMAGE)]
         tag: String,
     },
     /// Bootstrap or update a dev checkout: install deps and build, start nothing (source checkout only).
@@ -266,7 +267,7 @@ enum SkillAction {
         #[arg(long, default_value_t = DEFAULT_PORT)]
         port: u16,
         /// Container name.
-        #[arg(long, default_value = "agentos-runner-local")]
+        #[arg(long, default_value = docker::RUNNER_CONTAINER_LOCAL)]
         name: String,
         /// Use the runner's scripted fake model (offline; no credential).
         #[arg(long)]

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -192,21 +192,6 @@ pub fn port_forward_command(
     )
 }
 
-/// `kubectl config view --minify -o jsonpath={...server}`: the kubeconfig's
-/// current-context API server URL, used to pick the local egress IP.
-fn server_url_command() -> OpsCommand {
-    OpsCommand::new(
-        "kubectl",
-        vec![
-            plain("config"),
-            plain("view"),
-            plain("--minify"),
-            plain("-o"),
-            plain("jsonpath={.clusters[0].cluster.server}"),
-        ],
-    )
-}
-
 /// The `/api/` base URL the worker posts its placeholder edits to.
 fn advertised_url(host: &str, port: u16) -> String {
     format!("http://{host}:{port}/api/")
@@ -393,7 +378,7 @@ async fn resolve_advertise_host(listen_host: Option<&str>) -> Result<String> {
     if let Some(host) = listen_host {
         return Ok(host.to_string());
     }
-    let (ok, out, err) = run_capture(&server_url_command()).await?;
+    let (ok, out, err) = run_capture(&crate::ops::kubeconfig_host_cmd()).await?;
     if !ok {
         bail!(
             "could not read the kubeconfig API server to auto-detect a routable host ({}); \

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -271,7 +271,12 @@ pub fn mask_secret(value: &str) -> String {
 /// POSIX shell-quote a single token: leave it bare when it is composed only of
 /// safe characters, otherwise wrap in single quotes (so `--set` keys carrying
 /// `[0]` array indices print quoted, matching how they must be typed).
-fn shell_quote(s: &str) -> String {
+/// POSIX single-quote an argument for a copy-pasteable command line, leaving
+/// unambiguously-safe tokens bare. The one canonical implementation (#497): the
+/// TUI command echo (`interactive::render_command`) and the helm/kubectl argv
+/// printers both call this, so an empty argument renders as `''` everywhere
+/// rather than silently vanishing (the interactive copy's empty-`all()` bug).
+pub(crate) fn shell_quote(s: &str) -> String {
     fn is_safe(c: char) -> bool {
         c.is_ascii_alphanumeric()
             || matches!(c, '_' | '.' | '/' | ':' | '=' | '@' | ',' | '-' | '+')
@@ -995,7 +1000,10 @@ fn svc_cmd(o: &CommonOpts, suffix: &str) -> OpsCommand {
     )
 }
 
-fn kubeconfig_host_cmd() -> OpsCommand {
+/// `kubectl config view --minify -o jsonpath={...server}`: the current-context
+/// API-server URL. The one canonical builder (#497) shared by the ops egress-IP
+/// resolution and the message driver's advertise-host detection.
+pub(crate) fn kubeconfig_host_cmd() -> OpsCommand {
     OpsCommand::new(
         "kubectl",
         vec![
@@ -1336,7 +1344,12 @@ pub async fn down(opts: DownOpts) -> Result<()> {
         "this uninstalls release '{}' and deletes namespaces '{}' and 'agent-sandbox-system'",
         opts.common.release, opts.common.namespace
     ));
-    if !opts.yes && !confirm(&opts.common)? {
+    if !opts.yes
+        && !confirm(&format!(
+            "This uninstalls release '{}' and deletes namespaces '{}' and 'agent-sandbox-system'. Continue? [y/N] ",
+            opts.common.release, opts.common.namespace
+        ))?
+    {
         ui.note("aborted");
         return Ok(());
     }
@@ -1375,10 +1388,13 @@ pub async fn down(opts: DownOpts) -> Result<()> {
 }
 
 /// Read a y/N confirmation from stderr/stdin for `down` when `--yes` is absent.
-fn confirm(o: &CommonOpts) -> Result<bool> {
+/// Prompt on stderr for a y/N confirmation of a destructive action, returning
+/// whether the operator affirmed. The one canonical implementation (#497): every
+/// destructive verb passes its own fully-formed prompt (ending in `[y/N] `). A
+/// non-interactive session (piped/agent stdin) can never answer, so it refuses
+/// with the `--yes` remediation instead of blocking on a read that never returns.
+pub(crate) fn confirm(prompt: &str) -> Result<bool> {
     use std::io::{IsTerminal, Write};
-    // An agent (or any piped stdin) can never answer this prompt; refuse instead
-    // of blocking on a read that will never complete. `--yes` is the non-interactive path.
     if !std::io::stdin().is_terminal() {
         return Err(crate::exit::CliError::usage(
             "refusing to prompt for confirmation in a non-interactive session; re-run with --yes to proceed",
@@ -1386,10 +1402,7 @@ fn confirm(o: &CommonOpts) -> Result<bool> {
         .with_fix("pass --yes")
         .into());
     }
-    eprint!(
-        "This uninstalls release '{}' and deletes namespaces '{}' and 'agent-sandbox-system'. Continue? [y/N] ",
-        o.release, o.namespace
-    );
+    eprint!("{prompt}");
     std::io::stderr().flush().ok();
     let mut line = String::new();
     std::io::stdin()


### PR DESCRIPTION
Collapses four duplicated CLI helpers to one canonical definition each, deleting the copies. The load-bearing fix is the `shell_quote` empty-arg drop bug.

## shell_quote — the bug
Two implementations disagreed:
- `ops::shell_quote` force-quotes the empty string → `''`.
- `interactive::shell_quote` had no empty guard, so `"".chars().all(...)` is a **vacuous `all()` over an empty iterator → `true`**, rendering an empty argument as **nothing**. An empty recipe field silently vanished from the TUI's copy-pasteable command.

Now there is one `ops::shell_quote` (the superset safe-set: alphanumeric + `_ . / : = @ , - +`, plus the empty guard). `interactive::render_command` calls it, so an empty field renders as `''` everywhere. New test: `render_command_shows_an_empty_field_as_a_quoted_empty_string`. The always-quote variant in `commands.rs` stays separate (deliberately different, documented — its tests require `/tmp/plain` → `'/tmp/plain'`).

## Other dedups
- **confirm**: `ops::confirm` now takes a prompt string; `local::confirm_wipe` deleted. Both destructive verbs pass their own fully-formed prompt (byte-identical prompts preserved).
- **kubeconfig host builder**: one `ops::kubeconfig_host_cmd`; `message::server_url_command` deleted (identical argv).
- **runner image name**: `docker::RUNNER_IMAGE` / `docker::RUNNER_CONTAINER_LOCAL` constants replace the literal scattered across the artifact resolver, the boot path, `agentos build` defaults, and the update path.

## Scope
No behavior change beyond the empty-arg fix. The shared queue-connection clap block (local/cluster message+eval) is left alone — it coordinates with #466's `AgentTarget` work. Full CLI suite (fmt + clippy + test) green; no command-manifest change (defaults resolve to the same strings).

Ref CUR-1614
Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)