### PR TITLE
Cluster governance verbs resolve the release's API URL + key

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2151,26 +2151,42 @@ export const commandManifest = {
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
-              "help": "Platform API key",
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2213,26 +2229,42 @@ export const commandManifest = {
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
-              "help": "Platform API key",
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2271,26 +2303,42 @@ export const commandManifest = {
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
-              "help": "Platform API key",
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2321,26 +2369,42 @@ export const commandManifest = {
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
-              "help": "Platform API key",
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2383,24 +2447,42 @@ export const commandManifest = {
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2430,24 +2512,42 @@ export const commandManifest = {
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2477,24 +2577,42 @@ export const commandManifest = {
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2148,26 +2148,42 @@
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
-              "help": "Platform API key",
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2210,26 +2226,42 @@
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
-              "help": "Platform API key",
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2268,26 +2300,42 @@
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
-              "help": "Platform API key",
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2318,26 +2366,42 @@
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
-              "help": "Platform API base URL",
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
-              "help": "Platform API key",
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2380,24 +2444,42 @@
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2427,24 +2509,42 @@
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },
@@ -2474,24 +2574,42 @@
               "required": true
             },
             {
-              "default_values": [
-                "http://localhost:8000"
-              ],
               "env": "AGENTOS_API_URL",
               "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
               "id": "api_url",
               "long": "api-url",
               "positional": false,
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
               "id": "api_key",
               "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
               "positional": false,
               "required": false
             },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,16 +34,10 @@ impl TierDefaults for LocalTier {
     const API_URL: &'static str = "http://localhost:28000";
 }
 
-#[derive(Clone, Debug)]
-struct ClusterTier;
-
-impl TierDefaults for ClusterTier {
-    const API_URL: &'static str = "http://localhost:8000";
-}
-
-/// The flags every agent-target verb (`versions`, `memory`, `approvals`) takes,
-/// flattened into both tiers so a flag added here cannot be added to one tier
-/// and forgotten on the other (issue #466).
+/// The flags a LOCAL agent-target verb (`versions`, `memory`, `approvals`) takes.
+/// The local tier correctly defaults to the compose stack on localhost; the
+/// cluster tier discovers its connection from the release instead (see
+/// [`ClusterAgentTarget`] / [`ClusterConn`], #524), so it no longer shares this.
 #[derive(Args, Debug, Clone)]
 struct AgentTarget<T: TierDefaults> {
     /// Agent name or id.
@@ -67,6 +61,65 @@ impl<T: TierDefaults> From<AgentTarget<T>> for AgentActionOpts {
             dry_run: target.dry_run,
         }
     }
+}
+
+/// The connection surface for a cluster governance verb (#524). Unlike the local
+/// tier (which correctly defaults to the compose stack on localhost), a real Helm
+/// release serves the API through its UI `/api` NodePort proxy and randomizes
+/// `api.apiKey` at `cluster up` — so BOTH default to `None` and are DISCOVERED
+/// from the release (mirroring how `cluster deploy` already discovers the URL),
+/// rather than defaulting to `http://localhost:8000` + the `agentos-dev-key`
+/// sentinel, which parse cleanly and then fail to connect / 401. An explicit
+/// `--api-url`/`--api-key` (or `AGENTOS_API_URL`/`AGENTOS_API_KEY`) still wins.
+#[derive(Args, Debug, Clone)]
+struct ClusterConn {
+    /// Platform API base URL. Omit to discover the release's UI `/api` proxy.
+    #[arg(long, env = "AGENTOS_API_URL")]
+    api_url: Option<String>,
+    /// Platform API key. Omit to read the release's `api.apiKey` from its Secret.
+    #[arg(long, env = "AGENTOS_API_KEY")]
+    api_key: Option<String>,
+    /// Kubernetes namespace of the release. Default: agentos.
+    #[arg(long, default_value = "agentos")]
+    namespace: String,
+    /// Helm release name. Default: agentos.
+    #[arg(long, default_value = "agentos")]
+    release: String,
+}
+
+/// An agent-target cluster verb (`versions`/`memory`/`approvals`): the agent plus
+/// the discoverable [`ClusterConn`] and a `--dry-run`. The cluster analogue of
+/// `AgentTarget<LocalTier>`, which keeps its localhost defaults for the local tier.
+#[derive(Args, Debug, Clone)]
+struct ClusterAgentTarget {
+    /// Agent name or id.
+    agent: String,
+    #[command(flatten)]
+    conn: ClusterConn,
+    #[arg(long)]
+    dry_run: bool,
+}
+
+/// Resolve a cluster verb's `(api_url, api_key)`: an explicit flag/env value wins;
+/// otherwise discover it from the release (UI `/api` proxy for the URL, the chart
+/// Secret for the key). Discovery failures are actionable errors naming the
+/// release (see `ops::discover_ui_api_url` / `ops::discover_api_key`).
+async fn resolve_cluster_conn(conn: ClusterConn) -> anyhow::Result<(String, String)> {
+    let ClusterConn {
+        api_url,
+        api_key,
+        namespace,
+        release,
+    } = conn;
+    let api_url = match api_url {
+        Some(url) => url,
+        None => ops::discover_ui_api_url(&namespace, &release).await?,
+    };
+    let api_key = match api_key {
+        Some(key) => key,
+        None => ops::discover_api_key(&namespace, &release).await?,
+    };
+    Ok((api_url, api_key))
 }
 
 #[derive(Parser)]
@@ -1020,12 +1073,8 @@ enum ClusterAction {
     Kill {
         /// Agent name or id to kill.
         agent: String,
-        /// Platform API base URL.
-        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
-        api_url: String,
-        /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
-        api_key: String,
+        #[command(flatten)]
+        conn: ClusterConn,
         /// Confirm this destructive action (required; it stops the agent's runs).
         #[arg(long)]
         yes: bool,
@@ -1037,12 +1086,8 @@ enum ClusterAction {
     Resume {
         /// Agent name or id to resume.
         agent: String,
-        /// Platform API base URL.
-        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
-        api_url: String,
-        /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
-        api_key: String,
+        #[command(flatten)]
+        conn: ClusterConn,
         /// Print what would be done and exit without making a request.
         #[arg(long)]
         dry_run: bool,
@@ -1054,12 +1099,8 @@ enum ClusterAction {
         /// Daily spend cap in USD (BudgetConfig.max_usd_per_day). Must be > 0.
         #[arg(long)]
         limit: f64,
-        /// Platform API base URL.
-        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
-        api_url: String,
-        /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
-        api_key: String,
+        #[command(flatten)]
+        conn: ClusterConn,
         /// Print what would be done and exit without making a request.
         #[arg(long)]
         dry_run: bool,
@@ -1068,12 +1109,8 @@ enum ClusterAction {
     Delete {
         /// Agent name or id to delete.
         agent: String,
-        /// Platform API base URL.
-        #[arg(long, default_value = "http://localhost:8000", env = "AGENTOS_API_URL")]
-        api_url: String,
-        /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
-        api_key: String,
+        #[command(flatten)]
+        conn: ClusterConn,
         /// Confirm this destructive action (required; it permanently deletes the agent).
         #[arg(long)]
         yes: bool,
@@ -1084,17 +1121,17 @@ enum ClusterAction {
     /// List an agent's immutable versions (`GET /agents/{id}/versions`).
     Versions {
         #[command(flatten)]
-        target: AgentTarget<ClusterTier>,
+        target: ClusterAgentTarget,
     },
     /// Show what an agent has learned (its memory log; `GET /agents/{id}/memory`).
     Memory {
         #[command(flatten)]
-        target: AgentTarget<ClusterTier>,
+        target: ClusterAgentTarget,
     },
     /// View or set the tools whose calls require human approval (`PATCH /agents/{id}`).
     Approvals {
         #[command(flatten)]
-        target: AgentTarget<ClusterTier>,
+        target: ClusterAgentTarget,
         /// Tool name to gate behind approval (repeatable). Omit to show current gates.
         #[arg(long = "gate", value_name = "TOOL")]
         gate: Vec<String>,
@@ -1847,79 +1884,139 @@ async fn run(command: Option<Command>) -> Result<()> {
             }
             ClusterAction::Kill {
                 agent,
-                api_url,
-                api_key,
+                conn,
                 yes,
                 dry_run,
-            } => emit(
-                commands::kill(
-                    AgentActionOpts {
+            } => {
+                let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                emit(
+                    commands::kill(
+                        AgentActionOpts {
+                            api_url,
+                            api_key,
+                            agent,
+                            dry_run,
+                        },
+                        yes,
+                    )
+                    .await?,
+                )
+            }
+            ClusterAction::Resume {
+                agent,
+                conn,
+                dry_run,
+            } => {
+                let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                emit(
+                    commands::resume(AgentActionOpts {
                         api_url,
                         api_key,
                         agent,
                         dry_run,
-                    },
-                    yes,
+                    })
+                    .await?,
                 )
-                .await?,
-            ),
-            ClusterAction::Resume {
-                agent,
-                api_url,
-                api_key,
-                dry_run,
-            } => emit(
-                commands::resume(AgentActionOpts {
-                    api_url,
-                    api_key,
-                    agent,
-                    dry_run,
-                })
-                .await?,
-            ),
+            }
             ClusterAction::Budget {
                 agent,
                 limit,
-                api_url,
-                api_key,
+                conn,
                 dry_run,
-            } => emit(
-                commands::budget(
-                    AgentActionOpts {
-                        api_url,
-                        api_key,
-                        agent,
-                        dry_run,
-                    },
-                    limit,
+            } => {
+                let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                emit(
+                    commands::budget(
+                        AgentActionOpts {
+                            api_url,
+                            api_key,
+                            agent,
+                            dry_run,
+                        },
+                        limit,
+                    )
+                    .await?,
                 )
-                .await?,
-            ),
+            }
             ClusterAction::Delete {
                 agent,
-                api_url,
-                api_key,
+                conn,
                 yes,
                 dry_run,
-            } => emit(
-                commands::delete(
-                    AgentActionOpts {
+            } => {
+                let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                emit(
+                    commands::delete(
+                        AgentActionOpts {
+                            api_url,
+                            api_key,
+                            agent,
+                            dry_run,
+                        },
+                        yes,
+                    )
+                    .await?,
+                )
+            }
+            ClusterAction::Versions { target } => {
+                let ClusterAgentTarget {
+                    agent,
+                    conn,
+                    dry_run,
+                } = target;
+                let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                emit(
+                    commands::versions(AgentActionOpts {
                         api_url,
                         api_key,
                         agent,
                         dry_run,
-                    },
-                    yes,
+                    })
+                    .await?,
                 )
-                .await?,
-            ),
-            ClusterAction::Versions { target } => emit(commands::versions(target.into()).await?),
-            ClusterAction::Memory { target } => emit(commands::memory(target.into()).await?),
+            }
+            ClusterAction::Memory { target } => {
+                let ClusterAgentTarget {
+                    agent,
+                    conn,
+                    dry_run,
+                } = target;
+                let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                emit(
+                    commands::memory(AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    })
+                    .await?,
+                )
+            }
             ClusterAction::Approvals {
                 target,
                 gate,
                 clear,
-            } => emit(commands::approvals(target.into(), gate, clear).await?),
+            } => {
+                let ClusterAgentTarget {
+                    agent,
+                    conn,
+                    dry_run,
+                } = target;
+                let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                emit(
+                    commands::approvals(
+                        AgentActionOpts {
+                            api_url,
+                            api_key,
+                            agent,
+                            dry_run,
+                        },
+                        gate,
+                        clear,
+                    )
+                    .await?,
+                )
+            }
         },
         Some(Command::Schema) => {
             use clap::CommandFactory;
@@ -2321,6 +2418,56 @@ mod tests {
                 assert_eq!(app_token, "X");
             }
             _ => panic!("expected local comms command"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_cluster_conn_prefers_explicit_over_discovery() {
+        // #524: an explicit --api-url/--api-key (or env) wins and short-circuits
+        // discovery entirely -- no kubectl is shelled, so this resolves with no
+        // cluster. (The discovery branch is covered by ops::ui_api_url_from_parts
+        // unit tests + the actionable release-named errors.)
+        let conn = ClusterConn {
+            api_url: Some("https://api.example.test".into()),
+            api_key: Some("real-release-key".into()),
+            namespace: "agentos".into(),
+            release: "agentos".into(),
+        };
+        let (url, key) = resolve_cluster_conn(conn)
+            .await
+            .expect("explicit conn resolves");
+        assert_eq!(url, "https://api.example.test");
+        assert_eq!(key, "real-release-key");
+    }
+
+    #[test]
+    fn cluster_governance_verbs_take_namespace_and_release() {
+        // The discovery flags exist on a cluster governance verb so an omitted
+        // --api-url/--api-key can be resolved from the named release (#524).
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "cluster",
+            "versions",
+            "demo",
+            "--namespace",
+            "prod",
+            "--release",
+            "acme",
+        ])
+        .expect("cluster versions with --namespace/--release should parse");
+        match cli.command {
+            Some(Command::Cluster {
+                action: ClusterAction::Versions { target },
+            }) => {
+                assert_eq!(target.agent, "demo");
+                assert_eq!(target.conn.namespace, "prod");
+                assert_eq!(target.conn.release, "acme");
+                assert!(
+                    target.conn.api_url.is_none(),
+                    "omitted --api-url stays None for discovery"
+                );
+            }
+            _ => panic!("expected cluster versions"),
         }
     }
 

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1519,6 +1519,44 @@ fn api_url_usage_err(msg: impl Into<String>) -> anyhow::Error {
         .into()
 }
 
+/// A usage error (exit 2) whose fix hint points the operator at `--api-key`,
+/// the escape hatch when the release's API key cannot be read from its Secret.
+fn api_key_usage_err(msg: impl Into<String>) -> anyhow::Error {
+    crate::exit::CliError::usage(msg)
+        .with_fix("pass --api-key")
+        .into()
+}
+
+/// Discover a Helm release's platform API key by reading it out of the chart
+/// Secret (`<release>-secrets`, data key `apiKey`), decoded server-side by
+/// kubectl's `base64decode` so the plaintext never lands in argv (#524). The
+/// governance verbs use this so they authenticate against a REAL release whose
+/// `api.apiKey` was randomized at `cluster up`, instead of silently sending the
+/// dev sentinel `agentos-dev-key` and 401-ing. An explicit `--api-key`/env still
+/// wins (the caller only reaches here when neither was supplied). The value is
+/// never printed — it flows straight into the `X-API-Key` header.
+pub async fn discover_api_key(namespace: &str, release: &str) -> Result<String> {
+    let cmd = OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("get"),
+            plain("secret"),
+            plain(format!("{release}-secrets")),
+            plain("-o"),
+            plain("go-template={{ index .data \"apiKey\" | base64decode }}"),
+        ],
+    );
+    match run_capture(&cmd).await {
+        Ok((true, out, _)) if !out.trim().is_empty() => Ok(out.trim().to_string()),
+        _ => Err(api_key_usage_err(format!(
+            "could not read the API key from secret {release}-secrets in namespace {namespace}; \
+             pass --api-key or set AGENTOS_API_KEY to the release's api.apiKey"
+        ))),
+    }
+}
+
 /// Build the UI `/api` proxy base URL (`http://<host>:<ui-nodeport>/api`) from
 /// the UI service JSON and a resolved node host, or an actionable usage error.
 /// `cluster deploy` reaches the platform API through this proxy (the UI pod

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -245,10 +245,18 @@ fn agent_target_verbs_keep_their_per_tier_api_url_default() {
             "local {verb} lost its api-url default\n{local}"
         );
 
+        // The cluster tier deliberately has NO localhost:8000 default (#524):
+        // --api-url is optional and discovered from the release when omitted, so
+        // the dev localhost default (which silently fails against a real release)
+        // is gone. Instead the cluster verb exposes --namespace/--release.
         let cluster = output_text(&run_help(&["cluster", verb]));
         assert!(
-            cluster.contains("[default: http://localhost:8000]"),
-            "cluster {verb} lost its api-url default\n{cluster}"
+            !cluster.contains("[default: http://localhost:8000]"),
+            "cluster {verb} must not carry the dev localhost:8000 api-url default\n{cluster}"
+        );
+        assert!(
+            cluster.contains("--namespace") && cluster.contains("--release"),
+            "cluster {verb} must expose --namespace/--release for release discovery\n{cluster}"
         );
     }
 }
@@ -258,12 +266,26 @@ fn agent_target_verbs_keep_their_per_tier_api_url_default() {
 /// test fails if the two tiers ever drift apart again (issue #466).
 #[test]
 fn agent_target_verbs_expose_the_same_flags_on_both_tiers() {
+    // The two tiers share the agent-facing flags (--agent/--api-url/--api-key/
+    // --dry-run) but DIVERGE intentionally on the cluster side (#524): cluster
+    // adds --namespace/--release to discover the release's connection. So the
+    // cluster flag set must be a strict superset of the local one, differing only
+    // by those two discovery flags -- a flag added to local can still never be
+    // silently dropped from cluster.
     for verb in ["versions", "memory", "approvals"] {
         let local = help_flags(&["local", verb]);
         let cluster = help_flags(&["cluster", verb]);
+        for flag in &local {
+            assert!(
+                cluster.contains(flag),
+                "cluster {verb} is missing the local flag {flag:?}\nlocal: {local:?}\ncluster: {cluster:?}"
+            );
+        }
+        let extra: Vec<_> = cluster.iter().filter(|f| !local.contains(*f)).collect();
         assert_eq!(
-            local, cluster,
-            "local {verb} and cluster {verb} expose different flags"
+            extra.len(),
+            2,
+            "cluster {verb} should add exactly --namespace/--release; got extras {extra:?}"
         );
     }
 }


### PR DESCRIPTION
The six cluster governance verbs (`versions`/`memory`/`approvals`/`budget`/`kill`/`resume`, plus `delete`) defaulted `--api-url` to `http://localhost:8000` and `--api-key` to the `agentos-dev-key` sentinel — correct for the local compose stack, wrong for a real Helm release (which serves the API through its UI `/api` NodePort proxy and randomizes `api.apiKey` at `cluster up`). So a plain `agentos cluster versions demo` against a real release parsed cleanly and then failed with connection-refused or 401. A parse-level parity gate structurally can't catch this — the argv is valid and still doesn't work.

## Fix — discover the connection from the release
Mirroring how `cluster deploy` already discovers the URL:
- **`--api-url`** omitted → resolve the release's UI `/api` NodePort proxy (`ops::discover_ui_api_url`).
- **`--api-key`** omitted → read the release's `api.apiKey` out of its chart Secret `<release>-secrets`, decoded server-side by kubectl's `base64decode` so the plaintext never lands in argv (`ops::discover_api_key`). It flows straight into the `X-API-Key` header and is never printed.

Precedence unchanged in spirit: an explicit `--api-url`/`--api-key` (or `AGENTOS_API_URL`/`AGENTOS_API_KEY`) **wins** and short-circuits discovery. Discovery failures are actionable usage errors naming the release (`could not read the API key from secret <release>-secrets in namespace <ns>; pass --api-key …`).

## Surface
- The cluster verbs gain `--namespace`/`--release` (default `agentos`) to target the release; `--api-url`/`--api-key` become optional (no localhost/dev-key default).
- The **local** tier is untouched — it keeps its `http://localhost:28000` default via `AgentTarget<LocalTier>`. Cluster now uses a dedicated `ClusterConn`/`ClusterAgentTarget` (the old shared `ClusterTier` default is removed).

## Tests
- `resolve_cluster_conn_prefers_explicit_over_discovery` (AC#4 — explicit values resolve with no kubectl).
- `cluster_governance_verbs_take_namespace_and_release`.
- Updated the two surface tests: cluster must NOT carry the `localhost:8000` default and must expose `--namespace`/`--release`; the cross-tier flag test now asserts cluster is a strict superset of local (+2 discovery flags).
- Command + UI manifests regenerated. Full CLI suite green (the 2 real-Valkey queue tests are parallel-contention flakes; green serially).

Follow-up noted: `cluster observability` still doesn't exist (local-only) — tracked in #460.

Ref CUR-1615
Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)