### PR TITLE
local/cluster approvals reports the manifest-armed gates too

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -86,6 +86,21 @@ pub struct Deployment {
     pub id: String,
     pub environment: String,
     pub status: String,
+    // Extra DeploymentOut fields used to resolve the in-force version for the
+    // `approvals` gate read (#546); `#[serde(default)]` keeps the deploy path
+    // (which reads only id/environment/status) tolerant of a leaner response.
+    #[serde(default)]
+    pub version_id: Option<String>,
+    #[serde(default)]
+    pub deployed_at: Option<String>,
+}
+
+/// One readable text file from a version's stored bundle (`BundleFile` in
+/// openapi.json), from `GET /agents/{id}/versions/{version_id}/files`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BundleFile {
+    pub path: String,
+    pub content: String,
 }
 
 /// The agent kill-switch state (`KillState` in openapi.json): the response of
@@ -616,6 +631,52 @@ impl ApiClient {
             .json()
             .await
             .context("decoding eval matrix")
+    }
+
+    /// List an agent's deployments, oldest first: `GET /deployments?agent_id={id}`.
+    /// Used to resolve the in-force version whose bundle manifest gates the
+    /// `approvals` read must union in (#546).
+    pub async fn list_deployments(&self, agent_id: &str) -> Result<Vec<Deployment>> {
+        let resp = self
+            .http
+            .get(format!("{}/deployments", self.base_url))
+            .query(&[("agent_id", agent_id)])
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("GET /deployments")?;
+        Self::expect_ok(resp, "listing deployments")
+            .await?
+            .json()
+            .await
+            .context("decoding deployment list")
+    }
+
+    /// Read a version's authored text files (skills, manifest, eval cases):
+    /// `GET /agents/{id}/versions/{version_id}/files`. The `approvals` read pulls
+    /// the deployed bundle's manifest from here to recover its `approvalPolicy`
+    /// gates (#546).
+    pub async fn bundle_files(&self, agent_id: &str, version_id: &str) -> Result<Vec<BundleFile>> {
+        #[derive(serde::Deserialize)]
+        struct BundleFiles {
+            files: Vec<BundleFile>,
+        }
+        let resp = self
+            .http
+            .get(format!(
+                "{}/agents/{agent_id}/versions/{version_id}/files",
+                self.base_url
+            ))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("GET /agents/{id}/versions/{version_id}/files")?;
+        let files: BundleFiles = Self::expect_ok(resp, "reading bundle files")
+            .await?
+            .json()
+            .await
+            .context("decoding bundle files")?;
+        Ok(files.files)
     }
 
     /// Delete the agent: `DELETE /agents/{id}` (204 No Content on success).

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2079,7 +2079,18 @@ pub async fn approvals(
             }
         }
     } else {
-        agent.approval_required_tools.clone().unwrap_or_default()
+        // Report what the runner actually arms (#546): the UNION of the platform's
+        // mutable `approval_required_tools` field (delivered as
+        // AGENTOS_APPROVAL_REQUIRED_TOOLS) AND the in-force deployed bundle
+        // manifest's `approvalPolicy` gates. Reading only the API field reported an
+        // empty set while a manifest gate was armed and blocking.
+        let mut gated = agent.approval_required_tools.clone().unwrap_or_default();
+        for name in deployed_manifest_gate_names(&client, &agent.id).await? {
+            if !gated.contains(&name) {
+                gated.push(name);
+            }
+        }
+        gated
     };
     Ok(ApprovalsOutput::Gates {
         agent: agent.name,
@@ -2346,16 +2357,23 @@ fn read_bundle_gates(plugin_dir: &Path) -> Result<Vec<(String, String)>> {
         })?;
     let body = std::fs::read_to_string(&manifest_path)
         .with_context(|| format!("reading {}", manifest_path.display()))?;
-    // A manifest the runner's pydantic parse would reject: same all-or-nothing
-    // outcome, surfaced rather than swallowed into a cheerful empty list.
+    parse_manifest_gates(&body, &manifest_path.display().to_string())
+}
+
+/// Parse the `approvalPolicy` gates out of a plugin-manifest JSON body, mirroring
+/// the runner's `load_approval_policy` two-tier semantics (a missing REQUIRED key
+/// disarms every gate → usage error; a present-but-empty gate/route is dropped,
+/// siblings survive). `source` labels the manifest in errors. Shared by the skill
+/// tier (manifest on local disk) and the local/cluster tiers (manifest pulled from
+/// the deployed bundle over the API, #546) so both read gates identically.
+fn parse_manifest_gates(body: &str, source: &str) -> Result<Vec<(String, String)>> {
     let invalid = |problem: &str| {
         crate::exit::usage(format!(
-            "invalid plugin manifest {}: {problem}. The runner rejects this manifest and arms ZERO approval gates, including any well-formed ones",
-            manifest_path.display()
+            "invalid plugin manifest {source}: {problem}. The runner rejects this manifest and arms ZERO approval gates, including any well-formed ones"
         ))
     };
     let manifest: ManifestApprovals =
-        serde_json::from_str(&body).map_err(|e| invalid(&format!("not valid JSON ({e})")))?;
+        serde_json::from_str(body).map_err(|e| invalid(&format!("not valid JSON ({e})")))?;
     if manifest.name.is_none() {
         return Err(invalid("missing the required `name` field"));
     }
@@ -2384,6 +2402,61 @@ fn read_bundle_gates(plugin_dir: &Path) -> Result<Vec<(String, String)>> {
         }
     }
     Ok(gates)
+}
+
+/// The active deployment whose bundle is in force for an agent: prod outranks dev
+/// (mirroring `binding.py`), then most recent. `list_deployments` returns rows
+/// oldest-first, so "most recent" is the last match. `None` when the agent has no
+/// active deployment (nothing is running its bundle yet).
+fn select_in_force_deployment(
+    deployments: &[crate::api::Deployment],
+) -> Option<&crate::api::Deployment> {
+    let active: Vec<&crate::api::Deployment> = deployments
+        .iter()
+        .filter(|d| d.status == "active")
+        .collect();
+    active
+        .iter()
+        .rev()
+        .find(|d| d.environment == "prod")
+        .or_else(|| active.iter().rev().find(|d| d.environment == "dev"))
+        .or_else(|| active.last())
+        .copied()
+}
+
+/// The approval-gate tool names armed by the agent's in-force DEPLOYED bundle
+/// manifest (#546): resolve the active deployment → its version → the version's
+/// stored manifest → `approvalPolicy.gates[].gate`. This is the source the runner
+/// consults that the platform's mutable `approval_required_tools` field does NOT
+/// carry, so `local`/`cluster approvals` must union it in or it reports an empty
+/// gate set while the manifest gate is armed and blocking. Best-effort on the
+/// fetch (no deployment / no bundle / API hiccup → no manifest gates), but a
+/// deployed manifest that is actually invalid is surfaced (it disarms every gate).
+async fn deployed_manifest_gate_names(client: &ApiClient, agent_id: &str) -> Result<Vec<String>> {
+    let deployments = match client.list_deployments(agent_id).await {
+        Ok(d) => d,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let Some(version_id) =
+        select_in_force_deployment(&deployments).and_then(|d| d.version_id.clone())
+    else {
+        return Ok(Vec::new());
+    };
+    let files = match client.bundle_files(agent_id, &version_id).await {
+        Ok(f) => f,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let Some(manifest) = files
+        .iter()
+        .find(|f| MANIFEST_LOCATIONS.contains(&f.path.as_str()))
+    else {
+        return Ok(Vec::new());
+    };
+    let gates = parse_manifest_gates(
+        &manifest.content,
+        &format!("deployed bundle manifest ({})", manifest.path),
+    )?;
+    Ok(gates.into_iter().map(|(gate, _route)| gate).collect())
 }
 
 /// POSIX-shell-quote a value for safe interpolation into emitted shell text.
@@ -2551,8 +2624,8 @@ pub fn skill_memory_unavailable() -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::{
-        merge_secret_env, resolve_cases_path, seed_env_if_missing, select_passthrough_env,
-        validate_slack_channel, EnvSeed,
+        merge_secret_env, parse_manifest_gates, resolve_cases_path, seed_env_if_missing,
+        select_in_force_deployment, select_passthrough_env, validate_slack_channel, EnvSeed,
     };
     use std::path::{Path, PathBuf};
 
@@ -2961,6 +3034,70 @@ mod tests {
 
     fn usage_class(err: &anyhow::Error) -> crate::exit::ExitClass {
         crate::exit::classify(err).0
+    }
+
+    fn deployment(env: &str, status: &str, version: &str, ts: &str) -> crate::api::Deployment {
+        crate::api::Deployment {
+            id: format!("dep-{version}"),
+            environment: env.into(),
+            status: status.into(),
+            version_id: Some(version.into()),
+            deployed_at: Some(ts.into()),
+        }
+    }
+
+    #[test]
+    fn select_in_force_deployment_prefers_prod_then_most_recent() {
+        // Oldest-first, mixed envs/statuses. prod outranks dev; among a rank the
+        // most recent (last) active row wins; inactive rows are ignored (#546).
+        let deps = vec![
+            deployment("dev", "active", "v1", "2026-07-01"),
+            deployment("prod", "superseded", "v2", "2026-07-02"),
+            deployment("prod", "active", "v3", "2026-07-03"),
+            deployment("dev", "active", "v4", "2026-07-04"),
+        ];
+        assert_eq!(
+            select_in_force_deployment(&deps).and_then(|d| d.version_id.clone()),
+            Some("v3".to_string()),
+            "active prod wins over a newer active dev"
+        );
+        // No prod: newest active dev.
+        let dev_only = vec![
+            deployment("dev", "active", "a", "2026-07-01"),
+            deployment("dev", "active", "b", "2026-07-05"),
+        ];
+        assert_eq!(
+            select_in_force_deployment(&dev_only).and_then(|d| d.version_id.clone()),
+            Some("b".to_string())
+        );
+        // No active deployment at all -> nothing in force.
+        let none = vec![deployment("dev", "superseded", "x", "2026-07-01")];
+        assert!(select_in_force_deployment(&none).is_none());
+        assert!(select_in_force_deployment(&[]).is_none());
+    }
+
+    #[test]
+    fn parse_manifest_gates_extracts_gate_route_pairs() {
+        // The shared parser (#546) recovers approvalPolicy gates from raw manifest
+        // text, the same shape `local`/`cluster approvals` union into the report.
+        let gates = parse_manifest_gates(
+            r#"{"name":"x","version":"1","approvalPolicy":{"gates":[{"gate":"mcp__plugin_gh_github__create_issue","route":"eng"}]}}"#,
+            "test manifest",
+        )
+        .expect("valid manifest parses");
+        assert_eq!(
+            gates,
+            vec![(
+                "mcp__plugin_gh_github__create_issue".to_string(),
+                "eng".to_string()
+            )]
+        );
+        // A manifest missing the required `name` disarms every gate -> surfaced.
+        assert!(parse_manifest_gates(
+            r#"{"version":"1","approvalPolicy":{"gates":[{"gate":"Bash","route":"eng"}]}}"#,
+            "bad manifest",
+        )
+        .is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
`agentos local approvals <agent>` reported `gated_tools: []` while the agent's manifest `approvalPolicy` gate was armed and actively blocking closes. An operator asking "what does this agent need approval for?" was told "nothing" — the opposite of the truth, which is worse than an error (it invites trusting a gated agent as ungated).

## Root cause
The runner arms the **union** of two independent sources (`runner/__main__.py`):
```python
gated_tools = frozenset(config.approval_required_tools) | frozenset(load_approval_policy(plugin_dir))
```
- (a) the platform's mutable `approval_required_tools` field (delivered as `AGENTOS_APPROVAL_REQUIRED_TOOLS`), and
- (b) the deployed bundle manifest's `approvalPolicy.gates[].gate`.

`local approvals` read only (a). An agent gated purely via (b) — the immutable bundle — has an empty (a), so the verb reported zero gates while the runner was blocking.

## Fix — union both sources (pure CLI, existing endpoints)
The view path now unions (a) with (b), resolving (b) the way the runtime sees it:
active deployment → its version → `GET /agents/{id}/versions/{version_id}/files` → the `plugin.json` text → `approvalPolicy.gates[].gate`.

- The manifest gate parser is **extracted** as `parse_manifest_gates(body, source)` so the skill tier (manifest on local disk) and local/cluster (manifest pulled from the deployed bundle) share **one** parser with the runner's two-tier semantics (missing required key disarms every gate → error; present-but-empty gate dropped, siblings survive).
- `select_in_force_deployment` mirrors the runtime binding: active only, prod outranks dev, then most recent.
- Best-effort on the fetch: no deployment / no bundle / API hiccup → just the API field (never worse than today). A deployed manifest that is *actually invalid* is surfaced (it disarms every gate — worth knowing).

No API change; no clap-surface change (no manifest regen).

## Tests
- `select_in_force_deployment_prefers_prod_then_most_recent` (prod>dev>recent, ignores inactive, empty → None).
- `parse_manifest_gates_extracts_gate_route_pairs` (recovers gates from raw text; missing `name` errors).
- Existing `read_bundle_gates` tests still pass through the extracted parser. Full CLI suite green.

Ref CUR-1616
Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)