### PR TITLE
init --from-spec can express approvalPolicy and secrets

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -48,7 +48,13 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 The spec is a JSON object an agent writes after interviewing the human. `name`
 is the kebab-case bundle name; every `skills[].name` is kebab-case and unique;
 `connectors` (optional) is the raw `.mcp.json` `mcpServers` map (each server must
-define `command` or `url` as a string); `evals` reuses the frozen eval-case shape
+define `command` or `url` as a string); `secrets` (optional) is a list of
+connector-secret NAMES (env-var-shaped, no values, per ADR-0009) written to the
+manifest's `secrets`; `approvalPolicy` (optional) declares approval `gates`
+(`{gate, route}`) where an `mcp__` gate must be a fully-namespaced live tool name
+`mcp__plugin_<bundle>_<server>__<tool>` for a declared connector (a built-in like
+`Bash` needs no prefix) — so a spec can express a gated, authed agent without
+hand-editing `plugin.json`; `evals` reuses the frozen eval-case shape
 so the scaffolded `evals/cases.json` loads unchanged through `agentos skill eval`.
 An unknown TOP-LEVEL field is a hard error, so an authoring typo fails loud, but
 unknown keys INSIDE an eval case are ignored exactly as the platform's worker
@@ -69,6 +75,12 @@ with the platform grader, not an oversight.
   ],
   "connectors": {
     "crm": { "command": "crm-mcp", "args": ["--stdio"] }
+  },
+  "secrets": ["CRM_API_TOKEN"],
+  "approvalPolicy": {
+    "gates": [
+      { "gate": "mcp__plugin_deal-desk_crm__create_deal", "route": "default" }
+    ]
   },
   "evals": [
     {

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -200,12 +200,30 @@ fn render_skill_md(skill: &SkillSpec) -> String {
 /// already validated by `spec::parse`; this only lays down files, funneling
 /// through `write_bundle` for the identical collision refusal as `scaffold`.
 pub fn scaffold_from_spec(dir: &Path, spec: &AgentSpec) -> Result<Vec<PathBuf>> {
-    let manifest = serde_json::to_string_pretty(&serde_json::json!({
-        "name": spec.name,
-        "description": spec.description,
-        "version": "0.1.0",
-    }))
-    .expect("spec manifest serializes");
+    // Build the manifest incrementally so `secrets`/`approvalPolicy` are OMITTED
+    // when the spec declares none -- keeping the default scaffold byte-identical to
+    // the trivial case while letting a spec produce a gated, authed bundle without
+    // hand-editing plugin.json (#549).
+    let mut manifest_obj = serde_json::Map::new();
+    manifest_obj.insert("name".into(), serde_json::json!(spec.name));
+    manifest_obj.insert("description".into(), serde_json::json!(spec.description));
+    manifest_obj.insert("version".into(), serde_json::json!("0.1.0"));
+    if !spec.secrets.is_empty() {
+        manifest_obj.insert("secrets".into(), serde_json::json!(spec.secrets));
+    }
+    if let Some(policy) = &spec.approval_policy {
+        let gates: Vec<Value> = policy
+            .gates
+            .iter()
+            .map(|g| serde_json::json!({ "gate": g.gate, "route": g.route }))
+            .collect();
+        manifest_obj.insert(
+            "approvalPolicy".into(),
+            serde_json::json!({ "gates": gates }),
+        );
+    }
+    let manifest = serde_json::to_string_pretty(&Value::Object(manifest_obj))
+        .expect("spec manifest serializes");
 
     // `.mcp.json` carries the connectors verbatim under `mcpServers`; an empty
     // map yields `{"mcpServers": {}}`, matching the weather scaffold's seed.

--- a/cli/src/spec.rs
+++ b/cli/src/spec.rs
@@ -27,9 +27,28 @@ pub struct SkillSpec {
     pub instructions: String,
 }
 
+/// One approval gate a spec declares: the fully-namespaced LIVE tool name and the
+/// route it escalates to. Mirrors `plugin_format.models.ApprovalGate`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalGateSpec {
+    pub gate: String,
+    pub route: String,
+}
+
+/// The `approvalPolicy` a spec declares. Mirrors `plugin_format.models.ApprovalPolicy`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApprovalPolicySpec {
+    #[serde(default)]
+    pub gates: Vec<ApprovalGateSpec>,
+}
+
 /// The whole bundle an agent describes. `connectors` is the raw `.mcp.json`
 /// `mcpServers` map (server name -> server object) and is written through
-/// verbatim after validation.
+/// verbatim after validation. `secrets` (names only, ADR-0009) and
+/// `approval_policy` let a spec express a gated, authed agent without hand-editing
+/// the manifest afterwards (#549); both default to empty so existing specs parse.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AgentSpec {
@@ -38,7 +57,52 @@ pub struct AgentSpec {
     pub skills: Vec<SkillSpec>,
     #[serde(default)]
     pub connectors: Map<String, Value>,
+    /// Connector-secret NAMES the bundle needs at launch (`--secret <NAME>`); no
+    /// values, per ADR-0009. Written to the manifest's `secrets` array.
+    #[serde(default)]
+    pub secrets: Vec<String>,
+    /// Approval gates to arm at runtime. Written to the manifest's `approvalPolicy`.
+    #[serde(default, rename = "approvalPolicy")]
+    pub approval_policy: Option<ApprovalPolicySpec>,
     pub evals: Vec<EvalCase>,
+}
+
+/// Reject an `mcp__`-prefixed approval gate that is not a fully-namespaced live
+/// tool name for one of this bundle's declared connectors. Non-`mcp__` gates
+/// (built-ins like `Bash`/`Write`) pass untouched. Mirrors the namespacing check
+/// in `plugin_format` `_validate_approval_policy`.
+fn validate_gate_namespacing(
+    bundle: &str,
+    connectors: &Map<String, Value>,
+    gate: &str,
+) -> Result<()> {
+    if !gate.starts_with("mcp__") {
+        return Ok(());
+    }
+    // Try each declared connector's live prefix; the gate must carry a non-empty
+    // tool suffix after it.
+    for server in connectors.keys() {
+        let prefix = format!("mcp__plugin_{bundle}_{server}__");
+        if let Some(tool) = gate.strip_prefix(&prefix) {
+            if tool.is_empty() {
+                bail!(
+                    "spec approvalPolicy gate {gate:?} names connector {server:?} but has no tool after the prefix; expected {prefix}<tool>"
+                );
+            }
+            return Ok(());
+        }
+    }
+    let expected: Vec<String> = connectors
+        .keys()
+        .map(|s| format!("mcp__plugin_{bundle}_{s}__<tool>"))
+        .collect();
+    let hint = if expected.is_empty() {
+        "the spec declares no connectors, so it can gate only built-in tools (e.g. Bash)"
+            .to_string()
+    } else {
+        format!("expected one of: {}", expected.join(", "))
+    };
+    bail!("spec approvalPolicy gate {gate:?} is not a fully-namespaced live tool name; {hint}")
 }
 
 /// Deserialize the spec JSON (strict) then validate it. Returns actionable
@@ -105,6 +169,33 @@ fn validate(spec: &AgentSpec) -> Result<()> {
         let defines = |key: &str| obj.and_then(|o| o.get(key)).is_some_and(|v| v.is_string());
         if !(defines("command") || defines("url")) {
             bail!("connector {name:?} must define either 'command' (stdio) or 'url' (remote)");
+        }
+    }
+
+    // Secret NAMES must look like env vars (#549); the same syntax gate `secrets
+    // set`/`--secret` apply. Reserved-name rejection is deliberately left to the
+    // deploy-time `validate_bundle` backstop (the Rust CLI does not mirror the
+    // reserved set -- drift risk -- exactly as `unbound_declared_secrets` does).
+    for name in &spec.secrets {
+        crate::secrets::validate_name(name)
+            .map_err(|e| anyhow!("spec secret name {name:?} is invalid: {e}"))?;
+    }
+
+    // Approval gates: mirror plugin_format `_validate_approval_policy`. Each gate
+    // needs a non-empty `gate` and `route`, and an `mcp__`-prefixed gate must be a
+    // fully-namespaced LIVE tool name `mcp__plugin_<bundle>_<server>__<tool>`
+    // (bundle = spec name, server = a declared connector). A bare `mcp__<server>__`
+    // or a prefix with no tool suffix silently fails to gate at runtime, so reject
+    // it now with a message that shows the expected shape.
+    if let Some(policy) = &spec.approval_policy {
+        for g in &policy.gates {
+            if g.gate.trim().is_empty() {
+                bail!("spec approvalPolicy gate has an empty 'gate'");
+            }
+            if g.route.trim().is_empty() {
+                bail!("spec approvalPolicy gate {:?} has an empty 'route'", g.gate);
+            }
+            validate_gate_namespacing(&spec.name, &spec.connectors, g.gate.trim())?;
         }
     }
 

--- a/cli/tests/spec_scaffold.rs
+++ b/cli/tests/spec_scaffold.rs
@@ -101,6 +101,116 @@ fn scaffolds_the_full_bundle_from_a_valid_spec() {
     assert!(gitignore.contains(".agentos/"), "{gitignore}");
 }
 
+/// A spec declaring `secrets` and `approvalPolicy` scaffolds a gated, authed
+/// bundle whose manifest carries both verbatim -- no hand-editing plugin.json
+/// (#549). The gate is a fully-namespaced live tool name for the `crm` connector.
+#[test]
+fn scaffolds_secrets_and_approval_policy_into_the_manifest() {
+    let body = r#"{
+      "name": "deal-desk",
+      "description": "Gated authed deal desk.",
+      "skills": [
+        { "name": "deal-desk", "description": "Do it.", "instructions": "Body.\n" }
+      ],
+      "connectors": { "crm": { "command": "crm-mcp", "args": ["--stdio"] } },
+      "secrets": ["CRM_API_TOKEN"],
+      "approvalPolicy": {
+        "gates": [
+          { "gate": "mcp__plugin_deal-desk_crm__create_deal", "route": "default" }
+        ]
+      },
+      "evals": [
+        { "id": "e1", "input": "hi", "grader": { "kind": "contains", "expected": "ok" } }
+      ]
+    }"#;
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(body).expect("gated authed spec parses");
+    scaffold_from_spec(&out, &spec).expect("scaffold succeeds");
+
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.join(".claude-plugin/plugin.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(manifest["secrets"], serde_json::json!(["CRM_API_TOKEN"]));
+    assert_eq!(
+        manifest["approvalPolicy"]["gates"][0]["gate"],
+        "mcp__plugin_deal-desk_crm__create_deal"
+    );
+    assert_eq!(manifest["approvalPolicy"]["gates"][0]["route"], "default");
+}
+
+/// A spec that declares neither omits both keys, so the default scaffold shape is
+/// unchanged (no empty `secrets: []` / `approvalPolicy` noise).
+#[test]
+fn omits_secrets_and_approval_policy_when_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(valid_spec_json()).expect("valid spec parses");
+    scaffold_from_spec(&out, &spec).expect("scaffold succeeds");
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.join(".claude-plugin/plugin.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        manifest.get("secrets").is_none(),
+        "no secrets key: {manifest}"
+    );
+    assert!(
+        manifest.get("approvalPolicy").is_none(),
+        "no approvalPolicy key: {manifest}"
+    );
+}
+
+#[test]
+fn rejects_a_secret_name_that_is_not_env_var_shaped() {
+    let body = r#"{
+      "name": "x", "description": "d",
+      "skills": [ { "name": "s", "description": "d", "instructions": "b\n" } ],
+      "secrets": ["lowercase-bad"],
+      "evals": [ { "id": "e", "input": "i", "grader": { "kind": "contains", "expected": "ok" } } ]
+    }"#;
+    let err = parse(body)
+        .expect_err("bad secret name must error")
+        .to_string();
+    assert!(err.contains("lowercase-bad"), "names the offender: {err}");
+}
+
+#[test]
+fn rejects_an_approval_gate_missing_its_route() {
+    let body = r#"{
+      "name": "x", "description": "d",
+      "skills": [ { "name": "s", "description": "d", "instructions": "b\n" } ],
+      "approvalPolicy": { "gates": [ { "gate": "Bash", "route": "" } ] },
+      "evals": [ { "id": "e", "input": "i", "grader": { "kind": "contains", "expected": "ok" } } ]
+    }"#;
+    let err = parse(body).expect_err("empty route must error").to_string();
+    assert!(
+        err.to_lowercase().contains("route"),
+        "mentions route: {err}"
+    );
+}
+
+/// An `mcp__` gate that is not fully namespaced for a declared connector silently
+/// fails to gate at runtime, so the spec rejects it up front (#549 / ADR-0010).
+#[test]
+fn rejects_a_mis_namespaced_mcp_approval_gate() {
+    let body = r#"{
+      "name": "deal-desk", "description": "d",
+      "skills": [ { "name": "s", "description": "d", "instructions": "b\n" } ],
+      "connectors": { "crm": { "command": "crm-mcp" } },
+      "approvalPolicy": { "gates": [ { "gate": "mcp__crm__create_deal", "route": "default" } ] },
+      "evals": [ { "id": "e", "input": "i", "grader": { "kind": "contains", "expected": "ok" } } ]
+    }"#;
+    let err = parse(body)
+        .expect_err("bare mcp gate must error")
+        .to_string();
+    assert!(
+        err.contains("mcp__plugin_deal-desk_crm__"),
+        "shows the expected namespaced shape: {err}"
+    );
+}
+
 /// Every skill in a multi-skill spec becomes its own SKILL.md carrying that
 /// skill's name, description, allowed-tools (only when present), and body.
 #[test]


### PR DESCRIPTION
The spec scaffolder could only produce the trivial bundle. `AgentSpec` was `deny_unknown_fields` with no field for `secrets` or `approvalPolicy`, so the moment you wanted a **gated, authed** agent — the shape the docs push you toward — you had to hand-edit `.claude-plugin/plugin.json`, exactly where the frozen-format guarantees stop helping.

## Fix
`AgentSpec` now carries two optional fields:
- **`secrets`** — connector-secret names (env-var-shaped, no values, per ADR-0009), written to the manifest's `secrets`.
- **`approvalPolicy`** — `{gates: [{gate, route}]}`, written to the manifest's `approvalPolicy`.

`scaffold_from_spec` writes both into the manifest and **omits them when absent**, so the default scaffold shape is byte-identical to today.

Validation hand-mirrors `plugin_format` (`validate.py`), so a spec that parses scaffolds a bundle the deploy-time `validate_bundle` accepts:
- secret names match `^[A-Z_][A-Z0-9_]*$`;
- each gate has a non-empty `gate` and `route`;
- an `mcp__` gate must be a **fully-namespaced live tool name** `mcp__plugin_<bundle>_<server>__<tool>` for a declared connector — the check that makes a gated authed agent actually arm at runtime (a bare `mcp__crm__x` silently fails to gate). Built-ins like `Bash` need no prefix.

`deny_unknown_fields` stays on the top-level spec (authoring typos still fail loud); eval structs stay lenient; reserved-secret-name rejection stays the deploy-time backstop (the Rust CLI deliberately doesn't mirror the reserved set — drift risk — same as `unbound_declared_secrets`).

## Tests
- A gated+authed spec scaffolds a manifest carrying both keys with the exact shape.
- Absent → both keys omitted (default shape unchanged).
- Rejections: non-env-var secret name, empty `route`, mis-namespaced `mcp__crm__…` gate.
- `cli/README` spec-shape doc updated with both fields + a namespaced-gate example. Full CLI suite green; no clap-surface change.

Ref CUR-1619
Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)