### PR TITLE
Reserve redirect/capture-capable env from connector secrets

### DIFF
--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -176,8 +176,9 @@ def _validate_secret_map(value: dict[str, str] | None) -> dict[str, str] | None:
             # or be silently dropped by the worker binding's reserved-key
             # guard, so reject it on write.
             raise ValueError(
-                f"secret name {name!r} is reserved: it is a platform boot-env "
-                "or model-credential key and cannot be used for a connector secret"
+                f"secret name {name!r} is reserved: it is a platform boot-env, "
+                "model-credential, or redirect/capture-capable key and cannot be "
+                "used for a connector secret"
             )
         if not secret:
             raise ValueError(f"secret {name!r} has an empty value")

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -463,6 +463,32 @@ def test_agent_reserved_credential_secret_name_is_422(
     assert bad.status_code == 422, bad.text
 
 
+# #487: redirect/capture-capable env (proxy, extra CA, custom headers) is reserved
+# on the API write seam too, at the same 422 as the credential keys.
+_REDIRECT_CAPTURE_KEYS = [
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NODE_EXTRA_CA_CERTS",
+    "ANTHROPIC_CUSTOM_HEADERS",
+]
+
+
+@pytest.mark.parametrize("name", _REDIRECT_CAPTURE_KEYS)
+def test_agent_reserved_redirect_capture_secret_name_is_422(
+    client: Any, auth_headers: dict[str, str], clean_db: None, name: str
+) -> None:
+    bad = client.post(
+        "/agents",
+        json={
+            "name": "redirect-secret-agent",
+            "slack_channel": "C000000S05",
+            "secrets": {name: "x"},
+        },
+        headers=auth_headers,
+    )
+    assert bad.status_code == 422, bad.text
+
+
 def test_agent_legitimate_secret_name_still_creates(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:

--- a/charts/agentos/templates/_helpers.tpl
+++ b/charts/agentos/templates/_helpers.tpl
@@ -57,13 +57,14 @@ app.kubernetes.io/component: {{ .component }}
      define's body and fails CI if the two lists drift.
 
      IMPORTANT: the pin scans this body for env-name-shaped uppercase tokens, so
-     the body must contain EXACTLY these four keys and no other stray ones (this
-     comment lives OUTSIDE the define so it is never scanned). The whole
+     the body must contain EXACTLY these eight keys and no other stray ones (this
+     comment lives OUTSIDE the define so it is never scanned): the four runner
+     credential keys plus the four redirect/capture-capable keys (#487). The whole
      AGENTOS_ namespace is fenced separately by the hasPrefix rule in the
      connector-secret guard, so it is intentionally absent here. Emitted
      space-separated for consumption via `splitList " "`. */}}
 {{- define "agentos.reservedConnectorSecretNames" -}}
-ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKEN
+ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKEN HTTPS_PROXY HTTP_PROXY NODE_EXTRA_CA_CERTS ANTHROPIC_CUSTOM_HEADERS
 {{- end -}}
 
 {{/* ---- Backing-store hosts (in-cluster Service name, or BYO host) ---- */}}

--- a/charts/agentos/templates/agent-connector-secrets.yaml
+++ b/charts/agentos/templates/agent-connector-secrets.yaml
@@ -37,7 +37,7 @@ stringData:
   {{- $reserved := splitList " " (trim (include "agentos.reservedConnectorSecretNames" $)) }}
   {{- range $name, $value := $secrets }}
   {{- if or (hasPrefix "AGENTOS_" $name) (has $name $reserved) }}
-  {{- fail (printf "agentSandbox.connectorSecrets.%s.%s uses a reserved boot-env name (%q); a connector secret must not shadow a runner-owned model credential or an AGENTOS_* boot key" $agent $name $name) }}
+  {{- fail (printf "agentSandbox.connectorSecrets.%s.%s uses a reserved boot-env name (%q); a connector secret must not shadow a runner-owned model credential, an AGENTOS_* boot key, or a redirect/capture-capable key (proxy/CA/custom-headers)" $agent $name $name) }}
   {{- end }}
   {{ $name }}: {{ $value | quote }}
   {{- end }}

--- a/packages/plugin-format/src/plugin_format/reserved_env.py
+++ b/packages/plugin-format/src/plugin_format/reserved_env.py
@@ -2,7 +2,8 @@
 
 Single source of truth for the names a per-agent connector secret must never
 declare, consulted by every write seam so a connector secret cannot shadow a
-runner-owned model credential or a platform boot-env key:
+runner-owned model credential or a platform boot-env key, NOR a generic
+redirect/capture-capable key the SDK's HTTP/TLS stack reads (#487):
 
 - API validator ``agentos_api.schemas._validate_secret_map``,
 - bundle validator ``plugin_format.validate._validate_secrets``,
@@ -28,15 +29,32 @@ credential key is added there but not covered here (or if the Helm list drifts).
 from __future__ import annotations
 
 # The four runner ``sdk_auth`` credential keys that are NOT ``AGENTOS_``-prefixed.
-# These are the exact gap #457 closes -- and, per the drift pin, the ONLY
-# non-prefixed members allowed in the set (the Helm ``_helpers.tpl`` reserved
-# list must equal this subset).
+# These are the exact gap #457 closes. Together with ``_REDIRECT_CAPTURE_KEYS``
+# below, these are the non-prefixed members of the set; per the drift pin, the
+# Helm ``_helpers.tpl`` reserved list must equal that combined non-prefixed subset.
 _CREDENTIAL_KEYS = frozenset(
     {
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_API_KEY",
         "CLAUDE_CODE_OAUTH_TOKEN",
         "ANTHROPIC_AUTH_TOKEN",
+    }
+)
+
+# Generic, non-``AGENTOS_``-prefixed env that the SDK's HTTP/TLS stack (or Node)
+# reads to REDIRECT or CAPTURE the model session, rather than being a key the
+# worker/runner explicitly owns (#487). Each reaches the same end state #457 closed
+# for ``ANTHROPIC_BASE_URL``: a connector secret named one of these could route the
+# session (and its resolved credential) through an operator-named proxy, add a
+# trusted CA for transparent TLS MITM, or inject arbitrary headers onto model
+# calls. Fenced here so the reserved set means "reserved OR redirect/capture-
+# capable", not merely "keys we own".
+_REDIRECT_CAPTURE_KEYS = frozenset(
+    {
+        "HTTPS_PROXY",
+        "HTTP_PROXY",
+        "NODE_EXTRA_CA_CERTS",
+        "ANTHROPIC_CUSTOM_HEADERS",
     }
 )
 
@@ -69,7 +87,9 @@ _AGENTOS_BOOT_KEYS = frozenset(
     }
 )
 
-RESERVED_BOOT_ENV: frozenset[str] = _CREDENTIAL_KEYS | _AGENTOS_BOOT_KEYS
+RESERVED_BOOT_ENV: frozenset[str] = (
+    _CREDENTIAL_KEYS | _REDIRECT_CAPTURE_KEYS | _AGENTOS_BOOT_KEYS
+)
 
 
 def is_reserved_boot_env_name(name: str) -> bool:

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -489,8 +489,9 @@ def _validate_secrets(manifest: PluginManifest, c: _Collector) -> None:
             # binding at delivery time, or silently redirect the model session.
             c.error(
                 "secrets.name_reserved",
-                f"secret name {name!r} is reserved: it is a platform boot-env or "
-                "model-credential key and cannot be used for a connector secret",
+                f"secret name {name!r} is reserved: it is a platform boot-env, "
+                "model-credential, or redirect/capture-capable key and cannot be "
+                "used for a connector secret",
                 loc,
             )
 

--- a/packages/plugin-format/tests/test_reserved_env.py
+++ b/packages/plugin-format/tests/test_reserved_env.py
@@ -33,6 +33,18 @@ def test_credential_keys_are_members_of_the_set(name: str) -> None:
     assert name in RESERVED_BOOT_ENV
 
 
+@pytest.mark.parametrize(
+    "name",
+    ["HTTPS_PROXY", "HTTP_PROXY", "NODE_EXTRA_CA_CERTS", "ANTHROPIC_CUSTOM_HEADERS"],
+)
+def test_redirect_capture_keys_are_reserved(name: str) -> None:
+    # #487: generic env that redirects/captures the model session (proxy, extra
+    # CA, custom headers) is reserved even though the worker/runner don't "own" it
+    # and it carries no AGENTOS_ prefix -- it reaches the same capture end state.
+    assert is_reserved_boot_env_name(name) is True
+    assert name in RESERVED_BOOT_ENV
+
+
 def test_model_base_url_alias_is_reserved() -> None:
     # sdk_auth's AGENTOS_-prefixed alias of the base-URL seam.
     assert is_reserved_boot_env_name("AGENTOS_MODEL_BASE_URL") is True

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -201,6 +201,24 @@ def test_reserved_credential_secret_name_is_rejected(tmp_path: Path, name: str) 
     assert "secrets.name_reserved" in _codes(bundle)
 
 
+# #487: generic redirect/capture-capable env is reserved too -- a proxy, an extra
+# trusted CA, or custom headers on the model call reach the same capture end state.
+_REDIRECT_CAPTURE_KEYS = [
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NODE_EXTRA_CA_CERTS",
+    "ANTHROPIC_CUSTOM_HEADERS",
+]
+
+
+@pytest.mark.parametrize("name", _REDIRECT_CAPTURE_KEYS)
+def test_reserved_redirect_capture_secret_name_is_rejected(
+    tmp_path: Path, name: str
+) -> None:
+    bundle = _bundle(tmp_path, f'{{"name": "demo", "secrets": ["{name}"]}}')
+    assert "secrets.name_reserved" in _codes(bundle)
+
+
 def test_legitimate_connector_secret_name_is_not_reserved(tmp_path: Path) -> None:
     # Negative control: a real connector token name still validates clean.
     bundle = _bundle(


### PR DESCRIPTION
`RESERVED_BOOT_ENV` (#457) reserves the env keys the worker and the runner's `sdk_auth` **own**. It does not reserve generic env that redirects the model session or captures its credential by a different mechanism, each of which reaches the same end state #457 closed for `ANTHROPIC_BASE_URL`:

- **`HTTPS_PROXY` / `HTTP_PROXY`** — route the SDK's traffic (and its resolved credential) through an operator-named proxy.
- **`NODE_EXTRA_CA_CERTS`** — add a trusted CA, enabling transparent TLS MITM of the SDK.
- **`ANTHROPIC_CUSTOM_HEADERS`** — inject arbitrary headers onto model calls.

All four are env-var-shaped, non-`AGENTOS_`-prefixed, and pass `_SECRET_NAME_RE`, so they're injectable as connector secrets today.

## Fix
Broadens the reserved set from "keys we own" to "reserved **or** redirect/capture-capable":
- New `_REDIRECT_CAPTURE_KEYS` group in `plugin_format.reserved_env` folded into `RESERVED_BOOT_ENV`.
- The four names added to the Helm `agentos.reservedConnectorSecretNames` list **in lockstep** — the cross-language drift pin (`test_helm_reserved_list_matches_non_prefixed_members`) enforces equality, so both sides must move together.
- Reworded the bundle validator, API validator, and Helm-guard reserved-name errors ("…platform boot-env, model-credential, **or redirect/capture-capable** key…").

No schema drift (`RESERVED_BOOT_ENV` is a plain frozenset, not a Pydantic field — `check-contracts.sh` clean). No Rust change (the CLI deliberately defers reserved-name rejection to the deploy-time backstop — drift risk).

## Severity & migration
Operator-reachable only (same actor as #457), **mitigated in-cluster** by fail-closed egress (an unallowlisted proxy host is unreachable → DoS, not capture), **unmitigated on the local/compose tier**.

⚠️ **Migration:** unlike the `ANTHROPIC_*`/`AGENTOS_*` keys, these are plausible names a bundle author might innocently pick. An existing bundle/agent that legitimately declared one of the four as a connector secret will start failing its next deploy (bundle `secrets.name_reserved` / API 422 / Helm render `fail`). That's the intended tightening — worth checking deployed agents' secret maps before rollout.

## Tests
- `test_reserved_env` / `test_validate` / `test_agents` gain parametrized cases pinning all four as reserved (predicate, bundle `secrets.name_reserved`, API 422).
- The Helm↔Python parity pin passes (both now carry 8 non-prefixed members). 131 tests green.

Ref CUR-1620
Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)