### PR TITLE
Warn when a local/cluster message turn ends awaiting approval

### DIFF
--- a/cli/schema/message.schema.json
+++ b/cli/schema/message.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "agentos local|cluster message --json",
-  "description": "The agent-facing payload of `agentos local message --json` and `agentos cluster message --json`. Exactly one of three terminal-state shapes is emitted per invocation: a reply object (the model's final reply text, the thread the turn ran under, and whether a reply was captured), a timeout object (no reply captured before the deadline), or a dry-run descriptor (what a real run would enqueue). All keys are CLI-owned and locked.",
+  "description": "The agent-facing payload of `agentos local message --json` and `agentos cluster message --json`. Exactly one of four terminal-state shapes is emitted per invocation: a reply object (the model's final reply text, the thread the turn ran under, and whether a reply was captured), an awaiting-approval object (the turn parked on a human approval gate), a timeout object (no reply captured before the deadline), or a dry-run descriptor (what a real run would enqueue). All keys are CLI-owned and locked.",
   "oneOf": [
     {
       "title": "reply",
@@ -13,6 +13,19 @@
         "reply": { "type": ["string", "null"] },
         "thread": { "type": "string" },
         "finalized": { "type": "boolean" }
+      }
+    },
+    {
+      "title": "awaiting-approval",
+      "description": "The turn parked on a human approval gate: the worker posted an approval card rather than finalizing, so `finalized` is false and `awaiting_approval` marks the terminal state. `reply` is the card's placeholder text if seen. The persisted Approval holds this run's ephemeral CLI reply endpoint, so the resumed reply strands once the command exits (#529).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reply", "thread", "finalized", "awaiting_approval"],
+      "properties": {
+        "reply": { "type": ["string", "null"] },
+        "thread": { "type": "string" },
+        "finalized": { "const": false },
+        "awaiting_approval": { "const": true }
       }
     },
     {

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -49,6 +49,12 @@ const ACK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// Bounded drain after the ack to catch a final edit still in flight.
 const FINAL_DRAIN: Duration = Duration::from_millis(100);
 
+/// The Block Kit action id on the approval card's Approve button
+/// (`agentos_dispatcher.approval_actions.APPROVE_ACTION_ID`). Its presence in a
+/// captured Slack call body is the unambiguous signal that a turn parked
+/// awaiting approval and posted a card (#529).
+pub const APPROVE_ACTION_ID: &str = "agentos-approval-approve";
+
 /// One captured Slack Web API call at the stub.
 #[derive(Debug, Clone)]
 pub struct SlackCall {
@@ -56,6 +62,9 @@ pub struct SlackCall {
     pub channel: Option<String>,
     pub ts: Option<String>,
     pub text: Option<String>,
+    /// True when the raw body carried the approval card's Approve action id, i.e.
+    /// the worker parked this turn awaiting approval and posted a card (#529).
+    pub approval_card: bool,
 }
 
 /// If this call is a `chat.update` editing `placeholder_ts`, its new text.
@@ -165,6 +174,10 @@ async fn handle_call(
         .and_then(|value| value.to_str().ok())
         .unwrap_or("");
     let (channel, ts, text) = extract_fields(content_type, &body);
+    // The approval card's Approve button carries this action id in the blocks,
+    // which `extract_fields` does not parse -- match it on the raw body so an
+    // awaiting-approval turn is detectable regardless of encoding (#529).
+    let approval_card = body.contains(APPROVE_ACTION_ID);
     // chat.update echoes the existing ts; a hypothetical new-message call has no
     // ts, so synthesize one so the response still looks like Slack.
     let ts_out = ts
@@ -175,6 +188,7 @@ async fn handle_call(
         channel: channel.clone(),
         ts: ts.clone(),
         text: text.clone(),
+        approval_card,
     });
     Json(json!({ "ok": true, "ts": ts_out, "channel": channel, "text": text }))
 }
@@ -184,6 +198,12 @@ pub enum Outcome {
     Replied(String),
     /// The worker finished the turn but never edited the placeholder.
     CompletedNoEdit,
+    /// The turn parked awaiting human approval: the worker posted an approval
+    /// card (rather than finalizing) and persisted a durable `Approval` carrying
+    /// THIS run's reply endpoint. For `local`/`cluster message` that endpoint is
+    /// the CLI's throwaway stub, which dies when the command exits, so the resumed
+    /// reply has nowhere to land (#529). Carries the latest placeholder text seen.
+    AwaitingApproval(Option<String>),
     /// The deadline passed with no completion.
     TimedOut,
 }
@@ -201,11 +221,15 @@ pub async fn await_reply(
 ) -> Outcome {
     let deadline = Instant::now() + timeout;
     let mut latest: Option<String> = None;
+    // Whether the worker posted an approval card during this turn: the turn parked
+    // awaiting approval rather than finalizing normally (#529).
+    let mut awaiting_approval = false;
     let mut poll = tokio::time::interval(ACK_POLL_INTERVAL);
     loop {
         tokio::select! {
             call = stub.recv() => {
                 if let Some(call) = call {
+                    awaiting_approval |= call.approval_card;
                     if let Some(text) = placeholder_update_text(&call, placeholder_ts) {
                         latest = Some(text.to_string());
                     }
@@ -215,9 +239,13 @@ pub async fn await_reply(
                 if entry_acked(conn, stream, WORKER_GROUP, entry_id).await {
                     // Drain any final edit still in flight before deciding.
                     while let Ok(Some(call)) = tokio::time::timeout(FINAL_DRAIN, stub.recv()).await {
+                        awaiting_approval |= call.approval_card;
                         if let Some(text) = placeholder_update_text(&call, placeholder_ts) {
                             latest = Some(text.to_string());
                         }
+                    }
+                    if awaiting_approval {
+                        return Outcome::AwaitingApproval(latest);
                     }
                     return latest.map_or(Outcome::CompletedNoEdit, Outcome::Replied);
                 }
@@ -282,6 +310,7 @@ mod tests {
             channel: Some("C1".into()),
             ts: Some("1.2".into()),
             text: Some("the answer".into()),
+            approval_card: false,
         };
         assert_eq!(placeholder_update_text(&update, "1.2"), Some("the answer"));
         // Wrong ts (a different message).

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -347,6 +347,22 @@ pub fn message_timeout_json() -> serde_json::Value {
     })
 }
 
+/// The machine-readable object for a turn that ended **awaiting approval** (#529):
+/// the worker posted an approval card and parked, so the turn is not finalized
+/// (`finalized` false) and `awaiting_approval` marks the terminal state distinctly
+/// from a timeout. `reply` carries the card's placeholder text if one was seen.
+/// The persisted `Approval` holds THIS run's ephemeral CLI reply endpoint, so the
+/// resumed reply will strand once the command exits. Pure so it stays
+/// contract-testable against `cli/schema/message.schema.json`.
+pub fn message_awaiting_approval_json(thread: &str, reply: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "reply": reply,
+        "thread": thread,
+        "finalized": false,
+        "awaiting_approval": true,
+    })
+}
+
 /// The machine-readable descriptor for `local`/`cluster message --json --dry-run`
 /// (issue #354): what a real run would enqueue, without touching the network.
 /// `target` is `"local"` or `"cluster"`, `channel` is null when it would be
@@ -572,6 +588,19 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
+        Outcome::AwaitingApproval(reply) => {
+            step.done("awaiting approval");
+            if ui.json() {
+                ui.emit_json(&message_awaiting_approval_json(
+                    &thread_ts,
+                    reply.as_deref(),
+                ));
+            } else {
+                warn_approval_will_strand(ui);
+            }
+            persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
+            Ok(())
+        }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
             if ui.json() {
@@ -586,6 +615,25 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             std::process::exit(crate::exit::ExitClass::Transient.code());
         }
     }
+}
+
+/// The loud up-front warning a `local`/`cluster message` prints when its turn
+/// parked awaiting approval (#529): the reply stub is this process's throwaway
+/// endpoint, so the resumed reply -- delivered whenever a human approves -- has
+/// nowhere to land once the command exits (#505 dead-letters it rather than
+/// stalling the worker). Names the two ways to actually see a resumed reply.
+fn warn_approval_will_strand(ui: &crate::ui::Ui) {
+    ui.warn(
+        "this turn is awaiting human approval and will NOT deliver its reply here: the \
+         approval was persisted with this command's throwaway reply stub as its endpoint, and \
+         that stub dies when the command exits, so the resumed reply strands (it is \
+         dead-lettered, not lost silently).",
+    );
+    ui.note(
+        "to demo approvals end to end, drive the turn from a durable reply surface: connect a \
+         real Slack workspace (`agentos local comms --slack` / `agentos cluster comms --slack`) \
+         and mention the agent there, or resolve the approval and read the reply in Slack.",
+    );
 }
 
 /// The shared target noun message handler.
@@ -734,6 +782,19 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }
+        Outcome::AwaitingApproval(reply) => {
+            step.done("awaiting approval");
+            if ui.json() {
+                ui.emit_json(&message_awaiting_approval_json(
+                    &thread_ts,
+                    reply.as_deref(),
+                ));
+            } else {
+                warn_approval_will_strand(ui);
+            }
+            persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
+            Ok(())
+        }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
             if ui.json() {
@@ -795,7 +856,9 @@ pub struct EvalOpts {
 pub fn reply_passes(case: &EvalCase, outcome: &Outcome) -> bool {
     match outcome {
         Outcome::Replied(reply) => case.grader.grade(reply),
-        Outcome::CompletedNoEdit | Outcome::TimedOut => false,
+        // A turn that parked awaiting approval never produced a graded reply, so
+        // it fails the case (the same as a no-edit completion or a timeout).
+        Outcome::CompletedNoEdit | Outcome::AwaitingApproval(_) | Outcome::TimedOut => false,
     }
 }
 
@@ -943,6 +1006,7 @@ async fn run_eval_turns(
         // the human summary; a non-Replied outcome has no gradeable text.
         let output = match &outcome {
             Outcome::Replied(reply) => reply.clone(),
+            Outcome::AwaitingApproval(reply) => reply.clone().unwrap_or_default(),
             Outcome::CompletedNoEdit | Outcome::TimedOut => String::new(),
         };
         results.push((
@@ -1541,6 +1605,12 @@ mod tests {
         // No reply text and no completion never pass, mirroring turn_passes.
         assert!(!reply_passes(&case, &Outcome::CompletedNoEdit));
         assert!(!reply_passes(&case, &Outcome::TimedOut));
+        // A turn parked awaiting approval produced no graded reply -> never passes,
+        // even if the card text happens to contain the expected token (#529).
+        assert!(!reply_passes(
+            &case,
+            &Outcome::AwaitingApproval(Some("pong pending approval".into()))
+        ));
     }
 
     #[test]

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -6,7 +6,9 @@
 
 use agentos::commands::{eval_json, status_json};
 use agentos::exit;
-use agentos::message::{message_dry_run_json, message_reply_json, message_timeout_json};
+use agentos::message::{
+    message_awaiting_approval_json, message_dry_run_json, message_reply_json, message_timeout_json,
+};
 use agentos::observability::{local_endpoints, Endpoint, ObservabilityOutput};
 use agentos::ui::{CliOutput, DryRunPlan};
 use agentos_aci_protocol::SessionStatus;
@@ -164,6 +166,8 @@ fn message_schema_variants_are_mutually_exclusive() {
     for value in [
         message_reply_json("1700000000.000100", Some("hi")),
         message_reply_json("1700000000.000100", None),
+        message_awaiting_approval_json("1700000000.000100", Some("awaiting approval")),
+        message_awaiting_approval_json("1700000000.000100", None),
         message_timeout_json(),
         message_dry_run_json("local", "s", Some("C1"), "http://x/api/"),
     ] {
@@ -172,6 +176,23 @@ fn message_schema_variants_are_mutually_exclusive() {
             "each builder output must satisfy the oneOf: {value}"
         );
     }
+}
+
+#[test]
+fn message_awaiting_approval_json_validates_and_is_distinct() {
+    // #529: the awaiting-approval object is finalized:false + awaiting_approval:true,
+    // a distinct terminal state from a reply or a timeout.
+    let schema = load_schema("message.schema.json");
+    let v = validator(&schema);
+    let awaiting = message_awaiting_approval_json("1700000000.000100", Some("card text"));
+    assert!(
+        v.is_valid(&awaiting),
+        "awaiting-approval must validate against message.schema.json: {awaiting}"
+    );
+    assert_eq!(awaiting["finalized"], serde_json::json!(false));
+    assert_eq!(awaiting["awaiting_approval"], serde_json::json!(true));
+    assert_eq!(awaiting["reply"], serde_json::json!("card text"));
+    assert_eq!(awaiting["thread"], serde_json::json!("1700000000.000100"));
 }
 
 #[test]


### PR DESCRIPTION
`agentos local message` (and `cluster message`) stand up a throwaway reply stub on `localhost:8155` and inject it as the turn's `reply_handle.endpoint`. If the turn is approval-gated, that URL is persisted on the durable `Approval`, and the stub dies the moment the CLI exits — so the resumed reply (delivered whenever a human approves) has nowhere to land.

#505 bounded the damage (the resume turn dead-letters instead of stalling the whole worker), but the user still got **no warning up front**, so the documented way to demo approvals locally silently could not deliver its resumed reply.

## Fix
`local message` previously had no awaiting-approval outcome (`Outcome` was `Replied`/`CompletedNoEdit`/`TimedOut`) and never inspected turn status. Now:
- The Slack stub flags a captured call as an **approval card** when its body carries the Approve button's action id (`agentos-approval-approve`) — the unambiguous signal that the worker parked the turn and posted a card.
- `await_reply` tracks that and returns a new `Outcome::AwaitingApproval(latest_text)`.
- Both `message` handlers (local + cluster) print a **loud warning** that the reply will strand (dead-lettered, not lost silently) plus the two ways to actually see a resumed reply (connect a real Slack workspace via `comms --slack`, and read/resolve there).

`--json` gains a distinct **awaiting-approval** object (`finalized: false`, `awaiting_approval: true`) — a fourth `oneOf` variant in `message.schema.json`, so a machine consumer can tell it apart from a reply or a timeout. The eval grader (`reply_passes`) treats an awaiting-approval turn as a non-passing case.

## Tests
- `message_awaiting_approval_json` validates against the schema and is distinct (finalized:false / awaiting_approval:true); added to the mutually-exclusive-variants oneOf check.
- `reply_passes` never passes an awaiting-approval outcome, even if the card text contains the expected token.
- Full CLI suite green (fmt + clippy + test); no clap-surface change.

Ref CUR-1621
Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)