### PR TITLE
Extract one shared path-style S3 client builder

### DIFF
--- a/apps/api/src/agentos_api/storage.py
+++ b/apps/api/src/agentos_api/storage.py
@@ -20,8 +20,7 @@ extraction only makes it a drop-in when that demand arrives.
 
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-import boto3
-from botocore.client import Config as BotoConfig
+from aci_protocol.s3 import build_s3_client as shared_build_s3_client
 from botocore.exceptions import ClientError
 from starlette.concurrency import run_in_threadpool
 
@@ -68,20 +67,18 @@ class ObjectStore(Protocol):
 
 
 def build_s3_client(settings: Settings) -> "S3Client":
-    """Construct the path-style S3 client shared by every S3-backed store.
+    """Construct the path-style S3 client from the API's ``Settings``.
 
-    Path-style addressing is required for MinIO and works with AWS S3, so this is
-    the single construction the API writer and the worker reader must agree on
-    (the seam the blob-storage INTERFACE flags as "hand-aligned client sites").
-    Centralizing it here removes one copy of that alignment.
+    A thin adapter over the one shared builder (`aci_protocol.s3.build_s3_client`,
+    #501) so the API writer and the worker reader cannot drift on endpoint /
+    credentials / path-style addressing. Kept as a named function because callers
+    (and `test_storage_port`) import it from this module.
     """
-    return boto3.client(
-        "s3",
+    return shared_build_s3_client(
         endpoint_url=settings.s3_endpoint_url,
-        aws_access_key_id=settings.s3_access_key,
-        aws_secret_access_key=settings.s3_secret_key,
-        region_name=settings.s3_region,
-        config=BotoConfig(s3={"addressing_style": "path"}),
+        access_key=settings.s3_access_key,
+        secret_key=settings.s3_secret_key,
+        region=settings.s3_region,
     )
 
 

--- a/apps/worker/src/agentos_worker/bundle_store.py
+++ b/apps/worker/src/agentos_worker/bundle_store.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-import boto3
-from botocore.client import Config as BotoConfig
+from aci_protocol.s3 import build_s3_client
 from plugin_format import bundle_root, safe_extract
 
 from .config import WorkerConfig
@@ -54,13 +53,13 @@ class BundleStore:
 
     def __init__(self, config: WorkerConfig) -> None:
         self._bucket = config.bundle_bucket
-        self._client: S3Client = boto3.client(
-            "s3",
+        # The one shared path-style construction (#501), also used by the API's
+        # write path, so reader and writer cannot drift on addressing/creds.
+        self._client: S3Client = build_s3_client(
             endpoint_url=config.s3_endpoint_url,
-            aws_access_key_id=config.s3_access_key,
-            aws_secret_access_key=config.s3_secret_key,
-            region_name=config.s3_region,
-            config=BotoConfig(s3={"addressing_style": "path"}),
+            access_key=config.s3_access_key,
+            secret_key=config.s3_secret_key,
+            region=config.s3_region,
         )
 
     def get(self, key: str) -> bytes:

--- a/apps/worker/tests/eval/conftest.py
+++ b/apps/worker/tests/eval/conftest.py
@@ -18,16 +18,15 @@ import zipfile
 from collections.abc import AsyncIterator, Callable, Iterator
 from pathlib import Path
 
-import boto3
 import pytest
 from aci_protocol import Final, SessionStatus, ToolNote
+from aci_protocol.s3 import build_s3_client
 from agentos_worker.bundle_store import BundleStore
 from agentos_worker.config import WorkerConfig
 from agentos_worker.eval import EvalSuite
 from agentos_worker.runner_client import RunnerClient
 from aiohttp import web
 from aiohttp.test_utils import TestServer
-from botocore.client import Config as BotoConfig
 
 # The committed cross-language eval-case fixture, shared by the model and stream
 # tests. conftest.py -> parents[2] is apps/worker.
@@ -149,13 +148,11 @@ def bundles() -> Iterator[tuple[BundleStore, Callable[[EvalSuite | bytes], str]]
     helper. Uploaded objects are deleted on teardown; skips if MinIO is down."""
     cfg = WorkerConfig(**_MINIO)  # type: ignore[arg-type]
     store = BundleStore(cfg)
-    client = boto3.client(
-        "s3",
+    client = build_s3_client(
         endpoint_url=cfg.s3_endpoint_url,
-        aws_access_key_id=cfg.s3_access_key,
-        aws_secret_access_key=cfg.s3_secret_key,
-        region_name=cfg.s3_region,
-        config=BotoConfig(s3={"addressing_style": "path"}),
+        access_key=cfg.s3_access_key,
+        secret_key=cfg.s3_secret_key,
+        region=cfg.s3_region,
     )
     try:
         client.head_bucket(Bucket=cfg.bundle_bucket)

--- a/packages/aci-protocol/src/aci_protocol/s3.py
+++ b/packages/aci-protocol/src/aci_protocol/s3.py
@@ -1,0 +1,47 @@
+"""The one path-style S3/MinIO client construction (#501).
+
+The API's write path (`agentos_api.storage.BundleStore`) and the worker's read
+path (`agentos_worker.bundle_store.BundleStore`) must build their boto3 client
+identically -- same endpoint, credentials, region, and (load-bearing for MinIO)
+path-style addressing. That construction used to be hand-copied in each app (and a
+third time in a worker test fixture), a seam the blob-storage INTERFACE flagged as
+"hand-aligned client sites". This is the single builder both import so the
+alignment cannot drift.
+
+It takes primitives, not either app's config object, so it couples to neither
+`agentos_api.Settings` nor `agentos_worker.WorkerConfig`. `boto3` is imported
+lazily inside the function so importing this module (and the rest of
+``aci_protocol``) never requires boto3 for consumers that do not touch S3.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
+
+
+def build_s3_client(
+    *,
+    endpoint_url: str,
+    access_key: str,
+    secret_key: str,
+    region: str,
+) -> S3Client:
+    """Construct the path-style S3 client shared by every S3-backed store.
+
+    Path-style addressing is required for MinIO and works with AWS S3, so it is
+    fixed here. Callers pass their resolved config values as keyword primitives.
+    """
+    import boto3
+    from botocore.client import Config as BotoConfig
+
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+        config=BotoConfig(s3={"addressing_style": "path"}),
+    )

--- a/packages/aci-protocol/tests/test_s3.py
+++ b/packages/aci-protocol/tests/test_s3.py
@@ -1,0 +1,18 @@
+"""The shared S3 client builder (#501): path-style addressing, offline."""
+
+from aci_protocol.s3 import build_s3_client
+
+
+def test_build_s3_client_is_path_style() -> None:
+    # boto3.client() does no network I/O until a call is made, so this asserts the
+    # construction contract offline: path-style addressing (load-bearing for MinIO)
+    # and the endpoint the caller passed.
+    client = build_s3_client(
+        endpoint_url="http://minio.test:9000",
+        access_key="ak",
+        secret_key="sk",
+        region="us-east-1",
+    )
+    assert client.meta.config.s3["addressing_style"] == "path"
+    assert client.meta.endpoint_url == "http://minio.test:9000"
+    assert client.meta.region_name == "us-east-1"


### PR DESCRIPTION
The API write path (`agentos_api.storage.BundleStore`) and the worker read path (`agentos_worker.bundle_store.BundleStore`) hand-copied a **byte-identical** boto3 client construction — same endpoint, credentials, region, and the load-bearing path-style addressing for MinIO — plus a **third** copy in a worker test fixture. That's the seam the blob-storage INTERFACE flagged as "hand-aligned client sites": a divergence (addressing style, region) would silently break reads.

## Fix
One config-agnostic `aci_protocol.s3.build_s3_client(*, endpoint_url, access_key, secret_key, region)`:
- Lives in `aci-protocol` — both apps already depend on it (it's where the shared `service_config` landed in #496). `boto3` is imported **lazily inside the function** so importing `aci_protocol` never requires boto3 for consumers that don't touch S3 (dispatcher/runner).
- Takes primitives, not either app's config object, so it couples to neither `Settings` nor `WorkerConfig`.
- The API keeps a thin `build_s3_client(settings)` adapter (its `test_storage_port` and callers import it from `agentos_api.storage`).

Behaviour-preserving: the three constructions were provably identical (same 5 args, same `Config(s3={"addressing_style": "path"})`), so there was nothing to reconcile.

## Tests
- New `packages/aci-protocol/tests/test_s3.py` asserts path-style addressing + endpoint offline (boto3 does no I/O until a call).
- `apps/api/tests/test_storage_port.py` (path-style contract) stays green through the adapter.
- Full mypy + ruff clean; no contract drift (adding a module doesn't touch wire schemas).

Ref CUR-1622
Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)