### PR TITLE
Worker: fall back to the default transport when a resumed reply endpoint is unreachable

### DIFF
--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -8,16 +8,32 @@ one external service the kernel tests mock; everything else runs for real.
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Protocol
+from collections.abc import Awaitable, Callable
+from typing import Protocol, TypeVar
 
+import aiohttp
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
+from slack_sdk.web.async_slack_response import AsyncSlackResponse
 
 from .behaviorpacks import NavPack
 from .blocks import render
 
 logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+# "Unreachable" reply-endpoint errors (#530): the endpoint's HOST did not answer
+# -- a dead CLI stub whose process exited, a wrong port, a network drop. These are
+# aiohttp transport errors and asyncio timeouts, NOT SlackApiError: a SlackApiError
+# means the endpoint IS reachable and answered with an error (auth/channel), which
+# must keep its own text-only fallback and must NOT trigger a transport fallback.
+_UNREACHABLE_ERRORS: tuple[type[BaseException], ...] = (
+    aiohttp.ClientError,
+    asyncio.TimeoutError,
+)
 
 
 class SlackSink(Protocol):
@@ -106,6 +122,46 @@ class AsyncSlackSink:
             self._clients[base_url] = client
         return client
 
+    async def _with_transport_fallback(
+        self,
+        endpoint: str | None,
+        op: Callable[[AsyncWebClient], Awaitable[_T]],
+        *,
+        describe: str,
+    ) -> _T:
+        """Run ``op`` against this turn's endpoint, falling back to the worker
+        DEFAULT transport when that endpoint is UNREACHABLE (#530).
+
+        The motivating case: an approval turn resumed long after the original
+        ``local``/``cluster message`` command exited finalizes against the reply
+        endpoint persisted on the durable ``Approval`` -- the CLI's throwaway stub,
+        now dead. Rather than let the connection error propagate (and dead-letter
+        the resume, losing the reply), retry the same call on the default transport.
+
+        Guarded so a reply is never misdirected: the fallback fires only when the
+        failing target was a real per-turn ``endpoint`` AND a default is configured
+        AND it differs from that endpoint. A ``SlackApiError`` (endpoint reachable,
+        call rejected) is not an unreachability and is never caught here.
+        """
+        primary = self._client_for(endpoint)
+        resolved = endpoint or self._default_base_url
+        has_distinct_default = bool(
+            endpoint and self._default_base_url and resolved != self._default_base_url
+        )
+        try:
+            return await op(primary)
+        except _UNREACHABLE_ERRORS as exc:
+            if not has_distinct_default:
+                raise
+            logger.warning(
+                "%s: reply endpoint %r is unreachable (%s); falling back to the "
+                "default Slack transport",
+                describe,
+                endpoint,
+                exc,
+            )
+            return await op(self._client_for(None))
+
     async def update(
         self,
         *,
@@ -122,23 +178,27 @@ class AsyncSlackSink:
         # malformed block falls back to text, so partials never show raw JSON.
         # ``nav`` (the agent's hub-button pack, threaded from the kernel) appends
         # the no-dead-ends hub button to a structured reply; None leaves it be.
-        client = self._client_for(endpoint)
         rendered_text, blocks = render(text, nav)
-        if blocks is not None:
-            # Slack rejects the whole message if a block exceeds a limit we did not
-            # clamp; fall back to a text-only update so the turn still completes and
-            # the stream entry is acked instead of re-enqueuing the paid model turn.
-            try:
-                await client.chat_update(
-                    channel=channel, ts=ts, text=rendered_text, blocks=blocks
-                )
-            except SlackApiError:
-                logger.warning(
-                    "chat_update with blocks rejected for %s; retrying text-only", ts
-                )
+
+        async def op(client: AsyncWebClient) -> None:
+            if blocks is not None:
+                # Slack rejects the whole message if a block exceeds a limit we did
+                # not clamp; fall back to a text-only update (on the SAME reachable
+                # client) so the turn still completes and the stream entry is acked
+                # instead of re-enqueuing the paid model turn.
+                try:
+                    await client.chat_update(
+                        channel=channel, ts=ts, text=rendered_text, blocks=blocks
+                    )
+                except SlackApiError:
+                    logger.warning(
+                        "chat_update with blocks rejected for %s; retrying text-only", ts
+                    )
+                    await client.chat_update(channel=channel, ts=ts, text=rendered_text)
+            else:
                 await client.chat_update(channel=channel, ts=ts, text=rendered_text)
-        else:
-            await client.chat_update(channel=channel, ts=ts, text=rendered_text)
+
+        await self._with_transport_fallback(endpoint, op, describe="chat_update")
 
     async def post(
         self,
@@ -152,23 +212,28 @@ class AsyncSlackSink:
         # A rejected Block Kit payload falls back to text-only, mirroring
         # ``update``: the card is the resolve UI, but a plain-text notice still
         # beats losing the message (the API resolve path works regardless).
-        client = self._client_for(endpoint)
-        try:
-            if blocks is not None:
-                response = await client.chat_postMessage(
-                    channel=channel, text=text, blocks=blocks, thread_ts=thread_ts
-                )
-            else:
-                response = await client.chat_postMessage(
+        async def op(client: AsyncWebClient) -> AsyncSlackResponse:
+            try:
+                if blocks is not None:
+                    return await client.chat_postMessage(
+                        channel=channel, text=text, blocks=blocks, thread_ts=thread_ts
+                    )
+                return await client.chat_postMessage(
                     channel=channel, text=text, thread_ts=thread_ts
                 )
-        except SlackApiError:
-            if blocks is None:
-                raise
-            logger.warning("chat_postMessage with blocks rejected; retrying text-only")
-            response = await client.chat_postMessage(
-                channel=channel, text=text, thread_ts=thread_ts
-            )
+            except SlackApiError:
+                if blocks is None:
+                    raise
+                logger.warning(
+                    "chat_postMessage with blocks rejected; retrying text-only"
+                )
+                return await client.chat_postMessage(
+                    channel=channel, text=text, thread_ts=thread_ts
+                )
+
+        response = await self._with_transport_fallback(
+            endpoint, op, describe="chat_postMessage"
+        )
         ts = response.get("ts")
         return str(ts) if ts else None
 

--- a/apps/worker/tests/test_slack_sink.py
+++ b/apps/worker/tests/test_slack_sink.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 
+import aiohttp
 import pytest
 from agentos_worker.config import WorkerConfig
 from agentos_worker.slack_sink import AsyncSlackSink
@@ -236,3 +237,80 @@ def test_update_does_not_retry_when_blocks_update_succeeds() -> None:
 
     assert len(calls) == 1  # a spurious retry would make this 2
     assert isinstance(calls[0].get("blocks"), list)
+
+
+# --- #530: fall back to the default transport when a resumed reply endpoint is
+# unreachable (the ephemeral CLI stub died; its URL is persisted on the Approval).
+
+
+def _raise_connection_error():
+    async def _fake(**_kwargs):
+        raise aiohttp.ClientError("connection refused")
+
+    return _fake
+
+
+def _record_call(sink_calls, label):
+    async def _fake(**kwargs):
+        sink_calls.append(label)
+        return {"ok": True, "ts": "9.9"}
+
+    return _fake
+
+
+def test_update_falls_back_to_default_when_endpoint_unreachable() -> None:
+    sink = AsyncSlackSink("xoxb-test", base_url="http://default:1/api/")
+    landed: list[str] = []
+    # The per-turn (stub) client's host is dead -> connection error.
+    sink._client_for("http://stub:2/api/").chat_update = _raise_connection_error()  # type: ignore[method-assign]
+    sink._client_for(None).chat_update = _record_call(landed, "default")  # type: ignore[method-assign]
+
+    asyncio.run(sink.update(channel="C1", ts="1.1", text="hi", endpoint="http://stub:2/api/"))
+
+    assert landed == ["default"], "the resumed reply must land on the default transport"
+
+
+def test_slack_api_error_is_not_treated_as_unreachable() -> None:
+    # A SlackApiError means the endpoint IS reachable but rejected the call; it must
+    # NOT trigger a transport fallback (that would misroute a live-workspace reply).
+    sink = AsyncSlackSink("xoxb-test", base_url="http://default:1/api/")
+    default_hits: list[str] = []
+
+    async def _reject(**_kwargs):
+        raise SlackApiError("nope", response={"error": "channel_not_found"})
+
+    sink._client_for("http://stub:2/api/").chat_update = _reject  # type: ignore[method-assign]
+    sink._client_for(None).chat_update = _record_call(default_hits, "default")  # type: ignore[method-assign]
+
+    with pytest.raises(SlackApiError):
+        asyncio.run(
+            sink.update(channel="C1", ts="1.1", text="hi", endpoint="http://stub:2/api/")
+        )
+    assert default_hits == [], "a SlackApiError must not fall back to the default"
+
+
+def test_no_fallback_when_endpoint_equals_default() -> None:
+    # A turn already on the default transport has no alternate to try; the
+    # connection error propagates (there is nowhere else to send it).
+    sink = AsyncSlackSink("xoxb-test", base_url="http://default:1/api/")
+    sink._client_for(None).chat_update = _raise_connection_error()  # type: ignore[method-assign]
+
+    with pytest.raises(aiohttp.ClientError):
+        asyncio.run(sink.update(channel="C1", ts="1.1", text="hi"))  # no endpoint -> default
+
+
+def test_no_fallback_when_no_default_is_configured() -> None:
+    # No worker default (real Slack, no base_url): a dead per-turn endpoint has no
+    # safe fallback, so the error propagates rather than guessing a transport.
+    sink = AsyncSlackSink("xoxb-test")  # default is the real Slack sentinel
+    # Make BOTH the per-turn and the (real-Slack) default raise so a fallback, if it
+    # wrongly fired, would still error -- but we assert it never reaches the default.
+    default_hits: list[str] = []
+    sink._client_for("http://stub:2/api/").chat_update = _raise_connection_error()  # type: ignore[method-assign]
+    sink._client_for(None).chat_update = _record_call(default_hits, "default")  # type: ignore[method-assign]
+
+    with pytest.raises(aiohttp.ClientError):
+        asyncio.run(
+            sink.update(channel="C1", ts="1.1", text="hi", endpoint="http://stub:2/api/")
+        )
+    assert default_hits == [], "real-Slack default is not a safe fallback for a CLI-stub endpoint"


### PR DESCRIPTION
A turn carries a per-turn reply endpoint (#19). When an approval turn is **resumed** — often long after the `local`/`cluster message` command that started it has exited — the worker finalizes it against the endpoint persisted on the durable `Approval`: the CLI's throwaway stub, now dead. `AsyncWebClient`'s connection error there (`aiohttp.ClientError` / `asyncio.TimeoutError` — **not** `SlackApiError`) was uncaught, so the resume dead-lettered (#505) and the reply was silently lost. #529 warns the operator up front; this is the worker-side resilience.

## Fix (entirely in `slack_sink.py`, no kernel change)
`AsyncSlackSink.update`/`post` now route through `_with_transport_fallback`: run the call against the per-turn endpoint's client, and on an **unreachable** (connection-class) error retry the same call on the worker **default** transport.

Guarded so a reply is never misdirected:
- fires only when the failing target was a **real per-turn endpoint** AND a default is configured AND it **differs** from that endpoint (a turn already on the default has nowhere else to go);
- a **`SlackApiError`** (endpoint reachable, call rejected — auth/channel) is *not* an unreachability: it keeps its existing same-client text-only fallback and never triggers a transport switch.

The kernel is untouched — it keeps passing an opaque `endpoint` string; the sink owns transport selection (sacred-module rule respected).

## Tests (`test_slack_sink.py`, +4)
- an unreachable per-turn endpoint → the reply lands on the default transport;
- a `SlackApiError` does **not** fall back (no misroute of a live-workspace reply);
- no fallback when the endpoint equals the default (error propagates);
- no fallback when no default is configured. All 19 sink tests green; mypy + ruff clean.

Ref CUR-1624
Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)