### PR TITLE
Fix architecture-vision Job numbering and move SandboxClient off the k8s adapter

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -166,7 +166,7 @@ does not duplicate it.
 ### 3a. Substrate seam — `SandboxClient`
 
 The worker talks to a `SandboxClient` Protocol
-([`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient`](apps/worker/src/agentos_worker/sandbox/k8s.py))
+([`apps/worker/src/agentos_worker/sandbox/types.py::SandboxClient`](apps/worker/src/agentos_worker/sandbox/k8s.py))
 whose methods are `create_claim`, `get_claim`, `delete_claim`, `list_claims`,
 `get_sandbox`, `set_sandbox_mode`. Two implementations satisfy it:
 

--- a/apps/worker/src/agentos_worker/sandbox/__init__.py
+++ b/apps/worker/src/agentos_worker/sandbox/__init__.py
@@ -15,7 +15,6 @@ from .k8s import (
     MANAGED_BY_VALUE,
     THREAD_HASH_LABEL,
     KubernetesSandboxClient,
-    SandboxClient,
 )
 from .substrate import HISTORY_ENV, SESSION_ENV, SandboxSubstrate
 from .types import (
@@ -24,6 +23,7 @@ from .types import (
     NoRouteError,
     RouteRecord,
     RouteState,
+    SandboxClient,
     SandboxError,
     SandboxHandle,
     SandboxView,

--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -56,9 +56,8 @@ from ..bundle_store import BundleReader, extract_bundle
 from .k8s import (
     MANAGED_BY_LABEL,
     MANAGED_BY_VALUE,
-    OperatingMode,
 )
-from .types import ClaimView, SandboxError, SandboxView
+from .types import ClaimView, OperatingMode, SandboxError, SandboxView
 
 logger = logging.getLogger(__name__)
 

--- a/apps/worker/src/agentos_worker/sandbox/k8s.py
+++ b/apps/worker/src/agentos_worker/sandbox/k8s.py
@@ -11,12 +11,12 @@ the k8scratch e2e test.
 
 from __future__ import annotations
 
-from typing import Any, Literal, Protocol
+from typing import Any
 
 from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
 
-from .types import ClaimView, SandboxView
+from .types import ClaimView, OperatingMode, SandboxView
 
 CORE_GROUP = "agents.x-k8s.io"
 CORE_VERSION = "v1beta1"
@@ -26,8 +26,6 @@ EXT_VERSION = "v1beta1"
 MANAGED_BY_LABEL = "agentos.dev/managed-by"
 MANAGED_BY_VALUE = "agentos-sandbox-substrate"
 THREAD_HASH_LABEL = "agentos.dev/thread-hash"
-
-OperatingMode = Literal["Running", "Suspended"]
 
 # Per-claim env with no containerName reaches only the FIRST main container (the
 # agent-sandbox Overrides policy). The bundle ref must additionally reach the
@@ -56,29 +54,6 @@ CREDENTIALS_ENV = "AGENTOS_CREDENTIALS"
 # rather than leaking it. Defined locally to keep the substrate seam free of a
 # binding import (like BUNDLE_REF_ENV / CREDENTIALS_ENV above).
 CONNECTOR_SECRET_KEYS_ENV = "AGENTOS_CONNECTOR_SECRET_KEYS"
-
-
-class SandboxClient(Protocol):
-    """What the substrate needs from the cluster, and nothing more."""
-
-    def create_claim(
-        self,
-        name: str,
-        *,
-        pool: str,
-        env: dict[str, str] | None = None,
-        labels: dict[str, str] | None = None,
-    ) -> None: ...
-
-    def get_claim(self, name: str) -> ClaimView | None: ...
-
-    def delete_claim(self, name: str) -> None: ...
-
-    def list_claims(self, *, label_selector: str) -> list[ClaimView]: ...
-
-    def get_sandbox(self, name: str) -> SandboxView | None: ...
-
-    def set_sandbox_mode(self, name: str, mode: OperatingMode) -> None: ...
 
 
 def _conditions_ready(status: dict[str, Any]) -> bool:

--- a/apps/worker/src/agentos_worker/sandbox/substrate.py
+++ b/apps/worker/src/agentos_worker/sandbox/substrate.py
@@ -32,13 +32,13 @@ from .k8s import (
     MANAGED_BY_LABEL,
     MANAGED_BY_VALUE,
     THREAD_HASH_LABEL,
-    SandboxClient,
 )
 from .types import (
     ClaimTimeoutError,
     NoRouteError,
     RouteRecord,
     RouteState,
+    SandboxClient,
     SandboxHandle,
     SandboxView,
     SubstrateConfig,

--- a/apps/worker/src/agentos_worker/sandbox/types.py
+++ b/apps/worker/src/agentos_worker/sandbox/types.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 from dataclasses import asdict, dataclass
 from enum import StrEnum
+from typing import Literal, Protocol
 
 
 class RouteState(StrEnum):
@@ -139,6 +140,38 @@ class SandboxView:
     service_fqdn: str | None
     operating_mode: str
     port: int | None = None
+
+
+OperatingMode = Literal["Running", "Suspended"]
+
+
+class SandboxClient(Protocol):
+    """What the substrate needs from the cluster, and nothing more.
+
+    The port lives here in the substrate-neutral types module, NOT in a concrete
+    adapter (#543): it is the seam every backend implements (Kubernetes, Docker),
+    and declaring it inside the k8s adapter read as "the port is a Kubernetes
+    thing" -- the opposite of the swap-readiness the seam exists to provide.
+    """
+
+    def create_claim(
+        self,
+        name: str,
+        *,
+        pool: str,
+        env: dict[str, str] | None = None,
+        labels: dict[str, str] | None = None,
+    ) -> None: ...
+
+    def get_claim(self, name: str) -> ClaimView | None: ...
+
+    def delete_claim(self, name: str) -> None: ...
+
+    def list_claims(self, *, label_selector: str) -> list[ClaimView]: ...
+
+    def get_sandbox(self, name: str) -> SandboxView | None: ...
+
+    def set_sandbox_mode(self, name: str, mode: OperatingMode) -> None: ...
 
 
 class SandboxError(Exception):

--- a/docs/architecture-vision.md
+++ b/docs/architecture-vision.md
@@ -241,26 +241,26 @@ flowchart TB
         Worker --> API
     end
 
-    subgraph harness["Job 5: harness / runtime"]
+    subgraph harness["Job 1: harness / runtime"]
         SDK["claude-agent-sdk (today)"]
         HarnessAlt["ADK, Codex, Strands (candidates)"]
     end
 
-    subgraph obs["Job 1: observability store"]
+    subgraph obs["Job 2: observability store"]
         Collector["OTel Collector"]
         Langfuse["Langfuse (today) or Arize Phoenix"]
         Collector --> Langfuse
     end
 
-    subgraph evals["Job 2: evals"]
+    subgraph evals["Job 3: evals"]
         EvalStore["Langfuse scores (today) or Arize"]
     end
 
-    subgraph blob["Job 3: blob storage"]
+    subgraph blob["Job 4: blob storage"]
         S3["MinIO (today), S3, GCS"]
     end
 
-    subgraph db["Job 4: relational database"]
+    subgraph db["Job 5: relational database"]
         PG["Postgres (today) or managed SQL"]
     end
 

--- a/docs/interfaces/substrate/INTERFACE.md
+++ b/docs/interfaces/substrate/INTERFACE.md
@@ -23,16 +23,16 @@ The substrate is where a conversation thread claims, dials, suspends, and reaps 
 
 ## Current contract
 
-A second implementation must satisfy the `SandboxClient` `Protocol` at `apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient`, six methods:
+A second implementation must satisfy the `SandboxClient` `Protocol` at `apps/worker/src/agentos_worker/sandbox/types.py::SandboxClient`, six methods:
 
-- `create_claim(name, *, pool, env=None, labels=None) -> None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.create_claim`)
-- `get_claim(name) -> ClaimView | None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.get_claim`)
-- `delete_claim(name) -> None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.delete_claim`)
-- `list_claims(*, label_selector) -> list[ClaimView]` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.list_claims`)
-- `get_sandbox(name) -> SandboxView | None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.get_sandbox`)
-- `set_sandbox_mode(name, mode: OperatingMode) -> None` (`apps/worker/src/agentos_worker/sandbox/k8s.py::SandboxClient.set_sandbox_mode`)
+- `create_claim(name, *, pool, env=None, labels=None) -> None` (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxClient.create_claim`)
+- `get_claim(name) -> ClaimView | None` (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxClient.get_claim`)
+- `delete_claim(name) -> None` (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxClient.delete_claim`)
+- `list_claims(*, label_selector) -> list[ClaimView]` (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxClient.list_claims`)
+- `get_sandbox(name) -> SandboxView | None` (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxClient.get_sandbox`)
+- `set_sandbox_mode(name, mode: OperatingMode) -> None` (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxClient.set_sandbox_mode`)
 
-The exchanged value types are `ClaimView` (`apps/worker/src/agentos_worker/sandbox/types.py::ClaimView`: `name`, `ready`, `sandbox_name`, `labels`) and `SandboxView` (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxView`: `name`, `ready`, `service_fqdn`, `operating_mode`, `port`). `operating_mode` must report `"Running"` for a claim to be handed back (`apps/worker/src/agentos_worker/sandbox/substrate.py::SandboxSubstrate.claim`), and `OperatingMode` is `Literal["Running", "Suspended"]` (`apps/worker/src/agentos_worker/sandbox/k8s.py::OperatingMode`). The selector reads `AGENTOS_SANDBOX_SUBSTRATE` (default `"kubernetes"`, else `"docker"`) in `_sandbox_client()` at `apps/worker/src/agentos_worker/run.py::_sandbox_client`, which branches on the value inside that same function.
+The exchanged value types are `ClaimView` (`apps/worker/src/agentos_worker/sandbox/types.py::ClaimView`: `name`, `ready`, `sandbox_name`, `labels`) and `SandboxView` (`apps/worker/src/agentos_worker/sandbox/types.py::SandboxView`: `name`, `ready`, `service_fqdn`, `operating_mode`, `port`). `operating_mode` must report `"Running"` for a claim to be handed back (`apps/worker/src/agentos_worker/sandbox/substrate.py::SandboxSubstrate.claim`), and `OperatingMode` is `Literal["Running", "Suspended"]` (`apps/worker/src/agentos_worker/sandbox/types.py::OperatingMode`). The selector reads `AGENTOS_SANDBOX_SUBSTRATE` (default `"kubernetes"`, else `"docker"`) in `_sandbox_client()` at `apps/worker/src/agentos_worker/run.py::_sandbox_client`, which branches on the value inside that same function.
 
 ## Implementations today
 


### PR DESCRIPTION
Two documentation/structure defects found during the #541 architecture-docs crawl, both explicitly fenced off there.

## 1. Job-numbering inversion in `architecture-vision.md`
The prose numbers its six jobs one way (`### 1. Harness … ### 6. Communication channel`) and its own mermaid diagram another (`Job 1: observability`, `Job 5: harness / runtime`), so a reader following "Job 3" landed on the wrong box. Relabeled the diagram's `subgraph` job numbers to match the canonical ordered prose sections (harness=1, obs=2, evals=3, blob=4, db=5, channel=6). No prose reordering.

## 2. `SandboxClient` declared in a concrete adapter
The `SandboxClient` Protocol — the substrate seam `ARCHITECTURE.md` calls "the load-bearing design property of the whole system" — was declared inside `sandbox/k8s.py`, reading as "the port is a Kubernetes thing," the opposite of the swap-readiness it exists to provide.

Moved it to the substrate-neutral `sandbox/types.py` (alongside `ClaimView`/`SandboxView`), together with `OperatingMode` to avoid a `types ↔ k8s` circular import. `k8s.py`, `docker.py`, `substrate.py`, and the package `__init__` now import both from `.types`. Pure move — no behavior change.

## Verify
`apps/worker/tests/sandbox` + `test_run.py` (62 passed); ruff + mypy clean; imports resolve (`sandbox.SandboxClient is sandbox.types.SandboxClient`).

Ref CUR-1625
Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)