### PR TITLE
Fixture-gate the mirrored plugin-format name + mcp rules

### DIFF
--- a/cli/src/spec.rs
+++ b/cli/src/spec.rs
@@ -67,6 +67,21 @@ pub struct AgentSpec {
     pub evals: Vec<EvalCase>,
 }
 
+/// Whether an `.mcp.json` connector object is usable: it must define `command`
+/// (stdio) or `url` (remote), and any `command`/`url` present must be a string --
+/// mirroring `plugin_format` `_validate_mcp_object` + the `McpServer` string typing.
+/// The single accept decision the shared corpus (#491) tests against, so the CLI
+/// cannot silently drift from what the server-side `validate_bundle` accepts.
+pub(crate) fn mcp_object_valid(value: &Value) -> bool {
+    let obj = value.as_object();
+    let string_typed = ["command", "url"].iter().all(|key| {
+        obj.and_then(|o| o.get(*key))
+            .is_none_or(|field| field.is_null() || field.is_string())
+    });
+    let defines = |key: &str| obj.and_then(|o| o.get(key)).is_some_and(|v| v.is_string());
+    string_typed && (defines("command") || defines("url"))
+}
+
 /// Reject an `mcp__`-prefixed approval gate that is not a fully-namespaced live
 /// tool name for one of this bundle's declared connectors. Non-`mcp__` gates
 /// (built-ins like `Bash`/`Write`) pass untouched. Mirrors the namespacing check
@@ -158,6 +173,10 @@ fn validate(spec: &AgentSpec) -> Result<()> {
     // `validate_bundle` reject the emitted `.mcp.json` -- catch it now with a
     // message that names the offending field.
     for (name, value) in &spec.connectors {
+        if mcp_object_valid(value) {
+            continue;
+        }
+        // Rejected -- re-derive the specific reason for an actionable message.
         let obj = value.as_object();
         for key in ["command", "url"] {
             if let Some(field) = obj.and_then(|o| o.get(key)) {
@@ -166,10 +185,7 @@ fn validate(spec: &AgentSpec) -> Result<()> {
                 }
             }
         }
-        let defines = |key: &str| obj.and_then(|o| o.get(key)).is_some_and(|v| v.is_string());
-        if !(defines("command") || defines("url")) {
-            bail!("connector {name:?} must define either 'command' (stdio) or 'url' (remote)");
-        }
+        bail!("connector {name:?} must define either 'command' (stdio) or 'url' (remote)");
     }
 
     // Secret NAMES must look like env vars (#549); the same syntax gate `secrets
@@ -206,4 +222,44 @@ fn validate(spec: &AgentSpec) -> Result<()> {
     validate_suite(&spec.name, &spec.evals)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod corpus_tests {
+    use super::mcp_object_valid;
+    use crate::scaffold::valid_name;
+    use serde_json::Value;
+
+    // The shared cross-language corpus (#491): the SAME file the Python
+    // plugin-format test asserts against, so a name/mcp rule change on one side
+    // without the other fails a corpus test here or there.
+    const CORPUS: &str = include_str!("../../packages/plugin-format/schema/name-mcp.fixture.json");
+
+    fn corpus() -> Value {
+        serde_json::from_str(CORPUS).expect("corpus is valid JSON")
+    }
+
+    #[test]
+    fn valid_name_matches_the_shared_corpus() {
+        let c = corpus();
+        for n in c["valid_names"].as_array().unwrap() {
+            let n = n.as_str().unwrap();
+            assert!(valid_name(n), "corpus valid name rejected: {n:?}");
+        }
+        for n in c["invalid_names"].as_array().unwrap() {
+            let n = n.as_str().unwrap();
+            assert!(!valid_name(n), "corpus invalid name accepted: {n:?}");
+        }
+    }
+
+    #[test]
+    fn mcp_object_valid_matches_the_shared_corpus() {
+        let c = corpus();
+        for obj in c["valid_mcp"].as_array().unwrap() {
+            assert!(mcp_object_valid(obj), "corpus valid mcp rejected: {obj}");
+        }
+        for obj in c["invalid_mcp"].as_array().unwrap() {
+            assert!(!mcp_object_valid(obj), "corpus invalid mcp accepted: {obj}");
+        }
+    }
 }

--- a/packages/plugin-format/schema/name-mcp.fixture.json
+++ b/packages/plugin-format/schema/name-mcp.fixture.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Cross-language drift gate (#491) for the plugin-format name rule (^[a-z0-9]+(-[a-z0-9]+)*$) and the MCP connector-object rule (must define string command or url). Both the Python validator (packages/plugin-format) and the Rust CLI checks (cli/src/scaffold.rs::valid_name, cli/src/spec.rs) assert against this corpus, so a rule change on one side without the other fails a corpus test.",
+  "valid_names": ["a", "9", "x9", "deal-desk", "a-b-c1", "renewal-review"],
+  "invalid_names": ["", "-", "a-", "-x", "x-", "a--b", "-a-", "Deal-Desk", "deal_desk", "a b", "café"],
+  "valid_mcp": [
+    { "command": "crm-server" },
+    { "url": "https://mcp.example/api" },
+    { "command": "crm-server", "args": ["--stdio"] },
+    { "command": "c", "url": "https://x" }
+  ],
+  "invalid_mcp": [
+    {},
+    { "args": ["x"] },
+    { "command": 42 },
+    { "url": true },
+    { "command": null }
+  ]
+}

--- a/packages/plugin-format/tests/test_name_mcp_corpus.py
+++ b/packages/plugin-format/tests/test_name_mcp_corpus.py
@@ -1,0 +1,47 @@
+"""Cross-language drift gate (#491): the plugin-format name + MCP rules assert
+against the SAME shared corpus the Rust CLI checks use, so a rule change on one
+side without the other fails a corpus test here or there.
+"""
+
+import json
+from pathlib import Path
+
+from plugin_format import validate_bundle
+from plugin_format.validate import _NAME_RE
+
+_CORPUS = json.loads(
+    (Path(__file__).parents[1] / "schema" / "name-mcp.fixture.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+def test_name_rule_matches_the_shared_corpus() -> None:
+    for name in _CORPUS["valid_names"]:
+        assert _NAME_RE.match(name), f"corpus valid name rejected: {name!r}"
+    for name in _CORPUS["invalid_names"]:
+        assert not _NAME_RE.match(name), f"corpus invalid name accepted: {name!r}"
+
+
+def _mcp_codes(tmp_path: Path, connector: object) -> set[str]:
+    """Validate a bundle whose sole connector is ``connector``; return the mcp.*
+    error codes (empty = the connector object is accepted)."""
+    manifest = json.dumps({"name": "demo", "mcpServers": {"conn": connector}})
+    (tmp_path / ".claude-plugin").mkdir(parents=True)
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(
+        manifest, encoding="utf-8"
+    )
+    return {
+        issue.code
+        for issue in validate_bundle(tmp_path).errors
+        if issue.code.startswith("mcp.")
+    }
+
+
+def test_mcp_rule_matches_the_shared_corpus(tmp_path: Path) -> None:
+    for i, obj in enumerate(_CORPUS["valid_mcp"]):
+        codes = _mcp_codes(tmp_path / f"ok{i}", obj)
+        assert codes == set(), f"corpus valid mcp rejected {obj!r}: {codes}"
+    for i, obj in enumerate(_CORPUS["invalid_mcp"]):
+        codes = _mcp_codes(tmp_path / f"bad{i}", obj)
+        assert codes, f"corpus invalid mcp accepted: {obj!r}"


### PR DESCRIPTION
Two `plugin-format` validation rules are hand-mirrored into the CLI with no drift gate: `cli/src/scaffold.rs::valid_name` (vs `_NAME_RE = ^[a-z0-9]+(-[a-z0-9]+)*$`) and the MCP connector-object rule in `cli/src/spec.rs` (vs `_validate_mcp_object` + `McpServer` string typing). A shared corpus now pins both languages to one source of truth.

## The gate
- **`packages/plugin-format/schema/name-mcp.fixture.json`** — `{ valid_names, invalid_names, valid_mcp, invalid_mcp }`, covering the edge cases the rules turn on: leading/trailing/doubled hyphen, uppercase, underscore, space, non-ascii for names; command-or-url presence and string-typing for connectors.
- **Rust** (`cli/src/spec.rs`): extracted `mcp_object_valid` (the single accept decision the connector loop now calls, so the message path can't drift from the accept path) + an in-crate corpus test asserting `valid_name` and `mcp_object_valid` against the fixture via `include_str!` (the `queued-turn.fixture` pattern).
- **Python** (`packages/plugin-format/tests/test_name_mcp_corpus.py`): asserts `_NAME_RE` and `validate_bundle` against the **same** file.

A rule change on one side without the other now fails a corpus test on that side. (`valid_name` already matched the regex after a prior fix — this locks it so it can't silently re-diverge.)

## Verify
Rust: full CLI lib suite (359) green incl. the 2 corpus tests; fmt + clippy clean. Python: the 2 corpus tests pass; ruff clean.

Ref CUR-1628
Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
