### PR TITLE
Gate the Rust channel adapter's field bounds against the committed schema

### DIFF
--- a/cli/src/channel.rs
+++ b/cli/src/channel.rs
@@ -123,6 +123,28 @@ fn display_lines(
     lines
 }
 
+// Field bounds the channel-protocol schema declares
+// (`packages/channel-protocol/schema/channel-protocol.schema.json`). The Rust
+// adapter enforces them so a message the Python model would reject does not
+// render as an interactive widget here -- it degrades to plain text (the same
+// drop-to-fallback this parser already does for malformed input). Gated against
+// the committed schema corpus (#490) so these cannot silently drift.
+const ACTION_LABEL_MAX: usize = 75;
+const ACTION_VALUE_MAX: usize = 255;
+const INTERACTION_ID_MAX: usize = 255;
+const CHOICE_OPTIONS_MAX: usize = 10;
+
+/// An action's label/value are both 1..=max chars (schema min_length 1).
+fn action_bounds_ok(action: &Action) -> bool {
+    (1..=ACTION_LABEL_MAX).contains(&action.label.chars().count())
+        && (1..=ACTION_VALUE_MAX).contains(&action.value.chars().count())
+}
+
+/// An interaction id is 1..=255 chars.
+fn interaction_id_ok(id: &str) -> bool {
+    (1..=INTERACTION_ID_MAX).contains(&id.chars().count())
+}
+
 /// Parse a complete fenced semantic message. Legacy button pairs remain readable
 /// during migration, but only the versioned shape is the public contract.
 pub fn parse_terminal_message(text: &str) -> Option<TerminalMessage> {
@@ -145,37 +167,47 @@ pub fn parse_terminal_message(text: &str) -> Option<TerminalMessage> {
                 prompt,
                 options,
                 allow_free_text,
-            }) if !id.is_empty() && !options.is_empty() => (
-                options
-                    .into_iter()
-                    .map(|action| TerminalAction {
-                        label: action.label,
-                        value: action.value,
-                    })
-                    .collect(),
-                prompt,
-                allow_free_text,
-            ),
+            }) if interaction_id_ok(&id)
+                && (1..=CHOICE_OPTIONS_MAX).contains(&options.len())
+                && options.iter().all(action_bounds_ok) =>
+            {
+                (
+                    options
+                        .into_iter()
+                        .map(|action| TerminalAction {
+                            label: action.label,
+                            value: action.value,
+                        })
+                        .collect(),
+                    prompt,
+                    allow_free_text,
+                )
+            }
             Some(Interaction::Confirm {
                 id,
                 prompt,
                 confirm,
                 cancel,
                 allow_free_text,
-            }) if !id.is_empty() => (
-                vec![
-                    TerminalAction {
-                        label: confirm.label,
-                        value: confirm.value,
-                    },
-                    TerminalAction {
-                        label: cancel.label,
-                        value: cancel.value,
-                    },
-                ],
-                Some(prompt),
-                allow_free_text,
-            ),
+            }) if interaction_id_ok(&id)
+                && action_bounds_ok(&confirm)
+                && action_bounds_ok(&cancel) =>
+            {
+                (
+                    vec![
+                        TerminalAction {
+                            label: confirm.label,
+                            value: confirm.value,
+                        },
+                        TerminalAction {
+                            label: cancel.label,
+                            value: cancel.value,
+                        },
+                    ],
+                    Some(prompt),
+                    allow_free_text,
+                )
+            }
             _ => (Vec::new(), None, true),
         };
         return Some(TerminalMessage {
@@ -219,6 +251,43 @@ pub fn parse_terminal_message(text: &str) -> Option<TerminalMessage> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The committed cross-language corpus (#490): the SAME file the Python
+    /// channel-protocol model test asserts against, so a field-bound change on one
+    /// side without the other fails a corpus test here or there.
+    const CORPUS: &str =
+        include_str!("../../packages/channel-protocol/schema/channel-protocol.corpus.json");
+
+    fn fenced(message: &serde_json::Value) -> String {
+        format!("```agentos-reply\n{message}\n```")
+    }
+
+    #[test]
+    fn field_bounds_match_the_shared_schema_corpus() {
+        let corpus: serde_json::Value = serde_json::from_str(CORPUS).unwrap();
+        // A valid message renders an interactive widget (non-empty actions).
+        for message in corpus["valid"].as_array().unwrap() {
+            let parsed = parse_terminal_message(&fenced(message)).expect("valid message parses");
+            assert!(
+                !parsed.actions.is_empty(),
+                "corpus valid message rendered no widget: {message}"
+            );
+        }
+        // An out-of-bounds message must NOT render a widget: the bound guard fails
+        // and it degrades to plain text (no actions) -- the same rejection the
+        // Python model makes with a ValidationError.
+        for entry in corpus["invalid"].as_array().unwrap() {
+            let message = &entry["message"];
+            let widget = parse_terminal_message(&fenced(message))
+                .map(|m| !m.actions.is_empty())
+                .unwrap_or(false);
+            assert!(
+                !widget,
+                "corpus out-of-bounds message rendered a widget ({}): {message}",
+                entry["reason"]
+            );
+        }
+    }
 
     #[test]
     fn choice_renders_labels_but_preserves_values() {

--- a/packages/channel-protocol/schema/channel-protocol.corpus.json
+++ b/packages/channel-protocol/schema/channel-protocol.corpus.json
@@ -1,0 +1,321 @@
+{
+  "_comment": "Cross-language bound gate (#490): the committed channel-protocol schema declares field bounds (Action.label<=75, value<=255, interaction id<=255, choice options<=10, all min 1). The Python OutboundMessage model rejects violations; the Rust adapter (cli/src/channel.rs) must NOT render a violating message as a widget -- it degrades to plain text (no actions). Each side asserts against this corpus so a bound change on one side without the other fails a test.",
+  "valid": [
+    {
+      "version": "1.0",
+      "text": "Pick one",
+      "interaction": {
+        "kind": "choice",
+        "id": "repo",
+        "prompt": "Repository",
+        "options": [
+          {
+            "label": "AgentOS",
+            "value": "curie-eng/agentos"
+          }
+        ],
+        "allow_free_text": false
+      }
+    },
+    {
+      "version": "1.0",
+      "text": "Deploy?",
+      "interaction": {
+        "kind": "confirm",
+        "id": "deploy",
+        "prompt": "Deploy?",
+        "confirm": {
+          "label": "Deploy",
+          "value": "deploy"
+        },
+        "cancel": {
+          "label": "Cancel",
+          "value": "cancel"
+        },
+        "allow_free_text": false
+      }
+    },
+    {
+      "version": "1.0",
+      "text": "Pick one",
+      "interaction": {
+        "kind": "choice",
+        "id": "repo",
+        "prompt": "Repository",
+        "options": [
+          {
+            "label": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "value": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+          }
+        ],
+        "allow_free_text": false
+      }
+    },
+    {
+      "version": "1.0",
+      "text": "Pick one",
+      "interaction": {
+        "kind": "choice",
+        "id": "repo",
+        "prompt": "Repository",
+        "options": [
+          {
+            "label": "0",
+            "value": "0"
+          },
+          {
+            "label": "1",
+            "value": "1"
+          },
+          {
+            "label": "2",
+            "value": "2"
+          },
+          {
+            "label": "3",
+            "value": "3"
+          },
+          {
+            "label": "4",
+            "value": "4"
+          },
+          {
+            "label": "5",
+            "value": "5"
+          },
+          {
+            "label": "6",
+            "value": "6"
+          },
+          {
+            "label": "7",
+            "value": "7"
+          },
+          {
+            "label": "8",
+            "value": "8"
+          },
+          {
+            "label": "9",
+            "value": "9"
+          }
+        ],
+        "allow_free_text": false
+      }
+    },
+    {
+      "version": "1.0",
+      "text": "Pick one",
+      "interaction": {
+        "kind": "choice",
+        "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "prompt": "Repository",
+        "options": [
+          {
+            "label": "AgentOS",
+            "value": "curie-eng/agentos"
+          }
+        ],
+        "allow_free_text": false
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "reason": "label over 75",
+      "message": {
+        "version": "1.0",
+        "text": "Pick one",
+        "interaction": {
+          "kind": "choice",
+          "id": "repo",
+          "prompt": "Repository",
+          "options": [
+            {
+              "label": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "value": "v"
+            }
+          ],
+          "allow_free_text": false
+        }
+      }
+    },
+    {
+      "reason": "label empty",
+      "message": {
+        "version": "1.0",
+        "text": "Pick one",
+        "interaction": {
+          "kind": "choice",
+          "id": "repo",
+          "prompt": "Repository",
+          "options": [
+            {
+              "label": "",
+              "value": "v"
+            }
+          ],
+          "allow_free_text": false
+        }
+      }
+    },
+    {
+      "reason": "value over 255",
+      "message": {
+        "version": "1.0",
+        "text": "Pick one",
+        "interaction": {
+          "kind": "choice",
+          "id": "repo",
+          "prompt": "Repository",
+          "options": [
+            {
+              "label": "L",
+              "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          ],
+          "allow_free_text": false
+        }
+      }
+    },
+    {
+      "reason": "value empty",
+      "message": {
+        "version": "1.0",
+        "text": "Pick one",
+        "interaction": {
+          "kind": "choice",
+          "id": "repo",
+          "prompt": "Repository",
+          "options": [
+            {
+              "label": "L",
+              "value": ""
+            }
+          ],
+          "allow_free_text": false
+        }
+      }
+    },
+    {
+      "reason": "choice id over 255",
+      "message": {
+        "version": "1.0",
+        "text": "Pick one",
+        "interaction": {
+          "kind": "choice",
+          "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "prompt": "Repository",
+          "options": [
+            {
+              "label": "AgentOS",
+              "value": "curie-eng/agentos"
+            }
+          ],
+          "allow_free_text": false
+        }
+      }
+    },
+    {
+      "reason": "options over 10",
+      "message": {
+        "version": "1.0",
+        "text": "Pick one",
+        "interaction": {
+          "kind": "choice",
+          "id": "repo",
+          "prompt": "Repository",
+          "options": [
+            {
+              "label": "0",
+              "value": "0"
+            },
+            {
+              "label": "1",
+              "value": "1"
+            },
+            {
+              "label": "2",
+              "value": "2"
+            },
+            {
+              "label": "3",
+              "value": "3"
+            },
+            {
+              "label": "4",
+              "value": "4"
+            },
+            {
+              "label": "5",
+              "value": "5"
+            },
+            {
+              "label": "6",
+              "value": "6"
+            },
+            {
+              "label": "7",
+              "value": "7"
+            },
+            {
+              "label": "8",
+              "value": "8"
+            },
+            {
+              "label": "9",
+              "value": "9"
+            },
+            {
+              "label": "10",
+              "value": "10"
+            }
+          ],
+          "allow_free_text": false
+        }
+      }
+    },
+    {
+      "reason": "confirm id over 255",
+      "message": {
+        "version": "1.0",
+        "text": "Deploy?",
+        "interaction": {
+          "kind": "confirm",
+          "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "prompt": "Deploy?",
+          "confirm": {
+            "label": "Deploy",
+            "value": "deploy"
+          },
+          "cancel": {
+            "label": "Cancel",
+            "value": "cancel"
+          },
+          "allow_free_text": false
+        }
+      }
+    },
+    {
+      "reason": "confirm.confirm label over 75",
+      "message": {
+        "version": "1.0",
+        "text": "Deploy?",
+        "interaction": {
+          "kind": "confirm",
+          "id": "deploy",
+          "prompt": "Deploy?",
+          "confirm": {
+            "label": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "value": "deploy"
+          },
+          "cancel": {
+            "label": "Cancel",
+            "value": "cancel"
+          },
+          "allow_free_text": false
+        }
+      }
+    }
+  ]
+}

--- a/packages/channel-protocol/tests/test_corpus.py
+++ b/packages/channel-protocol/tests/test_corpus.py
@@ -1,0 +1,28 @@
+"""Cross-language bound gate (#490): the Python OutboundMessage model asserts
+against the SAME committed corpus the Rust adapter (cli/src/channel.rs) checks, so
+a field-bound change on one side without the other fails a corpus test.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from channel_protocol.models import OutboundMessage
+from pydantic import ValidationError
+
+_CORPUS = json.loads(
+    (Path(__file__).parents[1] / "schema" / "channel-protocol.corpus.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+def test_valid_messages_pass_the_model() -> None:
+    for message in _CORPUS["valid"]:
+        OutboundMessage.model_validate(message)
+
+
+def test_out_of_bounds_messages_are_rejected() -> None:
+    for entry in _CORPUS["invalid"]:
+        with pytest.raises(ValidationError):
+            OutboundMessage.model_validate(entry["message"])


### PR DESCRIPTION
The terminal renderer's Rust message model (`cli/src/channel.rs`) hand-mirrors the channel-protocol Pydantic models, but the committed schema's field bounds were enforced on the **Python side only** — the Rust adapter checked none of them, so an over-long or empty label rendered a widget the server model rejects. This is the live cross-channel wire; a silently mis-parsed field degrades rendering with no gate.

## Bounds now enforced in Rust (matching the schema)
| Field | Bound | Was enforced in Rust? |
|---|---|---|
| `Action.label` | 1–75 chars | no → **yes** |
| `Action.value` | 1–255 chars | no → **yes** |
| `Choice`/`Confirm` `id` | 1–255 chars | min only → **yes** |
| `Choice.options` | 1–10 | min only → **yes** |

`channel.rs` enforces these in its `Choice`/`Confirm` parse guards (`action_bounds_ok` / `interaction_id_ok`). A violating message **degrades to plain text** — the same drop-to-fallback the parser already does for malformed input — rather than rendering an interactive widget.

## The gate
- **`packages/channel-protocol/schema/channel-protocol.corpus.json`** — `{ valid, invalid }` with the boundary cases (label 76, value 256, id 256, 11 options, empty label/value).
- **Rust** test (`channel.rs`): each `valid` renders a widget (non-empty `actions`); each `invalid` does **not** (degrades to text). `include_str!` the corpus.
- **Python** test (`channel-protocol/tests/test_corpus.py`): `OutboundMessage.model_validate` accepts each `valid` and raises `ValidationError` on each `invalid`.

A deliberate bound change on one side without the other fails a corpus test on that side.

## Verify
Rust: channel tests (17) green incl. the corpus test; fmt + clippy clean. Python: corpus + `test_schema_compat` green; ruff clean.

Ref CUR-1627
Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)
