### PR TITLE
Structure operator, deploy, and skill-message output under --json

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -25,13 +25,15 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   `DryRunPlan { lines }` for a `--dry-run` plan -- and routes it through
   `Ui::emit`; handlers must not call the stdout emitters
   (`payload`/`payload_plain`/`kv`) directly, since those suppress under `--json`.
-  Two tracked exceptions: the schema-gated ADR-0021 builders (`skill
-  status`/`skill eval`, `skill check`, `local message`/`cluster message`,
-  `secrets list`, the error path, `guide`) still inline their own `if json()`
-  branch, sanctioned and tracked for migration onto `Ui::emit` in #474; and the
-  operator verbs (`up`, `down`, `status`, `comms`), `deploy`, and `skill message`
-  have real-path success output that is not yet structured under `--json`,
-  tracked in #485.
+  The operator verbs (`up`, `down`, `status`, `comms`), `deploy`, and `skill
+  message` now return typed `CliOutput`s on their real-path success too (#485):
+  the operator/deploy verbs route through `Ui::emit`, and `skill message` buffers
+  the streamed reply into one `SkillMessageOutput` under `--json` (it still
+  streams live in the human path). One tracked exception remains: the
+  schema-gated ADR-0021 builders (`skill status`/`skill eval`, `skill check`,
+  `local message`/`cluster message`, `secrets list`, the error path, `guide`)
+  still inline their own `if json()` branch, sanctioned and tracked for migration
+  onto `Ui::emit` in #474.
 - **The command manifest is a committed artifact; regenerate it in the same
   change as any command-surface edit (console/CLI parity, epic #145).** Any
   change to a clap `Command`/subcommand or an `*Action` enum — a renamed verb,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -961,6 +961,13 @@ pub async fn send(
     let ui = crate::ui::ui();
     let mut printer = TurnPrinter::default();
 
+    // Under `--json`, answer tokens are suppressed on stdout (they route through
+    // `ui.answer`), so a streamed turn would exit 0 with empty stdout (#485).
+    // Accumulate the full reply and emit one JSON object at the end instead. The
+    // human path is unchanged: it streams live and this buffer is never emitted.
+    let json = ui.json();
+    let mut reply = String::new();
+
     // A "thinking" spinner marks the wait for the first token; it is cleared the
     // instant streaming begins (committing no line) so the agent answer streams
     // clean. `streamed` tracks whether any answer token reached stdout;
@@ -991,7 +998,11 @@ pub async fn send(
                 // pace with no per-delta newline. Track mid-line state so a later
                 // note closes an un-terminated line first.
                 Some(TurnPart::Token(token)) => {
-                    ui.answer(&token);
+                    if json {
+                        reply.push_str(&token);
+                    } else {
+                        ui.answer(&token);
+                    }
                     streamed = true;
                     at_line_start = token.ends_with('\n');
                 }
@@ -1027,6 +1038,20 @@ pub async fn send(
     }
 
     if let Some(OutboundEvent::Final { status, .. }) = events.last() {
+        // Under `--json`, emit the one buffered turn object (reply + final
+        // status) rather than the streamed/human trailer (#485). Emit BEFORE any
+        // exit so a classified failure still carries its data to the consumer.
+        if json {
+            ui.emit(&SkillMessageOutput {
+                reply: std::mem::take(&mut reply),
+                status: status_str(status).to_string(),
+                finalized: true,
+            });
+            if *status == SessionStatus::ClassifiedFailure {
+                std::process::exit(1);
+            }
+            return Ok(());
+        }
         // Close the streamed answer on stdout only if the last thing written was
         // un-terminated token text; if a note already added its own newline (or
         // the last token ended in one) skip it to avoid a blank line. The status
@@ -1040,6 +1065,33 @@ pub async fn send(
         }
     }
     Ok(())
+}
+
+/// Output of `skill message` under `--json`: the full buffered reply plus the
+/// final session status. The human path streams tokens live and never builds
+/// this; it exists so `--json` emits one object instead of empty stdout (#485).
+#[derive(Debug)]
+pub struct SkillMessageOutput {
+    pub reply: String,
+    pub status: String,
+    pub finalized: bool,
+}
+
+impl crate::ui::CliOutput for SkillMessageOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "reply": self.reply,
+            "status": self.status,
+            "finalized": self.finalized,
+        })
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        // Only reached if a caller routes this through the human path; mirror the
+        // streamed output as a single block for completeness.
+        ui.answer(&self.reply);
+        ui.note(&format!("-- final ({})", self.status));
+    }
 }
 
 pub async fn eval(
@@ -1393,7 +1445,7 @@ fn unbound_declared_secrets(declared: &[String], bound: &[String]) -> Vec<String
         .collect()
 }
 
-pub async fn deploy(opts: DeployOpts) -> Result<()> {
+pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
     let plugin_dir = opts
         .plugin_dir
         .canonicalize()
@@ -1499,19 +1551,6 @@ pub async fn deploy(opts: DeployOpts) -> Result<()> {
         }
     };
 
-    ui.payload(&format!("deployed {plugin_name} {label} -> {env}"));
-    ui.kv(
-        "agent",
-        &format!("{} ({})", outcome.agent.name, ui.url(&outcome.agent.id)),
-    );
-    ui.kv(
-        "version",
-        &format!(
-            "{} ({})",
-            outcome.version.version_label,
-            ui.url(&outcome.version.id)
-        ),
-    );
     let channel = match &outcome.channel {
         ChannelOutcome::Created(channel) => channel.clone(),
         ChannelOutcome::Updated { from, to } => format!("updated to {to} (was {from})"),
@@ -1523,22 +1562,98 @@ pub async fn deploy(opts: DeployOpts) -> Result<()> {
             }
         }
     };
-    ui.kv("channel", &channel);
-    ui.kv(
-        "bundle",
-        &format!(
-            "{} sha256:{} {} bytes",
-            outcome.bundle.bundle_ref, outcome.bundle.bundle_sha256, outcome.bundle.size_bytes
-        ),
-    );
-    ui.kv(
-        "deployment",
-        &format!(
-            "{} [{}] {}",
-            outcome.deployment.id, outcome.deployment.environment, outcome.deployment.status
-        ),
-    );
-    Ok(())
+    Ok(DeployOutput {
+        plugin_name,
+        label,
+        env: env.to_string(),
+        agent_name: outcome.agent.name,
+        agent_id: outcome.agent.id,
+        version_label: outcome.version.version_label,
+        version_id: outcome.version.id,
+        channel,
+        bundle_ref: outcome.bundle.bundle_ref,
+        bundle_sha256: outcome.bundle.bundle_sha256,
+        bundle_size_bytes: outcome.bundle.size_bytes,
+        deployment_id: outcome.deployment.id,
+        deployment_environment: outcome.deployment.environment,
+        deployment_status: outcome.deployment.status,
+    })
+}
+
+/// Output of `<tier> deploy`: the deployed agent/version/channel/bundle/deployment
+/// summary. Owns its data so `to_json`/`render` outlive the `ApiClient`; the
+/// json-vs-human choice is made once in `Ui::emit` (#456, #485). Without this the
+/// real-path success emitted only `payload`/`kv`, which suppress under `--json`,
+/// so `deploy --json` exited 0 with empty stdout.
+#[derive(Debug)]
+pub struct DeployOutput {
+    pub plugin_name: String,
+    pub label: String,
+    pub env: String,
+    pub agent_name: String,
+    pub agent_id: String,
+    pub version_label: String,
+    pub version_id: String,
+    pub channel: String,
+    pub bundle_ref: String,
+    pub bundle_sha256: String,
+    pub bundle_size_bytes: u64,
+    pub deployment_id: String,
+    pub deployment_environment: String,
+    pub deployment_status: String,
+}
+
+impl crate::ui::CliOutput for DeployOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "plugin": self.plugin_name,
+            "label": self.label,
+            "environment": self.env,
+            "agent": {"name": self.agent_name, "id": self.agent_id},
+            "version": {"label": self.version_label, "id": self.version_id},
+            "channel": self.channel,
+            "bundle": {
+                "ref": self.bundle_ref,
+                "sha256": self.bundle_sha256,
+                "size_bytes": self.bundle_size_bytes,
+            },
+            "deployment": {
+                "id": self.deployment_id,
+                "environment": self.deployment_environment,
+                "status": self.deployment_status,
+            },
+        })
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        ui.payload(&format!(
+            "deployed {} {} -> {}",
+            self.plugin_name, self.label, self.env
+        ));
+        ui.kv(
+            "agent",
+            &format!("{} ({})", self.agent_name, ui.url(&self.agent_id)),
+        );
+        ui.kv(
+            "version",
+            &format!("{} ({})", self.version_label, ui.url(&self.version_id)),
+        );
+        ui.kv("channel", &self.channel);
+        ui.kv(
+            "bundle",
+            &format!(
+                "{} sha256:{} {} bytes",
+                self.bundle_ref, self.bundle_sha256, self.bundle_size_bytes
+            ),
+        );
+        ui.kv(
+            "deployment",
+            &format!(
+                "{} [{}] {}",
+                self.deployment_id, self.deployment_environment, self.deployment_status
+            ),
+        );
+    }
 }
 
 /// Shared flags for the agent-lifecycle verbs (`cluster kill|resume|budget|delete`).

--- a/cli/src/comms.rs
+++ b/cli/src/comms.rs
@@ -222,7 +222,33 @@ pub fn require_connect_tokens(disconnect: bool, app_token: &str, bot_token: &str
     Ok(())
 }
 
-pub async fn comms(opts: CommsOpts) -> Result<()> {
+/// Output of `<tier> comms`: the dry-run plan, or the resulting Slack wiring
+/// state. `--json` emits a JSON object; the real path formerly emitted only
+/// stderr notes, so `comms --json` on success exited 0 with empty stdout (#485).
+#[derive(Debug)]
+pub enum CommsOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Done { connected: bool },
+}
+
+impl crate::ui::CliOutput for CommsOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            CommsOutput::DryRun(plan) => plan.to_json(),
+            CommsOutput::Done { connected } => serde_json::json!({"connected": connected}),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        if let CommsOutput::DryRun(plan) = self {
+            plan.render(ui);
+        }
+        // The `Done` note is emitted live during execution (below), so nothing
+        // to render on the human path here.
+    }
+}
+
+pub async fn comms(opts: CommsOpts) -> Result<CommsOutput> {
     let ui = crate::ui::ui();
     require_connect_tokens(opts.disconnect, &opts.app_token, &opts.bot_token)?;
 
@@ -238,14 +264,13 @@ pub async fn comms(opts: CommsOpts) -> Result<()> {
     );
 
     if opts.common.dry_run {
-        ui.emit(&crate::ui::DryRunPlan {
+        return Ok(CommsOutput::DryRun(crate::ui::DryRunPlan {
             lines: cmds
                 .iter()
                 .chain(rollout.iter())
                 .map(|cmd| cmd.display())
                 .collect(),
-        });
-        return Ok(());
+        }));
     }
 
     require_on_path("helm")?;
@@ -276,10 +301,12 @@ pub async fn comms(opts: CommsOpts) -> Result<()> {
     } else {
         ui.note("Slack connected");
     }
-    Ok(())
+    Ok(CommsOutput::Done {
+        connected: !opts.disconnect,
+    })
 }
 
-pub async fn local_comms(opts: LocalCommsOpts) -> Result<()> {
+pub async fn local_comms(opts: LocalCommsOpts) -> Result<CommsOutput> {
     let ui = crate::ui::ui();
     require_connect_tokens(opts.disconnect, &opts.app_token, &opts.bot_token)?;
     let cmds = if opts.disconnect {
@@ -289,10 +316,9 @@ pub async fn local_comms(opts: LocalCommsOpts) -> Result<()> {
     };
 
     if opts.dry_run {
-        ui.emit(&crate::ui::DryRunPlan {
+        return Ok(CommsOutput::DryRun(crate::ui::DryRunPlan {
             lines: cmds.iter().map(|cmd| cmd.display()).collect(),
-        });
-        return Ok(());
+        }));
     }
 
     if opts.model_mode == ModelMode::FakePinnedDespiteCredential {
@@ -320,7 +346,9 @@ pub async fn local_comms(opts: LocalCommsOpts) -> Result<()> {
     } else {
         ui.note("Slack connected to the local stack (dispatcher running, worker on real Slack)");
     }
-    Ok(())
+    Ok(CommsOutput::Done {
+        connected: !opts.disconnect,
+    })
 }
 
 #[cfg(test)]

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -266,14 +266,61 @@ pub fn status_command(o: &LocalOpts) -> OpsCommand {
 // Verb handlers
 // ---------------------------------------------------------------------------
 
-pub async fn up(o: LocalOpts) -> Result<()> {
+/// Output of `local up`: the dry-run plan, or the started dev stack's advertised
+/// endpoints. Routes through `Ui::emit` so `--json` emits a JSON object instead
+/// of empty stdout (#485): the real path formerly ended in `ui.kv`, which
+/// suppresses under `--json`.
+#[derive(Debug)]
+pub enum LocalUpOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Up {
+        endpoints: Vec<(String, String)>,
+        slack: bool,
+    },
+}
+
+impl crate::ui::CliOutput for LocalUpOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            LocalUpOutput::DryRun(plan) => plan.to_json(),
+            LocalUpOutput::Up { endpoints, slack } => serde_json::json!({
+                "status": "up",
+                "endpoints": endpoints
+                    .iter()
+                    .map(|(name, url)| serde_json::json!({"name": name, "url": url}))
+                    .collect::<Vec<_>>(),
+                "slack": slack,
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            LocalUpOutput::DryRun(plan) => plan.render(ui),
+            LocalUpOutput::Up { endpoints, slack } => {
+                for (label, url) in endpoints {
+                    ui.kv(label, &ui.url(url));
+                }
+                if *slack {
+                    ui.note("Slack dispatcher started (Socket Mode; no host port).");
+                }
+                ui.note("Drive the local product loop (no Slack, no Kubernetes):");
+                ui.note(
+                    "  agentos local deploy --plugin-dir <dir> --slack-channel <C...> --api-url http://localhost:28000",
+                );
+                ui.note("  agentos local message \"<your question>\"");
+            }
+        }
+    }
+}
+
+pub async fn up(o: LocalOpts) -> Result<LocalUpOutput> {
     let ui = crate::ui::ui();
     let cmd = up_command(&o);
     if o.dry_run {
-        ui.emit(&crate::ui::DryRunPlan {
+        return Ok(LocalUpOutput::DryRun(crate::ui::DryRunPlan {
             lines: vec![cmd.display()],
-        });
-        return Ok(());
+        }));
     }
     require_on_path("docker")?;
     let cl = ui.checklist();
@@ -293,32 +340,55 @@ pub async fn up(o: LocalOpts) -> Result<()> {
             ),
         }
     }
-    for (label, url, is_core) in ENDPOINTS {
+    let endpoints = ENDPOINTS
+        .iter()
         // Under `--minimal` only the `core` services started, so advertise only
         // their endpoints; the `full`-only URLs would 404.
-        if !o.minimal || *is_core {
-            ui.kv(label, &ui.url(url));
-        }
-    }
-    if o.slack {
-        ui.note("Slack dispatcher started (Socket Mode; no host port).");
-    }
-    ui.note("Drive the local product loop (no Slack, no Kubernetes):");
-    ui.note(
-        "  agentos local deploy --plugin-dir <dir> --slack-channel <C...> --api-url http://localhost:28000",
-    );
-    ui.note("  agentos local message \"<your question>\"");
-    Ok(())
+        .filter(|(_, _, is_core)| !o.minimal || *is_core)
+        .map(|(label, url, _)| (label.to_string(), url.to_string()))
+        .collect();
+    Ok(LocalUpOutput::Up {
+        endpoints,
+        slack: o.slack,
+    })
 }
 
-pub async fn status(o: LocalOpts) -> Result<()> {
+/// Output of `local status`: the dry-run plan, or the `docker compose ps` rows.
+/// `--json` emits `{"services":[...lines]}` rather than the empty stdout the
+/// former `payload_plain` loop produced (#485).
+#[derive(Debug)]
+pub enum LocalStatusOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Services { rows: Vec<String> },
+}
+
+impl crate::ui::CliOutput for LocalStatusOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            LocalStatusOutput::DryRun(plan) => plan.to_json(),
+            LocalStatusOutput::Services { rows } => serde_json::json!({"services": rows}),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            LocalStatusOutput::DryRun(plan) => plan.render(ui),
+            LocalStatusOutput::Services { rows } => {
+                for line in rows {
+                    ui.payload_plain(line);
+                }
+            }
+        }
+    }
+}
+
+pub async fn status(o: LocalOpts) -> Result<LocalStatusOutput> {
     let ui = crate::ui::ui();
     let cmd = status_command(&o);
     if o.dry_run {
-        ui.emit(&crate::ui::DryRunPlan {
+        return Ok(LocalStatusOutput::DryRun(crate::ui::DryRunPlan {
             lines: vec![cmd.display()],
-        });
-        return Ok(());
+        }));
     }
     require_on_path("docker")?;
     // `docker compose ps` output is itself the payload table.
@@ -336,17 +406,64 @@ pub async fn status(o: LocalOpts) -> Result<()> {
         ui.failure(&format!("`docker compose ps` failed: {reason}"));
         bail!("`docker compose ps` exited nonzero");
     }
-    for line in out.lines() {
-        ui.payload_plain(line);
-    }
-    Ok(())
+    Ok(LocalStatusOutput::Services {
+        rows: out.lines().map(str::to_string).collect(),
+    })
 }
 
-pub async fn down(o: LocalDownOpts) -> Result<()> {
+/// Output of `local down`: the dry-run plan, an operator abort, or the stopped
+/// stack. `--json` emits a JSON object; the real path formerly ended in
+/// `ui.payload` (suppressed under `--json`, #485).
+#[derive(Debug)]
+pub enum LocalDownOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Aborted,
+    Down { volumes_wiped: bool, reaped: usize },
+}
+
+impl crate::ui::CliOutput for LocalDownOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            LocalDownOutput::DryRun(plan) => plan.to_json(),
+            LocalDownOutput::Aborted => serde_json::json!({"stopped": false, "aborted": true}),
+            LocalDownOutput::Down {
+                volumes_wiped,
+                reaped,
+            } => serde_json::json!({
+                "stopped": true,
+                "volumes_wiped": volumes_wiped,
+                "runners_reaped": reaped,
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            LocalDownOutput::DryRun(plan) => plan.render(ui),
+            LocalDownOutput::Aborted => ui.note("aborted"),
+            LocalDownOutput::Down {
+                volumes_wiped,
+                reaped,
+            } => {
+                if *reaped > 0 {
+                    ui.note(&format!("removed {reaped} runner container(s)"));
+                }
+                if *volumes_wiped {
+                    ui.payload("dev stack stopped; volumes wiped");
+                } else {
+                    ui.payload("dev stack stopped");
+                    ui.note("volumes kept (fast restart with `agentos local up`)");
+                }
+            }
+        }
+    }
+}
+
+pub async fn down(o: LocalDownOpts) -> Result<LocalDownOutput> {
     let ui = crate::ui::ui();
     let cmd = down_command(&o);
     if o.common.dry_run {
-        ui.emit(&crate::ui::DryRunPlan {
+        return Ok(LocalDownOutput::DryRun(crate::ui::DryRunPlan {
             lines: vec![
                 cmd.display(),
                 format!(
@@ -354,8 +471,7 @@ pub async fn down(o: LocalDownOpts) -> Result<()> {
                     docker::SANDBOX_LABEL
                 ),
             ],
-        });
-        return Ok(());
+        }));
     }
     if o.wipe {
         ui.warn(&format!(
@@ -368,8 +484,7 @@ pub async fn down(o: LocalDownOpts) -> Result<()> {
                 o.common.file
             ))?
         {
-            ui.note("aborted");
-            return Ok(());
+            return Ok(LocalDownOutput::Aborted);
         }
     }
     require_on_path("docker")?;
@@ -380,17 +495,11 @@ pub async fn down(o: LocalDownOpts) -> Result<()> {
         "stopping stack"
     };
     run_step(&cl, label, "stopped", &cmd).await?;
-    let count = docker::reap_labeled(docker::SANDBOX_LABEL).await?;
-    if count > 0 {
-        ui.note(&format!("removed {count} runner container(s)"));
-    }
-    if o.wipe {
-        ui.payload("dev stack stopped; volumes wiped");
-    } else {
-        ui.payload("dev stack stopped");
-        ui.note("volumes kept (fast restart with `agentos local up`)");
-    }
-    Ok(())
+    let reaped = docker::reap_labeled(docker::SANDBOX_LABEL).await?;
+    Ok(LocalDownOutput::Down {
+        volumes_wiped: o.wipe,
+        reaped,
+    })
 }
 
 #[cfg(test)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1328,15 +1328,17 @@ async fn run(command: Option<Command>) -> Result<()> {
                 slack,
             } => {
                 let file = resolve_compose_file(file, dry_run).await?;
-                local::up(LocalOpts {
-                    file,
-                    dry_run,
-                    minimal,
-                    local_model,
-                    slack,
-                    model_mode: local::model_mode_from_env(),
-                })
-                .await
+                emit(
+                    local::up(LocalOpts {
+                        file,
+                        dry_run,
+                        minimal,
+                        local_model,
+                        slack,
+                        model_mode: local::model_mode_from_env(),
+                    })
+                    .await?,
+                )
             }
             LocalAction::Down {
                 file,
@@ -1345,31 +1347,35 @@ async fn run(command: Option<Command>) -> Result<()> {
                 dry_run,
             } => {
                 let file = resolve_compose_file(file, dry_run).await?;
-                local::down(LocalDownOpts {
-                    common: LocalOpts {
+                emit(
+                    local::down(LocalDownOpts {
+                        common: LocalOpts {
+                            file,
+                            dry_run,
+                            minimal: false,
+                            local_model: None,
+                            slack: false,
+                            model_mode: local::ModelMode::DefaultFake,
+                        },
+                        wipe,
+                        yes,
+                    })
+                    .await?,
+                )
+            }
+            LocalAction::Status { file, dry_run } => {
+                let file = resolve_compose_file(file, dry_run).await?;
+                emit(
+                    local::status(LocalOpts {
                         file,
                         dry_run,
                         minimal: false,
                         local_model: None,
                         slack: false,
                         model_mode: local::ModelMode::DefaultFake,
-                    },
-                    wipe,
-                    yes,
-                })
-                .await
-            }
-            LocalAction::Status { file, dry_run } => {
-                let file = resolve_compose_file(file, dry_run).await?;
-                local::status(LocalOpts {
-                    file,
-                    dry_run,
-                    minimal: false,
-                    local_model: None,
-                    slack: false,
-                    model_mode: local::ModelMode::DefaultFake,
-                })
-                .await
+                    })
+                    .await?,
+                )
             }
             LocalAction::Comms {
                 slack,
@@ -1382,16 +1388,18 @@ async fn run(command: Option<Command>) -> Result<()> {
             } => {
                 comms::require_provider(slack)?;
                 let resolved_file = resolve_compose_file(file, dry_run).await?;
-                comms::local_comms(LocalCommsOpts {
-                    file: resolved_file,
-                    dry_run,
-                    app_token,
-                    bot_token,
-                    disconnect,
-                    model_mode: local::model_mode_from_env(),
-                    minimal,
-                })
-                .await
+                emit(
+                    comms::local_comms(LocalCommsOpts {
+                        file: resolved_file,
+                        dry_run,
+                        app_token,
+                        bot_token,
+                        disconnect,
+                        model_mode: local::model_mode_from_env(),
+                        minimal,
+                    })
+                    .await?,
+                )
             }
             LocalAction::Message {
                 text,
@@ -1503,20 +1511,22 @@ async fn run(command: Option<Command>) -> Result<()> {
                 let connect_hint = format!(
                     "the platform API at {api_url} is unreachable. Start the local stack first with `agentos local up`, then re-run (or pass --api-url if your API is elsewhere)."
                 );
-                commands::deploy(DeployOpts {
-                    plugin_dir,
-                    api_url,
-                    api_key,
-                    slack_channel,
-                    env,
-                    label,
-                    secret,
-                    // `local deploy` offers `--secret`, so enforce the
-                    // declared-secrets policy gate (#464).
-                    secret_binding_supported: true,
-                    connect_hint,
-                })
-                .await
+                emit(
+                    commands::deploy(DeployOpts {
+                        plugin_dir,
+                        api_url,
+                        api_key,
+                        slack_channel,
+                        env,
+                        label,
+                        secret,
+                        // `local deploy` offers `--secret`, so enforce the
+                        // declared-secrets policy gate (#464).
+                        secret_binding_supported: true,
+                        connect_hint,
+                    })
+                    .await?,
+                )
             }
             LocalAction::Versions { target } => emit(commands::versions(target.into()).await?),
             LocalAction::Memory { target } => emit(commands::memory(target.into()).await?),
@@ -1604,43 +1614,45 @@ async fn run(command: Option<Command>) -> Result<()> {
                 } else {
                     ops::resolve_up_credentials(fake_model, ops::model_credential_env())
                 };
-                ops::up(UpOpts {
-                    common: CommonOpts {
-                        namespace,
-                        release,
-                        dry_run,
-                    },
-                    chart,
-                    no_expose,
-                    set,
-                    allow_egress_host,
-                    // Populated by ops::up (resolve named providers to host
-                    // routes on a live run); empty here so the pure builder and
-                    // --dry-run start clean.
-                    resolved_egress_cidrs: vec![],
-                    allow_web_egress,
-                    fake_model,
-                    credentials,
-                    local_model,
-                    // Default `agentSandbox.runner.model` from the shell
-                    // `AGENTOS_MODEL` (None when unset/empty) for cross-tier
-                    // parity with `local up` (#361).
-                    model: std::env::var("AGENTOS_MODEL")
-                        .ok()
-                        .filter(|s| !s.is_empty()),
-                    // Populated by ops::up (generate on fresh install / reuse on
-                    // upgrade); empty here so the pure builder starts clean.
-                    secrets: vec![],
-                    dev,
-                })
-                .await
+                emit(
+                    ops::up(UpOpts {
+                        common: CommonOpts {
+                            namespace,
+                            release,
+                            dry_run,
+                        },
+                        chart,
+                        no_expose,
+                        set,
+                        allow_egress_host,
+                        // Populated by ops::up (resolve named providers to host
+                        // routes on a live run); empty here so the pure builder and
+                        // --dry-run start clean.
+                        resolved_egress_cidrs: vec![],
+                        allow_web_egress,
+                        fake_model,
+                        credentials,
+                        local_model,
+                        // Default `agentSandbox.runner.model` from the shell
+                        // `AGENTOS_MODEL` (None when unset/empty) for cross-tier
+                        // parity with `local up` (#361).
+                        model: std::env::var("AGENTOS_MODEL")
+                            .ok()
+                            .filter(|s| !s.is_empty()),
+                        // Populated by ops::up (generate on fresh install / reuse on
+                        // upgrade); empty here so the pure builder starts clean.
+                        secrets: vec![],
+                        dev,
+                    })
+                    .await?,
+                )
             }
             ClusterAction::Down {
                 namespace,
                 release,
                 yes,
                 dry_run,
-            } => {
+            } => emit(
                 ops::down(DownOpts {
                     common: CommonOpts {
                         namespace,
@@ -1649,20 +1661,20 @@ async fn run(command: Option<Command>) -> Result<()> {
                     },
                     yes,
                 })
-                .await
-            }
+                .await?,
+            ),
             ClusterAction::Status {
                 namespace,
                 release,
                 dry_run,
-            } => {
+            } => emit(
                 ops::status(CommonOpts {
                     namespace,
                     release,
                     dry_run,
                 })
-                .await
-            }
+                .await?,
+            ),
             ClusterAction::Observability {
                 namespace,
                 release,
@@ -1698,18 +1710,20 @@ async fn run(command: Option<Command>) -> Result<()> {
                     std::path::Path::new("charts/agentos").is_dir(),
                 )?;
                 let chart = materialize_artifact(resolved, dry_run, "chart").await?;
-                comms::comms(CommsOpts {
-                    common: CommonOpts {
-                        namespace,
-                        release,
-                        dry_run,
-                    },
-                    chart,
-                    app_token,
-                    bot_token,
-                    disconnect,
-                })
-                .await
+                emit(
+                    comms::comms(CommsOpts {
+                        common: CommonOpts {
+                            namespace,
+                            release,
+                            dry_run,
+                        },
+                        chart,
+                        app_token,
+                        bot_token,
+                        disconnect,
+                    })
+                    .await?,
+                )
             }
             ClusterAction::Message {
                 text,
@@ -1862,24 +1876,26 @@ async fn run(command: Option<Command>) -> Result<()> {
                 let connect_hint = format!(
                     "the platform API at {api_url} is unreachable. `cluster deploy` reaches the API through the UI /api proxy (no port-forward); confirm the release is healthy with `agentos cluster status`, or pass --api-url to target the API directly."
                 );
-                commands::deploy(DeployOpts {
-                    plugin_dir,
-                    api_url,
-                    api_key,
-                    slack_channel,
-                    env,
-                    label,
-                    // Cluster connector-secret delivery is deferred to #440; no
-                    // `--secret` flag on `cluster deploy` (see the note above).
-                    secret: Vec::new(),
-                    // Secret binding is not wired on cluster until #440, so the
-                    // declared-secrets policy gate (#464) is skipped here: it
-                    // would otherwise hard-fail every secrets-declaring bundle
-                    // with a `--secret <NAME>` remediation this tier lacks.
-                    secret_binding_supported: false,
-                    connect_hint,
-                })
-                .await
+                emit(
+                    commands::deploy(DeployOpts {
+                        plugin_dir,
+                        api_url,
+                        api_key,
+                        slack_channel,
+                        env,
+                        label,
+                        // Cluster connector-secret delivery is deferred to #440; no
+                        // `--secret` flag on `cluster deploy` (see the note above).
+                        secret: Vec::new(),
+                        // Secret binding is not wired on cluster until #440, so the
+                        // declared-secrets policy gate (#464) is skipped here: it
+                        // would otherwise hard-fail every secrets-declaring bundle
+                        // with a `--secret <NAME>` remediation this tier lacks.
+                        secret_binding_supported: false,
+                        connect_hint,
+                    })
+                    .await?,
+                )
             }
             ClusterAction::Kill {
                 agent,

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1160,7 +1160,39 @@ pub(crate) async fn run_step(
 // Verb handlers
 // ---------------------------------------------------------------------------
 
-pub async fn up(mut opts: UpOpts) -> Result<()> {
+/// Output of `cluster up`: the dry-run plan, or the installed release. `--json`
+/// emits a JSON object; the real path formerly ended in `ui.payload` (suppressed
+/// under `--json`, #485).
+#[derive(Debug)]
+pub enum ClusterUpOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Up { namespace: String, release: String },
+}
+
+impl crate::ui::CliOutput for ClusterUpOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            ClusterUpOutput::DryRun(plan) => plan.to_json(),
+            ClusterUpOutput::Up { namespace, release } => serde_json::json!({
+                "status": "up",
+                "namespace": namespace,
+                "release": release,
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            ClusterUpOutput::DryRun(plan) => plan.render(ui),
+            ClusterUpOutput::Up { .. } => {
+                ui.payload("agentos is up");
+                ui.note("Run `agentos cluster status` for pod health and URLs.");
+            }
+        }
+    }
+}
+
+pub async fn up(mut opts: UpOpts) -> Result<ClusterUpOutput> {
     let ui = crate::ui::ui();
     validate_web_egress_cidrs(&opts.allow_web_egress)
         .context("invalid --allow-web-egress value")?;
@@ -1263,10 +1295,9 @@ pub async fn up(mut opts: UpOpts) -> Result<()> {
         ));
     }
     if opts.common.dry_run {
-        ui.emit(&crate::ui::DryRunPlan {
+        return Ok(ClusterUpOutput::DryRun(crate::ui::DryRunPlan {
             lines: cmds.iter().map(|cmd| cmd.display()).collect(),
-        });
-        return Ok(());
+        }));
     }
     require_on_path("helm")?;
     let cl = ui.checklist();
@@ -1274,21 +1305,104 @@ pub async fn up(mut opts: UpOpts) -> Result<()> {
     for cmd in &cmds {
         run_step(&cl, &label, "installed", cmd).await?;
     }
-    ui.payload("agentos is up");
-    ui.note("Run `agentos cluster status` for pod health and URLs.");
-    Ok(())
+    Ok(ClusterUpOutput::Up {
+        namespace: opts.common.namespace.clone(),
+        release: opts.common.release.clone(),
+    })
 }
 
-pub async fn status(opts: CommonOpts) -> Result<()> {
-    let ui = crate::ui::ui();
+/// Output of `cluster status`: the dry-run plan, or the release/pod/URL summary.
+/// `--json` emits one JSON object; the real path formerly printed via
+/// `ui.payload`/scattered helpers (all suppressed under `--json`, #485).
+#[derive(Debug)]
+pub enum ClusterStatusOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Status(Box<ClusterStatus>),
+}
+
+/// The assembled `cluster status` reading. Owns its data so `to_json`/`render`
+/// can run after every capture completes.
+#[derive(Debug)]
+pub struct ClusterStatus {
+    pub namespace: String,
+    pub revision: String,
+    pub release_state: String,
+    pub release_found: bool,
+    pub release_missing_note: Option<String>,
+    pub pods: Vec<PodRow>,
+    pub ready: usize,
+    pub total: usize,
+    pub unhealthy: Vec<String>,
+    pub pods_listed: bool,
+    pub urls: Vec<ServiceUrl>,
+}
+
+impl crate::ui::CliOutput for ClusterStatusOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            ClusterStatusOutput::DryRun(plan) => plan.to_json(),
+            ClusterStatusOutput::Status(s) => {
+                let healthy = s.total > 0 && s.ready == s.total && s.unhealthy.is_empty();
+                serde_json::json!({
+                    "namespace": s.namespace,
+                    "revision": s.revision,
+                    "release_state": s.release_state,
+                    "release_found": s.release_found,
+                    "pods": {
+                        "ready": s.ready,
+                        "total": s.total,
+                        "unhealthy": s.unhealthy,
+                        "rows": s.pods.iter().map(PodRow::to_json).collect::<Vec<_>>(),
+                    },
+                    "urls": s.urls.iter().map(ServiceUrl::to_json).collect::<Vec<_>>(),
+                    "healthy": healthy,
+                })
+            }
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            ClusterStatusOutput::DryRun(plan) => plan.render(ui),
+            ClusterStatusOutput::Status(s) => {
+                ui.payload(&format!(
+                    "agentos · namespace {} · revision {} · {}",
+                    s.namespace, s.revision, s.release_state
+                ));
+                if let Some(note) = &s.release_missing_note {
+                    ui.note(note);
+                }
+                render_pod_table(ui, &s.pods);
+                if !s.pods_listed {
+                    ui.warn(&format!("could not list pods in namespace {}", s.namespace));
+                }
+                for url in &s.urls {
+                    url.render(ui);
+                }
+                if s.total > 0 && s.ready == s.total && s.unhealthy.is_empty() {
+                    ui.success(&format!("healthy ({}/{} pods ready)", s.ready, s.total));
+                } else if s.total == 0 {
+                    ui.warn("no pods running");
+                } else {
+                    let mut msg = format!("{}/{} pods ready", s.ready, s.total);
+                    if !s.unhealthy.is_empty() {
+                        msg.push_str(&format!("; not ready: {}", s.unhealthy.join(", ")));
+                    }
+                    ui.warn(&msg);
+                }
+            }
+        }
+    }
+}
+
+pub async fn status(opts: CommonOpts) -> Result<ClusterStatusOutput> {
     if opts.dry_run {
-        ui.emit(&crate::ui::DryRunPlan {
+        return Ok(ClusterStatusOutput::DryRun(crate::ui::DryRunPlan {
             lines: status_commands(&opts)
                 .iter()
                 .map(|cmd| cmd.display())
                 .collect(),
-        });
-        return Ok(());
+        }));
     }
     require_on_path("helm")?;
     require_on_path("kubectl")?;
@@ -1308,63 +1422,89 @@ pub async fn status(opts: CommonOpts) -> Result<()> {
     } else {
         ("not found".to_string(), "none".to_string())
     };
-    ui.payload(&format!(
-        "agentos · namespace {} · revision {} · {}",
-        opts.namespace, revision, release_state
-    ));
-    if !helm_ok {
-        ui.note(&format!(
+    let release_missing_note = (!helm_ok).then(|| {
+        format!(
             "release {} not found: {}",
             opts.release,
             helm_err.trim().lines().next().unwrap_or("no such release")
-        ));
-    }
+        )
+    });
 
     // (b) Pod health.
     let (ok, out, _) = run_capture(&pods_cmd(&opts)).await?;
-    let (ready, total, unhealthy) = if ok {
+    let (pods, ready, total, unhealthy) = if ok {
         let items: Vec<serde_json::Value> = serde_json::from_str::<serde_json::Value>(&out)
             .ok()
             .and_then(|v| v.get("items").and_then(|i| i.as_array()).cloned())
             .unwrap_or_default();
-        print_pod_summary(&items)
+        collect_pod_summary(&items)
     } else {
-        ui.warn(&format!(
-            "could not list pods in namespace {}",
-            opts.namespace
-        ));
-        (0, 0, Vec::new())
+        (Vec::new(), 0, 0, Vec::new())
     };
 
     // (c) URL discovery.
     let host = discover_host().await;
-    print_service_url(&opts, "ui", "UI", &host, true).await;
-    print_service_url(&opts, "langfuse-web", "Langfuse", &host, false).await;
+    let urls = vec![
+        resolve_service_url(&opts, "ui", "UI", &host, true).await,
+        resolve_service_url(&opts, "langfuse-web", "Langfuse", &host, false).await,
+    ];
 
-    // (d) Overall verdict.
-    if total > 0 && ready == total && unhealthy.is_empty() {
-        ui.success(&format!("healthy ({ready}/{total} pods ready)"));
-    } else if total == 0 {
-        ui.warn("no pods running");
-    } else {
-        let mut msg = format!("{ready}/{total} pods ready");
-        if !unhealthy.is_empty() {
-            msg.push_str(&format!("; not ready: {}", unhealthy.join(", ")));
-        }
-        ui.warn(&msg);
-    }
-
-    Ok(())
+    Ok(ClusterStatusOutput::Status(Box::new(ClusterStatus {
+        namespace: opts.namespace.clone(),
+        revision,
+        release_state,
+        release_found: helm_ok,
+        release_missing_note,
+        pods,
+        ready,
+        total,
+        unhealthy,
+        pods_listed: ok,
+        urls,
+    })))
 }
 
-pub async fn down(opts: DownOpts) -> Result<()> {
+/// Output of `cluster down`: the dry-run plan, an operator abort, or the removed
+/// release. `--json` emits a JSON object; the real path formerly ended in
+/// `ui.payload` (suppressed under `--json`, #485).
+#[derive(Debug)]
+pub enum ClusterDownOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Aborted,
+    Down { release_was_absent: bool },
+}
+
+impl crate::ui::CliOutput for ClusterDownOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            ClusterDownOutput::DryRun(plan) => plan.to_json(),
+            ClusterDownOutput::Aborted => serde_json::json!({"down": false, "aborted": true}),
+            ClusterDownOutput::Down { release_was_absent } => serde_json::json!({
+                "down": true,
+                "release_was_absent": release_was_absent,
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            ClusterDownOutput::DryRun(plan) => plan.render(ui),
+            ClusterDownOutput::Aborted => ui.note("aborted"),
+            ClusterDownOutput::Down { .. } => {
+                ui.payload("agentos is down");
+                ui.note("The agents.x-k8s.io CRDs are left in place intentionally.");
+            }
+        }
+    }
+}
+
+pub async fn down(opts: DownOpts) -> Result<ClusterDownOutput> {
     let ui = crate::ui::ui();
     let cmds = down_commands(&opts.common);
     if opts.common.dry_run {
-        ui.emit(&crate::ui::DryRunPlan {
+        return Ok(ClusterDownOutput::DryRun(crate::ui::DryRunPlan {
             lines: cmds.iter().map(|cmd| cmd.display()).collect(),
-        });
-        return Ok(());
+        }));
     }
     ui.warn(&format!(
         "this uninstalls release '{}' and deletes namespaces '{}' and 'agent-sandbox-system'",
@@ -1376,8 +1516,7 @@ pub async fn down(opts: DownOpts) -> Result<()> {
             opts.common.release, opts.common.namespace
         ))?
     {
-        ui.note("aborted");
-        return Ok(());
+        return Ok(ClusterDownOutput::Aborted);
     }
     require_on_path("helm")?;
     require_on_path("kubectl")?;
@@ -1408,9 +1547,9 @@ pub async fn down(opts: DownOpts) -> Result<()> {
     // Namespace sweep (runtime artifacts Helm does not own).
     run_step(&cl, "sweeping namespaces", "removed", &cmds[1]).await?;
 
-    ui.payload("agentos is down");
-    ui.note("The agents.x-k8s.io CRDs are left in place intentionally.");
-    Ok(())
+    Ok(ClusterDownOutput::Down {
+        release_was_absent: absent,
+    })
 }
 
 /// Read a y/N confirmation from stderr/stdin for `down` when `--yes` is absent.
@@ -1437,16 +1576,41 @@ pub(crate) fn confirm(prompt: &str) -> Result<bool> {
     Ok(matches!(line.trim(), "y" | "Y" | "yes" | "Yes"))
 }
 
-/// Render `kubectl get pods` output as a borderless table to stdout and return
-/// (ready count, steady state total, names of pods not Running) so the caller
-/// can summarise overall health. Terminal and terminating pods stay visible in
-/// the table but are excluded from the returned tally.
-fn print_pod_summary(pods: &[serde_json::Value]) -> (usize, usize, Vec<String>) {
-    let ui = crate::ui::ui();
+/// One pod's row in the `cluster status` table.
+#[derive(Debug)]
+pub struct PodRow {
+    pub name: String,
+    pub ready: String,
+    pub status: String,
+}
+
+impl PodRow {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({"pod": self.name, "ready": self.ready, "status": self.status})
+    }
+}
+
+/// Render the collected pod rows as a borderless table to stdout (human path).
+fn render_pod_table(ui: &crate::ui::Ui, pods: &[PodRow]) {
+    if pods.is_empty() {
+        return;
+    }
+    let rows: Vec<Vec<String>> = pods
+        .iter()
+        .map(|p| vec![p.name.clone(), p.ready.clone(), p.status.clone()])
+        .collect();
+    ui.payload_plain(&crate::ui::table(&["pod", "ready", "status"], &rows, &[]));
+}
+
+/// Summarise `kubectl get pods` output into (rows, ready count, steady-state
+/// total, names of pods not Running) WITHOUT printing, so the caller can render
+/// or serialize it (#485). Terminal and terminating pods stay in the rows but are
+/// excluded from the tally.
+fn collect_pod_summary(pods: &[serde_json::Value]) -> (Vec<PodRow>, usize, usize, Vec<String>) {
     let mut ready = 0usize;
     let mut total = 0usize;
     let mut unhealthy: Vec<String> = Vec::new();
-    let mut table_rows: Vec<Vec<String>> = Vec::new();
+    let mut table_rows: Vec<PodRow> = Vec::new();
     for pod in pods {
         let name = pod
             .get("metadata")
@@ -1491,7 +1655,11 @@ fn print_pod_summary(pods: &[serde_json::Value]) -> (usize, usize, Vec<String>) 
         } else {
             phase
         };
-        table_rows.push(vec![name.clone(), ready_col, display_status.to_string()]);
+        table_rows.push(PodRow {
+            name: name.clone(),
+            ready: ready_col,
+            status: display_status.to_string(),
+        });
         if phase == "Succeeded" || reason == "Completed" || terminating {
             continue;
         }
@@ -1504,14 +1672,7 @@ fn print_pod_summary(pods: &[serde_json::Value]) -> (usize, usize, Vec<String>) 
             unhealthy.push(name);
         }
     }
-    if !table_rows.is_empty() {
-        ui.payload_plain(&crate::ui::table(
-            &["pod", "ready", "status"],
-            &table_rows,
-            &[],
-        ));
-    }
-    (ready, total, unhealthy)
+    (table_rows, ready, total, unhealthy)
 }
 
 /// Resolve a routable node host: kubeconfig cluster server hostname, falling
@@ -1662,41 +1823,126 @@ fn node_internal_ip(nodes_json: &str) -> Option<String> {
 
 /// Print one service's access URL: a NodePort URL when exposed, else the
 /// port-forward command to reach a ClusterIP service.
-async fn print_service_url(o: &CommonOpts, suffix: &str, label: &str, host: &str, api: bool) {
-    let ui = crate::ui::ui();
+/// One resolved service URL row for `cluster status`. Owns its data so the
+/// status reading can be rendered (byte-identical to the prior `ui.kv` output)
+/// or serialized under `--json` (#485), instead of printing inline.
+#[derive(Debug)]
+pub struct ServiceUrl {
+    label: String,
+    name: String,
+    namespace: String,
+    api: bool,
+    kind: ServiceUrlKind,
+}
+
+#[derive(Debug)]
+enum ServiceUrlKind {
+    NotFound,
+    NodePortUrl(String),
+    UnassignedNodePort,
+    PortForward { local: u16, port: u16 },
+    Unreadable,
+}
+
+impl ServiceUrl {
+    fn to_json(&self) -> serde_json::Value {
+        let (url, note): (Option<String>, Option<String>) = match &self.kind {
+            ServiceUrlKind::NodePortUrl(url) => (Some(url.clone()), None),
+            ServiceUrlKind::NotFound => (None, Some(format!("service {} not found", self.name))),
+            ServiceUrlKind::UnassignedNodePort => (
+                None,
+                Some(format!(
+                    "service {} is NodePort but exposes no nodePort yet",
+                    self.name
+                )),
+            ),
+            ServiceUrlKind::PortForward { local, port } => {
+                let suffix_path = api_suffix_path(self.api);
+                (
+                    None,
+                    Some(port_forward_hint_with(
+                        &self.namespace,
+                        &self.name,
+                        *local,
+                        *port,
+                        &format!("http://localhost:{local}{suffix_path}"),
+                    )),
+                )
+            }
+            ServiceUrlKind::Unreadable => {
+                (None, Some(format!("could not read service {}", self.name)))
+            }
+        };
+        serde_json::json!({"name": self.label, "url": url, "note": note})
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match &self.kind {
+            ServiceUrlKind::NodePortUrl(url) => ui.kv(&self.label, &ui.url(url)),
+            ServiceUrlKind::NotFound => {
+                ui.kv(&self.label, &format!("service {} not found", self.name))
+            }
+            ServiceUrlKind::UnassignedNodePort => ui.kv(
+                &self.label,
+                &format!(
+                    "service {} is NodePort but exposes no nodePort yet",
+                    self.name
+                ),
+            ),
+            ServiceUrlKind::PortForward { local, port } => {
+                let suffix_path = api_suffix_path(self.api);
+                ui.kv(
+                    &self.label,
+                    &port_forward_hint_with(
+                        &self.namespace,
+                        &self.name,
+                        *local,
+                        *port,
+                        &ui.url(&format!("http://localhost:{local}{suffix_path}")),
+                    ),
+                )
+            }
+            ServiceUrlKind::Unreadable => ui.kv(
+                &self.label,
+                &format!("could not read service {}", self.name),
+            ),
+        }
+    }
+}
+
+async fn resolve_service_url(
+    o: &CommonOpts,
+    suffix: &str,
+    label: &str,
+    host: &str,
+    api: bool,
+) -> ServiceUrl {
     let name = format!("{}-{}", o.release, suffix);
+    let mk = |kind| ServiceUrl {
+        label: label.to_string(),
+        name: name.clone(),
+        namespace: o.namespace.clone(),
+        api,
+        kind,
+    };
     let (ok, out, _) = match run_capture(&svc_cmd(o, suffix)).await {
         Ok(res) => res,
-        Err(_) => {
-            ui.kv(label, &format!("service {name} not found"));
-            return;
-        }
+        Err(_) => return mk(ServiceUrlKind::NotFound),
     };
     if !ok {
-        ui.kv(label, &format!("service {name} not found"));
-        return;
+        return mk(ServiceUrlKind::NotFound);
     }
-    let suffix_path = api_suffix_path(api);
-    // Same discovery core as `cluster observability` (#460); this formatter owns
-    // the wording, so the status output stays byte-identical.
-    match resolve_service_endpoint(&out, host, api) {
-        ServiceEndpoint::NodePortUrl(url) => ui.kv(label, &ui.url(&url)),
-        ServiceEndpoint::UnassignedNodePort => ui.kv(
-            label,
-            &format!("service {name} is NodePort but exposes no nodePort yet"),
-        ),
-        ServiceEndpoint::PortForwardHint { local, port } => ui.kv(
-            label,
-            &port_forward_hint_with(
-                &o.namespace,
-                &name,
-                local,
-                port,
-                &ui.url(&format!("http://localhost:{local}{suffix_path}")),
-            ),
-        ),
-        ServiceEndpoint::Unreadable => ui.kv(label, &format!("could not read service {name}")),
-    }
+    // Same discovery core as `cluster observability` (#460); this owns the
+    // wording, so the status output stays byte-identical.
+    let kind = match resolve_service_endpoint(&out, host, api) {
+        ServiceEndpoint::NodePortUrl(url) => ServiceUrlKind::NodePortUrl(url),
+        ServiceEndpoint::UnassignedNodePort => ServiceUrlKind::UnassignedNodePort,
+        ServiceEndpoint::PortForwardHint { local, port } => {
+            ServiceUrlKind::PortForward { local, port }
+        }
+        ServiceEndpoint::Unreadable => ServiceUrlKind::Unreadable,
+    };
+    mk(kind)
 }
 
 /// From `kubectl get svc -o json`, return (type, first nodePort, first port).
@@ -2748,7 +2994,7 @@ mod tests {
     fn pod_summary_does_not_panic_on_empty() {
         // No items: empty items array.
         let items: Vec<serde_json::Value> = Vec::new();
-        let _ = print_pod_summary(&items);
+        let _ = collect_pod_summary(&items);
     }
 
     #[test]
@@ -2771,7 +3017,8 @@ mod tests {
         ]"#;
 
         let items: Vec<serde_json::Value> = serde_json::from_str(json).unwrap();
-        assert_eq!(print_pod_summary(&items), (10, 10, vec![]));
+        let (_, ready, total, unhealthy) = collect_pod_summary(&items);
+        assert_eq!((ready, total, unhealthy), (10, 10, vec![]));
     }
 
     #[test]
@@ -2783,8 +3030,9 @@ mod tests {
         ]"#;
 
         let items: Vec<serde_json::Value> = serde_json::from_str(json).unwrap();
+        let (_, ready, total, unhealthy) = collect_pod_summary(&items);
         assert_eq!(
-            print_pod_summary(&items),
+            (ready, total, unhealthy),
             (2, 3, vec!["dispatcher0".to_string()])
         );
     }

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -831,3 +831,123 @@ fn delete_output_json_shape_is_pinned() {
         json!({"agent": "weather", "deleted": true})
     );
 }
+
+// ---------------------------------------------------------------------------
+// The operator + deploy verbs' real-path `to_json` (#485)
+// ---------------------------------------------------------------------------
+//
+// These verbs' success path needs a live server/cluster, so the binary-driven
+// tests above cannot reach it. Pin their `to_json` shapes directly so a
+// dropped/renamed/added key fails here -- the same discipline the read verbs get.
+
+#[test]
+fn deploy_output_json_shape_is_pinned() {
+    use agentos::commands::DeployOutput;
+    assert_eq!(
+        DeployOutput {
+            plugin_name: "weather".to_string(),
+            label: "v1-123".to_string(),
+            env: "dev".to_string(),
+            agent_name: "weather".to_string(),
+            agent_id: "agt_1".to_string(),
+            version_label: "v1-123".to_string(),
+            version_id: "ver_1".to_string(),
+            channel: "unchanged (C123)".to_string(),
+            bundle_ref: "bundles/abc.tar.gz".to_string(),
+            bundle_sha256: "deadbeef00".to_string(),
+            bundle_size_bytes: 4096,
+            deployment_id: "dep_1".to_string(),
+            deployment_environment: "dev".to_string(),
+            deployment_status: "active".to_string(),
+        }
+        .to_json(),
+        json!({
+            "plugin": "weather",
+            "label": "v1-123",
+            "environment": "dev",
+            "agent": {"name": "weather", "id": "agt_1"},
+            "version": {"label": "v1-123", "id": "ver_1"},
+            "channel": "unchanged (C123)",
+            "bundle": {"ref": "bundles/abc.tar.gz", "sha256": "deadbeef00", "size_bytes": 4096},
+            "deployment": {"id": "dep_1", "environment": "dev", "status": "active"},
+        })
+    );
+}
+
+#[test]
+fn comms_output_json_shape_is_pinned() {
+    use agentos::comms::CommsOutput;
+    assert_eq!(
+        CommsOutput::DryRun(plan(&["helm upgrade"])).to_json(),
+        json!({"dry_run": true, "plan": ["helm upgrade"]})
+    );
+    // The disconnect case must emit `connected: false`, not omit the key.
+    assert_eq!(
+        CommsOutput::Done { connected: false }.to_json(),
+        json!({"connected": false})
+    );
+    assert_eq!(
+        CommsOutput::Done { connected: true }.to_json(),
+        json!({"connected": true})
+    );
+}
+
+#[test]
+fn cluster_up_down_output_json_shapes_are_pinned() {
+    use agentos::ops::{ClusterDownOutput, ClusterUpOutput};
+    assert_eq!(
+        ClusterUpOutput::Up {
+            namespace: "agentos".to_string(),
+            release: "agentos".to_string(),
+        }
+        .to_json(),
+        json!({"status": "up", "namespace": "agentos", "release": "agentos"})
+    );
+    assert_eq!(
+        ClusterDownOutput::Aborted.to_json(),
+        json!({"down": false, "aborted": true})
+    );
+    assert_eq!(
+        ClusterDownOutput::Down {
+            release_was_absent: false,
+        }
+        .to_json(),
+        json!({"down": true, "release_was_absent": false})
+    );
+}
+
+#[test]
+fn local_operator_output_json_shapes_are_pinned() {
+    use agentos::local::{LocalDownOutput, LocalStatusOutput, LocalUpOutput};
+    assert_eq!(
+        LocalUpOutput::Up {
+            endpoints: vec![("Console".to_string(), "http://localhost:28080".to_string())],
+            slack: false,
+        }
+        .to_json(),
+        json!({
+            "status": "up",
+            "endpoints": [{"name": "Console", "url": "http://localhost:28080"}],
+            "slack": false,
+        })
+    );
+    assert_eq!(
+        LocalStatusOutput::Services {
+            rows: vec!["NAME  STATUS".to_string()],
+        }
+        .to_json(),
+        json!({"services": ["NAME  STATUS"]})
+    );
+    assert_eq!(
+        LocalDownOutput::Down {
+            volumes_wiped: true,
+            reaped: 2,
+        }
+        .to_json(),
+        json!({"stopped": true, "volumes_wiped": true, "runners_reaped": 2})
+    );
+    assert_eq!(
+        LocalDownOutput::Aborted.to_json(),
+        json!({"stopped": false, "aborted": true})
+    );
+}


### PR DESCRIPTION
Under `--json`, every agent-facing verb must emit one JSON object to stdout — never empty stdout (#456, ADR-0021). The operator verbs (`local`/`cluster` `up`/`down`/`status`/`comms`), `deploy`, and `skill message` still ended their **real-path success** on the stdout emitters (`payload`/`kv`/`payload_plain`) or streamed answer tokens, all of which suppress under `--json` — so on success they exited 0 with empty stdout, the worst failure mode for an agent consumer.

Each now returns a typed `CliOutput` routed through the one `Ui::emit` success point:

- `deploy` → `DeployOutput`
- `cluster up`/`down`/`status` → `ClusterUp`/`Down`/`StatusOutput` (status's pod-table and service-URL helpers refactored to **collect** data rather than print, so the reading can be rendered byte-identically or serialized)
- `local up`/`status`/`down` → `LocalUp`/`Status`/`DownOutput`
- `local`/`cluster comms` → `CommsOutput`
- `skill message` buffers the streamed reply into one `SkillMessageOutput` under `--json`; the human path still streams live

`to_json` shapes are pinned by new unit tests in `json_emit_contract.rs`. No command-surface change, so no manifest regen. Updated the `cli/CLAUDE.md` invariant to reflect closure.

Closes #485
Ref CUR-1630