### PR TITLE
Wire the offline soak harness into CI and de-flake the sweeper test

### DIFF
--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -1506,8 +1506,19 @@ def test_run_expiry_sweeper_loop_sweeps_and_stops(
                         record = await crud.get_approval(session, approval_id)
                         assert record is not None
                         status = record.status
-                # The loop also enqueued the expiry resume turn.
-                assert len(await client.xrange(runs_stream)) == 1
+                # The loop also enqueued the expiry resume turn -- but the flip
+                # commits (crud.expire_approval) BEFORE the enqueue runs, so the
+                # status poll above can win the race between them. Poll for the
+                # stream entry too rather than asserting it immediately, or the
+                # sweeper's flip-before-enqueue ordering flakes this under load.
+                entries = await client.xrange(runs_stream)
+                while len(entries) < 1:
+                    assert asyncio.get_running_loop().time() < deadline, (
+                        "sweeper flipped the record but never enqueued the resume turn"
+                    )
+                    await asyncio.sleep(0.05)
+                    entries = await client.xrange(runs_stream)
+                assert len(entries) == 1
             finally:
                 stop.set()
                 # Wait-first loop wakes immediately on stop; it must finish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ testpaths = [
     "compose/tests",
     "examples/tests",
     "tools/doclint/tests",
+    # Only the offline harness unit tests -- NOT the whole tree: the cluster
+    # scenario in test_soak_resilience.py stays out of default collection and
+    # runs only under AGENTOS_SOAK=1 (#499).
+    "tests/soak/test_harness_unit.py",
 ]
 
 [tool.ruff]

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -18,8 +18,10 @@ The scenario never runs in default CI. It is gated on `AGENTOS_SOAK=1` and skips
 cleanly with no cluster. The pure-helper unit tests in `test_harness_unit.py`
 always run (offline, no cluster) and cover the deterministic harness logic.
 
-`tests/soak` is intentionally not in the pytest `testpaths`, so the scenario runs
-only when invoked by explicit path.
+Only `test_harness_unit.py` is in the pytest `testpaths` (`pyproject.toml`), so
+the offline helpers run in default CI while `test_soak_resilience.py` (the
+cluster scenario) stays out of default collection and runs only when invoked by
+explicit path or under `AGENTOS_SOAK=1`.
 
 ## How to run
 


### PR DESCRIPTION
Two small test-plumbing fixes.

**#422 — flaky sweeper test.** `test_run_expiry_sweeper_loop_sweeps_and_stops` polled until the approval status flipped to `expired`, then *immediately* asserted the resume-turn stream had one entry. But the sweeper commits the status flip (`crud.expire_approval`) **before** it enqueues the resume turn, so the status poll can win the race between the two — leaving the stream momentarily empty and flaking the assert under load. Keep the status poll, then poll for the stream entry too (bounded by the same 5s deadline). The sweeper ordering is untouched.

**#499 — soak harness ran nowhere.** `tests/soak/test_harness_unit.py` (12 offline, dependency-light unit tests over the harness helpers) was never collected: `tests/soak` was absent from pytest `testpaths`, so CI skipped it despite the README claiming the offline tests "always run" — a false coverage signal. Add just the offline file to `testpaths` (not the directory), so the cluster scenario in `test_soak_resilience.py` stays out of default collection behind its existing `AGENTOS_SOAK=1` gate. README corrected.

Closes #422
Closes #499
Ref CUR-1631