### PR TITLE
Classify a controller lease timeout distinctly from an RBAC failure

### DIFF
--- a/charts/agentos/ci/controller-rbac-assertions.sh
+++ b/charts/agentos/ci/controller-rbac-assertions.sh
@@ -245,5 +245,19 @@ if ! out="$(python3 "$ASSERT_PY" "$DEFAULT" "$NOCTRL" "$NOGATE" "$NS" 2>&1)"; th
 fi
 echo "$out"
 
+# --- (e) The preflight FAIL diagnostic classifies the CAUSE (issue #507) ---
+# A leader-election lease timeout and the #350 RBAC crash-loop both restart the
+# controller pod, so the gate must not blame NetworkPolicy RBAC unconditionally.
+# Assert the rendered Job script both DETECTS the lease signal and emits a
+# lease-specific (non-RBAC) diagnostic, so a regression back to the hardcoded
+# RBAC blame fails here.
+grep -q "leader election lost\|failed to renew lease" "$DEFAULT" \
+  || fail "(e) cause classification — preflight script must grep for a leader-election lease signal (issue #507)"
+grep -q "lost its leader-election lease" "$DEFAULT" \
+  || fail "(e) cause classification — preflight FAIL diagnostic must have a lease-specific branch (issue #507)"
+grep -q "NOT an RBAC/NetworkPolicy problem" "$DEFAULT" \
+  || fail "(e) cause classification — the lease diagnostic must explicitly disclaim RBAC as the cause (issue #507)"
+echo "  ok: (e) the controller-ready gate distinguishes a lease timeout from an RBAC failure"
+
 echo
-echo "PASS: exactly one read-only cluster networkpolicies grant (get/list/watch, bound to the controller SA); no cluster-wide mutate anywhere; namespaced Role keeps mutate and drops list/watch; the controller-ready gate renders on defaults and suppresses correctly under both flags."
+echo "PASS: exactly one read-only cluster networkpolicies grant (get/list/watch, bound to the controller SA); no cluster-wide mutate anywhere; namespaced Role keeps mutate and drops list/watch; the controller-ready gate renders on defaults, suppresses correctly under both flags, and classifies a lease timeout distinctly from an RBAC failure."

--- a/charts/agentos/templates/preflight-controller.yaml
+++ b/charts/agentos/templates/preflight-controller.yaml
@@ -130,7 +130,11 @@ spec:
               # The load-bearing assertion: poll the controller log for
               # "Starting workers" (emitted only after all informer caches
               # sync). Fail fast on a forbidden-networkpolicies log line or a
-              # restarting pod -- those are the #350 crash-loop signature.
+              # restarting pod. A restart is NOT diagnostic on its own: the #350
+              # crash-loop (RBAC) and a leader-election lease timeout (#507) both
+              # restart the pod, so classify the CAUSE from the logs instead of
+              # blaming NetworkPolicy RBAC unconditionally.
+              cause=unknown
               elapsed=0
               while [ "${elapsed}" -lt "${TIMEOUT}" ]; do
                 logs=$(kubectl logs "deployment/${DEPLOY}" -n "${CONTROLLER_NS}" --tail=-1 2>/dev/null || true)
@@ -157,10 +161,21 @@ spec:
                   prev=$(kubectl logs "deployment/${DEPLOY}" -n "${CONTROLLER_NS}" --tail=-1 --previous 2>/dev/null || true)
                 fi
 
-                if echo "${logs}" | grep -Eq "networkpolicies.*[Ff]orbidden" \
-                   || echo "${prev}" | grep -Eq "networkpolicies.*[Ff]orbidden" \
-                   || [ "${restarted}" -eq 1 ]; then
-                  echo "detected controller failure (forbidden networkpolicies log and/or restartCount>0)."
+                # Classify by the actual log signal, most-specific first. The
+                # forbidden-networkpolicies line is the #350 RBAC signature; a
+                # leader-election lease loss is the #507 signature (the manager
+                # exits and the pod restarts, but RBAC is fine).
+                if echo "${logs}${prev}" | grep -Eq "networkpolicies.*[Ff]orbidden"; then
+                  cause=rbac
+                  echo "detected controller failure (forbidden networkpolicies log)."
+                  break
+                elif echo "${logs}${prev}" | grep -Eq "leader election lost|failed to renew lease|error retrieving resource lock|timed out waiting for the condition.*lease"; then
+                  cause=lease
+                  echo "detected controller failure (leader-election lease not renewed)."
+                  break
+                elif [ "${restarted}" -eq 1 ]; then
+                  cause=restart
+                  echo "detected controller restart (restartCount>0) with no recognized failure signature."
                   break
                 fi
 
@@ -175,10 +190,26 @@ spec:
               echo "controller pod status:"
               kubectl get pods -n "${CONTROLLER_NS}" -l app=agent-sandbox-controller 2>/dev/null || true
               echo "---"
-              echo "RESULT: FAIL -- controller did not reach 'Starting workers' -- its NetworkPolicy"
-              echo "        informer likely cannot sync. Verify ClusterRole"
-              echo "        agent-sandbox-controller-networkpolicies-read exists and grants"
-              echo "        get/list/watch on networkpolicies cluster-wide (issue #350 / ADR-0023)."
+              case "${cause}" in
+                rbac)
+                  echo "RESULT: FAIL -- controller did not reach 'Starting workers' -- its NetworkPolicy"
+                  echo "        informer cannot sync (forbidden-networkpolicies logged). Verify ClusterRole"
+                  echo "        agent-sandbox-controller-networkpolicies-read exists and grants"
+                  echo "        get/list/watch on networkpolicies cluster-wide (issue #350 / ADR-0023)."
+                  ;;
+                lease)
+                  echo "RESULT: FAIL -- controller lost its leader-election lease before syncing (issue #507)."
+                  echo "        This is NOT an RBAC/NetworkPolicy problem -- the lease could not be renewed"
+                  echo "        in time, typically under API-server saturation or a too-tight lease deadline."
+                  echo "        Retry once the API server is healthy; if it recurs, loosen the controller's"
+                  echo "        leader-election lease/renew deadlines."
+                  ;;
+                *)
+                  echo "RESULT: FAIL -- controller did not reach 'Starting workers' within ${TIMEOUT}s and no"
+                  echo "        recognized failure signature (forbidden-networkpolicies or lease loss) was"
+                  echo "        logged. Inspect the controller log lines above for the cause."
+                  ;;
+              esac
               echo "        If this is an upgrade over a previously crash-looping controller, the"
               echo "        pod may still be in CrashLoopBackOff backoff -- delete the controller"
               echo "        pod and re-run 'helm test <release>'."


### PR DESCRIPTION
The controller-ready preflight (`templates/preflight-controller.yaml`) treated **any** `restartCount>0` as the #350 NetworkPolicy-RBAC crash-loop signature, and printed a hardcoded "verify the `agent-sandbox-controller-networkpolicies-read` ClusterRole" diagnostic on **every** FAIL path. But a leader-election lease timeout also restarts the controller pod (the manager loses the lease and exits), so an operator whose RBAC was perfectly fine got sent chasing a ClusterRole that was never the problem.

Now the poll loop classifies the failure cause from the controller log — `forbidden networkpolicies` ⇒ `rbac`, `leader election lost` / `failed to renew lease` ⇒ `lease`, else `unknown` — and the FAIL block is a `case` on that cause. The lease diagnostic explicitly disclaims RBAC and points at lease-renewal / API-server saturation; the unknown case makes no subsystem attribution. A bare restart with no recognized signature no longer implies RBAC.

Extended `ci/controller-rbac-assertions.sh` with assertion (e): the rendered Job script must contain the lease grep branch and the lease-specific, RBAC-disclaiming diagnostic, so a regression back to unconditional RBAC blame fails CI.

Closes #507
Ref CUR-1632