### PR TITLE
Resolve policy-gate routes on the fake-model tier too

### DIFF
--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -127,6 +127,9 @@ def build_runner(
                 can_use_tool=(
                     build_can_use_tool(approval_gate) if approval_gate is not None else None
                 ),
+                # Share the same gate so a scripted request_approval resolves its
+                # route through the real decision table on the offline tier (#561).
+                approval_gate=approval_gate,
             )
         plugins = load_plugins(config.session.plugin_dir)
         options = build_options(

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -131,58 +131,93 @@ def build_approval_server(gate: ApprovalGate | None = None) -> McpSdkServerConfi
     shipped two silent fail-opens).
     """
 
-    declared = _distinct_routes(gate)
-
     @tool(_TOOL_NAME, _TOOL_DESCRIPTION, _TOOL_SCHEMA)
     async def request_approval(args: dict[str, Any]) -> dict[str, Any]:
-        if gate is not None:
-            # policy_requested is sticky-True: any call this turn means a policy
-            # gate was raised. The per-request outcome (rejected/route), though,
-            # must be fully determined by THIS call so the last call in the turn
-            # wins -- a retry with a valid route after an is_error refusal must
-            # clear the prior rejection, or _merge_gate_block drops the approval
-            # the retry created (#544, Decision B recovery path).
-            gate.policy_requested = True
-            gate.policy_rejected = False
-            gate.policy_route = None
-        summary = str(args.get("summary") or "").strip()
-        if not summary:
-            if gate is not None:
-                gate.policy_rejected = True
-            return _approval_error(
-                "Rejected: pass a non-empty summary of what needs approval."
-            )
-        raw_route = args.get("route")
-        route = str(raw_route).strip() if raw_route is not None else ""
-        if declared:
-            if not route:
-                if len(declared) == 1:
-                    # Unambiguous: the manifest declares exactly one route, so
-                    # bind it rather than guessing or refusing.
-                    if gate is not None:
-                        gate.policy_route = declared[0]
-                else:
-                    if gate is not None:
-                        gate.policy_rejected = True
-                    return _approval_error(
-                        "Rejected: this decision has more than one approval route;"
-                        f" pass route as one of: {', '.join(declared)}."
-                    )
-            elif route in declared:
-                if gate is not None:
-                    gate.policy_route = route
-            else:
-                if gate is not None:
-                    gate.policy_rejected = True
-                return _approval_error(
-                    f"Rejected: unknown approval route {route!r};"
-                    f" pass route as one of: {', '.join(declared)}."
-                )
-        return _APPROVAL_OK
+        return process_approval_request(gate, args)
 
     return create_sdk_mcp_server(
         name=APPROVAL_SERVER_NAME, version="1.0.0", tools=[request_approval]
     )
+
+
+def resolve_policy_route(
+    declared: list[str], raw_route: Any
+) -> tuple[bool, str | None, str | None]:
+    """The pure route-resolution decision table (#544 Decision B, #561).
+
+    Returns ``(rejected, resolved_route, error_message)`` for a model-supplied
+    ``raw_route`` against the gate's ``declared`` manifest routes:
+
+    - no declared routes -> generic policy approval, ``(False, None, None)``;
+    - omitted route, exactly one declared -> auto-bind it, unambiguous;
+    - omitted route, more than one declared -> refuse (ambiguous);
+    - a declared route -> accept it;
+    - an unknown route -> refuse.
+
+    The route is normalized identically to ``load_approval_policy`` (a
+    ``.strip()``) so a route that validates green at deploy cannot fail to match
+    at runtime (#453). This is the ONE decision table both the real SDK path (the
+    ``request_approval`` tool) and the offline fake path share, so the fake tier
+    cannot silently widen a card to the requesting channel (#561).
+    """
+
+    route = str(raw_route).strip() if raw_route is not None else ""
+    if not declared:
+        return (False, None, None)
+    if not route:
+        if len(declared) == 1:
+            return (False, declared[0], None)
+        return (
+            True,
+            None,
+            "Rejected: this decision has more than one approval route;"
+            f" pass route as one of: {', '.join(declared)}.",
+        )
+    if route in declared:
+        return (False, route, None)
+    return (
+        True,
+        None,
+        f"Rejected: unknown approval route {route!r};"
+        f" pass route as one of: {', '.join(declared)}.",
+    )
+
+
+def process_approval_request(
+    gate: ApprovalGate | None, args: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply one ``request_approval`` call to ``gate`` and return the model result.
+
+    The single source of truth for the approval-request outcome, invoked from
+    BOTH the in-process MCP tool (real SDK path) and ``FakeModelSession`` (offline
+    path), so the two tiers resolve routes identically (#561). It mutates the
+    sticky policy flags on ``gate`` and returns the tool result the model sees.
+    """
+
+    if gate is not None:
+        # policy_requested is sticky-True: any call this turn means a policy
+        # gate was raised. The per-request outcome (rejected/route), though,
+        # must be fully determined by THIS call so the last call in the turn
+        # wins -- a retry with a valid route after an is_error refusal must
+        # clear the prior rejection, or _merge_gate_block drops the approval
+        # the retry created (#544, Decision B recovery path).
+        gate.policy_requested = True
+        gate.policy_rejected = False
+        gate.policy_route = None
+    summary = str(args.get("summary") or "").strip()
+    if not summary:
+        if gate is not None:
+            gate.policy_rejected = True
+        return _approval_error("Rejected: pass a non-empty summary of what needs approval.")
+    rejected, route, error = resolve_policy_route(_distinct_routes(gate), args.get("route"))
+    if rejected:
+        if gate is not None:
+            gate.policy_rejected = True
+        assert error is not None
+        return _approval_error(error)
+    if route is not None and gate is not None:
+        gate.policy_route = route
+    return _APPROVAL_OK
 
 
 # --- The permission gate (#245): canUseTool over approval-required tools --------

--- a/runner/src/agentos_runner/fake.py
+++ b/runner/src/agentos_runner/fake.py
@@ -21,6 +21,8 @@ from claude_agent_sdk import (
 )
 from claude_agent_sdk.types import CanUseTool, ToolPermissionContext
 
+from .approval import APPROVAL_TOOL_NAME, ApprovalGate, process_approval_request
+
 
 def _assistant(*blocks: Any, usage: dict[str, Any] | None = None) -> AssistantMessage:
     return AssistantMessage(content=list(blocks), model="fake-model", usage=usage)
@@ -114,10 +116,16 @@ class FakeModelSession:
         *,
         truncate_on_interrupt: bool = True,
         can_use_tool: CanUseTool | None = None,
+        approval_gate: ApprovalGate | None = None,
     ) -> None:
         self._script_factory = script_factory or self._default_script
         self._truncate_on_interrupt = truncate_on_interrupt
         self._can_use_tool = can_use_tool
+        # The shared policy gate (#561): a scripted request_approval block must
+        # run the SAME route-resolution decision table the real MCP tool does, or
+        # the fake tier omits the sole-route auto-bind / unknown-route refusal and
+        # silently widens the card -- the exact real-path regression #544 closed.
+        self._approval_gate = approval_gate
         self.connected = False
         self.queries: list[str] = []
         self.interrupts = 0
@@ -167,12 +175,20 @@ class FakeModelSession:
         the un-gated fake unchanged.
         """
 
-        if self._can_use_tool is None:
-            return
         if not isinstance(message, AssistantMessage):
             return
         for block in message.content:
-            if isinstance(block, ToolUseBlock):
+            if not isinstance(block, ToolUseBlock):
+                continue
+            if block.name == APPROVAL_TOOL_NAME and self._approval_gate is not None:
+                # Run the real decision table so the container fake tier resolves
+                # the route (sole-route auto-bind, unknown-route refusal) and sets
+                # the same sticky gate flags _merge_gate_block reconciles (#561).
+                # build_can_use_tool below leaves the (un-gated) approval tool
+                # untouched, so this is the only thing that sets the policy fields.
+                payload = block.input if isinstance(block.input, dict) else {}
+                process_approval_request(self._approval_gate, payload)
+            if self._can_use_tool is not None:
                 await self._can_use_tool(block.name, block.input, ToolPermissionContext())
 
     async def close(self) -> None:

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -840,6 +840,72 @@ def test_policy_gate_unknown_route_is_an_error_naming_valid_routes() -> None:
     anyio.run(go)
 
 
+async def _run_container_fake_policy_turn(
+    gate: ApprovalGate, summary: str, route: str | None = None
+) -> list[dict[str, object]]:
+    """Drive a policy turn on the CONTAINER fake tier (#561).
+
+    Unlike ``_run_policy_turn``, this wires the fake exactly as ``__main__``
+    does for ``AGENTOS_FAKE_MODEL`` -- ``can_use_tool=build_can_use_tool(gate)``
+    and ``approval_gate=gate`` -- with NO test-only callback that executes the
+    approval tool. So it exercises the real production offline path: the fake
+    itself must run the route-resolution decision table. Before #561 it did not,
+    and an omitted/unknown route flowed straight to the final unresolved.
+    """
+
+    session = FakeModelSession(
+        lambda: approval_turn(summary, route=route),
+        can_use_tool=build_can_use_tool(gate),
+        approval_gate=gate,
+    )
+    runner = SessionRunner(
+        session_factory=lambda: session,
+        ceiling=10_000,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="test",
+        session_id="s-1",
+        approval_gate=gate,
+    )
+    await runner.start()
+    return await _drain(runner, "please decide")
+
+
+def test_container_fake_binds_the_sole_route_and_refuses_bad_routes() -> None:
+    """#561: the container fake tier resolves routes like the real SDK path.
+
+    A parity break otherwise: the offline tier would leave a sole-route gate's
+    route None (card widens to the requesting channel) and let an unknown route
+    reach the final verbatim -- the exact regressions #544 closed on the real
+    path, silently reopened on local/cluster fake-model runs.
+    """
+
+    async def go() -> None:
+        # (1) sole declared route, omitted argument -> auto-bound.
+        gate = ApprovalGate(required=frozenset({"Bash"}), route_by_tool={"Bash": "managers"})
+        final = (await _run_container_fake_policy_turn(gate, "Discount for ACME"))[-1]
+        assert final["status"] == "awaiting-approval"
+        assert final["approval_route"] == "managers"
+
+        # (2) two declared routes, omitted argument -> ambiguous, refused: the
+        # turn does not end awaiting-approval on an unresolved route.
+        gate = ApprovalGate(
+            required=frozenset({"Bash", "Write"}),
+            route_by_tool={"Bash": "managers", "Write": "legal"},
+        )
+        final = (await _run_container_fake_policy_turn(gate, "Discount"))[-1]
+        assert final["approval_route"] is None
+        assert final["approval_summary"] is None
+
+        # (3) unknown route -> refused, never reaches the final verbatim.
+        gate = ApprovalGate(required=frozenset({"Bash"}), route_by_tool={"Bash": "managers"})
+        final = (await _run_container_fake_policy_turn(gate, "Discount", route="not-a-route"))[-1]
+        assert final["approval_route"] != "not-a-route"
+        assert final["approval_summary"] is None
+
+    anyio.run(go)
+
+
 def _write_bundle(tmp_path, route: str) -> str:
     """A minimal deployable bundle declaring one gate with ``route``."""
 


### PR DESCRIPTION
The policy-gate route-resolution decision table — sole-declared-route auto-bind, unknown/ambiguous-route refusal, `.strip()` normalization (#544 Decision B, #453) — lived *inside* the in-process `request_approval` MCP tool closure. That closure only executes on the real SDK path. The offline fake model (`AGENTOS_FAKE_MODEL`, `agentos skill up --fake-model`, the chart's sealed default pool) never ran it: its `_apply_gate` only ran the permission gate over tool blocks and never touched the scripted `request_approval` block. So on the fake tier:

- a manifest declaring exactly one route with the model omitting `route` left `approval_route = None` — the card widens to the requesting channel (the AC2 regression #544 closed on the real path), and
- an unknown route flowed straight through to the final as an arbitrary string instead of an `is_error` refusal.

A real local/cluster parity break.

Fix: extract the decision table into pure `resolve_policy_route(...)` + `process_approval_request(gate, args)` in `approval.py`. The real MCP tool is now a one-line wrapper over `process_approval_request`, and `FakeModelSession` calls the same function when it replays a scripted `request_approval` block — setting the identical sticky `policy_requested`/`policy_rejected`/`policy_route` flags that `_merge_gate_block` reconciles at turn end. `__main__` passes the shared `approval_gate` into the fake. New regression test drives the fake wired exactly as `__main__` does (no test-only executing callback) across the sole-route/ambiguous/unknown cases.

Entirely runner-internal — no frozen-contract change.

Closes #561
Ref CUR-1633