### PR TITLE
Distinguish unknown cost from $0.00 and drop eval traces from the summary

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -953,6 +953,11 @@
       "CostReport": {
         "description": "Daily spend series + total for an agent (L1 Cost view).",
         "properties": {
+          "cost_known": {
+            "default": true,
+            "title": "Cost Known",
+            "type": "boolean"
+          },
           "end": {
             "title": "End",
             "type": "string"
@@ -1735,6 +1740,11 @@
       "MetricsSummary": {
         "description": "Scalar totals for the Metrics tab stat row over a time window.",
         "properties": {
+          "cost_known": {
+            "default": true,
+            "title": "Cost Known",
+            "type": "boolean"
+          },
           "cost_usd": {
             "title": "Cost Usd",
             "type": "number"

--- a/apps/api/src/agentos_api/metrics.py
+++ b/apps/api/src/agentos_api/metrics.py
@@ -60,6 +60,15 @@ def resolve_window(
     return start_dt.isoformat(), end_dt.isoformat()
 
 
+# Eval traces are named `eval:<suite>:<case_id>` by the worker's eval recorder.
+# They are real billed runs but they are NOT product traffic, so counting them in
+# the OB1 metrics/cost summary inflates runs/tokens/cost with eval activity (#547).
+# The eval matrix has its own surface (EvalModelSummary); exclude eval traces here.
+# Excluded via the same name column the agent filter matches on, so no untested
+# filter shape is introduced.
+_EVAL_TRACE_PREFIX = "eval:"
+
+
 def _filters(view: str, environment: str | None, agent: str | None) -> list[dict[str, Any]]:
     name_col = "name" if view == "traces" else "traceName"
     filters: list[dict[str, Any]] = []
@@ -71,6 +80,17 @@ def _filters(view: str, environment: str | None, agent: str | None) -> list[dict
         filters.append(
             {"column": name_col, "operator": "contains", "value": agent, "type": "string"}
         )
+    # Drop eval traces from the aggregate (#547). Harmless when `agent` is set (an
+    # agent's `agentos-run:` traces never carry the eval name), load-bearing on the
+    # summary tab where `agent` is None and every trace in the window is counted.
+    filters.append(
+        {
+            "column": name_col,
+            "operator": "does not contain",
+            "value": _EVAL_TRACE_PREFIX,
+            "type": "string",
+        }
+    )
     return filters
 
 
@@ -152,8 +172,39 @@ async def summary(
         latency_p95_ms=scalars["latency_p95_ms"],
         tokens=int(scalars["tokens"]),
         cost_usd=scalars["cost_usd"],
+        cost_known=_cost_known(scalars["tokens"], scalars["cost_usd"]),
         error_rate=_error_rate(level_rows),
     )
+
+
+def _cost_known(tokens: float, cost_usd: float) -> bool:
+    """Whether a summed cost of `cost_usd` is a real total or a priced-to-zero gap.
+
+    Langfuse returns a generation's cost by matching its model to a stored price
+    row; with no matching row it returns 0 even when tokens were spent. So a
+    ``cost_usd == 0`` with ``tokens > 0`` is "cost unknown" (a missing price row),
+    not "free" -- the exact $0.00-for-a-billed-run confusion in #547. A genuinely
+    zero-token window (no work) stays cost-known.
+    """
+
+    return not (tokens > 0 and cost_usd == 0.0)
+
+
+async def cost_known(
+    lf: LangfuseClient,
+    start: str,
+    end: str,
+    environment: str | None,
+    agent: str | None,
+) -> bool:
+    """The `cost_known` flag for a window, for callers (get_cost) that fetch cost
+    without the token total. Runs the one extra tokens query summary already has."""
+
+    cost_rows = await lf.query_metrics(_scalar_query("cost_usd", start, end, environment, agent))
+    token_rows = await lf.query_metrics(_scalar_query("tokens", start, end, environment, agent))
+    cost = _num(cost_rows[0], _SPEC["cost_usd"][3]) if cost_rows else 0.0
+    tokens = _num(token_rows[0], _SPEC["tokens"][3]) if token_rows else 0.0
+    return _cost_known(tokens, cost)
 
 
 async def series(

--- a/apps/api/src/agentos_api/routers/control.py
+++ b/apps/api/src/agentos_api/routers/control.py
@@ -117,18 +117,17 @@ async def get_cost(
     # Cost is filtered by the agent's trace-name token: the runner names traces
     # agentos-run:agent-<id>-thread-<ts>, so we match traceName contains
     # `agent-<id>`. A fresh agent with no matching traces reads zero.
+    agent_filter = metrics_service.agent_trace_filter(agent.id)
     series = await metrics_service.series(
-        lf,
-        "cost_usd",
-        start_iso,
-        end_iso,
-        "day",
-        None,
-        metrics_service.agent_trace_filter(agent.id),
+        lf, "cost_usd", start_iso, end_iso, "day", None, agent_filter
     )
+    # A total of 0 over a window with token usage is a missing Langfuse price row,
+    # not a free agent -- flag it so the Cost view renders "unknown" not $0.00 (#547).
+    known = await metrics_service.cost_known(lf, start_iso, end_iso, None, agent_filter)
     return CostReport(
         start=start_iso,
         end=end_iso,
         total_usd=sum(point.value for point in series.points),
+        cost_known=known,
         points=series.points,
     )

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -615,6 +615,11 @@ class MetricsSummary(BaseModel):
     latency_p95_ms: float
     tokens: int
     cost_usd: float
+    # False when work happened (tokens > 0) but Langfuse priced it to exactly 0 --
+    # a missing model price row, not a genuinely free run (#547). Additive and
+    # defaulting True, so `cost_usd` stays a non-nullable float for existing
+    # clients; consumers render "unknown" rather than a misleading $0.00.
+    cost_known: bool = True
     error_rate: float
 
 
@@ -776,6 +781,10 @@ class CostReport(BaseModel):
     start: str
     end: str
     total_usd: float
+    # False when tokens were spent in the window but Langfuse priced them to 0
+    # (a missing model price row, not free usage) -- see MetricsSummary.cost_known
+    # (#547). Additive, defaults True; total_usd stays a non-nullable float.
+    cost_known: bool = True
     points: list[MetricPoint]
 
 

--- a/apps/api/tests/test_metrics_integration.py
+++ b/apps/api/tests/test_metrics_integration.py
@@ -152,6 +152,17 @@ def test_summary_matches_langfuse_aggregates(
         {
             "view": "traces",
             "metrics": [{"measure": "count", "aggregation": "count"}],
+            # The summary excludes eval traces (#547), so the reference aggregate
+            # must exclude them too or the counts diverge when the shared Langfuse
+            # holds eval traces in the window.
+            "filters": [
+                {
+                    "column": "name",
+                    "operator": "does not contain",
+                    "value": "eval:",
+                    "type": "string",
+                }
+            ],
             "fromTimestamp": start,
             "toTimestamp": end,
         }
@@ -162,6 +173,16 @@ def test_summary_matches_langfuse_aggregates(
         {
             "view": "observations",
             "metrics": [{"measure": "totalCost", "aggregation": "sum"}],
+            # Same eval exclusion as the summary (#547); observations key on
+            # traceName.
+            "filters": [
+                {
+                    "column": "traceName",
+                    "operator": "does not contain",
+                    "value": "eval:",
+                    "type": "string",
+                }
+            ],
             "fromTimestamp": start,
             "toTimestamp": end,
         }
@@ -207,7 +228,14 @@ def test_environment_filter_passes_through(
             "view": "traces",
             "metrics": [{"measure": "count", "aggregation": "count"}],
             "filters": [
-                {"column": "environment", "operator": "=", "value": "default", "type": "string"}
+                {"column": "environment", "operator": "=", "value": "default", "type": "string"},
+                # The summary excludes eval traces (#547); match it here too.
+                {
+                    "column": "name",
+                    "operator": "does not contain",
+                    "value": "eval:",
+                    "type": "string",
+                },
             ],
             "fromTimestamp": start,
             "toTimestamp": end,

--- a/apps/api/tests/test_metrics_unit.py
+++ b/apps/api/tests/test_metrics_unit.py
@@ -3,12 +3,34 @@
 import uuid
 
 from agentos_api.metrics import (
+    _cost_known,
     _error_rate,
     _filters,
     _scalar_query,
     agent_trace_filter,
     resolve_window,
 )
+
+
+def test_filters_exclude_eval_traces_from_the_aggregate() -> None:
+    # #547: eval traces (`eval:<suite>:<case>`) are billed but not product
+    # traffic; the summary must exclude them so runs/tokens/cost aren't inflated.
+    for view, name_col in (("traces", "name"), ("observations", "traceName")):
+        filters = _filters(view, None, None)
+        assert {
+            "column": name_col,
+            "operator": "does not contain",
+            "value": "eval:",
+            "type": "string",
+        } in filters, view
+
+
+def test_cost_known_flags_priced_to_zero_as_unknown() -> None:
+    # #547: tokens spent but cost summed to exactly 0 => a missing Langfuse price
+    # row, not a free run. A genuinely zero-work window stays cost-known.
+    assert _cost_known(tokens=2576, cost_usd=0.0) is False
+    assert _cost_known(tokens=2576, cost_usd=0.0506) is True
+    assert _cost_known(tokens=0, cost_usd=0.0) is True
 
 
 def test_agent_trace_filter_is_the_agent_id_token() -> None:


### PR DESCRIPTION
Two OB1 observability defects (#547).

**(a) $0.00 for a live billed run.** Langfuse derives a generation's cost by matching its model to a stored price row; with no matching row it returns `0` even when real tokens were spent (an OpenRouter-routed model with no seeded price prices to `0`, not `null`). The summary summed that `0` as if the run were free — indistinguishable from genuinely-free. Add an additive `cost_known: bool` to `MetricsSummary` and `CostReport`: `false` when tokens were spent (`tokens > 0`) but cost summed to exactly `0`. `cost_usd`/`total_usd` stay non-nullable floats — no OpenAPI-breaking change — so existing clients keep working and consumers render "unknown" instead of a misleading $0.00. (The eval matrix already models unknown-cost as `None`; this brings the metrics/cost surface in line without the breaking type change.)

**(b) Eval traces polluted the summary.** On the summary tab `agent` is `None`, so every trace in the window is counted — including the worker's eval traces (`eval:<suite>:<case>`), which are billed but not product traffic. Exclude them via the **same trace-name column the agent filter already matches on** (`does not contain "eval:"`), so no new/untested filter shape is introduced. The eval matrix keeps its own surface (`EvalModelSummary`).

`cost_known` computation and the eval-exclusion filter are pinned by unit tests; OpenAPI regenerated.

Closes #547
Ref CUR-1634