### PR TITLE
Cap eval-stream delivery and dead-letter exhausted evals

### DIFF
--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -361,3 +361,14 @@ class WorkerConfig(BaseSettings):
         which reasons about the same name.
         """
         return self.dead_letter_stream or f"{self.stream}:dead"
+
+    def eval_dead_letter_stream_name(self) -> str:
+        """The eval lane's graveyard: ``<eval_stream>:dead`` (#535).
+
+        Derived from ``eval_stream``, NOT ``dead_letter_stream_name()`` (which is
+        keyed to the runs ``stream``): the eval lane runs its own delivery cap, so
+        a permanently-failing eval must dead-letter to its own graveyard rather
+        than the runs graveyard. Always derived, so it can never collide with
+        ``eval_stream`` and needs no self-targeting validator.
+        """
+        return f"{self.eval_stream}:dead"

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -78,6 +78,10 @@ __all__ = [
 # Pause before retrying the blocking eval read after a transient transport error.
 _EVAL_READ_ERROR_BACKOFF_S = 0.5
 
+# Page size for the PEL scan in the delivery-cap check (#535); mirrors the runs
+# lane's _CAP_SCAN_PAGE so the whole pending list is cap-checked, not just its head.
+_EVAL_CAP_SCAN_PAGE = 1000
+
 
 class EvalReporter:
     """POSTs an EvalReport to the platform API's /evals/report, with retries."""
@@ -229,6 +233,16 @@ class EvalStreamConsumer(StreamConsumer):
             await self._sleep_or_stop(self._config.reclaim_interval_s)
 
     async def _reclaim_once(self) -> int:
+        """Reclaim eval entries a dead consumer left pending and re-run them.
+
+        Entries that have already spent their delivery budget are dead-lettered
+        first and then skipped, so a permanently-failing eval (an unresolvable
+        bundle, a provisioning failure) is not reclaimed and re-provisioned every
+        tick forever (#535) -- each redelivery would otherwise claim a sandbox and
+        run an LLM suite, burning money on a job that can never pass. Mirrors the
+        runs-lane cap (ADR-0039, #505) locally in the eval lane.
+        """
+        over_cap = await self._dead_letter_over_cap()
         reclaimed = 0
         cursor: str = "0-0"
         while not self._stop.is_set():
@@ -245,11 +259,112 @@ class EvalStreamConsumer(StreamConsumer):
             for entry_id, fields in entries:
                 if entry_id in self._inflight_ids:
                     continue  # still being handled here; not an orphan
+                if entry_id in over_cap:
+                    continue  # budget spent; never re-run it again
                 reclaimed += 1
                 await self._handle(entry_id, fields)
             if cursor in ("0-0", "0"):
                 break
         return reclaimed
+
+    async def _dead_letter_over_cap(self) -> set[str]:
+        """Dead-letter eval entries that have exhausted their delivery budget.
+
+        Reads ``times_delivered`` from the PEL with ``XPENDING`` BEFORE
+        ``XAUTOCLAIM`` (which bumps the count on claim), so the pre-claim value is
+        the budget already spent and an entry at ``>= max_delivery`` has had its
+        full budget. Pages the whole pending list (``XAUTOCLAIM`` pages all of it
+        too), keeps the ``IDLE`` filter equal to ``XAUTOCLAIM``'s
+        ``min_idle_time``, and keeps the ``_inflight_ids`` skip ahead of the cap
+        check -- the same invariants the runs lane holds (#505). Returns every
+        over-cap id (including ones whose dead-letter failed) so the caller never
+        re-dispatches them. One entry's failure is isolated so it cannot stop the
+        reclaim tick.
+        """
+        over_cap: set[str] = set()
+        cursor = "-"
+        while True:
+            pending = await self._redis.xpending_range(
+                self._config.eval_stream,
+                self._config.eval_consumer_group,
+                min=cursor,
+                max="+",
+                count=_EVAL_CAP_SCAN_PAGE,
+                idle=self._config.reclaim_min_idle_ms,
+            )
+            if not pending:
+                break
+            for row in pending:
+                entry_id = str(row["message_id"])
+                if entry_id in self._inflight_ids:
+                    continue
+                delivered = int(row["times_delivered"])
+                if delivered < self._config.max_delivery:
+                    continue
+                over_cap.add(entry_id)
+                try:
+                    fields = await self._entry_fields(entry_id)
+                    await self._dead_letter(
+                        entry_id, fields, reason="max-delivery-exceeded", delivery_count=delivered
+                    )
+                except Exception:
+                    logger.exception(
+                        "dead-lettering eval entry %s failed; left pending, not re-run",
+                        entry_id,
+                    )
+            if len(pending) < _EVAL_CAP_SCAN_PAGE:
+                break
+            cursor = f"({pending[-1]['message_id']}"
+        return over_cap
+
+    async def _entry_fields(self, entry_id: str) -> dict[str, str] | None:
+        """The original entry's fields, or None if it was already trimmed off the
+        stream (then a metadata-only graveyard row is written)."""
+        rows = await self._redis.xrange(self._config.eval_stream, min=entry_id, max=entry_id)
+        return dict(rows[0][1]) if rows else None
+
+    async def _dead_letter(
+        self,
+        entry_id: str,
+        fields: dict[str, str] | None,
+        *,
+        reason: str,
+        delivery_count: int,
+    ) -> None:
+        """Move an eval entry to ``<eval_stream>:dead`` and ack it off the group.
+
+        XADD before XACK (a crash between costs a duplicate graveyard row, never a
+        lost entry); the XADD is bounded by an approximate ``dead_letter_maxlen``
+        so the graveyard cannot OOM. Original ``dl_*`` keys are escaped so the
+        metadata written last always wins and the original stays recoverable --
+        the same convention the runs lane uses.
+        """
+        target = self._config.eval_dead_letter_stream_name()
+        payload: dict[str, str] = {
+            (f"dl_{k}" if k.startswith("dl_") else k): v for k, v in (fields or {}).items()
+        }
+        payload.update(
+            {
+                "dl_original_id": entry_id,
+                "dl_delivery_count": str(delivery_count),
+                "dl_reason": reason,
+                "dl_dead_lettered_at": datetime.now(UTC).isoformat(),
+            }
+        )
+        await self._redis.xadd(
+            target,
+            payload,
+            maxlen=self._config.dead_letter_maxlen,
+            approximate=True,
+        )
+        logger.error(
+            "dead-lettered eval entry %s after %d deliveries (reason=%s) -> %s",
+            entry_id,
+            delivery_count,
+            reason,
+            target,
+        )
+        await self._ack(entry_id)
 
     async def _handle(self, entry_id: str, fields: dict[str, str]) -> None:
         self._inflight_ids.add(entry_id)
@@ -260,9 +375,11 @@ class EvalStreamConsumer(StreamConsumer):
                 # would ack and DROP the job with no dead letter.
                 item = parse_eval_job(fields[STREAM_PAYLOAD_FIELD])
             except Exception:
-                # Poison pill: unprocessable on any redelivery, so ack and drop.
-                logger.exception("malformed eval work item %s; acking as poison", entry_id)
-                await self._ack(entry_id)
+                # Poison pill: unprocessable on any redelivery. Dead-letter it
+                # (not a bare ack) so the malformed entry is observable in the
+                # eval graveyard, matching the runs lane's unparseable path (#535).
+                logger.exception("malformed eval work item %s; dead-lettering as poison", entry_id)
+                await self._dead_letter(entry_id, fields, reason="unparseable", delivery_count=1)
                 return
             try:
                 result = await self._run_and_report(item)

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -408,9 +408,10 @@ def test_payload_with_unknown_field_still_runs_and_is_not_dropped(
     asyncio.run(go())
 
 
-def test_malformed_payload_is_acked_and_dropped(make_eval_harness, bundles) -> None:
-    """A payload that will never parse on any redelivery is logged, acked, and
-    dropped -- never reported, never stuck pending."""
+def test_malformed_payload_is_dead_lettered_not_dropped(make_eval_harness, bundles) -> None:
+    """A payload that will never parse on any redelivery is logged, dead-lettered
+    to the eval graveyard, and acked -- never reported, never stuck pending, and
+    (unlike the old bare-ack drop) observable in <eval_stream>:dead (#535)."""
     store, _upload = bundles
 
     async def go() -> None:
@@ -432,15 +433,95 @@ def test_malformed_payload_is_acked_and_dropped(make_eval_harness, bundles) -> N
                 await client.xadd(cfg.eval_stream, {"payload": "not valid json {"})
 
                 task = asyncio.create_task(consumer.run())
-                await asyncio.sleep(0.5)  # poison acks fast; give the loop a few cycles
+                await asyncio.sleep(0.5)  # poison dead-letters fast; give a few cycles
                 consumer.request_stop()
                 await task
 
                 assert reports == []  # never reported
                 summary = await client.xpending(cfg.eval_stream, cfg.eval_consumer_group)
-                assert summary["pending"] == 0  # acked and dropped, not stuck pending
+                assert summary["pending"] == 0  # acked, not stuck pending
+
+                grave = cfg.eval_dead_letter_stream_name()
+                rows = await client.xrange(grave)
+                assert len(rows) == 1
+                fields = rows[0][1]
+                assert fields["dl_reason"] == "unparseable"
+                assert fields["payload"] == "not valid json {"  # original recoverable
 
             await client.delete(cfg.eval_stream)
+            await client.delete(cfg.eval_dead_letter_stream_name())
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_over_cap_eval_is_dead_lettered_and_never_re_run(make_eval_harness, bundles) -> None:
+    """An eval that has exhausted its delivery budget is dead-lettered to
+    <eval_stream>:dead and acked off the group, so the reclaim loop never claims
+    and re-provisions it again (#535). Without the cap a permanently-failing eval
+    is re-run every tick, each redelivery burning a sandbox claim + an LLM suite."""
+    store, _upload = bundles
+
+    async def go() -> None:
+        async with make_eval_harness() as (_base_url, _fake, _client):
+            token = uuid.uuid4().hex[:8]
+            cfg = _cfg(
+                f"test:evals:{token}",
+                f"g-{token}",
+                max_delivery=2,
+                reclaim_min_idle_ms=0,
+            )
+            client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+            reports: list[dict[str, Any]] = []
+            async with httpx.AsyncClient(timeout=30.0) as lf_client:
+                consumer = _build_consumer(
+                    redis_client=client,
+                    cfg=cfg,
+                    bundle_store=store,
+                    substrate=_UnusedSubstrate(),
+                    reports=reports,
+                    lf_client=lf_client,
+                )
+                await consumer.ensure_group()
+                # The entry is dead-lettered before it is ever handled, so its
+                # bundle/target values are immaterial.
+                item = _item(
+                    suite="recl", sha=f"sha-{token}", bundle_ref=None, target_url=_base_url
+                )
+                await client.xadd(cfg.eval_stream, {"payload": item.model_dump_json()})
+
+                # Drive the pre-claim delivery count to the cap: read it once
+                # (delivered=1), then XCLAIM once more (delivered=2 == max_delivery).
+                await client.xreadgroup(
+                    cfg.eval_consumer_group, "dead-1", {cfg.eval_stream: ">"}, count=10
+                )
+                pending = await client.xpending_range(
+                    cfg.eval_stream, cfg.eval_consumer_group, min="-", max="+", count=10
+                )
+                entry_id = str(pending[0]["message_id"])
+                await client.xclaim(
+                    cfg.eval_stream, cfg.eval_consumer_group, "dead-2", 0, [entry_id]
+                )
+
+                over_cap = await consumer._dead_letter_over_cap()
+                assert over_cap == {entry_id}
+
+                # Acked off the group (never re-dispatched) and in the graveyard.
+                summary = await client.xpending(cfg.eval_stream, cfg.eval_consumer_group)
+                assert summary["pending"] == 0
+                grave = cfg.eval_dead_letter_stream_name()
+                rows = await client.xrange(grave)
+                assert len(rows) == 1
+                assert rows[0][1]["dl_reason"] == "max-delivery-exceeded"
+                assert int(rows[0][1]["dl_delivery_count"]) >= cfg.max_delivery
+
+                # A subsequent reclaim never re-runs it (no report, no provision):
+                # it is acked off the group, so XAUTOCLAIM finds nothing to claim.
+                assert await consumer._reclaim_once() == 0
+                assert reports == []
+
+            await client.delete(cfg.eval_stream)
+            await client.delete(cfg.eval_dead_letter_stream_name())
             await client.aclose()
 
     asyncio.run(go())


### PR DESCRIPTION
The eval reclaim loop (`eval/stream.py::_reclaim_once`) re-claimed and re-ran pending entries **forever** — no delivery cap, no dead-letter. A permanently-failing eval (an unresolvable bundle, a provisioning failure, a poison payload that fails before `_handle` can ack) was reclaimed and re-run on every tick, and each redelivery calls `_acquire_target` (provisioning a sandbox) and runs an LLM suite. Unbounded retries burn money, not just a slot. The runs lane has capped delivery since ADR-0039/#505; the eval lane never got it.

Port the cap into the **eval lane** (not the sacred runs `consumer.py`), reusing the shared config knobs:

- `_dead_letter_over_cap()` reads `times_delivered` from the PEL with `XPENDING` **before** `XAUTOCLAIM` (which bumps the count on claim), caps at `>= max_delivery`, pages the whole pending list, keeps the `IDLE` filter equal to `XAUTOCLAIM`'s `min_idle_time`, and keeps the `_inflight_ids` skip ahead of the cap check — the same invariants the runs lane holds.
- Over-cap entries dead-letter to a lane-specific `<eval_stream>:dead` (new `config.eval_dead_letter_stream_name()`, derived so it can never collide), `XADD` before `XACK`, bounded by the approximate `dead_letter_maxlen`, and are skipped in the reclaim loop so they are never re-run.
- The poison-pill path now dead-letters (`reason="unparseable"`) instead of a bare ack-and-drop, so malformed entries are observable in the eval graveyard.

Two new real-Valkey tests: an over-cap entry is dead-lettered + acked + never re-run, and a malformed payload lands in the graveyard with its original recoverable.

Closes #535
Ref CUR-1635