### PR TITLE
Doc hygiene: retire expiring assertions and fix stale governing-rule refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ Two different tools; do not conflate them.
   runner image is `IfNotPresent` and kept pinned on every node by the
   `agentSandbox.runner.prewarm` DaemonSet, which pulls at install/upgrade. A
   mid-boot pull of the ~380MB runner image blew the 90s claim timeout in a live
-  incident; never switch the runner image to `Always`
+  incident (2026-07-06); never switch the runner image to `Always`
   (`charts/agentos/templates/runner-prewarm.yaml`, `charts/agentos/values.yaml`).
 - **Suspend/resume is a cold rehydrate, not a live hibernate** (ADR-0003). A
   suspended sandbox's pod is deleted; resume creates a new pod and injects

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -537,7 +537,7 @@ from those, not from the images alone.
 
 ## 11. What is built vs deferred
 
-**Built and live-verified end to end** (32+ merged lanes; a real Slack
+**Built and live-verified end to end** (a real Slack
 conversation on a real model, a GHCR-default `helm install` on a fresh k3s
 cluster with the CLI deploy+chat loop answered through an in-cluster sandbox and
 an in-cluster Slack dispatcher, and a local middle-mode loop were all exercised —

--- a/README.md
+++ b/README.md
@@ -66,19 +66,10 @@ for the per-package verify commands and
 ## Status
 
 The core spine is built, covered by CI, and was live-verified end to end
-against a real Slack workspace on a real model: the frozen contracts, the API
-server, the dispatcher, the runner, the sandbox substrate (Kubernetes and
-local Docker), the worker concurrency kernel with deployment-to-runtime
-binding, the UI (shell plus create/deploy/Runs/Metrics/Logs/Cost/Versions
-wired to the real backend), the CLI (local inner loop plus the cluster
-operator lifecycle), the Helm chart with its security rails and the
-runner-image prewarm DaemonSet, git-flow (push-to-deploy, merge-to-promote),
-the eval plane (eval-stream consumer, matrix endpoint, PR-check reporter), and
-budgets plus the kill switch. Still ahead: wiring the UI's Evals matrix and
-Usage/Settings views to their existing backends, the soak/chaos suite, and
-retiring the fixture/showroom surface. See "What is built vs deferred" in
-[`ARCHITECTURE.md`](ARCHITECTURE.md#11-what-is-built-vs-deferred)
-for the precise built/in-progress split.
+against a real Slack workspace on a real model. For the precise, maintained
+built-vs-deferred split, see "What is built vs deferred" in
+[`ARCHITECTURE.md`](ARCHITECTURE.md#11-what-is-built-vs-deferred) — this file
+does not duplicate that list, which only drifts out of sync.
 
 Forward-looking work is planned and tracked in
 [GitHub issues](https://github.com/curie-eng/agentos/issues), with larger

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,13 +78,10 @@ Private Vulnerability Reporting is the channel.
 
 ## Supported versions
 
-AgentOS is pre-1.0. The latest release is **v0.2.0**. Only the latest minor
-release line receives security fixes.
-
-| Version | Supported |
-| ------- | --------- |
-| 0.2.x   | Yes       |
-| < 0.2   | No        |
+AgentOS is pre-1.0. Only the latest minor release line receives security
+fixes; older lines are unsupported. See the
+[Releases page](https://github.com/curie-eng/agentos/releases) for the current
+version rather than a number pinned here (which only goes stale).
 
 ## Operator responsibilities
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ git history (`git log -- docs/`).
   what it could become. The document we hold new features against. Read this to
   understand *why* the project exists before *how* it works.
 - [`../ARCHITECTURE.md`](../ARCHITECTURE.md): the as-built architecture reference
-  (the deep "what talks to what," with file:line citations). Start here for
+  (the deep "what talks to what," with path/symbol citations). Start here for
   detail.
 - [`diagrams/`](diagrams/): four focused, presentation-grade flow docs, each a
   single clean diagram with narration. Start here to explain the system to

--- a/docs/adr/0011-opencode-second-harness.md
+++ b/docs/adr/0011-opencode-second-harness.md
@@ -1,7 +1,7 @@
 # 11. OpenCode as the second harness behind the ACI
 
 Date: 2026-07-09
-Status: Proposed (acceptance gated on the steer spike below)
+Status: Accepted (gating steer spike done — ADR-0031, #25/PR #226)
 
 ## Context
 

--- a/docs/adr/0034-approval-authorizers-resolve-membership-in-the-api.md
+++ b/docs/adr/0034-approval-authorizers-resolve-membership-in-the-api.md
@@ -14,7 +14,7 @@ server-side placement, and the sequence the line is built in all stand.
 
 ## Context
 
-[ADR-0010](0010-approval-gates-and-human-in-the-loop.md) (Proposed) established
+[ADR-0010](0010-approval-gates-and-human-in-the-loop.md) (Accepted) established
 the approval primitive and named the authorizer line it intended to build:
 channel membership first, then user-group, explicit user-list, and
 platform-RBAC, all behind one server-side check at resolution time. Only the

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,7 +40,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0008 | [Multi-tenancy: one code path, pooled RLS, hard-siloed compute](0008-multi-tenancy.md) | Accepted |
 | 0009 | [Per-agent secrets and connector credentials](0009-per-agent-connector-auth.md) | Accepted |
 | 0010 | [Approval gates and human-in-the-loop](0010-approval-gates-and-human-in-the-loop.md) | Accepted |
-| 0011 | [OpenCode as the second harness behind the ACI](0011-opencode-second-harness.md) | Proposed (acceptance gated on the steer spike below) |
+| 0011 | [OpenCode as the second harness behind the ACI](0011-opencode-second-harness.md) | Accepted (gating steer spike done — ADR-0031, #25/PR #226) |
 | 0012 | [A substrate-agnostic worker and a channel-agnostic runner (the thin-shim thesis)](0012-substrate-and-channel-agnostic-core.md) | Accepted |
 | 0013 | [Concurrency and delivery: at-least-once streams with an idempotent, side-effect-aware kernel](0013-concurrency-and-delivery-model.md) | Accepted |
 | 0014 | [A git push is the deploy: immutable bundles, promote-not-rebuild, evals as a CI gate](0014-git-push-is-the-deploy.md) | Accepted |

--- a/docs/architecture-vision.md
+++ b/docs/architecture-vision.md
@@ -155,9 +155,9 @@ backend would touch all three.
 ### 5. Relational database (Postgres today)
 
 **Port:** SQL through SQLAlchemy 2.0 plus alembic migrations
-(`apps/api/src/agentos_api/models.py`, `apps/api/alembic/versions/`, four
-migrations). The schema is deliberately minimal: agents, agent_versions,
-deployments.
+(`apps/api/src/agentos_api/models.py`, `apps/api/alembic/versions/`; run
+`alembic heads` for the current tip rather than a count pinned here). The core
+schema centers on agents, agent_versions, and deployments.
 
 **Current adapter:** the chart's Postgres
 (`charts/agentos/templates/postgres.yaml`); locally, the compose stack.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -35,10 +35,10 @@ binary on `PATH`; the commands below assume `agentos` resolves.
 `cluster` target.
 
 If you build the CLI from source, build the runner image once from the repo
-root:
+root with `agentos build` (the single build entry point):
 
 ```bash
-docker build -f runner/Dockerfile -t agentos-runner .
+agentos build
 ```
 
 A released binary instead pulls the pinned runner image from `GHCR` on first
@@ -145,7 +145,7 @@ Only one local compose stack runs at a time.
 Use this as the verification loop for a code change:
 
 1. Rebuild what changed. Rebuild the runner image with
-   `docker build -f runner/Dockerfile -t agentos-runner .` if you touched runner
+   `agentos build` if you touched runner
    code. Run
    `agentos local deploy --plugin-dir . --slack-channel C-DEMO --api-url http://localhost:28000`
    again to push a changed bundle.

--- a/runner/README.md
+++ b/runner/README.md
@@ -64,10 +64,11 @@ smoke; no model call).
 ## Build and smoke
 
 The image compiles against the frozen workspace packages, so build from the repo
-root:
+root with `agentos build` (the one build entry point; it wraps the
+`docker build -f runner/Dockerfile` under the hood):
 
 ```bash
-docker build -f runner/Dockerfile -t agentos-runner .
+agentos build
 # Offline round-trip (fake model, no credential), OTel to the dev collector:
 docker run -d --name runner-smoke --network agentos_default \
   -e AGENTOS_FAKE_MODEL=1 -e AGENTOS_PLUGIN_DIR=/unused \


### PR DESCRIPTION
Addresses the concrete governing-rule contradictions and expiring assertions in #498.

**Governing-rule contradictions (A):**
- `runner/README.md` and `docs/onboarding.md` (×2) pointed operators at a raw `docker build -f runner/Dockerfile ...`, contradicting the root CLAUDE.md "one entry point" rule. Repointed at `agentos build`; the raw command remains only as the negative example in the root doc.
- `docs/adr/0034` called ADR-0010 "(Proposed)" — it is Accepted. Fixed.
- `docs/adr/0011` was `Status: Proposed (gated on the steer spike)`, but that spike is recorded as done in ADR-0031 (#25/PR #226). Promoted to Accepted with the pointer; ADR index regenerated.

**Expiring assertions (C):**
- `SECURITY.md` hardcoded "latest release is **v0.2.0**" (repo is already v0.4.0-rc.x) → version-free support policy pointing at the Releases page.
- `ARCHITECTURE.md` "32+ merged lanes" and `architecture-vision.md` "four migrations" (there are 16) → removed the counts, point at `alembic heads`.
- `README.md` duplicated the built/deferred status prose that drifts from ARCHITECTURE.md §11 → replaced with the link.
- `docs/README.md` still advertised "file:line citations" (the architecture doc now uses path/symbol citations) → corrected.

**Single gotcha narrative (B1):** merged the live-incident date (2026-07-06) into the canonical runner-image gotcha in AGENTS.md so it carries both the ~380MB/90s numbers and the date.

`doclint` is green (67 tests). The broader command-block / index dedup (B2/B3) is a more subjective doc-restructuring left as follow-up.

Closes #498
Ref CUR-1636