### PR TITLE
Exercise all five extension fields against the plugin-compat gate

### DIFF
--- a/examples/compat-fixture/.claude-plugin/plugin.json
+++ b/examples/compat-fixture/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "compat-fixture",
+  "version": "0.1.0",
+  "description": "Not a runnable agent: a plugin-compat gate fixture that carries all five AgentOS authoring extensions (systemPrompt, starterPrompts, secrets, triggers, approvalPolicy) so `claude plugin validate` exercises the warn-and-ignore degradation contract for every one of them (#538). A dedicated fixture keeps these fields off the real example bundles, where approvalPolicy and systemPrompt would change runtime behavior for no functional benefit.",
+  "author": { "name": "CurieTech" },
+  "keywords": ["fixture", "plugin-compat", "extensions"],
+  "systemPrompt": "You are a compatibility fixture; you are never actually run.",
+  "starterPrompts": [
+    "This bundle exists only to exercise the plugin-compat gate."
+  ],
+  "secrets": ["FIXTURE_CONNECTOR_TOKEN"],
+  "triggers": [
+    { "type": "cron", "schedule": "0 9 * * 1" },
+    { "type": "webhook", "path": "fixture-hook" }
+  ],
+  "approvalPolicy": {
+    "gates": [
+      { "gate": "Bash", "route": "fixture-route" }
+    ]
+  }
+}

--- a/examples/tests/test_plugin_compat_coverage.py
+++ b/examples/tests/test_plugin_compat_coverage.py
@@ -1,0 +1,54 @@
+"""The plugin-compat gate must exercise all five AgentOS authoring extensions.
+
+`scripts/check-plugin-compat.sh` runs `claude plugin validate` over every bundle
+under `examples/`, asserting our five extension fields (systemPrompt,
+starterPrompts, secrets, triggers, approvalPolicy) stay warn-and-ignored rather
+than rejected by Claude Code. But the gate can only exercise a field that some
+discovered bundle actually declares -- and before the compat-fixture bundle,
+three of the five (systemPrompt, triggers, approvalPolicy) appeared in NO example
+manifest, so the gate silently covered only two of them (#538).
+
+This test defends that coverage: every one of the five fields must appear in at
+least one discovered example bundle, so a future edit that drops a field from the
+fixture (leaving the gate to cover it vacuously) fails here.
+"""
+
+import json
+from pathlib import Path
+
+EXAMPLES = Path(__file__).resolve().parents[1]
+
+# The five AgentOS authoring extensions on the plugin manifest (plugin_format
+# models.py); each is unknown-to-Claude-Code by design and warned-and-ignored.
+_EXTENSION_FIELDS = (
+    "systemPrompt",
+    "starterPrompts",
+    "secrets",
+    "triggers",
+    "approvalPolicy",
+)
+
+
+def _discover_manifests() -> list[dict]:
+    """Every example bundle's parsed plugin manifest (same glob the gate uses)."""
+    manifests = []
+    for child in EXAMPLES.iterdir():
+        manifest = child / ".claude-plugin" / "plugin.json"
+        if child.is_dir() and child.name != "tests" and manifest.is_file():
+            manifests.append(json.loads(manifest.read_text()))
+    return manifests
+
+
+def test_every_extension_field_is_exercised_by_some_bundle() -> None:
+    manifests = _discover_manifests()
+    assert manifests, "no example bundles discovered; the gate would pass vacuously"
+    uncovered = [
+        field
+        for field in _EXTENSION_FIELDS
+        if not any(field in manifest for manifest in manifests)
+    ]
+    assert not uncovered, (
+        "these AgentOS extension fields appear in NO example bundle, so the "
+        f"plugin-compat gate never exercises them: {uncovered}. Add them to the "
+        "compat-fixture bundle (examples/compat-fixture/.claude-plugin/plugin.json)."
+    )


### PR DESCRIPTION
`scripts/check-plugin-compat.sh` runs `claude plugin validate` over every bundle under `examples/`, asserting AgentOS's five authoring extensions stay *warn-and-ignored* by Claude Code rather than rejected. But the gate can only exercise a field some discovered bundle actually declares — and three of the five (`systemPrompt`, `triggers`, `approvalPolicy`) appeared in **no** example manifest. So the nightly silently covered only `starterPrompts` and `secrets`; if Claude Code began rejecting `approvalPolicy`, the gate would have stayed green.

- Add a dedicated `examples/compat-fixture/` bundle carrying all five extensions in valid shapes. A dedicated fixture (rather than padding the real examples) keeps `approvalPolicy` and `systemPrompt` — which have **live runtime effects** (armed gates, agent persona) — off the shipped example agents, exactly the concern that set this aside.
- Add `test_plugin_compat_coverage.py`: every one of the five fields must appear in some discovered bundle, so dropping a field from the fixture fails loudly instead of leaving the gate to cover it vacuously.

The fixture declares no `mcpServers`/scripts, so the existing `test_example_mcp_declarations` checks skip it; it parses cleanly as a `PluginManifest`.

Closes #538
Ref CUR-1637