### PR TITLE
Add an opt-in runner false-completion check

### DIFF
--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -170,6 +170,7 @@ def build_runner(
         history_store=history_store,
         approval_gate=approval_gate,
         approval_resumed_kind=config.approval_resumed_kind,
+        false_completion_check=config.false_completion_check,
     )
 
 

--- a/runner/src/agentos_runner/config.py
+++ b/runner/src/agentos_runner/config.py
@@ -44,6 +44,12 @@ class RunnerConfig:
     # the past, used only to emit an observe-only warning when a resumed policy
     # turn takes no action. It must never influence can_use_tool.
     approval_resumed_kind: str | None
+    # Opt-in false-completion check (#517), authority-free and observe-only. When
+    # AGENTOS_FALSE_COMPLETION_CHECK is truthy, a turn that ends DONE with a
+    # substantive answer but ZERO tool calls emits a non-terminal warning frame.
+    # Default off, exactly like approval_resumed_kind's observe-only pattern; it
+    # never influences can_use_tool or the final's status.
+    false_completion_check: bool
     port: int
     runner_token: str | None
 
@@ -91,6 +97,8 @@ class RunnerConfig:
         approval_resumed_kind = (
             resumed_raw.strip() if resumed_raw and resumed_raw.strip() else None
         )
+        false_completion_raw = env.get("AGENTOS_FALSE_COMPLETION_CHECK", "")
+        false_completion_check = false_completion_raw.strip().lower() in ("1", "true", "yes")
         return cls(
             session=session,
             model=env.get("AGENTOS_MODEL"),
@@ -101,6 +109,7 @@ class RunnerConfig:
             approval_required_tools=approval_required,
             approval_grant_tool=approval_grant_tool,
             approval_resumed_kind=approval_resumed_kind,
+            false_completion_check=false_completion_check,
             port=int(env.get("AGENTOS_RUNNER_PORT", "8080")),
             runner_token=env.get("AGENTOS_RUNNER_TOKEN") or None,
         )

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -81,6 +81,10 @@ AUTH_REJECTED_CLASSIFICATION = "model-credential-rejected"
 # approved action ran", so it false-alarms on a text-only decision and
 # false-passes on any incidental tool -- which is why A2 ships observe-only.
 APPROVAL_NOT_ACTED_CLASSIFICATION = "approval-not-acted"
+# The false-completion warning classification (#517): a turn declared DONE with a
+# substantive answer but no tool-call evidence. Rides the free-form
+# ErrorEvent.classification field like the markers above, so it is contract-safe.
+FALSE_COMPLETION_CLASSIFICATION = "false-completion"
 
 
 def _is_auth_rejection(message: object) -> bool:
@@ -131,6 +135,7 @@ class SessionRunner:
         history_store: TranscriptStore | None = None,
         approval_gate: ApprovalGate | None = None,
         approval_resumed_kind: str | None = None,
+        false_completion_check: bool = False,
     ) -> None:
         self._factory = session_factory
         self._ceiling = ceiling
@@ -156,6 +161,9 @@ class SessionRunner:
         # this boot is resuming from a policy-gate approval. It confers no
         # capability -- it only arms the observe-only turn-end reconciliation.
         self._approval_resumed_kind = approval_resumed_kind
+        # Opt-in, observe-only false-completion check (#517): warn when a turn
+        # ends DONE with a substantive answer but zero tool calls. Off by default.
+        self._false_completion_check = false_completion_check
 
         self._session: ModelSession | None = None
         self._turn_lock = anyio.Lock()
@@ -425,6 +433,8 @@ class SessionRunner:
                     final = _apply_approval_override(self._reclassify(outbound), state)
                     for line in self._approval_not_acted_lines(state, final):
                         yield line
+                    for line in self._false_completion_lines(state, final):
+                        yield line
                     self._status = final.status
                     self._turn_open = False
                     # Capture the delivered reply so run_turn can persist the
@@ -453,6 +463,10 @@ class SessionRunner:
         self._merge_gate_block(state)
         final = _apply_approval_override(Final(text="", status=status), state)
         for line in self._approval_not_acted_lines(state, final):
+            yield line
+        # No-op on this empty-text fallback final (the check requires a
+        # substantive answer), kept beside its twin for parity.
+        for line in self._false_completion_lines(state, final):
             yield line
         self._status = final.status
         self._turn_open = False
@@ -496,6 +510,52 @@ class SessionRunner:
                             "the approved action was never taken"
                         ),
                         classification=APPROVAL_NOT_ACTED_CLASSIFICATION,
+                    )
+                )
+            ]
+        return []
+
+    def _false_completion_lines(self, state: TurnState, final: Final) -> list[str]:
+        """The OBSERVE-ONLY false-completion warning (#517).
+
+        Emits a single non-terminal warning frame -- never a non-clean final --
+        when a turn declared DONE with a substantive answer yet made ZERO tool
+        calls this turn. That is the runner-observable analog of "declared done
+        with no tool-call evidence" (Grok's laziness classifier). It keys on
+        ``tool_call_count`` (all tools), not ``side_effect_emitted`` (a proxy for
+        "some non-idempotent tool ran"), so a read-only investigation counts as
+        evidence and never trips this.
+
+        Opt-in and observe-only, deliberately: the runner cannot tell a
+        legitimately-answerable question ("what is 2+2", "summarize our last
+        exchange") from a lazy false completion without judging task intent, which
+        it does not do. So this instruments -- it warns and leaves the final clean
+        -- and, like the approval-not-acted signal, gates on
+        ``self._false_completion_check`` until real-trace rates justify any
+        promotion to enforce. An approval pause, budget halt, or classified
+        failure never reaches the clean-DONE case reconciled here.
+        """
+
+        if (
+            self._false_completion_check
+            and final.status is SessionStatus.DONE
+            and state.tool_call_count == 0
+            and final.text.strip()
+            and not state.approval_summary
+        ):
+            logger.warning(
+                "false completion session=%s: turn declared done with a "
+                "substantive answer but made no tool call",
+                self._session_id,
+            )
+            return [
+                to_ndjson_line(
+                    ErrorEvent(
+                        message=(
+                            "turn declared done with a substantive answer but made "
+                            "no tool call this turn (no evidence backing the claim)"
+                        ),
+                        classification=FALSE_COMPLETION_CLASSIFICATION,
                     )
                 )
             ]

--- a/runner/src/agentos_runner/translate.py
+++ b/runner/src/agentos_runner/translate.py
@@ -67,6 +67,13 @@ class TurnState:
     # but their empty-signature thinking block trips the SDK's result extraction,
     # leaving ``ResultMessage.result`` empty (issue #107).
     assistant_text: str = ""
+    # Count of ALL tool calls this turn (every ToolUseBlock), the evidence signal
+    # the false-completion check keys on (#517). Distinct from
+    # ``side_effect_emitted``, which flips only for non-idempotent tools: a
+    # read-only investigation (Read/Grep/WebSearch) IS tool-call evidence but
+    # leaves ``side_effect_emitted`` False, so this counter -- not that flag -- is
+    # the right "did any tool run" signal.
+    tool_call_count: int = 0
     # The delivered text of the terminal ``final`` for a successful turn, set by
     # the session loop when a DONE/idle final is produced. It is the assistant
     # reply recorded into the conversation transcript (#20); left None on a
@@ -125,6 +132,9 @@ def _translate_assistant(
                 events.append(TextDelta(text=block.text))
         elif isinstance(block, ToolUseBlock):
             events.append(ToolNote(text=f"running tool {block.name}", tool=block.name))
+            # Every tool call is evidence for the false-completion check (#517),
+            # including the approval-request tool below and read-only tools.
+            state.tool_call_count += 1
             if gen is not None:
                 gen.tool_span(block.name)
             if block.name == APPROVAL_TOOL_NAME:

--- a/runner/tests/test_false_completion.py
+++ b/runner/tests/test_false_completion.py
@@ -52,9 +52,8 @@ def _runner(script: list[object], *, check: bool) -> SessionRunner:
 def _drain(runner: SessionRunner) -> list[dict[str, object]]:
     async def go() -> list[dict[str, object]]:
         await runner.start()
-        lines = [
-            line async for line in runner.run_turn(Event(type="message", text="q", user="U", ts="0"))
-        ]
+        event = Event(type="message", text="q", user="U", ts="0")
+        lines = [line async for line in runner.run_turn(event)]
         return [json.loads(line) for line in lines]
 
     return anyio.run(go)
@@ -64,7 +63,8 @@ def _classifications(frames: list[dict[str, object]]) -> list[object]:
     return [f.get("classification") for f in frames if f.get("type") == "error"]
 
 
-_TEXT_ONLY = [_assistant(TextBlock(text="All set, nothing else to do.")), _result("All set, nothing else to do.")]
+_ANSWER = "All set, nothing else to do."
+_TEXT_ONLY = [_assistant(TextBlock(text=_ANSWER)), _result(_ANSWER)]
 
 
 def test_fires_on_done_with_answer_but_no_tool_call() -> None:

--- a/runner/tests/test_false_completion.py
+++ b/runner/tests/test_false_completion.py
@@ -1,0 +1,101 @@
+"""False-completion check (#517): observe-only, opt-in warning that a turn
+declared done with a substantive answer but no tool-call evidence.
+
+Drives the fake session with hand-built scripts so the tool-call count is exact,
+and asserts the warning fires only when opted in, keys on tool_call_count (not
+side_effect_emitted), and never changes the terminal final's status.
+"""
+
+from __future__ import annotations
+
+import json
+
+import anyio
+from aci_protocol import Event
+from agentos_runner.fake import FakeModelSession
+from agentos_runner.otel import RunTracer
+from agentos_runner.session import FALSE_COMPLETION_CLASSIFICATION, SessionRunner
+from agentos_runner.side_effects import SideEffectClassifier
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+
+
+def _assistant(*blocks: object) -> AssistantMessage:
+    return AssistantMessage(content=list(blocks), model="fake-model", usage=None)
+
+
+def _result(text: str) -> ResultMessage:
+    return ResultMessage(
+        subtype="success",
+        duration_ms=1,
+        duration_api_ms=1,
+        is_error=False,
+        num_turns=1,
+        session_id="fake-session",
+        result=text,
+        usage={"input_tokens": 5, "output_tokens": 3},
+    )
+
+
+def _runner(script: list[object], *, check: bool) -> SessionRunner:
+    session = FakeModelSession(lambda: script)
+    return SessionRunner(
+        session_factory=lambda: session,
+        ceiling=10_000,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="test",
+        session_id="s-1",
+        false_completion_check=check,
+    )
+
+
+def _drain(runner: SessionRunner) -> list[dict[str, object]]:
+    async def go() -> list[dict[str, object]]:
+        await runner.start()
+        lines = [
+            line async for line in runner.run_turn(Event(type="message", text="q", user="U", ts="0"))
+        ]
+        return [json.loads(line) for line in lines]
+
+    return anyio.run(go)
+
+
+def _classifications(frames: list[dict[str, object]]) -> list[object]:
+    return [f.get("classification") for f in frames if f.get("type") == "error"]
+
+
+_TEXT_ONLY = [_assistant(TextBlock(text="All set, nothing else to do.")), _result("All set, nothing else to do.")]
+
+
+def test_fires_on_done_with_answer_but_no_tool_call() -> None:
+    frames = _drain(_runner(_TEXT_ONLY, check=True))
+    final = frames[-1]
+    assert final["type"] == "final"
+    # Observe-only: the final stays DONE, and a single warning frame precedes it.
+    assert final["status"] == "done"
+    assert FALSE_COMPLETION_CLASSIFICATION in _classifications(frames)
+
+
+def test_off_by_default_no_warning() -> None:
+    frames = _drain(_runner(_TEXT_ONLY, check=False))
+    assert FALSE_COMPLETION_CLASSIFICATION not in _classifications(frames)
+    assert frames[-1]["status"] == "done"
+
+
+def test_no_false_alarm_when_a_read_only_tool_ran() -> None:
+    # A read-only Read is tool-call evidence even though it sets no side-effect
+    # flag; the check keys on tool_call_count, so it must NOT warn here.
+    script = [
+        _assistant(ToolUseBlock(id="t1", name="Read", input={"path": "/x"})),
+        _assistant(TextBlock(text="Here is the answer from the file.")),
+        _result("Here is the answer from the file."),
+    ]
+    frames = _drain(_runner(script, check=True))
+    assert FALSE_COMPLETION_CLASSIFICATION not in _classifications(frames)
+
+
+def test_no_warning_on_empty_answer() -> None:
+    # A DONE turn with no substantive text is not a false completion.
+    script = [_assistant(TextBlock(text="")), _result("")]
+    frames = _drain(_runner(script, check=True))
+    assert FALSE_COMPLETION_CLASSIFICATION not in _classifications(frames)


### PR DESCRIPTION
Steals Grok's "StalledFalseCompletion" laziness classifier in its runner-observable form: a turn that **declares done with a substantive answer but makes no tool call** has no evidence backing the claim.

- New `TurnState.tool_call_count` counts **every** `ToolUseBlock` this turn (incremented where each already becomes a `ToolNote`). This is distinct from `side_effect_emitted`, which flips only for non-idempotent tools — a read-only `Read`/`Grep`/`WebSearch` investigation IS tool-call evidence but leaves that flag False, so the counter is the correct "did any tool run" signal.
- `session._false_completion_lines` fires only when the turn ends `DONE`, with non-empty answer text, zero tool calls, and no approval pause — emitting a single non-terminal `ErrorEvent(classification="false-completion")` and leaving the terminal `Final` clean (`status=DONE` unchanged).
- Gated behind `AGENTOS_FALSE_COMPLETION_CHECK` (default **off**), mirroring the approval-not-acted observe-only pattern. The runner can't tell a legitimately-answerable question ("what's 2+2") from a lazy completion without judging task intent, so this **instruments** rather than enforces, and stays data-gated (like #559) until real-trace false-alarm/false-pass rates justify any promotion to enforce — the stronger enforce signal belongs in the eval layer.

Rides the free-form `ErrorEvent.classification` field (like `approval-not-acted`, `budget`), so **no frozen-contract change**; no new `SessionStatus`. Tests cover: fires on done+answer+no-tool, off by default, no false alarm when a read-only tool ran, and no fire on an empty answer.

Closes #517
Ref CUR-1638