### PR TITLE
Redact secrets from runner stdout logs and gen_ai span attributes

### DIFF
--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -17,7 +17,6 @@ import anyio
 from aiohttp import web
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
-from .redact import install_log_redaction
 from .approval import (
     ApprovalGate,
     build_approval_server,
@@ -38,6 +37,7 @@ from .hooks import load_bundle_hooks
 from .memory import MemoryRecord, MemoryStore, format_memory_preamble, resolve_memory
 from .otel import RunTracer, build_tracer_provider
 from .plugin import load_bundle_system_prompt, load_plugins
+from .redact import install_log_redaction
 from .sdk_auth import UnsupportedCredentialError, resolve_sdk_env
 from .server import create_app
 from .session import SessionRunner

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -17,6 +17,7 @@ import anyio
 from aiohttp import web
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
+from .redact import install_log_redaction
 from .approval import (
     ApprovalGate,
     build_approval_server,
@@ -265,6 +266,10 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    # Scrub credential-shaped tokens from every log line before it hits stdout
+    # (the worker captures runner stdout); defense-in-depth against an exception
+    # message echoing a forwarded secret (#518).
+    install_log_redaction()
     fake_model = os.environ.get("AGENTOS_FAKE_MODEL", "").lower() in ("1", "true", "yes")
     logger.info("runner starting fake_model=%s", fake_model)
     # A real session authenticates from the SDK's own credential env; map the

--- a/runner/src/agentos_runner/otel.py
+++ b/runner/src/agentos_runner/otel.py
@@ -30,7 +30,21 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import SpanKind, Tracer
 
+from .redact import redact
+
 _SERVICE_NAME = "agentos-runner"
+
+
+def _set_str_attr(span: Any, key: str, value: str) -> None:
+    """Set a STRING span attribute, redacted (#518).
+
+    Every string span attribute the runner emits goes through here, so a secret
+    that lands in a model string, tool name, or trace/session/user id is scrubbed
+    before the span ships to Langfuse. New string attributes must use this helper,
+    not raw ``set_attribute`` -- integer attributes (token counts) need no scrub.
+    """
+
+    span.set_attribute(key, redact(value))
 
 
 def build_tracer_provider(
@@ -96,11 +110,11 @@ class RunTracer:
         """
 
         with self._tracer.start_as_current_span("agent.run", kind=SpanKind.SERVER) as root:
-            root.set_attribute("langfuse.trace.name", trace_name)
+            _set_str_attr(root, "langfuse.trace.name", trace_name)
             if session_id:
-                root.set_attribute("langfuse.session.id", session_id)
+                _set_str_attr(root, "langfuse.session.id", session_id)
             if user_id:
-                root.set_attribute("langfuse.user.id", user_id)
+                _set_str_attr(root, "langfuse.user.id", user_id)
             with self._tracer.start_as_current_span("llm.generation") as gen:
                 span = _GenerationSpan(self._tracer, gen)
                 # Stamp the configured model at span open when AGENTOS_MODEL is
@@ -138,8 +152,8 @@ class _GenerationSpan:
 
         if self._model_recorded or not model:
             return
-        self._span.set_attribute("gen_ai.request.model", model)
-        self._span.set_attribute("model", model)
+        _set_str_attr(self._span, "gen_ai.request.model", model)
+        _set_str_attr(self._span, "model", model)
         self._model_recorded = True
 
     def record_usage(self, usage: Mapping[str, Any] | None) -> None:
@@ -170,5 +184,5 @@ class _GenerationSpan:
         """Emit a short ``execute_tool`` child span for one tool call."""
 
         with self._tracer.start_as_current_span("execute_tool") as tool:
-            tool.set_attribute("gen_ai.tool.name", tool_name)
+            _set_str_attr(tool, "gen_ai.tool.name", tool_name)
             tool.set_attribute("gen_ai.operation.name", "execute_tool")

--- a/runner/src/agentos_runner/redact.py
+++ b/runner/src/agentos_runner/redact.py
@@ -1,0 +1,112 @@
+"""Secret redaction over runner stdout logs and gen_ai span attribute values (#518).
+
+Defense-in-depth: the runner forwards a model credential and per-connector secrets
+into the sandbox, and an exception message or provider error body can echo one back
+onto stdout (which the worker captures) or into a span attribute (which ships to
+Langfuse). This module is the single source of truth for the credential-shaped
+patterns and the one ``redact`` function both the logging filter (``__main__``) and
+the span-attribute choke point (``otel``) apply, so the two cannot drift.
+
+It is a values-only output filter: it never adds or renames a log field or a span
+attribute key, so it stays compatible with the frozen ACI env contract, the
+``check`` CLI's committed JSON shape, and #512's forthcoming typed-telemetry
+validator (which drops records with unscrubbed secrets -- this scrub runs first).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+PLACEHOLDER = "[REDACTED]"
+
+# (name, pattern, sample). ``sample`` is a synthetic token the pattern must match,
+# used by the tripwire test so a new pattern added here without being wired into
+# ``redact`` -- or a pattern that stops matching its own shape -- fails CI. None of
+# the samples is a real secret.
+_PATTERNS: list[tuple[str, re.Pattern[str], str]] = [
+    ("anthropic-oauth", re.compile(r"sk-ant-oat[A-Za-z0-9_-]{6,}"), "sk-ant-oat01ABCDEFghij"),
+    ("anthropic-key", re.compile(r"sk-ant-[A-Za-z0-9_-]{6,}"), "sk-ant-api03ABCDEFghij"),
+    ("openrouter", re.compile(r"sk-or-[A-Za-z0-9_-]{6,}"), "sk-or-v1ABCDEFghijkl"),
+    ("openai-style", re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"), "sk-ABCDEFGHIJKLMNOPQRSTUV"),
+    ("xai", re.compile(r"\bxai-[A-Za-z0-9]{16,}\b"), "xai-ABCDEFGHIJKLMNOPqrst"),
+    ("aws-access-key", re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"), "AKIAIOSFODNN7EXAMPLE"),
+    (
+        "github-token",
+        re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"),
+        "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345",
+    ),
+    ("slack-token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"), "xoxb-1234567890-ABCDEFGH"),
+    ("bearer", re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{10,}"), "Bearer abcdef0123456789xyz"),
+    (
+        "jwt",
+        re.compile(r"\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\b"),
+        "eyJhbGciOi.eyJzdWIiOi.SflKxwRJSM",
+    ),
+    (
+        "pem-private-key",
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+            re.DOTALL,
+        ),
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIABC\n-----END RSA PRIVATE KEY-----",
+    ),
+    (
+        "url-credential-param",
+        re.compile(r"(?i)([?&](?:token|api[_-]?key|secret|password|access[_-]?token)=)[^&\s]+"),
+        "https://x.example?token=supersecretvalue",
+    ),
+]
+
+
+def redact(text: str) -> str:
+    """Replace every credential-shaped token in ``text`` with ``PLACEHOLDER``.
+
+    Order matters: the more specific ``sk-ant-oat``/``sk-ant-``/``sk-or-`` shapes
+    run before the generic ``sk-`` catch-all so the emitted placeholder is stable.
+    A non-secret string passes through unchanged.
+    """
+
+    for _name, pattern, _sample in _PATTERNS:
+        if _name == "url-credential-param":
+            # Keep the identifying key (token=), redact only the value.
+            text = pattern.sub(lambda m: m.group(1) + PLACEHOLDER, text)
+        else:
+            text = pattern.sub(PLACEHOLDER, text)
+    return text
+
+
+class RedactingLogFilter(logging.Filter):
+    """A logging filter that scrubs the fully-interpolated message.
+
+    Attached to every root handler, so a secret interpolated into ANY ``logger.*``
+    call -- most importantly an exception string echoed via ``%s`` -- is redacted
+    before it reaches stdout. It rewrites ``record.msg`` to the redacted, already-
+    formatted message and clears ``record.args`` so downstream formatting is a
+    no-op on the scrubbed text.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:  # a bad %-format should never crash the log path
+            return True
+        redacted = redact(message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+def install_log_redaction() -> None:
+    """Attach the redaction filter to every handler on the root logger.
+
+    Called once after ``logging.basicConfig``. A filter on the handler (not the
+    logger) scrubs records propagated from any child logger too, since they are
+    emitted through the root handler.
+    """
+
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if not any(isinstance(f, RedactingLogFilter) for f in handler.filters):
+            handler.addFilter(RedactingLogFilter())

--- a/runner/tests/test_redact.py
+++ b/runner/tests/test_redact.py
@@ -1,0 +1,97 @@
+"""Secret redaction (#518): the shared patterns, the log filter, and the span
+attribute choke point. The tripwire half fails if a pattern is added without
+being applied by ``redact``; the behavioral half proves a secret is scrubbed from
+a log line and a span attribute.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import anyio
+from aci_protocol import Event
+from agentos_runner import RunTracer, SideEffectClassifier
+from agentos_runner.fake import FakeModelSession
+from agentos_runner.redact import (
+    _PATTERNS,
+    PLACEHOLDER,
+    RedactingLogFilter,
+    redact,
+)
+from agentos_runner.session import SessionRunner
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+_SECRET = "sk-ant-oat01SECRETSENTINELvalue999"
+
+
+# --- tripwire: every pattern is wired into redact ------------------------------
+
+
+def test_every_pattern_is_applied_by_redact() -> None:
+    assert _PATTERNS, "the redaction pattern list must not be empty"
+    for name, _pattern, sample in _PATTERNS:
+        out = redact(f"prefix {sample} suffix")
+        assert PLACEHOLDER in out, f"pattern {name!r} produced no redaction for its sample"
+        # The distinctive tail of the sample secret must be gone. (url-credential
+        # keeps the `token=` key but drops the value, so check the value tail.)
+        secret_tail = sample.split("=")[-1][-8:]
+        assert secret_tail not in out, f"pattern {name!r} left its secret sample in the output"
+
+
+def test_redact_leaves_ordinary_text_untouched() -> None:
+    text = "connecting to the model; 42 tokens used; tool Read ran on /etc/hosts"
+    assert redact(text) == text
+
+
+# --- behavioral: logs ----------------------------------------------------------
+
+
+def test_log_filter_scrubs_an_interpolated_secret() -> None:
+    record = logging.LogRecord(
+        name="agentos_runner.test",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="credential resolution failed: %s",
+        args=(f"bad token {_SECRET}",),
+        exc_info=None,
+    )
+    assert RedactingLogFilter().filter(record) is True
+    message = record.getMessage()
+    assert _SECRET not in message
+    assert PLACEHOLDER in message
+
+
+# --- behavioral: span attributes ----------------------------------------------
+
+
+def test_span_string_attributes_are_redacted() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    # A secret smuggled into the model string (an SDK/provider echo) must not ship
+    # to Langfuse as a span attribute; it flows through _set_str_attr -> redact.
+    runner = SessionRunner(
+        session_factory=FakeModelSession,
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name=f"agentos-run:{_SECRET}",
+        model=f"model-{_SECRET}",
+    )
+
+    async def go() -> None:
+        await runner.start()
+        async for _ in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            pass
+
+    anyio.run(go)
+
+    spans = {s.name: s for s in exporter.get_finished_spans()}
+    trace_name = spans["agent.run"].attributes["langfuse.trace.name"]
+    model = spans["llm.generation"].attributes["gen_ai.request.model"]
+    assert _SECRET not in trace_name and PLACEHOLDER in trace_name
+    assert _SECRET not in model and PLACEHOLDER in model


### PR DESCRIPTION
Defense-in-depth (#518): the runner forwards a model credential and per-connector secrets into the sandbox, and an exception message or a provider error body can echo one back onto **stdout** (which the worker captures) or into a **gen_ai span attribute** (which ships to Langfuse).

New `redact` module is the single source of truth: one compiled pattern list (Anthropic `sk-ant-oat`/`sk-ant-`, OpenRouter `sk-or-`, OpenAI-style `sk-`, xAI, AWS `AKIA`/`ASIA`, GitHub, Slack tokens, `Bearer`, JWT, PEM private keys, URL credential params) and one `redact()` applied by both:

- a **root-handler logging filter** installed at boot — scrubs every `logger.*` line, most importantly the interpolated exception text at the credential-resolution / session-start / turn-failure sites; and
- the **one span-attribute choke point** `_set_str_attr`, through which every string span attribute the runner emits (`langfuse.trace.name`, `session/user id`, `gen_ai.request.model`, `model`, `gen_ai.tool.name`) already flows.

It is **values-only** — no log field or span attribute key is added or renamed — so it stays compatible with the frozen ACI env contract, the `check` CLI's committed JSON shape, and #512's forthcoming typed-telemetry validator (whose fail-closed drop runs *after* this scrub).

A **tripwire** test fails if a pattern is added to the list without `redact()` applying it (each pattern ships a synthetic sample that must be redacted); behavioral tests prove a secret is scrubbed from an interpolated log line and from an exported span attribute.

Closes #518
Ref CUR-1639