### PR TITLE
Emit structured JSON from init under --json

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -16,8 +16,9 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
 - **Under `--json`, the agent-facing read and result verbs emit one JSON object
   to stdout -- never empty stdout (issue #456).** That covers the read/query
   verbs (`versions`, `memory`, `approvals`, `observability`), the lifecycle
-  result verbs (`kill`, `resume`, `budget`, `delete`), and every verb's
-  `--dry-run` plan. Silent empty-stdout-exit-0 is the worst failure mode for an
+  result verbs (`kill`, `resume`, `budget`, `delete`), `init` (both the
+  plain-name and `--from-spec` branches, via `InitOutput`, issue #485), and every
+  verb's `--dry-run` plan. Silent empty-stdout-exit-0 is the worst failure mode for an
   agent consumer: it looks like success but carries no data. The json-vs-human
   decision lives in exactly one place, `Ui::emit` (the success-path mirror of
   `main.rs`'s centralized error emit). A new or refactored verb returns a

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -252,6 +252,8 @@ pub fn init(name: Option<String>, dir: Option<PathBuf>, from_spec: Option<PathBu
         let created = scaffold_from_spec(&dir, &spec)?;
         report_scaffold(
             ui,
+            spec.name.clone(),
+            Some(spec_path.clone()),
             format!(
                 "initialized plugin bundle '{}' in {} (from spec {})",
                 spec.name,
@@ -272,6 +274,8 @@ pub fn init(name: Option<String>, dir: Option<PathBuf>, from_spec: Option<PathBu
     let created = scaffold(&dir, &name)?;
     report_scaffold(
         ui,
+        name.clone(),
+        None,
         format!("initialized plugin bundle '{name}' in {}", dir.display()),
         created,
         &dir,
@@ -279,15 +283,68 @@ pub fn init(name: Option<String>, dir: Option<PathBuf>, from_spec: Option<PathBu
     Ok(())
 }
 
-/// Report a freshly scaffolded bundle: the success line, one `created` note per
-/// written path, and the `Next:` hint. Shared by both `init` branches so the
-/// only per-branch difference is the success message text.
-fn report_scaffold(ui: &crate::ui::Ui, success_msg: String, created: Vec<PathBuf>, dir: &Path) {
-    ui.success(&success_msg);
-    for path in created {
-        ui.note(&format!("created {}", path.display()));
+/// Report a freshly scaffolded bundle through the one success-path decision point
+/// (`Ui::emit`, issue #485): under `--json` emit one structured `InitOutput`
+/// object to stdout; otherwise render the success line, a `created` note per
+/// written path, and the `Next:` hint on stderr (byte-identical to before).
+/// Shared by both `init` branches so the only per-branch difference is the
+/// success message text and whether a spec sourced the bundle.
+fn report_scaffold(
+    ui: &crate::ui::Ui,
+    name: String,
+    from_spec: Option<PathBuf>,
+    success_msg: String,
+    created: Vec<PathBuf>,
+    dir: &Path,
+) {
+    ui.emit(&InitOutput {
+        name,
+        dir: dir.to_path_buf(),
+        from_spec,
+        created,
+        success_msg,
+    });
+}
+
+/// The result of `agentos init` (both the plain-name and `--from-spec` branches),
+/// carried through `Ui::emit`. Under `--json` an agent gets the bundle name, the
+/// directory, the spec source (null for the plain-name path), the list of created
+/// paths, and the next-step command -- never empty stdout (issue #485). Owns its
+/// data so `to_json`/`render` outlive the scaffold call.
+pub struct InitOutput {
+    pub name: String,
+    pub dir: PathBuf,
+    pub from_spec: Option<PathBuf>,
+    pub created: Vec<PathBuf>,
+    pub success_msg: String,
+}
+
+impl crate::ui::CliOutput for InitOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "initialized": true,
+            "name": self.name,
+            "dir": self.dir.display().to_string(),
+            "from_spec": self.from_spec.as_ref().map(|p| p.display().to_string()),
+            "created": self
+                .created
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>(),
+            "next": format!("cd {} && agentos skill up", self.dir.display()),
+        })
     }
-    ui.note(&format!("Next: cd {} && agentos skill up", dir.display()));
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        ui.success(&self.success_msg);
+        for path in &self.created {
+            ui.note(&format!("created {}", path.display()));
+        }
+        ui.note(&format!(
+            "Next: cd {} && agentos skill up",
+            self.dir.display()
+        ));
+    }
 }
 
 /// `agentos build`: build the runner image locally from the repo's Dockerfile.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -319,6 +319,19 @@ pub struct InitOutput {
     pub success_msg: String,
 }
 
+impl InitOutput {
+    /// The copy-pasteable next-step command. The dir is shell-quoted (only when
+    /// it carries a special char -- a kebab bundle name stays bare) so a path
+    /// with a space yields a valid `cd`, not a broken two-token one. Shared by
+    /// `to_json` and `render` so the machine and human forms never drift.
+    fn next_command(&self) -> String {
+        format!(
+            "cd {} && agentos skill up",
+            crate::ops::shell_quote(&self.dir.display().to_string())
+        )
+    }
+}
+
 impl crate::ui::CliOutput for InitOutput {
     fn to_json(&self) -> serde_json::Value {
         serde_json::json!({
@@ -331,7 +344,7 @@ impl crate::ui::CliOutput for InitOutput {
                 .iter()
                 .map(|p| p.display().to_string())
                 .collect::<Vec<_>>(),
-            "next": format!("cd {} && agentos skill up", self.dir.display()),
+            "next": self.next_command(),
         })
     }
 
@@ -340,10 +353,7 @@ impl crate::ui::CliOutput for InitOutput {
         for path in &self.created {
             ui.note(&format!("created {}", path.display()));
         }
-        ui.note(&format!(
-            "Next: cd {} && agentos skill up",
-            self.dir.display()
-        ));
+        ui.note(&format!("Next: {}", self.next_command()));
     }
 }
 

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -1081,3 +1081,24 @@ fn init_output_json_shape_is_pinned() {
         })
     );
 }
+
+/// The `next` command shell-quotes a dir with a space so it stays a single valid
+/// `cd` target, not a broken two-token command. A kebab path stays bare (asserted
+/// above), so this only fires for special-char paths.
+#[test]
+fn init_output_next_shell_quotes_a_dir_with_a_space() {
+    use std::path::PathBuf;
+    let out = InitOutput {
+        name: "deal-desk".to_string(),
+        dir: PathBuf::from("my bundle"),
+        from_spec: None,
+        created: vec![],
+        success_msg: String::new(),
+    }
+    .to_json();
+    assert_eq!(
+        out["next"],
+        json!("cd 'my bundle' && agentos skill up"),
+        "a dir with a space must be shell-quoted in the next command: {out}"
+    );
+}

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -481,8 +481,8 @@ fn cluster_comms_disconnect_dry_run_emits_plan_not_error() {
 
 use agentos::api::{MemoryEntry, Version};
 use agentos::commands::{
-    ApprovalsOutput, BudgetOutput, DeleteOutput, KillOutput, MemoryOutput, ResumeOutput,
-    VersionsOutput,
+    ApprovalsOutput, BudgetOutput, DeleteOutput, InitOutput, KillOutput, MemoryOutput,
+    ResumeOutput, VersionsOutput,
 };
 // `ObservabilityOutput` moved to the tier-aware `observability` seam (#460) so
 // both the local and cluster handlers return one type.
@@ -949,5 +949,135 @@ fn local_operator_output_json_shapes_are_pinned() {
     assert_eq!(
         LocalDownOutput::Aborted.to_json(),
         json!({"stopped": false, "aborted": true})
+    );
+}
+
+// ---------------------------------------------------------------------------
+// init --json (issue #485)
+// ---------------------------------------------------------------------------
+
+/// A minimal valid agent spec: one skill, one eval, no connectors. Enough for
+/// `parse`/`validate` to accept and `scaffold_from_spec` to write a bundle, so
+/// the binary-driven test below can exercise the real `init --from-spec`
+/// success path hermetically.
+const INIT_SPEC_JSON: &str = r#"{
+  "name": "deal-desk",
+  "description": "Prices and reviews deal desk requests.",
+  "skills": [
+    {
+      "name": "deal-desk",
+      "description": "Invoke when a rep submits a pricing exception request.",
+      "instructions": "Deal desk skill body.\n"
+    }
+  ],
+  "evals": [
+    { "id": "prices-a-deal", "input": "Quote 20% off for Acme", "grader": { "kind": "contains", "expected": "all done", "case_sensitive": false } }
+  ]
+}"#;
+
+/// Binary-driven: `agentos init --from-spec <spec> --json` on the real success
+/// path must emit ONE JSON object to stdout, not the 0-byte stdout it shipped
+/// with (issue #485). Asserting exit 0 alone is a FALSE GREEN here -- the bug
+/// was exit 0 WITH empty stdout -- so this asserts on the stdout BYTES. Hermetic:
+/// it writes a self-contained spec and scaffolds into a fresh tempdir, no network.
+#[test]
+fn init_from_spec_emits_json_object() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let spec_path = tmp.path().join("spec.json");
+    std::fs::write(&spec_path, INIT_SPEC_JSON).expect("write spec fixture");
+    let out_dir = tmp.path().join("bundle");
+
+    let output = Command::new(bin())
+        .args([
+            "init",
+            "--from-spec",
+            spec_path.to_str().unwrap(),
+            "--dir",
+            out_dir.to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .expect("run agentos init --from-spec --json");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "init --from-spec is hermetic and must exit 0\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !stdout.trim().is_empty(),
+        "`agentos init --from-spec --json` must not emit empty stdout (issue #485)\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("must emit parseable JSON: {e}\nstdout: {stdout}"));
+    assert!(
+        parsed.is_object(),
+        "`agentos init --from-spec --json` must emit a JSON object, got: {stdout}"
+    );
+    // Agent-facing keys: the name comes from the spec, from_spec is the source
+    // path (never null on this branch), created lists the written files.
+    assert_eq!(parsed["initialized"], json!(true));
+    assert_eq!(parsed["name"], json!("deal-desk"));
+    assert_eq!(
+        parsed["from_spec"],
+        json!(spec_path.to_str().unwrap()),
+        "from_spec must carry the spec source path on the --from-spec branch"
+    );
+    assert!(
+        parsed["created"].as_array().is_some_and(|c| !c.is_empty()),
+        "created must list the scaffolded files: {stdout}"
+    );
+    // The human success line must NOT leak onto stdout under --json.
+    assert!(
+        !stdout.contains("initialized plugin bundle"),
+        "the human success line must stay on stderr under --json: {stdout}"
+    );
+}
+
+/// Exact key-shape pin for `InitOutput::to_json` (both branches). Renaming,
+/// dropping, or adding a key fails. The plain-name branch's `from_spec` must be
+/// an explicit `null`, not an omitted key: an agent reads null as "not
+/// spec-sourced", where a missing key is ambiguous.
+#[test]
+fn init_output_json_shape_is_pinned() {
+    use std::path::PathBuf;
+    assert_eq!(
+        InitOutput {
+            name: "deal-desk".to_string(),
+            dir: PathBuf::from("deal-desk"),
+            from_spec: Some(PathBuf::from("spec.json")),
+            created: vec![PathBuf::from("deal-desk/.claude-plugin/plugin.json")],
+            success_msg: "rendered only on the human path".to_string(),
+        }
+        .to_json(),
+        json!({
+            "initialized": true,
+            "name": "deal-desk",
+            "dir": "deal-desk",
+            "from_spec": "spec.json",
+            "created": ["deal-desk/.claude-plugin/plugin.json"],
+            "next": "cd deal-desk && agentos skill up"
+        })
+    );
+    assert_eq!(
+        InitOutput {
+            name: "weather".to_string(),
+            dir: PathBuf::from("./weather"),
+            from_spec: None,
+            created: vec![],
+            success_msg: String::new(),
+        }
+        .to_json(),
+        json!({
+            "initialized": true,
+            "name": "weather",
+            "dir": "./weather",
+            "from_spec": null,
+            "created": [],
+            "next": "cd ./weather && agentos skill up"
+        })
     );
 }


### PR DESCRIPTION
Under `--json`, every agent-facing verb must emit one JSON object to stdout, never empty stdout (#456, ADR-0021). `agentos init` -- both the plain `NAME` branch and `--from-spec` -- ended its success path on `ui.success`/`ui.note`, which write to **stderr** and never route to stdout. So `agentos init --from-spec ... --json` exited 0 with **0 bytes on stdout** (confirmed on v0.4.0-rc.4 by a cold-start agent driving the CLI): the one machine-readable payload an agent most wants had no machine-readable form.

Both branches now route through a typed `InitOutput` and the single `Ui::emit` success point:

- Under `--json`: one object -> `{initialized, name, dir, from_spec, created, next}`. `from_spec` is an explicit `null` on the plain-name branch (a missing key would be ambiguous to an agent).
- Human path: renders the same success line + `created` notes + `Next:` hint on stderr, byte-identical to before.

**Scope decision (recorded):** the shared `report_scaffold` helper backs both branches, so this fixes the plain-name `init` too. Fixing only `--from-spec` would leave the sibling verb silently inconsistent under `--json`, so both are converted together. No clap surface change, so no manifest regen.

**Relationship to #580:** issue #485 spans several verbs. Open PR #580 covers the operator verbs (`up`/`down`/`status`/`comms`), `deploy`, and `skill message`; it does not touch `init`. This PR is the remaining `init` slice. Together they close the issue.

Tests assert stdout **bytes**, not just exit 0 (a bare exit-0 check is a false green here -- the bug was exit 0 *with* empty stdout): a binary-driven hermetic run of `init --from-spec --json` plus an exact `to_json` key-shape pin for both branches. `cli/CLAUDE.md`'s `--json` invariant now lists `init` as covered.

Closes #485