### PR TITLE
Extract the sandbox hardening securityContext helpers and render-assert them

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -123,6 +123,15 @@ jobs:
           set -euo pipefail
           bash charts/agentos/ci/connector-secrets-assertions.sh
 
+      # Prove every container in the untrusted sandbox pod renders the identical
+      # Rail 3 hardened securityContext from the shared helper (issue #493), so a
+      # helper edit that weakens the lockdown -- or a container that skips it --
+      # fails CI rather than silently shipping a looser sandbox.
+      - name: helm render assertions (sandbox hardening)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/sandbox-hardening-assertions.sh
+
       # Prove the dispatcher is told where the platform API is and how to
       # authenticate to it (issue #442). Unwired, it falls back to its code
       # default http://localhost:8000 -- itself -- and every Slack Approve click

--- a/charts/agentos/ci/sandbox-hardening-assertions.sh
+++ b/charts/agentos/ci/sandbox-hardening-assertions.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #493 (Rail 3 container hardening). The
+# container-level securityContext lockdown is applied to EVERY container in the
+# untrusted sandbox pod -- the runner, both bundle init containers, and the
+# litellm sidecar when enabled -- and was previously copy-pasted four times. It
+# now renders from one `agentos.sandboxHardening.securityContext` helper; this
+# test pins that the rendered lockdown is present and identical on every
+# container, so a helper edit that weakens (or a container that skips) the
+# lockdown fails CI.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+TPL=templates/agent-sandbox.yaml
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+DEFAULT="$TMP/default.yaml"
+LITELLM="$TMP/litellm.yaml"
+
+echo "=== Rendering SandboxTemplate (defaults; hardening on) ==="
+helm template rel "$CHART" --show-only "$TPL" > "$DEFAULT"
+
+echo "=== Rendering SandboxTemplate (litellm sidecar enabled) ==="
+helm template rel "$CHART" --show-only "$TPL" \
+  --set agentSandbox.runner.liteLLM.enabled=true \
+  --set agentSandbox.runner.liteLLM.configExistingSecret=my-litellm-cfg > "$LITELLM"
+
+ASSERT_PY="$TMP/assert.py"
+cat > "$ASSERT_PY" <<'PY'
+import sys, yaml
+
+# The hardened container securityContext every sandbox container must carry.
+EXPECTED = {
+    "allowPrivilegeEscalation": False,
+    "readOnlyRootFilesystem": True,
+    "runAsNonRoot": True,
+    "capabilities": {"drop": ["ALL"]},
+}
+
+
+def sandbox_template(path):
+    for doc in yaml.safe_load_all(open(path)):
+        if doc and doc.get("kind") == "SandboxTemplate":
+            return doc
+    raise SystemExit(f"no SandboxTemplate rendered in {path}")
+
+
+def check(path, expected_names):
+    tmpl = sandbox_template(path)
+    spec = tmpl["spec"]["podTemplate"]["spec"]
+    containers = (spec.get("initContainers") or []) + (spec.get("containers") or [])
+    names = {c["name"] for c in containers}
+    missing = set(expected_names) - names
+    if missing:
+        raise SystemExit(f"{path}: expected containers {sorted(missing)} not rendered (got {sorted(names)})")
+    for c in containers:
+        sc = c.get("securityContext")
+        if sc != EXPECTED:
+            raise SystemExit(
+                f"{path}: container {c['name']!r} securityContext is not the hardened "
+                f"lockdown.\n  expected: {EXPECTED}\n  got:      {sc}"
+            )
+    print(f"  ok: {sorted(names)} all carry the identical hardened securityContext")
+
+
+check(sys.argv[1], {"bundle-fetch", "bundle-extract", "runner"})
+check(sys.argv[2], {"bundle-fetch", "bundle-extract", "runner", "litellm"})
+PY
+
+if ! out="$(python3 "$ASSERT_PY" "$DEFAULT" "$LITELLM" 2>&1)"; then
+  fail "$out"
+fi
+echo "$out"
+
+echo
+echo "PASS: every sandbox container (runner, bundle-fetch, bundle-extract, and the litellm sidecar when enabled) renders the identical Rail 3 hardened securityContext from the shared helper."

--- a/charts/agentos/templates/_helpers.tpl
+++ b/charts/agentos/templates/_helpers.tpl
@@ -480,3 +480,31 @@ true
 true
 {{- end -}}
 {{- end -}}
+
+{{/* ---- Sandbox container hardening (Rail 3) ----
+     The identical container-level lockdown applied to the runner and every
+     helper container in the sandbox pod (bundle-fetch, bundle-extract, litellm).
+     Extracted so the four copies cannot drift (#493); callers keep their own
+     `{{- if $runner.hardening.enabled }}` guard and apply `nindent 10`. This is
+     the container securityContext only -- the pod-level securityContext
+     (runAsUser/fsGroup/seccomp) is a separate, non-duplicated block. */}}
+{{- define "agentos.sandboxHardening.securityContext" -}}
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop: [ALL]
+{{- end -}}
+
+{{/* ---- First-party service container securityContext ----
+     The `securityContext:` + `toYaml` wrapper the four first-party services (api,
+     worker, dispatcher, ui) each render from their own
+     `.Values.<svc>.containerSecurityContext`. Extracted so the wrapper lives once
+     (#493). Call with the container-security-context VALUE inside the existing
+     `{{- with .Values.<svc>.containerSecurityContext }}` guard and apply
+     `nindent 10`; the `with` handles the empty case exactly as before. */}}
+{{- define "agentos.containerSecurityContext" -}}
+securityContext:
+{{- toYaml . | nindent 2 }}
+{{- end -}}

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -213,12 +213,7 @@ spec:
           # write targets a mounted emptyDir (the fetched archive to `bundles`, mc's
           # config to the dedicated `mc-config` volume via MC_CONFIG_DIR), so a
           # read-only rootfs is safe.
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop: [ALL]
+          {{- include "agentos.sandboxHardening.securityContext" . | nindent 10 }}
           {{- end }}
           command:
             - /bin/sh
@@ -262,12 +257,7 @@ spec:
           # Same container-level lockdown as the runner (see bundle-fetch): all
           # writes target the mounted `bundles` volume, so a read-only rootfs is
           # safe here too.
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop: [ALL]
+          {{- include "agentos.sandboxHardening.securityContext" . | nindent 10 }}
           {{- end }}
           command:
             - /bin/sh
@@ -332,12 +322,7 @@ spec:
           {{- if $runner.hardening.enabled }}
           # Same container-level lockdown as the runner: the proxy only reads its
           # mounted config and talks upstream, so a read-only rootfs is safe.
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop: [ALL]
+          {{- include "agentos.sandboxHardening.securityContext" . | nindent 10 }}
           {{- end }}
           args:
             - --config
@@ -362,12 +347,7 @@ spec:
           image: {{ include "agentos.image" (dict "repository" $runner.image "tag" $runner.tag "digest" $runner.digest "defaultTag" $.Chart.AppVersion) | quote }}
           imagePullPolicy: {{ $runner.imagePullPolicy }}
           {{- if $runner.hardening.enabled }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop: [ALL]
+          {{- include "agentos.sandboxHardening.securityContext" . | nindent 10 }}
           {{- end }}
           ports:
             - name: aci

--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -49,8 +49,7 @@ spec:
           image: {{ include "agentos.image" (dict "repository" .Values.api.image.repository "tag" .Values.api.image.tag "digest" .Values.api.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           {{- with .Values.api.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- include "agentos.containerSecurityContext" . | nindent 10 }}
           {{- end }}
           command: ["alembic", "-c", "alembic.ini", "upgrade", "head"]
           env:
@@ -61,8 +60,7 @@ spec:
           image: {{ include "agentos.image" (dict "repository" .Values.api.image.repository "tag" .Values.api.image.tag "digest" .Values.api.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           {{- with .Values.api.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- include "agentos.containerSecurityContext" . | nindent 10 }}
           {{- end }}
           env:
             {{- include "agentos.env.postgres" . | nindent 12 }}

--- a/charts/agentos/templates/dispatcher.yaml
+++ b/charts/agentos/templates/dispatcher.yaml
@@ -34,8 +34,7 @@ spec:
           image: {{ include "agentos.image" (dict "repository" .Values.dispatcher.image.repository "tag" .Values.dispatcher.image.tag "digest" .Values.dispatcher.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.dispatcher.image.pullPolicy }}
           {{- with .Values.dispatcher.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- include "agentos.containerSecurityContext" . | nindent 10 }}
           {{- end }}
           env:
             {{- include "agentos.env.valkey" . | nindent 12 }}

--- a/charts/agentos/templates/ui.yaml
+++ b/charts/agentos/templates/ui.yaml
@@ -47,8 +47,7 @@ spec:
           image: {{ include "agentos.image" (dict "repository" .Values.ui.image.repository "tag" .Values.ui.image.tag "digest" .Values.ui.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           {{- with .Values.ui.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- include "agentos.containerSecurityContext" . | nindent 10 }}
           {{- end }}
           env:
             # nginx reverse-proxies /api/ to this upstream (the /api prefix is

--- a/charts/agentos/templates/worker.yaml
+++ b/charts/agentos/templates/worker.yaml
@@ -79,8 +79,7 @@ spec:
           image: {{ include "agentos.image" (dict "repository" .Values.worker.image.repository "tag" .Values.worker.image.tag "digest" .Values.worker.image.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           {{- with .Values.worker.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
+          {{- include "agentos.containerSecurityContext" . | nindent 10 }}
           {{- end }}
           env:
             {{- include "agentos.env.postgres" . | nindent 12 }}


### PR DESCRIPTION
The Rail 3 container-level lockdown (`allowPrivilegeEscalation: false`, `readOnlyRootFilesystem`, `runAsNonRoot`, drop `ALL` capabilities) was copy-pasted onto four sandbox containers — `bundle-fetch`, `bundle-extract`, `litellm`, `runner` — three of them carrying a "matches the runner" comment that promised what nothing enforced. The first-party service `securityContext:` + `toYaml` wrapper was likewise repeated five times (api ×2, worker, dispatcher, ui).

- Extract two `_helpers.tpl` defines: `agentos.sandboxHardening.securityContext` (the 5-line lockdown) and `agentos.containerSecurityContext` (the service wrapper), and route all nine call sites through them (callers keep their own `{{- if hardening.enabled }}` / `{{- with ...containerSecurityContext }}` guard and apply `nindent 10`).
- **Byte-identical**: verified with `helm template --output-dir <before>` vs `<after>` + `diff -r` — the only difference is the chart's own `randAlphaNum` secrets, which regenerate every render.
- Add `ci/sandbox-hardening-assertions.sh` (wired into `helm-ci.yaml`): renders the `SandboxTemplate` with defaults and with the litellm sidecar enabled, and asserts **every** container carries the *identical* hardened securityContext — so a helper edit that weakens the lockdown, or a container that skips it, fails CI.

The pod-level securityContext (runAsUser/fsGroup/seccomp) is a separate, non-duplicated block and is intentionally left out of the helper.

Closes #493
Ref CUR-1640