### PR TITLE
Add parity gates for behavior-pack pairs and eval-case mirrors

### DIFF
--- a/apps/api/tests/test_eval_case_schema_parity.py
+++ b/apps/api/tests/test_eval_case_schema_parity.py
@@ -50,7 +50,8 @@ def test_emitted_eval_case_validates_against_the_frozen_schema(kind: str) -> Non
         grader=GraderOut(kind=kind, expected="sunny", case_sensitive=False),
     )
     errors = sorted(_validator_for("EvalCase").iter_errors(case.model_dump()), key=str)
-    assert not errors, f"promote-emitted EvalCase failed the frozen schema: {[e.message for e in errors]}"
+    messages = [e.message for e in errors]
+    assert not errors, f"promote-emitted EvalCase failed the frozen schema: {messages}"
 
 
 def test_grader_kinds_match_the_schema_enum() -> None:

--- a/apps/api/tests/test_eval_case_schema_parity.py
+++ b/apps/api/tests/test_eval_case_schema_parity.py
@@ -1,0 +1,76 @@
+"""The API's promote-a-trace eval-case DTOs must conform to the frozen eval-case
+schema the worker eval runner enforces (#500).
+
+`EvalCaseOut` / `GraderOut` (`schemas.py`) are linked to the worker's frozen
+`EvalCase` / `Grader` (committed at `apps/worker/schema/eval-cases.schema.json`)
+only by a docstring. Nothing asserted that a case the promote endpoint mints
+actually validates against that schema, so the API could drift -- e.g. a new
+`GraderKind` added to the schema but not to `GraderOut`'s hard-coded literal, or
+a field added on one side only. This gate validates emitted cases against the
+committed schema and pins the field sets, so drift fails loudly.
+
+The API package deliberately does not import the worker, so the schema is read
+from its committed file by path, not imported.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from agentos_api.schemas import EvalCaseOut, GraderOut
+from jsonschema import Draft202012Validator
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "apps"
+    / "worker"
+    / "schema"
+    / "eval-cases.schema.json"
+)
+
+
+def _schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text())
+
+
+def _validator_for(def_name: str) -> Draft202012Validator:
+    schema = _schema()
+    # Validate an instance against one $def while keeping the sibling $defs
+    # resolvable (Grader references GraderKind, EvalCase references Grader).
+    return Draft202012Validator({"$ref": f"#/$defs/{def_name}", "$defs": schema["$defs"]})
+
+
+@pytest.mark.parametrize("kind", ["exact", "contains", "regex"])
+def test_emitted_eval_case_validates_against_the_frozen_schema(kind: str) -> None:
+    case = EvalCaseOut(
+        id="c1",
+        input="what is the weather?",
+        grader=GraderOut(kind=kind, expected="sunny", case_sensitive=False),
+    )
+    errors = sorted(_validator_for("EvalCase").iter_errors(case.model_dump()), key=str)
+    assert not errors, f"promote-emitted EvalCase failed the frozen schema: {[e.message for e in errors]}"
+
+
+def test_grader_kinds_match_the_schema_enum() -> None:
+    # A new grader kind added to the worker schema but not to GraderOut's literal
+    # (or vice versa) is a silent divergence -- the API would mint a kind the
+    # runner rejects, or reject a kind the runner accepts.
+    schema_kinds = set(_schema()["$defs"]["GraderKind"]["enum"])
+    api_kinds = set(GraderOut.model_fields["kind"].annotation.__args__)
+    assert api_kinds == schema_kinds, (
+        f"GraderOut.kind literals {sorted(api_kinds)} diverge from the schema "
+        f"GraderKind enum {sorted(schema_kinds)}"
+    )
+
+
+def test_eval_case_field_names_match_the_schema() -> None:
+    schema = _schema()
+    for model, def_name in ((EvalCaseOut, "EvalCase"), (GraderOut, "Grader")):
+        schema_props = set(schema["$defs"][def_name]["properties"])
+        model_fields = set(model.model_fields)
+        assert model_fields == schema_props, (
+            f"{model.__name__} fields {sorted(model_fields)} diverge from schema "
+            f"{def_name} properties {sorted(schema_props)}"
+        )

--- a/apps/worker/tests/test_behaviorpacks_parity.py
+++ b/apps/worker/tests/test_behaviorpacks_parity.py
@@ -1,0 +1,62 @@
+"""Field-name parity between the API write-side pack DTOs and the worker read-side
+value objects (#500).
+
+Behavior-pack config is authored/validated on the API (`schemas.py`, mutable
+`list` fields) and re-parsed at bind time by the worker
+(`behaviorpacks.py`, frozen `tuple` fields). The two representations differ on
+purpose (list vs tuple, `SettingConfig` vs frozen `Setting`), but their FIELD
+NAMES must agree: `BehaviorPacks.from_config` parses totally with pydantic's
+default `extra="ignore"`, so a field added on the write side but not the read
+side is silently dropped at runtime -- no 422, a dead knob. This gate compares
+field-name sets per pair so that divergence fails loudly instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from agentos_api import schemas as api
+from agentos_worker import behaviorpacks as worker
+
+# (API write-side model, worker read-side model). An added-but-unpaired pack
+# surfaces here too: forgetting to list it leaves it ungated, but the eight
+# below are the full BehaviorPacksConfig surface today.
+_PAIRS = [
+    (api.LoadPackConfig, worker.LoadPack),
+    (api.TipsPackConfig, worker.TipsPack),
+    (api.GreetingPackConfig, worker.GreetingPack),
+    (api.HelpPackConfig, worker.HelpPack),
+    (api.SettingConfig, worker.Setting),
+    (api.SettingsPackConfig, worker.SettingsPack),
+    (api.NavPackConfig, worker.NavPack),
+    (api.BehaviorPacksConfig, worker.BehaviorPacks),
+]
+
+
+@pytest.mark.parametrize("api_model, worker_model", _PAIRS, ids=lambda m: m.__name__)
+def test_pack_field_names_match_across_lanes(api_model, worker_model) -> None:
+    api_fields = set(api_model.model_fields)
+    worker_fields = set(worker_model.model_fields)
+    assert api_fields == worker_fields, (
+        f"{api_model.__name__} (API) and {worker_model.__name__} (worker) have "
+        f"diverged field sets; only-on-API fields are silently dropped by "
+        f"BehaviorPacks.from_config. Symmetric difference: "
+        f"{sorted(api_fields ^ worker_fields)}"
+    )
+
+
+def test_top_level_pack_keys_are_all_paired() -> None:
+    # Guard against a NEW pack added to BehaviorPacksConfig without a parity pair
+    # above: every sub-pack field of the top-level config must be represented.
+    top_level_fields = set(api.BehaviorPacksConfig.model_fields)
+    paired = {
+        "load": True,
+        "tips": True,
+        "greeting": True,
+        "help": True,
+        "settings": True,
+        "nav": True,
+    }
+    assert top_level_fields == set(paired), (
+        "BehaviorPacksConfig gained/lost a sub-pack; add it to _PAIRS and to this "
+        f"guard. Fields: {sorted(top_level_fields)}"
+    )

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -344,9 +344,10 @@ mod tests {
         // Every kind it enumerates must round-trip through the Rust loader, so a
         // kind added to the schema but not to this crate's GraderKind enum fails
         // here rather than silently rejecting a valid platform-authored case.
-        let schema: serde_json::Value =
-            serde_json::from_str(include_str!("../../apps/worker/schema/eval-cases.schema.json"))
-                .expect("committed eval-cases schema is valid JSON");
+        let schema: serde_json::Value = serde_json::from_str(include_str!(
+            "../../apps/worker/schema/eval-cases.schema.json"
+        ))
+        .expect("committed eval-cases schema is valid JSON");
         let kinds = schema["$defs"]["GraderKind"]["enum"]
             .as_array()
             .expect("GraderKind enum is an array");

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -339,6 +339,32 @@ mod tests {
     }
 
     #[test]
+    fn every_schema_grader_kind_deserializes() {
+        // The frozen eval-case schema owns the grader-kind vocabulary (#500).
+        // Every kind it enumerates must round-trip through the Rust loader, so a
+        // kind added to the schema but not to this crate's GraderKind enum fails
+        // here rather than silently rejecting a valid platform-authored case.
+        let schema: serde_json::Value =
+            serde_json::from_str(include_str!("../../apps/worker/schema/eval-cases.schema.json"))
+                .expect("committed eval-cases schema is valid JSON");
+        let kinds = schema["$defs"]["GraderKind"]["enum"]
+            .as_array()
+            .expect("GraderKind enum is an array");
+        assert!(!kinds.is_empty(), "schema declares no grader kinds");
+        for kind in kinds {
+            let kind = kind.as_str().expect("grader kind is a string");
+            let body = format!(
+                r#"{{"name":"s","cases":[{{"id":"c","input":"i","grader":{{"kind":"{kind}","expected":"x"}}}}]}}"#
+            );
+            let (_dir, path) = write(&body);
+            let suite = load_suite(&path).unwrap_or_else(|e| {
+                panic!("schema grader kind {kind:?} was rejected by the Rust loader: {e}")
+            });
+            assert_eq!(suite.cases.len(), 1);
+        }
+    }
+
+    #[test]
     fn renders_design_canon_lines() {
         assert_eq!(case_line("approver", true, 1.24), "\u{2713} approver  1.2s");
         assert_eq!(case_line("crm", false, 0.9), "\u{2717} crm  0.9s");


### PR DESCRIPTION
Three families of shapes are mirrored across lanes and validated on each side, but nothing gated the mirror — so a field added on one side is a silent runtime no-op.

- **Behavior packs** (8 pairs): the API write-side DTOs (`schemas.py`, mutable `list` fields) and the worker read-side value objects (`behaviorpacks.py`, frozen `tuple` fields) are re-parsed by `BehaviorPacks.from_config` with pydantic's default `extra="ignore"`, so a field added only on the API side is dropped with no 422 — a dead knob. New `test_behaviorpacks_parity.py` asserts field-name-set equality per pair (comparing names, not types, since the representations differ on purpose) and guards against a new top-level pack that isn't paired.
- **Eval-case promote DTOs**: `EvalCaseOut`/`GraderOut` were linked to the frozen `eval-cases.schema.json` only by a docstring. New `test_eval_case_schema_parity.py` validates emitted cases against the committed schema (all three grader kinds) and pins the grader-kind enum + field sets, so a schema-only kind/field addition fails.
- **CLI eval structs**: pinned only to the example seed by byte equality, which exercises one grader kind. New Rust test asserts every grader kind the committed schema enumerates round-trips through `load_suite`, so a schema kind absent from the Rust `GraderKind` enum fails.

All additive, read-only over existing shapes; neither family is a frozen contract (behavior packs ride on agent config; the eval-case schema has its own compat gate, which these read but never regenerate).

Closes #500
Ref CUR-1644