### PR TITLE
Add a release-version consistency gate and agentos dev bump-version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,6 +113,12 @@ jobs:
           persist-credentials: false
       - name: Toolchain
         run: rustup component add rustfmt clippy
+      # The release-coupled versions (cli/Cargo.toml, Chart.yaml version +
+      # appVersion) must agree on every PR, so a bump that forgets one field
+      # fails here rather than shipping a chart that pulls the wrong image (#489).
+      - name: Version consistency
+        working-directory: ${{ github.workspace }}
+        run: bash scripts/check-version-consistency.sh
       - name: Fmt
         run: cargo fmt --check
       # --locked on every resolving cargo command asserts the committed

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -265,13 +265,17 @@ jobs:
           persist-credentials: false
       - name: Add target
         run: rustup target add ${{ matrix.target }}
-      - name: Assert tag matches Cargo.toml version
-        working-directory: cli
+      - name: Assert tag matches the release-coupled versions
         run: |
+          set -euo pipefail
+          # The three fields (cli/Cargo.toml, Chart.yaml version + appVersion)
+          # must agree with each other AND with the tag; a stale appVersion ships
+          # a chart that pulls the wrong runner image (#489).
+          bash scripts/check-version-consistency.sh
           tag="${GITHUB_REF_NAME#v}"
-          pkg="$(grep -m1 '^version' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
+          pkg="$(grep -m1 '^version' cli/Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
           if [ "$tag" != "$pkg" ]; then
-            echo "tag v$tag does not match cli/Cargo.toml version $pkg" >&2
+            echo "tag v$tag does not match the release version $pkg" >&2
             exit 1
           fi
       - name: Build release

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2796,6 +2796,37 @@ export const commandManifest = {
           "about": "Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`)",
           "hidden": false,
           "name": "plugin-compat"
+        },
+        {
+          "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
+          "hidden": false,
+          "name": "version-check"
+        },
+        {
+          "about": "Set the release version across cli/Cargo.toml + Chart.yaml version/appVersion (and refresh the CLI lockfile) so a release cut can't leave the three out of sync. Does not commit or tag",
+          "args": [
+            {
+              "global": false,
+              "help": "The new release version: semver `X.Y.Z` or `X.Y.Z-rc.N`",
+              "id": "version",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Print the planned edits without writing anything",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "bump-version"
         }
       ]
     },

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2793,6 +2793,37 @@
           "about": "Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`)",
           "hidden": false,
           "name": "plugin-compat"
+        },
+        {
+          "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
+          "hidden": false,
+          "name": "version-check"
+        },
+        {
+          "about": "Set the release version across cli/Cargo.toml + Chart.yaml version/appVersion (and refresh the CLI lockfile) so a release cut can't leave the three out of sync. Does not commit or tag",
+          "args": [
+            {
+              "global": false,
+              "help": "The new release version: semver `X.Y.Z` or `X.Y.Z-rc.N`",
+              "id": "version",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Print the planned edits without writing anything",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "bump-version"
         }
       ]
     },

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -475,6 +475,134 @@ pub async fn dev_script(rel_path: &str) -> Result<()> {
     Ok(())
 }
 
+/// `agentos dev bump-version <X.Y.Z>`: set the release-coupled version across
+/// cli/Cargo.toml + Chart.yaml version/appVersion in one shot, so a release cut
+/// cannot leave the three out of sync (the drift the #489 consistency gate
+/// catches). It rewrites ONLY the line-anchored release fields (never a
+/// dependency `version = ` line), refreshes the CLI lockfile, and prints the
+/// commit + tag follow-up -- it does not commit, tag, or push. `--dry-run` prints
+/// the planned edits and writes nothing.
+pub async fn bump_version(version: &str, dry_run: bool) -> Result<()> {
+    let ui = crate::ui::ui();
+    // semver X.Y.Z with an optional -rc.N (the only pre-release shape we cut).
+    let semver = regex::Regex::new(r"^\d+\.\d+\.\d+(-rc\.\d+)?$").expect("static regex");
+    if !semver.is_match(version) {
+        return Err(crate::exit::usage(format!(
+            "version {version:?} must be semver X.Y.Z or X.Y.Z-rc.N"
+        )));
+    }
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `agentos dev \
+         bump-version` from an agentos source checkout.",
+    )?;
+
+    let cargo_path = root.join("cli/Cargo.toml");
+    let chart_path = root.join("charts/agentos/Chart.yaml");
+    let cargo = std::fs::read_to_string(&cargo_path)
+        .with_context(|| format!("reading {}", cargo_path.display()))?;
+    let chart = std::fs::read_to_string(&chart_path)
+        .with_context(|| format!("reading {}", chart_path.display()))?;
+
+    // Line-anchored so a dependency `version = "x"` line is never touched: only
+    // the first `version = ` at column 0 (the [package] version) is rewritten.
+    let cargo_new = replace_first_line(&cargo, "version = ", &format!("version = \"{version}\""))
+        .context("cli/Cargo.toml has no top-level `version = ` line")?;
+    let chart_new_v = replace_first_line(&chart, "version:", &format!("version: {version}"))
+        .context("Chart.yaml has no `version:` line")?;
+    let chart_new = replace_first_line(
+        &chart_new_v,
+        "appVersion:",
+        &format!("appVersion: \"{version}\""),
+    )
+    .context("Chart.yaml has no `appVersion:` line")?;
+
+    if dry_run {
+        ui.emit(&crate::ui::DryRunPlan {
+            lines: vec![
+                format!("cli/Cargo.toml: version = \"{version}\""),
+                format!("charts/agentos/Chart.yaml: version: {version}"),
+                format!("charts/agentos/Chart.yaml: appVersion: \"{version}\""),
+                "cargo update -p agentos (refresh Cargo.lock)".to_string(),
+            ],
+        });
+        return Ok(());
+    }
+
+    std::fs::write(&cargo_path, cargo_new)
+        .with_context(|| format!("writing {}", cargo_path.display()))?;
+    std::fs::write(&chart_path, chart_new)
+        .with_context(|| format!("writing {}", chart_path.display()))?;
+    ui.note(&format!(
+        "set version {version} in cli/Cargo.toml and charts/agentos/Chart.yaml"
+    ));
+
+    // Refresh the CLI lockfile so the committed Cargo.lock matches the new crate
+    // version. Best-effort: a missing cargo or offline registry must not fail the
+    // bump (the fields are already written); warn and let the operator run it.
+    let lock_ok = tokio::process::Command::new("cargo")
+        .args(["update", "-p", "agentos", "--precise", version])
+        .current_dir(root.join("cli"))
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !lock_ok {
+        ui.warn(
+            "could not refresh cli/Cargo.lock automatically; run `cargo update -p agentos` in cli/",
+        );
+    }
+
+    ui.emit(&BumpVersionOutput {
+        version: version.to_string(),
+    });
+    Ok(())
+}
+
+/// Replace the first line beginning with `prefix` (after optional leading
+/// whitespace) with `replacement`, preserving the line's indentation. Returns
+/// None when no such line exists.
+fn replace_first_line(content: &str, prefix: &str, replacement: &str) -> Option<String> {
+    let mut out = Vec::new();
+    let mut replaced = false;
+    for line in content.lines() {
+        if !replaced && line.trim_start().starts_with(prefix) {
+            let indent = &line[..line.len() - line.trim_start().len()];
+            out.push(format!("{indent}{replacement}"));
+            replaced = true;
+        } else {
+            out.push(line.to_string());
+        }
+    }
+    if !replaced {
+        return None;
+    }
+    let mut joined = out.join("\n");
+    if content.ends_with('\n') {
+        joined.push('\n');
+    }
+    Some(joined)
+}
+
+/// Output of `dev bump-version`: the version now set across the release fields.
+#[derive(Debug)]
+pub struct BumpVersionOutput {
+    pub version: String,
+}
+
+impl crate::ui::CliOutput for BumpVersionOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({"version": self.version})
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        ui.payload(&format!("bumped release version to {}", self.version));
+        ui.note(&format!(
+            "commit the change, then tag it: git commit -am \"release {v}\" && git tag v{v}",
+            v = self.version
+        ));
+    }
+}
+
 /// Bail with a friendly pointer when a required tool is not on PATH.
 fn require_tool(bin: &str, hint: &str) -> Result<()> {
     if on_path(bin) {
@@ -2624,10 +2752,31 @@ pub fn skill_memory_unavailable() -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::{
-        merge_secret_env, parse_manifest_gates, resolve_cases_path, seed_env_if_missing,
-        select_in_force_deployment, select_passthrough_env, validate_slack_channel, EnvSeed,
+        merge_secret_env, parse_manifest_gates, replace_first_line, resolve_cases_path,
+        seed_env_if_missing, select_in_force_deployment, select_passthrough_env,
+        validate_slack_channel, EnvSeed,
     };
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn replace_first_line_rewrites_only_the_first_anchored_line() {
+        // The [package] version, not a dependency `version = ` line below it.
+        let cargo = "[package]\nname = \"agentos\"\nversion = \"0.4.0\"\n\n[dependencies]\nserde = { version = \"1\" }\n";
+        let out = replace_first_line(cargo, "version = ", "version = \"0.5.0\"").unwrap();
+        assert!(out.contains("version = \"0.5.0\""));
+        // The dependency's inline version is untouched.
+        assert!(out.contains("serde = { version = \"1\" }"));
+        assert_eq!(out.matches("0.5.0").count(), 1);
+        assert!(out.ends_with('\n'));
+    }
+
+    #[test]
+    fn replace_first_line_preserves_indentation_and_reports_absence() {
+        let chart = "apiVersion: v2\nname: agentos\nappVersion: \"0.4.0\"\n";
+        let out = replace_first_line(chart, "appVersion:", "appVersion: \"0.5.0\"").unwrap();
+        assert!(out.contains("appVersion: \"0.5.0\""));
+        assert!(replace_first_line(chart, "nonexistent:", "x").is_none());
+    }
 
     /// Scaffold a bundle at `dir` under `name`, then overwrite its manifest's
     /// `secrets` policy with `secrets`. Shared setup for tests exercising the

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -285,6 +285,19 @@ enum DevAction {
     DocsLint,
     /// Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`).
     PluginCompat,
+    /// Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml
+    /// version, and appVersion (`bash scripts/check-version-consistency.sh`).
+    VersionCheck,
+    /// Set the release version across cli/Cargo.toml + Chart.yaml
+    /// version/appVersion (and refresh the CLI lockfile) so a release cut can't
+    /// leave the three out of sync. Does not commit or tag.
+    BumpVersion {
+        /// The new release version: semver `X.Y.Z` or `X.Y.Z-rc.N`.
+        version: String,
+        /// Print the planned edits without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1237,6 +1250,12 @@ async fn run(command: Option<Command>) -> Result<()> {
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh").await,
             DevAction::PluginCompat => commands::dev_script("scripts/check-plugin-compat.sh").await,
+            DevAction::VersionCheck => {
+                commands::dev_script("scripts/check-version-consistency.sh").await
+            }
+            DevAction::BumpVersion { version, dry_run } => {
+                commands::bump_version(&version, dry_run).await
+            }
         },
         Some(Command::Skill { action }) => match action {
             SkillAction::Up {

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Assert the release-coupled version fields agree (#489).
+#
+# Cutting a release hand-syncs three fields plus a git tag:
+#   - cli/Cargo.toml            version
+#   - charts/agentos/Chart.yaml version
+#   - charts/agentos/Chart.yaml appVersion
+# The release workflow re-derives the chart version from the tag, so a stale
+# committed appVersion still ships a "correct" release artifact while every
+# consumer of the COMMITTED chart (helm template, `agentos cluster up`) pulls the
+# wrong runner image tag (appVersion is the image-tag fallback). This gate catches
+# that drift on every PR and, reused by the release workflow, at tag time.
+#
+# Exits 0 when all three agree, 1 (naming the mismatch) otherwise. Prints the
+# agreed version on success so callers can capture it.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cargo_version="$(grep -m1 '^version = ' "$repo_root/cli/Cargo.toml" | sed -E 's/^version = "(.*)"/\1/')"
+chart_version="$(grep -m1 '^version:' "$repo_root/charts/agentos/Chart.yaml" | sed -E 's/^version:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')"
+chart_app_version="$(grep -m1 '^appVersion:' "$repo_root/charts/agentos/Chart.yaml" | sed -E 's/^appVersion:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')"
+
+fail=0
+if [ "$cargo_version" != "$chart_version" ]; then
+  echo "MISMATCH: cli/Cargo.toml version ($cargo_version) != Chart.yaml version ($chart_version)" >&2
+  fail=1
+fi
+if [ "$cargo_version" != "$chart_app_version" ]; then
+  echo "MISMATCH: cli/Cargo.toml version ($cargo_version) != Chart.yaml appVersion ($chart_app_version)" >&2
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "The release-coupled versions must agree. Run 'agentos dev bump-version <X.Y.Z>' to set all three." >&2
+  exit 1
+fi
+
+echo "version-consistency OK: cli/Cargo.toml, Chart.yaml version, and appVersion all = $cargo_version"


### PR DESCRIPTION
Cutting a release hand-syncs three fields plus a git tag: `cli/Cargo.toml` `version`, and `charts/agentos/Chart.yaml` `version` + `appVersion`. The release workflow re-derives the chart version *from the tag* (`helm package --version "$version" --app-version "$version"`), so a **stale committed `appVersion` still ships a "correct" release** — while every consumer of the *committed* chart (`helm template`, `agentos cluster up`) pulls the wrong runner image, because `appVersion` is the image-tag fallback. The only prior gate compared the tag to the crate version.

- **`scripts/check-version-consistency.sh`** asserts the three agree, printing the agreed version. Wired into **`ci.yaml`** (a per-PR gate, so a bump that forgets one field fails there) and **`release.yaml`** (extends the tag-match assert to cover all three at tag time).
- **`agentos dev version-check`** runs the gate locally; **`agentos dev bump-version <X.Y.Z>`** sets all three fields in one shot — line-anchored so a dependency `version = ` line is never touched — refreshes `cli/Cargo.lock`, and prints the commit + `git tag` follow-up (it does not commit/tag/push). `--dry-run` and `--json` supported.
- Regenerated `cli/command-manifest.json` and the committed `apps/ui/src/generated/commandManifest.ts` for the two new dev verbs (the `command_surface` drift test and the UI `CliHint.parity` suite pass).

Unit tests cover `replace_first_line` (rewrites only the first anchored line, leaves dependency versions and preserves indentation).

Closes #489
Ref CUR-1645