### PR TITLE
Migrate the non-streaming ADR-0021 --json builders to Ui::emit

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -199,10 +199,24 @@ pub async fn check(plugin_dir: PathBuf, image: String, timeout_s: u64) -> Result
         )
     })?;
 
-    let ui = crate::ui::ui();
-    if ui.json() {
-        ui.emit_json(&serde_json::to_value(&report)?);
-    } else {
+    crate::ui::ui().emit(&CheckOutput { report: &report });
+    check_outcome(&report).map_err(anyhow::Error::from)
+}
+
+/// Output of `skill check` (#474): the MCP-load report, structured under `--json`
+/// and rendered line-by-line otherwise, routed through the one `Ui::emit` point.
+/// Borrows the report so the caller can still pass it to `check_outcome`.
+struct CheckOutput<'a> {
+    report: &'a CheckReport,
+}
+
+impl crate::ui::CliOutput for CheckOutput<'_> {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self.report).unwrap_or_else(|_| serde_json::json!({}))
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        let report = self.report;
         let mut lines = vec![format!("declared: {}", report.declared.len())];
         lines.extend(report.matches.iter().map(|entry| {
             format!(
@@ -223,8 +237,6 @@ pub async fn check(plugin_dir: PathBuf, image: String, timeout_s: u64) -> Result
         lines.extend(report.hints.iter().map(|hint| format!("hint: {hint}")));
         ui.payload_plain(&lines.join("\n"));
     }
-
-    check_outcome(&report).map_err(anyhow::Error::from)
 }
 
 pub fn init(name: Option<String>, dir: Option<PathBuf>, from_spec: Option<PathBuf>) -> Result<()> {
@@ -940,14 +952,33 @@ pub async fn status(url: Option<String>) -> Result<()> {
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
     let status = client.status().await?;
-    let ui = crate::ui::ui();
-    if ui.json() {
-        ui.emit_json(&status_json(&url, &status));
-        return Ok(());
-    }
-    ui.note(&format!("runner {url}"));
-    ui.payload_plain(&serde_json::to_string_pretty(&status)?);
+    crate::ui::ui().emit(&StatusOutput {
+        url,
+        status: serde_json::to_value(&status)?,
+    });
     Ok(())
+}
+
+/// Output of `skill status` (#474). `to_json` delegates to the schema-gated
+/// `status_json` builder (byte-identical, so `cli/schema/status.schema.json` and
+/// `json_contract.rs` stay green); `render` reproduces the note + pretty payload.
+struct StatusOutput {
+    url: String,
+    status: serde_json::Value,
+}
+
+impl crate::ui::CliOutput for StatusOutput {
+    fn to_json(&self) -> serde_json::Value {
+        status_json(&self.url, &self.status)
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        ui.note(&format!("runner {}", self.url));
+        ui.payload_plain(
+            &serde_json::to_string_pretty(&self.status)
+                .unwrap_or_else(|_| self.status.to_string()),
+        );
+    }
 }
 
 pub async fn send(
@@ -1262,53 +1293,70 @@ pub fn report_sweep(rows: &[(String, usize, usize)]) -> Result<()> {
 /// `local eval`/`cluster eval` print the same summary `skill eval` does (the
 /// per-tier parity gate), not a hand-mirrored one.
 pub fn report_eval(results: &[EvalRow]) -> Result<()> {
-    let ui = crate::ui::ui();
     let total = results.len();
     let passed = results.iter().filter(|(_, ok, _, _)| *ok).count();
-
-    if ui.json() {
-        ui.emit_json(&eval_json(results, passed, total));
-        if passed < total {
-            std::process::exit(crate::exit::ExitClass::Failure.code());
-        }
-        return Ok(());
-    }
-
-    let rows: Vec<Vec<String>> = results
-        .iter()
-        .map(|(name, ok, seconds, _)| {
-            let result = if *ok {
-                format!("{} pass", '\u{2713}')
-            } else {
-                format!("{} fail", '\u{2717}')
-            };
-            vec![name.clone(), result, format!("{seconds:.1}s")]
-        })
-        .collect();
-    ui.payload_plain(&crate::ui::table(&["case", "result", "time"], &rows, &[2]));
-    if passed == total {
-        ui.success(&format!("{passed}/{total} passed"));
-    } else {
-        // Surface WHAT each red case actually replied, so a human need not re-run
-        // by hand to see why it failed (#548). Empty means the turn never produced
-        // gradeable text (no `done`/reply) -- itself the diagnosis.
-        for (name, _, _, output) in results.iter().filter(|(_, ok, _, _)| !*ok) {
-            let shown = if output.is_empty() {
-                "<no reply text>".to_string()
-            } else {
-                output.clone()
-            };
-            ui.note(&format!("{name} replied: {shown}"));
-        }
-        ui.warn(&format!(
-            "{passed}/{total} passed; {} failed",
-            total - passed
-        ));
-    }
+    // Emit through the one success point (#474), then apply the exit-code side
+    // effect for BOTH paths -- the json path had it inline, the human path after.
+    crate::ui::ui().emit(&EvalOutput {
+        results,
+        passed,
+        total,
+    });
     if passed < total {
         std::process::exit(crate::exit::ExitClass::Failure.code());
     }
     Ok(())
+}
+
+/// Output of `<tier> eval` (#474). `to_json` delegates to the schema-gated
+/// `eval_json` builder (byte-identical, so `cli/schema/eval.schema.json` and
+/// `json_contract.rs` stay green); `render` reproduces the per-case table and the
+/// roll-up verdict + per-red-case reply notes.
+struct EvalOutput<'a> {
+    results: &'a [EvalRow],
+    passed: usize,
+    total: usize,
+}
+
+impl crate::ui::CliOutput for EvalOutput<'_> {
+    fn to_json(&self) -> serde_json::Value {
+        eval_json(self.results, self.passed, self.total)
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        let (results, passed, total) = (self.results, self.passed, self.total);
+        let rows: Vec<Vec<String>> = results
+            .iter()
+            .map(|(name, ok, seconds, _)| {
+                let result = if *ok {
+                    format!("{} pass", '\u{2713}')
+                } else {
+                    format!("{} fail", '\u{2717}')
+                };
+                vec![name.clone(), result, format!("{seconds:.1}s")]
+            })
+            .collect();
+        ui.payload_plain(&crate::ui::table(&["case", "result", "time"], &rows, &[2]));
+        if passed == total {
+            ui.success(&format!("{passed}/{total} passed"));
+        } else {
+            // Surface WHAT each red case actually replied, so a human need not
+            // re-run by hand to see why it failed (#548). Empty means the turn
+            // never produced gradeable text (no `done`/reply) -- the diagnosis.
+            for (name, _, _, output) in results.iter().filter(|(_, ok, _, _)| !*ok) {
+                let shown = if output.is_empty() {
+                    "<no reply text>".to_string()
+                } else {
+                    output.clone()
+                };
+                ui.note(&format!("{name} replied: {shown}"));
+            }
+            ui.warn(&format!(
+                "{passed}/{total} passed; {} failed",
+                total - passed
+            ));
+        }
+    }
 }
 
 /// Where the eval cases live: an explicit `--cases` wins; otherwise

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -975,8 +975,7 @@ impl crate::ui::CliOutput for StatusOutput {
     fn render(&self, ui: &crate::ui::Ui) {
         ui.note(&format!("runner {}", self.url));
         ui.payload_plain(
-            &serde_json::to_string_pretty(&self.status)
-                .unwrap_or_else(|_| self.status.to_string()),
+            &serde_json::to_string_pretty(&self.status).unwrap_or_else(|_| self.status.to_string()),
         );
     }
 }

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -306,12 +306,22 @@ pub fn primer_markdown() -> String {
 /// `--json` flag prints the structured variant to stdout via the shared
 /// machine-output path (any human text would go to stderr).
 pub fn run() -> Result<()> {
-    let p = primer();
-    let ui = ui::ui();
-    if ui.json() {
-        ui.emit_json(&serde_json::to_value(&p)?);
-    } else {
-        ui.payload_plain(&render_markdown(&p));
-    }
+    ui::ui().emit(&GuideOutput { primer: primer() });
     Ok(())
+}
+
+/// Output of `agentos guide` (#474): the primer, structured under `--json` and
+/// rendered as markdown otherwise, routed through the one `Ui::emit` point.
+struct GuideOutput {
+    primer: Primer,
+}
+
+impl ui::CliOutput for GuideOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(&self.primer).unwrap_or_else(|_| serde_json::json!({}))
+    }
+
+    fn render(&self, ui: &ui::Ui) {
+        ui.payload_plain(&render_markdown(&self.primer));
+    }
 }

--- a/cli/src/secrets.rs
+++ b/cli/src/secrets.rs
@@ -64,18 +64,30 @@ pub fn set(opts: SetSecretOpts) -> Result<()> {
 }
 
 pub fn list() -> Result<()> {
-    let names = list_names()?;
-    let ui = crate::ui::ui();
-    if ui.json() {
-        ui.emit_json(&serde_json::json!({ "secrets": names }));
-        return Ok(());
-    }
-    if names.is_empty() {
-        ui.note("no AgentOS secrets saved");
-    } else {
-        ui.payload_plain(&names.join("\n"));
-    }
+    crate::ui::ui().emit(&SecretsListOutput {
+        names: list_names()?,
+    });
     Ok(())
+}
+
+/// Output of `secrets list` (#474): the saved secret NAMEs. Routes through the
+/// one `Ui::emit` point rather than an inline `if json()` branch.
+struct SecretsListOutput {
+    names: Vec<String>,
+}
+
+impl crate::ui::CliOutput for SecretsListOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({ "secrets": self.names })
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        if self.names.is_empty() {
+            ui.note("no AgentOS secrets saved");
+        } else {
+            ui.payload_plain(&self.names.join("\n"));
+        }
+    }
 }
 
 pub fn unset(opts: UnsetSecretOpts) -> Result<()> {


### PR DESCRIPTION
The tracked ADR-0021 exception verbs still inline their own `if ui.json() { emit_json(...) } else { <human> }` branch instead of returning a typed `CliOutput` through the one `Ui::emit` success point (#456) — the pattern PR #580 applied to the operator/deploy verbs.

Migrates the **five non-streaming** ones:
- `skill status` → `StatusOutput` (`to_json` delegates to the schema-gated `status_json`, byte-identical)
- `local`/`cluster`/`skill eval` → `EvalOutput` (delegates to `eval_json`; the exit-`Failure` side effect now runs once after the single emit, for both paths)
- `skill check` → `CheckOutput` (borrows the report so `check_outcome` still runs)
- `secrets list` → `SecretsListOutput`
- `guide` → `GuideOutput`

`cli/schema/{status,eval}.schema.json` and `json_contract.rs` stay green because each `to_json` delegates to the existing pure builder rather than re-inlining the JSON.

**Deliberately left for a follow-up on #474** (flagged in that issue's discussion as the hard part):
- `local`/`cluster message` — the human branch streams the reply live (`ui.answer`) and, on timeout, runs **async** stream `diagnostics(...).await`, which a sync `CliOutput::render` can't host; plus tier-specific dry-run branches. Converting it cleanly needs the async diagnostics pre-computed and the streaming reworked — its own change.
- the centralized **error** emit (`main.rs`) — already the one sanctioned second emit point (the mirror `Ui::emit` was modeled on), and its human render targets **stderr**, not the stdout payload the `CliOutput` trait models.

Ref #474