### PR TITLE
First-class local approval verbs: list pending, resolve as an actor

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1145,6 +1145,54 @@ export const commandManifest = {
                 "false"
               ],
               "required": false
+            },
+            {
+              "global": false,
+              "help": "List the agent's pending approval records instead of the gate config",
+              "id": "list",
+              "long": "list",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Resolve the approval with this id (approve by default; requires --as)",
+              "id": "resolve",
+              "long": "resolve",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "The actor resolving the approval (required with --resolve). The requester and approver may differ; the server blocks self-approval",
+              "id": "as_actor",
+              "long": "as",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Reject instead of approve (with --resolve)",
+              "id": "reject",
+              "long": "reject",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Optional note recorded with the resolution (with --resolve)",
+              "id": "note",
+              "long": "note",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,
@@ -2645,6 +2693,54 @@ export const commandManifest = {
                 "true",
                 "false"
               ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "List the agent's pending approval records instead of the gate config",
+              "id": "list",
+              "long": "list",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Resolve the approval with this id (approve by default; requires --as)",
+              "id": "resolve",
+              "long": "resolve",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "The actor resolving the approval (required with --resolve). The requester and approver may differ; the server blocks self-approval",
+              "id": "as_actor",
+              "long": "as",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Reject instead of approve (with --resolve)",
+              "id": "reject",
+              "long": "reject",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Optional note recorded with the resolution (with --resolve)",
+              "id": "note",
+              "long": "note",
+              "positional": false,
               "required": false
             }
           ],

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1142,6 +1142,54 @@
                 "false"
               ],
               "required": false
+            },
+            {
+              "global": false,
+              "help": "List the agent's pending approval records instead of the gate config",
+              "id": "list",
+              "long": "list",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Resolve the approval with this id (approve by default; requires --as)",
+              "id": "resolve",
+              "long": "resolve",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "The actor resolving the approval (required with --resolve). The requester and approver may differ; the server blocks self-approval",
+              "id": "as_actor",
+              "long": "as",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Reject instead of approve (with --resolve)",
+              "id": "reject",
+              "long": "reject",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Optional note recorded with the resolution (with --resolve)",
+              "id": "note",
+              "long": "note",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,
@@ -2642,6 +2690,54 @@
                 "true",
                 "false"
               ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "List the agent's pending approval records instead of the gate config",
+              "id": "list",
+              "long": "list",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Resolve the approval with this id (approve by default; requires --as)",
+              "id": "resolve",
+              "long": "resolve",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "The actor resolving the approval (required with --resolve). The requester and approver may differ; the server blocks self-approval",
+              "id": "as_actor",
+              "long": "as",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Reject instead of approve (with --resolve)",
+              "id": "reject",
+              "long": "reject",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Optional note recorded with the resolution (with --resolve)",
+              "id": "note",
+              "long": "note",
+              "positional": false,
               "required": false
             }
           ],

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -32,6 +32,27 @@ pub struct Agent {
     pub approval_required_tools: Option<Vec<String>>,
 }
 
+/// One approval record, hand-mirroring the committed `ApprovalOut` (#506). Only
+/// the fields the CLI renders are modeled; serde ignores the rest of the payload.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApprovalRecord {
+    pub id: String,
+    pub author: String,
+    #[serde(default)]
+    pub route: Option<String>,
+    #[serde(default)]
+    pub gate_kind: Option<String>,
+    #[serde(default)]
+    pub granted_tool: Option<String>,
+    pub status: String,
+    pub conversation_id: String,
+    pub summary: String,
+    #[serde(default)]
+    pub expires_at: Option<String>,
+    #[serde(default)]
+    pub resolved_by: Option<String>,
+}
+
 /// What a deploy did with the agent's Slack channel, for the summary printout.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChannelOutcome {
@@ -562,6 +583,57 @@ impl ApiClient {
             .json()
             .await
             .context("decoding memory list")
+    }
+
+    /// The pending approval records for an agent: `GET /approvals?status_filter=
+    /// pending&agent_id=<id>`. Hand-mirrors the committed `ApprovalOut` shape
+    /// (only the fields the CLI renders; serde ignores the rest), the same way
+    /// `Agent`/`KillState` mirror `openapi.json` (#506).
+    pub async fn list_pending_approvals(&self, agent_id: &str) -> Result<Vec<ApprovalRecord>> {
+        let resp = self
+            .http
+            .get(format!("{}/approvals", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .query(&[("status_filter", "pending"), ("agent_id", agent_id)])
+            .send()
+            .await
+            .context("GET /approvals")?;
+        Self::expect_ok(resp, "listing pending approvals")
+            .await?
+            .json()
+            .await
+            .context("decoding approvals")
+    }
+
+    /// Resolve one approval as a chosen actor: `POST /approvals/{id}/resolve`.
+    /// The server owns the resolve-once CAS, the authorizer (self-approval block,
+    /// route approvers), and the resume-turn enqueue; `resolved_by` is the acting
+    /// actor (the `--as` flag), which is what makes requester != approver
+    /// expressible without hand-curling the API (#506).
+    pub async fn resolve_approval(
+        &self,
+        approval_id: &str,
+        decision: &str,
+        resolved_by: &str,
+        note: Option<&str>,
+    ) -> Result<ApprovalRecord> {
+        let mut body = json!({ "decision": decision, "resolved_by": resolved_by });
+        if let Some(note) = note {
+            body["note"] = json!(note);
+        }
+        let resp = self
+            .http
+            .post(format!("{}/approvals/{approval_id}/resolve", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .context("POST /approvals/{id}/resolve")?;
+        Self::expect_ok(resp, "resolving approval")
+            .await?
+            .json()
+            .await
+            .context("decoding resolved approval")
     }
 
     /// Set the agent's approval-required tool gates: `PATCH /agents/{id}` with

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2398,16 +2398,28 @@ pub async fn memory(opts: AgentActionOpts) -> Result<MemoryOutput> {
     })
 }
 
-/// Output of `<tier> approvals <agent>`: the dry-run plan, or the gate list
-/// (empty vec == "no tools gated"). Owns its data so it outlives the `ApiClient`.
+/// The pending-list / resolve flags for `local approvals` (#506). Defaulted so
+/// the skill/cluster tiers, which keep only the gate view/set surface, pass an
+/// empty value.
+#[derive(Default)]
+pub struct ApprovalCmd {
+    pub list: bool,
+    pub resolve: Option<String>,
+    pub as_actor: Option<String>,
+    pub reject: bool,
+    pub note: Option<String>,
+}
+
+/// Output of `<tier> approvals <agent>`: the dry-run plan, the gate list (empty
+/// vec == "no tools gated"), the pending records, or a resolved record (#506).
+/// Owns its data so it outlives the `ApiClient`.
 ///
-/// `manifest_unreadable` carries the third state (#607). `gated_tools` alone
-/// cannot distinguish "the deployed bundle manifest declares no gates" from "the
-/// manifest could not be read at all" -- both used to arrive here as an empty vec
+/// `manifest_unreadable` carries the third gate-list state (#607): `gated_tools`
+/// alone cannot distinguish "the deployed bundle manifest declares no gates" from
+/// "the manifest could not be read at all" -- both used to arrive as an empty vec
 /// and render as the affirmative "calls run without approval". `Some(reason)`
 /// means the manifest lookup failed, so the list is what we could see rather than
-/// what is armed. Always `None` on the set path (`--gate`/`--clear`), which echoes
-/// the PATCHed platform field and never reads a manifest.
+/// what is armed. Always `None` on the set path (`--gate`/`--clear`).
 pub enum ApprovalsOutput {
     DryRun(crate::ui::DryRunPlan),
     Gates {
@@ -2415,6 +2427,28 @@ pub enum ApprovalsOutput {
         gated_tools: Vec<String>,
         manifest_unreadable: Option<String>,
     },
+    Pending {
+        agent: String,
+        records: Vec<crate::api::ApprovalRecord>,
+    },
+    Resolved {
+        record: crate::api::ApprovalRecord,
+    },
+}
+
+fn approval_record_json(r: &crate::api::ApprovalRecord) -> serde_json::Value {
+    serde_json::json!({
+        "id": r.id,
+        "author": r.author,
+        "route": r.route,
+        "gate_kind": r.gate_kind,
+        "granted_tool": r.granted_tool,
+        "status": r.status,
+        "conversation_id": r.conversation_id,
+        "summary": r.summary,
+        "expires_at": r.expires_at,
+        "resolved_by": r.resolved_by,
+    })
 }
 
 impl crate::ui::CliOutput for ApprovalsOutput {
@@ -2429,6 +2463,13 @@ impl crate::ui::CliOutput for ApprovalsOutput {
                 "agent": agent,
                 "gated_tools": gated_tools,
                 "manifest_unreadable": manifest_unreadable,
+            }),
+            ApprovalsOutput::Pending { agent, records } => serde_json::json!({
+                "agent": agent,
+                "pending": records.iter().map(approval_record_json).collect::<Vec<_>>(),
+            }),
+            ApprovalsOutput::Resolved { record } => serde_json::json!({
+                "resolved": approval_record_json(record),
             }),
         }
     }
@@ -2449,6 +2490,32 @@ impl crate::ui::CliOutput for ApprovalsOutput {
                 for tool in gated_tools {
                     ui.kv("gated", tool);
                 }
+            }
+            ApprovalsOutput::Pending { agent, records } => {
+                if records.is_empty() {
+                    ui.payload(&format!("{agent}: no pending approvals"));
+                } else {
+                    ui.payload(&format!("{agent} — {} pending approval(s):", records.len()));
+                    for r in records {
+                        let tool = r.granted_tool.as_deref().unwrap_or("-");
+                        let route = r.route.as_deref().unwrap_or("(requesting channel)");
+                        ui.kv(
+                            &r.id,
+                            &format!(
+                                "{} — {} [tool: {tool}, route: {route}, by: {}]",
+                                r.summary, r.conversation_id, r.author
+                            ),
+                        );
+                    }
+                }
+            }
+            ApprovalsOutput::Resolved { record } => {
+                ui.payload(&format!(
+                    "approval {} -> {} (by {})",
+                    record.id,
+                    record.status,
+                    record.resolved_by.as_deref().unwrap_or("?")
+                ));
             }
         }
     }
@@ -2491,7 +2558,62 @@ pub async fn approvals(
     opts: AgentActionOpts,
     gate: Vec<String>,
     clear: bool,
+    cmd: ApprovalCmd,
 ) -> Result<ApprovalsOutput> {
+    let gate_mode = clear || !gate.is_empty();
+
+    // --resolve <id> --as <user>: resolve one live approval record (#506). It is
+    // id-scoped, not gate config, so it is mutually exclusive with --gate/--clear/
+    // --list. Approve by default; --reject rejects.
+    if let Some(approval_id) = cmd.resolve {
+        if gate_mode || cmd.list {
+            return Err(crate::exit::usage(
+                "--resolve cannot be combined with --gate/--clear/--list",
+            ));
+        }
+        let actor = cmd.as_actor.ok_or_else(|| {
+            crate::exit::usage("--resolve requires --as <user> (the actor resolving it)")
+        })?;
+        let decision = if cmd.reject { "rejected" } else { "approved" };
+        if opts.dry_run {
+            return Ok(ApprovalsOutput::DryRun(crate::ui::DryRunPlan {
+                lines: vec![format!(
+                    "POST {}/approvals/{approval_id}/resolve decision={decision} resolved_by={actor:?}",
+                    opts.api_url
+                )],
+            }));
+        }
+        let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+        let record = client
+            .resolve_approval(&approval_id, decision, &actor, cmd.note.as_deref())
+            .await?;
+        return Ok(ApprovalsOutput::Resolved { record });
+    }
+
+    // --list: the agent's pending approval records (#506).
+    if cmd.list {
+        if gate_mode {
+            return Err(crate::exit::usage(
+                "--list cannot be combined with --gate/--clear",
+            ));
+        }
+        if opts.dry_run {
+            return Ok(ApprovalsOutput::DryRun(crate::ui::DryRunPlan {
+                lines: vec![format!(
+                    "GET {}/approvals?status_filter=pending&agent_id=<id>  (would resolve agent {:?} first)",
+                    opts.api_url, opts.agent
+                )],
+            }));
+        }
+        let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+        let agent = client.find_agent(&opts.agent).await?;
+        let records = client.list_pending_approvals(&agent.id).await?;
+        return Ok(ApprovalsOutput::Pending {
+            agent: agent.name,
+            records,
+        });
+    }
+
     if clear && !gate.is_empty() {
         return Err(crate::exit::usage(
             "--clear cannot be combined with --gate (clear removes all gates)",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -703,6 +703,22 @@ enum LocalAction {
         /// Clear all approval gates on the agent.
         #[arg(long)]
         clear: bool,
+        /// List the agent's pending approval records instead of the gate config.
+        #[arg(long)]
+        list: bool,
+        /// Resolve the approval with this id (approve by default; requires --as).
+        #[arg(long, value_name = "APPROVAL_ID")]
+        resolve: Option<String>,
+        /// The actor resolving the approval (required with --resolve). The
+        /// requester and approver may differ; the server blocks self-approval.
+        #[arg(long = "as", value_name = "USER")]
+        as_actor: Option<String>,
+        /// Reject instead of approve (with --resolve).
+        #[arg(long)]
+        reject: bool,
+        /// Optional note recorded with the resolution (with --resolve).
+        #[arg(long)]
+        note: Option<String>,
     },
     /// Show the local observability surfaces (AgentOS Console + Langfuse traces/cost + API base).
     Observability {
@@ -1153,6 +1169,22 @@ enum ClusterAction {
         /// Clear all approval gates on the agent.
         #[arg(long)]
         clear: bool,
+        /// List the agent's pending approval records instead of the gate config.
+        #[arg(long)]
+        list: bool,
+        /// Resolve the approval with this id (approve by default; requires --as).
+        #[arg(long, value_name = "APPROVAL_ID")]
+        resolve: Option<String>,
+        /// The actor resolving the approval (required with --resolve). The
+        /// requester and approver may differ; the server blocks self-approval.
+        #[arg(long = "as", value_name = "USER")]
+        as_actor: Option<String>,
+        /// Reject instead of approve (with --resolve).
+        #[arg(long)]
+        reject: bool,
+        /// Optional note recorded with the resolution (with --resolve).
+        #[arg(long)]
+        note: Option<String>,
     },
 }
 
@@ -1553,7 +1585,26 @@ async fn run(command: Option<Command>) -> Result<()> {
                 target,
                 gate,
                 clear,
-            } => emit(commands::approvals(target.into(), gate, clear).await?),
+                list,
+                resolve,
+                as_actor,
+                reject,
+                note,
+            } => emit(
+                commands::approvals(
+                    target.into(),
+                    gate,
+                    clear,
+                    commands::ApprovalCmd {
+                        list,
+                        resolve,
+                        as_actor,
+                        reject,
+                        note,
+                    },
+                )
+                .await?,
+            ),
             LocalAction::Observability { open } => emit(commands::observability(open).await?),
             LocalAction::Budget {
                 agent,
@@ -2030,6 +2081,11 @@ async fn run(command: Option<Command>) -> Result<()> {
                 target,
                 gate,
                 clear,
+                list,
+                resolve,
+                as_actor,
+                reject,
+                note,
             } => {
                 let ClusterAgentTarget {
                     agent,
@@ -2047,6 +2103,13 @@ async fn run(command: Option<Command>) -> Result<()> {
                         },
                         gate,
                         clear,
+                        commands::ApprovalCmd {
+                            list,
+                            resolve,
+                            as_actor,
+                            reject,
+                            note,
+                        },
                     )
                     .await?,
                 )
@@ -2708,6 +2771,7 @@ mod tests {
                         target,
                         gate,
                         clear,
+                        ..
                     },
             }) => {
                 assert_eq!(target.agent, "gh");

--- a/cli/tests/approvals_manifest_unreadable.rs
+++ b/cli/tests/approvals_manifest_unreadable.rs
@@ -10,7 +10,7 @@
 
 mod support;
 
-use agentos::commands::{approvals, AgentActionOpts, ApprovalsOutput};
+use agentos::commands::{approvals, AgentActionOpts, ApprovalCmd, ApprovalsOutput};
 use agentos::ui::CliOutput;
 use support::{serve, MockServer, Response};
 
@@ -45,6 +45,7 @@ async fn read_gates(server: &MockServer) -> ApprovalsOutput {
         },
         vec![],
         false,
+        ApprovalCmd::default(),
     )
     .await
     .expect("approvals should report the failure, not propagate it")
@@ -59,6 +60,9 @@ fn gates(out: &ApprovalsOutput) -> (Vec<String>, Option<String>) {
             ..
         } => (gated_tools.clone(), manifest_unreadable.clone()),
         ApprovalsOutput::DryRun(_) => panic!("expected the gate view, not a dry-run plan"),
+        ApprovalsOutput::Pending { .. } | ApprovalsOutput::Resolved { .. } => {
+            panic!("expected the gate view, not a pending/resolved record")
+        }
     }
 }
 

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -668,6 +668,52 @@ fn approvals_output_json_shape_is_pinned() {
     );
 }
 
+#[test]
+fn approvals_pending_and_resolved_json_shapes_are_pinned() {
+    use agentos::api::ApprovalRecord;
+    let record = || ApprovalRecord {
+        id: "ap_1".to_string(),
+        author: "U1".to_string(),
+        route: Some("managers".to_string()),
+        gate_kind: Some("permission".to_string()),
+        granted_tool: Some("Bash".to_string()),
+        status: "pending".to_string(),
+        conversation_id: "C1-thread-9".to_string(),
+        summary: "Deploy the thing".to_string(),
+        expires_at: Some("2026-07-16T00:00:00Z".to_string()),
+        resolved_by: None,
+    };
+    assert_eq!(
+        ApprovalsOutput::Pending {
+            agent: "weather".to_string(),
+            records: vec![record()],
+        }
+        .to_json(),
+        json!({
+            "agent": "weather",
+            "pending": [{
+                "id": "ap_1",
+                "author": "U1",
+                "route": "managers",
+                "gate_kind": "permission",
+                "granted_tool": "Bash",
+                "status": "pending",
+                "conversation_id": "C1-thread-9",
+                "summary": "Deploy the thing",
+                "expires_at": "2026-07-16T00:00:00Z",
+                "resolved_by": null,
+            }],
+        })
+    );
+    let mut resolved = record();
+    resolved.status = "approved".to_string();
+    resolved.resolved_by = Some("U2".to_string());
+    assert_eq!(
+        ApprovalsOutput::Resolved { record: resolved }.to_json()["resolved"]["status"],
+        json!("approved")
+    );
+}
+
 /// Deliberate, reviewed contract EVOLUTION (#460), not a weakened pin: the
 /// payload key `surfaces` and the row key `name` are unchanged, and this still
 /// asserts EXACT equality against a literal, so a dropped/renamed/added key


### PR DESCRIPTION
Driving the approve→resume loop locally meant hand-curling the platform API and hand-`XADD`ing a `QueuedTurn` onto Valkey. Add the missing CLI verbs over the already-frozen `/approvals` endpoints:

- **`approvals --list`** → `GET /approvals?status_filter=pending&agent_id=<id>`, rendering each pending record (id, summary, gated tool, route, author).
- **`approvals --resolve <id> --as <user> [--reject] [--note ...]`** → `POST /approvals/{id}/resolve`. `--as` is the acting actor, so requester ≠ approver is expressible without curling; the server owns the resolve-once CAS, the authorizer (self-approval block), and the resume-turn enqueue.

New `api.rs` `ApprovalRecord` (hand-mirrors `ApprovalOut`, the `Agent`/`KillState` pattern) + `list_pending_approvals`/`resolve_approval`. Added on **both** local and cluster (same endpoints; keeps the two-tier flag parity the `command_surface` test enforces). New `ApprovalsOutput::Pending`/`Resolved` routed through `Ui::emit` with pinned `to_json`. Mutual-exclusion guards on `--resolve`/`--list`/`--gate`. Command manifest + UI mirror regenerated.

The #505-dependent durable-reply turn-driving verb is intentionally left out (it needs the durable reply sink, not just an API wrapper).

Closes #506
Ref CUR-1646