### PR TITLE
Watch the dead-letter graveyard and alert on each new entry

### DIFF
--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -79,6 +79,18 @@ class Settings(BaseSettings):
     # Must match the worker's AGENTOS_STREAM (its consumer side).
     runs_stream: str = "agentos:runs"
 
+    # Dead-letter graveyard watcher (#531). The worker moves a permanently-failing
+    # entry to `<runs_stream>:dead` (ADR-0039, #505) and acks it; this watcher is
+    # the reader that alerts on each new dead-letter so the observable-single-loss
+    # trade is actually observable. Interval <= 0 disables it (tests/off-switch).
+    # It derives the graveyard name from runs_stream, matching the worker's default
+    # `dead_letter_stream_name()`; a worker that overrides AGENTOS_DEAD_LETTER_STREAM
+    # must set the override here too.
+    dead_letter_watch_interval_s: float = 30.0
+
+    def dead_letter_stream_name(self) -> str:
+        return f"{self.runs_stream}:dead"
+
     # How often the expiry sweeper scans for lapsed pending approvals (#412) and
     # resumes their stranded sessions. Values <= 0 disable the sweeper (the
     # operator kill lever and the fully-inert-app escape hatch for tests).

--- a/apps/api/src/agentos_api/graveyardwatcher.py
+++ b/apps/api/src/agentos_api/graveyardwatcher.py
@@ -1,0 +1,101 @@
+"""Dead-letter graveyard watcher (#531): the missing reader on ``<stream>:dead``.
+
+The worker's delivery cap (ADR-0039, #505) moves a permanently-failing entry to
+the ``<stream>:dead`` graveyard and acks it off the group -- trading a silent
+total consumer stall for an *observable* single loss. But the observable half was
+never built: the graveyard is a write-only sink, so a dead-letter emits only the
+worker's own log line and nothing platform-side watches it. This watcher is that
+reader.
+
+It scans the graveyard from a cursor and emits one structured alert per NEW
+dead-letter, so ops alerting (log-based; the repo has no metrics/Prometheus
+infra) can key off a single line. Design constraints from the issue:
+
+- **Read-only.** It ``XRANGE``s the stream; no consumer group, no ack, no
+  mutation -- safe to run alongside the worker's producer and any other reader.
+- **Alert from the observation, not a read-back.** The graveyard is bounded by an
+  approximate ``MAXLEN``, so under a flood the oldest rows evict; the watcher
+  alerts on each entry as it advances its cursor past it, never by re-reading a
+  row that may already be gone.
+- **Tail-start.** A fresh boot seeds the cursor at the stream tail so it does not
+  re-alert the entire historical graveyard; only dead-letters that arrive while
+  it is running are alerted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from redis.asyncio import Redis
+
+logger = logging.getLogger(__name__)
+
+
+def _text(value: Any) -> str:
+    """Decode a Valkey value to str. The API's client is created without
+    ``decode_responses``, so ids and field maps come back as ``bytes``; a
+    ``decode_responses=True`` client (tests) already yields ``str``."""
+    return value.decode() if isinstance(value, (bytes, bytearray)) else str(value)
+
+
+class GraveyardWatcher:
+    """Scans ``stream`` for new dead-letter entries and alerts on each."""
+
+    def __init__(self, valkey: Redis, *, stream: str, interval_seconds: float) -> None:
+        self._valkey = valkey
+        self._stream = stream
+        self._interval = interval_seconds
+        # Exclusive lower bound for the next scan. Seeded at the tail by
+        # ``seed_cursor`` so a boot does not re-alert history; "0-0" (alert on
+        # everything) is the safe fallback for an empty/absent stream.
+        self._cursor = "0-0"
+        # Monotonic count of alerts emitted, exposed for tests and any future
+        # health surface.
+        self.alerts_emitted = 0
+
+    async def seed_cursor(self) -> None:
+        """Set the cursor to the current tail so only NEW dead-letters alert."""
+        entries = await self._valkey.xrevrange(self._stream, count=1) or []
+        self._cursor = _text(entries[0][0]) if entries else "0-0"
+
+    async def scan_once(self) -> int:
+        """Alert every dead-letter after the cursor and advance it. Returns the
+        count alerted this pass."""
+        entries = await self._valkey.xrange(self._stream, min=f"({self._cursor}", max="+") or []
+        for entry_id_raw, fields_raw in entries:
+            entry_id = _text(entry_id_raw)
+            fields = {_text(k): _text(v) for k, v in (fields_raw or {}).items()}
+            self._alert(entry_id, fields)
+            self._cursor = entry_id
+        return len(entries)
+
+    def _alert(self, entry_id: str, fields: dict[str, str]) -> None:
+        self.alerts_emitted += 1
+        # A single, greppable ERROR line -- the operational-signal pattern this
+        # codebase already uses (structured logs + counters, no Prometheus).
+        logger.error(
+            "DEAD-LETTER alert: entry %s on %s (original=%s deliveries=%s reason=%s at=%s)",
+            entry_id,
+            self._stream,
+            fields.get("dl_original_id", "?"),
+            fields.get("dl_delivery_count", "?"),
+            fields.get("dl_reason", "?"),
+            fields.get("dl_dead_lettered_at", "?"),
+        )
+
+    async def run_forever(self) -> None:
+        """Seed at the tail, then scan on the interval forever, surviving errors."""
+        try:
+            await self.seed_cursor()
+        except Exception:
+            logger.exception("dead-letter watcher failed to seed its cursor; starting from 0")
+        while True:
+            await asyncio.sleep(self._interval)
+            try:
+                await self.scan_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("dead-letter watcher pass failed")

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -16,6 +16,7 @@ from .config import get_settings
 from .db import create_engine, create_sessionmaker
 from .evalqueue import EvalQueue
 from .github_checks import GitHubStatusReporter
+from .graveyardwatcher import GraveyardWatcher
 from .k8s import build_lazy_pod_lister, build_lazy_pod_log_reader
 from .killswitch import KillSwitch
 from .langfuse import LangfuseClient
@@ -118,6 +119,20 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         )
     else:
         app.state.sweeper_task = None
+    # The dead-letter graveyard watcher (#531): read-only reader on
+    # <runs_stream>:dead that alerts on each new dead-letter. Interval <= 0
+    # disables it. Read-only, so it needs no ordering vs valkey.aclose() beyond
+    # being cancelled before it.
+    if settings.dead_letter_watch_interval_s > 0:
+        watcher = GraveyardWatcher(
+            valkey,
+            stream=settings.dead_letter_stream_name(),
+            interval_seconds=settings.dead_letter_watch_interval_s,
+        )
+        app.state.graveyard_watcher = watcher
+        app.state.graveyard_watcher_task = asyncio.create_task(watcher.run_forever())
+    else:
+        app.state.graveyard_watcher_task = None
     try:
         yield
     finally:
@@ -140,6 +155,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             try:
                 await asyncio.wait_for(app.state.sweeper_task, 5.0)
             except (TimeoutError, asyncio.CancelledError):
+                pass
+        # Read-only, so simply cancel it before closing valkey.
+        watcher_task = getattr(app.state, "graveyard_watcher_task", None)
+        if watcher_task is not None:
+            watcher_task.cancel()
+            try:
+                await watcher_task
+            except asyncio.CancelledError:
                 pass
         await valkey.aclose()
         await http_client.aclose()

--- a/apps/api/tests/test_graveyard_watcher.py
+++ b/apps/api/tests/test_graveyard_watcher.py
@@ -1,0 +1,95 @@
+"""Dead-letter graveyard watcher (#531) against real Valkey.
+
+The worker moves a permanently-failing entry to ``<stream>:dead`` and acks it;
+nothing platform-side watched it. These tests pin the watcher's contract: it
+alerts once per NEW dead-letter, seeds at the tail so a boot does not re-alert
+history, and does not double-alert or suppress across an approximate-MAXLEN trim.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+import redis.asyncio as aioredis
+from agentos_api.graveyardwatcher import GraveyardWatcher
+
+_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
+_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
+_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
+
+
+def _client() -> aioredis.Redis:
+    return aioredis.Redis(
+        host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW, decode_responses=True
+    )
+
+
+async def _dead_letter(
+    client: aioredis.Redis, stream: str, *, original: str, reason: str
+) -> str:
+    return await client.xadd(
+        stream,
+        {
+            "payload": "{}",
+            "dl_original_id": original,
+            "dl_delivery_count": "5",
+            "dl_reason": reason,
+            "dl_dead_lettered_at": "2026-07-16T00:00:00+00:00",
+        },
+    )
+
+
+def test_alerts_once_per_new_dead_letter_and_seeds_at_tail() -> None:
+    async def go() -> None:
+        stream = f"test:agentos:runs:dead:{uuid.uuid4().hex}"
+        client = _client()
+        watcher = GraveyardWatcher(client, stream=stream, interval_seconds=0.01)
+        try:
+            # A pre-existing historical dead-letter: seeding at the tail must NOT
+            # re-alert it.
+            await _dead_letter(client, stream, original="1700000000000-0", reason="unparseable")
+            await watcher.seed_cursor()
+            assert await watcher.scan_once() == 0
+            assert watcher.alerts_emitted == 0
+
+            # Two new dead-letters arrive while the watcher runs -> two alerts.
+            await _dead_letter(client, stream, original="1700000000001-0", reason="max-delivery")
+            await _dead_letter(client, stream, original="1700000000002-0", reason="max-delivery")
+            assert await watcher.scan_once() == 2
+            assert watcher.alerts_emitted == 2
+
+            # A subsequent pass with nothing new alerts nothing (no double-alert).
+            assert await watcher.scan_once() == 0
+            assert watcher.alerts_emitted == 2
+        finally:
+            await client.delete(stream)
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_run_forever_alerts_a_new_dead_letter_then_stops() -> None:
+    async def go() -> None:
+        stream = f"test:agentos:runs:dead:{uuid.uuid4().hex}"
+        client = _client()
+        watcher = GraveyardWatcher(client, stream=stream, interval_seconds=0.02)
+        task = asyncio.create_task(watcher.run_forever())
+        try:
+            await asyncio.sleep(0.05)  # let it seed at the (empty) tail
+            await _dead_letter(client, stream, original="1700000000003-0", reason="unparseable")
+            for _ in range(100):
+                if watcher.alerts_emitted >= 1:
+                    break
+                await asyncio.sleep(0.01)
+            assert watcher.alerts_emitted == 1
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            await client.delete(stream)
+            await client.aclose()
+
+    asyncio.run(go())


### PR DESCRIPTION
The delivery cap (ADR-0039, #505) moves a permanently-failing entry to `<runs_stream>:dead` and acks it off the group — trading a silent total consumer stall for an *observable* single loss. But the observable half was never built: the graveyard is a write-only sink, so a dead-letter emits only the worker's own log line and nothing platform-side watches it.

Add `GraveyardWatcher`: a **read-only** API-side reader (co-located with the resume reconciler in the app lifespan) that scans `<runs_stream>:dead` from a tail-seeded cursor and emits one structured `ERROR` alert per **new** dead-letter — the log+counter operational-signal pattern this repo already uses (no Prometheus infra).

Design constraints from the issue:
- **Read-only** — `XRANGE` only; no consumer group, ack, or mutation, so it is safe alongside the worker's producer and any future reader.
- **Alert from the observation, not a read-back** — the graveyard is bounded by an approximate `MAXLEN`, so under a flood the oldest rows evict; it alerts as it advances its cursor past each entry, never by re-reading a row that may be gone.
- **Tail-start** — a fresh boot seeds the cursor at the tail so it never re-alerts history.

Decodes `bytes` defensively (the API's Valkey client has no `decode_responses`, unlike the tests'). Interval ≤ 0 disables it. Real-Valkey tests cover new-entry alerting, tail-seeding, and no-double-alert.

This is the alerting half of the dead-letter observability gap; the companion reconcile of a *stranded* approval whose resume turn dead-lettered (#532) needs a new terminal approval status + migration and is left for its own change.

Closes #531
Ref CUR-1647