### PR TITLE
BYO models: declared api_backend enum + env_key string-or-array

### DIFF
--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -71,6 +71,11 @@ MEMORY_TOKEN_ENV = "AGENTOS_MEMORY_TOKEN"
 HISTORY_REF_ENV = "AGENTOS_HISTORY_REF"
 HISTORY_TOKEN_ENV = "AGENTOS_HISTORY_TOKEN"
 BASE_URL_ENV = "ANTHROPIC_BASE_URL"
+# The endpoint's wire protocol (#514), declared so an OpenAI-shaped endpoint
+# fails loudly in the runner instead of being silently mis-dialed.
+API_BACKEND_ENV = "AGENTOS_MODEL_API_BACKEND"
+# Which env var(s) carry the model credential (#514): a bare name or a JSON array.
+MODEL_ENV_KEY_ENV = "AGENTOS_MODEL_ENV_KEY"
 MODEL_ENV = "AGENTOS_MODEL"
 # Per-claim bearer token the runner enforces on its ACI POST routes (issue #63).
 # Not a model credential, so apply_model_env never sees it; minted fresh per claim.
@@ -467,6 +472,10 @@ def apply_model_env(
     ``model_override`` is the per-agent AGENTOS_MODEL (#254): when set it wins
     over the worker's configured default model, so a single agent can be pinned
     to a specific model. None means "use the platform default" (config.model).
+    It is the ONLY per-agent knob here. The api_backend and env_key declarations
+    (#514) come from WorkerConfig only and take no override: they select which
+    wire protocol is dialed and which env var a credential is read from, so a
+    lower-privileged agent author must not be able to set them.
     """
     if config.fake_model:
         env[FAKE_MODEL_ENV] = "1"
@@ -474,6 +483,10 @@ def apply_model_env(
         env[CREDENTIALS_ENV] = config.credentials
     if config.model_base_url:
         env[BASE_URL_ENV] = config.model_base_url
+    if config.model_api_backend:
+        env[API_BACKEND_ENV] = config.model_api_backend
+    if config.model_env_key:
+        env[MODEL_ENV_KEY_ENV] = config.model_env_key
     model = model_override if model_override is not None else config.model
     if model:
         env[MODEL_ENV] = model

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -124,6 +124,12 @@ class WorkerConfig(BaseSettings):
     # Local model demo path: the worker can point the runner at an
     # Anthropic-compatible local endpoint without changing the fake-model default.
     model_base_url: str = Field(default="", validation_alias="AGENTOS_MODEL_BASE_URL")
+    # The endpoint's wire protocol and the env var(s) carrying the credential
+    # (#514), both declared rather than inferred. Operator scope like
+    # model_base_url: they select which env var a credential is read from and
+    # which wire protocol is dialed, so an agent author must never set them.
+    model_api_backend: str = Field(default="", validation_alias="AGENTOS_MODEL_API_BACKEND")
+    model_env_key: str = Field(default="", validation_alias="AGENTOS_MODEL_ENV_KEY")
     model: str = Field(default="", validation_alias="AGENTOS_MODEL")
 
     # When true, clear the Slack assistant-thread status (the "shimmer" the

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -190,6 +190,182 @@ def test_binding_boot_env_forwards_per_agent_model() -> None:
     assert env[MODEL_ENV] == "platform-default"
 
 
+# --- Operator-scoped model wire declaration (#514) -----------------------------
+#
+# The runner reads AGENTOS_MODEL_API_BACKEND (the endpoint's wire protocol) and
+# AGENTOS_MODEL_ENV_KEY (which env var carries the credential). The runner boot
+# env is closed-world -- only what apply_model_env emits is there -- so without a
+# producer here both vars are unreachable and the feature is dead config. Both
+# mirror model_base_url's chain exactly: WorkerConfig field -> apply_model_env ->
+# boot env, emitted only when non-empty.
+#
+# The env-var names are the cross-package contract with the runner; asserted by
+# their literal strings so this file never depends on a constant that only exists
+# after the feature lands (which would break collection of the whole module).
+API_BACKEND_ENV = "AGENTOS_MODEL_API_BACKEND"
+MODEL_ENV_KEY_ENV = "AGENTOS_MODEL_ENV_KEY"
+
+
+def test_binding_exports_the_new_model_env_constants() -> None:
+    # The emission sites must go through module constants, like BASE_URL_ENV does,
+    # rather than inline literals scattered across the two lanes.
+    from agentos_worker import binding
+
+    assert binding.API_BACKEND_ENV == API_BACKEND_ENV
+    assert binding.MODEL_ENV_KEY_ENV == MODEL_ENV_KEY_ENV
+
+
+def test_apply_model_env_forwards_api_backend_and_env_key_when_set() -> None:
+    env: dict[str, str] = {}
+    apply_model_env(
+        env,
+        WorkerConfig(
+            model_api_backend="messages",
+            model_env_key='["ANTHROPIC_AUTH_TOKEN"]',
+        ),
+    )
+
+    assert env[API_BACKEND_ENV] == "messages"
+    assert env[MODEL_ENV_KEY_ENV] == '["ANTHROPIC_AUTH_TOKEN"]'
+
+
+def test_apply_model_env_omits_api_backend_and_env_key_by_default() -> None:
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig())
+
+    assert API_BACKEND_ENV not in env
+    assert MODEL_ENV_KEY_ENV not in env
+
+
+def test_apply_model_env_omits_api_backend_and_env_key_when_empty_string() -> None:
+    # ABSENT, not present-and-empty. The runner treats "" as "not declared" and
+    # defaults, so emitting an empty var would work by accident today -- but it
+    # also makes the boot env lie about what was configured, and any consumer that
+    # checks presence rather than truthiness would then see a declaration that was
+    # never made.
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig(model_api_backend="", model_env_key=""))
+
+    assert API_BACKEND_ENV not in env
+    assert MODEL_ENV_KEY_ENV not in env
+
+
+def test_apply_model_env_composes_new_vars_with_the_existing_emission() -> None:
+    # The two additions must not disturb the fake_model / credentials / base_url /
+    # model emission they sit next to.
+    env: dict[str, str] = {}
+    apply_model_env(
+        env,
+        WorkerConfig(
+            fake_model=True,
+            credentials="cred-compose",
+            model_base_url="http://ollama:11434",
+            model="qwen3:4b",
+            model_api_backend="messages",
+            model_env_key="MY_PROVIDER_KEY",
+        ),
+    )
+
+    assert env[FAKE_MODEL_ENV] == "1"
+    assert env[CREDENTIALS_ENV] == "cred-compose"
+    assert env[BASE_URL_ENV] == "http://ollama:11434"
+    assert env[MODEL_ENV] == "qwen3:4b"
+    assert env[API_BACKEND_ENV] == "messages"
+    assert env[MODEL_ENV_KEY_ENV] == "MY_PROVIDER_KEY"
+
+
+def test_binding_boot_env_carries_api_backend_and_env_key() -> None:
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig(  # type: ignore[attr-defined]
+        model_api_backend="messages", model_env_key="MY_PROVIDER_KEY"
+    )
+
+    env = resolver.boot_env(_resolved(), "thread-1")
+    assert env[API_BACKEND_ENV] == "messages"
+    assert env[MODEL_ENV_KEY_ENV] == "MY_PROVIDER_KEY"
+
+
+def test_eval_boot_env_carries_api_backend_and_env_key() -> None:
+    # Both lanes boot the runner through apply_model_env, so the eval consumer
+    # gets the declaration too rather than silently dialing a different endpoint.
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(
+            model_api_backend="messages", model_env_key="MY_PROVIDER_KEY"
+        ),
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    item = EvalWorkItem(
+        agent_id=uuid.uuid4(),
+        version_id=uuid.uuid4(),
+        sha="deadbeef",
+        suite="smoke",
+        bundle_ref="bundles/x.zip",
+        requested_at="2026-07-05T00:00:00+00:00",
+    )
+
+    env = consumer._boot_env(item)
+    assert env[API_BACKEND_ENV] == "messages"
+    assert env[MODEL_ENV_KEY_ENV] == "MY_PROVIDER_KEY"
+
+
+# --- Operator scope is the security property, not a style choice (#514) --------
+#
+# Both vars are OPERATOR scope: they come from WorkerConfig and NEVER from the
+# per-agent row. AGENTOS_MODEL is per-agent (#254) precisely because a model id is
+# inert. These two are not: model_env_key names which env var the runner reads a
+# credential OUT of, and it is read from the same boot env that holds the scoped
+# state tokens (ADR-0033) and the agent's connector secrets. A per-agent override
+# would let anyone who can write an agent row aim the runner at those. The tests
+# below fail if someone later plumbs either one through the agent row.
+
+
+def test_apply_model_env_has_no_per_agent_override_params() -> None:
+    # Signature pin. model_override (#254, the per-agent model) is the ONLY
+    # per-agent parameter this function may take. A new *_override parameter here
+    # is the shape of the regression: it would mean an agent row can aim the
+    # credential read or redeclare the wire protocol.
+    import inspect
+
+    params = set(inspect.signature(apply_model_env).parameters)
+    assert params == {"env", "config", "model_override"}
+
+
+def test_resolved_deployment_carries_no_api_backend_or_env_key_field() -> None:
+    # The agent row is the other half of the same seam: if the columns never reach
+    # ResolvedDeployment, boot_env has nothing per-agent to forward.
+    fields = set(ResolvedDeployment.model_fields)
+    assert "model_api_backend" not in fields
+    assert "model_env_key" not in fields
+    assert "api_backend" not in fields
+    assert "env_key" not in fields
+
+
+def test_binding_boot_env_api_backend_is_not_overridable_per_agent() -> None:
+    # Operator config is the sole source: an agent row (here carrying its own
+    # pinned model, the one thing it MAY override) cannot change or supply either
+    # declaration.
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig(  # type: ignore[attr-defined]
+        model_api_backend="messages", model_env_key="MY_PROVIDER_KEY"
+    )
+
+    env = resolver.boot_env(_resolved(model="agent-pinned-model"), "thread-1")
+    assert env[MODEL_ENV] == "agent-pinned-model"  # per-agent model still wins
+    assert env[API_BACKEND_ENV] == "messages"  # operator scope, unchanged
+    assert env[MODEL_ENV_KEY_ENV] == "MY_PROVIDER_KEY"
+
+    # With the operator config silent, no agent row can conjure either var.
+    resolver._config = WorkerConfig()  # type: ignore[attr-defined]
+    env = resolver.boot_env(_resolved(model="agent-pinned-model"), "thread-1")
+    assert API_BACKEND_ENV not in env
+    assert MODEL_ENV_KEY_ENV not in env
+
+
 # --- Per-sandbox runner token minting (issue #63) -----------------------------
 # The env-var name is the cross-package contract with the runner; asserted by its
 # literal string so this test file never depends on a constant that only exists

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -281,6 +281,63 @@ def test_overrides_parity_with_from_env(monkeypatch: pytest.MonkeyPatch) -> None
         )
 
 
+# --- Operator-scoped model wire declaration (#514) ---------------------------
+#
+# Two new fields mirroring model_base_url: they read only their AGENTOS_* alias
+# and default to "" (not declared). They are deliberately absent from the
+# _WORKER_OVERRIDES parity oracle above -- that dict pins the vars the old
+# hand-rolled from_env read, and these are new, not a port of anything.
+
+
+def test_model_api_backend_and_env_key_default_to_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Undeclared is the default, so the producer emits nothing and the runner
+    keeps its own pre-#514 defaults."""
+    _clear_all_config_env(monkeypatch)
+
+    config = WorkerConfig()
+
+    assert config.model_api_backend == ""
+    assert config.model_env_key == ""
+
+
+def test_worker_config_reads_model_api_backend_and_env_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_MODEL_API_BACKEND", "messages")
+    monkeypatch.setenv("AGENTOS_MODEL_ENV_KEY", '["ANTHROPIC_AUTH_TOKEN"]')
+
+    config = WorkerConfig()
+
+    assert config.model_api_backend == "messages"
+    assert config.model_env_key == '["ANTHROPIC_AUTH_TOKEN"]'
+
+
+def test_model_api_backend_and_env_key_ignore_bare_field_name_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aliased like every other AGENTOS_* knob: a stray bare-name env var in the
+    pod env must not leak in."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("MODEL_API_BACKEND", "chat_completions")
+    monkeypatch.setenv("MODEL_ENV_KEY", "STRAY_NAME")
+
+    config = WorkerConfig()
+
+    assert config.model_api_backend == ""
+    assert config.model_env_key == ""
+
+
+def test_model_api_backend_and_env_key_populate_by_field_name() -> None:
+    """populate_by_name construction (used by the binding tests) works."""
+    config = WorkerConfig(model_api_backend="messages", model_env_key="MY_PROVIDER_KEY")
+
+    assert config.model_api_backend == "messages"
+    assert config.model_env_key == "MY_PROVIDER_KEY"
+
+
 # --- Per-service bool divergence (review #178) -------------------------------
 #
 # The old worker ``_b`` accepted only ("1", "true", "yes") as truthy -- notably

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -456,6 +456,8 @@ services:
       # export retries per span. AGENTOS_DOCKER_NETWORK stays on `:-` because the
       # network join is correct under `core` too.
       - AGENTOS_MODEL_BASE_URL=${AGENTOS_MODEL_BASE_URL:-}
+      - AGENTOS_MODEL_API_BACKEND=${AGENTOS_MODEL_API_BACKEND:-}
+      - AGENTOS_MODEL_ENV_KEY=${AGENTOS_MODEL_ENV_KEY:-}
       - AGENTOS_MODEL=${AGENTOS_MODEL:-}
       - AGENTOS_DOCKER_NETWORK=${AGENTOS_DOCKER_NETWORK:-agentos_default}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}

--- a/docs/adr/0048-declared-model-wire-protocol-and-credential-keys.md
+++ b/docs/adr/0048-declared-model-wire-protocol-and-credential-keys.md
@@ -55,7 +55,21 @@ byte-identical to today.
 [ADR-0047](0047-canonical-env-var-names.md), so the existing prefix rule in
 `packages/plugin-format/src/plugin_format/reserved_env.py` already fences a
 connector secret from shadowing them. They are enumerated in `_AGENTOS_BOOT_KEYS`
-for greppability and to satisfy the completeness pin.
+for greppability.
+
+**The producer is operator scope.** Both names are emitted into the boot env by
+`apps/worker/src/agentos_worker/binding.py::apply_model_env`, sourced from
+`apps/worker/src/agentos_worker/config.py::WorkerConfig` exactly as
+`model_base_url` is, and never from the per-agent row. `apply_model_env`'s
+existing `model_override` parameter stays scoped to `AGENTOS_MODEL` (#254) alone.
+
+**`parse_env_keys` fences what an env_key may TARGET.** Any `AGENTOS_`-prefixed
+name other than `AGENTOS_CREDENTIALS` is refused
+(`runner/src/agentos_runner/sdk_auth.py::parse_env_keys`), on both the bare-string
+and array forms, and one fenced name rejects the whole declaration rather than
+being silently dropped — a dropped name would let a typo'd or deliberate exfil
+attempt look like it worked. Non-`AGENTOS_` names stay allowed, since sourcing
+from a provider-native var is the point of the feature.
 
 **Scope: runner-local env config, deliberately NOT an `aci-protocol`
 `SessionConfig` field.** Model base URL and credential already flow as boot env
@@ -64,11 +78,19 @@ of the frozen wire protocol. The alternative — adding them to `SessionConfig` 
 was weighed and rejected: it would be a frozen-contract change requiring a
 `PROTOCOL_VERSION` bump for no gain today.
 
-**Trust boundary, considered.** `AGENTOS_MODEL_ENV_KEY` lets operator-supplied
-config name an arbitrary env var to read a credential from. That is the same trust
-level as `AGENTOS_MODEL_BASE_URL`, which can already redirect the session; boot env
-is operator-controlled, and a connector secret cannot declare either name (reserved
-prefix). No new privilege is granted.
+**Trust boundary.** `AGENTOS_MODEL_ENV_KEY` names an env var to read a credential
+from, and the runner boot env is shared: alongside the model credential it carries
+the platform's own scoped HMAC state tokens ([ADR-0033](0033-scoped-sandbox-token.md))
+and the agent's connector secrets. Unfenced, naming one of those under a base-URL
+override would forward it to a third-party endpoint as the `x-api-key` header —
+a secret-exfiltration primitive, not a same-trust-level change. Fencing the name a
+connector secret may DECLARE (the reserved prefix) guards shadowing, which is the
+other direction and does not help here. Two things make it safe: (a) the
+declaration is operator scope, sourced from `WorkerConfig` like `model_base_url`
+and never from the agent row, and (b) `parse_env_keys` refuses any
+`AGENTOS_`-prefixed target except `AGENTOS_CREDENTIALS`, so the platform's own boot
+vars can never be named as a credential source. A per-agent producer would reopen
+this and is therefore a new ADR, not a producer detail.
 
 ## Consequences
 
@@ -78,6 +100,10 @@ prefix). No new privilege is granted.
   "not supplied", never a credential.
 - A config author can source the credential from an env var that already exists
   (e.g. `["ANTHROPIC_AUTH_TOKEN","LC_ANTHROPIC_AUTH_TOKEN"]`) without renaming it.
+- The platform's own `AGENTOS_`-namespaced boot vars are unreachable as a
+  credential source, so the declaration cannot be turned into an exfiltration
+  channel. The cost is that a future platform-owned credential var would have to
+  be named `AGENTOS_CREDENTIALS` or reached by a deliberate widening of the fence.
 - Adding real `chat_completions` / `responses` support later means adding a
   translating adapter behind the same enum, with no config-surface change.
 - The enum has one dialable member today, so it buys legibility and a fast failure

--- a/docs/adr/0048-declared-model-wire-protocol-and-credential-keys.md
+++ b/docs/adr/0048-declared-model-wire-protocol-and-credential-keys.md
@@ -1,0 +1,84 @@
+# ADR-0048: Declare the model endpoint's wire protocol and credential keys
+
+Status: Accepted
+Date: 2026-07-17
+
+## Context
+
+The runner resolves a BYO model endpoint in `runner/src/agentos_runner/sdk_auth.py`.
+Two things about that endpoint were assumed rather than declared (#514):
+
+- **Wire protocol.** Any base-URL override was simply assumed to speak the
+  Anthropic Messages format, because that is the only format claude-agent-sdk can
+  dial. An operator who pointed `AGENTOS_MODEL_BASE_URL` at an OpenAI-shaped
+  `/chat/completions` endpoint got a confusing runtime failure from deep inside
+  the SDK rather than a clear config error.
+- **Credential source.** The credential was read from exactly one hardcoded env
+  var, `AGENTOS_CREDENTIALS`, and the "is it set" test conflated unset with
+  empty-string — the #229 gotcha, where an empty `ANTHROPIC_API_KEY` is a live
+  footgun rather than a harmless absence.
+
+Prior art: xai-org's grok-build declares the wire protocol as an explicit
+`api_backend` enum and accepts `env_key` as either a string or an array of names.
+
+## Decision
+
+**`AGENTOS_MODEL_API_BACKEND` declares the wire protocol** as an `ApiBackend`
+enum (`runner/src/agentos_runner/sdk_auth.py::ApiBackend`): `messages` |
+`chat_completions` | `responses`. Unset or empty defaults to `messages`
+(`runner/src/agentos_runner/sdk_auth.py::DEFAULT_API_BACKEND`), which is exactly
+the pre-change assumption, so no existing config changes behavior.
+
+**`ApiBackend.speaks_anthropic_wire` is the single deterministic branch point**
+(`runner/src/agentos_runner/sdk_auth.py::ApiBackend.speaks_anthropic_wire`).
+`resolve_sdk_env` (`runner/src/agentos_runner/sdk_auth.py::resolve_sdk_env`)
+checks it FIRST, before any credential or base-URL branching, so an undialable
+backend is rejected on the declaration itself rather than as a side effect of
+whichever path config happens to select. `chat_completions` and `responses` are
+declarable but rejected with an actionable message: the runner speaks Anthropic
+Messages via claude-agent-sdk, and reaching an OpenAI-shaped endpoint needs a
+translating proxy in front of the runner. They are in the enum because naming the
+thing you cannot do is what makes the rejection legible; a value the enum does not
+know raises the same error
+(`runner/src/agentos_runner/sdk_auth.py::UnsupportedApiBackendError`).
+
+**`AGENTOS_MODEL_ENV_KEY` declares which env var carries the credential**: a bare
+name or a JSON array of names (`runner/src/agentos_runner/sdk_auth.py::parse_env_keys`).
+Keys are walked in declared order and the first that is both set and non-empty
+wins (`runner/src/agentos_runner/sdk_auth.py::resolve_credential`); a
+present-but-empty key is skipped, never wins. Unset or empty defaults to
+`("AGENTOS_CREDENTIALS",)`
+(`runner/src/agentos_runner/sdk_auth.py::DEFAULT_CREDENTIAL_ENV_KEYS`),
+byte-identical to today.
+
+**Both new names are `AGENTOS_`-namespaced** per
+[ADR-0047](0047-canonical-env-var-names.md), so the existing prefix rule in
+`packages/plugin-format/src/plugin_format/reserved_env.py` already fences a
+connector secret from shadowing them. They are enumerated in `_AGENTOS_BOOT_KEYS`
+for greppability and to satisfy the completeness pin.
+
+**Scope: runner-local env config, deliberately NOT an `aci-protocol`
+`SessionConfig` field.** Model base URL and credential already flow as boot env
+outside that frozen contract; putting these two beside them keeps the change out
+of the frozen wire protocol. The alternative — adding them to `SessionConfig` —
+was weighed and rejected: it would be a frozen-contract change requiring a
+`PROTOCOL_VERSION` bump for no gain today.
+
+**Trust boundary, considered.** `AGENTOS_MODEL_ENV_KEY` lets operator-supplied
+config name an arbitrary env var to read a credential from. That is the same trust
+level as `AGENTOS_MODEL_BASE_URL`, which can already redirect the session; boot env
+is operator-controlled, and a connector secret cannot declare either name (reserved
+prefix). No new privilege is granted.
+
+## Consequences
+
+- The protocol is self-documenting per endpoint, and a mis-declared endpoint fails
+  fast with a fix instead of a deep SDK error.
+- The empty-string credential footgun is closed by construction: an empty value is
+  "not supplied", never a credential.
+- A config author can source the credential from an env var that already exists
+  (e.g. `["ANTHROPIC_AUTH_TOKEN","LC_ANTHROPIC_AUTH_TOKEN"]`) without renaming it.
+- Adding real `chat_completions` / `responses` support later means adding a
+  translating adapter behind the same enum, with no config-surface change.
+- The enum has one dialable member today, so it buys legibility and a fast failure
+  rather than new reach.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -77,4 +77,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0045 | [The status line is the mutable part of an immutable ADR](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md) | Accepted |
 | 0046 | [Converged approval gates: durable provenance, loud route resolution, and observe-only resume reconciliation](0046-converged-approval-gates-and-durable-provenance.md) | Accepted |
 | 0047 | [ADR-0047: Canonical env-var names for the API base URL and model credential](0047-canonical-env-var-names.md) | Accepted |
+| 0048 | [ADR-0048: Declare the model endpoint's wire protocol and credential keys](0048-declared-model-wire-protocol-and-credential-keys.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/docs/interfaces/model-provider/INTERFACE.md
+++ b/docs/interfaces/model-provider/INTERFACE.md
@@ -31,10 +31,27 @@ the Anthropic wire format (kept even for OpenRouter, so prompt caching survives)
 ## Current contract
 
 Resolution lives in `runner/src/agentos_runner/sdk_auth.py`. A provider is defined by
-three things:
+four things:
 
-- **Credential**, delivered as `AGENTOS_CREDENTIALS` (`runner/src/agentos_runner/sdk_auth.py::CREDENTIALS_ENV`).
-  `resolve_model_credential` (`runner/src/agentos_runner/sdk_auth.py::resolve_model_credential`) routes it by
+- **Wire protocol**, declared as `AGENTOS_MODEL_API_BACKEND`
+  (`runner/src/agentos_runner/sdk_auth.py::API_BACKEND_ENV`), one of the `ApiBackend`
+  members (`runner/src/agentos_runner/sdk_auth.py::ApiBackend`): `messages`,
+  `chat_completions`, `responses`. Unset or empty means `messages`
+  (`runner/src/agentos_runner/sdk_auth.py::DEFAULT_API_BACKEND`), which is what every
+  endpoint was previously assumed to speak. Only `messages` is dialable
+  (`runner/src/agentos_runner/sdk_auth.py::ApiBackend.speaks_anthropic_wire`) — the
+  runner speaks the Anthropic wire format via claude-agent-sdk, so the OpenAI-shaped
+  backends are declarable but rejected up front by `resolve_sdk_env`
+  (`runner/src/agentos_runner/sdk_auth.py::UnsupportedApiBackendError`); reaching one
+  needs a translating proxy in front of the runner. See
+  [ADR-0048](../../adr/0048-declared-model-wire-protocol-and-credential-keys.md).
+- **Credential**, delivered as `AGENTOS_CREDENTIALS`
+  (`runner/src/agentos_runner/sdk_auth.py::CREDENTIALS_ENV`) by default, or from the env
+  var names `AGENTOS_MODEL_ENV_KEY` declares
+  (`runner/src/agentos_runner/sdk_auth.py::MODEL_ENV_KEY_ENV`) — a bare name or a JSON
+  array of them, walked in order, first set and non-empty key winning
+  (`runner/src/agentos_runner/sdk_auth.py::resolve_credential`); a present-but-empty key
+  is skipped. `resolve_model_credential` (`runner/src/agentos_runner/sdk_auth.py::resolve_model_credential`) routes it by
   prefix: `sk-ant-oat...` → `CLAUDE_CODE_OAUTH_TOKEN`; other `sk-ant-...`
   → `ANTHROPIC_API_KEY`; `sk-or-...` (OpenRouter) → base-URL override; a bare `sk-...`
   raises `UnsupportedCredentialError` (`runner/src/agentos_runner/sdk_auth.py::UnsupportedCredentialError`). An SDK credential
@@ -93,4 +110,4 @@ The credential value is never logged.
 
 - **Epic(s):** #24 — bring your own model (OpenRouter + native Anthropic-format endpoints), the seam's forward work; #46 (closed) — the Ollama local-model demo mode, which also exercises this base-URL-override + credential path.
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — core config seam, not one of the six swappable jobs.
-- **ADR(s):** [ADR-0009](../../adr/0009-per-agent-connector-auth.md) — per-agent secrets and connector credentials (the model credential is the one credential the platform resolves today, via prefix mapping in `sdk_auth.py`).
+- **ADR(s):** [ADR-0009](../../adr/0009-per-agent-connector-auth.md) — per-agent secrets and connector credentials (the model credential is the one credential the platform resolves today, via prefix mapping in `sdk_auth.py`); [ADR-0048](../../adr/0048-declared-model-wire-protocol-and-credential-keys.md) — the endpoint's wire protocol and the credential's source env var are declared rather than assumed.

--- a/packages/plugin-format/src/plugin_format/reserved_env.py
+++ b/packages/plugin-format/src/plugin_format/reserved_env.py
@@ -66,6 +66,8 @@ _REDIRECT_CAPTURE_KEYS = frozenset(
 _AGENTOS_BOOT_KEYS = frozenset(
     {
         "AGENTOS_MODEL_BASE_URL",
+        "AGENTOS_MODEL_API_BACKEND",
+        "AGENTOS_MODEL_ENV_KEY",
         "AGENTOS_CREDENTIALS",
         "AGENTOS_MODEL",
         "AGENTOS_FAKE_MODEL",

--- a/runner/src/agentos_runner/INTERFACE.md
+++ b/runner/src/agentos_runner/INTERFACE.md
@@ -19,6 +19,24 @@ rather than a parallel path. This is one seam, many providers.
 When set to a non-empty value, the runner enters override mode. Unset or empty
 means normal Anthropic credential resolution (`resolve_model_credential`).
 
+### `AGENTOS_MODEL_API_BACKEND` (input)
+
+Declares the endpoint's wire protocol instead of leaving it assumed: one of
+`messages`, `chat_completions`, `responses` (the `ApiBackend` members). Unset or
+empty means `messages`, which is what override mode previously assumed of every
+endpoint. Only `messages` is dialable — the runner speaks the Anthropic Messages
+wire format via claude-agent-sdk — so `resolve_sdk_env` checks the declaration
+FIRST, before any credential or base-URL branching, and rejects an OpenAI-shaped
+backend with an actionable error rather than mis-dialing it. Reaching one needs a
+translating proxy in front of the runner. See ADR-0048.
+
+### `AGENTOS_MODEL_ENV_KEY` (input)
+
+Declares which env var(s) carry the credential: a bare name or a JSON array of
+names. The keys are walked in declared order and the first that is both set and
+non-empty wins; a present-but-empty key is skipped, never wins. Unset or empty
+defaults to `AGENTOS_CREDENTIALS`, the single hardcoded name read before this.
+
 ### `ANTHROPIC_API_KEY` (output, set by the runner)
 
 A NON-EMPTY no-op placeholder (`not-needed`, the `NO_OP_API_KEY` constant).
@@ -46,7 +64,8 @@ The model name (e.g. `qwen3:4b`), passed through to `ClaudeAgentOptions.model`.
 
 ## OpenRouter mapping
 
-An `sk-or-...` credential in `AGENTOS_CREDENTIALS` is auto-detected by
+An `sk-or-...` credential in the declared credential env var (`AGENTOS_CREDENTIALS`
+unless `AGENTOS_MODEL_ENV_KEY` says otherwise) is auto-detected by
 `resolve_model_credential`. The runner sets
 `ANTHROPIC_BASE_URL=https://openrouter.ai/api` and places the real key in
 `ANTHROPIC_API_KEY` (sent as the `x-api-key` header, which OpenRouter's Anthropic

--- a/runner/src/agentos_runner/sdk_auth.py
+++ b/runner/src/agentos_runner/sdk_auth.py
@@ -49,7 +49,11 @@ wins, so a config author is not forced onto the single hardcoded
 ``AGENTOS_CREDENTIALS`` name. A key that is present but EMPTY is skipped rather
 than winning -- an empty value is "not supplied", never a credential. Unset or
 empty, the list defaults to ``(AGENTOS_CREDENTIALS,)``, which is exactly today's
-behavior.
+behavior. What it may TARGET is fenced: the boot env also holds the platform's
+scoped state tokens (ADR-0033) and the agent's connector secrets, so an
+``AGENTOS_``-prefixed target (other than ``AGENTOS_CREDENTIALS`` itself) is
+refused, keeping the declaration from becoming a way to forward the platform's
+own secrets to a third-party endpoint.
 
 The credential value (and its length) is never logged or echoed.
 """
@@ -76,6 +80,10 @@ MODEL_BASE_URL_ENV = "AGENTOS_MODEL_BASE_URL"
 API_BACKEND_ENV = "AGENTOS_MODEL_API_BACKEND"
 # Declares which env var(s) carry the credential: a bare name or a JSON array.
 MODEL_ENV_KEY_ENV = "AGENTOS_MODEL_ENV_KEY"
+# The platform's own boot-env namespace. No var in it is a model credential
+# (AGENTOS_CREDENTIALS excepted), so it is off limits as an env_key target --
+# see parse_env_keys.
+_AGENTOS_ENV_PREFIX = "AGENTOS_"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api"
 
 # A Claude Code OAuth token shares the sk-ant- prefix with an API key; this more
@@ -181,6 +189,19 @@ def parse_env_keys(raw: str) -> tuple[str, ...]:
     config picks up stray empties and they carry no meaning. Valid JSON of the
     wrong shape (a non-string array member, a mapping, a bare number) and a list
     that reduces to nothing are config errors, raised loudly.
+
+    An ``AGENTOS_``-prefixed target is refused (``AGENTOS_CREDENTIALS``, the
+    canonical credential name, excepted). The runner boot env is shared: it also
+    carries the platform's own scoped state tokens (ADR-0033) and the agent's
+    connector secrets. Naming one of those as a credential source under a
+    base-URL override would forward it to a third-party endpoint as the
+    ``x-api-key`` header, so the fence exists to keep the declaration from being a
+    secret-exfiltration primitive. The platform's own boot vars are never a model
+    credential, so naming one is either a mistake or an attack, and the runner
+    refuses either way. One bad name poisons the whole declaration rather than
+    being dropped silently: a silently-dropped name would let a typo'd (or
+    deliberate) exfil attempt look like it worked. The error may name the
+    offending env var, never its value.
     """
     try:
         decoded: object = json.loads(raw)
@@ -201,6 +222,13 @@ def parse_env_keys(raw: str) -> tuple[str, ...]:
     keys = tuple(name.strip() for name in names if name.strip())
     if not keys:
         raise InvalidEnvKeyError(f"{MODEL_ENV_KEY_ENV} declares no usable env var name.")
+    for key in keys:
+        if key.startswith(_AGENTOS_ENV_PREFIX) and key != CREDENTIALS_ENV:
+            raise InvalidEnvKeyError(
+                f"{MODEL_ENV_KEY_ENV} may not name {key}: the platform's own "
+                f"{_AGENTOS_ENV_PREFIX}* boot vars are never a model credential. "
+                f"Name a provider-native env var, or {CREDENTIALS_ENV}."
+            )
     return keys
 
 

--- a/runner/src/agentos_runner/sdk_auth.py
+++ b/runner/src/agentos_runner/sdk_auth.py
@@ -32,12 +32,33 @@ these endpoints read). Canonical base URLs live in ``PROVIDER_BASE_URLS``. A
 Claude Code OAuth token (``sk-ant-oat``) is never forwarded to a third-party
 endpoint -- override mode keeps it blanked (hermetic).
 
+The endpoint's wire protocol is **declared, not inferred** (#514).
+``AGENTOS_MODEL_API_BACKEND`` names it as an ``ApiBackend`` member and defaults to
+``messages``, which is the only wire format the runner can dial: the session runs
+on claude-agent-sdk, which speaks the Anthropic Messages format. The
+OpenAI-shaped backends (``chat_completions``, ``responses``) are therefore
+declarable but rejected up front, in ``resolve_sdk_env``, before any credential or
+base-URL branching -- a deterministic gate, so an OpenAI-shaped endpoint fails
+loudly with an actionable message instead of being silently mis-dialed. Reaching
+one needs a translating proxy in front of the runner.
+
+Which env var carries the credential is likewise declarable (#514).
+``AGENTOS_MODEL_ENV_KEY`` holds either a bare env-var name or a JSON array of
+them; the keys are walked in order and the first that is both set and non-empty
+wins, so a config author is not forced onto the single hardcoded
+``AGENTOS_CREDENTIALS`` name. A key that is present but EMPTY is skipped rather
+than winning -- an empty value is "not supplied", never a credential. Unset or
+empty, the list defaults to ``(AGENTOS_CREDENTIALS,)``, which is exactly today's
+behavior.
+
 The credential value (and its length) is never logged or echoed.
 """
 
 from __future__ import annotations
 
+import json
 from collections.abc import MutableMapping
+from enum import StrEnum
 
 CREDENTIALS_ENV = "AGENTOS_CREDENTIALS"
 OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
@@ -49,6 +70,12 @@ AUTH_TOKEN_ENV = "ANTHROPIC_AUTH_TOKEN"
 # namespace (like AGENTOS_MODEL / AGENTOS_CREDENTIALS) instead of setting the
 # SDK's own ANTHROPIC_BASE_URL directly. The raw var wins when both are set.
 MODEL_BASE_URL_ENV = "AGENTOS_MODEL_BASE_URL"
+# Declares the endpoint's wire protocol (see module docstring). AGENTOS_-namespaced
+# like its MODEL_BASE_URL sibling, so it is already fenced by the reserved-boot-env
+# prefix rule in plugin_format.reserved_env.
+API_BACKEND_ENV = "AGENTOS_MODEL_API_BACKEND"
+# Declares which env var(s) carry the credential: a bare name or a JSON array.
+MODEL_ENV_KEY_ENV = "AGENTOS_MODEL_ENV_KEY"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api"
 
 # A Claude Code OAuth token shares the sk-ant- prefix with an API key; this more
@@ -83,6 +110,126 @@ NO_OP_API_KEY = "not-needed"
 
 class UnsupportedCredentialError(RuntimeError):
     """``AGENTOS_CREDENTIALS`` is a recognizably non-Anthropic credential."""
+
+
+class UnsupportedApiBackendError(RuntimeError):
+    """``AGENTOS_MODEL_API_BACKEND`` names an unknown or undialable wire format."""
+
+
+class InvalidEnvKeyError(ValueError):
+    """``AGENTOS_MODEL_ENV_KEY`` is not a name or a JSON array of names."""
+
+
+class ApiBackend(StrEnum):
+    """The wire protocol an endpoint speaks, as declared by config.
+
+    The member values are the wire contract: they are what a config author writes
+    into ``AGENTOS_MODEL_API_BACKEND``.
+    """
+
+    MESSAGES = "messages"
+    CHAT_COMPLETIONS = "chat_completions"
+    RESPONSES = "responses"
+
+    @property
+    def speaks_anthropic_wire(self) -> bool:
+        """Whether claude-agent-sdk can dial this backend directly.
+
+        The runner's session is a claude-agent-sdk session, which speaks only the
+        Anthropic Messages wire format. The OpenAI-shaped backends have a
+        different request/response body, so they are not dialable without a
+        translating proxy in front of the runner.
+        """
+        return self is ApiBackend.MESSAGES
+
+
+DEFAULT_API_BACKEND = ApiBackend.MESSAGES
+
+# The credential env var(s) consulted when AGENTOS_MODEL_ENV_KEY is not declared.
+# This is today's behavior expressed as the default of the new list.
+DEFAULT_CREDENTIAL_ENV_KEYS: tuple[str, ...] = (CREDENTIALS_ENV,)
+
+
+def resolve_api_backend(env: MutableMapping[str, str]) -> ApiBackend:
+    """Resolve the declared wire protocol, defaulting to Messages.
+
+    Unset or empty means "not declared", not "declared as empty", so both fall
+    back to ``DEFAULT_API_BACKEND`` and preserve the pre-#514 assumption that
+    every endpoint speaks Messages. The value is hand-written config, so casing
+    and stray whitespace are tolerated; anything else unrecognized raises rather
+    than silently defaulting, since a near-miss spelling would otherwise mis-dial.
+    """
+    raw = env.get(API_BACKEND_ENV, "").strip()
+    if not raw:
+        return DEFAULT_API_BACKEND
+    try:
+        return ApiBackend(raw.lower())
+    except ValueError:
+        supported = ", ".join(member.value for member in ApiBackend)
+        raise UnsupportedApiBackendError(
+            f"{API_BACKEND_ENV}={raw!r} is not a supported model API backend. "
+            f"Supported values: {supported}."
+        ) from None
+
+
+def parse_env_keys(raw: str) -> tuple[str, ...]:
+    """Parse ``AGENTOS_MODEL_ENV_KEY`` into an ordered tuple of env var names.
+
+    Accepts a JSON array of names or a single bare name. A bare name like
+    ``MY_CRED`` is not valid JSON, so a decode failure falls back to the
+    bare-string form rather than raising. Blank entries are dropped: hand-written
+    config picks up stray empties and they carry no meaning. Valid JSON of the
+    wrong shape (a non-string array member, a mapping, a bare number) and a list
+    that reduces to nothing are config errors, raised loudly.
+    """
+    try:
+        decoded: object = json.loads(raw)
+    except ValueError:
+        decoded = raw  # not JSON at all: the bare-name form
+    if isinstance(decoded, str):
+        names = [decoded]
+    elif isinstance(decoded, list):
+        if not all(isinstance(item, str) for item in decoded):
+            raise InvalidEnvKeyError(
+                f"{MODEL_ENV_KEY_ENV} must be an env var name or a JSON array of names."
+            )
+        names = [item for item in decoded if isinstance(item, str)]
+    else:
+        raise InvalidEnvKeyError(
+            f"{MODEL_ENV_KEY_ENV} must be an env var name or a JSON array of names."
+        )
+    keys = tuple(name.strip() for name in names if name.strip())
+    if not keys:
+        raise InvalidEnvKeyError(f"{MODEL_ENV_KEY_ENV} declares no usable env var name.")
+    return keys
+
+
+def resolve_credential_env_keys(env: MutableMapping[str, str]) -> tuple[str, ...]:
+    """Resolve the ordered credential env var names to consult.
+
+    Unset or empty falls back to ``DEFAULT_CREDENTIAL_ENV_KEYS``, keeping the
+    undeclared path byte-identical to today's single ``AGENTOS_CREDENTIALS`` read.
+    """
+    raw = env.get(MODEL_ENV_KEY_ENV, "").strip()
+    if not raw:
+        return DEFAULT_CREDENTIAL_ENV_KEYS
+    return parse_env_keys(raw)
+
+
+def resolve_credential(env: MutableMapping[str, str]) -> str:
+    """Read the credential from the first declared key that actually carries one.
+
+    Walks the keys in declared order and returns the first value that is both set
+    AND non-empty, or ``""`` when none is. A key that is present but empty is
+    SKIPPED rather than winning: an empty credential is "not supplied", and
+    letting it beat a real one further down the list is a silent auth failure. The
+    value is returned, never logged or echoed.
+    """
+    for key in resolve_credential_env_keys(env):
+        value = env.get(key)
+        if value:
+            return value
+    return ""
 
 
 def resolve_base_url_override(env: MutableMapping[str, str]) -> dict[str, str] | None:
@@ -131,15 +278,17 @@ def _is_forwardable_provider_credential(credential: str) -> bool:
 
 
 def resolve_model_credential(env: MutableMapping[str, str]) -> None:
-    """Populate the SDK credential env from ``AGENTOS_CREDENTIALS`` when needed.
+    """Populate the SDK credential env from the declared credential key when needed.
 
-    Mutates ``env`` in place. No-op when an SDK credential is already present or
-    ``AGENTOS_CREDENTIALS`` is unset. Raises ``UnsupportedCredentialError`` for a
-    recognizably non-Anthropic key.
+    The credential is read via ``resolve_credential`` (``AGENTOS_CREDENTIALS`` by
+    default, or the keys ``AGENTOS_MODEL_ENV_KEY`` declares). Mutates ``env`` in
+    place. No-op when an SDK credential is already present or no declared key
+    carries a value. Raises ``UnsupportedCredentialError`` for a recognizably
+    non-Anthropic key.
     """
     if any(env.get(var) for var in _SDK_CREDENTIAL_ENV):
         return  # an explicit SDK credential wins
-    credential = env.get(CREDENTIALS_ENV)
+    credential = resolve_credential(env)
     if not credential:
         return
     if credential.startswith("sk-ant-oat"):
@@ -175,6 +324,11 @@ def resolve_model_credential(env: MutableMapping[str, str]) -> None:
 def resolve_sdk_env(env: MutableMapping[str, str]) -> dict[str, str] | None:
     """Decide the SDK auth env from the boot env.
 
+    The declared wire protocol is checked FIRST, before any credential or base-URL
+    branching, so rejecting an undialable backend is a deterministic gate on the
+    declaration itself rather than a side effect of whichever path config happens
+    to select.
+
     An ``sk-or-`` OpenRouter credential is routed by ``resolve_model_credential``
     (which sets the OpenRouter base URL and the real key in ``ANTHROPIC_API_KEY``,
     the ``x-api-key`` header OpenRouter reads) even when ``ANTHROPIC_BASE_URL`` is
@@ -184,7 +338,17 @@ def resolve_sdk_env(env: MutableMapping[str, str]) -> dict[str, str] | None:
     Returns the override dict to pass as ``ClaudeAgentOptions.env`` (base-URL
     override mode), or ``None`` when resolution mutated ``env`` in place.
     """
-    credential = env.get(CREDENTIALS_ENV, "")
+    backend = resolve_api_backend(env)
+    if not backend.speaks_anthropic_wire:
+        raise UnsupportedApiBackendError(
+            f"{API_BACKEND_ENV}={backend.value!r} is not dialable by this runner. The "
+            "runner speaks the Anthropic Messages wire format via claude-agent-sdk; "
+            f"{ApiBackend.CHAT_COMPLETIONS.value!r} and {ApiBackend.RESPONSES.value!r} "
+            "are OpenAI-shaped and need a translating proxy in front of the runner. "
+            f"Set {API_BACKEND_ENV}={ApiBackend.MESSAGES.value!r} (the default) and "
+            "point the base URL at an Anthropic Messages endpoint."
+        )
+    credential = resolve_credential(env)
     if not credential.startswith("sk-or-"):
         override = resolve_base_url_override(env)
         if override is not None:

--- a/runner/tests/test_sdk_auth.py
+++ b/runner/tests/test_sdk_auth.py
@@ -7,22 +7,38 @@ from __future__ import annotations
 
 import pytest
 from agentos_runner.sdk_auth import (
+    API_BACKEND_ENV,
     API_KEY_ENV,
     AUTH_TOKEN_ENV,
     BASE_URL_ENV,
     CREDENTIALS_ENV,
     DEEPSEEK_BASE_URL,
+    DEFAULT_API_BACKEND,
+    DEFAULT_CREDENTIAL_ENV_KEYS,
     MODEL_BASE_URL_ENV,
+    MODEL_ENV_KEY_ENV,
     MOONSHOT_BASE_URL,
     NO_OP_API_KEY,
     OAUTH_TOKEN_ENV,
     OPENROUTER_BASE_URL,
     PROVIDER_BASE_URLS,
     ZHIPU_BASE_URL,
+    ApiBackend,
+    InvalidEnvKeyError,
+    UnsupportedApiBackendError,
     UnsupportedCredentialError,
+    parse_env_keys,
+    resolve_credential,
+    resolve_credential_env_keys,
     resolve_model_credential,
     resolve_sdk_env,
 )
+
+# Custom credential env var NAMES used by the env_key tests. Hoisted to named
+# constants because the secrets pre-commit hook false-positives on inline
+# *_TOKEN / *_KEY literals; these are variable names, never values.
+ALT_TOKEN_KEY = "ANTHROPIC_AUTH_TOKEN_ALT"
+MY_CRED_KEY = "MY_CRED"
 
 
 def test_anthropic_api_key_maps_to_api_key_env() -> None:
@@ -255,3 +271,246 @@ def test_bare_sk_still_rejected_without_base_url() -> None:
     # is no provider endpoint to forward it to.
     with pytest.raises(UnsupportedCredentialError):
         resolve_sdk_env({CREDENTIALS_ENV: "sk-PLACEHOLDER"})
+
+
+# --- Explicit api_backend wire-protocol enum (#514). Today every endpoint is
+# assumed to speak the Anthropic Messages wire format; AGENTOS_MODEL_API_BACKEND
+# makes that assumption declarable, so an OpenAI-shaped endpoint fails loudly
+# instead of being silently mis-dialed.
+
+
+def test_api_backend_defaults_to_messages_when_unset() -> None:
+    # Unset must preserve today's behavior: everything is assumed Messages.
+    from agentos_runner.sdk_auth import resolve_api_backend
+
+    assert resolve_api_backend({}) is ApiBackend.MESSAGES
+    assert DEFAULT_API_BACKEND is ApiBackend.MESSAGES
+
+
+def test_api_backend_defaults_to_messages_when_empty_string() -> None:
+    # An empty env var is "not declared", not "declared as empty" -- the same
+    # empty-string trap the credential path guards against.
+    from agentos_runner.sdk_auth import resolve_api_backend
+
+    assert resolve_api_backend({API_BACKEND_ENV: ""}) is ApiBackend.MESSAGES
+
+
+def test_api_backend_explicit_messages() -> None:
+    from agentos_runner.sdk_auth import resolve_api_backend
+
+    assert resolve_api_backend({API_BACKEND_ENV: "messages"}) is ApiBackend.MESSAGES
+
+
+@pytest.mark.parametrize("raw", ["MESSAGES", " Messages "])
+def test_api_backend_parsing_is_case_insensitive_and_trims(raw: str) -> None:
+    # Config authors hand-write this value; casing and stray whitespace must not
+    # turn a valid backend into a hard failure.
+    from agentos_runner.sdk_auth import resolve_api_backend
+
+    assert resolve_api_backend({API_BACKEND_ENV: raw}) is ApiBackend.MESSAGES
+
+
+def test_api_backend_chat_completions() -> None:
+    from agentos_runner.sdk_auth import resolve_api_backend
+
+    assert resolve_api_backend({API_BACKEND_ENV: "chat_completions"}) is ApiBackend.CHAT_COMPLETIONS
+
+
+def test_api_backend_responses() -> None:
+    from agentos_runner.sdk_auth import resolve_api_backend
+
+    assert resolve_api_backend({API_BACKEND_ENV: "responses"}) is ApiBackend.RESPONSES
+
+
+@pytest.mark.parametrize("raw", ["grpc", "chat-completions"])
+def test_api_backend_unrecognized_value_raises(raw: str) -> None:
+    # "chat-completions" (hyphen) is the near-miss spelling of a real member; an
+    # unrecognized value must fail loudly rather than silently defaulting.
+    from agentos_runner.sdk_auth import resolve_api_backend
+
+    with pytest.raises(UnsupportedApiBackendError):
+        resolve_api_backend({API_BACKEND_ENV: raw})
+
+
+@pytest.mark.parametrize(
+    ("backend", "speaks"),
+    [
+        (ApiBackend.MESSAGES, True),
+        (ApiBackend.CHAT_COMPLETIONS, False),
+        (ApiBackend.RESPONSES, False),
+    ],
+)
+def test_speaks_anthropic_wire(backend: ApiBackend, speaks: bool) -> None:
+    # The deterministic branch point: only the Messages wire format is dialable
+    # by claude-agent-sdk.
+    assert backend.speaks_anthropic_wire is speaks
+
+
+def test_api_backend_members_have_expected_wire_values() -> None:
+    # The enum is a wire contract; its string values are what config authors put
+    # in AGENTOS_MODEL_API_BACKEND.
+    assert ApiBackend.MESSAGES == "messages"
+    assert ApiBackend.CHAT_COMPLETIONS == "chat_completions"
+    assert ApiBackend.RESPONSES == "responses"
+    assert API_BACKEND_ENV == "AGENTOS_MODEL_API_BACKEND"
+
+
+@pytest.mark.parametrize("backend", ["chat_completions", "responses"])
+def test_resolve_sdk_env_rejects_non_anthropic_backend_with_base_url(backend: str) -> None:
+    # With a base URL set (the override path). The runner speaks the Anthropic
+    # Messages wire format only; failing loudly beats silently mis-dialing.
+    env = {BASE_URL_ENV: ZHIPU_BASE_URL, API_BACKEND_ENV: backend}
+    with pytest.raises(UnsupportedApiBackendError):
+        resolve_sdk_env(env)
+
+
+@pytest.mark.parametrize("backend", ["chat_completions", "responses"])
+def test_resolve_sdk_env_rejects_non_anthropic_backend_with_plain_key(backend: str) -> None:
+    # Same rejection on the plain sk-ant- path with NO base URL. Paired with the
+    # test above, this proves the branch is on the backend itself, not a side
+    # effect of the base-URL override path.
+    env = {CREDENTIALS_ENV: "sk-ant-PLACEHOLDER", API_BACKEND_ENV: backend}
+    with pytest.raises(UnsupportedApiBackendError):
+        resolve_sdk_env(env)
+
+
+def test_resolve_sdk_env_explicit_messages_matches_default_plain_key() -> None:
+    # Regression net: declaring "messages" explicitly must behave EXACTLY as the
+    # undeclared default does today.
+    env = {CREDENTIALS_ENV: "sk-ant-PLACEHOLDER", API_BACKEND_ENV: "messages"}
+    assert resolve_sdk_env(env) is None
+    assert env[API_KEY_ENV] == "sk-ant-PLACEHOLDER"
+    assert BASE_URL_ENV not in env
+
+
+def test_resolve_sdk_env_explicit_messages_matches_default_override() -> None:
+    # Same regression net on the base-URL override path.
+    env = {BASE_URL_ENV: "http://ollama:11434", API_BACKEND_ENV: "messages"}
+    override = resolve_sdk_env(env)
+
+    assert override is not None
+    assert override[BASE_URL_ENV] == "http://ollama:11434"
+    assert override[API_KEY_ENV] == NO_OP_API_KEY
+    assert override[AUTH_TOKEN_ENV] == ""
+
+
+def test_openrouter_credential_survives_default_backend() -> None:
+    # CRITICAL regression guard: the base-URL gate must NOT drop an explicit
+    # sk-or- BYO credential. Under the default (Messages) backend the key must
+    # still reach OpenRouter's endpoint as the real key, never the placeholder.
+    env = {CREDENTIALS_ENV: "sk-or-PLACEHOLDER"}
+    assert resolve_sdk_env(env) is None
+    assert env[BASE_URL_ENV] == OPENROUTER_BASE_URL
+    assert env[API_KEY_ENV] == "sk-or-PLACEHOLDER"
+    assert env[API_KEY_ENV] != NO_OP_API_KEY
+
+
+def test_openrouter_credential_survives_explicit_messages_backend() -> None:
+    # The same guard with the backend declared explicitly.
+    env = {CREDENTIALS_ENV: "sk-or-PLACEHOLDER", API_BACKEND_ENV: "messages"}
+    assert resolve_sdk_env(env) is None
+    assert env[BASE_URL_ENV] == OPENROUTER_BASE_URL
+    assert env[API_KEY_ENV] == "sk-or-PLACEHOLDER"
+    assert env[API_KEY_ENV] != NO_OP_API_KEY
+
+
+# --- env_key as string-or-array (#514). AGENTOS_MODEL_ENV_KEY declares which env
+# var(s) carry the credential, so a config author is not forced onto the single
+# hardcoded AGENTOS_CREDENTIALS name.
+
+
+def test_parse_env_keys_bare_string_is_one_element_tuple() -> None:
+    assert parse_env_keys("A") == ("A",)
+
+
+def test_parse_env_keys_json_array_preserves_order() -> None:
+    assert parse_env_keys('["A","B"]') == ("A", "B")
+
+
+def test_parse_env_keys_drops_blank_array_entries() -> None:
+    # Hand-written config picks up stray empty entries; they carry no meaning.
+    assert parse_env_keys('["A","","  ","B"]') == ("A", "B")
+
+
+def test_parse_env_keys_bare_string_that_is_not_json_falls_back() -> None:
+    # "MY_KEY" is not valid JSON. The JSON attempt must fall back to the
+    # bare-string form rather than raising.
+    assert parse_env_keys(MY_CRED_KEY) == (MY_CRED_KEY,)
+
+
+@pytest.mark.parametrize("raw", ['[1,2]', '{"a":1}', "[]", '["", "  "]', "5"])
+def test_parse_env_keys_invalid_raises(raw: str) -> None:
+    # Valid JSON of the wrong shape (non-string array members, a mapping, a bare
+    # number) and arrays that reduce to nothing are all config errors.
+    with pytest.raises(InvalidEnvKeyError):
+        parse_env_keys(raw)
+
+
+def test_resolve_credential_env_keys_defaults_when_unset() -> None:
+    assert resolve_credential_env_keys({}) == DEFAULT_CREDENTIAL_ENV_KEYS
+    assert DEFAULT_CREDENTIAL_ENV_KEYS == (CREDENTIALS_ENV,)
+    assert MODEL_ENV_KEY_ENV == "AGENTOS_MODEL_ENV_KEY"
+
+
+def test_resolve_credential_env_keys_defaults_when_empty_string() -> None:
+    assert resolve_credential_env_keys({MODEL_ENV_KEY_ENV: ""}) == DEFAULT_CREDENTIAL_ENV_KEYS
+
+
+def test_resolve_credential_skips_unset_key_and_takes_next() -> None:
+    env = {
+        MODEL_ENV_KEY_ENV: f'["{ALT_TOKEN_KEY}","{MY_CRED_KEY}"]',
+        MY_CRED_KEY: "sk-ant-PLACEHOLDER",
+    }
+    assert resolve_credential(env) == "sk-ant-PLACEHOLDER"
+
+
+def test_resolve_credential_skips_empty_key_and_takes_next() -> None:
+    # THE key assertion (the #229 empty-string gotcha, made explicit): a key that
+    # is present but empty must be SKIPPED, not win. An empty credential silently
+    # beating a real one downstream is exactly the failure this guards.
+    env = {
+        MODEL_ENV_KEY_ENV: f'["{ALT_TOKEN_KEY}","{MY_CRED_KEY}"]',
+        ALT_TOKEN_KEY: "",
+        MY_CRED_KEY: "sk-ant-PLACEHOLDER",
+    }
+    assert resolve_credential(env) == "sk-ant-PLACEHOLDER"
+
+
+def test_resolve_credential_first_set_key_wins_on_order() -> None:
+    env = {
+        MODEL_ENV_KEY_ENV: f'["{ALT_TOKEN_KEY}","{MY_CRED_KEY}"]',
+        ALT_TOKEN_KEY: "sk-ant-FIRST-PLACEHOLDER",
+        MY_CRED_KEY: "sk-ant-SECOND-PLACEHOLDER",
+    }
+    assert resolve_credential(env) == "sk-ant-FIRST-PLACEHOLDER"
+
+
+def test_resolve_credential_returns_empty_when_no_key_matches() -> None:
+    env = {MODEL_ENV_KEY_ENV: f'["{ALT_TOKEN_KEY}","{MY_CRED_KEY}"]'}
+    assert resolve_credential(env) == ""
+
+
+def test_resolve_credential_defaults_to_agentos_credentials() -> None:
+    # Byte-identical-to-today guard: with no AGENTOS_MODEL_ENV_KEY declared, the
+    # credential still comes from AGENTOS_CREDENTIALS.
+    assert resolve_credential({CREDENTIALS_ENV: "sk-ant-PLACEHOLDER"}) == "sk-ant-PLACEHOLDER"
+
+
+def test_resolve_sdk_env_sources_credential_from_custom_env_key_array() -> None:
+    # End-to-end: the two features compose. A credential sourced from a custom
+    # env_key array routes to ANTHROPIC_API_KEY exactly as it would from
+    # AGENTOS_CREDENTIALS.
+    env = {
+        MODEL_ENV_KEY_ENV: f'["{ALT_TOKEN_KEY}","{MY_CRED_KEY}"]',
+        MY_CRED_KEY: "sk-ant-PLACEHOLDER",
+    }
+    assert resolve_sdk_env(env) is None
+    assert env[API_KEY_ENV] == "sk-ant-PLACEHOLDER"
+    assert BASE_URL_ENV not in env
+
+
+def test_resolve_sdk_env_default_env_key_path_unchanged() -> None:
+    # Byte-identical-to-today guard on the full resolution path.
+    env = {CREDENTIALS_ENV: "sk-ant-PLACEHOLDER"}
+    assert resolve_sdk_env(env) is None
+    assert env[API_KEY_ENV] == "sk-ant-PLACEHOLDER"

--- a/runner/tests/test_sdk_auth.py
+++ b/runner/tests/test_sdk_auth.py
@@ -514,3 +514,118 @@ def test_resolve_sdk_env_default_env_key_path_unchanged() -> None:
     env = {CREDENTIALS_ENV: "sk-ant-PLACEHOLDER"}
     assert resolve_sdk_env(env) is None
     assert env[API_KEY_ENV] == "sk-ant-PLACEHOLDER"
+
+
+# --- env_key targeting fence (#514 hardening). resolve_credential walks whatever
+# names AGENTOS_MODEL_ENV_KEY hands it, but the runner boot env is shared: it also
+# carries the platform's own AGENTOS_-namespaced vars, including the scoped HMAC
+# state tokens (ADR-0033) the runner authenticates to the state API with. Naming
+# one of those as a credential source under a base-URL override would forward it
+# to a third-party endpoint as x-api-key -- a secret-exfiltration primitive. The
+# platform's own boot vars are never a model credential, so an AGENTOS_-prefixed
+# target is either a mistake or an attack, and the runner refuses either way.
+# AGENTOS_CREDENTIALS is the one exception: it IS the canonical credential name.
+# The existing reserved_env fence guards the name a connector secret may DECLARE;
+# this one guards the name an env_key may TARGET. Different direction, both needed.
+
+# Platform boot-env var NAMES the fence must refuse. Hoisted to named constants
+# because the secrets pre-commit hook false-positives on inline *_TOKEN / *_KEY
+# literals; these are variable names, never values.
+MEMORY_TOKEN_KEY = "AGENTOS_MEMORY_TOKEN"
+HISTORY_TOKEN_KEY = "AGENTOS_HISTORY_TOKEN"
+RUNNER_TOKEN_KEY = "AGENTOS_RUNNER_TOKEN"
+BUDGET_KEY = "AGENTOS_BUDGET"
+# An obvious fake placeholder standing in for a scoped state token's VALUE.
+FAKE_STATE_TOKEN_VALUE = "PLACEHOLDER-not-a-real-state-token"
+
+
+@pytest.mark.parametrize(
+    "name", [MEMORY_TOKEN_KEY, HISTORY_TOKEN_KEY, RUNNER_TOKEN_KEY, BUDGET_KEY]
+)
+def test_parse_env_keys_rejects_agentos_prefixed_target(name: str) -> None:
+    # The state tokens are the exfiltration targets; the budget stands in for the
+    # rest of the AGENTOS_ boot namespace (refs, ids) -- none is a credential.
+    with pytest.raises(InvalidEnvKeyError):
+        parse_env_keys(f'["{name}"]')
+
+
+def test_parse_env_keys_rejects_agentos_prefixed_bare_string_target() -> None:
+    # The fence applies to BOTH input forms; the bare-string path must not be a
+    # way around the array-form check.
+    with pytest.raises(InvalidEnvKeyError):
+        parse_env_keys(RUNNER_TOKEN_KEY)
+
+
+def test_parse_env_keys_allows_agentos_credentials_target() -> None:
+    # The one allowed AGENTOS_ name: it is the canonical credential var, and it is
+    # already the default, so declaring it explicitly must stay legal.
+    assert parse_env_keys(f'["{CREDENTIALS_ENV}"]') == (CREDENTIALS_ENV,)
+
+
+def test_parse_env_keys_allows_agentos_credentials_bare_string() -> None:
+    assert parse_env_keys(CREDENTIALS_ENV) == (CREDENTIALS_ENV,)
+
+
+def test_parse_env_keys_one_bad_name_poisons_the_whole_declaration() -> None:
+    # A mixed array raises rather than silently dropping the fenced name and
+    # falling through to the good one. Silently dropping would let a typo'd (or
+    # deliberate) exfil attempt LOOK like it worked -- the declaration resolves, a
+    # credential is found, nothing surfaces. Refusing the whole declaration makes
+    # the operator confront what they wrote.
+    with pytest.raises(InvalidEnvKeyError):
+        parse_env_keys(f'["{MEMORY_TOKEN_KEY}","{MY_CRED_KEY}"]')
+
+
+def test_parse_env_keys_still_allows_provider_native_names() -> None:
+    # Sourcing from a provider-native var is the whole point of the feature; the
+    # issue's own cited example (grok-build) is exactly this pair. Non-AGENTOS_
+    # names must stay allowed or the fence has eaten the feature.
+    assert parse_env_keys('["ANTHROPIC_AUTH_TOKEN","LC_ANTHROPIC_AUTH_TOKEN"]') == (
+        "ANTHROPIC_AUTH_TOKEN",
+        "LC_ANTHROPIC_AUTH_TOKEN",
+    )
+
+
+def test_parse_env_keys_still_allows_a_bare_non_agentos_name() -> None:
+    assert parse_env_keys("MY_PROVIDER_KEY") == ("MY_PROVIDER_KEY",)
+
+
+def test_resolve_credential_env_keys_rejects_agentos_prefixed_target() -> None:
+    # The fence is reachable through the env-facing resolver, not only through the
+    # parser it delegates to.
+    with pytest.raises(InvalidEnvKeyError):
+        resolve_credential_env_keys({MODEL_ENV_KEY_ENV: f'["{MEMORY_TOKEN_KEY}"]'})
+
+
+def test_resolve_sdk_env_refuses_to_exfiltrate_a_state_token_to_an_override() -> None:
+    # THE regression net for the actual vulnerability. A base URL points at a
+    # third-party endpoint and the declaration names the scoped state token
+    # (ADR-0033) that is sitting in the same boot env. Forwarding it would send the
+    # platform's own credential to that endpoint as the x-api-key header. It must
+    # raise, and the token value must never reach ANTHROPIC_API_KEY.
+    env = {
+        BASE_URL_ENV: ZHIPU_BASE_URL,
+        MODEL_ENV_KEY_ENV: f'["{MEMORY_TOKEN_KEY}"]',
+        MEMORY_TOKEN_KEY: FAKE_STATE_TOKEN_VALUE,
+    }
+    with pytest.raises(InvalidEnvKeyError) as excinfo:
+        resolve_sdk_env(env)
+
+    assert env.get(API_KEY_ENV) != FAKE_STATE_TOKEN_VALUE
+    assert API_KEY_ENV not in env  # nothing was resolved at all
+    # The error may name the offending VAR NAME (that is the actionable part) but
+    # must never echo the credential VALUE -- the module's no-echo discipline.
+    assert FAKE_STATE_TOKEN_VALUE not in str(excinfo.value)
+
+
+def test_resolve_sdk_env_refuses_state_token_on_the_plain_path_too() -> None:
+    # Same refusal with no base URL set, proving the gate is on the declaration
+    # itself rather than a side effect of the override branch.
+    env = {
+        MODEL_ENV_KEY_ENV: f'["{HISTORY_TOKEN_KEY}"]',
+        HISTORY_TOKEN_KEY: FAKE_STATE_TOKEN_VALUE,
+    }
+    with pytest.raises(InvalidEnvKeyError):
+        resolve_sdk_env(env)
+    assert API_KEY_ENV not in env
+    assert OAUTH_TOKEN_ENV not in env


### PR DESCRIPTION
Declares two things about a BYO model endpoint that the runner previously assumed, and closes the gaps review found in the first pass.

## What changed

**`api_backend` enum.** The wire protocol was inferred: any base-URL override was assumed to speak the Anthropic Messages format, since that is the only format claude-agent-sdk can dial. Pointing `AGENTOS_MODEL_BASE_URL` at an OpenAI-shaped endpoint failed deep inside the SDK instead of at the config. It is now declared via `AGENTOS_MODEL_API_BACKEND` as `messages | chat_completions | responses`, defaulting to `messages` so no existing config changes behavior. `ApiBackend.speaks_anthropic_wire` is the single branch point, checked at the top of `resolve_sdk_env` before any credential or base-URL branching, so an undialable backend is rejected on the declaration rather than as a side effect of the selected path. The OpenAI-shaped members are declarable but rejected with an actionable message; reaching one needs a translating proxy.

**`env_key` string-or-array.** `AGENTOS_MODEL_ENV_KEY` accepts a bare env var name or a JSON array of them. Keys are walked in declared order and the first that is both set and non-empty wins. A present-but-empty key is skipped rather than winning, which closes the empty-credential footgun from #229 by construction. Unset defaults to `AGENTOS_CREDENTIALS`, byte-identical to previous behavior.

## What review caught

The first pass had correct logic that was **unreachable**: the runner boot env is closed-world and nothing emitted either var, so neither could ever be declared. Both now have a producer mirroring `model_base_url`'s existing chain (`WorkerConfig` -> `apply_model_env` -> compose passthrough).

Making it reachable exposed a **secret-exfiltration primitive**, fixed in the same commit rather than after. The boot env also carries the scoped HMAC state tokens (`AGENTOS_MEMORY_TOKEN`, `AGENTOS_HISTORY_TOKEN`, `AGENTOS_RUNNER_TOKEN`) and the agent's connector secrets. An unfenced `env_key` naming one of those under a base-URL override would forward it to a third-party endpoint as the `x-api-key` header. The existing reserved-env prefix rule guards the name a connector secret may *declare*, which is shadowing, not targeting, so it did not help. Two things close it:

- The declaration is **operator scope**: sourced from `WorkerConfig`, never from the per-agent row. Pinned by a signature test so a later per-agent plumb-through fails loudly.
- `parse_env_keys` **refuses any `AGENTOS_`-prefixed target** except `AGENTOS_CREDENTIALS`, on both input forms. One fenced name rejects the whole declaration rather than being dropped, so a typo'd or deliberate attempt cannot look like it worked. Non-`AGENTOS_` names stay allowed, since sourcing from a provider-native var is the point.

## Decisions recorded

ADR-0048. Scoped to runner-local boot env rather than an `aci-protocol` `SessionConfig` field: base URL and credential already flow as boot env outside that frozen contract, so this avoids a `PROTOCOL_VERSION` bump for no gain today. Review also disproved two claims in the first draft of the ADR, both corrected: the `reserved_env` entry is for greppability only (the prefix rule already covers both names, and the pin passes without it), and the trust boundary is closed by operator scope plus the target fence, not by the reserved prefix.

The enum has one dialable member today, so it buys legibility and a fast failure rather than new reach.

## Verification

- 276 scoped tests pass (`runner/tests`, `apps/worker/tests/binding`, `test_config.py`, `packages/plugin-format/tests`); ruff, mypy, and `check-docs.sh` clean.
- Mutation-checked the load-bearing behavior: disabling the empty-string skip, the backend gate, and the `AGENTOS_` target fence each fails tests (9 fail when the fence is removed, including the exfiltration guard).
- E2E through the real chain: `WorkerConfig` reading real env -> `apply_model_env` -> runner resolution, confirming `["LC_ANTHROPIC_AUTH_TOKEN","MY_CRED"]` picks `MY_CRED` when the first is unset, and that the exfil attempt and an undialable backend are both refused with no credential value in the error.
- Four failures in `apps/worker/tests/eval/test_stream.py` are pre-existing and environmental, verified by reproducing them at the base commit with these changes stashed.

Closes #514