### PR TITLE
Move substrate-neutral label constants out of the k8s adapter

### DIFF
--- a/apps/worker/src/agentos_worker/sandbox/__init__.py
+++ b/apps/worker/src/agentos_worker/sandbox/__init__.py
@@ -10,14 +10,12 @@ Public surface for F1 (the worker kernel):
 
 from .affinity import AffinityStore
 from .docker import DockerError, DockerSandboxClient
-from .k8s import (
+from .k8s import KubernetesSandboxClient
+from .substrate import HISTORY_ENV, SESSION_ENV, SandboxSubstrate
+from .types import (
     MANAGED_BY_LABEL,
     MANAGED_BY_VALUE,
     THREAD_HASH_LABEL,
-    KubernetesSandboxClient,
-)
-from .substrate import HISTORY_ENV, SESSION_ENV, SandboxSubstrate
-from .types import (
     ClaimTimeoutError,
     ClaimView,
     NoRouteError,

--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -53,11 +53,14 @@ from ..binding import (
     PLUGIN_DIR_ENV,
 )
 from ..bundle_store import BundleReader, extract_bundle
-from .k8s import (
+from .types import (
     MANAGED_BY_LABEL,
     MANAGED_BY_VALUE,
+    ClaimView,
+    OperatingMode,
+    SandboxError,
+    SandboxView,
 )
-from .types import ClaimView, OperatingMode, SandboxError, SandboxView
 
 logger = logging.getLogger(__name__)
 

--- a/apps/worker/src/agentos_worker/sandbox/k8s.py
+++ b/apps/worker/src/agentos_worker/sandbox/k8s.py
@@ -16,16 +16,18 @@ from typing import Any
 from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
 
-from .types import ClaimView, OperatingMode, SandboxView
+from .types import (
+    MANAGED_BY_LABEL,
+    MANAGED_BY_VALUE,
+    ClaimView,
+    OperatingMode,
+    SandboxView,
+)
 
 CORE_GROUP = "agents.x-k8s.io"
 CORE_VERSION = "v1beta1"
 EXT_GROUP = "extensions.agents.x-k8s.io"
 EXT_VERSION = "v1beta1"
-
-MANAGED_BY_LABEL = "agentos.dev/managed-by"
-MANAGED_BY_VALUE = "agentos-sandbox-substrate"
-THREAD_HASH_LABEL = "agentos.dev/thread-hash"
 
 # Per-claim env with no containerName reaches only the FIRST main container (the
 # agent-sandbox Overrides policy). The bundle ref must additionally reach the

--- a/apps/worker/src/agentos_worker/sandbox/substrate.py
+++ b/apps/worker/src/agentos_worker/sandbox/substrate.py
@@ -28,12 +28,10 @@ import uuid
 
 from ..binding import RUNNER_TOKEN_ENV
 from .affinity import AffinityStore
-from .k8s import (
+from .types import (
     MANAGED_BY_LABEL,
     MANAGED_BY_VALUE,
     THREAD_HASH_LABEL,
-)
-from .types import (
     ClaimTimeoutError,
     NoRouteError,
     RouteRecord,

--- a/apps/worker/src/agentos_worker/sandbox/types.py
+++ b/apps/worker/src/agentos_worker/sandbox/types.py
@@ -15,6 +15,13 @@ from dataclasses import asdict, dataclass
 from enum import StrEnum
 from typing import Literal, Protocol
 
+# Substrate-neutral labels: every backend tags its managed objects with these
+# (the Kubernetes adapter on claims, the Docker adapter on containers), so they
+# live here rather than in either concrete adapter.
+MANAGED_BY_LABEL = "agentos.dev/managed-by"
+MANAGED_BY_VALUE = "agentos-sandbox-substrate"
+THREAD_HASH_LABEL = "agentos.dev/thread-hash"
+
 
 class RouteState(StrEnum):
     """Lifecycle state of a thread route recorded in the affinity store."""


### PR DESCRIPTION
Completes the extraction started in #575, which moved the `SandboxClient` Protocol into substrate-neutral `sandbox/types.py` but left the label constants behind in the Kubernetes adapter.

`MANAGED_BY_LABEL`, `MANAGED_BY_VALUE`, and `THREAD_HASH_LABEL` now live in `sandbox/types.py` alongside `SandboxClient` and `OperatingMode`. Neither the neutral composing core (`substrate.py`) nor the Docker adapter (`docker.py`) imports from `.k8s` any more; `k8s.py` imports the two labels it uses from `.types` like any other backend.

Previously the Docker substrate could not import without the Kubernetes adapter module loading, and a third backend would inherit the same k8s import for values that have nothing to do with Kubernetes (ADR-0012: the core stays substrate-agnostic).

Pure move: names, values, and the package `__all__` are unchanged.

Closes #609