### PR TITLE
Disclose an unreadable deployed manifest in approvals output

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2158,11 +2158,20 @@ pub async fn memory(opts: AgentActionOpts) -> Result<MemoryOutput> {
 
 /// Output of `<tier> approvals <agent>`: the dry-run plan, or the gate list
 /// (empty vec == "no tools gated"). Owns its data so it outlives the `ApiClient`.
+///
+/// `manifest_unreadable` carries the third state (#607). `gated_tools` alone
+/// cannot distinguish "the deployed bundle manifest declares no gates" from "the
+/// manifest could not be read at all" -- both used to arrive here as an empty vec
+/// and render as the affirmative "calls run without approval". `Some(reason)`
+/// means the manifest lookup failed, so the list is what we could see rather than
+/// what is armed. Always `None` on the set path (`--gate`/`--clear`), which echoes
+/// the PATCHed platform field and never reads a manifest.
 pub enum ApprovalsOutput {
     DryRun(crate::ui::DryRunPlan),
     Gates {
         agent: String,
         gated_tools: Vec<String>,
+        manifest_unreadable: Option<String>,
     },
 }
 
@@ -2170,28 +2179,67 @@ impl crate::ui::CliOutput for ApprovalsOutput {
     fn to_json(&self) -> serde_json::Value {
         match self {
             ApprovalsOutput::DryRun(plan) => plan.to_json(),
-            ApprovalsOutput::Gates { agent, gated_tools } => {
-                serde_json::json!({"agent": agent, "gated_tools": gated_tools})
-            }
+            ApprovalsOutput::Gates {
+                agent,
+                gated_tools,
+                manifest_unreadable,
+            } => serde_json::json!({
+                "agent": agent,
+                "gated_tools": gated_tools,
+                "manifest_unreadable": manifest_unreadable,
+            }),
         }
     }
 
     fn render(&self, ui: &crate::ui::Ui) {
         match self {
             ApprovalsOutput::DryRun(plan) => plan.render(ui),
-            ApprovalsOutput::Gates { agent, gated_tools } => {
-                if gated_tools.is_empty() {
-                    ui.payload(&format!(
-                        "{agent}: no tools are gated (calls run without approval)"
-                    ));
-                } else {
-                    ui.payload(&format!("{agent} — {} gated tool(s):", gated_tools.len()));
-                    for tool in gated_tools {
-                        ui.kv("gated", tool);
-                    }
+            ApprovalsOutput::Gates {
+                agent,
+                gated_tools,
+                manifest_unreadable,
+            } => {
+                ui.payload(&approvals_summary_line(
+                    agent,
+                    gated_tools,
+                    manifest_unreadable.as_deref(),
+                ));
+                for tool in gated_tools {
+                    ui.kv("gated", tool);
                 }
             }
         }
+    }
+}
+
+/// The human summary line for `<tier> approvals`' gate view.
+///
+/// Four lines for three states, because whether gates were found is orthogonal to
+/// whether we could read the manifest that declares them. The `unreadable` arm is
+/// the one that matters: an unanswered lookup must not borrow the vocabulary of an
+/// answered one. Reporting "no tools are gated (calls run without approval)"
+/// because the deployment list request errored tells the reader the runner will
+/// not pause, which is a claim this command never checked -- and the reader acts on
+/// it. Same reasoning as the skill tier's `gates_summary_line`, where the unseen
+/// source is the boot-time env override rather than the deployed manifest.
+///
+/// The unreadable-with-gates arm is not redundant: gates from the platform's
+/// `approval_required_tools` field are real, but presenting them without the
+/// caveat implies the list is the whole set.
+fn approvals_summary_line(agent: &str, gated_tools: &[String], unreadable: Option<&str>) -> String {
+    match (gated_tools.is_empty(), unreadable) {
+        (true, None) => format!("{agent}: no tools are gated (calls run without approval)"),
+        (false, None) => format!("{agent} — {} gated tool(s):", gated_tools.len()),
+        (true, Some(reason)) => format!(
+            "{agent}: the deployed bundle manifest could not be read ({reason}), so whether it \
+             gates any tool is unknown. The platform's approval_required_tools field lists none, \
+             which is not the same as nothing being gated"
+        ),
+        (false, Some(reason)) => format!(
+            "{agent} — {} gated tool(s), and this list may be incomplete: the deployed bundle \
+             manifest could not be read ({reason}), so any gate it declares is not shown:",
+            gated_tools.len()
+        ),
     }
 }
 
@@ -2227,13 +2275,13 @@ pub async fn approvals(
     let ui = crate::ui::ui();
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     let agent = client.find_agent(&opts.agent).await?;
-    let gates = if setting {
+    let (gates, unreadable) = if setting {
         let cl = ui.checklist();
         let step = cl.step(&format!("updating approval gates for {}", agent.name));
         match client.set_approval_tools(&agent.id, &gate).await {
             Ok(updated) => {
                 step.done("updated");
-                updated.approval_required_tools.unwrap_or_default()
+                (updated.approval_required_tools.unwrap_or_default(), None)
             }
             Err(err) => {
                 step.fail("failed");
@@ -2246,17 +2294,27 @@ pub async fn approvals(
         // AGENTOS_APPROVAL_REQUIRED_TOOLS) AND the in-force deployed bundle
         // manifest's `approvalPolicy` gates. Reading only the API field reported an
         // empty set while a manifest gate was armed and blocking.
+        //
+        // When that manifest half cannot be read, the union is only the field half
+        // and the report says so (#607) rather than passing a partial answer off as
+        // the effective set.
         let mut gated = agent.approval_required_tools.clone().unwrap_or_default();
-        for name in deployed_manifest_gate_names(&client, &agent.id).await? {
-            if !gated.contains(&name) {
-                gated.push(name);
+        match deployed_manifest_gate_names(&client, &agent.id).await? {
+            ManifestGates::Readable(names) => {
+                for name in names {
+                    if !gated.contains(&name) {
+                        gated.push(name);
+                    }
+                }
+                (gated, None)
             }
+            ManifestGates::Unreadable(reason) => (gated, Some(reason)),
         }
-        gated
     };
     Ok(ApprovalsOutput::Gates {
         agent: agent.name,
         gated_tools: gates,
+        manifest_unreadable: unreadable,
     })
 }
 
@@ -2594,31 +2652,64 @@ fn select_in_force_deployment(
 /// gate set while the manifest gate is armed and blocking. Best-effort on the
 /// fetch (no deployment / no bundle / API hiccup → no manifest gates), but a
 /// deployed manifest that is actually invalid is surfaced (it disarms every gate).
-async fn deployed_manifest_gate_names(client: &ApiClient, agent_id: &str) -> Result<Vec<String>> {
+///
+/// The empty-vec outcomes are NOT interchangeable, which is why this returns
+/// `ManifestGates` rather than a bare list (#607): "the manifest declares nothing"
+/// is an answer, "the API call failed" is the absence of one, and the caller's
+/// report reads very differently for each.
+enum ManifestGates {
+    /// The lookup completed. The vec is the manifest's armed gates, empty when
+    /// there is no deployed bundle, no manifest in it, or no `approvalPolicy`.
+    Readable(Vec<String>),
+    /// The lookup did not complete, so the manifest's gates are unknown. Carries
+    /// the reason, which is reported rather than swallowed.
+    Unreadable(String),
+}
+
+async fn deployed_manifest_gate_names(client: &ApiClient, agent_id: &str) -> Result<ManifestGates> {
     let deployments = match client.list_deployments(agent_id).await {
         Ok(d) => d,
-        Err(_) => return Ok(Vec::new()),
+        Err(err) => {
+            return Ok(ManifestGates::Unreadable(format!(
+                "listing the agent's deployments failed: {err}"
+            )))
+        }
     };
-    let Some(version_id) =
-        select_in_force_deployment(&deployments).and_then(|d| d.version_id.clone())
-    else {
-        return Ok(Vec::new());
+    // No active deployment is a real answer: nothing is running this agent's
+    // bundle, so no manifest gate can be armed from one.
+    let Some(deployment) = select_in_force_deployment(&deployments) else {
+        return Ok(ManifestGates::Readable(Vec::new()));
+    };
+    // A deployment IS in force but names no version. `version_id` is
+    // `#[serde(default)]`, so this is response drift rather than a stated absence
+    // -- the bundle exists and we simply cannot address it.
+    let Some(version_id) = deployment.version_id.clone() else {
+        return Ok(ManifestGates::Unreadable(format!(
+            "the in-force deployment {} reports no version id",
+            deployment.id
+        )));
     };
     let files = match client.bundle_files(agent_id, &version_id).await {
         Ok(f) => f,
-        Err(_) => return Ok(Vec::new()),
+        Err(err) => {
+            return Ok(ManifestGates::Unreadable(format!(
+                "fetching the deployed bundle's files failed: {err}"
+            )))
+        }
     };
     let Some(manifest) = files
         .iter()
         .find(|f| MANIFEST_LOCATIONS.contains(&f.path.as_str()))
     else {
-        return Ok(Vec::new());
+        return Ok(ManifestGates::Readable(Vec::new()));
     };
     let gates = parse_manifest_gates(
         &manifest.content,
         &format!("deployed bundle manifest ({})", manifest.path),
     )?;
-    Ok(gates.into_iter().map(|(gate, _route)| gate).collect())
+    Ok(ManifestGates::Readable(
+        gates.into_iter().map(|(gate, _route)| gate).collect(),
+    ))
 }
 
 /// POSIX-shell-quote a value for safe interpolation into emitted shell text.
@@ -3327,6 +3418,44 @@ mod tests {
         let none = vec![deployment("dev", "superseded", "x", "2026-07-01")];
         assert!(select_in_force_deployment(&none).is_none());
         assert!(select_in_force_deployment(&[]).is_none());
+    }
+
+    #[test]
+    fn approvals_summary_line_never_claims_ungated_when_the_manifest_is_unreadable() {
+        // The whole point of the three-state split (#607): "no gates found" and
+        // "could not look" are different answers, and only the first one licenses
+        // the affirmative claim. A failed manifest fetch used to collapse into the
+        // second branch here and report the agent as running without approval.
+        let ungated = super::approvals_summary_line("weather", &[], None);
+        assert!(
+            ungated.contains("no tools are gated (calls run without approval)"),
+            "a genuinely readable, gate-free agent still gets the affirmative claim: {ungated}"
+        );
+
+        let blind = super::approvals_summary_line("weather", &[], Some("the deploy list failed"));
+        assert!(
+            !blind.contains("no tools are gated"),
+            "an unreadable manifest must not render as an affirmative un-gated claim: {blind}"
+        );
+        assert!(
+            blind.contains("could not be read") && blind.contains("the deploy list failed"),
+            "the reason we could not look is disclosed: {blind}"
+        );
+
+        // Gates found from the platform field while the manifest was unreadable:
+        // the list is real but partial, and silence about that implies complete.
+        let partial =
+            super::approvals_summary_line("weather", &["Bash".into()], Some("the fetch failed"));
+        assert!(
+            partial.contains("incomplete") && partial.contains("could not be read"),
+            "a partial list discloses that more gates may be armed: {partial}"
+        );
+
+        let complete = super::approvals_summary_line("weather", &["Bash".into()], None);
+        assert!(
+            !complete.contains("incomplete") && complete.contains("1 gated tool(s)"),
+            "a fully-read gate list makes no incompleteness caveat: {complete}"
+        );
     }
 
     #[test]

--- a/cli/tests/approvals_manifest_unreadable.rs
+++ b/cli/tests/approvals_manifest_unreadable.rs
@@ -1,0 +1,149 @@
+//! Integration: `<tier> approvals <agent>` must never report an un-gated agent
+//! when the deployed bundle manifest lookup did not complete (#607).
+//!
+//! Driven through the real `approvals` handler and a real `ApiClient` against a
+//! wire-level stub, because the bug lives in the fetch path, not the renderer: a
+//! failed lookup that collapses to an empty gate list reads as the affirmative
+//! "nothing pauses for approval". A test that hands the renderer a
+//! ready-made reason cannot see that, so every case here makes the HTTP call
+//! actually fail (or succeed) and asserts what the command concluded from it.
+
+mod support;
+
+use agentos::commands::{approvals, AgentActionOpts, ApprovalsOutput};
+use agentos::ui::CliOutput;
+use support::{serve, MockServer, Response};
+
+const AGENT_ID: &str = "11111111-1111-1111-1111-111111111111";
+const VERSION_ID: &str = "22222222-2222-2222-2222-222222222222";
+
+/// The agent lookup always succeeds and gates nothing via the platform's mutable
+/// `approval_required_tools` field, so the manifest half is the only thing under
+/// test: whatever the report says about gates came from the deployment fetch.
+fn agents_response() -> Response {
+    Response::json(
+        200,
+        &format!(
+            r##"[{{"id":"{AGENT_ID}","name":"weather","slack_channel":"#weather","approval_required_tools":[]}}]"##
+        ),
+    )
+}
+
+fn deployment_json(version_id: &str) -> String {
+    format!(
+        r#"[{{"id":"dep-1","agent_id":"{AGENT_ID}","environment":"dev","status":"active","version_id":{version_id},"deployed_at":"2026-07-05T00:00:00Z"}}]"#
+    )
+}
+
+async fn read_gates(server: &MockServer) -> ApprovalsOutput {
+    approvals(
+        AgentActionOpts {
+            api_url: server.base_url.clone(),
+            api_key: "test-key".to_string(),
+            agent: "weather".to_string(),
+            dry_run: false,
+        },
+        vec![],
+        false,
+    )
+    .await
+    .expect("approvals should report the failure, not propagate it")
+}
+
+/// The gate list plus the unreadable reason, as the command concluded them.
+fn gates(out: &ApprovalsOutput) -> (Vec<String>, Option<String>) {
+    match out {
+        ApprovalsOutput::Gates {
+            gated_tools,
+            manifest_unreadable,
+            ..
+        } => (gated_tools.clone(), manifest_unreadable.clone()),
+        ApprovalsOutput::DryRun(_) => panic!("expected the gate view, not a dry-run plan"),
+    }
+}
+
+#[tokio::test]
+async fn a_failed_deployment_lookup_is_disclosed_rather_than_read_as_ungated() {
+    let server = serve(|req| match req.path.split('?').next().unwrap() {
+        "/agents" => agents_response(),
+        "/deployments" => Response::json(503, r#"{"detail":"upstream unavailable"}"#),
+        other => panic!("unexpected request: {other}"),
+    });
+
+    let out = read_gates(&server).await;
+    let (gated, unreadable) = gates(&out);
+    assert!(gated.is_empty(), "the platform field gates nothing here");
+    let reason = unreadable.expect("a 503 on the deployment list leaves the manifest unread");
+    assert!(
+        reason.contains("deployments"),
+        "the reason must name the lookup that failed, got {reason:?}"
+    );
+    assert_eq!(out.to_json()["manifest_unreadable"], reason.as_str());
+}
+
+#[tokio::test]
+async fn a_failed_bundle_files_lookup_is_disclosed_rather_than_read_as_ungated() {
+    let server = serve(|req| match req.path.split('?').next().unwrap() {
+        "/agents" => agents_response(),
+        "/deployments" => Response::json(200, &deployment_json(&format!(r#""{VERSION_ID}""#))),
+        p if p == format!("/agents/{AGENT_ID}/versions/{VERSION_ID}/files") => {
+            Response::json(404, r#"{"detail":"version not found"}"#)
+        }
+        other => panic!("unexpected request: {other}"),
+    });
+
+    let (gated, unreadable) = gates(&read_gates(&server).await);
+    assert!(gated.is_empty());
+    let reason = unreadable.expect("a 404 on the bundle files leaves the manifest unread");
+    assert!(
+        reason.contains("bundle"),
+        "the reason must name the lookup that failed, got {reason:?}"
+    );
+}
+
+#[tokio::test]
+async fn an_in_force_deployment_with_no_version_id_is_disclosed() {
+    // Response drift, not a stated absence: a bundle IS deployed and in force, we
+    // simply cannot address it to read its manifest.
+    let server = serve(|req| match req.path.split('?').next().unwrap() {
+        "/agents" => agents_response(),
+        "/deployments" => Response::json(200, &deployment_json("null")),
+        other => panic!("unexpected request: {other}"),
+    });
+
+    let (gated, unreadable) = gates(&read_gates(&server).await);
+    assert!(gated.is_empty());
+    let reason = unreadable.expect("an unaddressable in-force bundle leaves the manifest unread");
+    assert!(
+        reason.contains("version id"),
+        "the reason must name what was missing, got {reason:?}"
+    );
+}
+
+/// The positive control. Without it the three cases above are satisfiable by
+/// always claiming the manifest is unreadable, which would make the affirmative
+/// "no tools are gated" answer unreachable and the disclosure meaningless.
+#[tokio::test]
+async fn a_readable_gate_free_manifest_still_answers_that_nothing_is_gated() {
+    let server = serve(|req| match req.path.split('?').next().unwrap() {
+        "/agents" => agents_response(),
+        "/deployments" => Response::json(200, &deployment_json(&format!(r#""{VERSION_ID}""#))),
+        p if p == format!("/agents/{AGENT_ID}/versions/{VERSION_ID}/files") => Response::json(
+            200,
+            r#"{"files":[{"path":"plugin.json","content":"{\"name\":\"weather\"}"}]}"#,
+        ),
+        other => panic!("unexpected request: {other}"),
+    });
+
+    let out = read_gates(&server).await;
+    let (gated, unreadable) = gates(&out);
+    assert!(gated.is_empty());
+    assert_eq!(
+        unreadable, None,
+        "the manifest was read and declares no gate"
+    );
+    assert_eq!(
+        out.to_json()["manifest_unreadable"],
+        serde_json::Value::Null
+    );
+}

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -620,23 +620,50 @@ fn approvals_output_json_shape_is_pinned() {
     );
     // No gates: `gated_tools` must still be an empty array, never null/absent --
     // an agent consumer branches on the array, not on key presence.
+    //
+    // Deliberate, reviewed contract EVOLUTION (#607), not a weakened pin: `agent`
+    // and `gated_tools` keep their exact meaning, and this still asserts EXACT
+    // equality against a literal. What joins them is the additive
+    // `manifest_unreadable`, which separates "the deployed manifest declares no
+    // gates" (null, below) from "the manifest could not be read" (a reason string).
+    // Without it an empty `gated_tools` is ambiguous, and the ambiguity resolves in
+    // the unsafe direction: an agent reads `[]` as "nothing pauses for approval".
     assert_eq!(
         ApprovalsOutput::Gates {
             agent: "weather".to_string(),
             gated_tools: vec![],
+            manifest_unreadable: None,
         }
         .to_json(),
-        json!({"agent": "weather", "gated_tools": []})
+        json!({"agent": "weather", "gated_tools": [], "manifest_unreadable": null})
     );
     assert_eq!(
         ApprovalsOutput::Gates {
             agent: "weather".to_string(),
             gated_tools: vec!["Bash".to_string(), "mcp__weather__forecast".to_string()],
+            manifest_unreadable: None,
         }
         .to_json(),
         json!({
             "agent": "weather",
             "gated_tools": ["Bash", "mcp__weather__forecast"],
+            "manifest_unreadable": null,
+        })
+    );
+    // The manifest lookup failed. `gated_tools` is what the platform field alone
+    // carried, and `manifest_unreadable` is the machine-readable disclosure that it
+    // may not be the whole set.
+    assert_eq!(
+        ApprovalsOutput::Gates {
+            agent: "weather".to_string(),
+            gated_tools: vec![],
+            manifest_unreadable: Some("listing the agent's deployments failed: 503".to_string()),
+        }
+        .to_json(),
+        json!({
+            "agent": "weather",
+            "gated_tools": [],
+            "manifest_unreadable": "listing the agent's deployments failed: 503",
         })
     );
 }


### PR DESCRIPTION
`local`/`cluster approvals` swallowed every error from the deployed-bundle manifest lookup and collapsed the result into an empty gate list, then made the affirmative claim that no tools are gated. An operator confirming the gate surface before a change window could be told calls run without approval while a manifest gate was in fact armed and blocking.

The best-effort swallow itself is defensible. The defect was pairing that silence with an affirmative claim about a security surface, so the fix separates "looked and found nothing" from "could not look".

## What changed

- The manifest lookup now returns readable vs unreadable outcomes. A failed deployment list, a failed bundle-files fetch, and an in-force deployment carrying no version id are **unreadable**. No deployment, no manifest file, and a manifest declaring zero gates stay **readable** truthful answers. An invalid manifest still hard-errors as before.
- The unreadable state is disclosed in the human output and as a `manifest_unreadable` field in `--json`. The disclosure also fires when platform-field gates were found while the manifest was unreadable, since that list is then incomplete and silence would imply otherwise.
- `--json` is additive: `agent` and `gated_tools` keep their meaning.

## Testing

`cli/tests/approvals_manifest_unreadable.rs` drives the real `approvals()` handler through a real `ApiClient` against a wire-level stub, covering each unreadable arm plus a positive control that keeps a genuinely un-gated agent distinguishable. Each arm was observed failing under a temporary revert of its classification, with the positive control staying green.

## Follow-up (out of scope here)

Review flagged that the `--gate`/`--clear` set path emits the same affirmative un-gated claim without ever reading the manifest. It is the same class of lie but a different trigger and predates this change, so it is left for a separate issue.

Closes #607