### PR TITLE
Accept ADR-0042: adopt the LLM-as-a-Verifier semantic grader

### DIFF
--- a/docs/adr/0042-llm-as-a-verifier-grader-and-progress-signal.md
+++ b/docs/adr/0042-llm-as-a-verifier-grader-and-progress-signal.md
@@ -2,7 +2,20 @@
 
 Date: 2026-07-14
 
-Status: Proposed
+Status: Accepted
+
+Accepted 2026-07-17 by decision. The semantic verifier (`GraderKind.verifier`) is
+adopted as the direction: it judges correctness where no string match exists,
+which is the case a coding-agent bundle most often needs and the one a
+deterministic grader structurally cannot cover. The **Validation gate** section
+below is unmet at acceptance and `GraderKind.verifier` is not in the tree, so this
+acceptance waives [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)'s
+rule that a status is promoted only on evidence the decision is built. The gate's
+substance still governs the implementing work
+([#478](https://github.com/curie-eng/agentos/issues/478)), in particular the
+unresolved model-plane question: continuous scoring needs scoring-token logprobs,
+which the [ADR-0005](0005-claude-agent-sdk-adapter-and-frozen-aci.md)
+claude-agent-sdk/Anthropic default does not expose.
 
 Extends [ADR-0019](0019-freeze-eval-case-format.md) (the frozen eval-case format
 and its `GraderKind` extension point), [ADR-0022](0022-eval-completeness-tier-parity-and-trace-promotion.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,7 +71,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0039 | [Bounded delivery: a delivery cap and a dead-letter graveyard](0039-bounded-delivery-and-a-dead-letter-graveyard.md) | Accepted |
 | 0040 | [Adopt the Agent Client Protocol as an edge projection](0040-adopt-acp-as-an-edge-projection.md) | Proposed |
 | 0041 | [Every verb is answered at every tier](0041-every-verb-is-answered-at-every-tier.md) | Accepted |
-| 0042 | [Adopt LLM-as-a-Verifier: a continuous-score semantic grader and a live progress signal](0042-llm-as-a-verifier-grader-and-progress-signal.md) | Proposed |
+| 0042 | [Adopt LLM-as-a-Verifier: a continuous-score semantic grader and a live progress signal](0042-llm-as-a-verifier-grader-and-progress-signal.md) | Accepted |
 | 0043 | [The interface catalog is generated from declared front-matter and gated in CI](0043-generated-interface-catalog-and-doc-lint-gate.md) | Accepted |
 | 0044 | [Workflow-controlled agents run on AgentOS as a callable substrate first, a unified plane only on demand](0044-workflow-controlled-agents-callable-substrate.md) | Proposed |
 | 0045 | [The status line is the mutable part of an immutable ADR](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md) | Accepted |


### PR DESCRIPTION
Flips ADR-0042 (LLM-as-a-Verifier) from `Proposed` to `Accepted`, decided 2026-07-17. Adopts the semantic verifier (`GraderKind.verifier`) as the direction: it judges correctness where no string match exists, which is the case a coding-agent bundle most often needs and the one a deterministic grader structurally cannot cover.

Docs only. No graders, schema, CLI, or worker code is touched.

## Deliberate override of ADR-0045 — please read

ADR-0045 ("The status line is the mutable part of an immutable ADR", Accepted) governs this exact action and, read literally, forbids it:

> **A status is a claim about the tree, not about the release.** A `Proposed` ADR is promoted to `Accepted` only on evidence that the decision is built — a symbol in the tree, not a sentence in another ADR.

The verifier is **not built** on `main`:

- `apps/worker/src/agentos_worker/eval/models.py:25` — `GraderKind` is still `EXACT | CONTAINS | REGEX`.
- `git grep verifier` over `apps/worker`, `apps/api`, `cli/src` returns zero hits.
- ADR-0022's own status table still reads `| Semantic grader (GraderKind.verifier) | **not built** — see ADR-0042 | #478 |`, and that remains accurate.

ADR-0042 also self-gates: its `### Validation gate (before this moves to Accepted)` requires a spike proving human pass/fail agreement, acceptable run-to-run variance at the chosen `K`, and a resolved model-plane path. That last one is a real open question — continuous scoring needs scoring-token logprobs, which the ADR-0005 claude-agent-sdk/Anthropic default does not expose.

This acceptance is a conscious override of that criterion, made with the gap known. Rather than bury it, the waiver is stated on the page itself in the note under `Status:`, so a reader of ADR-0042 sees the tension without having to find this PR.

## Why the Validation gate section is left untouched

ADR-0045 permits exactly two edits here: the `Status:` line, and a note directly beneath it. Body prose is never rewritten — explicitly "not to soften a claim the tree has since disproved."

So the stale-sounding `### Validation gate (before this moves to Accepted)` section is **deliberately left byte-identical**. It is the record of what was argued on 2026-07-14, and the note under `Status:` records that the decision overrode it on 2026-07-17. Editing the gate away would have destroyed exactly the intent-gap record the ADR format exists to preserve. The gate's substance is not void: it still governs the implementing work on #478.

`Date: 2026-07-14` is likewise unchanged (authoring date); the 2026-07-17 decision date lives in the note, which is the region ADR-0045 makes mutable.

## Cross-references: checked, none were wrong

Every inbound reference to ADR-0042 was audited. **None asserted its status**, so none needed correcting:

- `docs/adr/0022-*.md:15-20` — says 0042 "extends this ADR", "supersedes one point of it", and "depends on the trajectory-forwarding decided here, so this ADR's Phase 1 is its prerequisite". All still true after acceptance; nothing misstated. ADR-0022 is Accepted and immutable regardless.
- `docs/adr/0022-*.md:233-235, 279, 339-344` — the supersession note, the "not built" status row, and the Alternatives back-reference. All still accurate.
- `docs/adr/0030-*.md:102` — a neutral mention of "ADR-0042's verifier". Unaffected.
- `docs/adr/0045-*.md:114` — refers to the 0042 renumbering, not its status.

The only stale surface was the generated index row, handled below.

## Index regenerated + lint output

`docs/adr/README.md` is machine-generated and reads `Status:` verbatim, so it was regenerated via the repo's gate rather than hand-edited. Command and real output:

```
$ bash scripts/check-docs.sh
== checking ADR numbers are unique ==
== regenerating the seam table, the ADR index, and per-doc headers ==
== checking for drift ==
== linting citations under the linted root ==
doclint: 10 line(s) suppressed by the ignore-line escape hatch
OK: the interface catalog is generated, drift-free, and every citation resolves.
$ echo $?
0
```

(The first run of this script failed as designed — it regenerates, then diffs against the committed tree, so the freshly regenerated index registered as drift with "Review, then commit them." The output above is the post-commit run. The only regenerated change was the 0042 row flipping `Proposed` to `Accepted`.)
