### PR TITLE
Redact secrets at the runner stdout and gen_ai span boundaries

### DIFF
--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -37,6 +37,7 @@ from .hooks import load_bundle_hooks
 from .memory import MemoryRecord, MemoryStore, format_memory_preamble, resolve_memory
 from .otel import RunTracer, build_tracer_provider
 from .plugin import load_bundle_system_prompt, load_plugins
+from .redact import install_stdout_redaction
 from .sdk_auth import UnsupportedCredentialError, resolve_sdk_env
 from .server import create_app
 from .session import SessionRunner
@@ -268,6 +269,7 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    install_stdout_redaction()
     fake_model = os.environ.get("AGENTOS_FAKE_MODEL", "").lower() in ("1", "true", "yes")
     logger.info("runner starting fake_model=%s", fake_model)
     # A real session authenticates from the SDK's own credential env; map the

--- a/runner/src/agentos_runner/otel.py
+++ b/runner/src/agentos_runner/otel.py
@@ -30,7 +30,19 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import SpanKind, Tracer
 
+from .redact import redact_span_attribute
+
 _SERVICE_NAME = "agentos-runner"
+
+
+def _set(span: Any, key: str, value: object) -> None:
+    """Set a span attribute through the redaction pass.
+
+    Every ``set_attribute`` in this module goes through here so a future attribute
+    cannot bypass the scrub by being written directly (see ``redact.py``).
+    """
+
+    span.set_attribute(key, redact_span_attribute(value))
 
 
 def build_tracer_provider(
@@ -96,11 +108,11 @@ class RunTracer:
         """
 
         with self._tracer.start_as_current_span("agent.run", kind=SpanKind.SERVER) as root:
-            root.set_attribute("langfuse.trace.name", trace_name)
+            _set(root, "langfuse.trace.name", trace_name)
             if session_id:
-                root.set_attribute("langfuse.session.id", session_id)
+                _set(root, "langfuse.session.id", session_id)
             if user_id:
-                root.set_attribute("langfuse.user.id", user_id)
+                _set(root, "langfuse.user.id", user_id)
             with self._tracer.start_as_current_span("llm.generation") as gen:
                 span = _GenerationSpan(self._tracer, gen)
                 # Stamp the configured model at span open when AGENTOS_MODEL is
@@ -138,8 +150,8 @@ class _GenerationSpan:
 
         if self._model_recorded or not model:
             return
-        self._span.set_attribute("gen_ai.request.model", model)
-        self._span.set_attribute("model", model)
+        _set(self._span, "gen_ai.request.model", model)
+        _set(self._span, "model", model)
         self._model_recorded = True
 
     def record_usage(self, usage: Mapping[str, Any] | None) -> None:
@@ -164,11 +176,11 @@ class _GenerationSpan:
         ):
             value = usage.get(key)
             if isinstance(value, int):
-                self._span.set_attribute(f"gen_ai.usage.{key}", value)
+                _set(self._span, f"gen_ai.usage.{key}", value)
 
     def tool_span(self, tool_name: str) -> None:
         """Emit a short ``execute_tool`` child span for one tool call."""
 
         with self._tracer.start_as_current_span("execute_tool") as tool:
-            tool.set_attribute("gen_ai.tool.name", tool_name)
-            tool.set_attribute("gen_ai.operation.name", "execute_tool")
+            _set(tool, "gen_ai.tool.name", tool_name)
+            _set(tool, "gen_ai.operation.name", "execute_tool")

--- a/runner/src/agentos_runner/redact.py
+++ b/runner/src/agentos_runner/redact.py
@@ -5,7 +5,16 @@ Defense in depth. AgentOS forwards real credentials into the sandbox (the ACI
 self-emits OTel spans to a trace backend, so a secret that reaches a log line or a
 span attribute has already left the trust boundary by the time anything downstream
 sees it. This module scrubs the value on the way out, at the last point the runner
-still owns it: stdout and the gen_ai span attributes.
+still owns it.
+
+Scope is the two boundaries issue #518 names: the runner's stdout logs and the
+gen_ai span attributes. That is not the whole of the runner's egress, and this
+module does not claim otherwise. ``server.py`` streams verbatim model output as
+NDJSON ACI frames, which is a larger surface left deliberately untouched here: the
+frames are the product contract, and scrubbing them is a separate decision.
+``check.py`` writes its own stdout without this pass, which is scoped out because
+it has no credential path and never issues a model query, and because its JSON
+output is a frozen contract that a scrub would mangle.
 
 This complements, and does not replace, the export-time validator in issue #512,
 which drops records that still carry an unscrubbed secret. That validator is the
@@ -45,15 +54,6 @@ def _placeholder(name: str) -> str:
     return f"[REDACTED:{name}]"
 
 
-# Composed from fragments rather than written as one literal: the repo's staged
-# diff secret scanner matches a full PEM header wherever it appears, and a
-# redactor for PEM blocks necessarily contains that header in its own pattern.
-# Splitting the marker keeps the scanner useful for real pasted keys.
-_PEM_LABEL = r"[A-Z ]*PRIVATE KEY-----"
-_PEM_BEGIN = "-----BEGIN " + _PEM_LABEL
-_PEM_END = "-----END " + _PEM_LABEL
-
-
 # Order is load bearing. ``url_secret_param`` is anchored on a query-param prefix
 # and runs before ``secret_assignment`` so a token carried in a URL is attributed
 # to the URL rule rather than swallowed by the generic assignment rule; the
@@ -64,7 +64,9 @@ _PEM_END = "-----END " + _PEM_LABEL
 REDACTION_RULES: tuple[RedactionRule, ...] = (
     RedactionRule(
         name="pem_private_key",
-        pattern=re.compile(_PEM_BEGIN + r"[\s\S]*?" + _PEM_END),
+        pattern=re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"
+        ),
         placeholder=_placeholder("pem_private_key"),
     ),
     RedactionRule(
@@ -150,17 +152,15 @@ def redact_text(text: str) -> str:
 def redact_span_attribute(value: object) -> object:
     """Redact a span attribute value, preserving its type.
 
-    Strings are scrubbed. Lists and tuples are scrubbed element-wise with the
-    container type preserved. Every other scalar (int, float, bool) passes through
-    untouched, so the ``gen_ai.usage.*`` token counts stay ints.
+    Strings are scrubbed; every other value (int, float, bool) passes through
+    untouched, so the ``gen_ai.usage.*`` token counts stay ints. Only str and int
+    attributes are set today. OTel also permits sequence values, and a sequence
+    would pass through here unscrubbed, so a caller that starts setting one must
+    extend this function and add its frozen vector.
     """
 
     if isinstance(value, str):
         return redact_text(value)
-    if isinstance(value, list):
-        return [redact_text(item) if isinstance(item, str) else item for item in value]
-    if isinstance(value, tuple):
-        return tuple(redact_text(item) if isinstance(item, str) else item for item in value)
     return value
 
 

--- a/runner/src/agentos_runner/redact.py
+++ b/runner/src/agentos_runner/redact.py
@@ -1,0 +1,194 @@
+"""Secret redaction at the runner's output boundaries.
+
+Defense in depth. AgentOS forwards real credentials into the sandbox (the ACI
+``AGENTOS_CREDENTIALS`` reference resolves to a live provider key) and the runner
+self-emits OTel spans to a trace backend, so a secret that reaches a log line or a
+span attribute has already left the trust boundary by the time anything downstream
+sees it. This module scrubs the value on the way out, at the last point the runner
+still owns it: stdout and the gen_ai span attributes.
+
+This complements, and does not replace, the export-time validator in issue #512,
+which drops records that still carry an unscrubbed secret. That validator is the
+alarm; this module is the scrub. Both exist because either one alone fails open:
+the scrub can miss a class the regexes do not know, and the validator can only
+discard a record after the fact.
+
+Tripwire contract: ``runner/tests/test_redact.py`` binds ``REDACTION_RULES`` to a
+frozen vector per rule and ``REDACTION_BOUNDARIES`` to a boundary per parametrized
+case. Adding a regex requires adding its frozen vector; adding an output boundary
+requires driving every vector through it. A rule applied at one boundary and absent
+at the other is a leak that no other test would catch.
+
+Rules are applied in registry order and first match wins, so they are written to be
+disjoint on the frozen vectors. Every pattern is precompiled at import and the pass
+is pure string work: no I/O and no environment reads, which keeps the runner's
+``AGENTOS_FAKE_MODEL`` path a true offline no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RedactionRule:
+    """One secret class: the pattern that finds it and the text that replaces it."""
+
+    name: str
+    pattern: re.Pattern[str]
+    placeholder: str
+
+
+def _placeholder(name: str) -> str:
+    return f"[REDACTED:{name}]"
+
+
+# Composed from fragments rather than written as one literal: the repo's staged
+# diff secret scanner matches a full PEM header wherever it appears, and a
+# redactor for PEM blocks necessarily contains that header in its own pattern.
+# Splitting the marker keeps the scanner useful for real pasted keys.
+_PEM_LABEL = r"[A-Z ]*PRIVATE KEY-----"
+_PEM_BEGIN = "-----BEGIN " + _PEM_LABEL
+_PEM_END = "-----END " + _PEM_LABEL
+
+
+# Order is load bearing. ``url_secret_param`` is anchored on a query-param prefix
+# and runs before ``secret_assignment`` so a token carried in a URL is attributed
+# to the URL rule rather than swallowed by the generic assignment rule; the
+# assignment rule cannot reach the URL case because it does not match after a
+# ``?`` or ``&``. ``jwt`` runs before ``bearer_token`` so a bare ``eyJ`` token is
+# attributed to the JWT rule. Every remaining rule is keyed on a vendor-specific
+# prefix, so they cannot overlap each other.
+REDACTION_RULES: tuple[RedactionRule, ...] = (
+    RedactionRule(
+        name="pem_private_key",
+        pattern=re.compile(_PEM_BEGIN + r"[\s\S]*?" + _PEM_END),
+        placeholder=_placeholder("pem_private_key"),
+    ),
+    RedactionRule(
+        name="url_secret_param",
+        pattern=re.compile(
+            r"[?&](?:token|secret|password|passwd|pwd|api_key|apikey|access_token|key|sig"
+            r"|signature)=[^&\s]+",
+            re.IGNORECASE,
+        ),
+        placeholder=_placeholder("url_secret_param"),
+    ),
+    RedactionRule(
+        name="jwt",
+        pattern=re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),
+        placeholder=_placeholder("jwt"),
+    ),
+    RedactionRule(
+        name="bearer_token",
+        pattern=re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]+"),
+        placeholder=_placeholder("bearer_token"),
+    ),
+    RedactionRule(
+        name="api_key",
+        pattern=re.compile(r"\b(?:sk|xai)[-_][A-Za-z0-9_-]{16,}"),
+        placeholder=_placeholder("api_key"),
+    ),
+    RedactionRule(
+        name="aws_access_key_id",
+        pattern=re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16,}"),
+        placeholder=_placeholder("aws_access_key_id"),
+    ),
+    RedactionRule(
+        name="github_pat",
+        pattern=re.compile(r"\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{20,})"),
+        placeholder=_placeholder("github_pat"),
+    ),
+    RedactionRule(
+        name="gitlab_token",
+        pattern=re.compile(r"\bglpat-[A-Za-z0-9_-]{16,}"),
+        placeholder=_placeholder("gitlab_token"),
+    ),
+    RedactionRule(
+        name="slack_token",
+        pattern=re.compile(r"\bxox[baps]-[A-Za-z0-9-]{10,}"),
+        placeholder=_placeholder("slack_token"),
+    ),
+    RedactionRule(
+        name="google_api_key",
+        pattern=re.compile(r"\bAIza[A-Za-z0-9_-]{30,}"),
+        placeholder=_placeholder("google_api_key"),
+    ),
+    # Deliberately narrow: only secret-bearing key names, and only ``=``. A wider
+    # key set or a ``:`` separator would eat ordinary runner log lines such as
+    # "runner configured session=s-1 model=claude-opus-4-8 port=8080".
+    RedactionRule(
+        name="secret_assignment",
+        pattern=re.compile(
+            r"\b(?:secret|password|passwd|pwd|api_key|apikey|access_token|token)=\S+",
+            re.IGNORECASE,
+        ),
+        placeholder=_placeholder("secret_assignment"),
+    ),
+    # Collapses the account portion only, so the remainder of the path stays
+    # readable. Generic by construction: never read $HOME, never bake in a name.
+    RedactionRule(
+        name="home_path",
+        pattern=re.compile(r"/(?:home|Users)/[^/\s]+"),
+        placeholder=_placeholder("home_path"),
+    ),
+)
+
+REDACTION_BOUNDARIES: tuple[str, ...] = ("stdout", "gen_ai_span")
+
+
+def redact_text(text: str) -> str:
+    """Apply every redaction rule, in registry order, to one string."""
+
+    for rule in REDACTION_RULES:
+        text = rule.pattern.sub(rule.placeholder, text)
+    return text
+
+
+def redact_span_attribute(value: object) -> object:
+    """Redact a span attribute value, preserving its type.
+
+    Strings are scrubbed. Lists and tuples are scrubbed element-wise with the
+    container type preserved. Every other scalar (int, float, bool) passes through
+    untouched, so the ``gen_ai.usage.*`` token counts stay ints.
+    """
+
+    if isinstance(value, str):
+        return redact_text(value)
+    if isinstance(value, list):
+        return [redact_text(item) if isinstance(item, str) else item for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_text(item) if isinstance(item, str) else item for item in value)
+    return value
+
+
+class RedactingLogFilter(logging.Filter):
+    """Scrubs secrets from a log record's fully formatted message.
+
+    The runner logs args-style throughout (``logger.info("tool=%s", name)``), so a
+    secret usually arrives in ``record.args`` and never appears in ``record.msg``.
+    Filtering ``msg`` alone would leak it, so this formats the record first and
+    replaces the pair with the scrubbed result.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        redacted = redact_text(message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+def install_stdout_redaction() -> None:
+    """Attach the redaction filter to every root logger handler, idempotently.
+
+    Repeated calls are a no-op on handlers that already carry the filter, so the
+    pass never stacks or double-redacts.
+    """
+
+    for handler in logging.getLogger().handlers:
+        if not any(isinstance(existing, RedactingLogFilter) for existing in handler.filters):
+            handler.addFilter(RedactingLogFilter())

--- a/runner/tests/test_redact.py
+++ b/runner/tests/test_redact.py
@@ -1,0 +1,242 @@
+"""Redaction: every secret class is scrubbed at every runner output boundary.
+
+The two boundaries are the runner's stdout (structured logs) and the gen_ai span
+attributes shipped to the trace backend. A regex that only one boundary applies is
+a leak, so each frozen vector is driven through the real code at BOTH boundaries:
+a real ``logging`` handler for stdout, and a real ``RunTracer`` plus in-memory
+exporter for spans. The two tripwires below make adding a rule or a boundary
+without that coverage fail CI.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import anyio
+import pytest
+from aci_protocol import Event
+from agentos_runner import RunTracer, SideEffectClassifier
+from agentos_runner.fake import FakeModelSession
+from agentos_runner.redact import (
+    REDACTION_BOUNDARIES,
+    REDACTION_RULES,
+    install_stdout_redaction,
+    redact_span_attribute,
+    redact_text,
+)
+from agentos_runner.session import SessionRunner
+from claude_agent_sdk import (
+    AssistantMessage,
+    ResultMessage,
+    TextBlock,
+    ToolUseBlock,
+)
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+# Every literal below is a hoisted, obviously-fake constant. The repo's
+# check-secrets pre-commit hook false-positives on inline token literals, so the
+# vectors are assembled from named constants and split prefixes rather than
+# written inline at the call site.
+FAKE_API_KEY = "sk-" + "FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000"
+FAKE_AWS_ACCESS_KEY_ID = "AKIA" + "EXAMPLEFAKEKEY0000"
+FAKE_GITHUB_PAT = "ghp_" + "0000FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE"
+FAKE_GITLAB_TOKEN = "glpat-" + "0000FAKEFAKEFAKEFAKE"
+FAKE_SLACK_TOKEN = "xoxb-" + "0000000000-0000000000-FAKEFAKEFAKEFAKEFAKEFAKE"
+FAKE_GOOGLE_API_KEY = "AIza" + "SyFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0"
+FAKE_PEM_PRIVATE_KEY = (
+    "-----BEGIN " + "RSA PRIVATE KEY-----\n"
+    "MIIFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE0000\n"
+    "-----END " + "RSA PRIVATE KEY-----"
+)
+FAKE_BEARER_HEADER = "Bearer " + "abc0000FAKEFAKEFAKEFAKEFAKEFAKE"
+FAKE_JWT = "eyJ" + "hbGciOiJIUzI1NiJ9.eyJzdWIiOiJmYWtlIn0.FAKEFAKEFAKEFAKEFAKEFAKE00"
+FAKE_URL_WITH_TOKEN = "https://example.invalid/hook?token=" + "0000FAKEFAKEFAKEFAKE"
+FAKE_SECRET_ASSIGNMENT = "secret=" + "0000FAKEFAKEFAKEVALUE"
+FAKE_HOME_PATH = "/home/theconnman/.config/agentos/settings.json"
+
+# The sensitive substring that must be absent from every boundary's output,
+# keyed by rule name. VECTORS is derived from this so the two cannot drift.
+SECRET_LITERALS: dict[str, str] = {
+    "api_key": FAKE_API_KEY,
+    "aws_access_key_id": FAKE_AWS_ACCESS_KEY_ID,
+    "github_pat": FAKE_GITHUB_PAT,
+    "gitlab_token": FAKE_GITLAB_TOKEN,
+    "slack_token": FAKE_SLACK_TOKEN,
+    "google_api_key": FAKE_GOOGLE_API_KEY,
+    "pem_private_key": FAKE_PEM_PRIVATE_KEY,
+    "bearer_token": FAKE_BEARER_HEADER,
+    "jwt": FAKE_JWT,
+    "url_secret_param": FAKE_URL_WITH_TOKEN,
+    "secret_assignment": FAKE_SECRET_ASSIGNMENT,
+    "home_path": FAKE_HOME_PATH,
+}
+
+# One frozen vector per rule: a realistic runner output line carrying that class
+# of secret. The tripwire below binds this table to REDACTION_RULES.
+VECTORS: tuple[tuple[str, str], ...] = tuple(
+    (name, f"runner output carrying {literal} in context")
+    for name, literal in SECRET_LITERALS.items()
+)
+
+BOUNDARIES: tuple[str, ...] = ("stdout", "gen_ai_span")
+
+CASES: tuple[tuple[str, str, str], ...] = tuple(
+    (name, vector, boundary) for name, vector in VECTORS for boundary in BOUNDARIES
+)
+
+
+def _placeholder(name: str) -> str:
+    return {rule.name: rule.placeholder for rule in REDACTION_RULES}[name]
+
+
+def _log_through_stdout(*args: object) -> str:
+    """Log through a real root handler with the stdout redaction pass installed."""
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        install_stdout_redaction()
+        logger = logging.getLogger("agentos_runner.test_redact")
+        logger.setLevel(logging.INFO)
+        logger.info(*args)
+    finally:
+        root.removeHandler(handler)
+    return stream.getvalue()
+
+
+def _span_attributes(vector: str) -> dict[str, dict[str, object]]:
+    """Drive a real turn whose trace name, model, and tool name carry the vector."""
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    usage = {"input_tokens": 20, "output_tokens": 8}
+
+    def script() -> list[object]:
+        return [
+            AssistantMessage(content=[TextBlock(text="working")], model=vector),
+            AssistantMessage(
+                content=[ToolUseBlock(id="t1", name=vector, input={"command": "echo hi"})],
+                model=vector,
+            ),
+            AssistantMessage(content=[TextBlock(text="done")], model=vector, usage=usage),
+            ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id="fake-session",
+                result="done",
+                usage=usage,
+            ),
+        ]
+
+    runner = SessionRunner(
+        session_factory=lambda: FakeModelSession(script_factory=script),
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name=vector,
+        model=vector,
+    )
+
+    async def go() -> None:
+        await runner.start()
+        async for _ in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            pass
+
+    anyio.run(go)
+    return {span.name: dict(span.attributes or {}) for span in exporter.get_finished_spans()}
+
+
+@pytest.mark.parametrize(("name", "vector", "boundary"), CASES)
+def test_every_rule_is_redacted_at_every_boundary(name: str, vector: str, boundary: str) -> None:
+    secret = SECRET_LITERALS[name]
+    placeholder = _placeholder(name)
+
+    if boundary == "stdout":
+        out = _log_through_stdout(vector)
+        assert secret not in out
+        assert placeholder in out
+        return
+
+    spans = _span_attributes(vector)
+    root = spans["agent.run"]
+    generation = spans["llm.generation"]
+    tool = spans["execute_tool"]
+
+    for value in (
+        root["langfuse.trace.name"],
+        generation["gen_ai.request.model"],
+        generation["model"],
+        tool["gen_ai.tool.name"],
+    ):
+        assert isinstance(value, str)
+        assert secret not in value
+        assert placeholder in value
+
+
+@pytest.mark.parametrize(("name", "vector"), VECTORS)
+def test_every_rule_is_redacted_through_the_logging_args_path(name: str, vector: str) -> None:
+    # The dangerous shape is `logger.info("token=%s", secret)`: the secret arrives
+    # via record.args and never appears in record.msg, so a filter that only scans
+    # msg leaks it. Redaction must run over the fully formatted message.
+    out = _log_through_stdout("runner emitted t=%s", vector)
+    assert SECRET_LITERALS[name] not in out
+    assert _placeholder(name) in out
+
+
+def test_non_string_span_attributes_survive_redaction() -> None:
+    spans = _span_attributes(VECTORS[0][1])
+    generation = spans["llm.generation"]
+
+    assert generation["gen_ai.usage.input_tokens"] == 20
+    assert generation["gen_ai.usage.output_tokens"] == 8
+    assert isinstance(generation["gen_ai.usage.input_tokens"], int)
+    assert isinstance(generation["gen_ai.usage.output_tokens"], int)
+
+
+def test_redact_span_attribute_preserves_non_string_types() -> None:
+    for value in (0, 42, True, False, 1.5):
+        result = redact_span_attribute(value)
+        assert result == value
+        assert type(result) is type(value)
+
+
+def test_redact_span_attribute_redacts_strings_inside_sequences() -> None:
+    result = redact_span_attribute([f"key {FAKE_API_KEY}", "plain"])
+    assert isinstance(result, list)
+    assert FAKE_API_KEY not in result[0]
+    assert _placeholder("api_key") in result[0]
+    assert result[1] == "plain"
+
+
+def test_every_rule_has_a_frozen_vector() -> None:
+    # TRIPWIRE. Adding a redaction regex requires adding a frozen vector here and
+    # confirming every boundary pass in REDACTION_BOUNDARIES actually redacts it.
+    # Without this gate a new rule can ship applied at one boundary and absent at
+    # the other, which is a leak that no other test would catch.
+    assert {rule.name for rule in REDACTION_RULES} == {name for name, _ in VECTORS}
+
+
+def test_every_boundary_is_exercised() -> None:
+    # TRIPWIRE. Adding a new runner output boundary requires extending this test
+    # module's parametrization to drive the real code at that boundary.
+    assert {boundary for _, _, boundary in CASES} == set(REDACTION_BOUNDARIES)
+
+
+def test_ordinary_log_lines_are_untouched() -> None:
+    line = "runner configured session=s-1 model=claude-opus-4-8 port=8080"
+    assert redact_text(line) == line
+
+
+def test_normal_prose_is_untouched() -> None:
+    line = "The turn finished after two tool calls and the budget ceiling was not reached."
+    assert redact_text(line) == line

--- a/runner/tests/test_redact.py
+++ b/runner/tests/test_redact.py
@@ -1,7 +1,7 @@
 """Redaction: every secret class is scrubbed at every runner output boundary.
 
-The two boundaries are the runner's stdout (structured logs) and the gen_ai span
-attributes shipped to the trace backend. A regex that only one boundary applies is
+The two boundaries this ticket scopes are the runner's stdout (structured logs) and
+the gen_ai span attributes shipped to the trace backend. A regex that only one applies is
 a leak, so each frozen vector is driven through the real code at BOTH boundaries:
 a real ``logging`` handler for stdout, and a real ``RunTracer`` plus in-memory
 exporter for spans. The two tripwires below make adding a rule or a boundary
@@ -208,14 +208,6 @@ def test_redact_span_attribute_preserves_non_string_types() -> None:
         result = redact_span_attribute(value)
         assert result == value
         assert type(result) is type(value)
-
-
-def test_redact_span_attribute_redacts_strings_inside_sequences() -> None:
-    result = redact_span_attribute([f"key {FAKE_API_KEY}", "plain"])
-    assert isinstance(result, list)
-    assert FAKE_API_KEY not in result[0]
-    assert _placeholder("api_key") in result[0]
-    assert result[1] == "plain"
 
 
 def test_every_rule_has_a_frozen_vector() -> None:


### PR DESCRIPTION
Adds a secret-redaction pass over the runner's stdout and its gen_ai span attributes, scrubbing values at the last point the runner still owns them.

Defense in depth, not a replacement for the sandbox boundary: we forward real credentials into the sandbox and self-emit OTel, so a secret that reaches a log line or a span attribute has already crossed the boundary by the time anything downstream sees it. This complements the export-time validator in #512 (the alarm); this is the scrub. Either alone fails open, since the scrub can miss a class the regexes do not know and the validator can only discard a record after the fact.

## What landed

- `redact.py`: an ordered, precompiled rule registry covering the classes the issue names, following the grok-build prior art: API keys (`sk-`/`xai-`/`sk_`), AWS `AKIA`/`ASIA`, GitHub PATs, GitLab and Slack tokens, Google keys, PEM blocks, `Bearer` headers, bare JWTs, sensitive URL query params, generic `secret=`/`password=`, and `$HOME` / username path collapsing.
- `otel.py`: all 8 `set_attribute` sites route through one `_set` helper, so a future attribute cannot bypass the pass. Token-count ints stay ints.
- `__main__.py`: the filter installs on the root stdout handler at process start.

The log filter redacts the **fully formatted** message rather than `record.msg`. The runner logs args-style throughout, so a secret normally arrives via `record.args` and never appears in `record.msg`; a filter scanning `msg` alone would look correct and leak every time.

## Tripwire

The tests bind the rule registry to a frozen vector per rule and drive every vector through every boundary, so a regex added without a vector, or without a pass applying it, fails CI. Verified by mutation rather than by assertion-reading. Each of these was applied and then reverted:

| Mutation | Result |
|---|---|
| Add a rule with no frozen vector | `test_every_rule_has_a_frozen_vector` fails |
| Bypass one span site with raw `set_attribute` | 12 failures on the span boundary |
| Filter scans `record.msg` only | 12 failures on the args path |

## Decisions recorded

- **Scope is the two boundaries the issue names, not all runner egress.** `server.py` streams verbatim model output as NDJSON ACI frames, a larger surface left untouched: the frames are the product contract and scrubbing them is a separate decision. `check.py`'s stdout is scoped out because it has no credential path, never issues a model query, and its JSON output is a frozen contract a scrub would mangle. Both are stated in the module docstring so the coverage claim is honest.
- **Rules are disjoint on the frozen vectors, applied first-match-wins**, with `url_secret_param` ordered ahead of the generic assignment rule. `secret_assignment` is deliberately narrow so ordinary lines like `session=s-1 model=claude-opus-4-8 port=8080` survive byte-identical; two tests pin that.
- **Sequence-valued span attributes pass through unscrubbed.** Only str and int attributes are set today, so element-wise container handling was unreachable code and came out. The docstring records the residual: a caller that starts setting a sequence must extend the function and add its frozen vector.
- **The PEM test vector is fragmented; the rule is not.** A PEM redactor necessarily contains the header in its own pattern, but the pattern's character-class form is invisible to both the staged-diff scanner and gitleaks, so only the test's literal vector needs splitting. The pre-commit gate stays intact against real pasted keys.

## Verification

`uv run pytest runner/tests -q` -> 341 passed, 4 skipped. `uv run ruff check runner/` and `uv run mypy` both clean.

Closes #518
