### PR TITLE
Arm a declared approval policy exactly as declared, or refuse to boot

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2472,12 +2472,13 @@ const MANIFEST_LOCATIONS: [&str; 2] = [".claude-plugin/plugin.json", "plugin.jso
 /// `plugin_format.models.ApprovalGate`, kept private here so `scaffold`'s
 /// `read_manifest` (used by `skill up`/`skill check`) keeps its narrow shape.
 ///
-/// Both fields are `Option` to keep the runner's two tiers distinguishable: the
-/// pydantic model declares `gate: str` / `route: str` with no default, so a
-/// MISSING key fails validation and disarms the whole policy, whereas a key
-/// present but empty only drops its own gate. Collapsing the two (via
-/// `#[serde(default)]` on a `String`) would report the siblings of a key-missing
-/// gate as armed when the runner arms nothing.
+/// Both fields are `Option` so a MISSING key stays distinguishable from one
+/// present but empty. Since #520 both refuse the manifest (the runner arms a
+/// declared policy exactly or not at all), so the distinction no longer changes
+/// the verdict -- but it still names the actual defect in the error, which is
+/// the difference between a fixable message and a puzzle. `#[serde(default)]`
+/// on a `String` would collapse them and report "empty" for a key that is
+/// simply absent.
 #[derive(Deserialize)]
 struct ApprovalGateDecl {
     gate: Option<String>,
@@ -2614,23 +2615,18 @@ fn gates_summary_line(gates: &[(String, String)]) -> String {
 /// Read the bundle's declared approval gates as `(gate, route)` pairs.
 ///
 /// The manifest is probed at `.claude-plugin/plugin.json` then `plugin.json`,
-/// mirroring the runner's `load_approval_policy`. That function's semantics are
-/// two-tier, and this mirrors both tiers because the difference decides whether a
-/// gate is armed at all:
+/// mirroring the runner's `load_approval_policy`. Since #520 that function is
+/// single-tier and fail-closed: ANY gate it cannot arm exactly as declared --
+/// a required key missing (the manifest's `name`, or a gate's `gate`/`route`),
+/// or a key present but empty/whitespace so it keys nothing -- raises rather
+/// than degrading to "nothing gated". So both shapes are reported here as one
+/// usage error naming the problem. The manifest is invalid input, deterministic
+/// and fixable by hand; reporting an empty list instead would read as "no gates
+/// configured", a different lie (#607).
 ///
-/// 1. A REQUIRED key missing (the manifest's `name`, or a gate's `gate`/`route`)
-///    fails `model_validate`, which `load_approval_policy` catches by returning
-///    `{}` -- the runner arms ZERO gates, not merely the offending one. Reported
-///    here as a usage error naming the problem: the manifest is invalid input,
-///    deterministic and fixable by hand, and reporting an empty list instead
-///    would read as "no gates configured" -- a different lie.
-/// 2. A key PRESENT but empty/whitespace passes validation and is dropped by the
-///    final comprehension's trim filter, so only THAT gate is skipped and its
-///    well-formed siblings stay armed.
-///
-/// A manifest with no `approvalPolicy` at all is neither: it yields no gates and
-/// no error. A bundle with no manifest is a usage error (the plugin dir is
-/// simply wrong).
+/// A manifest with no `approvalPolicy` at all, or an explicitly empty `gates`
+/// list, declares no gate: no gates and no error. A bundle with no manifest is a
+/// usage error (the plugin dir is simply wrong).
 fn read_bundle_gates(plugin_dir: &Path) -> Result<Vec<(String, String)>> {
     let manifest_path = MANIFEST_LOCATIONS
         .iter()
@@ -2648,11 +2644,13 @@ fn read_bundle_gates(plugin_dir: &Path) -> Result<Vec<(String, String)>> {
 }
 
 /// Parse the `approvalPolicy` gates out of a plugin-manifest JSON body, mirroring
-/// the runner's `load_approval_policy` two-tier semantics (a missing REQUIRED key
-/// disarms every gate → usage error; a present-but-empty gate/route is dropped,
-/// siblings survive). `source` labels the manifest in errors. Shared by the skill
-/// tier (manifest on local disk) and the local/cluster tiers (manifest pulled from
-/// the deployed bundle over the API, #546) so both read gates identically.
+/// the runner's `load_approval_policy` fail-closed semantics (#520): any declared
+/// gate the runner cannot arm exactly as declared -- a missing REQUIRED key, or a
+/// key present but empty -- refuses the whole manifest rather than arming a
+/// subset, so this reports a usage error for both. `source` labels the manifest in
+/// errors. Shared by the skill tier (manifest on local disk) and the local/cluster
+/// tiers (manifest pulled from the deployed bundle over the API, #546) so both
+/// read gates identically.
 fn parse_manifest_gates(body: &str, source: &str) -> Result<Vec<(String, String)>> {
     let invalid = |problem: &str| {
         crate::exit::usage(format!(
@@ -2671,10 +2669,13 @@ fn parse_manifest_gates(body: &str, source: &str) -> Result<Vec<(String, String)
             (_, None) => return Err(invalid("a gate in `approvalPolicy.gates` omits `route`")),
             (Some(gate), Some(route)) => (gate.trim(), route.trim()),
         };
-        // Tier 2: present but empty. Valid to the runner, dropped by its trim
-        // filter, siblings unaffected.
+        // Present but empty: parses, but keys nothing once trimmed, so the
+        // runner refuses to boot rather than arm a partial policy (#520).
+        // Reporting it as armed here would name a gate that stops the runner.
         if gate.is_empty() || route.is_empty() {
-            continue;
+            return Err(invalid(
+                "a gate in `approvalPolicy.gates` has an empty `gate` or `route`",
+            ));
         }
         // The runner keys a dict by the trimmed gate name, so a repeated gate
         // collapses to one entry: the first declaration fixes the position, the
@@ -3549,6 +3550,32 @@ mod tests {
         .is_err());
     }
 
+    #[test]
+    fn parse_manifest_gates_refuses_a_gate_the_runner_cannot_arm() {
+        // NEGATIVE CONTROL for the #520 CLI mirror. The runner refuses to boot
+        // on a declared gate it cannot arm, so reporting `Bash` as armed here
+        // would name a gate that in fact stops the runner. Restoring the old
+        // `continue` (drop the empty gate, keep its siblings) makes this fail.
+        for body in [
+            // Present but empty/whitespace: parses, keys nothing once trimmed.
+            r#"{"name":"x","approvalPolicy":{"gates":[{"gate":"Bash","route":"eng"},{"gate":"   ","route":"eng"}]}}"#,
+            r#"{"name":"x","approvalPolicy":{"gates":[{"gate":"Bash","route":"eng"},{"gate":"Write","route":""}]}}"#,
+            // Required key missing entirely.
+            r#"{"name":"x","approvalPolicy":{"gates":[{"gate":"Bash","route":"eng"},{"gate":"Write"}]}}"#,
+        ] {
+            assert!(
+                parse_manifest_gates(body, "partial manifest").is_err(),
+                "reported gates for a manifest the runner refuses: {body}"
+            );
+        }
+        // An explicitly empty gates list declares nothing: no gates, no error.
+        assert_eq!(
+            parse_manifest_gates(r#"{"name":"x","approvalPolicy":{"gates":[]}}"#, "empty")
+                .expect("an empty gates list is a valid declaration of no gates"),
+            Vec::new()
+        );
+    }
+
     #[tokio::test]
     async fn skill_approvals_view_lists_bundle_gates() {
         use crate::ui::CliOutput;
@@ -3597,20 +3624,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn skill_approvals_view_skips_incomplete_gate() {
-        use crate::ui::CliOutput;
+    async fn skill_approvals_view_refuses_an_incomplete_gate() {
         let dir = tempfile::tempdir().unwrap();
-        // The second gate has an empty route: mirror the runner's leniency and
-        // skip it rather than erroring, while the well-formed gate still shows.
+        // The second gate has an empty route, so it keys nothing and the runner
+        // refuses to boot on it (#520). Mirror that refusal: reporting `Bash` as
+        // armed while the runner will not start is the drift this test pins.
         write_manifest(
             dir.path(),
             ".claude-plugin/plugin.json",
             r#"{"name":"x","version":"1","approvalPolicy":{"gates":[{"gate":"Bash","route":"eng"},{"gate":"NoRoute","route":""}]}}"#,
         );
-        let out = super::skill_approvals(dir.path().to_path_buf(), vec![], false)
-            .await
-            .unwrap();
-        assert_eq!(gate_names(&out.to_json()), vec!["Bash".to_string()]);
+        assert!(
+            super::skill_approvals(dir.path().to_path_buf(), vec![], false)
+                .await
+                .is_err(),
+            "reported gates for a manifest the runner refuses to boot on"
+        );
     }
 
     #[tokio::test]

--- a/docs/adr/0050-declared-approval-policy-is-armed-exactly-or-not-at-all.md
+++ b/docs/adr/0050-declared-approval-policy-is-armed-exactly-or-not-at-all.md
@@ -1,0 +1,154 @@
+# 50. A declared approval policy is armed exactly as declared, or the runner refuses to boot
+
+Date: 2026-07-17
+
+Status: Accepted
+
+Implements [#520](https://github.com/curie-eng/agentos/issues/520) (sub-items 1
+and 2). Ports two fail-closed patterns reviewed in `xai-org/grok-build`; the
+patterns only, never the mechanism (Grok's sandbox is weaker than ours on every
+axis — in-process Landlock/Seatbelt, Linux-only, no egress allowlist, no
+per-agent secrets).
+
+## Context
+
+The runner decides which tools are approval-required by unioning two sources
+(`__main__`): the operator's `AGENTOS_APPROVAL_REQUIRED_TOOLS` (a bare list of
+names, no routes) and the bundle manifest's `approvalPolicy` gates (versioned
+with the agent, each carrying its route). Two fail-open surfaces sat in that
+merge.
+
+**1. Enforcement intent was read from the resolved map, not the declaration.**
+`load_approval_policy` swallowed `json.JSONDecodeError`, `ValueError`, and
+`OSError` and returned `{}`, on the reasoning that it mirrored the
+hooks/`systemPrompt` readers and that "the authoritative parse gate stays
+`load_plugins`". But `{}` is not a neutral value here: `__main__` builds
+`approval_gate = ... if gated_tools else None`, and a `None` gate means
+`can_use_tool` is never wired at all — the hardcoded bypass posture returns. So
+a bundle that *declared* gates but failed to parse booted with **nothing gated,
+silently**. The empty map is indistinguishable from a genuine no-policy bundle.
+
+The `load_plugins` backstop is real but incidental, and it does not cover the
+fake tier: `__main__.factory` returns `FakeModelSession` **before**
+`load_plugins` is ever called. On `skill`/`local --fake-model` — the tier
+operators use to rehearse approvals — the swallow was the whole gate. This repo
+already treats fake-tier divergence from the real gate path as a genuine bug,
+not a testing artifact (`fake.py`, citing #561/#544).
+
+The distinction the old docstring missed: hooks and `systemPrompt` degrade to a
+**narrower capability set** and `load_plugins` is a sufficient backstop for
+them. `approvalPolicy` degrades to a **wider authority set**. Same swallow,
+opposite blast radius.
+
+**2. A bundle could redefine the route of an operator-set gate.** The gated-tool
+set is a union, so a bundle already could not *remove* an operator's gate — the
+append-only half was correct. The routes were not. `route_by_tool` was assigned
+verbatim from the bundle's map, and the operator's list carries no routes of its
+own, so a bundle gate naming a tool the operator independently gated silently
+chose **which of the operator's own approval channels governs the operator's own
+gate**. The trusted name survives; its authority is redirected. ADR-0046 closed
+the adjacent fail-open (a named-but-*unbound* route no longer falls back to the
+requesting channel) but never addressed a bundle naming a route the operator
+*has* bound.
+
+Note what is **not** in scope. The egress allowlist was the issue's suspected
+home for pattern 1 and turns out to be already fail-closed end to end:
+`resolve_provider_egress_cidrs` hard-errors on an empty, failed, or
+non-globally-routable resolution rather than returning an empty vec, the chart's
+default-deny egress policy renders unconditionally, and `any_egress` is already
+derived from the declared opts (ADR-0032). No change was warranted there.
+
+## Decision
+
+**A declared approval policy is armed exactly as declared, or the runner refuses
+to boot.** Both halves fail closed, before the first turn.
+
+### 1. Enforcement intent is read from the raw declaration
+
+`load_approval_policy` reads the manifest's raw JSON *first* and answers "is a
+policy declared?" from it, never from the parsed result. Once an
+`approvalPolicy` key is present, enforcement intent is established and no
+downstream failure can revoke it — a parse error raises `ApprovalPolicyError`
+instead of returning `{}`. The empty map is reserved for the honest cases: no
+plugin dir, no manifest, no `approvalPolicy`, or an explicitly empty `gates`
+list.
+
+An unreadable manifest also raises: a manifest that will not parse cannot prove
+it declares no policy, so the fail-closed reading is to refuse rather than
+assume.
+
+Every **distinct declared gate name** must end up armed. The comparison is
+against distinct names rather than a count, deliberately: two entries for one
+tool are a last-wins duplicate that `plugin_format.validate_bundle` accepts, and
+rejecting them here would crash-loop a deploy-valid bundle. A validator and a
+loader that disagree are the #453 fail-open shape in reverse.
+
+### 2. A bundle may add gated names, never redefine an operator-set one
+
+`build_approval_gate` (extracted from `__main__`, so the merge is testable
+rather than inline) raises when a bundle gate names a tool already in the
+operator's list.
+
+It **raises rather than resolving to a side, because both resolutions widen**:
+honouring the bundle's route lets an untrusted bundle pick the approving
+audience, and dropping it falls back to ADR-0034 channel membership, which may
+be wider than the route the operator would have chosen. Refusing is the only
+reading that neither widens nor lets the bundle redefine. This mirrors
+ADR-0046's "escalate loudly, create no approval" over a silent fallback.
+
+### 3. The CLI mirror follows
+
+`parse_manifest_gates` mirrored the old two-tier semantics (missing required key
+→ whole-manifest reject; present-but-empty → drop that gate, siblings survive).
+The tiers are now collapsed: any gate the runner cannot arm refuses the whole
+manifest, so the CLI reports a usage error for both shapes. Left as-is, `skill
+approvals` would report `Bash` as armed for a manifest the runner refuses to
+boot on — a reporting/runtime drift in the same family as #607.
+
+## Alternatives considered
+
+- **Keep `{}` and rely on `load_plugins`.** Rejected: it does not run on the
+  fake tier at all, and it makes an authority boundary depend on a *different*
+  function happening to fail first. Enforcement intent must be intrinsic to the
+  declared policy — the substance of the ported pattern.
+- **Arm the gates that did parse and drop the rest.** Rejected: a partially
+  armed policy is the most dangerous outcome. The operator reads "gated" and
+  gets a subset, with no signal which gates are missing.
+- **Let the bundle's route win for an operator-set tool** (bundle is more
+  specific). Rejected: it is exactly the hollow-out — the operator's `Bash` gate
+  keeps its trusted name while an untrusted bundle picks its audience.
+- **Silently ignore the bundle's route for an operator-set tool.** Rejected: it
+  looks safe but falls back to ADR-0034 channel membership, which can be *wider*
+  than the bundle route it replaced. It trades a visible conflict for a quiet
+  widening.
+- **Pin the egress/secret profile across suspend/resume** (#520 sub-item 3).
+  Deferred, not rejected — see below.
+
+## Consequences
+
+- **Behavior change operators must know about:** a bundle whose `approvalPolicy`
+  is malformed, partially unarmable, or conflicts with the operator's gated-tool
+  list now fails the runner at boot instead of running ungated. On the real path
+  `load_plugins` already rejected most of these, so the visible change is
+  concentrated on the fake tier and on the new operator/bundle conflict. A
+  deploy-time-valid bundle is unaffected: `validate_bundle` rejects every shape
+  this now raises on, except the operator-conflict case, which is deployment
+  config the validator cannot see.
+- **The fake tier gains the gate it was missing**, so approvals rehearsed on
+  `skill`/`local --fake-model` now match the deployed tier's arming behavior.
+- **The operator/bundle conflict is a boot failure, not a warning.** An operator
+  migrating a tool from the `AGENTOS_APPROVAL_REQUIRED_TOOLS` stopgap to a
+  versioned manifest gate must drop it from the operator list in the same
+  change, rather than running with both. The error names both sides and the two
+  ways out.
+- **Sub-item 3 (resume pinning) remains open.** A resumed turn re-derives its
+  whole execution profile — model, bundle ref, connector secrets, gated-tool
+  list — from live config at resume time (`BindingResolver.resolve` /
+  `boot_env`), so config widened while an approval pends is picked up by the
+  resumed turn. That mirrors fresh-claim semantics by design. Pinning it needs
+  the profile persisted at suspend and a migration to carry it, which is its own
+  reviewed change. Note the issue's stated motivation for it — that the ADR-0035
+  grant discriminator is model-forgeable — no longer holds: ADR-0046 replaced the
+  summary-prefix sniff with runner-authored `gate_kind`/`granted_tool` columns,
+  and the grant itself is server-derived, agent-bound, tool-scoped and
+  single-use. The remaining surface is the surrounding profile, not the grant.

--- a/docs/adr/0050-declared-approval-policy-is-armed-exactly-or-not-at-all.md
+++ b/docs/adr/0050-declared-approval-policy-is-armed-exactly-or-not-at-all.md
@@ -40,16 +40,21 @@ The distinction the old docstring missed: hooks and `systemPrompt` degrade to a
 them. `approvalPolicy` degrades to a **wider authority set**. Same swallow,
 opposite blast radius.
 
-**2. A bundle could redefine the route of an operator-set gate.** The gated-tool
-set is a union, so a bundle already could not *remove* an operator's gate — the
-append-only half was correct. The routes were not. `route_by_tool` was assigned
-verbatim from the bundle's map, and the operator's list carries no routes of its
-own, so a bundle gate naming a tool the operator independently gated silently
-chose **which of the operator's own approval channels governs the operator's own
-gate**. The trusted name survives; its authority is redirected. ADR-0046 closed
-the adjacent fail-open (a named-but-*unbound* route no longer falls back to the
-requesting channel) but never addressed a bundle naming a route the operator
-*has* bound.
+**2. The anti-hollow-out property was already held — by the union.** The gated
+tool set is `operator | bundle`, and because no bundle-supplied value is ever
+subtracted from it, a bundle cannot keep a trusted name while emptying what it
+restricts. That is the Grok pattern's core, and AgentOS already satisfies it.
+What it did not hold was a regression *guard*: nothing pinned the union, so a
+later refactor to a dict update, a bundle-wins precedence, or `policy_routes`
+used directly as `required` would have broken it silently.
+
+The residual the union does not close is which **route** governs a tool both
+sources name. `route_by_tool` is taken verbatim from the bundle, and the
+operator's list carries no routes, so the bundle's route rides an operator-gated
+name and picks the approving audience. It is bounded: the bundle can only name a
+route the operator has itself bound to a channel in `approval_routes`, and
+ADR-0046 refuses an unbound one outright. The tool stays gated; the audience
+stays drawn from channels the operator chose.
 
 Note what is **not** in scope. The egress allowlist was the issue's suspected
 home for pattern 1 and turns out to be already fail-closed end to end:
@@ -83,18 +88,35 @@ tool are a last-wins duplicate that `plugin_format.validate_bundle` accepts, and
 rejecting them here would crash-loop a deploy-valid bundle. A validator and a
 loader that disagree are the #453 fail-open shape in reverse.
 
-### 2. A bundle may add gated names, never redefine an operator-set one
+### 2. The union is the anti-hollow-out mechanism, and is now pinned as one
 
 `build_approval_gate` (extracted from `__main__`, so the merge is testable
-rather than inline) raises when a bundle gate names a tool already in the
-operator's list.
+rather than inline) keeps the union and documents it as load-bearing rather than
+incidental. An adversarial test pins it: a bundle that re-declares the
+operator's own gate and adds its own must not drop either operator name. Any
+rebuild of this merge that lets bundle config subtract fails that test.
 
-It **raises rather than resolving to a side, because both resolutions widen**:
-honouring the bundle's route lets an untrusted bundle pick the approving
-audience, and dropping it falls back to ADR-0034 channel membership, which may
-be wider than the route the operator would have chosen. Refusing is the only
-reading that neither widens nor lets the bundle redefine. This mirrors
-ADR-0046's "escalate loudly, create no approval" over a silent fallback.
+An overlapping name **warns and proceeds**; it does not refuse. We first
+implemented the refusal and reversed it on review, because the refusal is
+disproportionate to a bounded widening and the crash it causes is reachable
+through the product's own documented flow:
+
+- `agentos <tier> approvals` reports the operator field and the deployed
+  manifest's gates as **one unlabeled list** (`cli/src/commands.rs`, the #607
+  union), while `--gate` writes a **full replacement** through `PATCH
+  /agents/{id}`. So an operator who reads the displayed gates and re-passes them
+  with one more writes bundle-declared names into the operator field. That is
+  the obvious flow, and it would have armed a boot-fatal error.
+- Nothing catches the overlap earlier: the API validates only non-empty and
+  comma-free, and `validate_bundle` cannot see deployment config.
+- Resume re-derives the same config, so an operator PATCHing a gate while an
+  approval pends would turn the approved action's resume into a crash — the
+  human says yes and the action never runs.
+
+Refusing to boot over a widening this bounded, in exchange for that, is a worse
+failure than the one it prevents. The honest fix is to close the CLI's
+read/write asymmetry (label provenance, make `--gate` additive) and only then
+consider a config-time refusal; that is its own change, tracked as follow-up.
 
 ### 3. The CLI mirror follows
 
@@ -114,33 +136,43 @@ boot on — a reporting/runtime drift in the same family as #607.
 - **Arm the gates that did parse and drop the rest.** Rejected: a partially
   armed policy is the most dangerous outcome. The operator reads "gated" and
   gets a subset, with no signal which gates are missing.
-- **Let the bundle's route win for an operator-set tool** (bundle is more
-  specific). Rejected: it is exactly the hollow-out — the operator's `Bash` gate
-  keeps its trusted name while an untrusted bundle picks its audience.
+- **Refuse to boot on an operator/bundle overlap.** Implemented, then reversed
+  on review — see Decision §2. It makes a bounded widening fatal, and the
+  `approvals --gate` replace-semantics walk operators straight into it.
 - **Silently ignore the bundle's route for an operator-set tool.** Rejected: it
   looks safe but falls back to ADR-0034 channel membership, which can be *wider*
   than the bundle route it replaced. It trades a visible conflict for a quiet
-  widening.
+  widening, and unlike the warn-and-proceed form it also discards information
+  the operator's own binding map authorized.
+- **Reject the overlap at `PATCH /agents/{id}` instead of at boot.** The right
+  end state — a config-time refusal is the same verdict without the crash-loop —
+  but it needs the in-force manifest resolvable at PATCH time and the CLI's
+  read/write asymmetry closed first, or it just moves the footgun. Follow-up.
 - **Pin the egress/secret profile across suspend/resume** (#520 sub-item 3).
   Deferred, not rejected — see below.
 
 ## Consequences
 
 - **Behavior change operators must know about:** a bundle whose `approvalPolicy`
-  is malformed, partially unarmable, or conflicts with the operator's gated-tool
-  list now fails the runner at boot instead of running ungated. On the real path
-  `load_plugins` already rejected most of these, so the visible change is
-  concentrated on the fake tier and on the new operator/bundle conflict. A
-  deploy-time-valid bundle is unaffected: `validate_bundle` rejects every shape
-  this now raises on, except the operator-conflict case, which is deployment
-  config the validator cannot see.
+  is malformed or partially unarmable now fails the runner at boot instead of
+  running ungated. A deploy-time-valid bundle is unaffected — `validate_bundle`
+  rejects every shape this raises on — so on the real path `load_plugins`
+  already rejected these and the visible change is concentrated on the fake
+  tier. The failure is loud: a structured `error_class=` line then a non-zero
+  exit before the port binds, matching the module's credential and session-start
+  precedents.
 - **The fake tier gains the gate it was missing**, so approvals rehearsed on
   `skill`/`local --fake-model` now match the deployed tier's arming behavior.
-- **The operator/bundle conflict is a boot failure, not a warning.** An operator
-  migrating a tool from the `AGENTOS_APPROVAL_REQUIRED_TOOLS` stopgap to a
-  versioned manifest gate must drop it from the operator list in the same
-  change, rather than running with both. The error names both sides and the two
-  ways out.
+- **Boot logs now carry the offending manifest field's value.** The pydantic
+  validation error is interpolated into the raise, so a malformed
+  `approvalPolicy` echoes the failing field into pod logs where it was
+  previously swallowed. Bounded to the single failing field, and the manifest
+  carries secret *names* only (never values), so this is a diagnosability win
+  rather than a leak — but it is a change in what boot logs contain.
+- **An operator/bundle overlap warns and proceeds.** The tool stays gated; the
+  bundle's route decides the audience, bounded by the operator's own
+  `approval_routes` binding map. Closing that residual properly starts with the
+  CLI read/write asymmetry (Decision §2), not with a runner-side refusal.
 - **Sub-item 3 (resume pinning) remains open.** A resumed turn re-derives its
   whole execution profile — model, bundle ref, connector secrets, gated-tool
   list — from live config at resume time (`BindingResolver.resolve` /

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -78,4 +78,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0046 | [Converged approval gates: durable provenance, loud route resolution, and observe-only resume reconciliation](0046-converged-approval-gates-and-durable-provenance.md) | Accepted |
 | 0047 | [ADR-0047: Canonical env-var names for the API base URL and model credential](0047-canonical-env-var-names.md) | Accepted |
 | 0048 | [ADR-0048: Declare the model endpoint's wire protocol and credential keys](0048-declared-model-wire-protocol-and-credential-keys.md) | Accepted |
+| 0050 | [A declared approval policy is armed exactly as declared, or the runner refuses to boot](0050-declared-approval-policy-is-armed-exactly-or-not-at-all.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -142,7 +142,14 @@ in code now:
   The bundle manifest's `approvalPolicy`
   gates (schema + deploy validation from #273) are consumed at runner boot
   (`load_approval_policy`): each `{gate, route}` pair adds the tool to the permission gate
-  and tags it with a route NAME, versioned with the agent. The policy-gate tool accepts an
+  and tags it with a route NAME, versioned with the agent. That consumption is
+  **fail-closed** (#520, ADR-0050): enforcement intent is read from the RAW declaration, so a
+  declared policy that cannot be armed exactly — unparseable, or any distinct declared gate
+  name arming nothing — refuses the boot instead of returning the empty map, which builds no
+  gate at all and silently restores the bypass posture. The gated-tool set stays the UNION of
+  the manifest gates and the operator's `AGENTOS_APPROVAL_REQUIRED_TOOLS`, and that union is
+  the anti-hollow-out mechanism: a bundle may ADD gated names but can never remove an
+  operator's. The policy-gate tool accepts an
   optional `route` argument for skill-raised requests, and the runner now **validates that
   route against the manifest's declared routes and fails loud** (#544, ADR-0046, Decision B):
   `build_approval_server(gate)` is per-gate so the `request_approval` tool can see the

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -99,7 +99,11 @@ declarations rejected), but they differ in whether the runtime acts on them yet:
 - `approvalPolicy` (`{gates: [{gate, route}]}` approval declarations, #273) is **consumed at
   runtime**, not merely validated: the runner reads the gates at boot (`load_approval_policy`,
   #247 / ADR-0010) and arms each `{gate, route}` on the permission gate — so calling this
-  "not-yet-built" is stale (see the [approval seam](../approval/INTERFACE.md)).
+  "not-yet-built" is stale (see the [approval seam](../approval/INTERFACE.md)). A declared
+  policy is armed **exactly as declared or the runner refuses to boot** (#520, ADR-0050):
+  every distinct declared gate name must arm, and a policy that is declared but unparseable
+  (or a manifest that cannot be read at all) fails the boot rather than degrading to an
+  unarmed empty map, which would restore the ungated bypass posture.
 - `triggers` (a list of `cron`/`webhook` declarations for waking the agent beyond chat, #273/#270 —
   see the [triggers seam](../triggers/INTERFACE.md)) is still **declaration-only**: its validator
   runs at deploy, but no runtime scheduler/ingress consumes a declared trigger yet (Epic #29).

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -18,7 +18,7 @@ from aiohttp import web
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .approval import (
-    ApprovalGate,
+    build_approval_gate,
     build_approval_server,
     build_can_use_tool,
     load_approval_policy,
@@ -101,18 +101,16 @@ def build_runner(
     # those calls pending approval; the gate object is shared with the
     # SessionRunner so a blocked call flips the turn's final to
     # awaiting-approval. Neither configured keeps the bypass posture.
+    # Both halves fail closed (#520): load_approval_policy raises rather than
+    # degrading a declared-but-unarmable policy to "nothing gated", and
+    # build_approval_gate refuses a bundle gate that would redefine the route
+    # of a tool the operator already gated. Either raises before the first
+    # turn, so a misdeclared policy never boots ungated.
     policy_routes = load_approval_policy(config.session.plugin_dir)
-    gated_tools = frozenset(config.approval_required_tools or ()) | frozenset(
-        policy_routes
-    )
-    approval_gate = (
-        ApprovalGate(
-            required=gated_tools,
-            route_by_tool=policy_routes,
-            grant_tool=config.approval_grant_tool,
-        )
-        if gated_tools
-        else None
+    approval_gate = build_approval_gate(
+        operator_tools=config.approval_required_tools,
+        policy_routes=policy_routes,
+        grant_tool=config.approval_grant_tool,
     )
 
     def factory() -> ModelSession:

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -18,6 +18,7 @@ from aiohttp import web
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .approval import (
+    ApprovalPolicyError,
     build_approval_gate,
     build_approval_server,
     build_can_use_tool,
@@ -106,12 +107,19 @@ def build_runner(
     # build_approval_gate refuses a bundle gate that would redefine the route
     # of a tool the operator already gated. Either raises before the first
     # turn, so a misdeclared policy never boots ungated.
-    policy_routes = load_approval_policy(config.session.plugin_dir)
-    approval_gate = build_approval_gate(
-        operator_tools=config.approval_required_tools,
-        policy_routes=policy_routes,
-        grant_tool=config.approval_grant_tool,
-    )
+    try:
+        policy_routes = load_approval_policy(config.session.plugin_dir)
+        approval_gate = build_approval_gate(
+            operator_tools=config.approval_required_tools,
+            policy_routes=policy_routes,
+            grant_tool=config.approval_grant_tool,
+        )
+    except ApprovalPolicyError as exc:
+        # Log then re-raise, matching the module's other two fatal boot paths
+        # (credential resolution, session start): a bare traceback is the one
+        # thing an operator cannot triage from pod logs.
+        logger.error("approval policy unusable error_class=%s: %s", type(exc).__name__, exc)
+        raise
 
     def factory() -> ModelSession:
         if fake_model:

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -31,6 +31,7 @@ identical seam as a real model call.
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -45,6 +46,8 @@ from claude_agent_sdk.types import (
     ToolPermissionContext,
 )
 from plugin_format import ApprovalPolicy, PluginManifest
+
+logger = logging.getLogger(__name__)
 
 # The server key under ClaudeAgentOptions.mcp_servers; the SDK prefixes tool
 # names as mcp__<server>__<tool>.
@@ -513,32 +516,35 @@ def build_approval_gate(
     bundle manifest's ``approvalPolicy`` (versioned with the agent, each gate
     carrying its route). Neither naming a tool keeps the bypass posture.
 
-    **The bundle may only ADD names, never redefine an operator-set one**
-    (#520). The gated-tool set is a union, so a bundle already cannot *remove*
-    an operator's gate. The routes are the hollow-out surface: the operator's
-    list carries no routes, so a bundle gate naming a tool the operator
-    independently gated would silently choose which of the operator's own
-    approval channels governs the operator's own gate -- the trusted name
-    survives while its authority is redirected.
+    **The bundle may only ADD names, never remove an operator-set one** (#520,
+    the anti-hollow-out property). The gated-tool set is a UNION, which is what
+    enforces that: no bundle-supplied value is subtracted from it, so a bundle
+    cannot keep a trusted name while emptying what it restricts. That invariant
+    is load-bearing -- rebuilding this merge as anything but a union (a dict
+    update, an override, a bundle-wins precedence) would silently break it.
 
-    That conflict raises rather than resolving to a side, because both
-    resolutions widen: honouring the bundle's route lets an untrusted bundle
-    pick the approving audience, and dropping it falls back to ADR-0034
-    channel membership, which may be wider than the route the operator would
-    have chosen. Refusing to boot is the only reading that neither widens nor
-    lets the bundle redefine, and it mirrors ADR-0046's "escalate loudly,
-    create no approval" over a silent fallback.
+    The residual surface the union does NOT close is which ROUTE governs a tool
+    both sources name: the operator's list carries no routes, so the bundle's
+    route rides an operator-gated name and picks the approving audience. It is
+    bounded -- the bundle can only name routes the operator has itself bound to
+    a channel in ``approval_routes``, and ADR-0046 refuses an unbound one
+    outright -- so the tool stays gated and the audience stays operator-chosen.
+    We log it rather than refusing: making it fatal is disproportionate to a
+    bounded widening, and `agentos <tier> approvals` reports the two sources as
+    one unlabeled list while `--gate` writes a full replacement, so echoing the
+    displayed set back is the documented way to CREATE this overlap. A boot
+    raise would crash-loop that flow, and would strand an approved action whose
+    resume re-derives the same config. See ADR-0050.
     """
 
     operator = frozenset(operator_tools or ())
     redefined = sorted(operator & set(policy_routes))
     if redefined:
-        raise ApprovalPolicyError(
-            f"the bundle declares approvalPolicy route(s) for {redefined!r}, which"
-            " the operator already gated via AGENTOS_APPROVAL_REQUIRED_TOOLS; a"
-            " bundle may add gated tools but may not redefine the approval route"
-            " of an operator-set gate. Remove the gate from the bundle manifest,"
-            " or drop the tool from the operator list to let the bundle own it."
+        logger.warning(
+            "bundle approvalPolicy declares route(s) for %r, which the operator"
+            " also gated via AGENTOS_APPROVAL_REQUIRED_TOOLS; the tool stays"
+            " gated and the bundle's route decides the approving audience",
+            redefined,
         )
     gated_tools = operator | frozenset(policy_routes)
     if not gated_tools:

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -31,6 +31,7 @@ identical seam as a real model call.
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -413,6 +414,17 @@ def build_can_use_tool(gate: ApprovalGate) -> CanUseTool:
 _MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
 
 
+class ApprovalPolicyError(RuntimeError):
+    """A declared approval policy cannot be armed exactly as declared.
+
+    Raised instead of degrading to "nothing is gated". A bundle that declares
+    a gate the runner cannot arm is a hard configuration error surfaced at
+    startup -- the same posture ``load_plugins`` takes for an invalid bundle,
+    and for the same reason: booting anyway answers with the wrong (here,
+    empty) authority set.
+    """
+
+
 def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
     """The bundle manifest's ``approvalPolicy`` gates as ``{tool: route}``.
 
@@ -420,9 +432,22 @@ def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
     class of the ADR-0010 permission gate); its ``route`` names the approval
     route the platform binds to a channel per deployment. Declared in the
     bundle so the policy is versioned and evaluable with the agent (#247);
-    validated at deploy by ``plugin_format.validate_bundle``. Best-effort,
-    mirroring the hooks/systemPrompt readers: no dir, no manifest, or no
-    policy yields {} and the authoritative parse gate stays load_plugins.
+    validated at deploy by ``plugin_format.validate_bundle``.
+
+    **Enforcement intent is read from the DECLARED policy, never from the
+    resolved map** (#520). The resolved map empties on a resolution error, so
+    deciding "must I enforce?" from it fails OPEN exactly when parsing broke:
+    ``__main__`` builds no gate at all from an empty map, restoring the
+    hardcoded bypass. This reader therefore raises ``ApprovalPolicyError``
+    once a policy is declared but cannot be armed as declared, and reserves
+    the empty map for the honest cases: no dir, no manifest, no
+    ``approvalPolicy``, or an explicitly empty ``gates`` list.
+
+    Unlike the hooks/systemPrompt readers this one is NOT best-effort. Those
+    degrade to a smaller capability set and ``load_plugins`` is a sufficient
+    backstop; this one degrades to a wider authority set, and ``load_plugins``
+    does not run on the fake tier at all (``__main__.factory`` returns first),
+    so the backstop is absent precisely where it would be needed.
     """
 
     if not plugin_dir:
@@ -433,17 +458,93 @@ def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
     )
     if manifest_path is None:
         return {}
+    # Read raw first: a manifest that will not parse cannot prove it declares
+    # no policy, so the fail-closed reading is to refuse rather than assume.
     try:
-        manifest = PluginManifest.model_validate(
-            json.loads(manifest_path.read_text(encoding="utf-8"))
-        )
-        if manifest.approvalPolicy is None:
-            return {}
-        policy = ApprovalPolicy.model_validate(manifest.approvalPolicy)
-    except (json.JSONDecodeError, ValueError, OSError):
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ApprovalPolicyError(
+            f"cannot read the bundle manifest at {manifest_path} to determine whether"
+            f" it declares an approvalPolicy; refusing to boot ungated ({exc})"
+        ) from exc
+    if not isinstance(raw, dict) or raw.get("approvalPolicy") is None:
         return {}
-    return {
+    # An approvalPolicy IS declared. From here every failure is fail-closed:
+    # the intent is established and a parse error cannot revoke it.
+    try:
+        manifest = PluginManifest.model_validate(raw)
+        policy = ApprovalPolicy.model_validate(manifest.approvalPolicy)
+    except (ValueError, TypeError) as exc:
+        raise ApprovalPolicyError(
+            f"the bundle at {root} declares an approvalPolicy that does not parse;"
+            f" refusing to boot with its gates unarmed ({exc})"
+        ) from exc
+    routes = {
         gate.gate.strip(): gate.route.strip()
         for gate in policy.gates
         if gate.gate and gate.gate.strip() and gate.route and gate.route.strip()
     }
+    # Compare DISTINCT declared names against armed names, not counts: two
+    # entries for one tool are a last-wins duplicate that validate_bundle
+    # accepts, and rejecting them here would crash-loop a deploy-valid bundle.
+    declared_names = {
+        gate.gate.strip() for gate in policy.gates if isinstance(gate.gate, str)
+    }
+    unarmed = declared_names - set(routes)
+    if unarmed:
+        raise ApprovalPolicyError(
+            f"the bundle at {root} declares approvalPolicy gate(s)"
+            f" {sorted(unarmed)!r} that arm no tool; refusing to boot with a"
+            " partially armed policy"
+        )
+    return routes
+
+
+def build_approval_gate(
+    *,
+    operator_tools: Sequence[str] | None,
+    policy_routes: dict[str, str],
+    grant_tool: str | None = None,
+) -> ApprovalGate | None:
+    """Merge the operator's gated tools with the bundle's declared gates.
+
+    Two sources name approval-required tools: ``AGENTOS_APPROVAL_REQUIRED_TOOLS``
+    (operator/per-agent config, a bare list of names with no route) and the
+    bundle manifest's ``approvalPolicy`` (versioned with the agent, each gate
+    carrying its route). Neither naming a tool keeps the bypass posture.
+
+    **The bundle may only ADD names, never redefine an operator-set one**
+    (#520). The gated-tool set is a union, so a bundle already cannot *remove*
+    an operator's gate. The routes are the hollow-out surface: the operator's
+    list carries no routes, so a bundle gate naming a tool the operator
+    independently gated would silently choose which of the operator's own
+    approval channels governs the operator's own gate -- the trusted name
+    survives while its authority is redirected.
+
+    That conflict raises rather than resolving to a side, because both
+    resolutions widen: honouring the bundle's route lets an untrusted bundle
+    pick the approving audience, and dropping it falls back to ADR-0034
+    channel membership, which may be wider than the route the operator would
+    have chosen. Refusing to boot is the only reading that neither widens nor
+    lets the bundle redefine, and it mirrors ADR-0046's "escalate loudly,
+    create no approval" over a silent fallback.
+    """
+
+    operator = frozenset(operator_tools or ())
+    redefined = sorted(operator & set(policy_routes))
+    if redefined:
+        raise ApprovalPolicyError(
+            f"the bundle declares approvalPolicy route(s) for {redefined!r}, which"
+            " the operator already gated via AGENTOS_APPROVAL_REQUIRED_TOOLS; a"
+            " bundle may add gated tools but may not redefine the approval route"
+            " of an operator-set gate. Remove the gate from the bundle manifest,"
+            " or drop the tool from the operator list to let the bundle own it."
+        )
+    gated_tools = operator | frozenset(policy_routes)
+    if not gated_tools:
+        return None
+    return ApprovalGate(
+        required=gated_tools,
+        route_by_tool=policy_routes,
+        grant_tool=grant_tool,
+    )

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -18,6 +18,8 @@ from agentos_runner.approval import (
     APPROVAL_SUMMARY_PREFIX,
     APPROVAL_TOOL_NAME,
     ApprovalGate,
+    ApprovalPolicyError,
+    build_approval_gate,
     build_approval_server,
     build_can_use_tool,
     guard_reserved_summary,
@@ -602,6 +604,173 @@ def test_load_approval_policy_reads_manifest_gates(tmp_path) -> None:
     assert load_approval_policy(str(tmp_path / "missing")) == {}
 
 
+# --- fail-closed hardening (#520): declared intent, anti-hollow-out merge -------
+
+
+def _write_manifest(tmp_path, body: str) -> str:
+    plugin = tmp_path / ".claude-plugin"
+    plugin.mkdir(exist_ok=True)
+    (plugin / "plugin.json").write_text(body)
+    return str(tmp_path)
+
+
+def test_declared_but_unparseable_policy_fails_closed(tmp_path) -> None:
+    """A declared gate that cannot be resolved must raise, never yield {}.
+
+    NEGATIVE CONTROL for #520 pattern 1. The resolved map empties on a
+    resolution error; deciding "must I enforce?" from it would silently drop
+    the gate and restore the bypass posture. Deleting the declared-intent
+    check in ``load_approval_policy`` makes this test fail: the call returns
+    {} instead of raising.
+    """
+
+    # `Bash` is complete and `Write` is missing its route. The whole map
+    # previously collapsed to {} -- silently ungating `Bash` too.
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "deal-desk",
+                "approvalPolicy": {
+                    "gates": [
+                        {"gate": "Bash", "route": "managers"},
+                        {"gate": "Write"},
+                    ]
+                },
+            }
+        ),
+    )
+    with pytest.raises(ApprovalPolicyError) as exc:
+        load_approval_policy(bundle)
+    assert "approvalPolicy" in str(exc.value)
+
+
+def test_declared_gate_that_arms_nothing_fails_closed(tmp_path) -> None:
+    """Every DISTINCT declared gate name must end up armed, or boot fails.
+
+    NEGATIVE CONTROL for #520 pattern 1. A blank gate name parses fine but
+    arms nothing, so the resolved map is a strict subset of what was
+    declared. Removing the declared-vs-armed comparison makes this pass
+    silently with `Bash` gated and the blank entry quietly dropped.
+    """
+
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "deal-desk",
+                "approvalPolicy": {
+                    "gates": [
+                        {"gate": "Bash", "route": "managers"},
+                        {"gate": "   ", "route": "legal"},
+                    ]
+                },
+            }
+        ),
+    )
+    with pytest.raises(ApprovalPolicyError):
+        load_approval_policy(bundle)
+
+
+def test_unreadable_manifest_cannot_prove_no_policy_is_declared(tmp_path) -> None:
+    """A corrupt manifest fails closed: absence of a policy is unprovable.
+
+    NEGATIVE CONTROL for #520 pattern 1. ``load_plugins`` rejects this bundle
+    on the real path, but the fake tier returns before ``load_plugins`` runs
+    (``__main__.factory``), so swallowing the parse error here is the fake
+    tier's whole gate. Restoring the ``return {}`` makes this test fail.
+    """
+
+    bundle = _write_manifest(tmp_path, "{not json at all")
+    with pytest.raises(ApprovalPolicyError):
+        load_approval_policy(bundle)
+
+
+def test_duplicate_gate_names_are_not_a_resolution_failure(tmp_path) -> None:
+    """Two entries for one tool arm that tool -- last wins, as before.
+
+    Guards the declared-vs-armed check against over-tightening into a
+    divergence from ``plugin_format.validate_bundle``: a bundle the deploy
+    validator accepts must never crash-loop the runner.
+    """
+
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "deal-desk",
+                "approvalPolicy": {
+                    "gates": [
+                        {"gate": "Bash", "route": "managers"},
+                        {"gate": "Bash", "route": "legal"},
+                    ]
+                },
+            }
+        ),
+    )
+    assert load_approval_policy(bundle) == {"Bash": "legal"}
+
+
+def test_explicitly_empty_gates_list_arms_nothing(tmp_path) -> None:
+    """`gates: []` declares no gate, so the empty map is the honest answer."""
+
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps({"name": "deal-desk", "approvalPolicy": {"gates": []}}),
+    )
+    assert load_approval_policy(bundle) == {}
+
+
+def test_bundle_may_not_route_a_tool_the_operator_gated() -> None:
+    """A bundle may ADD gated names, never redefine an operator-set one.
+
+    NEGATIVE CONTROL for #520 pattern 2. The operator gated `Bash` with no
+    route (ADR-0034 channel-membership default). A bundle naming a route for
+    `Bash` would silently pick which of the operator's own approval channels
+    governs the operator's own gate -- the trusted name survives, its
+    authority is redirected. Deleting the conflict check makes this test
+    fail: the gate is built with the bundle's route in `route_by_tool`.
+    """
+
+    with pytest.raises(ApprovalPolicyError) as exc:
+        build_approval_gate(
+            operator_tools=["Bash"],
+            policy_routes={"Bash": "legal"},
+        )
+    assert "Bash" in str(exc.value)
+
+
+def test_bundle_routes_apply_to_names_only_the_bundle_gates() -> None:
+    """The append-only case is untouched: bundle-only names keep their route."""
+
+    gate = build_approval_gate(
+        operator_tools=["Read"],
+        policy_routes={"Bash": "managers"},
+    )
+    assert gate is not None
+    # Union of both sources arms; the bundle's route rides only its own name.
+    assert gate.required == frozenset({"Read", "Bash"})
+    assert gate.route_by_tool == {"Bash": "managers"}
+
+
+def test_no_declared_gate_from_either_source_keeps_the_bypass_posture() -> None:
+    """Neither source naming a tool yields no gate, as before."""
+
+    assert build_approval_gate(operator_tools=None, policy_routes={}) is None
+
+
+def test_build_approval_gate_carries_the_grant_tool() -> None:
+    """The ADR-0035/0046 one-shot grant still reaches the gate unchanged."""
+
+    gate = build_approval_gate(
+        operator_tools=["Bash"],
+        policy_routes={},
+        grant_tool="Bash",
+    )
+    assert gate is not None
+    assert gate.grant_tool == "Bash"
+
+
 def test_gate_block_records_the_declared_route() -> None:
     gate = ApprovalGate(
         required=frozenset({"Bash", "Read"}), route_by_tool={"Bash": "managers"}
@@ -959,7 +1128,9 @@ def test_route_normalization_agrees_between_validator_and_runner(
     The contract, both directions:
       - validator ACCEPTS  -> the runner arms the gate, and the route it matches
         on is the same normalized value the validator judged.
-      - validator REJECTS  -> the gate never reaches the runner at all.
+      - validator REJECTS  -> the gate never reaches the runner at all. Since
+        #520 the runner is stricter still: a declared gate it cannot arm is a
+        boot failure, not a silent degrade to the unarmed empty map.
     """
 
     bundle = _write_bundle(tmp_path, declared)
@@ -969,16 +1140,16 @@ def test_route_normalization_agrees_between_validator_and_runner(
         f"errors={[e.code for e in result.errors]}"
     )
 
-    policy = load_approval_policy(bundle)
-
     if not validator_accepts:
         # A bundle the validator refuses never deploys, so the runner must never
-        # be holding an armed gate for it.
-        assert policy == {}, (
-            f"validator rejected {declared!r} but the runner still armed {policy!r} "
-            "-- a gate that validates red yet arms at runtime"
-        )
+        # be holding an armed gate for it -- and must not quietly boot ungated
+        # either, since a declared-but-unarmable gate means enforcement intent
+        # was expressed and could not be honoured (#520).
+        with pytest.raises(ApprovalPolicyError):
+            load_approval_policy(bundle)
         return
+
+    policy = load_approval_policy(bundle)
 
     # The validator accepted it, so the runner MUST have armed it, keyed on the
     # same normalization the validator evaluated (the stripped value).

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -721,36 +721,63 @@ def test_explicitly_empty_gates_list_arms_nothing(tmp_path) -> None:
     assert load_approval_policy(bundle) == {}
 
 
-def test_bundle_may_not_route_a_tool_the_operator_gated() -> None:
-    """A bundle may ADD gated names, never redefine an operator-set one.
+def test_a_bundle_cannot_hollow_out_an_operator_set_gate() -> None:
+    """A bundle may ADD gated names; it can never remove an operator's.
 
-    NEGATIVE CONTROL for #520 pattern 2. The operator gated `Bash` with no
-    route (ADR-0034 channel-membership default). A bundle naming a route for
-    `Bash` would silently pick which of the operator's own approval channels
-    governs the operator's own gate -- the trusted name survives, its
-    authority is redirected. Deleting the conflict check makes this test
-    fail: the gate is built with the bundle's route in `route_by_tool`.
+    NEGATIVE CONTROL for #520 pattern 2, pinning the anti-hollow-out property
+    the union already provides. The adversarial bundle here re-declares the
+    operator's own `Bash` and adds `Write`. Rebuilding this merge as anything
+    that lets bundle-supplied config subtract -- a dict update, a bundle-wins
+    precedence, `policy_routes` used directly as `required` -- drops `Read`
+    and/or `Bash` and fails this test. That is the Grok hollow-out shape: keep
+    the trusted name, empty what it restricts.
     """
 
-    with pytest.raises(ApprovalPolicyError) as exc:
-        build_approval_gate(
-            operator_tools=["Bash"],
-            policy_routes={"Bash": "legal"},
-        )
-    assert "Bash" in str(exc.value)
+    gate = build_approval_gate(
+        operator_tools=["Read", "Bash"],
+        policy_routes={"Bash": "legal", "Write": "managers"},
+    )
+    assert gate is not None
+    # Every operator name survives, whatever the bundle declared.
+    assert {"Read", "Bash"} <= gate.required
+    assert gate.required == frozenset({"Read", "Bash", "Write"})
 
 
-def test_bundle_routes_apply_to_names_only_the_bundle_gates() -> None:
-    """The append-only case is untouched: bundle-only names keep their route."""
+def test_bundle_routes_ride_the_names_the_bundle_gates() -> None:
+    """Bundle-only names keep their route; operator-only names carry none."""
 
     gate = build_approval_gate(
         operator_tools=["Read"],
         policy_routes={"Bash": "managers"},
     )
     assert gate is not None
-    # Union of both sources arms; the bundle's route rides only its own name.
     assert gate.required == frozenset({"Read", "Bash"})
+    # `Read` is operator-set with no route: ADR-0034 channel-membership default.
     assert gate.route_by_tool == {"Bash": "managers"}
+    assert gate.route_by_tool.get("Read") is None
+
+
+def test_an_overlapping_bundle_route_is_logged_not_fatal(caplog) -> None:
+    """The bounded residual the union does not close: who approves an
+    overlapping name.
+
+    The bundle's route rides an operator-gated name, so the bundle picks the
+    audience. It is bounded (the route must be one the operator bound, and
+    ADR-0046 refuses an unbound one), so this warns rather than refusing --
+    `approvals --gate` writes a full replacement over an unlabeled union of
+    both sources, making the overlap something the CLI itself creates. See
+    ADR-0050.
+    """
+
+    with caplog.at_level("WARNING"):
+        gate = build_approval_gate(
+            operator_tools=["Bash"],
+            policy_routes={"Bash": "legal"},
+        )
+    assert gate is not None
+    # Still gated -- the union never subtracts.
+    assert "Bash" in gate.required
+    assert any("Bash" in r.getMessage() for r in caplog.records), caplog.text
 
 
 def test_no_declared_gate_from_either_source_keeps_the_bypass_posture() -> None:


### PR DESCRIPTION
Ports the fail-closed patterns from the Grok Build review onto the runner's approval-gate merge. The patterns only, never the mechanism: Grok is weaker than us on egress and per-agent secrets.

Closes #520

Decision and the deferred remainder are recorded in **ADR-0050**.

## What shipped: sub-item 1, plus the guard sub-item 2 was actually missing

### 1. Enforcement intent is read from the declared policy, not the resolved set

`load_approval_policy` swallowed every parse error and returned `{}`. That is not a neutral value: `__main__` builds `approval_gate = ... if gated_tools else None`, and a `None` gate means `can_use_tool` is never wired — the hardcoded bypass posture returns. So a bundle that **declared** gates but failed to parse booted with **nothing gated, silently**, indistinguishable from a genuine no-policy bundle.

Now the raw manifest is read first and "is a policy declared?" is answered from it. Once declared, no downstream failure can revoke the intent — it raises rather than degrading. The empty map is reserved for the honest cases (no dir, no manifest, no `approvalPolicy`, an explicitly empty `gates` list). An unreadable manifest also raises: it cannot prove it declares no policy.

The old docstring said the backstop was `load_plugins`. That backstop is real but incidental, and it **does not run on the fake tier at all** — `__main__.factory` returns `FakeModelSession` before `load_plugins` is called. On `skill`/`local --fake-model`, the tier used to rehearse approvals, the swallow was the whole gate.

The distinction the old code missed: hooks and `systemPrompt` degrade to a **narrower capability set**; `approvalPolicy` degrades to a **wider authority set**. Same swallow, opposite blast radius.

### 2. The anti-hollow-out property was already held — it just wasn't pinned

The gated-tool set is `operator | bundle`. Because no bundle-supplied value is ever subtracted, a bundle already cannot keep a trusted name while emptying what it restricts. AgentOS satisfies the Grok pattern's core; what was missing was a **regression guard**. An adversarial test now pins it: a bundle that re-declares the operator's gate and adds its own must drop neither operator name. A dict update, a bundle-wins precedence, or `policy_routes` used directly as `required` all fail it.

**I implemented the stricter form first and reversed it on review.** The residual the union does not close is which *route* governs an overlapping name. Refusing to boot on that overlap turned out to be reachable through the product's own flow:

- `agentos <tier> approvals` reports the operator field and the deployed manifest's gates as **one unlabeled list**, while `--gate` writes a **full replacement**. Reading the displayed gates and re-passing them with one more writes bundle names into the operator field — the obvious flow, which the refusal made boot-fatal.
- Nothing catches it earlier: the API validates only non-empty/comma-free, and `validate_bundle` cannot see deployment config.
- Resume re-derives the same config, so PATCHing a gate while an approval pends would crash the approved action's resume — the human says yes, nothing runs.

The widening it prevented is bounded anyway: the bundle can only name a route the operator itself bound in `approval_routes`, and ADR-0046 refuses an unbound one, so the tool stays gated and the audience stays operator-chosen. So it **warns and proceeds**. Closing the residual properly starts with the CLI read/write asymmetry (label provenance, make `--gate` additive), which is its own change — noted below.

## Not changed, deliberately

**Egress** was the issue's suspected home for pattern 1 and needed no change: it is already fail-closed end to end. `resolve_provider_egress_cidrs` hard-errors on an empty, failed, or non-globally-routable resolution rather than returning an empty vec; the chart's default-deny egress policy renders unconditionally; and `any_egress` is already derived from the declared opts (ADR-0032).

## Deferred

- **Sub-item 3 (pin the egress/secret profile across suspend/resume).** A resumed turn re-derives its whole execution profile — model, bundle ref, connector secrets, gated-tool list — from live config (`BindingResolver.resolve`/`boot_env`), so config widened while an approval pends is picked up on resume. That mirrors fresh-claim semantics by design; pinning it needs the profile persisted at suspend plus a migration, which is its own reviewed change. **Note the issue's stated motivation for it no longer holds:** ADR-0046 (#544) already replaced the model-forgeable summary-prefix discriminator with runner-authored `gate_kind`/`granted_tool` columns, and the grant is server-derived, agent-bound, tool-scoped and single-use. The remaining surface is the surrounding profile, not the grant.
- **Sub-item 4 (an always-reconfirm tool class)** was listed as "consider" and is untouched.
- **The CLI read/write asymmetry** behind the reversal above: label gate provenance (`bundle` vs `operator`) in `ApprovalsOutput::Gates`, and make `--gate` additive-with-explicit-`--replace`. Prerequisite to any config-time refusal of the overlap.

## Tests

Each guard has a **negative-control test, verified failing under mutation** (restore the `return {}`, drop the declared-vs-armed check, swallow the unreadable-manifest raise, or replace the union with bundle-wins precedence — each fails its test).

Two existing tests encoded the old leniency and were rewritten to pin the new refusal, not weakened: the `#453` adversarial validator/loader probe (its contract "validator REJECTS → the gate never reaches the runner" still holds, now more strongly) and the CLI mirror's skip-incomplete-gate test.

The CLI mirror (`parse_manifest_gates`) collapses its two tiers to match, or `skill approvals` would report a gate as armed for a manifest the runner refuses to boot on — the reporting/runtime drift of #607.

Deploy-valid bundles are unaffected: `validate_bundle` rejects every shape this raises on, and the declared-vs-armed check compares **distinct names, not counts**, so a last-wins duplicate the validator accepts does not crash-loop the runner.

Verified: `uv run pytest -q` (full workspace), `uv run ruff check .`, `uv run mypy`, `cargo test`, `cargo fmt --check`, `scripts/check-docs.sh`.
