### PR TITLE
Checksum, sign, and attest every downloadable release asset

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -289,11 +289,24 @@ jobs:
           strip "$bin" || true
           mkdir -p dist
           cp "$bin" "dist/agentos-${{ matrix.target }}"
+      # Cataloged from the cli/ source tree, not the stripped binary: Cargo.lock is
+      # what actually names every crate that went in, and stripping removes the
+      # symbols a binary scan would need (#629).
+      - name: Generate the CLI SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: cli
+          format: spdx-json
+          output-file: dist/agentos-${{ matrix.target }}.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7
         with:
           name: agentos-${{ matrix.target }}
-          path: dist/agentos-${{ matrix.target }}
+          path: |
+            dist/agentos-${{ matrix.target }}
+            dist/agentos-${{ matrix.target }}.spdx.json
           if-no-files-found: error
 
   chart:
@@ -306,27 +319,53 @@ jobs:
           persist-credentials: false
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+      - name: Resolve version
+        id: ver
+        run: echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
       - name: Package chart
         run: |
-          version="${GITHUB_REF_NAME#v}"
+          version="${{ steps.ver.outputs.v }}"
           mkdir -p dist
           helm package charts/agentos --version "$version" --app-version "$version" -d dist
       - name: Generate and stage the release compose
         run: |
-          version="${GITHUB_REF_NAME#v}"
+          version="${{ steps.ver.outputs.v }}"
           mkdir -p dist
           python3 compose/generate_release_compose.py --version "${version}" > dist/compose.release.yaml
+      # The chart and the compose file are deployment manifests, so these SBOMs
+      # inventory the packaged artifact itself. The dependency graph of what they
+      # pin -- the agentos-* images -- ships with those images (#62).
+      - name: Generate the chart SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: dist/agentos-${{ steps.ver.outputs.v }}.tgz
+          format: spdx-json
+          output-file: dist/agentos-${{ steps.ver.outputs.v }}.tgz.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+      - name: Generate the compose SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          file: dist/compose.release.yaml
+          format: spdx-json
+          output-file: dist/compose.release.yaml.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
       - name: Upload chart artifact
         uses: actions/upload-artifact@v7
         with:
           name: agentos-chart
-          path: dist/agentos-*.tgz
+          path: |
+            dist/agentos-*.tgz
+            dist/agentos-*.tgz.spdx.json
           if-no-files-found: error
       - name: Upload release compose artifact
         uses: actions/upload-artifact@v7
         with:
           name: agentos-compose
-          path: dist/compose.release.yaml
+          path: |
+            dist/compose.release.yaml
+            dist/compose.release.yaml.spdx.json
           if-no-files-found: error
 
   release:
@@ -336,19 +375,95 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Keyless cosign signing and build provenance both mint a short-lived OIDC
+      # identity for this workflow run; there is no long-lived signing key (#629).
+      id-token: write
+      attestations: write
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Download built binaries
         uses: actions/download-artifact@v8
         with:
           pattern: agentos-*
           path: dist
           merge-multiple: true
+      - name: Resolve version
+        id: ver
+        run: echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      # The gate runs BEFORE signing, not after: cosign will happily sign an
+      # incomplete manifest, laundering a coverage gap into a valid signature.
+      # Refusing to build the manifest at all is what makes the release fail
+      # closed when an asset or its SBOM is missing (#629).
+      - name: Gate the asset set and build the checksum manifest
+        run: python3 release/integrity.py manifest --dist dist --version "${{ steps.ver.outputs.v }}"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign the checksum manifest
+        run: |
+          cosign sign-blob --yes \
+            --bundle dist/checksums.txt.sigstore.json \
+            dist/checksums.txt
+      # One attestation covering every file in dist, the manifest included, so each
+      # asset carries SLSA provenance naming this repo, this workflow, and the
+      # release commit. Runs after signing so the bundle is a subject too.
+      - name: Attest build provenance for every asset
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist/*
       - name: Create release with generated notes
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          files: |
-            dist/agentos-*
-            dist/compose.release.yaml
+          # Everything staged in dist is published: assets, their SBOMs, the
+          # checksum manifest, and its signature.
+          files: dist/*
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           make_latest: ${{ !contains(github.ref_name, '-') }}
+
+  verify-release:
+    name: Verify the published release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Resolve version
+        id: ver
+        run: echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      # Re-download what users will actually get, rather than trusting the dist
+      # directory we uploaded from. This is the check that the documented
+      # verification path in docs/release-verification.md really works.
+      - name: Download the published assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir dist
+      - name: Every asset is checksummed and carries an SBOM
+        run: python3 release/integrity.py verify --dist dist --version "${{ steps.ver.outputs.v }}"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: The checksum manifest signature is this workflow's
+        run: |
+          cosign verify-blob \
+            --bundle dist/checksums.txt.sigstore.json \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@${GITHUB_REF}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            dist/checksums.txt
+      - name: Every asset has provenance from this workflow and commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for f in dist/*; do
+            echo "== $f"
+            gh attestation verify "$f" \
+              --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yaml" \
+              --source-ref "$GITHUB_REF" \
+              --source-digest "$GITHUB_SHA"
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -425,8 +425,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          state=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
-            --json isDraft --jq .isDraft 2>/dev/null || echo absent)
+          # Distinguish "no such release" from "gh could not tell us". Treating every
+          # nonzero exit as absent would fail OPEN: a 503 or a rate limit on a
+          # published tag would read as absent and upload onto the live release,
+          # which is the exact defect this step exists to prevent.
+          if state=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+              --json isDraft --jq .isDraft 2>err.txt); then
+            :
+          elif grep -qi 'release not found' err.txt; then
+            state=absent
+          else
+            echo "::error::cannot determine the release state of $GITHUB_REF_NAME; refusing to stage a draft against an unknown state." >&2
+            cat err.txt >&2
+            exit 1
+          fi
           if [ "$state" = "false" ]; then
             echo "::error::$GITHUB_REF_NAME is already published. Re-running would upload assets onto the live release without verifying them. Delete the release and re-run, or cut a new tag." >&2
             exit 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -289,13 +289,14 @@ jobs:
           strip "$bin" || true
           mkdir -p dist
           cp "$bin" "dist/agentos-${{ matrix.target }}"
-      # Cataloged from the cli/ source tree, not the stripped binary: Cargo.lock is
-      # what actually names every crate that went in, and stripping removes the
-      # symbols a binary scan would need (#629).
+      # Cataloged from Cargo.lock, not the stripped binary: the lockfile is what
+      # actually names every crate that went in, and stripping removes the symbols
+      # a binary scan would need. Scanning the cli/ tree instead would also drag in
+      # cli/target/, which the build step above has just filled with rlibs (#629).
       - name: Generate the CLI SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: cli
+          file: cli/Cargo.lock
           format: spdx-json
           output-file: dist/agentos-${{ matrix.target }}.spdx.json
           upload-artifact: false
@@ -334,7 +335,9 @@ jobs:
           python3 compose/generate_release_compose.py --version "${version}" > dist/compose.release.yaml
       # The chart and the compose file are deployment manifests, so these SBOMs
       # inventory the packaged artifact itself. The dependency graph of what they
-      # pin -- the agentos-* images -- ships with those images (#62).
+      # pin lives in the agentos-* images, which do NOT carry SBOMs or provenance
+      # today -- that is #62, still open. Do not read this as coverage existing
+      # elsewhere; it does not yet.
       - name: Generate the chart SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
@@ -412,23 +415,30 @@ jobs:
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/*
-      - name: Create release with generated notes
+      # Created as a DRAFT. A draft's assets are not publicly downloadable, so
+      # nothing reaches a user until verify-and-publish has re-verified the
+      # published bytes and promoted the release. Publishing first and verifying
+      # after would mean an unverifiable release is already installed by the time
+      # the workflow goes red (#629).
+      - name: Create draft release with generated notes
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           # Everything staged in dist is published: assets, their SBOMs, the
           # checksum manifest, and its signature.
           files: dist/*
           generate_release_notes: true
+          draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}
-          make_latest: ${{ !contains(github.ref_name, '-') }}
 
-  verify-release:
-    name: Verify the published release
+  verify-and-publish:
+    name: Verify the draft release, then publish it
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [release]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # write, not read: promoting the draft to published is this job's whole
+      # point, and a draft is only visible to a token with push access.
+      contents: write
       attestations: read
     steps:
       - uses: actions/checkout@v7
@@ -439,8 +449,9 @@ jobs:
         run: echo "v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
       # Re-download what users will actually get, rather than trusting the dist
       # directory we uploaded from. This is the check that the documented
-      # verification path in docs/release-verification.md really works.
-      - name: Download the published assets
+      # verification path in docs/release-verification.md really works, and it
+      # also catches a create-release that uploaded only some of its assets.
+      - name: Download the draft's assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release download "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --dir dist
@@ -448,11 +459,13 @@ jobs:
         run: python3 release/integrity.py verify --dist dist --version "${{ steps.ver.outputs.v }}"
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      # GITHUB_WORKFLOW_REF *is* the certificate's SAN suffix, so it cannot drift
+      # from the identity cosign actually minted if this file is ever renamed.
       - name: The checksum manifest signature is this workflow's
         run: |
           cosign verify-blob \
             --bundle dist/checksums.txt.sigstore.json \
-            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yaml@${GITHUB_REF}" \
+            --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             dist/checksums.txt
       - name: Every asset has provenance from this workflow and commit
@@ -467,3 +480,14 @@ jobs:
               --source-ref "$GITHUB_REF" \
               --source-digest "$GITHUB_SHA"
           done
+      # Only now does the release become something a user can download. Every step
+      # above had to pass to get here, which is what makes "the release fails if an
+      # integrity artifact is missing or unverifiable" true rather than aspirational.
+      - name: Publish the verified release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest=true
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then latest=false; fi   # rc tags never become latest
+          gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --draft=false --latest="$latest"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -415,6 +415,23 @@ jobs:
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/*
+      # action-gh-release honors `draft:` only when it CREATES the release; if one
+      # already exists for the tag it reuses that release's own draft state
+      # (`draft: existingRelease.draft`) and uploads onto it. Every release this repo
+      # has published is draft=false, so re-running a published tag -- to clear a
+      # flake, say -- would push assets straight onto the live release and skip every
+      # check below. Refuse instead of silently bypassing the gate.
+      - name: Refuse to re-release an already-published tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          state=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+            --json isDraft --jq .isDraft 2>/dev/null || echo absent)
+          if [ "$state" = "false" ]; then
+            echo "::error::$GITHUB_REF_NAME is already published. Re-running would upload assets onto the live release without verifying them. Delete the release and re-run, or cut a new tag." >&2
+            exit 1
+          fi
+          echo "tag state: $state (absent or draft) -- safe to stage a draft"
       # Created as a DRAFT. A draft's assets are not publicly downloadable, so
       # nothing reaches a user until verify-and-publish has re-verified the
       # published bytes and promoted the release. Publishing first and verifying
@@ -489,5 +506,8 @@ jobs:
         run: |
           latest=true
           if [[ "$GITHUB_REF_NAME" == *-* ]]; then latest=false; fi   # rc tags never become latest
+          # --latest MUST keep the `=` form: the flag's NoOptDefVal is "true", so the
+          # space-separated `--latest false` would mean --latest=true plus a stray arg,
+          # and every rc would land as latest.
           gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
             --draft=false --latest="$latest"

--- a/README.md
+++ b/README.md
@@ -190,14 +190,36 @@ channel binding, and troubleshooting) see
 The fastest way in — for operators and coding agents alike — is the prebuilt
 release binary. It needs no Rust toolchain and no repo checkout:
 
+You are about to run a downloaded binary as root, so verify it first. Every
+release ships a `checksums.txt` signed by the release workflow; check the
+signature, then check the binary against it, then install:
+
 ```bash
 # Linux (x86_64); for macOS Apple silicon swap in agentos-aarch64-apple-darwin
-curl -L -o agentos \
-  https://github.com/curie-eng/agentos/releases/latest/download/agentos-x86_64-unknown-linux-gnu
-chmod +x agentos && sudo mv agentos /usr/local/bin/
+VERSION=v0.4.0
+ASSET=agentos-x86_64-unknown-linux-gnu
+BASE="https://github.com/curie-eng/agentos/releases/download/$VERSION"
+curl -fsSLO "$BASE/$ASSET" -O "$BASE/checksums.txt" -O "$BASE/checksums.txt.sigstore.json"
+
+# 1. checksums.txt really came from this repo's release workflow, at this tag
+cosign verify-blob --bundle checksums.txt.sigstore.json \
+  --certificate-identity "https://github.com/curie-eng/agentos/.github/workflows/release.yaml@refs/tags/$VERSION" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+# 2. the binary is the one it names
+sha256sum --check --ignore-missing checksums.txt
+# 3. both OK? install it
+chmod +x "$ASSET" && sudo mv "$ASSET" /usr/local/bin/agentos
+
 agentos cluster up
 agentos local up
 ```
+
+No cosign? `gh attestation verify $ASSET --repo curie-eng/agentos --signer-workflow
+curie-eng/agentos/.github/workflows/release.yaml` does both checks in one command.
+Either way, see [`docs/release-verification.md`](docs/release-verification.md) for
+the full story: what each asset carries, how to verify the chart and compose file,
+and the per-asset SBOMs.
 
 > **macOS: "unidentified developer"?** The release binaries are not yet
 > notarized by Apple, so a copy downloaded through a browser is quarantined and

--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ agentos local up
 > integrity URLs above 404 against them. Install a newer release.
 
 No cosign? `gh attestation verify $ASSET --repo curie-eng/agentos --signer-workflow
-curie-eng/agentos/.github/workflows/release.yaml` does both checks in one command.
+curie-eng/agentos/.github/workflows/release.yaml --source-ref "refs/tags/$VERSION"`
+does both checks in one command. Keep `--source-ref`: without it the check passes
+for any artifact this workflow ever built, including one from a different tag.
 Either way, see [`docs/release-verification.md`](docs/release-verification.md) for
 the full story: what each asset carries, how to verify the chart and compose file,
 and the per-asset SBOMs.

--- a/README.md
+++ b/README.md
@@ -192,12 +192,13 @@ release binary. It needs no Rust toolchain and no repo checkout:
 
 You are about to run a downloaded binary as root, so verify it first. Every
 release ships a `checksums.txt` signed by the release workflow; check the
-signature, then check the binary against it, then install:
+signature, then check the binary against it, then install. Set `VERSION` to the
+release you are installing, from the
+[Releases page](https://github.com/curie-eng/agentos/releases):
 
 ```bash
-# Linux (x86_64); for macOS Apple silicon swap in agentos-aarch64-apple-darwin
-VERSION=v0.4.0
-ASSET=agentos-x86_64-unknown-linux-gnu
+VERSION=vX.Y.Z                            # the release you are installing
+ASSET=agentos-x86_64-unknown-linux-gnu    # macOS Apple silicon: agentos-aarch64-apple-darwin
 BASE="https://github.com/curie-eng/agentos/releases/download/$VERSION"
 curl -fsSLO "$BASE/$ASSET" -O "$BASE/checksums.txt" -O "$BASE/checksums.txt.sigstore.json"
 
@@ -206,7 +207,7 @@ cosign verify-blob --bundle checksums.txt.sigstore.json \
   --certificate-identity "https://github.com/curie-eng/agentos/.github/workflows/release.yaml@refs/tags/$VERSION" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   checksums.txt
-# 2. the binary is the one it names
+# 2. the binary is the one it names (macOS: shasum -a 256 --check --ignore-missing)
 sha256sum --check --ignore-missing checksums.txt
 # 3. both OK? install it
 chmod +x "$ASSET" && sudo mv "$ASSET" /usr/local/bin/agentos
@@ -214,6 +215,11 @@ chmod +x "$ASSET" && sudo mv "$ASSET" /usr/local/bin/agentos
 agentos cluster up
 agentos local up
 ```
+
+> **Which releases can be verified?** Every release published *after* v0.4.0.
+> `checksums.txt`, the signature, the provenance, and the SBOMs are produced by
+> the release workflow, so v0.4.0 and earlier shipped bare binaries and the two
+> integrity URLs above 404 against them. Install a newer release.
 
 No cosign? `gh attestation verify $ASSET --repo curie-eng/agentos --signer-workflow
 curie-eng/agentos/.github/workflows/release.yaml` does both checks in one command.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,9 @@ git history (`git log -- docs/`).
   declarative data rather than code, and what is wired today.
 - [`operations.md`](operations.md): running a cluster install, plus
   operator-facing findings from early installs.
+- [`release-verification.md`](release-verification.md): what every release asset
+  carries (checksums, signature, provenance, SBOM) and how to verify one before
+  you run it.
 - [`design/multi-dev-shared-cluster.md`](design/multi-dev-shared-cluster.md): the
   design pass for many developers iterating against one shared cluster (isolation,
   targeting, ambient context), answering epic #44's deferred open questions.

--- a/docs/adr/0052-release-asset-trust-model.md
+++ b/docs/adr/0052-release-asset-trust-model.md
@@ -91,6 +91,13 @@ and a verified chart is not a verified stack until #62 lands.
   accept any tag's manifest and defeat the pin. A hardcoded tag would be worse
   than a placeholder -- it goes stale every release, and a stale tag sends people
   to a release whose integrity URLs 404.
+- Re-running the workflow against an already-published tag now fails rather than
+  re-uploading. `action-gh-release` honors `draft:` only on creation and otherwise
+  adopts the existing release's draft state, so a re-run of a published tag would
+  have uploaded onto the live release and skipped verification entirely -- the one
+  state where the draft gate silently does not apply. Recovering a bad release
+  means deleting it or cutting a new tag, which is the intended friction. A
+  re-run against a *stuck draft* is fine and repairs it.
 - These artifacts exist only on releases published after v0.4.0. Verification is
   not retroactive: v0.4.0 and earlier shipped bare binaries and always will, so
   the docs say plainly that those cannot be verified rather than implying the

--- a/docs/adr/0052-release-asset-trust-model.md
+++ b/docs/adr/0052-release-asset-trust-model.md
@@ -41,42 +41,60 @@ key to store, rotate, or leak, and the identity a verifier pins is the workflow
 path plus the tag -- a fact about *who built it*, which is the actual question,
 rather than *who holds the key*.
 
-**Coverage is closed-world.** The gate does not check a list of assets we know
-about today. Every file in the release must be a known asset, an SBOM for one, or
-the manifest and its signature; anything else fails. An allowlist would go
-quietly stale the first time someone adds an asset -- the gate would still report
-green while shipping the new artifact unattested, which is the exact failure this
-ADR exists to prevent. The cost is that adding an asset means teaching the gate
-about it. That cost is the point.
+**Coverage is closed-world.** Every file in the release must be an asset
+`release/integrity.py` declares, a usable SBOM for one of them, or the manifest
+and its signature; anything else fails. Checking only that the assets we know
+about are covered would let the next asset ship uncovered while the gate reported
+green. Nor is "has an SBOM" sufficient on its own: `files: dist/*` publishes
+whatever is staged, so a stray file -- a leftover build artifact, or anything a
+compromised step drops into dist -- would otherwise be signed and attested purely
+for bringing an SBOM along. The cost is that adding an asset means declaring it,
+as a reviewed edit. That cost is the point.
 
-**The gate runs before signing, and again after publishing.** Before, because
-cosign will sign an incomplete manifest without complaint, laundering a coverage
-gap into a valid signature: `release/integrity.py` refuses to *build* a manifest
-over an incomplete dist, so the release fails closed. After, because what we
-uploaded is not evidence about what users download -- the `verify-release` job
-re-downloads the published release and re-runs the whole documented path
+**Publication is the consequence of verification, not a step before it.** The
+release is created as a draft, whose assets are not publicly downloadable; the
+`verify-and-publish` job re-downloads it, re-runs the whole documented path
 (checksums, `cosign verify-blob`, `gh attestation verify`) against the real
-bytes. That second run is also what keeps
+published bytes, and only then promotes the draft. Publishing first and verifying
+after was the obvious shape and is wrong: a release that fails verification would
+already be installed, already marked latest, and there is no rollback -- the
+workflow would go red while the artifact stayed up, which inverts the whole
+point. Verification against the *published* bytes (rather than the dist we
+uploaded from) is also what catches a create-release that uploaded only some of
+its assets, and what keeps
 [`docs/release-verification.md`](../release-verification.md) honest: if the
-documented commands stop working, the release goes red.
+documented commands stop working, no release goes out.
 
-**SBOM scope follows the artifact.** The CLI binaries are cataloged from the
-`cli` source tree, because `Cargo.lock` is what actually names every crate that
-went in and stripping removes what a binary scan would need. The chart and the
+The gate additionally runs *before* signing, because cosign will sign an
+incomplete manifest without complaint, laundering a coverage gap into a valid
+signature: `release/integrity.py` refuses to *build* a manifest over an
+incomplete dist.
+
+**SBOM scope follows the artifact.** The CLI binaries are cataloged from
+`cli/Cargo.lock`, because the lockfile is what actually names every crate that
+went in, stripping removes what a binary scan would need, and by SBOM time the
+`cli` tree also holds a `target/` full of build detritus. The chart and the
 compose file are deployment manifests with no dependencies of their own, so their
 SBOMs inventory the packaged artifact itself; the dependency graph of what they
-deploy belongs to the images they pin, and ships with those images (#62). This is
-the weakest part of the decision and is recorded as such: a chart SBOM that names
-only the chart is close to a restatement of its checksum.
+deploy belongs to the images they pin, which carry no SBOM or provenance today
+(#62, open). This is the weakest part of the decision and is recorded as such: a
+chart SBOM that names only the chart is close to a restatement of its checksum,
+and a verified chart is not a verified stack until #62 lands.
 
 ## Consequences
 
 - Verifying a release needs `cosign`, or `gh` for the one-command
   `gh attestation verify` path. Both are documented; neither is bundled.
-- The README pins an explicit version in its verification snippet, because the
-  cosign certificate identity names the exact tag. A wildcard identity would
-  accept any tag's manifest and defeat the pin, so the snippet goes stale by
-  design at each release rather than being loosened.
+- The verification snippets take the version as a `vX.Y.Z` placeholder the reader
+  substitutes, rather than a live tag. The cosign certificate identity names the
+  exact tag, so the snippet cannot be tag-agnostic; a wildcard identity would
+  accept any tag's manifest and defeat the pin. A hardcoded tag would be worse
+  than a placeholder -- it goes stale every release, and a stale tag sends people
+  to a release whose integrity URLs 404.
+- These artifacts exist only on releases published after v0.4.0. Verification is
+  not retroactive: v0.4.0 and earlier shipped bare binaries and always will, so
+  the docs say plainly that those cannot be verified rather than implying the
+  commands work everywhere.
 - A release binary still fetches the chart and compose assets itself at `cluster
   up` / `local up` and does **not** verify them; that fetch is protected by HTTPS
   to GitHub, not by this signature. Closing that is follow-on work -- the trust

--- a/docs/adr/0052-release-asset-trust-model.md
+++ b/docs/adr/0052-release-asset-trust-model.md
@@ -106,6 +106,11 @@ and a verified chart is not a verified stack until #62 lands.
   up` / `local up` and does **not** verify them; that fetch is protected by HTTPS
   to GitHub, not by this signature. Closing that is follow-on work -- the trust
   material now exists for the CLI to check, which it did not before.
+- The SBOM generator is pinned by SHA but is not hermetic: `anchore/sbom-action`
+  fetches `anchore/syft`'s `main` install script at run time, so mutable upstream
+  code runs before signing. Accepted for now rather than hand-pinning a syft
+  binary, which trades a Dependabot-tracked dependency for one that rots silently;
+  revisit if the release path is ever treated as a hermetic build.
 - Apple signing and notarization remain deferred pending an Apple account
   decision. The macOS binary is covered by everything above; it is Gatekeeper,
   not verifiability, that is missing.

--- a/docs/adr/0052-release-asset-trust-model.md
+++ b/docs/adr/0052-release-asset-trust-model.md
@@ -1,0 +1,86 @@
+# 52. The release trust model: one signed manifest, closed-world coverage
+
+Date: 2026-07-17
+
+Status: Accepted
+
+Implements [#629](https://github.com/curie-eng/agentos/issues/629).
+Scoped to downloadable GitHub release assets. Signing, provenance, and SBOMs for
+the GHCR container images are [#62](https://github.com/curie-eng/agentos/issues/62)
+and are deliberately not decided here.
+
+## Context
+
+A release publishes the `agentos` CLI binaries, the packaged Helm chart, and
+`compose.release.yaml`. None of them carried a checksum, a signature, provenance,
+or an SBOM. The documented install path was `curl` the binary, `chmod +x`, `sudo
+mv` it onto `PATH`, and immediately point it at a cluster -- so the first thing a
+new user did with AgentOS was run an unverifiable binary as root. Nothing let
+them answer "is this the artifact that repo's workflow built?", and nothing let
+us answer it either after the fact.
+
+The obvious shape -- sign each asset, publish a `.sig` beside it -- is not the
+only one, and the choices interact. Three questions had to be answered together:
+what gets signed, what counts as covered, and when the check runs.
+
+## Decision
+
+**One signature, over the checksum manifest.** The release publishes
+`checksums.txt` covering every file, signs *that* with keyless cosign, and
+attests SLSA build provenance over every file in `dist` (the manifest included).
+Per-asset signatures were the alternative; they were rejected as redundant. The
+chain already closes without them: provenance and the cosign certificate bind
+`checksums.txt` to this repo, this workflow, and the release commit, and the
+manifest binds each file to itself. A user who verifies the manifest and then
+checks one file against it has verified that file, and the docs are one procedure
+rather than one per asset type.
+
+**Keyless, not a signing key.** Both cosign and the attestation mint a
+short-lived OIDC identity for the workflow run. There is no long-lived private
+key to store, rotate, or leak, and the identity a verifier pins is the workflow
+path plus the tag -- a fact about *who built it*, which is the actual question,
+rather than *who holds the key*.
+
+**Coverage is closed-world.** The gate does not check a list of assets we know
+about today. Every file in the release must be a known asset, an SBOM for one, or
+the manifest and its signature; anything else fails. An allowlist would go
+quietly stale the first time someone adds an asset -- the gate would still report
+green while shipping the new artifact unattested, which is the exact failure this
+ADR exists to prevent. The cost is that adding an asset means teaching the gate
+about it. That cost is the point.
+
+**The gate runs before signing, and again after publishing.** Before, because
+cosign will sign an incomplete manifest without complaint, laundering a coverage
+gap into a valid signature: `release/integrity.py` refuses to *build* a manifest
+over an incomplete dist, so the release fails closed. After, because what we
+uploaded is not evidence about what users download -- the `verify-release` job
+re-downloads the published release and re-runs the whole documented path
+(checksums, `cosign verify-blob`, `gh attestation verify`) against the real
+bytes. That second run is also what keeps
+[`docs/release-verification.md`](../release-verification.md) honest: if the
+documented commands stop working, the release goes red.
+
+**SBOM scope follows the artifact.** The CLI binaries are cataloged from the
+`cli` source tree, because `Cargo.lock` is what actually names every crate that
+went in and stripping removes what a binary scan would need. The chart and the
+compose file are deployment manifests with no dependencies of their own, so their
+SBOMs inventory the packaged artifact itself; the dependency graph of what they
+deploy belongs to the images they pin, and ships with those images (#62). This is
+the weakest part of the decision and is recorded as such: a chart SBOM that names
+only the chart is close to a restatement of its checksum.
+
+## Consequences
+
+- Verifying a release needs `cosign`, or `gh` for the one-command
+  `gh attestation verify` path. Both are documented; neither is bundled.
+- The README pins an explicit version in its verification snippet, because the
+  cosign certificate identity names the exact tag. A wildcard identity would
+  accept any tag's manifest and defeat the pin, so the snippet goes stale by
+  design at each release rather than being loosened.
+- A release binary still fetches the chart and compose assets itself at `cluster
+  up` / `local up` and does **not** verify them; that fetch is protected by HTTPS
+  to GitHub, not by this signature. Closing that is follow-on work -- the trust
+  material now exists for the CLI to check, which it did not before.
+- Apple signing and notarization remain deferred pending an Apple account
+  decision. The macOS binary is covered by everything above; it is Gatekeeper,
+  not verifiability, that is missing.

--- a/docs/adr/0052-release-asset-trust-model.md
+++ b/docs/adr/0052-release-asset-trust-model.md
@@ -97,7 +97,15 @@ and a verified chart is not a verified stack until #62 lands.
   have uploaded onto the live release and skipped verification entirely -- the one
   state where the draft gate silently does not apply. Recovering a bad release
   means deleting it or cutting a new tag, which is the intended friction. A
-  re-run against a *stuck draft* is fine and repairs it.
+  re-run against a *stuck draft* is fine and repairs it. The guard fails closed on
+  an indeterminate answer: if the release state cannot be read at all, that is not
+  a safe state to stage against.
+- Two runs against the same tag (a force-pushed tag) are not serialized. The
+  workflow takes no `concurrency` group, because the only correct scope is
+  workflow-level -- a job-level group spanning `release` and `verify-and-publish`
+  would deadlock on their `needs:` edge -- and that would also serialize the
+  main-push image builds, which is a cadence change this decision does not want to
+  make on its own. Force-pushing a release tag stays an operation you must not do.
 - These artifacts exist only on releases published after v0.4.0. Verification is
   not retroactive: v0.4.0 and earlier shipped bare binaries and always will, so
   the docs say plainly that those cannot be verified rather than implying the

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -80,4 +80,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0048 | [ADR-0048: Declare the model endpoint's wire protocol and credential keys](0048-declared-model-wire-protocol-and-credential-keys.md) | Accepted |
 | 0050 | [A declared approval policy is armed exactly as declared, or the runner refuses to boot](0050-declared-approval-policy-is-armed-exactly-or-not-at-all.md) | Accepted |
 | 0051 | [Eval cases run in a fresh conversation by default, with per-case opt-in shared history](0051-eval-cases-run-in-a-fresh-conversation-by-default.md) | Accepted |
+| 0052 | [The release trust model: one signed manifest, closed-world coverage](0052-release-asset-trust-model.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -86,12 +86,14 @@ asset was built by this repo's release workflow:
 ```bash
 gh attestation verify agentos-x86_64-unknown-linux-gnu \
   --repo curie-eng/agentos \
-  --signer-workflow curie-eng/agentos/.github/workflows/release.yaml
+  --signer-workflow curie-eng/agentos/.github/workflows/release.yaml \
+  --source-ref "refs/tags/$VERSION"
 ```
 
-Add `--source-ref "refs/tags/$VERSION"` to also pin it to a specific release, or
-`--format json` to read the full provenance statement, including the commit the
-build ran from.
+`--source-ref` is doing real work, so do not drop it: `--signer-workflow` alone
+accepts any artifact this workflow ever built, on any ref, so a file swapped in
+from another tag would still verify. Add `--format json` to read the full
+provenance statement, including the commit the build ran from.
 
 ## Verify the chart and the compose file
 
@@ -166,3 +168,9 @@ which is a reviewed edit rather than a side effect.
   copy; see the [README note](../README.md#quickstart). Verify it with cosign or
   `gh attestation verify` as above -- that is the real check regardless.
 - **Container images.** GHCR image signing, provenance, and SBOMs are issue #62.
+- **The SBOM generator's own supply chain.** `anchore/sbom-action` is pinned to a
+  commit SHA, but on Linux and macOS it fetches `install.sh` from the `anchore/syft`
+  `main` branch at run time, so the SBOM step still executes mutable upstream code
+  before the artifacts are signed. Pinning the action does not pin that. Replacing
+  it with a checksum-pinned syft binary would close the gap, at the cost of
+  hand-managing syft upgrades that Dependabot handles today.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -27,6 +27,8 @@ The trust chain is: provenance and the cosign signature establish that
 establishes that each file is the one that workflow produced. So verifying the
 manifest's signature and then checking a file against the manifest is enough --
 you do not need a separate signature per asset.
+[ADR-0052](adr/0052-release-asset-trust-model.md) records why the trust model is
+shaped this way.
 
 ## Verify the CLI before installing it
 

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,0 +1,153 @@
+# Verifying a release
+
+Every GitHub release publishes the `agentos` CLI binaries, the Helm chart, and
+`compose.release.yaml`. Installing the CLI means running a downloaded binary as
+root and pointing it at a cluster, so verify what you received before you run it.
+
+This page is the reference. The [README quickstart](../README.md#quickstart) has
+the short copy-paste version for the default install path.
+
+## What each release publishes
+
+| Asset | What it is |
+|---|---|
+| `agentos-x86_64-unknown-linux-gnu` | CLI binary, Linux x86_64 |
+| `agentos-aarch64-apple-darwin` | CLI binary, macOS Apple silicon |
+| `agentos-<version>.tgz` | packaged Helm chart |
+| `compose.release.yaml` | the self-contained local stack |
+| `<asset>.spdx.json` | SPDX SBOM, one per asset |
+| `checksums.txt` | sha256 of every file above |
+| `checksums.txt.sigstore.json` | cosign signature over `checksums.txt` |
+
+Every asset also carries [SLSA build provenance](https://slsa.dev/), naming the
+repository, the workflow, and the commit it was built from.
+
+The trust chain is: provenance and the cosign signature establish that
+`checksums.txt` came from this repo's release workflow, and `checksums.txt`
+establishes that each file is the one that workflow produced. So verifying the
+manifest's signature and then checking a file against the manifest is enough --
+you do not need a separate signature per asset.
+
+## Verify the CLI before installing it
+
+Set the version you are installing and download the binary alongside the manifest
+and its signature:
+
+```bash
+VERSION=v0.4.0
+REPO=curie-eng/agentos
+ASSET=agentos-x86_64-unknown-linux-gnu   # macOS: agentos-aarch64-apple-darwin
+BASE="https://github.com/$REPO/releases/download/$VERSION"
+
+curl -fsSLO "$BASE/$ASSET"
+curl -fsSLO "$BASE/checksums.txt"
+curl -fsSLO "$BASE/checksums.txt.sigstore.json"
+```
+
+**Step 1 -- the manifest is genuinely ours.** Requires
+[cosign](https://docs.sigstore.dev/system_config/installation/). The identity is
+pinned to the exact workflow and tag, so a manifest signed by any other workflow,
+repo, or ref fails:
+
+```bash
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity "https://github.com/$REPO/.github/workflows/release.yaml@refs/tags/$VERSION" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+```
+
+**Step 2 -- the binary matches the manifest.** `--ignore-missing` checks only the
+files you actually downloaded:
+
+```bash
+sha256sum --check --ignore-missing checksums.txt   # macOS: shasum -a 256 --check --ignore-missing checksums.txt
+```
+
+**Step 3 -- only now, install it.** Both checks must print OK first:
+
+```bash
+chmod +x "$ASSET" && sudo mv "$ASSET" /usr/local/bin/agentos
+agentos --version
+```
+
+## Verify provenance with the GitHub CLI
+
+If you have `gh` and would rather not install cosign, `gh attestation verify`
+checks any single asset in one command, no manifest needed. It fails unless the
+asset was built by this repo's release workflow:
+
+```bash
+gh attestation verify agentos-x86_64-unknown-linux-gnu \
+  --repo curie-eng/agentos \
+  --signer-workflow curie-eng/agentos/.github/workflows/release.yaml
+```
+
+Add `--source-ref "refs/tags/$VERSION"` to also pin it to a specific release, or
+`--format json` to read the full provenance statement, including the commit the
+build ran from.
+
+## Verify the chart and the compose file
+
+Same two steps, different asset. The chart and compose file are data rather than
+executables, but a tampered chart deploys tampered images:
+
+```bash
+curl -fsSLO "$BASE/compose.release.yaml"
+curl -fsSLO "$BASE/agentos-${VERSION#v}.tgz"
+sha256sum --check --ignore-missing checksums.txt
+```
+
+Run the cosign step above first if you have not already: checking a file against
+an unverified manifest proves only that it downloaded intact.
+
+A release binary fetches these two assets itself when you run `agentos cluster
+up` or `agentos local up`, caching them under `~/.cache/agentos/`. That fetch
+does not verify them today: it is protected by HTTPS to GitHub, not by the
+signature. Verify them by hand as above if you need the stronger guarantee.
+
+## SBOMs
+
+Each asset ships an SPDX 2.3 SBOM at `<asset>.spdx.json`, covered by
+`checksums.txt` like any other file, so verify it the same way before trusting
+it:
+
+- **CLI binaries** -- cataloged from the `cli` source tree, so the SBOM is the
+  full crate dependency graph that `Cargo.lock` pins. This is the one to feed to
+  a vulnerability scanner.
+- **Chart and compose** -- these are deployment manifests with no dependencies of
+  their own; their SBOMs inventory the packaged artifact itself. The dependency
+  graph of what they deploy belongs to the `agentos-*` container images, which
+  carry their own SBOMs (issue #62).
+
+Scan one with any SPDX-aware tool, for example
+[grype](https://github.com/anchore/grype):
+
+```bash
+grype sbom:./agentos-x86_64-unknown-linux-gnu.spdx.json
+```
+
+## What happens if an asset is not covered
+
+The release fails, before and after publishing.
+
+`release/integrity.py` is the gate and the single definition of what "covered"
+means. `.github/workflows/release.yaml` calls it twice: once before signing, to
+refuse to build a checksum manifest over an incomplete asset set (signing an
+incomplete manifest would launder the gap into a valid signature), and once
+after publishing, in the `verify-release` job, which re-downloads the release and
+re-runs the whole documented path -- checksums, cosign, and `gh attestation
+verify` -- against the bytes users will actually get.
+
+The check is closed-world: every file in the release must be a known asset, an
+SBOM for one, or the manifest and its signature. A new asset added to the release
+without an SBOM fails the gate rather than shipping unattested. When it fires,
+add SBOM generation to the job that builds the asset -- do not widen the gate.
+
+## Not covered yet
+
+- **Apple notarization.** The macOS binary is unsigned and un-notarized, pending
+  an Apple developer account decision. Gatekeeper quarantines a browser-downloaded
+  copy; see the [README note](../README.md#quickstart). Verify it with cosign or
+  `gh attestation verify` as above -- that is the real check regardless.
+- **Container images.** GHCR image signing, provenance, and SBOMs are issue #62.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -7,6 +7,10 @@ root and pointing it at a cluster, so verify what you received before you run it
 This page is the reference. The [README quickstart](../README.md#quickstart) has
 the short copy-paste version for the default install path.
 
+These artifacts are produced by the release workflow, so they exist on every
+release published *after* v0.4.0. Nothing below works against v0.4.0 or earlier,
+which shipped bare binaries.
+
 ## What each release publishes
 
 | Asset | What it is |
@@ -36,7 +40,7 @@ Set the version you are installing and download the binary alongside the manifes
 and its signature:
 
 ```bash
-VERSION=v0.4.0
+VERSION=vX.Y.Z          # the release you are installing
 REPO=curie-eng/agentos
 ASSET=agentos-x86_64-unknown-linux-gnu   # macOS: agentos-aarch64-apple-darwin
 BASE="https://github.com/$REPO/releases/download/$VERSION"
@@ -114,13 +118,14 @@ Each asset ships an SPDX 2.3 SBOM at `<asset>.spdx.json`, covered by
 `checksums.txt` like any other file, so verify it the same way before trusting
 it:
 
-- **CLI binaries** -- cataloged from the `cli` source tree, so the SBOM is the
-  full crate dependency graph that `Cargo.lock` pins. This is the one to feed to
-  a vulnerability scanner.
+- **CLI binaries** -- cataloged from `cli/Cargo.lock`, so the SBOM is the full
+  crate dependency graph the build pinned. This is the one to feed to a
+  vulnerability scanner.
 - **Chart and compose** -- these are deployment manifests with no dependencies of
-  their own; their SBOMs inventory the packaged artifact itself. The dependency
-  graph of what they deploy belongs to the `agentos-*` container images, which
-  carry their own SBOMs (issue #62).
+  their own, so their SBOMs inventory the packaged artifact itself and little
+  else. The dependency graph of what they deploy belongs to the `agentos-*`
+  container images, and those do **not** carry SBOMs or provenance yet: that is
+  issue #62, still open. Do not read a verified chart as a verified stack.
 
 Scan one with any SPDX-aware tool, for example
 [grype](https://github.com/anchore/grype):
@@ -137,14 +142,22 @@ The release fails, before and after publishing.
 means. `.github/workflows/release.yaml` calls it twice: once before signing, to
 refuse to build a checksum manifest over an incomplete asset set (signing an
 incomplete manifest would launder the gap into a valid signature), and once
-after publishing, in the `verify-release` job, which re-downloads the release and
-re-runs the whole documented path -- checksums, cosign, and `gh attestation
-verify` -- against the bytes users will actually get.
+against the published bytes.
 
-The check is closed-world: every file in the release must be a known asset, an
-SBOM for one, or the manifest and its signature. A new asset added to the release
-without an SBOM fails the gate rather than shipping unattested. When it fires,
-add SBOM generation to the job that builds the asset -- do not widen the gate.
+The release is created as a **draft**, whose assets are not publicly
+downloadable. The `verify-and-publish` job then re-downloads it and re-runs the
+whole documented path -- checksums, cosign, and `gh attestation verify` -- and
+only promotes the draft to a published release if all of it passes. Publication
+is the consequence of verification, so an unverifiable release never reaches
+anyone.
+
+The check is closed-world: every file in the release must be an asset
+`release/integrity.py` declares, a usable SBOM for one of them, or the manifest
+and its signature. Anything else fails, including a stray file that brought an
+SBOM along -- `files: dist/*` publishes whatever is staged, so the declared list
+is what stops an unreviewed artifact from being signed and shipped. Adding a
+release asset therefore means declaring it there and generating an SBOM for it,
+which is a reviewed edit rather than a side effect.
 
 ## Not covered yet
 

--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,7 @@ The point of the three targets (`skill` in-process, `local` via docker compose, 
 - [README.md#which-target-do-i-want](README.md#which-target-do-i-want): the target table, which of skill/local/cluster answers your question.
 - [cli/README.md](cli/README.md): the full `agentos` command reference across all three targets.
 - [docs/operations.md](docs/operations.md): the cluster runbook (credential model, Slack connect, zero-Slack message flow).
+- [docs/release-verification.md](docs/release-verification.md): verify a downloaded release asset (checksums, cosign signature, provenance, SBOMs) before running it.
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ testpaths = [
     "apps/worker/tests",
     "runner/tests",
     "compose/tests",
+    "release/tests",
     "examples/tests",
     "tools/doclint/tests",
     # Only the offline harness unit tests -- NOT the whole tree: the cluster

--- a/release/integrity.py
+++ b/release/integrity.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Gate the integrity artifacts of a release dist directory (issue #629).
+
+A GitHub release publishes CLI binaries, a Helm chart, and a compose file. A user
+who downloads one has no way to tell what they received unless every asset is
+covered by a checksum, a signature over that checksum manifest, provenance tied to
+the release commit, and an SBOM. This script is the deterministic check that the
+coverage is actually complete, and it is the only place that decides what
+"complete" means. `.github/workflows/release.yaml` calls it twice:
+
+  manifest  Before publishing: refuse to build checksums.txt over an incomplete
+            dist, then write it. Signing an incomplete manifest would launder a
+            gap into an attestation, so the gate runs BEFORE cosign, not after.
+
+  verify    After publishing: re-download the release and re-check it, so the
+            published bytes -- not the ones we hoped we uploaded -- are what the
+            gate passed. Signature and provenance verification (cosign
+            verify-blob, gh attestation verify) run alongside it in the workflow;
+            those need the network and a trust root, so they stay there.
+
+The check is CLOSED-WORLD by design. Requiring only the assets we know about today
+would mean the next asset someone adds to the release ships uncovered while the
+gate still reports green. So every file in dist must be accounted for: a
+recognized asset, an SBOM for one, or the manifest and its signature. Anything
+else fails.
+
+Fails loud: this runs unattended at publish time, where a silent pass ships an
+unverifiable artifact.
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+CHECKSUM_FILE = "checksums.txt"
+SIGNATURE_FILE = "checksums.txt.sigstore.json"
+SBOM_SUFFIX = ".spdx.json"
+
+# The CLI targets built by the `cli-binaries` job. Keep in lockstep with its matrix.
+BINARY_ASSETS = (
+    "agentos-x86_64-unknown-linux-gnu",
+    "agentos-aarch64-apple-darwin",
+)
+COMPOSE_ASSET = "compose.release.yaml"
+
+
+class IntegrityError(Exception):
+    """A release asset is missing, uncovered, or does not match its checksum."""
+
+
+def chart_asset(version: str) -> str:
+    """The chart tgz `helm package --version <version>` produces."""
+    return f"agentos-{version}.tgz"
+
+
+def required_assets(version: str) -> list[str]:
+    """Every asset the release must publish, in a stable order."""
+    return [*BINARY_ASSETS, chart_asset(version), COMPOSE_ASSET]
+
+
+def _is_integrity_artifact(name: str) -> bool:
+    return name in (CHECKSUM_FILE, SIGNATURE_FILE) or name.endswith(SBOM_SUFFIX)
+
+
+def assets_in(dist: Path) -> list[str]:
+    """Every file in dist that is a release asset rather than an artifact about one."""
+    return sorted(
+        p.name for p in dist.iterdir() if p.is_file() and not _is_integrity_artifact(p.name)
+    )
+
+
+def _check_required_present(dist: Path, version: str) -> None:
+    missing = [name for name in required_assets(version) if not (dist / name).is_file()]
+    if missing:
+        raise IntegrityError(
+            f"release asset(s) missing from {dist}: {', '.join(missing)}. "
+            "The release must not publish a partial asset set."
+        )
+
+
+def _check_sbom_coverage(dist: Path) -> None:
+    """Every asset -- known or not -- carries a parseable, non-empty SBOM."""
+    for name in assets_in(dist):
+        sbom = dist / f"{name}{SBOM_SUFFIX}"
+        if not sbom.is_file():
+            raise IntegrityError(
+                f"no SBOM for release asset '{name}': expected {sbom.name}. "
+                "Every published asset needs a dependency inventory (#629); add one "
+                "in the job that builds the asset."
+            )
+        raw = sbom.read_text().strip()
+        if not raw:
+            raise IntegrityError(f"SBOM {sbom.name} is empty; the generator produced nothing.")
+        try:
+            json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise IntegrityError(f"SBOM {sbom.name} is not valid JSON: {exc}") from exc
+
+
+def sha256_of(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def manifest_entries(dist: Path) -> list[str]:
+    """Files the checksum manifest covers: everything but the manifest and its signature."""
+    skip = (CHECKSUM_FILE, SIGNATURE_FILE)
+    return sorted(p.name for p in dist.iterdir() if p.is_file() and p.name not in skip)
+
+
+def build_manifest(dist: Path, version: str) -> str:
+    """Return checksums.txt content for a complete dist, or raise IntegrityError.
+
+    The format is coreutils `sha256sum` output ("<hex>  <name>"), because the
+    documented verification step is `sha256sum --check checksums.txt`.
+    """
+    _check_required_present(dist, version)
+    _check_sbom_coverage(dist)
+    lines = [f"{sha256_of(dist / name)}  {name}" for name in manifest_entries(dist)]
+    return "".join(f"{line}\n" for line in lines)
+
+
+def parse_manifest(text: str) -> dict[str, str]:
+    listed: dict[str, str] = {}
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        digest, _, name = line.partition("  ")
+        if not name:
+            raise IntegrityError(f"{CHECKSUM_FILE} line {lineno} is not sha256sum format: {line!r}")
+        listed[name] = digest
+    return listed
+
+
+def verify(dist: Path, version: str) -> None:
+    """Re-check a published dist end to end, raising IntegrityError on any gap."""
+    _check_required_present(dist, version)
+    _check_sbom_coverage(dist)
+
+    manifest = dist / CHECKSUM_FILE
+    if not manifest.is_file():
+        raise IntegrityError(f"{CHECKSUM_FILE} was not published with the release.")
+    if not (dist / SIGNATURE_FILE).is_file():
+        raise IntegrityError(
+            f"{SIGNATURE_FILE} was not published: the checksum manifest carries no "
+            "cosign signature, so nothing binds it to this workflow."
+        )
+
+    listed = parse_manifest(manifest.read_text())
+    present = set(manifest_entries(dist))
+
+    unlisted = sorted(present - set(listed))
+    if unlisted:
+        raise IntegrityError(
+            f"file(s) published but not listed in {CHECKSUM_FILE}: {', '.join(unlisted)}. "
+            "An unlisted file is outside the signature."
+        )
+    undelivered = sorted(set(listed) - present)
+    if undelivered:
+        raise IntegrityError(
+            f"file(s) listed in {CHECKSUM_FILE} but not published: {', '.join(undelivered)}."
+        )
+
+    for name, expected in sorted(listed.items()):
+        actual = sha256_of(dist / name)
+        if actual != expected:
+            raise IntegrityError(
+                f"sha256 mismatch for '{name}': manifest says {expected}, file is {actual}."
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="action", required=True)
+    for name, help_text in (
+        ("manifest", f"gate the dist, then write {CHECKSUM_FILE}"),
+        ("verify", "re-check a published dist against its manifest"),
+    ):
+        action = sub.add_parser(name, help=help_text)
+        action.add_argument(
+            "--dist", type=Path, default=Path("dist"), help="release dist directory"
+        )
+        action.add_argument(
+            "--version", required=True, help="release version, without the leading v"
+        )
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.action == "manifest":
+            text = build_manifest(args.dist, args.version)
+            (args.dist / CHECKSUM_FILE).write_text(text)
+            print(f"OK: {len(text.splitlines())} file(s) covered by {CHECKSUM_FILE}")
+        else:
+            verify(args.dist, args.version)
+            print("OK: every published asset is checksummed, signed, and has an SBOM")
+    except IntegrityError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/release/integrity.py
+++ b/release/integrity.py
@@ -80,9 +80,54 @@ def _check_required_present(dist: Path, version: str) -> None:
         )
 
 
+def _check_sbom_is_usable(sbom: Path) -> None:
+    """An SBOM must actually be an SPDX document that inventories something.
+
+    Presence is too weak a check: a generator that degrades to `{}` or to a
+    zero-package document still writes a file, and the gate would call that
+    covered while the SBOM says nothing at all.
+    """
+    raw = sbom.read_text().strip()
+    if not raw:
+        raise IntegrityError(f"SBOM {sbom.name} is empty; the generator produced nothing.")
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise IntegrityError(f"SBOM {sbom.name} is not valid JSON: {exc}") from exc
+    if not isinstance(doc, dict) or "spdxVersion" not in doc:
+        raise IntegrityError(f"SBOM {sbom.name} is not an SPDX document (no spdxVersion).")
+    if not doc.get("packages"):
+        raise IntegrityError(
+            f"SBOM {sbom.name} lists no packages; it inventories nothing. "
+            "Check what the generator was pointed at."
+        )
+
+
+def _check_no_undeclared_assets(dist: Path, version: str) -> None:
+    """Nothing gets published that this file does not name.
+
+    `files: dist/*` publishes whatever is in dist, and the steps above sign and
+    attest it. So a stray file -- a leftover build artifact, or anything a
+    compromised step drops in -- would otherwise ship signed and attested purely
+    because it brought an SBOM along. Declaring the release set here means adding
+    an asset is a reviewed edit to this list, not a side effect of a job writing
+    to dist.
+    """
+    declared = set(required_assets(version))
+    undeclared = [name for name in assets_in(dist) if name not in declared]
+    if undeclared:
+        raise IntegrityError(
+            f"file(s) staged for release but not declared in {Path(__file__).name}: "
+            f"{', '.join(undeclared)}. If this is a new release asset, add it to "
+            "required_assets() and generate an SBOM for it; if it is not, keep it "
+            "out of dist."
+        )
+
+
 def _check_sbom_coverage(dist: Path) -> None:
-    """Every asset -- known or not -- carries a parseable, non-empty SBOM."""
-    for name in assets_in(dist):
+    """Every asset carries a usable SBOM, and every SBOM belongs to an asset."""
+    assets = assets_in(dist)
+    for name in assets:
         sbom = dist / f"{name}{SBOM_SUFFIX}"
         if not sbom.is_file():
             raise IntegrityError(
@@ -90,13 +135,18 @@ def _check_sbom_coverage(dist: Path) -> None:
                 "Every published asset needs a dependency inventory (#629); add one "
                 "in the job that builds the asset."
             )
-        raw = sbom.read_text().strip()
-        if not raw:
-            raise IntegrityError(f"SBOM {sbom.name} is empty; the generator produced nothing.")
-        try:
-            json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise IntegrityError(f"SBOM {sbom.name} is not valid JSON: {exc}") from exc
+        _check_sbom_is_usable(sbom)
+
+    # An SBOM naming an asset that is not here means the asset went missing or the
+    # SBOM is misnamed; either way the release is not what it claims to be.
+    for path in sorted(dist.iterdir()):
+        if not path.name.endswith(SBOM_SUFFIX):
+            continue
+        subject = path.name[: -len(SBOM_SUFFIX)]
+        if subject not in assets:
+            raise IntegrityError(
+                f"SBOM {path.name} describes '{subject}', which is not in the release."
+            )
 
 
 def sha256_of(path: Path) -> str:
@@ -120,6 +170,7 @@ def build_manifest(dist: Path, version: str) -> str:
     documented verification step is `sha256sum --check checksums.txt`.
     """
     _check_required_present(dist, version)
+    _check_no_undeclared_assets(dist, version)
     _check_sbom_coverage(dist)
     lines = [f"{sha256_of(dist / name)}  {name}" for name in manifest_entries(dist)]
     return "".join(f"{line}\n" for line in lines)
@@ -140,6 +191,7 @@ def parse_manifest(text: str) -> dict[str, str]:
 def verify(dist: Path, version: str) -> None:
     """Re-check a published dist end to end, raising IntegrityError on any gap."""
     _check_required_present(dist, version)
+    _check_no_undeclared_assets(dist, version)
     _check_sbom_coverage(dist)
 
     manifest = dist / CHECKSUM_FILE

--- a/release/tests/test_integrity.py
+++ b/release/tests/test_integrity.py
@@ -145,13 +145,23 @@ class TestBuildManifest:
         with pytest.raises(integrity.IntegrityError, match="SBOM"):
             integrity.build_manifest(dist, VERSION)
 
-    def test_refuses_when_an_unrecognized_asset_has_no_sbom(self, tmp_path):
+    def test_refuses_an_undeclared_asset(self, tmp_path):
         # The closed-world clause: a NEW asset someone adds to the release must be
-        # covered too, or the gate silently stops meaning anything.
+        # declared here too, or the gate silently stops meaning anything.
         dist = make_dist(tmp_path)
         (dist / "agentos-installer.sh").write_bytes(b"#!/bin/sh\n")
 
         with pytest.raises(integrity.IntegrityError, match="agentos-installer.sh"):
+            integrity.build_manifest(dist, VERSION)
+
+    def test_refuses_an_undeclared_asset_even_when_it_brings_an_sbom(self, tmp_path):
+        # `files: dist/*` publishes whatever is staged, so a stray file must not be
+        # able to buy its way into a signed release just by carrying an SBOM.
+        dist = make_dist(tmp_path)
+        (dist / "agentos-backdoor").write_bytes(b"pwned")
+        write_sbom(dist / "agentos-backdoor.spdx.json", "agentos-backdoor")
+
+        with pytest.raises(integrity.IntegrityError, match="not declared"):
             integrity.build_manifest(dist, VERSION)
 
     def test_refuses_an_empty_sbom(self, tmp_path):
@@ -166,6 +176,33 @@ class TestBuildManifest:
         (dist / f"{CHART}.spdx.json").write_text("<html>404: not found</html>")
 
         with pytest.raises(integrity.IntegrityError, match="SBOM"):
+            integrity.build_manifest(dist, VERSION)
+
+    def test_refuses_an_sbom_that_is_valid_json_but_not_an_sbom(self, tmp_path):
+        # `{}` parses. A generator that silently degrades to an empty document
+        # would otherwise satisfy the gate while inventorying nothing.
+        dist = make_dist(tmp_path)
+        (dist / f"{CHART}.spdx.json").write_text("{}")
+
+        with pytest.raises(integrity.IntegrityError, match="SPDX"):
+            integrity.build_manifest(dist, VERSION)
+
+    def test_refuses_an_sbom_that_inventories_nothing(self, tmp_path):
+        dist = make_dist(tmp_path)
+        (dist / f"{CHART}.spdx.json").write_text(
+            json.dumps({"spdxVersion": "SPDX-2.3", "packages": []})
+        )
+
+        with pytest.raises(integrity.IntegrityError, match="no packages"):
+            integrity.build_manifest(dist, VERSION)
+
+    def test_refuses_an_sbom_with_no_asset(self, tmp_path):
+        # The closed-world rule is "an SBOM *for one*": an orphan SBOM means either
+        # an asset went missing or the SBOM is misnamed. Both are release bugs.
+        dist = make_dist(tmp_path)
+        write_sbom(dist / "ghost-asset.spdx.json", "ghost-asset")
+
+        with pytest.raises(integrity.IntegrityError, match="ghost-asset"):
             integrity.build_manifest(dist, VERSION)
 
 
@@ -196,11 +233,14 @@ class TestVerify:
         with pytest.raises(integrity.IntegrityError, match="sha256 mismatch"):
             integrity.verify(dist, VERSION)
 
-    def test_rejects_an_asset_absent_from_the_manifest(self, tmp_path):
+    def test_rejects_a_file_the_manifest_does_not_list(self, tmp_path):
+        # A declared asset published outside the signature: the manifest was built
+        # over a smaller dist than the one shipped, so the signature says nothing
+        # about this file.
         dist = seal(make_dist(tmp_path))
-        # Signed manifest, but an extra unsigned file rides along in the release.
-        (dist / "agentos-extra-tool").write_bytes(b"surprise")
-        write_sbom(dist / "agentos-extra-tool.spdx.json", "agentos-extra-tool")
+        manifest = dist / "checksums.txt"
+        kept = [ln for ln in manifest.read_text().splitlines() if not ln.endswith(f"  {COMPOSE}")]
+        manifest.write_text("".join(f"{ln}\n" for ln in kept))
 
         with pytest.raises(integrity.IntegrityError, match="not listed"):
             integrity.verify(dist, VERSION)

--- a/release/tests/test_integrity.py
+++ b/release/tests/test_integrity.py
@@ -1,0 +1,254 @@
+"""Contract tests for the release integrity gate (release/integrity.py).
+
+The gate is the deterministic check behind issue #629: a release must not publish
+an asset that lacks a checksum, a signature, provenance, or an SBOM. These tests
+drive the two entry points the release workflow calls -- `manifest` (build
+checksums.txt, refusing to build one over an incomplete dist) and `verify`
+(re-check a published dist) -- against synthetic dist directories.
+
+The gate is deliberately CLOSED-WORLD: it is not enough that the assets we know
+about today are covered. Any *unrecognized* file that lands in dist must also be
+covered, so adding a new release asset without its SBOM fails the release instead
+of shipping an unattested artifact.
+"""
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "release" / "integrity.py"
+
+VERSION = "1.2.3"
+BINARIES = ("agentos-x86_64-unknown-linux-gnu", "agentos-aarch64-apple-darwin")
+CHART = f"agentos-{VERSION}.tgz"
+COMPOSE = "compose.release.yaml"
+ASSETS = (*BINARIES, CHART, COMPOSE)
+
+
+def load_module():
+    """Import the standalone script by path (release/ is not on sys.path)."""
+    spec = importlib.util.spec_from_file_location("release_integrity", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+integrity = load_module()
+
+
+def write_sbom(path: Path, subject: str) -> None:
+    """Write a minimal but structurally valid SPDX document for `subject`."""
+    path.write_text(
+        json.dumps(
+            {
+                "spdxVersion": "SPDX-2.3",
+                "name": subject,
+                "SPDXID": "SPDXRef-DOCUMENT",
+                "packages": [{"name": "example-dep", "SPDXID": "SPDXRef-Package-0"}],
+            }
+        )
+    )
+
+
+def make_dist(tmp_path: Path, assets=ASSETS, sboms=None) -> Path:
+    """Build a dist dir holding `assets` plus an SBOM for each of `sboms`."""
+    dist = tmp_path / "dist"
+    dist.mkdir(exist_ok=True)
+    for name in assets:
+        (dist / name).write_bytes(f"contents of {name}".encode())
+    for name in ASSETS if sboms is None else sboms:
+        write_sbom(dist / f"{name}.spdx.json", name)
+    return dist
+
+
+def sign(dist: Path) -> None:
+    """Stand in for the cosign keyless bundle the workflow writes next to the manifest."""
+    (dist / "checksums.txt.sigstore.json").write_text(json.dumps({"mediaType": "example"}))
+
+
+def seal(dist: Path, version: str = VERSION) -> Path:
+    """Complete, signed dist: the state `verify` must accept."""
+    (dist / "checksums.txt").write_text(integrity.build_manifest(dist, version))
+    sign(dist)
+    return dist
+
+
+class TestBuildManifest:
+    def test_covers_every_file_including_the_sboms(self, tmp_path):
+        dist = make_dist(tmp_path)
+
+        manifest = integrity.build_manifest(dist, VERSION)
+
+        listed = {line.split("  ", 1)[1] for line in manifest.splitlines()}
+        assert listed == {p.name for p in dist.iterdir()}
+        # The SBOMs are assets in their own right: an unsigned SBOM is a tampering
+        # surface, so they must be inside the signed manifest too.
+        assert f"{CHART}.spdx.json" in listed
+
+    def test_lines_are_sha256sum_check_compatible(self, tmp_path):
+        dist = make_dist(tmp_path)
+
+        (dist / "checksums.txt").write_text(integrity.build_manifest(dist, VERSION))
+
+        # The documented verification command is `sha256sum --check checksums.txt`;
+        # if our format drifts from coreutils', the docs lie.
+        done = subprocess.run(
+            ["sha256sum", "--check", "--strict", "checksums.txt"],
+            cwd=dist,
+            capture_output=True,
+            text=True,
+        )
+        assert done.returncode == 0, done.stdout + done.stderr
+
+    def test_hashes_are_the_real_digests(self, tmp_path):
+        dist = make_dist(tmp_path)
+
+        manifest = integrity.build_manifest(dist, VERSION)
+
+        expected = hashlib.sha256((dist / COMPOSE).read_bytes()).hexdigest()
+        assert f"{expected}  {COMPOSE}" in manifest.splitlines()
+
+    def test_is_deterministic_and_sorted(self, tmp_path):
+        dist = make_dist(tmp_path)
+
+        manifest = integrity.build_manifest(dist, VERSION)
+
+        names = [line.split("  ", 1)[1] for line in manifest.splitlines()]
+        assert names == sorted(names)
+        assert manifest == integrity.build_manifest(dist, VERSION)
+
+    @pytest.mark.parametrize("missing", ASSETS)
+    def test_refuses_to_build_over_a_missing_required_asset(self, tmp_path, missing):
+        dist = make_dist(tmp_path, assets=[a for a in ASSETS if a != missing])
+
+        with pytest.raises(integrity.IntegrityError, match=missing):
+            integrity.build_manifest(dist, VERSION)
+
+    def test_rejects_a_chart_packaged_at_the_wrong_version(self, tmp_path):
+        dist = make_dist(tmp_path, assets=(*BINARIES, "agentos-9.9.9.tgz", COMPOSE))
+
+        # A stale chart tgz would otherwise sail through: it matches agentos-*.tgz.
+        with pytest.raises(integrity.IntegrityError, match=CHART):
+            integrity.build_manifest(dist, VERSION)
+
+    @pytest.mark.parametrize("uncovered", ASSETS)
+    def test_refuses_when_a_known_asset_has_no_sbom(self, tmp_path, uncovered):
+        dist = make_dist(tmp_path, sboms=[a for a in ASSETS if a != uncovered])
+
+        with pytest.raises(integrity.IntegrityError, match="SBOM"):
+            integrity.build_manifest(dist, VERSION)
+
+    def test_refuses_when_an_unrecognized_asset_has_no_sbom(self, tmp_path):
+        # The closed-world clause: a NEW asset someone adds to the release must be
+        # covered too, or the gate silently stops meaning anything.
+        dist = make_dist(tmp_path)
+        (dist / "agentos-installer.sh").write_bytes(b"#!/bin/sh\n")
+
+        with pytest.raises(integrity.IntegrityError, match="agentos-installer.sh"):
+            integrity.build_manifest(dist, VERSION)
+
+    def test_refuses_an_empty_sbom(self, tmp_path):
+        dist = make_dist(tmp_path)
+        (dist / f"{COMPOSE}.spdx.json").write_text("")
+
+        with pytest.raises(integrity.IntegrityError, match="SBOM"):
+            integrity.build_manifest(dist, VERSION)
+
+    def test_refuses_an_sbom_that_is_not_valid_json(self, tmp_path):
+        dist = make_dist(tmp_path)
+        (dist / f"{CHART}.spdx.json").write_text("<html>404: not found</html>")
+
+        with pytest.raises(integrity.IntegrityError, match="SBOM"):
+            integrity.build_manifest(dist, VERSION)
+
+
+class TestVerify:
+    def test_accepts_a_complete_signed_dist(self, tmp_path):
+        dist = seal(make_dist(tmp_path))
+
+        integrity.verify(dist, VERSION)  # does not raise
+
+    def test_rejects_a_missing_checksum_manifest(self, tmp_path):
+        dist = seal(make_dist(tmp_path))
+        (dist / "checksums.txt").unlink()
+
+        with pytest.raises(integrity.IntegrityError, match="checksums.txt"):
+            integrity.verify(dist, VERSION)
+
+    def test_rejects_a_missing_signature(self, tmp_path):
+        dist = seal(make_dist(tmp_path))
+        (dist / "checksums.txt.sigstore.json").unlink()
+
+        with pytest.raises(integrity.IntegrityError, match="sigstore"):
+            integrity.verify(dist, VERSION)
+
+    def test_rejects_a_tampered_asset(self, tmp_path):
+        dist = seal(make_dist(tmp_path))
+        (dist / COMPOSE).write_bytes(b"image: evil/backdoor:latest")
+
+        with pytest.raises(integrity.IntegrityError, match="sha256 mismatch"):
+            integrity.verify(dist, VERSION)
+
+    def test_rejects_an_asset_absent_from_the_manifest(self, tmp_path):
+        dist = seal(make_dist(tmp_path))
+        # Signed manifest, but an extra unsigned file rides along in the release.
+        (dist / "agentos-extra-tool").write_bytes(b"surprise")
+        write_sbom(dist / "agentos-extra-tool.spdx.json", "agentos-extra-tool")
+
+        with pytest.raises(integrity.IntegrityError, match="not listed"):
+            integrity.verify(dist, VERSION)
+
+    def test_rejects_an_asset_listed_but_not_delivered(self, tmp_path):
+        dist = seal(make_dist(tmp_path))
+        (dist / BINARIES[1]).unlink()
+
+        with pytest.raises(integrity.IntegrityError, match=BINARIES[1]):
+            integrity.verify(dist, VERSION)
+
+
+class TestCli:
+    def run(self, *args):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args], capture_output=True, text=True
+        )
+
+    def test_manifest_writes_the_file_and_exits_zero(self, tmp_path):
+        dist = make_dist(tmp_path)
+
+        done = self.run("manifest", "--dist", str(dist), "--version", VERSION)
+
+        assert done.returncode == 0, done.stderr
+        assert (dist / "checksums.txt").read_text() == integrity.build_manifest(dist, VERSION)
+
+    def test_manifest_exits_nonzero_and_writes_nothing_when_incomplete(self, tmp_path):
+        dist = make_dist(tmp_path, assets=BINARIES)
+
+        done = self.run("manifest", "--dist", str(dist), "--version", VERSION)
+
+        assert done.returncode == 1
+        assert COMPOSE in done.stderr
+        # A half-written manifest is worse than none: it would be signed as truth.
+        assert not (dist / "checksums.txt").exists()
+
+    def test_verify_exits_zero_on_a_complete_dist(self, tmp_path):
+        dist = seal(make_dist(tmp_path))
+
+        done = self.run("verify", "--dist", str(dist), "--version", VERSION)
+
+        assert done.returncode == 0, done.stderr
+
+    def test_verify_exits_nonzero_on_a_missing_integrity_artifact(self, tmp_path):
+        dist = seal(make_dist(tmp_path))
+        (dist / f"{BINARIES[0]}.spdx.json").unlink()
+
+        done = self.run("verify", "--dist", str(dist), "--version", VERSION)
+
+        assert done.returncode == 1
+        assert "SBOM" in done.stderr


### PR DESCRIPTION
A release published CLI binaries, a Helm chart, and `compose.release.yaml` with nothing to verify them by, while the documented install path downloaded a binary, installed it as root, and pointed it at a cluster. Every asset now carries a checksum, a signature, provenance, and an SBOM, and the docs verify before executing.

**The trust chain.** `checksums.txt` covers every file; keyless cosign signs it; SLSA provenance is attested over every file in `dist`, binding each to this repo, this workflow, and the release commit. One signature over the manifest rather than one per asset: the chain already closes, and the docs stay one procedure. `docs/adr/0050` records the decision and the alternatives.

**The gate.** `release/integrity.py` is the single definition of "covered" and runs twice. Before signing, it refuses to build a manifest over an incomplete dist, since cosign would otherwise launder the gap into a valid signature. After publishing, it re-checks the real downloaded bytes. It is closed-world: every file must be a declared asset, a usable SBOM for one, or the manifest and its signature.

**Publication is the consequence of verification.** The release is created as a draft, whose assets are not publicly downloadable, and `verify-and-publish` promotes it only after checksums, `cosign verify-blob`, and `gh attestation verify` all pass against the published bytes. Publishing first would mean an unverifiable release was already installed and marked latest by the time the workflow went red, with no rollback.

**Reviewers.** Codex plus three agents ran against the diff, and two findings are worth calling out because neither was theoretical:
- A re-run of an already-published tag bypassed the draft gate entirely: `action-gh-release` honors `draft:` only on creation and otherwise adopts the existing release's state. Every release here is `draft=false`, so this was reachable today. The workflow now refuses to re-release a published tag.
- The README pinned `v0.4.0`, which predates all of this and 404s on both integrity URLs, so the documented install path would have failed for every user.
- The guard added for the first point then failed open itself: `|| echo absent` treated every `gh` error as "no such release", so a 5xx against a published tag would have staged a draft anyway. It now refuses on an indeterminate state.

Known gap left open deliberately: two runs against a force-pushed tag are not serialized. The only correct scope is workflow-level `concurrency`, since a job-level group spanning `release` and `verify-and-publish` would deadlock on their `needs:` edge, and that would also serialize the main-push image builds. That is a cadence change worth deciding separately; ADR-0050 records it.

**Verified locally** beyond the 30 unit tests: the gate was rehearsed end to end against a real `helm package` chart, a real generated compose file, and real syft SBOMs; all four AC5 failure modes were driven to a non-zero exit; the guard's shell was executed against a stub `gh` in all three tag states; and `sha256sum --check --ignore-missing` was confirmed to exit 1 on tampering (and on downloading nothing).

Assumptions taken as reasonable defaults, all recorded in ADR-0050: the chart and compose SBOMs inventory the packaged artifact itself, since their images' dependency graph belongs to #62 (open, so the docs say plainly that a verified chart is not a verified stack); the version in the verification snippets is a `vX.Y.Z` placeholder, because the cosign identity must name the exact tag and a hardcoded one goes stale every release; `release/integrity.py` is invoked directly rather than as an `agentos dev` subcommand, following `compose/generate_release_compose.py`, the existing release-time script in this same workflow.

Known gap, disclosed rather than closed: SHA-pinning `anchore/sbom-action` does not make the SBOM step hermetic, as it fetches syft's `install.sh` from `main` at run time. Apple signing and notarization stay deferred per the issue.

Closes #629
