### PR TITLE
Raise critical dead letter alerts

### DIFF
--- a/apps/worker/src/agentos_worker/dead_letter_alert.py
+++ b/apps/worker/src/agentos_worker/dead_letter_alert.py
@@ -1,0 +1,49 @@
+"""Emit a stable alert record when the consumer dead letters an entry."""
+
+from __future__ import annotations
+
+import logging
+
+_SOURCE_LOGGER = "agentos_worker.consumer"
+_ALERT_LOGGER = "agentos_worker.alerts.dead_letter"
+_DEAD_LETTER_MESSAGE = "dead-lettered entry %s after %d deliveries (reason=%s) -> %s"
+
+
+class _DeadLetterAlertHandler(logging.Handler):
+    """Translate the consumer's dead letter record into an alert signal."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            if (
+                record.name != _SOURCE_LOGGER
+                or record.levelno != logging.ERROR
+                or record.msg != _DEAD_LETTER_MESSAGE
+                or not isinstance(record.args, tuple)
+                or len(record.args) != 4
+            ):
+                return
+
+            entry_id, delivery_count, reason, dead_stream = record.args
+            _ = _DEAD_LETTER_MESSAGE % record.args
+            alert = (
+                f"event=agentos.dead_letter entry_id={entry_id} "
+                f"delivery_count={delivery_count} reason={reason} "
+                f"dead_stream={dead_stream}"
+            )
+            logging.getLogger(_ALERT_LOGGER).critical(alert)
+        except Exception:
+            return
+
+
+def install_dead_letter_alerting() -> None:
+    """Install dead letter alerting hooks."""
+
+    source_logger = logging.getLogger(_SOURCE_LOGGER)
+    if any(
+        isinstance(handler, _DeadLetterAlertHandler) for handler in source_logger.handlers
+    ):
+        return
+    source_logger.addHandler(_DeadLetterAlertHandler())
+
+
+__all__ = ["install_dead_letter_alerting"]

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -26,6 +26,7 @@ from .binding import BindingResolver
 from .bundle_store import BundleStore
 from .config import WorkerConfig
 from .consumer import Consumer
+from .dead_letter_alert import install_dead_letter_alerting
 from .eval import EvalReporter, EvalStreamConsumer, LangfuseEvalRecorder
 from .heartbeat import run_heartbeat
 from .kernel import Kernel
@@ -270,6 +271,7 @@ async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
 
 def main(env: Mapping[str, str] | None = None) -> None:
     logging.basicConfig(level=logging.INFO)
+    install_dead_letter_alerting()
     resolved = env if env is not None else os.environ
     config = WorkerConfig()
     asyncio.run(_run(config, resolved))

--- a/apps/worker/tests/kernel/test_consumer_dead_letter.py
+++ b/apps/worker/tests/kernel/test_consumer_dead_letter.py
@@ -45,6 +45,7 @@ from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus
 from agentos_dispatcher.queue import to_stream_fields
 from agentos_worker.config import WorkerConfig
 from agentos_worker.consumer import Consumer
+from agentos_worker.dead_letter_alert import install_dead_letter_alerting
 from pydantic import ValidationError
 
 DONE = SessionStatus.DONE
@@ -777,6 +778,135 @@ def test_dead_letter_is_logged_loudly_with_the_operational_facts(
                 await h.async_redis.delete(_dead_stream(h.config))
 
     asyncio.run(go())
+
+
+def test_dead_letter_emits_one_retention_independent_critical_alert(
+    make_harness,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    source_logger = logging.getLogger("agentos_worker.consumer")
+    original_handlers = list(source_logger.handlers)
+    original_propagate = source_logger.propagate
+    for handler in original_handlers:
+        source_logger.removeHandler(handler)
+    source_logger.propagate = False
+
+    async def go() -> None:
+        async with make_harness(max_delivery=2, reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            async def always_fails(qevent: QueuedTurn) -> None:
+                raise RuntimeError("simulated dead reply endpoint")
+
+            h.kernel.process_event = always_fails  # type: ignore[method-assign,assignment]
+
+            qe = _qevent("poison turn", thread="tdl-alert", event_id="poison-alert")
+            entry_id = await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+            dead = _dead_stream(h.config)
+
+            try:
+                assert await _deliver_new(consumer, h) == 1
+                await _reclaim_and_settle(consumer)
+                assert entry_id in await _pending_ids(h)
+                await _reclaim_and_settle(consumer)
+
+                assert await h.async_redis.delete(dead) == 1
+
+                alerts = [
+                    record
+                    for record in caplog.records
+                    if record.name == "agentos_worker.alerts.dead_letter"
+                    and record.levelno == logging.CRITICAL
+                ]
+                assert len(alerts) == 1, f"expected one dead letter alert, got {alerts}"
+                assert alerts[0].getMessage() == (
+                    f"event=agentos.dead_letter entry_id={entry_id} delivery_count=2 "
+                    f"reason=max delivery exceeded dead_stream={dead}"
+                )
+
+                caplog.clear()
+                source_logger.error("unrelated consumer error for entry %s", entry_id)
+                source_logger.error(
+                    "dead-lettered entry %s after %d deliveries reason=%s -> %s",
+                    entry_id,
+                    2,
+                    "max delivery exceeded",
+                    dead,
+                )
+                source_logger.error(
+                    "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
+                    entry_id,
+                    2,
+                    "max delivery exceeded",
+                )
+                assert not [
+                    record
+                    for record in caplog.records
+                    if record.name == "agentos_worker.alerts.dead_letter"
+                    and record.levelno == logging.CRITICAL
+                ]
+
+                caplog.clear()
+                child_logger = logging.getLogger("agentos_worker.consumer.child")
+                child_logger.error(
+                    "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
+                    entry_id,
+                    2,
+                    "max delivery exceeded",
+                    dead,
+                )
+                assert not [
+                    record
+                    for record in caplog.records
+                    if record.name == "agentos_worker.alerts.dead_letter"
+                    and record.levelno == logging.CRITICAL
+                ]
+
+                caplog.clear()
+                source_logger.critical(
+                    "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
+                    entry_id,
+                    2,
+                    "max delivery exceeded",
+                    dead,
+                )
+                assert not [
+                    record
+                    for record in caplog.records
+                    if record.name == "agentos_worker.alerts.dead_letter"
+                    and record.levelno == logging.CRITICAL
+                ]
+
+                caplog.clear()
+                source_logger.error(
+                    "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
+                    entry_id,
+                    "two",
+                    "max delivery exceeded",
+                    dead,
+                )
+                assert not [
+                    record
+                    for record in caplog.records
+                    if record.name == "agentos_worker.alerts.dead_letter"
+                    and record.levelno == logging.CRITICAL
+                ]
+            finally:
+                await h.async_redis.delete(dead)
+
+    caplog.clear()
+    try:
+        install_dead_letter_alerting()
+        install_dead_letter_alerting()
+        with caplog.at_level(logging.ERROR):
+            asyncio.run(go())
+    finally:
+        for handler in list(source_logger.handlers):
+            source_logger.removeHandler(handler)
+        for handler in original_handlers:
+            source_logger.addHandler(handler)
+        source_logger.propagate = original_propagate
 
 
 def test_max_delivery_below_the_floor_is_rejected() -> None:

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -7,11 +7,13 @@ AGENTOS_FAKE_MODEL must fail loudly instead of silently degrading to a fake.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import Any
 
 import pytest
 from agentos_worker.config import WorkerConfig
-from agentos_worker.run import _sandbox_client, _substrate_config
+from agentos_worker.run import _sandbox_client, _substrate_config, main
 from agentos_worker.sandbox import DockerSandboxClient, SubstrateConfig
 
 _SUB = SubstrateConfig(namespace="default", warm_pool="pool")
@@ -153,3 +155,51 @@ def test_sandbox_client_docker_prepulls_image(monkeypatch) -> None:
         _SUB,
     )
     assert len(calls) == 1
+
+
+def test_main_installs_dead_letter_alerting(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    source_logger = logging.getLogger("agentos_worker.consumer")
+    original_handlers = list(source_logger.handlers)
+    original_propagate = source_logger.propagate
+    for handler in original_handlers:
+        source_logger.removeHandler(handler)
+    source_logger.propagate = False
+
+    captured_coroutines: list[Any] = []
+
+    def capture_run(coroutine: Any) -> None:
+        captured_coroutines.append(coroutine)
+
+    monkeypatch.setattr(asyncio, "run", capture_run)
+    caplog.clear()
+
+    try:
+        with caplog.at_level(logging.ERROR):
+            main({})
+            source_logger.error(
+                "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
+                "1730000000000-0",
+                2,
+                "max delivery exceeded",
+                "agentos:runs:dead",
+            )
+
+        assert len(captured_coroutines) == 1
+        alerts = [
+            record
+            for record in caplog.records
+            if record.name == "agentos_worker.alerts.dead_letter"
+            and record.levelno == logging.CRITICAL
+        ]
+        assert len(alerts) == 1, f"expected one dead letter alert, got {alerts}"
+    finally:
+        for coroutine in captured_coroutines:
+            coroutine.close()
+        for handler in list(source_logger.handlers):
+            source_logger.removeHandler(handler)
+        for handler in original_handlers:
+            source_logger.addHandler(handler)
+        source_logger.propagate = original_propagate


### PR DESCRIPTION
Closes #531

Adds a log based alert signal because AgentOS has no metrics backend. Worker startup installs an outside kernel handler that turns the exact dead letter ERROR into one stable CRITICAL event=agentos.dead_letter record. The signal is emitted synchronously and does not depend on the capped graveyard row remaining available.