### PR TITLE
Make the fake model a plumbing fixture, not a subject under test

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1110,7 +1110,7 @@
         "type": "object"
       },
       "EvalCell": {
-        "description": "One cell of the eval matrix: a case's result on a version.\n\n``model`` is the model the result was produced under (the matrix's model\ndimension), or ``None`` when the recording run carried no model tag.",
+        "description": "One cell of the eval matrix: a case's result on a version.\n\n``model`` is the model the result was produced under (the matrix's model\ndimension), or ``None`` when the recording run carried no model tag.\n\n``plumbing_ok`` means the case ran to completion but no grader judged it (the\nfake-model tier, ADR-0055). It is a distinct status rather than a pass or a\nfail because it is neither: the fake answers from a canned script, so its cell\ncarries no comparative information and must never read as a green promotion\ngate.",
         "properties": {
           "model": {
             "anyOf": [
@@ -1127,6 +1127,7 @@
             "enum": [
               "pass",
               "fail",
+              "plumbing_ok",
               "missing"
             ],
             "title": "Status",
@@ -1228,7 +1229,7 @@
         "type": "object"
       },
       "EvalModelSummary": {
-        "description": "A per-model rollup across the suite: pass-rate and total cost.\n\nThe model dimension of the matrix (issue #255): the same suite run across\nmodels is sliceable here into ``passed/total`` pass-rate and summed\n``cost_usd`` per model, so BYO-model work can compare which models a use case\ntolerates and at what cost. ``cost_usd`` is ``None`` when no case under this\nmodel reported a cost (e.g. the fake-model path), rather than a misleading 0.",
+        "description": "A per-model rollup across the suite: pass-rate and total cost.\n\nThe model dimension of the matrix (issue #255): the same suite run across\nmodels is sliceable here into ``passed/total`` pass-rate and summed\n``cost_usd`` per model, so BYO-model work can compare which models a use case\ntolerates and at what cost. ``cost_usd`` is ``None`` when no case under this\nmodel reported a cost (e.g. the fake-model path), rather than a misleading 0.\n\n``plumbing`` counts the rows that ran but were never graded (ADR-0055). They\nare excluded from ``passed``/``total``: counted as passes the fake model reads\n100% and counted as fails it reads 0%, both fabricated. The count keeps those\nrows visible instead of silently dropping them, so a model whose only rows are\nplumbing still appears with ``total == 0``.",
         "properties": {
           "cost_usd": {
             "anyOf": [
@@ -1254,6 +1255,11 @@
           },
           "passed": {
             "title": "Passed",
+            "type": "integer"
+          },
+          "plumbing": {
+            "default": 0,
+            "title": "Plumbing",
             "type": "integer"
           },
           "total": {

--- a/apps/api/src/agentos_api/evals.py
+++ b/apps/api/src/agentos_api/evals.py
@@ -1,21 +1,51 @@
 """Eval matrix (K1): assemble the case-by-version grid from Langfuse.
 
 K1's recorder writes, per case, a trace tagged version:<sha> + suite:<name> whose
-metadata carries case_id and the pass/fail (mirrored by an eval_pass score). The
-matrix reads pass/fail straight off each suite trace's metadata -- scoping to the
-traces just fetched, rather than joining a globally-paginated scores query -- and
-pivots them into rows = cases, columns = the last N versions, cells =
-pass/fail/missing. Pure builder so the pivot is unit-testable off canned data.
+metadata carries case_id and the outcome (mirrored, for a graded case, by an
+eval_pass score). The matrix reads the outcome straight off each suite trace's
+metadata -- scoping to the traces just fetched, rather than joining a
+globally-paginated scores query -- and pivots them into rows = cases, columns =
+the last N versions, cells = pass/fail/plumbing_ok/missing. Pure builder so the
+pivot is unit-testable off canned data.
 """
 
 from typing import Any, Literal
 
 from .schemas import EvalCell, EvalMatrix, EvalMatrixRow, EvalModelSummary
 
-Status = Literal["pass", "fail", "missing"]
+Status = Literal["pass", "fail", "plumbing_ok", "missing"]
 
 _VERSION_TAG = "version:"
 _MODEL_TAG = "model:"
+_PLUMBING_OK = "plumbing_ok"
+
+
+def _outcome_of(trace: dict[str, Any]) -> Status:
+    """This trace's cell status, from ``outcome`` when present.
+
+    ``outcome`` is authoritative over ``passed``: a non-graded row derives
+    ``passed=None``, but reading ``passed`` first would render any stale or
+    fabricated True as a green cell -- exactly the false green the fake tier's
+    non-graded outcome exists to prevent. A pre-#606 trace carries no ``outcome``
+    key at all, so it falls back to ``passed`` and historical matrix data keeps
+    rendering with no migration.
+    """
+    metadata = trace.get("metadata") or {}
+    outcome = metadata.get("outcome")
+    if outcome == _PLUMBING_OK:
+        return "plumbing_ok"
+    if outcome == "pass":
+        return "pass"
+    if outcome == "fail":
+        return "fail"
+    passed = metadata.get("passed")
+    if passed is None:
+        return "missing"
+    return "pass" if passed else "fail"
+
+
+def _is_graded(trace: dict[str, Any]) -> bool:
+    return _outcome_of(trace) in ("pass", "fail")
 
 
 def _version_of(trace: dict[str, Any]) -> str | None:
@@ -56,6 +86,26 @@ def _cost_of(trace: dict[str, Any]) -> float | None:
     return None
 
 
+def _supersedes(
+    trace: dict[str, Any], current: dict[str, Any] | None, ts: str
+) -> bool:
+    """Should ``trace`` replace ``current`` in its cell?
+
+    Newest wins, with one exception: a graded result always beats a non-graded one
+    regardless of timestamp. The grid is a promotion/comparison surface and a
+    plumbing row carries zero comparative information, so re-running the sealed
+    fake loop after a real eval must not erase the real signal just by being newer.
+    A plumbing row only occupies a cell no graded run has claimed; it stays visible
+    either way via the per-model plumbing count.
+    """
+    if current is None:
+        return True
+    trace_graded, current_graded = _is_graded(trace), _is_graded(current)
+    if trace_graded != current_graded:
+        return trace_graded
+    return ts >= str(current.get("timestamp") or "")
+
+
 def build_matrix(
     traces: list[dict[str, Any]],
     suite: str,
@@ -77,12 +127,10 @@ def build_matrix(
             continue
         ts = str(trace.get("timestamp") or "")
         key = (version, case_id)
-        if key not in latest or ts >= str(latest[key].get("timestamp") or ""):
+        if _supersedes(trace, latest.get(key), ts):
             latest[key] = trace
         model_key = (version, case_id, _model_of(trace))
-        if model_key not in latest_by_model or ts >= str(
-            latest_by_model[model_key].get("timestamp") or ""
-        ):
+        if _supersedes(trace, latest_by_model.get(model_key), ts):
             latest_by_model[model_key] = trace
         if ts >= version_last_seen.get(version, ""):
             version_last_seen[version] = ts
@@ -100,10 +148,7 @@ def build_matrix(
         trace = latest.get((version, case))
         if trace is None:
             return "missing"
-        passed = (trace.get("metadata") or {}).get("passed")
-        if passed is None:
-            return "missing"
-        return "pass" if passed else "fail"
+        return _outcome_of(trace)
 
     rows = [
         EvalMatrixRow(
@@ -141,30 +186,43 @@ def _model_summaries(
     displayed grid) is what lets a same-version sweep across N models keep all N
     rows instead of collapsing to whichever recorded last (#526). Cost sums only
     the cases that reported one; a model with no cost anywhere stays ``None``.
+
+    A non-graded row (ADR-0055) never enters ``passed``/``total`` -- there is no
+    verdict to average -- and is counted under ``plumbing`` instead, so the rows
+    are surfaced rather than dropped. The exclusion is per row, not per model: a
+    model with real graded rows keeps its true pass-rate even when a plumbing row
+    shares its label.
     """
     passed: dict[str | None, int] = {}
     total: dict[str | None, int] = {}
+    plumbing: dict[str | None, int] = {}
     cost: dict[str | None, float | None] = {}
     for (version, _case, model), trace in latest_by_model.items():
         if version not in version_set:
             continue
-        meta_passed = (trace.get("metadata") or {}).get("passed")
-        if meta_passed is None:
+        status = _outcome_of(trace)
+        if status == "plumbing_ok":
+            plumbing[model] = plumbing.get(model, 0) + 1
+            continue
+        if status == "missing":
             continue
         total[model] = total.get(model, 0) + 1
-        passed[model] = passed.get(model, 0) + (1 if meta_passed else 0)
+        passed[model] = passed.get(model, 0) + (1 if status == "pass" else 0)
         case_cost = _cost_of(trace)
         if case_cost is not None:
             cost[model] = (cost.get(model) or 0.0) + case_cost
 
-    # Deterministic order: named models sorted, unlabelled (None) last.
-    keys = sorted(total, key=lambda m: (m is None, m or ""))
+    # Deterministic order: named models sorted, unlabelled (None) last. A model
+    # whose every row was plumbing has no `total` entry, so the keys are the union
+    # -- otherwise a fully sealed sweep would vanish from the rollup entirely.
+    keys = sorted(set(total) | set(plumbing), key=lambda m: (m is None, m or ""))
     return [
         EvalModelSummary(
             model=model,
             passed=passed.get(model, 0),
-            total=total[model],
+            total=total.get(model, 0),
             cost_usd=cost.get(model),
+            plumbing=plumbing.get(model, 0),
         )
         for model in keys
     ]

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -650,10 +650,16 @@ class EvalCell(BaseModel):
 
     ``model`` is the model the result was produced under (the matrix's model
     dimension), or ``None`` when the recording run carried no model tag.
+
+    ``plumbing_ok`` means the case ran to completion but no grader judged it (the
+    fake-model tier, ADR-0055). It is a distinct status rather than a pass or a
+    fail because it is neither: the fake answers from a canned script, so its cell
+    carries no comparative information and must never read as a green promotion
+    gate.
     """
 
     version: str
-    status: Literal["pass", "fail", "missing"]
+    status: Literal["pass", "fail", "plumbing_ok", "missing"]
     model: str | None = None
 
 
@@ -672,12 +678,19 @@ class EvalModelSummary(BaseModel):
     ``cost_usd`` per model, so BYO-model work can compare which models a use case
     tolerates and at what cost. ``cost_usd`` is ``None`` when no case under this
     model reported a cost (e.g. the fake-model path), rather than a misleading 0.
+
+    ``plumbing`` counts the rows that ran but were never graded (ADR-0055). They
+    are excluded from ``passed``/``total``: counted as passes the fake model reads
+    100% and counted as fails it reads 0%, both fabricated. The count keeps those
+    rows visible instead of silently dropping them, so a model whose only rows are
+    plumbing still appears with ``total == 0``.
     """
 
     model: str | None = None
     passed: int
     total: int
     cost_usd: float | None = None
+    plumbing: int = 0
 
     @property
     def pass_rate(self) -> float:

--- a/apps/api/tests/test_evals_integration.py
+++ b/apps/api/tests/test_evals_integration.py
@@ -14,7 +14,7 @@ from typing import Any
 import httpx
 import pytest
 from agentos_api.config import get_settings
-from agentos_worker.eval.models import EvalCaseResult, EvalRunResult
+from agentos_worker.eval.models import EvalCaseResult, EvalOutcome, EvalRunResult
 from agentos_worker.eval.recorder import LangfuseEvalRecorder
 
 
@@ -31,13 +31,17 @@ def _stack_up() -> bool:
 pytestmark = pytest.mark.skipif(not _stack_up(), reason="dev stack not reachable")
 
 
+def _outcome(passed: bool) -> EvalOutcome:
+    return EvalOutcome.PASS if passed else EvalOutcome.FAIL
+
+
 def _result(version: str, suite: str, c1: bool, c2: bool) -> EvalRunResult:
     return EvalRunResult(
         version=version,
         suite=suite,
         results=[
-            EvalCaseResult(case_id="c1", passed=c1, output="o", latency_ms=1.0),
-            EvalCaseResult(case_id="c2", passed=c2, output="o", latency_ms=1.0),
+            EvalCaseResult(case_id="c1", outcome=_outcome(c1), output="o", latency_ms=1.0),
+            EvalCaseResult(case_id="c2", outcome=_outcome(c2), output="o", latency_ms=1.0),
         ],
     )
 

--- a/apps/api/tests/test_evals_unit.py
+++ b/apps/api/tests/test_evals_unit.py
@@ -146,3 +146,137 @@ def test_cells_carry_model_and_unlabelled_runs_sort_last() -> None:
         "opus": None,
         None: None,
     }
+
+
+def _otrace(
+    tid: str,
+    version: str,
+    case: str,
+    ts: str,
+    outcome: str,
+    model: str | None = None,
+    passed: Any = ...,
+) -> dict[str, Any]:
+    """A trace as the recorder writes it post-#606: an ``outcome`` alongside the
+    derived ``passed``. ``passed`` can be forced to prove which one the grid reads."""
+    tags = ["eval", f"version:{version}", "suite:s"]
+    if model:
+        tags.append(f"model:{model}")
+    if outcome == "plumbing_ok":
+        tags.append("plumbing")
+    if passed is ...:
+        passed = None if outcome == "plumbing_ok" else outcome == "pass"
+    meta: dict[str, Any] = {
+        "version": version,
+        "case_id": case,
+        "outcome": outcome,
+        "passed": passed,
+        "model": model,
+    }
+    return {"id": tid, "timestamp": ts, "tags": tags, "metadata": meta}
+
+
+def test_a_plumbing_cell_is_never_a_pass() -> None:
+    """The fake tier asserts only that the turn completed, so its cell must be a
+    distinct non-graded status: readable as "ran, not judged", impossible to mistake
+    for a green promotion gate."""
+    traces = [
+        _otrace("p1", "shaA", "c1", "2026-07-01T00:00:00Z", "plumbing_ok", "fake-model"),
+        _otrace("g1", "shaA", "c2", "2026-07-01T00:00:00Z", "fail", "opus"),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    cells = {
+        (row.case_id, cell.version): cell.status for row in matrix.rows for cell in row.cells
+    }
+    assert cells[("c1", "shaA")] == "plumbing_ok"
+    assert cells[("c2", "shaA")] == "fail"
+
+
+def test_the_outcome_wins_over_a_stale_passed_and_legacy_traces_still_render() -> None:
+    """``outcome`` is authoritative: a trace whose ``passed`` says True but whose
+    outcome is non-graded must NOT render green (that is exactly the false green).
+    A pre-#606 trace with no outcome key at all keeps rendering off ``passed``, so
+    historical matrix data needs no migration."""
+    traces = [
+        _otrace(
+            "new",
+            "shaA",
+            "c1",
+            "2026-07-01T00:00:00Z",
+            "plumbing_ok",
+            "fake-model",
+            passed=True,
+        ),
+        _trace("legacy", "shaA", "c2", "2026-07-01T00:00:00Z", passed=True),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    cells = {
+        (row.case_id, cell.version): cell.status for row in matrix.rows for cell in row.cells
+    }
+    assert cells[("c1", "shaA")] == "plumbing_ok"  # not "pass"
+    assert cells[("c2", "shaA")] == "pass"
+
+
+def test_a_later_plumbing_run_does_not_erase_an_earlier_graded_result() -> None:
+    """The grid is a promotion/comparison surface and a plumbing row carries zero
+    comparative information, so it must not overwrite real signal just by being
+    newer (someone re-running the sealed fake loop after a real eval). A graded cell
+    beats a plumbing cell regardless of timestamp; newest-wins still applies within
+    the same kind."""
+    traces = [
+        _otrace("graded", "shaA", "c1", "2026-07-01T00:00:00Z", "pass", "opus"),
+        _otrace("plumb", "shaA", "c1", "2026-07-09T00:00:00Z", "plumbing_ok", "fake-model"),
+        # c2 has only a plumbing run, so there is no graded signal to protect.
+        _otrace("only", "shaA", "c2", "2026-07-09T00:00:00Z", "plumbing_ok", "fake-model"),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    cells = {
+        (row.case_id, cell.version): cell for row in matrix.rows for cell in row.cells
+    }
+    assert cells[("c1", "shaA")].status == "pass"
+    assert cells[("c1", "shaA")].model == "opus"  # the graded run's label, not the fake's
+    assert cells[("c2", "shaA")].status == "plumbing_ok"
+
+
+def test_plumbing_rows_are_surfaced_without_diluting_any_pass_rate() -> None:
+    """A sealed sweep's rows must never enter a pass-rate: with 2 plumbing rows
+    counted as passes the fake model reads 100%, counted as fails it reads 0% -- both
+    fabricated. They are excluded from passed/total and surfaced as their own count,
+    so the rows stay visible rather than silently dropped."""
+    traces = [
+        _otrace("o1", "shaA", "c1", "2026-07-01T00:00:00Z", "pass", "opus"),
+        _otrace("o2", "shaA", "c2", "2026-07-01T00:00:00Z", "fail", "opus"),
+        _otrace("f1", "shaB", "c1", "2026-07-02T00:00:00Z", "plumbing_ok", "fake-model"),
+        _otrace("f2", "shaB", "c2", "2026-07-02T00:00:00Z", "plumbing_ok", "fake-model"),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    summaries = {m.model: m for m in matrix.model_summaries}
+    assert summaries["opus"].passed == 1
+    assert summaries["opus"].total == 2
+    assert summaries["opus"].pass_rate == 0.5
+    assert summaries["opus"].plumbing == 0
+
+    fake = summaries["fake-model"]
+    assert fake.total == 0  # nothing was graded...
+    assert fake.passed == 0
+    assert fake.plumbing == 2  # ...but the rows are visible, not dropped
+
+
+def test_a_plumbing_row_does_not_dilute_its_own_model_pass_rate() -> None:
+    """The exclusion is per-row, not per-model: a model with real graded rows keeps
+    its true pass-rate even when a plumbing row shares the label."""
+    traces = [
+        _otrace("g1", "shaA", "c1", "2026-07-01T00:00:00Z", "pass", "opus"),
+        _otrace("p1", "shaA", "c2", "2026-07-01T00:00:00Z", "plumbing_ok", "opus"),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    opus = next(m for m in matrix.model_summaries if m.model == "opus")
+    assert opus.passed == 1
+    assert opus.total == 1  # the plumbing row is not a denominator
+    assert opus.pass_rate == 1.0
+    assert opus.plumbing == 1

--- a/apps/worker/src/agentos_worker/eval/__init__.py
+++ b/apps/worker/src/agentos_worker/eval/__init__.py
@@ -9,6 +9,7 @@ them. Run a Job with ``python -m agentos_worker.eval``.
 from .models import (
     EvalCase,
     EvalCaseResult,
+    EvalOutcome,
     EvalRunResult,
     EvalSuite,
     ExpectedStatus,
@@ -40,6 +41,7 @@ __all__ = [
     "EvalCase",
     "EvalCaseResult",
     "EvalJob",
+    "EvalOutcome",
     "EvalReport",
     "EvalReporter",
     "EvalRunResult",

--- a/apps/worker/src/agentos_worker/eval/models.py
+++ b/apps/worker/src/agentos_worker/eval/models.py
@@ -19,7 +19,14 @@ from __future__ import annotations
 import re
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    computed_field,
+    field_validator,
+)
 
 
 class GraderKind(StrEnum):
@@ -130,8 +137,31 @@ class EvalSuite(BaseModel):
     cases: list[EvalCase] = Field(min_length=1)
 
 
+class EvalOutcome(StrEnum):
+    """How a case's turn ended: graded pass/fail, or completed but never graded.
+
+    ``PLUMBING_OK`` is the fake tier's outcome (ADR-0055): the fake model is a
+    plumbing fixture, so the only thing that tier asserts is that the turn
+    completed. No grader runs, so the row is neither a pass nor a fail -- keeping
+    it a distinct third value is what makes it impossible to mistake for a green
+    promotion gate. A fake turn that does *not* complete is still ``FAIL``: broken
+    plumbing is the one thing the tier must still catch.
+    """
+
+    PASS = "pass"
+    FAIL = "fail"
+    PLUMBING_OK = "plumbing_ok"
+
+
 class EvalCaseResult(BaseModel):
-    """The outcome of running one case: pass/fail, the output, and any error.
+    """The outcome of running one case: its verdict, the output, and any error.
+
+    ``passed`` is a derived view of ``outcome`` and is tri-state: ``True`` for a
+    graded pass, ``False`` for a graded fail, ``None`` for a non-graded plumbing
+    row. Deriving it (rather than storing it) means no caller can set the two
+    inconsistently, and ``None`` keeps an unmigrated reader fail-safe: it is falsy,
+    so a truthiness check under-reports rather than ever going false-green, and
+    nothing ever claims a row failed that no grader judged.
 
     ``cost_usd`` is the dollar cost the runner attributed to this case's turn
     when the harness reported usage/pricing; it is ``None`` when cost is not
@@ -142,11 +172,18 @@ class EvalCaseResult(BaseModel):
     """
 
     case_id: str
-    passed: bool
+    outcome: EvalOutcome
     output: str
     latency_ms: float
     error: str | None = None
     cost_usd: float | None = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def passed(self) -> bool | None:
+        if self.outcome is EvalOutcome.PLUMBING_OK:
+            return None
+        return self.outcome is EvalOutcome.PASS
 
 
 class EvalRunResult(BaseModel):
@@ -171,11 +208,47 @@ class EvalRunResult(BaseModel):
 
     @property
     def passed_count(self) -> int:
-        return sum(1 for r in self.results if r.passed)
+        return sum(1 for r in self.results if r.outcome is EvalOutcome.PASS)
+
+    @property
+    def plumbing_count(self) -> int:
+        return sum(1 for r in self.results if r.outcome is EvalOutcome.PLUMBING_OK)
+
+    @property
+    def graded_total(self) -> int:
+        """The rows a grader actually judged: the only honest pass-rate denominator."""
+        return self.total - self.plumbing_count
 
     def all_passed(self) -> bool:
+        """Did every case pass a grader? A pure grading predicate.
+
+        Deliberately False for an all-plumbing run: nothing was graded, so nothing
+        passed. "Did anything break" is :meth:`completed_without_failure`.
+        """
         return self.total > 0 and self.passed_count == self.total
 
+    def all_plumbing(self) -> bool:
+        """Every row completed but none was graded (a fake-tier run)."""
+        return self.total > 0 and self.plumbing_count == self.total
+
+    def completed_without_failure(self) -> bool:
+        """Did nothing break? The operational question a process exit asks.
+
+        An all-plumbing run is a clean completion without being a pass; a run
+        carrying any FAIL is red whether or not the rest was graded.
+        """
+        return not any(r.outcome is EvalOutcome.FAIL for r in self.results)
+
     def summary(self) -> str:
-        """The one-line ``34/36 passed`` string the PR check surfaces."""
-        return f"{self.passed_count}/{self.total} passed"
+        """The one-line ``34/36 passed`` string the PR check surfaces.
+
+        A non-graded run never renders as ``N/M passed``: both ``0/3`` (a red that
+        did not happen) and ``3/3`` (the false green) are lies about rows no grader
+        judged, so plumbing rows are named as such and stay out of the ratio.
+        """
+        if self.all_plumbing():
+            return f"{self.plumbing_count} plumbing OK (not graded)"
+        graded = f"{self.passed_count}/{self.graded_total} passed"
+        if self.plumbing_count:
+            return f"{graded}, {self.plumbing_count} plumbing OK"
+        return graded

--- a/apps/worker/src/agentos_worker/eval/recorder.py
+++ b/apps/worker/src/agentos_worker/eval/recorder.py
@@ -3,10 +3,12 @@
 Per the architecture (detailed-architecture section 4), eval Jobs write scores to
 Langfuse and the eval matrix reads the grid back keyed by version tag. This
 recorder posts, for each case, a Langfuse trace (input/output/metadata, tagged
-with the version and suite) plus an ``eval_pass`` numeric score (1.0 / 0.0) to the
-public ingestion API. The API server's matrix endpoint (a J1/observability
-handoff, not built here) then queries scores/traces filtered by the version tag to
-assemble the grid across N pinned versions.
+with the version and suite) plus, for a graded case, an ``eval_pass`` numeric score
+(1.0 / 0.0) to the public ingestion API. A non-graded case (the fake tier, ADR-0055)
+records its trace but no score: it has no grade, and either number would be a lie.
+The API server's matrix endpoint (a J1/observability handoff, not built here) then
+queries scores/traces filtered by the version tag to assemble the grid across N
+pinned versions.
 
 Ingestion is asynchronous on Langfuse v3 (queued, then materialized in
 ClickHouse), so a read-back is eventually consistent, not immediate.
@@ -20,7 +22,7 @@ from typing import Any
 
 import httpx
 
-from .models import EvalCaseResult, EvalRunResult
+from .models import EvalCaseResult, EvalOutcome, EvalRunResult
 
 SCORE_NAME = "eval_pass"
 
@@ -57,7 +59,12 @@ class LangfuseEvalRecorder:
             trace_id = uuid.uuid4().hex
             trace_ids.append(trace_id)
             batch.append(self._trace_event(trace_id, run, result, now))
-            batch.append(self._score_event(trace_id, result, now))
+            # A non-graded case has no grade to record: 0.0 would read as a fail
+            # that never happened and 1.0 is the false green. Omitting the score
+            # is the only honest shape -- the trace still lands, so the row stays
+            # visible with its outcome, it just carries no eval_pass.
+            if result.outcome is not EvalOutcome.PLUMBING_OK:
+                batch.append(self._score_event(trace_id, result, now))
 
         resp = await self._client.post(
             f"{self._base}/api/public/ingestion",
@@ -83,6 +90,11 @@ class LangfuseEvalRecorder:
         tags = ["eval", f"version:{run.version}", f"suite:{run.suite}"]
         if run.model:
             tags.append(f"model:{run.model}")
+        # A non-graded row is tagged so the grid can filter plumbing runs out of a
+        # comparison without parsing metadata; the tag means exactly "no grader
+        # judged this", never "this failed".
+        if result.outcome is EvalOutcome.PLUMBING_OK:
+            tags.append("plumbing")
         return {
             "id": uuid.uuid4().hex,
             "type": "trace-create",
@@ -99,6 +111,10 @@ class LangfuseEvalRecorder:
                     "suite": run.suite,
                     "model": run.model,
                     "case_id": result.case_id,
+                    "outcome": result.outcome.value,
+                    # Kept alongside `outcome` so an unmigrated reader stays
+                    # fail-safe: a plumbing row's null renders as missing, never as
+                    # a fabricated pass or fail. `outcome` is the authoritative one.
                     "passed": result.passed,
                     "latency_ms": result.latency_ms,
                     "cost_usd": result.cost_usd,

--- a/apps/worker/src/agentos_worker/eval/run.py
+++ b/apps/worker/src/agentos_worker/eval/run.py
@@ -42,16 +42,23 @@ async def run_eval_suite(
     recorder: LangfuseEvalRecorder | None = None,
     token: str | None = None,
     model: str | None = None,
+    fake: bool = False,
 ) -> EvalRunResult:
     """Run a suite against a runner endpoint and, if configured, record it.
 
     ``model`` is the model id the suite is being run under; it is threaded onto
     the ``EvalRunResult`` so the recorder can tag the model dimension and the
-    eval matrix can slice pass-rate/cost by model.
+    eval matrix can slice pass-rate/cost by model. ``fake`` says that runner is
+    the fake model, whose turns are never graded (ADR-0055).
     """
     async with RunnerClient() as runner:
         result = await EvalRunner(runner).run(
-            suite, base_url=base_url, version=version, token=token, model=model
+            suite,
+            base_url=base_url,
+            version=version,
+            token=token,
+            model=model,
+            fake=fake,
         )
     if recorder is not None:
         await recorder.record(result)
@@ -85,7 +92,11 @@ async def _main_async(env: Mapping[str, str]) -> int:
         )
 
     print(result.model_dump_json())
-    return 0 if result.all_passed() else 1
+    # The exit code answers "did anything break", not "did anything pass": a run
+    # whose cases were never graded (the fake tier) broke nothing, so failing the
+    # Job on it would report a failure that did not happen. A real FAIL -- including
+    # a fake turn that never completed -- is still non-zero.
+    return 0 if result.completed_without_failure() else 1
 
 
 def main(env: Mapping[str, str] | None = None) -> None:

--- a/apps/worker/src/agentos_worker/eval/runner.py
+++ b/apps/worker/src/agentos_worker/eval/runner.py
@@ -28,7 +28,7 @@ import aiohttp
 from aci_protocol import ErrorEvent, Event, Final, SessionStatus, TextDelta, ToolNote
 
 from ..runner_client import RunnerClient, RunnerError
-from .models import EvalCase, EvalCaseResult, EvalRunResult, EvalSuite
+from .models import EvalCase, EvalCaseResult, EvalOutcome, EvalRunResult, EvalSuite
 from .scorer import GraderScorer, Scorer
 
 
@@ -41,7 +41,8 @@ class EvalRunner:
     :class:`~.scorer.TrajectoryScorer` over the tool-call sequence) to score the
     same turns differently. The runner still owns the completion gate (a
     classified-failure or non-``done`` turn fails regardless of the scorer), so a
-    scorer only ever judges a turn that actually completed.
+    scorer only ever judges a turn that actually completed. A ``fake=True`` run
+    skips the scorer entirely (see :meth:`run`).
     """
 
     def __init__(self, runner: RunnerClient, *, scorer: Scorer | None = None) -> None:
@@ -56,7 +57,14 @@ class EvalRunner:
         version: str,
         token: str | None = None,
         model: str | None = None,
+        fake: bool = False,
     ) -> EvalRunResult:
+        """Run every case against ``base_url``.
+
+        ``fake`` says the runner behind ``base_url`` is the fake model, whose
+        canned replies no grader can meaningfully judge (ADR-0055). It is not a
+        scoring mode: the scorer is not consulted at all on a completed fake turn.
+        """
         results: list[EvalCaseResult] = []
         for case in suite.cases:
             # Fresh conversation by default (#550): reset the runner before a case
@@ -72,14 +80,14 @@ class EvalRunner:
                     results.append(
                         EvalCaseResult(
                             case_id=case.id,
-                            passed=False,
+                            outcome=EvalOutcome.FAIL,
                             output="",
                             latency_ms=0.0,
                             error=isolation_error,
                         )
                     )
                     continue
-            results.append(await self._run_case(case, base_url, token))
+            results.append(await self._run_case(case, base_url, token, fake=fake))
         return EvalRunResult(
             version=version, suite=suite.name, results=results, model=model
         )
@@ -98,7 +106,12 @@ class EvalRunner:
         return None
 
     async def _run_case(
-        self, case: EvalCase, base_url: str, token: str | None = None
+        self,
+        case: EvalCase,
+        base_url: str,
+        token: str | None = None,
+        *,
+        fake: bool = False,
     ) -> EvalCaseResult:
         start = time.monotonic()
         event = Event(type="eval_case", text=case.input, user="eval", ts="0")
@@ -125,7 +138,7 @@ class EvalRunner:
         except (RunnerError, aiohttp.ClientError, TimeoutError) as exc:
             return EvalCaseResult(
                 case_id=case.id,
-                passed=False,
+                outcome=EvalOutcome.FAIL,
                 output="",
                 latency_ms=_elapsed_ms(start),
                 error=str(exc),
@@ -138,7 +151,7 @@ class EvalRunner:
         if final_status is SessionStatus.CLASSIFIED_FAILURE:
             return EvalCaseResult(
                 case_id=case.id,
-                passed=False,
+                outcome=EvalOutcome.FAIL,
                 output=output,
                 latency_ms=_elapsed_ms(start),
                 error=error_detail or "runner reported a classified failure",
@@ -154,10 +167,24 @@ class EvalRunner:
         if final_status is None or final_status.value != expected.value:
             return EvalCaseResult(
                 case_id=case.id,
-                passed=False,
+                outcome=EvalOutcome.FAIL,
                 output=output,
                 latency_ms=_elapsed_ms(start),
                 error=f"turn ended {final_status}, expected status {expected.value!r}",
+            )
+        # The turn completed, which on the fake tier is the whole assertion: the
+        # fake answers from a canned script, so grading its text measures the
+        # script, not the agent. Returning before the scorer is what makes that
+        # literal -- no grader runs at all -- and the non-graded outcome keeps the
+        # row out of every pass-rate rather than fabricating one. This sits AFTER
+        # the gates above deliberately: a fake turn that never completed means the
+        # plumbing is genuinely broken, and catching that is this tier's only job.
+        if fake:
+            return EvalCaseResult(
+                case_id=case.id,
+                outcome=EvalOutcome.PLUMBING_OK,
+                output=output,
+                latency_ms=_elapsed_ms(start),
             )
         # The turn completed cleanly, so a negative verdict is the scorer saying
         # "no", not a runner/turn error -- keep `error` reserved for the latter
@@ -165,7 +192,7 @@ class EvalRunner:
         verdict = self._scorer.score(case, output, trajectory)
         return EvalCaseResult(
             case_id=case.id,
-            passed=verdict.passed,
+            outcome=EvalOutcome.PASS if verdict.passed else EvalOutcome.FAIL,
             output=output,
             latency_ms=_elapsed_ms(start),
         )

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -407,6 +407,7 @@ class EvalStreamConsumer(StreamConsumer):
                 recorder=self._recorder,
                 token=token,
                 model=self._eval_model(item),
+                fake=self._config.fake_model,
             )
         finally:
             if release_key is not None:
@@ -506,6 +507,22 @@ class EvalStreamConsumer(StreamConsumer):
         return result
 
     async def _report(self, item: EvalJob, repo: str | None, result: EvalRunResult) -> None:
+        # The frozen EvalReport carries passed_count/total only, and the API turns
+        # it into a GitHub commit status. That shape cannot express "ran but was
+        # never graded": 0/N posts a red that did not happen and N/N posts the
+        # false green this gate exists to prevent. So a run whose every case is
+        # non-graded posts nothing -- no commit status is better than a fabricated
+        # one. A run carrying any FAIL still reports: broken plumbing is a real red
+        # and must reach the PR check. Skipping is a completed report attempt, so
+        # the caller acks rather than leaving the entry pending forever.
+        if result.all_plumbing():
+            logger.info(
+                "eval %s @ %s ran plumbing-only (%d cases, not graded); no report posted",
+                item.suite,
+                item.sha,
+                result.total,
+            )
+            return
         await self._reporter.report(
             EvalReport(
                 repo_full_name=repo or str(item.agent_id),

--- a/apps/worker/tests/eval/test_models.py
+++ b/apps/worker/tests/eval/test_models.py
@@ -8,6 +8,7 @@ import pytest
 from agentos_worker.eval import (
     EvalCase,
     EvalCaseResult,
+    EvalOutcome,
     EvalRunResult,
     EvalSuite,
     ExpectedStatus,
@@ -47,9 +48,9 @@ def test_run_result_rollups() -> None:
         version="v1",
         suite="basics",
         results=[
-            EvalCaseResult(case_id="a", passed=True, output="4", latency_ms=1.0),
-            EvalCaseResult(case_id="b", passed=False, output="x", latency_ms=1.0),
-            EvalCaseResult(case_id="c", passed=True, output="ok", latency_ms=1.0),
+            EvalCaseResult(case_id="a", outcome=EvalOutcome.PASS, output="4", latency_ms=1.0),
+            EvalCaseResult(case_id="b", outcome=EvalOutcome.FAIL, output="x", latency_ms=1.0),
+            EvalCaseResult(case_id="c", outcome=EvalOutcome.PASS, output="ok", latency_ms=1.0),
         ],
     )
     assert result.total == 3
@@ -60,6 +61,53 @@ def test_run_result_rollups() -> None:
 
 def test_all_passed_is_false_for_empty_suite() -> None:
     assert EvalRunResult(version="v", suite="s", results=[]).all_passed() is False
+
+
+def _row(case_id: str, outcome: EvalOutcome) -> EvalCaseResult:
+    return EvalCaseResult(case_id=case_id, outcome=outcome, output="all done", latency_ms=1.0)
+
+
+def test_passed_is_derived_from_outcome_and_a_plumbing_row_is_neither() -> None:
+    # `passed` is a read-only view of `outcome`, so no caller can ever set the two
+    # inconsistently, and a non-graded row reports null: not a pass, not a fail.
+    assert _row("p", EvalOutcome.PASS).passed is True
+    assert _row("f", EvalOutcome.FAIL).passed is False
+    assert _row("k", EvalOutcome.PLUMBING_OK).passed is None
+    # The derived value survives serialization, which is what the recorder writes
+    # into trace metadata and what the matrix reads back.
+    assert _row("k", EvalOutcome.PLUMBING_OK).model_dump()["passed"] is None
+    assert _row("k", EvalOutcome.PLUMBING_OK).model_dump()["outcome"] == "plumbing_ok"
+
+
+def test_an_all_plumbing_run_is_never_a_pass_but_is_a_clean_completion() -> None:
+    run = EvalRunResult(
+        version="v1",
+        suite="s",
+        results=[_row("a", EvalOutcome.PLUMBING_OK), _row("b", EvalOutcome.PLUMBING_OK)],
+    )
+    # Nothing was graded, so nothing passed: `all_passed` stays a pure grading
+    # predicate and must not go green on rows no grader ever judged.
+    assert run.passed_count == 0
+    assert run.all_passed() is False
+    # ...but nothing broke either, so the eval Job's process exit is success.
+    assert run.completed_without_failure() is True
+    # The operator-facing rollup must read as plumbing, never as "0/2 passed" --
+    # that number is a lie in the other direction (no case failed).
+    summary = run.summary()
+    assert "plumbing" in summary.lower()
+    assert "0/2" not in summary
+
+
+def test_a_plumbing_run_carrying_a_failure_is_not_a_clean_completion() -> None:
+    # The fake tier's ONLY assertion is that the turn completed; when one did not,
+    # the plumbing is genuinely broken and the run must still be operationally red.
+    run = EvalRunResult(
+        version="v1",
+        suite="s",
+        results=[_row("a", EvalOutcome.PLUMBING_OK), _row("b", EvalOutcome.FAIL)],
+    )
+    assert run.completed_without_failure() is False
+    assert run.all_passed() is False
 
 
 # --- Frozen eval-case contract (issue #8) -------------------------------------

--- a/apps/worker/tests/eval/test_recorder.py
+++ b/apps/worker/tests/eval/test_recorder.py
@@ -15,7 +15,12 @@ from typing import Any
 
 import httpx
 import pytest
-from agentos_worker.eval import EvalCaseResult, EvalRunResult, LangfuseEvalRecorder
+from agentos_worker.eval import (
+    EvalCaseResult,
+    EvalOutcome,
+    EvalRunResult,
+    LangfuseEvalRecorder,
+)
 from agentos_worker.eval.recorder import SCORE_NAME
 
 _LF_HOST = os.environ.get("TEST_LANGFUSE_HOST", "http://localhost:23000")
@@ -99,7 +104,7 @@ def test_model_dimension_is_tagged_and_in_metadata() -> None:
                 results=[
                     EvalCaseResult(
                         case_id="c1",
-                        passed=True,
+                        outcome=EvalOutcome.PASS,
                         output="ok",
                         latency_ms=1.0,
                         cost_usd=0.0021,
@@ -139,7 +144,9 @@ def test_model_none_records_no_model_tag() -> None:
                 version="v1",
                 suite="s",
                 results=[
-                    EvalCaseResult(case_id="c1", passed=True, output="ok", latency_ms=1.0)
+                    EvalCaseResult(
+                        case_id="c1", outcome=EvalOutcome.PASS, output="ok", latency_ms=1.0
+                    )
                 ],
             )
             await recorder.record(run)
@@ -149,6 +156,125 @@ def test_model_none_records_no_model_tag() -> None:
         )["body"]
         assert not any(t.startswith("model:") for t in trace["tags"])
         assert trace["metadata"]["model"] is None
+
+    asyncio.run(go())
+
+
+async def _capture_batch(run: EvalRunResult) -> list[dict[str, Any]]:
+    """Record ``run`` through a mocked ingestion endpoint and return the batch."""
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured.append(json.loads(request.content))
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        recorder = LangfuseEvalRecorder(
+            base_url="http://langfuse.invalid",
+            public_key="pk",
+            secret_key="sk",
+            client=client,
+        )
+        await recorder.record(run)
+    batch: list[dict[str, Any]] = captured[0]["batch"]
+    return batch
+
+
+def _trace_by_case(batch: list[dict[str, Any]], case_id: str) -> dict[str, Any]:
+    return next(
+        e["body"]
+        for e in batch
+        if e["type"] == "trace-create" and e["body"]["metadata"]["case_id"] == case_id
+    )
+
+
+def test_a_plumbing_row_records_no_eval_pass_score() -> None:
+    """A non-graded run has no grade, so it gets no ``eval_pass`` score: 0.0 would
+    read as a fail that never happened and 1.0 is the false green this change
+    exists to kill. Omission is the only honest Langfuse shape. The FAIL row beside
+    it proves the suppression is per-row, not a blanket early return."""
+
+    async def go() -> None:
+        run = EvalRunResult(
+            version="v1",
+            suite="s",
+            model=None,
+            results=[
+                EvalCaseResult(
+                    case_id="plumb",
+                    outcome=EvalOutcome.PLUMBING_OK,
+                    output="all done",
+                    latency_ms=1.0,
+                ),
+                EvalCaseResult(
+                    case_id="broke",
+                    outcome=EvalOutcome.FAIL,
+                    output="",
+                    latency_ms=1.0,
+                    error="turn did not complete",
+                ),
+            ],
+        )
+        batch = await _capture_batch(run)
+
+        # Both cases are traced...
+        assert len([e for e in batch if e["type"] == "trace-create"]) == 2
+        # ...but only the graded (failed) one carries a score.
+        scores = [e for e in batch if e["type"] == "score-create"]
+        assert len(scores) == 1
+        assert scores[0]["body"]["name"] == SCORE_NAME
+        assert scores[0]["body"]["value"] == 0.0
+        broke_trace_id = _trace_by_case(batch, "broke")["id"]
+        assert scores[0]["body"]["traceId"] == broke_trace_id
+
+        plumb = _trace_by_case(batch, "plumb")
+        assert plumb["metadata"]["outcome"] == "plumbing_ok"
+        # `passed` stays in metadata so an unmigrated reader stays fail-safe: null
+        # renders as missing, never as a fabricated pass or fail.
+        assert plumb["metadata"]["passed"] is None
+        assert "plumbing" in plumb["tags"]
+        # A fake run is unlabelled (#606, main's 9a5dc1b): the fake model is never a
+        # real model, so no `model:` tag is emitted and the row lands in the
+        # matrix's unlabelled column rather than fabricating a model dimension.
+        assert not any(t.startswith("model:") for t in plumb["tags"])
+
+    asyncio.run(go())
+
+
+def test_a_graded_run_scores_every_case_and_is_not_tagged_plumbing() -> None:
+    """The real-model half is untouched: a graded run still emits its eval_pass
+    score per case and carries no plumbing tag, so the tag means what it says."""
+
+    async def go() -> None:
+        run = EvalRunResult(
+            version="v1",
+            suite="s",
+            model="claude-opus-4-8",
+            results=[
+                EvalCaseResult(
+                    case_id="c1", outcome=EvalOutcome.PASS, output="ok", latency_ms=1.0
+                ),
+                EvalCaseResult(
+                    case_id="c2", outcome=EvalOutcome.FAIL, output="no", latency_ms=1.0
+                ),
+            ],
+        )
+        batch = await _capture_batch(run)
+
+        scores = {
+            e["body"]["traceId"]: e["body"]["value"]
+            for e in batch
+            if e["type"] == "score-create"
+        }
+        assert scores[_trace_by_case(batch, "c1")["id"]] == 1.0
+        assert scores[_trace_by_case(batch, "c2")["id"]] == 0.0
+        for case_id, expected in (("c1", "pass"), ("c2", "fail")):
+            trace = _trace_by_case(batch, case_id)
+            assert trace["metadata"]["outcome"] == expected
+            assert "plumbing" not in trace["tags"]
 
     asyncio.run(go())
 
@@ -169,8 +295,12 @@ def test_records_per_case_results_and_reads_them_back() -> None:
                 version=version,
                 suite="recorder-test",
                 results=[
-                    EvalCaseResult(case_id="pass-case", passed=True, output="4", latency_ms=1.0),
-                    EvalCaseResult(case_id="fail-case", passed=False, output="x", latency_ms=1.0),
+                    EvalCaseResult(
+                        case_id="pass-case", outcome=EvalOutcome.PASS, output="4", latency_ms=1.0
+                    ),
+                    EvalCaseResult(
+                        case_id="fail-case", outcome=EvalOutcome.FAIL, output="x", latency_ms=1.0
+                    ),
                 ],
             )
             await recorder.record(run)

--- a/apps/worker/tests/eval/test_runner.py
+++ b/apps/worker/tests/eval/test_runner.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 
+import pytest
 from agentos_worker.eval import (
     EvalCase,
+    EvalOutcome,
     EvalRunner,
     EvalSuite,
     ExpectedStatus,
     Grader,
     GraderKind,
+    ScoreResult,
 )
 
 CONTAINS = GraderKind.CONTAINS
@@ -289,5 +293,101 @@ def test_all_passed_suite(make_eval_harness) -> None:
             result = await EvalRunner(client).run(suite, base_url=base_url, version="v1")
             assert result.all_passed() is True
             assert result.summary() == "2/2 passed"
+
+    asyncio.run(go())
+
+
+class _SpyScorer:
+    """A scorer that would pass ANYTHING, and counts the times it was consulted.
+
+    The unconditional ``passed=True`` is the point: if the fake path ever reaches
+    a grader, the case comes back PASS and ``calls`` is non-zero, so a test asserting
+    "never graded" cannot go green by accident.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def score(self, case: EvalCase, output: str, trajectory: Sequence[str]) -> ScoreResult:
+        self.calls += 1
+        return ScoreResult(passed=True)
+
+
+def _one_case_suite() -> EvalSuite:
+    # A grader the fake's canned "all done" could never satisfy on content, so a
+    # PLUMBING_OK outcome can only come from skipping grading, never from passing it.
+    return EvalSuite(
+        name="s",
+        cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="deal-desk"))],
+    )
+
+
+def test_a_fake_turn_is_never_graded_and_is_neither_pass_nor_fail(make_eval_harness) -> None:
+    """The fake model is a plumbing fixture, not a subject under test: the only
+    thing the fake tier asserts is that the turn completed. The grader must not run
+    at all, and the outcome is a distinct non-graded PLUMBING_OK."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "all done"}
+            spy = _SpyScorer()
+            result = await EvalRunner(client, scorer=spy).run(
+                _one_case_suite(), base_url=base_url, version="v1", fake=True
+            )
+
+            assert spy.calls == 0, "the grader must not run at all on a fake turn"
+            case = result.results[0]
+            assert case.outcome is EvalOutcome.PLUMBING_OK
+            assert case.passed is None  # not a pass, not a fail
+            assert case.error is None  # the turn completed; nothing broke
+            assert case.output == "all done"  # the turn's text is still recorded
+
+    asyncio.run(go())
+
+
+def test_a_real_turn_is_still_graded_when_the_run_is_not_fake(make_eval_harness) -> None:
+    """The falsifiability guard (#527/ADR-0022): PLUMBING_OK must not become a
+    backdoor that stops grading a real run. Off the fake tier, the same off-topic
+    answer against the same grader is a real, graded FAIL."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "all done"}
+            result = await EvalRunner(client).run(
+                _one_case_suite(), base_url=base_url, version="v1", fake=False
+            )
+
+            case = result.results[0]
+            assert case.outcome is EvalOutcome.FAIL
+            assert case.passed is False
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    "breakage", ["classified_failure_inputs", "idle_inputs", "fail_inputs"]
+)
+def test_a_fake_turn_that_does_not_complete_is_a_failure_not_plumbing_ok(
+    make_eval_harness, breakage: str
+) -> None:
+    """Ordering is load-bearing: the classified-failure / non-DONE / transport-error
+    gates run BEFORE the fake early return. A fake turn that did not complete means
+    the plumbing is genuinely broken -- the one thing this tier must still catch --
+    so it is a real FAIL, never the non-graded outcome."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "all done"}
+            getattr(fake, breakage).add("q")
+            spy = _SpyScorer()
+            result = await EvalRunner(client, scorer=spy).run(
+                _one_case_suite(), base_url=base_url, version="v1", fake=True
+            )
+
+            case = result.results[0]
+            assert case.outcome is EvalOutcome.FAIL
+            assert case.passed is False
+            assert case.error is not None  # the breakage reason is recorded
+            assert spy.calls == 0  # a broken turn is not graded either
 
     asyncio.run(go())

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -28,6 +28,7 @@ from typing import Any, cast
 import httpx
 import pytest
 import redis
+from aci_protocol import STREAM_PAYLOAD_FIELD
 from agentos_worker.binding import BUDGET_ENV, BUNDLE_REF_ENV, MODEL_ENV
 from agentos_worker.bundle_store import BundleStore
 from agentos_worker.config import WorkerConfig
@@ -42,7 +43,7 @@ from agentos_worker.eval import (
     LangfuseEvalRecorder,
     load_suite_from_bundle,
 )
-from agentos_worker.eval.models import EvalRunResult
+from agentos_worker.eval.models import EvalCaseResult, EvalOutcome, EvalRunResult
 from agentos_worker.sandbox import AffinityStore, SandboxSubstrate, SubstrateConfig
 from agentos_worker.sandbox.types import ClaimView, SandboxView
 from redis.asyncio import Redis as AsyncRedis
@@ -943,6 +944,133 @@ def test_eval_fake_model_install_refuses_to_label_a_model_never_called(
     assert consumer._eval_model(remote) == "claude-y"
 
 
+def _consumer(cfg: WorkerConfig, **wiring: Any) -> EvalStreamConsumer:
+    deps: dict[str, Any] = {
+        "redis": None,
+        "bundle_store": None,
+        "substrate": None,
+        "reporter": None,
+        "recorder": None,
+        "repo_lookup": None,
+    }
+    deps.update(wiring)
+    return EvalStreamConsumer(config=cfg, **deps)  # type: ignore[arg-type]
+
+
+def _canned_run(monkeypatch, outcomes: list[EvalOutcome]) -> None:
+    """Pin ``run_eval_suite`` to a result with the given per-case outcomes.
+
+    The report gate is what is under test here; the suite execution is the seam
+    being held still, exactly as the token-threading test does.
+    """
+    from agentos_worker.eval import stream as stream_module
+
+    async def _fake_run(suite: EvalSuite, *, version: str, **_kw: Any) -> EvalRunResult:
+        return EvalRunResult(
+            version=version,
+            suite=suite.name,
+            model=None,
+            results=[
+                EvalCaseResult(
+                    case_id=f"c{i}", outcome=outcome, output="all done", latency_ms=1.0
+                )
+                for i, outcome in enumerate(outcomes)
+            ],
+        )
+
+    monkeypatch.setattr(stream_module, "run_eval_suite", _fake_run)
+
+
+def _fake_job_consumer(reporter: Any) -> EvalStreamConsumer:
+    suite = EvalSuite(
+        name="s",
+        cases=[EvalCase(id="1", input="q", grader=Grader(kind=CONTAINS, expected="a"))],
+    )
+    return _consumer(
+        WorkerConfig(fake_model=True),
+        bundle_store=_FakeBundleStore(_suite_bundle(suite)),
+        substrate=_TokenSubstrate("tok"),
+        reporter=reporter,
+        repo_lookup=_StubRepo(),
+    )
+
+
+def test_an_all_plumbing_run_posts_no_eval_report_but_is_still_acked(monkeypatch) -> None:
+    """The frozen EvalReport carries passed_count/total only, and the API turns it
+    into a GitHub commit status. That shape cannot express non-graded: 0/N posts a
+    red that did not happen and N/N posts the false green this change exists to
+    kill. So an all-plumbing run posts nothing at all -- and the skip still counts
+    as a completed report attempt, so the entry is acked rather than redelivered
+    forever."""
+    _canned_run(monkeypatch, [EvalOutcome.PLUMBING_OK, EvalOutcome.PLUMBING_OK])
+    reporter = _FakeReporter()
+    consumer = _fake_job_consumer(reporter)
+    acked: list[str] = []
+
+    async def _record_ack(entry_id: str) -> None:
+        acked.append(entry_id)
+
+    monkeypatch.setattr(consumer, "_ack", _record_ack)
+    item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
+
+    async def go() -> None:
+        await consumer._handle("1-0", {STREAM_PAYLOAD_FIELD: item.model_dump_json()})
+
+    asyncio.run(go())
+
+    assert reporter.reports == []  # no commit status is better than a fabricated one
+    assert acked == ["1-0"]  # ...and the job is done, not left pending
+
+
+def test_a_fake_run_carrying_a_failure_still_posts_its_report(monkeypatch) -> None:
+    """A fake turn that did not complete means the plumbing is genuinely broken, so
+    that red is real and must reach the PR check."""
+    _canned_run(monkeypatch, [EvalOutcome.PLUMBING_OK, EvalOutcome.FAIL])
+    reporter = _FakeReporter()
+    consumer = _fake_job_consumer(reporter)
+    item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
+
+    async def go() -> None:
+        await consumer._run_and_report(item)
+
+    asyncio.run(go())
+
+    assert len(reporter.reports) == 1
+    report = reporter.reports[0]
+    assert report.sha == "deadbeef"
+    assert report.passed_count == 0  # nothing passed; the broken turn is the signal
+
+
+def test_a_real_run_still_posts_its_report(monkeypatch) -> None:
+    """The report gate is keyed on the non-graded outcome, not switched off wholesale:
+    a graded run reports exactly as before."""
+    _canned_run(monkeypatch, [EvalOutcome.PASS, EvalOutcome.PASS])
+    reporter = _FakeReporter()
+    consumer = _consumer(
+        WorkerConfig(fake_model=False),
+        bundle_store=_FakeBundleStore(
+            _suite_bundle(
+                EvalSuite(
+                    name="s",
+                    cases=[EvalCase(id="1", input="q", grader=Grader(kind=CONTAINS, expected="a"))],
+                )
+            )
+        ),
+        substrate=_TokenSubstrate("tok"),
+        reporter=reporter,
+        repo_lookup=_StubRepo(),
+    )
+    item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
+
+    async def go() -> None:
+        await consumer._run_and_report(item)
+
+    asyncio.run(go())
+
+    assert len(reporter.reports) == 1
+    assert reporter.reports[0].passed_count == 2
+
+
 def test_eval_boot_env_drops_reserved_connector_secret() -> None:
     """#457 eval-path parity: the eval consumer's connector-secret injection must
     honor the reserved-boot-env policy exactly like binding.boot_env does. A secret
@@ -996,10 +1124,12 @@ def test_eval_threads_claim_token_into_run_eval_suite(monkeypatch) -> None:
         recorder: Any = None,
         token: Any = None,
         model: Any = None,
+        fake: Any = None,
     ) -> EvalRunResult:
         captured["base_url"] = base_url
         captured["token"] = token
         captured["model"] = model
+        captured["fake"] = fake
         return EvalRunResult(version=version, suite=suite.name, results=[])
 
     monkeypatch.setattr(stream_module, "run_eval_suite", _capture_run)
@@ -1026,6 +1156,48 @@ def test_eval_threads_claim_token_into_run_eval_suite(monkeypatch) -> None:
 
     assert captured["base_url"] == "http://sandbox.local:8080"
     assert captured["token"] == "tok-eval-xyz"
+
+
+@pytest.mark.parametrize("fake_model", [True, False])
+def test_eval_threads_the_workers_fake_state_into_run_eval_suite(
+    monkeypatch, fake_model: bool
+) -> None:
+    """The worker is the sole authority on fake-ness: nothing downstream of the
+    stream can infer it (the ACI Final frame carries no model field and no fake
+    marker), so the consumer must hand its own config down to the grading layer.
+    Without this thread the runner would grade a canned reply -- the false green.
+    """
+    from agentos_worker.eval import stream as stream_module
+
+    captured: dict[str, Any] = {}
+
+    async def _capture_run(
+        suite: EvalSuite, *, version: str, fake: Any = None, **_kw: Any
+    ) -> EvalRunResult:
+        captured["fake"] = fake
+        return EvalRunResult(version=version, suite=suite.name, results=[])
+
+    monkeypatch.setattr(stream_module, "run_eval_suite", _capture_run)
+
+    suite = EvalSuite(
+        name="s",
+        cases=[EvalCase(id="1", input="q", grader=Grader(kind=CONTAINS, expected="a"))],
+    )
+    consumer = _consumer(
+        WorkerConfig(fake_model=fake_model),
+        bundle_store=_FakeBundleStore(_suite_bundle(suite)),
+        substrate=_TokenSubstrate("tok"),
+        reporter=_FakeReporter(),
+        repo_lookup=_StubRepo(),
+    )
+    item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.tgz", target_url=None)
+
+    async def go() -> None:
+        await consumer._run_and_report(item)
+
+    asyncio.run(go())
+
+    assert captured["fake"] is fake_model
 
 
 async def _assert_langfuse_traces(

--- a/cli/schema/eval.schema.json
+++ b/cli/schema/eval.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "agentos skill eval --json",
-  "description": "The agent-facing payload of `agentos skill eval --json`: the pass/fail roll-up plus one row per eval case.",
+  "description": "The agent-facing payload of `agentos skill eval --json`: the outcome roll-up plus one row per eval case.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["total", "passed", "failed", "cases"],
+  "required": ["total", "passed", "failed", "plumbing_ok", "cases"],
   "properties": {
     "total": {
       "type": "integer",
@@ -16,20 +16,31 @@
     },
     "failed": {
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "description": "Cases the grader FAILED. Counted, never inferred as `total - passed`: a `plumbing_ok` row was never graded and is not a failure."
+    },
+    "plumbing_ok": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Cases that completed on the fake model and so were not graded at all (ADR-0055). Neither passes nor failures; `passed + failed + plumbing_ok == total`."
     },
     "cases": {
       "type": "array",
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "passed", "seconds", "output"],
+        "required": ["id", "outcome", "passed", "seconds", "output"],
         "properties": {
           "id": {
             "type": "string"
           },
+          "outcome": {
+            "enum": ["pass", "fail", "plumbing_ok"],
+            "description": "The case's verdict. `plumbing_ok` is a third state, not a shade of pass or fail: the turn completed on the fake model, which returns one canned reply whatever the input, so no grader was run."
+          },
           "passed": {
-            "type": "boolean"
+            "type": ["boolean", "null"],
+            "description": "Tri-state view of `outcome`: true for pass, false for fail, null for plumbing_ok. A non-graded row claims neither verdict, so it is null rather than a fabricated false."
           },
           "seconds": {
             "type": "number"

--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -41,9 +41,12 @@ trap cleanup EXIT
 echo
 echo "=== agentos init --from-spec (non-interactive, agent-authored spec) ==="
 # AC #2: a coding agent writes a spec, the CLI scaffolds a runnable bundle from
-# it with zero prompts, and the spec-scaffolded evals/cases.json greens on the
-# eval path. The single grader is `contains "all done"` so it passes under the
-# offline fake model (fake.py's final frame text is "all done").
+# it with zero prompts, and the spec-scaffolded evals/cases.json runs on the eval
+# path. The grader is falsifiable (it requires the agent to name itself), NOT
+# tuned to the fake model's canned "all done" reply: a grader written to match
+# the fake manufactures a green, and CI carrying one is exactly why #612 went
+# unnoticed. Under --fake-model the grader is never consulted at all -- the run
+# reports the non-graded plumbing_ok (ADR-0055).
 cat > "$WORKDIR/agent-spec.json" <<'EOF'
 {
   "name": "deal-desk",
@@ -58,9 +61,9 @@ cat > "$WORKDIR/agent-spec.json" <<'EOF'
   ],
   "evals": [
     {
-      "id": "finishes-the-turn",
-      "input": "wrap it up",
-      "grader": { "kind": "contains", "expected": "all done", "case_sensitive": false }
+      "id": "introduces-itself",
+      "input": "In one short sentence, introduce yourself as the deal-desk agent.",
+      "grader": { "kind": "contains", "expected": "deal-desk", "case_sensitive": false }
     }
   ]
 }
@@ -69,24 +72,24 @@ EOF
 
 cd "$WORKDIR/deal-desk"
 
-# Eval cases matched to the runner's offline fake-model script (fake.py):
-# the scripted turn streams "Looking into it", a Bash tool note, then a final
-# frame whose text is "all done". The graded answer is the FINAL text only, so
-# every grader below must be satisfied by "all done" (interim streamed text such
-# as "looking into it" is no longer graded).
+# A second suite for the explicit `--cases` leg. Its graders are real domain
+# graders, deliberately NOT matched to the fake-model script's canned "all done"
+# reply: this run is offline under --fake-model, so the graders are never
+# consulted and the suite reports plumbing_ok. Writing them to match the fake
+# would only re-create the bypass that let #612 ship green.
 cat > evals/e2e-cases.json <<'EOF'
 {
   "name": "e2e",
   "cases": [
     {
-      "id": "finishes-the-turn",
-      "input": "wrap it up",
-      "grader": { "kind": "contains", "expected": "all done", "case_sensitive": false }
+      "id": "introduces-itself",
+      "input": "In one short sentence, introduce yourself as the deal-desk agent.",
+      "grader": { "kind": "contains", "expected": "deal-desk", "case_sensitive": false }
     },
     {
-      "id": "reports-done",
-      "input": "what is the status?",
-      "grader": { "kind": "contains", "expected": "done", "case_sensitive": false }
+      "id": "names-its-domain",
+      "input": "What kind of requests do you handle?",
+      "grader": { "kind": "contains", "expected": "pricing", "case_sensitive": false }
     }
   ]
 }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -15,7 +15,9 @@ use serde::{Deserialize, Serialize};
 use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
 use crate::bundle::pack_tar_gz;
 use crate::docker::{self, CheckSpec, StartSpec};
-use crate::evals::{graded_answer, load_suite, turn_passes, EvalSuite};
+use crate::evals::{
+    graded_answer, load_suite, outcome_label, rollup_line, turn_outcome, CaseOutcome, EvalSuite,
+};
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
 use crate::scaffold::{read_declared_secrets, read_manifest, scaffold, scaffold_from_spec};
@@ -1161,27 +1163,56 @@ pub fn status_json<T: serde::Serialize>(url: &str, status: &T) -> serde_json::Va
     serde_json::json!({ "url": url, "session": status })
 }
 
-/// One graded eval case: `(id, passed, seconds, output)`. `output` is the graded
-/// answer text (the reply `turn_passes`/`reply_passes` judged), carried so a red
-/// case is diagnosable from `--json` without a manual re-run (#548). Shared by the
-/// skill runner path and the local/cluster message path so both report the same
-/// shape through `report_eval`/`eval_json`.
-pub type EvalRow = (String, bool, f64, String);
+/// One eval case's result: `(id, outcome, seconds, output)`. `output` is the
+/// graded answer text (the reply `turn_outcome`/`reply_passes` judged), carried
+/// so a red case is diagnosable from `--json` without a manual re-run (#548).
+/// Shared by the skill runner path and the local/cluster message path so both
+/// report the same shape through `report_eval`/`eval_json`.
+pub type EvalRow = (String, CaseOutcome, f64, String);
 
-/// The `agentos skill eval --json` payload: the pass/fail roll-up plus one row
-/// per case. Pure so it stays unit/contract-testable against
+/// The three counts every eval surface reports. Split out so the `--json`
+/// payload, the human roll-up, and the exit code all read the SAME tally rather
+/// than each re-deriving it -- `failed` in particular must be counted, never
+/// inferred as `total - passed`, which would book every non-graded plumbing row
+/// as a failure (#606).
+fn eval_counts(results: &[EvalRow]) -> (usize, usize, usize) {
+    let count = |want: CaseOutcome| results.iter().filter(|(_, o, _, _)| *o == want).count();
+    (
+        count(CaseOutcome::Pass),
+        count(CaseOutcome::Fail),
+        count(CaseOutcome::PlumbingOk),
+    )
+}
+
+/// The `agentos skill eval --json` payload: the outcome roll-up plus one row per
+/// case. Pure so it stays unit/contract-testable against
 /// `cli/schema/eval.schema.json`.
-pub fn eval_json(results: &[EvalRow], passed: usize, total: usize) -> serde_json::Value {
+pub fn eval_json(results: &[EvalRow]) -> serde_json::Value {
+    // Derive every count from `results` in one pass so the rollup can never
+    // disagree with the per-case rows (no caller-supplied passed/total to drift).
+    let total = results.len();
+    let (passed, failed, plumbing_ok) = eval_counts(results);
     let cases: Vec<serde_json::Value> = results
         .iter()
-        .map(|(id, ok, seconds, output)| {
-            serde_json::json!({ "id": id, "passed": ok, "seconds": seconds, "output": output })
+        .map(|(id, outcome, seconds, output)| {
+            serde_json::json!({
+                "id": id,
+                "outcome": outcome,
+                // Tri-state (ADR-0055): a non-graded row claims neither verdict.
+                // `null` keeps a truthiness reader fail-safe (it under-reports,
+                // never false-greens) without ever alleging a failure that did
+                // not happen.
+                "passed": outcome.passed(),
+                "seconds": seconds,
+                "output": output,
+            })
         })
         .collect();
     serde_json::json!({
         "total": total,
         "passed": passed,
-        "failed": total - passed,
+        "failed": failed,
+        "plumbing_ok": plumbing_ok,
         "cases": cases,
     })
 }
@@ -1369,7 +1400,8 @@ pub async fn eval(
     secrets: Vec<String>,
     image: String,
 ) -> Result<()> {
-    let state_plugin_dir = state::load(Path::new("."))?.map(|s| PathBuf::from(s.plugin_dir));
+    let saved = state::load(Path::new("."))?;
+    let state_plugin_dir = saved.as_ref().map(|s| PathBuf::from(s.plugin_dir.clone()));
     let cases_path = resolve_cases_path(cases_path, Path::new("."), state_plugin_dir.as_deref())?;
     let suite = load_suite(&cases_path)?;
 
@@ -1389,22 +1421,41 @@ pub async fn eval(
         .await;
     }
 
+    let fake = drives_a_fake_runner(saved.as_ref(), url.as_deref());
     let url = resolve_url(url)?;
     let client = RunnerClient::new(&url)?;
     let ui = crate::ui::ui();
     let bar = ui.progress_bar(suite.cases.len() as u64, "running evals");
-    let results = run_suite_cases(&client, &suite, |_| bar.inc(1)).await?;
+    let results = run_suite_cases(&client, &suite, fake, |_| bar.inc(1)).await?;
     bar.finish();
 
     report_eval(&results)
 }
 
-/// Run every case in `suite` against a runner, returning `(id, passed, seconds)`
-/// rows. `on_case` is called once per completed case (progress). Shared by the
-/// single-runner path and the per-model sweep so both grade identically.
+/// Whether the runner `skill eval` is about to drive is the fake. Learned from
+/// `.agentos/runner.json` -- the CLI's own record of the runner IT booted, not a
+/// guess at the shell env.
+///
+/// An explicit `--url` that is not the recorded runner points somewhere the
+/// saved state says nothing about, so the recorded fake-ness does not transfer
+/// and the run stays graded. `resolve_url`'s precedence is explicit-wins, so
+/// this must mirror it: absent or matching URL only.
+fn drives_a_fake_runner(saved: Option<&state::RunnerState>, explicit_url: Option<&str>) -> bool {
+    match saved {
+        Some(s) if s.fake_model => explicit_url.is_none_or(|u| u == s.base_url),
+        _ => false,
+    }
+}
+
+/// Run every case in `suite` against a runner, returning `(id, outcome, seconds,
+/// output)` rows. `fake` says the runner is the fake model, in which case the
+/// cases are not graded at all. `on_case` is called once per completed case
+/// (progress). Shared by the single-runner path and the per-model sweep so both
+/// judge identically.
 async fn run_suite_cases(
     client: &RunnerClient,
     suite: &EvalSuite,
+    fake: bool,
     mut on_case: impl FnMut(usize),
 ) -> Result<Vec<EvalRow>> {
     let mut results = Vec::with_capacity(suite.cases.len());
@@ -1426,11 +1477,12 @@ async fn run_suite_cases(
             .send_event(EventType::EvalCase, &case.input, "U-eval", |_| {})
             .await?;
         let elapsed = started.elapsed().as_secs_f64();
-        // Capture the graded answer -- the exact text `turn_passes` judged -- so a
-        // red case can be diagnosed from `--json` without a manual re-run (#548).
+        // Capture the graded answer -- the exact text `turn_outcome` judged -- so
+        // a red case can be diagnosed from `--json` without a manual re-run
+        // (#548). A fake row carries its canned reply for the same reason.
         results.push((
             case.id.clone(),
-            turn_passes(case, &events),
+            turn_outcome(case, &events, fake),
             elapsed,
             graded_answer(&events),
         ));
@@ -1538,10 +1590,15 @@ async fn eval_sweep(
             }
         };
         let client = RunnerClient::new(&url)?;
-        let run = run_suite_cases(&client, suite, |_| {}).await;
+        // `boot_eval_runner` pins `fake_model: false`, so every sweep runner is a
+        // REAL model whatever the standing dev runner is -- the sweep grades.
+        let run = run_suite_cases(&client, suite, false, |_| {}).await;
         let _ = docker::remove_container(&name).await;
         let results = run?;
-        let passed = results.iter().filter(|(_, ok, _, _)| *ok).count();
+        let passed = results
+            .iter()
+            .filter(|(_, o, _, _)| *o == CaseOutcome::Pass)
+            .count();
         step.done(&format!("{passed}/{}", suite.cases.len()));
         rows.push((model.clone(), passed, suite.cases.len()));
     }
@@ -1594,20 +1651,22 @@ pub fn report_sweep(rows: &[(String, usize, usize)]) -> Result<()> {
 /// Render a finished eval run identically for every tier (`skill`, `local`,
 /// `cluster`): under `--json` the whole roll-up is one machine payload on
 /// stdout; otherwise the per-case table is payload -> stdout and the roll-up
-/// verdict is a diagnostic -> stderr. A failing run exits `Failure`. Shared so
-/// `local eval`/`cluster eval` print the same summary `skill eval` does (the
-/// per-tier parity gate), not a hand-mirrored one.
+/// verdict is a diagnostic -> stderr. Shared so `local eval`/`cluster eval`
+/// print the same summary `skill eval` does (the per-tier parity gate), not a
+/// hand-mirrored one.
+///
+/// Only a genuine `Fail` exits `Failure`. A run that graded nothing because it
+/// ran on the fake tier is operationally successful without being a pass, so it
+/// exits 0 and says "plumbing OK" in words -- the documented onboarding loop is
+/// not red (#612), and it is not fake-green either (#606).
 pub fn report_eval(results: &[EvalRow]) -> Result<()> {
-    let total = results.len();
-    let passed = results.iter().filter(|(_, ok, _, _)| *ok).count();
+    let (_passed, failed, _plumbing_ok) = eval_counts(results);
     // Emit through the one success point (#474), then apply the exit-code side
     // effect for BOTH paths -- the json path had it inline, the human path after.
-    crate::ui::ui().emit(&EvalOutput {
-        results,
-        passed,
-        total,
-    });
-    if passed < total {
+    // Only a genuine `Fail` (failed > 0) exits non-zero: a plumbing-only run
+    // graded nothing but is operationally successful, so it exits 0 (#606/#612).
+    crate::ui::ui().emit(&EvalOutput { results });
+    if failed > 0 {
         std::process::exit(crate::exit::ExitClass::Failure.code());
     }
     Ok(())
@@ -1619,36 +1678,44 @@ pub fn report_eval(results: &[EvalRow]) -> Result<()> {
 /// roll-up verdict + per-red-case reply notes.
 struct EvalOutput<'a> {
     results: &'a [EvalRow],
-    passed: usize,
-    total: usize,
 }
 
 impl crate::ui::CliOutput for EvalOutput<'_> {
     fn to_json(&self) -> serde_json::Value {
-        eval_json(self.results, self.passed, self.total)
+        eval_json(self.results)
     }
 
     fn render(&self, ui: &crate::ui::Ui) {
-        let (results, passed, total) = (self.results, self.passed, self.total);
+        let results = self.results;
+        let (passed, failed, plumbing_ok) = eval_counts(results);
         let rows: Vec<Vec<String>> = results
             .iter()
-            .map(|(name, ok, seconds, _)| {
-                let result = if *ok {
-                    format!("{} pass", '\u{2713}')
-                } else {
-                    format!("{} fail", '\u{2717}')
-                };
-                vec![name.clone(), result, format!("{seconds:.1}s")]
+            .map(|(name, outcome, seconds, _)| {
+                vec![
+                    name.clone(),
+                    outcome_label(*outcome),
+                    format!("{seconds:.1}s"),
+                ]
             })
             .collect();
         ui.payload_plain(&crate::ui::table(&["case", "result", "time"], &rows, &[2]));
-        if passed == total {
-            ui.success(&format!("{passed}/{total} passed"));
+        if failed == 0 {
+            ui.success(&rollup_line(passed, failed, plumbing_ok));
+            if plumbing_ok > 0 {
+                ui.note(
+                    "the fake model returns one canned reply whatever the input, so these cases \
+                     were not graded -- they prove the turn completed, nothing more. Re-run with \
+                     a real credential to grade them.",
+                );
+            }
         } else {
             // Surface WHAT each red case actually replied, so a human need not
             // re-run by hand to see why it failed (#548). Empty means the turn
             // never produced gradeable text (no `done`/reply) -- the diagnosis.
-            for (name, _, _, output) in results.iter().filter(|(_, ok, _, _)| !*ok) {
+            for (name, _, _, output) in results
+                .iter()
+                .filter(|(_, o, _, _)| *o == CaseOutcome::Fail)
+            {
                 let shown = if output.is_empty() {
                     "<no reply text>".to_string()
                 } else {
@@ -1657,8 +1724,8 @@ impl crate::ui::CliOutput for EvalOutput<'_> {
                 ui.note(&format!("{name} replied: {shown}"));
             }
             ui.warn(&format!(
-                "{passed}/{total} passed; {} failed",
-                total - passed
+                "{}; {failed} failed",
+                rollup_line(passed, failed, plumbing_ok)
             ));
         }
     }

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -205,10 +205,66 @@ pub fn graded_answer(events: &[OutboundEvent]) -> String {
 /// classified-failure or interrupted turn still never passes, because those
 /// statuses match neither `done` nor `awaiting-approval`.
 pub fn turn_passes(case: &EvalCase, events: &[OutboundEvent]) -> bool {
+    turn_completed(case, events) && case.grader.grade(&graded_answer(events))
+}
+
+/// True when the turn ended in a `final` frame whose status matches the case's
+/// `expect_status` (default `done`, or `awaiting-approval` for a gate-blocked
+/// case). The one assertion the fake tier makes, and the gate the real path
+/// applies before the grader is ever consulted; a classified-failure or
+/// interrupted turn matches neither expected status, so it never completes.
+fn turn_completed(case: &EvalCase, events: &[OutboundEvent]) -> bool {
     let Some(OutboundEvent::Final { status, .. }) = events.last() else {
         return false;
     };
-    case.expect_status.matches(status) && case.grader.grade(&graded_answer(events))
+    case.expect_status.matches(status)
+}
+
+/// What a run of one eval case concluded. `PlumbingOk` is a THIRD state, not a
+/// shade of pass or fail: the fake model is a plumbing fixture, not a subject
+/// under test (ADR-0055), so a fake turn is never graded and can claim neither
+/// verdict. Mirrors the worker's `EvalOutcome`; the two vocabularies stay
+/// aligned or the skill/local/cluster parity this file exists to hold breaks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaseOutcome {
+    Pass,
+    Fail,
+    PlumbingOk,
+}
+
+impl CaseOutcome {
+    /// The tri-state `passed` an agent consumer reads: a non-graded row claims
+    /// neither verdict, so it is `null` rather than a fabricated `false`.
+    pub fn passed(self) -> Option<bool> {
+        match self {
+            CaseOutcome::Pass => Some(true),
+            CaseOutcome::Fail => Some(false),
+            CaseOutcome::PlumbingOk => None,
+        }
+    }
+}
+
+/// The outcome of one case's turn. `fake` says the runner that produced `events`
+/// was booted with the fake model.
+///
+/// The completion gate runs FIRST and applies to both tiers: a turn that did not
+/// reach its `expect_status` is a genuine `Fail` whatever produced it, and on the
+/// fake tier that is the only thing left to catch. Past the gate the two tiers
+/// diverge: a fake turn returns `PlumbingOk` WITHOUT consulting the grader at all,
+/// so no grader verdict -- in either direction -- can reach a fake run's outcome.
+pub fn turn_outcome(case: &EvalCase, events: &[OutboundEvent], fake: bool) -> CaseOutcome {
+    if !turn_completed(case, events) {
+        return CaseOutcome::Fail;
+    }
+    if fake {
+        return CaseOutcome::PlumbingOk;
+    }
+    if case.grader.grade(&graded_answer(events)) {
+        CaseOutcome::Pass
+    } else {
+        CaseOutcome::Fail
+    }
 }
 
 /// One rendered result line: check-or-cross, name, duration (design canon).
@@ -219,6 +275,32 @@ pub fn case_line(name: &str, passed: bool, seconds: f64) -> String {
 
 pub fn summary_line(passed: usize, total: usize) -> String {
     format!("{passed}/{total} passed")
+}
+
+/// The mark and word for one case's outcome in the results table. A plumbing row
+/// gets neither the check nor the cross: it is not a verdict.
+pub fn outcome_label(outcome: CaseOutcome) -> String {
+    match outcome {
+        CaseOutcome::Pass => format!("{} pass", '\u{2713}'),
+        CaseOutcome::Fail => format!("{} fail", '\u{2717}'),
+        CaseOutcome::PlumbingOk => format!("{} plumbing OK", '\u{2022}'),
+    }
+}
+
+/// The run's one-line verdict. A run with no plumbing rows reads exactly as it
+/// always did (`summary_line`); once any row is non-graded the line says so in
+/// words, because `N/N passed` on a run that graded nothing is the false green
+/// this whole outcome exists to kill (#606). Pure so the wording is testable.
+pub fn rollup_line(passed: usize, failed: usize, plumbing_ok: usize) -> String {
+    if plumbing_ok == 0 {
+        return summary_line(passed, passed + failed);
+    }
+    let plumbing = format!("{plumbing_ok} plumbing OK (not graded)");
+    let graded = passed + failed;
+    if graded == 0 {
+        return plumbing;
+    }
+    format!("{}, {plumbing}", summary_line(passed, graded))
 }
 
 #[cfg(test)]

--- a/cli/src/guide.rs
+++ b/cli/src/guide.rs
@@ -97,7 +97,11 @@ pub fn primer() -> Primer {
             Rung {
                 tier: "skill",
                 command: "agentos skill eval",
-                purpose: "Run evals/cases.json in-process. This is the promotion gate; it must be green.",
+                purpose: "Run evals/cases.json in-process. This is the promotion gate -- but only \
+                          under a real credential, where the cases are graded. Under --fake-model \
+                          it reports plumbing_ok: the fake returns one canned reply whatever the \
+                          input, so nothing is graded and a green here says only that the turn \
+                          completed.",
             },
             Rung {
                 tier: "skill",
@@ -174,7 +178,9 @@ pub fn primer() -> Primer {
             Decision {
                 question: "how an eval gates promotion",
                 answer: "evals/cases.json is the contract. `agentos skill eval` must be green before \
-                         you deploy; `agentos local eval` and `agentos cluster eval` re-run the SAME \
+                         you deploy -- green under a real credential, since the fake model grades \
+                         nothing and only reports plumbing_ok; \
+                         `agentos local eval` and `agentos cluster eval` re-run the SAME \
                          cases with the SAME grader at each tier (the per-tier parity gate), so a \
                          suite that is green at skill can be re-asserted verbatim once deployed. \
                          Merging to main promotes to prod (git flow is the deploy model). Never \

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -73,7 +73,10 @@ pub enum ModelMode {
 
 /// Match the runner's truthy parse of `AGENTOS_FAKE_MODEL`
 /// (`runner/src/agentos_runner/__main__.py`): lowercase one of `1`/`true`/`yes`.
-fn fake_model_is_truthy(v: &str) -> bool {
+/// The runtime's own reading of `AGENTOS_FAKE_MODEL`. Shared with the eval
+/// sweep's worker probe (`message::probe_fake_model`) so the CLI judges a
+/// deployed worker's fake-ness by the same rule the worker judges itself.
+pub(crate) fn fake_model_is_truthy(v: &str) -> bool {
     matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes")
 }
 

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1024,7 +1024,11 @@ async fn run_eval_turns(
         };
         results.push((
             case.id.clone(),
-            reply_passes(case, &outcome),
+            if reply_passes(case, &outcome) {
+                crate::evals::CaseOutcome::Pass
+            } else {
+                crate::evals::CaseOutcome::Fail
+            },
             elapsed,
             output,
         ));
@@ -1108,6 +1112,186 @@ pub fn select_agent_id(agents: &[Agent], channel: Option<&str>) -> Result<String
     }
 }
 
+/// Refuse a `--model` sweep against a stack running the fake model (#606, AC2 of
+/// #612). Pure so the class and the wording are testable with no stack.
+///
+/// The fake never calls a model: it returns one canned reply whatever the input
+/// and whatever the requested model, so a sweep of N models compares one string
+/// to itself N times and reports a comparison that never happened. The default
+/// parity-gate run (no `--model`) on a fake stack is the DOCUMENTED onboarding
+/// loop and stays allowed -- it asserts plumbing, and it claims nothing about
+/// any model.
+///
+/// Usage (exit 2), never `Unsupported` (exit 4): supplying a credential makes
+/// this exact argv work, so a model sweep is not absent from this tier by
+/// construction, which is ADR-0041's boundary for exit 4.
+pub fn guard_fake_sweep(fake: bool, models: &[String], local: bool) -> Result<()> {
+    if !fake || models.is_empty() {
+        return Ok(());
+    }
+    let fix = if local {
+        "set AGENTOS_CREDENTIALS to a real model credential and re-run `agentos local up`, then \
+         sweep again"
+    } else {
+        "re-install the release with a real model (`--set agentSandbox.runner.fakeModel=false`, \
+         plus a model credential) and sweep again"
+    };
+    // The reason has to be the one that actually applies. With a single
+    // `--model` there is no comparison to fabricate: the request simply cannot
+    // be honored. The comparison-axis rationale is only true from two up.
+    let why = if models.len() == 1 {
+        format!(
+            "this stack runs the fake model, so it will never call `{}`: the fake answers every \
+             input with the same scripted text whatever --model asks for. The run would be that \
+             canned script, not the model you pinned.",
+            models[0]
+        )
+    } else {
+        format!(
+            "this stack runs the fake model, so sweeping {} models would compare one canned reply \
+             to itself: the fake never calls a model, and answers every input with the same \
+             scripted text whatever --model asks for. Every row would be labelled fake-model and \
+             carry an identical answer, so the comparison would be fabricated.",
+            models.len()
+        )
+    };
+    Err(anyhow::Error::from(
+        crate::exit::CliError::usage(why).with_fix(fix),
+    ))
+}
+
+/// Read the fake-ness of the tier's DEPLOYED worker: the already-composed value
+/// of `AGENTOS_FAKE_MODEL` on the artifact that is actually running.
+///
+/// Deliberately a read of the output, not a re-derivation of the input. The
+/// chart's effective value is the composite `fakeModel AND NOT inference.deploy`
+/// and compose's is `${AGENTOS_FAKE_MODEL:-1}`; re-deriving either in the CLI
+/// would give a second config that drifts from the truth (an
+/// `inference.deploy` + `fakeModel=true` install is a REAL install, and shell
+/// env is not what the running container was booted with). A probe failure is
+/// reported as itself; it never falls back to a default guess.
+async fn probe_fake_model(opts: &EvalOpts) -> Result<bool> {
+    let env = if opts.local {
+        let worker = local_worker_container().await?;
+        let cmd = OpsCommand::new(
+            "docker",
+            vec![
+                plain("inspect"),
+                plain(&worker),
+                plain("--format"),
+                plain("{{range .Config.Env}}{{println .}}{{end}}"),
+            ],
+        );
+        let (ok, stdout, stderr) = run_capture(&cmd).await?;
+        if !ok {
+            bail!(
+                "inspecting the local worker container {worker}: {}",
+                stderr.trim()
+            );
+        }
+        stdout
+            .lines()
+            .find_map(|l| l.strip_prefix("AGENTOS_FAKE_MODEL="))
+            .map(str::to_string)
+    } else {
+        require_on_path("kubectl")?;
+        let deployment = format!("deployment/{}-worker", opts.release);
+        let cmd = OpsCommand::new(
+            "kubectl",
+            vec![
+                plain("-n"),
+                plain(&opts.namespace),
+                plain("get"),
+                plain(&deployment),
+                plain("-o"),
+                plain(
+                    "jsonpath={.spec.template.spec.containers[*].env[?(@.name==\"AGENTOS_FAKE_MODEL\")].value}",
+                ),
+            ],
+        );
+        let (ok, stdout, stderr) = run_capture(&cmd).await?;
+        if !ok {
+            bail!(
+                "reading {deployment} in namespace {} to check whether the release runs the fake \
+                 model: {}",
+                opts.namespace,
+                stderr.trim()
+            );
+        }
+        let value = stdout.trim().to_string();
+        (!value.is_empty()).then_some(value)
+    };
+    // An absent variable means the worker was booted without the flag at all,
+    // which is the live path on both tiers (compose only defaults to fake
+    // through `${AGENTOS_FAKE_MODEL:-1}`, which materializes the value).
+    Ok(env
+        .as_deref()
+        .is_some_and(crate::local::fake_model_is_truthy))
+}
+
+/// The compose service the worker runs as, per `compose.dev.yaml`. Container
+/// NAMES vary with the compose project (`<project>-agentos-worker-1`), so the
+/// service label is the only stable selector; `cli/tests/fake_tier_plumbing.rs`
+/// pins this against the compose file so a service rename cannot silently
+/// blind the probe again.
+pub(crate) const COMPOSE_WORKER_SERVICE: &str = "agentos-worker";
+
+/// The label selector the probe matches on, quoted into diagnostics so an
+/// operator can re-run the same `docker ps` and see what the CLI saw.
+fn worker_label_selector() -> String {
+    format!("label=com.docker.compose.service={COMPOSE_WORKER_SERVICE}")
+}
+
+fn worker_ps_command() -> OpsCommand {
+    OpsCommand::new(
+        "docker",
+        vec![
+            plain("ps"),
+            plain("--filter"),
+            plain(worker_label_selector()),
+            plain("--format"),
+            plain("{{.Names}}"),
+        ],
+    )
+}
+
+/// Pick the one running compose worker from `docker ps` output. Zero or many is
+/// an explicit diagnostic: guessing which stack the sweep would hit is exactly
+/// the fabrication this probe exists to prevent. Both diagnostics name the
+/// selector rather than asserting a stack-wide fact the probe did not check --
+/// "no container matched X" is verifiable; "there is no stack" is not.
+fn select_worker_container(stdout: &str) -> Result<String> {
+    let names: Vec<&str> = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+    match names.as_slice() {
+        [only] => Ok((*only).to_string()),
+        [] => bail!(
+            "no running container matches `{}`, so the sweep cannot read which model the local \
+             stack is running. Start a stack with `agentos local up`.",
+            worker_label_selector()
+        ),
+        many => bail!(
+            "{} running containers match `{}` ({}); a sweep cannot tell which stack it would \
+             measure. Stop the extras with `agentos local down`.",
+            many.len(),
+            worker_label_selector(),
+            many.join(", ")
+        ),
+    }
+}
+
+async fn local_worker_container() -> Result<String> {
+    let cmd = worker_ps_command();
+    let (ok, stdout, stderr) = run_capture(&cmd).await?;
+    if !ok {
+        bail!("listing the local worker container: {}", stderr.trim());
+    }
+    select_worker_container(&stdout)
+}
+
 /// The `--model` sweep at the local/cluster tier: enqueue one platform eval per
 /// model against the agent's active dev version, then poll the matrix for the
 /// per-model pass-rate the recorder writes (#526). Unlike the skill sweep (which
@@ -1116,11 +1300,14 @@ pub fn select_agent_id(agents: &[Agent], channel: Option<&str>) -> Result<String
 async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
     let ui = crate::ui::ui();
     if opts.dry_run {
+        // A dry run is an offline, non-mutating plan: it does not probe the
+        // runtime, so it must not claim what the current stack would do.
         ui.emit(&crate::ui::DryRunPlan {
             lines: eval_dry_run_lines(&opts, &suite.name, suite.cases.len()),
         });
         return Ok(());
     }
+    guard_fake_sweep(probe_fake_model(&opts).await?, &opts.models, opts.local)?;
 
     // The trigger + matrix reads go over the platform API. Local reaches it
     // directly; cluster tunnels an api port-forward kept alive for the whole poll.
@@ -1387,6 +1574,60 @@ async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The probe is only honest if it filters on the service compose actually
+    /// runs the worker as. It previously matched `service=worker`, which exists
+    /// nowhere in the compose file, so the fake-sweep guard silently never fired
+    /// against a running stack and the CLI reported "no stack" while one ran.
+    #[test]
+    fn the_probe_matches_the_worker_service_compose_declares() {
+        let compose = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../compose.dev.yaml"),
+        )
+        .expect("compose.dev.yaml is readable from the cli crate");
+        assert!(
+            compose.contains(&format!("\n  {COMPOSE_WORKER_SERVICE}:\n")),
+            "compose.dev.yaml declares no `{COMPOSE_WORKER_SERVICE}:` service, so the probe's \
+             docker ps filter would match nothing"
+        );
+        assert_eq!(
+            worker_label_selector(),
+            "label=com.docker.compose.service=agentos-worker"
+        );
+        let argv = worker_ps_command().display();
+        assert!(
+            argv.contains("--filter label=com.docker.compose.service=agentos-worker"),
+            "docker ps argv lost the service filter: {argv}"
+        );
+    }
+
+    #[test]
+    fn one_matching_container_is_the_worker_to_inspect() {
+        assert_eq!(
+            select_worker_container("agentos-agentos-worker-1\n").unwrap(),
+            "agentos-agentos-worker-1"
+        );
+    }
+
+    /// Zero and many are diagnostics about the SELECTOR, never a claim about
+    /// the world the probe did not check.
+    #[test]
+    fn zero_and_many_matches_are_diagnostics_naming_the_selector() {
+        let none = select_worker_container("\n  \n").unwrap_err().to_string();
+        assert!(
+            none.contains("no running container matches")
+                && none.contains("com.docker.compose.service=agentos-worker"),
+            "{none}"
+        );
+        let many = select_worker_container("a-agentos-worker-1\nb-agentos-worker-1\n")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            many.contains("2 running containers match")
+                && many.contains("a-agentos-worker-1, b-agentos-worker-1"),
+            "{many}"
+        );
+    }
 
     fn agent(name: &str, channel: &str) -> Agent {
         Agent {

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -5,8 +5,11 @@
 //! `skills/<name>/SKILL.md` with YAML frontmatter, a root `.mcp.json`, plus a
 //! CLI-local `evals/cases.json` seed (a suite object
 //! `{name, cases: [{id, input, grader}]}`, hand-mirroring the frozen eval-case
-//! schema) for `agentos skill eval` -- a single smoke case that passes on any
-//! completed turn. Two more files teach the developer's coding agent how to
+//! schema) for `agentos skill eval` -- a single smoke case whose grader is
+//! falsifiable: it requires the agent to name itself, so an empty, broken, or
+//! off-topic turn fails it (#527). Under `--fake-model` that grader never runs
+//! at all -- the fake tier is a plumbing fixture and reports the non-graded
+//! `plumbing_ok` (ADR-0055). Two more files teach the developer's coding agent how to
 //! drive the harness: a root `AGENTS.md` (the cross-agent auto-scanned standard)
 //! and an installable primer skill at `.claude/skills/using-agentos/SKILL.md`
 //! whose body is rendered from `guide::primer_markdown()` so it can never drift
@@ -50,10 +53,17 @@ fn skill_md(name: &str) -> String {
     )
 }
 
-/// The `evals/cases.json` seed: a single smoke case named for `<name>`. The
-/// `contains ""` grader passes on any completed (`Done`) turn, so the scaffold
-/// is green out of the box under both `--fake-model` and a real credential --
-/// a status gate the author replaces with real graders first.
+/// The `evals/cases.json` seed: a single smoke case named for `<name>`, graded
+/// by a falsifiable `contains: <name>` (#527) -- the agent must name itself, so
+/// a broken, empty, or off-topic turn is red.
+///
+/// The two tiers reach that grader differently, and neither is "green out of the
+/// box". Under a real credential the case is graded and a correct introduction
+/// passes it. Under `--fake-model` the case is NOT graded at all: the fake
+/// answers every input with the same canned text, so `skill eval` reports the
+/// non-graded `plumbing_ok` -- exit 0, but a claim about the plumbing, not about
+/// the agent (ADR-0055). Replacing this with a real domain grader is the
+/// author's first step either way.
 fn eval_cases(name: &str) -> String {
     serde_json::to_string_pretty(&serde_json::json!({
         "name": name,
@@ -84,7 +94,7 @@ fn eval_cases(name: &str) -> String {
 /// current landmine list.
 fn agents_md(name: &str) -> String {
     format!(
-        "# Agent instructions: {name}\n\nThis is an AgentOS bundle (a Claude Code plugin shape). The full harness\nprimer is one command away and is the source of truth:\n\n    agentos guide\n\n## The loop\n\n1. `agentos skill up --fake-model` -- boot the runner offline, no credential.\n2. Edit `skills/{name}/SKILL.md` (behavior) and `evals/cases.json` (the contract).\n3. `agentos skill eval` -- must be green before any deploy. Merging to main promotes.\n4. `agentos skill down` when finished.\n\n## Rules\n\n- Verify before running: `agentos schema` lists every real command; never\n  invoke one you have not confirmed.\n- The eval file is the promotion gate and never changes across tiers\n  (skill/local/cluster). Never deploy on red.\n- Landmines: run `agentos guide` (or read\n  `.claude/skills/using-agentos/SKILL.md`) for the full, current list.\n- The scaffolded eval is a starter smoke test: it only checks the agent named\n  itself, so it fails on an empty/errored turn but proves nothing about the\n  real work. Replace it with a FALSIFIABLE grader -- one a plausibly-broken\n  agent would fail -- as the first authoring step (ADR-0022).\n"
+        "# Agent instructions: {name}\n\nThis is an AgentOS bundle (a Claude Code plugin shape). The full harness\nprimer is one command away and is the source of truth:\n\n    agentos guide\n\n## The loop\n\n1. `agentos skill up --fake-model` -- boot the runner offline, no credential.\n   The fake model is plumbing, not a subject under test: it answers every input\n   with the same canned reply, so nothing it says is evidence about behavior.\n2. Edit `skills/{name}/SKILL.md` (behavior) and `evals/cases.json` (the contract).\n3. `agentos skill eval` under `--fake-model` reports `plumbing_ok` -- it proves\n   the turn completed, and grades nothing. Re-run it with a real credential to\n   grade the cases; that green is the promotion gate. Merging to main promotes.\n4. `agentos skill down` when finished.\n\n## Rules\n\n- Verify before running: `agentos schema` lists every real command; never\n  invoke one you have not confirmed.\n- The eval file is the promotion gate and never changes across tiers\n  (skill/local/cluster). Grading, and therefore green and red, is a\n  real-credential concept; never deploy on red.\n- Landmines: run `agentos guide` (or read\n  `.claude/skills/using-agentos/SKILL.md`) for the full, current list.\n- The scaffolded eval is a starter smoke test: it only checks the agent named\n  itself, so it fails on an empty/errored turn but proves nothing about the\n  real work. Replace it with a FALSIFIABLE grader -- one a plausibly-broken\n  agent would fail -- as the first authoring step (ADR-0022).\n"
     )
 }
 
@@ -361,7 +371,8 @@ mod tests {
                 .unwrap();
         assert!(mcp["mcpServers"].is_object());
 
-        // Single smoke case named for <name>: contains "" (status-gated pass).
+        // Single smoke case named for <name>, graded by a falsifiable
+        // `contains: <name>` (#527) -- never the vacuous `contains ""`.
         let cases: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(dir.path().join("evals/cases.json")).unwrap(),
         )

--- a/cli/tests/fake_tier_plumbing.rs
+++ b/cli/tests/fake_tier_plumbing.rs
@@ -1,0 +1,494 @@
+//! Issues #612 + #606: the fake model is a plumbing fixture, not a subject
+//! under test.
+//!
+//! Two rules are pinned here, both stated as behavior:
+//!
+//! 1. The fake tier asserts ONLY that the turn completed. It never runs a
+//!    content grader, and its outcome is a distinct non-graded `plumbing_ok`
+//!    that is neither pass nor fail (`passed: null`).
+//! 2. A `--model` sweep against a fake/sealed stack is REFUSED Usage-shaped
+//!    (exit 2), never `Unsupported` (exit 4): supplying a credential makes the
+//!    verb work, so the concept is not absent by construction (ADR-0041).
+//!
+//! Written test-first: `evals::CaseOutcome`, `evals::turn_outcome`, and
+//! `message::guard_fake_sweep` do not exist yet, so this file does not compile
+//! until the implementer builds them.
+//!
+//! On the runner mock: `support::serve` is the established external-seam mock
+//! (the runner is a separate service over HTTP/NDJSON). The frames it serves are
+//! the fake's REAL canned turn -- `runner/src/agentos_runner/fake.py`
+//! `default_turn()` emits exactly a "Looking into it" text delta, a `Bash` tool
+//! use, and a `final` with text "all done" and status `done`. The eval cases are
+//! the scaffold's REAL seeded `evals/cases.json`, written by the real `agentos
+//! init` binary and never hand-substituted (#612's AC is explicit on this). The
+//! whole defect lives in the collision between those two real artifacts: the
+//! seeded grader requires the bundle name and "all done" does not contain it.
+
+mod support;
+
+use std::path::Path;
+use std::process::Command;
+
+use agentos::evals::{
+    load_suite, turn_outcome, CaseOutcome, EvalCase, ExpectedStatus, Grader, GraderKind,
+};
+use agentos::exit::{classify, ExitClass};
+use agentos::message::guard_fake_sweep;
+use agentos::state::{self, RunnerState};
+use agentos_aci_protocol::{OutboundEvent, SessionStatus, PROTOCOL_VERSION};
+use support::{serve, Response};
+
+const BUNDLE: &str = "deal-desk";
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_agentos")
+}
+
+fn output_text(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned() + &String::from_utf8_lossy(&output.stderr)
+}
+
+fn frame(json: serde_json::Value) -> String {
+    serde_json::to_string(&json).unwrap()
+}
+
+/// `fake.py::default_turn()` on the wire: the canned turn every fake-model run
+/// produces, whatever the input. Its graded answer is "all done".
+fn fake_canned_turn() -> Vec<String> {
+    vec![
+        frame(serde_json::json!({
+            "type": "text_delta", "version": PROTOCOL_VERSION, "text": "Looking into it"
+        })),
+        frame(serde_json::json!({
+            "type": "tool_note", "version": PROTOCOL_VERSION, "text": "echo hi", "tool": "Bash"
+        })),
+        frame(serde_json::json!({
+            "type": "final", "version": PROTOCOL_VERSION, "text": "all done", "status": "done"
+        })),
+    ]
+}
+
+/// A real-model turn that satisfies the seeded grader: it names the bundle.
+fn on_topic_turn() -> Vec<String> {
+    vec![frame(serde_json::json!({
+        "type": "final", "version": PROTOCOL_VERSION,
+        "text": "I am the deal-desk agent.", "status": "done"
+    }))]
+}
+
+/// `agentos init <BUNDLE>` into a temp dir via the real binary, so the eval
+/// suite under test is the shipped seed rather than a fixture.
+fn scaffold(dir: &Path) -> std::path::PathBuf {
+    let out = dir.join(BUNDLE);
+    let output = Command::new(bin())
+        .arg("init")
+        .arg(BUNDLE)
+        .arg("--dir")
+        .arg(&out)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run agentos init");
+    assert!(
+        output.status.success(),
+        "init must scaffold\n{}",
+        output_text(&output)
+    );
+    out
+}
+
+/// Record the runner `skill eval` will drive, exactly as `skill up` does: the
+/// CLI's own record of the runner it booted is where fake-ness is learned from.
+fn record_runner(bundle: &Path, base_url: &str, fake_model: bool) {
+    state::save(
+        bundle,
+        &RunnerState {
+            container_id: "c0ffee".into(),
+            container_name: format!("agentos-{BUNDLE}"),
+            image: "agentos-runner".into(),
+            port: 8080,
+            base_url: base_url.to_string(),
+            session_id: "s1".into(),
+            plugin_dir: bundle.display().to_string(),
+            fake_model,
+            ollama_container: None,
+            network: None,
+            model_base_url: None,
+        },
+    )
+    .expect("record runner state");
+}
+
+fn skill_eval(bundle: &Path, json: bool) -> std::process::Output {
+    let mut cmd = Command::new(bin());
+    cmd.arg("skill").arg("eval").current_dir(bundle);
+    if json {
+        cmd.arg("--json");
+    }
+    cmd.stdin(std::process::Stdio::null())
+        .output()
+        .expect("run agentos skill eval")
+}
+
+// --- AC1: the scaffold's own documented loop is not red --------------------
+
+/// The documented onboarding loop (`init` -> `skill up --fake-model` ->
+/// `skill eval`) exits 0 on an untouched scaffold, and reports the run as
+/// non-graded plumbing rather than as a pass. This is #612's headline AC.
+///
+/// Deleting the impl fails this three ways: grading the fake turn makes the seed
+/// red (exit 1), calling it a pass makes `outcome`/`passed` wrong, and dropping
+/// the tri-state makes `passed` a boolean.
+#[test]
+fn the_scaffolded_fake_loop_exits_zero_and_reports_plumbing_not_a_pass() {
+    let server = serve(|_req| Response::ndjson(&fake_canned_turn()));
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = scaffold(dir.path());
+    record_runner(&bundle, &server.base_url, true);
+
+    let output = skill_eval(&bundle, true);
+    assert!(
+        output.status.success(),
+        "the scaffold's own documented fake loop must not be red\n{}",
+        output_text(&output)
+    );
+
+    let body: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("--json emits one object");
+    assert_eq!(
+        body["plumbing_ok"], 1,
+        "the rollup must count the non-graded row: {body}"
+    );
+    assert_eq!(body["failed"], 0, "a plumbing row is not a failure: {body}");
+    let case = &body["cases"][0];
+    assert_eq!(
+        case["outcome"], "plumbing_ok",
+        "the fake row's outcome is neither pass nor fail: {body}"
+    );
+    assert!(
+        case["passed"].is_null(),
+        "`passed` is tri-state; a non-graded row claims neither: {body}"
+    );
+}
+
+/// The human rollup for an all-plumbing run must read as plumbing. `1/1 passed`
+/// on a run that never graded anything is the exact false green #606 is about,
+/// and a human reading the onboarding loop's output is who it would fool.
+#[test]
+fn the_human_rollup_of_a_fake_run_never_claims_passed() {
+    let server = serve(|_req| Response::ndjson(&fake_canned_turn()));
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = scaffold(dir.path());
+    record_runner(&bundle, &server.base_url, true);
+
+    let output = skill_eval(&bundle, false);
+    assert!(output.status.success(), "{}", output_text(&output));
+    let text = output_text(&output);
+    assert!(
+        !text.contains("1/1 passed"),
+        "a non-graded run must never render as a pass-rate:\n{text}"
+    );
+    assert!(
+        text.to_lowercase().contains("plumbing"),
+        "the rollup must name what actually happened:\n{text}"
+    );
+}
+
+/// Falsifiability guard (#527 / #553 intent): `plumbing_ok` must not become a
+/// backdoor to the vacuous grader #527 removed. On the REAL path the seeded
+/// grader still fails an off-topic turn -- and "all done" is exactly the
+/// off-topic reply, since it never names the bundle.
+#[test]
+fn the_seeded_grader_still_fails_an_off_topic_turn_on_the_real_path() {
+    let server = serve(|_req| Response::ndjson(&fake_canned_turn()));
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = scaffold(dir.path());
+    record_runner(&bundle, &server.base_url, false);
+
+    let output = skill_eval(&bundle, true);
+    assert!(
+        !output.status.success(),
+        "a real-model turn that never names the bundle must stay red\n{}",
+        output_text(&output)
+    );
+    let body: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("--json emits one object even on red");
+    assert_eq!(body["failed"], 1, "{body}");
+    assert_eq!(body["cases"][0]["outcome"], "fail", "{body}");
+    assert_eq!(body["cases"][0]["passed"], false, "{body}");
+}
+
+/// The positive control for the guard above: on the real path an on-topic turn
+/// passes. Without this, a grader that failed everything would satisfy the
+/// falsifiability test and nothing would notice.
+#[test]
+fn the_seeded_grader_passes_an_on_topic_turn_on_the_real_path() {
+    let server = serve(|_req| Response::ndjson(&on_topic_turn()));
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = scaffold(dir.path());
+    record_runner(&bundle, &server.base_url, false);
+
+    let output = skill_eval(&bundle, true);
+    assert!(output.status.success(), "{}", output_text(&output));
+    let body: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(body["passed"], 1, "{body}");
+    assert_eq!(body["cases"][0]["outcome"], "pass", "{body}");
+    assert_eq!(body["cases"][0]["passed"], true, "{body}");
+}
+
+/// The scaffold's seeded suite is what the loop above actually ran: a
+/// falsifiable `contains: <name>` grader. Pins the artifact the whole AC1 story
+/// depends on, through the same loader `skill eval` uses.
+#[test]
+fn the_scaffold_seeds_a_falsifiable_grader_the_fake_reply_does_not_satisfy() {
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = scaffold(dir.path());
+    let suite = load_suite(&bundle.join("evals/cases.json")).expect("the seed loads");
+    let case = &suite.cases[0];
+    assert_eq!(case.grader.kind, GraderKind::Contains);
+    assert_eq!(case.grader.expected, BUNDLE);
+    assert!(
+        !case.grader.grade("all done"),
+        "the seed must stay falsifiable: the fake's canned reply must NOT satisfy it, \
+         which is precisely why the fake tier cannot be graded"
+    );
+}
+
+// --- The grader never runs on a fake turn ----------------------------------
+
+fn case_requiring(expected: &str) -> EvalCase {
+    EvalCase {
+        id: "c".into(),
+        input: "introduce yourself".into(),
+        grader: Grader {
+            kind: GraderKind::Contains,
+            expected: expected.into(),
+            case_sensitive: false,
+        },
+        shared_history: false,
+        expect_status: ExpectedStatus::Done,
+    }
+}
+
+fn final_event(text: &str, status: SessionStatus) -> OutboundEvent {
+    OutboundEvent::Final {
+        version: PROTOCOL_VERSION.into(),
+        text: text.into(),
+        status,
+        approval_summary: None,
+        approval_route: None,
+        approval_gate_kind: None,
+        approval_granted_tool: None,
+    }
+}
+
+/// The mandate, as one assertion: a completed fake turn is `PlumbingOk` even
+/// when the grader would FAIL it. The grader is not consulted at all, so its
+/// verdict cannot reach the outcome.
+#[test]
+fn a_completed_fake_turn_is_plumbing_ok_even_when_the_grader_would_fail_it() {
+    let case = case_requiring(BUNDLE);
+    let events = vec![final_event("all done", SessionStatus::Done)];
+    assert!(
+        !case.grader.grade("all done"),
+        "precondition: this grader fails the fake's canned text"
+    );
+    assert_eq!(
+        turn_outcome(&case, &events, true),
+        CaseOutcome::PlumbingOk,
+        "a fake turn's outcome must not depend on the grader"
+    );
+}
+
+/// The converse: a completed fake turn the grader would PASS is still
+/// `PlumbingOk`, never `Pass`. A fake run cannot earn a grade in either
+/// direction -- otherwise a grader tuned to the canned text (the #612 e2e.sh
+/// bypass) manufactures a green.
+#[test]
+fn a_completed_fake_turn_the_grader_would_pass_is_still_plumbing_ok() {
+    let case = case_requiring("all done");
+    let events = vec![final_event("all done", SessionStatus::Done)];
+    assert!(case.grader.grade("all done"), "precondition");
+    assert_eq!(
+        turn_outcome(&case, &events, true),
+        CaseOutcome::PlumbingOk,
+        "a fake run must never be reported as a graded pass"
+    );
+}
+
+/// Ordering is load-bearing: the `Done` gate runs BEFORE the fake early return.
+/// The fake tier's one and only assertion is that the turn completed, so a
+/// fake turn that did not complete is a genuine `Fail` -- the one thing this
+/// tier must still catch.
+#[test]
+fn a_fake_turn_that_did_not_complete_is_still_a_fail() {
+    let case = case_requiring("all done");
+    let failed = vec![final_event("all done", SessionStatus::ClassifiedFailure)];
+    assert_eq!(
+        turn_outcome(&case, &failed, true),
+        CaseOutcome::Fail,
+        "a classified-failure fake turn means the plumbing genuinely broke"
+    );
+    let unfinished: Vec<OutboundEvent> = vec![OutboundEvent::TextDelta {
+        version: PROTOCOL_VERSION.into(),
+        text: "all done".into(),
+    }];
+    assert_eq!(
+        turn_outcome(&case, &unfinished, true),
+        CaseOutcome::Fail,
+        "a fake turn with no final never completed"
+    );
+}
+
+/// The real path is unchanged: `turn_outcome(.., fake = false)` is the graded
+/// verdict `turn_passes` gave, and never `PlumbingOk`.
+#[test]
+fn the_real_path_still_grades_and_never_returns_plumbing_ok() {
+    let case = case_requiring(BUNDLE);
+    let on_topic = vec![final_event(
+        "I am the deal-desk agent.",
+        SessionStatus::Done,
+    )];
+    let off_topic = vec![final_event("all done", SessionStatus::Done)];
+    assert_eq!(turn_outcome(&case, &on_topic, false), CaseOutcome::Pass);
+    assert_eq!(turn_outcome(&case, &off_topic, false), CaseOutcome::Fail);
+    let failed = vec![final_event(
+        "I am the deal-desk agent.",
+        SessionStatus::ClassifiedFailure,
+    )];
+    assert_eq!(
+        turn_outcome(&case, &failed, false),
+        CaseOutcome::Fail,
+        "the Done gate still precedes the grader on the real path"
+    );
+}
+
+// --- AC2: fake + `--model` refuses, Usage-shaped ---------------------------
+
+fn models() -> Vec<String> {
+    vec!["claude-opus-4-8".into(), "claude-sonnet-5".into()]
+}
+
+/// A sweep on a fake stack compares one canned string to itself, so it is
+/// refused. The class is the contract an agent branches on: Usage (exit 2),
+/// because supplying a credential makes the verb work -- it is not absent by
+/// construction, which is ADR-0041's boundary for exit 4.
+#[test]
+fn a_model_sweep_on_a_fake_local_stack_is_refused_usage_shaped() {
+    let err = guard_fake_sweep(true, &models(), true).expect_err("a fake sweep must be refused");
+    let (class, fix) = classify(&err);
+    assert_eq!(
+        class,
+        ExitClass::Usage,
+        "a credential makes this verb work, so it is Usage (2), not Unsupported (4)"
+    );
+    let shown = format!("{err:#}");
+    assert!(
+        shown.to_lowercase().contains("fake"),
+        "the message must name the reason the sweep is meaningless: {shown}"
+    );
+    assert!(
+        shown.contains("compare one canned reply to itself")
+            && shown.contains("sweeping 2 models")
+            && shown.contains("fabricated"),
+        "a real sweep's reason is the fabricated comparison axis, counted correctly: {shown}"
+    );
+    let fix = fix.expect("the refusal must carry an actionable fix");
+    assert!(
+        fix.contains("AGENTOS_CREDENTIALS"),
+        "the local tier's fix is supplying a credential: {fix}"
+    );
+}
+
+/// A single `--model` is still refused -- the ruling is "fake + --model", not
+/// "fake + a sweep" -- but there is no comparison to fabricate, so the message
+/// must give the reason that applies: the caller pinned a model this stack will
+/// never call. A refusal that states the wrong reason is the same defect class
+/// this whole guard exists to stop.
+#[test]
+fn a_single_model_on_a_fake_stack_is_refused_for_the_reason_that_applies() {
+    let one = vec!["claude-opus-4-8".to_string()];
+    let err = guard_fake_sweep(true, &one, true).expect_err("fake + --model is refused at N=1 too");
+    let (class, fix) = classify(&err);
+    assert_eq!(
+        class,
+        ExitClass::Usage,
+        "N=1 keeps the same class as a sweep: a credential makes it work"
+    );
+    let shown = format!("{err:#}");
+    assert!(
+        shown.contains("claude-opus-4-8") && shown.contains("never call"),
+        "the reason must be that the pinned model is never called: {shown}"
+    );
+    assert!(
+        !shown.contains("compare")
+            && !shown.contains("comparison")
+            && !shown.contains("fabricated"),
+        "there is no comparison at N=1, so the comparison rationale must not appear: {shown}"
+    );
+    assert!(
+        !shown.contains("1 models"),
+        "the message must not read as a plural sweep of one: {shown}"
+    );
+    assert!(
+        fix.expect("the refusal must carry an actionable fix")
+            .contains("AGENTOS_CREDENTIALS"),
+        "N=1 keeps the tier's fix hint"
+    );
+}
+
+/// `cluster eval` funnels through the same seam and gets the same class, with
+/// the fix naming the knob that tier actually has.
+#[test]
+fn a_model_sweep_on_a_fake_cluster_release_is_refused_usage_shaped() {
+    let err = guard_fake_sweep(true, &models(), false).expect_err("a fake sweep must be refused");
+    let (class, fix) = classify(&err);
+    assert_eq!(class, ExitClass::Usage);
+    let fix = fix.expect("the refusal must carry an actionable fix");
+    assert!(
+        fix.contains("fakeModel"),
+        "the cluster tier's fix is the chart value, not an env var: {fix}"
+    );
+}
+
+/// A sweep on a REAL stack is the whole point of #526 ("can we move this skill
+/// to a cheaper model") and must not be blocked.
+#[test]
+fn a_model_sweep_on_a_real_stack_is_allowed() {
+    guard_fake_sweep(false, &models(), true).expect("a real stack sweeps");
+    guard_fake_sweep(false, &models(), false).expect("a real release sweeps");
+}
+
+/// The guard must not swallow the AC1 loop: the default parity-gate run (no
+/// `--model`) on a fake stack is exactly the documented onboarding loop and
+/// stays allowed. A guard keyed on fake-ness alone would refuse it.
+#[test]
+fn the_default_parity_gate_run_on_a_fake_stack_is_not_refused() {
+    guard_fake_sweep(true, &[], true).expect("the fake parity-gate run is the documented loop");
+    guard_fake_sweep(true, &[], false).expect("the fake parity-gate run is the documented loop");
+}
+
+/// `--dry-run` is an offline, non-mutating plan: it does not probe the runtime,
+/// so it cannot and must not claim what the current stack would do. It stays
+/// exit 0 even with a sweep's `--model` flags.
+#[test]
+fn a_dry_run_sweep_does_not_probe_and_is_not_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = scaffold(dir.path());
+    let output = Command::new(bin())
+        .arg("cluster")
+        .arg("eval")
+        .arg("--model")
+        .arg("claude-opus-4-8")
+        .arg("--model")
+        .arg("claude-sonnet-5")
+        .arg("--dry-run")
+        .current_dir(&bundle)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run agentos cluster eval --dry-run");
+    assert!(
+        output.status.success(),
+        "a dry-run plan must not probe the runtime or refuse\n{}",
+        output_text(&output)
+    );
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -5,6 +5,7 @@
 //! implementer creates the schemas alongside the `--json` wiring.
 
 use agentos::commands::{eval_json, status_json};
+use agentos::evals::CaseOutcome;
 use agentos::exit;
 use agentos::message::{
     message_awaiting_approval_json, message_dry_run_json, message_reply_json, message_timeout_json,
@@ -38,28 +39,99 @@ fn status_json_validates_against_status_schema() {
 #[test]
 fn eval_json_validates_against_eval_schema() {
     let schema = load_schema("eval.schema.json");
-    // Two cases, one pass one fail: (id, passed, seconds, output) rows plus the
+    // Two cases, one pass one fail: (id, outcome, seconds, output) rows plus the
     // roll-up. The failing case carries a non-empty reply for diagnosis (#548).
     let results = vec![
         (
             "case-pass".to_string(),
-            true,
+            CaseOutcome::Pass,
             1.5_f64,
             "the answer is 4".to_string(),
         ),
         (
             "case-fail".to_string(),
-            false,
+            CaseOutcome::Fail,
             0.25_f64,
             "i do not know".to_string(),
         ),
     ];
-    let value = eval_json(&results, 1, 2);
+    let value = eval_json(&results);
     let v = validator(&schema);
     assert!(
         v.is_valid(&value),
         "eval_json output must validate against eval.schema.json: {value}"
     );
+}
+
+/// The non-graded row is the new contract surface (ADR-0055, #612/#606): it must
+/// validate, report `outcome: "plumbing_ok"` with a NULL `passed`, and land in
+/// its own roll-up count rather than being folded into passed or failed.
+///
+/// Deleting the tri-state (making `passed` a bare bool) fails the null assert;
+/// deriving `failed` as `total - passed` again fails the `failed` assert, which
+/// is the false red R1 rejected.
+#[test]
+fn a_plumbing_ok_row_validates_and_is_neither_passed_nor_failed() {
+    let schema = load_schema("eval.schema.json");
+    let results = vec![(
+        "case-plumbing".to_string(),
+        CaseOutcome::PlumbingOk,
+        0.5_f64,
+        "all done".to_string(),
+    )];
+    let value = eval_json(&results);
+    let v = validator(&schema);
+    assert!(
+        v.is_valid(&value),
+        "a plumbing_ok row must validate against eval.schema.json: {value}"
+    );
+    assert_eq!(value["plumbing_ok"], 1, "{value}");
+    assert_eq!(
+        value["failed"], 0,
+        "a non-graded row is not a failure; `failed` must be counted, not derived: {value}"
+    );
+    assert_eq!(value["cases"][0]["outcome"], "plumbing_ok", "{value}");
+    assert!(
+        value["cases"][0]["passed"].is_null(),
+        "a non-graded row claims neither verdict: {value}"
+    );
+}
+
+/// The roll-up partitions the rows: every case lands in exactly one of the three
+/// counts. A mixed run is where a naive `total - passed` or a plumbing row
+/// silently folded into `passed` would show up.
+#[test]
+fn the_eval_rollup_partitions_every_row_across_the_three_outcomes() {
+    let schema = load_schema("eval.schema.json");
+    let results = vec![
+        (
+            "p".to_string(),
+            CaseOutcome::Pass,
+            1.0_f64,
+            "right".to_string(),
+        ),
+        (
+            "f".to_string(),
+            CaseOutcome::Fail,
+            1.0_f64,
+            "wrong".to_string(),
+        ),
+        (
+            "k".to_string(),
+            CaseOutcome::PlumbingOk,
+            1.0_f64,
+            "all done".to_string(),
+        ),
+    ];
+    let value = eval_json(&results);
+    assert!(validator(&schema).is_valid(&value), "{value}");
+    assert_eq!(value["total"], 3, "{value}");
+    assert_eq!(value["passed"], 1, "{value}");
+    assert_eq!(
+        value["failed"], 1,
+        "only the graded failure counts: {value}"
+    );
+    assert_eq!(value["plumbing_ok"], 1, "{value}");
 }
 
 #[test]
@@ -316,8 +388,13 @@ fn observability_schema_gate_has_teeth() {
 fn eval_schema_gate_has_teeth() {
     // negative control: proves the schema gate discriminates
     let schema = load_schema("eval.schema.json");
-    let results = vec![("only".to_string(), true, 1.0_f64, "ok".to_string())];
-    let mut value = eval_json(&results, 1, 1);
+    let results = vec![(
+        "only".to_string(),
+        CaseOutcome::Pass,
+        1.0_f64,
+        "ok".to_string(),
+    )];
+    let mut value = eval_json(&results);
     // Strip a required top-level key; a schema with real teeth must now reject.
     value
         .as_object_mut()

--- a/cli/tests/spec_scaffold.rs
+++ b/cli/tests/spec_scaffold.rs
@@ -33,10 +33,13 @@ fn output_text(output: &std::process::Output) -> String {
 }
 
 /// A valid two-skill spec with one connector and one eval. The single eval
-/// grader is `{kind: contains, expected: "all done"}` deliberately: that is the
-/// fake-model-compatible grader that makes the offline `skill eval` parity demo
-/// pass, so a spec authored this way scaffolds a suite that greens without a
-/// real model.
+/// grader is FALSIFIABLE -- it requires the agent to name itself, so a broken,
+/// empty, or off-topic turn fails it. This is the same footing #553 put the
+/// `init` lane on; the spec lane was left behind on a `contains "all done"`
+/// grader tuned to the fake model's canned reply (#612). No grader needs to be
+/// fake-compatible any more: the fake tier is a plumbing fixture and is never
+/// graded at all, so a grader written to match its canned text buys nothing but
+/// a false green.
 fn valid_spec_json() -> &'static str {
     r#"{
       "name": "deal-desk",
@@ -58,7 +61,7 @@ fn valid_spec_json() -> &'static str {
         "crm": { "command": "crm-mcp", "args": ["--stdio"] }
       },
       "evals": [
-        { "id": "prices-a-deal", "input": "Quote 20% off for Acme", "grader": { "kind": "contains", "expected": "all done", "case_sensitive": false } }
+        { "id": "prices-a-deal", "input": "Quote 20% off for Acme as the deal-desk agent", "grader": { "kind": "contains", "expected": "deal-desk", "case_sensitive": false } }
       ]
     }"#
 }
@@ -372,7 +375,37 @@ fn scaffolded_evals_load_through_the_skill_eval_loader() {
     let case = &suite.cases[0];
     assert_eq!(case.id, "prices-a-deal");
     assert_eq!(case.grader.kind, GraderKind::Contains);
-    assert_eq!(case.grader.expected, "all done");
+    assert_eq!(case.grader.expected, "deal-desk");
+}
+
+/// A spec-scaffolded grader carries through to the eval path FALSIFIABLE, on the
+/// same footing as the `init` lane's seed (#553 / #527). #612: this lane kept a
+/// grader tuned to the fake model's canned "all done", which passed on output the
+/// fake produces regardless of the agent -- a green that proved nothing. Since
+/// the fake tier is never graded at all, a grader may and must be written to
+/// judge the real work.
+#[test]
+fn a_spec_scaffolded_grader_is_not_satisfied_by_the_fake_models_canned_reply() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(valid_spec_json()).unwrap();
+    scaffold_from_spec(&out, &spec).unwrap();
+
+    let suite = load_suite(&out.join("evals/cases.json")).expect("suite loads");
+    let grader = &suite.cases[0].grader;
+    // "all done" is `fake.py::default_turn()`'s final text, whatever the input.
+    assert!(
+        !grader.grade("all done"),
+        "a spec-scaffolded grader must judge the real work, not the fake's canned text"
+    );
+    assert!(
+        !grader.grade(""),
+        "an empty turn must never satisfy a scaffolded grader"
+    );
+    assert!(
+        grader.grade("The deal-desk agent quotes 20% off for Acme."),
+        "an on-topic answer must still pass"
+    );
 }
 
 // --- validation / error behavior ------------------------------------------

--- a/docs/adr/0022-eval-completeness-tier-parity-and-trace-promotion.md
+++ b/docs/adr/0022-eval-completeness-tier-parity-and-trace-promotion.md
@@ -12,6 +12,11 @@ and the eval issues under it. Read
 [ADR-0021](0021-agentos-is-a-harness-for-coding-agents.md) first: evals are the
 contract the harness's parity promise is measured against.
 
+[ADR-0055](0055-the-fake-model-is-a-plumbing-fixture.md) **bounds** this ADR
+without superseding it: this ADR's thesis holds for every tier that runs a real
+model, and 0054 says what it means on the fake tier, where no model is called and
+so nothing is graded.
+
 [ADR-0042](0042-llm-as-a-verifier-grader-and-progress-signal.md) extends this ADR
 with the **semantic** grader (`GraderKind.verifier`) and supersedes one point of it:
 this ADR's rejection of an LLM judge inside the frozen enum. The two divide by case

--- a/docs/adr/0055-the-fake-model-is-a-plumbing-fixture.md
+++ b/docs/adr/0055-the-fake-model-is-a-plumbing-fixture.md
@@ -1,0 +1,201 @@
+# 55. The fake model is a plumbing fixture, not a subject under test
+
+Date: 2026-07-17
+
+Status: Accepted
+
+**Bounds [ADR-0022](0022-eval-completeness-tier-parity-and-trace-promotion.md)**
+("Eval completeness"); it does not supersede it. ADR-0022's thesis — a green eval
+means the agent did the work — holds unchanged for every tier that runs a real
+model. This ADR says what the sentence means on the one tier where no model runs
+at all. Per [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md),
+0022 carries a status-line pointer here rather than an edited body.
+
+Read [ADR-0041](0041-every-verb-is-answered-at-every-tier.md) for the exit-class
+boundary this ADR leans on, and [ADR-0019](0019-freeze-eval-case-format.md) for
+the frozen eval-**case** format this ADR does not touch.
+
+## Context
+
+The runner ships a fake model (`runner/src/agentos_runner/fake.py`) so the
+authoring loop runs offline with no credential: `agentos skill up --fake-model`
+is the fastest rung on the parity ladder, and it is the default in CI, in the
+chart's sealed pool, and in compose (`${AGENTOS_FAKE_MODEL:-1}`). The fake is a
+mock **at the adapter seam**: everything above it — translation, budget,
+side-effect flagging, status, NDJSON, HTTP, the approval lifecycle — runs
+unmodified. Its `default_turn()` returns one canned script whatever the input:
+a text delta, a `Bash` tool note, and a final frame whose text is `all done`.
+
+Two defects, filed separately, turned out to be one decision seen from two sides.
+
+**[#612](https://github.com/curie-eng/agentos/issues/612): the documented
+onboarding loop was red.** [#527](https://github.com/curie-eng/agentos/issues/527)
+correctly removed the scaffold's vacuous `contains ""` grader (it passed on any
+output, including an empty or errored turn) and
+[#553](https://github.com/curie-eng/agentos/issues/553) replaced it with a
+falsifiable `contains: <name>` — the agent must name itself. But the canned reply
+`all done` does not contain the bundle name, so `init` -> `skill up --fake-model`
+-> `skill eval`, the loop the product's own guide documents, failed on an
+untouched scaffold. CI missed it because `cli/scripts/e2e.sh` wrote its own
+`cases.json` with a grader tuned to match the fake's canned text.
+
+**[#606](https://github.com/curie-eng/agentos/issues/606): fake runs were landing
+in the matrix labelled with real model names.**
+[#526](https://github.com/curie-eng/agentos/issues/526) gave `local eval` and
+`cluster eval` a `--model` sweep so an operator could answer "can we move this
+skill to a cheaper model", and `_eval_model` tagged each matrix cell with the
+requested model. On a fake stack no model is ever called, so a sweep of N models
+produced N rows of the same canned reply, each labelled with a real model id and
+each carrying a pass-rate. The comparison an operator would make a promotion
+decision on was fabricated.
+
+The two obvious fixes are both wrong, and their wrongness is the actual finding:
+
+- **Make the fake pass the grader** (echo the bundle name, or write graders that
+  match `all done`). This is what #612's own note floats and what `e2e.sh`
+  already did. It makes the fake pass a *content* grader — manufacturing exactly
+  the false green #606 is about.
+- **Make the scaffold's grader vacuous again** so the fake passes it. This
+  re-introduces the unfalsifiable seed #527 removed, and an unfalsifiable case
+  propagates into every bundle scaffolded from it.
+
+Both fail because they answer "how do we make the fake tier green?" The question
+is malformed. The fake never calls a model, so there is no agent behavior for a
+content grader to have an opinion about. A green there was never evidence, and a
+red there was never a defect.
+
+## Decision
+
+**The fake model is a plumbing fixture, not a subject under test.** Four rules
+follow.
+
+### 1. The fake tier asserts only that the turn completed. It is never graded.
+
+A fake turn's outcome does not depend on the grader, because the grader is not
+called. Implemented as an early return placed **after** the existing
+`done`-status gate and **before** the scorer, in both languages:
+`turn_outcome(case, events, fake)` (`cli/src/evals.rs`) and `_run_case`
+(`apps/worker/.../eval/runner.py`). The ordering is load-bearing — see rule 2.
+
+The grader itself stays **falsifiable** and unchanged. #527's intent is preserved
+exactly: the seed still requires the agent to name itself, and still fails a
+broken, empty, or off-topic turn on any real-model path. `plumbing_ok` is not a
+backdoor to the vacuous grader; it is a statement that no grader ran.
+
+### 2. A fake turn that does not complete is still a failure.
+
+The fake tier's *one* assertion is that the turn completed. A non-`done` or
+classified-failure fake turn means the plumbing genuinely broke, and that is the
+one thing this tier must still catch. The `done` gate therefore runs before the
+fake early return, not after it.
+
+### 3. The outcome is `plumbing_ok`: a third state, not a shade of pass or fail.
+
+`EvalOutcome` / `CaseOutcome` gain `plumbing_ok` alongside `pass` and `fail`. One
+literal for the concept everywhere — the outcome value, the trace metadata, the
+API's `EvalCell.status`, and the CLI's `--json` rollup key — so the vocabulary
+cannot drift across the two languages.
+
+`passed` survives as a **derived, tri-state** view: `pass -> true`,
+`fail -> false`, `plumbing_ok -> null`. Derived, so no constructor can set
+`outcome` and `passed` inconsistently — `outcome` is the single source of truth.
+Tri-state rather than `false`, because `false` is a lie in the other direction:
+it books a failure that did not happen, and a `0/3` rollup reads as a red run.
+`null` drops out of both counts, and it is fail-safe — `None`/`null` is falsy, so
+an unmigrated truthiness reader under-reports rather than false-greens. Both the
+API's existing `_status` (which renders `passed=None` as `missing`) and
+`_model_summaries` (which already skips `None`) therefore degrade honestly with
+no migration.
+
+Consequently: `failed` is **counted**, never inferred as `total - passed`, and an
+all-plumbing run exits **0** — it is operationally successful without being a
+pass. The rollup says so in words ("3 plumbing OK (not graded)"), never `3/3
+passed`. The frozen `EvalReport` POST, whose `passed_count`/`total` shape cannot
+express non-graded, is **skipped** for an all-plumbing fake run rather than made
+to post a `0/N` false red or an `N/N` false green; a fake run containing a real
+`fail` still posts, because that red is genuine.
+
+### 4. Fake + `--model` is refused, Usage-shaped (exit 2), never Unsupported (4).
+
+A sweep against a canned reply compares one string to itself, so the CLI refuses
+it at the single `message::eval` seam both `local eval` and `cluster eval` funnel
+through, with a message naming the reason and a fix naming the remedy
+(`AGENTOS_CREDENTIALS` locally, `--set agentSandbox.runner.fakeModel=false` on
+cluster).
+
+**Exit 2, not 4, and the distinction is the whole of ADR-0041's boundary.** Exit
+4 means the concept does not exist at this tier *by construction* — no input and
+no retry changes it, and the only fix is another tier. That is not this. A model
+sweep exists at this tier; supplying a credential makes this exact argv work. The
+fix is an input, so it is a usage error. Exit 4 here would tell an agent to go
+somewhere else when the answer was to bring a credential.
+
+The default parity-gate run (no `--model`) on a fake stack is **not** refused: it
+is the documented onboarding loop, and it claims nothing about any model.
+
+### The worker is the sole authority on fake-ness
+
+`AGENTOS_FAKE_MODEL` is set on the worker only, and the worker is the only
+component that both knows fake-ness and sits upstream of grading. Two
+consequences.
+
+**Fake-ness never goes on the ACI wire.** The `Final` frame carries `text` and
+`status` and no model field; `packages/aci-protocol` is a frozen contract, so a
+new field costs a version bump plus tri-language codegen — to ship information
+the worker already holds locally. The worker's `_eval_model` returning the
+`fake-model` sentinel (never `item.model`) is the actual #606 invariant, and it
+holds for every caller of the eval plane, not just the CLI.
+
+**The API is not taught `AGENTOS_FAKE_MODEL`.** A second copy of the config would
+drift from the truth, and it could not reproduce the chart's composite
+(`fakeModel AND NOT inference.deploy`) anyway — an `inference.deploy` install
+with `fakeModel=true` is a *real* install. The CLI's refusal is UX, not the
+guarantee, and it reads the **deployed artifact's already-composed value**
+(`docker inspect` on the compose worker; `kubectl` jsonpath on
+`deployment/<release>-worker`) rather than re-deriving chart logic. Reading the
+output honors the composite for free; re-deriving it would get it wrong. A probe
+failure is reported as itself and never falls back to a guessed default, and
+`--dry-run` does not probe at all — an offline plan must not claim what the
+current runtime would do.
+
+`POST /evals/trigger` remains callable directly, so the two guards are deliberate
+defense-in-depth at different altitudes: different mechanisms, different layers.
+If the CLI guard is bypassed, all N rows label `fake-model` and collapse to one
+summary row — which is honest, because one thing ran.
+
+## Consequences
+
+**Every default `local eval --model` sweep now refuses**, because compose
+defaults to `AGENTOS_FAKE_MODEL=1`. This is a visible behavior change for anyone
+who was reading those numbers — but those numbers were fabricated, which is the
+point. The refusal message carries the fix, so it should read as a remedy rather
+than a regression.
+
+**The scaffold's documented loop is green without being fake-green.** `init` ->
+`skill up --fake-model` -> `skill eval` exits 0 and reports plumbing. The guide
+and the scaffolded comments now say what the fake rung actually proves, rather
+than calling it a promotion gate that "must be green".
+
+**`e2e.sh` no longer writes graders tuned to the fake's canned text.** That bypass
+is why CI missed #612; a suite written to match the fake asserts nothing.
+
+**A mixed matrix keeps its graded signal.** `latest_by_model` keys on
+`(version, case, model)` and the fake sentinel is a distinct key, so rows do not
+collapse. In the displayed `(version, case)` cell, a **graded trace beats a
+plumbing trace regardless of timestamp**: the grid is a promotion surface, a
+plumbing row carries zero comparative information, and it must not erase graded
+signal by being newer. Plumbing runs stay visible via the summary count.
+
+**Costs accepted.** A third outcome state is a shape change rippling through two
+languages, a committed JSON schema, and the matrix API. A tri-state `passed`
+means a hypothetical strict external consumer could fail on `null` — bounded
+here, since no in-tree consumer deserializes `passed` across a typed boundary,
+and a loud failure on `null` is the ADR-0041-preferred outcome versus silently
+ingesting a fabricated `false`.
+
+**Not decided here.** The eval-case *content* ([#619](https://github.com/curie-eng/agentos/issues/619),
+[#620](https://github.com/curie-eng/agentos/issues/620)), the tool-call grader
+([#621](https://github.com/curie-eng/agentos/issues/621)), and unresolvable-model
+validation ([#622](https://github.com/curie-eng/agentos/issues/622)). No
+`GraderKind` is added: `plumbing_ok` is a *result* shape, not a *case* shape, so
+ADR-0019's frozen case format is untouched.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,4 +83,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0052 | [The release trust model: one signed manifest, closed-world coverage](0052-release-asset-trust-model.md) | Accepted |
 | 0053 | [Add an expected terminal status to the frozen eval-case format](0053-expected-terminal-status-in-eval-cases.md) | Accepted |
 | 0054 | [Local Docker runner containers are hardened and network-isolated](0054-local-docker-runner-hardening.md) | Accepted |
+| 0055 | [The fake model is a plumbing fixture, not a subject under test](0055-the-fake-model-is-a-plumbing-fixture.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
## What

The fake model is a plumbing fixture, not a subject under test. #612 and #606 are two faces of one decision:

1. **The fake tier asserts only that the turn completed.** It never runs a content grader. Its outcome is a distinct non-graded `plumbing_ok`, neither a pass nor a fail. A content-falsifiable grader (#553) and a canned reply structurally cannot coexist in one artifact, which is what turned the scaffold red (#612).
2. **Fake + `--model` is refused.** A sweep against a canned reply compares one string to itself. The refusal is `Usage`-shaped (exit 2), not `Unsupported` (exit 4): supplying a credential makes the verb work, so the concept is not absent by construction (the ADR-0041 boundary).

Recorded as ADR-0055, which bounds ADR-0022 rather than superseding it.

### Reconciled with `main`'s independently-merged #606 fix

While this branch was open, `main` merged `9a5dc1b` ("Leave a fake-model eval run unlabelled, not tagged with an uncalled model", Closes #606), which fixes the **labelling** half of #606 by leaving a fake row's model dimension `None`. This PR **adopts that approach** rather than its own sentinel: a fake row is unlabelled (`None`), not tagged `fake-model`. The genuinely-novel part this PR still carries is the **outcome** half — the `plumbing_ok` tri-state (#612), the fake-sweep refusal, and ADR-0055 — which `9a5dc1b` did not touch. The model label and the outcome are orthogonal: a fake row is now unlabelled **and** carries `plumbing_ok`, so it can never read as a green promotion gate regardless of the label.

The worker is the sole authority on fake-ness (the ACI wire carries no fake marker, so `EvalJob` and `packages/aci-protocol` are untouched). `passed` becomes a derived tri-state: `plumbing_ok` reports `null`, so it drops out of every pass and fail count instead of fabricating either.

## Proof

### AC1 (#612) — a fresh scaffold's own documented fake loop is not red

```
$ agentos init deal-desk
$ agentos skill up --fake-model
$ agentos skill eval
case             result         time
deal-desk-smoke  • plumbing OK  0.0s
✓ 1 plumbing OK (not graded)
the fake model returns one canned reply whatever the input, so these cases were
not graded -- they prove the turn completed, nothing more. Re-run with a real
credential to grade them.
# exit 0
```

`--json` on the same run (the outcome is impossible to mistake for a pass):

```
{"cases":[{"id":"deal-desk-smoke","outcome":"plumbing_ok","output":"all done","passed":null,"seconds":0.003}],"failed":0,"passed":0,"plumbing_ok":1,"total":1}
```

The seeded grader is unchanged from #553 (falsifiable `contains: deal-desk`); it still fails a broken, empty, or off-topic turn on the real path.

### AC2 (#606) — a sealed sweep refuses, Usage-shaped

Run against a genuinely sealed compose worker (`AGENTOS_FAKE_MODEL=1`, no credentials):

```
$ agentos local eval --cases evals/cases.json --model claude-opus-4-8 --model claude-sonnet-5
Error: this stack runs the fake model, so sweeping 2 models would compare one canned reply to itself: the fake never calls a model, and answers every input with the same scripted text whatever --model asks for. Every row would be labelled fake-model and carry an identical answer, so the comparison would be fabricated.
# exit 2
```

A single `--model` is also refused (fake + `--model` is refused, not merely fake + a sweep), with the reason that actually applies for one model:

```
$ agentos local eval --cases evals/cases.json --model claude-opus-4-8
Error: this stack runs the fake model, so it will never call `claude-opus-4-8`: the fake answers every input with the same scripted text whatever --model asks for. The run would be that canned script, not the model you pinned.
# exit 2
```

### AC3 (#606) — no fake run is labelled with a real model

On a fake install `_eval_model` returns `None` (unlabelled) before it ever consults `item.model`, logging the discarded request rather than dropping it silently; the `target_url` runner we did not boot is exempt. The regression guard is `test_eval_fake_model_install_refuses_to_label_a_model_never_called` in `apps/worker/tests/eval/test_stream.py` (from `main`'s `9a5dc1b`): it asserts a sealed run with a requested model records `None`, and fails on the pre-fix `_eval_model` that returned `item.model` unconditionally. The recorder then emits no `model:` tag for a `None`-model run, so a fake row lands in the matrix's unlabelled column instead of fabricating a model dimension.

## Notes for the reviewer

- The three stale `cli/src/scaffold.rs` comments promising the scaffold is "green out of the box under both `--fake-model` and a real credential" are corrected, and the generated scaffold `AGENTS.md` plus `cli/src/guide.rs` no longer promise the fake loop must be green.
- `cli/scripts/e2e.sh` no longer writes its own bypass `cases.json` matched to the fake's canned text, which is why CI missed #612.
- `apps/worker/.../binding.py` is intentionally unchanged: `apply_model_env` setting the fake flag regardless of the override is correct.
- **Rebased onto current `origin/main`**, which advanced during this work to include the eval-stream delivery cap (#505), the per-case fresh-conversation reset (#550, ADR-0051), the frozen `expect_status` terminal-status field (#262, ADR-0053), the fake-row label fix (#606, `9a5dc1b`), and the local Docker runner hardening (#663, ADR-0054). The shared completion gate now honors `expect_status` (a gate-blocked case's `awaiting-approval` counts as completed) on both the Rust and Python sides, with the `plumbing_ok` outcome layered on top.
- The ADR is numbered **0055**, not 0051: `main` took 0051 (#550), 0052 (release trust), 0053 (#262), and 0054 (#663 local Docker hardening) while this branch was open, so this ADR moved to the next free number to avoid the doclint ADR-uniqueness collision at merge time.

Closes #612, #606
