### PR TITLE
Replace the browser-held platform key with authenticated console sessions

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -29,7 +29,7 @@ worker, Postgres, MinIO/S3, Langfuse, and GitHub.
   platform-key path: it is a browser-only defense, and the CLI/worker/runner must
   keep authenticating with the header credential alone.
 - **`require_platform_key` is the platform-key-only subset**, used by the console
-  operator routes (`POST /console/login-codes`, `GET|DELETE /console/sessions`)
+  operator routes (`POST /console/login-codes`, `DELETE /console/sessions`)
   so a session cannot mint its own successor or mass-revoke the store it belongs
   to (ADR-0049). It is a strict subset of `require_api_key`, not a second scheme.
   Reach for it when a route must be the CLI's and not the browser's.

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -7,21 +7,43 @@ worker, Postgres, MinIO/S3, Langfuse, and GitHub.
 
 ## Load-bearing invariants
 
-- **Auth is one shared API key today.** `require_api_key` (`auth.py`) compares
-  the `X-API-Key` header against `Settings.api_key` with `hmac.compare_digest`.
-  This is explicitly MVP-only; GitHub-App identity work is expected to
-  replace it eventually, but until that lands, do not add a second
-  auth scheme for a new router without raising it in an issue/PR first --
-  every router should share the one dependency.
+- **Auth is one shared dependency, carrying two credentials today.**
+  `require_api_key` (`auth.py`) accepts EITHER the shared platform key (the
+  `X-API-Key` header, compared against `Settings.api_key` with
+  `hmac.compare_digest`) OR a live console session (ADR-0049, #630). The
+  platform key is explicitly MVP-only; GitHub-App identity work is expected to
+  replace it eventually, but until that lands, do not add a second auth
+  scheme for a new router without raising it in an issue/PR first -- every
+  router should share the one dependency. Order inside it is load-bearing: the
+  platform-key check runs first and returns before the session store is read, so
+  machine callers pay no database read.
+- **The console session is a browser credential and needs the CSRF header
+  (ADR-0049, #630).** `require_api_key` accepts the `agentos_console_session`
+  cookie only when the request also carries `X-Console-Session`
+  (`CONSOLE_SESSION_HEADER`). A cookie is ambient authority and `SameSite=Strict`
+  does not close that -- "site" ignores the port, so `http://localhost:8080` is
+  same-site with every other localhost port, and the body-less `POST
+  /agents/{id}/kill` is a CORS-simple request nothing preflights. The custom
+  header cannot be set cross-origin without a preflight this CORS-free API
+  fails. Do not drop the header requirement, and do not extend it to the
+  platform-key path: it is a browser-only defense, and the CLI/worker/runner must
+  keep authenticating with the header credential alone.
+- **`require_platform_key` is the platform-key-only subset**, used by the console
+  operator routes (`POST /console/login-codes`, `GET|DELETE /console/sessions`)
+  so a session cannot mint its own successor or mass-revoke the store it belongs
+  to (ADR-0049). It is a strict subset of `require_api_key`, not a second scheme.
+  Reach for it when a route must be the CLI's and not the browser's.
 - **The `state` router authenticates differently, on purpose (ADR-0033, #410).**
   `require_state_access` (`routers/state.py`) accepts EITHER the platform key OR a
   scoped, path-`agent_id`-bound `state` token minted by the worker for the
   sandbox, so a sandboxed agent can rehydrate its own memory/transcript without
-  holding a resolve-capable platform-wide key. Every OTHER router keeps
-  `require_api_key` (platform key only); a scoped token is rejected everywhere
-  else, including `/approvals/{id}/resolve`. Do not collapse the state router
-  back onto `require_api_key`, and do not extend scoped-token acceptance to
-  another router without a new ADR.
+  holding a resolve-capable platform-wide key. It does NOT accept a console
+  session; equally, a scoped `state` token is rejected by `require_api_key`
+  everywhere else, including `/approvals/{id}/resolve`. The two dependencies are
+  deliberately disjoint extensions of the platform key, so neither is a
+  laundering path into the other. Do not collapse the state router back onto
+  `require_api_key`, and do not extend scoped-token acceptance to another router
+  without a new ADR.
 - **The GitHub webhook is authenticated differently, on purpose.** `/github/webhook`
   verifies the HMAC signature GitHub sends (`x-hub-signature-256` against
   `settings.github_webhook_secret`), not the API key -- GitHub cannot send an

--- a/apps/api/alembic/versions/0017_console_sessions.py
+++ b/apps/api/alembic/versions/0017_console_sessions.py
@@ -29,7 +29,6 @@ def upgrade() -> None:
     op.create_table(
         "console_sessions",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
-        sa.Column("label", sa.String(), nullable=True),
         sa.Column("login_code_hash", sa.String(), nullable=False),
         sa.Column(
             "login_code_expires_at", sa.DateTime(timezone=True), nullable=False

--- a/apps/api/alembic/versions/0017_console_sessions.py
+++ b/apps/api/alembic/versions/0017_console_sessions.py
@@ -1,0 +1,74 @@
+"""add console_sessions (CLI-minted login codes, #630 / ADR-0049)
+
+The console's credential becomes a server-managed, revocable session cookie
+established by exchanging a single-use login code the CLI mints under the
+platform key. This table is the session store: one row per grant, holding only
+the SHA-256 digests of the login code and the session token, both expiries, and
+the consumed/revoked markers.
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-07-17
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0017"
+down_revision: str | None = "0016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "agentos"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "console_sessions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("label", sa.String(), nullable=True),
+        sa.Column("login_code_hash", sa.String(), nullable=False),
+        sa.Column(
+            "login_code_expires_at", sa.DateTime(timezone=True), nullable=False
+        ),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("session_token_hash", sa.String(), nullable=True),
+        sa.Column("session_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        schema=SCHEMA,
+    )
+    # Unique so a lookup by digest is the only read either credential needs, and
+    # a collision is a database error rather than an ambiguous match.
+    op.create_index(
+        "ix_console_sessions_login_code_hash",
+        "console_sessions",
+        ["login_code_hash"],
+        unique=True,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "ix_console_sessions_session_token_hash",
+        "console_sessions",
+        ["session_token_hash"],
+        unique=True,
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_console_sessions_session_token_hash", "console_sessions", schema=SCHEMA
+    )
+    op.drop_index(
+        "ix_console_sessions_login_code_hash", "console_sessions", schema=SCHEMA
+    )
+    op.drop_table("console_sessions", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -945,6 +945,181 @@
         "title": "BundleOut",
         "type": "object"
       },
+      "ConsoleLoginCodeMint": {
+        "description": "Mint a login code. The label is an operator's note for the inventory.",
+        "properties": {
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          }
+        },
+        "title": "ConsoleLoginCodeMint",
+        "type": "object"
+      },
+      "ConsoleLoginCodeOut": {
+        "description": "The one and only moment the raw login code is readable.\n\nIt is never stored (only its digest is) and never returned again, so a\ncaller that loses it mints another.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          },
+          "session_id": {
+            "format": "uuid",
+            "title": "Session Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "expires_at",
+          "session_id"
+        ],
+        "title": "ConsoleLoginCodeOut",
+        "type": "object"
+      },
+      "ConsoleRevokeOut": {
+        "description": "How many live sessions the sweep killed.",
+        "properties": {
+          "revoked": {
+            "title": "Revoked",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "revoked"
+        ],
+        "title": "ConsoleRevokeOut",
+        "type": "object"
+      },
+      "ConsoleSessionExchange": {
+        "description": "Exchange a login code for a session cookie.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "ConsoleSessionExchange",
+        "type": "object"
+      },
+      "ConsoleSessionListItem": {
+        "description": "One session in the operator's inventory.\n\nAn inventory, never a way to read a session: no field here carries the code,\nthe token, or either digest. ``expires_at`` is the expiry that currently\ngoverns the row -- the session's once exchanged, the login code's until then.",
+        "properties": {
+          "consumed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Consumed At"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "expires_at"
+        ],
+        "title": "ConsoleSessionListItem",
+        "type": "object"
+      },
+      "ConsoleSessionOut": {
+        "description": "The established session's fixed absolute expiry. The token itself is\nreturned only as the HttpOnly cookie, never in the body.",
+        "properties": {
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "expires_at"
+        ],
+        "title": "ConsoleSessionOut",
+        "type": "object"
+      },
+      "ConsoleSessionStatus": {
+        "description": "Whether the caller's cookie names a live session, for the console's own\n\"am I logged in\" check. Never carries the token or its digest.",
+        "properties": {
+          "authenticated": {
+            "title": "Authenticated",
+            "type": "boolean"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          }
+        },
+        "required": [
+          "authenticated"
+        ],
+        "title": "ConsoleSessionStatus",
+        "type": "object"
+      },
       "CostReport": {
         "description": "Daily spend series + total for an agent (L1 Cost view).",
         "properties": {
@@ -2414,6 +2589,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -2464,6 +2655,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -2534,6 +2741,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -2583,6 +2806,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -2640,6 +2879,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -2710,6 +2965,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -2766,6 +3037,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -2836,6 +3123,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -2892,6 +3195,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -2994,6 +3313,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -3053,6 +3388,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -3109,6 +3460,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -3169,6 +3536,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -3254,6 +3637,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -3313,6 +3712,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -3393,6 +3808,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -3451,6 +3882,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -3901,6 +4348,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -3961,6 +4424,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -4041,6 +4520,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -4105,6 +4600,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -4184,6 +4695,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -4293,6 +4820,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -4344,6 +4887,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -4414,6 +4973,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -4473,6 +5048,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -4538,6 +5129,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "requestBody": {
@@ -4599,6 +5206,317 @@
         ]
       }
     },
+    "/console/login-codes": {
+      "post": {
+        "description": "Mint a login code for an operator to paste into the console.\n\nUnder the platform key on purpose: this is the CLI's endpoint, not the\nbrowser's. An unauthenticated caller that could mint its own code could log\nitself in, which would make the whole exchange decorative.",
+        "operationId": "mint_login_code_console_login_codes_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConsoleLoginCodeMint"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleLoginCodeOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mint Login Code",
+        "tags": [
+          "console"
+        ]
+      }
+    },
+    "/console/session": {
+      "delete": {
+        "description": "Self-logout: revoke the session server-side and clear the cookie.\n\nBoth halves matter. Clearing the cookie alone would leave a stolen copy of\nthe token live, so the row write is the real revocation. Idempotent, so a\nlogout without a live session is still a 204.",
+        "operationId": "logout_console_session_delete",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Logout",
+        "tags": [
+          "console"
+        ]
+      },
+      "get": {
+        "description": "Whether the caller's cookie names a live session, for the console's own\n\"am I logged in\" check. Anonymous is a 200 with authenticated=false, not a\n401: not being logged in is the answer, not an error.",
+        "operationId": "get_session_status_console_session_get",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleSessionStatus"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Session Status",
+        "tags": [
+          "console"
+        ]
+      },
+      "post": {
+        "description": "Exchange a login code for the session cookie. No auth dependency: the\ncode is the credential, and the cookie is what this call establishes.\n\nThe Origin gate runs BEFORE the code is touched, so a refusal costs the\noperator nothing: the code is still live to retry over the port-forward the\nfix names.",
+        "operationId": "exchange_login_code_console_session_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "origin",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Origin"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConsoleSessionExchange"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleSessionOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Exchange Login Code",
+        "tags": [
+          "console"
+        ]
+      }
+    },
+    "/console/sessions": {
+      "delete": {
+        "description": "Revoke every live console grant. The operator's kill switch for the\nconsole, and why the session is a durable row rather than a signed token:\nthis takes effect on the next request, with no key rotation and no restart.",
+        "operationId": "revoke_sessions_console_sessions_delete",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleRevokeOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Revoke Sessions",
+        "tags": [
+          "console"
+        ]
+      },
+      "get": {
+        "description": "The operator's inventory of console sessions.\n\nAn inventory, never a way to read one: no digest and no raw credential is\nprojected here, so a listing cannot be replayed into a login.",
+        "operationId": "list_sessions_console_sessions_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ConsoleSessionListItem"
+                  },
+                  "title": "Response List Sessions Console Sessions Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Sessions",
+        "tags": [
+          "console"
+        ]
+      }
+    },
     "/deployments": {
       "get": {
         "operationId": "list_deployments_deployments_get",
@@ -4634,6 +5552,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -4685,6 +5619,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -4755,6 +5705,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -4823,6 +5789,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -4871,6 +5853,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -4930,6 +5928,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -5100,6 +6114,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -5163,6 +6193,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -5221,6 +6267,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -5354,6 +6416,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -5467,6 +6545,22 @@
               ],
               "title": "X-Api-Key"
             }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
+            }
           }
         ],
         "responses": {
@@ -5531,6 +6625,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],
@@ -5640,6 +6750,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "agentos_console_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agentos Console Session"
             }
           }
         ],

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -945,6 +945,25 @@
         "title": "BundleOut",
         "type": "object"
       },
+      "ConsoleErrorOut": {
+        "description": "A refusal the operator can act on: what happened and what fixes it.\n\nThe `{error, fix}` pair of ADR-0021, flat rather than nested under `detail`,\nso the console can render the fix verbatim.",
+        "properties": {
+          "error": {
+            "title": "Error",
+            "type": "string"
+          },
+          "fix": {
+            "title": "Fix",
+            "type": "string"
+          }
+        },
+        "required": [
+          "error",
+          "fix"
+        ],
+        "title": "ConsoleErrorOut",
+        "type": "object"
+      },
       "ConsoleLoginCodeMint": {
         "description": "Mint a login code. The label is an operator's note for the inventory.",
         "properties": {
@@ -987,6 +1006,20 @@
           "session_id"
         ],
         "title": "ConsoleLoginCodeOut",
+        "type": "object"
+      },
+      "ConsoleLoginRefusedOut": {
+        "description": "A refused login code. One message for unknown, spent, expired, and\nrevoked alike: which one it was is not the caller's to learn.",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "ConsoleLoginRefusedOut",
         "type": "object"
       },
       "ConsoleRevokeOut": {
@@ -2591,6 +2624,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -2655,6 +2704,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -2743,6 +2808,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -2806,6 +2887,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -2879,6 +2976,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -2967,6 +3080,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -3037,6 +3166,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -3125,6 +3270,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -3195,6 +3356,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -3315,6 +3492,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -3387,6 +3580,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -3463,6 +3672,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -3536,6 +3761,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -3639,6 +3880,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -3712,6 +3969,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -3810,6 +4083,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -3882,6 +4171,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -4350,6 +4655,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -4424,6 +4745,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -4522,6 +4859,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -4600,6 +4953,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -4695,6 +5064,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -4822,6 +5207,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -4887,6 +5288,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -4975,6 +5392,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -5048,6 +5481,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -5128,6 +5577,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -5398,6 +5863,26 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleErrorOut"
+                }
+              }
+            },
+            "description": "The origin is not a secure context, so a browser would drop the Secure session cookie. The login code is NOT consumed."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleLoginRefusedOut"
+                }
+              }
+            },
+            "description": "The login code is unknown, already spent, expired, or revoked. Which one it was is deliberately not distinguished."
+          },
           "422": {
             "content": {
               "application/json": {
@@ -5555,6 +6040,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -5619,6 +6120,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -5707,6 +6224,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -5791,6 +6324,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -5853,6 +6402,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -5928,6 +6493,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -6116,6 +6697,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -6195,6 +6792,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -6267,6 +6880,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -6418,6 +7047,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -6547,6 +7192,22 @@
             }
           },
           {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
+            }
+          },
+          {
             "in": "cookie",
             "name": "agentos_console_session",
             "required": false,
@@ -6625,6 +7286,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {
@@ -6750,6 +7427,22 @@
                 }
               ],
               "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-console-session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Console-Session"
             }
           },
           {

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -965,20 +965,8 @@
         "type": "object"
       },
       "ConsoleLoginCodeMint": {
-        "description": "Mint a login code. The label is an operator's note for the inventory.",
-        "properties": {
-          "label": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Label"
-          }
-        },
+        "description": "Mint a login code. Carries no fields: the mint is a bare request under the\nplatform key, and an empty body validates.",
+        "properties": {},
         "title": "ConsoleLoginCodeMint",
         "type": "object"
       },
@@ -1048,68 +1036,6 @@
           "code"
         ],
         "title": "ConsoleSessionExchange",
-        "type": "object"
-      },
-      "ConsoleSessionListItem": {
-        "description": "One session in the operator's inventory.\n\nAn inventory, never a way to read a session: no field here carries the code,\nthe token, or either digest. ``expires_at`` is the expiry that currently\ngoverns the row -- the session's once exchanged, the login code's until then.",
-        "properties": {
-          "consumed_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Consumed At"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "expires_at": {
-            "format": "date-time",
-            "title": "Expires At",
-            "type": "string"
-          },
-          "id": {
-            "format": "uuid",
-            "title": "Id",
-            "type": "string"
-          },
-          "label": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Label"
-          },
-          "revoked_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Revoked At"
-          }
-        },
-        "required": [
-          "id",
-          "created_at",
-          "expires_at"
-        ],
-        "title": "ConsoleSessionListItem",
         "type": "object"
       },
       "ConsoleSessionOut": {
@@ -5945,58 +5871,6 @@
           }
         },
         "summary": "Revoke Sessions",
-        "tags": [
-          "console"
-        ]
-      },
-      "get": {
-        "description": "The operator's inventory of console sessions.\n\nAn inventory, never a way to read one: no digest and no raw credential is\nprojected here, so a listing cannot be replayed into a login.",
-        "operationId": "list_sessions_console_sessions_get",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "X-Api-Key"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/ConsoleSessionListItem"
-                  },
-                  "title": "Response List Sessions Console Sessions Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List Sessions",
         "tags": [
           "console"
         ]

--- a/apps/api/src/agentos_api/auth.py
+++ b/apps/api/src/agentos_api/auth.py
@@ -13,6 +13,7 @@ import hmac
 from typing import Annotated
 
 from fastapi import Cookie, Header, HTTPException, status
+from sqlalchemy.exc import SQLAlchemyError
 
 from . import crud
 from .config import get_settings
@@ -23,6 +24,52 @@ API_KEY_HEADER = "X-API-Key"
 # The console's session cookie. Named here because it is a credential the shared
 # dependency accepts; the console router sets and clears it.
 CONSOLE_SESSION_COOKIE = "agentos_console_session"
+
+# The header that must accompany the cookie on the cookie path, and the CSRF
+# control the cookie itself cannot provide (ADR-0049).
+#
+# A cookie is ambient authority: the browser attaches it to a cross-origin form
+# post whether or not the page that forged the request has any business with
+# this API. `SameSite=Strict` does not close that, because "site" ignores the
+# port: the ADR's own prescribed login path is http://localhost:8080, which is
+# same-site with every other localhost port -- any dev server, any hostile
+# package's server. A body-less POST to /agents/{id}/kill from such a page is a
+# CORS-simple request, so nothing preflights it and the cookie rides along.
+#
+# A custom request header is not settable cross-origin without a preflight, and
+# this API deliberately runs no CORS middleware, so the preflight fails and the
+# forged request never reaches the route. This is the OWASP custom-request-header
+# defense, and it restores the structural immunity the `X-API-Key` header
+# credential had before the cookie existed. Any value is accepted: the header's
+# presence is the whole proof, because being able to set it at all is what a
+# cross-origin attacker cannot do.
+CONSOLE_SESSION_HEADER = "X-Console-Session"
+
+SESSION_STORE_DOWN_BODY = {
+    "error": (
+        "cannot verify the console session: the session store is unreachable"
+    ),
+    "fix": (
+        "Use the CLI, which authenticates with the platform key and needs no "
+        "session: agentos cluster status, agentos cluster agents. The console "
+        "cannot authenticate while the database is down."
+    ),
+}
+
+
+class ConsoleSessionStoreUnavailable(Exception):
+    """The cookie path could not reach the session store.
+
+    Raised by `require_api_key` and rendered as a 503 by the handler
+    `main.create_app` registers. It is not an HTTPException because the
+    `{error, fix}` shape here is the flat one the console's other failure
+    (the exchange's insecure-origin 400) already returns, and FastAPI's
+    HTTPException handler would nest it under `detail`.
+
+    It must not collapse into the 401: telling an operator their session is bad
+    when Postgres is merely down sends them to log in again, which cannot work
+    either, instead of to the CLI that does.
+    """
 
 
 def verify_platform_key(x_api_key: str | None) -> bool:
@@ -60,22 +107,35 @@ async def require_api_key(
     session: SessionDep,
     x_api_key: Annotated[str | None, Header()] = None,
     agentos_console_session: Annotated[str | None, Cookie()] = None,
+    x_console_session: Annotated[str | None, Header()] = None,
 ) -> None:
     """The platform key (machine callers) OR a live console session cookie.
 
     Order is load-bearing: the platform-key path is checked first and returns
-    before the session is ever used, so the worker, runner, and CLI still pay no
-    database read. A console session costs one indexed read per request, which
-    is what makes revocation and expiry take effect immediately rather than when
-    a cached decision happens to lapse.
+    before the session or the CSRF header is ever looked at, so the worker,
+    runner, and CLI still pay no database read and are never asked for a header
+    a browser-only defense exists to require. A console session costs one
+    indexed read per request, which is what makes revocation and expiry take
+    effect immediately rather than when a cached decision happens to lapse.
+
+    The cookie path additionally requires `X-Console-Session`
+    (CONSOLE_SESSION_HEADER): see that constant for why the cookie alone is
+    CSRF-able even with SameSite=Strict.
     """
 
     if verify_platform_key(x_api_key):
         return
-    if agentos_console_session and await crud.live_console_session(
-        session, agentos_console_session
-    ):
-        return
+    if agentos_console_session and x_console_session is not None:
+        try:
+            live = await crud.live_console_session(session, agentos_console_session)
+        except SQLAlchemyError as exc:
+            # The kill switch and the pod-log proxy are what an operator reaches
+            # for when the system is sick, and neither needed Postgres to
+            # authenticate before the cookie existed. An opaque 500 there is the
+            # worst possible moment for one.
+            raise ConsoleSessionStoreUnavailable() from exc
+        if live:
+            return
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="missing or invalid API key",

--- a/apps/api/src/agentos_api/auth.py
+++ b/apps/api/src/agentos_api/auth.py
@@ -1,17 +1,28 @@
-"""Single-API-key authentication.
+"""Shared authentication for every router.
 
 MVP auth is one shared key delivered in the `X-API-Key` header and compared
 against Settings.api_key. J1 replaces this with GitHub-App-scoped identities.
+
+`require_api_key` also accepts a live console session cookie (#630, ADR-0049),
+so the browser never has to hold the platform key. That is an extension of the
+one shared dependency rather than a second auth scheme on a router, which is
+the boundary apps/api/CLAUDE.md draws.
 """
 
 import hmac
 from typing import Annotated
 
-from fastapi import Header, HTTPException, status
+from fastapi import Cookie, Header, HTTPException, status
 
+from . import crud
 from .config import get_settings
+from .deps import SessionDep
 
 API_KEY_HEADER = "X-API-Key"
+
+# The console's session cookie. Named here because it is a credential the shared
+# dependency accepts; the console router sets and clears it.
+CONSOLE_SESSION_COOKIE = "agentos_console_session"
 
 
 def verify_platform_key(x_api_key: str | None) -> bool:
@@ -25,11 +36,47 @@ def verify_platform_key(x_api_key: str | None) -> bool:
     return hmac.compare_digest(x_api_key, get_settings().api_key)
 
 
-async def require_api_key(
+async def require_platform_key(
     x_api_key: Annotated[str | None, Header()] = None,
 ) -> None:
+    """The platform key and nothing else: `require_api_key` minus the console
+    cookie.
+
+    For the console's own operator surface (#630, ADR-0049), which is the CLI's
+    to call, not the browser's. A console session must not be able to mint
+    itself a fresh login code -- that would be the refresh token the ADR rules
+    out, quietly defeating the fixed absolute session lifetime -- nor enumerate
+    or mass-revoke the session store it is merely a member of.
+    """
+
     if not verify_platform_key(x_api_key):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="missing or invalid API key",
         )
+
+
+async def require_api_key(
+    session: SessionDep,
+    x_api_key: Annotated[str | None, Header()] = None,
+    agentos_console_session: Annotated[str | None, Cookie()] = None,
+) -> None:
+    """The platform key (machine callers) OR a live console session cookie.
+
+    Order is load-bearing: the platform-key path is checked first and returns
+    before the session is ever used, so the worker, runner, and CLI still pay no
+    database read. A console session costs one indexed read per request, which
+    is what makes revocation and expiry take effect immediately rather than when
+    a cached decision happens to lapse.
+    """
+
+    if verify_platform_key(x_api_key):
+        return
+    if agentos_console_session and await crud.live_console_session(
+        session, agentos_console_session
+    ):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="missing or invalid API key",
+    )

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -35,6 +35,15 @@ class Settings(BaseSettings):
     # Single shared API key. Dev-only default; override in any shared deployment.
     api_key: str = "agentos-dev-key"
 
+    # Console sessions (#630, ADR-0049). The login code is a short-lived,
+    # single-use handoff between the CLI that mints it and the browser tab that
+    # exchanges it, so it only has to outlive a copy-paste. The session is a
+    # fixed absolute lifetime with no sliding refresh: a long-lived console tab
+    # is asked to log in again. Neither is a secret, so both stay out of the #57
+    # prod boot gate -- they are durations, not credentials.
+    console_login_code_ttl_seconds: int = 600  # 10 minutes
+    console_session_ttl_seconds: int = 43200  # 12 hours
+
     # Human-readable org/workspace name the UI reads (open /config endpoint) to
     # brand the app. Overridable via ORG_NAME for a white-labeled deployment.
     org_name: str = "AgentOS"

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -3,7 +3,6 @@
 import hashlib
 import secrets
 import uuid
-from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -695,7 +694,7 @@ def _digest(value: str) -> str:
 
 
 async def mint_console_login_code(
-    session: AsyncSession, label: str | None, ttl_seconds: int
+    session: AsyncSession, ttl_seconds: int
 ) -> tuple[str, ConsoleSession]:
     """Mint a single-use login code. Returns the RAW code and its row.
 
@@ -711,7 +710,6 @@ async def mint_console_login_code(
 
     code = secrets.token_urlsafe(CONSOLE_TOKEN_BYTES)
     row = ConsoleSession(
-        label=label,
         login_code_hash=_digest(code),
         login_code_expires_at=func.now() + timedelta(seconds=ttl_seconds),
     )
@@ -828,12 +826,3 @@ async def revoke_all_console_sessions(session: AsyncSession) -> int:
     revoked = len(result.scalars().all())
     await session.commit()
     return revoked
-
-
-async def list_console_sessions(session: AsyncSession) -> Sequence[ConsoleSession]:
-    """Every session row, newest first, for the operator's inventory."""
-
-    found = await session.scalars(
-        select(ConsoleSession).order_by(ConsoleSession.created_at.desc())
-    )
-    return found.all()

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -702,13 +702,18 @@ async def mint_console_login_code(
     The raw code is returned exactly once, to the CLI caller that minted it
     under the platform key; only its digest is stored, so nothing can hand it
     back later.
+
+    The expiry is computed DB-side (``func.now()``, not the API's clock) because
+    every liveness predicate below evaluates against ``func.now()``. Stamping on
+    one clock and judging on another makes the real lifetime the skew between
+    them, so a code or session can outlive its nominal TTL.
     """
 
     code = secrets.token_urlsafe(CONSOLE_TOKEN_BYTES)
     row = ConsoleSession(
         label=label,
         login_code_hash=_digest(code),
-        login_code_expires_at=datetime.now(UTC) + timedelta(seconds=ttl_seconds),
+        login_code_expires_at=func.now() + timedelta(seconds=ttl_seconds),
     )
     session.add(row)
     await session.commit()
@@ -727,10 +732,14 @@ async def exchange_console_login_code(
     ``consumed_at IS NULL`` guard is the compare-and-set (the same resolve-once
     idiom approvals use), so two concurrent exchanges of one code cannot both
     win and mint two sessions.
+
+    The session expiry is computed DB-side and read back from the RETURNING
+    clause, so the expiry reported to the caller is the same value
+    ``live_console_session`` will later judge against ``func.now()``. See
+    ``mint_console_login_code`` for why one clock must own the lifetime.
     """
 
     token = secrets.token_urlsafe(CONSOLE_TOKEN_BYTES)
-    expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
     result = await session.execute(
         update(ConsoleSession)
         .where(
@@ -742,13 +751,13 @@ async def exchange_console_login_code(
         .values(
             consumed_at=func.now(),
             session_token_hash=_digest(token),
-            session_expires_at=expires_at,
+            session_expires_at=func.now() + timedelta(seconds=ttl_seconds),
         )
-        .returning(ConsoleSession.id)
+        .returning(ConsoleSession.session_expires_at)
     )
-    consumed = result.scalar_one_or_none()
+    expires_at = result.scalar_one_or_none()
     await session.commit()
-    if consumed is None:
+    if expires_at is None:
         return None
     return token, expires_at
 

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -1,6 +1,9 @@
 """Database access helpers for agents, versions, deployments, and approvals."""
 
+import hashlib
+import secrets
 import uuid
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -13,6 +16,7 @@ from .models import (
     Approval,
     ApprovalAuditEntry,
     ApprovalStatus,
+    ConsoleSession,
     Deployment,
     Environment,
 )
@@ -668,3 +672,159 @@ async def list_approval_audit(
         .order_by(ApprovalAuditEntry.created_at)
     )
     return list(result)
+
+
+# --- Console sessions (#630, ADR-0049) --------------------------------------
+
+# Entropy for a login code and a session token. Both are bearer credentials, so
+# they are unguessable rather than memorable; token_urlsafe's argument is BYTES
+# of entropy, not the printed length.
+CONSOLE_TOKEN_BYTES = 32
+
+
+def _digest(value: str) -> str:
+    """The stored form of a login code or session token.
+
+    Hashing lives here, behind the store, so no caller ever holds a digest and
+    every lookup below is an indexed equality on this value. A plain SHA-256 is
+    right for a 32-byte random secret: there is no low-entropy guess space for a
+    slow KDF to protect, and the digest is what a database read would leak.
+    """
+
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+async def mint_console_login_code(
+    session: AsyncSession, label: str | None, ttl_seconds: int
+) -> tuple[str, ConsoleSession]:
+    """Mint a single-use login code. Returns the RAW code and its row.
+
+    The raw code is returned exactly once, to the CLI caller that minted it
+    under the platform key; only its digest is stored, so nothing can hand it
+    back later.
+    """
+
+    code = secrets.token_urlsafe(CONSOLE_TOKEN_BYTES)
+    row = ConsoleSession(
+        label=label,
+        login_code_hash=_digest(code),
+        login_code_expires_at=datetime.now(UTC) + timedelta(seconds=ttl_seconds),
+    )
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return code, row
+
+
+async def exchange_console_login_code(
+    session: AsyncSession, code: str, ttl_seconds: int
+) -> tuple[str, datetime] | None:
+    """Consume a login code and mint its session. Returns the RAW token and the
+    session's expiry, or None when the code is unknown, spent, expired, or
+    revoked (all one indistinguishable refusal to the caller).
+
+    Single-use is the conditional UPDATE, not a read-then-write: the
+    ``consumed_at IS NULL`` guard is the compare-and-set (the same resolve-once
+    idiom approvals use), so two concurrent exchanges of one code cannot both
+    win and mint two sessions.
+    """
+
+    token = secrets.token_urlsafe(CONSOLE_TOKEN_BYTES)
+    expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
+    result = await session.execute(
+        update(ConsoleSession)
+        .where(
+            ConsoleSession.login_code_hash == _digest(code),
+            ConsoleSession.consumed_at.is_(None),
+            ConsoleSession.login_code_expires_at > func.now(),
+            ConsoleSession.revoked_at.is_(None),
+        )
+        .values(
+            consumed_at=func.now(),
+            session_token_hash=_digest(token),
+            session_expires_at=expires_at,
+        )
+        .returning(ConsoleSession.id)
+    )
+    consumed = result.scalar_one_or_none()
+    await session.commit()
+    if consumed is None:
+        return None
+    return token, expires_at
+
+
+async def live_console_session(
+    session: AsyncSession, token: str
+) -> ConsoleSession | None:
+    """The live session a raw cookie token names, or None.
+
+    One indexed read per request, with liveness evaluated in the same statement:
+    a revoked or expired session is simply not found, so revocation takes effect
+    on the next request with nothing to invalidate. ``session_expires_at >
+    now()`` also excludes an unconsumed code's NULL, so a login code can never
+    act as a session token.
+    """
+
+    found: ConsoleSession | None = await session.scalar(
+        select(ConsoleSession).where(
+            ConsoleSession.session_token_hash == _digest(token),
+            ConsoleSession.revoked_at.is_(None),
+            ConsoleSession.session_expires_at > func.now(),
+        )
+    )
+    return found
+
+
+async def revoke_console_session(session: AsyncSession, token: str) -> None:
+    """Revoke the session a raw cookie token names (self-logout).
+
+    A durable row write, so a copy of the cookie taken before logout is dead
+    too; clearing only the browser's copy would leave a stolen token live.
+    Idempotent: an unknown or already-revoked token updates nothing.
+    """
+
+    await session.execute(
+        update(ConsoleSession)
+        .where(
+            ConsoleSession.session_token_hash == _digest(token),
+            ConsoleSession.revoked_at.is_(None),
+        )
+        .values(revoked_at=func.now())
+    )
+    await session.commit()
+
+
+async def revoke_all_console_sessions(session: AsyncSession) -> int:
+    """Revoke every live grant; returns how many were killed.
+
+    "Live" is the governing expiry: a session's once the code is exchanged, the
+    login code's until then, so an unexchanged code is killed by the same sweep
+    rather than surviving as a way back in. Already-revoked and already-expired
+    rows are not live, so a second sweep revokes nothing.
+    """
+
+    result = await session.execute(
+        update(ConsoleSession)
+        .where(
+            ConsoleSession.revoked_at.is_(None),
+            func.coalesce(
+                ConsoleSession.session_expires_at,
+                ConsoleSession.login_code_expires_at,
+            )
+            > func.now(),
+        )
+        .values(revoked_at=func.now())
+        .returning(ConsoleSession.id)
+    )
+    revoked = len(result.scalars().all())
+    await session.commit()
+    return revoked
+
+
+async def list_console_sessions(session: AsyncSession) -> Sequence[ConsoleSession]:
+    """Every session row, newest first, for the operator's inventory."""
+
+    found = await session.scalars(
+        select(ConsoleSession).order_by(ConsoleSession.created_at.desc())
+    )
+    return found.all()

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -10,8 +10,10 @@ from contextlib import asynccontextmanager
 
 import httpx
 import redis.asyncio as redis
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, status
+from fastapi.responses import JSONResponse
 
+from .auth import SESSION_STORE_DOWN_BODY, ConsoleSessionStoreUnavailable
 from .config import get_settings
 from .db import create_engine, create_sessionmaker
 from .evalqueue import EvalQueue
@@ -177,6 +179,19 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 def create_app() -> FastAPI:
     app = FastAPI(title="AgentOS API", version="0.1.0", lifespan=lifespan)
+
+    @app.exception_handler(ConsoleSessionStoreUnavailable)
+    async def _session_store_unavailable(
+        request: Request, exc: ConsoleSessionStoreUnavailable
+    ) -> JSONResponse:
+        """A console session could not be verified because its store is down
+        (#630, ADR-0049). A 503 with the CLI as the fix, never a 500 and never a
+        401: the operator's session is fine, the database is not."""
+
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content=SESSION_STORE_DOWN_BODY,
+        )
 
     @app.get("/health", tags=["health"])
     async def health() -> dict[str, str]:

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -27,6 +27,7 @@ from .routers import (
     approvals,
     bundles,
     config,
+    console,
     control,
     deployments,
     evals,
@@ -182,6 +183,7 @@ def create_app() -> FastAPI:
         return {"status": "ok"}
 
     app.include_router(config.router)
+    app.include_router(console.router)
     app.include_router(agents.router)
     app.include_router(deployments.router)
     app.include_router(bundles.router)

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -273,9 +273,6 @@ class ConsoleSession(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
-    # Operator-supplied note for the inventory listing ("laptop"), never a
-    # credential.
-    label: Mapped[str | None] = mapped_column(default=None)
     # SHA-256 hex of the minted login code. Unique so the exchange is a single
     # indexed lookup by digest.
     login_code_hash: Mapped[str] = mapped_column(unique=True, index=True)

--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Enum, ForeignKey, UniqueConstraint, func
+from sqlalchemy import DateTime, Enum, ForeignKey, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -248,6 +248,56 @@ class ApprovalAuditEntry(Base):
     # written before this column existed have none.
     evidence: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+
+
+class ConsoleSession(Base):
+    """A console login code and the session it becomes (#630, ADR-0049).
+
+    One row covers both halves of the flow, because they are the same grant at
+    two points in its life: the CLI mints a login code (``login_code_hash`` +
+    ``login_code_expires_at``), and the browser exchanges it exactly once for a
+    session token (``consumed_at`` + ``session_token_hash`` +
+    ``session_expires_at``).
+
+    Only SHA-256 digests of the code and the token are stored, so a database
+    read cannot replay a session. Both are looked up BY digest, never by
+    fetching rows and comparing, so the index does the work and no candidate
+    set is ever materialized.
+
+    Revocation is the ``revoked_at`` column write: a durable row an operator can
+    kill, which is what a self-contained signed token could not offer.
+    """
+
+    __tablename__ = "console_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    # Operator-supplied note for the inventory listing ("laptop"), never a
+    # credential.
+    label: Mapped[str | None] = mapped_column(default=None)
+    # SHA-256 hex of the minted login code. Unique so the exchange is a single
+    # indexed lookup by digest.
+    login_code_hash: Mapped[str] = mapped_column(unique=True, index=True)
+    login_code_expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    # Set at exchange; a non-NULL value is what makes the code single-use.
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    # SHA-256 hex of the session token the cookie carries, and its fixed
+    # absolute lifetime. NULL until the code is exchanged.
+    session_token_hash: Mapped[str | None] = mapped_column(
+        default=None, unique=True, index=True
+    )
+    session_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), default=None
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
 
 class WorkflowStateEntry(Base):

--- a/apps/api/src/agentos_api/routers/console.py
+++ b/apps/api/src/agentos_api/routers/console.py
@@ -1,0 +1,224 @@
+"""Console login: CLI-minted login codes and the session cookie they buy
+(#630, ADR-0049).
+
+The console used to authenticate by sending the shared platform key from browser
+JavaScript, which meant the key travelled in a URL, browser history, the Referer
+header, and proxy logs, and authorized every router. Here the browser never sees
+it: the CLI mints a short-lived single-use login code under the platform key, and
+the console exchanges that code for an HttpOnly session cookie that page script
+cannot read and an operator can revoke with a row write.
+
+The routes split by who calls them. Minting and the operator's inventory are the
+CLI's, under the platform key. The exchange and the session's own
+status/logout are the browser's, and carry no auth dependency because the cookie
+is the thing they are establishing or reading.
+"""
+
+from typing import Annotated, Any
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Cookie, Depends, Header, Response, status
+from fastapi.responses import JSONResponse
+
+from .. import crud
+from ..auth import CONSOLE_SESSION_COOKIE, require_platform_key
+from ..config import get_settings
+from ..deps import SessionDep
+from ..schemas import (
+    ConsoleLoginCodeMint,
+    ConsoleLoginCodeOut,
+    ConsoleRevokeOut,
+    ConsoleSessionExchange,
+    ConsoleSessionListItem,
+    ConsoleSessionOut,
+    ConsoleSessionStatus,
+)
+
+router = APIRouter(prefix="/console", tags=["console"])
+
+# Hosts a browser treats as a secure context over plaintext, and therefore for
+# which it honors a Secure cookie. Everything else must be https.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+_INSECURE_ORIGIN_FIX = (
+    "Reach the console over a secure context and log in again: "
+    "kubectl port-forward -n agentos svc/agentos-ui 8080:80 "
+    "then open http://localhost:8080. A plaintext origin (a NodePort URL) "
+    "cannot hold the session cookie."
+)
+
+
+def _is_secure_context(origin: str | None) -> bool:
+    """Whether a browser at this origin would treat itself as a secure context.
+
+    Fail-closed and by construction: a missing, empty, or unparseable Origin is
+    not a secure context, so the exchange refuses rather than establishing a
+    session over a channel that does not protect it.
+    """
+
+    if not origin:
+        return False
+    parsed = urlparse(origin)
+    if parsed.scheme == "https":
+        return True
+    return parsed.scheme == "http" and parsed.hostname in _LOOPBACK_HOSTS
+
+
+@router.post(
+    "/login-codes",
+    response_model=ConsoleLoginCodeOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_platform_key)],
+)
+async def mint_login_code(
+    data: ConsoleLoginCodeMint, session: SessionDep
+) -> ConsoleLoginCodeOut:
+    """Mint a login code for an operator to paste into the console.
+
+    Under the platform key on purpose: this is the CLI's endpoint, not the
+    browser's. An unauthenticated caller that could mint its own code could log
+    itself in, which would make the whole exchange decorative.
+    """
+
+    settings = get_settings()
+    code, row = await crud.mint_console_login_code(
+        session, data.label, settings.console_login_code_ttl_seconds
+    )
+    return ConsoleLoginCodeOut(
+        code=code, expires_at=row.login_code_expires_at, session_id=row.id
+    )
+
+
+@router.post("/session", response_model=ConsoleSessionOut)
+async def exchange_login_code(
+    data: ConsoleSessionExchange,
+    session: SessionDep,
+    response: Response,
+    origin: Annotated[str | None, Header()] = None,
+) -> Any:
+    """Exchange a login code for the session cookie. No auth dependency: the
+    code is the credential, and the cookie is what this call establishes.
+
+    The Origin gate runs BEFORE the code is touched, so a refusal costs the
+    operator nothing: the code is still live to retry over the port-forward the
+    fix names.
+    """
+
+    if not _is_secure_context(origin):
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={
+                "error": (
+                    "refusing to establish a console session from a non-secure "
+                    f"origin {origin!r}: the session cookie is Secure, and a "
+                    "browser would silently drop it over plaintext"
+                ),
+                "fix": _INSECURE_ORIGIN_FIX,
+            },
+        )
+
+    settings = get_settings()
+    exchanged = await crud.exchange_console_login_code(
+        session, data.code, settings.console_session_ttl_seconds
+    )
+    if exchanged is None:
+        # Unknown, spent, expired, or revoked are one refusal: which one it was
+        # is not the caller's to learn.
+        return JSONResponse(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            content={"detail": "invalid or expired login code"},
+        )
+    token, expires_at = exchanged
+    response.set_cookie(
+        CONSOLE_SESSION_COOKIE,
+        token,
+        max_age=settings.console_session_ttl_seconds,
+        httponly=True,  # page script cannot read the credential it authenticates with
+        secure=True,
+        samesite="strict",  # the CSRF control (ADR-0049); the API runs no CORS
+        path="/",
+    )
+    return ConsoleSessionOut(expires_at=expires_at)
+
+
+@router.get("/session", response_model=ConsoleSessionStatus)
+async def get_session_status(
+    session: SessionDep,
+    agentos_console_session: Annotated[str | None, Cookie()] = None,
+) -> ConsoleSessionStatus:
+    """Whether the caller's cookie names a live session, for the console's own
+    "am I logged in" check. Anonymous is a 200 with authenticated=false, not a
+    401: not being logged in is the answer, not an error."""
+
+    row = (
+        await crud.live_console_session(session, agentos_console_session)
+        if agentos_console_session
+        else None
+    )
+    if row is None:
+        return ConsoleSessionStatus(authenticated=False, expires_at=None)
+    return ConsoleSessionStatus(authenticated=True, expires_at=row.session_expires_at)
+
+
+@router.delete("/session", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(
+    session: SessionDep,
+    agentos_console_session: Annotated[str | None, Cookie()] = None,
+) -> Response:
+    """Self-logout: revoke the session server-side and clear the cookie.
+
+    Both halves matter. Clearing the cookie alone would leave a stolen copy of
+    the token live, so the row write is the real revocation. Idempotent, so a
+    logout without a live session is still a 204.
+    """
+
+    if agentos_console_session:
+        await crud.revoke_console_session(session, agentos_console_session)
+    response = Response(status_code=status.HTTP_204_NO_CONTENT)
+    # The attributes must match the ones the cookie was set with, or the browser
+    # keeps its copy alongside the expired one.
+    response.delete_cookie(
+        CONSOLE_SESSION_COOKIE, path="/", httponly=True, secure=True, samesite="strict"
+    )
+    return response
+
+
+@router.get(
+    "/sessions",
+    response_model=list[ConsoleSessionListItem],
+    dependencies=[Depends(require_platform_key)],
+)
+async def list_sessions(session: SessionDep) -> list[ConsoleSessionListItem]:
+    """The operator's inventory of console sessions.
+
+    An inventory, never a way to read one: no digest and no raw credential is
+    projected here, so a listing cannot be replayed into a login.
+    """
+
+    return [
+        ConsoleSessionListItem(
+            id=row.id,
+            label=row.label,
+            created_at=row.created_at,
+            # The expiry that currently governs the row: the session's once the
+            # code is exchanged, the login code's until then.
+            expires_at=row.session_expires_at or row.login_code_expires_at,
+            consumed_at=row.consumed_at,
+            revoked_at=row.revoked_at,
+        )
+        for row in await crud.list_console_sessions(session)
+    ]
+
+
+@router.delete(
+    "/sessions",
+    response_model=ConsoleRevokeOut,
+    dependencies=[Depends(require_platform_key)],
+)
+async def revoke_sessions(session: SessionDep) -> ConsoleRevokeOut:
+    """Revoke every live console grant. The operator's kill switch for the
+    console, and why the session is a durable row rather than a signed token:
+    this takes effect on the next request, with no key rotation and no restart.
+    """
+
+    return ConsoleRevokeOut(revoked=await crud.revoke_all_console_sessions(session))

--- a/apps/api/src/agentos_api/routers/console.py
+++ b/apps/api/src/agentos_api/routers/console.py
@@ -25,8 +25,10 @@ from ..auth import CONSOLE_SESSION_COOKIE, require_platform_key
 from ..config import get_settings
 from ..deps import SessionDep
 from ..schemas import (
+    ConsoleErrorOut,
     ConsoleLoginCodeMint,
     ConsoleLoginCodeOut,
+    ConsoleLoginRefusedOut,
     ConsoleRevokeOut,
     ConsoleSessionExchange,
     ConsoleSessionListItem,
@@ -89,7 +91,30 @@ async def mint_login_code(
     )
 
 
-@router.post("/session", response_model=ConsoleSessionOut)
+@router.post(
+    "/session",
+    response_model=ConsoleSessionOut,
+    # Both refusals are declared, not just the happy path (#630). They are the
+    # two outcomes a console MUST render -- one is an instruction to fix the
+    # URL, the other is "that code is no good" -- and an undeclared failure
+    # shape is one the UI has to guess at, which is how a wrong stub ships.
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "model": ConsoleErrorOut,
+            "description": (
+                "The origin is not a secure context, so a browser would drop "
+                "the Secure session cookie. The login code is NOT consumed."
+            ),
+        },
+        status.HTTP_401_UNAUTHORIZED: {
+            "model": ConsoleLoginRefusedOut,
+            "description": (
+                "The login code is unknown, already spent, expired, or revoked. "
+                "Which one it was is deliberately not distinguished."
+            ),
+        },
+    },
+)
 async def exchange_login_code(
     data: ConsoleSessionExchange,
     session: SessionDep,
@@ -135,7 +160,10 @@ async def exchange_login_code(
         max_age=settings.console_session_ttl_seconds,
         httponly=True,  # page script cannot read the credential it authenticates with
         secure=True,
-        samesite="strict",  # the CSRF control (ADR-0049); the API runs no CORS
+        # Defense in depth, NOT the CSRF control: SameSite ignores the port, so
+        # this is same-site with every other localhost port. The control is the
+        # X-Console-Session header require_api_key demands (ADR-0049).
+        samesite="strict",
         path="/",
     )
     return ConsoleSessionOut(expires_at=expires_at)

--- a/apps/api/src/agentos_api/routers/console.py
+++ b/apps/api/src/agentos_api/routers/console.py
@@ -8,8 +8,8 @@ it: the CLI mints a short-lived single-use login code under the platform key, an
 the console exchanges that code for an HttpOnly session cookie that page script
 cannot read and an operator can revoke with a row write.
 
-The routes split by who calls them. Minting and the operator's inventory are the
-CLI's, under the platform key. The exchange and the session's own
+The routes split by who calls them. Minting and the operator's kill switch are
+the CLI's, under the platform key. The exchange and the session's own
 status/logout are the browser's, and carry no auth dependency because the cookie
 is the thing they are establishing or reading.
 """
@@ -31,7 +31,6 @@ from ..schemas import (
     ConsoleLoginRefusedOut,
     ConsoleRevokeOut,
     ConsoleSessionExchange,
-    ConsoleSessionListItem,
     ConsoleSessionOut,
     ConsoleSessionStatus,
 )
@@ -84,7 +83,7 @@ async def mint_login_code(
 
     settings = get_settings()
     code, row = await crud.mint_console_login_code(
-        session, data.label, settings.console_login_code_ttl_seconds
+        session, settings.console_login_code_ttl_seconds
     )
     return ConsoleLoginCodeOut(
         code=code, expires_at=row.login_code_expires_at, session_id=row.id
@@ -209,33 +208,6 @@ async def logout(
         CONSOLE_SESSION_COOKIE, path="/", httponly=True, secure=True, samesite="strict"
     )
     return response
-
-
-@router.get(
-    "/sessions",
-    response_model=list[ConsoleSessionListItem],
-    dependencies=[Depends(require_platform_key)],
-)
-async def list_sessions(session: SessionDep) -> list[ConsoleSessionListItem]:
-    """The operator's inventory of console sessions.
-
-    An inventory, never a way to read one: no digest and no raw credential is
-    projected here, so a listing cannot be replayed into a login.
-    """
-
-    return [
-        ConsoleSessionListItem(
-            id=row.id,
-            label=row.label,
-            created_at=row.created_at,
-            # The expiry that currently governs the row: the session's once the
-            # code is exchanged, the login code's until then.
-            expires_at=row.session_expires_at or row.login_code_expires_at,
-            consumed_at=row.consumed_at,
-            revoked_at=row.revoked_at,
-        )
-        for row in await crud.list_console_sessions(session)
-    ]
 
 
 @router.delete(

--- a/apps/api/src/agentos_api/routers/state.py
+++ b/apps/api/src/agentos_api/routers/state.py
@@ -31,8 +31,13 @@ async def require_state_access(
     x_api_key: Annotated[str | None, Header()] = None,
 ) -> None:
     """State-router auth (ADR-0033): the platform key (trusted callers) OR a
-    scoped ``state`` token bound to this path's ``agent_id`` (the sandbox). Every
-    other router keeps the platform-key-only ``require_api_key``."""
+    scoped ``state`` token bound to this path's ``agent_id`` (the sandbox).
+
+    Every other router keeps ``require_api_key``, which accepts the platform key
+    or a console session (ADR-0049) and never a scoped token. The two are
+    disjoint extensions of the same platform key on purpose: a scoped token must
+    not reach a resolve-capable route, and a console session must not reach a
+    sandbox's state namespace."""
 
     if verify_platform_key(x_api_key):
         return

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -853,9 +853,8 @@ class MemoryEntryEdit(BaseModel):
 
 
 class ConsoleLoginCodeMint(BaseModel):
-    """Mint a login code. The label is an operator's note for the inventory."""
-
-    label: str | None = None
+    """Mint a login code. Carries no fields: the mint is a bare request under the
+    platform key, and an empty body validates."""
 
 
 class ConsoleLoginCodeOut(BaseModel):
@@ -907,22 +906,6 @@ class ConsoleSessionStatus(BaseModel):
 
     authenticated: bool
     expires_at: datetime | None = None
-
-
-class ConsoleSessionListItem(BaseModel):
-    """One session in the operator's inventory.
-
-    An inventory, never a way to read a session: no field here carries the code,
-    the token, or either digest. ``expires_at`` is the expiry that currently
-    governs the row -- the session's once exchanged, the login code's until then.
-    """
-
-    id: uuid.UUID
-    label: str | None = None
-    created_at: datetime
-    expires_at: datetime
-    consumed_at: datetime | None = None
-    revoked_at: datetime | None = None
 
 
 class ConsoleRevokeOut(BaseModel):

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -876,6 +876,24 @@ class ConsoleSessionExchange(BaseModel):
     code: str
 
 
+class ConsoleErrorOut(BaseModel):
+    """A refusal the operator can act on: what happened and what fixes it.
+
+    The `{error, fix}` pair of ADR-0021, flat rather than nested under `detail`,
+    so the console can render the fix verbatim.
+    """
+
+    error: str
+    fix: str
+
+
+class ConsoleLoginRefusedOut(BaseModel):
+    """A refused login code. One message for unknown, spent, expired, and
+    revoked alike: which one it was is not the caller's to learn."""
+
+    detail: str
+
+
 class ConsoleSessionOut(BaseModel):
     """The established session's fixed absolute expiry. The token itself is
     returned only as the HttpOnly cookie, never in the body."""

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -847,3 +847,67 @@ class MemoryEntryEdit(BaseModel):
 
     content: str
     expected_version: int
+
+
+# --- Console sessions (#630, ADR-0049) --------------------------------------
+
+
+class ConsoleLoginCodeMint(BaseModel):
+    """Mint a login code. The label is an operator's note for the inventory."""
+
+    label: str | None = None
+
+
+class ConsoleLoginCodeOut(BaseModel):
+    """The one and only moment the raw login code is readable.
+
+    It is never stored (only its digest is) and never returned again, so a
+    caller that loses it mints another.
+    """
+
+    code: str
+    expires_at: datetime
+    session_id: uuid.UUID
+
+
+class ConsoleSessionExchange(BaseModel):
+    """Exchange a login code for a session cookie."""
+
+    code: str
+
+
+class ConsoleSessionOut(BaseModel):
+    """The established session's fixed absolute expiry. The token itself is
+    returned only as the HttpOnly cookie, never in the body."""
+
+    expires_at: datetime
+
+
+class ConsoleSessionStatus(BaseModel):
+    """Whether the caller's cookie names a live session, for the console's own
+    "am I logged in" check. Never carries the token or its digest."""
+
+    authenticated: bool
+    expires_at: datetime | None = None
+
+
+class ConsoleSessionListItem(BaseModel):
+    """One session in the operator's inventory.
+
+    An inventory, never a way to read a session: no field here carries the code,
+    the token, or either digest. ``expires_at`` is the expiry that currently
+    governs the row -- the session's once exchanged, the login code's until then.
+    """
+
+    id: uuid.UUID
+    label: str | None = None
+    created_at: datetime
+    expires_at: datetime
+    consumed_at: datetime | None = None
+    revoked_at: datetime | None = None
+
+
+class ConsoleRevokeOut(BaseModel):
+    """How many live sessions the sweep killed."""
+
+    revoked: int

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -26,6 +26,22 @@ def test_agents_accept_valid_key(
     assert client.get("/agents", headers=auth_headers).status_code == 200
 
 
+def test_bogus_console_session_cookie_is_rejected(client: Any) -> None:
+    # require_api_key grew a second accepted credential (a live console session
+    # cookie, ADR-0049/#630). An unrecognized cookie must not widen anything.
+    client.cookies.set("agentos_console_session", "not-a-session")
+    assert client.get("/agents").status_code == 401
+
+
+def test_platform_key_is_honored_alongside_a_bogus_console_cookie(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The platform-key path is checked first and unchanged (ADR-0049): a machine
+    # caller with a valid key is not broken by a junk cookie riding along.
+    client.cookies.set("agentos_console_session", "not-a-session")
+    assert client.get("/agents", headers=auth_headers).status_code == 200
+
+
 def test_scoped_state_token_is_rejected_on_a_crud_route(client: Any) -> None:
     # A scoped sandbox "state" token authorizes the state namespace only; it must
     # be rejected by the shared require_api_key guard on every other route, so the

--- a/apps/api/tests/test_console_session.py
+++ b/apps/api/tests/test_console_session.py
@@ -133,12 +133,8 @@ def _parse_ts(value: str) -> datetime:
     return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
 
 
-def _mint_code(
-    client: Any, auth_headers: dict[str, str], label: str | None = None
-) -> dict[str, Any]:
-    resp = client.post(
-        "/console/login-codes", headers=auth_headers, json={"label": label}
-    )
+def _mint_code(client: Any, auth_headers: dict[str, str]) -> dict[str, Any]:
+    resp = client.post("/console/login-codes", headers=auth_headers, json={})
     assert resp.status_code == 201, resp.text
     return resp.json()
 
@@ -187,7 +183,7 @@ def test_minted_code_carries_an_expiry_from_the_configured_ttl(
     console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
 ) -> None:
     before = datetime.now(UTC)
-    minted = _mint_code(console_client, auth_headers, label="laptop")
+    minted = _mint_code(console_client, auth_headers)
 
     ttl = get_settings().console_login_code_ttl_seconds
     assert ttl == 600  # the shipped default the ADR specifies
@@ -363,48 +359,6 @@ def test_revoking_all_sessions_kills_a_live_cookie_immediately(
         # Only LIVE sessions count, so a second sweep revokes nothing.
         again = console_client.delete("/console/sessions", headers=auth_headers)
         assert again.json() == {"revoked": 0}
-
-
-def test_listing_sessions_requires_the_platform_key_and_leaks_no_secret(
-    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
-) -> None:
-    assert console_client.get("/console/sessions").status_code == 401
-    assert (
-        console_client.get(
-            "/console/sessions", headers={"X-API-Key": "wrong"}
-        ).status_code
-        == 401
-    )
-
-    minted = _mint_code(console_client, auth_headers, label="laptop")
-    exchanged = _exchange(console_client, minted["code"])
-    assert exchanged.status_code == 200, exchanged.text
-    token = _cookie_value(exchanged)
-
-    listed = console_client.get("/console/sessions", headers=auth_headers)
-    assert listed.status_code == 200, listed.text
-    items = listed.json()
-    assert len(items) == 1
-    item = items[0]
-    assert set(item) == {
-        "id",
-        "label",
-        "created_at",
-        "expires_at",
-        "consumed_at",
-        "revoked_at",
-    }
-    assert item["id"] == minted["session_id"]
-    assert item["label"] == "laptop"
-    assert item["consumed_at"] is not None
-    assert item["revoked_at"] is None
-
-    # The listing is an operator's inventory of sessions, never a way to read
-    # one: neither the code nor the token may be recoverable from it.
-    body = listed.text
-    assert minted["code"] not in body
-    assert token not in body
-    assert _sha256(token) not in body
 
 
 def test_only_hashes_of_the_code_and_token_are_stored(

--- a/apps/api/tests/test_console_session.py
+++ b/apps/api/tests/test_console_session.py
@@ -1,0 +1,504 @@
+"""Console sessions and CLI-minted login codes (ADR-0049, #630).
+
+Real Postgres (the conftest's disposable per-run database), nothing internal
+mocked. The console's credential is a server-managed, revocable session cookie
+established by exchanging a single-use login code that the CLI mints under the
+platform key. These tests pin the outcomes that make that stronger than the
+status quo: browser code never sees the platform key, the cookie alone
+authorizes a real protected route, only hashes reach the database, and
+revocation is immediate.
+
+Two deliberate test-side choices:
+
+* The TestClient runs on an ``https://`` base URL. The exchange sets a
+  ``Secure`` cookie, and a standards-conformant cookie jar (httpx's, and every
+  browser's) refuses to store a ``Secure`` cookie received over plaintext. An
+  ``http://testserver`` client would silently drop the cookie and every
+  assertion below would be testing nothing.
+* Expiry is driven by ageing the stored rows rather than sleeping, and the
+  ageing helper discovers the expiry columns from ``information_schema`` rather
+  than hardcoding their names, so these tests pin the behavior without dictating
+  the column spelling.
+"""
+
+import asyncio
+import hashlib
+import uuid
+from datetime import UTC, datetime
+from http.cookies import SimpleCookie
+from typing import Any
+
+import pytest
+from agentos_api.config import get_settings
+from agentos_api.main import create_app
+from agentos_api.sandbox_token import mint
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+COOKIE_NAME = "agentos_console_session"
+TABLE = "agentos.console_sessions"
+
+# A secure-context origin a real console is served from, and a plaintext
+# NodePort origin, which is the exact case the exchange must refuse.
+HTTPS_ORIGIN = "https://console.example"
+NODEPORT_ORIGIN = "http://10.1.2.3:30000"
+
+
+@pytest.fixture
+def console_client(_disposable_db: Any) -> Any:
+    """A TestClient on an https origin, so the Secure session cookie is kept."""
+
+    with TestClient(create_app(), base_url="https://testserver") as test_client:
+        yield test_client
+
+
+def _run(coro_factory: Any) -> Any:
+    async def _main() -> Any:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            return await coro_factory(engine)
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_main())
+
+
+@pytest.fixture
+def clean_console_sessions(migrated: None) -> None:
+    """Row counts and revocation totals below are exact, so each test starts
+    from an empty table (the conftest's clean_db truncates the agent tables
+    only)."""
+
+    async def _truncate(engine: Any) -> None:
+        async with engine.begin() as conn:
+            await conn.execute(text(f"TRUNCATE {TABLE}"))
+
+    _run(_truncate)
+
+
+def _rows() -> list[dict[str, Any]]:
+    async def _select(engine: Any) -> list[dict[str, Any]]:
+        async with engine.connect() as conn:
+            result = await conn.execute(text(f"select * from {TABLE}"))
+            return [dict(row) for row in result.mappings().all()]
+
+    return _run(_select)
+
+
+def _expire_all_sessions() -> int:
+    """Force every expiry on every stored session to an elapsed timestamp.
+
+    Sets an ABSOLUTE past timestamp rather than subtracting an interval: a
+    relative shift has to out-run whichever TTL produced the value, so it would
+    silently leave a 12-hour session live and the test would pass or fail for a
+    reason that has nothing to do with expiry.
+
+    Discovers the expiry columns from the catalog instead of naming them, so
+    these tests pin "an elapsed expiry is refused" rather than a column
+    spelling. Returns the number of rows expired.
+    """
+
+    async def _expire(engine: Any) -> int:
+        async with engine.begin() as conn:
+            found = await conn.execute(
+                text(
+                    "select column_name from information_schema.columns "
+                    "where table_schema = 'agentos' "
+                    "and table_name = 'console_sessions' "
+                    "and column_name like '%expires%'"
+                )
+            )
+            cols = list(found.scalars().all())
+            assert cols, f"{TABLE} stores no expiry column to age"
+            assignments = ", ".join(
+                f"{col} = now() - interval '1 hour'" for col in cols
+            )
+            expired = await conn.execute(text(f"update {TABLE} set {assignments}"))
+            return int(expired.rowcount)
+
+    return _run(_expire)
+
+
+def _parse_ts(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _mint_code(
+    client: Any, auth_headers: dict[str, str], label: str | None = None
+) -> dict[str, Any]:
+    resp = client.post(
+        "/console/login-codes", headers=auth_headers, json={"label": label}
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _exchange(client: Any, code: str, origin: str = HTTPS_ORIGIN) -> Any:
+    return client.post(
+        "/console/session", json={"code": code}, headers={"Origin": origin}
+    )
+
+
+def _cookie_value(resp: Any) -> str:
+    jar = SimpleCookie()
+    jar.load(resp.headers["set-cookie"])
+    return jar[COOKIE_NAME].value
+
+
+def _login(client: Any, auth_headers: dict[str, str]) -> str:
+    """Full front-door flow; returns the raw session token the cookie carries."""
+
+    minted = _mint_code(client, auth_headers)
+    resp = _exchange(client, minted["code"])
+    assert resp.status_code == 200, resp.text
+    return _cookie_value(resp)
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def test_minting_a_login_code_requires_the_platform_key(
+    console_client: Any, clean_console_sessions: None
+) -> None:
+    # The mint endpoint is the CLI's, not the browser's: an unauthenticated
+    # caller must not be able to hand itself a code and log in.
+    assert console_client.post("/console/login-codes", json={}).status_code == 401
+    assert (
+        console_client.post(
+            "/console/login-codes", json={}, headers={"X-API-Key": "wrong"}
+        ).status_code
+        == 401
+    )
+    assert _rows() == []
+
+
+def test_minted_code_carries_an_expiry_from_the_configured_ttl(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    before = datetime.now(UTC)
+    minted = _mint_code(console_client, auth_headers, label="laptop")
+
+    ttl = get_settings().console_login_code_ttl_seconds
+    assert ttl == 600  # the shipped default the ADR specifies
+    delta = (_parse_ts(minted["expires_at"]) - before).total_seconds()
+    assert ttl - 60 < delta <= ttl + 5
+    assert uuid.UUID(str(minted["session_id"]))
+    assert minted["code"]
+
+
+def test_session_cookie_alone_authorizes_a_protected_route(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    # The point of the whole design: the browser holds no platform key, and the
+    # cookie it does hold is a real credential on a real router.
+    assert console_client.get("/agents").status_code == 401
+
+    _login(console_client, auth_headers)
+
+    resp = console_client.get("/agents")
+    assert resp.status_code == 200, resp.text
+    assert "X-API-Key" not in resp.request.headers
+    assert COOKIE_NAME in console_client.cookies
+
+
+def test_set_cookie_carries_the_hardening_attributes(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    # HttpOnly is what makes this strictly stronger than the status quo (page
+    # script cannot read the credential); SameSite=Strict is the CSRF control.
+    minted = _mint_code(console_client, auth_headers)
+    resp = _exchange(console_client, minted["code"])
+    assert resp.status_code == 200, resp.text
+
+    raw = resp.headers["set-cookie"]
+    assert raw.startswith(f"{COOKIE_NAME}=")
+    lowered = raw.lower()
+    assert "httponly" in lowered
+    assert "secure" in lowered
+    assert "samesite=strict" in lowered
+    assert "path=/" in lowered
+
+
+def test_login_code_is_single_use(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    minted = _mint_code(console_client, auth_headers)
+    first = _exchange(console_client, minted["code"])
+    assert first.status_code == 200, first.text
+    first_token = _cookie_value(first)
+
+    # A replayed code buys nothing...
+    replay = _exchange(console_client, minted["code"])
+    assert replay.status_code == 401
+
+    # ...and the refusal did not collaterally kill the session it minted.
+    assert console_client.cookies[COOKIE_NAME] == first_token
+    assert console_client.get("/agents").status_code == 200
+
+
+def test_unknown_login_code_is_rejected(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    assert _exchange(console_client, "not-a-real-code").status_code == 401
+    assert COOKIE_NAME not in console_client.cookies
+
+
+def test_expired_login_code_is_rejected(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    minted = _mint_code(console_client, auth_headers)
+    assert _expire_all_sessions() == 1
+
+    assert _exchange(console_client, minted["code"]).status_code == 401
+    assert COOKIE_NAME not in console_client.cookies
+    assert console_client.get("/agents").status_code == 401
+
+
+def test_expired_session_cookie_is_rejected_on_a_protected_route(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    _login(console_client, auth_headers)
+    assert console_client.get("/agents").status_code == 200
+
+    assert _expire_all_sessions() == 1
+
+    # Fixed absolute lifetime, no sliding refresh (ADR-0049).
+    assert console_client.get("/agents").status_code == 401
+    status = console_client.get("/console/session")
+    assert status.status_code == 200
+    assert status.json() == {"authenticated": False, "expires_at": None}
+
+
+def test_get_session_reports_the_live_session(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    anonymous = console_client.get("/console/session")
+    assert anonymous.status_code == 200
+    assert anonymous.json() == {"authenticated": False, "expires_at": None}
+
+    minted = _mint_code(console_client, auth_headers)
+    exchanged = _exchange(console_client, minted["code"])
+    assert exchanged.status_code == 200, exchanged.text
+
+    live = console_client.get("/console/session")
+    assert live.status_code == 200
+    body = live.json()
+    assert body["authenticated"] is True
+    assert _parse_ts(body["expires_at"]) == _parse_ts(exchanged.json()["expires_at"])
+
+    ttl = get_settings().console_session_ttl_seconds
+    assert ttl == 43200  # the shipped default the ADR specifies
+    delta = (_parse_ts(body["expires_at"]) - datetime.now(UTC)).total_seconds()
+    assert ttl - 60 < delta <= ttl + 5
+
+
+def test_self_logout_revokes_the_session_and_is_idempotent(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    _login(console_client, auth_headers)
+    assert console_client.get("/agents").status_code == 200
+
+    out = console_client.delete("/console/session")
+    assert out.status_code == 204
+    assert out.content == b""
+    # The cookie is cleared client-side...
+    assert COOKIE_NAME not in console_client.cookies
+    assert console_client.get("/agents").status_code == 401
+    assert console_client.get("/console/session").json()["authenticated"] is False
+
+    # ...and server-side, so a copy of the cookie taken before logout is dead.
+    # (Clearing only the browser's copy would leave a stolen token live.)
+    assert console_client.delete("/console/session").status_code == 204
+
+
+def test_self_logout_kills_a_stolen_copy_of_the_cookie(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    token = _login(console_client, auth_headers)
+    stolen = {"Cookie": f"{COOKIE_NAME}={token}"}
+    assert console_client.get("/agents").status_code == 200
+
+    assert console_client.delete("/console/session").status_code == 204
+
+    # Revocation is a durable row write, not a cookie deletion.
+    assert console_client.get("/agents", headers=stolen).status_code == 401
+
+
+def test_revoking_all_sessions_kills_a_live_cookie_immediately(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    other = TestClient(create_app(), base_url="https://testserver")
+    with other:
+        _login(console_client, auth_headers)
+        _login(other, auth_headers)
+        assert console_client.get("/agents").status_code == 200
+        assert other.get("/agents").status_code == 200
+
+        assert console_client.delete("/console/sessions").status_code == 401
+        assert (
+            console_client.delete(
+                "/console/sessions", headers={"X-API-Key": "wrong"}
+            ).status_code
+            == 401
+        )
+
+        killed = console_client.delete("/console/sessions", headers=auth_headers)
+        assert killed.status_code == 200, killed.text
+        assert killed.json() == {"revoked": 2}
+
+        assert console_client.get("/agents").status_code == 401
+        assert other.get("/agents").status_code == 401
+
+        # Only LIVE sessions count, so a second sweep revokes nothing.
+        again = console_client.delete("/console/sessions", headers=auth_headers)
+        assert again.json() == {"revoked": 0}
+
+
+def test_listing_sessions_requires_the_platform_key_and_leaks_no_secret(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    assert console_client.get("/console/sessions").status_code == 401
+    assert (
+        console_client.get(
+            "/console/sessions", headers={"X-API-Key": "wrong"}
+        ).status_code
+        == 401
+    )
+
+    minted = _mint_code(console_client, auth_headers, label="laptop")
+    exchanged = _exchange(console_client, minted["code"])
+    assert exchanged.status_code == 200, exchanged.text
+    token = _cookie_value(exchanged)
+
+    listed = console_client.get("/console/sessions", headers=auth_headers)
+    assert listed.status_code == 200, listed.text
+    items = listed.json()
+    assert len(items) == 1
+    item = items[0]
+    assert set(item) == {
+        "id",
+        "label",
+        "created_at",
+        "expires_at",
+        "consumed_at",
+        "revoked_at",
+    }
+    assert item["id"] == minted["session_id"]
+    assert item["label"] == "laptop"
+    assert item["consumed_at"] is not None
+    assert item["revoked_at"] is None
+
+    # The listing is an operator's inventory of sessions, never a way to read
+    # one: neither the code nor the token may be recoverable from it.
+    body = listed.text
+    assert minted["code"] not in body
+    assert token not in body
+    assert _sha256(token) not in body
+
+
+def test_only_hashes_of_the_code_and_token_are_stored(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    minted = _mint_code(console_client, auth_headers)
+    exchanged = _exchange(console_client, minted["code"])
+    assert exchanged.status_code == 200, exchanged.text
+    token = _cookie_value(exchanged)
+    code = minted["code"]
+
+    rows = _rows()
+    assert len(rows) == 1
+    stored = {str(value) for value in rows[0].values()}
+
+    # A database read must not replay a session (ADR-0049): the raw values are
+    # absent and their SHA-256 digests are what is on disk.
+    assert code not in stored
+    assert token not in stored
+    assert _sha256(code) in stored
+    assert _sha256(token) in stored
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        HTTPS_ORIGIN,
+        "https://agentos.internal:8443",
+        "http://localhost:5173",
+        "http://127.0.0.1:4273",
+        "http://[::1]:8080",
+    ],
+)
+def test_exchange_allows_a_secure_context_origin(
+    console_client: Any,
+    auth_headers: dict[str, str],
+    clean_console_sessions: None,
+    origin: str,
+) -> None:
+    # Browsers treat https and loopback as secure contexts and honor Secure
+    # cookies for both, so both must be able to log in.
+    minted = _mint_code(console_client, auth_headers)
+    resp = _exchange(console_client, minted["code"], origin=origin)
+    assert resp.status_code == 200, resp.text
+    assert _cookie_value(resp)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [NODEPORT_ORIGIN, "http://agentos.internal:30080"],
+)
+def test_exchange_refuses_a_plaintext_origin_with_a_fix(
+    console_client: Any,
+    auth_headers: dict[str, str],
+    clean_console_sessions: None,
+    origin: str,
+) -> None:
+    # Fail-closed: a Secure cookie set over plaintext is silently unprotected,
+    # so the exchange refuses and hands back the instruction that fixes it.
+    minted = _mint_code(console_client, auth_headers)
+    resp = _exchange(console_client, minted["code"], origin=origin)
+    assert resp.status_code == 400, resp.text
+    body = resp.json()
+    assert body.get("error")
+    assert "port-forward" in body.get("fix", "")
+    assert COOKIE_NAME not in console_client.cookies
+
+    # A refused exchange must not have burned the code: the operator can retry
+    # over the port-forward the fix told them to open.
+    retry = _exchange(console_client, minted["code"])
+    assert retry.status_code == 200, retry.text
+
+
+def test_exchange_refuses_a_missing_origin(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    minted = _mint_code(console_client, auth_headers)
+    resp = console_client.post("/console/session", json={"code": minted["code"]})
+    assert resp.status_code == 400, resp.text
+    assert resp.json().get("error")
+    assert COOKIE_NAME not in console_client.cookies
+
+
+def test_scoped_state_token_is_not_accepted_as_a_console_session(
+    console_client: Any, clean_console_sessions: None
+) -> None:
+    # A sandbox `state` token (ADR-0033) is scoped to one agent's state
+    # namespace. The console cookie is a second credential on the shared
+    # require_api_key dependency; it must not become a laundering path that
+    # promotes a scoped token to platform-wide access.
+    token = mint(
+        get_settings().api_key,
+        agent=str(uuid.uuid4()),
+        scope="state",
+        exp=4102444800,  # 2100-01-01, valid at test time
+    )
+    assert (
+        console_client.get(
+            "/agents", headers={"Cookie": f"{COOKIE_NAME}={token}"}
+        ).status_code
+        == 401
+    )
+    assert (
+        console_client.get("/agents", headers={"X-API-Key": token}).status_code == 401
+    )

--- a/apps/api/tests/test_console_session.py
+++ b/apps/api/tests/test_console_session.py
@@ -4,9 +4,10 @@ Real Postgres (the conftest's disposable per-run database), nothing internal
 mocked. The console's credential is a server-managed, revocable session cookie
 established by exchanging a single-use login code that the CLI mints under the
 platform key. These tests pin the outcomes that make that stronger than the
-status quo: browser code never sees the platform key, the cookie alone
-authorizes a real protected route, only hashes reach the database, and
-revocation is immediate.
+status quo: browser code never sees the platform key, the cookie (with the
+``X-Console-Session`` CSRF header) authorizes a real protected route, a forged
+cross-site request carrying the cookie does not, only hashes reach the database,
+and revocation is immediate.
 
 Two deliberate test-side choices:
 
@@ -34,10 +35,17 @@ from agentos_api.main import create_app
 from agentos_api.sandbox_token import mint
 from fastapi.testclient import TestClient
 from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import create_async_engine
 
 COOKIE_NAME = "agentos_console_session"
 TABLE = "agentos.console_sessions"
+
+# The CSRF header the cookie path requires (ADR-0049). Sent explicitly on every
+# cookie-authenticated call below rather than defaulted onto the client, so that
+# a test asserting 401 is visibly asserting "the session is dead", not silently
+# passing because the header went missing.
+CONSOLE_HEADER = {"X-Console-Session": "1"}
 
 # A secure-context origin a real console is served from, and a plaintext
 # NodePort origin, which is the exact case the exchange must refuse.
@@ -189,16 +197,16 @@ def test_minted_code_carries_an_expiry_from_the_configured_ttl(
     assert minted["code"]
 
 
-def test_session_cookie_alone_authorizes_a_protected_route(
+def test_session_cookie_authorizes_a_protected_route_with_no_platform_key(
     console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
 ) -> None:
     # The point of the whole design: the browser holds no platform key, and the
     # cookie it does hold is a real credential on a real router.
-    assert console_client.get("/agents").status_code == 401
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 401
 
     _login(console_client, auth_headers)
 
-    resp = console_client.get("/agents")
+    resp = console_client.get("/agents", headers=CONSOLE_HEADER)
     assert resp.status_code == 200, resp.text
     assert "X-API-Key" not in resp.request.headers
     assert COOKIE_NAME in console_client.cookies
@@ -236,7 +244,7 @@ def test_login_code_is_single_use(
 
     # ...and the refusal did not collaterally kill the session it minted.
     assert console_client.cookies[COOKIE_NAME] == first_token
-    assert console_client.get("/agents").status_code == 200
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 200
 
 
 def test_unknown_login_code_is_rejected(
@@ -254,19 +262,19 @@ def test_expired_login_code_is_rejected(
 
     assert _exchange(console_client, minted["code"]).status_code == 401
     assert COOKIE_NAME not in console_client.cookies
-    assert console_client.get("/agents").status_code == 401
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 401
 
 
 def test_expired_session_cookie_is_rejected_on_a_protected_route(
     console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
 ) -> None:
     _login(console_client, auth_headers)
-    assert console_client.get("/agents").status_code == 200
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 200
 
     assert _expire_all_sessions() == 1
 
     # Fixed absolute lifetime, no sliding refresh (ADR-0049).
-    assert console_client.get("/agents").status_code == 401
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 401
     status = console_client.get("/console/session")
     assert status.status_code == 200
     assert status.json() == {"authenticated": False, "expires_at": None}
@@ -299,14 +307,14 @@ def test_self_logout_revokes_the_session_and_is_idempotent(
     console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
 ) -> None:
     _login(console_client, auth_headers)
-    assert console_client.get("/agents").status_code == 200
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 200
 
     out = console_client.delete("/console/session")
     assert out.status_code == 204
     assert out.content == b""
     # The cookie is cleared client-side...
     assert COOKIE_NAME not in console_client.cookies
-    assert console_client.get("/agents").status_code == 401
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 401
     assert console_client.get("/console/session").json()["authenticated"] is False
 
     # ...and server-side, so a copy of the cookie taken before logout is dead.
@@ -318,8 +326,8 @@ def test_self_logout_kills_a_stolen_copy_of_the_cookie(
     console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
 ) -> None:
     token = _login(console_client, auth_headers)
-    stolen = {"Cookie": f"{COOKIE_NAME}={token}"}
-    assert console_client.get("/agents").status_code == 200
+    stolen = {"Cookie": f"{COOKIE_NAME}={token}", **CONSOLE_HEADER}
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 200
 
     assert console_client.delete("/console/session").status_code == 204
 
@@ -334,8 +342,8 @@ def test_revoking_all_sessions_kills_a_live_cookie_immediately(
     with other:
         _login(console_client, auth_headers)
         _login(other, auth_headers)
-        assert console_client.get("/agents").status_code == 200
-        assert other.get("/agents").status_code == 200
+        assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 200
+        assert other.get("/agents", headers=CONSOLE_HEADER).status_code == 200
 
         assert console_client.delete("/console/sessions").status_code == 401
         assert (
@@ -349,8 +357,8 @@ def test_revoking_all_sessions_kills_a_live_cookie_immediately(
         assert killed.status_code == 200, killed.text
         assert killed.json() == {"revoked": 2}
 
-        assert console_client.get("/agents").status_code == 401
-        assert other.get("/agents").status_code == 401
+        assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 401
+        assert other.get("/agents", headers=CONSOLE_HEADER).status_code == 401
 
         # Only LIVE sessions count, so a second sweep revokes nothing.
         again = console_client.delete("/console/sessions", headers=auth_headers)
@@ -495,10 +503,125 @@ def test_scoped_state_token_is_not_accepted_as_a_console_session(
     )
     assert (
         console_client.get(
-            "/agents", headers={"Cookie": f"{COOKIE_NAME}={token}"}
+            "/agents", headers={"Cookie": f"{COOKIE_NAME}={token}", **CONSOLE_HEADER}
         ).status_code
         == 401
     )
     assert (
         console_client.get("/agents", headers={"X-API-Key": token}).status_code == 401
     )
+
+
+def test_cookie_without_the_csrf_header_cannot_kill_an_agent(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    """The CSRF regression test, shaped like the real attack (ADR-0049).
+
+    Before the session cookie existed, the console's authority was an
+    ``X-API-Key`` header, which is structurally CSRF-immune: a cross-origin page
+    cannot set it without a preflight. A cookie is ambient, and SameSite=Strict
+    does not save it -- "site" ignores the port, so the ADR's own prescribed
+    ``http://localhost:8080`` login path is same-site with every other localhost
+    port. This is the exact request such a page can auto-submit: a body-less
+    cross-origin form POST to the kill switch, which is a CORS-SIMPLE request, so
+    nothing preflights it and the absent CORS middleware rejects nothing. The
+    cookie rides along; only the missing custom header stops it.
+    """
+
+    agent = console_client.post(
+        "/agents",
+        headers=auth_headers,
+        json={"name": "csrf-target", "slack_channel": "C0123ABCDEF"},
+    )
+    assert agent.status_code == 201, agent.text
+    agent_id = agent.json()["id"]
+
+    _login(console_client, auth_headers)
+    # The session is live and CAN kill when it asks properly...
+    assert (
+        console_client.get(f"/agents/{agent_id}/kill", headers=CONSOLE_HEADER).status_code
+        == 200
+    )
+
+    # ...but the forged request, which carries the cookie and nothing else, is
+    # refused. A cross-origin page cannot add the header without a preflight this
+    # CORS-free API fails.
+    forged = console_client.post(
+        f"/agents/{agent_id}/kill",
+        headers={"Origin": "http://evil.localhost:1234"},
+    )
+    assert forged.status_code == 401, forged.text
+    assert COOKIE_NAME in console_client.cookies  # the cookie WAS sent
+
+    # The kill switch did not fire.
+    state = console_client.get(f"/agents/{agent_id}/kill", headers=CONSOLE_HEADER)
+    assert state.status_code == 200, state.text
+    assert state.json() == {"killed": False}
+
+
+def test_cookie_with_the_csrf_header_still_authorizes(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    # The header's PRESENCE is the whole proof: being able to set it at all is
+    # what a cross-origin attacker cannot do, so its value is not a secret and
+    # is not checked.
+    _login(console_client, auth_headers)
+
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 200
+    assert (
+        console_client.get(
+            "/agents", headers={"X-Console-Session": "anything"}
+        ).status_code
+        == 200
+    )
+    assert console_client.get("/agents").status_code == 401
+
+
+def test_platform_key_needs_no_csrf_header_and_no_session(
+    console_client: Any, auth_headers: dict[str, str], clean_console_sessions: None
+) -> None:
+    # The CSRF header is a browser-only defense. The worker, runner, and CLI
+    # authenticate with the platform key alone and must never be asked for it --
+    # requiring it of them would buy nothing and break every existing caller.
+    resp = console_client.get("/agents", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    assert "X-Console-Session" not in resp.request.headers
+    assert COOKIE_NAME not in console_client.cookies
+    assert _rows() == []  # the platform-key path read no session
+
+
+def test_session_store_being_down_is_a_503_naming_the_cli_not_a_500(
+    console_client: Any,
+    auth_headers: dict[str, str],
+    clean_console_sessions: None,
+    monkeypatch: Any,
+) -> None:
+    """A database outage must not turn the kill switch opaque (ADR-0049).
+
+    The kill switch and the pod-log proxy are what an operator reaches for when
+    the system is already sick, and neither needed Postgres to authenticate
+    before the cookie existed. A 500 there is the worst possible moment for one,
+    and a 401 would be a lie that sends the operator to log in again -- which
+    also cannot work while the store is down.
+    """
+
+    from agentos_api import auth as auth_module
+
+    _login(console_client, auth_headers)
+    assert console_client.get("/agents", headers=CONSOLE_HEADER).status_code == 200
+
+    async def _down(*_args: Any, **_kwargs: Any) -> None:
+        raise OperationalError("select 1", {}, Exception("connection refused"))
+
+    monkeypatch.setattr(auth_module.crud, "live_console_session", _down)
+
+    resp = console_client.get("/agents", headers=CONSOLE_HEADER)
+    assert resp.status_code == 503, resp.text
+    body = resp.json()
+    assert body.get("error")
+    # The fix is the CLI: it holds the platform key and needs no session.
+    assert "CLI" in body.get("fix", "")
+
+    # The platform key is unaffected: it returns before the store is ever read,
+    # so a machine caller still works while the console cannot.
+    assert console_client.get("/agents", headers=auth_headers).status_code == 200

--- a/apps/ui/.env.example
+++ b/apps/ui/.env.example
@@ -10,6 +10,7 @@ AGENTOS_API_TARGET=http://localhost:8000
 # the app runs on fixtures and only wires when the URL carries ?api=1.
 # VITE_WIRED=1
 
-# API key sent as X-API-Key. Defaults to the dev key when unset. The ?api_key=
-# URL param overrides this at runtime (dev/test convenience only).
-# VITE_API_KEY=agentos-dev-key
+# There is deliberately no API-key setting here (#630 / ADR-0049). The console
+# authenticates with a session cookie exchanged for a single-use login code from
+# `agentos <local|cluster> console login`; the platform key is never given to
+# browser code, so there is nothing to configure.

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -100,8 +100,15 @@ render without `?api=1`. Swap the rest by replacing the `src/fixtures` selectors
 **How wiring is gated.** `src/api/config.ts` resolves the mode at runtime, so a
 single build serves both the fixture demo and the live run:
 - Wired ON when the URL has `?api=1` (or the build set `VITE_WIRED=1`).
-- The API key is `?api_key=` else `VITE_API_KEY` else the dev default; sent as
-  `X-API-Key`.
+- There is no API key in the browser (#630 / [ADR-0049](../../docs/adr/0049-console-sessions-and-cli-minted-login-codes.md)).
+  A wired console authenticates with an HttpOnly session cookie, exchanged for a
+  single-use login code minted by `agentos <local|cluster> console login`. Every
+  call sends `credentials: "same-origin"` and no `X-API-Key` header. `?api_key=`,
+  `VITE_API_KEY`, and the dev-key fallback are deleted, not deprecated.
+- `ConsoleGate` (`src/components/ConsoleGate.tsx`) sits above the shell: while
+  unauthenticated it renders the login view *instead of* the console, so a locked
+  console mounts no provider and makes no authenticated call. Fixture mode never
+  calls the session endpoint at all.
 - All calls go to the same-origin `/api` prefix. `vite.config.ts` proxies `/api`
   to `AGENTOS_API_TARGET` (default `http://localhost:8000`), stripping the
   prefix. This avoids CORS: apps/api has no CORS middleware, so the browser must

--- a/apps/ui/e2e/agent-detail-wired.spec.ts
+++ b/apps/ui/e2e/agent-detail-wired.spec.ts
@@ -1,4 +1,12 @@
 import { test, expect, type Page } from "@playwright/test";
+import { stubConsoleSession } from "./console-session";
+
+// #630: these specs drive an authenticated console; the login gate itself is
+// covered by console-login.spec.ts.
+test.beforeEach(async ({ page }) => {
+  await stubConsoleSession(page);
+});
+
 
 // FX2 headline: the wired agent-detail surface. Open an agent from the Agents
 // list, see its active version's SKILL.md, edit it, and ship a new version via

--- a/apps/ui/e2e/cold-start-wired.spec.ts
+++ b/apps/ui/e2e/cold-start-wired.spec.ts
@@ -1,4 +1,12 @@
 import { test, expect, type Page } from "@playwright/test";
+import { stubConsoleSession } from "./console-session";
+
+// #630: these specs drive an authenticated console; the login gate itself is
+// covered by console-login.spec.ts.
+test.beforeEach(async ({ page }) => {
+  await stubConsoleSession(page);
+});
+
 
 // The cold-start loop (H2 backend-driven shell), stackless via route stubs:
 // empty DB -> onboarding -> create an agent -> it appears in the real Agents

--- a/apps/ui/e2e/console-login.spec.ts
+++ b/apps/ui/e2e/console-login.spec.ts
@@ -183,6 +183,32 @@ test("the login code and api_key never enter the URL or any history entry (AC1, 
   }
 });
 
+test("no request Referer header carries the api_key, login code, or dev key (AC5)", async ({ page }) => {
+  // AC5's referrers half, proven directly rather than transitively. The login
+  // code travels only in the exchange POST body and the key has no URL path at
+  // all, so a request's Referer -- the referring document's full same-origin
+  // URL -- must never echo any of them onward to a downstream host. Driven from
+  // the clean `/?api=1` origin (no planted key) so the Referer values captured
+  // are the real ones a normal login produces.
+  await stubSession(page);
+  const referers: { url: string; referer: string | undefined }[] = [];
+  page.on("request", (req) => referers.push({ url: req.url(), referer: req.headers()["referer"] }));
+
+  await page.goto("/?api=1");
+  await logIn(page);
+  await expect(page.getByRole("navigation")).toBeVisible({ timeout: 10_000 });
+
+  // Real captured values, not a presence check: at least one request must have
+  // actually sent a Referer, or this proves nothing.
+  const seen = referers.filter((req) => req.referer !== undefined);
+  expect(seen.length, "no request carried a Referer header: nothing was asserted").toBeGreaterThan(0);
+  for (const req of seen) {
+    expect(req.referer, `Referer on request to ${req.url}`).not.toContain("api_key");
+    expect(req.referer, `Referer on request to ${req.url}`).not.toContain(LOGIN_CODE);
+    expect(req.referer, `Referer on request to ${req.url}`).not.toContain(DEV_KEY);
+  }
+});
+
 test("a planted ?api_key= is inert: it never reaches a request, and no request carries the key or code (AC3, AC5)", async ({
   page,
 }) => {

--- a/apps/ui/e2e/console-login.spec.ts
+++ b/apps/ui/e2e/console-login.spec.ts
@@ -1,0 +1,226 @@
+import { test, expect, type Page } from "@playwright/test";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath, URL as NodeURL } from "node:url";
+
+// Issue #630 / ADR-0049: the console authenticates with a server-managed session
+// cookie exchanged for a CLI-minted single-use login code. The platform key has
+// no browser-reachable path at all.
+//
+// AC map:
+//   AC1 -> the dist scan (no key in the static bundle) and the URL/history proof.
+//   AC2 -> the login gate: unauthenticated console renders the login view, and a
+//          successful exchange transitions to the real console.
+//   AC3 -> the request log carries no X-API-Key header on any request.
+//   AC5 -> the dist scan, the history proof, and the request-log proof together.
+//
+// Stackless: every /api call is stubbed with page.route, so this runs in the
+// default `chromium` project with no backend.
+
+// Assembled at runtime so this spec file never contains the literal it scans for.
+const DEV_KEY = ["agentos", "dev", "key"].join("-");
+const LOGIN_CODE = "AAAA-BBBB-CCCC";
+
+function json(status: number, body: unknown) {
+  return { status, contentType: "application/json", body: JSON.stringify(body) };
+}
+
+const SUMMARY = {
+  start: "2026-06-28",
+  end: "2026-07-05",
+  runs: 0,
+  latency_p95_ms: 0,
+  tokens: 0,
+  cost_usd: 0,
+  error_rate: 0,
+};
+
+// A console-session backend that starts unauthenticated and flips only when the
+// right code is exchanged. `sessionCalls` records every method the page used, so
+// a test can assert the fixture demo never touches the endpoint at all.
+async function stubSession(page: Page) {
+  const state = { authenticated: false };
+  const sessionCalls: string[] = [];
+  const codesSeen: string[] = [];
+
+  await page.route("**/api/console/session", async (route) => {
+    const method = route.request().method();
+    sessionCalls.push(method);
+    if (method === "POST") {
+      const body = JSON.parse(route.request().postData() ?? "{}");
+      codesSeen.push(body.code);
+      if (body.code !== LOGIN_CODE) {
+        return route.fulfill(json(400, { detail: "login code is expired or already used" }));
+      }
+      state.authenticated = true;
+      return route.fulfill(json(201, { authenticated: true, expires_at: "2026-07-18T00:00:00Z" }));
+    }
+    if (method === "DELETE") {
+      state.authenticated = false;
+      return route.fulfill({ status: 204, body: "" });
+    }
+    return route.fulfill(
+      json(200, {
+        authenticated: state.authenticated,
+        expires_at: state.authenticated ? "2026-07-18T00:00:00Z" : null,
+      }),
+    );
+  });
+
+  await page.route(/\/api\/agents(\?.*)?$/, (route) => route.fulfill(json(200, [])));
+  await page.route("**/api/observability/metrics/summary*", (route) => route.fulfill(json(200, SUMMARY)));
+  await page.route("**/api/langfuse/traces*", (route) => route.fulfill(json(200, [])));
+  await page.route("**/api/config", (route) => route.fulfill(json(200, { org_name: "acme-corp" })));
+
+  return { sessionCalls, codesSeen };
+}
+
+// Record every URL that ever becomes a history entry: the initial one plus every
+// pushState/replaceState the app performs. history entries are not enumerable,
+// so instrumenting the only two APIs that create them is the complete view.
+async function recordHistory(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const seen: string[] = [location.href];
+    (window as unknown as { __historyUrls: string[] }).__historyUrls = seen;
+    for (const name of ["pushState", "replaceState"] as const) {
+      const original = history[name].bind(history);
+      history[name] = (...args: Parameters<typeof original>) => {
+        original(...args);
+        seen.push(location.href);
+      };
+    }
+  });
+}
+
+async function historyUrls(page: Page): Promise<string[]> {
+  const recorded = await page.evaluate(() => (window as unknown as { __historyUrls: string[] }).__historyUrls);
+  return [...recorded, page.url()];
+}
+
+async function logIn(page: Page): Promise<void> {
+  await page.getByTestId("console-login-code").fill(LOGIN_CODE);
+  await page.getByTestId("console-login-submit").click();
+}
+
+test("wired + unauthenticated renders the login gate, and a valid code transitions to the real console (AC2)", async ({
+  page,
+}) => {
+  await stubSession(page);
+  await page.goto("/?api=1");
+
+  // Gate closed: the login view is up and the console shell is not rendered.
+  await expect(page.getByTestId("console-login")).toBeVisible();
+  await expect(page.getByRole("navigation")).toHaveCount(0);
+  await expect(page.getByText("Welcome to AgentOS")).toHaveCount(0);
+
+  await logIn(page);
+
+  // Gate open: a real state transition, not merely an element appearing.
+  await expect(page.getByTestId("console-login")).toHaveCount(0);
+  await expect(page.getByRole("navigation")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("Welcome to AgentOS")).toBeVisible();
+});
+
+test("a rejected login code keeps the gate closed and shows the server's reason (AC2)", async ({ page }) => {
+  await stubSession(page);
+  await page.goto("/?api=1");
+  await expect(page.getByTestId("console-login")).toBeVisible();
+
+  await page.getByTestId("console-login-code").fill("STALE-CODE");
+  await page.getByTestId("console-login-submit").click();
+
+  await expect(page.getByTestId("console-login-error")).toContainText(/expired|already used/i);
+  await expect(page.getByTestId("console-login")).toBeVisible();
+  await expect(page.getByRole("navigation")).toHaveCount(0);
+});
+
+test("the login code and api_key never enter the URL or any history entry (AC1, AC5)", async ({ page }) => {
+  await stubSession(page);
+  await recordHistory(page);
+  await page.goto("/?api=1");
+  await logIn(page);
+  await expect(page.getByRole("navigation")).toBeVisible({ timeout: 10_000 });
+
+  const urls = await historyUrls(page);
+  expect(urls.length).toBeGreaterThan(0);
+  for (const url of urls) {
+    expect(url, `history entry ${url}`).not.toContain("api_key");
+    expect(url, `history entry ${url}`).not.toContain(LOGIN_CODE);
+    expect(url, `history entry ${url}`).not.toContain(DEV_KEY);
+  }
+});
+
+test("a planted ?api_key= is inert: it never reaches a request, and no request carries the key or code (AC3, AC5)", async ({
+  page,
+}) => {
+  await stubSession(page);
+  const requests: { url: string; header: string | undefined; kind: string }[] = [];
+  page.on("request", (req) =>
+    requests.push({ url: req.url(), header: req.headers()["x-api-key"], kind: req.resourceType() }),
+  );
+
+  await page.goto(`/?api=1&api_key=${DEV_KEY}`);
+  await logIn(page);
+  await expect(page.getByRole("navigation")).toBeVisible({ timeout: 10_000 });
+
+  // No request the app itself originates may carry the key. The top-level
+  // document navigation is excluded because the browser is obliged to fetch the
+  // very URL this test plants, and the sibling history test above forbids the
+  // app from rewriting it away. Everything the app sends (xhr, fetch, script,
+  // stylesheet, image) is in scope, and the document requests are checked
+  // separately below.
+  const sent = requests.filter((req) => req.kind !== "document");
+  expect(sent.length, "the app made no subresource requests: the page never loaded").toBeGreaterThan(0);
+  for (const req of sent) {
+    expect(req.url, `request to ${req.url}`).not.toContain("api_key=");
+    expect(req.url, `request to ${req.url}`).not.toContain(DEV_KEY);
+    expect(req.url, `request to ${req.url}`).not.toContain(LOGIN_CODE);
+  }
+
+  // Every request, document included, must be header clean.
+  for (const req of requests) {
+    expect(req.header, `X-API-Key header on ${req.url}`).toBeUndefined();
+  }
+
+  // The planted navigation is the one and only document request allowed to
+  // carry the key, and it must actually carry it, or this test proves nothing.
+  const [planted, ...extraDocs] = requests.filter((req) => req.kind === "document");
+  expect(planted?.url, "the api_key param was never planted").toContain(`api_key=${DEV_KEY}`);
+  for (const doc of extraDocs) {
+    expect(doc.url, `document request to ${doc.url}`).not.toContain("api_key=");
+    expect(doc.url, `document request to ${doc.url}`).not.toContain(DEV_KEY);
+    expect(doc.url, `document request to ${doc.url}`).not.toContain(LOGIN_CODE);
+  }
+});
+
+test("fixture mode makes no console-session call and shows no login gate (AC2 scope)", async ({ page }) => {
+  const { sessionCalls } = await stubSession(page);
+  await page.goto("/?state=3");
+
+  await expect(page.getByTestId("demo-banner")).toBeVisible();
+  await expect(page.getByTestId("console-login")).toHaveCount(0);
+  await expect(page.getByRole("navigation")).toBeVisible();
+  // The stackless fixture demo must stay backend-free.
+  expect(sessionCalls).toEqual([]);
+});
+
+// AC5's static-asset half. This lives in the Playwright suite because the suite's
+// webServer already runs `pnpm build`, so dist/ is guaranteed to be the current
+// build. A vitest test would have no such guarantee.
+test("the built bundle contains no platform key (AC1, AC5)", async () => {
+  const dist = fileURLToPath(new NodeURL("../dist", import.meta.url));
+
+  const files: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else files.push(full);
+    }
+  };
+  walk(dist);
+
+  expect(files.length, "dist is empty: the build did not run").toBeGreaterThan(0);
+  const offenders = files.filter((f) => readFileSync(f, "utf8").includes(DEV_KEY));
+  expect(offenders.map((f) => f.slice(dist.length + 1))).toEqual([]);
+});

--- a/apps/ui/e2e/console-login.spec.ts
+++ b/apps/ui/e2e/console-login.spec.ts
@@ -19,7 +19,8 @@ import { fileURLToPath, URL as NodeURL } from "node:url";
 
 // Assembled at runtime so this spec file never contains the literal it scans for.
 const DEV_KEY = ["agentos", "dev", "key"].join("-");
-const LOGIN_CODE = "AAAA-BBBB-CCCC";
+// A real code is secrets.token_urlsafe(32): 43 base64url chars, no dashes.
+const LOGIN_CODE = "hQ2m8LxF0vTnPzR6wKdYbJ7sGcAeUiOl3ZpXrNyMt4Q";
 
 function json(status: number, body: unknown) {
   return { status, contentType: "application/json", body: JSON.stringify(body) };
@@ -50,10 +51,12 @@ async function stubSession(page: Page) {
       const body = JSON.parse(route.request().postData() ?? "{}");
       codesSeen.push(body.code);
       if (body.code !== LOGIN_CODE) {
-        return route.fulfill(json(400, { detail: "login code is expired or already used" }));
+        // The server collapses unknown/spent/expired/revoked into one 401 {detail}.
+        return route.fulfill(json(401, { detail: "invalid or expired login code" }));
       }
       state.authenticated = true;
-      return route.fulfill(json(201, { authenticated: true, expires_at: "2026-07-18T00:00:00Z" }));
+      // ConsoleSessionOut: the expiry is the whole body; the token is the cookie.
+      return route.fulfill(json(200, { expires_at: "2026-07-18T00:00:00Z" }));
     }
     if (method === "DELETE") {
       state.authenticated = false;
@@ -130,6 +133,36 @@ test("a rejected login code keeps the gate closed and shows the server's reason 
   await page.getByTestId("console-login-submit").click();
 
   await expect(page.getByTestId("console-login-error")).toContainText(/expired|already used/i);
+  await expect(page.getByTestId("console-login")).toBeVisible();
+  await expect(page.getByRole("navigation")).toHaveCount(0);
+});
+
+test("an insecure-origin refusal shows the operator the port-forward fix, not a bare error (AC2)", async ({
+  page,
+}) => {
+  // The one path a sealed install's first-run operator is most likely to hit:
+  // opening the plaintext NodePort URL. The exchange's only 400 is {error, fix},
+  // and the fix is the operator's sole way in. If the console renders just
+  // "Bad Request", they are stranded.
+  await page.route(/\/api\/agents(\?.*)?$/, (route) => route.fulfill(json(200, [])));
+  await page.route("**/api/config", (route) => route.fulfill(json(200, { org_name: "acme-corp" })));
+  await page.route("**/api/console/session", (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill(
+        json(400, {
+          error: "refusing to establish a console session from a non-secure origin 'http://10.0.0.4:30080'",
+          fix: "Reach the console over a secure context and log in again: kubectl port-forward -n agentos svc/agentos-ui 8080:80 then open http://localhost:8080.",
+        }),
+      );
+    }
+    return route.fulfill(json(200, { authenticated: false, expires_at: null }));
+  });
+
+  await page.goto("/?api=1");
+  await logIn(page);
+
+  await expect(page.getByTestId("console-login-error")).toContainText("non-secure origin");
+  await expect(page.getByTestId("console-login-fix")).toContainText("kubectl port-forward");
   await expect(page.getByTestId("console-login")).toBeVisible();
   await expect(page.getByRole("navigation")).toHaveCount(0);
 });

--- a/apps/ui/e2e/console-session.ts
+++ b/apps/ui/e2e/console-session.ts
@@ -1,0 +1,18 @@
+import type { Page } from "@playwright/test";
+
+// #630 / ADR-0049: a wired console renders its shell only for an authenticated
+// session. The specs that import this exercise the console's *views*, and have
+// always implicitly assumed a usable console; this states that precondition
+// explicitly now that one exists, the same way they already stub /api/agents.
+//
+// The gate itself -- unauthenticated, rejected code, fixture mode -- is covered
+// by console-login.spec.ts, which drives the real exchange instead of this stub.
+export async function stubConsoleSession(page: Page): Promise<void> {
+  await page.route("**/api/console/session", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ authenticated: true, expires_at: "2026-07-18T00:00:00Z" }),
+    }),
+  );
+}

--- a/apps/ui/e2e/cost-kill-wired.spec.ts
+++ b/apps/ui/e2e/cost-kill-wired.spec.ts
@@ -1,4 +1,12 @@
 import { test, expect, type Page } from "@playwright/test";
+import { stubConsoleSession } from "./console-session";
+
+// #630: these specs drive an authenticated console; the login gate itself is
+// covered by console-login.spec.ts.
+test.beforeEach(async ({ page }) => {
+  await stubConsoleSession(page);
+});
+
 
 // Wired Cost view + kill switch (L1) in the stackless suite: the app runs in
 // ?api=1 mode with the L1 endpoints stubbed via route interception (mutable

--- a/apps/ui/e2e/delete-agent-wired.spec.ts
+++ b/apps/ui/e2e/delete-agent-wired.spec.ts
@@ -1,4 +1,12 @@
 import { test, expect, type Page } from "@playwright/test";
+import { stubConsoleSession } from "./console-session";
+
+// #630: these specs drive an authenticated console; the login gate itself is
+// covered by console-login.spec.ts.
+test.beforeEach(async ({ page }) => {
+  await stubConsoleSession(page);
+});
+
 
 // Wired Agents delete flow (stackless via route stubs): the agent list is
 // mutable so a successful DELETE drops the card, and a 409 (active deployment)

--- a/apps/ui/e2e/demo-banner.spec.ts
+++ b/apps/ui/e2e/demo-banner.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { stubConsoleSession } from "./console-session";
 
 // FX2 item 2: without ?api=1 the UI is a convincing demo on fake data. A
 // persistent banner must make that unmistakable and offer the wired app.
@@ -13,10 +14,15 @@ test("fixture mode shows the demo-data banner with a connect link", async ({ pag
 });
 
 test("wired mode does not show the demo banner", async ({ page }) => {
+  // #630: sign the console in, so this asserts the wired *shell* has no banner.
+  // Without a session the login gate renders instead, and the assertion would
+  // pass for the wrong reason -- the banner is absent from the gate too.
+  await stubConsoleSession(page);
   // Keep the wired agent list request from hanging the page.
   await page.route("**/api/agents", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
   );
   await page.goto("/?api=1");
+  await expect(page.getByRole("navigation")).toBeVisible();
   await expect(page.getByTestId("demo-banner")).toHaveCount(0);
 });

--- a/apps/ui/e2e/observability-wired.spec.ts
+++ b/apps/ui/e2e/observability-wired.spec.ts
@@ -1,4 +1,12 @@
 import { test, expect, type Page } from "@playwright/test";
+import { stubConsoleSession } from "./console-session";
+
+// #630: these specs drive an authenticated console; the login gate itself is
+// covered by console-login.spec.ts.
+test.beforeEach(async ({ page }) => {
+  await stubConsoleSession(page);
+});
+
 
 // Wired Observability (OB1) in the stackless suite: the app runs in ?api=1 mode
 // but the observability API is stubbed with real-shaped responses via route

--- a/apps/ui/e2e/trace-detail-wired.spec.ts
+++ b/apps/ui/e2e/trace-detail-wired.spec.ts
@@ -1,4 +1,12 @@
 import { test, expect, type Page, type Route } from "@playwright/test";
+import { stubConsoleSession } from "./console-session";
+
+// #630: these specs drive an authenticated console; the login gate itself is
+// covered by console-login.spec.ts.
+test.beforeEach(async ({ page }) => {
+  await stubConsoleSession(page);
+});
+
 
 // FX2 items 3 & 4: the wired trace drill-in. A trace with no observations is a
 // legitimate empty state (honest empty view, not an error toast); a trace whose

--- a/apps/ui/e2e/versions-wired.spec.ts
+++ b/apps/ui/e2e/versions-wired.spec.ts
@@ -1,4 +1,12 @@
 import { test, expect, type Page } from "@playwright/test";
+import { stubConsoleSession } from "./console-session";
+
+// #630: these specs drive an authenticated console; the login gate itself is
+// covered by console-login.spec.ts.
+test.beforeEach(async ({ page }) => {
+  await stubConsoleSession(page);
+});
+
 
 // Wired Versions tab (stackless via route stubs): real versions joined with the
 // agent's deployments (environment / status / deployed_at), no Eval column, and

--- a/apps/ui/src/api/api.test.ts
+++ b/apps/ui/src/api/api.test.ts
@@ -49,7 +49,9 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 describe("api client", () => {
-  it("sends the API key and returns the parsed agent", async () => {
+  // #630/ADR-0049: the console authenticates with the session cookie, so the
+  // create call carries no platform key and must let the cookie ride along.
+  it("creates an agent on the session cookie, with no API-key header", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse(201, { id: "a1", name: "deal-desk", slack_channel: "#revenue-ops", created_at: "now" }),
     );
@@ -58,7 +60,8 @@ describe("api client", () => {
     expect(agent.id).toBe("a1");
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe("/api/agents");
-    expect((init.headers as Record<string, string>)["X-API-Key"]).toBeTruthy();
+    expect((init.headers as Record<string, string>)["X-API-Key"]).toBeUndefined();
+    expect(init.credentials).toBe("same-origin");
   });
 
   it("surfaces validator issues from a 422 as BundleValidationError", async () => {
@@ -202,7 +205,8 @@ describe("agent-detail client calls", () => {
     expect(url).toBe("/api/agents/a1");
     expect(init.method).toBe("PATCH");
     expect(JSON.parse(init.body)).toEqual({ slack_channel: "C9999ZZZZ" });
-    expect((init.headers as Record<string, string>)["X-API-Key"]).toBeTruthy();
+    expect((init.headers as Record<string, string>)["X-API-Key"]).toBeUndefined();
+    expect(init.credentials).toBe("same-origin");
   });
 
   it("activates a version by POSTing a deployment", async () => {

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -1,7 +1,13 @@
 // Typed client for the B1/B2 API, reached through the same-origin /api proxy.
-// Every call carries the X-API-Key header. Shapes mirror apps/api/openapi.json.
+// Shapes mirror apps/api/openapi.json.
+//
+// Authentication is the console session cookie and nothing else (#630 /
+// ADR-0049): the cookie is HttpOnly, so this module cannot read it and never
+// tries to. Every call opts into sending it with `credentials: "same-origin"`.
+// No call carries the platform key -- it has no browser-reachable path, so
+// there is no key here to attach.
 
-import { API_PREFIX, apiKey } from "./config";
+import { API_PREFIX } from "./config";
 
 // Open (unauthenticated) app config: the configurable org/workspace name.
 export interface AppConfig {
@@ -100,9 +106,12 @@ function url(path: string): string {
   return `${API_PREFIX}${path}`;
 }
 
-function headers(extra?: Record<string, string>): Record<string, string> {
-  return { "X-API-Key": apiKey(), ...extra };
-}
+// Spread into every request init so the HttpOnly session cookie rides along.
+// The API is strictly same-origin (it runs no CORS middleware on purpose), so
+// "same-origin" is both the correct scope and the tightest one.
+const SAME_ORIGIN = { credentials: "same-origin" } as const;
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
 
 async function jsonOrThrow<T>(resp: Response): Promise<T> {
   if (resp.ok) return (await resp.json()) as T;
@@ -129,6 +138,51 @@ function describeError(body: unknown): string | null {
   return null;
 }
 
+// ---- console session (#630 / ADR-0049) ----
+
+/** The console's own auth state, as the server sees it. */
+export interface ConsoleSession {
+  authenticated: boolean;
+  expires_at: string | null;
+}
+
+/**
+ * Read the current console session. A 401 is the expected answer for a console
+ * that has not logged in yet, so it resolves to an unauthenticated session
+ * rather than throwing: being logged out is a state the gate renders, not an
+ * error it has to recover from. Any other failure still throws ApiError.
+ */
+export async function getSession(): Promise<ConsoleSession> {
+  const resp = await fetch(url("/console/session"), { ...SAME_ORIGIN });
+  if (resp.status === 401) return { authenticated: false, expires_at: null };
+  return jsonOrThrow<ConsoleSession>(resp);
+}
+
+/**
+ * Exchange a single-use login code minted by `agentos <local|cluster> console
+ * login` for a session. The server consumes the code and returns the session as
+ * an HttpOnly cookie, so the code is spent here and never stored: this module
+ * keeps it only as the argument of this call. A rejected or expired code
+ * surfaces as ApiError carrying the server's reason.
+ */
+export async function activateSession(code: string): Promise<ConsoleSession> {
+  const resp = await fetch(url("/console/session"), {
+    method: "POST",
+    ...SAME_ORIGIN,
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ code }),
+  });
+  return jsonOrThrow<ConsoleSession>(resp);
+}
+
+/** Revoke the current session server-side (the row is marked, not deleted). */
+export async function logout(): Promise<void> {
+  const resp = await fetch(url("/console/session"), { method: "DELETE", ...SAME_ORIGIN });
+  if (resp.ok) return;
+  const body = await resp.json().catch(() => null);
+  throw new ApiError(resp.status, describeError(body) ?? resp.statusText);
+}
+
 export async function createAgent(input: {
   name: string;
   slack_channel: string;
@@ -137,7 +191,8 @@ export async function createAgent(input: {
 }): Promise<AgentOut> {
   const resp = await fetch(url("/agents"), {
     method: "POST",
-    headers: headers({ "Content-Type": "application/json" }),
+    ...SAME_ORIGIN,
+    headers: JSON_HEADERS,
     body: JSON.stringify(input),
   });
   return jsonOrThrow<AgentOut>(resp);
@@ -149,7 +204,8 @@ export async function createVersion(
 ): Promise<VersionOut> {
   const resp = await fetch(url(`/agents/${agentId}/versions`), {
     method: "POST",
-    headers: headers({ "Content-Type": "application/json" }),
+    ...SAME_ORIGIN,
+    headers: JSON_HEADERS,
     body: JSON.stringify(input),
   });
   return jsonOrThrow<VersionOut>(resp);
@@ -169,7 +225,7 @@ export async function uploadBundle(
   form.append("file", archive, "bundle.zip");
   const resp = await fetch(url(`/agents/${agentId}/versions/${versionId}/bundle`), {
     method: "PUT",
-    headers: headers(),
+    ...SAME_ORIGIN,
     body: form,
   });
   if (resp.ok) return (await resp.json()) as BundleOut;
@@ -200,14 +256,14 @@ function extractIssues(body: unknown): BundleIssue[] | null {
 // traces carry the `agent-<id>` name token); without it, all recent traces.
 export async function listTraces(limit = 20, agentId?: string): Promise<RawTrace[]> {
   const resp = await fetch(url(`/langfuse/traces${query({ limit, agent_id: agentId })}`), {
-    headers: headers(),
+    ...SAME_ORIGIN,
   });
   return jsonOrThrow<RawTrace[]>(resp);
 }
 
 export async function getTrace(traceId: string): Promise<TraceTree> {
   const resp = await fetch(url(`/langfuse/traces/${encodeURIComponent(traceId)}`), {
-    headers: headers(),
+    ...SAME_ORIGIN,
   });
   return jsonOrThrow<TraceTree>(resp);
 }
@@ -217,7 +273,7 @@ export async function getTrace(traceId: string): Promise<TraceTree> {
 export async function promoteTraceToEvalCase(traceId: string): Promise<EvalCaseOut> {
   const resp = await fetch(url(`/langfuse/traces/${encodeURIComponent(traceId)}/eval-case`), {
     method: "POST",
-    headers: headers(),
+    ...SAME_ORIGIN,
   });
   return jsonOrThrow<EvalCaseOut>(resp);
 }
@@ -266,7 +322,7 @@ export interface RunnerPods {
 // Non-2xx throws ApiError carrying the status: 503 (no cluster), 502 (other).
 export async function listRunnerPods(namespace?: string): Promise<RunnerPods> {
   const resp = await fetch(url(`/observability/runners${query({ namespace })}`), {
-    headers: headers(),
+    ...SAME_ORIGIN,
   });
   return jsonOrThrow<RunnerPods>(resp);
 }
@@ -289,7 +345,7 @@ function query(params: Record<string, string | number | boolean | undefined>): s
 
 export async function getMetricsSummary(filter: MetricFilter = {}): Promise<MetricsSummary> {
   const resp = await fetch(url(`/observability/metrics/summary${query({ ...filter })}`), {
-    headers: headers(),
+    ...SAME_ORIGIN,
   });
   return jsonOrThrow<MetricsSummary>(resp);
 }
@@ -301,7 +357,7 @@ export async function getMetricSeries(
 ): Promise<MetricSeries> {
   const resp = await fetch(
     url(`/observability/metrics/series${query({ metric, granularity, ...filter })}`),
-    { headers: headers() },
+    { ...SAME_ORIGIN },
   );
   return jsonOrThrow<MetricSeries>(resp);
 }
@@ -323,7 +379,7 @@ export async function getRunnerLogs(
     url(
       `/observability/runners/${encodeURIComponent(namespace)}/${encodeURIComponent(pod)}/logs${query({ ...opts })}`,
     ),
-    { headers: headers() },
+    { ...SAME_ORIGIN },
   );
   return jsonOrThrow<PodLogs>(resp);
 }
@@ -348,14 +404,14 @@ export interface KillState {
 }
 
 export async function getAgents(): Promise<AgentOut[]> {
-  const resp = await fetch(url("/agents"), { headers: headers() });
+  const resp = await fetch(url("/agents"), { ...SAME_ORIGIN });
   return jsonOrThrow<AgentOut[]>(resp);
 }
 
 // The open /config endpoint (no API key required) carries the configurable
 // org/workspace name the shared chrome renders.
 export async function getConfig(): Promise<AppConfig> {
-  const resp = await fetch(url("/config"));
+  const resp = await fetch(url("/config"), { ...SAME_ORIGIN });
   return jsonOrThrow<AppConfig>(resp);
 }
 
@@ -369,7 +425,8 @@ export async function updateAgent(
 ): Promise<AgentOut> {
   const resp = await fetch(url(`/agents/${agentId}`), {
     method: "PATCH",
-    headers: headers({ "Content-Type": "application/json" }),
+    ...SAME_ORIGIN,
+    headers: JSON_HEADERS,
     body: JSON.stringify(patch),
   });
   return jsonOrThrow<AgentOut>(resp);
@@ -378,19 +435,19 @@ export async function updateAgent(
 // Delete an agent (cascades its versions/deployments server-side; 204 No Content
 // on success). A 409 (active deployment) surfaces via the thrown ApiError.
 export async function deleteAgent(agentId: string): Promise<void> {
-  const resp = await fetch(url(`/agents/${agentId}`), { method: "DELETE", headers: headers() });
+  const resp = await fetch(url(`/agents/${agentId}`), { method: "DELETE", ...SAME_ORIGIN });
   if (resp.ok) return;
   const body = await resp.json().catch(() => null);
   throw new ApiError(resp.status, describeError(body) ?? resp.statusText);
 }
 
 export async function getCost(agentId: string, range: { start?: string; end?: string } = {}): Promise<CostReport> {
-  const resp = await fetch(url(`/agents/${agentId}/cost${query({ ...range })}`), { headers: headers() });
+  const resp = await fetch(url(`/agents/${agentId}/cost${query({ ...range })}`), { ...SAME_ORIGIN });
   return jsonOrThrow<CostReport>(resp);
 }
 
 export async function getBudget(agentId: string): Promise<BudgetConfig> {
-  const resp = await fetch(url(`/agents/${agentId}/budget`), { headers: headers() });
+  const resp = await fetch(url(`/agents/${agentId}/budget`), { ...SAME_ORIGIN });
   return jsonOrThrow<BudgetConfig>(resp);
 }
 
@@ -399,14 +456,15 @@ export async function getBudget(agentId: string): Promise<BudgetConfig> {
 export async function putBudget(agentId: string, budget: BudgetConfig): Promise<BudgetConfig> {
   const resp = await fetch(url(`/agents/${agentId}/budget`), {
     method: "PUT",
-    headers: headers({ "Content-Type": "application/json" }),
+    ...SAME_ORIGIN,
+    headers: JSON_HEADERS,
     body: JSON.stringify(budget),
   });
   return jsonOrThrow<BudgetConfig>(resp);
 }
 
 export async function getKillState(agentId: string): Promise<KillState> {
-  const resp = await fetch(url(`/agents/${agentId}/kill`), { headers: headers() });
+  const resp = await fetch(url(`/agents/${agentId}/kill`), { ...SAME_ORIGIN });
   return jsonOrThrow<KillState>(resp);
 }
 
@@ -436,12 +494,12 @@ export interface BundleFiles {
 }
 
 export async function listVersions(agentId: string): Promise<VersionOut[]> {
-  const resp = await fetch(url(`/agents/${agentId}/versions`), { headers: headers() });
+  const resp = await fetch(url(`/agents/${agentId}/versions`), { ...SAME_ORIGIN });
   return jsonOrThrow<VersionOut[]>(resp);
 }
 
 export async function listDeployments(agentId: string): Promise<DeploymentOut[]> {
-  const resp = await fetch(url(`/deployments${query({ agent_id: agentId })}`), { headers: headers() });
+  const resp = await fetch(url(`/deployments${query({ agent_id: agentId })}`), { ...SAME_ORIGIN });
   return jsonOrThrow<DeploymentOut[]>(resp);
 }
 
@@ -449,7 +507,7 @@ export async function listDeployments(agentId: string): Promise<DeploymentOut[]>
 // by the env-scoped Agents/Overview views to decide which agents are live in the
 // selected environment.
 export async function listAllDeployments(): Promise<DeploymentOut[]> {
-  const resp = await fetch(url("/deployments"), { headers: headers() });
+  const resp = await fetch(url("/deployments"), { ...SAME_ORIGIN });
   return jsonOrThrow<DeploymentOut[]>(resp);
 }
 
@@ -459,7 +517,7 @@ export async function listAllDeployments(): Promise<DeploymentOut[]> {
  * the version yet; callers distinguish it via the thrown ApiError's status.
  */
 export async function getVersionFiles(agentId: string, versionId: string): Promise<BundleFiles> {
-  const resp = await fetch(url(`/agents/${agentId}/versions/${versionId}/files`), { headers: headers() });
+  const resp = await fetch(url(`/agents/${agentId}/versions/${versionId}/files`), { ...SAME_ORIGIN });
   return jsonOrThrow<BundleFiles>(resp);
 }
 
@@ -480,7 +538,8 @@ export interface DeploymentCreate {
 export async function createDeployment(input: DeploymentCreate): Promise<DeploymentOut> {
   const resp = await fetch(url("/deployments"), {
     method: "POST",
-    headers: headers({ "Content-Type": "application/json" }),
+    ...SAME_ORIGIN,
+    headers: JSON_HEADERS,
     body: JSON.stringify(input),
   });
   return jsonOrThrow<DeploymentOut>(resp);
@@ -507,7 +566,7 @@ export interface MemoryEntry {
 
 // List an agent's learned memory, oldest first (empty for a fresh agent).
 export async function listMemory(agentId: string): Promise<MemoryEntry[]> {
-  const resp = await fetch(url(`/agents/${agentId}/memory`), { headers: headers() });
+  const resp = await fetch(url(`/agents/${agentId}/memory`), { ...SAME_ORIGIN });
   return jsonOrThrow<MemoryEntry[]>(resp);
 }
 
@@ -521,7 +580,8 @@ export async function editMemory(
 ): Promise<MemoryEntry> {
   const resp = await fetch(url(`/agents/${agentId}/memory/${index}`), {
     method: "PUT",
-    headers: headers({ "Content-Type": "application/json" }),
+    ...SAME_ORIGIN,
+    headers: JSON_HEADERS,
     body: JSON.stringify({ content, expected_version: expectedVersion }),
   });
   return jsonOrThrow<MemoryEntry>(resp);
@@ -537,7 +597,7 @@ export async function deleteMemory(
     url(`/agents/${agentId}/memory/${index}${query({ expected_version: expectedVersion })}`),
     {
       method: "DELETE",
-      headers: headers(),
+      ...SAME_ORIGIN,
     },
   );
   if (resp.ok) return;
@@ -546,11 +606,11 @@ export async function deleteMemory(
 }
 
 export async function killAgent(agentId: string): Promise<KillState> {
-  const resp = await fetch(url(`/agents/${agentId}/kill`), { method: "POST", headers: headers() });
+  const resp = await fetch(url(`/agents/${agentId}/kill`), { method: "POST", ...SAME_ORIGIN });
   return jsonOrThrow<KillState>(resp);
 }
 
 export async function resumeAgent(agentId: string): Promise<KillState> {
-  const resp = await fetch(url(`/agents/${agentId}/resume`), { method: "POST", headers: headers() });
+  const resp = await fetch(url(`/agents/${agentId}/resume`), { method: "POST", ...SAME_ORIGIN });
   return jsonOrThrow<KillState>(resp);
 }

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -95,10 +95,20 @@ export class BundleValidationError extends Error {
 /** Thrown for any other non-2xx response. */
 export class ApiError extends Error {
   status: number;
-  constructor(status: number, message: string) {
+  /**
+   * The server's remediation text, from the `{error, fix}` bodies the API sends
+   * on the failures it can tell the operator how to fix (the console exchange's
+   * insecure-origin 400, the session store being unreachable). null when the
+   * response carried no `fix`. Kept a distinct field rather than concatenated
+   * into `message` so a view can render the reason and the instruction as the
+   * two different things they are.
+   */
+  fix: string | null;
+  constructor(status: number, message: string, fix: string | null = null) {
     super(message);
     this.name = "ApiError";
     this.status = status;
+    this.fix = fix;
   }
 }
 
@@ -106,20 +116,71 @@ function url(path: string): string {
   return `${API_PREFIX}${path}`;
 }
 
+// The CSRF header the API requires alongside the session cookie (ADR-0049).
+// The cookie is ambient authority and SameSite=Strict does not close that: the
+// "site" a browser compares ignores the port, so http://localhost:8080 (the
+// port-forward login URL) is same-site with every other localhost port, and a
+// body-less POST like /agents/{id}/kill is a CORS-simple request that no
+// preflight guards. A custom header cannot be set cross-origin without a
+// preflight, which this CORS-free API answers with a rejection -- so carrying it
+// is what makes the cookie unusable by a forged cross-site request. apps/api
+// rejects the cookie without it, so every call must send it. Presence is the
+// check; the value is arbitrary.
+const CSRF_HEADERS = { "X-Console-Session": "1" };
+
 // Spread into every request init so the HttpOnly session cookie rides along.
 // The API is strictly same-origin (it runs no CORS middleware on purpose), so
 // "same-origin" is both the correct scope and the tightest one.
-const SAME_ORIGIN = { credentials: "same-origin" } as const;
+const SAME_ORIGIN = { credentials: "same-origin", headers: { ...CSRF_HEADERS } } as const;
 
-const JSON_HEADERS = { "Content-Type": "application/json" };
+// Callers that send a JSON body replace `headers` wholesale, so the CSRF header
+// is folded in here rather than lost. The multipart upload passes no headers at
+// all (fetch must pick the boundary), so it keeps SAME_ORIGIN's copy.
+const JSON_HEADERS = { ...CSRF_HEADERS, "Content-Type": "application/json" };
 
 async function jsonOrThrow<T>(resp: Response): Promise<T> {
   if (resp.ok) return (await resp.json()) as T;
-  const body = await resp.json().catch(() => null);
-  throw new ApiError(resp.status, describeError(body) ?? resp.statusText);
+  throw await apiErrorFrom(resp);
 }
 
-function describeError(body: unknown): string | null {
+// The one place a non-2xx response becomes an ApiError, so every caller gets the
+// same treatment of both error shapes the API sends. statusText ("Bad Request")
+// stays the last resort: it names nothing the operator can act on, so it is used
+// only when the server sent no legible body at all.
+async function apiErrorFrom(resp: Response): Promise<ApiError> {
+  return apiError(resp.status, await resp.json().catch(() => null), resp.statusText);
+}
+
+// Body-based variant, for the one caller that must read the body itself (the
+// bundle 422 inspects it for validator issues before deciding what to throw).
+function apiError(status: number, body: unknown, statusText: string): ApiError {
+  const described = describeError(body);
+  return new ApiError(status, described?.message ?? statusText, described?.fix ?? null);
+}
+
+interface DescribedError {
+  message: string;
+  fix: string | null;
+}
+
+function describeError(body: unknown): DescribedError | null {
+  // The agent-facing {error, fix} shape (ADR-0021): a reason plus the operator's
+  // way out. The console exchange's only 400 is this shape, and its `fix` is the
+  // port-forward instruction that is the sole route in from a plaintext origin.
+  if (body && typeof body === "object" && "error" in body) {
+    const error = (body as { error: unknown }).error;
+    if (typeof error === "string") {
+      const fix = (body as { fix?: unknown }).fix;
+      return { message: error, fix: typeof fix === "string" ? fix : null };
+    }
+  }
+  const detailMessage = describeDetail(body);
+  return detailMessage === null ? null : { message: detailMessage, fix: null };
+}
+
+// FastAPI's {detail} shape, in its three flavors: a string, a nested {detail},
+// or a field-validation array.
+function describeDetail(body: unknown): string | null {
   if (body && typeof body === "object" && "detail" in body) {
     const detail = (body as { detail: unknown }).detail;
     if (typeof detail === "string") return detail;
@@ -140,21 +201,30 @@ function describeError(body: unknown): string | null {
 
 // ---- console session (#630 / ADR-0049) ----
 
-/** The console's own auth state, as the server sees it. */
+/** The console's own auth state, as the server sees it (ConsoleSessionStatus). */
 export interface ConsoleSession {
   authenticated: boolean;
   expires_at: string | null;
 }
 
 /**
- * Read the current console session. A 401 is the expected answer for a console
- * that has not logged in yet, so it resolves to an unauthenticated session
- * rather than throwing: being logged out is a state the gate renders, not an
- * error it has to recover from. Any other failure still throws ApiError.
+ * The established session (ConsoleSessionOut). The expiry is the whole body: the
+ * token is returned only as the HttpOnly cookie, and there is no `authenticated`
+ * field, because a response at all IS the authentication.
+ */
+export interface ConsoleSessionOut {
+  expires_at: string;
+}
+
+/**
+ * Read the current console session. This never 401s by design -- an anonymous
+ * caller is a 200 with authenticated=false, because not being logged in is the
+ * answer, not an error -- so there is no 401 branch here. A genuine failure
+ * (the session store being down, say) throws ApiError, which the gate treats as
+ * locked.
  */
 export async function getSession(): Promise<ConsoleSession> {
   const resp = await fetch(url("/console/session"), { ...SAME_ORIGIN });
-  if (resp.status === 401) return { authenticated: false, expires_at: null };
   return jsonOrThrow<ConsoleSession>(resp);
 }
 
@@ -163,24 +233,25 @@ export async function getSession(): Promise<ConsoleSession> {
  * login` for a session. The server consumes the code and returns the session as
  * an HttpOnly cookie, so the code is spent here and never stored: this module
  * keeps it only as the argument of this call. A rejected or expired code
- * surfaces as ApiError carrying the server's reason.
+ * surfaces as ApiError carrying the server's reason (401); an exchange refused
+ * for a non-secure origin surfaces as ApiError whose `fix` names the
+ * port-forward the operator needs (400).
  */
-export async function activateSession(code: string): Promise<ConsoleSession> {
+export async function activateSession(code: string): Promise<ConsoleSessionOut> {
   const resp = await fetch(url("/console/session"), {
     method: "POST",
     ...SAME_ORIGIN,
     headers: JSON_HEADERS,
     body: JSON.stringify({ code }),
   });
-  return jsonOrThrow<ConsoleSession>(resp);
+  return jsonOrThrow<ConsoleSessionOut>(resp);
 }
 
 /** Revoke the current session server-side (the row is marked, not deleted). */
 export async function logout(): Promise<void> {
   const resp = await fetch(url("/console/session"), { method: "DELETE", ...SAME_ORIGIN });
   if (resp.ok) return;
-  const body = await resp.json().catch(() => null);
-  throw new ApiError(resp.status, describeError(body) ?? resp.statusText);
+  throw await apiErrorFrom(resp);
 }
 
 export async function createAgent(input: {
@@ -232,7 +303,7 @@ export async function uploadBundle(
   const body = await resp.json().catch(() => null);
   const issues = extractIssues(body);
   if (resp.status === 422 && issues) throw new BundleValidationError(issues);
-  throw new ApiError(resp.status, describeError(body) ?? resp.statusText);
+  throw apiError(resp.status, body, resp.statusText);
 }
 
 // The bundle 422 body is { detail: { detail: "...", errors: [ {code,message,location} ] } }.
@@ -437,8 +508,7 @@ export async function updateAgent(
 export async function deleteAgent(agentId: string): Promise<void> {
   const resp = await fetch(url(`/agents/${agentId}`), { method: "DELETE", ...SAME_ORIGIN });
   if (resp.ok) return;
-  const body = await resp.json().catch(() => null);
-  throw new ApiError(resp.status, describeError(body) ?? resp.statusText);
+  throw await apiErrorFrom(resp);
 }
 
 export async function getCost(agentId: string, range: { start?: string; end?: string } = {}): Promise<CostReport> {
@@ -601,8 +671,7 @@ export async function deleteMemory(
     },
   );
   if (resp.ok) return;
-  const body = await resp.json().catch(() => null);
-  throw new ApiError(resp.status, describeError(body) ?? resp.statusText);
+  throw await apiErrorFrom(resp);
 }
 
 export async function killAgent(agentId: string): Promise<KillState> {

--- a/apps/ui/src/api/config.ts
+++ b/apps/ui/src/api/config.ts
@@ -3,14 +3,17 @@
 //
 // Resolution:
 //  - Wired ON when the URL carries ?api=1, or when built with VITE_WIRED=1.
-//  - The API key comes from ?api_key=, else VITE_API_KEY, else the dev default.
 //  - Calls always go to the same-origin /api prefix, which Vite proxies to the
 //    real API server (apps/api has no CORS, so same-origin is required).
 //
+// There is deliberately no credential here (#630 / ADR-0049). The console
+// authenticates with an HttpOnly session cookie, exchanged for a CLI-minted
+// single-use login code, so the platform key has no browser-reachable path at
+// all: no ?api_key= param, no VITE_API_KEY, no dev-key fallback. Those three
+// inputs are deleted rather than deprecated, so there is nothing to regress on.
+//
 // When wired is OFF (the default), every view stays on fixtures exactly as H1a
 // shipped it: no network calls, so stackless E2E and unit tests need no backend.
-
-const DEV_API_KEY = "agentos-dev-key";
 
 function params(): URLSearchParams {
   if (typeof window === "undefined") return new URLSearchParams();
@@ -20,10 +23,6 @@ function params(): URLSearchParams {
 export function isWired(): boolean {
   if (params().get("api") === "1") return true;
   return import.meta.env.VITE_WIRED === "1";
-}
-
-export function apiKey(): string {
-  return params().get("api_key") || import.meta.env.VITE_API_KEY || DEV_API_KEY;
 }
 
 // Same-origin prefix; Vite's proxy forwards it to AGENTOS_API_TARGET.

--- a/apps/ui/src/api/session.test.ts
+++ b/apps/ui/src/api/session.test.ts
@@ -1,0 +1,287 @@
+// Issue #630 / ADR-0049: the platform key has no browser-reachable path.
+//
+// These tests pin the negative half of the decision (nothing in the client
+// carries the platform key, and the `?api_key=` param is inert rather than
+// merely unused) and the positive half (the console-session client calls).
+//
+// AC map:
+//   AC1 "never placed in a URL, static browser bundle, browser storage, or
+//        client readable configuration" -> the no-header, param-inert,
+//        no-apiKey-export, no-storage tests here.
+//   AC3 "authorized without giving browser code the raw platform credential"
+//        -> the same-origin credentials tests here.
+//   AC2 "revocable authenticated session" -> the getSession/activateSession/
+//        logout contract tests here.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath, URL as NodeURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as config from "./config";
+import * as client from "./client";
+import {
+  ApiError,
+  createAgent,
+  createDeployment,
+  deleteAgent,
+  getConfig,
+  listTraces,
+  listVersions,
+  updateAgent,
+} from "./client";
+
+// The console-session contract this suite pins. These are resolved off the
+// module namespace rather than imported by name on purpose: `pnpm build` runs
+// `tsc -b` over the tests, so a named import of a not-yet-written export would
+// fail the type build and take the whole Playwright suite down with it. Resolved
+// this way, a missing export is a legible runtime failure in exactly the test
+// that needs it, and the real function is exercised once it lands.
+export interface ConsoleSession {
+  authenticated: boolean;
+  expires_at: string | null;
+}
+
+function sessionApi<T>(name: string): T {
+  const fn = (client as Record<string, unknown>)[name];
+  if (typeof fn !== "function") {
+    throw new TypeError(`client.${name} is not implemented yet (#630)`);
+  }
+  return fn as T;
+}
+
+const getSession = (): Promise<ConsoleSession> => sessionApi<() => Promise<ConsoleSession>>("getSession")();
+const activateSession = (code: string): Promise<ConsoleSession> =>
+  sessionApi<(code: string) => Promise<ConsoleSession>>("activateSession")(code);
+const logout = (): Promise<void> => sessionApi<() => Promise<void>>("logout")();
+
+// Assembled at runtime so this file itself never contains the literal, which
+// would poison the source-scan test below.
+const DEV_KEY = ["agentos", "dev", "key"].join("-");
+const PLANTED = "supersecret";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function noBody(status: number): Response {
+  return new Response(null, { status });
+}
+
+type Init = RequestInit & { headers?: Record<string, string> };
+
+function headerNames(init: Init | undefined): string[] {
+  return Object.keys(init?.headers ?? {});
+}
+
+function headerValues(init: Init | undefined): string[] {
+  return Object.values(init?.headers ?? {});
+}
+
+// Every call recorded by the fetch spy, flattened to a searchable string so a
+// leak anywhere in the URL, headers, or body is caught.
+function callText(call: [string, Init | undefined]): string {
+  const [url, init] = call;
+  return [url, JSON.stringify(init?.headers ?? {}), String(init?.body ?? "")].join(" ");
+}
+
+function setSearch(search: string): void {
+  window.history.replaceState({}, "", `/${search}`);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  setSearch("");
+});
+
+// A representative spread of verbs and shapes: GET, POST with a JSON body,
+// PATCH, DELETE, and a query-string GET. If any one of them regains the header
+// or drops the cookie, one of these fails.
+async function exerciseClient(): Promise<void> {
+  await createAgent({ name: "deal-desk", slack_channel: "C1" });
+  await listVersions("a1");
+  await updateAgent("a1", { slack_channel: "C2" });
+  await deleteAgent("a1");
+  await listTraces(5, "a1");
+  await createDeployment({ agent_id: "a1", version_id: "v1", environment: "prod" });
+}
+
+describe("the client never carries the platform key (AC1, AC3)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse(200, {})));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("sends no X-API-Key header on any verb", async () => {
+    await exerciseClient();
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(6);
+    for (const [url, init] of fetchMock.mock.calls as [string, Init][]) {
+      const names = headerNames(init).map((n) => n.toLowerCase());
+      expect(names, `header on ${url}`).not.toContain("x-api-key");
+      expect(names, `header on ${url}`).not.toContain("authorization");
+    }
+  });
+
+  it("sends no header whose value is the published dev key", async () => {
+    await exerciseClient();
+    for (const [url, init] of fetchMock.mock.calls as [string, Init][]) {
+      expect(headerValues(init), `header value on ${url}`).not.toContain(DEV_KEY);
+    }
+  });
+
+  it("passes credentials same-origin on every authenticated call so the session cookie rides along", async () => {
+    await exerciseClient();
+    for (const [url, init] of fetchMock.mock.calls as [string, Init][]) {
+      expect(init?.credentials, `credentials on ${url}`).toBe("same-origin");
+    }
+  });
+
+  it("passes credentials same-origin on the open /config call too", async () => {
+    await getConfig();
+    const [, init] = fetchMock.mock.calls[0] as [string, Init];
+    expect(init?.credentials).toBe("same-origin");
+  });
+
+  it("leaves ?api_key= inert: it reaches no URL, header, or body", async () => {
+    setSearch(`?api=1&api_key=${PLANTED}`);
+    await exerciseClient();
+    for (const call of fetchMock.mock.calls as [string, Init][]) {
+      const text = callText(call);
+      expect(text, `leak in call to ${call[0]}`).not.toContain(PLANTED);
+      const names = headerNames(call[1]).map((n) => n.toLowerCase());
+      expect(names).not.toContain("x-api-key");
+    }
+  });
+
+  it("makes byte-identical requests with and without ?api_key= present", async () => {
+    await exerciseClient();
+    const clean = (fetchMock.mock.calls as [string, Init][]).map(callText);
+
+    fetchMock.mockClear();
+    setSearch(`?api=1&api_key=${PLANTED}`);
+    await exerciseClient();
+    const planted = (fetchMock.mock.calls as [string, Init][]).map(callText);
+
+    expect(planted).toEqual(clean);
+  });
+});
+
+describe("the api module exposes no platform-key surface (AC1)", () => {
+  it("exports no apiKey function from config", () => {
+    expect(Object.keys(config)).not.toContain("apiKey");
+    expect((config as Record<string, unknown>).apiKey).toBeUndefined();
+  });
+
+  it("re-exports no apiKey through the client either", () => {
+    expect((client as Record<string, unknown>).apiKey).toBeUndefined();
+  });
+
+  it("keeps isWired working from ?api=1 and VITE_WIRED", () => {
+    setSearch("?api=1");
+    expect(config.isWired()).toBe(true);
+    setSearch("");
+    expect(config.isWired()).toBe(false);
+  });
+
+  it("does not contain the dev key string anywhere under src/api", () => {
+    const dir = fileURLToPath(new NodeURL(".", import.meta.url));
+    const offenders = readdirSync(dir)
+      .filter((f) => f.endsWith(".ts") || f.endsWith(".tsx"))
+      .filter((f) => readFileSync(join(dir, f), "utf8").includes(DEV_KEY));
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("console session client (AC2)", () => {
+  it("GET /console/session returns the session state", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { authenticated: true, expires_at: "2026-07-18T00:00:00Z" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const session = await getSession();
+    const [url, init] = fetchMock.mock.calls[0] as [string, Init];
+    expect(url).toBe("/api/console/session");
+    expect(init?.method ?? "GET").toBe("GET");
+    expect(init?.credentials).toBe("same-origin");
+    expect(session.authenticated).toBe(true);
+    expect(session.expires_at).toBe("2026-07-18T00:00:00Z");
+  });
+
+  it("GET /console/session reports an unauthenticated console rather than throwing on 401", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(401, { detail: "no console session" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const session = await getSession();
+    expect(session.authenticated).toBe(false);
+  });
+
+  it("POST /console/session sends the code in the body and returns the live session", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(201, { authenticated: true, expires_at: "2026-07-18T00:00:00Z" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const session = await activateSession("AAAA-BBBB-CCCC");
+    const [url, init] = fetchMock.mock.calls[0] as [string, Init];
+    expect(url).toBe("/api/console/session");
+    expect(init?.method).toBe("POST");
+    expect(init?.credentials).toBe("same-origin");
+    expect(JSON.parse(String(init?.body))).toEqual({ code: "AAAA-BBBB-CCCC" });
+    expect(session.authenticated).toBe(true);
+  });
+
+  it("POST /console/session surfaces a rejected code as ApiError with the server's fix text", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(400, { detail: "login code is expired or already used" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const err = (await activateSession("STALE-CODE").catch((e: unknown) => e)) as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(400);
+    expect(err.message).toContain("expired");
+  });
+
+  it("DELETE /console/session revokes the session and surfaces failures as ApiError", async () => {
+    const ok = vi.fn().mockResolvedValue(noBody(204));
+    vi.stubGlobal("fetch", ok);
+    await logout();
+    const [url, init] = ok.mock.calls[0] as [string, Init];
+    expect(url).toBe("/api/console/session");
+    expect(init?.method).toBe("DELETE");
+    expect(init?.credentials).toBe("same-origin");
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(500, { detail: "store unavailable" })));
+    const err = (await logout().catch((e: unknown) => e)) as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(500);
+  });
+
+  it("never writes the login code to storage or to the URL", async () => {
+    // The harness's own setSearch calls history.replaceState, so the URL must be
+    // staged BEFORE the spies are installed. Otherwise the spies record the
+    // setup's own call and the assertions below could never pass for any
+    // implementation. Installed after staging, they observe only activateSession.
+    setSearch("?api=1");
+
+    const localSet = vi.spyOn(Storage.prototype, "setItem");
+    const push = vi.spyOn(window.history, "pushState");
+    const replace = vi.spyOn(window.history, "replaceState");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse(201, { authenticated: true, expires_at: "2026-07-18T00:00:00Z" })),
+    );
+
+    await activateSession("AAAA-BBBB-CCCC");
+
+    expect(localSet).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+    expect(window.localStorage.length).toBe(0);
+    expect(window.sessionStorage.length).toBe(0);
+    expect(window.location.href).not.toContain("AAAA-BBBB-CCCC");
+  });
+});

--- a/apps/ui/src/api/session.test.ts
+++ b/apps/ui/src/api/session.test.ts
@@ -42,6 +42,14 @@ export interface ConsoleSession {
   expires_at: string | null;
 }
 
+// POST /console/session returns the established session's expiry and nothing
+// else: the token is the HttpOnly cookie, and there is no `authenticated` field
+// (apps/api ConsoleSessionOut). Kept distinct from ConsoleSession so a stub that
+// invents `authenticated` here fails to type-check.
+export interface ConsoleSessionOut {
+  expires_at: string;
+}
+
 function sessionApi<T>(name: string): T {
   const fn = (client as Record<string, unknown>)[name];
   if (typeof fn !== "function") {
@@ -51,14 +59,19 @@ function sessionApi<T>(name: string): T {
 }
 
 const getSession = (): Promise<ConsoleSession> => sessionApi<() => Promise<ConsoleSession>>("getSession")();
-const activateSession = (code: string): Promise<ConsoleSession> =>
-  sessionApi<(code: string) => Promise<ConsoleSession>>("activateSession")(code);
+const activateSession = (code: string): Promise<ConsoleSessionOut> =>
+  sessionApi<(code: string) => Promise<ConsoleSessionOut>>("activateSession")(code);
 const logout = (): Promise<void> => sessionApi<() => Promise<void>>("logout")();
 
 // Assembled at runtime so this file itself never contains the literal, which
 // would poison the source-scan test below.
 const DEV_KEY = ["agentos", "dev", "key"].join("-");
 const PLANTED = "supersecret";
+
+// A real login code is secrets.token_urlsafe(32): 43 base64url characters, no
+// dashes and no grouping. Fixtures use the real shape so nothing here certifies
+// a format the CLI cannot mint.
+const LOGIN_CODE = "hQ2m8LxF0vTnPzR6wKdYbJ7sGcAeUiOl3ZpXrNyMt4Q";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -172,6 +185,53 @@ describe("the client never carries the platform key (AC1, AC3)", () => {
   });
 });
 
+// The cookie is ambient authority: SameSite=Strict is a SITE control and ignores
+// the port, so http://localhost:8080 is same-site with every other localhost
+// port, and a body-less POST (e.g. /agents/{id}/kill) is a CORS-simple request
+// nothing preflights. The custom header cannot be set cross-origin without a
+// preflight this CORS-free API fails, so it is what makes the cookie unusable by
+// a forged cross-site request. apps/api rejects the cookie without it.
+describe("every call carries the console CSRF header (ADR-0049)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse(200, {})));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  function consoleHeader(init: Init | undefined): string | undefined {
+    const entry = Object.entries(init?.headers ?? {}).find(
+      ([name]) => name.toLowerCase() === "x-console-session",
+    );
+    return entry?.[1];
+  }
+
+  it("sends X-Console-Session on every authenticated verb", async () => {
+    await exerciseClient();
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(6);
+    for (const [url, init] of fetchMock.mock.calls as [string, Init][]) {
+      expect(consoleHeader(init), `X-Console-Session on ${url}`).toBe("1");
+    }
+  });
+
+  it("sends X-Console-Session on the multipart bundle upload, which sets no Content-Type", async () => {
+    // uploadBundle replaces the JSON headers wholesale so fetch can pick the
+    // multipart boundary; the header must survive that.
+    await client.uploadBundle("a1", "v1", new Blob(["zip"]));
+    const [url, init] = fetchMock.mock.calls[0] as [string, Init];
+    expect(consoleHeader(init), `X-Console-Session on ${url}`).toBe("1");
+  });
+
+  it("sends X-Console-Session on the session endpoints themselves", async () => {
+    await getSession();
+    await logout();
+    expect(fetchMock.mock.calls.length).toBe(2);
+    for (const [url, init] of fetchMock.mock.calls as [string, Init][]) {
+      expect(consoleHeader(init), `X-Console-Session on ${url}`).toBe("1");
+    }
+  });
+});
+
 describe("the api module exposes no platform-key surface (AC1)", () => {
   it("exports no apiKey function from config", () => {
     expect(Object.keys(config)).not.toContain("apiKey");
@@ -213,36 +273,59 @@ describe("console session client (AC2)", () => {
     expect(session.expires_at).toBe("2026-07-18T00:00:00Z");
   });
 
-  it("GET /console/session reports an unauthenticated console rather than throwing on 401", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(401, { detail: "no console session" }));
+  it("GET /console/session reports an unauthenticated console without throwing", async () => {
+    // The server answers anonymous with 200 authenticated=false, never a 401:
+    // not being logged in is the answer, not an error (apps/api console router).
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { authenticated: false, expires_at: null }));
     vi.stubGlobal("fetch", fetchMock);
     const session = await getSession();
     expect(session.authenticated).toBe(false);
+    expect(session.expires_at).toBeNull();
   });
 
-  it("POST /console/session sends the code in the body and returns the live session", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(jsonResponse(201, { authenticated: true, expires_at: "2026-07-18T00:00:00Z" }));
+  it("POST /console/session sends the code in the body and returns the session expiry", async () => {
+    // 200 with ConsoleSessionOut = {expires_at} only. There is no `authenticated`
+    // field to read: the cookie is the session, and the gate opens on this call
+    // resolving at all.
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { expires_at: "2026-07-18T00:00:00Z" }));
     vi.stubGlobal("fetch", fetchMock);
-    const session = await activateSession("AAAA-BBBB-CCCC");
+    const session = await activateSession(LOGIN_CODE);
     const [url, init] = fetchMock.mock.calls[0] as [string, Init];
     expect(url).toBe("/api/console/session");
     expect(init?.method).toBe("POST");
     expect(init?.credentials).toBe("same-origin");
-    expect(JSON.parse(String(init?.body))).toEqual({ code: "AAAA-BBBB-CCCC" });
-    expect(session.authenticated).toBe(true);
+    expect(JSON.parse(String(init?.body))).toEqual({ code: LOGIN_CODE });
+    expect(session.expires_at).toBe("2026-07-18T00:00:00Z");
   });
 
-  it("POST /console/session surfaces a rejected code as ApiError with the server's fix text", async () => {
+  it("POST /console/session surfaces a rejected code as ApiError carrying the server's reason", async () => {
+    // The server collapses unknown/spent/expired/revoked into one 401 {detail}.
     const fetchMock = vi
       .fn()
-      .mockResolvedValue(jsonResponse(400, { detail: "login code is expired or already used" }));
+      .mockResolvedValue(jsonResponse(401, { detail: "invalid or expired login code" }));
     vi.stubGlobal("fetch", fetchMock);
-    const err = (await activateSession("STALE-CODE").catch((e: unknown) => e)) as ApiError;
+    const err = (await activateSession("stale-code").catch((e: unknown) => e)) as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+    expect(err.message).toContain("invalid or expired login code");
+  });
+
+  it("POST /console/session surfaces the insecure-origin 400's fix, not just its reason", async () => {
+    // The exchange's only 400 is {error, fix} (apps/api console router), and the
+    // `fix` names the port-forward that is the operator's ONLY way in from a
+    // plaintext NodePort URL. Dropping it strands them on "Bad Request".
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(400, {
+        error: "refusing to establish a console session from a non-secure origin 'http://10.0.0.4:30080'",
+        fix: "Reach the console over a secure context and log in again: kubectl port-forward -n agentos svc/agentos-ui 8080:80 then open http://localhost:8080.",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const err = (await activateSession(LOGIN_CODE).catch((e: unknown) => e)) as ApiError;
     expect(err).toBeInstanceOf(ApiError);
     expect(err.status).toBe(400);
-    expect(err.message).toContain("expired");
+    expect(err.message).toContain("non-secure origin");
+    expect(err.fix).toContain("kubectl port-forward");
   });
 
   it("DELETE /console/session revokes the session and surfaces failures as ApiError", async () => {
@@ -270,18 +353,15 @@ describe("console session client (AC2)", () => {
     const localSet = vi.spyOn(Storage.prototype, "setItem");
     const push = vi.spyOn(window.history, "pushState");
     const replace = vi.spyOn(window.history, "replaceState");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(jsonResponse(201, { authenticated: true, expires_at: "2026-07-18T00:00:00Z" })),
-    );
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, { expires_at: "2026-07-18T00:00:00Z" })));
 
-    await activateSession("AAAA-BBBB-CCCC");
+    await activateSession(LOGIN_CODE);
 
     expect(localSet).not.toHaveBeenCalled();
     expect(push).not.toHaveBeenCalled();
     expect(replace).not.toHaveBeenCalled();
     expect(window.localStorage.length).toBe(0);
     expect(window.sessionStorage.length).toBe(0);
-    expect(window.location.href).not.toContain("AAAA-BBBB-CCCC");
+    expect(window.location.href).not.toContain(LOGIN_CODE);
   });
 });

--- a/apps/ui/src/components/ConsoleGate.tsx
+++ b/apps/ui/src/components/ConsoleGate.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { isWired } from "../api/config";
+import { activateSession, getSession } from "../api/client";
+import { ConsoleLogin } from "./ConsoleLogin";
+
+// The wired console's auth gate (#630 / ADR-0049).
+//
+// It is a real state transition, not an overlay: while locked, the console
+// shell is not rendered at all, so nothing behind it mounts, fetches, or 401s.
+// That is why this sits above StoreProvider/WiredProvider in main.tsx rather
+// than inside the shell.
+//
+// Fixture mode (no ?api=1) is untouched: the gate opens immediately and never
+// calls the session endpoint, so the stackless demo stays backend-free.
+
+type Phase = "checking" | "locked" | "open";
+
+export function ConsoleGate({ children }: { children: ReactNode }) {
+  const wired = isWired();
+  const [phase, setPhase] = useState<Phase>(wired ? "checking" : "open");
+
+  useEffect(() => {
+    if (!wired) return;
+    let live = true;
+    getSession()
+      .then((session) => {
+        if (live) setPhase(session.authenticated ? "open" : "locked");
+      })
+      // Fail closed: if the session state cannot be read, show the login view
+      // rather than a shell whose every call is about to be rejected.
+      .catch(() => {
+        if (live) setPhase("locked");
+      });
+    return () => {
+      live = false;
+    };
+  }, [wired]);
+
+  // Throws on a rejected code, which ConsoleLogin renders inline; a non-2xx has
+  // already thrown by the time this resolves, so success is the only path here.
+  const activate = useCallback(async (code: string) => {
+    await activateSession(code);
+    setPhase("open");
+  }, []);
+
+  // Nothing is rendered until the session state is known: showing the login
+  // view first would flash a gate at an operator who is already signed in.
+  if (phase === "checking") return null;
+  if (phase === "locked") return <ConsoleLogin onActivate={activate} />;
+  return <>{children}</>;
+}

--- a/apps/ui/src/components/ConsoleLogin.tsx
+++ b/apps/ui/src/components/ConsoleLogin.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { C, R } from "../tokens";
+import { Button } from "../primitives";
+import { ApiError } from "../api/client";
+
+// The console's login gate (#630 / ADR-0049). The operator pastes a single-use
+// login code minted by the AgentOS CLI; the exchange sets an HttpOnly session
+// cookie server-side. Nothing here is a password: the code is spent on the
+// first exchange, it is never stored, and this component holds it only as
+// component state for as long as the field shows it.
+//
+// Ported from the existing design language: the card/border elevation and mono
+// input treatment already used by the create-agent modal, no new visual idiom.
+
+export function ConsoleLogin({ onActivate }: { onActivate: (code: string) => Promise<void> }) {
+  const [code, setCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function submit() {
+    const value = code.trim();
+    if (!value || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onActivate(value);
+      // On success the gate swaps this view out, so there is no state to reset.
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Could not reach the API.");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      data-testid="console-login"
+      style={{
+        fontFamily: C.sans,
+        color: C.text,
+        background: C.page,
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 24,
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 420 }}>
+        <div
+          style={{
+            background: C.card,
+            border: "1px solid " + C.border,
+            borderRadius: R.cardLg,
+            padding: 28,
+          }}
+        >
+          <h1 style={{ fontSize: 19, fontWeight: 400, color: C.text, margin: "0 0 6px" }}>Sign in to AgentOS</h1>
+          <p style={{ fontSize: 13, color: C.muted, lineHeight: 1.5, margin: "0 0 20px" }}>
+            {/*
+              The exact `agentos ... console login` invocation is deliberately not
+              written out here. Per apps/ui/CLAUDE.md every agentos command string
+              in a component must resolve from the committed manifest through
+              cliCommand(), and the console login verb is not in the manifest yet
+              (it is the CLI half of #630). Once `pnpm gen:manifest` picks it up
+              this paragraph gets a CliHint next to it.
+            */}
+            Run the AgentOS CLI&rsquo;s console login command on this install to mint a login code, then paste it
+            below. Codes are single use and expire.
+          </p>
+
+          <label htmlFor="console-login-code" style={{ fontSize: 13, fontWeight: 500, display: "block", marginBottom: 6 }}>
+            Login code
+          </label>
+          <input
+            id="console-login-code"
+            data-testid="console-login-code"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void submit();
+            }}
+            autoFocus
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="AAAA-BBBB-CCCC"
+            style={{
+              width: "100%",
+              background: C.input,
+              border: "1px solid " + (error ? C.destructive : C.borderStrong),
+              borderRadius: R.input,
+              padding: "8px 10px",
+              color: C.text,
+              fontFamily: C.mono,
+              fontSize: 13,
+              marginBottom: 14,
+            }}
+          />
+
+          {error ? (
+            <div
+              data-testid="console-login-error"
+              style={{
+                border: "1px solid rgba(229,77,46,.3)",
+                background: "rgba(229,77,46,.06)",
+                borderRadius: R.btn,
+                padding: "8px 10px",
+                fontSize: 12.5,
+                color: C.destructive,
+                fontFamily: C.mono,
+                marginBottom: 14,
+              }}
+            >
+              {error}
+            </div>
+          ) : null}
+
+          <Button
+            label={busy ? "Signing in…" : "Sign in"}
+            variant="primary"
+            full
+            disabled={busy || code.trim() === ""}
+            testId="console-login-submit"
+            onClick={() => void submit()}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/ConsoleLogin.tsx
+++ b/apps/ui/src/components/ConsoleLogin.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { C, R } from "../tokens";
 import { Button } from "../primitives";
+import { cliCommand } from "../primitives/cliCommand";
 import { ApiError } from "../api/client";
 
 // The console's login gate (#630 / ADR-0049). The operator pastes a single-use
@@ -55,18 +56,40 @@ export function ConsoleLogin({ onActivate }: { onActivate: (code: string) => Pro
           }}
         >
           <h1 style={{ fontSize: 19, fontWeight: 400, color: C.text, margin: "0 0 6px" }}>Sign in to AgentOS</h1>
-          <p style={{ fontSize: 13, color: C.muted, lineHeight: 1.5, margin: "0 0 20px" }}>
-            {/*
-              The exact `agentos ... console login` invocation is deliberately not
-              written out here. Per apps/ui/CLAUDE.md every agentos command string
-              in a component must resolve from the committed manifest through
-              cliCommand(), and the console login verb is not in the manifest yet
-              (it is the CLI half of #630). Once `pnpm gen:manifest` picks it up
-              this paragraph gets a CliHint next to it.
-            */}
-            Run the AgentOS CLI&rsquo;s console login command on this install to mint a login code, then paste it
-            below. Codes are single use and expire.
+          <p style={{ fontSize: 13, color: C.muted, lineHeight: 1.5, margin: "0 0 12px" }}>
+            Mint a login code with the AgentOS CLI on this install, then paste it below. Codes are single use and
+            expire.
           </p>
+          {/*
+            Both tiers are shown because this view CANNOT know which one it is
+            serving: `env` is a store concept, and the gate mounts above
+            StoreProvider on purpose (a locked console must not mount the
+            providers that fetch). Naming one tier would be a guess that is wrong
+            half the time, so the operator picks the line matching their install.
+
+            Plain text rather than a <CliHint>: CliHint calls useStore() for its
+            "Copied" toast, and there is no store above the gate. The parity rule
+            in apps/ui/CLAUDE.md is that the command STRING resolves from the
+            committed manifest via cliCommand() -- which it does here -- not that
+            it must be carried by CliHint.
+          */}
+          <div
+            data-testid="console-login-cli"
+            style={{
+              background: C.input,
+              border: "1px solid " + C.border,
+              borderRadius: R.btn,
+              padding: "8px 10px",
+              fontFamily: C.mono,
+              fontSize: 12,
+              color: C.muted,
+              lineHeight: 1.7,
+              marginBottom: 20,
+            }}
+          >
+            <div>{cliCommand("cluster.console.login")}</div>
+            <div>{cliCommand("local.console.login")}</div>
+          </div>
 
           <label htmlFor="console-login-code" style={{ fontSize: 13, fontWeight: 500, display: "block", marginBottom: 6 }}>
             Login code

--- a/apps/ui/src/components/ConsoleLogin.tsx
+++ b/apps/ui/src/components/ConsoleLogin.tsx
@@ -16,6 +16,11 @@ import { ApiError } from "../api/client";
 export function ConsoleLogin({ onActivate }: { onActivate: (code: string) => Promise<void> }) {
   const [code, setCode] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // The server's remediation text, rendered as its own line. On a sealed install
+  // reached over a plaintext NodePort URL this is the port-forward instruction,
+  // and it is the operator's ONLY way in: dropping it would strand them on a
+  // bare reason with no next step.
+  const [fix, setFix] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   async function submit() {
@@ -23,11 +28,13 @@ export function ConsoleLogin({ onActivate }: { onActivate: (code: string) => Pro
     if (!value || busy) return;
     setBusy(true);
     setError(null);
+    setFix(null);
     try {
       await onActivate(value);
       // On success the gate swaps this view out, so there is no state to reset.
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "Could not reach the API.");
+      setFix(e instanceof ApiError ? e.fix : null);
       setBusy(false);
     }
   }
@@ -105,7 +112,7 @@ export function ConsoleLogin({ onActivate }: { onActivate: (code: string) => Pro
             autoFocus
             autoComplete="off"
             spellCheck={false}
-            placeholder="AAAA-BBBB-CCCC"
+            placeholder="Paste your login code"
             style={{
               width: "100%",
               background: C.input,
@@ -134,6 +141,21 @@ export function ConsoleLogin({ onActivate }: { onActivate: (code: string) => Pro
               }}
             >
               {error}
+              {fix ? (
+                <div
+                  data-testid="console-login-fix"
+                  style={{
+                    marginTop: 8,
+                    paddingTop: 8,
+                    borderTop: "1px solid rgba(229,77,46,.25)",
+                    color: C.muted,
+                    lineHeight: 1.6,
+                    wordBreak: "break-word",
+                  }}
+                >
+                  {fix}
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -634,9 +634,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                ""
-              ],
               "env": "SLACK_APP_TOKEN",
               "global": false,
               "help": "Slack app token. Defaults from SLACK_APP_TOKEN",
@@ -646,9 +643,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                ""
-              ],
               "env": "SLACK_BOT_TOKEN",
               "global": false,
               "help": "Slack bot token. Defaults from SLACK_BOT_TOKEN",
@@ -721,9 +715,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "valkeypass"
-              ],
               "env": "AGENTOS_VALKEY_PASSWORD",
               "global": false,
               "help": "Valkey password (compose default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
@@ -741,9 +732,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key for the default-channel lookup",
@@ -819,9 +807,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "valkeypass"
-              ],
               "env": "AGENTOS_VALKEY_PASSWORD",
               "global": false,
               "help": "Valkey password (compose default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
@@ -839,9 +824,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key for the default-channel lookup",
@@ -935,9 +917,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key",
@@ -1011,9 +990,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1058,9 +1034,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1105,9 +1078,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1199,6 +1169,95 @@ export const commandManifest = {
           "name": "approvals"
         },
         {
+          "about": "Log in to the local AgentOS Console, or revoke every console session",
+          "hidden": false,
+          "name": "console",
+          "subcommands": [
+            {
+              "about": "Mint a single-use login code to paste into the console",
+              "args": [
+                {
+                  "default_values": [
+                    "http://localhost:28000"
+                  ],
+                  "env": "AGENTOS_API_URL",
+                  "global": false,
+                  "id": "api_url",
+                  "long": "api-url",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "env": "AGENTOS_API_KEY",
+                  "global": false,
+                  "id": "api_key",
+                  "long": "api-key",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Optional note recorded on the session, to tell sessions apart",
+                  "id": "label",
+                  "long": "label",
+                  "positional": false,
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "login"
+            },
+            {
+              "about": "Revoke every live console session (the kill switch)",
+              "args": [
+                {
+                  "default_values": [
+                    "http://localhost:28000"
+                  ],
+                  "env": "AGENTOS_API_URL",
+                  "global": false,
+                  "id": "api_url",
+                  "long": "api-url",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "env": "AGENTOS_API_KEY",
+                  "global": false,
+                  "id": "api_key",
+                  "long": "api-key",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "revoke"
+            }
+          ]
+        },
+        {
           "about": "Show the local observability surfaces (AgentOS Console + Langfuse traces/cost + API base)",
           "args": [
             {
@@ -1247,9 +1306,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1294,9 +1350,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1353,9 +1406,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1601,6 +1651,139 @@ export const commandManifest = {
           "name": "status"
         },
         {
+          "about": "Log in to the release's AgentOS Console, or revoke every console session",
+          "hidden": false,
+          "name": "console",
+          "subcommands": [
+            {
+              "about": "Mint a single-use login code to paste into the console",
+              "args": [
+                {
+                  "env": "AGENTOS_API_URL",
+                  "global": false,
+                  "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
+                  "id": "api_url",
+                  "long": "api-url",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "env": "AGENTOS_API_KEY",
+                  "global": false,
+                  "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
+                  "id": "api_key",
+                  "long": "api-key",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "agentos"
+                  ],
+                  "global": false,
+                  "help": "Kubernetes namespace of the release. Default: agentos",
+                  "id": "namespace",
+                  "long": "namespace",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "agentos"
+                  ],
+                  "global": false,
+                  "help": "Helm release name. Default: agentos",
+                  "id": "release",
+                  "long": "release",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Optional note recorded on the session, to tell sessions apart",
+                  "id": "label",
+                  "long": "label",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Print the request that would be made and exit without executing",
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "login"
+            },
+            {
+              "about": "Revoke every live console session (the kill switch)",
+              "args": [
+                {
+                  "env": "AGENTOS_API_URL",
+                  "global": false,
+                  "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
+                  "id": "api_url",
+                  "long": "api-url",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "env": "AGENTOS_API_KEY",
+                  "global": false,
+                  "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
+                  "id": "api_key",
+                  "long": "api-key",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "agentos"
+                  ],
+                  "global": false,
+                  "help": "Kubernetes namespace of the release. Default: agentos",
+                  "id": "namespace",
+                  "long": "namespace",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "agentos"
+                  ],
+                  "global": false,
+                  "help": "Helm release name. Default: agentos",
+                  "id": "release",
+                  "long": "release",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Print the request that would be made and exit without executing",
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "revoke"
+            }
+          ]
+        },
+        {
           "about": "Show the release's observability surfaces (AgentOS Console + Langfuse traces/cost + API base)",
           "args": [
             {
@@ -1681,9 +1864,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                ""
-              ],
               "env": "SLACK_APP_TOKEN",
               "global": false,
               "help": "Slack app token. Defaults from SLACK_APP_TOKEN",
@@ -1693,9 +1873,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                ""
-              ],
               "env": "SLACK_BOT_TOKEN",
               "global": false,
               "help": "Slack bot token. Defaults from SLACK_BOT_TOKEN",
@@ -1843,9 +2020,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "valkeypass"
-              ],
               "env": "AGENTOS_VALKEY_PASSWORD",
               "global": false,
               "help": "Valkey password (chart default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
@@ -1866,9 +2040,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key for the default-channel lookup",
@@ -1996,9 +2167,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "valkeypass"
-              ],
               "env": "AGENTOS_VALKEY_PASSWORD",
               "global": false,
               "help": "Valkey password (chart default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
@@ -2019,9 +2187,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key for the default-channel lookup",
@@ -2134,9 +2299,6 @@ export const commandManifest = {
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key",

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1205,14 +1205,6 @@ export const commandManifest = {
                     "false"
                   ],
                   "required": false
-                },
-                {
-                  "global": false,
-                  "help": "Optional note recorded on the session, to tell sessions apart",
-                  "id": "label",
-                  "long": "label",
-                  "positional": false,
-                  "required": false
                 }
               ],
               "hidden": false,
@@ -1695,14 +1687,6 @@ export const commandManifest = {
                   "help": "Helm release name. Default: agentos",
                   "id": "release",
                   "long": "release",
-                  "positional": false,
-                  "required": false
-                },
-                {
-                  "global": false,
-                  "help": "Optional note recorded on the session, to tell sessions apart",
-                  "id": "label",
-                  "long": "label",
                   "positional": false,
                   "required": false
                 },

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./styles.css";
 import { App } from "./App";
+import { ConsoleGate } from "./components/ConsoleGate";
 import { StoreProvider } from "./state/store";
 import { WiredProvider } from "./state/wired";
 
@@ -15,11 +16,18 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <StoreProvider>
-        <WiredProvider>
-          <App />
-        </WiredProvider>
-      </StoreProvider>
+      {/*
+        The console session gate (#630) sits above the shell so a locked console
+        never mounts the providers that fetch: while it is closed, WiredProvider
+        does not exist and no authenticated call is made.
+      */}
+      <ConsoleGate>
+        <StoreProvider>
+          <WiredProvider>
+            <App />
+          </WiredProvider>
+        </StoreProvider>
+      </ConsoleGate>
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/ui/src/primitives/CliHint.parity.test.tsx
+++ b/apps/ui/src/primitives/CliHint.parity.test.tsx
@@ -11,9 +11,11 @@ import { StoreProvider } from "../state/store";
 
 const PRODUCTION_ROOT = join(process.cwd(), "src");
 const EXPECTED_COMMAND_IDS = [
+  "cluster.console.login",
   "cluster.deploy",
   "cluster.status",
   "init",
+  "local.console.login",
   "local.deploy",
   "local.status",
 ] as const;

--- a/apps/ui/src/primitives/parity.ts
+++ b/apps/ui/src/primitives/parity.ts
@@ -53,6 +53,12 @@ export const WIRED_ACTIONS = [
   { id: "budget", label: "Set budget", mapping: { command: "cluster.budget" } },
   { id: "delete", label: "Delete an agent", mapping: { command: "cluster.delete" } },
 
+  // ConsoleLogin (#630) — the login gate names the verb that mints a code. Both
+  // tiers are listed because the gate cannot know which one serves it: it mounts
+  // above the store that carries `env`.
+  { id: "console-login-cluster", label: "Mint a console login code (prod)", mapping: { command: "cluster.console.login" } },
+  { id: "console-login-local", label: "Mint a console login code (dev)", mapping: { command: "local.console.login" } },
+
   // Genuinely-unmapped actions: no dedicated CLI verb exists yet. These render
   // the honest amber glyph linking to the parity epic instead of a command.
   { id: "rollback", label: "Roll back to an earlier version", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -631,9 +631,6 @@
               "required": false
             },
             {
-              "default_values": [
-                ""
-              ],
               "env": "SLACK_APP_TOKEN",
               "global": false,
               "help": "Slack app token. Defaults from SLACK_APP_TOKEN",
@@ -643,9 +640,6 @@
               "required": false
             },
             {
-              "default_values": [
-                ""
-              ],
               "env": "SLACK_BOT_TOKEN",
               "global": false,
               "help": "Slack bot token. Defaults from SLACK_BOT_TOKEN",
@@ -718,9 +712,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "valkeypass"
-              ],
               "env": "AGENTOS_VALKEY_PASSWORD",
               "global": false,
               "help": "Valkey password (compose default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
@@ -738,9 +729,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key for the default-channel lookup",
@@ -816,9 +804,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "valkeypass"
-              ],
               "env": "AGENTOS_VALKEY_PASSWORD",
               "global": false,
               "help": "Valkey password (compose default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
@@ -836,9 +821,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key for the default-channel lookup",
@@ -932,9 +914,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key",
@@ -1008,9 +987,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1055,9 +1031,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1102,9 +1075,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1196,6 +1166,95 @@
           "name": "approvals"
         },
         {
+          "about": "Log in to the local AgentOS Console, or revoke every console session",
+          "hidden": false,
+          "name": "console",
+          "subcommands": [
+            {
+              "about": "Mint a single-use login code to paste into the console",
+              "args": [
+                {
+                  "default_values": [
+                    "http://localhost:28000"
+                  ],
+                  "env": "AGENTOS_API_URL",
+                  "global": false,
+                  "id": "api_url",
+                  "long": "api-url",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "env": "AGENTOS_API_KEY",
+                  "global": false,
+                  "id": "api_key",
+                  "long": "api-key",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Optional note recorded on the session, to tell sessions apart",
+                  "id": "label",
+                  "long": "label",
+                  "positional": false,
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "login"
+            },
+            {
+              "about": "Revoke every live console session (the kill switch)",
+              "args": [
+                {
+                  "default_values": [
+                    "http://localhost:28000"
+                  ],
+                  "env": "AGENTOS_API_URL",
+                  "global": false,
+                  "id": "api_url",
+                  "long": "api-url",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "env": "AGENTOS_API_KEY",
+                  "global": false,
+                  "id": "api_key",
+                  "long": "api-key",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "revoke"
+            }
+          ]
+        },
+        {
           "about": "Show the local observability surfaces (AgentOS Console + Langfuse traces/cost + API base)",
           "args": [
             {
@@ -1244,9 +1303,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1291,9 +1347,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1350,9 +1403,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "id": "api_key",
@@ -1598,6 +1648,139 @@
           "name": "status"
         },
         {
+          "about": "Log in to the release's AgentOS Console, or revoke every console session",
+          "hidden": false,
+          "name": "console",
+          "subcommands": [
+            {
+              "about": "Mint a single-use login code to paste into the console",
+              "args": [
+                {
+                  "env": "AGENTOS_API_URL",
+                  "global": false,
+                  "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
+                  "id": "api_url",
+                  "long": "api-url",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "env": "AGENTOS_API_KEY",
+                  "global": false,
+                  "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
+                  "id": "api_key",
+                  "long": "api-key",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "agentos"
+                  ],
+                  "global": false,
+                  "help": "Kubernetes namespace of the release. Default: agentos",
+                  "id": "namespace",
+                  "long": "namespace",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "agentos"
+                  ],
+                  "global": false,
+                  "help": "Helm release name. Default: agentos",
+                  "id": "release",
+                  "long": "release",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Optional note recorded on the session, to tell sessions apart",
+                  "id": "label",
+                  "long": "label",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Print the request that would be made and exit without executing",
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "login"
+            },
+            {
+              "about": "Revoke every live console session (the kill switch)",
+              "args": [
+                {
+                  "env": "AGENTOS_API_URL",
+                  "global": false,
+                  "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
+                  "id": "api_url",
+                  "long": "api-url",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "env": "AGENTOS_API_KEY",
+                  "global": false,
+                  "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
+                  "id": "api_key",
+                  "long": "api-key",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "agentos"
+                  ],
+                  "global": false,
+                  "help": "Kubernetes namespace of the release. Default: agentos",
+                  "id": "namespace",
+                  "long": "namespace",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "default_values": [
+                    "agentos"
+                  ],
+                  "global": false,
+                  "help": "Helm release name. Default: agentos",
+                  "id": "release",
+                  "long": "release",
+                  "positional": false,
+                  "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Print the request that would be made and exit without executing",
+                  "id": "dry_run",
+                  "long": "dry-run",
+                  "positional": false,
+                  "possible_values": [
+                    "true",
+                    "false"
+                  ],
+                  "required": false
+                }
+              ],
+              "hidden": false,
+              "name": "revoke"
+            }
+          ]
+        },
+        {
           "about": "Show the release's observability surfaces (AgentOS Console + Langfuse traces/cost + API base)",
           "args": [
             {
@@ -1678,9 +1861,6 @@
               "required": false
             },
             {
-              "default_values": [
-                ""
-              ],
               "env": "SLACK_APP_TOKEN",
               "global": false,
               "help": "Slack app token. Defaults from SLACK_APP_TOKEN",
@@ -1690,9 +1870,6 @@
               "required": false
             },
             {
-              "default_values": [
-                ""
-              ],
               "env": "SLACK_BOT_TOKEN",
               "global": false,
               "help": "Slack bot token. Defaults from SLACK_BOT_TOKEN",
@@ -1840,9 +2017,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "valkeypass"
-              ],
               "env": "AGENTOS_VALKEY_PASSWORD",
               "global": false,
               "help": "Valkey password (chart default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
@@ -1863,9 +2037,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key for the default-channel lookup",
@@ -1993,9 +2164,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "valkeypass"
-              ],
               "env": "AGENTOS_VALKEY_PASSWORD",
               "global": false,
               "help": "Valkey password (chart default `valkeypass`). Prefer the AGENTOS_VALKEY_PASSWORD env var over passing a real secret on the command line, where it leaks via `ps` and shell history",
@@ -2016,9 +2184,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key for the default-channel lookup",
@@ -2131,9 +2296,6 @@
               "required": false
             },
             {
-              "default_values": [
-                "agentos-dev-key"
-              ],
               "env": "AGENTOS_API_KEY",
               "global": false,
               "help": "Platform API key",

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1202,14 +1202,6 @@
                     "false"
                   ],
                   "required": false
-                },
-                {
-                  "global": false,
-                  "help": "Optional note recorded on the session, to tell sessions apart",
-                  "id": "label",
-                  "long": "label",
-                  "positional": false,
-                  "required": false
                 }
               ],
               "hidden": false,
@@ -1692,14 +1684,6 @@
                   "help": "Helm release name. Default: agentos",
                   "id": "release",
                   "long": "release",
-                  "positional": false,
-                  "required": false
-                },
-                {
-                  "global": false,
-                  "help": "Optional note recorded on the session, to tell sessions apart",
-                  "id": "label",
-                  "long": "label",
                   "positional": false,
                   "required": false
                 },

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -87,6 +87,19 @@ pub struct Version {
     pub created_at: Option<String>,
 }
 
+/// A freshly minted console login code (`ConsoleLoginCodeOut`, #630/ADR-0049).
+///
+/// The `code` is a single-use, short-lived credential the operator pastes into
+/// the console, NOT the platform key. It is meant to be printed: that is the
+/// whole point of minting it, since it is what lets the browser establish a
+/// session without ever receiving the key that authorizes every router.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConsoleLoginCode {
+    pub code: String,
+    pub expires_at: String,
+    pub session_id: String,
+}
+
 /// One learned memory entry (`MemoryEntryOut`) for the `memory` listing verb.
 #[derive(Debug, Clone, Deserialize)]
 pub struct MemoryEntry {
@@ -769,6 +782,47 @@ impl ApiClient {
             .context("DELETE /agents/{id}")?;
         Self::expect_ok(resp, "deleting the agent").await?;
         Ok(())
+    }
+
+    /// Mint a single-use console login code: `POST /console/login-codes`
+    /// (#630/ADR-0049). Under the platform key on purpose -- minting is the
+    /// CLI's job, which is what keeps the browser off the key entirely.
+    pub async fn mint_console_login_code(&self, label: Option<&str>) -> Result<ConsoleLoginCode> {
+        let resp = self
+            .http
+            .post(format!("{}/console/login-codes", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .json(&json!({ "label": label }))
+            .send()
+            .await
+            .context("POST /console/login-codes")?;
+        Self::expect_ok(resp, "minting a console login code")
+            .await?
+            .json()
+            .await
+            .context("decoding the minted login code")
+    }
+
+    /// Revoke every live console grant: `DELETE /console/sessions`, returning
+    /// how many rows were revoked. The operator's kill switch for the console.
+    pub async fn revoke_console_sessions(&self) -> Result<u64> {
+        #[derive(Deserialize)]
+        struct Revoked {
+            revoked: u64,
+        }
+        let resp = self
+            .http
+            .delete(format!("{}/console/sessions", self.base_url))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("DELETE /console/sessions")?;
+        let out: Revoked = Self::expect_ok(resp, "revoking console sessions")
+            .await?
+            .json()
+            .await
+            .context("decoding the revoke result")?;
+        Ok(out.revoked)
     }
 }
 

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -787,12 +787,12 @@ impl ApiClient {
     /// Mint a single-use console login code: `POST /console/login-codes`
     /// (#630/ADR-0049). Under the platform key on purpose -- minting is the
     /// CLI's job, which is what keeps the browser off the key entirely.
-    pub async fn mint_console_login_code(&self, label: Option<&str>) -> Result<ConsoleLoginCode> {
+    pub async fn mint_console_login_code(&self) -> Result<ConsoleLoginCode> {
         let resp = self
             .http
             .post(format!("{}/console/login-codes", self.base_url))
             .header("X-API-Key", &self.api_key)
-            .json(&json!({ "label": label }))
+            .json(&json!({}))
             .send()
             .await
             .context("POST /console/login-codes")?;

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2725,15 +2725,22 @@ pub enum ConsoleLoginOutput {
         /// if we cannot name the URL, and failing the mint over a cosmetic
         /// lookup would throw away a live credential.
         console_url: Option<String>,
+        /// Set when `console_url`'s origin is one the login exchange refuses (a
+        /// plaintext NodePort console): the loopback path that can accept this
+        /// code. `None` when the console URL is already loginable.
+        login: Option<crate::ops::ConsoleLoginPath>,
     },
 }
 
 impl crate::ui::CliOutput for ConsoleLoginOutput {
-    /// `{"code","expires_at","session_id","console_url":<string|null>}`.
+    /// `{"code","expires_at","session_id","console_url":<string|null>,
+    /// "login":{"url","port_forward"}|null}`.
     ///
-    /// `console_url` is emitted with an explicit null rather than omitted when
-    /// unresolved, per the repo convention pinned by
-    /// `kill_output_json_shape_is_pinned`.
+    /// `console_url` and `login` are emitted with an explicit null rather than
+    /// omitted when unresolved / not needed, per the repo convention pinned by
+    /// `kill_output_json_shape_is_pinned`. `login` is structured data, not a
+    /// hint buried in prose: an agent under `--json` reads `login.url` as the
+    /// URL this code can be spent at (#630, ADR-0049).
     fn to_json(&self) -> serde_json::Value {
         match self {
             ConsoleLoginOutput::DryRun(plan) => plan.to_json(),
@@ -2742,11 +2749,16 @@ impl crate::ui::CliOutput for ConsoleLoginOutput {
                 expires_at,
                 session_id,
                 console_url,
+                login,
             } => serde_json::json!({
                 "code": code,
                 "expires_at": expires_at,
                 "session_id": session_id,
                 "console_url": console_url,
+                "login": login.as_ref().map(|l| serde_json::json!({
+                    "url": l.url,
+                    "port_forward": l.port_forward,
+                })),
             }),
         }
     }
@@ -2758,6 +2770,7 @@ impl crate::ui::CliOutput for ConsoleLoginOutput {
                 code,
                 expires_at,
                 console_url,
+                login,
                 ..
             } => {
                 ui.kv("login code", code);
@@ -2768,6 +2781,15 @@ impl crate::ui::CliOutput for ConsoleLoginOutput {
                         "could not resolve the console URL; find it with `agentos cluster status`",
                     ),
                 }
+                // The console URL above is a plaintext origin, so the exchange
+                // would refuse this code there. Name the URL it CAN be spent at,
+                // at the exact moment the operator is about to spend it.
+                if let Some(login) = login {
+                    ui.kv(
+                        "log in at",
+                        &format!("{}  then {}", login.port_forward, ui.url(&login.url)),
+                    );
+                }
                 ui.note("single use: open the console, paste the code, and it is spent");
             }
         }
@@ -2777,13 +2799,14 @@ impl crate::ui::CliOutput for ConsoleLoginOutput {
 /// `<tier> console login`: mint a single-use login code for the console
 /// (`POST /console/login-codes`, #630/ADR-0049).
 ///
-/// `console_url` is resolved by the caller because the tiers resolve it
-/// differently (a fixed localhost URL vs the release's `ui` service), which is
-/// the same split `observability` already draws between the two tiers.
+/// `access` is resolved by the caller because the tiers resolve it differently
+/// (a fixed loopback localhost URL, already a secure context, vs the release's
+/// `ui` service, which may be a plaintext NodePort the exchange refuses), which
+/// is the same split `observability` already draws between the two tiers.
 pub async fn console_login(
     opts: ConsoleOpts,
     label: Option<String>,
-    console_url: Option<String>,
+    access: crate::ops::ConsoleAccess,
 ) -> Result<ConsoleLoginOutput> {
     if opts.dry_run {
         return Ok(ConsoleLoginOutput::DryRun(crate::ui::DryRunPlan {
@@ -2796,7 +2819,8 @@ pub async fn console_login(
         code: minted.code,
         expires_at: minted.expires_at,
         session_id: minted.session_id,
-        console_url,
+        console_url: access.url,
+        login: access.login,
     })
 }
 
@@ -4425,12 +4449,17 @@ mod tests {
             expires_at: "2026-07-17T12:00:00Z".into(),
             session_id: "11111111-1111-1111-1111-111111111111".into(),
             console_url: None,
+            login: None,
         };
         let json = out.to_json();
         assert!(
             json.get("console_url")
                 .is_some_and(serde_json::Value::is_null),
             "an unresolved console_url must be an explicit null, not omitted: {json}"
+        );
+        assert!(
+            json.get("login").is_some_and(serde_json::Value::is_null),
+            "a console that needs no port-forward must say so with an explicit null: {json}"
         );
         assert_eq!(json["code"], "abc123");
         assert_eq!(json["expires_at"], "2026-07-17T12:00:00Z");
@@ -4447,7 +4476,9 @@ mod tests {
             api_key: "K".into(),
             dry_run: true,
         };
-        let login = super::console_login(opts(), None, None).await.unwrap();
+        let login = super::console_login(opts(), None, Default::default())
+            .await
+            .unwrap();
         assert_eq!(login.to_json()["dry_run"], true);
         assert_eq!(
             login.to_json()["plan"][0],
@@ -4472,12 +4503,40 @@ mod tests {
             expires_at: "2026-07-17T12:00:00Z".into(),
             session_id: "sid".into(),
             console_url: Some("http://localhost:28080/?api=1".into()),
+            login: None,
         };
         let json = out.to_json().to_string();
         assert!(json.contains("abc123"), "the code is the point of the verb");
         assert!(
             !json.contains("agentos-dev-key"),
             "the platform key must never reach the output"
+        );
+    }
+
+    /// A code minted against a plaintext NodePort console must name the loopback
+    /// URL it can actually be spent at, as DATA: an agent reading `--json` needs
+    /// `login.url`, not a sentence (#630, ADR-0049).
+    #[test]
+    fn console_login_carries_the_loginable_path_when_the_console_is_plaintext() {
+        use crate::ui::CliOutput;
+        let out = super::ConsoleLoginOutput::Minted {
+            code: "abc123".into(),
+            expires_at: "2026-07-17T12:00:00Z".into(),
+            session_id: "sid".into(),
+            console_url: Some("http://10.0.0.5:30080/?api=1".into()),
+            login: crate::ops::login_path_for(
+                "http://10.0.0.5:30080/?api=1",
+                "agentos",
+                "agentos-ui",
+                80,
+            ),
+        };
+        let json = out.to_json();
+        assert_eq!(json["console_url"], "http://10.0.0.5:30080/?api=1");
+        assert_eq!(json["login"]["url"], "http://localhost:8080/?api=1");
+        assert_eq!(
+            json["login"]["port_forward"],
+            "kubectl -n agentos port-forward svc/agentos-ui 8080:80"
         );
     }
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2694,6 +2694,157 @@ pub async fn approvals(
     })
 }
 
+/// Shared flags for the console verbs (`<tier> console login|revoke`, #630).
+///
+/// Deliberately not `AgentActionOpts`: a console session belongs to the INSTALL,
+/// not to an agent, so there is no agent to resolve and no `agent` field to
+/// carry. Both verbs authenticate with the platform key, which is the whole
+/// point of ADR-0049 -- session management is reachable only from where the key
+/// already lives, so a session can never mint its own successor.
+pub struct ConsoleOpts {
+    pub api_url: String,
+    pub api_key: String,
+    pub dry_run: bool,
+}
+
+/// Output of `<tier> console login`: the dry-run plan, or the minted code.
+///
+/// Owns its data so `to_json`/`render` outlive the `ApiClient`. What is printed
+/// here is the single-use CODE, never the platform key: the code is a
+/// short-lived credential for exactly one session, and printing it is the
+/// mechanism by which the operator never has to handle the key.
+#[derive(Debug)]
+pub enum ConsoleLoginOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Minted {
+        code: String,
+        expires_at: String,
+        session_id: String,
+        /// The console to paste the code into, when it could be resolved. An
+        /// `Option` rather than a hard failure: a code we minted is valid even
+        /// if we cannot name the URL, and failing the mint over a cosmetic
+        /// lookup would throw away a live credential.
+        console_url: Option<String>,
+    },
+}
+
+impl crate::ui::CliOutput for ConsoleLoginOutput {
+    /// `{"code","expires_at","session_id","console_url":<string|null>}`.
+    ///
+    /// `console_url` is emitted with an explicit null rather than omitted when
+    /// unresolved, per the repo convention pinned by
+    /// `kill_output_json_shape_is_pinned`.
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            ConsoleLoginOutput::DryRun(plan) => plan.to_json(),
+            ConsoleLoginOutput::Minted {
+                code,
+                expires_at,
+                session_id,
+                console_url,
+            } => serde_json::json!({
+                "code": code,
+                "expires_at": expires_at,
+                "session_id": session_id,
+                "console_url": console_url,
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            ConsoleLoginOutput::DryRun(plan) => plan.render(ui),
+            ConsoleLoginOutput::Minted {
+                code,
+                expires_at,
+                console_url,
+                ..
+            } => {
+                ui.kv("login code", code);
+                ui.kv("expires at", expires_at);
+                match console_url {
+                    Some(url) => ui.kv("console", &ui.url(url)),
+                    None => ui.note(
+                        "could not resolve the console URL; find it with `agentos cluster status`",
+                    ),
+                }
+                ui.note("single use: open the console, paste the code, and it is spent");
+            }
+        }
+    }
+}
+
+/// `<tier> console login`: mint a single-use login code for the console
+/// (`POST /console/login-codes`, #630/ADR-0049).
+///
+/// `console_url` is resolved by the caller because the tiers resolve it
+/// differently (a fixed localhost URL vs the release's `ui` service), which is
+/// the same split `observability` already draws between the two tiers.
+pub async fn console_login(
+    opts: ConsoleOpts,
+    label: Option<String>,
+    console_url: Option<String>,
+) -> Result<ConsoleLoginOutput> {
+    if opts.dry_run {
+        return Ok(ConsoleLoginOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!("POST {}/console/login-codes", opts.api_url)],
+        }));
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let minted = client.mint_console_login_code(label.as_deref()).await?;
+    Ok(ConsoleLoginOutput::Minted {
+        code: minted.code,
+        expires_at: minted.expires_at,
+        session_id: minted.session_id,
+        console_url,
+    })
+}
+
+/// Output of `<tier> console revoke`: the dry-run plan, or the revoked count.
+#[derive(Debug)]
+pub enum ConsoleRevokeOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Done { revoked: u64 },
+}
+
+impl crate::ui::CliOutput for ConsoleRevokeOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            ConsoleRevokeOutput::DryRun(plan) => plan.to_json(),
+            ConsoleRevokeOutput::Done { revoked } => serde_json::json!({ "revoked": revoked }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            ConsoleRevokeOutput::DryRun(plan) => plan.render(ui),
+            ConsoleRevokeOutput::Done { revoked } => {
+                ui.payload(&format!("revoked {revoked} console session(s)"));
+                ui.note("mint a new way in with `console login`");
+            }
+        }
+    }
+}
+
+/// `<tier> console revoke`: revoke every live console session
+/// (`DELETE /console/sessions`, #630/ADR-0049).
+///
+/// No `--yes` confirmation gate, deliberately diverging from `kill`: this is the
+/// operator's kill switch for a credential they believe is compromised, and a
+/// prompt between them and revocation is the wrong thing to put there. It is
+/// also cheap to undo -- `console login` mints a new way in -- which is what
+/// makes the asymmetry with `kill` (which stops an agent's runs) correct.
+pub async fn console_revoke(opts: ConsoleOpts) -> Result<ConsoleRevokeOutput> {
+    if opts.dry_run {
+        return Ok(ConsoleRevokeOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!("DELETE {}/console/sessions", opts.api_url)],
+        }));
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let revoked = client.revoke_console_sessions().await?;
+    Ok(ConsoleRevokeOutput::Done { revoked })
+}
+
 /// `local observability`: print the local platform's observability surfaces --
 /// the AgentOS Console, the Langfuse UI, and the API base -- resolved through the
 /// shared tier-aware endpoint seam (`crate::observability`).
@@ -4260,6 +4411,73 @@ mod tests {
         assert_eq!(
             super::human_env_line("AGENTOS_APPROVAL_REQUIRED_TOOLS="),
             "AGENTOS_APPROVAL_REQUIRED_TOOLS=''"
+        );
+    }
+
+    /// The console-login payload shape is a contract an agent parses (#630).
+    /// `console_url` must be an explicit null when unresolved, never omitted --
+    /// the repo convention pinned by `kill_output_json_shape_is_pinned`.
+    #[test]
+    fn console_login_json_shape_is_pinned() {
+        use crate::ui::CliOutput;
+        let out = super::ConsoleLoginOutput::Minted {
+            code: "abc123".into(),
+            expires_at: "2026-07-17T12:00:00Z".into(),
+            session_id: "11111111-1111-1111-1111-111111111111".into(),
+            console_url: None,
+        };
+        let json = out.to_json();
+        assert!(
+            json.get("console_url")
+                .is_some_and(serde_json::Value::is_null),
+            "an unresolved console_url must be an explicit null, not omitted: {json}"
+        );
+        assert_eq!(json["code"], "abc123");
+        assert_eq!(json["expires_at"], "2026-07-17T12:00:00Z");
+        assert_eq!(json["session_id"], "11111111-1111-1111-1111-111111111111");
+    }
+
+    #[tokio::test]
+    async fn console_dry_run_plans_the_request_and_makes_none() {
+        use crate::ui::CliOutput;
+        // An unroutable URL: if a dry run ever sent a request, this would error
+        // rather than return a plan, so the assertion proves no call was made.
+        let opts = || super::ConsoleOpts {
+            api_url: "http://127.0.0.1:1".into(),
+            api_key: "K".into(),
+            dry_run: true,
+        };
+        let login = super::console_login(opts(), None, None).await.unwrap();
+        assert_eq!(login.to_json()["dry_run"], true);
+        assert_eq!(
+            login.to_json()["plan"][0],
+            "POST http://127.0.0.1:1/console/login-codes"
+        );
+
+        let revoke = super::console_revoke(opts()).await.unwrap();
+        assert_eq!(revoke.to_json()["dry_run"], true);
+        assert_eq!(
+            revoke.to_json()["plan"][0],
+            "DELETE http://127.0.0.1:1/console/sessions"
+        );
+    }
+
+    /// The minted code IS meant to be printed -- it is the credential that keeps
+    /// the platform key out of the browser. The platform key never is.
+    #[test]
+    fn console_login_renders_the_code_and_never_the_platform_key() {
+        use crate::ui::CliOutput;
+        let out = super::ConsoleLoginOutput::Minted {
+            code: "abc123".into(),
+            expires_at: "2026-07-17T12:00:00Z".into(),
+            session_id: "sid".into(),
+            console_url: Some("http://localhost:28080/?api=1".into()),
+        };
+        let json = out.to_json().to_string();
+        assert!(json.contains("abc123"), "the code is the point of the verb");
+        assert!(
+            !json.contains("agentos-dev-key"),
+            "the platform key must never reach the output"
         );
     }
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2805,7 +2805,6 @@ impl crate::ui::CliOutput for ConsoleLoginOutput {
 /// is the same split `observability` already draws between the two tiers.
 pub async fn console_login(
     opts: ConsoleOpts,
-    label: Option<String>,
     access: crate::ops::ConsoleAccess,
 ) -> Result<ConsoleLoginOutput> {
     if opts.dry_run {
@@ -2814,7 +2813,7 @@ pub async fn console_login(
         }));
     }
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
-    let minted = client.mint_console_login_code(label.as_deref()).await?;
+    let minted = client.mint_console_login_code().await?;
     Ok(ConsoleLoginOutput::Minted {
         code: minted.code,
         expires_at: minted.expires_at,
@@ -4476,7 +4475,7 @@ mod tests {
             api_key: "K".into(),
             dry_run: true,
         };
-        let login = super::console_login(opts(), None, Default::default())
+        let login = super::console_login(opts(), Default::default())
             .await
             .unwrap();
         assert_eq!(login.to_json()["dry_run"], true);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -92,7 +92,7 @@ impl From<ConsoleTarget> for commands::ConsoleOpts {
 /// (#630/ADR-0049).
 ///
 /// The connection flattens onto each LEAF rather than onto `console` itself, so
-/// the flags read after the verb (`console login --label x`) exactly as they do
+/// the flags read after the verb (`console login --api-key x`) exactly as they do
 /// for every other verb in this CLI. The cluster twin is a separate enum because
 /// the two tiers genuinely differ in how they connect -- localhost defaults here
 /// vs release discovery there (#524) -- which is the same split that stopped
@@ -103,9 +103,6 @@ enum LocalConsoleAction {
     Login {
         #[command(flatten)]
         target: ConsoleTarget,
-        /// Optional note recorded on the session, to tell sessions apart.
-        #[arg(long)]
-        label: Option<String>,
     },
     /// Revoke every live console session (the kill switch).
     Revoke {
@@ -123,9 +120,6 @@ enum ClusterConsoleAction {
     Login {
         #[command(flatten)]
         conn: ClusterConn,
-        /// Optional note recorded on the session, to tell sessions apart.
-        #[arg(long)]
-        label: Option<String>,
         /// Print the request that would be made and exit without executing.
         #[arg(long)]
         dry_run: bool,
@@ -1697,10 +1691,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                 // resolves from consts while the cluster twin shells kubectl.
                 // That URL is loopback, hence already a secure context, so the
                 // login exchange accepts it and there is no port-forward to name.
-                LocalConsoleAction::Login { target, label } => emit(
+                LocalConsoleAction::Login { target } => emit(
                     commands::console_login(
                         target.into(),
-                        label,
                         ops::ConsoleAccess {
                             url: Some(agentos::observability::LOCAL_CONSOLE_URL.to_string()),
                             login: None,
@@ -1853,11 +1846,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 .await?,
             ),
             ClusterAction::Console { action } => match action {
-                ClusterConsoleAction::Login {
-                    conn,
-                    label,
-                    dry_run,
-                } => {
+                ClusterConsoleAction::Login { conn, dry_run } => {
                     let common = CommonOpts {
                         namespace: conn.namespace.clone(),
                         release: conn.release.clone(),
@@ -1879,7 +1868,6 @@ async fn run(command: Option<Command>) -> Result<()> {
                                 api_key,
                                 dry_run,
                             },
-                            label,
                             access,
                         )
                         .await?,
@@ -2827,31 +2815,21 @@ mod tests {
     fn local_console_login_and_revoke_parse_with_flags_after_the_verb() {
         // The flags flatten onto the LEAF, so they read after the verb the way
         // every other verb in this CLI takes its flags.
-        match Cli::try_parse_from([
-            "agentos",
-            "local",
-            "console",
-            "login",
-            "--label",
-            "laptop",
-            "--api-key",
-            "K",
-        ])
-        .expect("local console login")
-        .command
+        match Cli::try_parse_from(["agentos", "local", "console", "login", "--api-key", "K"])
+            .expect("local console login")
+            .command
         {
             Some(Command::Local {
                 action:
                     LocalAction::Console {
-                        action: LocalConsoleAction::Login { target, label },
+                        action: LocalConsoleAction::Login { target },
                     },
             }) => {
-                assert_eq!(label.as_deref(), Some("laptop"));
                 assert_eq!(target.api_key, "K");
             }
             _ => panic!("expected local console login"),
         }
-        // --label is optional: the bare verb must mint.
+        // The bare verb must mint with no flags.
         assert!(Cli::try_parse_from(["agentos", "local", "console", "login"]).is_ok());
         assert!(matches!(
             Cli::try_parse_from(["agentos", "local", "console", "revoke"])

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1695,11 +1695,16 @@ async fn run(command: Option<Command>) -> Result<()> {
                 // The local console is always at a fixed localhost URL, so it
                 // needs no discovery -- the same reason `local observability`
                 // resolves from consts while the cluster twin shells kubectl.
+                // That URL is loopback, hence already a secure context, so the
+                // login exchange accepts it and there is no port-forward to name.
                 LocalConsoleAction::Login { target, label } => emit(
                     commands::console_login(
                         target.into(),
                         label,
-                        Some(agentos::observability::LOCAL_CONSOLE_URL.to_string()),
+                        ops::ConsoleAccess {
+                            url: Some(agentos::observability::LOCAL_CONSOLE_URL.to_string()),
+                            login: None,
+                        },
                     )
                     .await?,
                 ),
@@ -1862,10 +1867,10 @@ async fn run(command: Option<Command>) -> Result<()> {
                     // Skipped under --dry-run: the dry-run plan does not carry a
                     // console URL, so resolving one would be three kubectl calls
                     // whose only result is discarded.
-                    let console_url = if dry_run {
-                        None
+                    let access = if dry_run {
+                        ops::ConsoleAccess::default()
                     } else {
-                        ops::discover_console_url(&common).await
+                        ops::discover_console_access(&common).await
                     };
                     emit(
                         commands::console_login(
@@ -1875,7 +1880,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                                 dry_run,
                             },
                             label,
-                            console_url,
+                            access,
                         )
                         .await?,
                     )

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -45,7 +45,7 @@ struct AgentTarget<T: TierDefaults> {
     agent: String,
     #[arg(long, default_value = T::API_URL, env = "AGENTOS_API_URL")]
     api_url: String,
-    #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
+    #[arg(long, default_value = message::DEFAULT_API_KEY, env = "AGENTOS_API_KEY", hide_env_values = true, value_parser = message::api_key_or_default)]
     api_key: String,
     #[arg(long)]
     dry_run: bool,
@@ -62,6 +62,82 @@ impl<T: TierDefaults> From<AgentTarget<T>> for AgentActionOpts {
             dry_run: target.dry_run,
         }
     }
+}
+
+/// The connection flags a LOCAL console verb takes (#630): `AgentTarget<LocalTier>`
+/// minus the agent positional, because a console session belongs to the install
+/// rather than to an agent. The cluster tier uses [`ClusterConn`] instead, for
+/// the same reason every other cluster verb does: it discovers the release's key.
+#[derive(Args, Debug, Clone)]
+struct ConsoleTarget {
+    #[arg(long, default_value = LocalTier::API_URL, env = "AGENTOS_API_URL")]
+    api_url: String,
+    #[arg(long, default_value = message::DEFAULT_API_KEY, env = "AGENTOS_API_KEY", hide_env_values = true, value_parser = message::api_key_or_default)]
+    api_key: String,
+    #[arg(long)]
+    dry_run: bool,
+}
+
+impl From<ConsoleTarget> for commands::ConsoleOpts {
+    fn from(target: ConsoleTarget) -> Self {
+        commands::ConsoleOpts {
+            api_url: target.api_url,
+            api_key: target.api_key,
+            dry_run: target.dry_run,
+        }
+    }
+}
+
+/// `local console <verb>`: get into the local console, or shut every way in
+/// (#630/ADR-0049).
+///
+/// The connection flattens onto each LEAF rather than onto `console` itself, so
+/// the flags read after the verb (`console login --label x`) exactly as they do
+/// for every other verb in this CLI. The cluster twin is a separate enum because
+/// the two tiers genuinely differ in how they connect -- localhost defaults here
+/// vs release discovery there (#524) -- which is the same split that stopped
+/// `AgentTarget<T>` being shared across the tiers.
+#[derive(Subcommand, Debug, Clone)]
+enum LocalConsoleAction {
+    /// Mint a single-use login code to paste into the console.
+    Login {
+        #[command(flatten)]
+        target: ConsoleTarget,
+        /// Optional note recorded on the session, to tell sessions apart.
+        #[arg(long)]
+        label: Option<String>,
+    },
+    /// Revoke every live console session (the kill switch).
+    Revoke {
+        #[command(flatten)]
+        target: ConsoleTarget,
+    },
+}
+
+/// `cluster console <verb>`: the [`LocalConsoleAction`] twin for a real release.
+/// It carries [`ClusterConn`], so an omitted `--api-key` is DISCOVERED from the
+/// release Secret and the operator never handles the platform key.
+#[derive(Subcommand, Debug, Clone)]
+enum ClusterConsoleAction {
+    /// Mint a single-use login code to paste into the console.
+    Login {
+        #[command(flatten)]
+        conn: ClusterConn,
+        /// Optional note recorded on the session, to tell sessions apart.
+        #[arg(long)]
+        label: Option<String>,
+        /// Print the request that would be made and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Revoke every live console session (the kill switch).
+    Revoke {
+        #[command(flatten)]
+        conn: ClusterConn,
+        /// Print the request that would be made and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 /// The connection surface for a cluster governance verb (#524). Unlike the local
@@ -588,7 +664,7 @@ enum LocalAction {
         #[arg(long)]
         api_url: Option<String>,
         /// Platform API key for the default-channel lookup.
-        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, value_parser = message::api_key_or_default)]
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, hide_env_values = true, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Synthetic Slack user id for the enqueued event.
         #[arg(long, default_value = message::DEFAULT_USER)]
@@ -629,7 +705,7 @@ enum LocalAction {
         #[arg(long)]
         api_url: Option<String>,
         /// Platform API key for the default-channel lookup.
-        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, value_parser = message::api_key_or_default)]
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, hide_env_values = true, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Synthetic Slack user id for the enqueued events.
         #[arg(long, default_value = message::DEFAULT_USER)]
@@ -662,7 +738,7 @@ enum LocalAction {
         )]
         api_url: String,
         /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
+        #[arg(long, default_value = message::DEFAULT_API_KEY, env = "AGENTOS_API_KEY", hide_env_values = true, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Slack channel to bind the agent to. On first create it defaults to
         /// C0LOCALDEV; on redeploy it is only moved when you pass this flag, so
@@ -720,6 +796,11 @@ enum LocalAction {
         #[arg(long)]
         note: Option<String>,
     },
+    /// Log in to the local AgentOS Console, or revoke every console session.
+    Console {
+        #[command(subcommand)]
+        action: LocalConsoleAction,
+    },
     /// Show the local observability surfaces (AgentOS Console + Langfuse traces/cost + API base).
     Observability {
         /// Also open the browsable surfaces in a browser. Off by default: the URLs
@@ -741,7 +822,7 @@ enum LocalAction {
             env = "AGENTOS_API_URL"
         )]
         api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
+        #[arg(long, default_value = message::DEFAULT_API_KEY, env = "AGENTOS_API_KEY", hide_env_values = true, value_parser = message::api_key_or_default)]
         api_key: String,
         #[arg(long)]
         dry_run: bool,
@@ -756,7 +837,7 @@ enum LocalAction {
             env = "AGENTOS_API_URL"
         )]
         api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
+        #[arg(long, default_value = message::DEFAULT_API_KEY, env = "AGENTOS_API_KEY", hide_env_values = true, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Confirm the action.
         #[arg(long)]
@@ -774,7 +855,7 @@ enum LocalAction {
             env = "AGENTOS_API_URL"
         )]
         api_url: String,
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
+        #[arg(long, default_value = message::DEFAULT_API_KEY, env = "AGENTOS_API_KEY", hide_env_values = true, value_parser = message::api_key_or_default)]
         api_key: String,
         #[arg(long)]
         dry_run: bool,
@@ -866,6 +947,11 @@ enum ClusterAction {
         /// Print the read-only commands that would run and exit.
         #[arg(long)]
         dry_run: bool,
+    },
+    /// Log in to the release's AgentOS Console, or revoke every console session.
+    Console {
+        #[command(subcommand)]
+        action: ClusterConsoleAction,
     },
     /// Show the release's observability surfaces (AgentOS Console + Langfuse traces/cost + API base).
     Observability {
@@ -973,7 +1059,7 @@ enum ClusterAction {
         #[arg(long, default_value_t = message::DEFAULT_API_LOCAL_PORT)]
         api_local_port: u16,
         /// Platform API key for the default-channel lookup.
-        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, value_parser = message::api_key_or_default)]
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, hide_env_values = true, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Synthetic Slack user id for the enqueued event.
         #[arg(long, default_value = message::DEFAULT_USER)]
@@ -1035,7 +1121,7 @@ enum ClusterAction {
         #[arg(long, default_value_t = message::DEFAULT_API_LOCAL_PORT)]
         api_local_port: u16,
         /// Platform API key for the default-channel lookup.
-        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, value_parser = message::api_key_or_default)]
+        #[arg(long, env = "AGENTOS_API_KEY", default_value = message::DEFAULT_API_KEY, hide_env_values = true, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Synthetic Slack user id for the enqueued events.
         #[arg(long, default_value = message::DEFAULT_USER)]
@@ -1073,7 +1159,7 @@ enum ClusterAction {
         #[arg(long, default_value = "agentos")]
         release: String,
         /// Platform API key.
-        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
+        #[arg(long, default_value = message::DEFAULT_API_KEY, env = "AGENTOS_API_KEY", hide_env_values = true, value_parser = message::api_key_or_default)]
         api_key: String,
         /// Slack channel to bind the agent to. On first create it defaults to
         /// C0LOCALDEV; on redeploy it is only moved when you pass this flag, so
@@ -1605,6 +1691,22 @@ async fn run(command: Option<Command>) -> Result<()> {
                 )
                 .await?,
             ),
+            LocalAction::Console { action } => match action {
+                // The local console is always at a fixed localhost URL, so it
+                // needs no discovery -- the same reason `local observability`
+                // resolves from consts while the cluster twin shells kubectl.
+                LocalConsoleAction::Login { target, label } => emit(
+                    commands::console_login(
+                        target.into(),
+                        label,
+                        Some(agentos::observability::LOCAL_CONSOLE_URL.to_string()),
+                    )
+                    .await?,
+                ),
+                LocalConsoleAction::Revoke { target } => {
+                    emit(commands::console_revoke(target.into()).await?)
+                }
+            },
             LocalAction::Observability { open } => emit(commands::observability(open).await?),
             LocalAction::Budget {
                 agent,
@@ -1745,6 +1847,51 @@ async fn run(command: Option<Command>) -> Result<()> {
                 })
                 .await?,
             ),
+            ClusterAction::Console { action } => match action {
+                ClusterConsoleAction::Login {
+                    conn,
+                    label,
+                    dry_run,
+                } => {
+                    let common = CommonOpts {
+                        namespace: conn.namespace.clone(),
+                        release: conn.release.clone(),
+                        dry_run,
+                    };
+                    let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                    // Skipped under --dry-run: the dry-run plan does not carry a
+                    // console URL, so resolving one would be three kubectl calls
+                    // whose only result is discarded.
+                    let console_url = if dry_run {
+                        None
+                    } else {
+                        ops::discover_console_url(&common).await
+                    };
+                    emit(
+                        commands::console_login(
+                            commands::ConsoleOpts {
+                                api_url,
+                                api_key,
+                                dry_run,
+                            },
+                            label,
+                            console_url,
+                        )
+                        .await?,
+                    )
+                }
+                ClusterConsoleAction::Revoke { conn, dry_run } => {
+                    let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                    emit(
+                        commands::console_revoke(commands::ConsoleOpts {
+                            api_url,
+                            api_key,
+                            dry_run,
+                        })
+                        .await?,
+                    )
+                }
+            },
             ClusterAction::Observability {
                 namespace,
                 release,
@@ -2665,6 +2812,102 @@ mod tests {
         // local budget/kill/resume are the mirrored lifecycle verbs.
         assert!(Cli::try_parse_from(["agentos", "local", "budget", "gh", "--limit", "1"]).is_ok());
         assert!(Cli::try_parse_from(["agentos", "local", "kill", "gh", "--yes"]).is_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // Console login (#630 / ADR-0049): the only way into a sealed console.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn local_console_login_and_revoke_parse_with_flags_after_the_verb() {
+        // The flags flatten onto the LEAF, so they read after the verb the way
+        // every other verb in this CLI takes its flags.
+        match Cli::try_parse_from([
+            "agentos",
+            "local",
+            "console",
+            "login",
+            "--label",
+            "laptop",
+            "--api-key",
+            "K",
+        ])
+        .expect("local console login")
+        .command
+        {
+            Some(Command::Local {
+                action:
+                    LocalAction::Console {
+                        action: LocalConsoleAction::Login { target, label },
+                    },
+            }) => {
+                assert_eq!(label.as_deref(), Some("laptop"));
+                assert_eq!(target.api_key, "K");
+            }
+            _ => panic!("expected local console login"),
+        }
+        // --label is optional: the bare verb must mint.
+        assert!(Cli::try_parse_from(["agentos", "local", "console", "login"]).is_ok());
+        assert!(matches!(
+            Cli::try_parse_from(["agentos", "local", "console", "revoke"])
+                .expect("local console revoke")
+                .command,
+            Some(Command::Local {
+                action: LocalAction::Console {
+                    action: LocalConsoleAction::Revoke { .. }
+                }
+            })
+        ));
+    }
+
+    #[test]
+    fn cluster_console_login_defaults_its_key_to_discovery() {
+        // The whole point of ADR-0049's minting story: an omitted --api-key is
+        // DISCOVERED from the release Secret, so the operator never handles the
+        // platform key. A `Some(...)` default here would send the dev sentinel
+        // and 401 against a real release (#524).
+        match Cli::try_parse_from(["agentos", "cluster", "console", "login"])
+            .expect("cluster console login")
+            .command
+        {
+            Some(Command::Cluster {
+                action:
+                    ClusterAction::Console {
+                        action: ClusterConsoleAction::Login { conn, dry_run, .. },
+                    },
+            }) => {
+                assert_eq!(conn.api_key, None, "must discover, not default");
+                assert_eq!(conn.api_url, None, "must discover, not default");
+                assert_eq!(conn.namespace, "agentos");
+                assert_eq!(conn.release, "agentos");
+                assert!(!dry_run);
+            }
+            _ => panic!("expected cluster console login"),
+        }
+        // An explicit key still wins, matching every other cluster verb.
+        match Cli::try_parse_from(["agentos", "cluster", "console", "revoke", "--api-key", "K"])
+            .expect("cluster console revoke --api-key")
+            .command
+        {
+            Some(Command::Cluster {
+                action:
+                    ClusterAction::Console {
+                        action: ClusterConsoleAction::Revoke { conn, .. },
+                    },
+            }) => assert_eq!(conn.api_key.as_deref(), Some("K")),
+            _ => panic!("expected cluster console revoke"),
+        }
+    }
+
+    #[test]
+    fn console_verbs_accept_the_global_json_flag_and_dry_run() {
+        // ADR-0021: every verb answers a machine consumer.
+        assert!(Cli::try_parse_from(["agentos", "local", "console", "login", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["agentos", "cluster", "console", "login", "--json"]).is_ok());
+        assert!(Cli::try_parse_from(["agentos", "local", "console", "login", "--dry-run"]).is_ok());
+        assert!(
+            Cli::try_parse_from(["agentos", "cluster", "console", "revoke", "--dry-run"]).is_ok()
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1715,6 +1715,96 @@ fn node_http_url(host: &str, port: u16, path: &str) -> String {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Console secure context (#630, ADR-0049).
+// ---------------------------------------------------------------------------
+
+/// Hosts a browser treats as a secure context over plaintext, and therefore for
+/// which it honors the `Secure` console session cookie.
+///
+/// **Mirrors `apps/api/src/agentos_api/routers/console.py::_is_secure_context`
+/// and its `_LOOPBACK_HOSTS`.** The API is the authority: it refuses the
+/// `POST /console/session` exchange from any other origin. This copy exists only
+/// so the CLI can tell the operator, before they try, which URL will be accepted.
+/// A drift between the two would make the CLI confidently name a URL that then
+/// 400s, which is worse than saying nothing, so the two must be changed together.
+const LOOPBACK_HOSTS: [&str; 3] = ["localhost", "127.0.0.1", "::1"];
+
+/// The local port `console_login_path` forwards to. 8080 rather than the
+/// service's own port so the forward needs no root, and it matches the
+/// `kubectl port-forward` command the API already names in its refusal fix.
+const CONSOLE_LOCAL_PORT: u16 = 8080;
+
+/// Split a URL into its lowercased scheme and host, or None when it is not
+/// parseable as one. An IPv6 literal comes back unbracketed (`[::1]` -> `::1`),
+/// matching what Python's `urlparse(...).hostname` yields on the API side.
+fn scheme_and_host(url: &str) -> Option<(String, String)> {
+    let (scheme, rest) = url.split_once("://")?;
+    let authority = rest.split(['/', '?', '#']).next()?;
+    let authority = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    let host = match authority.strip_prefix('[') {
+        Some(after) => after.split_once(']')?.0,
+        None => authority.split(':').next()?,
+    };
+    if scheme.is_empty() || host.is_empty() {
+        return None;
+    }
+    Some((scheme.to_ascii_lowercase(), host.to_ascii_lowercase()))
+}
+
+/// Whether a browser at `url` would treat itself as a secure context, and so
+/// would keep the `Secure` console session cookie the login exchange sets.
+///
+/// Fail closed, by construction: an unparseable URL is not a secure context.
+/// See `LOOPBACK_HOSTS` for why this rule is a deliberate mirror of the API's.
+pub fn is_secure_context(url: &str) -> bool {
+    let Some((scheme, host)) = scheme_and_host(url) else {
+        return false;
+    };
+    if scheme == "https" {
+        return true;
+    }
+    scheme == "http" && LOOPBACK_HOSTS.contains(&host.as_str())
+}
+
+/// The loopback path that can actually accept a login code, for a console whose
+/// own URL cannot (a plaintext NodePort origin).
+///
+/// The CLI does not hold the forward open; it names the command, and the
+/// operator runs it. Both fields are data an agent reads under `--json`, not
+/// prose.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsoleLoginPath {
+    /// The `kubectl port-forward` command to run.
+    pub port_forward: String,
+    /// The loopback console URL that forward makes loginable.
+    pub url: String,
+}
+
+/// Build the loopback login path for a console service. Pure: no cluster contact.
+pub fn console_login_path(namespace: &str, service: &str, port: u16) -> ConsoleLoginPath {
+    ConsoleLoginPath {
+        port_forward: format!(
+            "kubectl -n {namespace} port-forward svc/{service} {CONSOLE_LOCAL_PORT}:{port}"
+        ),
+        url: format!(
+            "http://localhost:{CONSOLE_LOCAL_PORT}{}",
+            api_suffix_path(true)
+        ),
+    }
+}
+
+/// The login path for `console_url`, or None when that URL is already loginable.
+/// Pure: `console_url` is only inspected, never fetched.
+pub fn login_path_for(
+    console_url: &str,
+    namespace: &str,
+    service: &str,
+    port: u16,
+) -> Option<ConsoleLoginPath> {
+    (!is_secure_context(console_url)).then(|| console_login_path(namespace, service, port))
+}
+
 /// A usage error (exit 2) whose fix hint points the operator at `--api-url`,
 /// the escape hatch for every UI-proxy discovery failure.
 fn api_url_usage_err(msg: impl Into<String>) -> anyhow::Error {
@@ -1837,6 +1927,11 @@ pub struct ServiceUrl {
     namespace: String,
     api: bool,
     kind: ServiceUrlKind,
+    /// Set only for a console row whose resolved URL is not a secure context:
+    /// the URL is fine to print (it carries no secret and renders the console),
+    /// but the login exchange refuses that origin, so the operator also needs
+    /// the loopback path that works (#630, ADR-0049).
+    login: Option<ConsoleLoginPath>,
 }
 
 #[derive(Debug)]
@@ -1877,12 +1972,30 @@ impl ServiceUrl {
                 (None, Some(format!("could not read service {}", self.name)))
             }
         };
-        serde_json::json!({"name": self.label, "url": url, "note": note})
+        // `login` is an explicit null when the row is already loginable, per the
+        // repo convention that an agent-read payload never omits a key (#485).
+        let login = self
+            .login
+            .as_ref()
+            .map(|l| serde_json::json!({"url": l.url, "port_forward": l.port_forward}));
+        serde_json::json!({"name": self.label, "url": url, "note": note, "login": login})
     }
 
     fn render(&self, ui: &crate::ui::Ui) {
         match &self.kind {
-            ServiceUrlKind::NodePortUrl(url) => ui.kv(&self.label, &ui.url(url)),
+            ServiceUrlKind::NodePortUrl(url) => {
+                ui.kv(&self.label, &ui.url(url));
+                // The URL above still renders the console, so it stays printed
+                // unchanged. It just cannot hold a session, so name the path
+                // that can rather than leaving the operator at a login that
+                // 400s (#630, ADR-0049).
+                if let Some(login) = &self.login {
+                    ui.kv(
+                        &format!("{} login", self.label),
+                        &format!("{}  then {}", login.port_forward, ui.url(&login.url)),
+                    );
+                }
+            }
             ServiceUrlKind::NotFound => {
                 ui.kv(&self.label, &format!("service {} not found", self.name))
             }
@@ -1922,19 +2035,20 @@ async fn resolve_service_url(
     api: bool,
 ) -> ServiceUrl {
     let name = format!("{}-{}", o.release, suffix);
-    let mk = |kind| ServiceUrl {
+    let mk = |kind, login| ServiceUrl {
         label: label.to_string(),
         name: name.clone(),
         namespace: o.namespace.clone(),
         api,
         kind,
+        login,
     };
     let (ok, out, _) = match run_capture(&svc_cmd(o, suffix)).await {
         Ok(res) => res,
-        Err(_) => return mk(ServiceUrlKind::NotFound),
+        Err(_) => return mk(ServiceUrlKind::NotFound, None),
     };
     if !ok {
-        return mk(ServiceUrlKind::NotFound);
+        return mk(ServiceUrlKind::NotFound, None);
     }
     // Same discovery core as `cluster observability` (#460); this owns the
     // wording, so the status output stays byte-identical.
@@ -1946,7 +2060,19 @@ async fn resolve_service_url(
         }
         ServiceEndpoint::Unreadable => ServiceUrlKind::Unreadable,
     };
-    mk(kind)
+    // Only the console (`api`) has a login to be refused, and only a NodePort
+    // URL can be the plaintext origin that gets refused: the port-forward kinds
+    // already land the operator on loopback.
+    let login = match (&kind, api) {
+        (ServiceUrlKind::NodePortUrl(url), true) => login_path_for(
+            url,
+            &o.namespace,
+            &name,
+            parse_service(&out).map_or(0, |(_, _, port)| port),
+        ),
+        _ => None,
+    };
+    mk(kind, login)
 }
 
 /// From `kubectl get svc -o json`, return (type, first nodePort, first port).
@@ -2196,6 +2322,36 @@ pub async fn discover_console_url(opts: &CommonOpts) -> Option<String> {
         .into_iter()
         .find(|e| e.name == "AgentOS Console")
         .and_then(|e| e.url)
+}
+
+/// How to reach the release's console, and how to log into it: the URL, plus the
+/// loopback path when that URL's origin is one the login exchange refuses.
+#[derive(Debug, Default)]
+pub struct ConsoleAccess {
+    pub url: Option<String>,
+    pub login: Option<ConsoleLoginPath>,
+}
+
+/// Resolve the console URL for `cluster console login` and, when that URL is a
+/// plaintext origin, the loopback path that can actually accept the code.
+///
+/// Naming a URL the operator's browser cannot log into is the whole point of
+/// this: `cluster up --expose` ships a NodePort console, so on the topology the
+/// chart actually deploys, the URL alone is never enough (#630, ADR-0049).
+pub async fn discover_console_access(opts: &CommonOpts) -> ConsoleAccess {
+    let url = discover_console_url(opts).await;
+    let login = match &url {
+        Some(url) if !is_secure_context(url) => {
+            let name = format!("{}-ui", opts.release);
+            let port = fetch_service(opts, "ui")
+                .await
+                .and_then(|svc| parse_service(&svc))
+                .map_or(0, |(_, _, port)| port);
+            Some(console_login_path(&opts.namespace, &name, port))
+        }
+        _ => None,
+    };
+    ConsoleAccess { url, login }
 }
 
 /// The read-only commands `agentos cluster observability` runs (and prints under
@@ -3340,6 +3496,119 @@ mod tests {
             node_http_url("10.0.0.5", 30080, ""),
             "http://10.0.0.5:30080"
         );
+    }
+
+    /// The decision that decides what `cluster status` and `console login` tell
+    /// the operator. It must agree, case for case, with
+    /// `apps/api/.../routers/console.py::_is_secure_context`, which is what
+    /// actually accepts or refuses the exchange: an https origin, or a loopback
+    /// host over plaintext. Anything else, including an unparseable URL, is not.
+    #[test]
+    fn secure_context_mirrors_the_api_gate() {
+        // https passes on any host, which is the API's first branch verbatim.
+        assert!(is_secure_context("https://console.example.com/?api=1"));
+        assert!(is_secure_context("https://10.0.0.5:30080/?api=1"));
+        // Loopback over plaintext: the three hosts in the API's _LOOPBACK_HOSTS.
+        assert!(is_secure_context("http://localhost:8080/?api=1"));
+        assert!(is_secure_context("http://127.0.0.1:8080/?api=1"));
+        assert!(is_secure_context("http://[::1]:8080/?api=1"));
+        // Scheme and host are compared case-insensitively, as urlparse does.
+        assert!(is_secure_context("HTTP://LocalHost:8080/?api=1"));
+        // The NodePort console the chart actually deploys: refused at exchange.
+        assert!(!is_secure_context("http://10.0.0.5:30080/?api=1"));
+        assert!(!is_secure_context("http://node.local:30080/?api=1"));
+        // A host merely containing a loopback name is not one.
+        assert!(!is_secure_context("http://localhost.evil.example/?api=1"));
+        // Fail closed on anything unparseable, matching the API's `if not origin`.
+        assert!(!is_secure_context(""));
+        assert!(!is_secure_context("not a url"));
+        assert!(!is_secure_context("ftp://localhost/"));
+    }
+
+    #[test]
+    fn login_path_is_named_only_for_a_console_that_refuses_a_login() {
+        // A plaintext NodePort console: the operator gets the forward that works.
+        assert_eq!(
+            login_path_for("http://10.0.0.5:30080/?api=1", "agentos", "agentos-ui", 80),
+            Some(ConsoleLoginPath {
+                port_forward: "kubectl -n agentos port-forward svc/agentos-ui 8080:80".into(),
+                url: "http://localhost:8080/?api=1".into(),
+            })
+        );
+        // Already loginable: no extra noise on either output.
+        assert_eq!(
+            login_path_for(
+                "https://console.example.com/?api=1",
+                "agentos",
+                "agentos-ui",
+                80
+            ),
+            None
+        );
+        assert_eq!(
+            login_path_for("http://localhost:8080/?api=1", "agentos", "agentos-ui", 80),
+            None
+        );
+    }
+
+    /// `cluster status` must print the plain console URL (secret-free, and it
+    /// renders) AND, when that URL cannot hold a session, the loopback path that
+    /// can. Under `--json` the loopback path is data an agent reads, not prose.
+    #[test]
+    fn status_console_row_carries_the_loginable_path_for_a_plaintext_nodeport() {
+        let row = ServiceUrl {
+            label: "UI".into(),
+            name: "agentos-ui".into(),
+            namespace: "agentos".into(),
+            api: true,
+            kind: ServiceUrlKind::NodePortUrl("http://10.0.0.5:30080/?api=1".into()),
+            login: login_path_for("http://10.0.0.5:30080/?api=1", "agentos", "agentos-ui", 80),
+        };
+        let json = row.to_json();
+        assert_eq!(json["url"], "http://10.0.0.5:30080/?api=1");
+        assert_eq!(json["login"]["url"], "http://localhost:8080/?api=1");
+        assert_eq!(
+            json["login"]["port_forward"],
+            "kubectl -n agentos port-forward svc/agentos-ui 8080:80"
+        );
+    }
+
+    #[test]
+    fn status_console_row_stays_quiet_when_the_console_is_already_loginable() {
+        for url in [
+            "https://console.example.com/?api=1",
+            "http://localhost:30080/?api=1",
+        ] {
+            let row = ServiceUrl {
+                label: "UI".into(),
+                name: "agentos-ui".into(),
+                namespace: "agentos".into(),
+                api: true,
+                kind: ServiceUrlKind::NodePortUrl(url.into()),
+                login: login_path_for(url, "agentos", "agentos-ui", 80),
+            };
+            let json = row.to_json();
+            assert_eq!(json["url"], url);
+            assert!(
+                json["login"].is_null(),
+                "a loginable console must not be told to port-forward: {json}"
+            );
+        }
+    }
+
+    /// Langfuse is not a console and has no login to refuse, so a plaintext
+    /// NodePort URL there earns no port-forward advice.
+    #[test]
+    fn a_non_console_row_never_names_a_login_path() {
+        let row = ServiceUrl {
+            label: "Langfuse".into(),
+            name: "agentos-langfuse-web".into(),
+            namespace: "agentos".into(),
+            api: false,
+            kind: ServiceUrlKind::NodePortUrl("http://10.0.0.5:30081".into()),
+            login: None,
+        };
+        assert!(row.to_json()["login"].is_null());
     }
 
     #[test]

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1379,6 +1379,10 @@ impl crate::ui::CliOutput for ClusterStatusOutput {
                 for url in &s.urls {
                     url.render(ui);
                 }
+                // The console URL above carries no secret and never will
+                // (ADR-0049), so it is not a way in on its own. Name the verb
+                // that is, or the operator is left guessing at a URL that 401s.
+                ui.note("log in to the console with `agentos cluster console login`");
                 if s.total > 0 && s.ready == s.total && s.unhealthy.is_empty() {
                     ui.success(&format!("healthy ({}/{} pods ready)", s.ready, s.total));
                 } else if s.total == 0 {
@@ -2176,6 +2180,22 @@ pub async fn cluster_observability_endpoints(
         ),
         api_base_endpoint(opts, ui_svc.as_deref(), host.as_deref()),
     ]
+}
+
+/// The release's console URL for `cluster console login`, or None when it cannot
+/// be resolved.
+///
+/// Reuses the same discovery `cluster status` and `cluster observability` use,
+/// so the URL a login names is the URL those verbs print -- one resolution, not
+/// a third derivation. Returns an Option rather than erroring: a minted code is
+/// valid whether or not we can name the console, so a failed cosmetic lookup
+/// must not throw away a live credential.
+pub async fn discover_console_url(opts: &CommonOpts) -> Option<String> {
+    cluster_observability_endpoints(opts)
+        .await
+        .into_iter()
+        .find(|e| e.name == "AgentOS Console")
+        .and_then(|e| e.url)
 }
 
 /// The read-only commands `agentos cluster observability` runs (and prints under

--- a/cli/src/schema.rs
+++ b/cli/src/schema.rs
@@ -87,13 +87,25 @@ fn arg_to_value(arg: &clap::Arg) -> Value {
     obj.insert("required".into(), json!(arg.is_required_set()));
     obj.insert("global".into(), json!(arg.is_global_set()));
 
-    let defaults: Vec<String> = arg
-        .get_default_values()
-        .iter()
-        .map(|v| v.to_string_lossy().into_owned())
-        .collect();
-    if !defaults.is_empty() {
-        obj.insert("default_values".into(), json!(defaults));
+    // A credential's default is deliberately NOT emitted (#630). The console
+    // bundles this manifest into `dist/`, so any default here is a static asset
+    // served to every browser -- and `--api-key`'s default IS the API's own
+    // `Settings.api_key` default, i.e. the live platform key on a dev install.
+    // `hide_env_values` is the marker: it is already how this CLI declares "this
+    // arg carries a credential" (cli/CLAUDE.md), so keying off it means a new
+    // credential arg is covered the moment it follows the existing convention,
+    // rather than needing to be remembered here. The arg, its `--help`, and its
+    // runtime default are all unchanged; only the machine-readable snapshot
+    // stops carrying the value.
+    if !arg.is_hide_env_values_set() {
+        let defaults: Vec<String> = arg
+            .get_default_values()
+            .iter()
+            .map(|v| v.to_string_lossy().into_owned())
+            .collect();
+        if !defaults.is_empty() {
+            obj.insert("default_values".into(), json!(defaults));
+        }
     }
 
     let possible: Vec<String> = arg
@@ -144,6 +156,46 @@ mod tests {
                 ),
             )
             .subcommand(Command::new("hidden-one").hide(true))
+            .subcommand(
+                Command::new("auth").about("Auth it").arg(
+                    Arg::new("api-key")
+                        .long("api-key")
+                        .env("DEMO_API_KEY")
+                        .hide_env_values(true)
+                        .default_value("demo-dev-key")
+                        .help("Key"),
+                ),
+            )
+    }
+
+    /// A credential arg's default must never reach the manifest (#630): the
+    /// console bundles this file, so a default here is a credential served as a
+    /// static asset. The arg itself must still be described in full, or the
+    /// console's `cliCommand()` hints lose a real flag.
+    #[test]
+    fn manifest_omits_a_credential_args_default_but_keeps_the_arg() {
+        let value = manifest(&sample());
+        let subs = value["subcommands"].as_array().expect("subcommands");
+        let auth = subs.iter().find(|c| c["name"] == "auth").expect("auth");
+        let key = auth["args"]
+            .as_array()
+            .expect("auth args")
+            .iter()
+            .find(|a| a["id"] == "api-key")
+            .expect("api-key arg");
+
+        assert!(
+            key.get("default_values").is_none(),
+            "a credential default must not be emitted into the manifest: {key:?}"
+        );
+        assert!(
+            !manifest_json(&sample()).contains("demo-dev-key"),
+            "the credential value must not appear anywhere in the manifest"
+        );
+        // The arg is described, just without its value.
+        assert_eq!(key["long"], "api-key");
+        assert_eq!(key["env"], "DEMO_API_KEY");
+        assert_eq!(key["help"], "Key");
     }
 
     #[test]

--- a/docs/adr/0049-console-sessions-and-cli-minted-login-codes.md
+++ b/docs/adr/0049-console-sessions-and-cli-minted-login-codes.md
@@ -81,8 +81,8 @@ the way in, not a 500 and not a 401 -- the kill switch and the pod-log proxy are
 what an operator reaches for when the system is already sick, and neither of them
 needed Postgres to authenticate before this ADR.
 
-**A session cannot mint or manage sessions.** The three operator routes
-(`POST /console/login-codes`, `GET /console/sessions`, `DELETE /console/sessions`)
+**A session cannot mint or manage sessions.** The two operator routes
+(`POST /console/login-codes`, `DELETE /console/sessions`)
 depend on `require_platform_key`, which is the pre-existing platform-key-only
 check: a strict subset of `require_api_key`, not a second scheme. This is
 load-bearing rather than cautious. If a session cookie could mint a login code,

--- a/docs/adr/0049-console-sessions-and-cli-minted-login-codes.md
+++ b/docs/adr/0049-console-sessions-and-cli-minted-login-codes.md
@@ -1,0 +1,142 @@
+# 49. Console sessions and CLI-minted login codes
+
+Date: 2026-07-17
+
+Status: Accepted
+
+Implements [#630](https://github.com/curie-eng/agentos/issues/630).
+
+## Context
+
+The console authenticates to the API by sending the shared platform key from
+browser JavaScript. `apiKey()` (`apps/ui/src/api/config.ts`) resolves it from a
+`?api_key=` URL query parameter, else the build-time `VITE_API_KEY`, else the
+published dev default `agentos-dev-key`, and `headers()`
+(`apps/ui/src/api/client.ts`) attaches it as `X-API-Key` on every call.
+
+None of those three inputs works on a sealed install, and the way they fail is
+the problem. The chart generates a strong random `apiKey` per release
+(`charts/agentos/templates/secrets.yaml`) and injects it into the API pod only
+(`charts/agentos/templates/api.yaml`). The UI image never receives it: its
+Dockerfile bakes no `VITE_API_KEY`, so `apiKey()` falls through to the hardcoded
+dev default, which cannot match the release's random key. The console therefore
+401s until the operator reads the key out of the Kubernetes Secret and appends
+`&api_key=<real key>` to the URL that `agentos cluster status` printed.
+
+That is the whole hole. The platform key is not a page credential: it authorizes
+every router except the deliberately-scoped `state` router (ADR-0033) and the
+GitHub webhook, which means deployments, approval resolution, memory, traces,
+budgets, and the kill switch. Putting it in a URL to make the console usable
+writes a credential with that blast radius into browser history, the Referer
+header on any outbound link, proxy and ingress access logs, and shell history,
+and ships it over plaintext NodePort traffic. The `?api_key=` parameter is not a
+convenience that happens to be insecure; it is the only documented way to use a
+sealed console, so every real operator is pushed onto it.
+
+The launch scope is single operator, single tenant, self hosted. Tenant-scoped
+principals are [#151](https://github.com/curie-eng/agentos/issues/151) and are
+explicitly not in scope here. This decision must therefore close the credential
+exposure without importing an identity system.
+
+## Decision
+
+The console authenticates with a **server-managed, revocable session cookie**,
+established by exchanging a **single-use login code minted by the CLI**. The
+browser never receives the platform key on any path.
+
+**One session store.** A `console_sessions` table (Postgres, one Alembic
+revision) holds a row per session: the SHA-256 of its login code, the SHA-256 of
+its session token, both expiries, and `consumed_at` / `revoked_at`. Only hashes
+are stored, so a database read cannot replay a session. Revocation is a column
+write, which is what makes the session revocable in the sense the issue requires:
+a durable row a human can kill, not a self-contained signed token that stays
+valid until it expires.
+
+**Minting is CLI-side and never handles the key by hand.** `agentos <local|cluster>
+console login` calls `POST /console/login-codes` under the platform key and
+prints a short-lived single-use code. On a cluster it sources the key through the
+existing `discover_api_key()` (`cli/src/ops.rs`), which reads the release Secret
+and flows the value straight into the `X-API-Key` header without ever printing
+it. The operator copies a code, never the key.
+
+**Exchange sets the cookie.** The console posts the code to `POST
+/console/session`, an unauthenticated endpoint that consumes the code, mints a
+session token, and returns it as a cookie: `HttpOnly` (browser JS cannot read
+it), `Secure`, `SameSite=Strict`, `Path=/`. `HttpOnly` is what makes this
+strictly stronger than the status quo: script on the page cannot exfiltrate the
+credential it authenticates with.
+
+**One shared dependency still gates every router.** `require_api_key`
+(`apps/api/src/agentos_api/auth.py`) accepts the platform key **or** a live
+console session, in that order, and stays the single dependency every router
+depends on. The platform-key path is unchanged and hits no database, so the
+worker, runner, and CLI are untouched. This extends the shared dependency rather
+than adding a second auth scheme to a router, which is the boundary
+`apps/api/CLAUDE.md` draws.
+
+**TLS is enforced at exchange, fail-closed.** `POST /console/session` reads the
+`Origin` header and refuses with a `{error, fix}` 400 unless the origin is
+`https:` or a loopback host (`localhost`, `127.0.0.1`, `[::1]`), which browsers
+treat as a secure context and for which they honor `Secure` cookies. A plaintext
+NodePort origin is refused with the `kubectl port-forward` command as the fix.
+The cookie is therefore only ever established over a channel that protects it,
+and the failure is a legible instruction rather than a silently-unprotected
+session.
+
+**`SameSite=Strict` is the CSRF control**, backed by an `Origin` equality check
+on the exchange. The API has no CORS middleware on purpose and the console is
+strictly same-origin (`apps/ui/CLAUDE.md`), so a cross-site page can neither read
+a response nor cause the cookie to ride along on a forged request.
+
+`agentos cluster status` keeps printing the plain console URL with no secret in
+it, and now names `agentos cluster console login` as the way to get in.
+
+## Consequences
+
+The raw platform key no longer has a browser-reachable path. `?api_key=`,
+`VITE_API_KEY`, and the `agentos-dev-key` fallback are deleted from the UI rather
+than deprecated, so there is no input left to regress onto; a build-output test
+asserts the dev key string does not appear in `dist/`.
+
+Logging into the console requires CLI access to the install. For a single
+operator who already runs `agentos cluster up`, this is not a new dependency, and
+it is strictly less handling than reading a Secret by hand. It would be the wrong
+trade for a multi-user console, which is exactly what #151 exists to design.
+
+A console session costs one indexed database read per request. The platform-key
+path short-circuits before that read, so no machine caller pays it.
+
+Sessions expire on a fixed absolute lifetime with no refresh. A long-lived
+console tab will be asked to log in again. Sliding expiry is deliberately not
+built: it is speculative until an operator complains.
+
+## Alternatives considered
+
+**A password form that posts the platform key.** The console shows a password
+field, posts the key once, and gets a session cookie back. This is the
+conventional shape and needs no CLI verb. Rejected: it still hands the raw
+platform key to browser code. Script injected on the login page, a browser
+extension, or a password manager sync would capture a credential that authorizes
+deployments, approvals, and the kill switch platform-wide, and that credential
+cannot be revoked without rotating the Secret and restarting the API. The
+login-code exchange gives an attacker at that same moment nothing better than a
+single revocable session. The issue's acceptance is explicit that browser code
+must not receive the raw administrator credential, and a password field is
+browser code receiving it.
+
+**Injecting the key into the UI pod and proxying from nginx.** The UI pod already
+proxies `/api`; it could hold the key and attach the header server-side.
+Rejected: it authenticates the *pod*, not the operator, so anyone who can reach
+the NodePort is an administrator. That is a worse hole than the one being closed,
+and it is unrevocable.
+
+**A signed stateless session token (JWT-shaped), reusing the ADR-0033 idiom.**
+The `sandbox_token` HMAC pattern is proven in this codebase and needs no table.
+Rejected: it is not revocable. A stolen token stays valid until expiry, and the
+only kill switch is rotating `api_key`, which breaks the worker and runner at the
+same time. The issue requires a revocable session, and revocation wants durable
+state.
+
+**An external identity provider or OAuth.** Rejected as out of scope: it imports
+an identity system for one operator, and tenant-scoped principals are #151's
+decision to make, not this one's to pre-empt.

--- a/docs/adr/0049-console-sessions-and-cli-minted-login-codes.md
+++ b/docs/adr/0049-console-sessions-and-cli-minted-login-codes.md
@@ -68,11 +68,18 @@ credential it authenticates with.
 
 **One shared dependency still gates every router.** `require_api_key`
 (`apps/api/src/agentos_api/auth.py`) accepts the platform key **or** a live
-console session, in that order, and stays the single dependency every router
-depends on. The platform-key path is unchanged and hits no database, so the
-worker, runner, and CLI are untouched. This extends the shared dependency rather
-than adding a second auth scheme to a router, which is the boundary
-`apps/api/CLAUDE.md` draws.
+console session (cookie plus `X-Console-Session`, below), in that order, and
+stays the single dependency every router depends on. The platform-key path is
+unchanged and hits no database and requires no header, so the worker, runner, and
+CLI are untouched. This extends the shared dependency rather than adding a second
+auth scheme to a router, which is the boundary `apps/api/CLAUDE.md` draws.
+
+The order is also what keeps a database outage from taking the platform key down
+with it. A machine caller returns before the session store is ever read. A
+console caller whose read fails gets a `{error, fix}` **503** naming the CLI as
+the way in, not a 500 and not a 401 -- the kill switch and the pod-log proxy are
+what an operator reaches for when the system is already sick, and neither of them
+needed Postgres to authenticate before this ADR.
 
 **A session cannot mint or manage sessions.** The three operator routes
 (`POST /console/login-codes`, `GET /console/sessions`, `DELETE /console/sessions`)
@@ -84,19 +91,44 @@ name and would quietly defeat the fixed absolute lifetime this ADR chose. Sessio
 management is therefore reachable only from the CLI, which is where the platform
 key already lives.
 
-**TLS is enforced at exchange, fail-closed.** `POST /console/session` reads the
-`Origin` header and refuses with a `{error, fix}` 400 unless the origin is
-`https:` or a loopback host (`localhost`, `127.0.0.1`, `[::1]`), which browsers
-treat as a secure context and for which they honor `Secure` cookies. A plaintext
-NodePort origin is refused with the `kubectl port-forward` command as the fix.
-The cookie is therefore only ever established over a channel that protects it,
-and the failure is a legible instruction rather than a silently-unprotected
-session.
+**The exchange guards the browser's secure context, which is a footgun guard and
+not a transport proof.** `POST /console/session` reads the `Origin` header and
+refuses with a `{error, fix}` 400 unless the origin is `https:` or a loopback
+host (`localhost`, `127.0.0.1`, `[::1]`) -- the origins for which a browser
+considers itself a secure context and therefore honors a `Secure` cookie. A
+plaintext NodePort origin is refused with the `kubectl port-forward` command as
+the fix, instead of the browser silently discarding the cookie and the operator
+seeing an unexplained failed login.
 
-**`SameSite=Strict` is the CSRF control**, backed by an `Origin` equality check
-on the exchange. The API has no CORS middleware on purpose and the console is
-strictly same-origin (`apps/ui/CLAUDE.md`), so a cross-site page can neither read
-a response nor cause the cookie to ride along on a forged request.
+Be precise about what this is worth. The check reads scheme and hostname only;
+it is not an `Origin` equality check against an allowlist, so any `https://`
+origin passes. `Origin` is client-asserted and the transport itself is never
+inspected, so this does not enforce TLS and curl can forge the header freely.
+That costs nothing: a non-browser caller forging `Origin` obtains a session it
+could already have obtained with the same login code over the same channel. The
+gate exists for the one caller that cannot lie about its origin -- a browser --
+and its only job is to convert a silent drop into a legible instruction.
+
+**The CSRF control is the `X-Console-Session` request header, with
+`SameSite=Strict` as defense in depth.** `require_api_key` accepts the session
+cookie only when the request also carries `X-Console-Session`; the platform-key
+path never looks at it. The header is not settable on a cross-origin request
+without a CORS preflight, and the API deliberately runs no CORS middleware, so
+the preflight fails and the forged request never reaches a route. This is the
+OWASP custom-request-header defense, and it restores the structural CSRF
+immunity that `X-API-Key` had before the console's authority became a cookie.
+
+`SameSite=Strict` alone is **not** sufficient, and it is worth saying why rather
+than repeating the folklore. `SameSite` scopes to a *site*, and a site ignores
+the port. The login path this ADR prescribes is `http://localhost:8080` behind a
+port-forward, which is same-site with every other `localhost` port: any local dev
+server, any hostile package's dev server. Worse, the kill switch and resume take
+no request body, so a cross-origin auto-submitted
+`<form method="POST" action="/api/agents/<uuid>/kill">` is a CORS-*simple*
+request -- nothing preflights it, so an absent CORS middleware rejects nothing,
+and `SameSite=Strict` permits it because it is same-site. The custom header is
+what closes that; `SameSite=Strict` remains because it costs nothing and narrows
+the same class from a genuinely cross-site page.
 
 `agentos cluster status` keeps printing the plain console URL with no secret in
 it, and now names `agentos cluster console login` as the way to get in.
@@ -115,6 +147,12 @@ trade for a multi-user console, which is exactly what #151 exists to design.
 
 A console session costs one indexed database read per request. The platform-key
 path short-circuits before that read, so no machine caller pays it.
+
+Every console request must carry `X-Console-Session`, so the console's API client
+attaches it centrally (`apps/ui/src/api/client.ts`) exactly as it used to attach
+`X-API-Key`. Anything else that ever authenticates with the cookie has to do the
+same. A machine caller must NOT be made to send it: it is a browser-only defense,
+and requiring it of the CLI would buy nothing and break every existing caller.
 
 Sessions expire on a fixed absolute lifetime with no refresh. A long-lived
 console tab will be asked to log in again. Sliding expiry is deliberately not

--- a/docs/adr/0049-console-sessions-and-cli-minted-login-codes.md
+++ b/docs/adr/0049-console-sessions-and-cli-minted-login-codes.md
@@ -74,6 +74,16 @@ worker, runner, and CLI are untouched. This extends the shared dependency rather
 than adding a second auth scheme to a router, which is the boundary
 `apps/api/CLAUDE.md` draws.
 
+**A session cannot mint or manage sessions.** The three operator routes
+(`POST /console/login-codes`, `GET /console/sessions`, `DELETE /console/sessions`)
+depend on `require_platform_key`, which is the pre-existing platform-key-only
+check: a strict subset of `require_api_key`, not a second scheme. This is
+load-bearing rather than cautious. If a session cookie could mint a login code,
+it could mint its own successor indefinitely, which is a refresh token by another
+name and would quietly defeat the fixed absolute lifetime this ADR chose. Session
+management is therefore reachable only from the CLI, which is where the platform
+key already lives.
+
 **TLS is enforced at exchange, fail-closed.** `POST /console/session` reads the
 `Origin` header and refuses with a `{error, fix}` 400 unless the origin is
 `https:` or a loopback host (`localhost`, `127.0.0.1`, `[::1]`), which browsers

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -78,6 +78,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0046 | [Converged approval gates: durable provenance, loud route resolution, and observe-only resume reconciliation](0046-converged-approval-gates-and-durable-provenance.md) | Accepted |
 | 0047 | [ADR-0047: Canonical env-var names for the API base URL and model credential](0047-canonical-env-var-names.md) | Accepted |
 | 0048 | [ADR-0048: Declare the model endpoint's wire protocol and credential keys](0048-declared-model-wire-protocol-and-credential-keys.md) | Accepted |
+| 0049 | [Console sessions and CLI-minted login codes](0049-console-sessions-and-cli-minted-login-codes.md) | Accepted |
 | 0050 | [A declared approval policy is armed exactly as declared, or the runner refuses to boot](0050-declared-approval-policy-is-armed-exactly-or-not-at-all.md) | Accepted |
 | 0051 | [Eval cases run in a fresh conversation by default, with per-case opt-in shared history](0051-eval-cases-run-in-a-fresh-conversation-by-default.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Closes #630

The console authenticated by sending the shared platform admin key from browser
JavaScript, resolved from a `?api_key=` URL param, a build-time `VITE_API_KEY`, or
the published `agentos-dev-key` default. On a sealed cluster none of those match
the release's randomized key, so the only documented way in was to read the key
out of the Kubernetes Secret and paste it into the URL, writing a credential that
authorizes deploys, approval resolution, memory, budgets, and the kill switch into
browser history, referrers, and plaintext NodePort logs.

This replaces that with a revocable, server-managed session cookie, established by
exchanging a single-use login code the CLI mints. Design and rejected alternatives
are in ADR-0049.

## What changed
- **API:** a `console_sessions` store keyed on SHA-256 hashes of the login code
  and session token; single-use exchange via a `consumed_at IS NULL` compare-and-set;
  durable revocation. `require_api_key` now accepts the platform key (first, no DB
  read, machine callers untouched) or a live session cookie. The operator routes
  stay platform-key-only, so a session cannot mint its own successor.
- **UI:** the platform key and all three of its inputs are deleted from the browser.
  Every call sends the `HttpOnly` cookie via `credentials: same-origin` and carries
  no key. A login gate mounts above the data providers so a locked console never
  fetches.
- **CLI:** `agentos <local|cluster> console login` mints a code (sourcing the key
  server-side via the existing `discover_api_key`, never printing it) and
  `console revoke` is the kill switch. `cluster status` prints a secret-free URL and
  the loginable port-forward path.
- The `--api-key` flag default no longer bundles `agentos-dev-key` into the console's
  static assets.

## Security hardening (in the same change)
Moving the console's authority from a header credential to a cookie introduces a
CSRF vector the header did not have: `SameSite=Strict` ignores the port, so the
prescribed `localhost:8080` port-forward origin is same-site with every other
localhost port, and the body-less kill/resume routes are reachable by a cross-site
simple form POST. The cookie path therefore also requires an `X-Console-Session`
request header, which cannot be set cross-origin without a preflight the deliberately
absent CORS rejects. An auth-time database outage returns a 503 naming the CLI, not
an opaque 500 on the kill switch.

## Known limitation (follow-up)
The chart ships the console over plaintext NodePort with no TLS. The exchange is
fail-closed: it refuses a plaintext origin (a browser would silently drop the
`Secure` cookie) and directs the operator to `kubectl port-forward`, whose tunnel is
TLS-secured end to end. So the credential is never exposed on a cleartext wire, but
the shipped NodePort URL is not directly loginable without the port-forward. An
in-chart HTTPS ingress is a separate deployment-topology decision, deliberately out
of this minimal session change.
