### PR TITLE
Declare pydantic-settings dependency in aci-protocol

### DIFF
--- a/packages/aci-protocol/pyproject.toml
+++ b/packages/aci-protocol/pyproject.toml
@@ -5,6 +5,7 @@ description = "Frozen ACI session protocol and NDJSON event types (Pydantic sour
 requires-python = ">=3.13"
 dependencies = [
     "pydantic>=2.9",
+    "pydantic-settings>=2.7",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -28,10 +28,14 @@ version = "0.0.0"
 source = { editable = "packages/aci-protocol" }
 dependencies = [
     { name = "pydantic" },
+    { name = "pydantic-settings" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.9" }]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.9" },
+    { name = "pydantic-settings", specifier = ">=2.7" },
+]
 
 [[package]]
 name = "agentos-api"


### PR DESCRIPTION
`packages/aci-protocol/src/aci_protocol/service_config.py` imports `pydantic_settings.sources.EnvSettingsSource`, but `packages/aci-protocol/pyproject.toml` declared only `pydantic>=2.9`. The package didn't declare what it imports.

It resolves today only because `worker` and `dispatcher` pull `pydantic-settings` transitively. Importing `aci_protocol.service_config` from any consumer that doesn't already depend on `pydantic-settings` raises `ModuleNotFoundError`.

## Fix

Add `pydantic-settings>=2.7` (the same specifier the `apps/*` packages use) to `aci-protocol`'s dependencies and regenerate `uv.lock`.

This is settings plumbing, not a wire model change, so no `PROTOCOL_VERSION` bump is owed.

## Verification

- `uv sync` clean; `uv.lock` gains only the `pydantic-settings` node under `aci-protocol`
- `uv run pytest packages/aci-protocol/tests -q` -> 81 passed
- `uv run ruff check .` -> clean; `uv run mypy` -> clean
- `python -c "import aci_protocol.service_config"` now succeeds with only `aci-protocol`'s own declared deps

(The 29 failures in a full repo-root `pytest -q` run are pre-existing and environmental: no local Postgres/API server/Valkey. They are unrelated to this one-line dependency declaration.)

## Out of scope

The issue also raises whether env-var plumbing belongs in the wire-contract package (an ADR-0017-owed placement question). That's an architecture decision, deliberately left untouched here; this PR is the minimal dependency-correctness fix only. If the team decides relocation is right, it should land as its own ADR + change.

Closes #610