### PR TITLE
Backstop dead-lettered resume turns in the reconciler

### DIFF
--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -120,6 +120,23 @@ class Settings(BaseSettings):
     resume_reconciler_grace_seconds: int = 900
     resume_reconciler_batch_limit: int = 100
 
+    # Dead-lettered resume backstop (#532): each reconciler pass first scans the
+    # graveyard for resume turns that reached the runs stream (resumed_at marked)
+    # but then died at the worker's delivery cap (#505) and were dead-lettered,
+    # re-opening them (resumed_at -> NULL) so the reconcile pass re-enqueues them.
+    #
+    # resume_dead_letter_stream overrides the graveyard stream the backstop scans;
+    # empty derives `<runs_stream>:dead`. It MUST match the worker's
+    # AGENTOS_DEAD_LETTER_STREAM / its `<stream>:dead` derivation, or the backstop
+    # reads the wrong stream.
+    #
+    # resume_dead_letter_scan_limit caps the graveyard rows scanned per pass
+    # (XRANGE COUNT). Resume-turn dead-letters are rare and the graveyard is
+    # MAXLEN-bounded, so this only caps a pathological scan; a row beyond the cap
+    # is picked up on a later pass as the graveyard trims.
+    resume_dead_letter_stream: str = ""
+    resume_dead_letter_scan_limit: int = 1000
+
     # The Slack bot token the API uses for its OWN user-group lookups (#420),
     # rather than trusting a caller's claim about who is in a group. The same
     # token the dispatcher and worker already hold; empty is the normal state

--- a/apps/api/src/agentos_api/crud.py
+++ b/apps/api/src/agentos_api/crud.py
@@ -502,6 +502,51 @@ async def mark_approval_resumed(session: AsyncSession, approval_id: uuid.UUID) -
     await session.commit()
 
 
+async def reopen_dead_lettered_resume(
+    session: AsyncSession, approval_id: uuid.UUID, *, dead_lettered_after: datetime
+) -> bool:
+    """Re-open an approval whose DELIVERED resume turn was dead-lettered (#532).
+
+    A resume turn that reached the runs stream (so ``resumed_at`` was marked)
+    can still die at the worker's delivery cap (#505) and be moved to the
+    graveyard, acked off, and never woken -- a row the NULL-gated finder cannot
+    re-select. Clearing ``resumed_at`` puts it back on the reconciler's owed-wake
+    work-list so the standard reconcile pass re-enqueues it. Conditional UPDATE
+    mirroring ``mark_approval_resumed``; returns whether a row was re-opened.
+
+    The ``resumed_at < dead_lettered_after`` guard is LOAD-BEARING for
+    idempotency: it fires only when the CURRENTLY-marked wake predates THIS
+    dead-letter, so a graveyard row that persists across passes (the stream is
+    only approximately trimmed) cannot repeatedly re-open a row that has since
+    been re-enqueued -- its new ``resumed_at`` is newer than the row's
+    dead-letter time. A genuinely new dead-letter carries a newer time and
+    re-triggers. A row already re-opened (``resumed_at`` NULL) matches zero rows,
+    so the standard NULL-gated reconciler owns it, never this path.
+
+    The comparison is a CROSS-NODE clock comparison: ``resumed_at`` is stamped
+    by Postgres (``func.now()`` on the inline mark path) or the API pod clock
+    (``datetime.now(UTC)`` on the reconcile re-enqueue path), while
+    ``dead_lettered_after`` is the worker pod's clock (``dl_dead_lettered_at``).
+    It is safe because the gap between marking a wake and exhausting the
+    delivery cap is minutes, dwarfing realistic NTP skew.
+    """
+
+    result = await session.execute(
+        update(Approval)
+        .where(
+            Approval.id == approval_id,
+            Approval.status.in_(_RESUMABLE_STATUSES),
+            Approval.resumed_at.is_not(None),
+            Approval.resumed_at < dead_lettered_after,
+        )
+        .values(resumed_at=None)
+        .returning(Approval.id)
+    )
+    reopened = result.scalar_one_or_none() is not None
+    await session.commit()
+    return reopened
+
+
 # The statuses an owed-wake row can carry: a terminal outcome that must still
 # reach its suspended session. ``expired`` belongs here since #412 gave both
 # expiry paths (the sweeper and the resolve-path expiry branch) a resume turn of

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -63,7 +63,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.valkey = valkey
     app.state.kill_switch = KillSwitch(valkey)
     app.state.eval_queue = EvalQueue(valkey)
-    app.state.resume_queue = ResumeQueue(valkey, stream=settings.runs_stream)
+    app.state.resume_queue = ResumeQueue(
+        valkey,
+        stream=settings.runs_stream,
+        dead_letter_stream=settings.resume_dead_letter_stream or None,
+    )
     # The composition root for approvals (#420, ADR-0034): the only place that
     # names Slack to build the approver-set selector, so the authorizer and the
     # resolve endpoint depend on ports rather than on a provider. The usergroup
@@ -96,6 +100,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         interval_seconds=settings.resume_reconciler_interval_seconds,
         grace_seconds=settings.resume_reconciler_grace_seconds,
         batch_limit=settings.resume_reconciler_batch_limit,
+        dead_letter_scan_limit=settings.resume_dead_letter_scan_limit,
     )
     app.state.resume_reconciler = reconciler
     app.state.resume_reconciler_task = (

--- a/apps/api/src/agentos_api/resumequeue.py
+++ b/apps/api/src/agentos_api/resumequeue.py
@@ -12,6 +12,7 @@ holding the model's JSON). The turn's ``event_id`` is deterministic per
 approval, so the worker's done-marker dedupes any double-enqueue.
 """
 
+import uuid
 from datetime import UTC, datetime
 from typing import Any
 
@@ -26,6 +27,25 @@ def resume_event_id(approval_id: object) -> str:
     """The deterministic idempotency key of an approval's resume turn."""
 
     return f"approval-{approval_id}-resolved"
+
+
+def parse_resume_event_id(event_id: str) -> uuid.UUID | None:
+    """The inverse of ``resume_event_id``: recover the approval id, or None.
+
+    Strips the ``approval-`` prefix and the ``-resolved`` suffix (the historical
+    shared key both the resolve and expiry paths use -- see
+    ``build_expiry_resume_turn``) and parses the middle as a UUID. Returns None
+    when the shape does not match or the middle is not a valid UUID, so the
+    dead-letter scan never mistakes a non-resume graveyard row for an approval.
+    """
+
+    if not event_id.startswith("approval-") or not event_id.endswith("-resolved"):
+        return None
+    middle = event_id[len("approval-") : -len("-resolved")]
+    try:
+        return uuid.UUID(middle)
+    except ValueError:
+        return None
 
 
 def _build_turn(approval: Approval, *, author: str, text: str) -> QueuedTurn:
@@ -121,7 +141,13 @@ def resume_turn_for(approval: Approval) -> QueuedTurn:
 class ResumeQueue:
     """Producer half of the resume seam (the worker's runs consumer is the other)."""
 
-    def __init__(self, client: redis.Redis, stream: str | None = None) -> None:
+    def __init__(
+        self,
+        client: redis.Redis,
+        stream: str | None = None,
+        *,
+        dead_letter_stream: str | None = None,
+    ) -> None:
         # The runs stream is declared once, on the settings object (#492): the
         # module constant this used to default to was a second declaration of
         # the same name. Settings.runs_stream defaults to the shared
@@ -130,8 +156,47 @@ class ResumeQueue:
         # when the queue is built, not at import time.
         self._client = client
         self._stream = stream if stream is not None else get_settings().runs_stream
+        # The graveyard the #532 backstop scans (READ-ONLY here; the API never
+        # mutates it). The derivation MUST match the worker's
+        # WorkerConfig.dead_letter_stream_name() (`<stream>:dead`). An operator
+        # who overrides the worker's AGENTOS_DEAD_LETTER_STREAM or AGENTOS_STREAM
+        # must set the API's override to match, or the backstop reads the wrong
+        # graveyard.
+        self._dead_letter_stream = dead_letter_stream or f"{self._stream}:dead"
 
     async def enqueue(self, turn: QueuedTurn) -> str:
         fields: dict[Any, Any] = {STREAM_PAYLOAD_FIELD: turn.model_dump_json()}
         stream_id = await self._client.xadd(self._stream, fields)
         return stream_id.decode() if isinstance(stream_id, bytes) else str(stream_id)
+
+    async def read_dead_letter(
+        self, *, count: int
+    ) -> list[tuple[str, dict[str, str]]]:
+        """Read up to ``count`` MOST-RECENT graveyard rows, newest-first
+        (READ-ONLY; never XDEL/XACK).
+
+        Scans with ``xrevrange`` so a freshly dead-lettered resume turn (which
+        lands at the newest end of the graveyard) is seen promptly even when
+        older graveyard rows have not yet evicted and the scan cap sits below
+        the worker's graveyard MAXLEN.
+
+        Normalizes each entry id and every field key/value from bytes-or-str to
+        str (the same bytes-guard ``enqueue`` applies to the xadd id), so the
+        caller sees plain strings regardless of the client's decode_responses
+        setting.
+        """
+
+        entries = await self._client.xrevrange(self._dead_letter_stream, count=count)
+        result: list[tuple[str, dict[str, str]]] = []
+        for entry_id, fields in entries or []:
+            entry_id_str = (
+                entry_id.decode() if isinstance(entry_id, bytes) else str(entry_id)
+            )
+            fields_str = {
+                (k.decode() if isinstance(k, bytes) else str(k)): (
+                    v.decode() if isinstance(v, bytes) else str(v)
+                )
+                for k, v in (fields or {}).items()
+            }
+            result.append((entry_id_str, fields_str))
+        return result

--- a/apps/api/src/agentos_api/resumereconciler.py
+++ b/apps/api/src/agentos_api/resumereconciler.py
@@ -16,6 +16,12 @@ expiry wake the one permanently unrecoverable case. Which turn a candidate owes
 follows from its status, so the reconciler defers to ``resume_turn_for`` rather
 than carrying the mapping itself.
 
+Each pass is two steps (#532): ``reopen_dead_lettered_resumes`` first re-opens
+any approval whose DELIVERED resume turn (``resumed_at`` set) died at the
+worker's delivery cap and was dead-lettered -- a case the NULL-gated finder
+above cannot re-select -- then ``reconcile_once`` re-enqueues every owed wake,
+so a row re-opened this pass is re-enqueued in the same pass.
+
 Three qualifications shape the design:
 
 - **Grace window (load-bearing).** ``reconcile_once`` only considers records
@@ -52,14 +58,50 @@ Three qualifications shape the design:
 
 import asyncio
 import logging
+import uuid
 from datetime import UTC, datetime, timedelta
 
+from aci_protocol import QueuedTurn
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from . import crud
-from .resumequeue import ResumeQueue, resume_turn_for
+from .resumequeue import ResumeQueue, parse_resume_event_id, resume_turn_for
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_dead_lettered_resume(
+    fields: dict[str, str],
+) -> tuple[uuid.UUID, datetime] | None:
+    """Decode a graveyard row into ``(approval_id, dead_lettered_at)`` or None.
+
+    Returns None for any row the scan cannot act on: no ``payload`` field, a
+    payload that is not a valid ``QueuedTurn``, an ``event_id`` that is not a
+    resume key, a missing ``dl_dead_lettered_at``, or one that does not parse.
+    The timestamp is normalized to naive UTC to compare against the naive
+    ``resumed_at`` column.
+    """
+
+    payload = fields.get("payload")
+    if payload is None:
+        return None
+    try:
+        turn = QueuedTurn.model_validate_json(payload)
+    except ValidationError:
+        return None
+    approval_id = parse_resume_event_id(turn.event_id)
+    if approval_id is None:
+        return None
+    raw = fields.get("dl_dead_lettered_at")
+    if raw is None:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    dt_naive = dt.astimezone(UTC).replace(tzinfo=None) if dt.tzinfo else dt
+    return approval_id, dt_naive
 
 
 class ResumeReconciler:
@@ -73,12 +115,14 @@ class ResumeReconciler:
         interval_seconds: int,
         grace_seconds: int,
         batch_limit: int,
+        dead_letter_scan_limit: int = 1000,
     ) -> None:
         self._sessionmaker = sessionmaker
         self._resume_queue = resume_queue
         self._interval_seconds = interval_seconds
         self._grace_seconds = grace_seconds
         self._batch_limit = batch_limit
+        self._dead_letter_scan_limit = dead_letter_scan_limit
 
     async def reconcile_once(self) -> int:
         """Re-enqueue every owed wake past the grace horizon; return the count.
@@ -128,8 +172,75 @@ class ResumeReconciler:
                 logger.info("approval %s resume turn re-enqueued", approval_id)
         return count
 
+    async def reopen_dead_lettered_resumes(self) -> int:
+        """Re-open approvals whose DELIVERED resume turn was dead-lettered (#532).
+
+        The gap: a resume turn that reached the runs stream (so ``resumed_at`` was
+        marked by the inline path) can still die at the worker's delivery cap
+        (#505). The worker moves it to the ``<runs>:dead`` graveyard and acks it
+        off, so the sandbox never woke -- yet ``resumed_at`` is SET, and the
+        NULL-gated finder (``list_resolved_unresumed``) never re-selects it. Such
+        a row is stranded forever without this pass.
+
+        The signal is a graveyard row whose payload ``event_id`` decodes back to
+        an approval id via ``parse_resume_event_id``. For each such row this pass
+        clears ``resumed_at`` (re-opens the approval) and DEFERS the actual
+        re-enqueue to the standard ``reconcile_once`` pass -- ``run_forever``
+        runs this immediately before it each cycle, so a row re-opened here is
+        re-enqueued in the same cycle.
+
+        Eviction / best-effort contract: the graveyard is bounded by an
+        approximate MAXLEN, so a row is transient -- act only while it exists, and
+        never assume permanence. A row beyond the scan cap is picked up on a later
+        pass as the graveyard trims.
+
+        Idempotency: ``crud.reopen_dead_lettered_resume`` only fires when the
+        currently-marked ``resumed_at`` predates the row's dead-letter time, so a
+        row that persists across passes cannot re-open a row already re-enqueued
+        (its new ``resumed_at`` is newer). And a row already re-opened
+        (``resumed_at`` NULL) is owned by the standard NULL-gated finder, never
+        this path. A Valkey read failure logs and returns the count so far -- a
+        graveyard read blip never kills the pass (mirrors ``reconcile_once``'s
+        per-record isolation).
+        """
+
+        count = 0
+        try:
+            entries = await self._resume_queue.read_dead_letter(
+                count=self._dead_letter_scan_limit
+            )
+        except Exception:
+            logger.warning(
+                "resume dead-letter scan read failed, skipping this pass",
+                exc_info=True,
+            )
+            return count
+
+        for _entry_id, fields in entries:
+            parsed = _parse_dead_lettered_resume(fields)
+            if parsed is None:
+                continue
+            approval_id, dead_lettered_at = parsed
+            async with self._sessionmaker() as session:
+                reopened = await crud.reopen_dead_lettered_resume(
+                    session, approval_id, dead_lettered_after=dead_lettered_at
+                )
+            if reopened:
+                count += 1
+                logger.info(
+                    "approval %s resume turn was dead-lettered; re-opened as an "
+                    "owed wake",
+                    approval_id,
+                )
+        return count
+
     async def run_forever(self) -> None:
         """Reconcile on the interval forever; never die from a reconcile error.
+
+        Each pass is two steps: first ``reopen_dead_lettered_resumes`` re-opens
+        any approval whose delivered resume turn was dead-lettered (#532), then
+        ``reconcile_once`` re-enqueues every owed wake -- so a row re-opened this
+        pass is re-enqueued in the same pass.
 
         The loop sleeps before each pass (including the first): the inline path
         handles the common case, so a just-started pod need not sweep instantly,
@@ -140,6 +251,7 @@ class ResumeReconciler:
         while True:
             await asyncio.sleep(self._interval_seconds)
             try:
+                await self.reopen_dead_lettered_resumes()
                 await self.reconcile_once()
             except asyncio.CancelledError:
                 raise

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -72,6 +72,9 @@ def valkey(runs_stream: str) -> Iterator[redis.Redis]:
         pytest.skip(f"Valkey not reachable: {exc}")
     yield client
     client.delete(runs_stream)
+    # #532's graveyard-scan tests write to the dead-letter stream too; clean it
+    # between tests so a persisted row never leaks into the next test's scan.
+    client.delete(runs_stream + ":dead")
     client.close()
 
 
@@ -667,3 +670,340 @@ def test_reconciler_skips_row_locked_by_concurrent_claim(
     turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
     assert turn.event_id == f"approval-{approval_id}-resolved"
     assert resumed_at is not None
+
+
+# --- #532: dead-lettered resume backstop ---------------------------------------
+#
+# The NULL-gated finder (`list_resolved_unresumed`) misses a resume turn that
+# DID reach the runs stream (so `resumed_at` is SET) and then died at the worker's
+# delivery cap (#505): the worker moves it to the `<runs>:dead` graveyard and acks
+# it off, leaving `resumed_at` set but the sandbox never woken. `#532` adds a
+# graveyard-scan pass that RE-OPENS such approvals (clears `resumed_at`) so the
+# existing reconcile pass re-enqueues them. These tests seed a real graveyard row
+# and assert the real `resumed_at` NULL<->set transitions and stream landings.
+
+
+def _dl_iso(seconds_ago: float = 0.0) -> str:
+    """A tz-aware UTC ISO-8601 ``now - seconds_ago`` ending in ``+00:00``.
+
+    The worker stamps ``dl_dead_lettered_at`` with ``datetime.now(UTC).isoformat()``;
+    the backstop parses it to naive UTC to compare against the naive ``resumed_at``
+    column. Seeding with the same tz-aware shape keeps the parse honest.
+    """
+
+    return (datetime.now(UTC) - timedelta(seconds=seconds_ago)).isoformat()
+
+
+def _seed_graveyard_row(
+    valkey: redis.Redis,
+    runs_stream: str,
+    approval_id: uuid.UUID,
+    *,
+    dead_lettered_at: str,
+    status: str = ApprovalStatus.approved,
+    resolved_by: str | None = "U9",
+) -> None:
+    """Seed one dead-lettered resume turn onto ``<runs>:dead``, sync, as the worker
+    would: the QueuedTurn's ``event_id`` is ``resume_event_id(approval_id)`` (so the
+    backstop parses it back to this approval), plus the ``dl_*`` metadata columns."""
+
+    from agentos_api.resumequeue import build_resume_turn
+
+    approval = _detached_approval(status, resolved_by=resolved_by)
+    approval.id = approval_id
+    turn = build_resume_turn(approval)
+    valkey.xadd(
+        f"{runs_stream}:dead",
+        {
+            "payload": turn.model_dump_json(),
+            "dl_dead_lettered_at": dead_lettered_at,
+            "dl_original_id": "1-0",
+            "dl_delivery_count": "5",
+            "dl_reason": "max delivery exceeded",
+        },
+    )
+
+
+def test_reopen_dead_lettered_resume_reenqueues_owed_wake(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """Core AC: a delivered-but-dead-lettered wake is detected, re-opened, and
+    re-enqueued -- the gap the NULL-gated finder alone cannot close.
+
+    The row carries ``resolved_at`` set AND ``resumed_at`` set (the wake reached
+    the stream, so the inline path marked it) yet the sandbox never woke because
+    the turn died at the delivery cap and was dead-lettered. First prove the gap:
+    a bare ``reconcile_once`` enqueues nothing and leaves ``resumed_at`` set,
+    because ``list_resolved_unresumed`` filters ``resumed_at IS NULL``. Then the
+    graveyard scan re-opens it (``resumed_at`` -> NULL) and the very next
+    ``reconcile_once`` re-enqueues the resume turn and re-marks it.
+    """
+
+    async def insert_and_prove_gap(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[uuid.UUID, int, datetime | None]:
+        approval_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(3600),
+            resumed_at=_naive(1800),
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker,
+            queue,
+            interval_seconds=30,
+            grace_seconds=0,
+            batch_limit=100,
+            dead_letter_scan_limit=1000,
+        )
+        gap_count = await reconciler.reconcile_once()
+        return approval_id, gap_count, await _resumed_at(sessionmaker, approval_id)
+
+    approval_id, gap_count, gap_resumed = _run_async(insert_and_prove_gap, runs_stream)
+
+    # The gap: the finder never re-selects a row whose resumed_at is set.
+    assert gap_count == 0
+    assert valkey.xrange(runs_stream) == []
+    assert gap_resumed is not None
+
+    # A graveyard row dead-lettered AFTER the wake was marked delivered.
+    _seed_graveyard_row(
+        valkey, runs_stream, approval_id, dead_lettered_at=_dl_iso(0)
+    )
+
+    async def reopen_then_reconcile(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[int, datetime | None, int, datetime | None]:
+        reconciler = ResumeReconciler(
+            sessionmaker,
+            queue,
+            interval_seconds=30,
+            grace_seconds=0,
+            batch_limit=100,
+            dead_letter_scan_limit=1000,
+        )
+        reopened = await reconciler.reopen_dead_lettered_resumes()
+        resumed_after_reopen = await _resumed_at(sessionmaker, approval_id)
+        reconcile_count = await reconciler.reconcile_once()
+        return (
+            reopened,
+            resumed_after_reopen,
+            reconcile_count,
+            await _resumed_at(sessionmaker, approval_id),
+        )
+
+    reopened, resumed_after_reopen, reconcile_count, resumed_final = _run_async(
+        reopen_then_reconcile, runs_stream
+    )
+
+    assert reopened == 1
+    assert resumed_after_reopen is None  # the backstop cleared it
+    assert reconcile_count == 1
+    assert resumed_final is not None  # the re-enqueue re-marked it
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    turn = QueuedTurn.model_validate(json.loads(entries[0][1]["payload"]))
+    assert turn.event_id == f"approval-{approval_id}-resolved"
+
+
+def test_reopen_is_idempotent_against_persistent_graveyard_row(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """A graveyard row that survives across passes (the stream's MAXLEN has not
+    evicted it) is re-opened at most once: the ``resumed_at < dl_dead_lettered_at``
+    guard fails on the second pass because the re-enqueue re-marked ``resumed_at``
+    to a time NEWER than the row's dead-letter timestamp. No duplicate wake.
+    """
+
+    async def insert(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> uuid.UUID:
+        return await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(3600),
+            resumed_at=_naive(1800),
+        )
+
+    approval_id = _run_async(insert, runs_stream)
+
+    # Dead-lettered between the original wake (30m ago) and now, so the FIRST
+    # reopen matches; the re-enqueue then re-marks resumed_at to now (> this).
+    _seed_graveyard_row(
+        valkey, runs_stream, approval_id, dead_lettered_at=_dl_iso(1500)
+    )
+
+    async def reopen_reconcile_reopen(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[int, datetime | None, int, int, datetime | None]:
+        reconciler = ResumeReconciler(
+            sessionmaker,
+            queue,
+            interval_seconds=30,
+            grace_seconds=0,
+            batch_limit=100,
+            dead_letter_scan_limit=1000,
+        )
+        first = await reconciler.reopen_dead_lettered_resumes()
+        resumed_after_reopen = await _resumed_at(sessionmaker, approval_id)
+        reconcile_count = await reconciler.reconcile_once()
+        # The row is STILL present in the graveyard; a second scan must no-op.
+        second = await reconciler.reopen_dead_lettered_resumes()
+        return (
+            first,
+            resumed_after_reopen,
+            reconcile_count,
+            second,
+            await _resumed_at(sessionmaker, approval_id),
+        )
+
+    first, resumed_after_reopen, reconcile_count, second, resumed_final = _run_async(
+        reopen_reconcile_reopen, runs_stream
+    )
+
+    assert first == 1
+    assert resumed_after_reopen is None
+    assert reconcile_count == 1
+    assert second == 0  # the guard rejects the now-newer resumed_at
+    assert resumed_final is not None  # not re-cleared: no duplicate wake
+    # Exactly one re-enqueue reached the stream across both scans.
+    assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_reopen_ignores_stale_graveyard_row(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """A graveyard row OLDER than the approval's current ``resumed_at`` is a
+    successful LATER delivery's stale corpse, not an owed wake: re-opening it would
+    re-wake a session that already resumed. The ``resumed_at < dl_dead_lettered_at``
+    guard excludes it -- 0 re-opened, ``resumed_at`` untouched.
+    """
+
+    async def insert(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> uuid.UUID:
+        return await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(3600),
+            resumed_at=_naive(0),  # woke just now, AFTER the dead-letter below
+        )
+
+    approval_id = _run_async(insert, runs_stream)
+    _seed_graveyard_row(
+        valkey, runs_stream, approval_id, dead_lettered_at=_dl_iso(3600)
+    )
+
+    async def reopen(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[int, datetime | None]:
+        reconciler = ResumeReconciler(
+            sessionmaker,
+            queue,
+            interval_seconds=30,
+            grace_seconds=0,
+            batch_limit=100,
+            dead_letter_scan_limit=1000,
+        )
+        count = await reconciler.reopen_dead_lettered_resumes()
+        return count, await _resumed_at(sessionmaker, approval_id)
+
+    count, resumed_at = _run_async(reopen, runs_stream)
+
+    assert count == 0
+    assert resumed_at is not None  # the later delivery's mark stands
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_reopen_ignores_malformed_and_non_resume_rows(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """The scan tolerates graveyard rows it cannot act on -- no payload, an
+    unparseable payload, or a valid turn whose ``event_id`` is not a resume id --
+    returning 0 and never raising. An unrelated delivered approval is untouched,
+    proving the scan clears only rows it positively matched to a resume event.
+    """
+
+    from aci_protocol import ReplyHandle
+
+    async def insert(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> uuid.UUID:
+        return await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(3600),
+            resumed_at=_naive(0),
+        )
+
+    unrelated_id = _run_async(insert, runs_stream)
+
+    dead = f"{runs_stream}:dead"
+    # (a) metadata-only row: no payload field at all.
+    valkey.xadd(
+        dead,
+        {
+            "dl_dead_lettered_at": _dl_iso(0),
+            "dl_original_id": "1-0",
+            "dl_delivery_count": "5",
+            "dl_reason": "max delivery exceeded",
+        },
+    )
+    # (b) payload that is not valid QueuedTurn JSON.
+    valkey.xadd(
+        dead,
+        {"payload": "this is not json", "dl_dead_lettered_at": _dl_iso(0)},
+    )
+    # (c) a valid QueuedTurn whose event_id is NOT a resume id.
+    non_resume = QueuedTurn(
+        event_id="eval-123",
+        conversation_id="th-eval",
+        author="system",
+        text="not a resume turn",
+        reply_handle=ReplyHandle(channel="C1", placeholder="p-1", endpoint=None),
+        received_at=datetime.now(UTC).isoformat(),
+    )
+    valkey.xadd(
+        dead,
+        {"payload": non_resume.model_dump_json(), "dl_dead_lettered_at": _dl_iso(0)},
+    )
+
+    async def reopen(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[int, datetime | None]:
+        reconciler = ResumeReconciler(
+            sessionmaker,
+            queue,
+            interval_seconds=30,
+            grace_seconds=0,
+            batch_limit=100,
+            dead_letter_scan_limit=1000,
+        )
+        count = await reconciler.reopen_dead_lettered_resumes()
+        return count, await _resumed_at(sessionmaker, unrelated_id)
+
+    count, unrelated_resumed = _run_async(reopen, runs_stream)
+
+    assert count == 0
+    assert unrelated_resumed is not None  # untouched by the tolerant scan
+    assert valkey.xrange(runs_stream) == []
+
+
+def test_parse_resume_event_id_inverts_resume_event_id() -> None:
+    """``parse_resume_event_id`` is the exact inverse of ``resume_event_id`` for a
+    real resume key, and returns None for anything that is not one -- so the scan
+    never mistakes a non-resume graveyard row for an approval to re-open.
+
+    Pure unit: no DB, no Valkey. The UUID round-trip is the load-bearing case;
+    the None cases fence the malformed shapes the scan must skip.
+    """
+
+    from agentos_api.resumequeue import parse_resume_event_id, resume_event_id
+
+    approval_id = uuid.uuid4()
+    assert parse_resume_event_id(resume_event_id(approval_id)) == approval_id
+
+    assert parse_resume_event_id("eval-123") is None
+    assert parse_resume_event_id("approval--resolved") is None
+    assert parse_resume_event_id("approval-not-a-uuid-resolved") is None
+    assert parse_resume_event_id(uuid.uuid4().hex) is None


### PR DESCRIPTION
## Problem

A resume turn that reaches the `agentos:runs` stream marks `resumed_at`, then can die at the worker's delivery cap and be moved to the dead-letter graveyard and acked off. The approval is then resolved with `resumed_at` set but its sandbox never woke, and the reconciler's `resumed_at IS NULL` finder never re-selects it, so it is stranded forever. This is the pre-existing gap that bounded delivery (#505 / ADR-0039) makes visible and localized, and matches the shape seen in cold-start E2E run 6.

## Change

- Add a graveyard-scan pass (`ResumeReconciler.reopen_dead_lettered_resumes`) that runs immediately before `reconcile_once` each cycle. It reads the `<runs>:dead` graveyard (read-only, newest-first), maps each resume turn's `event_id` back to its approval via `parse_resume_event_id`, and clears `resumed_at` so the standard reconcile pass re-enqueues the owed wake in the same cycle.
- Idempotency is a load-bearing conditional UPDATE guard (`resumed_at < dead_lettered_after`): a graveyard row that persists across passes (the graveyard has an approximate MAXLEN, so this is eviction-safe and never assumes the row is permanent) cannot repeatedly re-open a row that has since been re-enqueued; a genuinely newer dead-letter carries a newer timestamp and re-triggers. A row already re-opened (`resumed_at` NULL) is owned by the standard NULL-gated finder, never this path.
- Derive the graveyard stream as `<runs_stream>:dead` to match the worker's `WorkerConfig.dead_letter_stream_name()`, with a `resume_dead_letter_stream` override and a `resume_dead_letter_scan_limit` knob. The API only reads the graveyard (never XDEL/XACK).

Scoped to `apps/api`, deliberately outside the single-stream worker-kernel scope of #505. Builds to the intent of ADR-0039 (bounded delivery) and #411 (resume reconciler).

## Tests

New tests assert real `resumed_at` NULL<->set transitions and real stream landings against Postgres + Valkey (no mocks): the core detect-reopen-reenqueue path (first proving the gap that a bare `reconcile_once` misses it), idempotency against a persistent graveyard row, stale-row exclusion, malformed/non-resume row tolerance, and a `parse_resume_event_id` unit round-trip. `uv run pytest apps/api/tests` is green apart from one pre-existing environmental Langfuse connection test; `ruff` and `mypy` clean.

Closes #532