### PR TITLE
Eval cases run in a fresh conversation by default

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1073,7 +1073,7 @@
         "type": "string"
       },
       "EvalCaseOut": {
-        "description": "An eval case conforming to the frozen eval-case format (#8, ADR-0019):\nan input prompt plus the grader that judges the answer. Emitted by the\npromote-a-trace-to-an-eval-case endpoint (#259).",
+        "description": "An eval case conforming to the frozen eval-case format (#8, ADR-0019):\nan input prompt plus the grader that judges the answer. Emitted by the\npromote-a-trace-to-an-eval-case endpoint (#259).\n\n``shared_history`` mirrors the worker's ``EvalCase`` field (#550, ADR-0051):\na promoted trace is a standalone case, so it emits the ``False`` default\n(fresh conversation). Kept here to satisfy the schema field-parity gate; the\npromote endpoint has no reason to mint a history-chained case.",
         "properties": {
           "grader": {
             "$ref": "#/components/schemas/GraderOut"
@@ -1085,6 +1085,11 @@
           "input": {
             "title": "Input",
             "type": "string"
+          },
+          "shared_history": {
+            "default": false,
+            "title": "Shared History",
+            "type": "boolean"
           }
         },
         "required": [

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -413,11 +413,17 @@ class GraderOut(BaseModel):
 class EvalCaseOut(BaseModel):
     """An eval case conforming to the frozen eval-case format (#8, ADR-0019):
     an input prompt plus the grader that judges the answer. Emitted by the
-    promote-a-trace-to-an-eval-case endpoint (#259)."""
+    promote-a-trace-to-an-eval-case endpoint (#259).
+
+    ``shared_history`` mirrors the worker's ``EvalCase`` field (#550, ADR-0051):
+    a promoted trace is a standalone case, so it emits the ``False`` default
+    (fresh conversation). Kept here to satisfy the schema field-parity gate; the
+    promote endpoint has no reason to mint a history-chained case."""
 
     id: str
     input: str
     grader: GraderOut
+    shared_history: bool = False
 
 
 class VersionCreate(BaseModel):

--- a/apps/worker/schema/eval-cases.schema.json
+++ b/apps/worker/schema/eval-cases.schema.json
@@ -1,7 +1,7 @@
 {
   "$defs": {
     "EvalCase": {
-      "description": "One eval: an input prompt and the grader that judges the answer.",
+      "description": "One eval: an input prompt and the grader that judges the answer.\n\n``shared_history`` is the per-case isolation opt-out (#550). Each case runs\nin a *fresh conversation* by default (``False``): the eval driver resets the\nrunner's conversation before the case so it cannot answer from an earlier\ncase's history instead of actually invoking its tools -- a false green for a\nside-effecting agent (the behavior under test never ran) and a silent, order-\ndependent suite. Set ``True`` to deliberately chain a case onto the prior\ncase's conversation (a multi-turn scenario expressed as ordered cases); the\ndriver then skips the reset so the case inherits that history. On the *first*\ncase it is a no-op-with-caveat: there is no prior case to chain onto, so it\nonly means \"do not reset first\", inheriting whatever state the runner already\nheld (empty on a freshly-booted eval runner). Optional with a ``False``\ndefault, so it is a backward-compatible addition to the frozen eval-case\nschema (ADR-0019): an existing suite that omits it keeps decoding.",
       "properties": {
         "grader": {
           "$ref": "#/$defs/Grader"
@@ -13,6 +13,11 @@
         "input": {
           "title": "Input",
           "type": "string"
+        },
+        "shared_history": {
+          "default": false,
+          "title": "Shared History",
+          "type": "boolean"
         }
       },
       "required": [

--- a/apps/worker/src/agentos_worker/eval/models.py
+++ b/apps/worker/src/agentos_worker/eval/models.py
@@ -76,13 +76,29 @@ class Grader(BaseModel):
 
 
 class EvalCase(BaseModel):
-    """One eval: an input prompt and the grader that judges the answer."""
+    """One eval: an input prompt and the grader that judges the answer.
+
+    ``shared_history`` is the per-case isolation opt-out (#550). Each case runs
+    in a *fresh conversation* by default (``False``): the eval driver resets the
+    runner's conversation before the case so it cannot answer from an earlier
+    case's history instead of actually invoking its tools -- a false green for a
+    side-effecting agent (the behavior under test never ran) and a silent, order-
+    dependent suite. Set ``True`` to deliberately chain a case onto the prior
+    case's conversation (a multi-turn scenario expressed as ordered cases); the
+    driver then skips the reset so the case inherits that history. On the *first*
+    case it is a no-op-with-caveat: there is no prior case to chain onto, so it
+    only means "do not reset first", inheriting whatever state the runner already
+    held (empty on a freshly-booted eval runner). Optional with a ``False``
+    default, so it is a backward-compatible addition to the frozen eval-case
+    schema (ADR-0019): an existing suite that omits it keeps decoding.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     id: str
     input: str
     grader: Grader
+    shared_history: bool = False
 
 
 class EvalSuite(BaseModel):

--- a/apps/worker/src/agentos_worker/eval/runner.py
+++ b/apps/worker/src/agentos_worker/eval/runner.py
@@ -7,11 +7,17 @@ accumulated text deltas if no final arrives); the grader turns that into pass/fa
 A case whose turn errors is recorded as a failed case with the error, so one bad
 case never aborts the suite.
 
-Isolation note: cases are run sequentially against the given runner base_url, so
-they share that runner session. Strong per-case isolation (a fresh sandbox per
-case) is the Job-orchestration layer's choice (the API fans out eval Jobs per
-version @ sha); this runner executes whatever suite it is handed against one
-endpoint.
+Isolation note: cases run sequentially against one runner base_url, but each
+case runs in a *fresh conversation* by default (#550). Before a case the runner
+issues a ``reset`` (``POST /v1/reset``) that discards the runner's conversation,
+so a case can never answer from an earlier case's history instead of actually
+invoking its tools -- a false green for a side-effecting agent, and a silent
+order-dependence in the suite. A case that sets ``shared_history=True`` opts out
+of the reset and deliberately inherits the prior case's conversation (a
+multi-turn scenario expressed as ordered cases). Strong *sandbox* isolation (a
+fresh pod per case) remains the Job-orchestration layer's choice (the API fans
+out eval Jobs per version @ sha); the fresh-conversation reset is the per-case
+guarantee this in-process runner gives on one endpoint.
 """
 
 from __future__ import annotations
@@ -51,10 +57,45 @@ class EvalRunner:
         token: str | None = None,
         model: str | None = None,
     ) -> EvalRunResult:
-        results = [await self._run_case(case, base_url, token) for case in suite.cases]
+        results: list[EvalCaseResult] = []
+        for case in suite.cases:
+            # Fresh conversation by default (#550): reset the runner before a case
+            # so it cannot inherit an earlier case's history. A shared_history
+            # case skips the reset and deliberately chains onto what preceded it.
+            if not case.shared_history:
+                isolation_error = await self._isolate(base_url, token)
+                if isolation_error is not None:
+                    # Could not establish isolation: fail the case rather than run
+                    # it against a possibly-leaked conversation (a false green is
+                    # exactly what #550 removes). One bad reset never aborts the
+                    # suite, matching the per-case error handling in _run_case.
+                    results.append(
+                        EvalCaseResult(
+                            case_id=case.id,
+                            passed=False,
+                            output="",
+                            latency_ms=0.0,
+                            error=isolation_error,
+                        )
+                    )
+                    continue
+            results.append(await self._run_case(case, base_url, token))
         return EvalRunResult(
             version=version, suite=suite.name, results=results, model=model
         )
+
+    async def _isolate(self, base_url: str, token: str | None) -> str | None:
+        """Reset the runner's conversation; return an error string on failure.
+
+        None on success. A failed reset means the fresh-conversation guarantee
+        could not be established, so the caller fails the case instead of running
+        it against a leaked history.
+        """
+        try:
+            await self._runner.reset(base_url, token)
+        except (RunnerError, aiohttp.ClientError, TimeoutError) as exc:
+            return f"failed to reset conversation for isolation: {exc}"
+        return None
 
     async def _run_case(
         self, case: EvalCase, base_url: str, token: str | None = None

--- a/apps/worker/src/agentos_worker/runner_client.py
+++ b/apps/worker/src/agentos_worker/runner_client.py
@@ -118,6 +118,22 @@ class RunnerClient:
                 body = await resp.text()
                 raise RunnerError(f"/v1/interrupt -> {resp.status}: {body}")
 
+    async def reset(self, base_url: str, token: str | None = None) -> None:
+        """Discard the runner's conversation so the next turn starts fresh (#550).
+
+        The eval driver calls this between cases to enforce per-case isolation.
+        A 409 (a turn is still active) is surfaced as a ``RunnerError`` like any
+        other unexpected status: the eval flow is sequential, so a turn should
+        never be live at reset time -- a 409 here is a real ordering bug, not a
+        condition to swallow.
+        """
+        async with self._session.post(
+            f"{base_url}/v1/reset", headers=_auth_headers(token)
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                raise RunnerError(f"/v1/reset -> {resp.status}: {body}")
+
     async def status(self, base_url: str) -> dict[str, object]:
         async with self._session.get(f"{base_url}/status") as resp:
             if resp.status != 200:

--- a/apps/worker/tests/eval/conftest.py
+++ b/apps/worker/tests/eval/conftest.py
@@ -53,12 +53,24 @@ _MINIO: dict[str, object] = {
 
 
 class FakeEvalRunner:
-    """Answers /v1/event with ``responses[input]`` (or 500 for ``fail_inputs``)."""
+    """Answers /v1/event with ``responses[input]`` (or 500 for ``fail_inputs``).
+
+    Models a single long-lived conversation the way the real runner does: every
+    delivered ``/v1/event`` input is appended to ``history`` and ``POST /v1/reset``
+    clears it. An input listed in ``recall_inputs`` answers with the joined
+    conversation history *so far* rather than a canned response, so a test can
+    prove a case answering from a prior case's history (the #550 false green) --
+    and prove that the per-case reset now clears that history.
+    """
 
     def __init__(self) -> None:
         self.app = web.Application()
         self.app.add_routes(
-            [web.post("/v1/event", self._event), web.get("/status", self._status)]
+            [
+                web.post("/v1/event", self._event),
+                web.post("/v1/reset", self._reset),
+                web.get("/status", self._status),
+            ]
         )
         self.responses: dict[str, str] = {}
         self.fail_inputs: set[str] = set()
@@ -74,9 +86,26 @@ class FakeEvalRunner:
         self.tool_calls: dict[str, list[str]] = {}
         self.default_output = ""
         self.seen: list[dict[str, str]] = []
+        # The accumulated conversation: every delivered input, cleared by reset.
+        self.history: list[str] = []
+        # Inputs that answer from `history` (prior inputs joined) instead of a
+        # canned response -- the memory-recall shape #550 is about.
+        self.recall_inputs: set[str] = set()
+        # How many times /v1/reset was called (isolation assertions).
+        self.resets = 0
+        # When True, /v1/reset answers 500 -- models a runner that could not
+        # establish per-case isolation.
+        self.fail_reset = False
 
     async def _status(self, _request: web.Request) -> web.Response:
         return web.json_response({"status": "done", "turn_active": False})
+
+    async def _reset(self, _request: web.Request) -> web.Response:
+        self.resets += 1
+        if self.fail_reset:
+            return web.json_response({"error": "reset boom"}, status=500)
+        self.history.clear()
+        return web.json_response({"ok": True})
 
     async def _event(self, request: web.Request) -> web.StreamResponse:
         body = await request.json()
@@ -84,7 +113,13 @@ class FakeEvalRunner:
         text = body["text"]
         if text in self.fail_inputs:
             return web.json_response({"error": "boom"}, status=500)
-        output = self.responses.get(text, self.default_output)
+        # A recall input answers from the conversation so far (the history that a
+        # reset would have cleared); otherwise fall back to the canned response.
+        if text in self.recall_inputs:
+            output = " | ".join(self.history)
+        else:
+            output = self.responses.get(text, self.default_output)
+        self.history.append(text)
         if text in self.classified_failure_inputs:
             status = SessionStatus.CLASSIFIED_FAILURE
         elif text in self.idle_inputs:

--- a/apps/worker/tests/eval/test_runner.py
+++ b/apps/worker/tests/eval/test_runner.py
@@ -107,6 +107,117 @@ def test_idle_awaiting_input_final_fails_even_if_text_matches(make_eval_harness)
     asyncio.run(go())
 
 
+def test_fresh_conversation_by_default_reds_a_case_that_only_passes_from_history(
+    make_eval_harness,
+) -> None:
+    """The #550 regression: a case that could only pass by inheriting a prior
+    case's history goes RED under the fresh-conversation default.
+
+    The recall case answers with the joined conversation so far. If it ran in the
+    seed case's conversation, its answer would contain the seed's secret and the
+    grader would pass -- the exact false green #550 removes. With the per-case
+    reset, the recall case starts fresh, its answer omits the secret, and it
+    fails. Ordering is no longer load-bearing."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"remember secret 42": "ok, noted"}
+            fake.recall_inputs = {"what is the secret?"}
+            suite = EvalSuite(
+                name="leak",
+                cases=[
+                    EvalCase(
+                        id="seed",
+                        input="remember secret 42",
+                        grader=Grader(kind=CONTAINS, expected="ok"),
+                    ),
+                    EvalCase(
+                        id="recall",
+                        input="what is the secret?",
+                        grader=Grader(kind=CONTAINS, expected="42"),
+                    ),
+                ],
+            )
+            result = await EvalRunner(client).run(suite, base_url=base_url, version="v1")
+
+            by_id = {r.case_id: r for r in result.results}
+            assert by_id["seed"].passed is True
+            # The recall case CANNOT see the seed's history, so it goes red.
+            assert by_id["recall"].passed is False
+            assert by_id["recall"].output == ""  # no prior turn leaked in
+            assert result.summary() == "1/2 passed"
+            # The runner was reset before every fresh-conversation case.
+            assert fake.resets == 2
+
+    asyncio.run(go())
+
+
+def test_shared_history_opt_in_lets_a_case_inherit_prior_history(
+    make_eval_harness,
+) -> None:
+    """The opt-in half of #550: a case marked ``shared_history`` skips the reset
+    and deliberately inherits the prior case's conversation, so the same recall
+    case that fails in isolation now passes."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"remember secret 42": "ok, noted"}
+            fake.recall_inputs = {"what is the secret?"}
+            suite = EvalSuite(
+                name="chain",
+                cases=[
+                    EvalCase(
+                        id="seed",
+                        input="remember secret 42",
+                        grader=Grader(kind=CONTAINS, expected="ok"),
+                    ),
+                    EvalCase(
+                        id="recall",
+                        input="what is the secret?",
+                        grader=Grader(kind=CONTAINS, expected="42"),
+                        shared_history=True,
+                    ),
+                ],
+            )
+            result = await EvalRunner(client).run(suite, base_url=base_url, version="v1")
+
+            by_id = {r.case_id: r for r in result.results}
+            assert by_id["seed"].passed is True
+            # recall inherited the seed turn, so its answer carries the secret.
+            assert by_id["recall"].passed is True
+            assert "remember secret 42" in by_id["recall"].output
+            assert result.summary() == "2/2 passed"
+            # Reset ran before the seed case but NOT before the shared_history one.
+            assert fake.resets == 1
+
+    asyncio.run(go())
+
+
+def test_a_failed_reset_fails_the_case_rather_than_leaking_history(
+    make_eval_harness,
+) -> None:
+    """If isolation cannot be established (the reset endpoint errors), the case is
+    failed with an error rather than run against a possibly-leaked conversation --
+    a false green is exactly what #550 removes."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "the answer is 4"}
+            fake.fail_reset = True  # the runner cannot establish isolation
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(client).run(suite, base_url=base_url, version="v1")
+
+            case = result.results[0]
+            assert case.passed is False
+            assert case.error is not None and "reset" in case.error
+            assert result.summary() == "0/1 passed"
+
+    asyncio.run(go())
+
+
 def test_all_passed_suite(make_eval_harness) -> None:
     async def go() -> None:
         async with make_eval_harness() as (base_url, fake, client):

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1409,6 +1409,18 @@ async fn run_suite_cases(
 ) -> Result<Vec<EvalRow>> {
     let mut results = Vec::with_capacity(suite.cases.len());
     for (i, case) in suite.cases.iter().enumerate() {
+        // Fresh conversation by default (#550): reset the runner before a case so
+        // it cannot answer from an earlier case's history instead of actually
+        // invoking its tools. A shared_history case skips the reset and inherits
+        // the prior case's conversation on purpose (a multi-turn scenario).
+        if !case.shared_history {
+            client.reset().await.with_context(|| {
+                format!(
+                    "resetting the runner conversation before case {:?}",
+                    case.id
+                )
+            })?;
+        }
         let started = Instant::now();
         let events = client
             .send_event(EventType::EvalCase, &case.input, "U-eval", |_| {})

--- a/cli/src/eval_init.rs
+++ b/cli/src/eval_init.rs
@@ -118,7 +118,12 @@ pub fn interview<R: BufRead, W: Write>(
         let input = ask_required(r, w, "  Prompt sent to the agent: ")?;
         let grader = ask_grader(r, w)?;
 
-        cases.push(EvalCase { id, input, grader });
+        cases.push(EvalCase {
+            id,
+            input,
+            grader,
+            shared_history: false,
+        });
 
         if !ask_yes_no(r, w, "\nAdd another case? [Y/n]: ", true)? {
             break;

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -74,6 +74,21 @@ pub struct EvalCase {
     pub id: String,
     pub input: String,
     pub grader: Grader,
+    /// Per-case isolation opt-out (#550). Each case runs in a *fresh
+    /// conversation* by default (`false`): `agentos skill eval` resets the runner
+    /// before the case so it cannot answer from an earlier case's history instead
+    /// of actually invoking its tools -- a false green for a side-effecting agent,
+    /// and a silent order-dependence in the suite. Set `true` to deliberately
+    /// chain a case onto the prior case's conversation (a multi-turn scenario as
+    /// ordered cases); the driver then skips the reset. On the first case it is a
+    /// no-op-with-caveat (no prior case to chain onto -- it only means "do not
+    /// reset first", inheriting any state the runner already held). Optional with
+    /// a `false`
+    /// default so it stays byte-compatible with the frozen eval-case schema
+    /// (`shared_history: false` is omitted on serialize, mirroring an authored
+    /// suite that never wrote the field).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub shared_history: bool,
 }
 
 /// A named set of eval cases run together against one plugin version.
@@ -195,6 +210,7 @@ mod tests {
             id: "c".into(),
             input: "hi".into(),
             grader: g,
+            shared_history: false,
         }
     }
 
@@ -235,6 +251,29 @@ mod tests {
         assert_eq!(suite.cases[0].id, "a");
         assert_eq!(suite.cases[0].grader.kind, GraderKind::Contains);
         assert!(!suite.cases[0].grader.case_sensitive);
+    }
+
+    #[test]
+    fn shared_history_defaults_to_false_and_reads_true_when_set() {
+        // Omitted -> false (backward compatible with every authored suite).
+        let (_dir, path) = write(
+            r#"{"name":"s","cases":[{"id":"a","input":"b","grader":{"kind":"contains","expected":"x"}}]}"#,
+        );
+        assert!(!load_suite(&path).unwrap().cases[0].shared_history);
+        // Present and true -> the case opts into the prior case's conversation.
+        let (_dir2, path2) = write(
+            r#"{"name":"s","cases":[{"id":"a","input":"b","grader":{"kind":"contains","expected":"x"},"shared_history":true}]}"#,
+        );
+        assert!(load_suite(&path2).unwrap().cases[0].shared_history);
+    }
+
+    #[test]
+    fn a_false_shared_history_is_omitted_on_serialize() {
+        // Byte-compat with the frozen schema: a fresh-conversation case (the
+        // default) serializes exactly as a suite that never wrote the field, so
+        // the scaffold and spec-authored cases.json stay unchanged.
+        let json = serde_json::to_string(&case(grader(GraderKind::Contains, "x", false))).unwrap();
+        assert!(!json.contains("shared_history"), "got: {json}");
     }
 
     #[test]

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1589,6 +1589,7 @@ mod tests {
                 expected: expected.into(),
                 case_sensitive: false,
             },
+            shared_history: false,
         }
     }
 

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -68,6 +68,29 @@ impl RunnerClient {
         resp.json().await.context("decoding /status body")
     }
 
+    /// Discard the runner's conversation so the next turn starts fresh (#550).
+    ///
+    /// `agentos skill eval` calls this between cases to enforce per-case
+    /// isolation: a case must not answer from an earlier case's history instead
+    /// of actually invoking its tools. Not an ACI wire frame -- a runner control
+    /// route like `/status`, so it takes no body. A 409 (a turn is still active)
+    /// surfaces as an error; the eval loop is sequential, so a turn is never live
+    /// at reset time.
+    pub async fn reset(&self) -> Result<()> {
+        let resp = self
+            .http
+            .post(format!("{}/v1/reset", self.base_url))
+            .send()
+            .await
+            .with_context(|| format!("POST {}/v1/reset", self.base_url))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            bail!("POST /v1/reset returned {status}: {}", body.trim());
+        }
+        Ok(())
+    }
+
     /// Open a turn: POST the event frame, stream back the outbound events.
     ///
     /// `on_event` fires per frame as it arrives (live streaming to the

--- a/docs/adr/0051-eval-cases-run-in-a-fresh-conversation-by-default.md
+++ b/docs/adr/0051-eval-cases-run-in-a-fresh-conversation-by-default.md
@@ -1,0 +1,130 @@
+# 51. Eval cases run in a fresh conversation by default, with per-case opt-in shared history
+
+Date: 2026-07-17
+
+Status: Accepted
+
+Implements [#550](https://github.com/curie-eng/agentos/issues/550). Extends
+ADR-0019 (the frozen eval-case format): it adds one optional field to that schema
+and pins the runtime isolation semantics the format now implies. It does not
+supersede ADR-0019; the suite-object-with-graders shape stays canonical and
+frozen in place.
+
+## Context
+
+Both eval-suite runners drive their cases sequentially against **one** runner
+endpoint: the platform worker (`apps/worker/.../eval/runner.py`) and the CLI's
+`agentos skill eval` (`cli/src/commands.rs::run_suite_cases`). The runner holds
+one long-lived model session per process (ADR-0003, for prompt-cache affinity
+across a thread's turns), so every case in a suite ran **inside the same growing
+conversation**. Case N could see cases 1..N-1's messages.
+
+A cold-start end-to-end run on v0.4.0-rc.4 surfaced the failure directly:
+
+> Case 3 answered from case 2's history without re-calling the tool. Fine for
+> prompts, quietly wrong for side-effecting agents.
+
+For an agent whose whole job is a side effect (close an issue, post a message,
+call an API), a case that answers from conversational memory instead of actually
+invoking the tool is a **false green**: the eval reports pass while the behavior
+under test never ran. It is the same failure class as a test asserting on a mock
+instead of the thing under test, which this repo already treats as a real bug
+(`fake.py`, the never-mock-the-thing-under-test rule). It also makes case
+**ordering** silently load-bearing: the suite's verdict depends on which case ran
+first, invisibly.
+
+Note the two other eval paths that already isolate and are therefore out of
+scope. The `local message` / `cluster message` eval path
+(`cli/src/message.rs::run_eval_turns`) gives each case its own thread key, so the
+kernel routes each to its own session — no cross-talk. And the platform's
+Job-orchestration layer fans out a fresh **sandbox** per version @ sha. This ADR
+is about the per-case guarantee an in-process suite runner gives against **one**
+endpoint, which neither of those covers.
+
+## Decision
+
+**Each eval case runs in a fresh conversation by default. Shared history is an
+explicit, per-case opt-in.**
+
+### 1. A runner control route resets the conversation
+
+The runner exposes `POST /v1/reset`: it tears down the current SDK session and
+reconnects a new one from the same factory, so the next turn starts with no
+accumulated conversation. It is a runner control route (like `/status` and
+`/healthz`), **not** an ACI wire frame — so it needs no `aci-protocol` version
+bump and does not touch the frozen wire contract. It refuses with 409 while a
+turn is active, mirroring the steer finish-race boundary, and is gated by the
+same bearer token as the other `POST` routes.
+
+This is a deliberate, explicit control — **not** per-turn session churn. The
+one-long-lived-session-per-process invariant still holds for the message path,
+which never calls reset. A thread with a durable `AGENTOS_HISTORY_REF` still
+rehydrates *its own* history preamble on reconnect (that is the thread's real
+history, not a cross-case leak); an eval runner, which has no history ref, comes
+up empty.
+
+### 2. The suite runners reset before each fresh-conversation case
+
+Both suite runners issue a reset before a case unless that case opts out. Reset
+runs before **every** non-shared case, including the first, so a case is truly
+fresh even against a persistent `skill up` runner that carries prior
+`skill message` history — "fresh by default" does not depend on the endpoint
+having been freshly booted.
+
+If isolation cannot be established (the reset call errors), the worker **fails
+that case** with the error rather than running it against a possibly-leaked
+conversation — a false green is exactly what this ADR removes. One failed reset
+never aborts the suite, matching the existing per-case error handling.
+
+### 3. `shared_history` is the per-case opt-out
+
+`EvalCase` gains an optional `shared_history: bool` field, default `false`. A
+case that sets it `true` skips the reset and deliberately inherits the prior
+case's conversation — a multi-turn scenario expressed as ordered cases. It is a
+new **optional** field with a default, so it is a backward-compatible addition to
+the frozen schema (ADR-0019): an existing suite that omits it keeps decoding, the
+CLI mirror omits a `false` value on serialize so authored `cases.json` files stay
+byte-identical, and the drift gate
+(`tests/eval/test_schema_compat.py`, `scripts/check-contracts.sh`) is
+regenerated in the same change per ADR-0019's mechanism.
+
+## Alternatives considered
+
+- **A fresh sandbox per case.** The strongest isolation, and it is already the
+  Job layer's choice for cross-version fan-out. Rejected as the per-case default:
+  a container per case is far slower and heavier than an in-session reset, and
+  the AC asks for a fresh *conversation*, not a fresh *pod*. Sandbox isolation
+  stays available at the layer that already owns it.
+- **A `new_conversation` flag on the ACI `Event` frame.** Rejected: it is a
+  change to the frozen wire contract (a new field on a frozen model, a version
+  bump, cross-language regeneration) for what is really a session-control action,
+  not message content. A control route keeps the wire contract untouched.
+- **Reset only between cases, never before the first.** Rejected: a persistent
+  `skill up` runner can carry history from a prior `skill message`, so the first
+  case would silently inherit it. Resetting before every non-shared case makes
+  the guarantee uniform and endpoint-state-independent.
+- **Make isolation the only behavior, no opt-in.** Rejected: the AC requires
+  that shared history be expressible when genuinely wanted (a multi-turn
+  scenario). A per-case flag keeps the default safe while leaving the door open,
+  explicitly.
+- **Swallow a failed reset and run the case anyway.** Rejected: it reintroduces
+  the exact false green — a case run against un-cleared history reports a pass the
+  behavior never earned. A reset that cannot be established fails the case.
+
+## Consequences
+
+- **Behavior change suite authors must know about:** a suite that quietly relied
+  on an earlier case priming a later one now goes red on the later case unless it
+  is marked `shared_history: true`. That red is the point — it exposes a false
+  green and a load-bearing ordering that were previously invisible.
+- **Eval runs are slightly slower.** A fresh-conversation case pays one session
+  reconnect (a fresh SDK session, no prompt-cache reuse across cases). This is
+  the intended trade: per-case correctness over cross-case cache affinity, which
+  was never a property evals should have depended on.
+- **The regression is pinned.** A worker test drives a stateful fake runner where
+  a recall case can only pass by inheriting a prior case's history; it now fails
+  under the default and passes only when the case opts into `shared_history`, and
+  a failed reset fails the case rather than leaking history.
+- **The wire contract is untouched.** `/v1/reset` is a runner control route, so
+  no `aci-protocol` version bump and no conformance change; only the eval-case
+  schema (a derivative of the worker Pydantic models, ADR-0019) moves, additively.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,4 +79,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0047 | [ADR-0047: Canonical env-var names for the API base URL and model credential](0047-canonical-env-var-names.md) | Accepted |
 | 0048 | [ADR-0048: Declare the model endpoint's wire protocol and credential keys](0048-declared-model-wire-protocol-and-credential-keys.md) | Accepted |
 | 0050 | [A declared approval policy is armed exactly as declared, or the runner refuses to boot](0050-declared-approval-policy-is-armed-exactly-or-not-at-all.md) | Accepted |
+| 0051 | [Eval cases run in a fresh conversation by default, with per-case opt-in shared history](0051-eval-cases-run-in-a-fresh-conversation-by-default.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/runner/src/agentos_runner/server.py
+++ b/runner/src/agentos_runner/server.py
@@ -13,6 +13,10 @@ Productizes the prototype's aiohttp ``/run`` into the ACI session channel:
                          caller falls back to a fresh ``/v1/event``
 - ``POST /v1/interrupt`` hard-stop the live turn: body is an ACI ``interrupt``
                          frame; the open turn's final is reclassified to idle
+- ``POST /v1/reset``     discard the conversation and start a fresh model
+                         session (eval isolation, #550); 409 while a turn is
+                         active. Not an ACI wire frame -- a runner control route,
+                         like /status and /healthz, so it takes no body
 
 One turn consumes the SDK generator at a time (enforced by the runner's turn
 lock); steer and interrupt are side-channel injections whose output surfaces on
@@ -35,7 +39,7 @@ _NDJSON = "application/x-ndjson"
 # The three ACI POST routes that drive a turn; gated when a token is configured.
 # /healthz and /status stay open so the chart readinessProbe (no auth header)
 # keeps working.
-_GATED_PATHS = frozenset({"/v1/event", "/v1/steer", "/v1/interrupt"})
+_GATED_PATHS = frozenset({"/v1/event", "/v1/steer", "/v1/interrupt", "/v1/reset"})
 
 # Typed app key so aiohttp resolves the runner without the string-key warning.
 RUNNER: web.AppKey[SessionRunner] = web.AppKey("runner", SessionRunner)
@@ -96,6 +100,7 @@ def create_app(runner: SessionRunner, token: str | None = None) -> web.Applicati
             web.post("/v1/event", _event),
             web.post("/v1/steer", _steer),
             web.post("/v1/interrupt", _interrupt),
+            web.post("/v1/reset", _reset),
         ]
     )
     app.on_cleanup.append(_on_cleanup)
@@ -174,4 +179,17 @@ async def _interrupt(request: web.Request) -> web.Response:
         return web.json_response({"error": "expected an interrupt frame"}, status=400)
 
     await runner.interrupt(frame.reason)
+    return web.json_response({"ok": True})
+
+
+async def _reset(request: web.Request) -> web.Response:
+    runner: SessionRunner = request.app[RUNNER]
+    # Refuse to reset a session mid-turn: tearing the SDK session down under a
+    # live turn would strand the open /v1/event stream. 409 mirrors the steer
+    # finish-race boundary -- the caller resets once the turn has completed.
+    if runner.turn_active:
+        return web.json_response(
+            {"error": "cannot reset while a turn is active"}, status=409
+        )
+    await runner.reset()
     return web.json_response({"ok": True})

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -276,6 +276,36 @@ class SessionRunner:
             await self._session.close()
         self._tracer.shutdown()
 
+    async def reset(self) -> None:
+        """Discard the conversation and start a fresh model session (#550).
+
+        Eval isolation: the eval driver calls this between cases so each case
+        runs in a fresh conversation and cannot answer from an earlier case's
+        history instead of actually invoking its tools (a false green for a
+        side-effecting agent, and a silent order-dependence in the suite). Reset
+        tears down the current SDK session and reconnects a new one from the same
+        factory, so the next turn starts with no accumulated conversation; a
+        thread with a durable ``AGENTOS_HISTORY_REF`` still rehydrates its own
+        history preamble on reconnect (that is the thread's real history, not a
+        cross-case leak), while an eval runner (no history ref) comes up empty.
+
+        This is a deliberate, explicit control -- NOT per-turn session churn. The
+        one-long-lived-session-per-process invariant (prompt-cache affinity
+        across a thread's turns, ADR-0003) still holds for the message path,
+        which never calls reset. Held under the turn lock so it can never race a
+        live turn; the server refuses a reset while a turn is active (409) so the
+        lock is free the moment this runs.
+        """
+
+        async with self._turn_lock:
+            if self._session is not None:
+                await self._session.close()
+            self._session = self._factory()
+            await self._session.connect()
+            self._interrupt_requested = False
+            self._turn_open = False
+            self._status = SessionStatus.IDLE_AWAITING_INPUT
+
     async def steer(self, text: str) -> bool:
         """Inject a follow-up message into the live turn without consuming output.
 

--- a/runner/tests/test_server.py
+++ b/runner/tests/test_server.py
@@ -90,6 +90,72 @@ def test_steer_takes_an_event_frame_and_conflicts_without_a_turn() -> None:
     anyio.run(go)
 
 
+def test_reset_endpoint_starts_a_fresh_session() -> None:
+    # The factory hands out a NEW fake each call, so a reset is observable: the
+    # runner's live session object changes identity after /v1/reset (#550).
+    sessions: list[FakeModelSession] = []
+
+    def factory() -> FakeModelSession:
+        fake = FakeModelSession()
+        sessions.append(fake)
+        return fake
+
+    runner = SessionRunner(
+        session_factory=factory,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+    )
+
+    async def go() -> None:
+        await runner.start()
+        first = runner._session  # noqa: SLF001 - identity check is the assertion
+        async with TestClient(TestServer(create_app(runner))) as client:
+            resp = await client.post("/v1/reset")
+            assert resp.status == 200
+            assert (await resp.json())["ok"] is True
+            # A fresh session replaced the original one; the old one was closed
+            # and the new one connected. (Asserted inside the client context: the
+            # app cleanup closes the live session on exit.)
+            second = runner._session  # noqa: SLF001
+            assert second is not first
+            assert first.connected is False
+            assert second is not None and second.connected is True
+            assert runner.status == SessionStatus.IDLE_AWAITING_INPUT
+
+    anyio.run(go)
+
+
+def test_reset_is_refused_while_a_turn_is_active() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner))) as client:
+            # Simulate a live turn: reset must 409 rather than tear the session
+            # down under an open /v1/event stream.
+            runner._turn_open = True  # noqa: SLF001
+            resp = await client.post("/v1/reset")
+            assert resp.status == 409
+
+    anyio.run(go)
+
+
+def test_reset_requires_auth_when_a_token_is_configured() -> None:
+    runner, _ = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            unauth = await client.post("/v1/reset")
+            assert unauth.status == 401
+            ok = await client.post("/v1/reset", headers=_AUTH)
+            assert ok.status == 200
+
+    anyio.run(go)
+
+
 _TOKEN = "test-token-xyz"
 _AUTH = {"Authorization": f"Bearer {_TOKEN}"}
 _EVENT_FRAME = {"kind": "event", "type": "message", "text": "hi", "user": "U", "ts": "1"}


### PR DESCRIPTION
## Problem

Both in-process eval **suite** runners drive their cases sequentially against one runner endpoint that holds a single long-lived model session (prompt-cache affinity, ADR-0003). So every case in a suite ran inside the same growing conversation, and a later case could answer from an earlier case's history instead of actually invoking its tools. For a side-effecting agent that is a **false green**: the eval passes while the behavior under test never ran, and case ordering becomes silently load-bearing.

Found on v0.4.0-rc.4 during a cold-start end-to-end run: "Case 3 answered from case 2's history without re-calling the tool."

## Fix

- **Runner `POST /v1/reset` control route** (not an ACI wire frame, so no contract version bump): tears down and reconnects the model session, clearing the conversation. Returns 409 while a turn is active; token-gated like the other POST routes. The turn lock, not the 409, is the real safety mechanism.
- **Both suite runners reset before every non-shared case, including the first** — the worker `EvalRunner` and the CLI `skill eval` `run_suite_cases` — so isolation does not depend on the endpoint being freshly booted. A failed reset **fails that case** rather than running it against a possibly-leaked conversation.
- **`EvalCase.shared_history`** (optional, default `false`): set `true` to deliberately chain a case onto the prior case's conversation. Backward-compatible addition to the frozen eval-case schema (ADR-0019); the CLI mirror omits a `false` value on serialize so authored `cases.json` stay byte-identical. `EvalCaseOut` mirrors the field to satisfy the API/worker field-parity gate; the frozen schema and `openapi.json` are regenerated in-change.
- **Regression coverage**: a worker test drives a stateful fake runner where a recall case can only pass by inheriting a prior case's history; it now goes red under the default and passes only with `shared_history=true`, and a failed reset fails the case. Mutation-checked (reverting the reset makes the recall case go green from the seed's history).

The one-long-lived-session invariant stays intact for the message path (reset is eval-only, never per-turn churn). The `local`/`cluster message` eval path already isolates (one thread per case) and Job-level sandbox fan-out is unchanged; this closes the one-endpoint suite-runner gap.

Decision recorded in **ADR-0051** (extends ADR-0019).

## Reviewers
Reviewed pre-PR by spec-vs-impl (PASS, all 3 ACs met), scope-creep (PASS, zero orphan hunks), and code-reviewer (APPROVE, test quality strong / mutation-verified).

## Follow-up (non-blocking)
The CLI `run_suite_cases` reset-per-case behavior is covered by the shared contract + the worker regression test + serde byte-compat tests + the live `cli/scripts/e2e.sh`, but has no dedicated in-process HTTP regression test (the CLI test suite has no mock-runner harness today). Worth adding a CLI-level red-on-leak test if a mock-runner harness lands.

Closes #550