### PR TITLE
Consolidate dispatcher Socket Mode test doubles

### DIFF
--- a/apps/dispatcher/tests/conftest.py
+++ b/apps/dispatcher/tests/conftest.py
@@ -2,13 +2,39 @@
 compose stack (per repo test discipline: never mock Valkey). Only the Slack Web
 API and socket transport are faked."""
 
+import logging
 import os
 import uuid
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 import redis
 from agentos_dispatcher.config import DispatcherConfig
+from slack_bolt.authorization import AuthorizeResult
+
+
+def _authorize(**_kwargs: Any) -> AuthorizeResult:
+    """Shared authorization stub: Bolt's ``authorize`` callback resolved to a
+    fixed bot identity, so Socket Mode tests skip the real auth.test call."""
+    return AuthorizeResult(
+        enterprise_id=None,
+        team_id="T1",
+        bot_token="xoxb-test",
+        bot_id="B1",
+        bot_user_id="U0BOT",
+    )
+
+
+class FakeSocketClient:
+    """Captures the envelope acks Bolt sends back over the socket."""
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger("fake-socket")
+        self.acked_envelope_ids: list[str] = []
+
+    def send_socket_mode_response(self, response: Any) -> None:
+        self.acked_envelope_ids.append(response.envelope_id)
 
 # Compose defaults (compose.dev.yaml maps Valkey to host port 26379, password
 # valkeypass). Overridable for CI via TEST_VALKEY_* env vars.

--- a/apps/dispatcher/tests/test_approval_actions.py
+++ b/apps/dispatcher/tests/test_approval_actions.py
@@ -9,7 +9,6 @@ resolved by X", and the ordinary-button catch-all never double-handles an
 approval click.
 """
 
-import logging
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -24,9 +23,10 @@ from agentos_dispatcher.approval_actions import (
 from agentos_dispatcher.config import DispatcherConfig
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
-from slack_bolt.authorization import AuthorizeResult
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.web import WebClient
+
+from .conftest import FakeSocketClient, _authorize
 
 APPROVAL_ID = "9a1e8a10-0000-0000-0000-000000000246"
 
@@ -56,25 +56,6 @@ _COULD_NOT_VERIFY_GROUP_REASON = (
     "could not verify approver group membership: this approval's route is "
     "bound to a Slack user group and the membership lookup failed"
 )
-
-
-def _authorize(**_kwargs: Any) -> AuthorizeResult:
-    return AuthorizeResult(
-        enterprise_id=None,
-        team_id="T1",
-        bot_token="xoxb-test",
-        bot_id="B1",
-        bot_user_id="U0BOT",
-    )
-
-
-class FakeSocketClient:
-    def __init__(self) -> None:
-        self.logger = logging.getLogger("fake-socket")
-        self.acked_envelope_ids: list[str] = []
-
-    def send_socket_mode_response(self, response: Any) -> None:
-        self.acked_envelope_ids.append(response.envelope_id)
 
 
 class ScriptedResolver:

--- a/apps/dispatcher/tests/test_dispatch.py
+++ b/apps/dispatcher/tests/test_dispatch.py
@@ -5,7 +5,6 @@ API client (the only two things faked, per test discipline), and assert the full
 lifecycle step: envelope -> ack -> in-thread placeholder -> XADD to real Valkey.
 """
 
-import logging
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -15,32 +14,12 @@ from agentos_dispatcher.config import DispatcherConfig
 from agentos_dispatcher.queue import from_stream_fields
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
-from slack_bolt.authorization import AuthorizeResult
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.web import WebClient
 
+from .conftest import FakeSocketClient, _authorize
+
 BOT_TS = "555.000"
-
-
-def _authorize(**_kwargs: Any) -> AuthorizeResult:
-    return AuthorizeResult(
-        enterprise_id=None,
-        team_id="T1",
-        bot_token="xoxb-test",
-        bot_id="B1",
-        bot_user_id="U0BOT",
-    )
-
-
-class FakeSocketClient:
-    """Captures the envelope acks Bolt sends back over the socket."""
-
-    def __init__(self) -> None:
-        self.logger = logging.getLogger("fake-socket")
-        self.acked_envelope_ids: list[str] = []
-
-    def send_socket_mode_response(self, response: Any) -> None:
-        self.acked_envelope_ids.append(response.envelope_id)
 
 
 def _build(config: DispatcherConfig, redis_client: redis.Redis) -> tuple[App, WebClient]:


### PR DESCRIPTION
The Socket Mode authorization stub (`_authorize`) and socket response recorder (`FakeSocketClient`) were defined identically in `test_dispatch.py` and `test_approval_actions.py`, despite an existing shared `tests/conftest.py`.

## Change
- Move `_authorize` and `FakeSocketClient` into `apps/dispatcher/tests/conftest.py`.
- Both modules import them via `from .conftest import ...`, the same relative-conftest pattern the worker sandbox tests use under `--import-mode=importlib`.
- Pure test-scaffolding cleanup: no dispatcher behavior change, no assertions weakened.

## Verify
- `uv run pytest apps/dispatcher/tests/test_dispatch.py apps/dispatcher/tests/test_approval_actions.py` -> 20 passed.
- `uv run ruff check` and `uv run mypy` clean.

Closes #637