### PR TITLE
Centralize Python plugin manifest resolution

### DIFF
--- a/apps/api/src/agentos_api/bundles.py
+++ b/apps/api/src/agentos_api/bundles.py
@@ -13,6 +13,7 @@ import zipfile
 from pathlib import Path
 
 from plugin_format import (
+    MANIFEST_LOCATIONS,
     UnsupportedArchive,
     ValidationResult,
     bundle_root,
@@ -71,12 +72,6 @@ def extract_and_validate(data: bytes, dest: Path) -> tuple[str, str, ValidationR
     return extension, content_type, result
 
 
-# The bundle's manifest locations, used here to build the text-surface allowlist
-# in ``_collect_text_files`` (the extraction/unwrap copy now lives in
-# ``plugin_format.archive``).
-_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
-
-
 def _collect_text_files(root: Path) -> list[tuple[str, str]]:
     """The bundle's known text files as (bundle-relative posix path, content).
 
@@ -87,7 +82,7 @@ def _collect_text_files(root: Path) -> list[tuple[str, str]]:
     """
 
     candidates: list[Path] = []
-    for fixed in (*_MANIFEST_LOCATIONS, Path("evals/cases.json")):
+    for fixed in (*MANIFEST_LOCATIONS, Path("evals/cases.json")):
         if (root / fixed).is_file():
             candidates.append(root / fixed)
     candidates.extend(p for p in root.glob("skills/**/SKILL.md") if p.is_file())

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -7,6 +7,7 @@ escalates to the orchestrator.
 """
 
 from .archive import UnsupportedArchive, bundle_root, safe_extract
+from .manifest import MANIFEST_LOCATIONS, resolve_manifest
 from .models import (
     ApprovalGate,
     ApprovalPolicy,
@@ -28,6 +29,8 @@ __all__ = [
     "__version__",
     "RESERVED_BOOT_ENV",
     "is_reserved_boot_env_name",
+    "MANIFEST_LOCATIONS",
+    "resolve_manifest",
     "PluginManifest",
     "Author",
     "SkillFrontmatter",

--- a/packages/plugin-format/src/plugin_format/archive.py
+++ b/packages/plugin-format/src/plugin_format/archive.py
@@ -21,10 +21,7 @@ import tarfile
 import zipfile
 from pathlib import Path
 
-# Where the plugin manifest lives; used only to locate the bundle root inside an
-# archive that wraps everything in one folder. (validate.py keeps its own copy
-# for the frozen validator; this one serves the extraction path.)
-_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
+from .manifest import resolve_manifest
 
 
 class UnsupportedArchive(Exception):
@@ -81,7 +78,7 @@ def safe_extract(data: bytes, dest: Path) -> None:
 
 
 def _has_manifest(directory: Path) -> bool:
-    return any((directory / loc).is_file() for loc in _MANIFEST_LOCATIONS)
+    return resolve_manifest(directory) is not None
 
 
 def bundle_root(extracted: Path) -> Path:

--- a/packages/plugin-format/src/plugin_format/manifest.py
+++ b/packages/plugin-format/src/plugin_format/manifest.py
@@ -1,0 +1,31 @@
+"""Where a plugin bundle's manifest lives, and how to find it.
+
+The Claude Code plugin manifest is ``.claude-plugin/plugin.json``; a bare
+``plugin.json`` at the bundle root is accepted as a fallback (see the package
+README's Decisions). This module is the single owner of that ordered lookup so
+validation, archive handling, bundle inspection, and the runner readers cannot
+drift on the locations or their precedence. It is a location policy only: it
+makes no schema, wire, or protocol change.
+"""
+
+from pathlib import Path
+
+# Ordered manifest locations, most-specific first. ``.claude-plugin/plugin.json``
+# is canonical; a root ``plugin.json`` is the accepted fallback.
+MANIFEST_LOCATIONS: tuple[Path, ...] = (
+    Path(".claude-plugin") / "plugin.json",
+    Path("plugin.json"),
+)
+
+
+def resolve_manifest(root: str | Path) -> Path | None:
+    """Return the first existing manifest under ``root``, or ``None``.
+
+    Walks ``MANIFEST_LOCATIONS`` in order and returns the path of the first entry
+    that is an existing file, preserving ``.claude-plugin/plugin.json`` precedence
+    over a root ``plugin.json``. Returns ``None`` when neither exists.
+    """
+    base = Path(root)
+    return next(
+        (base / loc for loc in MANIFEST_LOCATIONS if (base / loc).is_file()), None
+    )

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -13,6 +13,7 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
+from .manifest import resolve_manifest
 from .models import (
     _TRIGGER_TYPES,
     ApprovalPolicy,
@@ -32,9 +33,6 @@ _TRIGGERS_ADAPTER = TypeAdapter(list[TriggerDeclaration])
 # Claude Code plugin names are kebab-case: lowercase alphanumerics and hyphens.
 _NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
-# The manifest lives at .claude-plugin/plugin.json; a bare plugin.json at the
-# bundle root is accepted as a fallback (see README Decisions).
-_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
 
 
 class ValidationIssue(BaseModel):
@@ -90,9 +88,7 @@ def validate_bundle(path: str | Path) -> ValidationResult:
 
 
 def _validate_manifest(root: Path, c: _Collector) -> PluginManifest | None:
-    manifest_path = next(
-        (root / loc for loc in _MANIFEST_LOCATIONS if (root / loc).is_file()), None
-    )
+    manifest_path = resolve_manifest(root)
     if manifest_path is None:
         c.error(
             "manifest.missing",

--- a/packages/plugin-format/tests/test_manifest.py
+++ b/packages/plugin-format/tests/test_manifest.py
@@ -1,0 +1,45 @@
+"""The shared manifest-location resolver (#636).
+
+One helper owns the ordered manifest locations so validation, archive handling,
+API bundle inspection, and the runner readers cannot drift on the path or its
+precedence. These cover the three behaviors every caller relies on: the primary
+path, the fallback path, and a missing manifest.
+"""
+
+from pathlib import Path
+
+from plugin_format import MANIFEST_LOCATIONS, resolve_manifest
+
+
+def test_primary_path_wins(tmp_path: Path) -> None:
+    canonical = tmp_path / ".claude-plugin" / "plugin.json"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text("{}", encoding="utf-8")
+    # A root plugin.json also present: precedence must still pick the canonical one.
+    (tmp_path / "plugin.json").write_text("{}", encoding="utf-8")
+
+    assert resolve_manifest(tmp_path) == canonical
+
+
+def test_root_plugin_json_is_the_fallback(tmp_path: Path) -> None:
+    fallback = tmp_path / "plugin.json"
+    fallback.write_text("{}", encoding="utf-8")
+
+    assert resolve_manifest(tmp_path) == fallback
+
+
+def test_missing_manifest_resolves_to_none(tmp_path: Path) -> None:
+    assert resolve_manifest(tmp_path) is None
+
+
+def test_locations_are_ordered_most_specific_first() -> None:
+    assert MANIFEST_LOCATIONS == (
+        Path(".claude-plugin") / "plugin.json",
+        Path("plugin.json"),
+    )
+
+
+def test_accepts_str_root(tmp_path: Path) -> None:
+    (tmp_path / "plugin.json").write_text("{}", encoding="utf-8")
+
+    assert resolve_manifest(str(tmp_path)) == tmp_path / "plugin.json"

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -45,7 +45,7 @@ from claude_agent_sdk.types import (
     PermissionResultDeny,
     ToolPermissionContext,
 )
-from plugin_format import ApprovalPolicy, PluginManifest
+from plugin_format import ApprovalPolicy, PluginManifest, resolve_manifest
 
 logger = logging.getLogger(__name__)
 
@@ -414,8 +414,6 @@ def build_can_use_tool(gate: ApprovalGate) -> CanUseTool:
 
 # --- The manifest approval policy (#247): gates shipped in the bundle -----------
 
-_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
-
 
 class ApprovalPolicyError(RuntimeError):
     """A declared approval policy cannot be armed exactly as declared.
@@ -456,9 +454,7 @@ def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
     if not plugin_dir:
         return {}
     root = Path(plugin_dir)
-    manifest_path = next(
-        (root / loc for loc in _MANIFEST_LOCATIONS if (root / loc).is_file()), None
-    )
+    manifest_path = resolve_manifest(root)
     if manifest_path is None:
         return {}
     # Read raw first: a manifest that will not parse cannot prove it declares

--- a/runner/src/agentos_runner/hooks.py
+++ b/runner/src/agentos_runner/hooks.py
@@ -23,10 +23,9 @@ from pathlib import Path
 from typing import Any
 
 from claude_agent_sdk import HookMatcher
-from plugin_format import HookMatcherConfig, PluginManifest
+from plugin_format import HookMatcherConfig, PluginManifest, resolve_manifest
 from pydantic import TypeAdapter, ValidationError
 
-_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
 _HOOKS_ADAPTER = TypeAdapter(dict[str, list[HookMatcherConfig]])
 
 # Deny convention (Claude Code): a command hook that exits with this code blocks
@@ -47,9 +46,7 @@ def _load_manifest_hooks(plugin_dir: str | None) -> dict[str, list[HookMatcherCo
     if not plugin_dir:
         return None
     root = Path(plugin_dir)
-    manifest_path = next(
-        (root / loc for loc in _MANIFEST_LOCATIONS if (root / loc).is_file()), None
-    )
+    manifest_path = resolve_manifest(root)
     if manifest_path is None:
         return None
     try:

--- a/runner/src/agentos_runner/plugin.py
+++ b/runner/src/agentos_runner/plugin.py
@@ -13,11 +13,7 @@ import json
 from pathlib import Path
 
 from claude_agent_sdk import SdkPluginConfig
-from plugin_format import PluginManifest, validate_bundle
-
-# The manifest lives at .claude-plugin/plugin.json; a bare plugin.json at the
-# bundle root is accepted as a fallback, mirroring plugin_format's own lookup.
-_MANIFEST_LOCATIONS = (Path(".claude-plugin") / "plugin.json", Path("plugin.json"))
+from plugin_format import PluginManifest, resolve_manifest, validate_bundle
 
 
 class PluginBundleError(RuntimeError):
@@ -37,10 +33,7 @@ def load_bundle_system_prompt(plugin_dir: str | None) -> str | None:
 
     if not plugin_dir:
         return None
-    root = Path(plugin_dir)
-    manifest_path = next(
-        (root / loc for loc in _MANIFEST_LOCATIONS if (root / loc).is_file()), None
-    )
+    manifest_path = resolve_manifest(plugin_dir)
     if manifest_path is None:
         return None
     try:


### PR DESCRIPTION
Six Python callers independently resolved the same two manifest locations (`.claude-plugin/plugin.json`, then root `plugin.json`). A future path or precedence change could drift between validation, archive handling, bundle inspection, and the runner readers.

## Change
- Add `plugin_format.manifest`, the single owner of the ordered locations: `MANIFEST_LOCATIONS` (the tuple) and `resolve_manifest(root)` (first existing manifest, or `None`).
- Callers switched to it:
  - `plugin_format.validate` (`_validate_manifest`) and `plugin_format.archive` (`_has_manifest`)
  - `apps/api` bundle text-surface collector (`_collect_text_files`)
  - runner `plugin` (system-prompt reader), `hooks`, and `approval` readers
- Implementation cleanup only: **no schema, wire, or protocol change.**

## Notes
- Primary path precedence (`.claude-plugin/plugin.json`) and the root `plugin.json` fallback are unchanged; each caller keeps its current validation and error behavior.
- `runner/check.py` reads only the canonical path (no fallback) and is intentionally left untouched to preserve its behavior; it is not one of the readers the issue enumerates.

## Verify
- New `packages/plugin-format/tests/test_manifest.py`: primary path, fallback path, missing manifest, ordering, str-root.
- `uv run pytest` across plugin-format, runner, and API bundle tests -> pass; schema-compat gate green.
- `uv run ruff check` and `uv run mypy` clean.

Closes #636