### PR TITLE
Bound the GitHub webhook body before authentication

### DIFF
--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -59,6 +59,13 @@ class Settings(BaseSettings):
     # Outbound GitHub commit-status API for the eval PR check (K1).
     github_api_url: str = "https://api.github.com"
     github_token: str = ""
+    # Upper bound on the GitHub webhook request body, enforced before the body is
+    # fully buffered, parsed, or HMAC-authenticated (#633) so an unauthenticated
+    # oversized request cannot exhaust memory. GitHub caps webhook payloads at
+    # 25 MB and does not deliver anything larger, so a legitimately signed push
+    # is always under this bound. Keep any ingress/proxy body-size limit fronting
+    # the API aligned with (>=) this value so the two agree on what is rejected.
+    github_webhook_max_body_bytes: int = 25 * 1024 * 1024  # 25 MiB
     eval_check_context: str = "agentos/evals"
     # Suite name put on the fan-out request for a dev-push eval run (the plugin
     # bundle carries the suite itself; the consumer resolves it by this name).

--- a/apps/api/src/agentos_api/routers/github.py
+++ b/apps/api/src/agentos_api/routers/github.py
@@ -17,6 +17,43 @@ from ..schemas import WebhookResult
 router = APIRouter(prefix="/github", tags=["github"])
 
 
+async def _read_bounded_body(request: Request, max_bytes: int) -> bytes:
+    """Read the request body, rejecting anything over ``max_bytes`` early.
+
+    The bound is enforced BEFORE the whole body is buffered, parsed, or
+    authenticated (#633), so an unauthenticated oversized request cannot make
+    the app hold an unbounded body in memory. A declared ``Content-Length`` over
+    the bound is refused without reading a byte; then the body is read in chunks
+    and refused the moment the accumulated size crosses the bound, so an absent
+    or lying ``Content-Length`` (including a chunked/streamed request) is held to
+    the same limit. Raises 413 on an oversized body.
+    """
+
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            declared_len = int(declared)
+        except ValueError:
+            declared_len = -1  # unparseable: fall through to streamed enforcement
+        if declared_len > max_bytes:
+            raise HTTPException(
+                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                "webhook body exceeds the maximum size",
+            )
+
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                "webhook body exceeds the maximum size",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 @router.post("/webhook", response_model=WebhookResult)
 async def github_webhook(
     request: Request,
@@ -27,7 +64,7 @@ async def github_webhook(
     x_hub_signature_256: str | None = Header(default=None),
 ) -> WebhookResult:
     settings = get_settings()
-    body = await request.body()
+    body = await _read_bounded_body(request, settings.github_webhook_max_body_bytes)
     if not verify_signature(
         settings.github_webhook_secret, body, x_hub_signature_256
     ):

--- a/apps/api/tests/test_webhook_body_bound.py
+++ b/apps/api/tests/test_webhook_body_bound.py
@@ -1,0 +1,132 @@
+"""The GitHub webhook bounds its request body before authentication (#633).
+
+A directly exposed webhook must not let an unauthenticated oversized request
+buffer an unbounded body in memory. These drive the real endpoint (mounted on a
+minimal app with the infra deps stubbed, so no DB is needed) and assert the
+bound fires ahead of auth, holds for a lying/absent Content-Length and a
+streamed body, and does not disturb the valid/invalid signature outcomes.
+"""
+
+import hashlib
+import hmac
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from agentos_api.config import Settings
+from agentos_api.deps import get_eval_queue, get_session, get_store
+from agentos_api.routers import github as github_router
+from agentos_api.schemas import WebhookResult
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+SECRET = "webhook-test-secret"
+MAX = 512  # a small bound so tests need not send megabytes
+
+
+def _sign(body: bytes) -> str:
+    return "sha256=" + hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setattr(
+        github_router,
+        "get_settings",
+        lambda: Settings(
+            github_webhook_secret=SECRET, github_webhook_max_body_bytes=MAX
+        ),
+    )
+
+    async def _fake_push(*_args: Any, **_kwargs: Any) -> WebhookResult:
+        # A signed push that clears the size gate reaches process_push; stub it
+        # so the endpoint test needs no Postgres/clone.
+        return WebhookResult(status="deployed")
+
+    monkeypatch.setattr(github_router, "process_push", _fake_push)
+
+    app = FastAPI()
+    app.include_router(github_router.router)
+    app.dependency_overrides[get_session] = lambda: None
+    app.dependency_overrides[get_store] = lambda: None
+    app.dependency_overrides[get_eval_queue] = lambda: None
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _post(client: TestClient, body: bytes, *, event: str, sign: bool) -> Any:
+    headers = {"X-GitHub-Event": event, "Content-Type": "application/json"}
+    if sign:
+        headers["X-Hub-Signature-256"] = _sign(body)
+    return client.post("/github/webhook", content=body, headers=headers)
+
+
+def test_accepts_a_body_at_the_limit(client: TestClient) -> None:
+    # A body of exactly the bound is accepted (ping short-circuits before the DB
+    # path), proving the gate rejects only what is strictly over the limit and a
+    # valid signature still works.
+    body = b"x" * MAX
+    resp = _post(client, body, event="ping", sign=True)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pong"
+
+
+def test_rejects_a_body_over_the_limit(client: TestClient) -> None:
+    body = b"x" * (MAX + 1)
+    # Even a body carrying a valid signature is refused: the bound fires before
+    # authentication is consulted.
+    resp = _post(client, body, event="push", sign=True)
+    assert resp.status_code == 413
+
+
+def test_rejects_a_streamed_oversize_body_without_content_length(
+    client: TestClient,
+) -> None:
+    # A chunked request sends no Content-Length, so the fast-path header check
+    # cannot catch it; the streamed accumulation must. httpx sends chunked when
+    # content is an iterator.
+    def _chunks() -> Iterator[bytes]:
+        for _ in range(4):
+            yield b"y" * 200  # 800 bytes total, over MAX
+
+    resp = client.post(
+        "/github/webhook",
+        content=_chunks(),
+        headers={"X-GitHub-Event": "push", "Content-Type": "application/json"},
+    )
+    assert resp.status_code == 413
+
+
+def test_oversize_is_rejected_before_authentication(client: TestClient) -> None:
+    # No signature header at all, oversized body: still 413, not 401. The size
+    # gate precedes the signature check by design.
+    resp = _post(client, b"z" * (MAX + 50), event="push", sign=False)
+    assert resp.status_code == 413
+
+
+def test_within_limit_invalid_signature_fails_closed(client: TestClient) -> None:
+    body = b'{"ref":"refs/heads/dev"}'
+    resp = client.post(
+        "/github/webhook",
+        content=body,
+        headers={
+            "X-GitHub-Event": "push",
+            "X-Hub-Signature-256": "sha256=" + "0" * 64,
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_within_limit_missing_signature_fails_closed(client: TestClient) -> None:
+    resp = _post(client, b'{"ref":"refs/heads/dev"}', event="push", sign=False)
+    assert resp.status_code == 401
+
+
+def test_within_limit_valid_signature_proceeds(client: TestClient) -> None:
+    # A normal signed push under the bound clears both gates and reaches
+    # process_push (stubbed), i.e. it enqueues in the real path.
+    body = b'{"ref":"refs/heads/dev","after":"a","repository":{}}'
+    resp = _post(client, body, event="push", sign=True)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deployed"


### PR DESCRIPTION
The GitHub webhook buffered the full request body with `await request.body()` before validating the HMAC, and enforced no body-size limit. A directly exposed webhook could therefore consume application memory using unauthenticated oversized requests.

## Change
- Read the body through `_read_bounded_body`, which:
  - refuses a declared `Content-Length` over the bound **without reading a byte**, then
  - reads the body in chunks and refuses the moment the accumulated size crosses the bound.
  This holds an absent or lying `Content-Length` (including a chunked/streamed request) to the same limit.
- The bound is enforced **before** the body is fully buffered, parsed, or authenticated, so an oversized request gets `413` irrespective of its signature.
- Add `Settings.github_webhook_max_body_bytes` (default **25 MiB**), documented as aligned with GitHub's 25 MB webhook payload cap (GitHub never delivers anything larger, so a legitimately signed push is always under it) and with any ingress/proxy body-size limit fronting the API.

Normal signed requests still enqueue; missing or invalid signatures still fail closed with `401`.

## Verify (acceptance criteria)
New `apps/api/tests/test_webhook_body_bound.py`:
- accepted boundary size (body == limit) -> 200
- oversized body with a valid signature -> 413 (rejected before auth)
- streamed oversized body with no `Content-Length` -> 413
- oversized body, no signature -> 413 (bound precedes auth)
- within-limit invalid / missing signature -> 401 (fail closed)
- within-limit valid signature -> reaches `process_push`

Existing `test_gitflow_integration.py` (real signed pushes against Postgres/MinIO) -> 8 passed, confirming the normal enqueue path is unchanged. `ruff`, `mypy`, and the OpenAPI drift gate are clean.

Closes #633