### PR TITLE
Widen the weather eval to accept spelled-out degrees

### DIFF
--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -374,7 +374,23 @@ mod tests {
         // and the loader ignores the documentation-only `note` key on the case.
         assert_eq!(case.id, "reports-a-temperature");
         assert_eq!(case.grader.kind, GraderKind::Regex);
-        assert_eq!(case.grader.expected, "\\d+\\s*°");
+        assert_eq!(case.grader.expected, "\\d+\\s*(°|deg)");
+    }
+
+    #[test]
+    fn weather_grader_accepts_spelled_out_degrees_and_still_rejects_a_refusal() {
+        // #620: the glyph-only pattern graded a correct plain-English answer red.
+        // Drive the AC strings through the committed grader as `agentos skill eval`
+        // does, so the widened pattern is verified where the runtime grades.
+        let body = include_str!("../../examples/weather/evals/cases.json");
+        let (_dir, path) = write(body);
+        let grader = &load_suite(&path).unwrap().cases[0].grader;
+
+        assert!(grader.grade("The high in San Francisco today is 68 degrees Fahrenheit"));
+        assert!(grader.grade("High near 68 deg F"));
+        assert!(grader.grade("Today's high is 68°"));
+        // A refusal with no temperature figure must still fail closed.
+        assert!(!grader.grade("I could not confirm a current forecast"));
     }
 
     #[test]

--- a/examples/weather/evals/cases.json
+++ b/examples/weather/evals/cases.json
@@ -6,10 +6,10 @@
       "input": "What's the weather in San Francisco today? Give the high in Fahrenheit.",
       "grader": {
         "kind": "regex",
-        "expected": "\\d+\\s*°",
+        "expected": "\\d+\\s*(°|deg)",
         "case_sensitive": false
       },
-      "note": "Falsifiable: an agent that cannot fetch a matching forecast follows the SKILL rule and refuses ('I could not confirm a current forecast') with no temperature figure, which fails this grader -- unlike the old `contains: weather`, which the input itself guaranteed. LIMIT: a fake-model agent that INVENTS a plausible temperature still passes; proving the agent actually fetched a source needs the tool-call grader (ADR-0022 Phase 1)."
+      "note": "Falsifiable: an agent that cannot fetch a matching forecast follows the SKILL rule and refuses ('I could not confirm a current forecast') with no temperature figure, which fails this grader -- unlike the old `contains: weather`, which the input itself guaranteed. The pattern accepts a numeric high with either the degree glyph or the spelled-out unit, so '68 degrees Fahrenheit', '68 deg F', and '68°' all pass (#620; `deg` is a prefix of `degree`/`degrees`, case-folded). Two residual limits remain, neither expressible in the frozen exact|contains|regex taxonomy: (1) FALSE POSITIVE -- a fake-model agent that INVENTS a plausible temperature still passes; proving the agent actually fetched a source needs the tool-call grader (ADR-0022 Phase 1) and the semantic verifier (ADR-0042, #618, which #620 is a stopgap for); (2) FALSE NEGATIVE -- a correct answer that carries no numeric figure adjacent to a degree token (e.g. spelled-out 'sixty-eight Fahrenheit', or a bare '68F' with no glyph or 'deg') would still be graded red."
     }
   ]
 }


### PR DESCRIPTION
`examples/weather/evals/cases.json` graded with `regex: "\d+\s*°"`, and the graders normalize only case (`apps/worker/.../eval/models.py`, mirrored in `cli/src/evals.rs`) - no glyph-to-word mapping. So an agent that fetched a real forecast and answered "The high in San Francisco today is 68 degrees Fahrenheit" went **red**. The eval punished the agent for being correct, and the note did not mention it.

## Change
- Widen the pattern to `\d+\s*(°|deg)`. `deg` is a prefix of `degree`/`degrees` and the grader case-folds, so **"68 degrees Fahrenheit", "68 deg F", and "68°" all pass**; a refusal with no figure ("I could not confirm a current forecast") still fails closed.
- Correct the `note` to state both residual limits, neither expressible in the frozen `exact|contains|regex` taxonomy:
  1. **False positive** - a fake-model agent that invents a plausible temperature still passes; catching that needs the tool-call grader (ADR-0022 Phase 1) and the semantic verifier (ADR-0042, #618).
  2. **False negative** - a correct answer carrying no numeric-plus-degree-token figure (spelled-out "sixty-eight Fahrenheit", or a bare "68F") would still be graded red.

This is the stopgap for the false-negative half of **#618**; it does not close #618's hallucination hole.

## Verify
- Updated `loads_the_committed_weather_example` and added `weather_grader_accepts_spelled_out_degrees_and_still_rejects_a_refusal`, which drives the AC strings through the committed grader. `cargo test --lib evals` -> 17 passed.
- `cargo fmt --check` and `cargo clippy -D warnings` clean.
- Confirmed the Python grader engine matches the same strings (cross-engine parity).

Closes #620