### PR TITLE
Accept spelled-out degrees in the weather eval grader (stopgap for #618)

### DIFF
--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -374,7 +374,31 @@ mod tests {
         // and the loader ignores the documentation-only `note` key on the case.
         assert_eq!(case.id, "reports-a-temperature");
         assert_eq!(case.grader.kind, GraderKind::Regex);
-        assert_eq!(case.grader.expected, "\\d+\\s*°");
+        // #620: the pattern accepts the degree glyph AND the spelled-out unit, so
+        // a correct plain-English forecast is no longer graded red. The alternation
+        // stays inside the Python-re / Rust-regex intersection (no lookaround, no
+        // backreferences), so the CLI compiles it identically to the platform.
+        assert_eq!(case.grader.expected, "\\d+\\s*(°|deg)");
+    }
+
+    #[test]
+    fn weather_grader_accepts_glyph_and_spelled_unit_but_not_a_figureless_refusal() {
+        // #620: prove the committed pattern's behavior by EXECUTING the grader
+        // (not by inspecting the string) against the acceptance strings. The glyph
+        // and both spellings pass; a refusal that carries no figure fails.
+        let body = include_str!("../../examples/weather/evals/cases.json");
+        let (_dir, path) = write(body);
+        let grader = &load_suite(&path).unwrap().cases[0].grader;
+        assert!(grader.grade("68°"), "glyph form must pass");
+        assert!(grader.grade("68 deg F"), "abbreviated unit must pass");
+        assert!(
+            grader.grade("The high in San Francisco today is 68 degrees Fahrenheit"),
+            "spelled-out unit must pass"
+        );
+        assert!(
+            !grader.grade("I could not confirm a current forecast"),
+            "a refusal with no temperature figure must still fail"
+        );
     }
 
     #[test]

--- a/examples/weather/evals/cases.json
+++ b/examples/weather/evals/cases.json
@@ -6,10 +6,10 @@
       "input": "What's the weather in San Francisco today? Give the high in Fahrenheit.",
       "grader": {
         "kind": "regex",
-        "expected": "\\d+\\s*°",
+        "expected": "\\d+\\s*(°|deg)",
         "case_sensitive": false
       },
-      "note": "Falsifiable: an agent that cannot fetch a matching forecast follows the SKILL rule and refuses ('I could not confirm a current forecast') with no temperature figure, which fails this grader -- unlike the old `contains: weather`, which the input itself guaranteed. LIMIT: a fake-model agent that INVENTS a plausible temperature still passes; proving the agent actually fetched a source needs the tool-call grader (ADR-0022 Phase 1)."
+      "note": "Falsifiable: an agent that cannot fetch a matching forecast follows the SKILL rule and refuses ('I could not confirm a current forecast') with no temperature figure, which fails this grader -- unlike the old `contains: weather`, which the input itself guaranteed. The pattern accepts both the degree glyph ('68°') and the spelled-out unit ('68 degrees Fahrenheit', '68 deg F'), because the graders case-fold but never map glyph to word (models.py:64-75); before #620 a correct plain-English answer was punished for using the word instead of the symbol. RESIDUAL LIMITS: (1) this case grades the PRESENCE of a temperature figure, not its PROVENANCE -- a fake-model agent that INVENTS a plausible temperature ('72 degrees') still passes. (2) That invented-temperature false positive is #618's scope and stays open; closing it needs the semantic verifier grader (GraderKind.verifier, ADR-0042, itself blocked on ADR-0022 Phase 1), which no member of the frozen exact|contains|regex taxonomy can express. #620 is only the false-negative stopgap."
     }
   ]
 }


### PR DESCRIPTION
Stopgap for the false-negative half of #618. The weather eval case graded with `regex: "\d+\s*°"`; the graders case-fold but apply no glyph-to-word normalization (`apps/worker/src/agentos_worker/eval/models.py:64-75`, mirrored in `cli/src/evals.rs`), so a correct plain-English forecast like "The high in San Francisco today is 68 degrees Fahrenheit" graded **red** — the eval punished the agent for being right.

## Change
- Widen the pattern to `\d+\s*(°|deg)` so the spelled-out unit passes alongside the glyph. The alternation stays inside the Python-`re` ∩ Rust-`regex` intersection (plain alternation, no lookaround or backreferences), so both engines compile it identically.
- Rewrite the case `note` to state both residual limits honestly: (1) the case grades a temperature figure's **presence, not its provenance**, and (2) an agent that **invents** a plausible temperature still passes — that false positive is #618's scope and stays open, needing the ADR-0042 semantic verifier grader (itself blocked on ADR-0022 Phase 1).
- Update the CLI parse test to the new pattern and add an execution test that grades the four acceptance strings through the real `Grader`.

## Scope
This fixes **only** the false negative. It does **not** close #618, and does not touch the github-issues example or the scaffold seed. #619's positive-control CI gate has not landed (still open), so there was nothing to extend there.

## Proof (executed, not by inspection)

Real worker `Grader.grade` (Python `re`), grading the committed `cases.json`:
```
kind: regex | expected: '\\d+\\s*(°|deg)'
--------------------------------------------------------------
PASS  grade()=True  want=True   '68 degrees Fahrenheit'
PASS  grade()=True  want=True   '68 deg F'
PASS  grade()=True  want=True   '68°'
PASS  grade()=True  want=True   'The high in San Francisco today is 68 degrees Fahrenheit'
PASS  grade()=False want=False  'I could not confirm a current forecast'
--------------------------------------------------------------
ALL BEHAVE AS SPECIFIED
```

Rust `regex` crate via `cargo test --lib evals::` (new `weather_grader_accepts_glyph_and_spelled_unit_but_not_a_figureless_refusal` + updated `loads_the_committed_weather_example`):
```
test evals::tests::loads_the_committed_weather_example ... ok
test evals::tests::weather_grader_accepts_glyph_and_spelled_unit_but_not_a_figureless_refusal ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 356 filtered out
```

`cargo fmt --check` clean. No Python source changed, so the worker suite is unaffected.

Closes #620
Ref #618
