### PR TITLE
Share the eval stream and consumer-group literals

### DIFF
--- a/apps/api/src/agentos_api/evalqueue.py
+++ b/apps/api/src/agentos_api/evalqueue.py
@@ -20,9 +20,9 @@ from datetime import UTC, datetime
 from typing import Any, cast
 
 import redis.asyncio as redis
-from aci_protocol import STREAM_PAYLOAD_FIELD, EvalJob, parse_eval_job
+from aci_protocol import EVAL_STREAM_DEFAULT, STREAM_PAYLOAD_FIELD, EvalJob, parse_eval_job
 
-EVAL_STREAM = "agentos:evals"
+EVAL_STREAM = EVAL_STREAM_DEFAULT
 
 
 def to_stream_fields(job: EvalJob) -> dict[str, str]:

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -21,6 +21,8 @@ from typing import Annotated
 
 from aci_protocol.service_config import (
     API_KEY_ENV,
+    EVAL_CONSUMER_GROUP_DEFAULT,
+    EVAL_STREAM_DEFAULT,
     HEARTBEAT_FILE_ENV,
     HEARTBEAT_INTERVAL_ENV,
     RUNS_STREAM_DEFAULT,
@@ -282,10 +284,11 @@ class WorkerConfig(BaseSettings):
     # Eval stream (F3): a separate consumer group on agentos:evals runs eval
     # suites and reports results to the platform API and Langfuse.
     eval_stream: str = Field(
-        default="agentos:evals", validation_alias="AGENTOS_EVAL_STREAM"
+        default=EVAL_STREAM_DEFAULT, validation_alias="AGENTOS_EVAL_STREAM"
     )
     eval_consumer_group: str = Field(
-        default="agentos-eval-workers", validation_alias="AGENTOS_EVAL_CONSUMER_GROUP"
+        default=EVAL_CONSUMER_GROUP_DEFAULT,
+        validation_alias="AGENTOS_EVAL_CONSUMER_GROUP",
     )
     eval_consumer_name: str = Field(default_factory=_default_consumer_name)
     # On first creation the eval group starts at (now - this window) rather than

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -12,6 +12,10 @@ pub const RUNS_STREAM_DEFAULT: &str = "agentos:runs";
 
 pub const WORKER_GROUP_DEFAULT: &str = "agentos-workers";
 
+pub const EVAL_STREAM_DEFAULT: &str = "agentos:evals";
+
+pub const EVAL_CONSUMER_GROUP_DEFAULT: &str = "agentos-eval-workers";
+
 pub const STREAM_PAYLOAD_FIELD: &str = "payload";
 
 fn parse_semver(value: &str) -> Option<(u64, u64)> {

--- a/packages/aci-protocol/src/aci_protocol/__init__.py
+++ b/packages/aci-protocol/src/aci_protocol/__init__.py
@@ -40,6 +40,8 @@ from .ndjson import (
 )
 from .reference import reference_producer
 from .service_config import (
+    EVAL_CONSUMER_GROUP_DEFAULT,
+    EVAL_STREAM_DEFAULT,
     RUNS_STREAM_DEFAULT,
     STREAM_PAYLOAD_FIELD,
     WORKER_GROUP_DEFAULT,
@@ -70,6 +72,8 @@ __all__ = [
     # shared transport literals (defaults + the stream payload field)
     "RUNS_STREAM_DEFAULT",
     "WORKER_GROUP_DEFAULT",
+    "EVAL_STREAM_DEFAULT",
+    "EVAL_CONSUMER_GROUP_DEFAULT",
     "STREAM_PAYLOAD_FIELD",
     # inbound
     "Event",

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -29,6 +29,8 @@ from .events import (
     ToolNote,
 )
 from .service_config import (
+    EVAL_CONSUMER_GROUP_DEFAULT,
+    EVAL_STREAM_DEFAULT,
     RUNS_STREAM_DEFAULT,
     STREAM_PAYLOAD_FIELD,
     WORKER_GROUP_DEFAULT,
@@ -338,6 +340,8 @@ def render_rust() -> str:
         # JSON Schema and do not move the wire fingerprint.
         f'pub const RUNS_STREAM_DEFAULT: &str = "{RUNS_STREAM_DEFAULT}";',
         f'pub const WORKER_GROUP_DEFAULT: &str = "{WORKER_GROUP_DEFAULT}";',
+        f'pub const EVAL_STREAM_DEFAULT: &str = "{EVAL_STREAM_DEFAULT}";',
+        f'pub const EVAL_CONSUMER_GROUP_DEFAULT: &str = "{EVAL_CONSUMER_GROUP_DEFAULT}";',
         f'pub const STREAM_PAYLOAD_FIELD: &str = "{STREAM_PAYLOAD_FIELD}";',
         _VERSION_GUARD,
         _string_enum(

--- a/packages/aci-protocol/src/aci_protocol/service_config.py
+++ b/packages/aci-protocol/src/aci_protocol/service_config.py
@@ -48,6 +48,15 @@ RUNS_STREAM_DEFAULT = "agentos:runs"
 WORKER_GROUP_DEFAULT = "agentos-workers"
 STREAM_PAYLOAD_FIELD = "payload"
 
+# The eval lane's twins of the two above (#626, the deliberate deferral from
+# #492). The eval stream and its own consumer group were still hand-mirrored per
+# lane (the API producer, the worker consumer), the same drift risk #492 closed
+# for the runs stream. Same treatment: one declaration here, env-overridable
+# through each lane's pydantic field (AGENTOS_EVAL_STREAM /
+# AGENTOS_EVAL_CONSUMER_GROUP). Not wire models either, so no protocol bump.
+EVAL_STREAM_DEFAULT = "agentos:evals"
+EVAL_CONSUMER_GROUP_DEFAULT = "agentos-eval-workers"
+
 
 def api_url_validation_alias() -> AliasChoices:
     """The ``validation_alias`` for the platform API base URL field: the canonical


### PR DESCRIPTION
Follow-up from #492 (PR #624), documented there as its only deliberate deferral.

The eval stream name `agentos:evals` (`apps/api/.../evalqueue.py`, `apps/worker/.../config.py`) and the eval consumer group `agentos-eval-workers` (`apps/worker/.../config.py`) were still declared as per-lane string literals - the same hand-mirroring drift #492 closed for the runs stream. #492's acceptance criteria enumerated only the runs-stream, worker consumer group, and payload envelope key, so these were left alone to avoid scope creep.

## Change (same treatment as #492)
- Declare `EVAL_STREAM_DEFAULT` and `EVAL_CONSUMER_GROUP_DEFAULT` once in `aci_protocol.service_config`, next to `RUNS_STREAM_DEFAULT` / `WORKER_GROUP_DEFAULT`. These are plain string constants, **not** Pydantic wire models - not in the exported JSON Schema and not in the wire fingerprint - so there is no `PROTOCOL_VERSION` bump.
- Export them from the package and emit them into the generated Rust crate (`generated/rust/src/lib.rs`) alongside the runs-stream literals.
- The API (`evalqueue.EVAL_STREAM`) and worker (`config.eval_stream` / `eval_consumer_group`) bind them, so the env-override plumbing (`AGENTOS_EVAL_STREAM` / `AGENTOS_EVAL_CONSUMER_GROUP`) is preserved.

## Verify
- `python -m aci_protocol.rust_export` regenerated the crate; the only change is the two new consts. No schema or `wire.lock` diff.
- `uv run pytest` - schema-compat + wire-lock gates green; eval-lane tests (`apps/api` evals: 54, `apps/worker` eval stream: 16) pass; worker `test_config` passes.
- `ruff`, `mypy`, and `cargo check` (generated crate compiles via the CLI) clean.

Closes #626