### PR TITLE
Gate documented dataclass field lists against the code (follow-up to #656)

### DIFF
--- a/tools/doclint/src/agentos_doclint/__init__.py
+++ b/tools/doclint/src/agentos_doclint/__init__.py
@@ -24,6 +24,7 @@ from .citation import (
     CodeSpan,
     classify,
     find_code_spans,
+    find_field_enumerations,
     is_line_suppressed,
     link_target_matches_citation,
     path_exists,
@@ -46,7 +47,7 @@ from .generate import (
     replace_region,
     seam_link,
 )
-from .symbols import SymbolCache, SymbolSyntaxError, resolve_symbol
+from .symbols import SymbolCache, SymbolSyntaxError, dataclass_fields, resolve_symbol
 from .vision import VISION_REL, read_swap_readiness
 
 __all__ = [
@@ -406,6 +407,8 @@ def _lint_doc(
     for span in find_code_spans(text):
         raw.extend(_check_span(repo_root, rel, span, cache))
 
+    raw.extend(_check_field_enumerations(repo_root, rel, text, cache))
+
     kept: list[Finding] = []
     suppressed_lines: set[int] = set()
     for finding in raw:
@@ -489,6 +492,58 @@ def _check_citation(
                 span.content,
                 f"symbol '{classification.symbol}' does not resolve",
                 line=span.line,
+            )
+        )
+    return findings
+
+
+def _check_field_enumerations(
+    repo_root: Path, rel: str, text: str, cache: SymbolCache
+) -> list[Finding]:
+    """A sealed ``(`Class`: `a`, `b`, ...)`` field list must match the cited
+    class's actual annotated fields.
+
+    #573 deleted ``ClaimView.labels`` from the dataclass and both adapters but
+    left the substrate seam doc's field list intact, so a second implementer
+    building to the documented contract gets a ``TypeError`` on construction.
+    The citation still resolved, so citation resolution alone never caught the
+    stale field (#615). This complements the link-text-vs-target check by gating
+    the other described-shape drift: a documented field list. Compared as sets,
+    so field REORDERING is allowed; only extra/missing fields are flagged."""
+    findings: list[Finding] = []
+    for enum in find_field_enumerations(text):
+        classification = classify(enum.citation)
+        if classification.kind != "citation" or not classification.symbol:
+            continue
+        if not classification.path.endswith(".py"):
+            continue
+        if not path_exists(repo_root, classification.path):
+            continue  # a missing path is the citation walk's finding, not ours
+        try:
+            actual = dataclass_fields(
+                repo_root / classification.path, classification.symbol, cache
+            )
+        except SymbolSyntaxError:
+            continue  # a syntax error is the citation walk's finding
+        if not actual:
+            continue  # not a field-bearing dataclass -> nothing to compare
+        documented = set(enum.fields)
+        real = set(actual)
+        if documented == real:
+            continue
+        extra = sorted(documented - real)
+        missing = sorted(real - documented)
+        parts: list[str] = []
+        if extra:
+            parts.append(f"documents field(s) not on the class: {', '.join(extra)}")
+        if missing:
+            parts.append(f"omits actual field(s): {', '.join(missing)}")
+        findings.append(
+            Finding(
+                rel,
+                enum.citation,
+                "documented field list does not match the cited class; " + "; ".join(parts),
+                line=enum.line,
             )
         )
     return findings

--- a/tools/doclint/src/agentos_doclint/citation.py
+++ b/tools/doclint/src/agentos_doclint/citation.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from markdown_it import MarkdownIt
+from markdown_it.token import Token
 
 # The single recognized extension list, shared by the path rule and the raw
 # line-ban rule. Two lists would drift, which is the whole subject of #452.
@@ -142,6 +143,99 @@ def find_code_spans(text: str) -> list[CodeSpan]:
                 line = start_line + 1 + line_offset if start_line is not None else None
                 spans.append(CodeSpan(content=child.content, line=line, href=current_href))
     return spans
+
+
+_FIELD_IDENT = re.compile(r"[a-z_][a-z0-9_]*")
+
+
+@dataclass(frozen=True)
+class FieldEnumeration:
+    citation: str  # the citation code-span text (path::Symbol)
+    fields: tuple[str, ...]
+    line: int | None
+
+
+def find_field_enumerations(text: str) -> list[FieldEnumeration]:
+    """Find sealed field lists of the form `` `path::Class`: `a`, `b`, `c`) ``.
+
+    A citation code-span immediately followed by a text ``:`` intro, then a run
+    of backticked bare identifiers separated only by ``,``/``and``/whitespace,
+    terminated by a ``)``. Only this sealed shape is returned, so a prose
+    sentence that happens to mention a field or two is not mistaken for a
+    complete enumeration (#615)."""
+    source_lines = text.split("\n")
+    results: list[FieldEnumeration] = []
+    for token in _MD.parse(text):
+        if token.type != "inline" or token.children is None:
+            continue
+        if token.map is not None:
+            start_line = token.map[0]
+            block_text = "\n".join(source_lines[token.map[0] : token.map[1]])
+        else:
+            start_line = None
+            block_text = ""
+        cursor = 0
+        children = token.children
+        # Pre-compute each code_inline's line by walking cursor in order.
+        line_by_index: dict[int, int | None] = {}
+        for idx, child in enumerate(children):
+            if child.type == "code_inline":
+                line_offset, cursor = _locate_span(block_text, child.content, cursor)
+                line_by_index[idx] = (
+                    start_line + 1 + line_offset if start_line is not None else None
+                )
+        for idx, child in enumerate(children):
+            if child.type != "code_inline":
+                continue
+            if "::" not in child.content:
+                continue
+            enum = _parse_field_run(children, idx)
+            if enum is not None:
+                results.append(
+                    FieldEnumeration(
+                        citation=child.content,
+                        fields=enum,
+                        line=line_by_index.get(idx),
+                    )
+                )
+    return results
+
+
+def _parse_field_run(children: list[Token], start_idx: int) -> tuple[str, ...] | None:
+    """Return the sealed field tuple following the citation at ``start_idx``, or
+    None if the shape is not `` : `field`, `field`, ... ) ``."""
+    intro = children[start_idx + 1] if start_idx + 1 < len(children) else None
+    if intro is None or intro.type != "text":
+        return None
+    text_after = intro.content
+    if ":" not in text_after:
+        return None
+    # Everything after the first ':' in the intro token must be blank (the
+    # fields are their own code spans). Rejects ": something prose".
+    if text_after.split(":", 1)[1].strip() != "":
+        return None
+    fields: list[str] = []
+    j = start_idx + 2
+    while j < len(children):
+        c = children[j]
+        if c.type == "code_inline":
+            if not _FIELD_IDENT.fullmatch(c.content):
+                return None
+            fields.append(c.content)
+            j += 1
+            continue
+        if c.type == "text":
+            if ")" in c.content:
+                before = c.content.split(")", 1)[0]
+                if before.strip(" ,") in ("", "and"):
+                    return tuple(fields) if fields else None
+                return None
+            if c.content.strip(" ,") in ("", "and"):
+                j += 1
+                continue
+            return None
+        return None
+    return None
 
 
 @dataclass(frozen=True)

--- a/tools/doclint/src/agentos_doclint/symbols.py
+++ b/tools/doclint/src/agentos_doclint/symbols.py
@@ -68,6 +68,33 @@ def resolve_symbol(file_path: Path, dotted: str, cache: SymbolCache | None = Non
     return _resolve_in_body(tree.body, parts)
 
 
+def dataclass_fields(
+    file_path: Path, dotted: str, cache: SymbolCache | None = None
+) -> list[str] | None:
+    """Ordered annotated field names of the cited class (its ``AnnAssign``
+    targets), or ``None`` if ``dotted`` does not resolve to a class. Static ast
+    only, never imports. A class with no annotated fields returns ``[]``."""
+    tree = cache.parse(file_path) if cache is not None else _parse(file_path)
+    node = _find_class(tree.body, dotted.split("."))
+    if node is None:
+        return None
+    fields: list[str] = []
+    for stmt in node.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            fields.append(stmt.target.id)
+    return fields
+
+
+def _find_class(body: list[ast.stmt], parts: list[str]) -> ast.ClassDef | None:
+    head, rest = parts[0], parts[1:]
+    for node in body:
+        if isinstance(node, ast.ClassDef) and node.name == head:
+            if not rest:
+                return node
+            return _find_class(node.body, rest)
+    return None
+
+
 def _resolve_in_body(body: list[ast.stmt], parts: list[str]) -> bool:
     head, rest = parts[0], parts[1:]
 

--- a/tools/doclint/tests/fixtures/clean_repo/runner/src/agentos_runner/approval.py
+++ b/tools/doclint/tests/fixtures/clean_repo/runner/src/agentos_runner/approval.py
@@ -4,9 +4,19 @@ The doclint symbol resolver parses this file with ``ast`` (never imports it),
 so the bindings below are the ground truth the resolution tests cite against.
 """
 
+from dataclasses import dataclass
+
 from ._helpers import build_options  # ImportFrom-bound name, resolvable at this site
 
 GRANT_PREFIX = "agentos:grant"  # module-level constant (assignment target)
+
+
+@dataclass(frozen=True)
+class SomeData:
+    """Field-bearing dataclass, ground truth for the field-enumeration check."""
+
+    a: str
+    b: int
 
 
 def authorize_approval(actor: str) -> bool:
@@ -22,4 +32,4 @@ class ApprovalGate:
         _ = tool
 
 
-__all__ = ["authorize_approval", "ApprovalGate", "GRANT_PREFIX", "build_options"]
+__all__ = ["authorize_approval", "ApprovalGate", "GRANT_PREFIX", "SomeData", "build_options"]

--- a/tools/doclint/tests/test_field_enumeration.py
+++ b/tools/doclint/tests/test_field_enumeration.py
@@ -1,0 +1,88 @@
+"""Dataclass-field-enumeration match (#615).
+
+A sealed parenthetical field list of the form
+`` `path::Class`: `a`, `b`, ...) `` must equal the cited class's actual
+annotated fields. #573 deleted ``ClaimView.labels`` from the dataclass and both
+adapters but left the seam doc's field list intact; the citation resolved, so
+citation resolution alone never caught the stale field. This complements the
+link-text-vs-target gate by catching the other described-shape drift. These
+tests drive the public CLI over a copied fixture tree, asserting through exit
+code and message text only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .conftest import RunLint, write
+
+DATA = "runner/src/agentos_runner/approval.py::SomeData"
+
+
+def test_extra_field_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    write(
+        clean_repo,
+        "docs/fields_extra.md",
+        f"The payload is `{DATA}` (`{DATA}`: `a`, `b`, `ghost`).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "ghost" in out
+    assert "does not match" in out
+
+
+def test_missing_field_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    write(
+        clean_repo,
+        "docs/fields_missing.md",
+        f"The payload is `{DATA}` (`{DATA}`: `a`).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "does not match" in out
+    assert "b" in out
+
+
+def test_exact_match_passes(clean_repo: Path, run_lint: RunLint) -> None:
+    write(
+        clean_repo,
+        "docs/fields_ok.md",
+        f"The payload is `{DATA}` (`{DATA}`: `a`, `b`).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_reordered_fields_pass(clean_repo: Path, run_lint: RunLint) -> None:
+    # Set comparison: order is allowed to differ.
+    write(
+        clean_repo,
+        "docs/fields_reordered.md",
+        f"The payload is `{DATA}` (`{DATA}`: `b`, `a`).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_non_sealed_prose_does_not_fire(clean_repo: Path, run_lint: RunLint) -> None:
+    # A prose sentence that mentions a field or two is not a sealed enumeration.
+    write(
+        clean_repo,
+        "docs/fields_prose.md",
+        f"The `{DATA}` type carries `a` and other things.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_class_without_annotated_fields_is_skipped(clean_repo: Path, run_lint: RunLint) -> None:
+    # ApprovalGate has methods but no annotated fields; a listed "field" must not
+    # produce a mismatch finding (there is nothing to compare against).
+    cls = "runner/src/agentos_runner/approval.py::ApprovalGate"
+    write(
+        clean_repo,
+        "docs/fields_methods.md",
+        f"The gate is `{cls}` (`{cls}`: `consume_grant`).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out


### PR DESCRIPTION
## What

Follow-up to #656, which closed #615 by fixing the three drifted seam docs and adding a **link-text-vs-target** gate (a decorated link whose target disagrees with its cited path). This PR adds the *sibling* gate the issue also named but #656 did not implement: a **documented dataclass field enumeration** that no longer matches the class.

> Note: this branch originally carried the full #615 fix, but #656 merged first and closed the issue. I rebased and reduced this PR to only the genuinely-new slice — the field-enumeration check — dropping the now-redundant doc fixes and link check.

### Why it matters
#573 deleted `ClaimView.labels` from the dataclass and both adapters but left the substrate seam doc's field list intact. The `::ClaimView` citation still *resolved*, so citation resolution (and the new link check) never caught it — a second implementer building to the documented contract would get a `TypeError` on construction. #656 already fixed that specific doc; this gates the whole *class* of drift so it cannot recur.

### The check
- `find_field_enumerations` matches only the **sealed** shape ``(`Class`: `a`, `b`, ...)`` — a citation, a `:` intro, a run of backticked bare identifiers, terminated by `)`. Prose that merely mentions a field or two is not mistaken for a complete list.
- `dataclass_fields` reads the cited class's `AnnAssign` fields by static `ast` (never imports).
- `_check_field_enumerations` compares them as **sets** (reordering allowed); extra/missing fields are flagged. Non-dataclass or fieldless classes are skipped.

## Verification (red then green)
Transiently re-introducing the removed `ClaimView.labels` field and running the linter over the real repo:
```
docs/interfaces/substrate/INTERFACE.md:35: ...types.py::ClaimView: documented field list does not match the cited class; documents field(s) not on the class: labels
```
linter exit = 1; silent once the field is removed. `uv run mypy`, `uv run ruff check tools/doclint`, `uv run pytest -q tools/doclint` (**75 passed**, 6 new), and `bash scripts/check-docs.sh` (exit 0) all pass. The new unit tests fail without the implementation.

Refs #615