### PR TITLE
Add a CI falsifiability gate for the committed eval cases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -331,3 +331,41 @@ jobs:
         run: docker build -t agentos-dispatcher:ci-smoke -f apps/dispatcher/Dockerfile .
       - name: Entrypoint imports resolve in the built image
         run: docker run --rm --entrypoint python agentos-dispatcher:ci-smoke -c "import agentos_dispatcher; import aci_protocol"
+
+  # FALSIFIABILITY gate for the committed eval suites (issue #619). This is NOT
+  # an E2E test: it never runs a real agent or makes a model call. It boots the
+  # runner's scripted FAKE model (offline, no credential, no network) -- a
+  # do-nothing agent whose only reply is the canned "all done" -- and runs every
+  # committed eval suite (examples/*/evals/cases.json + the init scaffold seed at
+  # apps/worker/schema/eval-cases.example.json) through the real `agentos skill
+  # eval` path, failing if ANY case passes. A case that greens against a
+  # responder that calls no tool and ignores the input is unfalsifiable (#527),
+  # which is exactly what this gate forbids reaching main. Suites are discovered,
+  # not hardcoded, so a new suite needs no edit here. The input-parrot
+  # vacuousness control (the `contains: "weather"` class) and the positive
+  # control (each grader greens on a known-good exemplar) are grader-level and
+  # ride the Rust job (cli/tests/eval_falsifiability.rs) -- the fake model can
+  # only ever say "all done", so those cannot be expressed through this path.
+  # Reuses the release binary the Rust job already built and uploaded, and builds
+  # the runner image locally (plain `docker build`, no registry auth).
+  eval-falsifiability:
+    name: Eval falsifiability gate (fake model, offline)
+    runs-on: ubuntu-latest
+    needs: rust
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Download the agentos binary built by the Rust job
+        uses: actions/download-artifact@v7
+        with:
+          name: agentos-x86_64-linux-${{ github.sha }}
+          path: cli/target/release
+      - name: Make the binary executable
+        run: chmod +x cli/target/release/agentos
+      - name: Build the runner image locally
+        run: docker build -t agentos-runner -f runner/Dockerfile .
+      - name: Falsifiability gate (every committed case must go RED against the fake model)
+        env:
+          AGENTOS_BIN: cli/target/release/agentos
+        run: bash cli/scripts/eval-falsifiability.sh

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2894,6 +2894,11 @@ export const commandManifest = {
           "name": "plugin-compat"
         },
         {
+          "about": "Run the committed eval suites through the fake model and assert every case goes RED -- the falsifiability gate's real-path negative control (#619, `bash cli/scripts/eval-falsifiability.sh`). Offline, no credential",
+          "hidden": false,
+          "name": "eval-falsifiability"
+        },
+        {
           "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
           "hidden": false,
           "name": "version-check"

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -165,3 +165,15 @@ AGENTOS_E2E_API_URL=http://localhost:8000 bash cli/scripts/e2e.sh
 ```
 Both require the `agentos-runner` image built once from the repo root
 (`docker build -f runner/Dockerfile -t agentos-runner .`).
+
+Falsifiability gate (issue #619) -- a gate, NOT an E2E test: it never runs a real
+agent or makes a model call. Its real-path half boots the FAKE model and asserts
+every committed eval suite goes RED (a case that greens against a do-nothing
+agent is unfalsifiable, #527):
+```bash
+agentos dev eval-falsifiability   # bash cli/scripts/eval-falsifiability.sh
+```
+The grader-level half (the `contains: "weather"` input-parrot vacuousness control
+and the known-good-exemplar positive control) rides `cargo test`
+(`cli/tests/eval_falsifiability.rs`); together they are the gate. Both run
+offline with no credential.

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2891,6 +2891,11 @@
           "name": "plugin-compat"
         },
         {
+          "about": "Run the committed eval suites through the fake model and assert every case goes RED -- the falsifiability gate's real-path negative control (#619, `bash cli/scripts/eval-falsifiability.sh`). Offline, no credential",
+          "hidden": false,
+          "name": "eval-falsifiability"
+        },
+        {
           "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
           "hidden": false,
           "name": "version-check"

--- a/cli/scripts/eval-falsifiability.sh
+++ b/cli/scripts/eval-falsifiability.sh
@@ -88,8 +88,9 @@ FAILED=0
 for suite in "${SUITES[@]}"; do
     rel="${suite#"$REPO_ROOT"/}"
     echo "--- $rel"
-    # skill eval exits non-zero when ANY case passes; capture the JSON either way
-    # so we can assert passed==0 (ALL red), not merely "some failed".
+    # skill eval exits non-zero when ANY case is RED (here that is ALL of them,
+    # which is the pass condition, not a failure); capture the JSON regardless of
+    # exit code and assert passed==0 off the parsed rollup, not off the exit code.
     out="$("$BIN" --json skill eval --cases "$suite" --url "$URL" || true)"
     passed="$(printf '%s' "$out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["passed"])' 2>/dev/null || echo "ERR")"
     total="$(printf '%s' "$out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["total"])' 2>/dev/null || echo "ERR")"
@@ -101,7 +102,7 @@ for suite in "${SUITES[@]}"; do
     fi
     echo "    $passed/$total passed against the do-nothing fake agent"
     if [[ "$passed" != "0" ]]; then
-        greeners="$(printf '%s' "$out" | python3 -c 'import json,sys; print(", ".join(c["id"] for c in json.load(sys.stdin)["cases"] if c["passed"]))')"
+        greeners="$(printf '%s' "$out" | python3 -c 'import json,sys; print(", ".join(c["id"] for c in json.load(sys.stdin)["cases"] if c["passed"]))' 2>/dev/null || echo "(unparseable)")"
         echo "    UNFALSIFIABLE: these cases pass against a do-nothing agent (#527): $greeners" >&2
         FAILED=1
     fi

--- a/cli/scripts/eval-falsifiability.sh
+++ b/cli/scripts/eval-falsifiability.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Falsifiability gate, real-path negative control (issue #619).
+#
+# This is a FALSIFIABILITY gate, NOT an E2E test: it never runs a real agent or
+# makes a model call. It boots the runner's scripted FAKE model (offline, no
+# credential, no network) -- a do-nothing agent whose only reply is the canned
+# final "all done" -- and runs every COMMITTED eval suite through the real
+# `agentos skill eval` path. A genuinely falsifiable case (#527) must go RED
+# against this do-nothing agent, so the gate FAILS if ANY committed case passes.
+#
+# Suites are discovered, not hardcoded: every examples/*/evals/cases.json plus
+# the `agentos init` scaffold seed at apps/worker/schema/eval-cases.example.json.
+# Adding a suite needs no edit here.
+#
+# The input-parrot vacuousness control (AC4) and the positive control (AC2) are
+# grader-level and live in cli/tests/eval_falsifiability.rs -- the fake model can
+# only ever say "all done", so those exemplars cannot be expressed through this
+# real path. Together the two halves are the gate.
+#
+# Requirements: docker + an agentos-runner image (built by CI, or `agentos build`
+# locally). The CLI binary is reused from $AGENTOS_BIN if set+executable, else
+# built with cargo. Run from anywhere:
+#
+#   bash cli/scripts/eval-falsifiability.sh
+#
+# Env knobs:
+#   AGENTOS_BIN                path to a prebuilt agentos binary (skip cargo build)
+#   AGENTOS_FALSIFY_IMAGE      runner image (default agentos-runner)
+#   AGENTOS_FALSIFY_PORT       host port (default 7246)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="${AGENTOS_FALSIFY_IMAGE:-agentos-runner}"
+PORT="${AGENTOS_FALSIFY_PORT:-7246}"
+CONTAINER="agentos-falsifiability-runner"
+BUNDLE="$REPO_ROOT/examples/weather"
+
+echo "=== Resolve the agentos binary ==="
+if [[ -n "${AGENTOS_BIN:-}" && -x "${AGENTOS_BIN:-}" ]]; then
+    # Absolutize: the gate cd's into a throwaway dir before invoking the binary,
+    # so a relative $AGENTOS_BIN (as CI passes) must be pinned to an absolute path
+    # here or it stops resolving after the cd.
+    BIN="$(cd "$(dirname "$AGENTOS_BIN")" && pwd)/$(basename "$AGENTOS_BIN")"
+    echo "using prebuilt binary: $BIN"
+else
+    (cd "$REPO_ROOT/cli" && cargo build --release --quiet)
+    BIN="$REPO_ROOT/cli/target/release/agentos"
+fi
+"$BIN" --version
+
+# Discover every committed suite: examples/*/evals/cases.json + the scaffold seed.
+mapfile -t SUITES < <(find "$REPO_ROOT/examples" -mindepth 2 -maxdepth 3 -path '*/evals/cases.json' | sort)
+SUITES+=("$REPO_ROOT/apps/worker/schema/eval-cases.example.json")
+echo
+echo "=== Committed suites under gate (${#SUITES[@]}) ==="
+printf '  %s\n' "${SUITES[@]#"$REPO_ROOT"/}"
+if (( ${#SUITES[@]} < 3 )); then
+    echo "expected at least 3 committed suites; found ${#SUITES[@]}" >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Mount a throwaway COPY of a valid bundle so the recorded .agentos/runner.json
+# lands in the temp dir, never in the tree. The fake model ignores the bundle
+# and the input entirely (it only ever replies "all done"), so any valid bundle
+# serves; the eval below dials the runner by explicit --url regardless.
+cp -r "$BUNDLE" "$WORKDIR/bundle"
+
+echo
+echo "=== agentos skill up (fake model, offline) ==="
+"$BIN" skill up \
+    --plugin-dir "$WORKDIR/bundle" \
+    --image "$IMAGE" \
+    --port "$PORT" \
+    --name "$CONTAINER" \
+    --fake-model
+URL="http://localhost:$PORT"
+
+echo
+echo "=== Negative control: every committed case must go RED against the fake model ==="
+FAILED=0
+for suite in "${SUITES[@]}"; do
+    rel="${suite#"$REPO_ROOT"/}"
+    echo "--- $rel"
+    # skill eval exits non-zero when ANY case passes; capture the JSON either way
+    # so we can assert passed==0 (ALL red), not merely "some failed".
+    out="$("$BIN" --json skill eval --cases "$suite" --url "$URL" || true)"
+    passed="$(printf '%s' "$out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["passed"])' 2>/dev/null || echo "ERR")"
+    total="$(printf '%s' "$out" | python3 -c 'import json,sys; print(json.load(sys.stdin)["total"])' 2>/dev/null || echo "ERR")"
+    if [[ "$passed" == "ERR" || "$total" == "ERR" ]]; then
+        echo "    could not parse eval --json output:" >&2
+        printf '%s\n' "$out" >&2
+        FAILED=1
+        continue
+    fi
+    echo "    $passed/$total passed against the do-nothing fake agent"
+    if [[ "$passed" != "0" ]]; then
+        greeners="$(printf '%s' "$out" | python3 -c 'import json,sys; print(", ".join(c["id"] for c in json.load(sys.stdin)["cases"] if c["passed"]))')"
+        echo "    UNFALSIFIABLE: these cases pass against a do-nothing agent (#527): $greeners" >&2
+        FAILED=1
+    fi
+done
+
+echo
+echo "=== agentos skill down ==="
+( cd "$WORKDIR/bundle" && "$BIN" skill down ) || true
+
+if (( FAILED )); then
+    echo
+    echo "FALSIFIABILITY GATE FAILED: at least one committed eval case greens against the fake model." >&2
+    exit 1
+fi
+
+echo
+echo "FALSIFIABILITY GATE PASS: every committed eval case is red against the fake model."

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -285,6 +285,10 @@ enum DevAction {
     DocsLint,
     /// Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`).
     PluginCompat,
+    /// Run the committed eval suites through the fake model and assert every case
+    /// goes RED -- the falsifiability gate's real-path negative control (#619,
+    /// `bash cli/scripts/eval-falsifiability.sh`). Offline, no credential.
+    EvalFalsifiability,
     /// Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml
     /// version, and appVersion (`bash scripts/check-version-consistency.sh`).
     VersionCheck,
@@ -1282,6 +1286,9 @@ async fn run(command: Option<Command>) -> Result<()> {
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh").await,
             DevAction::PluginCompat => commands::dev_script("scripts/check-plugin-compat.sh").await,
+            DevAction::EvalFalsifiability => {
+                commands::dev_script("cli/scripts/eval-falsifiability.sh").await
+            }
             DevAction::VersionCheck => {
                 commands::dev_script("scripts/check-version-consistency.sh").await
             }
@@ -2345,6 +2352,14 @@ mod tests {
             cli.command,
             Some(Command::Dev {
                 action: DevAction::DocsLint
+            })
+        ));
+        let cli = Cli::try_parse_from(["agentos", "dev", "eval-falsifiability"])
+            .expect("dev eval-falsifiability should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::EvalFalsifiability
             })
         ));
     }

--- a/cli/tests/data/eval_falsifiability_fixtures.json
+++ b/cli/tests/data/eval_falsifiability_fixtures.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Fixtures for the eval falsifiability gate (issue #619). NOT eval cases: this is gate data. `exemplars` maps <suite-name>/<case-id> to a known-good synthetic agent answer that MUST green the case's grader today (the positive control, AC2). `input_satisfiable_baseline` lists the committed cases whose grader is already satisfied by the case's own input verbatim (the input-parrot broken agent, AC4): the gate blocks NEW input-satisfiable cases while baselining these known ones so it stays green on main without editing a committed case. Tightening or removing a baselined case is tracked separately, not done in this gate. See ADR-0022, #527, #553.",
+  "exemplars": {
+    "weather/reports-a-temperature": "The high in San Francisco today is about 68°.",
+    "github-issues/reads-a-specific-issue-content": "Issue #7 proposes promoting the queue payload into the aci-protocol contract.",
+    "github-issues/reads-a-specific-issue-state": "It is closed.",
+    "github-issues/lists-real-issue-numbers": "A few open issues: #10, #12, and #15.",
+    "example/example-smoke": "Hello, I am the example agent for this platform."
+  },
+  "input_satisfiable_baseline": [
+    "github-issues/reads-a-specific-issue-state",
+    "example/example-smoke"
+  ]
+}

--- a/cli/tests/eval_falsifiability.rs
+++ b/cli/tests/eval_falsifiability.rs
@@ -1,0 +1,243 @@
+//! Falsifiability gate for the committed eval suites (issue #619).
+//!
+//! This is a FALSIFIABILITY gate, NOT an end-to-end test: it never runs a real
+//! agent or makes a model call. It exercises the frozen graders (the same
+//! `agentos::evals::Grader::grade` the runner path grades with) against
+//! controlled synthetic outputs to prove every committed case is falsifiable --
+//! i.e. that a plausibly-broken agent (#527) cannot pass it, and that the grader
+//! is not simply broken for everything.
+//!
+//! Three controls, all offline and deterministic, all driven off the committed
+//! suites discovered on disk (so a new suite is covered with no edit here):
+//!
+//!   A. Negative (no-op agent): no committed case may green against a canned
+//!      response that ignores the input -- the fake model's "all done" final and
+//!      a silent empty answer. A case that greens here calls no tool and reads no
+//!      input yet passes, which is exactly the unfalsifiable shape #527 forbids.
+//!      The real-path form of this control (boot the fake runner, run
+//!      `agentos skill eval`, assert the red rollup) lives in
+//!      `cli/scripts/eval-falsifiability.sh` and its CI job; this is the fast,
+//!      credential-free mirror.
+//!
+//!   B. Negative (input-parrot agent, AC4): no committed case's grader may be
+//!      satisfied by the case's OWN input verbatim, beyond an explicit baseline
+//!      of cases that are input-satisfiable today. This is what catches the
+//!      `contains: "weather"` vacuousness class -- a grader the input itself
+//!      guarantees -- which the no-op control cannot see (the fake's "all done"
+//!      does not contain the input). The baseline keeps the gate green on main
+//!      without editing a committed case; any NEW input-satisfiable case fails.
+//!
+//!   C. Positive (AC2): every committed case's grader must GREEN against a
+//!      known-good synthetic exemplar, so the gate cannot be satisfied by every
+//!      grader simply being broken. Every discovered case must have an exemplar
+//!      (completeness), so a new suite forces one to be supplied.
+//!
+//! Fixtures (exemplars + input-satisfiable baseline) live in
+//! `tests/data/eval_falsifiability_fixtures.json`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use agentos::evals::{load_suite, turn_passes, EvalCase, EvalSuite};
+use agentos_aci_protocol::{OutboundEvent, SessionStatus, PROTOCOL_VERSION};
+use serde::Deserialize;
+
+/// Repo root, resolved from the crate manifest dir (`cli/`).
+fn repo_root() -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+}
+
+/// The committed eval suites the gate covers, discovered on disk so a new suite
+/// is picked up with no edit: every `examples/*/evals/cases.json`, plus the
+/// `agentos init` scaffold seed at `apps/worker/schema/eval-cases.example.json`.
+/// Returns `(key_prefix, suite)` where `key_prefix` is the suite name used to
+/// build the stable `<suite>/<case-id>` key.
+fn discover_suites() -> Vec<(String, EvalSuite)> {
+    let root = repo_root();
+    let mut paths: Vec<PathBuf> = Vec::new();
+
+    let examples = root.join("examples");
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(&examples)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", examples.display()))
+        .map(|e| e.expect("dir entry").path())
+        .collect();
+    entries.sort();
+    for dir in entries {
+        let cases = dir.join("evals/cases.json");
+        if cases.is_file() {
+            paths.push(cases);
+        }
+    }
+    paths.push(root.join("apps/worker/schema/eval-cases.example.json"));
+
+    let suites: Vec<(String, EvalSuite)> = paths
+        .iter()
+        .map(|p| {
+            let suite = load_suite(p).unwrap_or_else(|e| panic!("loading {}: {e:#}", p.display()));
+            (suite.name.clone(), suite)
+        })
+        .collect();
+
+    // A vacuously-empty discovery would make every assertion below pass for the
+    // wrong reason; assert we actually found the known suites.
+    assert!(
+        suites.len() >= 3,
+        "expected at least 3 committed suites (weather, github-issues, example scaffold seed), \
+         found {}: {:?}",
+        suites.len(),
+        suites.iter().map(|(n, _)| n).collect::<Vec<_>>()
+    );
+    suites
+}
+
+/// The stable per-case key used across the gate and the fixtures file.
+fn case_key(suite_name: &str, case: &EvalCase) -> String {
+    format!("{suite_name}/{}", case.id)
+}
+
+/// A completed turn whose graded final text is `text` (status `done`). Mirrors
+/// the shape `graded_answer`/`turn_passes` judge: the final frame's text.
+fn done_turn(text: &str) -> Vec<OutboundEvent> {
+    vec![OutboundEvent::Final {
+        version: PROTOCOL_VERSION.into(),
+        text: text.into(),
+        status: SessionStatus::Done,
+        approval_summary: None,
+        approval_route: None,
+        approval_gate_kind: None,
+        approval_granted_tool: None,
+    }]
+}
+
+#[derive(Debug, Deserialize)]
+struct Fixtures {
+    exemplars: BTreeMap<String, String>,
+    input_satisfiable_baseline: BTreeSet<String>,
+}
+
+fn fixtures() -> Fixtures {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/data/eval_falsifiability_fixtures.json"
+    );
+    let raw =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("reading fixtures {path}: {e}"));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("fixtures {path} must be valid JSON: {e}"))
+}
+
+/// Control A -- negative, no-op agent. No committed case may pass against a
+/// response that ignores the input entirely. The fake model's final text is
+/// "all done"; a silent agent answers with nothing. Either passing a case means
+/// the case greens without any real work.
+#[test]
+fn no_committed_case_passes_against_a_no_op_agent() {
+    let broken_outputs = ["all done", ""];
+    let mut offenders: Vec<String> = Vec::new();
+    for (name, suite) in discover_suites() {
+        for case in &suite.cases {
+            for output in broken_outputs {
+                if turn_passes(case, &done_turn(output)) {
+                    offenders.push(format!(
+                        "{} greens on no-op answer {output:?}",
+                        case_key(&name, case)
+                    ));
+                }
+            }
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these committed eval cases pass against a do-nothing agent, so they are \
+         unfalsifiable (#527); tighten or remove the grader:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// Control B -- negative, input-parrot agent (AC4). No committed case's grader
+/// may be satisfied by the case's own input verbatim, except the explicit
+/// baseline of cases that are input-satisfiable today. Catches the
+/// `contains: "weather"` class the no-op control cannot see. Exact set equality
+/// keeps the baseline honest: a NEW input-satisfiable case fails, and a stale
+/// baseline entry (a case that is no longer input-satisfiable) also fails so the
+/// baseline is pruned rather than left to rot.
+#[test]
+fn no_committed_case_is_input_satisfiable_beyond_the_baseline() {
+    let baseline = fixtures().input_satisfiable_baseline;
+    let mut actual: BTreeSet<String> = BTreeSet::new();
+    for (name, suite) in discover_suites() {
+        for case in &suite.cases {
+            // The broken agent parrots the prompt back. `turn_passes` requires a
+            // completed `done` turn, so grade the parroted input through the same
+            // pass condition the runner path uses.
+            if turn_passes(case, &done_turn(&case.input)) {
+                actual.insert(case_key(&name, case));
+            }
+        }
+    }
+
+    let new_violations: Vec<&String> = actual.difference(&baseline).collect();
+    assert!(
+        new_violations.is_empty(),
+        "these committed eval cases are satisfied by their own input -- a grader the \
+         input itself guarantees is vacuous (AC4, #527). Rewrite the grader to require \
+         something only a real answer carries:\n  {:?}",
+        new_violations
+    );
+
+    let stale: Vec<&String> = baseline.difference(&actual).collect();
+    assert!(
+        stale.is_empty(),
+        "these input-satisfiable-baseline entries are no longer input-satisfiable; \
+         remove them from tests/data/eval_falsifiability_fixtures.json:\n  {:?}",
+        stale
+    );
+}
+
+/// Control C -- positive (AC2). Every committed case's grader must green against
+/// a known-good synthetic exemplar, so the gate is not silently satisfied by
+/// every grader being broken. Completeness is enforced: every discovered case
+/// must have an exemplar, and every exemplar must map to a real case.
+#[test]
+fn every_grader_greens_on_its_known_good_exemplar() {
+    let exemplars = fixtures().exemplars;
+    let mut keys: BTreeSet<String> = BTreeSet::new();
+    let mut red: Vec<String> = Vec::new();
+
+    for (name, suite) in discover_suites() {
+        for case in &suite.cases {
+            let key = case_key(&name, case);
+            keys.insert(key.clone());
+            let Some(exemplar) = exemplars.get(&key) else {
+                continue; // missing-exemplar completeness is asserted below
+            };
+            // Grade the exemplar through the same pass condition the runner path
+            // uses (a completed `done` turn whose final text is the exemplar).
+            if !turn_passes(case, &done_turn(exemplar)) {
+                red.push(format!(
+                    "{key} -> exemplar {exemplar:?} does NOT satisfy its grader"
+                ));
+            }
+        }
+    }
+
+    let exemplar_keys: BTreeSet<String> = exemplars.keys().cloned().collect();
+    let missing: Vec<&String> = keys.difference(&exemplar_keys).collect();
+    assert!(
+        missing.is_empty(),
+        "these committed cases have no known-good exemplar in \
+         tests/data/eval_falsifiability_fixtures.json (add one that satisfies the grader):\n  {:?}",
+        missing
+    );
+    let orphan: Vec<&String> = exemplar_keys.difference(&keys).collect();
+    assert!(
+        orphan.is_empty(),
+        "these exemplars reference a case that no longer exists; remove them:\n  {:?}",
+        orphan
+    );
+    assert!(
+        red.is_empty(),
+        "these known-good exemplars fail their grader -- the grader rejects a correct \
+         answer, or the exemplar drifted:\n  {}",
+        red.join("\n  ")
+    );
+}


### PR DESCRIPTION
## What

Nothing in CI ran any committed eval case. The only coverage was a parse assertion (`cli/src/evals.rs` `loads_the_committed_weather_example`), so a grader could rot, an anchor could move, or a vacuous case could be reintroduced with every check green. That is how two eval defects reached `main` green (a weather grader that rejects a correct answer, #620/#618; a scaffold seed that went red, #612).

This adds a **falsifiability gate** (not an E2E test: it never runs a real agent or makes a model call) with two complementary halves, both offline (fake model, no credential, no network) and driven off suites **discovered on disk**, so a new suite needs no gate edit.

### Real-path negative control
`cli/scripts/eval-falsifiability.sh` (also `agentos dev eval-falsifiability`) + a new `eval-falsifiability` CI job. Boots the runner's scripted fake model and runs **every committed suite** (`examples/*/evals/cases.json` + the init scaffold seed `apps/worker/schema/eval-cases.example.json`) through the real `agentos skill eval`, failing if **any case greens** against a do-nothing agent. The fake model only ever replies "all done", so a genuinely falsifiable case (#527) must go red. Every committed case is red today.

### Grader-level controls (Rust, `cli/tests/eval_falsifiability.rs`)
The fake model cannot emit an arbitrary exemplar, so these ride `cargo test`:
- **Input-parrot control (AC4):** fails any grader satisfied by its own input verbatim (the `contains: "weather"` vacuousness class), which the no-op path cannot see.
- **Positive control (AC2):** asserts each grader greens on a known-good exemplar, with a full case↔exemplar bijection so a new case forces a green exemplar.

## Demonstration that the gate bites

Reintroducing a vacuous case and reverting:

Grader-level input-parrot control (AC4), injecting `contains: "weather"` on the weather input:
```
$ cargo test --test eval_falsifiability   # with the vacuous case injected
these committed eval cases are satisfied by their own input ... : ["weather/vacuous-weather"]
test result: FAILED. 1 passed; 2 failed
$ cargo test --test eval_falsifiability   # after reverting
test result: ok. 3 passed; 0 failed
```

Real-path negative control, injecting a `contains: "done"` case that greens against the fake "all done":
```
$ bash cli/scripts/eval-falsifiability.sh  # with the greening case injected
    1/2 passed against the do-nothing fake agent
    UNFALSIFIABLE: these cases pass against a do-nothing agent (#527): greens-on-fake
FALSIFIABILITY GATE FAILED
$ bash cli/scripts/eval-falsifiability.sh  # after reverting
    0/3 ... 0/1 ... 0/1 passed against the do-nothing fake agent
FALSIFIABILITY GATE PASS
```

## Finding: two committed cases are already input-satisfiable

The input-parrot control legitimately flags two **pre-existing** committed cases whose grader is satisfied by the case's own input:
- `github-issues/reads-a-specific-issue-state` — grader `contains: "closed"`, input "...is issue #7 open or **closed**?"
- `example/example-smoke` — grader `contains: "example"`, input "...introduce yourself as the **example** agent."

Per the task constraints (do not modify committed cases; keep the gate green on `main`; #612/#620 are tracked separately), these are **baselined** in `input_satisfiable_baseline` (documented in the fixtures `_comment` and the test doc). The gate blocks any **new** input-satisfiable case while grandfathering these two, and enforces exact set-equality so the baseline self-prunes when a case is later tightened. Recommend tightening these two graders under a follow-up (they parrot-pass without reading the issue).

## Scope honesty

This gate exercises graders against controlled outputs. It is a falsifiability gate, **not** an end-to-end proof that a real agent does the work (that needs credentials and belongs in a separate credentialed job). The job name and all docs say so.

Refs #527, #553, #612, ADR-0022
Closes #619