### PR TITLE
Harden local Docker runner isolation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,6 +55,27 @@ silently false-pass. Run it against your cluster to verify enforcement.
 and gVisor only isolates if the RuntimeClass is installed. Both are operator
 responsibilities (see below).
 
+### Local mode is not the Kubernetes boundary
+
+The local developer loop (`agentos local up` / `agentos skill up`, the Docker
+substrate) **accepts TRUSTED bundles only.** It is a convenience for developing
+and demoing your own bundles on a laptop, not a security boundary for running
+untrusted code. The Kubernetes sandbox rails above (gVisor + default-deny
+NetworkPolicy + per-agent RBAC) are the only supported boundary for untrusted
+bundles; do not use local mode to run a bundle you would not run as a plain
+script on your machine.
+
+Local mode still applies practical container isolation as defense-in-depth so a
+trusted-but-buggy bundle cannot casually escalate on the host: each runner
+container boots with a **read-only root filesystem** (writable `tmpfs` for `/tmp`
+and `$HOME` only), **all Linux capabilities dropped**, **no-new-privileges**, the
+Docker **default seccomp profile**, and **bounded pids/memory/cpu**, and it joins
+a **dedicated `agentos_runner` network** that carries only its documented
+dependencies (telemetry collector, local model, and the API state endpoint) --
+never the data tier (Postgres/Valkey/MinIO) and never the Docker daemon socket
+(which only the worker holds). These controls reduce blast radius; they are not a
+substitute for the Kubernetes boundary.
+
 ## Reporting a vulnerability
 
 Please report security issues privately through **GitHub Private Vulnerability

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -37,6 +37,7 @@ from .sandbox import (
     AffinityStore,
     DockerSandboxClient,
     KubernetesSandboxClient,
+    RunnerHardening,
     SandboxClient,
     SandboxSubstrate,
     SubstrateConfig,
@@ -126,6 +127,10 @@ def _sandbox_client(
             network=env.get("AGENTOS_DOCKER_NETWORK") or None,
             otel_endpoint=env.get("OTEL_EXPORTER_OTLP_ENDPOINT") or None,
             default_plugin_dir=config.bundle_plugin_dir,
+            # Container isolation for every spawned runner (#631): read-only
+            # rootfs, dropped caps, no-new-privileges, bounded resources. Mirrors
+            # the K8s runner securityContext; overridable via AGENTOS_RUNNER_*.
+            hardening=RunnerHardening.from_env(env),
             environ=env,
         )
         # Prewarm the runner image once at startup so the first claim window is

--- a/apps/worker/src/agentos_worker/sandbox/__init__.py
+++ b/apps/worker/src/agentos_worker/sandbox/__init__.py
@@ -9,7 +9,7 @@ Public surface for F1 (the worker kernel):
 """
 
 from .affinity import AffinityStore
-from .docker import DockerError, DockerSandboxClient
+from .docker import DockerError, DockerSandboxClient, RunnerHardening
 from .k8s import KubernetesSandboxClient
 from .substrate import HISTORY_ENV, SESSION_ENV, SandboxSubstrate
 from .types import (
@@ -44,6 +44,7 @@ __all__ = [
     "NoRouteError",
     "RouteRecord",
     "RouteState",
+    "RunnerHardening",
     "SandboxClient",
     "SandboxError",
     "SandboxHandle",

--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -47,6 +47,7 @@ import tempfile
 import urllib.error
 import urllib.request
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..binding import (
@@ -93,6 +94,99 @@ _WORKER_OWNED_ENV = frozenset(
 )
 
 
+@dataclass(frozen=True)
+class RunnerHardening:
+    """Container-level isolation applied to every runner container the Docker
+    substrate boots.
+
+    Local mode accepts TRUSTED bundles only and is NOT the Kubernetes security
+    boundary (that is the Helm path: gVisor + a default-deny egress
+    NetworkPolicy). These controls are practical defense-in-depth that mirror the
+    K8s runner ``securityContext`` + ``resources`` (charts/agentos:
+    ``readOnlyRootFilesystem``, ``capabilities.drop: [ALL]``,
+    ``allowPrivilegeEscalation: false``, ``seccompProfile: RuntimeDefault``, and
+    bounded cpu/memory), so a trusted-but-buggy bundle cannot escalate on the
+    host, reach the Docker daemon, or roam the data tier.
+
+    Every field is overridable from the worker env (``from_env``) so an operator
+    can loosen a limit a heavy bundle needs without editing code; ``enabled=0``
+    turns the whole set off for debugging. Docker's default seccomp profile (the
+    RuntimeDefault equivalent) stays active whenever hardening is on -- this code
+    never passes ``seccomp=unconfined``.
+    """
+
+    enabled: bool = True
+    read_only_root: bool = True
+    # tmpfs mounts (the emptyDir equivalent) so a read-only-rootfs runner can
+    # still write HOME and /tmp. Mirrors the chart's runner writablePaths. The
+    # runner image runs as uid 1000; sticky world-writable (mode 1777) mounts let
+    # it create entries it owns under a root-owned mount, matching the chart's
+    # fsGroup-owned emptyDir semantics.
+    writable_paths: tuple[str, ...] = ("/tmp", "/home/runner")
+    drop_all_capabilities: bool = True
+    no_new_privileges: bool = True
+    # Bounded process/memory/cpu (chart runner limits: memory 768Mi, cpu "1").
+    # pids has no chart analogue; a fork-bomb ceiling is cheap defense here.
+    pids_limit: int = 512
+    memory_limit: str = "768m"
+    cpu_limit: str = "1"
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str]) -> RunnerHardening:
+        """Build from ``AGENTOS_RUNNER_HARDENING*`` env, falling back to the
+        K8s-mirroring defaults above. Any unset knob keeps its default."""
+
+        def _flag(name: str, default: bool) -> bool:
+            raw = env.get(name)
+            if raw is None or raw == "":
+                return default
+            return raw.strip().lower() not in ("0", "false", "no", "off")
+
+        enabled = _flag("AGENTOS_RUNNER_HARDENING", True)
+        paths_raw = env.get("AGENTOS_RUNNER_WRITABLE_PATHS")
+        writable_paths = (
+            tuple(p for p in (s.strip() for s in paths_raw.split(",")) if p)
+            if paths_raw
+            else cls.writable_paths
+        )
+        pids_raw = env.get("AGENTOS_RUNNER_PIDS_LIMIT")
+        return cls(
+            enabled=enabled,
+            read_only_root=_flag("AGENTOS_RUNNER_READ_ONLY", True),
+            writable_paths=writable_paths,
+            drop_all_capabilities=_flag("AGENTOS_RUNNER_CAP_DROP_ALL", True),
+            no_new_privileges=_flag("AGENTOS_RUNNER_NO_NEW_PRIVILEGES", True),
+            pids_limit=int(pids_raw) if pids_raw else cls.pids_limit,
+            memory_limit=env.get("AGENTOS_RUNNER_MEMORY_LIMIT") or cls.memory_limit,
+            cpu_limit=env.get("AGENTOS_RUNNER_CPU_LIMIT") or cls.cpu_limit,
+        )
+
+    def run_args(self) -> list[str]:
+        """The ``docker run`` flags that impose this hardening. Empty when
+        disabled, so a debug run degrades to the pre-hardening argv exactly."""
+        if not self.enabled:
+            return []
+        args: list[str] = []
+        if self.read_only_root:
+            args.append("--read-only")
+            for path in self.writable_paths:
+                # rw + sticky world-writable so the non-root runner can write.
+                args += ["--tmpfs", f"{path}:rw,mode=1777"]
+        if self.drop_all_capabilities:
+            args += ["--cap-drop", "ALL"]
+        if self.no_new_privileges:
+            # Blocks setuid/gain-privilege on exec (== allowPrivilegeEscalation:
+            # false). Docker's default seccomp profile is left active alongside.
+            args += ["--security-opt", "no-new-privileges"]
+        if self.pids_limit > 0:
+            args += ["--pids-limit", str(self.pids_limit)]
+        if self.memory_limit:
+            args += ["--memory", self.memory_limit]
+        if self.cpu_limit:
+            args += ["--cpus", self.cpu_limit]
+        return args
+
+
 class DockerError(SandboxError):
     """A ``docker`` CLI invocation failed.
 
@@ -116,6 +210,7 @@ class DockerSandboxClient:
         host: str = "127.0.0.1",
         default_plugin_dir: str = "/bundles/current",
         healthz_timeout_s: float = 0.5,
+        hardening: RunnerHardening | None = None,
         environ: Mapping[str, str] | None = None,
     ) -> None:
         self._image = image
@@ -125,6 +220,10 @@ class DockerSandboxClient:
         self._host = host
         self._default_plugin_dir = default_plugin_dir
         self._healthz_timeout_s = healthz_timeout_s
+        # Container isolation (read-only rootfs, dropped caps, no-new-privileges,
+        # bounded resources). Defaults to the K8s-mirroring RunnerHardening; a
+        # None means "use the on-by-default set", never "no hardening".
+        self._hardening = hardening if hardening is not None else RunnerHardening()
         # Presence-only view of the worker environment, used to decide which SDK
         # credential vars to forward by name. Never read for their values.
         self._environ = environ if environ is not None else os.environ
@@ -153,6 +252,13 @@ class DockerSandboxClient:
             "-p",
             f"{self._host}::{RUNNER_CONTAINER_PORT}",
         ]
+        # Container isolation flags (read-only rootfs + tmpfs, cap-drop ALL,
+        # no-new-privileges, bounded pids/memory/cpu). The runner never receives
+        # the Docker socket -- only the worker does -- so the daemon stays out of
+        # reach; the data tier is denied by the runner's dedicated network (see
+        # AGENTOS_DOCKER_NETWORK). This is local trusted-bundle defense-in-depth,
+        # not the K8s security boundary.
+        args += self._hardening.run_args()
         for key, value in (labels or {}).items():
             args += ["--label", f"{key}={value}"]
         if self._network:

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -17,6 +17,7 @@ from agentos_worker.sandbox.docker import (
     RUNNER_CONTAINER_PORT,
     DockerError,
     DockerSandboxClient,
+    RunnerHardening,
 )
 
 
@@ -427,6 +428,101 @@ def test_extract_bundle_unwraps_single_wrapper_dir() -> None:
         root = extract_bundle(_plugin_tar_gz(wrapper=None), Path(tmp))
         assert root == Path(tmp)
         assert (root / ".claude-plugin" / "plugin.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Container hardening (#631): every spawned runner is isolated at the container
+# level (read-only rootfs, dropped caps, no privilege escalation, bounded
+# resources) and never receives the Docker socket or a route to the data tier.
+# ---------------------------------------------------------------------------
+
+
+def test_create_claim_applies_container_hardening_by_default() -> None:
+    # A default client hardens every runner: read-only rootfs + tmpfs for the
+    # writable paths, all caps dropped, no-new-privileges, bounded pids/mem/cpu.
+    client = _RecordingDocker(image="agentos-runner", bundle_store=_FakeBundleStore())
+    client.create_claim("t1", pool="pool", env={"AGENTOS_FAKE_MODEL": "1"})
+    argv = client.calls[0]
+    assert "--read-only" in argv
+    tmpfs = _flag_values(argv, "--tmpfs")
+    assert "/tmp:rw,mode=1777" in tmpfs
+    assert "/home/runner:rw,mode=1777" in tmpfs
+    assert "ALL" in _flag_values(argv, "--cap-drop")
+    assert "no-new-privileges" in _flag_values(argv, "--security-opt")
+    assert "512" in _flag_values(argv, "--pids-limit")
+    assert "768m" in _flag_values(argv, "--memory")
+    assert "1" in _flag_values(argv, "--cpus")
+    # The default seccomp profile stays active: never disabled.
+    assert all("seccomp=unconfined" not in a for a in argv)
+
+
+def test_runner_never_receives_the_docker_socket() -> None:
+    # AC3: the runner must not be able to reach the Docker daemon. Only the worker
+    # mounts the socket; a spawned runner never gets it as a bind mount.
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        environ={"CLAUDE_CODE_OAUTH_TOKEN": "sk-PLACEHOLDER"},
+    )
+    client.create_claim("t1", pool="pool", env={"AGENTOS_BUDGET": "{}"})
+    assert all("docker.sock" not in m for m in _flag_values(client.calls[0], "-v"))
+
+
+def test_hardening_disabled_emits_no_hardening_flags() -> None:
+    # An explicit opt-out (AGENTOS_RUNNER_HARDENING=0) degrades to the
+    # pre-hardening argv exactly, for debugging a bundle the rails break.
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        hardening=RunnerHardening.from_env({"AGENTOS_RUNNER_HARDENING": "0"}),
+    )
+    client.create_claim("t1", pool="pool", env={"AGENTOS_FAKE_MODEL": "1"})
+    argv = client.calls[0]
+    assert "--read-only" not in argv
+    assert _flag_values(argv, "--cap-drop") == []
+    assert _flag_values(argv, "--memory") == []
+
+
+def test_hardening_env_overrides_limits_and_paths() -> None:
+    # Each knob is overridable so an operator can loosen a limit a heavy bundle
+    # needs without editing code.
+    hardening = RunnerHardening.from_env(
+        {
+            "AGENTOS_RUNNER_MEMORY_LIMIT": "2g",
+            "AGENTOS_RUNNER_CPU_LIMIT": "2",
+            "AGENTOS_RUNNER_PIDS_LIMIT": "1024",
+            "AGENTOS_RUNNER_WRITABLE_PATHS": "/tmp, /home/runner, /var/scratch",
+        }
+    )
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        hardening=hardening,
+    )
+    client.create_claim("t1", pool="pool", env={"AGENTOS_FAKE_MODEL": "1"})
+    argv = client.calls[0]
+    assert "2g" in _flag_values(argv, "--memory")
+    assert "2" in _flag_values(argv, "--cpus")
+    assert "1024" in _flag_values(argv, "--pids-limit")
+    tmpfs = _flag_values(argv, "--tmpfs")
+    assert "/var/scratch:rw,mode=1777" in tmpfs
+    assert "/tmp:rw,mode=1777" in tmpfs
+
+
+def test_hardening_read_only_opt_out_keeps_other_rails() -> None:
+    # Turning off just the read-only rootfs (a bundle that legitimately writes
+    # outside the tmpfs paths) still drops caps and blocks privilege escalation.
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        hardening=RunnerHardening.from_env({"AGENTOS_RUNNER_READ_ONLY": "false"}),
+    )
+    client.create_claim("t1", pool="pool", env={"AGENTOS_FAKE_MODEL": "1"})
+    argv = client.calls[0]
+    assert "--read-only" not in argv
+    assert _flag_values(argv, "--tmpfs") == []  # no read-only -> no tmpfs needed
+    assert "ALL" in _flag_values(argv, "--cap-drop")
+    assert "no-new-privileges" in _flag_values(argv, "--security-opt")
 
 
 def test_ensure_image_pulls_when_absent() -> None:

--- a/cli/src/docker.rs
+++ b/cli/src/docker.rs
@@ -45,10 +45,36 @@ pub struct CheckSpec {
     pub timeout_s: u64,
 }
 
+/// Container-isolation flags applied to every local runner container (#631):
+/// a read-only root filesystem (+ tmpfs for `/tmp` and the non-root runner's
+/// HOME so it can still write), all Linux capabilities dropped, and
+/// no-new-privileges. Mirrors the K8s runner `securityContext` and the worker
+/// Docker substrate's `RunnerHardening`
+/// (`apps/worker/src/agentos_worker/sandbox/docker.py`). Local mode accepts
+/// TRUSTED bundles only and is not the Kubernetes security boundary; these are
+/// practical defense-in-depth so a trusted-but-buggy bundle cannot escalate on
+/// the host. Docker's default seccomp profile stays active (never unconfined).
+/// Resource caps (memory/cpu) are intentionally left to the worker substrate,
+/// which runs the untrusted product loop; the interactive skill-dev loop here
+/// keeps them off so a developer's heavy local run is not throttled.
+fn runner_hardening_args() -> Vec<String> {
+    vec![
+        "--read-only".into(),
+        "--tmpfs".into(),
+        "/tmp:rw,mode=1777".into(),
+        "--tmpfs".into(),
+        "/home/runner:rw,mode=1777".into(),
+        "--cap-drop".into(),
+        "ALL".into(),
+        "--security-opt".into(),
+        "no-new-privileges".into(),
+    ]
+}
+
 impl CheckSpec {
     /// The one shot check container argv (after the `docker` executable).
     pub fn run_args(&self) -> Vec<String> {
-        vec![
+        let mut args: Vec<String> = vec![
             "run".into(),
             "--rm".into(),
             // Offline contract: the check must never reach the network. A bundle
@@ -58,6 +84,11 @@ impl CheckSpec {
             // legitimate in-bundle stdio-server case.
             "--network".into(),
             "none".into(),
+        ];
+        // Same container isolation as the long-lived runner (#631): the check
+        // executes an untrusted bundle's MCP servers, so it must not run looser.
+        args.extend(runner_hardening_args());
+        args.extend([
             "-v".into(),
             format!("{}:/plugin:ro", self.plugin_dir),
             "-e".into(),
@@ -68,7 +99,8 @@ impl CheckSpec {
             "python".into(),
             "-m".into(),
             "agentos_runner.check".into(),
-        ]
+        ]);
+        args
     }
 }
 
@@ -93,6 +125,9 @@ impl StartSpec {
             "-e".into(),
             format!("AGENTOS_BUDGET={}", self.budget_json),
         ];
+        // Container isolation (#631): read-only rootfs + tmpfs, cap-drop ALL,
+        // no-new-privileges. Mirrors the worker Docker substrate + K8s runner.
+        args.extend(runner_hardening_args());
         if self.fake_model {
             args.push("-e".into());
             args.push("AGENTOS_FAKE_MODEL=1".into());
@@ -548,6 +583,49 @@ mod tests {
         assert!(joined.contains("--network agentos_default"));
         assert!(joined.contains("-e OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318"));
         assert_eq!(args.last().unwrap(), "agentos-runner");
+    }
+
+    #[test]
+    fn run_args_apply_container_hardening() {
+        // Every local runner boots hardened (#631): read-only rootfs with tmpfs
+        // for /tmp and HOME, all caps dropped, and no privilege escalation.
+        let joined = spec().run_args().join(" ");
+        assert!(joined.contains("--read-only"), "{joined}");
+        assert!(joined.contains("--tmpfs /tmp:rw,mode=1777"), "{joined}");
+        assert!(
+            joined.contains("--tmpfs /home/runner:rw,mode=1777"),
+            "{joined}"
+        );
+        assert!(joined.contains("--cap-drop ALL"), "{joined}");
+        assert!(
+            joined.contains("--security-opt no-new-privileges"),
+            "{joined}"
+        );
+        // The default seccomp profile is left active -- never disabled.
+        assert!(!joined.contains("seccomp=unconfined"), "{joined}");
+    }
+
+    #[test]
+    fn check_run_args_are_isolated_and_hardened() {
+        // The offline MCP-load check runs untrusted bundle code, so it stays
+        // network-isolated AND carries the same container hardening.
+        let spec = CheckSpec {
+            image: "agentos-runner".into(),
+            plugin_dir: "/tmp/deal-desk".into(),
+            timeout_s: 30,
+        };
+        let joined = spec.run_args().join(" ");
+        assert!(joined.contains("--network none"), "{joined}");
+        assert!(joined.contains("--read-only"), "{joined}");
+        assert!(joined.contains("--cap-drop ALL"), "{joined}");
+        assert!(
+            joined.contains("--security-opt no-new-privileges"),
+            "{joined}"
+        );
+        assert!(
+            joined.trim_end().ends_with("agentos_runner.check"),
+            "{joined}"
+        );
     }
 
     #[test]

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -205,7 +205,10 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
                 format!("http://ollama:{OLLAMA_PORT}"),
             ),
             ("AGENTOS_MODEL".into(), model.clone()),
-            ("AGENTOS_DOCKER_NETWORK".into(), "agentos_default".into()),
+            // Spawned runners join the dedicated, data-tier-free runner network
+            // (#631). ollama is multi-homed onto it, so `--local-model` resolves
+            // `ollama` by name without exposing postgres/valkey/minio.
+            ("AGENTOS_DOCKER_NETWORK".into(), "agentos_runner".into()),
             // Pin the compose project name so the default network is always
             // `agentos_default`, regardless of the working-directory basename
             // (which is what compose otherwise derives the project name from).
@@ -599,7 +602,7 @@ mod tests {
             .contains(&(String::from("AGENTOS_MODEL"), String::from("qwen3:4b"))));
         assert!(cmd.env.contains(&(
             String::from("AGENTOS_DOCKER_NETWORK"),
-            String::from("agentos_default"),
+            String::from("agentos_runner"),
         )));
         assert!(cmd.env.contains(&(
             String::from("COMPOSE_PROJECT_NAME"),

--- a/cli/tests/skill_check.rs
+++ b/cli/tests/skill_check.rs
@@ -132,12 +132,24 @@ fn check_run_args_are_the_exact_offline_argv() {
     };
     let args = spec.run_args();
 
-    // The argv MUST be exactly this vector, in this order.
+    // The argv MUST be exactly this vector, in this order. The check runs
+    // untrusted bundle MCP code, so it is offline (--network none) AND hardened
+    // at the container level (#631): read-only rootfs + tmpfs, cap-drop ALL,
+    // no-new-privileges.
     let expected: Vec<String> = [
         "run",
         "--rm",
         "--network",
         "none",
+        "--read-only",
+        "--tmpfs",
+        "/tmp:rw,mode=1777",
+        "--tmpfs",
+        "/home/runner:rw,mode=1777",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
         "-v",
         "/tmp/deal-desk:/plugin:ro",
         "-e",

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -161,6 +161,10 @@ services:
   ollama:
     image: ollama/ollama:0.24.0
     profiles: [local-model]
+    # Multi-homed onto agentos_runner (#631) so a hardened runner on that
+    # isolated network can resolve `ollama` by name for --local-model, while the
+    # data tier stays off it.
+    networks: [default, agentos_runner]
     ports:
       - "21434:11434"
     volumes:
@@ -240,6 +244,10 @@ services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.119.0
     profiles: *full_profiles
+    # Multi-homed onto agentos_runner (#631): a hardened runner exports OTLP to
+    # `otel-collector:4318` from the isolated runner network, while the collector
+    # still reaches langfuse-web on the default network.
+    networks: [default, agentos_runner]
     command: ["--config=/etc/otel/collector-config.yaml"]
     depends_on:
       langfuse-web:
@@ -290,6 +298,14 @@ services:
   agentos-api:
     image: ghcr.io/curie-eng/agentos-api:latest
     profiles: *core_profiles
+    # Multi-homed onto agentos_runner (#631): the runner's documented `state`
+    # dependency is the API's /agents/.../state endpoints, so the API is the one
+    # control-plane surface reachable from the isolated runner network. Being a
+    # core-profile always-up service, it also guarantees the agentos_runner
+    # network exists even for a `--minimal` (core-only) stack, so the worker's
+    # `--network agentos_runner` always resolves. The data tier
+    # (postgres/valkey/minio/clickhouse) is deliberately NOT on this network.
+    networks: [default, agentos_runner]
     depends_on:
       postgres:
         condition: service_healthy
@@ -367,16 +383,26 @@ services:
   # hand-run host process. It uses the DOCKER sandbox substrate: it spawns runner
   # CONTAINERS on the host's Docker daemon through the mounted socket.
   #
-  # SECURITY: this service is host-root-equivalent BY DESIGN. Mounting
+  # SECURITY: this WORKER service is host-root-equivalent BY DESIGN. Mounting
   # /var/run/docker.sock and running as user 0 gives it the same power as the
-  # host's docker CLI (i.e. host root). This is a LOCAL DEVELOPER CONVENIENCE
-  # with NO security boundary -- it is identical in power to the documented
-  # host-process middle mode (a developer running `python -m agentos_worker` with
-  # docker access). Do NOT model production on this. The hardened path is the
-  # Helm deployment (charts/agentos): the worker there uses the Kubernetes
-  # substrate (no docker socket), and runner sandboxes run under gVisor with a
-  # default-deny egress NetworkPolicy. The socket mount and user:0 are confined
-  # to THIS service; no other service in this file gets them.
+  # host's docker CLI (i.e. host root). This is a LOCAL DEVELOPER CONVENIENCE and
+  # is NOT the Kubernetes security boundary -- it is identical in power to the
+  # documented host-process middle mode (a developer running
+  # `python -m agentos_worker` with docker access). Do NOT model production on
+  # this. The hardened path is the Helm deployment (charts/agentos): the worker
+  # there uses the Kubernetes substrate (no docker socket), and runner sandboxes
+  # run under gVisor with a default-deny egress NetworkPolicy. The socket mount
+  # and user:0 are confined to THIS service; no other service in this file gets
+  # them.
+  #
+  # The RUNNER CONTAINERS this worker spawns ARE hardened (#631), even though the
+  # worker itself is not: each runner boots with a read-only rootfs (+ tmpfs for
+  # /tmp and HOME), all Linux capabilities dropped, no-new-privileges, the
+  # default seccomp profile, and bounded pids/memory/cpu, and joins the isolated
+  # `agentos_runner` network (no data-tier reach, no docker socket). This is
+  # practical trusted-bundle defense-in-depth for local mode -- see
+  # apps/worker/src/agentos_worker/sandbox/docker.py (RunnerHardening). Local mode
+  # accepts TRUSTED bundles only; it is not a substitute for the K8s boundary.
   #
   # network_mode: host recreates the exact topology the Docker substrate was
   # written and tested against (the host-process middle mode): the worker reaches
@@ -440,12 +466,16 @@ services:
       - ANTHROPIC_API_KEY
       - CLAUDE_CODE_OAUTH_TOKEN
       - AGENTOS_CREDENTIALS
-      # By default, the worker joins spawned sandbox containers to the compose
-      # network (AGENTOS_DOCKER_NETWORK=agentos_default) and points them at the
-      # shipped collector (OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318),
-      # so a plain `agentos local up` traces with no manual flags. The network
-      # join is also what lets --local-model resolve ollama by name. Both are
-      # overridable from the shell.
+      # By default, the worker joins spawned sandbox containers to the DEDICATED
+      # runner network (AGENTOS_DOCKER_NETWORK=agentos_runner, #631) and points
+      # them at the shipped collector (OTEL_EXPORTER_OTLP_ENDPOINT=
+      # http://otel-collector:4318), so a plain `agentos local up` traces with no
+      # manual flags. agentos_runner carries only the runner's documented
+      # dependencies -- otel-collector (telemetry), ollama (--local-model), and
+      # agentos-api (state) -- NOT the data tier (postgres/valkey/minio), so a
+      # trusted-but-buggy bundle cannot reach the stores' embedded credentials.
+      # The collector join is also what lets --local-model resolve ollama by name.
+      # Both are overridable from the shell.
       #
       # The endpoint default is what a full-profile `local up` gets. It uses the
       # `${VAR-default}` form (substitute only when UNSET), not `${VAR:-default}`
@@ -454,12 +484,12 @@ services:
       # --minimal selects the `core` profile, which does not start otel-collector,
       # and a runner pointed at a host that never resolves stalls on synchronous
       # export retries per span. AGENTOS_DOCKER_NETWORK stays on `:-` because the
-      # network join is correct under `core` too.
+      # runner network is created (via agentos-api's membership) under `core` too.
       - AGENTOS_MODEL_BASE_URL=${AGENTOS_MODEL_BASE_URL:-}
       - AGENTOS_MODEL_API_BACKEND=${AGENTOS_MODEL_API_BACKEND:-}
       - AGENTOS_MODEL_ENV_KEY=${AGENTOS_MODEL_ENV_KEY:-}
       - AGENTOS_MODEL=${AGENTOS_MODEL:-}
-      - AGENTOS_DOCKER_NETWORK=${AGENTOS_DOCKER_NETWORK:-agentos_default}
+      - AGENTOS_DOCKER_NETWORK=${AGENTOS_DOCKER_NETWORK:-agentos_runner}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
     restart: unless-stopped
 
@@ -501,6 +531,19 @@ services:
       # explicitly rather than relying on the two defaults happening to match.
       AGENTOS_API_KEY: agentos-dev-key
     restart: unless-stopped
+
+networks:
+  # The dedicated runner network (#631). Spawned runner containers join THIS
+  # (AGENTOS_DOCKER_NETWORK=agentos_runner), never the default network that
+  # carries the data tier (postgres/valkey/minio/clickhouse). Only the runner's
+  # documented dependencies are multi-homed onto it -- otel-collector
+  # (telemetry), ollama (--local-model), and agentos-api (state) -- so a
+  # trusted-but-buggy bundle cannot reach the stores' embedded credentials, and a
+  # real-model run still gets external egress (this is a normal, non-`internal`
+  # bridge). `name:` pins the actual network name so the worker's
+  # `--network agentos_runner` resolves regardless of the compose project name.
+  agentos_runner:
+    name: agentos_runner
 
 volumes:
   postgres_data:

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -261,6 +261,47 @@ def compose_docs():
     ]
 
 
+def test_runner_network_excludes_data_tier():
+    """The dedicated `agentos_runner` network carries only the runner's
+    documented dependencies, never the data tier (#631).
+
+    A hardened runner joins `agentos_runner` (AGENTOS_DOCKER_NETWORK). Membership
+    of that network is the local mirror of the K8s data-tier NetworkPolicy: the
+    stores (postgres/valkey/minio/clickhouse) must NOT be on it, so a
+    trusted-but-buggy bundle cannot reach their embedded credentials by service
+    name, while otel-collector (telemetry), ollama (local model), and agentos-api
+    (state) must be, so the documented flows still resolve.
+    """
+    runner_net = "agentos_runner"
+    data_tier = {"postgres", "valkey", "minio", "clickhouse"}
+    required_members = {"otel-collector", "ollama", "agentos-api"}
+    for label, doc in compose_docs():
+        # The network is declared with an explicit, project-independent name so
+        # `--network agentos_runner` resolves regardless of the compose project.
+        networks = doc.get("networks") or {}
+        assert runner_net in networks, f"{label}: {runner_net} network not declared"
+        assert (networks[runner_net] or {}).get("name") == runner_net, (
+            f"{label}: {runner_net} must pin an explicit `name:` so the worker's "
+            f"--network {runner_net} resolves regardless of compose project name"
+        )
+
+        def members_of(svc, _doc=doc):
+            nets = _doc["services"][svc].get("networks") or []
+            # networks may be a list or a mapping; normalize to a set of names.
+            return set(nets) if isinstance(nets, list) else set(nets.keys())
+
+        for store in data_tier & set(doc["services"]):
+            assert runner_net not in members_of(store), (
+                f"{label}: data-tier service {store!r} is ON the {runner_net} "
+                f"network; a runner could reach the store's credentials directly"
+            )
+        for dep in required_members & set(doc["services"]):
+            assert runner_net in members_of(dep), (
+                f"{label}: {dep!r} is NOT on the {runner_net} network; a hardened "
+                f"runner cannot resolve its documented dependency by name"
+            )
+
+
 def test_dispatcher_api_base_url_is_in_network():
     """The dispatcher points at the API by compose service name, not localhost.
 
@@ -384,10 +425,12 @@ def test_worker_traces_to_shipped_collector_by_default():
             f"nowhere to go"
         )
         docker_network = resolve_shell_default(env.get("AGENTOS_DOCKER_NETWORK"))
-        assert docker_network == "agentos_default", (
+        assert docker_network == "agentos_runner", (
             f"{label}: agentos-worker AGENTOS_DOCKER_NETWORK resolves to "
-            f"{docker_network!r}, expected agentos_default so spawned sandbox "
-            f"containers can resolve otel-collector by name"
+            f"{docker_network!r}, expected agentos_runner (#631): the dedicated, "
+            "data-tier-free runner network onto which otel-collector, ollama, and "
+            "agentos-api are multi-homed so a hardened runner resolves its "
+            "documented dependencies by name without reaching the stores"
         )
 
 

--- a/docs/adr/0054-local-docker-runner-hardening.md
+++ b/docs/adr/0054-local-docker-runner-hardening.md
@@ -1,0 +1,80 @@
+# 54. Local Docker runner containers are hardened and network-isolated
+
+Date: 2026-07-17
+
+Status: Accepted
+
+Implements [#631](https://github.com/curie-eng/agentos/issues/631). Applies, to
+the local Docker substrate, the container-level isolation that
+[ADR-0006](0006-security-rails-as-chart-defaults.md) ships as Kubernetes chart
+defaults and that [#493] hardens for rendered Kubernetes sandbox containers. It
+does not change, and is not, the Kubernetes security boundary.
+
+## Context
+
+AgentOS runs a bundle as arbitrary code; the supported security boundary is the
+Kubernetes sandbox (gVisor + a default-deny egress NetworkPolicy + per-agent
+RBAC), documented in [`SECURITY.md`](../../SECURITY.md) and ADR-0006.
+
+The local developer loop is a second substrate. `agentos local up` runs the
+compose stack and the worker spawns runner containers on the host Docker daemon
+([`apps/worker/src/agentos_worker/sandbox/docker.py`](../../apps/worker/src/agentos_worker/sandbox/docker.py)),
+and `agentos skill up` boots a runner directly
+([`cli/src/docker.rs`](../../cli/src/docker.rs)). Before this ADR those runner
+containers ran with no container hardening and joined the shared compose network
+(`agentos_default`), where a bundle could reach the data tier
+(Postgres/Valkey/MinIO) by service name even though the runner never uses those
+stores directly. The worker itself is host-root-equivalent by design (it holds
+the Docker socket); that is unchanged. The gap was the *runner* containers: they
+had avoidable host, daemon-adjacent, and data-tier reach for no functional
+reason.
+
+Local mode is scoped to **trusted** bundles, so this is not a boundary for
+untrusted code. But "trusted" is not "infallible": a buggy-but-trusted bundle
+should not be able to casually escalate on the host or read a store's embedded
+credentials off the shared network. That reachability is pure downside.
+
+## Decision
+
+**Every runner container the local substrate spawns is hardened at the container
+level and joined to a dedicated, data-tier-free network.** The controls mirror
+the K8s runner `securityContext` + `resources` so local and cluster tell the same
+isolation story:
+
+- **Read-only root filesystem** with writable `tmpfs` for `/tmp` and the
+  non-root runner's `$HOME` only (the emptyDir-equivalent writable paths).
+- **All Linux capabilities dropped** (`--cap-drop ALL`).
+- **No privilege escalation** (`--security-opt no-new-privileges`), with Docker's
+  **default seccomp profile** left active (never `unconfined`).
+- **Bounded pids/memory/cpu** on the worker substrate (the untrusted product
+  loop): memory and cpu mirror the chart runner limits. The interactive
+  `skill up` dev loop applies the filesystem/capability/privilege controls but
+  leaves resource caps off, so a developer's heavy local run is not throttled.
+- **No Docker socket** in any runner (only the worker mounts it) and **no data
+  tier**: runners join a dedicated `agentos_runner` network onto which only the
+  runner's documented dependencies are multi-homed -- the OTel collector
+  (telemetry), Ollama (`--local-model`), and the API (the `state` endpoint) --
+  never Postgres/Valkey/MinIO. A real-model run still gets external egress
+  (`agentos_runner` is a normal, non-`internal` bridge).
+
+The worker substrate's controls are expressed as a `RunnerHardening` value
+overridable from `AGENTOS_RUNNER_*` env, so an operator can loosen a limit a
+heavy trusted bundle needs, or disable the set for debugging, without editing
+code.
+
+## Consequences
+
+- A local runner can no longer reach the data tier or the Docker daemon, and
+  cannot write outside its tmpfs mounts, drop-in capabilities, or gain privilege
+  on exec. Blast radius from a trusted-but-buggy bundle shrinks accordingly.
+- Local and Kubernetes now apply the same *shape* of container isolation, so the
+  local loop is a more honest rehearsal of the deployed one.
+- This remains **defense-in-depth for trusted bundles, not a security boundary
+  for untrusted code.** The only supported boundary for untrusted bundles is the
+  Kubernetes path. `SECURITY.md` states this explicitly.
+- The dedicated network requires the runner's dependencies to be multi-homed onto
+  it in `compose.dev.yaml`; a future dependency the runner must reach has to be
+  added to `agentos_runner` (the same fail-closed discipline as the chart's
+  `allowedEgress`).
+
+[#493]: https://github.com/curie-eng/agentos/issues/493

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,4 +82,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0051 | [Eval cases run in a fresh conversation by default, with per-case opt-in shared history](0051-eval-cases-run-in-a-fresh-conversation-by-default.md) | Accepted |
 | 0052 | [The release trust model: one signed manifest, closed-world coverage](0052-release-asset-trust-model.md) | Accepted |
 | 0053 | [Add an expected terminal status to the frozen eval-case format](0053-expected-terminal-status-in-eval-cases.md) | Accepted |
+| 0054 | [Local Docker runner containers are hardened and network-isolated](0054-local-docker-runner-hardening.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Harden every runner container the local Docker substrate spawns, mirroring the
Kubernetes runner `securityContext` + `resources` without claiming to be the
Kubernetes boundary. Local mode remains a convenient trusted-bundle workflow.

## What changed
- **Worker substrate** (`RunnerHardening`, `apps/worker/.../sandbox/docker.py`):
  every runner boots with a read-only rootfs (+ tmpfs for `/tmp` and `$HOME`),
  `--cap-drop ALL`, `--security-opt no-new-privileges`, the default seccomp
  profile, and bounded pids/memory/cpu (768Mi / 1 cpu). Overridable via
  `AGENTOS_RUNNER_*`.
- **CLI `skill up`/check runner** (`cli/src/docker.rs`): same
  filesystem/capability/privilege rails (resource caps left to the product-loop
  worker so an interactive dev run is not throttled).
- **Network isolation**: runners join a dedicated `agentos_runner` network
  carrying only their documented dependencies (otel-collector, ollama, and the
  API `state` endpoint) — never the data tier (Postgres/Valkey/MinIO) and never
  the Docker socket (only the worker holds it).
- **Docs**: `SECURITY.md` states local mode accepts trusted bundles only and is
  not the Kubernetes isolation boundary; ADR-0053 records the decision.

## Verification
- Unit tests (worker argv, CLI argv incl. frozen check argv, compose
  network-membership regression) all green; ruff + cargo fmt clean.
- Live end-to-end on the full compose stack: fake-model and real-model
  (OAuth) messages both round-trip through a hardened runner. `docker inspect`
  confirms read-only rootfs, cap-drop ALL, no-new-privileges, pids 512, mem
  768Mi, cpu 1, tmpfs, `agentos_runner`-only. In-container probes confirm
  DENIED data tier (postgres/valkey/minio DNS-blocked) and Docker socket
  (absent), read-only rootfs enforced, `CapEff=0`, `NoNewPrivs=1`, `Seccomp=2`,
  and REACHABLE otel-collector. Stack fully torn down afterward.

## Notes
- The base advanced mid-flight (#629 merged and took ADR-0052); this branch is
  rebased onto current `main` and its ADR renumbered to 0053.
- A local `cargo clippy` flags a pre-existing `collapsible_match` in
  `interactive.rs` (untouched here) that CI's pinned toolchain does not.

Closes #631
