### PR TITLE
Dial runner by shared-network container IP on the docker substrate

### DIFF
--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -24,8 +24,12 @@ containers, so one container is simultaneously the "claim" and the "sandbox"
 (claim name == container name == sandbox name), and there is no bundle-fetch init
 pair -- the worker fetches the plugin bundle from MinIO and bind-mounts it. The
 host-process worker reaches each runner over a loopback-bound, Docker-assigned
-host port (``docker port <name> 8080``); the container additionally joins the
-compose network when one is configured, so it can reach the OTel collector by
+host port (``docker port <name> 8080``) -- but only when it can actually reach
+that host loopback. A worker running as a host-net *container* on Docker Desktop
+(macOS/Windows) shares the VM's netns and cannot, so when a network is
+configured the worker instead dials the runner on its shared-network container
+IP at the fixed container port (``_dial_endpoint``), which is reachable in every
+topology; the container joins that network anyway to reach the OTel collector by
 name. Readiness (the substrate's ``claim.ready`` gate) is the runner's own
 ``/healthz`` answering, so ``claim()`` never returns a handle to a not-yet-listening
 runner. Suspend maps to ``docker pause`` (the process freezes but keeps its port);
@@ -272,14 +276,15 @@ class DockerSandboxClient:
             operating_mode = "Running"
         else:
             return None
-        port = self._published_port(name)
+        endpoint = self._dial_endpoint(name)
         return SandboxView(
             name=name,
             ready=status == "running",
-            # Dial target is ready only once the host port is published.
-            service_fqdn=self._host if port is not None else None,
+            # Dial target is ready only once the runner is reachable: its
+            # shared-network container IP (preferred) or the published host port.
+            service_fqdn=endpoint[0] if endpoint is not None else None,
             operating_mode=operating_mode,
-            port=port,
+            port=endpoint[1] if endpoint is not None else None,
         )
 
     def set_sandbox_mode(self, name: str, mode: OperatingMode) -> None:
@@ -330,9 +335,7 @@ class DockerSandboxClient:
         return status, labels
 
     def _published_port(self, name: str) -> int | None:
-        out = self._docker(
-            ["port", name, f"{RUNNER_CONTAINER_PORT}/tcp"], check=False
-        )
+        out = self._docker(["port", name, f"{RUNNER_CONTAINER_PORT}/tcp"], check=False)
         for line in out.splitlines():
             line = line.strip()
             if not line:
@@ -343,11 +346,58 @@ class DockerSandboxClient:
                 return int(port)
         return None
 
-    def _healthz_ok(self, name: str) -> bool:
+    def _container_ip(self, name: str) -> str | None:
+        """The runner's IP on the configured docker network, or None.
+
+        A host-networked worker *container* on Docker Desktop (macOS/Windows)
+        shares the Docker VM's network namespace, where the runner's port
+        published on the *host* loopback is unreachable but its bridge-network
+        IP is. Dialing the container directly on the shared network is reachable
+        across all three worker topologies (a real host-process worker, a
+        native-Linux host-net worker, and a Docker Desktop host-net worker), so
+        it is preferred whenever a network is configured. Returns None when no
+        network is set or the address is not yet assigned.
+        """
+        if not self._network:
+            return None
+        out = self._docker(
+            ["inspect", "--format", "{{json .NetworkSettings.Networks}}", name],
+            check=False,
+        )
+        if not out.strip():
+            return None
+        try:
+            nets = json.loads(out)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(nets, dict) or not nets:
+            return None
+        entry = nets.get(self._network)
+        if not isinstance(entry, dict):
+            # Fall back to whatever single network the container joined.
+            entry = next(iter(nets.values()), None)
+        ip = entry.get("IPAddress") if isinstance(entry, dict) else None
+        return ip or None
+
+    def _dial_endpoint(self, name: str) -> tuple[str, int] | None:
+        """(host, port) the worker reaches the runner on, or None if not yet
+        dialable. Prefer the container's shared-network address (reachable from
+        a Docker Desktop VM netns); fall back to the Docker-assigned loopback
+        host port for a host-process worker with no shared network."""
+        ip = self._container_ip(name)
+        if ip is not None:
+            return ip, RUNNER_CONTAINER_PORT
         port = self._published_port(name)
         if port is None:
+            return None
+        return self._host, port
+
+    def _healthz_ok(self, name: str) -> bool:
+        endpoint = self._dial_endpoint(name)
+        if endpoint is None:
             return False
-        url = f"http://{self._host}:{port}/healthz"
+        host, port = endpoint
+        url = f"http://{host}:{port}/healthz"
         try:
             with urllib.request.urlopen(url, timeout=self._healthz_timeout_s) as resp:
                 return bool(200 <= resp.status < 300)

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -13,7 +13,11 @@ import tarfile
 from pathlib import Path
 
 from agentos_worker.bundle_store import extract_bundle
-from agentos_worker.sandbox.docker import DockerError, DockerSandboxClient
+from agentos_worker.sandbox.docker import (
+    RUNNER_CONTAINER_PORT,
+    DockerError,
+    DockerSandboxClient,
+)
 
 
 class _FakeBundleStore:
@@ -134,9 +138,7 @@ def test_sdk_credential_forwarded_by_name_only() -> None:
 
 
 def test_sdk_credential_not_forwarded_when_absent() -> None:
-    client = _RecordingDocker(
-        image="agentos-runner", bundle_store=_FakeBundleStore(), environ={}
-    )
+    client = _RecordingDocker(image="agentos-runner", bundle_store=_FakeBundleStore(), environ={})
     client.create_claim("t1", pool="pool", env={"AGENTOS_FAKE_MODEL": "1"})
     envs = _flag_values(client.calls[0], "-e")
     assert "CLAUDE_CODE_OAUTH_TOKEN" not in envs
@@ -153,9 +155,7 @@ def test_agentos_credentials_forwarded_by_name_never_as_value() -> None:
     )
     # The worker also hands it in the boot env (from config.credentials); it must
     # still never be emitted as a -e KEY=value pair.
-    client.create_claim(
-        "t1", pool="pool", env={"AGENTOS_CREDENTIALS": "sk-ant-PLACEHOLDER-secret"}
-    )
+    client.create_claim("t1", pool="pool", env={"AGENTOS_CREDENTIALS": "sk-ant-PLACEHOLDER-secret"})
     argv = client.calls[0]
     envs = _flag_values(argv, "-e")
     assert "AGENTOS_CREDENTIALS" in envs  # forwarded by name
@@ -227,9 +227,7 @@ def test_no_credential_forwarded_under_fake_model() -> None:
             "AGENTOS_CREDENTIALS": "sk-ant-PLACEHOLDER",
         },
     )
-    client.create_claim(
-        "t1", pool="pool", env={"AGENTOS_FAKE_MODEL": "1", "AGENTOS_BUDGET": "{}"}
-    )
+    client.create_claim("t1", pool="pool", env={"AGENTOS_FAKE_MODEL": "1", "AGENTOS_BUDGET": "{}"})
     envs = _flag_values(client.calls[0], "-e")
     assert "CLAUDE_CODE_OAUTH_TOKEN" not in envs  # ambient SDK token not forwarded
     assert "ANTHROPIC_API_KEY" not in envs
@@ -313,6 +311,56 @@ def test_get_sandbox_treats_dead_container_as_gone() -> None:
     for dead in ("exited", "dead", "created", "restarting"):
         client.outputs = {"inspect": f"{dead}\t{{}}", "port": ""}
         assert client.get_sandbox("t1") is None, dead
+
+
+class _NetworkAwareDocker(DockerSandboxClient):
+    """Fake that distinguishes the status inspect from the networks inspect (both
+    are ``docker inspect``, so keying on the subcommand alone is not enough)."""
+
+    def __init__(self, *, networks_json: str, **kwargs: object) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self._networks_json = networks_json
+
+    def _docker(self, args: list[str], *, check: bool = True) -> str:
+        if args and args[0] == "inspect":
+            if any("NetworkSettings.Networks" in a for a in args):
+                return self._networks_json
+            return "running\t{}"
+        if args and args[0] == "port":
+            return "127.0.0.1:49173\n"
+        return ""
+
+
+def test_get_sandbox_dials_container_ip_on_shared_network() -> None:
+    # A host-net worker container on a Docker Desktop VM cannot reach the runner's
+    # host-loopback publish, but can reach its shared-network container IP. So the
+    # dial target is that IP at the fixed container port, not the host port.
+    client = _NetworkAwareDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        network="agentos_default",
+        networks_json='{"agentos_default": {"IPAddress": "172.20.0.11"}}',
+    )
+    view = client.get_sandbox("t1")
+    assert view is not None
+    assert view.service_fqdn == "172.20.0.11"
+    assert view.port == RUNNER_CONTAINER_PORT  # not the Docker-assigned host port
+    assert view.operating_mode == "Running"
+
+
+def test_get_sandbox_falls_back_to_published_port_without_network_ip() -> None:
+    # No shared-network IP yet (or no network): dial the Docker-assigned host
+    # loopback port, preserving the host-process worker path.
+    client = _NetworkAwareDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        network="agentos_default",
+        networks_json="{}",
+    )
+    view = client.get_sandbox("t1")
+    assert view is not None
+    assert view.service_fqdn == "127.0.0.1"
+    assert view.port == 49173
 
 
 def test_prepare_bundle_is_readable_by_nonroot_runner() -> None:
@@ -416,9 +464,7 @@ def test_ensure_image_is_best_effort_on_pull_failure(caplog) -> None:
         def _docker(self, args: list[str], *, check: bool = True) -> str:
             self.calls.append(args)
             if args[0] == "pull":
-                raise DockerError(
-                    "docker pull failed (1): SENTINEL_STDERR_LEAK"
-                )
+                raise DockerError("docker pull failed (1): SENTINEL_STDERR_LEAK")
             return ""  # inspect: absent
 
     client = _PullFailsDocker(image="agentos-runner", bundle_store=_FakeBundleStore())


### PR DESCRIPTION
## Problem
The local docker sandbox substrate published the runner's port on the Mac-host loopback (`-p 127.0.0.1::8080`) and dialed `127.0.0.1:<hostport>/healthz` for the `claim.ready` gate. But the compose worker runs `network_mode: host`, which **on Docker Desktop for Mac is the Docker VM's netns, not the Mac's** — so the host-loopback publish is unreachable from the worker. Every local turn failed with `claim not bound within 90.0s` → `runner-error after 3 attempts`; `agentos skill` worked only because it runs as a real Mac host process.

Proof, dialing a live runner from inside the worker container:
- `http://172.20.0.11:8080/healthz` (container bridge IP on `agentos_default`) → **200**
- `http://127.0.0.1:<hostport>/healthz` (Mac-host publish) → **connection refused**

## Fix
When a docker network is configured, dial the runner on its **shared-network container IP at the fixed container port** (`_container_ip`/`_dial_endpoint`), falling back to the published host port for the host-process path. Both `_healthz_ok` and `get_sandbox` route through it — reachable across a host-process worker, a native-Linux host-net worker, and a Docker Desktop host-net worker alike. The `-p` publish is kept (harmless, useful for a host-process worker and humans).

## Tests
- `apps/worker/tests/sandbox/test_docker.py`: added a container-IP-dial case and a published-port-fallback case (24 pass; ruff clean).
- Verified end-to-end on Docker Desktop for Mac: a full platform turn now reaches the runner and completes — `turn start → tool call → turn end status=done`.

Ref CUR-1649

🤖 Generated with [Claude Code](https://claude.com/claude-code)