### PR TITLE
Leave a fake-model eval run unlabelled, not tagged with an uncalled model

### DIFF
--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -132,9 +132,7 @@ def load_suite_from_bundle(data: bytes, suite_name: str) -> EvalSuite | None:
         with tempfile.TemporaryDirectory() as tmp:
             dest = Path(tmp)
             safe_extract(data, dest)
-            cases = next(
-                (p for p in dest.rglob("cases.json") if p.parent.name == "evals"), None
-            )
+            cases = next((p for p in dest.rglob("cases.json") if p.parent.name == "evals"), None)
             if cases is None:
                 return None
             loaded = EvalSuite.model_validate_json(cases.read_text())
@@ -183,8 +181,7 @@ class EvalStreamConsumer(StreamConsumer):
         # keeps its position, so this only bounds the very first creation.
         cutoff_ms = int(
             (
-                datetime.now(UTC)
-                - timedelta(hours=self._config.eval_stream_max_age_hours)
+                datetime.now(UTC) - timedelta(hours=self._config.eval_stream_max_age_hours)
             ).timestamp()
             * 1000
         )
@@ -428,9 +425,7 @@ class EvalStreamConsumer(StreamConsumer):
             return None
         return load_suite_from_bundle(data, item.suite)
 
-    async def _acquire_target(
-        self, item: EvalJob
-    ) -> tuple[str | None, str | None, str | None]:
+    async def _acquire_target(self, item: EvalJob) -> tuple[str | None, str | None, str | None]:
         if item.target_url is not None:
             # dev/test shortcut: eval a given runner. Not a claim of ours, so no
             # token -- the driver omits the header (only-when-configured).
@@ -439,9 +434,7 @@ class EvalStreamConsumer(StreamConsumer):
         try:
             connector_secrets = await self._repo_lookup.secrets_for(item.agent_id)
             env = self._boot_env(item, connector_secrets)
-            handle = await asyncio.to_thread(
-                self._substrate.claim, release_key, env=env
-            )
+            handle = await asyncio.to_thread(self._substrate.claim, release_key, env=env)
         except SandboxError:
             logger.exception("could not provision a runner for eval %s", item.sha)
             return None, None, None
@@ -451,14 +444,29 @@ class EvalStreamConsumer(StreamConsumer):
         """The model dimension for this run: the caller-requested ``item.model``
         when set (#526, a sweep pins each run to a distinct model), else the model
         the eval's runner is booted with (``config.model``, the same value
-        ``apply_model_env`` forwards as ``AGENTOS_MODEL``). A requested model is
-        always the label, so a sweep run is never silently unlabelled. The dev/test
+        ``apply_model_env`` forwards as ``AGENTOS_MODEL``). The dev/test
         ``target_url`` shortcut evals a runner we did not boot, so unless the caller
-        named a model its model is unknown and left unlabelled."""
+        named a model its model is unknown and left unlabelled.
+
+        A fake-model install (the sealed default, or ``AGENTOS_FAKE_MODEL=1``) runs
+        the canned ``FakeModelSession`` regardless of the requested model, so a row
+        is left unlabelled rather than tagged with a model that was never called:
+        labelling it would fabricate a cross-model comparison the sweep never
+        performed (#606, ADR-0041's "an empty success is a lie"). The runner we did
+        not boot (``target_url``) is exempt -- our fake flag says nothing about what
+        it ran."""
+        if item.target_url is not None:
+            return item.model
+        if self._config.fake_model:
+            if item.model is not None:
+                logger.warning(
+                    "eval requested model %r but this install runs the fake model; "
+                    "recording the row unlabelled rather than as a model never called",
+                    item.model,
+                )
+            return None
         if item.model is not None:
             return item.model
-        if item.target_url is not None:
-            return None
         return self._config.model or None
 
     def _boot_env(
@@ -491,17 +499,13 @@ class EvalStreamConsumer(StreamConsumer):
         apply_model_env(env, self._config, model_override=item.model)
         return env
 
-    async def _report_failed(
-        self, item: EvalJob, repo: str | None, reason: str
-    ) -> EvalRunResult:
+    async def _report_failed(self, item: EvalJob, repo: str | None, reason: str) -> EvalRunResult:
         logger.error("eval %s @ %s failed: %s", item.suite, item.sha, reason)
         result = EvalRunResult(version=item.sha, suite=item.suite, results=[])
         await self._report(item, repo, result)
         return result
 
-    async def _report(
-        self, item: EvalJob, repo: str | None, result: EvalRunResult
-    ) -> None:
+    async def _report(self, item: EvalJob, repo: str | None, result: EvalRunResult) -> None:
         await self._reporter.report(
             EvalReport(
                 repo_full_name=repo or str(item.agent_id),
@@ -513,6 +517,4 @@ class EvalStreamConsumer(StreamConsumer):
         )
 
     async def _ack(self, entry_id: str) -> None:
-        await self._xack(
-            self._config.eval_stream, self._config.eval_consumer_group, entry_id
-        )
+        await self._xack(self._config.eval_stream, self._config.eval_consumer_group, entry_id)

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import httpx
+import pytest
 import redis
 from agentos_worker.binding import BUDGET_ENV, BUNDLE_REF_ENV, MODEL_ENV
 from agentos_worker.bundle_store import BundleStore
@@ -124,9 +125,7 @@ class _FakeK8s:
         claim = self.claims.get(name)
         if claim is None:
             return None
-        return ClaimView(
-            name=claim.name, ready=True, sandbox_name=claim.sandbox_name
-        )
+        return ClaimView(name=claim.name, ready=True, sandbox_name=claim.sandbox_name)
 
     def delete_claim(self, name: str) -> None:
         self.claims.pop(name, None)
@@ -898,6 +897,50 @@ def test_eval_requested_model_labels_even_a_target_url_run() -> None:
     assert consumer._eval_model(labelled) == "claude-y"
     unlabelled = _item(suite="s", sha="d", bundle_ref=None, target_url="http://runner")
     assert consumer._eval_model(unlabelled) is None
+
+
+def test_eval_fake_model_install_refuses_to_label_a_model_never_called(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#606: a fake-model install (the sealed default, or AGENTOS_FAKE_MODEL=1) runs
+    the canned FakeModelSession regardless of the requested model. A sweep row must
+    NOT be tagged with a model that was never called -- that fabricates a
+    cross-model comparison indistinguishable from a real one (ADR-0041). The row is
+    left unlabelled, and the discarded request is logged rather than silently
+    dropped."""
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(fake_model=True, model="worker-default"),
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    booted = _item(
+        suite="s",
+        sha="deadbeef",
+        bundle_ref="bundles/x.zip",
+        target_url=None,
+        model="claude-opus-4-8",
+    )
+    with caplog.at_level(logging.WARNING):
+        assert consumer._eval_model(booted) is None  # NOT "claude-opus-4-8"
+    assert any("claude-opus-4-8" in r.getMessage() for r in caplog.records), (
+        "the discarded requested model must be logged, not silently dropped"
+    )
+
+    # A fake run with no requested model is unlabelled too (not the worker default,
+    # which the fake session never calls either).
+    default_item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.zip", target_url=None)
+    assert consumer._eval_model(default_item) is None
+
+    # The target_url runner we did not boot is exempt: our fake flag says nothing
+    # about what that runner ran, so a caller-asserted label still stands.
+    remote = _item(
+        suite="s", sha="d", bundle_ref=None, target_url="http://runner", model="claude-y"
+    )
+    assert consumer._eval_model(remote) == "claude-y"
 
 
 def test_eval_boot_env_drops_reserved_connector_secret() -> None:


### PR DESCRIPTION
## Problem
On a sealed install (the chart default `agentSandbox.runner.fakeModel: true` → `config.fake_model`), a model sweep runs **every** row on the canned `FakeModelSession`, but `_eval_model` (`apps/worker/src/agentos_worker/eval/stream.py`) returned the caller-requested real model name as the matrix label. The operator reads a cross-model comparison (`claude-opus-4-8` vs `claude-sonnet-5`, identical pass-rates) that **never called a model** — ADR-0041's "an empty success is a lie an agent cannot detect," in the eval surface.

## Fix
When `config.fake_model` is set, `_eval_model` leaves the row **unlabelled** (returns `None`) rather than tagging it with a model that was never called, and **logs** the discarded request so it isn't silently dropped. The `target_url` runner we did not boot is exempt — our fake flag says nothing about what that runner ran, so a caller-asserted label still stands.

## Tests
- `apps/worker/tests/eval/test_stream.py`: new `test_eval_fake_model_install_refuses_to_label_a_model_never_called` — a fake install with a requested model returns `None` (not the model) and logs it; the `target_url` label still stands. Full eval-stream suite green (17 passed); ruff clean.

Chosen AC option: "refuse to label the row with a model that was not called" (localized, no cross-tier exit-code plumbing).

Closes #606
Ref CUR-1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)