### PR TITLE
Operator opt-in for policy-gate tool grantability (grantableViaPolicy)

### DIFF
--- a/apps/api/src/agentos_api/models.py
+++ b/apps/api/src/agentos_api/models.py
@@ -204,10 +204,12 @@ class Approval(Base):
     # is ``'permission'`` when the tool-permission gate denied a real tool call,
     # ``'policy'`` when the model asked for a business-decision approval; it is
     # the column the worker branches on instead of sniffing the summary prefix.
-    # ``granted_tool`` is the tool name a resume-turn grant is bound to and is
-    # only ever set for ``gate_kind='permission'`` (a policy gate never authorizes
-    # a tool). Both NULL from an older runner that predates them, which is the
-    # rolling-deploy window the worker's prefix fallback covers.
+    # ``granted_tool`` is the tool name a resume-turn grant is bound to. It is set
+    # for ``gate_kind='permission'`` and, since #558, for a ``gate_kind='policy'``
+    # gate the operator opted into grantability (grantableViaPolicy) -- the runner
+    # stamps the manifest tool onto it for those gates and leaves it NULL for
+    # every other policy gate. Both NULL from an older runner that predates them,
+    # which is the rolling-deploy window the worker's prefix fallback covers.
     gate_kind: Mapped[str | None] = mapped_column(default=None)
     granted_tool: Mapped[str | None] = mapped_column(default=None)
 

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -528,8 +528,10 @@ class ApprovalOut(BaseModel):
     dedupe_key: str
     route: str | None
     card_channel: str | None
-    # Gate provenance (#544): which gate fired, and the tool a permission-gate
-    # grant is bound to. Both NULL for a policy gate or a pre-#544 row.
+    # Gate provenance (#544): which gate fired, and the tool a grant is bound to.
+    # Both NULL for a pre-#544 row. A permission gate carries granted_tool; a
+    # policy gate carries it too when the operator opted the manifest gate into
+    # grantability (grantableViaPolicy, #558), and NULL otherwise.
     gate_kind: str | None
     granted_tool: str | None
     status: str

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -263,12 +263,17 @@ class BindingResolver:
         ``granted_tool`` column and does not re-derive it. Three cases on
         ``gate_kind``:
 
-        * ``'policy'`` -- refuse OUTRIGHT, whatever ``granted_tool`` contains
-          (Decision C defence in depth): a policy gate authorizes a business
-          decision and never a tool, so even a corrupted or hand-edited row
-          cannot turn one into a grant. This is the seam #430/#410 were filed on.
-        * ``'permission'`` -- return the ``granted_tool`` column (the trusted
-          ``can_use_tool`` value the runner denied), never a parse of the summary.
+        * ``'policy'`` or ``'permission'`` -- return the ``granted_tool`` column
+          (or None when NULL). For a permission gate this is the trusted
+          ``can_use_tool`` value the runner denied. For a policy gate, #558
+          (superseding ADR-0046 Decision C's outright refusal) lets an
+          operator-opted ``grantableViaPolicy`` gate carry a grant: the runner
+          stamps the MANIFEST-declared tool onto ``granted_tool`` for exactly
+          those gates and leaves it NULL for every other policy gate, so honoring
+          the column grants the opted-in gates and preserves #544's no-grant
+          default (NULL -> None) elsewhere. The value is never model-authored
+          (runner-sourced from the manifest), never a parse of the summary, so
+          the #430/#410 forgery seam stays closed.
         * ``NULL`` -- the rolling-deploy window (edge case 7): a NEW worker met an
           OLD pinned runner whose final carried no provenance. Fall back to the
           legacy summary-prefix parse -- byte-identical to today's behavior, so a
@@ -306,10 +311,16 @@ class BindingResolver:
         if row_agent_id is None or row_agent_id != agent_id:
             return None
         gate_kind = row["gate_kind"]
-        if gate_kind == "policy":
-            # Refuse outright: a policy gate never grants a tool (Decision A/C).
-            return None
-        if gate_kind == "permission":
+        if gate_kind in ("policy", "permission"):
+            # #558 (supersedes ADR-0046 Decision C's "policy refuses outright"): a
+            # policy gate mints a grant ONLY when the operator opted its manifest
+            # gate into grantability (grantableViaPolicy). The runner stamps the
+            # manifest-declared tool onto granted_tool for exactly those gates and
+            # leaves it NULL otherwise, so honoring the column grants the opted-in
+            # gates and preserves #544's no-grant default (NULL -> None) for every
+            # other policy gate. granted_tool is never model-authored (the runner
+            # sources it from the manifest), so this cannot be reached by a
+            # prompt-injected model. The permission path is unchanged.
             tool: str | None = row["granted_tool"]
             return tool or None
         # gate_kind IS NULL: the old-runner fallback, today's prefix parse.

--- a/apps/worker/tests/binding/test_approval_grant.py
+++ b/apps/worker/tests/binding/test_approval_grant.py
@@ -243,15 +243,51 @@ def test_approved_policy_gate_never_grants() -> None:
     asyncio.run(go())
 
 
-def test_policy_gate_with_a_granted_tool_column_still_grants_nothing() -> None:
-    # Decision C's defence in depth. This row is IMPOSSIBLE from a correct
-    # runner -- Decision A means a policy gate never populates granted_tool. It
-    # exists anyway (a hand-edited row, a future runner bug), and the worker
-    # refuses it on gate_kind alone, regardless of what the column says.
-    #
-    # Deliberately redundant: this is the seam #430 and #410 were both filed
-    # against, and the invariant belongs stated at the point where the authority
-    # is actually handed out.
+def test_approved_policy_gate_with_granted_tool_grants_it() -> None:
+    # #558 SUPERSESSION of the old "policy gate grants nothing even with a
+    # granted_tool column" invariant. The operator opt-in `grantableViaPolicy`
+    # lets a policy approval mint a one-shot grant, and the runner writes the
+    # granted MANIFEST tool onto the row. So an approved policy row WITH a
+    # non-null granted_tool now RETURNS that tool. The value is still trusted
+    # (runner-written from the manifest, never model-supplied), so the forgery
+    # protection below is unaffected -- a model controls only the summary.
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            await _skip_if_unreachable(engine)
+            agent_id = uuid.uuid4()
+            approval_id = uuid.uuid4()
+            await _seed_agent(engine, agent_id)
+            await _seed_approval(
+                engine,
+                approval_id=approval_id,
+                status="approved",
+                summary="Close the ACME issue",
+                agent_id=agent_id,
+                gate_kind="policy",
+                granted_tool="close_issue",  # the operator-opted-in grant
+            )
+            try:
+                tool = await _resolver(engine).approval_grant_tool(
+                    resume_event_id(approval_id), agent_id
+                )
+                assert tool == "close_issue", (
+                    "an approved grantable-policy row hands out its granted_tool "
+                    "column (#558)"
+                )
+            finally:
+                await _cleanup_agents(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_approved_policy_gate_with_null_granted_tool_grants_nothing() -> None:
+    # The default #544 behavior is PRESERVED: a policy approval the operator did
+    # NOT mark grantable carries a NULL granted_tool, and the worker returns
+    # None. This is the honest common case (most policy gates are not grantable),
+    # and it is the same NULL-column row the forgery guard below relies on.
     async def go() -> None:
         engine = create_async_engine(_DB_URL)
         try:
@@ -266,15 +302,14 @@ def test_policy_gate_with_a_granted_tool_column_still_grants_nothing() -> None:
                 summary="Give ACME a 20% discount",
                 agent_id=agent_id,
                 gate_kind="policy",
-                granted_tool="Bash",  # a corrupted / impossible row
+                granted_tool=None,
             )
             try:
                 tool = await _resolver(engine).approval_grant_tool(
                     resume_event_id(approval_id), agent_id
                 )
                 assert tool is None, (
-                    "gate_kind='policy' must refuse outright, whatever "
-                    "granted_tool contains"
+                    "a policy approval with no granted_tool mints no grant (#544)"
                 )
             finally:
                 await _cleanup_agents(engine, [agent_id])

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2859,6 +2859,13 @@ const MANIFEST_LOCATIONS: [&str; 2] = [".claude-plugin/plugin.json", "plugin.jso
 struct ApprovalGateDecl {
     gate: Option<String>,
     route: Option<String>,
+    /// Operator opt-in (#558). Unlike `gate`/`route`, collapsing absent/false is
+    /// intentional here: a bool with a safe default carries no absent-vs-empty
+    /// distinction worth preserving. Unread -- this struct only mirrors the
+    /// manifest shape for round-trip parsing on the display/parse path.
+    #[allow(dead_code)]
+    #[serde(default, rename = "grantableViaPolicy")]
+    grantable_via_policy: bool,
 }
 
 /// The manifest `approvalPolicy` object; mirrors `plugin_format.models.ApprovalPolicy`.
@@ -3323,7 +3330,7 @@ mod tests {
     use super::{
         merge_secret_env, parse_manifest_gates, replace_first_line, resolve_cases_path,
         seed_env_if_missing, select_in_force_deployment, select_passthrough_env,
-        validate_slack_channel, EnvSeed,
+        validate_slack_channel, ApprovalGateDecl, EnvSeed,
     };
     use serde::Deserialize;
     use std::path::{Path, PathBuf};
@@ -3971,6 +3978,22 @@ mod tests {
                 .expect("an empty gates list is a valid declaration of no gates"),
             Vec::new()
         );
+    }
+
+    #[test]
+    fn approval_gate_decl_parses_grantable_via_policy() {
+        // #558: the operator opt-in on a manifest gate. Absent -> defaults false
+        // (old manifests keep the no-grant baseline); present true -> parses.
+        let without: ApprovalGateDecl =
+            serde_json::from_str(r#"{"gate":"close_issue","route":"deal-desk"}"#)
+                .expect("a gate without grantableViaPolicy parses");
+        assert!(!without.grantable_via_policy);
+
+        let with: ApprovalGateDecl = serde_json::from_str(
+            r#"{"gate":"close_issue","route":"deal-desk","grantableViaPolicy":true}"#,
+        )
+        .expect("a gate with grantableViaPolicy:true parses");
+        assert!(with.grantable_via_policy);
     }
 
     #[tokio::test]

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -225,7 +225,17 @@ pub fn scaffold_from_spec(dir: &Path, spec: &AgentSpec) -> Result<Vec<PathBuf>> 
         let gates: Vec<Value> = policy
             .gates
             .iter()
-            .map(|g| serde_json::json!({ "gate": g.gate, "route": g.route }))
+            .map(|g| {
+                // Emit `grantableViaPolicy` only when true so specs that don't
+                // use the opt-in keep a byte-identical default scaffold (#558).
+                let mut gate = serde_json::Map::new();
+                gate.insert("gate".into(), serde_json::json!(g.gate));
+                gate.insert("route".into(), serde_json::json!(g.route));
+                if g.grantable_via_policy {
+                    gate.insert("grantableViaPolicy".into(), serde_json::json!(true));
+                }
+                Value::Object(gate)
+            })
             .collect();
         manifest_obj.insert(
             "approvalPolicy".into(),

--- a/cli/src/spec.rs
+++ b/cli/src/spec.rs
@@ -34,6 +34,11 @@ pub struct SkillSpec {
 pub struct ApprovalGateSpec {
     pub gate: String,
     pub route: String,
+    /// Operator opt-in: lets a policy-gate approval mint a one-shot tool grant
+    /// for this gate (#558). Unlike `gate`/`route`, where absent-vs-empty is
+    /// load-bearing, a bool with a safe default may collapse absent and false.
+    #[serde(default, rename = "grantableViaPolicy")]
+    pub grantable_via_policy: bool,
 }
 
 /// The `approvalPolicy` a spec declares. Mirrors `plugin_format.models.ApprovalPolicy`.

--- a/cli/tests/spec_scaffold.rs
+++ b/cli/tests/spec_scaffold.rs
@@ -143,6 +143,46 @@ fn scaffolds_secrets_and_approval_policy_into_the_manifest() {
     assert_eq!(manifest["approvalPolicy"]["gates"][0]["route"], "default");
 }
 
+/// A spec gate marked `grantableViaPolicy: true` scaffolds that flag verbatim
+/// into the emitted manifest's approvalPolicy gate (#558), so a deployed bundle
+/// carries the operator opt-in the runner/worker read to mint a one-shot grant.
+/// A gate that omits it scaffolds no `true` flag (default no-grant) and still
+/// validates.
+#[test]
+fn scaffolds_grantable_via_policy_flag_into_the_manifest() {
+    let body = r#"{
+      "name": "deal-desk",
+      "description": "Gated deal desk with a grantable gate.",
+      "skills": [
+        { "name": "deal-desk", "description": "Do it.", "instructions": "Body.\n" }
+      ],
+      "approvalPolicy": {
+        "gates": [
+          { "gate": "close_issue", "route": "deal-desk", "grantableViaPolicy": true },
+          { "gate": "escalate", "route": "managers" }
+        ]
+      },
+      "evals": [
+        { "id": "e1", "input": "hi", "grader": { "kind": "contains", "expected": "ok" } }
+      ]
+    }"#;
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    let spec = parse(body).expect("grantable-gate spec parses");
+    scaffold_from_spec(&out, &spec).expect("scaffold succeeds");
+
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out.join(".claude-plugin/plugin.json")).unwrap(),
+    )
+    .unwrap();
+    let gates = &manifest["approvalPolicy"]["gates"];
+    // The opted-in gate carries the flag verbatim.
+    assert_eq!(gates[0]["gate"], "close_issue");
+    assert_eq!(gates[0]["grantableViaPolicy"], serde_json::json!(true));
+    // The non-opted gate scaffolds no `true` flag (omitted or false).
+    assert_ne!(gates[1]["grantableViaPolicy"], serde_json::json!(true));
+}
+
 /// A spec that declares neither omits both keys, so the default scaffold shape is
 /// unchanged (no empty `secrets: []` / `approvalPolicy` noise).
 #[test]

--- a/docs/adr/0056-operator-opt-in-for-policy-gate-grantability.md
+++ b/docs/adr/0056-operator-opt-in-for-policy-gate-grantability.md
@@ -1,0 +1,135 @@
+# 56. An operator opt-in makes a policy gate grantable; a heuristic never does
+
+Date: 2026-07-17
+
+Status: Accepted
+
+Implements [#558](https://github.com/curie-eng/agentos/issues/558).
+Supersedes the "a policy gate refuses a grant outright" half of
+[ADR-0046](0046-converged-approval-gates-and-durable-provenance.md) Decision C —
+and only that half. Every other property ADR-0046 established (durable
+runner-authored `gate_kind`/`granted_tool` provenance, loud route resolution,
+observe-only resume reconciliation, and the convergence of the two gate paths on
+one lifecycle) is unchanged. ADR-0046 itself named this change as the sanctioned
+way to reintroduce policy-gate grantability and deferred it here.
+
+## Context
+
+Under ADR-0046 a **policy gate never mints a one-shot tool grant**. The
+permission gate stays the sole tool authority, so a policy-gated action costs the
+human two approvals: one for the business decision, one for the tool execution.
+`translate.py` stamps `approval_gate_kind='policy'` with `approval_granted_tool`
+left `None`, and the worker's `approval_grant_tool`
+(`apps/worker/src/agentos_worker/binding.py`) refused any `gate_kind='policy'`
+row outright.
+
+That is correct but not free. The design behind ADR-0046 established why a
+*heuristic* cannot close the gap, and this ADR does not relitigate it. The
+rejected heuristic let a policy approval mint a grant whenever the model's
+manifest-validated `route` resolved to exactly one manifest gate. It fails on
+**argument visibility**, an asymmetry between the two approval cards:
+
+- A **permission-gate** card shows the tool **and its rendered arguments**
+  (`summarize_tool_call` renders the blocked `tool_input`). The human approves a
+  concrete call.
+- A **policy-gate** card shows a model-authored framing plus, at most, a bare
+  tool name — never rendered tool arguments. If that approval also releases a
+  tool grant, the tool then runs on resume with arguments the human never saw.
+
+So policy-grantability is a strict **widening** of the argument-scoping gap
+ADR-0035 already accepts, not a preservation of it. A disclosure line does not
+fix it: it appears on every granting card, habituates within a week, and needs
+the approver to know the business-action → tool mapping to catch a mismatch.
+Route selection also picks the **approver audience**, so a single model-chosen
+argument would select both the tool and which humans are asked. The bound
+degrades linearly as manifests grow. The double-approval UX the heuristic tried
+to avoid is not a defect: the two approvals authorize genuinely different things,
+and the second card is the argument-visibility control the first cannot deliver.
+
+The residual is real, though: some operators legitimately want a business
+approval to also carry the tool through, accept that the card shows no arguments,
+and know their own manifest well enough to reason about it. The question #558
+answers is *who* may make that trade, and the answer cannot be a heuristic over a
+model-chosen route.
+
+## Decision
+
+**Grantability is an explicit, per-gate, operator-authored opt-in in the plugin
+manifest. Neither a heuristic nor the model ever confers it.**
+
+### 1. The manifest carries the opt-in
+
+`ApprovalGate` (`packages/plugin-format`) gains an optional boolean
+`grantableViaPolicy` (default `false`). An operator marks a gate grantable
+explicitly:
+
+```json
+{"gate": "close_issue", "route": "deal-desk", "grantableViaPolicy": true}
+```
+
+Because a gate's `gate` field **is a tool name** (the runner arms it as a
+permission-gated tool and keys its route off it), an opted-in gate declares:
+"when a policy approval resolves to route `deal-desk`, also mint a one-shot grant
+for the `close_issue` tool." The granted tool is the manifest's `gate` value —
+**operator-authored, never a model-supplied string.** The model's `route`
+argument only selects among gates the operator already declared; it cannot invent
+a tool, and it is validated against the manifest's declared routes exactly as
+before.
+
+### 2. One normalization, shared by the validator and the loader
+
+`plugin_format.grantable_routes` (`packages/plugin-format/src/plugin_format/approval_policy.py`)
+is the single function that maps the declared gates to `{route: tool}` for
+grantable gates, and reports any route claimed by more than one **distinct**
+grantable tool as **ambiguous**. Both the deploy-time validator
+(`_validate_approval_policy`) and the runtime loader
+(`resolve_approval_policy`) call it, so they normalize identically by
+construction (`.strip()`, case-sensitive) rather than by two implementations that
+must be kept in step. This is the #453/#544 fail-open class stated as a
+structural guarantee: a config that validates green cannot arm something
+different at runtime, and an executed test pins the agreement.
+
+An **ambiguous** grantable route (two grantable gates, same route, different
+tool) is a hard **deploy error** (`approval_policy.grant_route_ambiguous`): left
+to runtime it would validate green and arm no grant — the exact silent fail-open
+this repo rejects. The loader also excludes an ambiguous route from its grant map
+as defense in depth, so even a bundle that somehow bypassed the validator arms no
+ambiguous grant.
+
+### 3. The runner stamps, the worker honors
+
+On an accepted policy request the runner stamps
+`approval_granted_tool = gate.grantable_tool_for_route(resolved_route)` — the
+manifest tool for an opted-in route, or `None` otherwise. `gate_kind` stays
+`'policy'`. The worker's `approval_grant_tool` now returns the `granted_tool`
+column for a `gate_kind='policy'` row instead of refusing it outright: a
+non-opted policy gate leaves the column `NULL` and still grants nothing, so
+**ADR-0046's behavior is the exact default for every gate the operator did not
+mark grantable.** `granted_tool` is never model-authored, and the human approval,
+status, and agent-bind guards are all unchanged, so this does not widen what a
+prompt-injected model — or a compromised sandbox, which already authors
+`granted_tool` on the permission path — can reach. No new `gate_kind` value and
+no migration: the existing nullable `granted_tool` column (migration `0015`) and
+its `CHECK (gate_kind IN ('permission','policy'))` are reused as-is.
+
+## Consequences
+
+- **A policy-grant card still shows no tool arguments.** That asymmetry with a
+  permission card is unchanged and is the whole reason grantability is an opt-in:
+  it converts the residual argument-scoping risk from **ambient** (a heuristic
+  granting on every resolvable route) to **deliberate** (an operator marking one
+  gate, accepting that its approval carries a tool the human approves without
+  seeing its arguments). An operator who does not opt in is exactly where
+  ADR-0046 left them.
+- **The default is byte-identical to #544.** No `grantableViaPolicy`, or
+  `false`, means no grant — same column, same worker verdict, same two-approval
+  flow.
+- **The worker's "refuse policy outright" defense-in-depth is deliberately
+  relaxed for opted-in gates.** It was load-bearing only while policy-never-grants
+  was absolute; the opt-in is what the operator trades it for. The permission
+  path, the model-forgery protections (`guard_reserved_summary`, the
+  manifest-sourced tool), and the NULL-`gate_kind` rolling-deploy fallback are all
+  unchanged.
+- **The CLI manifest mirrors carry the field** so `agentos <tier> approvals` and
+  `init --from-spec` round-trip a grantable gate without dropping it; the arming
+  and ambiguity logic stays Python-authoritative.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -85,4 +85,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0053 | [Add an expected terminal status to the frozen eval-case format](0053-expected-terminal-status-in-eval-cases.md) | Accepted |
 | 0054 | [Local Docker runner containers are hardened and network-isolated](0054-local-docker-runner-hardening.md) | Accepted |
 | 0055 | [The fake model is a plumbing fixture, not a subject under test](0055-the-fake-model-is-a-plumbing-fixture.md) | Accepted |
+| 0056 | [An operator opt-in makes a policy gate grantable; a heuristic never does](0056-operator-opt-in-for-policy-gate-grantability.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -97,9 +97,14 @@ in code now:
   ADR-0035's summary-prefix discriminator): for a `gate_kind='permission'` row it injects
   `AGENTOS_APPROVAL_GRANT_TOOL=<granted_tool>` (`GRANT_TOOL_ENV`, the exact tool name
   `can_use_tool` denied, a trusted runner-authored value); for a `gate_kind='policy'` row it
-  **refuses outright** (a policy gate never mints a grant — the model's arguments can never
-  select which tool receives bypass authority, the #430 invariant now enforced by the column,
-  not the prefix); and only for a `gate_kind IS NULL` row (the rolling-deploy window where an
+  injects the same `AGENTOS_APPROVAL_GRANT_TOOL` from the `granted_tool` column **when that
+  column is non-null** — the runner sets it only for a manifest gate the operator opted into
+  grantability via `grantableViaPolicy` (#558, ADR-0056), with the granted tool sourced from
+  the manifest's `gate` value, **never a model-supplied string**, so the model's arguments still
+  can never select which tool receives bypass authority (the #430 invariant, now enforced by
+  the manifest opt-in and the column rather than the prefix). A policy gate the operator did
+  not mark grantable leaves `granted_tool` NULL and still grants nothing — the #544 default is
+  unchanged; and only for a `gate_kind IS NULL` row (the rolling-deploy window where an
   in-flight older runner image emitted no provenance) does it fall back to the OLD
   `summarize_tool_call` summary-prefix parse, byte-identical to prior behavior. The runner gate
   allows exactly one call to that tool on
@@ -107,8 +112,9 @@ in code now:
   grant on the next turn so an adopted warm-pod follow-up cannot inherit it. The grant is
   **tool-name-scoped** (a different gated tool, or a second call to the same one, still
   gates), **agent-bound** (delivered only when the approval's `agent_id` matches the
-  agent resolved for the channel, so a rebound channel cannot cross-grant), **permission-gate
-  only** (enforced by the `gate_kind` column; for the NULL-fallback window the
+  agent resolved for the channel, so a rebound channel cannot cross-grant), scoped to
+  **a permission gate, or an operator-opted (`grantableViaPolicy`) policy gate** (enforced by
+  the `gate_kind`/`granted_tool` columns; for the NULL-fallback window the
   `summarize_tool_call` prefix is still a RESERVED namespace, and the runner guards
   model-authored policy-gate summaries out of it via `guard_reserved_summary`, so a
   policy-gate request cannot forge a permission-gate grant in that window either), and

--- a/packages/plugin-format/schema/plugin-format.schema.json
+++ b/packages/plugin-format/schema/plugin-format.schema.json
@@ -2,11 +2,16 @@
   "$defs": {
     "ApprovalGate": {
       "additionalProperties": true,
-      "description": "One approval gate declaration: a gate point plus the route it sends to.\n\n``gate`` names the point at which the agent pauses for approval (e.g. a tool\nclass or lifecycle point); ``route`` names the approval route that decides.\nBoth are required \u2014 an incomplete gate is rejected at deploy.",
+      "description": "One approval gate declaration: a gate point plus the route it sends to.\n\n``gate`` names the point at which the agent pauses for approval (e.g. a tool\nclass or lifecycle point); ``route`` names the approval route that decides.\nBoth are required \u2014 an incomplete gate is rejected at deploy.\n``grantableViaPolicy`` is the operator opt-in (#558): when true, a policy-gate\napproval on this gate's route MAY mint a one-shot grant for the manifest tool\n``gate`` names; default false preserves #544's policy-never-grants behavior.",
       "properties": {
         "gate": {
           "title": "Gate",
           "type": "string"
+        },
+        "grantableViaPolicy": {
+          "default": false,
+          "title": "Grantableviapolicy",
+          "type": "boolean"
         },
         "route": {
           "title": "Route",

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -6,6 +6,7 @@ is a frozen interface (see the package README); a change stops the task and
 escalates to the orchestrator.
 """
 
+from .approval_policy import grantable_routes
 from .archive import UnsupportedArchive, bundle_root, safe_extract
 from .manifest import MANIFEST_LOCATIONS, resolve_manifest
 from .models import (
@@ -41,6 +42,7 @@ __all__ = [
     "TriggerDeclaration",
     "ApprovalPolicy",
     "ApprovalGate",
+    "grantable_routes",
     "validate_bundle",
     "ValidationResult",
     "ValidationIssue",

--- a/packages/plugin-format/src/plugin_format/approval_policy.py
+++ b/packages/plugin-format/src/plugin_format/approval_policy.py
@@ -1,0 +1,61 @@
+"""Normalize the manifest's grantable approval-policy gates (#558).
+
+The operator opt-in ``grantableViaPolicy`` marks a gate whose policy-gate
+approval MAY mint a one-shot grant for the tool the gate names (its ``gate``
+field, MANIFEST-supplied, never model-supplied). ``grantable_routes`` is the
+SINGLE normalization shared by the deploy-time validator
+(``plugin_format.validate``) and the runtime loader
+(``agentos_runner.approval.resolve_approval_policy``). Sharing one helper makes
+the two paths identical *by construction* -- the #453/#544 lesson that a
+validator and a runtime loader normalizing separately can silently disagree and
+ship a fail-open.
+"""
+
+from __future__ import annotations
+
+from .models import ApprovalGate
+
+
+def grantable_routes(
+    gates: list[ApprovalGate],
+) -> tuple[dict[str, str], set[str]]:
+    """Resolve the grantable ``{route: tool}`` map and the ambiguous routes.
+
+    For each gate with ``grantableViaPolicy`` truthy AND a non-empty stripped
+    ``gate`` AND a non-empty stripped ``route``, accumulate ``route`` -> the set
+    of tools claiming it (``tool = gate.gate.strip()``, ``route =
+    gate.route.strip()``). ``.strip()`` and case-SENSITIVE comparison mirror
+    ``load_approval_policy`` so a config that validates green at deploy resolves
+    identically at runtime (#453).
+
+    Returns ``(resolved, ambiguous)``:
+
+    - ``resolved`` maps each route whose tool-set holds exactly ONE distinct tool
+      to that tool. A route named twice by the SAME tool is a duplicate, not a
+      conflict: still one distinct tool, still resolved.
+    - ``ambiguous`` is the set of routes claimed by MORE than one distinct tool.
+      Such a route is excluded from ``resolved`` (arms no grant) and reported so
+      the deploy validator can reject it, rather than validating green while
+      arming nothing (the #453 shape).
+
+    Non-grantable gates and gates with a blank ``gate`` or ``route`` are ignored.
+    """
+
+    tools_by_route: dict[str, set[str]] = {}
+    for gate in gates:
+        if not gate.grantableViaPolicy:
+            continue
+        tool = gate.gate.strip()
+        route = gate.route.strip()
+        if not tool or not route:
+            continue
+        tools_by_route.setdefault(route, set()).add(tool)
+
+    resolved: dict[str, str] = {}
+    ambiguous: set[str] = set()
+    for route, tools in tools_by_route.items():
+        if len(tools) == 1:
+            resolved[route] = next(iter(tools))
+        else:
+            ambiguous.add(route)
+    return resolved, ambiguous

--- a/packages/plugin-format/src/plugin_format/models.py
+++ b/packages/plugin-format/src/plugin_format/models.py
@@ -103,12 +103,16 @@ class ApprovalGate(BaseModel):
     ``gate`` names the point at which the agent pauses for approval (e.g. a tool
     class or lifecycle point); ``route`` names the approval route that decides.
     Both are required — an incomplete gate is rejected at deploy.
+    ``grantableViaPolicy`` is the operator opt-in (#558): when true, a policy-gate
+    approval on this gate's route MAY mint a one-shot grant for the manifest tool
+    ``gate`` names; default false preserves #544's policy-never-grants behavior.
     """
 
     model_config = _LENIENT
 
     gate: str
     route: str
+    grantableViaPolicy: bool = False
 
 
 class ApprovalPolicy(BaseModel):

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -13,6 +13,7 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
+from .approval_policy import grantable_routes
 from .manifest import resolve_manifest
 from .models import (
     _TRIGGER_TYPES,
@@ -428,6 +429,22 @@ def _validate_approval_policy(
                 _gate_not_namespaced_message(stripped_gate, manifest.name, mcp_servers or set()),
                 loc,
             )
+
+    # #558: an operator-opted grantable route claimed by more than one distinct
+    # tool would validate green yet arm no grant (the ambiguous route is excluded
+    # by the shared normalizer), so reject it here. grantable_routes is the SAME
+    # helper the runtime loader uses, so the validator and loader agree on which
+    # routes are grantable by construction (#453).
+    _, ambiguous = grantable_routes(policy.gates)
+    for route in sorted(ambiguous):
+        c.error(
+            "approval_policy.grant_route_ambiguous",
+            f"more than one grantableViaPolicy gate claims route {route!r} with a"
+            " different tool; it is ambiguous which tool a policy approval would"
+            " grant, so the route would validate but arm no grant. Make the"
+            " grantable gates on this route name the same tool, or drop the opt-in.",
+            "plugin.json (approvalPolicy)",
+        )
 
 
 def _gate_not_namespaced_message(gate: str, bundle: str, mcp_servers: set[str]) -> str:

--- a/packages/plugin-format/tests/test_approval_policy.py
+++ b/packages/plugin-format/tests/test_approval_policy.py
@@ -1,0 +1,101 @@
+"""Unit table for ``plugin_format.grantable_routes`` (#558).
+
+The operator opt-in ``grantableViaPolicy`` marks a gate whose policy-gate
+approval MAY mint a one-shot grant for the tool the gate names (its ``gate``
+field, MANIFEST-supplied, never model-supplied). ``grantable_routes`` derives the
+``{route: tool}`` map the runner and worker consume, plus the set of routes that
+are AMBIGUOUS (one route claimed by more than one distinct grantable tool) and so
+excluded from the map. Comparison is case-sensitive and both fields are stripped,
+mirroring ``load_approval_policy``'s normalization so a config that validates
+green at deploy resolves identically at runtime (#453).
+"""
+
+from plugin_format import ApprovalGate, grantable_routes
+
+
+def _gate(gate: str, route: str, grantable: bool = False) -> ApprovalGate:
+    return ApprovalGate.model_validate(
+        {"gate": gate, "route": route, "grantableViaPolicy": grantable}
+    )
+
+
+def test_empty_input_yields_empty_map_and_no_ambiguity() -> None:
+    assert grantable_routes([]) == ({}, set())
+
+
+def test_single_grantable_gate_maps_route_to_tool() -> None:
+    routes, ambiguous = grantable_routes(
+        [_gate("close_issue", "deal-desk", grantable=True)]
+    )
+    assert routes == {"deal-desk": "close_issue"}
+    assert ambiguous == set()
+
+
+def test_non_grantable_gates_are_ignored() -> None:
+    # Absent / false grantableViaPolicy contributes nothing.
+    routes, ambiguous = grantable_routes(
+        [
+            _gate("close_issue", "deal-desk", grantable=False),
+            _gate("escalate", "managers"),
+        ]
+    )
+    assert routes == {}
+    assert ambiguous == set()
+
+
+def test_route_with_two_distinct_tools_is_ambiguous_and_excluded() -> None:
+    routes, ambiguous = grantable_routes(
+        [
+            _gate("close_issue", "deal-desk", grantable=True),
+            _gate("escalate", "deal-desk", grantable=True),
+        ]
+    )
+    # Excluded from the resolved map AND surfaced in the ambiguous set.
+    assert routes == {}
+    assert ambiguous == {"deal-desk"}
+
+
+def test_duplicate_same_tool_same_route_is_not_ambiguous() -> None:
+    # One route, one DISTINCT tool (declared twice) is a duplicate, not a
+    # conflict: a single entry, nothing ambiguous.
+    routes, ambiguous = grantable_routes(
+        [
+            _gate("close_issue", "deal-desk", grantable=True),
+            _gate("close_issue", "deal-desk", grantable=True),
+        ]
+    )
+    assert routes == {"deal-desk": "close_issue"}
+    assert ambiguous == set()
+
+
+def test_gate_and_route_are_stripped() -> None:
+    routes, ambiguous = grantable_routes(
+        [_gate("  close_issue  ", "  deal-desk  ", grantable=True)]
+    )
+    assert routes == {"deal-desk": "close_issue"}
+    assert ambiguous == set()
+
+
+def test_blank_gate_or_route_is_ignored() -> None:
+    # A grantable gate whose gate or route is empty once stripped keys nothing.
+    routes, ambiguous = grantable_routes(
+        [
+            _gate("   ", "deal-desk", grantable=True),
+            _gate("close_issue", "   ", grantable=True),
+        ]
+    )
+    assert routes == {}
+    assert ambiguous == set()
+
+
+def test_route_matching_is_case_sensitive() -> None:
+    # Deal-Desk and deal-desk are distinct routes, so two grantable gates on
+    # them do not collide: both resolve, nothing is ambiguous.
+    routes, ambiguous = grantable_routes(
+        [
+            _gate("close_issue", "Deal-Desk", grantable=True),
+            _gate("escalate", "deal-desk", grantable=True),
+        ]
+    )
+    assert routes == {"Deal-Desk": "close_issue", "deal-desk": "escalate"}
+    assert ambiguous == set()

--- a/packages/plugin-format/tests/test_models.py
+++ b/packages/plugin-format/tests/test_models.py
@@ -1,5 +1,5 @@
 import pytest
-from plugin_format import McpServer, PluginManifest, SkillFrontmatter
+from plugin_format import ApprovalGate, McpServer, PluginManifest, SkillFrontmatter
 from pydantic import ValidationError
 
 
@@ -85,3 +85,24 @@ def test_manifest_trigger_and_approval_policy_fields() -> None:
     # Absent -> None (backward compatible).
     bare = PluginManifest.model_validate({"name": "demo"})
     assert bare.triggers is None and bare.approvalPolicy is None
+
+
+def test_approval_gate_grantable_via_policy_field() -> None:
+    """The operator opt-in ``grantableViaPolicy`` round-trips on ApprovalGate (#558).
+
+    A gate the operator explicitly marks may mint a one-shot grant on a policy
+    approval; absent, it defaults False (the #544 no-grant baseline), so an old
+    manifest keeps its behavior.
+    """
+
+    gate = ApprovalGate.model_validate(
+        {"gate": "close_issue", "route": "deal-desk", "grantableViaPolicy": True}
+    )
+    assert gate.grantableViaPolicy is True
+    # Absent -> False (backward compatible; existing gates keep the no-grant default).
+    gate2 = ApprovalGate.model_validate({"gate": "close_issue", "route": "deal-desk"})
+    assert gate2.grantableViaPolicy is False
+    # Serializes back under the verbatim camelCase key and round-trips.
+    dumped = gate.model_dump()
+    assert dumped["grantableViaPolicy"] is True
+    assert ApprovalGate.model_validate(dumped).grantableViaPolicy is True

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -328,6 +328,65 @@ def test_builtin_tool_gate_passes(tmp_path: Path) -> None:
     assert not [i for i in result.errors if i.code.startswith("approval_policy.")]
 
 
+# --- grantable-via-policy gates (#558): an ambiguous grantable route is rejected -
+#
+# A gate the operator marks ``grantableViaPolicy: true`` opts that gate's policy
+# approval into minting a one-shot grant for the tool it names. When two grantable
+# gates claim the SAME route with DIFFERENT tools, the route cannot resolve to a
+# single grant tool, so it is rejected at deploy with
+# ``approval_policy.grant_route_ambiguous``.
+
+_GRANT_AMBIGUOUS_CODE = "approval_policy.grant_route_ambiguous"
+
+
+def test_single_grantable_gate_passes(tmp_path: Path) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "close_issue", "route": "deal-desk", "grantableViaPolicy": true}]}}',
+    )
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+    assert _GRANT_AMBIGUOUS_CODE not in {i.code for i in result.errors}
+
+
+def test_two_grantable_gates_same_route_different_tool_is_ambiguous(
+    tmp_path: Path,
+) -> None:
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "close_issue", "route": "deal-desk", "grantableViaPolicy": true}, '
+        '{"gate": "escalate", "route": "deal-desk", "grantableViaPolicy": true}]}}',
+    )
+    assert _GRANT_AMBIGUOUS_CODE in _codes(bundle)
+
+
+def test_two_grantable_gates_same_route_same_tool_is_not_ambiguous(
+    tmp_path: Path,
+) -> None:
+    # One route, one DISTINCT tool declared twice: a duplicate, not a conflict.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "close_issue", "route": "deal-desk", "grantableViaPolicy": true}, '
+        '{"gate": "close_issue", "route": "deal-desk", "grantableViaPolicy": true}]}}',
+    )
+    assert _GRANT_AMBIGUOUS_CODE not in _codes(bundle)
+
+
+def test_non_grantable_duplicate_route_pair_is_not_ambiguous(tmp_path: Path) -> None:
+    # Two gates share a route with different tools, but neither opts in, so the
+    # grant-ambiguity check ignores them entirely.
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "approvalPolicy": {"gates": ['
+        '{"gate": "close_issue", "route": "deal-desk"}, '
+        '{"gate": "escalate", "route": "deal-desk"}]}}',
+    )
+    assert _GRANT_AMBIGUOUS_CODE not in _codes(bundle)
+
+
 def test_correctly_namespaced_gate_passes_without_asserting_the_tool(tmp_path: Path) -> None:
     # send_contract is a tool nothing declares and nothing could know without
     # running the server. The prefix is correct, so the gate passes: the suffix

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -22,7 +22,7 @@ from .approval import (
     build_approval_gate,
     build_approval_server,
     build_can_use_tool,
-    load_approval_policy,
+    resolve_approval_policy,
 )
 from .config import RunnerConfig
 from .fake import FakeModelSession
@@ -103,17 +103,18 @@ def build_runner(
     # those calls pending approval; the gate object is shared with the
     # SessionRunner so a blocked call flips the turn's final to
     # awaiting-approval. Neither configured keeps the bypass posture.
-    # Both halves fail closed (#520): load_approval_policy raises rather than
+    # Both halves fail closed (#520): resolve_approval_policy raises rather than
     # degrading a declared-but-unarmable policy to "nothing gated", and
     # build_approval_gate refuses a bundle gate that would redefine the route
     # of a tool the operator already gated. Either raises before the first
     # turn, so a misdeclared policy never boots ungated.
     try:
-        policy_routes = load_approval_policy(config.session.plugin_dir)
+        resolution = resolve_approval_policy(config.session.plugin_dir)
         approval_gate = build_approval_gate(
             operator_tools=config.approval_required_tools,
-            policy_routes=policy_routes,
+            policy_routes=resolution.route_by_tool,
             grant_tool=config.approval_grant_tool,
+            grantable_by_route=resolution.grantable_by_route,
         )
     except ApprovalPolicyError as exc:
         # Log then re-raise, matching the module's other two fatal boot paths

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -45,7 +45,12 @@ from claude_agent_sdk.types import (
     PermissionResultDeny,
     ToolPermissionContext,
 )
-from plugin_format import ApprovalPolicy, PluginManifest, resolve_manifest
+from plugin_format import (
+    ApprovalPolicy,
+    PluginManifest,
+    grantable_routes,
+    resolve_manifest,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -324,6 +329,14 @@ class ApprovalGate:
     boot-turn-only so it never leaks across turns: ``reset()`` runs at the start
     of every turn, so the FIRST reset (the boot turn) preserves a freshly
     injected grant and every later reset clears it.
+
+    ``grantable_by_route`` is the #558 operator-opt-in map: for a manifest gate
+    marked ``grantableViaPolicy``, it binds the gate's route to the MANIFEST tool
+    that a policy approval on that route may grant. The session stamps
+    ``approval_granted_tool`` from ``grantable_tool_for_route`` at turn end, so
+    the granted tool comes from the manifest, never a model-supplied string; a
+    route absent from this map resolves to None, preserving #544's no-grant
+    default.
     """
 
     required: frozenset[str] = field(default_factory=frozenset)
@@ -348,7 +361,20 @@ class ApprovalGate:
     policy_rejected: bool = False
     policy_route: str | None = None
     grant_tool: str | None = None
+    grantable_by_route: dict[str, str] = field(default_factory=dict)
     _boot_turn_seen: bool = False
+
+    def grantable_tool_for_route(self, route: str | None) -> str | None:
+        """The manifest tool a policy approval on ``route`` may grant (#558).
+
+        None when ``route`` is None or the operator did not mark a gate on this
+        route ``grantableViaPolicy``, preserving #544's no-grant default. The
+        value comes from the manifest, never a model-supplied string.
+        """
+
+        if route is None:
+            return None
+        return self.grantable_by_route.get(route)
 
     def reset(self) -> None:
         self.pending_summary = None
@@ -426,8 +452,23 @@ class ApprovalPolicyError(RuntimeError):
     """
 
 
-def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
-    """The bundle manifest's ``approvalPolicy`` gates as ``{tool: route}``.
+@dataclass(frozen=True)
+class ApprovalPolicyResolution:
+    """The single parse of a bundle's ``approvalPolicy`` (#544/#558).
+
+    ``route_by_tool`` is the ``{tool: route}`` map every gated tool the runner
+    intercepts binds to; ``grantable_by_route`` is the #558 opt-in map of routes
+    an operator marked ``grantableViaPolicy`` to the MANIFEST tool a policy
+    approval on that route may grant. An honest empty policy yields
+    ``ApprovalPolicyResolution({}, {})``.
+    """
+
+    route_by_tool: dict[str, str]
+    grantable_by_route: dict[str, str]
+
+
+def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
+    """Parse the bundle manifest's ``approvalPolicy`` gates once (#544/#558).
 
     A gate's ``gate`` field names the tool the runner intercepts (the tool
     class of the ADR-0010 permission gate); its ``route`` names the approval
@@ -441,7 +482,7 @@ def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
     ``__main__`` builds no gate at all from an empty map, restoring the
     hardcoded bypass. This reader therefore raises ``ApprovalPolicyError``
     once a policy is declared but cannot be armed as declared, and reserves
-    the empty map for the honest cases: no dir, no manifest, no
+    the empty resolution for the honest cases: no dir, no manifest, no
     ``approvalPolicy``, or an explicitly empty ``gates`` list.
 
     Unlike the hooks/systemPrompt readers this one is NOT best-effort. Those
@@ -449,14 +490,21 @@ def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
     backstop; this one degrades to a wider authority set, and ``load_plugins``
     does not run on the fake tier at all (``__main__.factory`` returns first),
     so the backstop is absent precisely where it would be needed.
+
+    The grantable map (#558) is computed from the SAME normalization the deploy
+    validator uses (``plugin_format.grantable_routes``), so validator and loader
+    agree on which routes are grantable by construction (#453). The loader
+    IGNORES the ambiguous set as defense in depth: it arms no ambiguous grant but
+    does NOT raise on it -- the ambiguous gates still arm their tools, so the
+    policy is armable, and the deploy validator already rejects the ambiguity.
     """
 
     if not plugin_dir:
-        return {}
+        return ApprovalPolicyResolution({}, {})
     root = Path(plugin_dir)
     manifest_path = resolve_manifest(root)
     if manifest_path is None:
-        return {}
+        return ApprovalPolicyResolution({}, {})
     # Read raw first: a manifest that will not parse cannot prove it declares
     # no policy, so the fail-closed reading is to refuse rather than assume.
     try:
@@ -467,7 +515,7 @@ def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
             f" it declares an approvalPolicy; refusing to boot ungated ({exc})"
         ) from exc
     if not isinstance(raw, dict) or raw.get("approvalPolicy") is None:
-        return {}
+        return ApprovalPolicyResolution({}, {})
     # An approvalPolicy IS declared. From here every failure is fail-closed:
     # the intent is established and a parse error cannot revoke it.
     try:
@@ -496,7 +544,23 @@ def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
             f" {sorted(unarmed)!r} that arm no tool; refusing to boot with a"
             " partially armed policy"
         )
-    return routes
+    # #558: derive the grantable route -> manifest tool map. The ambiguous set is
+    # ignored here (arm no ambiguous grant); the deploy validator already rejects
+    # it, so this is belt-and-braces, not the enforcement point.
+    grantable_by_route, _ambiguous = grantable_routes(policy.gates)
+    return ApprovalPolicyResolution(routes, grantable_by_route)
+
+
+def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
+    """The bundle manifest's ``approvalPolicy`` gates as ``{tool: route}``.
+
+    A thin wrapper over ``resolve_approval_policy`` returning only the
+    ``route_by_tool`` map, preserved for callers that need just the gated-tool
+    routes (and its existing fail-closed test suite). See
+    ``resolve_approval_policy`` for the full fail-closed contract.
+    """
+
+    return resolve_approval_policy(plugin_dir).route_by_tool
 
 
 def build_approval_gate(
@@ -504,6 +568,7 @@ def build_approval_gate(
     operator_tools: Sequence[str] | None,
     policy_routes: dict[str, str],
     grant_tool: str | None = None,
+    grantable_by_route: dict[str, str] | None = None,
 ) -> ApprovalGate | None:
     """Merge the operator's gated tools with the bundle's declared gates.
 
@@ -549,4 +614,5 @@ def build_approval_gate(
         required=gated_tools,
         route_by_tool=policy_routes,
         grant_tool=grant_tool,
+        grantable_by_route=grantable_by_route or {},
     )

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -621,6 +621,11 @@ class SessionRunner:
                 state.approval_gate_kind = None
             else:
                 state.approval_route = gate.policy_route
+                # #558: an operator-opted grantable gate mints the one-shot grant; the tool
+                # comes from the manifest (never the model's summary/route args). A
+                # non-grantable route resolves to None -> no grant, preserving #544's default.
+                # gate_kind stays 'policy' (stamped in translate.py).
+                state.approval_granted_tool = gate.grantable_tool_for_route(gate.policy_route)
 
         if gate.pending_summary and not state.approval_summary:
             state.approval_summary = gate.pending_summary

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -19,11 +19,13 @@ from agentos_runner.approval import (
     APPROVAL_TOOL_NAME,
     ApprovalGate,
     ApprovalPolicyError,
+    ApprovalPolicyResolution,
     build_approval_gate,
     build_approval_server,
     build_can_use_tool,
     guard_reserved_summary,
     load_approval_policy,
+    resolve_approval_policy,
     summarize_tool_call,
 )
 from agentos_runner.config import RunnerConfig
@@ -1287,7 +1289,14 @@ def test_policy_gate_never_carries_a_granted_tool(
     """
 
     async def go() -> None:
-        gate = ApprovalGate(required=frozenset(route_by_tool), route_by_tool=route_by_tool)
+        # No gate is opted into grantability (empty grantable_by_route), so this
+        # pins the DEFAULT #544 no-grant behavior (#558): a policy approval on a
+        # gate the operator did NOT mark grantable never mints authority.
+        gate = ApprovalGate(
+            required=frozenset(route_by_tool),
+            route_by_tool=route_by_tool,
+            grantable_by_route={},
+        )
         frames = await _run_policy_turn(gate, "Give ACME 20% off", route=route_arg)
 
         final = frames[-1]
@@ -1299,6 +1308,248 @@ def test_policy_gate_never_carries_a_granted_tool(
         )
 
     anyio.run(go)
+
+
+# --- #558: operator opt-in grantableViaPolicy on a policy gate ------------------
+#
+# A gate the operator marks grantableViaPolicy:true opts that gate's policy
+# approval into minting a one-shot grant for the tool the MANIFEST names (its
+# `gate` field, resolved server-side, never model-supplied). The runner surfaces
+# it as `approval_granted_tool` on the awaiting-approval final, still gate_kind
+# 'policy'. A non-opted route stays None (the #544 baseline); a rejected route
+# stays None (no approval exists to grant against).
+
+
+def test_resolve_approval_policy_returns_routes_and_grantable_map(tmp_path) -> None:
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "deal-desk",
+                "approvalPolicy": {
+                    "gates": [
+                        {"gate": "Bash", "route": "managers"},
+                        {
+                            "gate": "close_issue",
+                            "route": "deal-desk",
+                            "grantableViaPolicy": True,
+                        },
+                    ]
+                },
+            }
+        ),
+    )
+    resolution = resolve_approval_policy(bundle)
+    assert isinstance(resolution, ApprovalPolicyResolution)
+    assert resolution.route_by_tool == {
+        "Bash": "managers",
+        "close_issue": "deal-desk",
+    }
+    # Only the opted-in gate contributes a grantable route: route -> its tool.
+    assert resolution.grantable_by_route == {"deal-desk": "close_issue"}
+
+
+def test_resolve_approval_policy_no_opt_in_has_empty_grantable_map(tmp_path) -> None:
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "deal-desk",
+                "approvalPolicy": {
+                    "gates": [{"gate": "Bash", "route": "managers"}]
+                },
+            }
+        ),
+    )
+    resolution = resolve_approval_policy(bundle)
+    assert resolution.route_by_tool == {"Bash": "managers"}
+    assert resolution.grantable_by_route == {}
+
+
+def test_resolve_approval_policy_excludes_ambiguous_grantable_route(tmp_path) -> None:
+    # Two grantable gates claim one route with different tools. validate_bundle
+    # rejects this at DEPLOY; the loader is defense-in-depth: it arms the tools
+    # (route_by_tool) but refuses to hand the ambiguous route a grant, WITHOUT
+    # raising (both tools still arm, so the policy is armable).
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "deal-desk",
+                "approvalPolicy": {
+                    "gates": [
+                        {
+                            "gate": "close_issue",
+                            "route": "deal-desk",
+                            "grantableViaPolicy": True,
+                        },
+                        {
+                            "gate": "escalate",
+                            "route": "deal-desk",
+                            "grantableViaPolicy": True,
+                        },
+                    ]
+                },
+            }
+        ),
+    )
+    resolution = resolve_approval_policy(bundle)
+    assert resolution.route_by_tool == {
+        "close_issue": "deal-desk",
+        "escalate": "deal-desk",
+    }
+    assert resolution.grantable_by_route == {}
+
+
+def test_grantable_tool_for_route_lookup() -> None:
+    gate = ApprovalGate(
+        required=frozenset({"Bash"}),
+        route_by_tool={"Bash": "deal-desk"},
+        grantable_by_route={"deal-desk": "close_issue"},
+    )
+    assert gate.grantable_tool_for_route(None) is None
+    assert gate.grantable_tool_for_route("deal-desk") == "close_issue"
+    assert gate.grantable_tool_for_route("unknown") is None
+
+
+def test_build_approval_gate_carries_the_grantable_map() -> None:
+    gate = build_approval_gate(
+        operator_tools=["Bash"],
+        policy_routes={"Bash": "managers"},
+        grantable_by_route={"managers": "close_issue"},
+    )
+    assert gate is not None
+    assert gate.grantable_by_route == {"managers": "close_issue"}
+
+
+def test_policy_gate_grantable_route_carries_the_manifest_tool() -> None:
+    """An accepted policy request on a GRANTABLE route stamps the manifest tool.
+
+    The sole manifest route binds implicitly; because the operator marked it
+    grantable, the awaiting-approval final carries approval_granted_tool = the
+    manifest's tool, still gate_kind 'policy'."""
+
+    async def go() -> None:
+        gate = ApprovalGate(
+            required=frozenset({"Bash"}),
+            route_by_tool={"Bash": "managers"},
+            grantable_by_route={"managers": "close_issue"},
+        )
+        frames = await _run_policy_turn(gate, "Close the ACME issue")
+
+        final = frames[-1]
+        assert final["status"] == "awaiting-approval"
+        assert final["approval_gate_kind"] == "policy"
+        assert final["approval_route"] == "managers"
+        assert final["approval_granted_tool"] == "close_issue"
+
+    anyio.run(go)
+
+
+def test_policy_gate_non_grantable_route_stays_none() -> None:
+    """An accepted policy request on a route the operator did NOT mark grantable
+    carries no grant (the #544 baseline)."""
+
+    async def go() -> None:
+        gate = ApprovalGate(
+            required=frozenset({"Bash"}),
+            route_by_tool={"Bash": "managers"},
+            grantable_by_route={},
+        )
+        frames = await _run_policy_turn(gate, "Close the ACME issue")
+
+        final = frames[-1]
+        assert final["status"] == "awaiting-approval"
+        assert final["approval_gate_kind"] == "policy"
+        assert final["approval_granted_tool"] is None
+
+    anyio.run(go)
+
+
+def test_policy_gate_rejected_route_stays_none() -> None:
+    """A rejected request (unknown route) creates no approval, so there is
+    nothing to grant against: the turn ends clean with no granted tool."""
+
+    async def go() -> None:
+        gate = ApprovalGate(
+            required=frozenset({"Bash"}),
+            route_by_tool={"Bash": "managers"},
+            grantable_by_route={"managers": "close_issue"},
+        )
+        frames = await _run_policy_turn(gate, "Close the ACME issue", route="not-a-route")
+
+        final = frames[-1]
+        # A refused request creates no approval; the final is a clean terminal.
+        assert final["status"] == "done"
+        assert final.get("approval_granted_tool") is None
+
+
+    anyio.run(go)
+
+
+def test_validate_and_loader_agree_on_grantable_routes(tmp_path) -> None:
+    """Executed parity (#453/#544 pin): one manifest through BOTH the deploy-time
+    validator and the runtime loader must agree on which routes are grantable.
+
+    An ACCEPTED config's grantable route is armed in the loader; an ambiguous
+    config the validator REJECTS is armed as no-grant (excluded) by the loader.
+    """
+
+    accept_dir = tmp_path / "accept"
+    accept_dir.mkdir()
+    accept = _write_manifest(
+        accept_dir,
+        json.dumps(
+            {
+                "name": "deal-desk",
+                "approvalPolicy": {
+                    "gates": [
+                        {
+                            "gate": "close_issue",
+                            "route": "deal-desk",
+                            "grantableViaPolicy": True,
+                        }
+                    ]
+                },
+            }
+        ),
+    )
+    accept_result = validate_bundle(accept)
+    assert accept_result.valid, accept_result.errors
+    assert resolve_approval_policy(accept).grantable_by_route == {
+        "deal-desk": "close_issue"
+    }
+
+    reject_dir = tmp_path / "reject"
+    reject_dir.mkdir()
+    reject = _write_manifest(
+        reject_dir,
+        json.dumps(
+            {
+                "name": "deal-desk",
+                "approvalPolicy": {
+                    "gates": [
+                        {
+                            "gate": "close_issue",
+                            "route": "deal-desk",
+                            "grantableViaPolicy": True,
+                        },
+                        {
+                            "gate": "escalate",
+                            "route": "deal-desk",
+                            "grantableViaPolicy": True,
+                        },
+                    ]
+                },
+            }
+        ),
+    )
+    reject_result = validate_bundle(reject)
+    assert "approval_policy.grant_route_ambiguous" in {
+        i.code for i in reject_result.errors
+    }
+    # The loader arms the same config as no-grant: the ambiguous route is excluded.
+    assert resolve_approval_policy(reject).grantable_by_route == {}
 
 
 def test_permission_gate_grants_the_denied_tool_name() -> None:


### PR DESCRIPTION
Adds a per-gate operator opt-in `grantableViaPolicy` to the plugin manifest `approvalPolicy`, so a policy-gate approval may mint a one-shot tool grant **only** for gates the operator explicitly marked grantable. This converts the residual argument-scoping risk from ambient to deliberate, and implements ADR-0056 — the reintroduction ADR-0046 itself deferred to this issue.

## What changed
- `grantableViaPolicy: bool = false` on the manifest `ApprovalGate`. Default off, so the #544 policy-never-grants behavior is the **exact** default.
- One shared normalizer `plugin_format.grantable_routes` is used by **both** the deploy validator and the runtime loader, so they agree by construction (the #453/#544 fail-open class). An ambiguous grantable route (one route claimed by >1 tool) is a hard deploy error (`approval_policy.grant_route_ambiguous`) and arms no grant.
- The runner stamps `approval_granted_tool` from the manifest gate's own `gate` value for an opted-in route — **never** a model-supplied string; the model's `route` only selects among operator-declared gates. The worker now honors the `granted_tool` column for `gate_kind='policy'` rows; a non-opted policy gate leaves it NULL and grants nothing.
- No DB migration and no ACI version bump: reuses the existing `gate_kind`/`granted_tool` columns (#544, migration 0015). ADR-0056 supersedes **only** the "policy refuses outright" half of ADR-0046 Decision C; every other ADR-0046 property is unchanged.

## Assumptions (recorded)
- The granted tool is the manifest gate's `gate` field (which is a tool name), disambiguated by the resolved route; a route that maps to more than one grantable tool is rejected at deploy rather than guessing.

## Review
code-reviewer APPROVE (0 blocking/major/minor); security-reviewer no blocking (the argument-visibility asymmetry is accepted-by-design and is exactly what the default-off opt-in gates); scope-creep 0; spec-vs-impl all 4 ACs met with executed tests, including a validator↔loader parity test. Codex review was unavailable on the run host.

Full Python suite: 1723 passed / 15 skipped. 6 pre-existing `apps/worker/tests/eval/test_stream.py` E2E tests fail in the local env (eval-runner provisioning timeout); the diff touches no eval/stream/consumer/kernel code, so they are environmental — CI's python job is the arbiter.

Closes #558
