### PR TITLE
Migrate skill-check manifest read to the shared resolver (#671)

### DIFF
--- a/runner/src/agentos_runner/check.py
+++ b/runner/src/agentos_runner/check.py
@@ -31,6 +31,7 @@ from typing import Any
 
 from aci_protocol import BootEnv
 from claude_agent_sdk import ClaudeSDKClient
+from plugin_format import resolve_manifest
 
 from .adapter import build_options
 from .plugin import PluginBundleError, load_plugins
@@ -114,7 +115,8 @@ def extract_declared(plugin_dir: str) -> list[dict[str, Any]]:
             )
             seen.add(name)
 
-    manifest = _read_json(root / ".claude-plugin" / "plugin.json")
+    manifest_path = resolve_manifest(root)
+    manifest = _read_json(manifest_path) if manifest_path is not None else None
     mcp = manifest.get("mcpServers") if isinstance(manifest, dict) else None
 
     if isinstance(mcp, dict):

--- a/runner/tests/test_check.py
+++ b/runner/tests/test_check.py
@@ -144,6 +144,23 @@ def test_extract_bare_mcp_json_form(tmp_path: Path) -> None:
     assert by_name["bare-probe"]["source"] == ".mcp.json"
 
 
+def test_extract_root_plugin_json_fallback_is_reported(tmp_path: Path) -> None:
+    # Root-level plugin.json (no .claude-plugin/ dir) is the accepted fallback
+    # location (packages/plugin-format's MANIFEST_LOCATIONS, issue #653); the
+    # resolver must find it and the declared server must still surface.
+    bundle = tmp_path / "root_manifest"
+    bundle.mkdir()
+    (bundle / "plugin.json").write_text(
+        json.dumps({"name": "root-bundle", "mcpServers": {"root-probe": {"command": "python3"}}}),
+        encoding="utf-8",
+    )
+    declared = extract_declared(str(bundle))
+    by_name = {d["name"]: d for d in declared}
+    assert "root-probe" in by_name
+    assert by_name["root-probe"]["form"] == "inline"
+    assert by_name["root-probe"]["source"] == "plugin.json"
+
+
 def test_extract_no_mcp_anywhere_is_empty(tmp_path: Path) -> None:
     bundle = _write_bundle(tmp_path / "nomcp", {"name": "no-mcp-bundle"})
     assert extract_declared(str(bundle)) == []


### PR DESCRIPTION
`extract_declared()` in `runner/check.py` read only the hardcoded `.claude-plugin/plugin.json`, so `agentos skill check` under-reported MCP servers for a bundle shipping its manifest at the accepted root `plugin.json` fallback. It now resolves via `plugin_format.resolve_manifest`, honoring the same ordered `MANIFEST_LOCATIONS` as the six readers consolidated in #653 — the string-pointer / inline / bare-file detection is otherwise unchanged.

Adds a test that a root-`plugin.json`-only bundle's MCP server is reported by `skill check`, matching what the runner loads.

Follow-up to #653.

Closes #671