### PR TITLE
approvals --list requests server-max limit and signals truncation

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -235,6 +235,12 @@ fn warn_if_insecure(base_url: &str) {
 }
 
 impl ApiClient {
+    /// The server caps `/approvals` results at this many rows
+    /// (`apps/api/.../routers/approvals.py`: `min(max(limit, 1), 200)`); the CLI
+    /// requests exactly the cap so hitting it is how the caller detects possible
+    /// truncation of the pending list (#670).
+    pub const APPROVALS_LIST_LIMIT: usize = 200;
+
     pub fn new(base_url: &str, api_key: &str) -> Result<Self> {
         warn_if_insecure(base_url);
         let http = reqwest::Client::builder()
@@ -593,15 +599,22 @@ impl ApiClient {
     }
 
     /// The pending approval records for an agent: `GET /approvals?status_filter=
-    /// pending&agent_id=<id>`. Hand-mirrors the committed `ApprovalOut` shape
-    /// (only the fields the CLI renders; serde ignores the rest), the same way
-    /// `Agent`/`KillState` mirror `openapi.json` (#506).
+    /// pending&agent_id=<id>&limit=<APPROVALS_LIST_LIMIT>`. Hand-mirrors the
+    /// committed `ApprovalOut` shape (only the fields the CLI renders; serde
+    /// ignores the rest), the same way `Agent`/`KillState` mirror
+    /// `openapi.json` (#506). The `limit` query param requests the server's max
+    /// page size explicitly rather than relying on its default (#670).
     pub async fn list_pending_approvals(&self, agent_id: &str) -> Result<Vec<ApprovalRecord>> {
+        let limit = Self::APPROVALS_LIST_LIMIT.to_string();
         let resp = self
             .http
             .get(format!("{}/approvals", self.base_url))
             .header("X-API-Key", &self.api_key)
-            .query(&[("status_filter", "pending"), ("agent_id", agent_id)])
+            .query(&[
+                ("status_filter", "pending"),
+                ("agent_id", agent_id),
+                ("limit", limit.as_str()),
+            ])
             .send()
             .await
             .context("GET /approvals")?;

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2509,6 +2509,11 @@ pub enum ApprovalsOutput {
     Pending {
         agent: String,
         records: Vec<crate::api::ApprovalRecord>,
+        /// `true` when `records.len()` hit the server's page-size cap
+        /// (`ApiClient::APPROVALS_LIST_LIMIT`), meaning more pending approvals
+        /// may exist beyond what was fetched (#670). Always present (never
+        /// conditionally omitted), per the repo's superset-JSON convention.
+        truncated: bool,
     },
     Resolved {
         record: crate::api::ApprovalRecord,
@@ -2543,9 +2548,15 @@ impl crate::ui::CliOutput for ApprovalsOutput {
                 "gated_tools": gated_tools,
                 "manifest_unreadable": manifest_unreadable,
             }),
-            ApprovalsOutput::Pending { agent, records } => serde_json::json!({
+            ApprovalsOutput::Pending {
+                agent,
+                records,
+                truncated,
+            } => serde_json::json!({
                 "agent": agent,
                 "pending": records.iter().map(approval_record_json).collect::<Vec<_>>(),
+                "count": records.len(),
+                "truncated": truncated,
             }),
             ApprovalsOutput::Resolved { record } => serde_json::json!({
                 "resolved": approval_record_json(record),
@@ -2570,7 +2581,11 @@ impl crate::ui::CliOutput for ApprovalsOutput {
                     ui.kv("gated", tool);
                 }
             }
-            ApprovalsOutput::Pending { agent, records } => {
+            ApprovalsOutput::Pending {
+                agent,
+                records,
+                truncated,
+            } => {
                 if records.is_empty() {
                     ui.payload(&format!("{agent}: no pending approvals"));
                 } else {
@@ -2586,6 +2601,13 @@ impl crate::ui::CliOutput for ApprovalsOutput {
                             ),
                         );
                     }
+                }
+                if *truncated {
+                    ui.payload(&format!(
+                        "this list is capped at {} (the server max) and more pending approvals \
+                         may exist; resolve some and re-run to see the rest",
+                        crate::api::ApiClient::APPROVALS_LIST_LIMIT
+                    ));
                 }
             }
             ApprovalsOutput::Resolved { record } => {
@@ -2679,17 +2701,21 @@ pub async fn approvals(
         if opts.dry_run {
             return Ok(ApprovalsOutput::DryRun(crate::ui::DryRunPlan {
                 lines: vec![format!(
-                    "GET {}/approvals?status_filter=pending&agent_id=<id>  (would resolve agent {:?} first)",
-                    opts.api_url, opts.agent
+                    "GET {}/approvals?status_filter=pending&agent_id=<id>&limit={}  (would resolve agent {:?} first)",
+                    opts.api_url,
+                    crate::api::ApiClient::APPROVALS_LIST_LIMIT,
+                    opts.agent
                 )],
             }));
         }
         let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
         let agent = client.find_agent(&opts.agent).await?;
         let records = client.list_pending_approvals(&agent.id).await?;
+        let truncated = records.len() >= crate::api::ApiClient::APPROVALS_LIST_LIMIT;
         return Ok(ApprovalsOutput::Pending {
             agent: agent.name,
             records,
+            truncated,
         });
     }
 

--- a/cli/tests/approvals_list_truncation.rs
+++ b/cli/tests/approvals_list_truncation.rs
@@ -1,0 +1,202 @@
+//! Integration: `<tier> approvals <agent> --list` must request the server's max
+//! page size and surface an explicit truncation signal when the result hits
+//! that cap, so a `--json` consumer can tell a complete pending list from a
+//! possibly-truncated one (#670).
+//!
+//! Driven through the real `approvals` handler and a real `ApiClient` against a
+//! wire-level stub: the regression this guards is "the CLI sends no `limit`
+//! and silently renders a capped 50-row page as the complete list," which only
+//! shows up by inspecting the actual outgoing request path, not by
+//! hand-constructing `ApprovalsOutput::Pending`.
+
+mod support;
+
+use agentos::api::ApiClient;
+use agentos::commands::{approvals, AgentActionOpts, ApprovalCmd, ApprovalsOutput};
+use agentos::ui::CliOutput;
+use support::{serve, MockServer, Response};
+
+const AGENT_ID: &str = "11111111-1111-1111-1111-111111111111";
+const TEST_API_KEY: &str = "test-key";
+
+fn agents_response() -> Response {
+    Response::json(
+        200,
+        &format!(
+            r##"[{{"id":"{AGENT_ID}","name":"weather","slack_channel":"#weather","approval_required_tools":[]}}]"##
+        ),
+    )
+}
+
+/// `n` synthetic pending records, wire-shaped like `ApprovalOut` (only the
+/// fields the CLI reads; the rest are ignored by serde, same as elsewhere in
+/// this suite).
+fn pending_records_json(n: usize) -> String {
+    let records: Vec<String> = (0..n)
+        .map(|i| {
+            format!(
+                r#"{{"id":"ap_{i}","author":"U1","route":null,"gate_kind":null,"granted_tool":"Bash","status":"pending","conversation_id":"C1-thread-{i}","summary":"do the thing","expires_at":null,"resolved_by":null}}"#
+            )
+        })
+        .collect();
+    format!("[{}]", records.join(","))
+}
+
+async fn list_pending(server: &MockServer) -> ApprovalsOutput {
+    approvals(
+        AgentActionOpts {
+            api_url: server.base_url.clone(),
+            api_key: TEST_API_KEY.to_string(),
+            agent: "weather".to_string(),
+            dry_run: false,
+        },
+        vec![],
+        false,
+        ApprovalCmd {
+            list: true,
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("approvals --list should succeed against a well-formed mock")
+}
+
+fn pending_fields(out: &ApprovalsOutput) -> (usize, bool) {
+    match out {
+        ApprovalsOutput::Pending {
+            records, truncated, ..
+        } => (records.len(), *truncated),
+        ApprovalsOutput::DryRun(_) => panic!("expected the pending list, not a dry-run plan"),
+        ApprovalsOutput::Gates { .. } => panic!("expected the pending list, not the gate view"),
+        ApprovalsOutput::Resolved { .. } => {
+            panic!("expected the pending list, not a resolved record")
+        }
+    }
+}
+
+/// (a) The core regression guard: deleting the `limit` query param must fail
+/// this. The mock asserts on the raw outgoing request path so it cannot be
+/// satisfied by a handler that always fetches the server's default page size.
+#[tokio::test]
+async fn list_request_sends_the_server_max_limit() {
+    let expected_limit = format!("limit={}", ApiClient::APPROVALS_LIST_LIMIT);
+    let expected_limit_in_handler = expected_limit.clone();
+    let server = serve(move |req| match req.path.split('?').next().unwrap() {
+        "/agents" => agents_response(),
+        "/approvals" => {
+            assert!(
+                req.path.contains(&expected_limit_in_handler),
+                "expected the request to ask for the server's max page size, got path {:?}",
+                req.path
+            );
+            assert!(
+                req.path.contains("status_filter=pending"),
+                "expected status_filter=pending in {:?}",
+                req.path
+            );
+            assert!(
+                req.path.contains(&format!("agent_id={AGENT_ID}")),
+                "expected agent_id={AGENT_ID} in {:?}",
+                req.path
+            );
+            Response::json(200, &pending_records_json(3))
+        }
+        other => panic!("unexpected request: {other}"),
+    });
+
+    let out = list_pending(&server).await;
+    let (count, truncated) = pending_fields(&out);
+    assert_eq!(count, 3);
+    assert!(!truncated);
+
+    let recorded = server.recorded();
+    let approvals_req = recorded
+        .iter()
+        .find(|r| r.path.starts_with("/approvals"))
+        .expect("the /approvals endpoint must have been called");
+    assert!(approvals_req.path.contains(&expected_limit));
+}
+
+/// (b) Hitting the cap means more pending approvals may exist beyond what was
+/// fetched: `truncated` must be `true` and both `to_json()` keys must reflect it.
+#[tokio::test]
+async fn exactly_the_cap_is_reported_as_truncated() {
+    let server = serve(|req| match req.path.split('?').next().unwrap() {
+        "/agents" => agents_response(),
+        "/approvals" => Response::json(200, &pending_records_json(ApiClient::APPROVALS_LIST_LIMIT)),
+        other => panic!("unexpected request: {other}"),
+    });
+
+    let out = list_pending(&server).await;
+    let (count, truncated) = pending_fields(&out);
+    assert_eq!(count, ApiClient::APPROVALS_LIST_LIMIT);
+    assert!(
+        truncated,
+        "hitting the server cap must be reported as a possibly-truncated list"
+    );
+
+    let json = out.to_json();
+    assert_eq!(json["truncated"], true);
+    assert_eq!(json["count"], ApiClient::APPROVALS_LIST_LIMIT);
+}
+
+/// (c) The positive control: under the cap, nothing about the list is
+/// ambiguous, so `truncated` stays `false` in both the struct and the JSON.
+#[tokio::test]
+async fn under_the_cap_is_reported_as_complete() {
+    let server = serve(|req| match req.path.split('?').next().unwrap() {
+        "/agents" => agents_response(),
+        "/approvals" => Response::json(200, &pending_records_json(3)),
+        other => panic!("unexpected request: {other}"),
+    });
+
+    let out = list_pending(&server).await;
+    let (count, truncated) = pending_fields(&out);
+    assert_eq!(count, 3);
+    assert!(!truncated);
+
+    let json = out.to_json();
+    assert_eq!(json["truncated"], false);
+    assert_eq!(json["count"], 3);
+}
+
+/// (d) The dry-run plan must report the same `limit` the real request sends
+/// (#670 review finding): a hand-maintained dry-run string can drift from
+/// `list_pending_approvals`'s actual query params without either the
+/// truncation tests above or a dry-run consumer noticing. No mock server is
+/// installed here because the dry-run path returns before any HTTP call.
+#[tokio::test]
+async fn dry_run_plan_reports_the_same_limit_as_the_real_request() {
+    let out = approvals(
+        AgentActionOpts {
+            api_url: "http://localhost:28000".to_string(),
+            api_key: TEST_API_KEY.to_string(),
+            agent: "weather".to_string(),
+            dry_run: true,
+        },
+        vec![],
+        false,
+        ApprovalCmd {
+            list: true,
+            ..ApprovalCmd::default()
+        },
+    )
+    .await
+    .expect("approvals --list --dry-run should succeed without any network call");
+
+    match out {
+        ApprovalsOutput::DryRun(plan) => {
+            let expected_limit = format!("limit={}", ApiClient::APPROVALS_LIST_LIMIT);
+            assert!(
+                plan.lines[0].contains(&expected_limit),
+                "expected the dry-run plan to report the same limit as the real request, got {:?}",
+                plan.lines[0]
+            );
+        }
+        ApprovalsOutput::Pending { .. } => panic!("expected a dry-run plan, not the pending list"),
+        ApprovalsOutput::Gates { .. } => panic!("expected a dry-run plan, not the gate view"),
+        ApprovalsOutput::Resolved { .. } => {
+            panic!("expected a dry-run plan, not a resolved record")
+        }
+    }
+}

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -687,6 +687,7 @@ fn approvals_pending_and_resolved_json_shapes_are_pinned() {
         ApprovalsOutput::Pending {
             agent: "weather".to_string(),
             records: vec![record()],
+            truncated: false,
         }
         .to_json(),
         json!({
@@ -703,6 +704,8 @@ fn approvals_pending_and_resolved_json_shapes_are_pinned() {
                 "expires_at": "2026-07-16T00:00:00Z",
                 "resolved_by": null,
             }],
+            "count": 1,
+            "truncated": false,
         })
     );
     let mut resolved = record();


### PR DESCRIPTION
`agentos approvals --list` sent no `limit` to `GET /approvals`, so the server default of 50 rows was rendered as the complete pending set. With 51+ pending approvals the oldest were silently undiscoverable via the CLI (introduced by #595).

## What changed
- The CLI now requests the server's max page size (`limit=200`, the API's documented cap) via a single `ApiClient::APPROVALS_LIST_LIMIT` constant, so one call surfaces as many pending approvals as the API will return.
- When the result hits that cap (more may be pending), the list is marked truncated in **both** the human render (an explicit "resolve some and re-run" warning line) and the `--json` output (new always-emitted `truncated` bool + `count`), so a `--json` consumer can distinguish a complete list from a partial one.
- The `--list --dry-run` plan now reports the same `limit` the real request sends.

Scope is deliberately CLI-only: no API, `openapi.json`, or offset-pagination change. Draining 200+ pending approvals is handled by resolving a batch and re-running (the truncation signal tells the operator when to loop).

Closes #670