### PR TITLE
Resolve root-relative and external-URL hrefs in the doclint citation gate

### DIFF
--- a/tools/doclint/src/agentos_doclint/citation.py
+++ b/tools/doclint/src/agentos_doclint/citation.py
@@ -334,6 +334,12 @@ def path_exists(repo_root: Path, rel_path: str) -> bool:
     return (repo_root / rel_path).is_file()
 
 
+def _is_external_url(href: str) -> bool:
+    """True when ``href`` is an absolute ``http(s)`` URL, not an in-tree path."""
+    lowered = href.strip().lower()
+    return lowered.startswith("http://") or lowered.startswith("https://")
+
+
 def link_target_matches_citation(
     repo_root: Path, doc_rel: str, cite_path: str, href: str
 ) -> bool:
@@ -345,16 +351,28 @@ def link_target_matches_citation(
     the citation does not describe -- the exact drift #575 left in ARCHITECTURE.md,
     where the text cited ``types.py`` but the link went to ``k8s.py``.
 
-    The href is resolved with normal markdown semantics (relative to the doc's
-    own directory) and compared to the citation resolved from the repo root.
-    A pure-anchor href (``#section``, no path) is a same-doc link, not a file
-    target, so it is treated as consistent.
+    A relative href is resolved with normal markdown semantics (relative to the
+    doc's own directory), while a leading-slash href is repo-root-anchored (as a
+    site serves ``/path``) and resolved from the repo root -- so a nested doc can
+    cite a file with a root-relative link without false-failing. The comparison
+    target is the citation resolved from the repo root.
+
+    Two hrefs describe no in-repo file to compare against and are treated as
+    consistent: a pure-anchor href (``#section``, no path) is a same-doc link,
+    and an absolute external URL (``http://``/``https://``) points outside the
+    tree entirely.
     """
+
+    if _is_external_url(href):
+        return True
 
     href_path = href.split("#", 1)[0].split("?", 1)[0].strip()
     if not href_path:
         return True
-    doc_dir = (repo_root / doc_rel).parent
-    href_abs = (doc_dir / href_path).resolve()
+    if href_path.startswith("/"):
+        href_abs = (repo_root / href_path.lstrip("/")).resolve()
+    else:
+        doc_dir = (repo_root / doc_rel).parent
+        href_abs = (doc_dir / href_path).resolve()
     cite_abs = (repo_root / cite_path).resolve()
     return href_abs == cite_abs

--- a/tools/doclint/tests/test_citation.py
+++ b/tools/doclint/tests/test_citation.py
@@ -201,3 +201,58 @@ def test_link_target_matching_cited_path_passes(
     )
     code, _ = run_lint(clean_repo)
     assert code == 0
+
+
+def test_link_target_root_relative_href_from_nested_doc_passes(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # A decorated citation in a nested doc whose href is written repo-root-
+    # relative (leading slash) points at the cited file just as the text says.
+    # Doc-relative resolution would send it under the doc's own directory and
+    # false-fail; the href must be resolved from the repo root instead.
+    write(
+        clean_repo,
+        "docs/subsystem/notes.md",
+        "The gate is a "
+        "([`runner/src/agentos_runner/approval.py::ApprovalGate`]"
+        "(/runner/src/agentos_runner/approval.py)).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_link_target_external_url_href_passes(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # An http(s) href names no file inside the repo, so there is nothing to
+    # compare the cited path against; it is treated as consistent rather than
+    # resolved as a bogus relative filesystem path.
+    write(
+        clean_repo,
+        "docs/subsystem/notes.md",
+        "The gate is a "
+        "([`runner/src/agentos_runner/approval.py::ApprovalGate`]"
+        "(https://github.com/curie-eng/agentos/blob/main/"
+        "runner/src/agentos_runner/approval.py)).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_link_target_root_relative_href_still_catches_real_mismatch(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Resolving a root-relative href from the repo root must not weaken the
+    # gate: a leading-slash target pointing at a genuinely different file than
+    # the citation text still fails.
+    write(
+        clean_repo,
+        "docs/subsystem/notes.md",
+        "The gate is a "
+        "([`runner/src/agentos_runner/approval.py::ApprovalGate`]"
+        "(/cli/src/queue.rs)).\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "cli/src/queue.rs" in out
+    assert "does not point at" in out.lower()


### PR DESCRIPTION
The doclint link-target-vs-citation gate (added in #656) resolved every decorated-citation href doc-relative only, so a legitimate citation whose href is repo-root-relative (leading slash) or an external URL would false-fail from any nested doc. This is preventive hardening of a dev-only gate: no false positive fires on the docs currently in the tree, but the resolution gap is real.

## Change (scoped to `link_target_matches_citation` in `citation.py` + tests)

- **Leading-slash href** is now resolved from the repo root, not the doc directory (a `Path("/docs") / "/runner/x.py"` reset to the filesystem root before, never matching the citation).
- **Absolute external URL** (`http://`/`https://`) is treated as consistent: it names no in-repo file to compare the cited path against.
- **Pure-`#anchor` href** handling is unchanged.

## Tests (red→green)

- Nested-doc citation with a repo-root-relative (`/runner/...`) href passes.
- Nested-doc citation with an external-URL href passes.
- A leading-slash href pointing at a genuinely different file still fails (guards against softening the gate).

`uv run pytest tools/doclint/tests` → 78 passed. `python -m agentos_doclint --repo-root .` → exit 0, no new findings. ruff + mypy clean on the changed files.

Assumption noted: "clearly repo-root-relative" is keyed on a leading slash, the only unambiguous signal (a slash-less path is indistinguishable from a doc-relative one).

Closes #672