### PR TITLE
Hoist shared docker test fakes into sandbox conftest

### DIFF
--- a/apps/worker/tests/sandbox/conftest.py
+++ b/apps/worker/tests/sandbox/conftest.py
@@ -22,6 +22,34 @@ from agentos_worker.sandbox import (
     SandboxView,
     SubstrateConfig,
 )
+from agentos_worker.sandbox.docker import DockerSandboxClient
+
+
+class _FakeBundleStore:
+    def __init__(self, data: bytes = b"") -> None:
+        self._data = data
+        self.requested: list[str] = []
+
+    def get(self, key: str) -> bytes:
+        self.requested.append(key)
+        return self._data
+
+
+class _RecordingDocker(DockerSandboxClient):
+    """Captures every docker argv and returns canned stdout per subcommand."""
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.calls: list[list[str]] = []
+        self.outputs: dict[str, str] = {}
+
+    def _docker(self, args: list[str], *, check: bool = True) -> str:
+        self.calls.append(args)
+        return self.outputs.get(args[0], "")
+
+
+def _flag_values(argv: list[str], flag: str) -> list[str]:
+    return [argv[i + 1] for i, a in enumerate(argv) if a == flag and i + 1 < len(argv)]
 
 _VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
 _VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -20,28 +20,7 @@ from agentos_worker.sandbox.docker import (
     RunnerHardening,
 )
 
-
-class _FakeBundleStore:
-    def __init__(self, data: bytes = b"") -> None:
-        self._data = data
-        self.requested: list[str] = []
-
-    def get(self, key: str) -> bytes:
-        self.requested.append(key)
-        return self._data
-
-
-class _RecordingDocker(DockerSandboxClient):
-    """Captures every docker argv and returns canned stdout per subcommand."""
-
-    def __init__(self, **kwargs: object) -> None:
-        super().__init__(**kwargs)  # type: ignore[arg-type]
-        self.calls: list[list[str]] = []
-        self.outputs: dict[str, str] = {}
-
-    def _docker(self, args: list[str], *, check: bool = True) -> str:
-        self.calls.append(args)
-        return self.outputs.get(args[0], "")
+from .conftest import _FakeBundleStore, _flag_values, _RecordingDocker
 
 
 def _plugin_tar_gz(wrapper: str | None) -> bytes:
@@ -55,10 +34,6 @@ def _plugin_tar_gz(wrapper: str | None) -> bytes:
         info.size = len(manifest)
         tf.addfile(info, io.BytesIO(manifest))
     return buf.getvalue()
-
-
-def _flag_values(argv: list[str], flag: str) -> list[str]:
-    return [argv[i + 1] for i, a in enumerate(argv) if a == flag and i + 1 < len(argv)]
 
 
 def test_create_claim_argv_carries_boot_env() -> None:

--- a/apps/worker/tests/sandbox/test_vector_credential_forwarding.py
+++ b/apps/worker/tests/sandbox/test_vector_credential_forwarding.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from agentos_worker.sandbox.docker import DockerSandboxClient
+from .conftest import _FakeBundleStore, _flag_values, _RecordingDocker
 
 _VECTORS = (
     Path(__file__).resolve().parents[4]
@@ -49,33 +49,6 @@ _EXPECTED_VECTOR_KEYS = frozenset(
         "expected",
     }
 )
-
-
-class _FakeBundleStore:
-    def get(self, key: str) -> bytes:
-        return b""
-
-
-class _RecordingDocker(DockerSandboxClient):
-    """Captures every docker argv; the docker CLI is the one external dependency."""
-
-    def __init__(self, **kwargs: object) -> None:
-        super().__init__(**kwargs)  # type: ignore[arg-type]
-        self.calls: list[list[str]] = []
-
-    def _docker(self, args: list[str], *, check: bool = True) -> str:
-        self.calls.append(args)
-        return ""
-
-
-def _forwarded_names(argv: list[str]) -> list[str]:
-    """The by-name forwards: `-e NAME` args, not the `-e KEY=VALUE` pairs the
-    generic boot-env loop emits."""
-    return [
-        argv[i + 1]
-        for i, a in enumerate(argv)
-        if a == "-e" and i + 1 < len(argv) and "=" not in argv[i + 1]
-    ]
 
 
 def _assert_known_keys(vector: dict[str, object]) -> None:
@@ -114,7 +87,9 @@ def _run_vector(vector: dict[str, object]) -> list[str]:
     client.create_claim("t1", pool="pool", env=env)
     argv = client.calls[0]
     assert all("PLACEHOLDER" not in a for a in argv)  # no credential value in argv
-    return _forwarded_names(argv)
+    # The by-name forwards: `-e NAME` args, not the `-e KEY=VALUE` pairs the
+    # generic boot-env loop emits.
+    return [v for v in _flag_values(argv, "-e") if "=" not in v]
 
 
 def test_worker_matches_every_forwarding_vector() -> None:


### PR DESCRIPTION
Consolidates the three test helpers that `test_vector_credential_forwarding.py` re-implemented as subsets of the versions already in `test_docker.py`.

- `_FakeBundleStore`, `_RecordingDocker`, and `_flag_values` now live once in `apps/worker/tests/sandbox/conftest.py` (the established home for shared fakes like `FakeSandboxClient`), using the superset `test_docker.py` versions.
- Both test modules import them from `.conftest`, mirroring the existing `from .conftest import ...` in `test_substrate.py`. No test module imports another.
- The vector lane's `_forwarded_names` helper collapses to `[v for v in _flag_values(argv, "-e") if "=" not in v]`, keeping the `-e NAME` vs `-e KEY=VALUE` distinction as the only lane-specific logic. The forwarded-name assertions are unchanged.

The optional `parents[4]` repo-root centralization from the issue Note is skipped deliberately (new abstraction, not reuse).

Verified: `uv run pytest apps/worker/tests/sandbox -q` green (37 passed, 22 skipped on the Valkey/e2e gates); ruff clean.

Closes #604