### PR TITLE
Keep the runner turn lock from wedging on a cross-task close

### DIFF
--- a/runner/src/agentos_runner/server.py
+++ b/runner/src/agentos_runner/server.py
@@ -25,6 +25,7 @@ the open ``/v1/event`` stream, exactly as the PT-2 steering proof showed.
 
 from __future__ import annotations
 
+import contextlib
 import hmac
 from typing import cast
 
@@ -146,8 +147,15 @@ async def _event(request: web.Request) -> web.StreamResponse:
 
     response = web.StreamResponse(status=200, headers={"Content-Type": _NDJSON})
     await response.prepare(request)
-    async for line in runner.run_turn(frame):
-        await response.write(line.encode("utf-8"))
+    # aclosing guarantees the generator is finalized on THIS driving task. On a
+    # client disconnect, response.write() raises from this frame; without
+    # aclosing the suspended generator would instead be closed later by the
+    # asyncgen GC on a different task, releasing the turn lock cross-task (see
+    # SessionRunner._turn_lock). aclosing keeps the teardown -- and the turn
+    # interrupt in run_turn's finally -- on the task that opened it.
+    async with contextlib.aclosing(runner.run_turn(frame)) as stream:
+        async for line in stream:
+            await response.write(line.encode("utf-8"))
     await response.write_eof()
     return response
 

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import time
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
 
 import anyio
 from aci_protocol import (
@@ -166,7 +166,21 @@ class SessionRunner:
         self._false_completion_check = false_completion_check
 
         self._session: ModelSession | None = None
-        self._turn_lock = anyio.Lock()
+        # One turn consumes the SDK generator at a time. This MUST be a
+        # Semaphore, not an anyio.Lock, to survive a cross-task teardown: if a
+        # run_turn generator is ever finalized by the asyncgen GC on a task
+        # other than the one that opened it (the client-disconnect race #679),
+        # anyio.Lock.release() from that non-owner task raises "current task is
+        # not holding this lock" and leaves _owner_task set -- wedging the lock
+        # permanently so every future turn blocks forever. A Semaphore's release
+        # is owner-agnostic, so it frees cleanly no matter which task closes the
+        # generator. The server's contextlib.aclosing (see server.py) is the
+        # primary fix -- it keeps finalization on the driving task -- and this is
+        # the defense-in-depth that keeps a stray cross-task close from wedging.
+        # max_value=1 keeps the loud double-release guard anyio.Lock gave us: a
+        # stray unbalanced release raises ValueError instead of silently
+        # over-permitting two concurrent turns on the single SDK generator.
+        self._turn_lock = anyio.Semaphore(1, max_value=1)
         self._interrupt_requested = False
         self._status = SessionStatus.IDLE_AWAITING_INPUT
         self._started = False
@@ -343,8 +357,13 @@ class SessionRunner:
         async for line in self.run_turn(message):
             yield line
 
-    async def run_turn(self, event: Event) -> AsyncIterator[str]:
-        """Run one turn, streaming ACI NDJSON lines and enforcing the budget."""
+    async def run_turn(self, event: Event) -> AsyncGenerator[str]:
+        """Run one turn, streaming ACI NDJSON lines and enforcing the budget.
+
+        Returns an async *generator* (not just an iterator): the server wraps it
+        in ``contextlib.aclosing`` so a client disconnect finalizes it on the
+        driving task, and ``aclosing`` requires the ``aclose`` a generator has.
+        """
 
         if self._session is None:
             raise RuntimeError("session not started")

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -378,6 +378,48 @@ def test_abandoned_stream_interrupts_the_sdk() -> None:
     assert fake.interrupts >= 1
 
 
+def test_cross_task_abandon_does_not_wedge_turn_lock() -> None:
+    # Client-disconnect mid-stream (#679): the server drives run_turn and, when
+    # response.write() raises on disconnect, the suspended generator is finalized
+    # by the asyncgen GC on a DIFFERENT task than the one that opened it. The turn
+    # lock must survive that cross-task teardown. An anyio.Lock released off-owner
+    # raises "current task is not holding this lock" AND leaves itself held,
+    # wedging every future turn forever; a Semaphore's owner-agnostic release does
+    # not. This closes the generator from a child task, then asserts a fresh turn
+    # still acquires the lock and runs to a terminal final.
+    runner, fake = _runner()
+
+    async def go() -> None:
+        await runner.start()
+        gen = runner.run_turn(Event(type="message", text="first", user="U", ts="1"))
+        await gen.__anext__()  # turn live; the lock is held by THIS task
+        assert runner.turn_active
+
+        # Finalize the abandoned generator on a different task, mimicking the
+        # asyncgen GC finalizer running off the driving frame. With the old
+        # anyio.Lock this raises and wedges the lock; the task group would then
+        # propagate the RuntimeError and fail the test here.
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(gen.aclose)
+        assert runner.turn_active is False
+
+        # The discriminator: a subsequent turn must acquire the lock and finish.
+        # fail_after turns a permanent wedge into a failure instead of a hang.
+        lines: list[str] = []
+        with anyio.fail_after(5):
+            async for line in runner.run_turn(
+                Event(type="message", text="second", user="U", ts="2")
+            ):
+                lines.append(line)
+
+        events = parse_ndjson("".join(lines))
+        assert events[-1].type == "final"
+        assert events[-1].status == SessionStatus.DONE
+
+    anyio.run(go)
+    assert fake.queries[-1] == "second"  # the second turn actually ran
+
+
 def test_build_options_carries_resume_ref() -> None:
     # Rehydrate-from-history (ADR-0003): a history ref becomes the SDK resume id.
     options = build_options(


### PR DESCRIPTION
## Problem

On a client disconnect mid-stream, `server.py`'s `_event` drove `runner.run_turn(...)` with no `contextlib.aclosing`. When `response.write()` raised from the driver frame, the suspended async generator was left to be finalized later by the asyncgen GC finalizer, which runs on a **different task**. `run_turn` wraps its body in `async with self._turn_lock` (an `anyio.Lock`), and releasing that lock from a non-owner task raises `"current task is not holding this lock"` **before** clearing the owner, leaving the lock permanently held. Every subsequent turn on that `SessionRunner` then blocked forever -- the whole sandbox wedged, not just the abandoned turn.

## Fix

- **`server.py`**: wrap the drive in `contextlib.aclosing(...)` so the generator is finalized on the driving task (root-cause fix), keeping the turn-lock release and the interrupt teardown on the task that opened it.
- **`session.py`**: switch the turn gate from `anyio.Lock()` to `anyio.Semaphore(1, max_value=1)`. A semaphore's release is owner-agnostic, so a stray cross-task close frees it cleanly instead of wedging (defense-in-depth); `max_value=1` preserves the loud double-release guard the Lock provided.
- `run_turn` annotated `AsyncGenerator[str]` so `aclosing` type-checks; `AsyncGenerator` is a subtype of `AsyncIterator`, so existing `async for` consumers are unaffected.

## Test

New `test_cross_task_abandon_does_not_wedge_turn_lock` closes a live `run_turn` generator from a **child** task (mimicking the GC finalizer) and asserts a subsequent turn still acquires the lock and reaches a terminal final. It was verified to fail against the old `anyio.Lock` with the exact `"current task is not holding this lock"` `RuntimeError`, and to pass with the fix. The pre-existing abandon test only closed from the same task, so it never exercised this hazard.

Runner suite: 385 passed, 4 skipped (credential-gated live tests). `ruff` + `mypy` green.

Closes #679