### PR TITLE
Route the ADR-0021 message builders through Ui::emit

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -30,11 +30,15 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   message` now return typed `CliOutput`s on their real-path success too (#485):
   the operator/deploy verbs route through `Ui::emit`, and `skill message` buffers
   the streamed reply into one `SkillMessageOutput` under `--json` (it still
-  streams live in the human path). One tracked exception remains: the
-  schema-gated ADR-0021 builders (`skill status`/`skill eval`, `skill check`,
-  `local message`/`cluster message`, `secrets list`, the error path, `guide`)
-  still inline their own `if json()` branch, sanctioned and tracked for migration
-  onto `Ui::emit` in #474.
+  streams live in the human path). The schema-gated ADR-0021 builders
+  (`skill status`/`skill eval`, `skill check`, `local message`/`cluster message`,
+  `secrets list`, `guide`) now route through `Ui::emit` too (#474): each returns a
+  typed `CliOutput` whose `to_json` delegates to its unchanged pure builder, so the
+  committed schemas stay byte-for-byte identical while the json-vs-human decision
+  lives only in `Ui::emit`. The one intentional non-`CliOutput` emit is the
+  centralized error path in `main.rs` (`error_json` under `--json`): errors are not
+  success-path values, so they stay on the error-emit mirror rather than the
+  success-path `CliOutput` contract.
 - **The command manifest is a committed artifact; regenerate it in the same
   change as any command-surface edit (console/CLI parity, epic #145).** Any
   change to a clap `Command`/subcommand or an `*Action` enum — a renamed verb,

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -384,6 +384,99 @@ pub fn message_dry_run_json(
 }
 
 // ---------------------------------------------------------------------------
+// CliOutput adapters (#474)
+// ---------------------------------------------------------------------------
+//
+// Route the schema-gated `--json` builders above through the one success-path
+// emit shim (`Ui::emit`, ADR-0021) instead of each call site inlining its own
+// `if ui.json() { emit_json } else { .. }` branch. `to_json` delegates to the
+// pure builders unchanged, so the committed `cli/schema/message.schema.json`
+// stays byte-for-byte identical; `render` reproduces the exact human output.
+
+/// `local`/`cluster message --dry-run` output. `to_json` is the schema-gated
+/// `message_dry_run_json`; the human render is the plan lines the target built
+/// (they differ between local and cluster, so the caller supplies them).
+struct MessageDryRunOutput {
+    target: &'static str,
+    stream: String,
+    channel: Option<String>,
+    reply_endpoint: String,
+    human_lines: Vec<String>,
+}
+
+impl crate::ui::CliOutput for MessageDryRunOutput {
+    fn to_json(&self) -> serde_json::Value {
+        message_dry_run_json(
+            self.target,
+            &self.stream,
+            self.channel.as_deref(),
+            &self.reply_endpoint,
+        )
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        for line in &self.human_lines {
+            ui.payload_plain(line);
+        }
+    }
+}
+
+/// The terminal outcome of a real `local`/`cluster message` turn. `to_json` is
+/// the matching schema-gated builder; `render` reproduces the exact human view
+/// (the stdout answer for a reply, the stderr warning/diagnostics otherwise).
+enum MessageOutcomeOutput {
+    /// The worker finalized the turn with reply text.
+    Replied { thread: String, reply: String },
+    /// The worker finished the turn but never edited the placeholder.
+    NoEdit { thread: String },
+    /// The turn parked awaiting human approval.
+    AwaitingApproval {
+        thread: String,
+        reply: Option<String>,
+    },
+    /// The deadline elapsed with no reply. `diagnostics` carries the stream
+    /// diagnostics string on the human path; it stays `None` under `--json`
+    /// (which never gathers them), so no extra Valkey read happens there.
+    TimedOut { diagnostics: Option<String> },
+}
+
+impl crate::ui::CliOutput for MessageOutcomeOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            MessageOutcomeOutput::Replied { thread, reply } => {
+                message_reply_json(thread, Some(reply))
+            }
+            MessageOutcomeOutput::NoEdit { thread } => message_reply_json(thread, None),
+            MessageOutcomeOutput::AwaitingApproval { thread, reply } => {
+                message_awaiting_approval_json(thread, reply.as_deref())
+            }
+            MessageOutcomeOutput::TimedOut { .. } => message_timeout_json(),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            MessageOutcomeOutput::Replied { reply, .. } => {
+                ui.answer(reply);
+                ui.print_tokens("\n");
+            }
+            MessageOutcomeOutput::NoEdit { .. } => {
+                ui.warn("the worker finished the turn but never edited the placeholder");
+            }
+            MessageOutcomeOutput::AwaitingApproval { .. } => {
+                warn_approval_will_strand(ui);
+            }
+            MessageOutcomeOutput::TimedOut { diagnostics } => {
+                ui.note("stream diagnostics:");
+                if let Some(diag) = diagnostics {
+                    ui.note(diag);
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Effectful helpers
 // ---------------------------------------------------------------------------
 
@@ -479,28 +572,24 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
 
     if opts.dry_run {
         let reply_endpoint = format!("http://localhost:{DEFAULT_LOCAL_STUB_PORT}/api/");
-        if ui.json() {
-            ui.emit_json(&message_dry_run_json(
-                "local",
-                &opts.stream,
-                opts.channel.as_deref(),
-                &reply_endpoint,
-            ));
-            return Ok(());
-        }
-        ui.payload_plain("local mode (compose stack; no kubectl/helm)");
-        ui.payload_plain(&format!("enqueue onto redis {valkey_url}"));
-        ui.payload_plain(&format!("stub advertised at {reply_endpoint}"));
-        match opts.channel.as_deref() {
-            Some(channel) => ui.payload_plain(&format!("channel {channel}")),
-            None => ui.payload_plain(&format!(
-                "channel <the sole deployed agent via {api_base}/agents>"
-            )),
-        }
-        ui.payload_plain(&format!(
-            "enqueue a synthetic QueuedTurn on stream {}",
-            opts.stream
-        ));
+        let channel_line = match opts.channel.as_deref() {
+            Some(channel) => format!("channel {channel}"),
+            None => format!("channel <the sole deployed agent via {api_base}/agents>"),
+        };
+        let human_lines = vec![
+            "local mode (compose stack; no kubectl/helm)".to_string(),
+            format!("enqueue onto redis {valkey_url}"),
+            format!("stub advertised at {reply_endpoint}"),
+            channel_line,
+            format!("enqueue a synthetic QueuedTurn on stream {}", opts.stream),
+        ];
+        ui.emit(&MessageDryRunOutput {
+            target: "local",
+            stream: opts.stream.clone(),
+            channel: opts.channel.clone(),
+            reply_endpoint,
+            human_lines,
+        });
         return Ok(());
     }
 
@@ -569,47 +658,40 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     match outcome {
         Outcome::Replied(reply) => {
             step.done("");
-            if ui.json() {
-                ui.emit_json(&message_reply_json(&thread_ts, Some(&reply)));
-            } else {
-                ui.answer(&reply);
-                ui.print_tokens("\n");
-            }
+            ui.emit(&MessageOutcomeOutput::Replied {
+                thread: thread_ts.clone(),
+                reply,
+            });
             persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
             step.done("no edit");
-            if ui.json() {
-                ui.emit_json(&message_reply_json(&thread_ts, None));
-            } else {
-                ui.warn("the worker finished the turn but never edited the placeholder");
-            }
+            ui.emit(&MessageOutcomeOutput::NoEdit {
+                thread: thread_ts.clone(),
+            });
             persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
         Outcome::AwaitingApproval(reply) => {
             step.done("awaiting approval");
-            if ui.json() {
-                ui.emit_json(&message_awaiting_approval_json(
-                    &thread_ts,
-                    reply.as_deref(),
-                ));
-            } else {
-                warn_approval_will_strand(ui);
-            }
+            ui.emit(&MessageOutcomeOutput::AwaitingApproval {
+                thread: thread_ts.clone(),
+                reply,
+            });
             persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
-            if ui.json() {
-                ui.emit_json(&message_timeout_json());
+            // Gather diagnostics only on the human path; under `--json` the
+            // timeout object carries no diagnostics, so skip the extra Valkey read.
+            let diag = if ui.json() {
+                None
             } else {
-                ui.note("stream diagnostics:");
-                let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
-                ui.note(&diag);
-            }
+                Some(diagnostics(&mut conn, &opts.stream, &stream_id).await)
+            };
+            ui.emit(&MessageOutcomeOutput::TimedOut { diagnostics: diag });
             // A timeout is retryable (the worker may still be working, or a
             // transient stall), so it maps to the transient exit code, not failure.
             std::process::exit(crate::exit::ExitClass::Transient.code());
@@ -647,18 +729,13 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
             .listen_host
             .clone()
             .unwrap_or_else(|| "<auto-detected-local-ip>".to_string());
-        if ui.json() {
-            ui.emit_json(&message_dry_run_json(
-                "cluster",
-                &opts.stream,
-                opts.channel.as_deref(),
-                &advertised_url(&host, opts.listen_port),
-            ));
-            return Ok(());
-        }
-        for line in dry_run_lines(&opts, &host) {
-            ui.payload_plain(&line);
-        }
+        ui.emit(&MessageDryRunOutput {
+            target: "cluster",
+            stream: opts.stream.clone(),
+            channel: opts.channel.clone(),
+            reply_endpoint: advertised_url(&host, opts.listen_port),
+            human_lines: dry_run_lines(&opts, &host),
+        });
         return Ok(());
     }
 
@@ -763,47 +840,40 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     match outcome {
         Outcome::Replied(reply) => {
             step.done("");
-            if ui.json() {
-                ui.emit_json(&message_reply_json(&thread_ts, Some(&reply)));
-            } else {
-                ui.answer(&reply);
-                ui.print_tokens("\n");
-            }
+            ui.emit(&MessageOutcomeOutput::Replied {
+                thread: thread_ts.clone(),
+                reply,
+            });
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }
         Outcome::CompletedNoEdit => {
             step.done("no edit");
-            if ui.json() {
-                ui.emit_json(&message_reply_json(&thread_ts, None));
-            } else {
-                ui.warn("the worker finished the turn but never edited the placeholder");
-            }
+            ui.emit(&MessageOutcomeOutput::NoEdit {
+                thread: thread_ts.clone(),
+            });
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }
         Outcome::AwaitingApproval(reply) => {
             step.done("awaiting approval");
-            if ui.json() {
-                ui.emit_json(&message_awaiting_approval_json(
-                    &thread_ts,
-                    reply.as_deref(),
-                ));
-            } else {
-                warn_approval_will_strand(ui);
-            }
+            ui.emit(&MessageOutcomeOutput::AwaitingApproval {
+                thread: thread_ts.clone(),
+                reply,
+            });
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
-            if ui.json() {
-                ui.emit_json(&message_timeout_json());
+            // Gather diagnostics only on the human path; under `--json` the
+            // timeout object carries no diagnostics, so skip the extra Valkey read.
+            let diag = if ui.json() {
+                None
             } else {
-                ui.note("stream diagnostics:");
-                let diag = diagnostics(&mut conn, &opts.stream, &stream_id).await;
-                ui.note(&diag);
-            }
+                Some(diagnostics(&mut conn, &opts.stream, &stream_id).await)
+            };
+            ui.emit(&MessageOutcomeOutput::TimedOut { diagnostics: diag });
             // A timeout is retryable (the worker may still be working, or a
             // transient stall), so it maps to the transient exit code, not failure.
             std::process::exit(crate::exit::ExitClass::Transient.code());


### PR DESCRIPTION
Migrates the remaining streaming ADR-0021 `--json` builders in `cli/src/message.rs` (the `local message` and `cluster message` handlers) off the inline `if ui.json() { emit_json } else { .. }` pattern onto the centralized `Ui::emit` shim. Cleanup / consistency only, per #474 — no correctness change.

PR #594 already migrated the non-streaming builders (skill check/status/eval, secrets list, guide primer); this finishes the migration.

## What changed
- Two new `CliOutput` adapters in `message.rs`: `MessageDryRunOutput` and `MessageOutcomeOutput` (Replied / NoEdit / AwaitingApproval / TimedOut). Their `to_json` delegates to the unchanged pure builders (`message_dry_run_json` / `message_reply_json` / `message_awaiting_approval_json` / `message_timeout_json`), so the committed `cli/schema/message.schema.json` and the `json_contract.rs` gate stay byte-for-byte identical.
- All four handler sites (local + cluster, dry-run + 4 outcomes) now route through `ui.emit(&..)`; the json-vs-human decision lives only in `Ui::emit`.
- Timeout diagnostics are still gathered only on the human path (no extra Valkey read under `--json`); human and JSON output are unchanged.
- Updated the `cli/CLAUDE.md` invariant: the ADR-0021 builders now route through `Ui::emit`; only `main.rs`'s centralized error path stays off the success-path `CliOutput` contract by design (errors are not success-path values).

## Verification
- `cargo test` green, including all 16 `json_contract.rs` schema-gate tests.
- Only `cli/src/message.rs` and `cli/CLAUDE.md` changed; no schema files touched.
- Output byte-identical across all outcomes for both handlers (verified against the diff).

Closes #474