### PR TITLE
Mint runner state refs from a runner-facing API base

### DIFF
--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -424,7 +424,15 @@ class BindingResolver:
         # The memory ref (#264): the agent's scoped namespace on the durable
         # state store (#23/#248). The runner dereferences it at boot to load
         # prior memory and to append learned records with provenance.
-        base = self._config.api_base_url.rstrip("/")
+        #
+        # Minted from the RUNNER-facing API base, not the worker's self-dial
+        # api_base_url (#678): the runner dereferences these refs, and in the
+        # docker substrate it lives on the bridge runner network where the
+        # worker's host-net localhost URL is unreachable, so a self-dial base
+        # left every spawn "booting without memory/history". runner_facing_api_
+        # base_url falls back to api_base_url (byte-identical to before) when the
+        # runner-facing base is not split out.
+        base = self._config.runner_facing_api_base_url.rstrip("/")
         memory_ref = f"{base}/agents/{resolved.agent_id}/state/memory"
         # The history ref (#20, ADR-0029): this thread's transcript key on the
         # same state store. It is deterministic per (agent, thread), so a fresh,

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -312,6 +312,25 @@ class WorkerConfig(BaseSettings):
     api_base_url: str = Field(
         default="http://localhost:8000", validation_alias=api_url_validation_alias()
     )
+    # The API base a SPAWNED RUNNER dials, distinct from api_base_url above, which
+    # is the worker's OWN self-dial URL (its /evals/report, binding resolve). The
+    # two diverge whenever the worker and the runner sit on different networks:
+    # in the docker substrate the worker runs host-net and reaches the API at the
+    # published localhost port, but the runner container it spawns joins the
+    # bridge runner network and can only reach the API by its in-network service
+    # name (compose: http://agentos-api:8000). AGENTOS_MEMORY_REF/AGENTOS_HISTORY_REF
+    # are minted for the runner, so they must be built from THIS base, not the
+    # worker's localhost self-dial (#678). Empty means "not split out": the ref
+    # falls back to api_base_url, byte-identical to the pre-#678 behavior. That
+    # fallback is correct wherever the worker's own api_base_url is already
+    # runner-reachable; it does NOT by itself make an unreachable api_base_url
+    # reachable. The k8s substrate is a separate case -- a default chart install
+    # wires neither AGENTOS_API_URL nor this on the worker, so its runner state
+    # refs are the same localhost gap in the opposite substrate, out of #678's
+    # docker scope -- see runner_facing_api_base_url.
+    runner_api_base_url: str = Field(
+        default="", validation_alias="AGENTOS_RUNNER_API_URL"
+    )
     api_key: str = Field(default="agentos-dev-key", validation_alias=API_KEY_ENV)
     report_max_attempts: int = 3
     report_backoff_base_s: float = Field(default=0.5, gt=0)
@@ -331,6 +350,21 @@ class WorkerConfig(BaseSettings):
     )
 
     key_prefix: str = "agentos:worker"
+
+    @property
+    def runner_facing_api_base_url(self) -> str:
+        """The API base a spawned runner dials, falling back to the self-dial URL.
+
+        ``runner_api_base_url`` overrides only when the runner sits on a different
+        network than the worker (the docker substrate: host-net worker, bridge-net
+        runner). When it is unset this falls back to api_base_url, byte-identical
+        to the pre-#678 behavior -- correct wherever the worker's own api_base_url
+        is already runner-reachable, but not itself a fix for a substrate where it
+        is not (see the field comment on the k8s gap). Callers minting
+        runner-facing refs (AGENTOS_MEMORY_REF / AGENTOS_HISTORY_REF) read this,
+        never api_base_url directly (#678).
+        """
+        return self.runner_api_base_url or self.api_base_url
 
     @property
     def valkey_socket_timeout_s(self) -> float:

--- a/apps/worker/tests/binding/test_boot_env_golden.py
+++ b/apps/worker/tests/binding/test_boot_env_golden.py
@@ -94,6 +94,48 @@ def test_plain_bound_run_renders_the_frozen_boot_env() -> None:
     assert verify(token, "agentos-dev-key", agent=str(_AGENT), scope="memory") is False
 
 
+def test_state_refs_are_minted_from_the_runner_facing_base() -> None:
+    """#678: AGENTOS_MEMORY_REF/AGENTOS_HISTORY_REF are dereferenced by the
+    RUNNER, so they must be built from the runner-facing API base, never the
+    worker's self-dial URL.
+
+    In the docker substrate the worker runs host-net and self-dials the API at a
+    published localhost port, while the runner it spawns lives on the bridge
+    runner network and reaches the API only by its in-network service name. A ref
+    minted from the worker's localhost base is unreachable from the runner, which
+    boots "without memory/history" every spawn. When runner_api_base_url is set,
+    both refs must carry that host and not the localhost self-dial base.
+    """
+    config = WorkerConfig(
+        api_base_url="http://localhost:28000",
+        runner_api_base_url="http://agentos-api:8000",
+    )
+    env = _boot_env(config, _resolved())
+
+    assert env["AGENTOS_MEMORY_REF"] == (
+        f"http://agentos-api:8000/agents/{_AGENT}/state/memory"
+    )
+    assert env["AGENTOS_HISTORY_REF"] == (
+        f"http://agentos-api:8000/agents/{_AGENT}/state/transcript/{_THREAD}"
+    )
+    # The worker's own self-dial localhost base must not leak into either ref.
+    assert "localhost:28000" not in env["AGENTOS_MEMORY_REF"]
+    assert "localhost:28000" not in env["AGENTOS_HISTORY_REF"]
+
+
+def test_state_refs_fall_back_to_the_self_dial_base_when_undivided() -> None:
+    """With runner_api_base_url unset the runner reaches the API at the worker's
+    own URL (k8s in-cluster, single-host local), so the refs are unchanged."""
+    env = _boot_env(WorkerConfig(api_base_url="http://in-cluster-api:8000"), _resolved())
+
+    assert env["AGENTOS_MEMORY_REF"] == (
+        f"http://in-cluster-api:8000/agents/{_AGENT}/state/memory"
+    )
+    assert env["AGENTOS_HISTORY_REF"] == (
+        f"http://in-cluster-api:8000/agents/{_AGENT}/state/transcript/{_THREAD}"
+    )
+
+
 def test_fully_loaded_run_renders_the_frozen_boot_env() -> None:
     config = WorkerConfig(
         fake_model=True,

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -111,6 +111,11 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         "AGENTOS_RUNNER_IMAGE",
         "AGENTOS_SANDBOX_SUBSTRATE",
         "AGENTOS_WARM_POOL",
+        # The runner-facing API base (#678): WorkerConfig reads it from the
+        # WORKER's env to MINT AGENTOS_MEMORY_REF/AGENTOS_HISTORY_REF (which ARE
+        # declared boot keys, rendered from the declaration). It is a worker-side
+        # knob for what URL those refs carry, never itself a sandbox boot key.
+        "AGENTOS_RUNNER_API_URL",
         # The local-model demo base URL: an operator knob on the WORKER and on the
         # runner's sdk_auth mapping. It is not a BootEnv field; the boot key the
         # worker actually emits from it is ANTHROPIC_BASE_URL.

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -338,6 +338,79 @@ def test_model_api_backend_and_env_key_populate_by_field_name() -> None:
     assert config.model_env_key == "MY_PROVIDER_KEY"
 
 
+# --- Runner-facing API base (#678) -------------------------------------------
+#
+# A field distinct from api_base_url (the worker's self-dial URL): the API base a
+# SPAWNED RUNNER dials. Defaults to "" (undivided) and reads only its AGENTOS_*
+# alias. Kept out of the _WORKER_OVERRIDES parity oracle -- like the #514 fields,
+# it is new, not a port of the old hand-rolled from_env.
+
+
+def test_runner_api_base_url_defaults_to_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Undivided is the default: the runner reaches the API at the worker's own
+    self-dial URL (k8s in-cluster, single-host local)."""
+    _clear_all_config_env(monkeypatch)
+
+    config = WorkerConfig()
+
+    assert config.runner_api_base_url == ""
+
+
+def test_worker_config_reads_runner_api_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_RUNNER_API_URL", "http://agentos-api:8000")
+
+    config = WorkerConfig()
+
+    assert config.runner_api_base_url == "http://agentos-api:8000"
+
+
+def test_runner_api_base_url_ignores_bare_field_name_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aliased like every other AGENTOS_* knob: a stray bare-name env var in the
+    pod env must not leak in."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("RUNNER_API_BASE_URL", "http://stray:9000")
+
+    config = WorkerConfig()
+
+    assert config.runner_api_base_url == ""
+
+
+def test_runner_facing_api_base_url_falls_back_to_self_dial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset runner_api_base_url resolves to api_base_url, so k8s and single-host
+    local -- where the runner reaches the API at the worker's URL -- are unchanged."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_API_URL", "http://in-cluster-api:8000")
+
+    config = WorkerConfig()
+
+    assert config.runner_api_base_url == ""
+    assert config.runner_facing_api_base_url == "http://in-cluster-api:8000"
+
+
+def test_runner_facing_api_base_url_prefers_the_runner_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the two networks diverge (docker substrate), the runner-facing base
+    wins over the worker's localhost self-dial URL."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_API_URL", "http://localhost:28000")
+    monkeypatch.setenv("AGENTOS_RUNNER_API_URL", "http://agentos-api:8000")
+
+    config = WorkerConfig()
+
+    assert config.api_base_url == "http://localhost:28000"
+    assert config.runner_facing_api_base_url == "http://agentos-api:8000"
+
+
 def test_agentos_dead_letter_stream_reaches_the_dead_letter_field(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -454,6 +454,15 @@ services:
       - S3_SECRET_KEY=miniosecret
       - BUNDLE_BUCKET=agentos-bundles
       - AGENTOS_API_URL=http://localhost:28000
+      # The worker runs host-net, so it self-dials the API at the published
+      # localhost port above. But the runner containers it spawns join the
+      # bridge runner network (agentos_runner), where that localhost port is
+      # unreachable -- they reach the API only by its in-network service name.
+      # AGENTOS_MEMORY_REF/AGENTOS_HISTORY_REF are minted for the runner to
+      # dereference, so they must be built from this runner-facing base, not the
+      # worker's self-dial URL (#678). agentos-api joins agentos_runner (via its
+      # network membership), so this name resolves from a spawned runner.
+      - AGENTOS_RUNNER_API_URL=http://agentos-api:8000
       - SLACK_API_BASE_URL=${SLACK_API_BASE_URL-http://localhost:8155/api/}
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-xoxb-dev}
       # Fake model by default (no credential needed). `agentos local up` reaches


### PR DESCRIPTION
## Problem

The worker minted `AGENTOS_MEMORY_REF` / `AGENTOS_HISTORY_REF` from its own `api_base_url`, which in the docker substrate is the worker's host-net self-dial URL (`http://localhost:28000` in compose). The runner that dereferences those refs lives on the bridge runner network, where that localhost port is unreachable, so every spawn booted "without memory/history".

Same Docker-Desktop-VM-localhost root class as #664/CUR-1649, but the inverse (runner -> API) direction, untouched by that fix.

## Change

- Add a distinct `WorkerConfig` field `runner_api_base_url` (`AGENTOS_RUNNER_API_URL`) for the API base a spawned runner dials, separate from the worker's self-dial `api_base_url`.
- Resolve via a `runner_facing_api_base_url` property that falls back to `api_base_url` when unset, byte-identical to prior behavior (frozen golden tests confirm no wire drift).
- `binding.boot_env` mints both state refs from the runner-facing base.
- Wire `AGENTOS_RUNNER_API_URL=http://agentos-api:8000` on the compose worker service (`agentos-api` is multi-homed onto `agentos_runner`, so the name resolves from a spawned runner).

## Tests

`test_state_refs_are_minted_from_the_runner_facing_base` asserts both refs carry the runner-facing host and that the localhost self-dial base does not leak; a companion test covers the unset fallback. Config tests cover default-empty, alias read, bare-name rejection, and both resolution branches. `AGENTOS_RUNNER_API_URL` is allowlisted in the #488 single-declaration gate as a worker-side knob (it mints already-declared boot keys; it is not itself a sandbox boot key). Full worker unit tests + ruff green.

## Note (out of scope, follow-up)

A default k8s chart install wires neither `AGENTOS_API_URL` nor `AGENTOS_RUNNER_API_URL` on the worker Deployment, so its runner state refs are the same localhost gap on the opposite substrate (byte-identical before and after this change, out of #678's docker scope). Fixing it means pointing the worker's API env at the in-cluster API Service (mirroring the dispatcher's `_helpers.tpl` derivation) plus a chart render-assertion. Left as a follow-up rather than expanding this PR into the chart.

Closes #678