### PR TITLE
Isolate per-entry handler errors in the worker consume loop

### DIFF
--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -12,7 +12,7 @@ import asyncio
 import logging
 import os
 import signal
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -239,31 +239,76 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     )
 
 
+async def _supervise(
+    name: str,
+    factory: Callable[[], Awaitable[None]],
+    shutdown: asyncio.Event,
+    *,
+    restart_backoff_s: float = 1.0,
+) -> None:
+    """Run a worker task, restarting it if it crashes, until shutdown is requested.
+
+    Each consumer's ``run()`` returns only when its own stop is requested. If one
+    instead raises -- a latent bug, or an error that escaped its own read loop --
+    restarting it keeps its siblings (runs, evals, killswitch, heartbeat) alive
+    rather than letting the exception propagate out of the top-level gather and
+    tear the whole worker down (#673). Paired with ``return_exceptions=True`` on
+    that gather, this is the defence-in-depth behind the per-entry isolation in
+    ``StreamConsumer._consume``. ``CancelledError`` is a ``BaseException`` and
+    still propagates, so cooperative shutdown is unaffected.
+
+    ``factory`` is a thunk (e.g. a bound ``run`` method) so each restart gets a
+    fresh coroutine; ``run()`` is re-entrant (group creation is BUSYGROUP-safe).
+    """
+    while not shutdown.is_set():
+        try:
+            await factory()
+            return
+        except Exception:
+            if shutdown.is_set():
+                return
+            logger.exception("worker task %s crashed; restarting", name)
+            try:
+                await asyncio.wait_for(shutdown.wait(), timeout=restart_backoff_s)
+            except TimeoutError:
+                pass
+
+
 async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
     rt = build(config, env)
 
     loop = asyncio.get_running_loop()
 
-    # Liveness heartbeat runs on this same event loop, so a wedged loop stops
-    # touching the file and the k8s exec probe restarts the pod (issue #71).
-    hb_stop = asyncio.Event()
+    # A single shutdown flag governs every supervised task. The liveness
+    # heartbeat runs on this same event loop, so a wedged loop stops touching the
+    # file and the k8s exec probe restarts the pod (issue #71).
+    shutdown = asyncio.Event()
 
     def _stop() -> None:
         rt.consumer.request_stop()
         rt.killswitch.request_stop()
         rt.eval_consumer.request_stop()
-        hb_stop.set()
+        shutdown.set()
 
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, _stop)
 
     logging.getLogger("agentos_worker").info("worker starting")
     try:
+        # return_exceptions=True + per-task restart: a crash in one consumer must
+        # not cancel its siblings (#673). Supervisors only return on shutdown.
         await asyncio.gather(
-            rt.consumer.run(),
-            rt.killswitch.run(),
-            rt.eval_consumer.run(),
-            run_heartbeat(config.heartbeat_file, config.heartbeat_interval_s, hb_stop),
+            _supervise("runs", rt.consumer.run, shutdown),
+            _supervise("killswitch", rt.killswitch.run, shutdown),
+            _supervise("evals", rt.eval_consumer.run, shutdown),
+            _supervise(
+                "heartbeat",
+                lambda: run_heartbeat(
+                    config.heartbeat_file, config.heartbeat_interval_s, shutdown
+                ),
+                shutdown,
+            ),
+            return_exceptions=True,
         )
     finally:
         await rt.runner.close()

--- a/apps/worker/src/agentos_worker/stream_consumer.py
+++ b/apps/worker/src/agentos_worker/stream_consumer.py
@@ -123,7 +123,28 @@ class StreamConsumer:
             streams = cast("list[tuple[str, list[StreamEntry]]]", resp)
             for _stream, entries in streams:
                 for entry_id, fields in entries:
-                    await handler(entry_id, fields)
+                    try:
+                        await handler(entry_id, fields)
+                    except Exception:
+                        # A handler-internal error must not escape this loop. The
+                        # realistic trigger is a transient transport fault (a Valkey
+                        # failover/blip) hit while a poison-pill entry is being
+                        # dead-lettered via XADD to ``<stream>:dead`` (#585 widened
+                        # this with a second eval dead-letter site). This loop shares
+                        # one event loop with the other consumers (runs, evals,
+                        # killswitch, heartbeat) under the top-level gather, so an
+                        # escaping exception would tear its siblings down (#673).
+                        # Log and continue: the entry is left un-acked in the PEL, so
+                        # the reclaim loop re-delivers it (and dead-letters it once the
+                        # delivery cap is hit) rather than being lost. ``CancelledError``
+                        # is a ``BaseException`` and still propagates, so cooperative
+                        # shutdown is unaffected.
+                        spec.logger.exception(
+                            "handler failed for entry %s on stream %s; "
+                            "left pending for reclaim",
+                            entry_id,
+                            spec.stream,
+                        )
 
     async def _sleep_or_stop(self, seconds: float) -> None:
         try:

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import pytest
 from agentos_worker.config import WorkerConfig
-from agentos_worker.run import _sandbox_client, _substrate_config, main
+from agentos_worker.run import _sandbox_client, _substrate_config, _supervise, main
 from agentos_worker.sandbox import DockerSandboxClient, SubstrateConfig
 
 _SUB = SubstrateConfig(namespace="default", warm_pool="pool")
@@ -203,3 +203,114 @@ def test_main_installs_dead_letter_alerting(
         for handler in original_handlers:
             source_logger.addHandler(handler)
         source_logger.propagate = original_propagate
+
+
+# -- _supervise: per-task restart + sibling isolation (#673) -----------------
+
+
+def test_supervise_restarts_a_crashing_task_until_shutdown(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A consumer that crashes is restarted rather than allowed to escape. The
+    task settles once it returns cleanly (its own stop was requested)."""
+
+    async def go() -> None:
+        shutdown = asyncio.Event()
+        calls = {"n": 0}
+
+        async def factory() -> None:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ConnectionError("boom")
+            # Third run behaves like a real consumer: return once stopped.
+            shutdown.set()
+
+        with caplog.at_level(logging.ERROR, logger="agentos_worker.run"):
+            await asyncio.wait_for(
+                _supervise("evals", factory, shutdown, restart_backoff_s=0),
+                timeout=2,
+            )
+
+        assert calls["n"] == 3  # crashed twice, restarted twice, then returned
+        restarts = [
+            r
+            for r in caplog.records
+            if r.name == "agentos_worker.run" and "crashed; restarting" in r.getMessage()
+        ]
+        assert len(restarts) == 2
+
+    asyncio.run(go())
+
+
+def test_supervise_does_not_restart_after_shutdown() -> None:
+    """A crash arriving as shutdown is requested must not trigger a restart, and
+    must not propagate out of the supervisor."""
+
+    async def go() -> None:
+        shutdown = asyncio.Event()
+        calls = {"n": 0}
+
+        async def factory() -> None:
+            calls["n"] += 1
+            shutdown.set()
+            raise ConnectionError("boom")
+
+        await asyncio.wait_for(
+            _supervise("runs", factory, shutdown, restart_backoff_s=0),
+            timeout=2,
+        )
+        assert calls["n"] == 1  # no restart after shutdown
+
+    asyncio.run(go())
+
+
+def test_supervise_returns_when_task_completes_cleanly() -> None:
+    async def go() -> None:
+        shutdown = asyncio.Event()
+        calls = {"n": 0}
+
+        async def factory() -> None:
+            calls["n"] += 1
+
+        await asyncio.wait_for(
+            _supervise("heartbeat", factory, shutdown, restart_backoff_s=0),
+            timeout=2,
+        )
+        assert calls["n"] == 1  # returned on first clean completion, no restart
+
+    asyncio.run(go())
+
+
+def test_crashing_supervised_task_does_not_cancel_its_siblings() -> None:
+    """The #673 core: one consumer crashing (and restarting) must not tear down a
+    sibling consumer sharing the same event loop under the top-level gather."""
+
+    async def go() -> None:
+        shutdown = asyncio.Event()
+        sibling_ran = {"ok": False}
+        crashes = {"n": 0}
+
+        async def crasher() -> None:
+            crashes["n"] += 1
+            if crashes["n"] >= 3:
+                shutdown.set()  # last crash also asks everything to stop
+            raise ConnectionError("boom")
+
+        async def sibling() -> None:
+            # Only completes if it was NOT cancelled by the crasher's failure.
+            await shutdown.wait()
+            sibling_ran["ok"] = True
+
+        await asyncio.wait_for(
+            asyncio.gather(
+                _supervise("crasher", crasher, shutdown, restart_backoff_s=0),
+                _supervise("sibling", sibling, shutdown, restart_backoff_s=0),
+                return_exceptions=True,
+            ),
+            timeout=2,
+        )
+
+        assert crashes["n"] == 3
+        assert sibling_ran["ok"] is True
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_stream_consumer.py
+++ b/apps/worker/tests/test_stream_consumer.py
@@ -1,0 +1,87 @@
+"""Dispatch-level isolation in the shared consume loop (#673).
+
+A handler-internal error (the realistic trigger: a transient transport fault
+during a poison-pill dead-letter XADD) must not escape ``_consume``. If it did,
+it would propagate out of the loop and -- because every consumer shares one event
+loop under the top-level gather -- tear its siblings (runs, evals, killswitch,
+heartbeat) down. The loop must instead log-and-continue, leaving the entry
+un-acked in the PEL for the reclaim loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from agentos_worker.stream_consumer import ReadLoopSpec, StreamConsumer
+
+
+class _FakeBroker:
+    """Returns one batch of entries, then drains (requesting stop) so the loop
+    terminates. Only the two verbs ``_consume`` touches are implemented."""
+
+    def __init__(self, batch: list[tuple[str, dict[str, str]]], on_drained) -> None:  # noqa: ANN001
+        # xreadgroup returns list[(stream, entries)]; hand back one stream's worth.
+        self._responses: list[object] = [[("s", batch)]]
+        self._on_drained = on_drained
+
+    async def xgroup_create(self, *a, **k):  # noqa: ANN002, ANN003, ANN201
+        return True
+
+    async def xreadgroup(self, *a, **k):  # noqa: ANN002, ANN003, ANN201
+        if self._responses:
+            return self._responses.pop(0)
+        self._on_drained()  # no more work: ask the loop to stop
+        return []
+
+
+def _spec(logger: logging.Logger) -> ReadLoopSpec:
+    return ReadLoopSpec(
+        stream="s",
+        group="g",
+        consumer="c",
+        count=10,
+        block_ms=5,
+        backoff_s=0.0,
+        timeout_msg="timeout: %s",
+        connection_msg="connection: %s",
+        logger=logger,
+    )
+
+
+def test_handler_exception_does_not_tear_down_the_consume_loop(caplog) -> None:  # noqa: ANN001
+    """A handler that raises on the middle entry still lets the loop process the
+    entries before and after it, and the loop returns normally (no propagation)."""
+
+    async def go() -> None:
+        handled: list[str] = []
+
+        async def handler(entry_id: str, _fields: dict[str, str]) -> None:
+            handled.append(entry_id)
+            if entry_id == "2-0":
+                raise ConnectionError("dead-letter XADD hit a Valkey blip")
+
+        batch = [("1-0", {}), ("2-0", {}), ("3-0", {})]
+        # The broker asks the loop to stop once its one batch is drained; wire the
+        # callback to the consumer after construction to avoid a chicken-and-egg.
+        holder: dict[str, StreamConsumer] = {}
+        broker = _FakeBroker(batch, lambda: holder["c"].request_stop())
+        consumer = StreamConsumer(broker)  # type: ignore[arg-type]
+        holder["c"] = consumer
+
+        logger = logging.getLogger("agentos_worker.test_consume")
+        with caplog.at_level(logging.ERROR, logger=logger.name):
+            # Must not raise -- the ConnectionError on "2-0" is isolated.
+            await asyncio.wait_for(consumer._consume(_spec(logger), handler), timeout=2)
+
+        # The sibling entries on either side of the failing one were both handled:
+        # the exception did not abort the batch or the loop.
+        assert handled == ["1-0", "2-0", "3-0"]
+
+        # The failure was logged with a traceback (exception-level), naming the entry.
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "2-0" in errors[0].getMessage()
+        assert errors[0].exc_info is not None
+
+    asyncio.run(go())


### PR DESCRIPTION
The shared consume loop dispatched each entry's handler with no per-entry exception isolation, so a handler-internal error (the realistic trigger: a transient transport fault during a poison-pill dead-letter `XADD` to `<stream>:dead`) escaped the loop and, because every consumer shares one event loop under the top-level `gather`, could cancel the sibling consumers (runs, evals, killswitch, heartbeat) together.

## Changes
- **`stream_consumer.py`** — wrap the per-entry `await handler(...)` in `StreamConsumer._consume` with `try/except Exception`: log-and-continue, leaving the entry un-acked in the PEL so the reclaim loop re-delivers it (and dead-letters it once the delivery cap is hit) rather than losing it. `CancelledError` (a `BaseException`) still propagates, so cooperative shutdown is unaffected. This is the single dispatch-level fix, so the sacred single-owner `consumer.py` poison branch is untouched.
- **`run.py`** — supervise the top-level worker `gather` with `return_exceptions=True` plus a `_supervise` per-task restart wrapper, so a crash in one consumer no longer tears down its siblings. The heartbeat-only `hb_stop` Event becomes a single `shutdown` Event that governs every supervised task.

The eval lane awaits its handler inline (the vulnerable path, widened by the #585 eval dead-letter site); the runs lane already isolated via background tasks. The dispatch-level fix protects any inline-handler consumer generically.

## Tests
- `test_stream_consumer.py`: a handler raising on the middle of three entries still processes the entries on both sides and the loop returns without propagating.
- `test_run.py`: `_supervise` restarts a crashing task until shutdown, does not restart after shutdown, returns on clean completion, and a crashing supervised task does not cancel its siblings.
- Full `uv run pytest apps/worker` green against the live dev stack (462 passed, 1 skipped); ruff + mypy clean.

Closes #673