### PR TITLE
Drop an OAuth-shaped BYO credential under a base-URL override

### DIFF
--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -92,6 +92,14 @@ _SDK_PASSTHROUGH_ENV = (
     "CLAUDE_CODE_OAUTH_TOKEN",
     "ANTHROPIC_API_KEY",
 )
+# A Claude Code OAuth token shares the sk-ant- prefix with an API key; this more
+# specific prefix marks it. Under a base-URL override the runner blanks such a
+# token (runner sdk_auth.resolve_sdk_env), so forwarding it authenticates nothing
+# and only lands a real token in the container's /proc/1/environ. Kept a literal
+# mirror of runner/src/agentos_runner/sdk_auth.py::OAUTH_TOKEN_PREFIX -- the
+# authority for the prefix semantics -- and pinned across both lanes by the
+# `byo_oauth_shaped` vector input (issue #603).
+_OAUTH_TOKEN_PREFIX = "sk-ant-oat"
 # Env keys the worker sets explicitly or forwards specially, so the generic
 # value loop must not also emit them: the plugin dir and sandbox id are set
 # explicitly, the bundle ref named a MinIO object the worker already fetched
@@ -311,18 +319,27 @@ class DockerSandboxClient:
         # same-uid agent):
         #   - fake-model run (AGENTOS_FAKE_MODEL): the runner authenticates nothing,
         #     so forward no credential at all.
-        #   - base-URL-override / local run (ANTHROPIC_BASE_URL): drop only the
-        #     ambient SDK fallback -- a local endpoint needs no real Anthropic token.
-        #     An EXPLICIT AGENTOS_CREDENTIALS is still forwarded, because the runner
-        #     routes an sk-or- OpenRouter key into ANTHROPIC_API_KEY even with a
-        #     preset base URL (runner sdk_auth.resolve_sdk_env); suppressing it would
-        #     break BYO OpenRouter.
+        #   - base-URL-override / local run (ANTHROPIC_BASE_URL): drop the ambient
+        #     SDK fallback -- a local endpoint needs no real Anthropic token -- and
+        #     also drop an EXPLICIT AGENTOS_CREDENTIALS that is OAuth-shaped
+        #     (sk-ant-oat): the runner blanks such a token under the override
+        #     (runner sdk_auth.resolve_sdk_env), so forwarding it authenticates
+        #     nothing and only lands a real token in /proc/1/environ (issue #603).
+        #     A non-OAuth provider key (e.g. sk-or- OpenRouter) is still forwarded,
+        #     because the runner routes it into ANTHROPIC_API_KEY even with a preset
+        #     base URL; suppressing it would break BYO OpenRouter.
         fake_model = FAKE_MODEL_ENV in env
         base_url_override = BASE_URL_ENV in env
         if not fake_model:
-            if self._environ.get(CREDENTIALS_ENV):
+            byo = self._environ.get(CREDENTIALS_ENV)
+            drop_oauth_byo = (
+                base_url_override
+                and byo is not None
+                and byo.startswith(_OAUTH_TOKEN_PREFIX)
+            )
+            if byo and not drop_oauth_byo:
                 args += ["-e", CREDENTIALS_ENV]
-            elif not base_url_override:
+            elif not byo and not base_url_override:
                 for var in _SDK_PASSTHROUGH_ENV:
                     if var in self._environ:
                         args += ["-e", var]

--- a/apps/worker/tests/sandbox/test_vector_credential_forwarding.py
+++ b/apps/worker/tests/sandbox/test_vector_credential_forwarding.py
@@ -31,11 +31,14 @@ _VECTORS = (
 _AMBIENT_OAUTH = "sk-PLACEHOLDER-oauth"
 _AMBIENT_ANTHROPIC_CRED = "sk-ant-PLACEHOLDER-key"
 _BYO_CREDENTIAL = "sk-or-PLACEHOLDER-byo"
+# An OAuth-shaped BYO credential: the sk-ant-oat prefix is what the rule sniffs
+# to drop it under a base-URL override (issue #603). Still a placeholder value.
+_BYO_OAUTH_CREDENTIAL = "sk-ant-oat-PLACEHOLDER-byo"
 
 # Every key a vector row may carry. Checked exactly, so an unrecognized key is a
 # loud failure rather than an input this lane silently ignores: a row that grows
-# a sixth input would otherwise pass vacuously, which is the exact drift the gate
-# exists to catch. The Rust lane rejects unknown fields the same way, via
+# a seventh input would otherwise pass vacuously, which is the exact drift the
+# gate exists to catch. The Rust lane rejects unknown fields the same way, via
 # `#[serde(deny_unknown_fields)]` on its ForwardingVector.
 _EXPECTED_VECTOR_KEYS = frozenset(
     {
@@ -44,6 +47,7 @@ _EXPECTED_VECTOR_KEYS = frozenset(
         "fake_model",
         "base_url_override",
         "byo_credential",
+        "byo_oauth_shaped",
         "ambient_oauth",
         "ambient_api_key",
         "expected",
@@ -102,7 +106,9 @@ def _run_vector(vector: dict[str, object]) -> list[str]:
 
     environ: dict[str, str] = {}
     if vector["byo_credential"]:
-        environ["AGENTOS_CREDENTIALS"] = _BYO_CREDENTIAL
+        environ["AGENTOS_CREDENTIALS"] = (
+            _BYO_OAUTH_CREDENTIAL if vector["byo_oauth_shaped"] else _BYO_CREDENTIAL
+        )
     if vector["ambient_oauth"]:
         environ["CLAUDE_CODE_OAUTH_TOKEN"] = _AMBIENT_OAUTH
     if vector["ambient_api_key"]:

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -755,9 +755,13 @@ fn find_repo_root() -> Option<PathBuf> {
 ///   untrusted, egress-rail-less container readable via /proc/1/environ.
 /// - an explicit non-empty AGENTOS_CREDENTIALS (`byo_credential`): the operator's
 ///   chosen BYO credential, forwarded ALONE so an ambient SDK token can neither
-///   shadow it nor ride into the sandbox. Kept even under a `base_url_override`:
-///   the runner routes an sk-or- OpenRouter key into ANTHROPIC_API_KEY with a
-///   preset base URL, so dropping it would break BYO OpenRouter.
+///   shadow it nor ride into the sandbox. Kept under a `base_url_override` when it
+///   is a provider key -- the runner routes an sk-or- OpenRouter key into
+///   ANTHROPIC_API_KEY with a preset base URL, so dropping it would break BYO
+///   OpenRouter -- but DROPPED under an override when it is OAuth-shaped
+///   (`sk-ant-oat`): the runner blanks such a token behind an override
+///   (runner sdk_auth.resolve_sdk_env), so forwarding it authenticates nothing and
+///   only lands a real token in the container's /proc/1/environ (issue #603).
 /// - otherwise: the ambient SDK creds for the legacy real-Anthropic path, each
 ///   only when `ambient_present` reports it, and only when there is no
 ///   `base_url_override` -- a local endpoint needs no real Anthropic token.
@@ -774,7 +778,13 @@ fn select_passthrough_env(
     if fake_model {
         return Vec::new();
     }
-    if byo_credential.is_some_and(|c| !c.is_empty()) {
+    if let Some(cred) = byo_credential.filter(|c| !c.is_empty()) {
+        // An OAuth-shaped token under a base-URL override authenticates nothing
+        // (the runner blanks it), so drop it rather than leave a real token inert
+        // in /proc/1/environ; a provider key is still routed and kept (issue #603).
+        if base_url_override && cred.starts_with(OAUTH_TOKEN_PREFIX) {
+            return Vec::new();
+        }
         return vec!["AGENTOS_CREDENTIALS".into()];
     }
     if base_url_override {
@@ -786,6 +796,12 @@ fn select_passthrough_env(
         .map(String::from)
         .collect()
 }
+
+/// A Claude Code OAuth token shares the sk-ant- prefix with an API key; this more
+/// specific prefix marks it (issue #603). A literal mirror of
+/// runner/src/agentos_runner/sdk_auth.py::OAUTH_TOKEN_PREFIX, the authority for the
+/// prefix semantics, and of the worker lane's `_OAUTH_TOKEN_PREFIX`.
+const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
 
 /// Append `--secret` env var NAMES to the model-credential passthrough list,
 /// de-duplicating. Unlike the model credential these are NOT suppressed under a
@@ -3552,6 +3568,38 @@ mod tests {
     }
 
     #[test]
+    fn oauth_shaped_byo_dropped_under_base_url_override() {
+        // An sk-ant-oat OAuth token authenticates nothing behind a base-URL
+        // override, so it is dropped rather than left inert in /proc/1/environ
+        // (issue #603). The ambient fallback is also suppressed under the override.
+        assert_eq!(
+            select_passthrough_env(false, true, Some("sk-ant-oat-x"), &all_ambient_present),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn provider_byo_kept_under_base_url_override() {
+        // A non-OAuth provider key (sk-or- OpenRouter) is routed into
+        // ANTHROPIC_API_KEY even behind a preset base URL, so it is still
+        // forwarded -- dropping it would break BYO OpenRouter (issue #603).
+        assert_eq!(
+            select_passthrough_env(false, true, Some("sk-or-x"), &all_ambient_present),
+            vec!["AGENTOS_CREDENTIALS".to_string()]
+        );
+    }
+
+    #[test]
+    fn oauth_shaped_byo_kept_without_override() {
+        // The OAuth drop is gated on the override: on the legacy real-Anthropic
+        // path an sk-ant-oat token is a valid credential and is forwarded alone.
+        assert_eq!(
+            select_passthrough_env(false, false, Some("sk-ant-oat-x"), &all_ambient_present),
+            vec!["AGENTOS_CREDENTIALS".to_string()]
+        );
+    }
+
+    #[test]
     fn empty_byo_credential_falls_back_to_sdk_vars() {
         // An empty AGENTOS_CREDENTIALS (a blank line in .env) is treated as unset,
         // so the ambient SDK vars carry the legacy real-Anthropic credential.
@@ -3597,6 +3645,7 @@ mod tests {
         fake_model: bool,
         base_url_override: bool,
         byo_credential: bool,
+        byo_oauth_shaped: bool,
         ambient_oauth: bool,
         ambient_api_key: bool,
         expected: Vec<String>,
@@ -3643,7 +3692,13 @@ mod tests {
                 "ANTHROPIC_API_KEY" => vector.ambient_api_key,
                 _ => false,
             };
-            let byo = vector.byo_credential.then_some("sk-or-PLACEHOLDER-byo");
+            // An OAuth-shaped BYO is sk-ant-oat; a provider key is sk-or-. Both are
+            // placeholders and forwarded by NAME, so neither value enters the argv.
+            let byo = vector.byo_credential.then_some(if vector.byo_oauth_shaped {
+                "sk-ant-oat-PLACEHOLDER-byo"
+            } else {
+                "sk-or-PLACEHOLDER-byo"
+            });
             assert_eq!(
                 select_passthrough_env(
                     vector.fake_model,

--- a/tests/vectors/model-credential-forwarding.json
+++ b/tests/vectors/model-credential-forwarding.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Single source of truth for model-credential forwarding across the Python worker (apps/worker/src/agentos_worker/sandbox/docker.py) and the Rust CLI (cli/src/commands.rs::select_passthrough_env). Changing a rule here requires changing both lanes; changing a lane without changing this file fails that lane's test. Read by apps/worker/tests/sandbox/test_vector_credential_forwarding.py and by the vector loop in cli/src/commands.rs's test module. The five inputs are booleans because the rule keys on presence and never on a credential's content. expected is an ordered list of env NAMES; both lanes assert order. Both lanes reject unknown fields, so adding an input here without teaching both lanes fails both: a key one lane cannot see would otherwise pass vacuously.",
+  "comment": "Single source of truth for model-credential forwarding across the Python worker (apps/worker/src/agentos_worker/sandbox/docker.py) and the Rust CLI (cli/src/commands.rs::select_passthrough_env). Changing a rule here requires changing both lanes; changing a lane without changing this file fails that lane's test. Read by apps/worker/tests/sandbox/test_vector_credential_forwarding.py and by the vector loop in cli/src/commands.rs's test module. Five of the six inputs are presence booleans; the rule keys on a credential's content in exactly one case: `byo_oauth_shaped` marks a BYO credential as an OAuth-shaped Claude Code token (sk-ant-oat prefix, per runner/src/agentos_runner/sdk_auth.py::OAUTH_TOKEN_PREFIX), which under a base-URL override authenticates against nothing and is dropped so a real token never sits inert in a container that resolves none (issue #603). expected is an ordered list of env NAMES; both lanes assert order. Both lanes reject unknown fields, so adding an input here without teaching both lanes fails both: a key one lane cannot see would otherwise pass vacuously.",
   "vectors": [
     {
       "name": "fake_model_forwards_nothing_even_with_byo",
@@ -7,6 +7,7 @@
       "fake_model": true,
       "base_url_override": false,
       "byo_credential": true,
+      "byo_oauth_shaped": false,
       "ambient_oauth": true,
       "ambient_api_key": true,
       "expected": []
@@ -17,6 +18,7 @@
       "fake_model": true,
       "base_url_override": false,
       "byo_credential": false,
+      "byo_oauth_shaped": false,
       "ambient_oauth": true,
       "ambient_api_key": true,
       "expected": []
@@ -27,6 +29,7 @@
       "fake_model": true,
       "base_url_override": true,
       "byo_credential": true,
+      "byo_oauth_shaped": false,
       "ambient_oauth": true,
       "ambient_api_key": true,
       "expected": []
@@ -37,28 +40,64 @@
       "fake_model": false,
       "base_url_override": false,
       "byo_credential": true,
+      "byo_oauth_shaped": false,
       "ambient_oauth": true,
       "ambient_api_key": true,
       "expected": ["AGENTOS_CREDENTIALS"]
     },
     {
       "name": "base_url_override_keeps_explicit_byo",
-      "why": "The runner routes an sk-or- OpenRouter key into ANTHROPIC_API_KEY even with a preset base URL; suppressing it would break BYO OpenRouter.",
+      "why": "The runner routes an sk-or- OpenRouter provider key into ANTHROPIC_API_KEY even with a preset base URL; suppressing it would break BYO OpenRouter. A provider key is not OAuth-shaped, so the override drop does not apply.",
       "fake_model": false,
       "base_url_override": true,
       "byo_credential": true,
+      "byo_oauth_shaped": false,
       "ambient_oauth": true,
       "ambient_api_key": true,
       "expected": ["AGENTOS_CREDENTIALS"]
     },
     {
       "name": "base_url_override_keeps_explicit_byo_without_ambient",
-      "why": "The BYO credential under an override does not depend on any ambient token being present.",
+      "why": "The BYO provider key under an override does not depend on any ambient token being present.",
       "fake_model": false,
       "base_url_override": true,
       "byo_credential": true,
+      "byo_oauth_shaped": false,
       "ambient_oauth": false,
       "ambient_api_key": false,
+      "expected": ["AGENTOS_CREDENTIALS"]
+    },
+    {
+      "name": "base_url_override_drops_oauth_shaped_byo",
+      "why": "An sk-ant-oat OAuth token under a base-URL override authenticates against nothing (the runner blanks it), so forwarding it only lands a real token in /proc/1/environ of a container that resolves none. Drop it (issue #603), unlike a provider key.",
+      "fake_model": false,
+      "base_url_override": true,
+      "byo_credential": true,
+      "byo_oauth_shaped": true,
+      "ambient_oauth": true,
+      "ambient_api_key": true,
+      "expected": []
+    },
+    {
+      "name": "base_url_override_drops_oauth_shaped_byo_without_ambient",
+      "why": "The OAuth-shaped drop under an override does not depend on any ambient token being present; the override run forwards nothing.",
+      "fake_model": false,
+      "base_url_override": true,
+      "byo_credential": true,
+      "byo_oauth_shaped": true,
+      "ambient_oauth": false,
+      "ambient_api_key": false,
+      "expected": []
+    },
+    {
+      "name": "oauth_shaped_byo_forwarded_without_override",
+      "why": "The OAuth-shape drop is gated on the base-URL override: on the legacy real-Anthropic path an sk-ant-oat token is a valid credential the runner routes into CLAUDE_CODE_OAUTH_TOKEN, so it is still forwarded.",
+      "fake_model": false,
+      "base_url_override": false,
+      "byo_credential": true,
+      "byo_oauth_shaped": true,
+      "ambient_oauth": true,
+      "ambient_api_key": true,
       "expected": ["AGENTOS_CREDENTIALS"]
     },
     {
@@ -67,6 +106,7 @@
       "fake_model": false,
       "base_url_override": true,
       "byo_credential": false,
+      "byo_oauth_shaped": false,
       "ambient_oauth": true,
       "ambient_api_key": true,
       "expected": []
@@ -77,6 +117,7 @@
       "fake_model": false,
       "base_url_override": true,
       "byo_credential": false,
+      "byo_oauth_shaped": false,
       "ambient_oauth": false,
       "ambient_api_key": false,
       "expected": []
@@ -87,6 +128,7 @@
       "fake_model": false,
       "base_url_override": false,
       "byo_credential": false,
+      "byo_oauth_shaped": false,
       "ambient_oauth": true,
       "ambient_api_key": true,
       "expected": ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]
@@ -97,6 +139,7 @@
       "fake_model": false,
       "base_url_override": false,
       "byo_credential": false,
+      "byo_oauth_shaped": false,
       "ambient_oauth": true,
       "ambient_api_key": false,
       "expected": ["CLAUDE_CODE_OAUTH_TOKEN"]
@@ -107,6 +150,7 @@
       "fake_model": false,
       "base_url_override": false,
       "byo_credential": false,
+      "byo_oauth_shaped": false,
       "ambient_oauth": false,
       "ambient_api_key": true,
       "expected": ["ANTHROPIC_API_KEY"]
@@ -117,6 +161,7 @@
       "fake_model": false,
       "base_url_override": false,
       "byo_credential": false,
+      "byo_oauth_shaped": false,
       "ambient_oauth": false,
       "ambient_api_key": false,
       "expected": []


### PR DESCRIPTION
## What

The shared three-state model-credential forwarding rule kept an explicit `AGENTOS_CREDENTIALS` under a base-URL override, on the grounds that a BYO OpenRouter key (`sk-or-`) must reach `ANTHROPIC_API_KEY` behind a preset base URL. But the rule keyed on the credential being *explicit*, not on its *shape*: `--local-model` plus an `sk-ant-oat` OAuth token landed a real Anthropic credential into a container that authenticates against nothing. The runner blanks such a token under the override, so it is inert as to egress, but it still sits in `/proc/1/environ`, recoverable by a same-uid agent.

This drops an OAuth-shaped (`sk-ant-oat`) BYO credential under a base-URL override, while still forwarding provider keys such as `sk-or-` so BYO OpenRouter keeps working. The shape check is gated on the override: on the legacy real-Anthropic path an `sk-ant-oat` token is still a valid credential and is forwarded.

## Where

Lands in both lanes plus new vector rows, keeping the #495 cross-language golden-vector gate green:

- `apps/worker/src/agentos_worker/sandbox/docker.py` (the authority)
- `cli/src/commands.rs::select_passthrough_env`
- `tests/vectors/model-credential-forwarding.json` (new `byo_oauth_shaped` input; rows pinning the drop under override, the without-ambient drop, and the without-override keep)

`sk-ant-oat` is a literal mirror of the runner's `OAUTH_TOKEN_PREFIX` (`runner/src/agentos_runner/sdk_auth.py`), which owns the prefix semantics.

## Design note

The issue asked whether the runner's value-routing layer (which already knows the prefix semantics) is the better home for the shape check. It stays in the two selection lanes as directed, because the selection lanes are what the #495 golden-vector gate asserts against and moving the check downstream would leave the gate blind to it. The prefix literal is kept as a documented mirror of the runner constant rather than a re-derivation.

## Assumption

No ADR was authored: this converges onto the already-shipped posture #495 established rather than introducing a new architecture decision; the issue is the record.

## Verify

- Worker: `uv run pytest apps/worker/tests/sandbox` -> 37 passed
- CLI: `cargo test --lib` -> 390 passed (vector loop + new focused tests)
- `cargo fmt --check`, `ruff check`, `mypy` clean on changed files. (One pre-existing `collapsible_if` clippy hit in `cli/src/interactive.rs`, untouched by this diff, is a newer-local-toolchain false positive that CI's pinned toolchain does not raise.)

Closes #603