### PR TITLE
Disable the expired approval card on the worker

### DIFF
--- a/apps/worker/src/agentos_worker/approval_cards.py
+++ b/apps/worker/src/agentos_worker/approval_cards.py
@@ -1,0 +1,93 @@
+"""Remember where an approval's Slack card was posted, so an expiry can disable it.
+
+When the kernel pauses a run for approval (#246, ADR-0010) it posts a Block Kit
+card with live Approve/Reject buttons. On resolution the dispatcher edits that
+card in place from the click's interaction payload. An EXPIRY has no click
+(#419): the #412 sweeper -- or a resolve attempt that arrives past the SLA --
+flips the record to ``expired`` and enqueues a platform-authored resume turn,
+but nothing ever touched the card, so its buttons keep looking live.
+
+This tiny Valkey store bridges what the click payload would otherwise carry: the
+kernel remembers the card's channel/ts/summary keyed by the suspended thread at
+pause time, and pops it when the expiry resume turn arrives to disable the card.
+Keyed by thread because a suspended thread has exactly one pending approval at a
+time; a later approval on the same thread overwrites the entry, and the resume
+turn (resolve OR expiry) pops it either way.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from redis.asyncio import Redis
+
+from .config import WorkerConfig
+
+# The card outlives the turn that posted it by however long the approval SLA runs
+# (hours to days), so its memory must too. A fixed, generous ceiling avoids a new
+# boot-env knob: an entry that outlives this is only ever cleaned up by TTL, and a
+# card whose memory lapsed simply is not auto-disabled (the resolve-click path
+# still heals it on the next interaction).
+DEFAULT_CARD_TTL_S = 14 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class ApprovalCardRef:
+    """Where a posted approval card lives, enough to edit it in place later."""
+
+    channel: str
+    ts: str
+    summary: str
+    endpoint: str | None = None
+
+
+class ApprovalCardStore:
+    """Valkey memory of posted approval cards, keyed by suspended thread."""
+
+    def __init__(
+        self, redis: Redis, config: WorkerConfig, *, ttl_s: int = DEFAULT_CARD_TTL_S
+    ) -> None:
+        self._redis = redis
+        self._config = config
+        self._ttl_s = ttl_s
+
+    async def remember(
+        self,
+        thread: str,
+        *,
+        channel: str,
+        ts: str,
+        summary: str,
+        endpoint: str | None,
+    ) -> None:
+        payload = json.dumps(
+            {"channel": channel, "ts": ts, "summary": summary, "endpoint": endpoint}
+        )
+        await self._redis.set(
+            self._config.approval_card_key(thread), payload, ex=self._ttl_s
+        )
+
+    async def pop(self, thread: str) -> ApprovalCardRef | None:
+        """Return and delete the remembered card for this thread, or None.
+
+        GETDEL so the memory is consumed exactly once: a redelivered resume turn
+        finds nothing and no-ops, and a resolved card (the dispatcher's job) is
+        cleaned up here rather than lingering to the TTL.
+        """
+
+        raw = await self._redis.getdel(self._config.approval_card_key(thread))
+        if not raw:
+            return None
+        try:
+            data = json.loads(raw)
+            return ApprovalCardRef(
+                channel=str(data["channel"]),
+                ts=str(data["ts"]),
+                summary=str(data["summary"]),
+                endpoint=data.get("endpoint"),
+            )
+        except (ValueError, KeyError, TypeError):
+            # A corrupt or shape-drifted entry must not break the resume; treat
+            # it as no remembered card (the click path can still heal the card).
+            return None

--- a/apps/worker/src/agentos_worker/blocks.py
+++ b/apps/worker/src/agentos_worker/blocks.py
@@ -346,3 +346,32 @@ def approval_card(
         },
     ]
     return fallback, blocks
+
+
+def expired_approval_card(*, summary: str) -> tuple[str, list[dict[str, Any]]]:
+    """The approval card rebuilt in its EXPIRED, no-longer-actionable form (#419).
+
+    The same summary the live card showed, with the Approve/Reject actions block
+    dropped and an expiry line in its place -- so the card cannot be clicked and
+    reads as settled. This is the expiry mirror of the dispatcher's resolved-card
+    edit, rebuilt from the remembered summary because the worker does not keep the
+    original card's blocks. Returns ``(fallback_text, blocks)`` for ``chat.update``.
+    """
+
+    clamped = _truncate(to_mrkdwn(summary), _APPROVAL_SUMMARY_MAX)
+    fallback = _truncate(f"Approval expired: {summary}", _SLACK_TEXT_MAX)
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": _truncate("Approval expired", _HEADER_MAX),
+                "emoji": True,
+            },
+        },
+        {"type": "section", "text": {"type": "mrkdwn", "text": clamped}},
+        _context_block(
+            "This request expired and can no longer be approved or rejected."
+        ),
+    ]
+    return fallback, blocks

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -391,6 +391,12 @@ class WorkerConfig(BaseSettings):
     def lock_key(self, thread_key: str) -> str:
         return f"{self.key_prefix}:lock:{thread_key}"
 
+    def approval_card_key(self, thread_key: str) -> str:
+        # Where a suspended thread's posted approval card lives, so an expiry can
+        # disable it (#419). Keyed by thread: one pending approval per suspended
+        # thread at a time.
+        return f"{self.key_prefix}:approval-card:{thread_key}"
+
     def dead_letter_stream_name(self) -> str:
         """The graveyard stream: the explicit override, else derived ``<stream>:dead``.
 

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -73,6 +73,17 @@ logger = logging.getLogger(__name__)
 # (budget-exceeded, model/server errors) escalates rather than looping.
 RETRYABLE_CLASSIFICATIONS = frozenset({"rate-limit", "runner-error"})
 
+# The platform-authored prefix that marks an approval resume turn as an EXPIRY
+# (vs a resolve). Set by ``resumequeue.build_expiry_resume_turn`` on both expiry
+# paths (the #412 sweeper and a past-SLA resolve); ``build_resume_turn`` uses
+# ``[approval resolved]`` instead. This text marker -- not the turn author -- is
+# the expiry discriminator: ``author`` is caller-supplied on a resolve
+# (``resolved_by``), and "system" is the codebase's reserved machine-actor name
+# (e.g. the sweeper's audit rows), so a resolver named "system" would otherwise
+# get its resolved card wrongly stamped expired. The marker is a stable
+# platform contract on a platform-authored turn -- not user-intent guessing.
+_EXPIRY_RESUME_MARKER = "[approval expired]"
+
 
 @dataclass
 class TurnOutcome:
@@ -660,23 +671,25 @@ class Kernel:
 
         The two expiry paths -- the #412 sweeper and a resolve attempt that
         arrives past the SLA -- both flip the record to ``expired`` and enqueue a
-        platform-authored resume turn (author "system"); neither ever touched the
-        card, so its Approve/Reject buttons kept looking live. Here the kernel,
-        which owns the card surface, pops the card it remembered at pause time and
-        edits it into its settled ``expired`` form -- the expiry mirror of the
-        dispatcher's resolved-card edit.
+        platform-authored resume turn prefixed ``[approval expired]``; neither
+        ever touched the card, so its Approve/Reject buttons kept looking live.
+        Here the kernel, which owns the card surface, pops the card it remembered
+        at pause time and edits it into its settled ``expired`` form -- the expiry
+        mirror of the dispatcher's resolved-card edit.
 
-        A RESOLVE resume (author is the resolver) only pops the memory to clean it
-        up; the dispatcher already edited that card from the click. Fully
-        best-effort: any failure here must never fail the resume, and the cheap
-        event-id check gates the Valkey pop so ordinary turns pay nothing.
+        A RESOLVE resume (``[approval resolved]``) only pops the memory to clean
+        it up; the dispatcher already edited that card from the click. The
+        expiry-vs-resolve discriminator is the platform-authored text marker, not
+        the turn author -- see ``_EXPIRY_RESUME_MARKER``. Fully best-effort: any
+        failure here must never fail the resume, and the cheap event-id check
+        gates the Valkey pop so ordinary turns pay nothing.
         """
 
         if self._card_store is None or not self._is_approval_resume(qevent.event_id):
             return
         try:
             ref = await self._card_store.pop(qevent.conversation_id)
-            if ref is None or qevent.author != "system":
+            if ref is None or not qevent.text.startswith(_EXPIRY_RESUME_MARKER):
                 return
             fallback, blocks = expired_approval_card(summary=ref.summary)
             await self._sink.update_message(

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -46,6 +46,7 @@ from aci_protocol import (
 )
 from pydantic import ValidationError
 
+from .approval_cards import ApprovalCardStore
 from .approvals import ApprovalBackendError, ApprovalCreator, ApprovalRequest
 from .behaviorpacks import (
     BehaviorPacks,
@@ -56,7 +57,7 @@ from .behaviorpacks import (
     sample_tip,
 )
 from .binding import GRANT_TOOL_ENV, RESUMED_KIND_ENV, BindingResolver
-from .blocks import approval_card
+from .blocks import approval_card, expired_approval_card
 from .config import WorkerConfig
 from .killswitch import KillSwitch
 from .markers import Markers
@@ -210,6 +211,7 @@ class Kernel:
         binding: BindingResolver | None = None,
         killswitch: KillSwitch | None = None,
         approvals: ApprovalCreator | None = None,
+        card_store: ApprovalCardStore | None = None,
     ) -> None:
         self._substrate = substrate
         self._runner = runner
@@ -226,6 +228,10 @@ class Kernel:
         # deployment without the API), an awaiting-approval run degrades to an
         # escalation instead of suspending a session nothing could ever resume.
         self._approvals = approvals
+        # Remembers where each suspended thread's approval card was posted so an
+        # EXPIRY can disable it (#419); absent (unwired tests) simply skips the
+        # card teardown -- the resolve-click path still heals a card on click.
+        self._card_store = card_store
         # Which threads are running which agent, so a kill interrupts the agent's
         # live turns. Populated while a turn owner streams.
         self._active_by_agent: dict[uuid.UUID, set[str]] = {}
@@ -266,6 +272,13 @@ class Kernel:
             if await self._markers.is_done(event_id):
                 logger.info("event %s already done; skipping", event_id)
                 return
+
+            # If this is the resume turn of an EXPIRED approval, disable its live
+            # approval card before running the continuation (#419). Best-effort and
+            # gated to the platform-authored expiry resume, so it never touches a
+            # resolved card (the dispatcher edits that from the click) or an
+            # ordinary turn.
+            await self._finalize_expired_card(qevent)
 
             # Crash-safety: a prior attempt executed a side effect but never
             # reached done (worker died mid-run). Do not auto-retry the action.
@@ -634,6 +647,55 @@ class Kernel:
             # up generic, without the agent's bundle.
             return await asyncio.to_thread(self._substrate.resume, thread, env=boot_env)
 
+    @staticmethod
+    def _is_approval_resume(event_id: str) -> bool:
+        # The deterministic key the API stamps on every approval resume turn
+        # (``approval-<id>-resolved``; resumequeue.resume_event_id). The suffix is
+        # a frozen historical contract shared by the resolve and expiry paths, so
+        # matching it here does not couple to a mutable string.
+        return event_id.startswith("approval-") and event_id.endswith("-resolved")
+
+    async def _finalize_expired_card(self, qevent: QueuedTurn) -> None:
+        """Disable the approval card when an EXPIRED approval resumes (#419).
+
+        The two expiry paths -- the #412 sweeper and a resolve attempt that
+        arrives past the SLA -- both flip the record to ``expired`` and enqueue a
+        platform-authored resume turn (author "system"); neither ever touched the
+        card, so its Approve/Reject buttons kept looking live. Here the kernel,
+        which owns the card surface, pops the card it remembered at pause time and
+        edits it into its settled ``expired`` form -- the expiry mirror of the
+        dispatcher's resolved-card edit.
+
+        A RESOLVE resume (author is the resolver) only pops the memory to clean it
+        up; the dispatcher already edited that card from the click. Fully
+        best-effort: any failure here must never fail the resume, and the cheap
+        event-id check gates the Valkey pop so ordinary turns pay nothing.
+        """
+
+        if self._card_store is None or not self._is_approval_resume(qevent.event_id):
+            return
+        try:
+            ref = await self._card_store.pop(qevent.conversation_id)
+            if ref is None or qevent.author != "system":
+                return
+            fallback, blocks = expired_approval_card(summary=ref.summary)
+            await self._sink.update_message(
+                channel=ref.channel,
+                ts=ref.ts,
+                text=fallback,
+                blocks=blocks,
+                endpoint=ref.endpoint,
+            )
+            logger.info(
+                "disabled expired approval card for thread %s", qevent.conversation_id
+            )
+        except Exception as exc:  # noqa: BLE001 - card teardown is best-effort
+            logger.warning(
+                "expired approval card teardown failed for thread %s: %s",
+                qevent.conversation_id,
+                exc,
+            )
+
     async def _pause_for_approval(
         self,
         qevent: QueuedTurn,
@@ -759,24 +821,40 @@ class Kernel:
         fallback, card_blocks = approval_card(
             approval_id=created.id, summary=summary, requested_by=qevent.author
         )
+        # In the requesting channel the card joins the thread and rides the
+        # trigger's transport; a route-bound channel has no such thread and is
+        # policy, not a per-turn reply, so it posts top-level over the worker's
+        # default Slack transport.
+        in_requesting_channel = card_channel == qevent.reply_handle.channel
+        card_endpoint = qevent.reply_handle.endpoint if in_requesting_channel else None
         try:
-            await self._sink.post(
+            card_ts = await self._sink.post(
                 channel=card_channel,
                 text=fallback,
                 blocks=card_blocks,
-                # In the requesting channel the card joins the thread and rides
-                # the trigger's transport; a route-bound channel has no such
-                # thread and is policy, not a per-turn reply, so it posts
-                # top-level over the worker's default Slack transport.
-                thread_ts=thread if card_channel == qevent.reply_handle.channel else None,
-                endpoint=(
-                    qevent.reply_handle.endpoint
-                    if card_channel == qevent.reply_handle.channel
-                    else None
-                ),
+                thread_ts=thread if in_requesting_channel else None,
+                endpoint=card_endpoint,
             )
         except Exception as exc:  # noqa: BLE001 - the pause stands without the card
             logger.warning("approval card post failed for %s: %s", created.id, exc)
+        else:
+            # Remember where the card landed so an EXPIRY -- which, unlike a
+            # resolve, carries no click to locate the card -- can disable it
+            # later (#419). Best-effort: a lost memory only means the card is not
+            # auto-disabled, and the resolve-click path still heals it.
+            if card_ts and self._card_store is not None:
+                try:
+                    await self._card_store.remember(
+                        thread,
+                        channel=card_channel,
+                        ts=card_ts,
+                        summary=summary,
+                        endpoint=card_endpoint,
+                    )
+                except Exception as exc:  # noqa: BLE001 - best-effort memory
+                    logger.warning(
+                        "remembering approval card for %s failed: %s", created.id, exc
+                    )
         logger.info(
             "thread %s suspended awaiting approval %s", thread, created.id
         )

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -21,6 +21,7 @@ import redis
 from redis.asyncio import Redis as AsyncRedis
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
+from .approval_cards import ApprovalCardStore
 from .approvals import ApprovalClient
 from .binding import BindingResolver
 from .bundle_store import BundleStore
@@ -190,6 +191,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         approvals=ApprovalClient(
             api_base_url=config.api_base_url, api_key=config.api_key, client=eval_http
         ),
+        card_store=ApprovalCardStore(async_redis, config),
     )
     killswitch = KillSwitch(async_redis, on_kill=kernel.interrupt_agent)
     kernel.attach_killswitch(killswitch)

--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -85,6 +85,23 @@ class SlackSink(Protocol):
         approval card. Raises on failure so the caller decides best-effort."""
         ...
 
+    async def update_message(
+        self,
+        *,
+        channel: str,
+        ts: str,
+        text: str,
+        blocks: list[dict[str, object]],
+        endpoint: str | None = None,
+    ) -> None:
+        """Edit an already-posted platform message's blocks in place (disabling
+        the expired approval card, #419).
+
+        Distinct from ``update`` (which renders reply Markdown through
+        ``render``) and ``post`` (a brand-new message): this replaces a known
+        message's blocks verbatim. Best-effort at the call site."""
+        ...
+
 
 class AsyncSlackSink:
     """A SlackSink backed by the Slack Web API (chat.update).
@@ -236,6 +253,34 @@ class AsyncSlackSink:
         )
         ts = response.get("ts")
         return str(ts) if ts else None
+
+    async def update_message(
+        self,
+        *,
+        channel: str,
+        ts: str,
+        text: str,
+        blocks: list[dict[str, object]],
+        endpoint: str | None = None,
+    ) -> None:
+        # A rejected Block Kit payload falls back to text-only, mirroring
+        # ``post``/``update``: disabling the card is best-effort, but a plain-text
+        # expiry notice still beats leaving live-looking buttons.
+        async def op(client: AsyncWebClient) -> None:
+            try:
+                await client.chat_update(
+                    channel=channel, ts=ts, text=text, blocks=blocks
+                )
+            except SlackApiError:
+                logger.warning(
+                    "card chat_update with blocks rejected for %s; retrying text-only",
+                    ts,
+                )
+                await client.chat_update(channel=channel, ts=ts, text=text)
+
+        await self._with_transport_fallback(
+            endpoint, op, describe="chat_update(card)"
+        )
 
     async def set_status(
         self, *, channel: str, thread_ts: str, status: str, endpoint: str | None = None

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 import pytest
 import redis
 from aci_protocol import Final, OutboundEvent, SessionStatus
+from agentos_worker.approval_cards import ApprovalCardStore
 from agentos_worker.behaviorpacks import NavPack
 from agentos_worker.config import WorkerConfig
 from agentos_worker.kernel import Kernel
@@ -114,6 +115,11 @@ class FakeSink(SlackSink):
         self.posts: list[
             tuple[str, str, list[dict[str, object]] | None, str | None, str | None]
         ] = []
+        # In-place block edits of an already-posted message (the expired approval
+        # card, #419): (channel, ts, text, blocks, endpoint) per update_message.
+        self.card_updates: list[
+            tuple[str, str, str, list[dict[str, object]], str | None]
+        ] = []
 
     async def update(
         self,
@@ -149,6 +155,17 @@ class FakeSink(SlackSink):
     ) -> str | None:
         self.posts.append((channel, text, blocks, thread_ts, endpoint))
         return f"posted-{len(self.posts)}"
+
+    async def update_message(
+        self,
+        *,
+        channel: str,
+        ts: str,
+        text: str,
+        blocks: list[dict[str, object]],
+        endpoint: str | None = None,
+    ) -> None:
+        self.card_updates.append((channel, ts, text, blocks, endpoint))
 
     @property
     def last_text(self) -> str | None:
@@ -334,6 +351,7 @@ class Harness:
     config: WorkerConfig
     async_redis: AsyncRedis
     fake_k8s: FakeK8s
+    card_store: ApprovalCardStore
     killswitch: object | None = None
 
 
@@ -391,6 +409,7 @@ async def kernel_harness(
     )
     sink = FakeSink()
     runner_client = RunnerClient(total_timeout_s=30.0)
+    card_store = ApprovalCardStore(async_redis, config)
     kernel = Kernel(
         substrate=substrate,
         runner=runner_client,
@@ -405,6 +424,7 @@ async def kernel_harness(
         config=config,
         binding=binding,  # type: ignore[arg-type]
         approvals=approvals,  # type: ignore[arg-type]
+        card_store=card_store,
     )
     killswitch = None
     if with_killswitch:
@@ -414,7 +434,15 @@ async def kernel_harness(
         kernel.attach_killswitch(killswitch)
     try:
         yield Harness(
-            substrate, kernel, sink, fake_runner, config, async_redis, fake_k8s, killswitch
+            substrate,
+            kernel,
+            sink,
+            fake_runner,
+            config,
+            async_redis,
+            fake_k8s,
+            card_store,
+            killswitch,
         )
     finally:
         with contextlib.suppress(Exception):

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -540,3 +540,104 @@ def test_card_routed_to_requesting_channel_keeps_the_trigger_endpoint(
             assert endpoint == _CLI_STUB
 
     asyncio.run(go())
+
+
+# --- Expired-approval card teardown (#419) ------------------------------------
+
+
+def _resume_turn(
+    text: str, *, thread: str, approval_id: str, author: str
+) -> QueuedTurn:
+    """The API's approval resume turn: the deterministic ``approval-<id>-resolved``
+    event id both the resolve and expiry paths stamp, replayed into the same
+    placeholder. The expiry path authors it as "system"; a resolve names the
+    resolver."""
+
+    return QueuedTurn(
+        event_id=f"approval-{approval_id}-resolved",
+        conversation_id=thread,
+        author=author,
+        text=text,
+        reply_handle=ReplyHandle(channel="C1", placeholder="p-1", endpoint=None),
+        received_at="2026-07-14T00:00:00+00:00",
+    )
+
+
+def test_expiry_resume_disables_the_approval_card(make_harness) -> None:
+    """#419: an EXPIRED approval's resume turn (author "system", enqueued by the
+    #412 sweeper or a past-SLA resolve attempt) disables the live card in place --
+    buttons gone, an expiry line in their stead -- mirroring the resolved-card
+    edit, since no click will ever arrive to do it."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        thread = "th-expire-card"
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script("Give ACME a 20% discount")
+            await h.kernel.process_event(_qevent("please discount", thread=thread))
+
+            # The live card was posted and its location remembered, because an
+            # expiry (unlike a resolve) carries no click to locate the card.
+            assert len(h.sink.posts) == 1
+            assert await h.async_redis.exists(h.config.approval_card_key(thread))
+            card_ts = "posted-1"  # the FakeSink's returned ts for the first post
+
+            # The expiry resume turn the sweeper enqueues (author "system").
+            h.runner.default_script = [Final(text="Acknowledged the expiry.", status=DONE)]
+            await h.kernel.process_event(
+                _resume_turn(
+                    "[approval expired] not approved in time",
+                    thread=thread,
+                    approval_id="appr-1",
+                    author="system",
+                )
+            )
+
+            # The card was edited in place: same ts, no actions block, an expiry
+            # line where the Approve/Reject buttons were.
+            assert len(h.sink.card_updates) == 1
+            channel, ts, text, blocks, endpoint = h.sink.card_updates[0]
+            assert (channel, ts) == ("C1", card_ts)
+            assert endpoint is None
+            assert all(b.get("type") != "actions" for b in blocks)
+            assert "expired" in text.lower()
+            assert any("expired" in str(b).lower() for b in blocks)
+
+            # The memory was consumed (GETDEL), so a redelivery no-ops.
+            assert not await h.async_redis.exists(h.config.approval_card_key(thread))
+
+            # The continuation still streamed into the placeholder.
+            assert h.sink.last_text == "Acknowledged the expiry."
+
+    asyncio.run(go())
+
+
+def test_resolve_resume_leaves_the_card_to_the_dispatcher(make_harness) -> None:
+    """#419: a RESOLVE resume (author is the resolver) must NOT edit the card --
+    the dispatcher already did from the click -- but it still consumes the
+    remembered card so no stale memory lingers into a later approval."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        thread = "th-resolve-card"
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script("Refund order 42")
+            await h.kernel.process_event(_qevent("refund?", thread=thread))
+            assert await h.async_redis.exists(h.config.approval_card_key(thread))
+
+            h.runner.default_script = [Final(text="Refunded.", status=DONE)]
+            await h.kernel.process_event(
+                _resume_turn(
+                    "[approval resolved] approved by U9",
+                    thread=thread,
+                    approval_id="appr-1",
+                    author="U9",
+                )
+            )
+
+            # No worker-side card edit (the dispatcher owns the resolved card)...
+            assert h.sink.card_updates == []
+            # ...but the memory was cleaned up so a later approval cannot collide.
+            assert not await h.async_redis.exists(h.config.approval_card_key(thread))
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -641,3 +641,38 @@ def test_resolve_resume_leaves_the_card_to_the_dispatcher(make_harness) -> None:
             assert not await h.async_redis.exists(h.config.approval_card_key(thread))
 
     asyncio.run(go())
+
+
+def test_resolve_authored_by_a_system_named_actor_does_not_expire_the_card(
+    make_harness,
+) -> None:
+    """#419 hardening: the expiry-vs-resolve discriminator is the platform text
+    marker, NOT the author. A resolver whose identity is literally "system" (the
+    codebase's reserved machine-actor name) must not get its RESOLVED card wrongly
+    stamped expired -- the ``[approval resolved]`` text keeps it off the expiry
+    path."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        thread = "th-system-resolver"
+        async with make_harness(approvals=approvals) as h:
+            h.runner.default_script = _awaiting_script("Refund order 42")
+            await h.kernel.process_event(_qevent("refund?", thread=thread))
+            assert await h.async_redis.exists(h.config.approval_card_key(thread))
+
+            h.runner.default_script = [Final(text="Refunded.", status=DONE)]
+            await h.kernel.process_event(
+                _resume_turn(
+                    "[approval resolved] approved by system",
+                    thread=thread,
+                    approval_id="appr-1",
+                    author="system",  # a resolver literally named "system"
+                )
+            )
+
+            # Author is "system" but the text says RESOLVED: the card is left to
+            # the dispatcher, never stamped expired by the worker.
+            assert h.sink.card_updates == []
+            assert not await h.async_redis.exists(h.config.approval_card_key(thread))
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -390,3 +390,24 @@ def test_approval_card_clamps_oversized_summary() -> None:
     # Section mrkdwn stays under Slack's 3000-char cap; fallback under 40k.
     assert len(card[1]["text"]["text"]) <= 2900
     assert len(fallback) <= 39000
+
+
+def test_expired_approval_card_drops_buttons_and_marks_expired() -> None:
+    # #419: the expired form keeps the summary but has NO actions block, and
+    # states it can no longer be resolved -- so the card cannot be clicked.
+    from agentos_worker.blocks import expired_approval_card
+
+    fallback, card = expired_approval_card(summary="Give ACME a 20% discount")
+    assert "Give ACME a 20% discount" in fallback
+    assert card[0]["type"] == "header"
+    assert "Give ACME a 20% discount" in card[1]["text"]["text"]
+    assert all(block.get("type") != "actions" for block in card)
+    assert "expired" in str(card[-1]).lower()
+
+
+def test_expired_approval_card_clamps_oversized_summary() -> None:
+    from agentos_worker.blocks import expired_approval_card
+
+    fallback, card = expired_approval_card(summary="x" * 10000)
+    assert len(card[1]["text"]["text"]) <= 2900
+    assert len(fallback) <= 39000


### PR DESCRIPTION
When an approval expires, its Slack Block Kit approval card was never updated: neither expiry path (the #412 sweeper or a past-SLA resolve that returns 410) ever touched the card the way a resolve click does, so its Approve/Reject buttons kept looking live.

The kernel now remembers each posted card's channel/ts/summary in Valkey at pause time (keyed by the suspended thread), since an expiry -- unlike a resolve -- carries no click to locate the card. When the platform-authored expiry resume turn arrives, the kernel pops that memory and edits the card into a settled "expired" form (Approve/Reject gone, an expiry line in their place), mirroring the dispatcher's resolved-card edit. Both expiry paths enqueue that same resume turn, so one worker-side hook covers the sweeper and the 410-click alike; the worker owns the card surface.

Expiry vs resolve is discriminated by the platform-authored `[approval expired]` text marker (not the turn author), so a resolver whose identity happens to be the reserved "system" name can never get its resolved card wrongly stamped expired.

Best-effort throughout: a lost card memory only means the card is not auto-disabled, and the resolve-click path still heals it on click. No API or frozen-contract change.

Adds `ApprovalCardStore` (Valkey), `SlackSink.update_message` (an in-place block edit distinct from the placeholder-render update and a new post), and `blocks.expired_approval_card`. Unit tests cover the expiry-update path, the resolve guard, and the "system"-named-resolver regression.

Closes #419