### PR TITLE
Add a cold-start parity ladder as agentos dev e2e-ladder

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,3 +369,101 @@ jobs:
         env:
           AGENTOS_BIN: cli/target/release/agentos
         run: bash cli/scripts/eval-falsifiability.sh
+
+  # COLD-START PARITY LADDER (issue #690), skill + local rungs only. A
+  # meta-analysis of all 41 bug issues filed against this repo found roughly
+  # 18 were caught ONLY by a manual cold-start dogfood run and never surfaced
+  # by unit tests, review, or existing CI -- whole classes of bug had no
+  # lower-tier signal at all: compose env wiring (#545), profile asymmetry
+  # (#233, #342), deploy-then-message reachability (#352, #359), and
+  # fake/live model defaults (#343). The ladder drives the real `agentos`
+  # verbs end to end (rung 1: the skill-tier `e2e.sh`; rung 2: `local
+  # up --minimal` -> `local deploy` -> `local message` with the reply
+  # asserted -> `local down`) against a real runner container, sealed with
+  # the fake model, so this class of bug fails CI instead of surviving to
+  # the next manual dogfood pass.
+  #
+  # The cluster rung is NOT run here and is NOT covered by this job. It needs
+  # a real cluster, a Helm install, the runner prewarm DaemonSet, and a
+  # host-reachable reply stub -- none of which exist in this workflow today.
+  # It is verified by hand against k8scratch; the PR body carries the
+  # follow-up issue that tracks wiring it into CI on a kind cluster. Do not
+  # read this job as full-ladder coverage.
+  #
+  # Rung 2 brings up the `core` compose profile for real, unlike the Python
+  # job above (which never starts agentos-api/worker to dodge private-registry
+  # pulls). `agentos-api` and `agentos-migrate` pull
+  # `ghcr.io/curie-eng/agentos-api:latest`, a private GHCR image this workflow
+  # has no credentials for, so it is built locally first and tagged to match
+  # -- compose only pulls a tag that is absent from the local image store, so
+  # a matching local tag satisfies both services with no registry auth.
+  # `agentos-worker` builds from source at `up` time via
+  # compose/worker-local.Dockerfile, but that Dockerfile's own FROM is
+  # `ghcr.io/curie-eng/agentos-worker:${BASE_TAG}` (default `latest`), another
+  # private pull one layer down that the compose file has no build-arg wired
+  # to override. The same local-tag trick applies: build the worker base image
+  # from source and tag it `ghcr.io/curie-eng/agentos-worker:latest` so the
+  # overlay's FROM resolves locally too. Both are the same pattern the
+  # `worker-local-image` job above already uses for its own base build, and
+  # both builds are throwaway (this runner's Docker daemon is discarded at job
+  # end; nothing here is ever pushed).
+  #
+  # Rung 2's worker spawns sibling runner containers through the mounted
+  # Docker socket (network_mode: host, AGENTOS_SANDBOX_SUBSTRATE=docker); the
+  # runner image it spawns must already exist on the host daemon, which it
+  # does once the `agentos-runner` build below completes. GitHub-hosted
+  # runners support Docker-in-Docker this way, but this is confirmed by the
+  # first green live run of this job in CI, not asserted from first
+  # principles -- if that first run does not go green, treat the
+  # docker-socket path as unverified rather than assuming the theory above is
+  # right.
+  #
+  # A third private-image seam, easy to miss because it is not a compose
+  # `image:` pull: compose.dev.yaml sets AGENTOS_RUNNER_IMAGE=
+  # ghcr.io/curie-eng/agentos-runner:latest on the worker service, and
+  # apps/worker/src/agentos_worker/run.py reads that env var (falling back to
+  # bare `agentos-runner` only when it is unset) to name the image it spawns
+  # per message. Rung 1 (skill) and the CLI's own dev-build default both use
+  # the bare `agentos-runner` tag the build step below produces, but rung 2's
+  # worker asks for the ghcr.io-qualified tag instead. Retag the same local
+  # build under both names rather than building twice, so one rung's image
+  # choice cannot silently break the other.
+  #
+  # Reuses the release binary the Rust job already built and uploaded. The
+  # local rung needs a working Docker daemon for `docker compose`;
+  # ubuntu-latest ships one, the same assumption the `compose` job above
+  # already relies on. `AGENTOS_E2E_TIERS` and `AGENTOS_E2E_LIVE` are left
+  # unset, so the script's own defaults apply: skill + local rungs, fake
+  # model, credential-free. Expect this to be the slowest job in the
+  # workflow -- three image builds (runner, api, worker base) plus one more
+  # (the worker-local overlay) that compose triggers itself, on top of the
+  # actual up/deploy/message/down round trip; `local up --wait` alone can run
+  # up to compose's 300s default wait timeout if a service is slow to report
+  # healthy.
+  e2e-ladder:
+    name: E2E parity ladder (skill + local, fake model)
+    runs-on: ubuntu-latest
+    needs: rust
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Download the agentos binary built by the Rust job
+        uses: actions/download-artifact@v7
+        with:
+          name: agentos-x86_64-linux-${{ github.sha }}
+          path: cli/target/release
+      - name: Make the binary executable
+        run: chmod +x cli/target/release/agentos
+      - name: Build the runner image locally
+        run: docker build -t agentos-runner -f runner/Dockerfile .
+      - name: Retag the runner image for the compose worker (AGENTOS_RUNNER_IMAGE, no registry auth)
+        run: docker tag agentos-runner ghcr.io/curie-eng/agentos-runner:latest
+      - name: Build the api image locally (satisfies agentos-api + agentos-migrate, no registry auth)
+        run: docker build -t ghcr.io/curie-eng/agentos-api:latest -f apps/api/Dockerfile .
+      - name: Build the worker base image locally (satisfies the worker-local overlay's FROM, no registry auth)
+        run: docker build -t ghcr.io/curie-eng/agentos-worker:latest -f apps/worker/Dockerfile .
+      - name: Parity ladder (skill + local rungs, fake model, credential-free)
+        env:
+          AGENTOS_BIN: cli/target/release/agentos
+        run: bash cli/scripts/e2e-ladder.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,15 @@ and commit the regenerated files; CI runs the same check (`scripts/check-docs.sh
 Test discipline: test-first for behavior-bearing code; mock ONLY external
 services (Slack, Anthropic, GitHub); NEVER mock Postgres/Valkey/Langfuse -- run
 integration tests against the dev stack below. A change that only makes tests
-pass by weakening assertions is a regression.
+pass by weakening assertions is a regression. At parity seams, include at least
+one negative or secondary-path test per AC (see the parity-seam registry).
+Assertions about an external API or SDK's shape or auth must be grounded in
+provider docs or observed behavior, cited in a test comment, never in the
+implementation's own assumption. Any read-modify-write on a versioned row needs a
+stale-version conflict test (match the CAS pattern in
+`apps/api/src/agentos_api/routers/state.py`). Every stream consumer lane derives
+bounded delivery + dead-letter from the shared transport; a lane without a
+delivery cap is a bug.
 
 ## The dev stack: compose.dev.yaml
 
@@ -166,6 +174,42 @@ its own reviewed, backward-compatible change first, before dependent lanes
 proceed. This also applies whenever an adopted component (Langfuse, Agent
 Sandbox, Bolt) cannot do what a spec claims: stop and raise it with the evidence
 rather than silently diverging.
+
+## Parity seams: cover the sibling or file it
+
+Sibling-path drift is the dominant historical bug class here: logic or hardening
+lands on one side of a structural seam while its twin keeps the old behavior.
+Known seam pairs:
+
+- worker vs CLI credential forwarding -- `_SDK_PASSTHROUGH_ENV`
+  (`apps/worker/src/agentos_worker/sandbox/docker.py`) and the CLI picker
+  (`cli/src/commands.rs`) can't share code across Python/Rust, so they are frozen
+  together in `tests/vectors/model-credential-forwarding.json`.
+- real SDK vs fake model session in the runner (`FakeModelSession`, `runner/src/agentos_runner/fake.py`).
+- runs lane vs eval lane stream consumers (`apps/worker/src/agentos_worker/consumer.py` vs `eval/stream.py`, both on the shared `stream_consumer.py`).
+- CLI-side vs API-side input validation (validate at the API/persistence boundary, mirror in the CLI).
+- `local up` vs `local down` compose profile sets.
+- `compose.dev.yaml` vs the generated release compose.
+- `core` vs `full` compose profiles.
+- `local` vs `cluster` verb pairs (reachability defaults, outcome enums).
+- CLI `--json` DTOs vs the API models they mirror.
+- deploy-time validators vs the runtime loaders that re-parse the same value (share normalization code).
+
+A PR touching one side of a seam must route the behavior through a shared helper
+both sides call, change both sides in the same PR, or name the sibling in the PR
+body with a follow-up issue number. Prefer parity by construction over remembered
+duplication. Ship a test that arms the behavior via the secondary path only
+(bundle-manifest-only gate, fake-tier-only, minimal-profile-only) and asserts it
+matches the primary path.
+
+## Guards are outcome-tested
+
+A new or modified gate, validator, denylist, or preflight lands only with a
+demonstration that it rejects a violating input by execution, not by reading the
+code. Its regression test asserts the outcome through the real consumer path (the
+filter the user hits, the loader that re-parses the value), never an internal
+struct field. No doc or comment may claim a protection that no code realizes -- a
+claimed-but-absent guard is worse than none.
 
 ## E2E verification is mandatory
 
@@ -254,6 +298,10 @@ Two different tools; do not conflate them.
   before touching that area. An ADR is not just what we chose; it **must record what
   we decided against and why** (the alternatives and their rejection). If no real
   alternative is being closed off, it is not an ADR.
+- An ADR or plan whose rationale claims observability, convergence, protection, or
+  parity must name the code path that realizes the claim in the same change, or
+  name the tracked follow-up issue that will. A rationale that says "this becomes
+  observable" without a consumer or alert is an unmet claim and blocks acceptance.
 - Write a **GitHub issue** (with a rich description) for a **feature**, however
   large. A new CLI command, a UI surface, a connector: it may be a lot of code, but
   it is deletable and does not change the architecture, so it is a feature, not an

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2884,6 +2884,11 @@ export const commandManifest = {
           "name": "e2e"
         },
         {
+          "about": "Run the cold-start parity ladder across the skill, local, and cluster tiers, fake model by default (#690, `bash cli/scripts/e2e-ladder.sh`)",
+          "hidden": false,
+          "name": "e2e-ladder"
+        },
+        {
           "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
           "hidden": false,
           "name": "docs-lint"

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -165,10 +165,24 @@ exercises the deploy leg:
 ```bash
 AGENTOS_E2E_NETWORK=agentos_default \
 AGENTOS_E2E_OTEL=http://otel-collector:4318 \
-AGENTOS_E2E_API_URL=http://localhost:8000 bash cli/scripts/e2e.sh
+AGENTOS_E2E_API_URL=http://localhost:28000 bash cli/scripts/e2e.sh
 ```
 Both require the `agentos-runner` image built once from the repo root
 (`docker build -f runner/Dockerfile -t agentos-runner .`).
+
+Cold-start parity ladder (issue #690, `agentos dev e2e-ladder` ->
+`cli/scripts/e2e-ladder.sh`) -- an E2E test, same as the scripted E2E above, not
+the falsifiability gate below it. It chains three rungs: rung 1 delegates to
+`e2e.sh` unchanged; rung 2 drives `local up --minimal` -> `local deploy` ->
+`local message` (reply asserted) -> `local down`; rung 3 drives `cluster
+deploy` -> `cluster message` against a pre-installed release, a real round
+trip with no manual port-forward. `AGENTOS_E2E_TIERS` (default `skill,local`,
+or `all` for `skill,local,cluster`) selects rungs; `AGENTOS_E2E_LIVE` (default
+fake, `1` for live) governs the local and cluster rungs only, since the skill
+rung stays fake. One-command pre-release gate:
+```bash
+AGENTOS_E2E_TIERS=all agentos dev e2e-ladder
+```
 
 Falsifiability gate (issue #619) -- a gate, NOT an E2E test: it never runs a real
 agent or makes a model call. Its real-path half boots the FAKE model and asserts

--- a/cli/README.md
+++ b/cli/README.md
@@ -203,6 +203,7 @@ they error clearly -- a release binary has no dev scripts.
 | `agentos dev contracts` | `bash scripts/check-contracts.sh` -- check the frozen contracts. |
 | `agentos dev chart-check` | `bash charts/agentos/ci/render-assertions.sh` -- render-assert the Helm chart. |
 | `agentos dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
+| `agentos dev e2e-ladder` | `bash cli/scripts/e2e-ladder.sh` -- the cold-start parity ladder (skill, local, cluster rungs). |
 
 ## `skill` target: runner-only, fully offline
 
@@ -543,8 +544,30 @@ bash cli/scripts/e2e.sh
 # with the compose stack + a local API:
 AGENTOS_E2E_NETWORK=agentos_default \
 AGENTOS_E2E_OTEL=http://otel-collector:4318 \
-AGENTOS_E2E_API_URL=http://localhost:8000 bash cli/scripts/e2e.sh
+AGENTOS_E2E_API_URL=http://localhost:28000 bash cli/scripts/e2e.sh
 ```
 
 Requires an `agentos-runner` image (`docker build -f runner/Dockerfile -t
 agentos-runner .` from the repo root).
+
+The cold-start parity ladder (`agentos dev e2e-ladder`, `cli/scripts/e2e-ladder.sh`)
+runs the same skill-tier script as rung 1, then adds a local rung (`local up
+--minimal` -> `local deploy` -> `local message` with the reply asserted ->
+`local down`) and a cluster rung (`cluster deploy` then `cluster message`, a
+real round trip with no manual port-forward) against a pre-installed release.
+Two env knobs configure it:
+
+- `AGENTOS_E2E_TIERS` -- which rungs to run. Defaults to `skill,local`
+  (credential-free, CI-safe); `all` runs `skill,local,cluster`. A tier named
+  explicitly is required, and its absence fails the run; a tier not named is
+  skipped.
+- `AGENTOS_E2E_LIVE` -- unset or `0` runs the fake model (credential-free, the
+  default); `1` runs the live-credential variant for pre-release manual passes
+  and fails fast if no model credential is present. It governs the local and
+  cluster rungs only; the skill rung stays fake.
+
+The one-command pre-release gate:
+
+```bash
+AGENTOS_E2E_TIERS=all agentos dev e2e-ladder
+```

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2881,6 +2881,11 @@
           "name": "e2e"
         },
         {
+          "about": "Run the cold-start parity ladder across the skill, local, and cluster tiers, fake model by default (#690, `bash cli/scripts/e2e-ladder.sh`)",
+          "hidden": false,
+          "name": "e2e-ladder"
+        },
+        {
           "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
           "hidden": false,
           "name": "docs-lint"

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -1,0 +1,438 @@
+#!/bin/bash
+# Cold-start parity ladder for the agentos CLI (issue #690).
+#
+# This is an E2E test, not a gate: it drives the SAME bundle through each
+# deployment tier with the tier's own real verbs and asserts a turn actually
+# finalized. Rung 1 (skill) is the existing `cli/scripts/e2e.sh`, invoked as is
+# so the skill leg has exactly one implementation. Rung 2 (local) is
+# `local up --minimal` -> `local deploy` -> `local message` -> `local down`.
+# Rung 3 (cluster) is `cluster deploy` -> `cluster message` against a release
+# that is ALREADY installed; the ladder never installs or uninstalls one.
+#
+# What it is NOT: it is not a compose test and not a helm test. Every step goes
+# through an `agentos` verb, because the point is to catch a tier whose verb
+# drifted from its sibling. The one raw-docker use is the post-teardown
+# assertion that nothing agentos-related survived.
+#
+# Blast radius of the teardown sweep: sandbox containers are matched by the
+# substrate label, which is host-wide and not per-worktree, so the sweep only
+# runs when THIS ladder brought the compose stack up. A stack it merely reused
+# belongs to another session, and so do that session's sandboxes.
+#
+# Fake model by default, so a default run is credential-free even on a box that
+# HAS credentials. Under AGENTOS_E2E_LIVE=1 the ladder runs the real model and
+# requires a credential up front. Under fake it asserts PLUMBING only -- that a
+# turn finalized and a reply came back -- never reply CONTENT (ADR-0055, #612):
+# an assertion tuned to the fake's canned reply manufactures a green.
+#
+# Requirements: docker, a cargo toolchain (or $AGENTOS_BIN), and an
+# agentos-runner image (`agentos build`). Rung 3 additionally needs a reachable
+# cluster with a release installed. Run from anywhere:
+#
+#   bash cli/scripts/e2e-ladder.sh
+#
+# Env knobs:
+#   AGENTOS_E2E_TIERS        comma list of rungs (default skill,local; `all` =
+#                            skill,local,cluster). A NAMED tier is REQUIRED: if
+#                            cluster is named and no release responds, exit 1.
+#   AGENTOS_E2E_LIVE         1 = real model on rungs 2 and 3 (rung 1 stays fake)
+#   AGENTOS_BIN              path to a prebuilt agentos binary (skip cargo build)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TIERS="${AGENTOS_E2E_TIERS:-skill,local}"
+LIVE="${AGENTOS_E2E_LIVE:-0}"
+# Fixed, not an env knob: the ladder asserts PLUMBING, so the bundle it ships is
+# a fixed input of the test rather than something a caller varies.
+BUNDLE_SRC="$REPO_ROOT/examples/weather"
+# Hardcoded, and deliberately NOT an env knob: the stub port is the constant
+# DEFAULT_LOCAL_STUB_PORT in cli/src/message.rs, pinned to the compose worker's
+# SLACK_API_BASE_URL. An override would only move this script's precheck, so it
+# could green-light an occupied 8155 and then hang on the message timeout.
+STUB_PORT=8155
+PROMPT="What is the weather in Denver right now?"
+# The fake model's only reply (runner/src/agentos_runner/fake.py). It is used
+# ONLY as a live-mode negative control -- "the reply must not be this" -- never
+# as a pass condition. Matching it to green is the #612 bypass.
+FAKE_SENTINEL="all done"
+
+# Set once the ladder itself brought the compose stack up. The thread that
+# brought a stack up owns tearing it down, so a stack that was already running
+# when the ladder started is reused and left alone.
+LOCAL_STACK_OWNED=0
+
+# The label the sandbox substrate stamps on every runner container it spawns
+# (cli/src/docker.rs SANDBOX_LABEL, apps/worker sandbox/types.py). Container
+# NAMES are per-thread (agentos-thread-<digest>-<nonce>), so a name filter
+# matches nothing; the label is the only handle that actually selects them.
+SANDBOX_LABEL="agentos.dev/managed-by=agentos-sandbox-substrate"
+
+echo "=== Resolve the agentos binary ==="
+if [[ -n "${AGENTOS_BIN:-}" && -x "${AGENTOS_BIN:-}" ]]; then
+    # Absolutize: the ladder invokes the binary from other directories, so a
+    # relative $AGENTOS_BIN (as CI passes) must be pinned here or it stops
+    # resolving later.
+    BIN="$(cd "$(dirname "$AGENTOS_BIN")" && pwd)/$(basename "$AGENTOS_BIN")"
+    echo "using prebuilt binary: $BIN"
+else
+    (cd "$REPO_ROOT/cli" && cargo build --release --quiet)
+    BIN="$REPO_ROOT/cli/target/release/agentos"
+fi
+"$BIN" --version
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+    # Capture the real exit code FIRST: a teardown command that fails must not
+    # turn a red run green, and a successful teardown must not mask a red rung.
+    local code=$?
+    set +e
+    # The compose worker spawns runner containers as SIBLINGS on the host daemon
+    # via the mounted docker socket, so a rung that died before `local down` can
+    # strand them. This raw sweep is a BACKSTOP, not duplication: `local down`
+    # already reaps this same label itself (docker::reap_labeled in
+    # cli/src/local.rs, #613) and bails loudly if the reap is incomplete, so on
+    # any normal path there is nothing here to find. It exists only for the case
+    # where `local down` never ran or failed, which is exactly the case that
+    # strands containers. Sweep ONLY when this ladder owned the stack: the label is
+    # host-wide, and force-removing another session's sandboxes would break a
+    # run this one has no business touching.
+    if (( LOCAL_STACK_OWNED )); then
+        echo
+        echo "=== teardown: agentos local down ==="
+        # Tolerated failure, on top of `set +e`: the stack may never have
+        # finished coming up, and a failed `local down` must not skip the
+        # sandbox sweep below or change the exit code captured above.
+        "$BIN" local down || echo "warning: \`local down\` failed during teardown; sweeping anyway." >&2
+        local orphans
+        orphans="$(docker ps -aq --filter "label=$SANDBOX_LABEL" 2>/dev/null)"
+        if [[ -n "$orphans" ]]; then
+            echo "sweeping orphaned sandbox containers"
+            # shellcheck disable=SC2086
+            docker rm -f $orphans >/dev/null 2>&1
+        fi
+    fi
+    rm -rf "$WORKDIR"
+    exit "$code"
+}
+trap cleanup EXIT
+# Without these, a Ctrl-C or a kill can end the shell without running the EXIT
+# trap, stranding a running stack on a box that cannot afford one.
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# The ONE place the fake/live asymmetry is stated. There is no shared
+# fake-model control across tiers: skill takes a `--fake-model` flag, local
+# reads AGENTOS_FAKE_MODEL, and cluster bakes it into the install. Keeping the
+# translation here means the seam is written down once.
+apply_model_mode() {
+    if [[ "$LIVE" == "1" ]]; then
+        if [[ -z "${ANTHROPIC_API_KEY:-}" && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" && -z "${AGENTOS_CREDENTIALS:-}" ]]; then
+            echo "error: AGENTOS_E2E_LIVE=1 needs a model credential in the environment, and none is set." >&2
+            echo "fix: export ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or AGENTOS_CREDENTIALS, or drop AGENTOS_E2E_LIVE to run sealed against the fake model." >&2
+            exit 1
+        fi
+        # Live means live: an inherited AGENTOS_FAKE_MODEL=1 would silently seal
+        # a run the operator asked to be real.
+        unset AGENTOS_FAKE_MODEL
+        echo "model mode: LIVE (real model on the local and cluster rungs)"
+    else
+        # Exported, not merely defaulted: a developer shell that happens to carry
+        # ANTHROPIC_API_KEY must still get the sealed run. That is what
+        # credential-free-by-default means.
+        export AGENTOS_FAKE_MODEL=1
+        echo "model mode: FAKE (sealed; AGENTOS_FAKE_MODEL=1 exported for the local rung)"
+    fi
+    echo "note: the skill rung is fake either way -- cli/scripts/e2e.sh hardcodes --fake-model."
+    echo "note: the cluster rung's model is a property of the installed release (cluster up --fake-model), not of this run."
+}
+
+# Accept ONLY the `reply` shape with finalized == true and a non-empty reply.
+# The other three shapes in cli/schema/message.schema.json get distinct
+# messages, because awaiting-approval and timed-out have different causes and a
+# merged message wastes debugging time.
+assert_finalized_reply() {
+    local label="$1" payload="$2" verdict reply
+    # stdout only: --json puts the payload on stdout and human text on stderr,
+    # so a combined-stream parse fails intermittently and reads like a product bug.
+    verdict="$(printf '%s' "$payload" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+except Exception:
+    print("unparseable")
+    sys.exit(0)
+if not isinstance(d, dict):
+    print("unparseable")
+elif d.get("dry_run"):
+    print("dry_run")
+elif d.get("awaiting_approval"):
+    print("awaiting_approval")
+elif d.get("timed_out"):
+    print("timed_out")
+elif d.get("finalized") is True and isinstance(d.get("reply"), str):
+    # An empty reply is a distinct failure, not a parse failure: the turn
+    # finalized but nothing came back, which is exactly the plumbing break
+    # this assertion exists to catch.
+    print("ok" if d["reply"].strip() else "empty_reply")
+    print(d["reply"])
+else:
+    print("not_finalized")
+' || echo "unparseable")"
+    # Split the two-line protocol on the FIRST newline: line one is the verdict,
+    # everything after it is the reply. `reply` first, because the second
+    # expansion overwrites the string both read.
+    reply="${verdict#*$'\n'}"
+    verdict="${verdict%%$'\n'*}"
+
+    case "$verdict" in
+        ok) ;;
+        empty_reply)
+            echo "$label: the turn finalized but the reply was empty, so no output made it back through the plumbing." >&2
+            return 1 ;;
+        awaiting_approval)
+            echo "$label: the turn parked on an approval gate instead of finalizing; the ladder's bundle must not require approval." >&2
+            return 1 ;;
+        timed_out)
+            echo "$label: no reply finalized before the deadline. The worker never completed the turn." >&2
+            return 1 ;;
+        dry_run)
+            echo "$label: got a dry-run descriptor; the ladder must run for real, never with --dry-run." >&2
+            return 1 ;;
+        not_finalized)
+            echo "$label: the payload is neither finalized nor a known terminal shape." >&2
+            printf '%s\n' "$payload" >&2
+            return 1 ;;
+        *)
+            echo "$label: could not parse message --json output:" >&2
+            printf '%s\n' "$payload" >&2
+            return 1 ;;
+    esac
+
+    echo "$label: turn finalized with a reply (plumbing asserted, content deliberately not graded)"
+    if [[ "$LIVE" == "1" ]]; then
+        # Live-only negative control, not a grader: the fake model cannot say
+        # anything but the sentinel, so a live run that returns it never reached
+        # a real model.
+        if [[ "$reply" == "$FAKE_SENTINEL" ]]; then
+            echo "$label: live run returned the fake model's canned reply, so the run was not live." >&2
+            return 1
+        fi
+        echo "$label: reply is not the fake sentinel (live negative control)"
+    fi
+}
+
+# The local reply stub binds a fixed port. A second ladder, or any process
+# holding it, would otherwise hang until the 300s message timeout and look like
+# a product failure.
+assert_stub_port_free() {
+    if (exec 3<>"/dev/tcp/127.0.0.1/$STUB_PORT") 2>/dev/null; then
+        echo "error: port $STUB_PORT is already in use, and the local reply stub must bind it." >&2
+        echo "fix: stop the process holding it (another ladder run, or a stale local message), then re-run." >&2
+        return 1
+    fi
+}
+
+# Rung 1: the existing skill-tier round trip, invoked as is. Never copied.
+rung_skill() {
+    echo
+    echo "########## rung 1/3: skill ##########"
+    bash "$REPO_ROOT/cli/scripts/e2e.sh"
+}
+
+# Rung 2: the compose tier, cold start to teardown.
+rung_local() {
+    echo
+    echo "########## rung 2/3: local (compose) ##########"
+
+    assert_stub_port_free
+
+    if [[ -n "$(docker ps -q --filter 'name=agentos-api' 2>/dev/null)" ]]; then
+        # Reuse it and do NOT tear it down: the thread that brought a stack up
+        # owns tearing it down, in both directions.
+        echo "a compose stack is already running; reusing it and leaving teardown to whoever started it"
+        if [[ "$LIVE" == "1" ]]; then
+            # Model mode is fixed at `local up` time, so a reused stack may have
+            # been started sealed. Warn rather than refuse: the live-only fake
+            # sentinel control below catches it for real.
+            echo "warning: AGENTOS_E2E_LIVE=1, but the reused stack's model mode was fixed by whoever ran \`local up\` and is NOT verified here." >&2
+            echo "warning: if that stack was started with the fake model, this 'live' rung runs sealed; \`local down\` then re-run to be sure." >&2
+        fi
+    else
+        echo
+        echo "=== agentos local up --minimal ==="
+        # --minimal selects the core profile and blanks the OTel endpoint itself
+        # (core has no collector), so the ladder passes no profiles and no OTel env.
+        #
+        # Claim ownership BEFORE starting, never after: `local up` blocks for
+        # seconds while it waits for health, and containers exist for that whole
+        # window. Setting the flag afterwards means a signal or a mid-boot
+        # failure leaves the trap disowning a stack this run created, stranding
+        # it. Claiming a stack that then fails to boot is harmless, because
+        # `local down` is safe against a partial or already-stopped stack.
+        LOCAL_STACK_OWNED=1
+        "$BIN" local up --minimal
+    fi
+
+    echo
+    echo "=== agentos local deploy ==="
+    # No --api-url: the default IS the cold-start path a real user hits, and
+    # exercising the default is the point. First create binds C0LOCALDEV, so the
+    # message below can resolve the sole deployed agent with no --channel.
+    "$BIN" local deploy --plugin-dir "$WORKDIR/bundle"
+
+    echo
+    echo "=== agentos local message --json ==="
+    # Re-probe: the precheck above ran before `local up` and `local deploy`,
+    # potentially minutes ago, and the stub binds the port only now.
+    assert_stub_port_free
+    local out
+    # `|| true`: the timeout shape exits non-zero, and the assertion helper is
+    # what must classify it, not set -e.
+    out="$("$BIN" --json local message "$PROMPT" || true)"
+    printf '%s\n' "$out"
+    assert_finalized_reply "local" "$out"
+
+    if (( LOCAL_STACK_OWNED )); then
+        echo
+        echo "=== agentos local down ==="
+        "$BIN" local down
+        LOCAL_STACK_OWNED=0
+
+        echo
+        echo "=== assert nothing agentos-related survived ==="
+        # Both checks filter by LABEL, never by name. `--filter name=agentos` is
+        # a host-wide SUBSTRING match, so on a shared box it reds on containers
+        # belonging to other worktrees and sessions (an unrelated
+        # `agentos-runner-local` from a concurrent `skill up` is enough), and a
+        # gate that cries wolf is a gate someone disables. A run may only assert
+        # on what it owns.
+        local survivors
+        # The compose project name is pinned to `agentos` by the CLI
+        # (cli/src/local.rs COMPOSE_PROJECT_NAME), so this selects exactly the
+        # services `local up` started and nothing else.
+        survivors="$(docker ps --filter 'label=com.docker.compose.project=agentos' --format '{{.Names}}')"
+        if [[ -n "$survivors" ]]; then
+            echo "local down left compose services running:" >&2
+            printf '%s\n' "$survivors" >&2
+            return 1
+        fi
+        # Sandbox containers are named per thread, so a `name=agentos-runner`
+        # filter matches nothing and the assertion would pass no matter what
+        # survived.
+        survivors="$(docker ps --filter "label=$SANDBOX_LABEL" --format '{{.Names}}')"
+        if [[ -n "$survivors" ]]; then
+            echo "sibling sandbox containers survived teardown:" >&2
+            printf '%s\n' "$survivors" >&2
+            return 1
+        fi
+        echo "no agentos containers running"
+    fi
+}
+
+# Rung 3: the deployed release. Requires one to already exist; it is never
+# installed or torn down here, because the cluster is shared.
+rung_cluster() {
+    echo
+    echo "########## rung 3/3: cluster ##########"
+
+    echo
+    echo "=== agentos cluster status (gate) ==="
+    # Gate on the PAYLOAD, not the exit code: `cluster status` is a read-only
+    # report verb and exits 0 even when the release is absent (it just prints
+    # "release agentos not found"), so an exit-code gate never fires and the
+    # rung falls through into a confusing `cluster deploy` failure instead.
+    # --json puts the object on stdout and human text on stderr.
+    local status_json found
+    status_json="$("$BIN" --json cluster status 2>/dev/null || true)"
+    printf '%s\n' "$status_json"
+    found="$(printf '%s' "$status_json" | python3 -c '
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    print("no")
+    sys.exit(0)
+print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
+' || echo "no")"
+    if [[ "$found" != "yes" ]]; then
+        echo "error: AGENTOS_E2E_TIERS named the cluster rung, but no installed release was reported by \`agentos --json cluster status\`." >&2
+        echo "fix: install a release with \`agentos cluster up --fake-model\` (or point kubectl at the right context), or drop cluster from AGENTOS_E2E_TIERS." >&2
+        return 1
+    fi
+
+    echo
+    echo "=== agentos cluster deploy ==="
+    # No --api-url: deploy auto-discovers the release's UI /api proxy over
+    # NodePort. No --secret: it is declined at this tier by design (#440).
+    "$BIN" cluster deploy --plugin-dir "$WORKDIR/bundle"
+
+    echo
+    echo "=== agentos cluster message --json ==="
+    # No --thread: an existing thread keeps the sandbox and bundle it first
+    # booted with, so reusing one could silently test a stale bundle. cluster
+    # message manages its own port-forwards and reply stub; never forward by hand.
+    local out
+    out="$("$BIN" --json cluster message "$PROMPT" || true)"
+    printf '%s\n' "$out"
+    assert_finalized_reply "cluster" "$out"
+}
+
+echo
+echo "=== ladder configuration ==="
+echo "tiers: $TIERS"
+apply_model_mode
+
+if [[ "$TIERS" == "all" ]]; then
+    TIERS="skill,local,cluster"
+fi
+RUN_SKILL=0
+RUN_LOCAL=0
+RUN_CLUSTER=0
+IFS=',' read -r -a SELECTED <<< "$TIERS"
+for tier in "${SELECTED[@]}"; do
+    case "$tier" in
+        skill) RUN_SKILL=1 ;;
+        local) RUN_LOCAL=1 ;;
+        cluster) RUN_CLUSTER=1 ;;
+        "") ;;
+        *)
+            echo "error: unknown tier '$tier' in AGENTOS_E2E_TIERS." >&2
+            echo "fix: use a comma list of skill, local, cluster, or the shorthand 'all'." >&2
+            exit 1 ;;
+    esac
+done
+if (( ! RUN_SKILL && ! RUN_LOCAL && ! RUN_CLUSTER )); then
+    echo "error: AGENTOS_E2E_TIERS selected no rungs." >&2
+    echo "fix: set it to a comma list of skill, local, cluster, or 'all'." >&2
+    exit 1
+fi
+
+# A throwaway COPY of the bundle: deploy records state into the bundle dir, and
+# that must never land in the tree.
+cp -r "$BUNDLE_SRC" "$WORKDIR/bundle"
+
+# Rungs run strictly in order and never in parallel: they share host ports, and
+# rung 1 must release its runner container before rung 2 starts.
+if (( RUN_SKILL )); then
+    rung_skill
+else
+    echo
+    echo "SKIPPING rung 1 (skill): not named in AGENTOS_E2E_TIERS."
+fi
+if (( RUN_LOCAL )); then
+    rung_local
+else
+    echo
+    echo "SKIPPING rung 2 (local): not named in AGENTOS_E2E_TIERS."
+fi
+if (( RUN_CLUSTER )); then
+    rung_cluster
+else
+    echo
+    echo "SKIPPING rung 3 (cluster): not named in AGENTOS_E2E_TIERS. It needs a live"
+    echo "release and host-reachable pods, so it is opt-in: AGENTOS_E2E_TIERS=all."
+fi
+
+echo
+echo "LADDER PASS (tiers: $TIERS)"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -281,6 +281,9 @@ enum DevAction {
     ChartCheck,
     /// Run the scripted CLI end-to-end test (`bash cli/scripts/e2e.sh`).
     E2e,
+    /// Run the cold-start parity ladder across the skill, local, and cluster
+    /// tiers, fake model by default (#690, `bash cli/scripts/e2e-ladder.sh`).
+    E2eLadder,
     /// Lint the interface catalog docs (`bash scripts/check-docs.sh`).
     DocsLint,
     /// Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`).
@@ -1284,6 +1287,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 commands::dev_script("charts/agentos/ci/render-assertions.sh").await
             }
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
+            DevAction::E2eLadder => commands::dev_script("cli/scripts/e2e-ladder.sh").await,
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh").await,
             DevAction::PluginCompat => commands::dev_script("scripts/check-plugin-compat.sh").await,
             DevAction::EvalFalsifiability => {
@@ -2362,6 +2366,24 @@ mod tests {
                 action: DevAction::EvalFalsifiability
             })
         ));
+        let cli = Cli::try_parse_from(["agentos", "dev", "e2e-ladder"])
+            .expect("dev e2e-ladder should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::E2eLadder
+            })
+        ));
+    }
+
+    // Proves the `dev` verb set is closed: an unrecognized verb must fail to
+    // parse rather than silently falling through. Without this negative case,
+    // a typo'd verb name (e.g. a future rename that missed a call site) could
+    // ship without ever being caught by the positive-path tests above.
+    #[test]
+    fn dev_unknown_subcommand_rejected() {
+        let result = Cli::try_parse_from(["agentos", "dev", "e2e-ladder-typo"]);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Extends the skill-tier E2E round trip into a repeatable cold-start parity ladder covering all three tiers, surfaced as `agentos dev e2e-ladder`.

**Stacked on #689.** Cut from `origin/task/bug-meta-guardrails` so the new AGENTS.md parity-seam registry and guard/test-discipline rules applied to this run. The AGENTS.md diff disappears once #689 merges.

## What

- New `cli/scripts/e2e-ladder.sh` with three rungs. Rung 1 delegates to `cli/scripts/e2e.sh` unchanged, so the skill leg has exactly one implementation. Rung 2 drives `local up --minimal` -> `local deploy` -> `local message` (reply asserted) -> `local down`, then asserts nothing this run owns survived. Rung 3 is a real cluster round trip: `cluster deploy` then `cluster message`, no manual port-forward.
- `AGENTOS_E2E_TIERS` selects rungs (default `skill,local`; `all` adds cluster). A tier named explicitly is required and fails the run if unavailable; a tier not named is skipped loudly.
- Fake model by default, so a run is credential-free even on a box that has credentials. `AGENTOS_E2E_LIVE=1` opts into the real model and fails fast without one.
- New CI job runs the credential-free skill and local rungs.

`cli/scripts/e2e.sh` has a zero diff, per the first acceptance criterion.

## Verification

Live pass on this box via the real subcommand, not just the script: `agentos dev e2e-ladder` green end to end, rung 2 deploying a real agent and finalizing a turn in 1.6s, `local down` reaping the runner, and `docker ps` clean afterwards. Repeated against a non-virgin database to confirm the redeploy path.

Guards were demonstrated rejecting violating input by execution, per the AGENTS.md rule. Two bugs were found this way that static review missed:

- The cluster gate never fired. `cluster status` exits 0 even with no release installed, so `if ! cluster status` was dead and a named cluster tier died later at `cluster deploy` with a confusing error. Now gates on `cluster status --json` `release_found`.
- An interrupt during `local up` stranded the entire stack. Ownership was claimed after `local up` returned, but that call blocks for ~12s while containers already exist, so the trap disowned a stack it had created. Ownership is now claimed before starting. Re-demonstrated: SIGTERM mid-rung now tears everything down and preserves exit 143.

Also fixed from review: the orphan sweep filtered on a container name that never exists (sandboxes are named per thread, so the sweep and its assertion were both vacuous, now label-based); the teardown assertion used a host-wide `name=agentos` substring match that red on other sessions' containers, now scoped to this run's compose project and sandbox label; a finalized turn with an empty reply passed.

Guards executed: cluster-tier-required, unknown-tier rejection, live-without-credential fail-fast, interrupt teardown, manifest drift gate (red when stale, green after regen). Not executed and not claimed: the stack-down, broken-bundle, and worker-stopped scenarios.

Under the fake model the ladder asserts plumbing only and never reply content, per ADR-0055. An assertion tuned to the fake's canned reply is the #612 bypass; the sentinel appears only as a live-mode negative control.

## Out of scope, with follow-ups

- #692 wire the cluster rung into CI on a kind cluster. It needs a real cluster, a Helm install, the prewarm DaemonSet, and a host-reachable reply stub, so it is opt-in here and verified by hand.
- #693 teach `e2e.sh` a live-credential mode and make it honor `AGENTOS_BIN`. It hardcodes `--fake-model`, so live mode governs rungs 2 and 3 only.
- #694 retire `e2e.sh`'s cluster-verb-against-compose deploy leg, now superseded by rung 2.
- #695 add a rung against the generated release compose. This is the `compose.dev.yaml` versus release-compose seam disposition.

## Notes for the reviewer

- The CI job builds and locally tags `ghcr.io/curie-eng/agentos-api:latest` and `ghcr.io/curie-eng/agentos-worker:latest` because CI has no registry auth and both are private. The worker one is needed transitively: `compose/worker-local.Dockerfile`'s `FROM` is that private image and `local up` gives no way to thread a custom `BASE_TAG`.
- Out-of-scope but deliberate: the documented `AGENTOS_E2E_API_URL` port is corrected from 8000 to 28000 in both docs. 8000 is the in-container port; 28000 is what compose publishes on the host.
- Local `cargo clippy` fails on `src/interactive.rs` with rust-clippy 1.95.0. That reproduces identically on the base branch and is unrelated to this change.

Closes #690
