### PR TITLE
Add --json field-parity gate for CLI API-mirror structs

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2904,6 +2904,11 @@ export const commandManifest = {
           "name": "eval-falsifiability"
         },
         {
+          "about": "Assert every `Deserialize` struct in `cli/src/api.rs` is declared in `cli/api-mirrors.json` and covers its API model's fields (#691, `bash cli/scripts/check-field-parity.sh`). Offline, no credential",
+          "hidden": false,
+          "name": "field-parity"
+        },
+        {
           "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
           "hidden": false,
           "name": "version-check"

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -149,6 +149,10 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   Deployment exists (a real workspace is connected) unless `--force-wire`. Do
   not drop that guard: the stub wiring is cluster-wide and would divert a live
   workspace's replies.
+- **A new `Deserialize` struct in `cli/src/api.rs` must be declared in
+  `cli/api-mirrors.json`** (as a `mirrors` entry with its allowlisted field
+  omissions, or a `non_mirrors` entry with a one-line reason). `agentos dev
+  field-parity` is the check (#691).
 
 ## Verify
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "syn",
  "tar",
  "tempfile",
  "time",
@@ -2604,9 +2605,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -72,3 +72,8 @@ jsonschema = { version = "0.48", default-features = false }
 # The frozen ACI types are a normal dependency of the lib, but integration test
 # crates need them by name to build a SessionStatus for the status_json contract.
 agentos-aci-protocol = { path = "../packages/aci-protocol/generated/rust" }
+# AST parse of cli/src/api.rs for the --json field-parity gate (#691): resolve
+# serde rename/skip/flatten and derive spellings exactly. `full` parses fn
+# bodies, `visit` recurses into fn/impl-body items (the method-local BundleFiles),
+# `extra-traits` gives the PartialEq the walk relies on.
+syn = { version = "2", features = ["full", "visit", "extra-traits"] }

--- a/cli/README.md
+++ b/cli/README.md
@@ -204,6 +204,7 @@ they error clearly -- a release binary has no dev scripts.
 | `agentos dev chart-check` | `bash charts/agentos/ci/render-assertions.sh` -- render-assert the Helm chart. |
 | `agentos dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
 | `agentos dev e2e-ladder` | `bash cli/scripts/e2e-ladder.sh` -- the cold-start parity ladder (skill, local, cluster rungs). |
+| `agentos dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI api.rs mirror structs cover their platform API model fields (#691). |
 
 ## `skill` target: runner-only, fully offline
 

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -1,0 +1,107 @@
+{
+  "_comment": "Declared mirrors of apps/api committed openapi.json models. See issue #691. Every Deserialize struct in cli/src/api.rs must appear in exactly one of mirrors or non_mirrors. Each omission names the CLI consumer path and why it does not read the field. Check with: agentos dev field-parity",
+  "openapi": "apps/api/openapi.json",
+  "source": "cli/src/api.rs",
+  "mirrors": [
+    {
+      "struct": "Version",
+      "schema": "VersionOut",
+      "omissions": []
+    },
+    {
+      "struct": "Agent",
+      "schema": "AgentOut",
+      "omissions": [
+        { "field": "repo_full_name", "why": "The deploy flow (ApiClient::resolve_agent/find_agent) matches and creates agents by name and reconciles slack_channel; it never reads the agent's linked git repo, so repo_full_name is not deserialized." },
+        { "field": "behavior_packs", "why": "No CLI path reads an agent's behavior-pack list; deploy uploads a bundle rather than composing packs, so behavior_packs is never consumed." },
+        { "field": "model", "why": "The CLI never displays or acts on an agent's default model (model routing is server- and claim-time bound, #473); the deploy and lifecycle verbs read only id/name/slack_channel." },
+        { "field": "approval_routes", "why": "The approvals verbs drive per-record gates via ApprovalRecord; the agent-level route roster (approval_routes) is enforced server-side and never read by the CLI." },
+        { "field": "secrets", "why": "update_agent_secrets WRITES connector-secret names; the CLI never reads the stored secrets list back, so the response field is not modeled." },
+        { "field": "created_at", "why": "No CLI verb prints an agent's creation timestamp; the deploy summary and lifecycle verbs render id/name/slack_channel only." }
+      ]
+    },
+    {
+      "struct": "ApprovalRecord",
+      "schema": "ApprovalOut",
+      "omissions": [
+        { "field": "agent_id", "why": "The approvals verbs (commands::approvals) already scope the query by --agent, so the record's echoed agent_id is redundant to what the caller passed and is not rendered." },
+        { "field": "reply_channel", "why": "Slack reply-routing (reply_channel) is consumed by the worker to post the approval card, not by the CLI, which renders the record for a human operator." },
+        { "field": "reply_placeholder", "why": "The card placeholder text is a worker/Slack rendering detail; the approvals listing shows summary/gate, not the card body." },
+        { "field": "reply_endpoint", "why": "The reply callback endpoint routes a Slack action back to the API; the CLI resolve path posts to /approvals/{id}/resolve directly and never reads it." },
+        { "field": "dedupe_key", "why": "The idempotency key is a server-side dedupe concern; the CLI neither displays it nor resubmits on it." },
+        { "field": "card_channel", "why": "Where the approval card was posted is a Slack-delivery detail; the operator-facing listing renders conversation_id/summary, not the card channel." },
+        { "field": "resolution_note", "why": "resolve_approval SENDS a note via --note; it does not read back the stored resolution_note when listing pending approvals." },
+        { "field": "created_at", "why": "The listing shows expires_at (the actionable deadline), not the creation timestamp, which the operator does not act on." },
+        { "field": "resolved_at", "why": "list_pending_approvals filters to status=pending, which by definition carry no resolution timestamp, so resolved_at is never populated on the records the CLI renders." }
+      ]
+    },
+    {
+      "struct": "MemoryEntry",
+      "schema": "MemoryEntryOut",
+      "omissions": [
+        { "field": "provenance", "why": "The memory list verb renders index/content/version; provenance is a nested MemoryProvenanceOut $ref with no CLI mirror, and carrying it would require a second struct out of this gate's scope." }
+      ]
+    },
+    {
+      "struct": "Bundle",
+      "schema": "BundleOut",
+      "omissions": [
+        { "field": "version_id", "why": "upload_bundle returns the bundle to the deploy summary, which already holds the Version it just created (ApiClient::deploy), so the bundle's echoed version_id is redundant." }
+      ]
+    },
+    {
+      "struct": "Deployment",
+      "schema": "DeploymentOut",
+      "omissions": [
+        { "field": "agent_id", "why": "list_deployments/create_deployment are already agent-scoped by the caller, so the record's echoed agent_id adds nothing the deploy summary or approvals-gate read uses." },
+        { "field": "commit_sha", "why": "The deploy summary and the approvals gate read resolve the in-force version via version_id; the deployment's commit_sha is not read. Follow-up parity candidate (same family as #548), flagged in the PR body, not added here." }
+      ]
+    },
+    {
+      "struct": "BundleFile",
+      "schema": "BundleFile",
+      "omissions": []
+    },
+    {
+      "struct": "BundleFiles",
+      "schema": "BundleFiles",
+      "omissions": []
+    },
+    {
+      "struct": "KillState",
+      "schema": "KillState",
+      "omissions": []
+    },
+    {
+      "struct": "BudgetConfig",
+      "schema": "BudgetConfig",
+      "omissions": []
+    },
+    {
+      "struct": "EvalTriggerResult",
+      "schema": "EvalTriggerResult",
+      "omissions": [
+        { "field": "agent_id", "why": "trigger_eval is called with the agent the caller chose; the sweep pairs the enqueued job to its matrix row by stream_id/sha, so the echoed agent_id is unused." },
+        { "field": "version_id", "why": "The sweep scopes readiness by the run's sha column on the matrix, not by version_id; the trigger's version_id is never read." },
+        { "field": "bundle_ref", "why": "The artifact pointer is surfaced on the version/bundle path, not off the eval trigger; the sweep reads only stream_id/sha/suite/model here." }
+      ]
+    },
+    {
+      "struct": "EvalModelSummary",
+      "schema": "EvalModelSummary",
+      "omissions": [
+        { "field": "plumbing", "why": "RISK: plumbing marks a fixture/plumbing-only row (#612/#606). The model sweep (cli/src/evals.rs) reads model/passed/total/cost_usd and cannot today distinguish a plumbing-fixture row from a real subject-under-test row. Not wired in this PR; filed as follow-up F2 (sweep scoping, #608)." }
+      ]
+    },
+    {
+      "struct": "EvalMatrix",
+      "schema": "EvalMatrix",
+      "omissions": [
+        { "field": "cases", "why": "The sweep reads the per-model rollup (model_summaries) and the version columns (versions); the per-case identifiers (cases) that label the grid are not read by the CLI." },
+        { "field": "rows", "why": "The per-case pass/fail grid (rows) is carried by the endpoint but unused by the sweep, which needs only the per-model rollup; the existing doc comment on EvalMatrix already states this." },
+        { "field": "models", "why": "The model dimension the CLI acts on is model_summaries[].model; the separate models label list is not read." }
+      ]
+    }
+  ],
+  "non_mirrors": []
+}

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2901,6 +2901,11 @@
           "name": "eval-falsifiability"
         },
         {
+          "about": "Assert every `Deserialize` struct in `cli/src/api.rs` is declared in `cli/api-mirrors.json` and covers its API model's fields (#691, `bash cli/scripts/check-field-parity.sh`). Offline, no credential",
+          "hidden": false,
+          "name": "field-parity"
+        },
+        {
           "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
           "hidden": false,
           "name": "version-check"

--- a/cli/scripts/check-field-parity.sh
+++ b/cli/scripts/check-field-parity.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Field-parity gate (#691): every `Deserialize` struct in cli/src/api.rs must
+# be declared in cli/api-mirrors.json (as a mirror or a non_mirror), and each
+# declared mirror struct must cover its API model's fields per
+# cli/api-mirrors.json's allowlisted omissions. See cli/tests/api_field_parity.rs.
+set -euo pipefail
+
+cargo test --manifest-path cli/Cargo.toml --test api_field_parity -- --nocapture

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -85,6 +85,14 @@ pub struct Version {
     pub created_by: Option<String>,
     #[serde(default)]
     pub created_at: Option<String>,
+    /// `VersionOut.agent_id` (#691). `VersionOut` marks it required, but the
+    /// deploy path tolerates lean responses, so `#[serde(default)]` is kept
+    /// consistent with the other extra fields above.
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    /// `VersionOut.bundle_ref` (#691). Same lean-response tolerance as above.
+    #[serde(default)]
+    pub bundle_ref: Option<String>,
 }
 
 /// One learned memory entry (`MemoryEntryOut`) for the `memory` listing verb.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2359,11 +2359,13 @@ impl crate::ui::CliOutput for VersionsOutput {
                     .iter()
                     .map(|v| {
                         serde_json::json!({
+                            "id": v.id,
                             "version_label": v.version_label,
                             "commit_sha": v.commit_sha,
                             "bundle_sha256": v.bundle_sha256,
                             "created_by": v.created_by,
                             "created_at": v.created_at,
+                            "bundle_ref": v.bundle_ref,
                         })
                     })
                     .collect();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -292,6 +292,10 @@ enum DevAction {
     /// goes RED -- the falsifiability gate's real-path negative control (#619,
     /// `bash cli/scripts/eval-falsifiability.sh`). Offline, no credential.
     EvalFalsifiability,
+    /// Assert every `Deserialize` struct in `cli/src/api.rs` is declared in
+    /// `cli/api-mirrors.json` and covers its API model's fields (#691,
+    /// `bash cli/scripts/check-field-parity.sh`). Offline, no credential.
+    FieldParity,
     /// Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml
     /// version, and appVersion (`bash scripts/check-version-consistency.sh`).
     VersionCheck,
@@ -1292,6 +1296,9 @@ async fn run(command: Option<Command>) -> Result<()> {
             DevAction::PluginCompat => commands::dev_script("scripts/check-plugin-compat.sh").await,
             DevAction::EvalFalsifiability => {
                 commands::dev_script("cli/scripts/eval-falsifiability.sh").await
+            }
+            DevAction::FieldParity => {
+                commands::dev_script("cli/scripts/check-field-parity.sh").await
             }
             DevAction::VersionCheck => {
                 commands::dev_script("scripts/check-version-consistency.sh").await

--- a/cli/tests/api_field_parity.rs
+++ b/cli/tests/api_field_parity.rs
@@ -1,0 +1,375 @@
+// Field-parity gate (issue #691): every CLI struct that mirrors a platform API
+// model must carry that model's fields, and every deliberate omission must be
+// declared and justified in `cli/api-mirrors.json`. This binary asserts that
+// invariant on the real tree and drives the real comparator over drifted
+// fixtures to prove it rejects each violation class by execution (AC5).
+//
+// ─── Shared comparator contract (Stream A implements this VERBATIM) ──────────
+// The helper lives at `cli/tests/support/field_parity.rs`, reached below via a
+// `#[path = ...]` include. Its ENTIRE public surface is one pure function plus
+// one enum. Copy both exactly; tests assert on `Violation` variants + payload,
+// never on message strings.
+//
+//   pub fn violations(
+//       rust_src: &str,                  // contents of the Rust source to walk
+//       openapi: &serde_json::Value,     // parsed OpenAPI doc (components.schemas)
+//       manifest: &serde_json::Value,    // parsed api-mirrors.json manifest
+//   ) -> Vec<Violation>;
+//
+//   #[derive(Debug, Clone, PartialEq, Eq)]
+//   pub enum Violation {
+//       /// Schema defines a property the struct neither carries nor allowlists.
+//       MissingField { struct_name: String, schema: String, field: String },
+//       /// Struct carries a wire field the schema does not define.
+//       UnknownField { struct_name: String, schema: String, field: String },
+//       /// A `Deserialize` struct in the source is in neither `mirrors` nor `non_mirrors`.
+//       UndeclaredStruct { struct_name: String },
+//       /// A manifest entry names a struct the source walk never found.
+//       StructNotFound { struct_name: String },
+//       /// A dishonest omission: struct actually carries the field, the schema no
+//       /// longer has it, or the omission's `why` is blank/missing.
+//       StaleOmission { struct_name: String, schema: String, field: String },
+//       /// A manifest `schema` is absent from `components.schemas`.
+//       SchemaNotFound { struct_name: String, schema: String },
+//       /// The schema (object-level `allOf`/`anyOf`) or the struct (a
+//       /// `#[serde(flatten)]` field) cannot be decomposed field-by-field.
+//       UnsupportedShape { struct_name: String, schema: String },
+//       /// Two `Deserialize` structs share one bare name; the manifest keys by
+//       /// name, so only the first is ever field-checked.
+//       DuplicateStruct { struct_name: String },
+//       /// A manifest entry lacks a required key (`struct`/`schema`), so its
+//       /// struct would silently escape field comparison.
+//       MalformedManifestEntry { detail: String },
+//   }
+//
+// Precedence rules Stream A MUST honor so each fixture triggers one variant:
+//  - A struct with any `#[serde(flatten)]` field => emit `UnsupportedShape` for
+//    that struct and do NOT run field comparison on it.
+//  - An object-level `allOf`/`anyOf` schema => `UnsupportedShape`; skip field
+//    comparison (a naive read would see zero required fields and pass silently).
+//  - An omission entry suppresses `MissingField` for its field regardless of the
+//    `why` content; a blank/missing `why` is reported as `StaleOmission` (NOT
+//    `MissingField`).
+//  - Wire name governs coverage: `#[serde(rename = "x")]` maps the field to `x`;
+//    `rename_all` applies the container transform; a bare field uses its ident.
+//  - The walk recognizes both derive spellings (`Deserialize` and
+//    `serde::Deserialize`) and recurses into items nested in fn/impl bodies.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[path = "support/field_parity.rs"]
+mod field_parity;
+
+use field_parity::{violations, Violation};
+use serde_json::Value;
+
+// ─── Loaders ─────────────────────────────────────────────────────────────────
+
+fn repo_text(rel: &str) -> String {
+    let path = format!("{}/../{}", env!("CARGO_MANIFEST_DIR"), rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn repo_json(rel: &str) -> Value {
+    let raw = repo_text(rel);
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {rel}: {e}"))
+}
+
+fn fixture_text(name: &str) -> String {
+    let path = format!(
+        "{}/tests/data/field-parity/{}",
+        env!("CARGO_MANIFEST_DIR"),
+        name
+    );
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn fixture_json(name: &str) -> Value {
+    let raw = fixture_text(name);
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {name}: {e}"))
+}
+
+/// The drifted fixture triple that drives every rejection case.
+fn fixtures() -> (String, Value, Value) {
+    (
+        fixture_text("drifted-api.rs"),
+        fixture_json("drifted-openapi.json"),
+        fixture_json("drifted-mirrors.json"),
+    )
+}
+
+// ─── Payload matchers (variant + payload, never message strings) ─────────────
+
+fn has_missing_field(vs: &[Violation], struct_name: &str, field: &str) -> bool {
+    vs.iter().any(|v| {
+        matches!(v, Violation::MissingField { struct_name: s, field: f, .. }
+            if s == struct_name && f == field)
+    })
+}
+
+fn has_unknown_field(vs: &[Violation], struct_name: &str, field: &str) -> bool {
+    vs.iter().any(|v| {
+        matches!(v, Violation::UnknownField { struct_name: s, field: f, .. }
+            if s == struct_name && f == field)
+    })
+}
+
+fn has_stale_omission(vs: &[Violation], struct_name: &str, field: &str) -> bool {
+    vs.iter().any(|v| {
+        matches!(v, Violation::StaleOmission { struct_name: s, field: f, .. }
+            if s == struct_name && f == field)
+    })
+}
+
+fn has_undeclared_struct(vs: &[Violation], struct_name: &str) -> bool {
+    vs.iter()
+        .any(|v| matches!(v, Violation::UndeclaredStruct { struct_name: s } if s == struct_name))
+}
+
+fn has_struct_not_found(vs: &[Violation], struct_name: &str) -> bool {
+    vs.iter()
+        .any(|v| matches!(v, Violation::StructNotFound { struct_name: s } if s == struct_name))
+}
+
+fn has_schema_not_found(vs: &[Violation], struct_name: &str, schema: &str) -> bool {
+    vs.iter().any(|v| {
+        matches!(v, Violation::SchemaNotFound { struct_name: s, schema: sc }
+            if s == struct_name && sc == schema)
+    })
+}
+
+fn has_unsupported_shape(vs: &[Violation], struct_name: &str) -> bool {
+    vs.iter().any(
+        |v| matches!(v, Violation::UnsupportedShape { struct_name: s, .. } if s == struct_name),
+    )
+}
+
+fn has_duplicate_struct(vs: &[Violation], struct_name: &str) -> bool {
+    vs.iter()
+        .any(|v| matches!(v, Violation::DuplicateStruct { struct_name: s } if s == struct_name))
+}
+
+fn has_malformed_manifest_entry(vs: &[Violation], needle: &str) -> bool {
+    vs.iter().any(
+        |v| matches!(v, Violation::MalformedManifestEntry { detail } if detail.contains(needle)),
+    )
+}
+
+fn mentions_struct(vs: &[Violation], struct_name: &str) -> bool {
+    vs.iter().any(|v| match v {
+        Violation::MissingField { struct_name: s, .. }
+        | Violation::UnknownField { struct_name: s, .. }
+        | Violation::UndeclaredStruct { struct_name: s }
+        | Violation::StructNotFound { struct_name: s }
+        | Violation::StaleOmission { struct_name: s, .. }
+        | Violation::SchemaNotFound { struct_name: s, .. }
+        | Violation::DuplicateStruct { struct_name: s }
+        | Violation::UnsupportedShape { struct_name: s, .. } => s == struct_name,
+        Violation::MalformedManifestEntry { .. } => false,
+    })
+}
+
+// ─── Real-tree assertions (AC1, AC3) ─────────────────────────────────────────
+
+#[test]
+fn real_tree_has_no_field_parity_violations() {
+    let src = repo_text("cli/src/api.rs");
+    let openapi = repo_json("apps/api/openapi.json");
+    let manifest = repo_json("cli/api-mirrors.json");
+
+    let vs = violations(&src, &openapi, &manifest);
+    assert!(
+        vs.is_empty(),
+        "cli/src/api.rs has drifted from apps/api/openapi.json. Each entry below \
+         is fixed by either adding the field to the struct or declaring the \
+         omission (with a justification) in cli/api-mirrors.json:\n{vs:#?}"
+    );
+}
+
+#[test]
+fn version_struct_carries_the_full_version_out() {
+    // The issue's named drift: `Version` must cover `agent_id` and `bundle_ref`.
+    // Checked independently of the generic sweep so a manifest mistake cannot
+    // hide it.
+    let src = repo_text("cli/src/api.rs");
+    let openapi = repo_json("apps/api/openapi.json");
+    let manifest = repo_json("cli/api-mirrors.json");
+
+    let vs = violations(&src, &openapi, &manifest);
+    let version_violations: Vec<&Violation> = vs
+        .iter()
+        .filter(|v| match v {
+            Violation::MissingField { struct_name, .. }
+            | Violation::UnknownField { struct_name, .. }
+            | Violation::UndeclaredStruct { struct_name }
+            | Violation::StructNotFound { struct_name }
+            | Violation::StaleOmission { struct_name, .. }
+            | Violation::SchemaNotFound { struct_name, .. }
+            | Violation::DuplicateStruct { struct_name }
+            | Violation::UnsupportedShape { struct_name, .. } => struct_name == "Version",
+            Violation::MalformedManifestEntry { .. } => false,
+        })
+        .collect();
+    assert!(
+        version_violations.is_empty(),
+        "Version does not fully mirror VersionOut (expected agent_id + bundle_ref \
+         covered, zero omissions):\n{version_violations:#?}"
+    );
+}
+
+// ─── Guard-rejects-a-violating-input demonstrations (AC5) ────────────────────
+
+#[test]
+fn rejects_a_struct_missing_a_required_schema_field() {
+    // case 1
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(
+        has_missing_field(&vs, "MissingFieldMirror", "dropped"),
+        "{vs:#?}"
+    );
+}
+
+#[test]
+fn rejects_a_stale_allowlist_entry() {
+    // case 2: an omission for a field the struct actually carries.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(
+        has_stale_omission(&vs, "StaleCarriesMirror", "beta"),
+        "{vs:#?}"
+    );
+}
+
+#[test]
+fn rejects_an_allowlist_entry_for_a_field_the_schema_no_longer_has() {
+    // case 3
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(
+        has_stale_omission(&vs, "StaleShrunkMirror", "delta"),
+        "{vs:#?}"
+    );
+}
+
+#[test]
+fn rejects_an_undeclared_deserialize_struct() {
+    // case 4: D2's teeth — a Deserialize struct in neither list.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(has_undeclared_struct(&vs, "UndeclaredMirror"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_a_struct_field_absent_from_the_schema() {
+    // case 5: a CLI field with no API field behind it is always a bug.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(
+        has_unknown_field(&vs, "UnknownFieldMirror", "phantom"),
+        "{vs:#?}"
+    );
+}
+
+#[test]
+fn rejects_a_missing_schema() {
+    // case 6: a named schema absent from components.schemas -> not a skip.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(
+        has_schema_not_found(&vs, "MissingSchemaMirror", "NoSuchSchema"),
+        "{vs:#?}"
+    );
+}
+
+#[test]
+fn rejects_an_unsupported_schema_shape() {
+    // case 7: an object-level allOf schema must fail closed, never pass silently.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(has_unsupported_shape(&vs, "AllOfMirror"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_serde_flatten() {
+    // case 8: flatten makes the wire-name mapping non-local -> UnsupportedShape.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(has_unsupported_shape(&vs, "FlattenMirror"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_an_empty_omission_justification() {
+    // case 9: an omission with a blank `why` is not a justified omission.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(has_stale_omission(&vs, "BlankWhyMirror", "q"), "{vs:#?}");
+}
+
+#[test]
+fn honors_serde_rename_on_both_sides() {
+    // case 10: paired positive/negative — proves the gate reads the WIRE name.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    // Positive: the renamed field covers the schema -> no violation for it.
+    assert!(
+        !mentions_struct(&vs, "RenamePositive"),
+        "renamed field should satisfy coverage:\n{vs:#?}"
+    );
+    // Negative: the same ident without the rename leaves `fooBar` uncovered.
+    assert!(
+        has_missing_field(&vs, "RenameNegative", "fooBar"),
+        "{vs:#?}"
+    );
+}
+
+#[test]
+fn rejects_an_undeclared_deserialize_struct_inside_a_fn_body() {
+    // case 11: the nested-item walk proof — a `serde::Deserialize` struct declared
+    // inside an impl-method body, absent from the manifest.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(has_undeclared_struct(&vs, "NestedUndeclared"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_a_manifest_entry_for_a_struct_the_source_does_not_have() {
+    // case 12: the symmetric fail-closed twin of case 6 — a dangling manifest
+    // entry makes a walk defect observable instead of silently shrinking the set.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(has_struct_not_found(&vs, "GhostStruct"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_a_skip_deserializing_field_as_non_coverage() {
+    // case 13: `#[serde(skip_deserializing)]` drops the field from the wire (the
+    // decoder fills it from Default), so it must NOT satisfy coverage for the
+    // schema property it names -> MissingField.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(
+        has_missing_field(&vs, "SkipDeserMirror", "discarded"),
+        "{vs:#?}"
+    );
+}
+
+#[test]
+fn rejects_a_duplicated_struct_name() {
+    // case 14: two `Deserialize` structs share one bare name; the manifest keys by
+    // name so the second is never field-checked -> DuplicateStruct, fail-closed.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(has_duplicate_struct(&vs, "DupNameMirror"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_a_manifest_entry_missing_a_required_key() {
+    // case 15: a `mirrors` entry lacking `schema` would silently skip field
+    // comparison for its struct -> MalformedManifestEntry, fail-closed.
+    let (src, oa, mf) = fixtures();
+    let vs = violations(&src, &oa, &mf);
+    assert!(
+        has_malformed_manifest_entry(&vs, "MalformedEntryMirror"),
+        "{vs:#?}"
+    );
+}

--- a/cli/tests/data/field-parity/drifted-api.rs
+++ b/cli/tests/data/field-parity/drifted-api.rs
@@ -1,0 +1,133 @@
+// Fixture Rust source for cli/tests/api_field_parity.rs (issue #691).
+//
+// Parsed as TEXT by `syn`; this file is never compiled as a crate, so it needs
+// no real dependencies and unused items are fine. Each `Deserialize` struct is
+// engineered to trigger exactly one field-parity `Violation` (or none, for the
+// serde-rename positive) against drifted-openapi.json + drifted-mirrors.json.
+// The case map lives in api_field_parity.rs; keep the two in sync.
+
+use serde::Deserialize;
+
+// case 1: `dropped` is in the schema, not on the struct, not allowlisted -> MissingField.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MissingFieldMirror {
+    pub kept: String,
+}
+
+// case 2: the manifest declares `beta` omitted, but the struct carries it -> StaleOmission.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StaleCarriesMirror {
+    pub alpha: String,
+    pub beta: String,
+}
+
+// case 3: the manifest declares `delta` omitted, but the schema no longer has it -> StaleOmission.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StaleShrunkMirror {
+    pub gamma: String,
+}
+
+// case 4: a Deserialize struct absent from both `mirrors` and `non_mirrors` -> UndeclaredStruct.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UndeclaredMirror {
+    pub anything: String,
+}
+
+// case 5: `phantom` is a wire field with no schema property behind it -> UnknownField.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UnknownFieldMirror {
+    pub known: String,
+    pub phantom: String,
+}
+
+// case 6: the manifest points this at a schema absent from components.schemas -> SchemaNotFound.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MissingSchemaMirror {
+    pub y: String,
+}
+
+// case 7: the mirrored schema is object-level `allOf`-composed -> UnsupportedShape.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AllOfMirror {
+    pub z: String,
+}
+
+// case 8: a `#[serde(flatten)]` field makes the wire mapping non-local -> UnsupportedShape.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FlattenMirror {
+    pub base: String,
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, String>,
+}
+
+// case 9: the omission entry for `q` has a blank `why` -> StaleOmission.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BlankWhyMirror {
+    pub p: String,
+}
+
+// case 10 (positive): `foo_bar` renamed to the wire name `fooBar` covers the
+// schema's `fooBar` property -> no violation. Proves the gate reads the WIRE name.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RenamePositive {
+    #[serde(rename = "fooBar")]
+    pub foo_bar: String,
+}
+
+// case 10 (negative): same ident, no rename; the wire name stays `foo_bar`, so
+// the schema's `fooBar` is uncovered -> MissingField (`fooBar`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct RenameNegative {
+    pub foo_bar: String,
+}
+
+// case 13: `discarded` is `#[serde(skip_deserializing)]`, so it is dropped from the
+// wire (decoder fills it from Default) and must NOT cover the schema's `discarded`
+// property -> MissingField. `kept` covers the schema's `kept` (so no UnknownField).
+#[derive(Debug, Clone, Deserialize)]
+pub struct SkipDeserMirror {
+    pub kept: String,
+    #[serde(skip_deserializing)]
+    pub discarded: String,
+}
+
+// case 15: `MalformedEntryMirror` exists in the source but its `mirrors` entry omits
+// the required `schema` key -> MalformedManifestEntry (would otherwise silently skip
+// field comparison for this struct).
+#[derive(Debug, Clone, Deserialize)]
+pub struct MalformedEntryMirror {
+    pub w: String,
+}
+
+// A non-Deserialize host type; carries the fn-body-local struct for case 11.
+pub struct FixtureClient;
+
+impl FixtureClient {
+    // case 11: a Deserialize struct declared INSIDE an impl-method body, using the
+    // qualified `serde::Deserialize` spelling (matching cli/src/api.rs:752), absent
+    // from the manifest -> UndeclaredStruct. Proves the walk recurses into fn bodies.
+    pub fn nested(&self) {
+        #[derive(serde::Deserialize)]
+        struct NestedUndeclared {
+            files: Vec<String>,
+        }
+    }
+
+    // case 14: two `Deserialize` structs share the bare name `DupNameMirror` (legal
+    // Rust — each is fn-body-local). The manifest keys by name, so only the first is
+    // ever field-checked; the walk sees both -> DuplicateStruct. Declared in
+    // `non_mirrors` so DuplicateStruct is the ONLY violation this pair triggers.
+    pub fn dup_a(&self) {
+        #[derive(serde::Deserialize)]
+        struct DupNameMirror {
+            first: String,
+        }
+    }
+
+    pub fn dup_b(&self) {
+        #[derive(serde::Deserialize)]
+        struct DupNameMirror {
+            second: String,
+        }
+    }
+}

--- a/cli/tests/data/field-parity/drifted-mirrors.json
+++ b/cli/tests/data/field-parity/drifted-mirrors.json
@@ -1,0 +1,29 @@
+{
+  "_comment": "Fixture manifest for cli/tests/api_field_parity.rs (issue #691). Deliberately drifted so each entry triggers exactly one Violation; see the case map in that test. `openapi`/`source` are informational here (the comparator receives all three inputs directly).",
+  "openapi": "drifted-openapi.json",
+  "source": "drifted-api.rs",
+  "mirrors": [
+    { "struct": "MissingFieldMirror", "schema": "MissingFieldSchema", "omissions": [] },
+    { "struct": "StaleCarriesMirror", "schema": "StaleCarriesSchema", "omissions": [
+      { "field": "beta", "why": "deploy path reads alpha only" }
+    ] },
+    { "struct": "StaleShrunkMirror", "schema": "StaleShrunkSchema", "omissions": [
+      { "field": "delta", "why": "field removed from the API model; this entry is now stale" }
+    ] },
+    { "struct": "UnknownFieldMirror", "schema": "UnknownFieldSchema", "omissions": [] },
+    { "struct": "MissingSchemaMirror", "schema": "NoSuchSchema", "omissions": [] },
+    { "struct": "AllOfMirror", "schema": "AllOfSchema", "omissions": [] },
+    { "struct": "FlattenMirror", "schema": "FlattenSchema", "omissions": [] },
+    { "struct": "BlankWhyMirror", "schema": "BlankWhySchema", "omissions": [
+      { "field": "q", "why": "" }
+    ] },
+    { "struct": "RenamePositive", "schema": "RenamePositiveSchema", "omissions": [] },
+    { "struct": "RenameNegative", "schema": "RenameNegativeSchema", "omissions": [] },
+    { "struct": "SkipDeserMirror", "schema": "SkipDeserSchema", "omissions": [] },
+    { "struct": "MalformedEntryMirror", "omissions": [] }
+  ],
+  "non_mirrors": [
+    { "struct": "GhostStruct", "why": "manifest entry for a struct the source no longer declares" },
+    { "struct": "DupNameMirror", "why": "duplicate-name pair; only DuplicateStruct should fire" }
+  ]
+}

--- a/cli/tests/data/field-parity/drifted-openapi.json
+++ b/cli/tests/data/field-parity/drifted-openapi.json
@@ -1,0 +1,84 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "field-parity fixture", "version": "0.0.0" },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "MissingFieldSchema": {
+        "type": "object",
+        "properties": {
+          "kept": { "type": "string" },
+          "dropped": { "type": "string" }
+        },
+        "required": ["kept", "dropped"]
+      },
+      "StaleCarriesSchema": {
+        "type": "object",
+        "properties": {
+          "alpha": { "type": "string" },
+          "beta": { "type": "string" }
+        }
+      },
+      "StaleShrunkSchema": {
+        "type": "object",
+        "properties": {
+          "gamma": { "type": "string" }
+        }
+      },
+      "UnknownFieldSchema": {
+        "type": "object",
+        "properties": {
+          "known": { "type": "string" }
+        }
+      },
+      "AllOfBase": {
+        "type": "object",
+        "properties": {
+          "base_field": { "type": "string" }
+        }
+      },
+      "AllOfSchema": {
+        "allOf": [
+          { "$ref": "#/components/schemas/AllOfBase" },
+          {
+            "type": "object",
+            "properties": { "z": { "type": "string" } }
+          }
+        ]
+      },
+      "FlattenSchema": {
+        "type": "object",
+        "properties": {
+          "base": { "type": "string" }
+        }
+      },
+      "BlankWhySchema": {
+        "type": "object",
+        "properties": {
+          "p": { "type": "string" },
+          "q": { "type": "string" }
+        }
+      },
+      "RenamePositiveSchema": {
+        "type": "object",
+        "properties": {
+          "fooBar": { "type": "string" }
+        }
+      },
+      "RenameNegativeSchema": {
+        "type": "object",
+        "properties": {
+          "fooBar": { "type": "string" }
+        }
+      },
+      "SkipDeserSchema": {
+        "type": "object",
+        "properties": {
+          "kept": { "type": "string" },
+          "discarded": { "type": "string" }
+        },
+        "required": ["kept", "discarded"]
+      }
+    }
+  }
+}

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -523,8 +523,12 @@ fn versions_output_json_shape_is_pinned() {
         json!({"agent": "weather", "versions": []})
     );
     // Two versions, one with every optional field `None` and one with them all
-    // `Some`, so the null-vs-value rendering of each optional is pinned. `id` is
-    // deliberately NOT emitted; adding it would fail this exact-match.
+    // `Some`, so the null-vs-value rendering of each optional is pinned. Per
+    // issue #691 / E1, each element emits exactly: `id`, `version_label`,
+    // `commit_sha`, `bundle_sha256`, `created_by`, `created_at`, `bundle_ref`.
+    // `id` and `bundle_ref` are now emitted (an agent needs `id` to address the
+    // version); `agent_id` is carried on the struct but deliberately NOT emitted
+    // (the payload already carries `agent`, the query was agent-scoped).
     assert_eq!(
         VersionsOutput::List {
             agent: "weather".to_string(),
@@ -536,6 +540,8 @@ fn versions_output_json_shape_is_pinned() {
                     bundle_sha256: None,
                     created_by: None,
                     created_at: None,
+                    agent_id: None,
+                    bundle_ref: None,
                 },
                 Version {
                     id: "ver_2".to_string(),
@@ -544,6 +550,8 @@ fn versions_output_json_shape_is_pinned() {
                     bundle_sha256: Some("deadbeef00".to_string()),
                     created_by: Some("bconn".to_string()),
                     created_at: Some("2026-07-16T00:00:00Z".to_string()),
+                    agent_id: Some("agt_1".to_string()),
+                    bundle_ref: Some("bundles/abc.tar.gz".to_string()),
                 },
             ],
         }
@@ -552,18 +560,22 @@ fn versions_output_json_shape_is_pinned() {
             "agent": "weather",
             "versions": [
                 {
+                    "id": "ver_1",
                     "version_label": "v1",
                     "commit_sha": null,
                     "bundle_sha256": null,
                     "created_by": null,
                     "created_at": null,
+                    "bundle_ref": null,
                 },
                 {
+                    "id": "ver_2",
                     "version_label": "v2",
                     "commit_sha": "abc1234",
                     "bundle_sha256": "deadbeef00",
                     "created_by": "bconn",
                     "created_at": "2026-07-16T00:00:00Z",
+                    "bundle_ref": "bundles/abc.tar.gz",
                 },
             ],
         })

--- a/cli/tests/support/field_parity.rs
+++ b/cli/tests/support/field_parity.rs
@@ -1,0 +1,465 @@
+//! Field-parity comparator for the `--json` gate (issue #691).
+//!
+//! Pure, side-effect-free core of the gate: given the text of a Rust source
+//! (`cli/src/api.rs` on the real tree, a fixture otherwise), a parsed OpenAPI
+//! doc, and a parsed `api-mirrors.json` manifest, return every way a mirror
+//! struct has drifted from the API model it declares it mirrors. The gate test
+//! (`cli/tests/api_field_parity.rs`) asserts on the returned `Violation`
+//! variants; this module never prints or panics on drift.
+//!
+//! Design notes (kept here, out of the terse return):
+//!
+//! * The struct inventory is EVERY `Deserialize`-deriving struct in the source,
+//!   found via a `syn::visit::Visit` walk. `visit` (not a flat `File.items`
+//!   loop) is what reaches structs declared inside fn / impl-method bodies — the
+//!   real tree has exactly one, `serde::Deserialize struct BundleFiles` inside
+//!   `ApiClient::bundle_files` (`cli/src/api.rs:751-755`). The walk recognizes
+//!   both the bare `Deserialize` and qualified `serde::Deserialize` derive
+//!   spellings (last path segment == `Deserialize`), and deliberately does NOT
+//!   match `Serialize`.
+//! * Wire name governs coverage, not the Rust ident: `#[serde(rename="x")]`,
+//!   container `#[serde(rename_all=...)]` are applied; `#[serde(skip)]` drops the
+//!   field from the wire; `#[serde(alias=...)]` is an ADDITIONAL accepted name so
+//!   it never counts as coverage; `#[serde(default)]` / `skip_serializing_if` are
+//!   irrelevant to coverage and ignored.
+//! * Fail-closed shapes: a `#[serde(flatten)]` field or an object-level
+//!   `allOf`/`anyOf`/`oneOf` schema cannot be decomposed field-by-field, so the
+//!   struct yields `UnsupportedShape` and is NOT read as zero-required (which
+//!   would silently pass).
+//! * An omission entry always suppresses `MissingField` for its field; a
+//!   dishonest omission (blank/missing `why`, or a field the struct actually
+//!   carries, or a field the schema no longer defines) additionally yields
+//!   `StaleOmission`.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+use syn::visit::Visit;
+
+/// A single way a mirror struct has drifted from its declared API schema. The
+/// gate test matches on these variants and their payload, never on messages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Violation {
+    /// Schema defines a property the struct neither carries nor allowlists.
+    MissingField {
+        struct_name: String,
+        schema: String,
+        field: String,
+    },
+    /// Struct carries a wire field the schema does not define.
+    UnknownField {
+        struct_name: String,
+        schema: String,
+        field: String,
+    },
+    /// A `Deserialize` struct in the source is in neither `mirrors` nor `non_mirrors`.
+    UndeclaredStruct { struct_name: String },
+    /// A manifest entry names a struct the source walk never found.
+    StructNotFound { struct_name: String },
+    /// A dishonest omission: struct actually carries the field, the schema no
+    /// longer has it, or the omission's `why` is blank/missing.
+    StaleOmission {
+        struct_name: String,
+        schema: String,
+        field: String,
+    },
+    /// A manifest `schema` is absent from `components.schemas`.
+    SchemaNotFound { struct_name: String, schema: String },
+    /// The schema (object-level `allOf`/`anyOf`) or the struct (a
+    /// `#[serde(flatten)]` field) cannot be decomposed field-by-field.
+    UnsupportedShape { struct_name: String, schema: String },
+    /// The inventory holds more than one `Deserialize` struct with this bare
+    /// name; the manifest keys by name, so the second is never field-checked.
+    DuplicateStruct { struct_name: String },
+    /// A manifest entry is missing a required key (`struct`/`schema`), so its
+    /// struct would silently escape field comparison.
+    MalformedManifestEntry { detail: String },
+}
+
+/// One `Deserialize` struct recovered from the source: its bare name, the set of
+/// wire field names (rename/rename_all/skip applied), and whether it has a
+/// `#[serde(flatten)]` field (which makes it undecomposable).
+struct CollectedStruct {
+    name: String,
+    wire_fields: BTreeSet<String>,
+    has_flatten: bool,
+}
+
+/// serde attributes distilled from a field's (or container's) `#[serde(...)]`
+/// attrs. Only the knobs that affect wire-name coverage are captured.
+#[derive(Default)]
+struct SerdeAttrs {
+    rename: Option<String>,
+    rename_all: Option<String>,
+    skip: bool,
+    flatten: bool,
+}
+
+fn parse_serde_attrs(attrs: &[syn::Attribute]) -> SerdeAttrs {
+    let mut out = SerdeAttrs::default();
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        // Errors are ignored: any serde attr shape this codebase does not use
+        // would simply leave `out` at its earlier state; the real tree only uses
+        // rename / rename_all / skip / flatten / default / skip_serializing_if /
+        // alias, all handled below.
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("skip") || meta.path.is_ident("skip_deserializing") {
+                // `skip` drops the field from BOTH directions; `skip_deserializing`
+                // drops it from the wire (the decoder populates from Default), so it
+                // does NOT cover its schema property either. `skip_serializing`
+                // (below, ignored) is still deserialized and DOES cover.
+                out.skip = true;
+            } else if meta.path.is_ident("flatten") {
+                out.flatten = true;
+            } else if meta.path.is_ident("rename") {
+                let lit: syn::LitStr = meta.value()?.parse()?;
+                out.rename = Some(lit.value());
+            } else if meta.path.is_ident("rename_all") {
+                let lit: syn::LitStr = meta.value()?.parse()?;
+                out.rename_all = Some(lit.value());
+            } else if meta.input.peek(syn::Token![=]) {
+                // Any other value-bearing key (default = "..", alias = "..",
+                // skip_serializing_if = "..") — consume and ignore. `alias`
+                // deliberately does NOT count as coverage.
+                let _: syn::Expr = meta.value()?.parse()?;
+            }
+            Ok(())
+        });
+    }
+    out
+}
+
+/// Does any `#[derive(...)]` on this item name `Deserialize` (bare or
+/// `serde::Deserialize`)? Matches on the last path segment, so `Serialize` never
+/// counts.
+fn derives_deserialize(attrs: &[syn::Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("derive") {
+            continue;
+        }
+        let mut found = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if let Some(seg) = meta.path.segments.last() {
+                if seg.ident == "Deserialize" {
+                    found = true;
+                }
+            }
+            Ok(())
+        });
+        if found {
+            return true;
+        }
+    }
+    false
+}
+
+/// serde's `rename_all` word-splitting is on the snake_case field ident.
+fn apply_rename_all(rule: &str, ident: &str) -> String {
+    // Rust fields arrive snake_case; split on `_` into words.
+    let words: Vec<&str> = ident.split('_').filter(|w| !w.is_empty()).collect();
+    let capitalize = |w: &str| {
+        let mut c = w.chars();
+        match c.next() {
+            Some(f) => f.to_ascii_uppercase().to_string() + &c.as_str().to_ascii_lowercase(),
+            None => String::new(),
+        }
+    };
+    match rule {
+        "lowercase" => ident.to_ascii_lowercase(),
+        "UPPERCASE" => ident.to_ascii_uppercase(),
+        "PascalCase" => words.iter().map(|w| capitalize(w)).collect(),
+        "camelCase" => {
+            let mut it = words.iter();
+            let first = it
+                .next()
+                .map(|w| w.to_ascii_lowercase())
+                .unwrap_or_default();
+            first + &it.map(|w| capitalize(w)).collect::<String>()
+        }
+        "snake_case" => words.join("_"),
+        "SCREAMING_SNAKE_CASE" => words
+            .iter()
+            .map(|w| w.to_ascii_uppercase())
+            .collect::<Vec<_>>()
+            .join("_"),
+        "kebab-case" => words.join("-"),
+        "SCREAMING-KEBAB-CASE" => words
+            .iter()
+            .map(|w| w.to_ascii_uppercase())
+            .collect::<Vec<_>>()
+            .join("-"),
+        // Unknown rule: leave the ident untouched rather than guess.
+        _ => ident.to_string(),
+    }
+}
+
+/// Walks a parsed Rust file collecting every `Deserialize`-deriving struct,
+/// including those nested in fn / impl-method bodies (the reason this is a
+/// `Visit` walk and not a `File.items` loop).
+#[derive(Default)]
+struct StructCollector {
+    structs: Vec<CollectedStruct>,
+}
+
+impl<'ast> Visit<'ast> for StructCollector {
+    fn visit_item_struct(&mut self, node: &'ast syn::ItemStruct) {
+        if derives_deserialize(&node.attrs) {
+            let container = parse_serde_attrs(&node.attrs);
+            let mut wire_fields = BTreeSet::new();
+            let mut has_flatten = false;
+            if let syn::Fields::Named(named) = &node.fields {
+                for field in &named.named {
+                    let fs = parse_serde_attrs(&field.attrs);
+                    if fs.flatten {
+                        has_flatten = true;
+                        continue;
+                    }
+                    if fs.skip {
+                        continue;
+                    }
+                    let Some(ident) = field.ident.as_ref() else {
+                        continue;
+                    };
+                    let ident = ident.to_string();
+                    let wire = if let Some(rename) = fs.rename {
+                        rename
+                    } else if let Some(rule) = &container.rename_all {
+                        apply_rename_all(rule, &ident)
+                    } else {
+                        ident
+                    };
+                    wire_fields.insert(wire);
+                }
+            }
+            self.structs.push(CollectedStruct {
+                name: node.ident.to_string(),
+                wire_fields,
+                has_flatten,
+            });
+        }
+        // Continue the default traversal so structs nested inside THIS struct's
+        // context (and, at the file level, inside fn/impl bodies) are still seen.
+        syn::visit::visit_item_struct(self, node);
+    }
+}
+
+fn walk_structs(rust_src: &str) -> Vec<CollectedStruct> {
+    let file = match syn::parse_file(rust_src) {
+        Ok(f) => f,
+        // A source we cannot parse yields no structs; the real-tree test would
+        // then fail loudly on the manifest's dangling entries (StructNotFound),
+        // which is the correct fail-closed signal.
+        Err(_) => return Vec::new(),
+    };
+    let mut collector = StructCollector::default();
+    collector.visit_file(&file);
+    collector.structs
+}
+
+/// Extracts `e[key]` as a wire string, e.g. a manifest entry's declared
+/// struct/schema name. Reused for the declared-name set, the malformed-entry
+/// scan, the StructNotFound scan, and the per-mirror field comparison.
+fn entry_str<'a>(e: &'a Value, key: &str) -> Option<&'a str> {
+    e.get(key).and_then(|v| v.as_str())
+}
+
+/// Property names of a schema object, empty if it declares none.
+fn schema_props(schema: &Value) -> BTreeSet<String> {
+    schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .map(|o| o.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// An object-level composition keyword the gate refuses to decompose.
+fn is_composed_schema(schema: &Value) -> bool {
+    schema.get("allOf").is_some() || schema.get("anyOf").is_some() || schema.get("oneOf").is_some()
+}
+
+/// Compare the mirror structs in `rust_src` against the schemas they declare in
+/// `manifest`, using `openapi`'s `components.schemas`. Pure: same inputs, same
+/// output, so the fixtures drive it identically to the real tree.
+pub fn violations(rust_src: &str, openapi: &Value, manifest: &Value) -> Vec<Violation> {
+    let mut out = Vec::new();
+
+    let structs = walk_structs(rust_src);
+    let found_names: BTreeSet<&str> = structs.iter().map(|s| s.name.as_str()).collect();
+
+    // DuplicateStruct: the manifest keys by bare struct name, so two same-named
+    // `Deserialize` structs (legal Rust — e.g. two fn-body-local structs) collapse
+    // to one manifest key and only the FIRST is ever field-checked. Fail closed:
+    // flag each duplicated name once.
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    let mut flagged_dup: BTreeSet<&str> = BTreeSet::new();
+    for s in &structs {
+        let name = s.name.as_str();
+        if !seen.insert(name) && flagged_dup.insert(name) {
+            out.push(Violation::DuplicateStruct {
+                struct_name: name.to_string(),
+            });
+        }
+    }
+
+    let mirrors: &[Value] = manifest
+        .get("mirrors")
+        .and_then(|m| m.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let non_mirrors: &[Value] = manifest
+        .get("non_mirrors")
+        .and_then(|m| m.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+
+    // Every declared struct name, across both lists.
+    let declared: BTreeSet<String> = mirrors
+        .iter()
+        .chain(non_mirrors.iter())
+        .filter_map(|e| entry_str(e, "struct").map(String::from))
+        .collect();
+
+    // MalformedManifestEntry: a `mirrors` entry lacking `struct` or `schema`, or a
+    // `non_mirrors` entry lacking `struct`, has no valid key. Such an entry would
+    // otherwise be silently skipped in field comparison (and, if it has a struct,
+    // suppress that struct's UndeclaredStruct), letting the struct escape checking.
+    // Fail closed: flag it.
+    for m in mirrors {
+        let has_struct = entry_str(m, "struct");
+        let has_schema = entry_str(m, "schema");
+        if has_struct.is_none() || has_schema.is_none() {
+            let detail = match (has_struct, has_schema) {
+                (Some(st), None) => format!("mirrors entry for struct {st:?} missing schema"),
+                (None, Some(sc)) => format!("mirrors entry missing struct (schema {sc:?})"),
+                _ => "mirrors entry missing struct and schema".to_string(),
+            };
+            out.push(Violation::MalformedManifestEntry { detail });
+        }
+    }
+    for e in non_mirrors {
+        if entry_str(e, "struct").is_none() {
+            out.push(Violation::MalformedManifestEntry {
+                detail: "non_mirrors entry missing struct".to_string(),
+            });
+        }
+    }
+
+    // UndeclaredStruct: an inventoried struct in neither list (D2's teeth).
+    for s in &structs {
+        if !declared.contains(&s.name) {
+            out.push(Violation::UndeclaredStruct {
+                struct_name: s.name.clone(),
+            });
+        }
+    }
+
+    // StructNotFound: a manifest entry (either list) naming a struct the walk
+    // never found — the fail-closed twin that makes a walk defect observable.
+    for entry in mirrors.iter().chain(non_mirrors.iter()) {
+        if let Some(name) = entry_str(entry, "struct") {
+            if !found_names.contains(name) {
+                out.push(Violation::StructNotFound {
+                    struct_name: name.to_string(),
+                });
+            }
+        }
+    }
+
+    let empty_schemas = serde_json::Map::new();
+    let schemas = openapi
+        .get("components")
+        .and_then(|c| c.get("schemas"))
+        .and_then(|s| s.as_object())
+        .unwrap_or(&empty_schemas);
+
+    // Field comparison, per mirror entry.
+    for m in mirrors {
+        let Some(struct_name) = entry_str(m, "struct") else {
+            continue;
+        };
+        let Some(schema_name) = entry_str(m, "schema") else {
+            continue;
+        };
+        // No struct found for this entry -> already reported as StructNotFound.
+        let Some(s) = structs.iter().find(|s| s.name.as_str() == struct_name) else {
+            continue;
+        };
+
+        let Some(schema) = schemas.get(schema_name) else {
+            out.push(Violation::SchemaNotFound {
+                struct_name: struct_name.to_string(),
+                schema: schema_name.to_string(),
+            });
+            continue;
+        };
+
+        if s.has_flatten {
+            out.push(Violation::UnsupportedShape {
+                struct_name: struct_name.to_string(),
+                schema: schema_name.to_string(),
+            });
+            continue;
+        }
+        if is_composed_schema(schema) {
+            out.push(Violation::UnsupportedShape {
+                struct_name: struct_name.to_string(),
+                schema: schema_name.to_string(),
+            });
+            continue;
+        }
+
+        let props = schema_props(schema);
+        let wire = &s.wire_fields;
+
+        // Validate omissions. An omission always suppresses MissingField for its
+        // field; a dishonest one additionally yields StaleOmission.
+        let mut suppressed: BTreeSet<String> = BTreeSet::new();
+        if let Some(omissions) = m.get("omissions").and_then(|o| o.as_array()) {
+            for om in omissions {
+                let Some(field) = om.get("field").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                suppressed.insert(field.to_string());
+                let why = om.get("why").and_then(|v| v.as_str()).unwrap_or("").trim();
+                let dishonest = why.is_empty()      // blank/missing justification
+                    || wire.contains(field)         // struct actually carries it
+                    || !props.contains(field); // schema no longer defines it
+                if dishonest {
+                    out.push(Violation::StaleOmission {
+                        struct_name: struct_name.to_string(),
+                        schema: schema_name.to_string(),
+                        field: field.to_string(),
+                    });
+                }
+            }
+        }
+
+        // MissingField: a schema property neither carried nor suppressed.
+        for p in &props {
+            if !wire.contains(p) && !suppressed.contains(p) {
+                out.push(Violation::MissingField {
+                    struct_name: struct_name.to_string(),
+                    schema: schema_name.to_string(),
+                    field: p.clone(),
+                });
+            }
+        }
+
+        // UnknownField: a wire field with no schema property behind it. No
+        // allowlist path — a CLI field with no API field is always a bug.
+        for w in wire {
+            if !props.contains(w) {
+                out.push(Violation::UnknownField {
+                    struct_name: struct_name.to_string(),
+                    schema: schema_name.to_string(),
+                    field: w.clone(),
+                });
+            }
+        }
+    }
+
+    out
+}


### PR DESCRIPTION
Adds a mechanical gate asserting every struct in `cli/src/api.rs` that mirrors a platform API response model carries that model's fields, so a field added to (or load-bearing in) the API cannot silently be absent from the CLI's `--json` surface. Closes the drift class behind #548, #456, #341.

## Approach
Option (b) from the issue: an assertion gate with a declared allowlist, not codegen. The CLI mirrors are deliberately partial read-views, so the invariant we want is "every divergence is declared and reviewed" — an allowlist, not "identical" — which is why full codegen (right for the frozen ACI wire types) is the wrong tool here.

- `cli/tests/support/field_parity.rs` — a `syn`-based comparator: inventories every `Deserialize` struct in `api.rs` (recursing into fn/impl bodies so a method-local decoder like `BundleFiles` can't escape), honors serde `rename`/`rename_all`/`skip`/`skip_deserializing`, and **fails closed** on `flatten`, object-level `allOf`, missing/dangling schemas, duplicate struct names, and malformed manifest entries.
- `cli/api-mirrors.json` — the declaration artifact: 13 mirrors, every deliberate omission declared with a consumer-derived justification (replacing prose drive-by comments so review sees every divergence).
- `cli/tests/api_field_parity.rs` — real-tree assertion + 15 fixture-driven rejection cases, each proving the gate rejects a drift class **by execution**.
- `agentos dev field-parity` — the contributor entry point; rides the existing `cargo test` CI job with no workflow changes.
- `Version` gains `agent_id` + `bundle_ref` (closes the concrete named drift); `versions --json` now emits `id` + `bundle_ref` (the #548 parity-evidence shape). `agent_id` is carried on the struct for parity but not emitted (the payload already carries `agent`).

## Sibling seams (deferred, per the parity-seam rule)
- #699 — `CliOutput::to_json` emit-hop parity (a `to_json` can still drop a field its DTO carries; the one instance, `versions` dropping `id`, is fixed here)
- #700 — `EvalModelSummary.plumbing` unmodeled in the CLI sweep
- #701 — `plugin_format` hand-mirrors are ungated (frozen-contract sibling)

Closes #691
