### PR TITLE
Fix approval-gate shorthand fail-open and complete local approvals offline

### DIFF
--- a/apps/worker/CLAUDE.md
+++ b/apps/worker/CLAUDE.md
@@ -58,6 +58,12 @@ simplification.
   flag-clean retry *classification* inside one delivery. Do not conflate them.
 - **Transient failure is unchanged**: a mid-turn crash still reclaims, retries,
   and acks. Only an exhausted budget dead-letters.
+- **Exception (#708): approval-resume reply is best-effort in the pure-offline
+  loop.** When an approval-resume turn's reply endpoint is unreachable AND no
+  default Slack transport is configured, `AsyncSlackSink` swallows the
+  unreachable error instead of raising -- the turn ACKs without delivering the
+  reply instead of dead-lettering. A configured default transport, or any
+  non-resume turn, still raises and dead-letters normally.
 - **The graveyard has no consumer group, but it IS bounded** by an approximate
   `MAXLEN` (`AGENTOS_DEAD_LETTER_MAXLEN`, default 10000) on every `XADD`. The
   unparseable path dead-letters per inbound entry, so an unbounded graveyard hands

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -193,6 +193,18 @@ Rules (detailed-architecture 2b), each with an integration test that provokes it
   every later turn. **Transient failures are unaffected:** a worker that crashes
   mid-turn still has its entry reclaimed, retried, and acked exactly as before;
   only an exhausted delivery budget dead-letters.
+- **Exception: best-effort reply on an approval-resume turn, pure-offline
+  loop** (#708). The scenario above is exactly an approval-resume turn whose
+  reply endpoint (the CLI's throwaway stub) died with the process that
+  created it. When there is genuinely no default Slack transport configured
+  (`self._default_base_url is None`), that unreachable reply no longer
+  dead-letters the resume: the kernel marks the turn `best_effort` and
+  `AsyncSlackSink._with_transport_fallback` logs and swallows the
+  unreachable-endpoint error instead of raising, so the already-granted tool
+  call still executes and the turn ACKs (the reply is still captured in the
+  transcript, just not delivered). A reply over a *configured* default
+  transport, and any non-resume turn, still raises on an unreachable
+  endpoint and follows the normal retry/dead-letter path above.
 
 ### The dead-letter graveyard
 

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -159,6 +159,7 @@ class _ThrottledReply:
         nav: NavPack | None = None,
         no_edit: bool = False,
         endpoint: str | None = None,
+        best_effort: bool = False,
     ) -> None:
         self._sink = sink
         self._channel = channel
@@ -167,6 +168,12 @@ class _ThrottledReply:
         self._no_edit = no_edit
         self._last = 0.0
         self._last_text: str | None = None
+        # Whether this turn's reply delivery is best-effort (#708): set only for an
+        # approval-resume turn (the caller derives it from _is_approval_resume). The
+        # granted tool already ran in the runner, so an undeliverable reply to a
+        # now-dead CLI stub with no default transport completes the turn rather than
+        # dead-lettering the resolved approval. Threaded to the sink per update.
+        self._best_effort = best_effort
         # The bound agent's hub-button pack, forwarded to the sink so a render of
         # a COMPLETE structured reply can add the no-dead-ends hub button (in
         # practice the final flush, which is the update that carries one). None
@@ -192,6 +199,7 @@ class _ThrottledReply:
             text=text,
             nav=self._nav,
             endpoint=self._endpoint,
+            best_effort_unreachable=self._best_effort,
         )
 
     async def finalize(self, text: str) -> None:
@@ -204,6 +212,7 @@ class _ThrottledReply:
             text=text or "(no response)",
             nav=self._nav,
             endpoint=self._endpoint,
+            best_effort_unreachable=self._best_effort,
         )
 
 
@@ -884,6 +893,18 @@ class Kernel:
             nav=nav,
             no_edit=self._config.slack_no_edit_streaming,
             endpoint=qevent.reply_handle.endpoint,
+            # Reply delivery is best-effort ONLY on an approval-resume turn (the
+            # granted tool has already executed in the runner): a dead reply
+            # endpoint with no default transport completes the turn instead of
+            # dead-lettering the resolved approval. Recognized structurally by the
+            # resume event_id, the same platform-authored resume signal the #419
+            # card teardown keys off (see the marker note above _is_approval_resume).
+            # This intentionally covers BOTH resume flavors -- the ``[approval
+            # resolved]`` resolve path and the ``[approval expired]`` expiry path --
+            # since both carry the ``approval-<id>-resolved`` event_id matched by
+            # _is_approval_resume. That shared coverage is deliberate and
+            # plan-ratified, not an oversight.
+            best_effort=self._is_approval_resume(qevent.event_id),
         )
         try:
             # ``async with`` releases the aiohttp response on every exit path

--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Protocol, TypeVar
+from typing import Protocol, TypeVar, cast
 
 import aiohttp
 from slack_sdk.errors import SlackApiError
@@ -53,6 +53,7 @@ class SlackSink(Protocol):
         text: str,
         nav: NavPack | None = None,
         endpoint: str | None = None,
+        best_effort_unreachable: bool = False,
     ) -> None: ...
 
     async def set_status(
@@ -145,6 +146,7 @@ class AsyncSlackSink:
         op: Callable[[AsyncWebClient], Awaitable[_T]],
         *,
         describe: str,
+        best_effort_unreachable: bool = False,
     ) -> _T:
         """Run ``op`` against this turn's endpoint, falling back to the worker
         DEFAULT transport when that endpoint is UNREACHABLE (#530).
@@ -159,6 +161,23 @@ class AsyncSlackSink:
         failing target was a real per-turn ``endpoint`` AND a default is configured
         AND it differs from that endpoint. A ``SlackApiError`` (endpoint reachable,
         call rejected) is not an unreachability and is never caught here.
+
+        ``best_effort_unreachable`` (#708) covers the pure-offline case: on a
+        resume turn (kernel gates it via ``_is_approval_resume``) whose reply
+        endpoint is dead and where there is genuinely NO default configured at all
+        (``self._default_base_url is None`` -- the pure-offline local loop), log
+        and RETURN instead of re-raising, so the resolved approval's
+        already-executed turn ACKs instead of dead-lettering. The reply is still
+        durably captured in the transcript, so it is not lost. When a default IS
+        configured, the swallow never fires: a per-turn endpoint takes the #530
+        default fallback above, and a reply already targeting the configured
+        default that is unreachable is a genuine outage that stays LOUD.
+
+        Best-effort delivery intentionally covers BOTH resume flavors -- the
+        ``[approval resolved]`` resolve path and the ``[approval expired]`` expiry
+        path -- because both carry the same ``approval-<id>-resolved`` event_id the
+        kernel matches with ``_is_approval_resume``. That shared coverage is
+        deliberate and plan-ratified, not an oversight.
         """
         primary = self._client_for(endpoint)
         resolved = endpoint or self._default_base_url
@@ -168,16 +187,41 @@ class AsyncSlackSink:
         try:
             return await op(primary)
         except _UNREACHABLE_ERRORS as exc:
-            if not has_distinct_default:
-                raise
-            logger.warning(
-                "%s: reply endpoint %r is unreachable (%s); falling back to the "
-                "default Slack transport",
-                describe,
-                endpoint,
-                exc,
-            )
-            return await op(self._client_for(None))
+            if has_distinct_default:
+                logger.warning(
+                    "%s: reply endpoint %r is unreachable (%s); falling back to the "
+                    "default Slack transport",
+                    describe,
+                    endpoint,
+                    exc,
+                )
+                return await op(self._client_for(None))
+            # The best-effort swallow (#708) fires ONLY in the pure-offline case
+            # where there is genuinely NO configured default transport at all
+            # (``self._default_base_url is None``). It must NOT key off
+            # ``not has_distinct_default``: that is also False when the reply is
+            # going over a CONFIGURED default (``endpoint`` is None or equals the
+            # default), where the target is a real, reachable-in-principle Slack.
+            # An unreachable-class error there is a genuine transient OUTAGE that
+            # must stay LOUD (raise -> reclaim -> retry per ADR-0039), never be
+            # silently swallowed and acked. A resumed turn that then hits ANOTHER
+            # approval gate or fails posts via ``_pause_for_approval``/``_escalate``
+            # with ``best_effort_unreachable=False`` and therefore stays loud
+            # (dead-letters) even in this offline loop -- a second approval card or
+            # an escalation must never be silently dropped; surfacing via
+            # dead-letter is correct, and completing those offline is out of scope
+            # for #708.
+            if best_effort_unreachable and self._default_base_url is None:
+                logger.warning(
+                    "%s: reply endpoint %r is unreachable (%s) with no default "
+                    "transport; completing the resume turn best-effort without "
+                    "delivering the reply",
+                    describe,
+                    endpoint,
+                    exc,
+                )
+                return cast(_T, None)
+            raise
 
     async def update(
         self,
@@ -187,6 +231,7 @@ class AsyncSlackSink:
         text: str,
         nav: NavPack | None = None,
         endpoint: str | None = None,
+        best_effort_unreachable: bool = False,
     ) -> None:
         # The runner emits Markdown; Slack renders mrkdwn. ``render`` converts to
         # mrkdwn and, if the reply carries a complete ``agentos-reply`` block,
@@ -215,7 +260,12 @@ class AsyncSlackSink:
             else:
                 await client.chat_update(channel=channel, ts=ts, text=rendered_text)
 
-        await self._with_transport_fallback(endpoint, op, describe="chat_update")
+        await self._with_transport_fallback(
+            endpoint,
+            op,
+            describe="chat_update",
+            best_effort_unreachable=best_effort_unreachable,
+        )
 
     async def post(
         self,

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -18,6 +18,7 @@ import uuid
 from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass, field
 
+import aiohttp
 import pytest
 import redis
 from aci_protocol import Final, OutboundEvent, SessionStatus
@@ -120,6 +121,16 @@ class FakeSink(SlackSink):
         self.card_updates: list[
             tuple[str, str, str, list[dict[str, object]], str | None]
         ] = []
+        # #708 test infra: endpoints whose HOST is dead (a CLI stub that exited).
+        # A reply-delivery ``update`` to one models the pure-offline local loop --
+        # no distinct default transport -- so it RAISES the same aiohttp transport
+        # error ``_with_transport_fallback`` re-raises (#530), UNLESS the caller
+        # opts into best-effort delivery (``best_effort_unreachable=True``), which
+        # logs-and-returns. This is what proves the flag -- not luck -- is what
+        # converts a resume turn's dead-letter into a terminal ACK.
+        self.dead_endpoints: set[str] = set()
+        # Reply deliveries that were swallowed best-effort (channel, ts, text).
+        self.swallowed: list[tuple[str, str, str]] = []
 
     async def update(
         self,
@@ -129,7 +140,13 @@ class FakeSink(SlackSink):
         text: str,
         nav: NavPack | None = None,
         endpoint: str | None = None,
+        best_effort_unreachable: bool = False,
     ) -> None:
+        if endpoint is not None and endpoint in self.dead_endpoints:
+            if best_effort_unreachable:
+                self.swallowed.append((channel, ts, text))
+                return
+            raise aiohttp.ClientError(f"reply endpoint {endpoint!r} is unreachable")
         self.updates.append((channel, ts, text))
         self.update_navs.append(nav)
         self.update_endpoints.append(endpoint)

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import asyncio
 import uuid
 
+import aiohttp
+import pytest
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from agentos_worker.approvals import ApprovalBackendError, ApprovalRequest, CreatedApproval
 from agentos_worker.sandbox.types import RouteState
@@ -674,5 +676,109 @@ def test_resolve_authored_by_a_system_named_actor_does_not_expire_the_card(
             # the dispatcher, never stamped expired by the worker.
             assert h.sink.card_updates == []
             assert not await h.async_redis.exists(h.config.approval_card_key(thread))
+
+    asyncio.run(go())
+
+
+# --- Best-effort resume reply when the CLI stub endpoint is dead (#708) --------
+
+
+def test_resume_reply_best_effort_completes_offline_when_endpoint_is_dead(
+    make_harness,
+) -> None:
+    """AC-708-1/2 (#708, PRIMARY): a resolved approval's resume turn whose per-turn
+    reply endpoint is the now-dead CLI stub, delivered on a worker with NO distinct
+    default transport (the pure-offline local loop), must still COMPLETE -- the
+    granted tool executes exactly once and the turn reaches terminal ACK -- instead
+    of dead-lettering because the reply cannot be delivered.
+
+    Today the reply-delivery ``update`` raises the aiohttp transport error
+    ``_with_transport_fallback`` re-raises when there is no distinct default (#530
+    only rescues the has-default case), so ``process_event`` escapes; the consumer
+    then leaves the entry pending, redelivers it to the delivery cap, and
+    dead-letters it (#505) -- a full re-run per redelivery and the resolved approval
+    never completes. The done marker is the proof it did NOT: it is written only
+    once the turn is terminally handled (the consumer then acks it).
+
+    The fix makes a resume turn's reply best-effort: the kernel gates the new
+    ``best_effort_unreachable`` flag on ``_is_approval_resume(event_id)`` for the
+    reply-delivery ``update`` calls (streaming edits + final reply). The resume
+    ``event_id`` shape (``approval-<uuid>-resolved``) is authored by
+    ``resumequeue.resume_event_id`` -- the format authority the worker recognizer
+    keys off across the api/worker seam.
+    """
+
+    async def go() -> None:
+        from agentos_api.resumequeue import resume_event_id
+
+        grant_event = resume_event_id(uuid.uuid4())
+        binding = GrantBinding(
+            grant_event_id=grant_event, grant_tool="mcp__github__create_issue"
+        )
+        async with make_harness(binding=binding) as h:
+            # Offline local loop: the reply endpoint (the CLI stub) is dead, and the
+            # worker sink has NO distinct default transport to fall back to.
+            h.sink.dead_endpoints.add(_CLI_STUB)
+
+            # The granted tool runs to done in the runner during the resume turn.
+            h.runner.default_script = [Final(text="Issue created.", status=DONE)]
+            resume_turn = QueuedTurn(
+                event_id=grant_event,
+                conversation_id="th-offline-resume",
+                author="U9",
+                text="[approval resolved] approved by U9",
+                reply_handle=ReplyHandle(
+                    channel="C1", placeholder="p-1", endpoint=_CLI_STUB
+                ),
+                received_at="2026-07-14T00:00:00+00:00",
+            )
+
+            # Must NOT raise: a dead reply endpoint on a resume turn no longer
+            # dead-letters the resolved approval.
+            await h.kernel.process_event(resume_turn)
+
+            # Terminal ACK, not dead-letter.
+            assert await h.async_redis.exists(h.config.done_key(grant_event))
+
+            # The granted tool executed exactly once: the resume turn opened a
+            # single runner turn, and that claim carried the one-shot #430 grant.
+            assert h.runner.opened == ["[approval resolved] approved by U9"]
+            resumed_env = h.fake_k8s.claim_envs[-1]
+            assert resumed_env is not None
+            assert (
+                resumed_env.get("AGENTOS_APPROVAL_GRANT_TOOL")
+                == "mcp__github__create_issue"
+            )
+
+    asyncio.run(go())
+
+
+def test_normal_turn_reply_stays_loud_when_endpoint_is_dead(make_harness) -> None:
+    """AC-708-4 (#708): the best-effort swallow is scoped to resume turns. A NORMAL
+    (non ``approval-<uuid>-resolved``) turn hitting the same dead endpoint + no
+    distinct default must STILL fail loudly -- a fresh local turn whose stub crashed
+    mid-turn is a genuine failure that must surface, not silently complete. Extends
+    ``test_no_fallback_when_no_default_is_configured``'s intent to the kernel.
+
+    The transport error propagates out of ``process_event`` (leaving the entry
+    pending for reclaim), so the turn is NOT marked done -- the inverse of the
+    resume case above."""
+
+    async def go() -> None:
+        async with make_harness() as h:  # no binding -> a plain, non-resume turn
+            h.sink.dead_endpoints.add(_CLI_STUB)
+            h.runner.default_script = [Final(text="done", status=DONE)]
+            ev = _qevent(
+                "hello",
+                thread="th-normal-dead",
+                event_id="ev-normal-1",  # not the resume shape
+                endpoint=_CLI_STUB,
+            )
+
+            with pytest.raises(aiohttp.ClientError):
+                await h.kernel.process_event(ev)
+
+            # Not silently completed: no done marker was written.
+            assert not await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -598,12 +598,18 @@ def test_booting_update_failure_never_fails_the_turn(make_harness) -> None:
                 text: str,
                 nav: NavPack | None = None,
                 endpoint: str | None = None,
+                best_effort_unreachable: bool = False,
             ) -> None:
                 if text == booting and fired["n"] == 0:
                     fired["n"] += 1
                     raise RuntimeError("injected Slack failure on booting update")
                 await original_update(
-                    channel=channel, ts=ts, text=text, nav=nav, endpoint=endpoint
+                    channel=channel,
+                    ts=ts,
+                    text=text,
+                    nav=nav,
+                    endpoint=endpoint,
+                    best_effort_unreachable=best_effort_unreachable,
                 )
 
             h.sink.update = flaky_update  # type: ignore[method-assign]

--- a/apps/worker/tests/test_slack_sink.py
+++ b/apps/worker/tests/test_slack_sink.py
@@ -314,3 +314,121 @@ def test_no_fallback_when_no_default_is_configured() -> None:
             sink.update(channel="C1", ts="1.1", text="hi", endpoint="http://stub:2/api/")
         )
     assert default_hits == [], "real-Slack default is not a safe fallback for a CLI-stub endpoint"
+
+
+# --- #708: best-effort resume reply when the endpoint is unreachable and there is
+# no distinct default (the pure-offline local loop). The swallow POLICY lives in the
+# sink; the "is this a resume turn" DECISION lives in the kernel (_is_approval_resume)
+# and reaches the sink as ``best_effort_unreachable``.
+
+
+def test_best_effort_unreachable_swallows_when_no_default() -> None:
+    # A resume turn's reply is best-effort: with no distinct default (offline loop)
+    # and a dead per-turn endpoint, best_effort_unreachable makes update
+    # log-and-return instead of re-raising, so the resolved approval's turn ACKs
+    # instead of dead-lettering. It must also never misroute to the real-Slack
+    # default (there is no safe fallback for a CLI-stub endpoint).
+    sink = AsyncSlackSink("xoxb-test")  # no base_url -> no distinct default
+    default_hits: list[str] = []
+    sink._client_for("http://stub:2/api/").chat_update = _raise_connection_error()  # type: ignore[method-assign]
+    sink._client_for(None).chat_update = _record_call(default_hits, "default")  # type: ignore[method-assign]
+
+    # Must NOT raise.
+    asyncio.run(
+        sink.update(
+            channel="C1",
+            ts="1.1",
+            text="hi",
+            endpoint="http://stub:2/api/",
+            best_effort_unreachable=True,
+        )
+    )
+    assert default_hits == [], "best-effort swallow must not misroute to the default"
+
+
+def test_best_effort_false_still_raises_when_no_default() -> None:
+    # The discriminator guard: without the flag (the default False, i.e. every
+    # non-resume turn and the loud _drop_with_message/_escalate paths), a dead
+    # endpoint with no default still raises loudly -- unchanged from
+    # test_no_fallback_when_no_default_is_configured.
+    sink = AsyncSlackSink("xoxb-test")
+    sink._client_for("http://stub:2/api/").chat_update = _raise_connection_error()  # type: ignore[method-assign]
+
+    with pytest.raises(aiohttp.ClientError):
+        asyncio.run(
+            sink.update(
+                channel="C1",
+                ts="1.1",
+                text="hi",
+                endpoint="http://stub:2/api/",
+                best_effort_unreachable=False,
+            )
+        )
+
+
+def test_slack_api_error_not_swallowed_even_with_best_effort() -> None:
+    # A SlackApiError means the endpoint IS reachable but rejected the call; it is
+    # NOT an unreachability, so best_effort_unreachable must NOT swallow it (that
+    # would hide a real delivery rejection). Only transport-unreachable errors
+    # (_UNREACHABLE_ERRORS) are in scope for the best-effort resume swallow.
+    sink = AsyncSlackSink("xoxb-test")
+
+    async def _reject(**_kwargs):
+        raise SlackApiError("nope", response={"error": "channel_not_found"})
+
+    sink._client_for("http://stub:2/api/").chat_update = _reject  # type: ignore[method-assign]
+
+    with pytest.raises(SlackApiError):
+        asyncio.run(
+            sink.update(
+                channel="C1",
+                ts="1.1",
+                text="hi",
+                endpoint="http://stub:2/api/",
+                best_effort_unreachable=True,
+            )
+        )
+
+
+def test_best_effort_stays_loud_when_default_transport_is_the_dead_target() -> None:
+    # F1 (side-effects HIGH): the best-effort swallow must fire ONLY in the pure
+    # no-default-configured case. Here a default IS configured and the reply is
+    # going over that CONFIGURED default (endpoint=None), so an unreachable error
+    # is a genuine transient OUTAGE of a real Slack transport -- it must stay LOUD
+    # (raise -> reclaim -> retry per ADR-0039), NOT be swallowed and acked. Even
+    # though has_distinct_default is False here, best_effort must not swallow.
+    sink = AsyncSlackSink("xoxb-test", base_url="http://default:1/api/")
+    sink._client_for(None).chat_update = _raise_connection_error()  # type: ignore[method-assign]
+
+    with pytest.raises(aiohttp.ClientError):
+        asyncio.run(
+            sink.update(
+                channel="C1",
+                ts="1.1",
+                text="hi",
+                endpoint=None,
+                best_effort_unreachable=True,
+            )
+        )
+
+
+def test_best_effort_still_falls_back_to_default_when_present() -> None:
+    # #530 stays byte-for-byte: with a distinct default configured, a dead per-turn
+    # endpoint on a resume turn STILL falls back to the default transport. The new
+    # flag only governs the no-distinct-default branch; it must not alter the
+    # has-default path (the reply still LANDS on the default, it is not swallowed).
+    sink = AsyncSlackSink("xoxb-test", base_url="http://default:1/api/")
+    landed: list[str] = []
+    sink._client_for("http://stub:2/api/").chat_update = _raise_connection_error()  # type: ignore[method-assign]
+    sink._client_for(None).chat_update = _record_call(landed, "default")  # type: ignore[method-assign]
+
+    asyncio.run(
+        sink.update(
+            channel="C1",
+            ts="1.1",
+            text="hi",
+            endpoint="http://stub:2/api/",
+            best_effort_unreachable=True,
+        )
+    )
+    assert landed == ["default"], "the flag must not bypass the #530 default-transport fallback"

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -186,20 +186,26 @@ in code now:
   `GET /approvals/{id}/audit`): actor, channel evidence, decision, and the authorizer
   snapshot -- who resolved, and why they counted (or were refused).
 
-### Arming a gate: use the fully-namespaced tool name
+### Arming a gate: bare MCP shorthand is normalized; unresolvable names fail closed
 
-The permission gate (`agents.approval_required_tools`, the runner's `can_use_tool`
-callback) matches a configured tool name by exact string equality -- no
-normalization, no prefix matching. The name you arm must be the tool's LIVE,
-fully-namespaced name, not the bare tool name.
-
-For a bundle-declared MCP tool that live name is
+The permission gate (`agents.approval_required_tools`, forwarded as
+`AGENTOS_APPROVAL_REQUIRED_TOOLS`) matches a tool by its LIVE, fully-namespaced
+runtime name. For a bundle-declared MCP tool that live name is
 `mcp__plugin_<bundle>_<server>__<tool>`, where `<bundle>` is the
 .claude-plugin/plugin.json `name` and `<server>` is the `.mcp.json` server key,
-for example `mcp__plugin_github-issues_github__create_issue`. The bare form
-`mcp__<server>__<tool>` (e.g. `mcp__github__create_issue`) does NOT match: a gate
-armed with it silently never intercepts the call, and a destructive tool runs
-with no approval whatsoever.
+for example `mcp__plugin_github-issues_github__create_issue`.
+
+**Since #703**, `build_approval_gate` (`runner/src/agentos_runner/approval.py`)
+normalizes each operator-supplied name to its effective form before arming:
+a bare `mcp__<server>__<tool>` shorthand is rewritten to the
+`mcp__plugin_<bundle>_<server>__<tool>` name when `<server>` matches a
+bundle-declared MCP server. Built-in tool names and already-effective
+`mcp__plugin_...` names pass through verbatim. There is no verbatim carve-out
+for an `mcp__`-shaped name that names no other server form. If an
+`mcp__`-shaped name cannot be resolved to a declared bundle server, the
+runner refuses to boot with `ApprovalPolicyError` rather than arming nothing
+-- previously this failed open: an unresolvable shorthand silently never
+matched and the gated tool ran with no approval whatsoever.
 
 Confirm the exact live name before arming a gate rather than guessing it.
 `agentos skill check` prints a `match: <server> -> plugin:<bundle>:<server>`

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -6,7 +6,11 @@ is a frozen interface (see the package README); a change stops the task and
 escalates to the orchestrator.
 """
 
-from .approval_policy import grantable_routes
+from .approval_policy import (
+    declared_mcp_server_names,
+    effective_operator_gate,
+    grantable_routes,
+)
 from .archive import UnsupportedArchive, bundle_root, safe_extract
 from .manifest import MANIFEST_LOCATIONS, resolve_manifest
 from .models import (
@@ -43,6 +47,8 @@ __all__ = [
     "ApprovalPolicy",
     "ApprovalGate",
     "grantable_routes",
+    "declared_mcp_server_names",
+    "effective_operator_gate",
     "validate_bundle",
     "ValidationResult",
     "ValidationIssue",

--- a/packages/plugin-format/src/plugin_format/approval_policy.py
+++ b/packages/plugin-format/src/plugin_format/approval_policy.py
@@ -13,7 +13,14 @@ ship a fail-open.
 
 from __future__ import annotations
 
-from .models import ApprovalGate
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from .manifest import resolve_manifest
+from .models import ApprovalGate, McpConfig, PluginManifest
 
 
 def grantable_routes(
@@ -59,3 +66,177 @@ def grantable_routes(
         else:
             ambiguous.add(route)
     return resolved, ambiguous
+
+
+# --- Operator gate-name normalization (#703): shared by the deploy validator ----
+# and the runtime loader, so an operator-supplied gate name and a manifest gate
+# name resolve to the SAME effective runtime form by construction (the #453/#544
+# validator/runtime-drift lesson).
+
+
+def effective_tool_prefix(bundle_name: str, server: str) -> str:
+    """The live tool-name prefix the SDK plugin-namespacing produces (#703).
+
+    The SAME template ``validate.py`` builds ``expected_prefixes`` from and
+    ``effective_operator_gate`` matches against -- ONE definition shared by the
+    deploy-time validator and the runtime loader so the prefix format cannot
+    drift between them (the #453/#544 lesson).
+    """
+
+    return f"mcp__plugin_{bundle_name}_{server}__"
+
+
+def _longest_matching_server(
+    name: str, servers: set[str], prefix_of: Callable[[str], str]
+) -> str | None:
+    """The declared server whose ``prefix_of(server)`` matches ``name``, or ``None``.
+
+    A server matches when ``name`` starts with ``prefix_of(server)`` AND has a
+    non-empty remainder after it (``len(name) > len(prefix)``). When more than
+    one declared server matches (one server name is a prefix of another), the
+    LONGEST server name wins the tie -- the more specific match.
+    """
+
+    best_server: str | None = None
+    for s in servers:
+        prefix = prefix_of(s)
+        if name.startswith(prefix) and len(name) > len(prefix):
+            if best_server is None or len(s) > len(best_server):
+                best_server = s
+    return best_server
+
+
+def _mcp_server_names(obj: object) -> set[str] | None:
+    """The set of server names an mcp declaration object names, or ``None``.
+
+    Accepts both a full config object (``{"mcpServers": {...}}``) and a bare
+    servers map (``{name: server}``), matching ``validate._validate_mcp_object``'s
+    payload wrapping so the name derivation is identical on both sides. ``None``
+    means the declaration failed to validate (unreadable), which poisons the
+    declared-server union.
+    """
+
+    payload = obj if isinstance(obj, dict) and "mcpServers" in obj else {"mcpServers": obj}
+    try:
+        config = McpConfig.model_validate(payload)
+    except ValidationError:
+        return None
+    return set(config.mcpServers)
+
+
+def declared_mcp_server_names(root: str | Path) -> set[str] | None:
+    """The MCP server names a bundle declares, or ``None`` when unknowable.
+
+    Reads the manifest's inline ``mcpServers`` object AND the root ``.mcp.json``,
+    returning the union of every server name across both. ``None`` is the poison
+    value ``validate._validate_mcp`` uses: a declaration existed but could not be
+    read (invalid JSON, a config that failed to validate, or the path-string form
+    the real loader ignores), so the declared-server set is unknowable and a gate
+    cross-check must fail closed rather than assert against a partial set. An empty
+    set is the distinct fact that a declaration was read and named no servers.
+    """
+
+    root = Path(root)
+    servers: set[str] = set()
+    unreadable = False
+
+    manifest_path = resolve_manifest(root)
+    if manifest_path is not None:
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest = PluginManifest.model_validate(data)
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError, ValidationError):
+            # The manifest itself is unreadable, so its declared servers are
+            # unknowable -- poison the whole set.
+            return None
+        declared = manifest.mcpServers
+        if isinstance(declared, dict):
+            result = _mcp_server_names(declared)
+            if result is None:
+                unreadable = True
+            else:
+                servers |= result
+        elif isinstance(declared, str):
+            # The path-string form parses but the real loader ignores it, so the
+            # servers never register: unknowable, not empty.
+            unreadable = True
+
+    root_mcp = root / ".mcp.json"
+    if root_mcp.is_file():
+        try:
+            data = json.loads(root_mcp.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+            unreadable = True
+        else:
+            result = _mcp_server_names(data)
+            if result is None:
+                unreadable = True
+            else:
+                servers |= result
+
+    if unreadable:
+        return None
+    return servers
+
+
+def effective_operator_gate(
+    bundle_name: str | None, servers: set[str] | None, name: str
+) -> str | None:
+    """Map an operator gate name to its effective runtime tool name (#703).
+
+    The SDK plugin-prefixes a bundle MCP tool to
+    ``mcp__plugin_<bundle>_<server>__<tool>``. An operator who writes the natural
+    shorthand ``mcp__<server>__<tool>`` in ``AGENTOS_APPROVAL_REQUIRED_TOOLS`` must
+    have it rewritten to that effective form, or the gate arms a literal that the
+    runtime name never matches (a silent fail-open). Returns:
+
+    - the rewritten effective name when ``name`` is ``mcp__<server>__<tool>`` and
+      ``<server>`` is a declared bundle server. ``<server>`` is resolved by
+      MATCHING the shorthand against the declared servers (a server name may itself
+      contain ``__``, so splitting at the first ``__`` would misparse
+      ``mcp__foo__bar__do`` as server ``foo``); the longest matching server name
+      wins when one is a prefix of another. The effective prefix is built exactly
+      as ``validate.py`` constructs ``expected_prefixes``;
+    - ``name`` verbatim only for a built-in with no ``mcp__`` prefix (armed by raw
+      name), OR for an already ``mcp__plugin_``-prefixed name that MATCHES an
+      expected prefix ``mcp__plugin_<bundle>_<server>__`` for a declared server
+      (with a non-empty tool remainder), mirroring ``validate.py``'s
+      ``expected_prefixes`` check -- an already-prefixed name is NOT trusted blindly
+      (a typo'd ``mcp__plugin_wrongbundle_wrongserver__tool`` would arm a literal the
+      runtime never matches, a fail-open);
+    - ``None`` when ``name`` is ``mcp__``-shaped and cannot be verified against a
+      declared server: an undeclared server, no declared servers, ``servers is
+      None`` or a falsy ``bundle_name`` (cannot construct the prefix to verify), an
+      empty tool remainder, or an already-prefixed name matching no expected
+      prefix. The operator override is never deploy-validated, so this runtime
+      check is its sole defense -- "cannot verify" fails CLOSED, not through. The
+      caller fails closed on ``None``.
+    """
+
+    # A built-in tool (Bash, Write, ...) carries no mcp__ prefix: armed by raw
+    # name, never rewritten and never server-checked.
+    if not name.startswith("mcp__"):
+        return name
+    # Every mcp__-shaped name is verified against the declared-server set. Without
+    # it (unreadable declaration, or no bundle name to build the prefix) nothing can
+    # be verified, so fail closed -- this runtime check is the operator override's
+    # only defense.
+    if servers is None or not bundle_name:
+        return None
+    # Already the effective plugin-namespaced form: verify it matches an expected
+    # prefix mcp__plugin_<bundle>_<server>__ for a declared server (with a non-empty
+    # tool remainder), exactly as validate.py asserts. Do NOT trust it verbatim.
+    if name.startswith("mcp__plugin_"):
+        matched = _longest_matching_server(
+            name, servers, lambda s: effective_tool_prefix(bundle_name, s)
+        )
+        return name if matched is not None else None
+    # An mcp__<server>__<tool> shorthand: resolve <server> by matching against the
+    # declared servers rather than splitting at the first __ (a server name may
+    # contain __). Prefer the longest match to disambiguate when one server name is
+    # a prefix of another; require a non-empty tool remainder.
+    best_server = _longest_matching_server(name, servers, lambda s: f"mcp__{s}__")
+    if best_server is None:
+        return None
+    tool = name[len(f"mcp__{best_server}__") :]
+    return f"mcp__plugin_{bundle_name}_{best_server}__{tool}"

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -13,7 +13,7 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
-from .approval_policy import grantable_routes
+from .approval_policy import declared_mcp_server_names, effective_tool_prefix, grantable_routes
 from .manifest import resolve_manifest
 from .models import (
     _TRIGGER_TYPES,
@@ -181,18 +181,19 @@ def _validate_mcp(root: Path, manifest: PluginManifest, c: _Collector) -> set[st
     path, or a config that failed to validate); it poisons the union, because a
     single unreadable source makes the declared-server set unknowable. An empty
     set is a different fact: a declaration was read and named no servers.
+
+    The declaration objects are still walked here for their error layering (the
+    ``_Collector`` messages), but the RETURNED set -- which
+    ``_validate_approval_policy`` builds gate prefixes from -- comes from the
+    shared ``declared_mcp_server_names`` derivation the runtime loader also uses,
+    so the deploy validator and the runner normalize gate names identically by
+    construction (#453/#703). Deriving both from one function is the anti-drift
+    guarantee; the per-source walks below only produce actionable errors.
     """
 
     declared = manifest.mcpServers
-    servers: set[str] = set()
-    unreadable = False
-
     if isinstance(declared, dict):
-        result = _validate_mcp_object(declared, "plugin.json (mcpServers)", c)
-        if result is None:
-            unreadable = True
-        else:
-            servers |= result
+        _validate_mcp_object(declared, "plugin.json (mcpServers)", c)
     elif isinstance(declared, str):
         c.error(
             "mcp.declared_pointer",
@@ -201,22 +202,12 @@ def _validate_mcp(root: Path, manifest: PluginManifest, c: _Collector) -> set[st
             'object instead: "mcpServers": {"<name>": {"command": "..."}}.',
             "plugin.json",
         )
-        # An unreadable declaration, not an empty one: poison the set so the
-        # approval-gate cross-check stays silent instead of stacking a
-        # misleading "gate names an undeclared server" error on top of this.
-        unreadable = True
 
     root_mcp = root / ".mcp.json"
     if root_mcp.is_file():
-        result = _validate_mcp_file(root_mcp, ".mcp.json", c)
-        if result is None:
-            unreadable = True
-        else:
-            servers |= result
+        _validate_mcp_file(root_mcp, ".mcp.json", c)
 
-    if unreadable:
-        return None
-    return servers
+    return declared_mcp_server_names(root)
 
 
 def _validate_mcp_file(path: Path, location: str, c: _Collector) -> set[str] | None:
@@ -393,7 +384,7 @@ def _validate_approval_policy(
     # (_NAME_RE) but a server key can, so parsing mcp__plugin_a_b_c__t is
     # ambiguous. Constructing and testing startswith sidesteps that entirely.
     expected_prefixes: set[str] | None = (
-        {f"mcp__plugin_{manifest.name}_{s}__" for s in mcp_servers}
+        {effective_tool_prefix(manifest.name, s) for s in mcp_servers}
         if mcp_servers is not None
         else None
     )
@@ -452,7 +443,7 @@ def _gate_not_namespaced_message(gate: str, bundle: str, mcp_servers: set[str]) 
 
     if mcp_servers:
         declared = "Expected one of: " + ", ".join(
-            sorted(f"mcp__plugin_{bundle}_{s}__<tool>" for s in mcp_servers)
+            sorted(f"{effective_tool_prefix(bundle, s)}<tool>" for s in mcp_servers)
         )
     else:
         declared = "This bundle declares no MCP servers"
@@ -460,8 +451,14 @@ def _gate_not_namespaced_message(gate: str, bundle: str, mcp_servers: set[str]) 
         f"approval gate {gate!r} is not a live MCP tool name. A bundle-declared "
         f"MCP tool's live name is mcp__plugin_{bundle}_<server>__<tool>. "
         f"{declared}. A built-in tool gate (e.g. Bash) carries no mcp__ prefix. "
-        "To arm a live tool name this bundle does not declare, add it to the "
-        "per-agent AGENTOS_APPROVAL_REQUIRED_TOOLS env knob."
+        "A MANIFEST approvalPolicy gate must be the fully-namespaced live name "
+        "(this deploy gate does not normalize it). The per-agent "
+        "AGENTOS_APPROVAL_REQUIRED_TOOLS env knob is more lenient (#703): the runner "
+        "normalizes a bare mcp__<server>__<tool> shorthand for a DECLARED server to "
+        "its effective name, and also accepts an already-namespaced "
+        "mcp__plugin_<bundle>_<server>__<tool> or a built-in name -- but only for a "
+        "server the bundle declares; it never arms a name that names no declared "
+        "server. Namespace this manifest gate to its live name."
     )
 
 

--- a/packages/plugin-format/tests/test_effective_operator_gate.py
+++ b/packages/plugin-format/tests/test_effective_operator_gate.py
@@ -1,0 +1,172 @@
+"""Unit table for the shared operator-gate normalization helpers (#703).
+
+``effective_operator_gate(bundle_name, servers, name)`` maps an operator-supplied
+``AGENTOS_APPROVAL_REQUIRED_TOOLS`` name to the effective runtime tool name the SDK
+plugin-prefixes a bundle MCP tool to, returning the rewritten effective name, the
+name verbatim when it needs no rewrite (a built-in or an already-effective name),
+or ``None`` when it is an unresolvable ``mcp__`` shorthand (the caller fails
+closed). ``declared_mcp_server_names(root)`` reads the bundle's declared MCP server
+names (inline manifest ``mcpServers`` + root ``.mcp.json``) with the same
+poison-to-``None`` semantics as ``validate._validate_mcp``.
+
+The ``mcp__plugin_<bundle>_<server>__`` prefix is the exact shape the deploy
+validator asserts (validate.py:
+    ``expected_prefixes = {f"mcp__plugin_{manifest.name}_{s}__" for s in mcp_servers}``
+), so this helper and the validator normalize identically by construction (#453).
+"""
+
+import json
+
+from plugin_format import declared_mcp_server_names, effective_operator_gate
+
+# --- effective_operator_gate: shorthand -> effective / verbatim / None -----------
+
+
+def test_shorthand_for_declared_server_maps_to_effective_name() -> None:
+    assert (
+        effective_operator_gate("b", {"github"}, "mcp__github__update_issue")
+        == "mcp__plugin_b_github__update_issue"
+    )
+
+
+def test_builtin_name_passes_verbatim() -> None:
+    # No mcp__ prefix -> a built-in, armed by raw name; never rewritten, even when
+    # the bundle declares servers.
+    assert effective_operator_gate("b", {"github"}, "Bash") == "Bash"
+
+
+def test_already_effective_name_passes_verbatim() -> None:
+    # Already mcp__plugin_-prefixed -> passed through unchanged (the suffix is
+    # unknowable without running the server, mirroring validate.py).
+    name = "mcp__plugin_b_github__update_issue"
+    assert effective_operator_gate("b", {"github"}, name) == name
+
+
+def test_shorthand_for_undeclared_server_is_unresolvable() -> None:
+    # mcp__-shaped, names a server the bundle does not declare, not already
+    # mcp__plugin_-prefixed -> unresolvable; the caller fails closed.
+    assert effective_operator_gate("b", {"github"}, "mcp__slack__post") is None
+
+
+def test_shorthand_for_server_name_containing_double_underscore() -> None:
+    # A declared server name may itself contain "__" (McpConfig permits it, the
+    # manifest validator accepts it). The shorthand must resolve by MATCHING the
+    # declared server set, not by splitting at the FIRST "__" -- otherwise
+    # mcp__foo__bar__do splits to server "foo" (undeclared) and fails a valid
+    # bundle closed. The server is foo__bar, the tool is do.
+    assert (
+        effective_operator_gate("b", {"foo__bar"}, "mcp__foo__bar__do")
+        == "mcp__plugin_b_foo__bar__do"
+    )
+
+
+def test_shorthand_prefers_longest_matching_server_name() -> None:
+    # When one declared server name is a prefix of another, the LONGEST match wins
+    # so the resolution is unambiguous: with both "foo" and "foo__bar" declared,
+    # mcp__foo__bar__do resolves to server foo__bar (tool do), not foo (tool
+    # bar__do).
+    assert (
+        effective_operator_gate("b", {"foo", "foo__bar"}, "mcp__foo__bar__do")
+        == "mcp__plugin_b_foo__bar__do"
+    )
+
+
+def test_already_prefixed_name_for_undeclared_prefix_fails_closed() -> None:
+    # An already mcp__plugin_-prefixed operator name is NOT trusted verbatim: it
+    # must match an expected prefix mcp__plugin_<bundle>_<server>__ for a DECLARED
+    # server (with a non-empty tool remainder), mirroring validate.py's
+    # expected_prefixes check. A typo'd wrongbundle/wrongserver name arms a literal
+    # the runtime never matches -> fail OPEN; this must fail CLOSED (None).
+    assert (
+        effective_operator_gate(
+            "b", {"github"}, "mcp__plugin_wrongbundle_wrongserver__tool"
+        )
+        is None
+    )
+
+
+def test_already_prefixed_name_with_empty_tool_suffix_fails_closed() -> None:
+    # The bare expected prefix with no tool suffix arms nothing -> fail closed.
+    assert effective_operator_gate("b", {"github"}, "mcp__plugin_b_github__") is None
+
+
+def test_shorthand_with_no_declared_servers_is_unresolvable() -> None:
+    assert effective_operator_gate("b", set(), "mcp__github__update_issue") is None
+
+
+def test_poisoned_servers_fail_mcp_names_closed_but_pass_builtins_verbatim() -> None:
+    # servers=None is the poison from an unreadable MCP declaration: neither an
+    # mcp__ shorthand NOR an already mcp__plugin_-prefixed name can be verified
+    # against the declared-server set, so both fail CLOSED (None). This runtime
+    # cross-check is the sole defense for the never-deploy-validated operator
+    # override, so "cannot verify" must fail closed, not pass through. Only a
+    # built-in (no mcp__ prefix, no server lookup) still passes verbatim.
+    assert effective_operator_gate("b", None, "mcp__github__update_issue") is None
+    assert (
+        effective_operator_gate("b", None, "mcp__plugin_b_github__update_issue")
+        is None
+    )
+    assert effective_operator_gate("b", None, "Bash") == "Bash"
+
+
+def test_falsy_bundle_name_fails_mcp_names_closed() -> None:
+    # No bundle name means the effective prefix cannot be constructed to verify an
+    # mcp__ name -> fail closed. Built-ins still pass verbatim.
+    assert effective_operator_gate("", {"github"}, "mcp__github__update_issue") is None
+    assert (
+        effective_operator_gate("", {"github"}, "mcp__plugin_b_github__update_issue")
+        is None
+    )
+    assert effective_operator_gate("", {"github"}, "Bash") == "Bash"
+
+
+# --- declared_mcp_server_names: inline manifest + root .mcp.json, poison -> None --
+
+
+def _bundle(tmp_path, manifest: str, mcp_json: str | None = None):
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(manifest, encoding="utf-8")
+    if mcp_json is not None:
+        (tmp_path / ".mcp.json").write_text(mcp_json, encoding="utf-8")
+    return tmp_path
+
+
+def test_declared_names_union_inline_manifest_and_root_mcp_json(tmp_path) -> None:
+    # Both the inline manifest mcpServers object AND a root .mcp.json contribute;
+    # the result is their union.
+    root = _bundle(
+        tmp_path,
+        json.dumps({"name": "b", "mcpServers": {"github": {"command": "gh"}}}),
+        json.dumps({"mcpServers": {"slack": {"command": "slack-server"}}}),
+    )
+    assert declared_mcp_server_names(root) == {"github", "slack"}
+
+
+def test_declared_names_poison_to_none_on_unreadable_declaration(tmp_path) -> None:
+    # The string-pointer mcpServers form is a declaration the real loader ignores;
+    # _validate_mcp poisons the set to None. This helper must match, so a gate
+    # cross-check stays silent rather than asserting against a partial set.
+    root = _bundle(
+        tmp_path,
+        json.dumps({"name": "b", "mcpServers": "config/servers.json"}),
+    )
+    assert declared_mcp_server_names(root) is None
+
+
+def test_declared_names_poison_to_none_on_non_utf8_mcp_json(tmp_path) -> None:
+    # A non-UTF-8 .mcp.json raises UnicodeDecodeError (a ValueError, NOT an
+    # OSError), which must be caught and poison the set to None rather than escape
+    # as a bare traceback and defeat the fail-closed intent.
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "b"}), encoding="utf-8"
+    )
+    (tmp_path / ".mcp.json").write_bytes(b"\xff\xfe not utf-8")
+    assert declared_mcp_server_names(tmp_path) is None
+
+
+def test_declared_names_poison_to_none_on_non_utf8_manifest(tmp_path) -> None:
+    # A non-UTF-8 manifest likewise raises UnicodeDecodeError; poison to None.
+    (tmp_path / ".claude-plugin").mkdir()
+    (tmp_path / ".claude-plugin" / "plugin.json").write_bytes(b"\xff\xfe\x00")
+    assert declared_mcp_server_names(tmp_path) is None

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -115,6 +115,10 @@ def build_runner(
             policy_routes=resolution.route_by_tool,
             grant_tool=config.approval_grant_tool,
             grantable_by_route=resolution.grantable_by_route,
+            # Bundle identity so an operator mcp__<server>__<tool> shorthand
+            # normalizes to its effective plugin-prefixed runtime name (#703).
+            bundle_name=resolution.bundle_name,
+            mcp_servers=resolution.mcp_servers,
         )
     except ApprovalPolicyError as exc:
         # Log then re-raise, matching the module's other two fatal boot paths

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -48,6 +48,8 @@ from claude_agent_sdk.types import (
 from plugin_format import (
     ApprovalPolicy,
     PluginManifest,
+    declared_mcp_server_names,
+    effective_operator_gate,
     grantable_routes,
     resolve_manifest,
 )
@@ -461,10 +463,21 @@ class ApprovalPolicyResolution:
     an operator marked ``grantableViaPolicy`` to the MANIFEST tool a policy
     approval on that route may grant. An honest empty policy yields
     ``ApprovalPolicyResolution({}, {})``.
+
+    ``bundle_name`` and ``mcp_servers`` carry the bundle identity
+    ``build_approval_gate`` needs to normalize an operator gate name to its
+    effective plugin-prefixed runtime form (#703). They are populated even when
+    the bundle declares no ``approvalPolicy``, because an operator may still gate
+    a bundle MCP tool by the ``AGENTOS_APPROVAL_REQUIRED_TOOLS`` shorthand.
+    ``mcp_servers`` is ``None`` when the declared-server set is unknowable (the
+    ``declared_mcp_server_names`` poison), which fails an ``mcp__`` shorthand
+    closed. Both are ``None`` when there is no bundle/manifest to read.
     """
 
     route_by_tool: dict[str, str]
     grantable_by_route: dict[str, str]
+    bundle_name: str | None = None
+    mcp_servers: set[str] | None = None
 
 
 def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
@@ -514,8 +527,18 @@ def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
             f"cannot read the bundle manifest at {manifest_path} to determine whether"
             f" it declares an approvalPolicy; refusing to boot ungated ({exc})"
         ) from exc
+    # Bundle identity for operator gate-name normalization (#703): the runner must
+    # resolve an operator mcp__<server>__<tool> shorthand to its effective
+    # plugin-prefixed runtime name, so read the bundle name and declared MCP
+    # servers even when the bundle declares no approvalPolicy of its own -- an
+    # operator may still gate a bundle MCP tool via the env knob.
+    name = raw.get("name") if isinstance(raw, dict) else None
+    bundle_name = name if isinstance(name, str) else None
+    mcp_servers = declared_mcp_server_names(root)
     if not isinstance(raw, dict) or raw.get("approvalPolicy") is None:
-        return ApprovalPolicyResolution({}, {})
+        return ApprovalPolicyResolution(
+            {}, {}, bundle_name=bundle_name, mcp_servers=mcp_servers
+        )
     # An approvalPolicy IS declared. From here every failure is fail-closed:
     # the intent is established and a parse error cannot revoke it.
     try:
@@ -548,7 +571,9 @@ def resolve_approval_policy(plugin_dir: str | None) -> ApprovalPolicyResolution:
     # ignored here (arm no ambiguous grant); the deploy validator already rejects
     # it, so this is belt-and-braces, not the enforcement point.
     grantable_by_route, _ambiguous = grantable_routes(policy.gates)
-    return ApprovalPolicyResolution(routes, grantable_by_route)
+    return ApprovalPolicyResolution(
+        routes, grantable_by_route, bundle_name=bundle_name, mcp_servers=mcp_servers
+    )
 
 
 def load_approval_policy(plugin_dir: str | None) -> dict[str, str]:
@@ -569,6 +594,8 @@ def build_approval_gate(
     policy_routes: dict[str, str],
     grant_tool: str | None = None,
     grantable_by_route: dict[str, str] | None = None,
+    bundle_name: str | None = None,
+    mcp_servers: set[str] | None = None,
 ) -> ApprovalGate | None:
     """Merge the operator's gated tools with the bundle's declared gates.
 
@@ -598,7 +625,36 @@ def build_approval_gate(
     resume re-derives the same config. See ADR-0050.
     """
 
-    operator = frozenset(operator_tools or ())
+    # Normalize each operator-supplied name to its effective runtime form BEFORE
+    # the overlap computation (#703, decision A2). The SDK plugin-prefixes a
+    # bundle MCP tool to mcp__plugin_<bundle>_<server>__<tool>, so an operator
+    # shorthand mcp__<server>__<tool> must be rewritten or the gate arms a literal
+    # the runtime name never matches -- a silent fail-open. Built-ins and
+    # already-effective mcp__plugin_ names pass verbatim (the manifest-half
+    # policy_routes are already deploy-validated to effective form and are NOT
+    # re-normalized here). An mcp__-shaped name that resolves to no declared
+    # server fails CLOSED (raise), matching resolve_approval_policy's #520 posture
+    # -- it never degrades to ungated (the anti-hollow-out union still never
+    # subtracts). Normalizing before ``redefined`` makes the ADR-0050 overlap warn
+    # fire on effective names, so an operator shorthand and its manifest twin
+    # collide correctly.
+    normalized: list[str] = []
+    for raw_name in operator_tools or ():
+        name = raw_name.strip()
+        if not name:
+            continue
+        effective = effective_operator_gate(bundle_name, mcp_servers, name)
+        if effective is None:
+            raise ApprovalPolicyError(
+                f"operator approval gate {name!r} names an MCP tool that cannot be"
+                " resolved to a declared bundle server; refusing to boot with a"
+                " gate that would arm nothing. Namespace it to its live"
+                " mcp__plugin_<bundle>_<server>__<tool> name, or check the bundle"
+                f" declares that server (declared servers: {mcp_servers})"
+            )
+        normalized.append(effective)
+
+    operator = frozenset(normalized)
     redefined = sorted(operator & set(policy_routes))
     if redefined:
         logger.warning(

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -1976,3 +1976,190 @@ def test_resumed_policy_turn_that_halted_on_budget_does_not_warn() -> None:
         )
 
     anyio.run(go)
+
+
+# --- #703: operator gate-name normalization + fail-closed ------------------------
+#
+# AGENTOS_APPROVAL_REQUIRED_TOOLS is taken verbatim, but the SDK plugin-prefixes a
+# bundle MCP tool to mcp__plugin_<bundle>_<server>__<tool>. So an operator who
+# writes the natural shorthand mcp__<server>__<tool> never matches the effective
+# runtime name and the guarded call runs UNAPPROVED (a fail-open). build_approval_gate
+# gains bundle_name/mcp_servers and normalizes each operator name to its effective
+# form against the bundle's declared servers, failing closed (ApprovalPolicyError)
+# on any mcp__-shaped name that is not already mcp__plugin_-prefixed AND names an
+# undeclared server. The plugin-prefix shape is the exact form the deploy validator
+# asserts (validate.py:
+#   expected_prefixes = {f"mcp__plugin_{manifest.name}_{s}__" for s in mcp_servers}
+# ), so operator and manifest halves normalize identically by construction (#453).
+
+
+def test_operator_shorthand_gate_denies_the_effective_runtime_name() -> None:
+    """AC-703-1: an operator gate written as the mcp__<server>__<tool> shorthand
+    must intercept the SDK's plugin-prefixed effective runtime name.
+
+    The operator shorthand mcp__github__update_issue must normalize to
+    mcp__plugin_b_github__update_issue and DENY the effective call. Today the gate
+    arms the un-prefixed literal, the effective name never matches, and the call
+    runs unapproved (PermissionResultAllow) -- the fail-open this closes. Driven
+    through the public can_use_tool callback, not a set-membership peek.
+    """
+
+    async def go() -> None:
+        gate = build_approval_gate(
+            operator_tools=["mcp__github__update_issue"],
+            policy_routes={},
+            bundle_name="b",
+            mcp_servers={"github"},
+        )
+        assert gate is not None
+        callback = build_can_use_tool(gate)
+        result = await callback(
+            "mcp__plugin_b_github__update_issue",
+            {"issue": 1},
+            ToolPermissionContext(),
+        )
+        assert isinstance(result, PermissionResultDeny)
+
+    anyio.run(go)
+
+
+def test_operator_mcp_gate_naming_undeclared_server_fails_closed() -> None:
+    """AC-703-2: an mcp__-shaped operator gate that cannot resolve to a declared
+    bundle server must RAISE ApprovalPolicyError, never build a silently-unarming
+    gate.
+
+    Fail closed on the unresolvable, matching resolve_approval_policy's #520
+    posture. Covered both when the bundle declares no matching server
+    (mcp_servers=set()) and when no MCP declaration was readable (mcp_servers=None,
+    the _validate_mcp poison). Today build_approval_gate silently builds a gate
+    whose literal name never fires.
+    """
+
+    for servers in (set(), None):
+        with pytest.raises(ApprovalPolicyError):
+            build_approval_gate(
+                operator_tools=["mcp__github__update_issue"],
+                policy_routes={},
+                bundle_name="b",
+                mcp_servers=servers,
+            )
+
+
+def test_builtin_and_already_effective_operator_gates_pass_verbatim() -> None:
+    """AC-703-4: names that need no rewrite arm verbatim and never raise.
+
+    (a) a built-in (Bash) carries no mcp__ prefix -> armed by raw name;
+    (b) an already-effective mcp__plugin_<bundle>_<server>__<tool> name is passed
+        through unchanged (mirrors validate.py, which only asserts the
+        mcp__plugin_ prefix; the tool suffix is unknowable without the server) and
+        does NOT raise.
+    """
+
+    async def go() -> None:
+        # (a) built-in passes verbatim and denies the raw call.
+        builtin = build_approval_gate(
+            operator_tools=["Bash"],
+            policy_routes={},
+            bundle_name="b",
+            mcp_servers={"github"},
+        )
+        assert builtin is not None
+        assert isinstance(
+            await build_can_use_tool(builtin)(
+                "Bash", {"command": "x"}, ToolPermissionContext()
+            ),
+            PermissionResultDeny,
+        )
+
+        # (b) already-effective passes verbatim, denies, and does not raise.
+        effective = build_approval_gate(
+            operator_tools=["mcp__plugin_b_github__update_issue"],
+            policy_routes={},
+            bundle_name="b",
+            mcp_servers={"github"},
+        )
+        assert effective is not None
+        assert isinstance(
+            await build_can_use_tool(effective)(
+                "mcp__plugin_b_github__update_issue",
+                {"issue": 1},
+                ToolPermissionContext(),
+            ),
+            PermissionResultDeny,
+        )
+
+    anyio.run(go)
+
+
+def test_manifest_gate_half_stays_fail_closed_after_operator_normalization(
+    tmp_path,
+) -> None:
+    """AC-703-3 (sibling / #453 no-regression): normalizing the OPERATOR half must
+    not weaken the MANIFEST half.
+
+    (1) A manifest approvalPolicy gate already in the effective form
+        mcp__plugin_b_github__update_issue still arms and denies unchanged when
+        build_approval_gate is called with the new bundle_name/mcp_servers params
+        (the manifest half is deploy-validated to effective form and rides
+        policy_routes verbatim, never re-normalized).
+    (2) A manifest gate carrying the bare mcp__github__update_issue shorthand still
+        FAILS validate_bundle (the deploy gate), proving the manifest half stays
+        fail-closed. Reuses the #453 validator pattern
+        (validate.py: approval_policy.gate_not_namespaced).
+    """
+
+    # (2) the deploy validator still rejects the bare shorthand manifest gate.
+    bundle = _write_manifest(
+        tmp_path,
+        json.dumps(
+            {
+                "name": "b",
+                "mcpServers": {"github": {"command": "gh-server"}},
+                "approvalPolicy": {
+                    "gates": [
+                        {"gate": "mcp__github__update_issue", "route": "legal"}
+                    ]
+                },
+            }
+        ),
+    )
+    result = validate_bundle(bundle)
+    assert not result.valid
+    assert "approval_policy.gate_not_namespaced" in {i.code for i in result.errors}
+
+    # (1) the effective manifest gate arms and denies, unchanged by normalization.
+    async def go() -> None:
+        gate = build_approval_gate(
+            operator_tools=None,
+            policy_routes={"mcp__plugin_b_github__update_issue": "legal"},
+            bundle_name="b",
+            mcp_servers={"github"},
+        )
+        assert gate is not None
+        denied = await build_can_use_tool(gate)(
+            "mcp__plugin_b_github__update_issue",
+            {"issue": 1},
+            ToolPermissionContext(),
+        )
+        assert isinstance(denied, PermissionResultDeny)
+
+    anyio.run(go)
+
+
+def test_already_prefixed_operator_gate_naming_wrong_bundle_fails_closed() -> None:
+    """AC-703-2 (residual fail-open): an already mcp__plugin_-prefixed operator
+    gate is NOT trusted verbatim -- it must name a DECLARED server's expected
+    prefix, else it arms a literal the runtime name never matches (fail OPEN).
+
+    A typo'd mcp__plugin_wrongbundle_wrongserver__tool against a bundle "b"
+    declaring only "github" must RAISE ApprovalPolicyError, not silently build a
+    gate that arms nothing. Mirrors validate.py's expected_prefixes assertion.
+    """
+
+    with pytest.raises(ApprovalPolicyError):
+        build_approval_gate(
+            operator_tools=["mcp__plugin_wrongbundle_wrongserver__tool"],
+            policy_routes={},
+            bundle_name="b",
+            mcp_servers={"github"},
+        )


### PR DESCRIPTION
Closes #703, #708

## #703 — approval-gate shorthand fail-open (security)
An operator approval gate configured via `AGENTOS_APPROVAL_REQUIRED_TOOLS` with a bare `mcp__<server>__<tool>` shorthand never matched the effective plugin-prefixed runtime name `mcp__plugin_<bundle>_<server>__<tool>`, so the guarded tool ran **without approval** — a fail-open on a safety control.

The runner now normalizes each operator gate name to its effective form against the bundle's declared MCP servers (resolving the server against the declared-name set, so a server name containing `__` still matches), and **fails closed** (`ApprovalPolicyError` at boot) when an `mcp__`-shaped name cannot be resolved to a declared server. The deploy validator and the runtime now share one server-name and prefix derivation, so they cannot drift (the #453 lesson). Built-in and already-effective `mcp__plugin_…` names pass verbatim — there is no verbatim carve-out for an unresolvable `mcp__` name. The manifest gate half (already deploy-validated, #453) is unchanged.

## #708 — local approvals cannot complete offline
A resumed approval whose reply endpoint (the exited local CLI reply stub) was dead, with no Slack transport configured, dead-lettered instead of completing — so the resolved approval's real tool never ran.

An approval-resume reply is now **best-effort only in that pure-offline case** (unreachable endpoint AND no default transport configured): the resumed tool executes and the turn ACKs instead of dead-lettering. A reply over a *configured* default transport, and every *non-resume* turn, still fail loudly (raise → reclaim → retry). Escalations and second-approval prompts are never swallowed. Resume detection reuses the existing structural `_is_approval_resume` recognizer (no text-sniffing, kernel touch is comment + one flag).

**Known limitation (follow-up):** a resume that hits a *second* approval gate or fails within the pure-offline loop still dead-letters by design — an escalation or a second approval card must surface, not be silently dropped. Completing those offline is out of scope here.

## Verification
Failing tests committed first, then the fix. Full suite green (1000 passed), ruff + mypy clean, no wire-contract drift. The #703 fix was live-verified through the real `build_runner` boot path (effective-name arming, fail-closed boot, and the `__`-in-server-name case); the #708 offline resume completion is covered by a real-Valkey integration test. The full `agentos local` compose loop with a model credential is the recommended post-merge deployed-surface check.