### PR TITLE
Warn on mistaken approval-gate names; drop internal jargon from the default booting placeholder

### DIFF
--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -153,8 +153,11 @@ class WorkerConfig(BaseSettings):
 
     # Shown by editing the dispatcher's placeholder to a "booting" state before the
     # sandbox claim, so the cold-boot wait is not silent. Best-effort; overridable.
+    # Kept free of internal implementation vocabulary ("runner", "sandbox") by
+    # default (#717) -- an end user talking to an agent should never see agentos's
+    # own architecture terms in a status line.
     booting_text: str = Field(
-        default="Booting a runner for your request.",
+        default="Working on it...",
         validation_alias="AGENTOS_BOOTING_TEXT",
     )
 

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -56,6 +56,34 @@ from plugin_format import (
 
 logger = logging.getLogger(__name__)
 
+# Best-effort only (#712): NOT authoritative, NOT used for any gating
+# decision -- only to decide whether a bare operator gate name is worth a
+# "did you mean mcp__<server>__<tool>?" warning. The SDK does not export an
+# enumerable built-in tool list, and this set may drift from a future SDK
+# version; a name missing from here is not an error, just an unwarned pass,
+# and a name present here that isn't actually offered in a given session is
+# similarly harmless (it just arms nothing, same as today).
+_KNOWN_BUILTIN_TOOLS = frozenset(
+    {
+        "Task",
+        "Bash",
+        "BashOutput",
+        "KillShell",
+        "Read",
+        "Write",
+        "Edit",
+        "MultiEdit",
+        "Glob",
+        "Grep",
+        "WebFetch",
+        "WebSearch",
+        "NotebookEdit",
+        "NotebookRead",
+        "TodoWrite",
+        "ExitPlanMode",
+    }
+)
+
 # The server key under ClaudeAgentOptions.mcp_servers; the SDK prefixes tool
 # names as mcp__<server>__<tool>.
 APPROVAL_SERVER_NAME = "agentos"
@@ -651,6 +679,33 @@ def build_approval_gate(
                 " gate that would arm nothing. Namespace it to its live"
                 " mcp__plugin_<bundle>_<server>__<tool> name, or check the bundle"
                 f" declares that server (declared servers: {mcp_servers})"
+            )
+        # A bare (non-mcp__) name is armed VERBATIM as a built-in tool name,
+        # never rewritten or checked (#712): `effective_operator_gate` has no
+        # way to tell a real built-in ("Bash") from an operator's mistaken bare
+        # MCP tool name ("resolve_leak" meant as shorthand for an in-bundle MCP
+        # tool). That second case silently arms a literal the SDK's
+        # `can_use_tool` callback can never match -- a fail-open on a
+        # security-relevant control, with no signal anywhere that the gate is
+        # a no-op. We cannot fail closed here (no authoritative built-in tool
+        # list is importable from this frozen-adjacent path, and a legitimate
+        # built-in gate must keep working), but we can stop it being SILENT:
+        # warn when the name isn't among the well-known Claude Code built-ins,
+        # naming the mcp__<server>__<tool> form the operator likely meant.
+        if (
+            effective == name
+            and not name.startswith("mcp__")
+            and name not in _KNOWN_BUILTIN_TOOLS
+        ):
+            logger.warning(
+                "operator approval gate %r does not match any well-known Claude Code"
+                " built-in tool name. It will be armed VERBATIM and will silently"
+                " gate nothing if it was meant as shorthand for an in-bundle MCP"
+                " tool -- use the mcp__<server>__<tool> form instead (declared"
+                " servers: %s). If %r really is a built-in tool, ignore this warning.",
+                name,
+                mcp_servers,
+                name,
             )
         normalized.append(effective)
 

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -2091,6 +2091,47 @@ def test_builtin_and_already_effective_operator_gates_pass_verbatim() -> None:
     anyio.run(go)
 
 
+def test_bare_non_builtin_operator_gate_warns_it_may_be_a_silent_no_op(caplog) -> None:
+    """#712: a bare (non-mcp__) operator gate name that ISN'T a well-known
+    built-in tool is still armed verbatim (unchanged behavior -- we cannot
+    fail closed here without an authoritative built-in tool list), but it
+    must no longer be SILENT. This is exactly the shape that bit revenue-leak:
+    `AGENTOS_APPROVAL_REQUIRED_TOOLS=resolve_leak` (meant as shorthand for an
+    in-bundle MCP tool) armed a literal name the SDK's `can_use_tool` callback
+    can never match, with zero signal anywhere that the gate does nothing.
+    """
+    with caplog.at_level("WARNING"):
+        gate = build_approval_gate(
+            operator_tools=["resolve_leak"],
+            policy_routes={},
+            bundle_name="revenue-leak",
+            mcp_servers={"revenue-leak-engine"},
+        )
+    assert gate is not None
+    assert gate.required == frozenset({"resolve_leak"})  # unchanged: still arms verbatim
+    assert any(
+        "resolve_leak" in r.getMessage() and "mcp__" in r.getMessage()
+        for r in caplog.records
+    ), caplog.text
+
+
+def test_known_builtin_operator_gate_does_not_warn(caplog) -> None:
+    """#712 (no false positives): a real built-in tool name (Bash) must not
+    trigger the "does not match any well-known built-in" warning -- it is a
+    legitimate, common gate target, not a mistake."""
+    with caplog.at_level("WARNING"):
+        gate = build_approval_gate(
+            operator_tools=["Bash"],
+            policy_routes={},
+            bundle_name="revenue-leak",
+            mcp_servers={"revenue-leak-engine"},
+        )
+    assert gate is not None
+    assert not any(
+        "does not match any well-known" in r.getMessage() for r in caplog.records
+    )
+
+
 def test_manifest_gate_half_stays_fail_closed_after_operator_normalization(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Summary

Two small, unrelated fixes found while getting a real agent (revenue-leak) working end-to-end locally:

- **#712**: `AGENTOS_APPROVAL_REQUIRED_TOOLS`/`--gate`'s bare-name shorthand silently arms nothing when it's meant as shorthand for an in-bundle MCP tool (e.g. `resolve_leak` instead of `mcp__revenue-leak-engine__resolve_leak`) -- a fail-open on a security-relevant control with zero signal anywhere. Can't fail closed (no authoritative built-in-tool list to check against, and real built-in gates like `Bash` must keep working), so this adds a warning instead: a bare name that doesn't match a well-known Claude Code built-in now logs naming the `mcp__<server>__<tool>` form the operator likely meant.
- **#717**: the worker's default per-turn "booting" placeholder ("Booting a runner for your request.") named internal architecture directly to the end Slack user. Changed the default to "Working on it..." -- still overridable via `AGENTOS_BOOTING_TEXT`, just no longer leaky out of the box.

## Test plan

- [x] `uv run pytest runner/tests apps/worker/tests -q` -- 873 passed, 5 skipped (unrelated, pre-existing skips)
- [x] Two new tests added for #712: a bare non-builtin name warns (`test_bare_non_builtin_operator_gate_warns_it_may_be_a_silent_no_op`), a real built-in (`Bash`) does not false-positive (`test_known_builtin_operator_gate_does_not_warn`)
- [x] `uv run ruff check .` -- clean
- [x] `uv run mypy` -- clean (150 source files, config-scoped as CI runs it)
- [x] Manually reproduced the #712 gap against a real deployed bundle (JSON-RPC + `agentos skill message` with a real model) before writing the fix, confirming a bare gate name armed nothing silently; confirmed the warning now fires with the fix

Full context for both (part of a longer debugging session getting a real agent working against this local stack): `platform/custom-agents/revenue-leak-agentos/revleak-review.md` (a sibling repo, not part of this PR).

Closes #712.
Closes #717.