### PR TITLE
Give the sandbox docker-run network error an actionable remediation hint

### DIFF
--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -544,12 +544,41 @@ class DockerSandboxClient:
         )
         if proc.returncode != 0:
             if check:
+                stderr = proc.stderr.strip()
                 # Never echo args: they may carry AGENTOS_CREDENTIALS.
                 raise DockerError(
-                    f"docker {args[0]} failed ({proc.returncode}): {proc.stderr.strip()}"
+                    f"docker {args[0]} failed ({proc.returncode}): {stderr}"
+                    f"{self._network_remediation_hint(stderr)}"
                 )
             return ""
         return proc.stdout
+
+    def _network_remediation_hint(self, stderr: str) -> str:
+        """An actionable one-liner appended when ``stderr`` names our own
+        configured docker network as missing (#715).
+
+        A stack whose compose topology has drifted (e.g. a service was
+        recreated individually, bypassing `docker compose up`'s network
+        reconciliation) surfaces this as a bare `docker: Error response from
+        daemon: failed to set up container networking: network <name> not
+        found` with nothing to act on beyond raw container logs -- exactly
+        what escalated as an opaque runner-error while getting a real agent
+        working locally. This does not auto-heal (the substrate has no compose
+        project to reconcile from); it only turns the dead end into a next
+        step for whoever is reading the worker's logs."""
+        if (
+            self._network
+            and "network" in stderr
+            and self._network in stderr
+            and "not found" in stderr
+        ):
+            return (
+                " -- the docker network the sandbox substrate expects"
+                f" ({self._network!r}) does not exist; run `agentos local up`"
+                " (or the cluster/compose equivalent) to reconcile the stack's"
+                " topology, then retry"
+            )
+        return ""
 
     def ensure_image(self) -> None:
         """Pre-pull the runner image if absent (IfNotPresent semantics).

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -571,4 +571,46 @@ def test_ensure_image_is_best_effort_when_docker_unavailable(caplog) -> None:
         client.ensure_image()  # must return normally, no exception propagates
     assert ["image", "inspect", "agentos-runner"] in client.calls
     assert "agentos-runner" in caplog.text  # the warning names the image
-    assert "docker inspect" not in caplog.text  # but never dumps the argv
+
+
+def test_missing_runner_network_error_carries_a_remediation_hint(monkeypatch) -> None:
+    """#715: a `docker run` failing because our own configured network doesn't
+    exist (compose topology drift -- exactly what escalated as an opaque
+    runner-error while getting a real agent working locally) must raise a
+    DockerError that tells the reader what to DO, not just what failed."""
+    import subprocess
+
+    from agentos_worker.sandbox.docker import DockerError as _DockerError
+
+    class _FakeCompletedProcess:
+        returncode = 125
+        stderr = (
+            "docker: Error response from daemon: failed to set up container"
+            " networking: network agentos_runner not found."
+        )
+        stdout = ""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _FakeCompletedProcess())
+
+    client = DockerSandboxClient(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(),
+        network="agentos_runner",
+    )
+    try:
+        client._docker(["run", "--rm", "agentos-runner"])
+        raise AssertionError("expected DockerError")
+    except _DockerError as exc:
+        assert "agentos_runner" in str(exc)
+        assert "agentos local up" in str(exc)
+
+
+def test_docker_error_without_a_matching_network_name_carries_no_hint() -> None:
+    """The remediation hint is specific to OUR configured network going
+    missing -- an unrelated docker failure (e.g. no such image) must not gain
+    a misleading "run agentos local up" tacked onto it."""
+    client = DockerSandboxClient(
+        image="agentos-runner", bundle_store=_FakeBundleStore(), network="agentos_runner"
+    )
+    hint = client._network_remediation_hint("Error: No such image: agentos-runner:latest")
+    assert hint == ""


### PR DESCRIPTION
## Summary

A local compose stack whose topology has drifted (e.g. a single service like `agentos-worker` was rebuilt/recreated individually via `docker compose up --no-deps <service>`, bypassing compose's network reconciliation) hits a missing `agentos_runner` docker network at the very first sandbox claim. Today that surfaces only as:

```
docker run failed (125): docker: Error response from daemon: failed to set up container networking: network agentos_runner not found.
```

...buried in the worker container's raw logs, with the Slack-facing side just showing the generic `"The run failed (runner-error) after 3 attempt(s). Flagging for a human."` escalation. Nothing anywhere points at the fix.

This adds a targeted remediation hint: when the docker CLI's stderr names our own configured network as the missing one, `DockerError`'s message gets a one-line append pointing at `agentos local up` to reconcile the stack. Deliberately not an auto-heal (this code has no compose-project context to reconcile from) -- just turns a dead end into a next step for whoever's reading the logs.

Does not touch `kernel.py`/`consumer.py`/`threadlock.py`/`markers.py` -- only `sandbox/docker.py`, which isn't part of the "sacred" kernel module set.

## Test plan

- [x] New test: a `docker run` failure naming our configured network raises a `DockerError` whose message includes both the network name and `agentos local up`
- [x] New test: an unrelated docker failure (e.g. missing image) gets no hint appended -- the check is specific to our own network name, not any "not found" text
- [x] `uv run pytest apps/worker/tests/sandbox -q` -- 60 passed, 1 skipped (pre-existing, unrelated)
- [x] `uv run ruff check .` -- clean
- [x] `uv run mypy` -- clean

Found while getting a real agent working end-to-end against a local stack; full context in `platform/custom-agents/revenue-leak-agentos/revleak-review.md` (a sibling repo, not part of this PR).

Closes #715.