### PR TITLE
Add an operator command to force a fresh sandbox for a stuck thread

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2119,6 +2119,20 @@
         "title": "StateEntryPut",
         "type": "object"
       },
+      "ThreadResetState": {
+        "description": "Whether a thread has a pending forced-sandbox-release request (#713).",
+        "properties": {
+          "requested": {
+            "title": "Requested",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "requested"
+        ],
+        "title": "ThreadResetState",
+        "type": "object"
+      },
       "TipsPackConfig": {
         "description": "Rotating capability tips for one agent (mirrors behaviorpacks.TipsPack).\nSeparate from LoadPackConfig: a load line is what the agent is doing now, a\ntip advertises what it can do.",
         "properties": {
@@ -3884,6 +3898,75 @@
         "summary": "Append State",
         "tags": [
           "state"
+        ]
+      }
+    },
+    "/agents/{agent_id}/threads/{thread_key}/reset": {
+      "post": {
+        "description": "Force the thread's sandbox to be released (#713): the worker's next\nmaintenance tick deletes its claim and route, so the NEXT message on this\nthread cold-creates a fresh sandbox instead of adopting one that may be\nrunning stale env (a rotated credential, an unpicked-up redeploy, a wedge\nfrom a partial local-stack upgrade). A live turn on the thread, if any, is\ninterrupted first -- see ``Kernel.release_thread``. Does not delete\nconversation history: a fresh sandbox still rehydrates from the durable\ntranscript on its next claim, same as any other cold-create.\n\n``agent_id`` scopes the action to a specific agent's registration (matching\nevery other verb on this router) but is not itself required to resolve the\nthread -- the release is purely thread-keyed, mirroring\n``SandboxSubstrate.release``.",
+        "operationId": "reset_thread_agents__agent_id__threads__thread_key__reset_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "thread_key",
+            "required": true,
+            "schema": {
+              "title": "Thread Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadResetState"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Reset Thread",
+        "tags": [
+          "control"
         ]
       }
     },

--- a/apps/api/src/agentos_api/deps.py
+++ b/apps/api/src/agentos_api/deps.py
@@ -14,6 +14,7 @@ from .killswitch import KillSwitch
 from .langfuse import LangfuseClient
 from .resumequeue import ResumeQueue
 from .storage import ObjectStore
+from .threadreset import ThreadResetRequests
 
 
 async def get_session(request: Request) -> AsyncIterator[AsyncSession]:
@@ -62,6 +63,11 @@ def get_resume_queue(request: Request) -> ResumeQueue:
     return resume_queue
 
 
+def get_thread_reset_requests(request: Request) -> ThreadResetRequests:
+    requests: ThreadResetRequests = request.app.state.thread_reset_requests
+    return requests
+
+
 def get_approver_sets(request: Request) -> ApproverSetSelector:
     """Picks the approver set a route binding calls for (#420).
 
@@ -83,3 +89,6 @@ EvalQueueDep = Annotated[EvalQueue, Depends(get_eval_queue)]
 GitHubReporterDep = Annotated[GitHubStatusReporter, Depends(get_github_reporter)]
 ResumeQueueDep = Annotated[ResumeQueue, Depends(get_resume_queue)]
 ApproverSetSelectorDep = Annotated[ApproverSetSelector, Depends(get_approver_sets)]
+ThreadResetRequestsDep = Annotated[
+    ThreadResetRequests, Depends(get_thread_reset_requests)
+]

--- a/apps/api/src/agentos_api/main.py
+++ b/apps/api/src/agentos_api/main.py
@@ -40,6 +40,7 @@ from .slack_approvers import SlackApproverSetSelector
 from .slack_usergroups import SlackUserGroupClient
 from .storage import BundleStore
 from .sweeper import run_expiry_sweeper
+from .threadreset import ThreadResetRequests
 
 
 @asynccontextmanager
@@ -62,6 +63,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     valkey: redis.Redis = redis.from_url(settings.valkey_dsn())
     app.state.valkey = valkey
     app.state.kill_switch = KillSwitch(valkey)
+    app.state.thread_reset_requests = ThreadResetRequests(valkey)
     app.state.eval_queue = EvalQueue(valkey)
     # resume_dead_letter_stream stays the narrower override that wins when set;
     # its fallback is now the unified graveyard name (which honors

--- a/apps/api/src/agentos_api/routers/control.py
+++ b/apps/api/src/agentos_api/routers/control.py
@@ -13,9 +13,15 @@ from .. import crud
 from .. import metrics as metrics_service
 from ..auth import require_api_key
 from ..config import get_settings
-from ..deps import KillSwitchDep, LangfuseDep, SessionDep
+from ..deps import KillSwitchDep, LangfuseDep, SessionDep, ThreadResetRequestsDep
 from ..models import Agent
-from ..schemas import BehaviorPacksConfig, BudgetConfig, CostReport, KillState
+from ..schemas import (
+    BehaviorPacksConfig,
+    BudgetConfig,
+    CostReport,
+    KillState,
+    ThreadResetState,
+)
 
 router = APIRouter(
     prefix="/agents/{agent_id}",
@@ -55,6 +61,32 @@ async def get_kill_state(
 ) -> KillState:
     await _load_agent(session, agent_id)
     return KillState(killed=await kill_switch.is_killed(agent_id))
+
+
+@router.post("/threads/{thread_key}/reset", response_model=ThreadResetState)
+async def reset_thread(
+    agent_id: uuid.UUID,
+    thread_key: str,
+    session: SessionDep,
+    thread_reset_requests: ThreadResetRequestsDep,
+) -> ThreadResetState:
+    """Force the thread's sandbox to be released (#713): the worker's next
+    maintenance tick deletes its claim and route, so the NEXT message on this
+    thread cold-creates a fresh sandbox instead of adopting one that may be
+    running stale env (a rotated credential, an unpicked-up redeploy, a wedge
+    from a partial local-stack upgrade). A live turn on the thread, if any, is
+    interrupted first -- see ``Kernel.release_thread``. Does not delete
+    conversation history: a fresh sandbox still rehydrates from the durable
+    transcript on its next claim, same as any other cold-create.
+
+    ``agent_id`` scopes the action to a specific agent's registration (matching
+    every other verb on this router) but is not itself required to resolve the
+    thread -- the release is purely thread-keyed, mirroring
+    ``SandboxSubstrate.release``.
+    """
+    await _load_agent(session, agent_id)
+    await thread_reset_requests.request(thread_key)
+    return ThreadResetState(requested=True)
 
 
 @router.get("/budget", response_model=BudgetConfig)

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -771,6 +771,12 @@ class KillState(BaseModel):
     killed: bool
 
 
+class ThreadResetState(BaseModel):
+    """Whether a thread has a pending forced-sandbox-release request (#713)."""
+
+    requested: bool
+
+
 class CostReport(BaseModel):
     """Daily spend series + total for an agent (L1 Cost view)."""
 

--- a/apps/api/src/agentos_api/threadreset.py
+++ b/apps/api/src/agentos_api/threadreset.py
@@ -1,0 +1,41 @@
+"""Force a fresh sandbox for one stuck thread (#713).
+
+A thread's sandbox binds whatever env it booted with for its entire life (model
+credential, Slack wiring, bundle version) -- the worker only re-derives env for
+a *new* claim, never for one already adopted by a live route. When that env
+goes stale (a rotated credential, a bundle redeploy the thread hasn't picked
+up, a sandbox wedged after a partial local-stack upgrade), the only way to
+force a cold-create today is to reach into Kubernetes/Docker and the Valkey
+route key by hand.
+
+This is a lightweight signal, not a pub/sub channel like the kill switch
+(``killswitch.py``): a thread-reset request is a one-shot administrative
+action with no live "is this still requested" state to gate a running turn on,
+so a Valkey SET the worker's existing maintenance tick drains is enough -- no
+new subscriber process, no new lifecycle to manage. ``THREAD_RESET_SET`` is
+duplicated verbatim in ``apps/worker/src/agentos_worker/consumer.py`` (the
+worker's own copy), the same cross-service-constant pattern the kill switch
+already uses (`apps/worker/src/agentos_worker/killswitch.py`'s
+``KILL_KEY_PREFIX``/``KILL_CHANNEL`` mirror this module's) since neither
+service imports the other's package.
+"""
+
+import redis.asyncio as redis
+
+THREAD_RESET_SET = "agentos:thread-reset-requests"
+
+
+class ThreadResetRequests:
+    """Requests (from the API) and drains (from the worker) pending thread
+    keys whose sandbox should be force-released on the next maintenance tick."""
+
+    def __init__(self, client: redis.Redis) -> None:
+        self._client = client
+
+    async def request(self, thread_key: str) -> None:
+        """Queue ``thread_key`` for a forced sandbox release. Idempotent --
+        adding an already-pending thread is a no-op (a Valkey SET member)."""
+        await self._client.sadd(THREAD_RESET_SET, thread_key)
+
+    async def is_pending(self, thread_key: str) -> bool:
+        return bool(await self._client.sismember(THREAD_RESET_SET, thread_key))

--- a/apps/api/tests/test_control_integration.py
+++ b/apps/api/tests/test_control_integration.py
@@ -80,6 +80,47 @@ def test_kill_sets_flag_and_publishes_event(
         valkey.delete(key)
 
 
+def test_reset_thread_queues_a_pending_request(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+) -> None:
+    """#713: the endpoint queues the thread for the worker's maintenance tick
+    to drain -- it does not (cannot, from the API process) release the
+    sandbox itself. Real Valkey, real SADD, no mocking."""
+    from agentos_api.threadreset import THREAD_RESET_SET
+
+    agent_id = _make_agent(client, auth_headers)
+    valkey.srem(THREAD_RESET_SET, "t-reset-1")
+    try:
+        resp = client.post(
+            f"/agents/{agent_id}/threads/t-reset-1/reset", headers=auth_headers
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"requested": True}
+        assert valkey.sismember(THREAD_RESET_SET, "t-reset-1")
+
+        # Idempotent: requesting an already-pending thread again is a no-op.
+        again = client.post(
+            f"/agents/{agent_id}/threads/t-reset-1/reset", headers=auth_headers
+        )
+        assert again.status_code == 200
+        assert valkey.scard(THREAD_RESET_SET) >= 1
+    finally:
+        valkey.srem(THREAD_RESET_SET, "t-reset-1")
+
+
+def test_reset_thread_requires_a_real_agent(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    resp = client.post(
+        "/agents/00000000-0000-0000-0000-000000000000/threads/t-x/reset",
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+
+
 def test_budget_round_trips_through_postgres(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:

--- a/apps/worker/src/agentos_worker/consumer.py
+++ b/apps/worker/src/agentos_worker/consumer.py
@@ -63,6 +63,13 @@ _READ_ERROR_BACKOFF_S = 0.5
 # the IDLE filter plus the empty-page early-out make it a single round-trip.
 _CAP_SCAN_PAGE = 1000
 
+# An operator-requested thread reset (#713): the API SADDs a thread_key here
+# (`apps/api/src/agentos_api/threadreset.py`) and the maintenance tick SPOPs
+# it to force-release that thread's sandbox. Not a stream -- a one-shot
+# administrative signal has no ordering/redelivery/dead-letter needs, so a
+# plain Valkey SET is enough.
+THREAD_RESET_SET = "agentos:thread-reset-requests"
+
 
 class Consumer(StreamConsumer):
     """Runs the read loop and the periodic reclaim/reap maintenance loop."""
@@ -76,6 +83,13 @@ class Consumer(StreamConsumer):
         max_concurrency: int = 16,
     ) -> None:
         super().__init__(redis)
+        # The base class narrows self._redis to the StreamBroker port (stream
+        # verbs only, by design -- a second broker implementation need not
+        # support anything else). The thread-reset drain (#713) needs a plain
+        # Valkey SET (SADD/SPOP), which isn't part of that port's contract, so
+        # it gets its own concretely-typed handle onto the same connection
+        # rather than widening StreamBroker for one unrelated feature.
+        self._valkey: Redis = redis
         self._kernel = kernel
         self._config = config
         self._sem = asyncio.Semaphore(max_concurrency)
@@ -271,9 +285,46 @@ class Consumer(StreamConsumer):
             try:
                 await self._reclaim_once()
                 await self._kernel.reap_orphans()
+                await self._drain_thread_reset_requests()
             except Exception:
                 logger.exception("maintenance tick failed")
             await self._sleep_or_stop(self._config.reclaim_interval_s)
+
+    async def _drain_thread_reset_requests(self) -> None:
+        """Force-release any thread whose sandbox an operator requested reset
+        for (#713). ``THREAD_RESET_SET`` mirrors
+        ``apps/api/src/agentos_api/threadreset.py``'s constant verbatim (same
+        cross-service-constant pattern the kill switch already uses, since
+        the API and worker are separate deployables that do not import each
+        other's package).
+
+        ``SPOP`` (not ``SMEMBERS``) so a request is claimed and removed
+        atomically -- a concurrent tick (this worker's own next iteration, or
+        a second replica) can never double-process or leave a member behind
+        on a partial failure. One failed release (a substrate error) is
+        logged and does not block the rest of the batch; the request is
+        already popped, so a release that fails needs a fresh request to
+        retry -- acceptable for a manual operator action, unlike the queue's
+        own bounded-retry delivery guarantee."""
+        while True:
+            raw = await self._valkey.spop(THREAD_RESET_SET)
+            if raw is None:
+                return
+            # SPOP with no count (as called here) always returns a single
+            # bare member, never the set-of-members shape its overload
+            # allows with an explicit count -- narrow away that shape for
+            # the type checker rather than the client's imprecise overload.
+            assert isinstance(raw, (str, bytes)), f"unexpected SPOP shape: {raw!r}"
+            thread_key = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+            try:
+                released = await self._kernel.release_thread(thread_key)
+                logger.info(
+                    "thread reset: released sandbox for %s (route existed: %s)",
+                    thread_key,
+                    released,
+                )
+            except Exception:
+                logger.exception("thread reset failed for %s", thread_key)
 
     async def _reclaim_once(self) -> int:
         """Reclaim entries pending too long from any (dead) consumer and retry.

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -460,6 +460,21 @@ class Kernel:
         await self._runner.interrupt(handle.base_url, reason, token=handle.token or None)
         return True
 
+    async def release_thread(self, thread_key: str) -> bool:
+        """Force-release the thread's sandbox (#713, an operator action): delete
+        its substrate claim and route so the next message cold-creates fresh,
+        picking up current model/Slack config instead of adopting a sandbox
+        that may be running stale env from when it first booted. History is
+        not lost -- a cold-created sandbox rehydrates its transcript from the
+        durable state store on claim, the same as any other fresh claim.
+
+        Any live turn is interrupted first (best-effort: `interrupt_thread`
+        already no-ops safely when nothing is live) so `release` never yanks
+        the claim out from under a running turn without at least trying to
+        stop it cleanly. True if a route existed to release."""
+        await self.interrupt_thread(thread_key, "operator requested a sandbox reset")
+        return await asyncio.to_thread(self._substrate.release, thread_key)
+
     def attach_killswitch(self, killswitch: KillSwitch) -> None:
         """Wire the kill switch after construction (it needs interrupt_agent)."""
         self._killswitch = killswitch

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 import redis.exceptions
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from agentos_dispatcher.queue import to_stream_fields
-from agentos_worker.consumer import Consumer
+from agentos_worker.consumer import THREAD_RESET_SET, Consumer
 
 DONE = SessionStatus.DONE
 
@@ -222,5 +222,71 @@ def test_reclaims_and_reprocesses_a_dead_consumers_pending_entry(make_harness) -
             assert h.runner.opened == ["orphan"]
             summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
             assert summary["pending"] == 0  # reclaimed entry acked after reprocessing
+
+    asyncio.run(go())
+
+
+def test_maintenance_tick_drains_pending_thread_reset_requests(make_harness) -> None:
+    """#713: an operator-requested thread reset (the API SADDs the thread_key
+    into THREAD_RESET_SET) is picked up and applied by the maintenance tick,
+    releasing that thread's sandbox and popping it off the pending set."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", thread="tDrain"))
+            assert h.substrate.lookup("tDrain") is not None
+
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await h.async_redis.sadd(THREAD_RESET_SET, "tDrain")
+
+            await consumer._drain_thread_reset_requests()
+
+            assert h.substrate.lookup("tDrain") is None  # released
+            assert await h.async_redis.scard(THREAD_RESET_SET) == 0  # popped, not left behind
+
+    asyncio.run(go())
+
+
+def test_maintenance_tick_thread_reset_is_a_noop_when_nothing_pending(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness() as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer._drain_thread_reset_requests()  # must not raise
+
+    asyncio.run(go())
+
+
+def test_maintenance_tick_thread_reset_one_failure_does_not_block_the_rest(
+    make_harness, caplog
+) -> None:
+    """A release failure for one requested thread (e.g. a transient substrate
+    error) is logged and does not prevent the rest of the batch from being
+    drained -- an operator resetting several stuck threads at once should not
+    have one bad apple silently strand the others unprocessed."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", thread="tOk"))
+
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await h.async_redis.sadd(THREAD_RESET_SET, "tBoom", "tOk")
+
+            original_release_thread = h.kernel.release_thread
+
+            async def flaky_release_thread(thread_key: str) -> bool:
+                if thread_key == "tBoom":
+                    raise RuntimeError("injected substrate failure")
+                return await original_release_thread(thread_key)
+
+            h.kernel.release_thread = flaky_release_thread  # type: ignore[method-assign]
+
+            with caplog.at_level(logging.ERROR):
+                await consumer._drain_thread_reset_requests()
+
+            assert h.substrate.lookup("tOk") is None  # still processed despite tBoom's failure
+            assert await h.async_redis.scard(THREAD_RESET_SET) == 0  # both popped either way
+            assert any("tBoom" in r.getMessage() for r in caplog.records)
 
     asyncio.run(go())

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -622,3 +622,57 @@ def test_booting_update_failure_never_fails_the_turn(make_harness) -> None:
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
+
+
+def test_release_thread_force_releases_a_live_route(make_harness) -> None:
+    """#713: an operator can force-release a thread's sandbox even though it
+    has a live (not suspended, not dead) route -- the whole point is to evict
+    a sandbox that is up and answering but running stale env, not just one
+    that already died on its own (that path -- claim()'s stale-sandbox
+    eviction -- already existed)."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", thread="tRelease"))
+            assert h.substrate.lookup("tRelease") is not None  # the route is live
+
+            released = await h.kernel.release_thread("tRelease")
+            assert released is True
+            assert h.substrate.lookup("tRelease") is None  # gone: next claim is fresh
+
+    asyncio.run(go())
+
+
+def test_release_thread_interrupts_a_live_turn_first(make_harness) -> None:
+    """Releasing a thread mid-turn interrupts it first rather than yanking the
+    claim out from under a running turn silently."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="thinking")]
+            h.runner.tail = [Final(text="stopped", status=IDLE)]
+
+            e1 = _qevent("start", thread="tReleaseMidTurn")
+            t1 = asyncio.create_task(h.kernel.process_event(e1))
+            await _wait_until(lambda: h.runner.turn_active)
+
+            released = await h.kernel.release_thread("tReleaseMidTurn")
+            assert released is True
+            assert h.runner.interrupts == 1  # interrupted, not silently abandoned
+
+            hold.set()
+            await t1
+
+    asyncio.run(go())
+
+
+def test_release_thread_with_no_route_is_a_noop(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness() as h:
+            released = await h.kernel.release_thread("never-seen-thread")
+            assert released is False
+
+    asyncio.run(go())


### PR DESCRIPTION
## Summary

A thread's sandbox binds whatever env it booted with for its entire life (model credential, Slack wiring, bundle version) -- the worker only re-derives env for a *new* claim, never for one a live route has already adopted. When that env goes stale (a rotated credential, a redeploy the thread hasn't picked up, a sandbox wedged by a partial local-stack upgrade), the only way to force a cold-create today is to reach into Kubernetes/Docker and the Valkey route key by hand -- which is exactly what I had to do manually while getting a real agent working end-to-end locally.

`SandboxSubstrate.release()` (delete the claim + drop the route) already existed but had zero operator-facing surface -- grep shows nothing ever called it. This wires one up:

- **`Kernel.release_thread(thread_key)`** (`kernel.py`): interrupts any live turn first (best-effort, mirrors `interrupt_thread`'s existing no-op-when-idle behavior), then releases the substrate route. Purely additive -- does not touch the four core kernel rules (one-live-session/steer, finish-race, steer-vs-interrupt, no-auto-retry-after-side-effects) or any of their existing code paths.
- **`POST /agents/{agent_id}/threads/{thread_key}/reset`**: queues the thread key into a plain Valkey SET (`threadreset.py`). Deliberately *not* a new pub/sub channel like the kill switch -- a one-shot administrative action has no ordering/redelivery/dead-letter need a stream buys, so a SET the maintenance tick drains is the simpler, sufficient primitive.
- **`Consumer._drain_thread_reset_requests`** (`consumer.py`): a new step in the existing maintenance tick, alongside `_reclaim_once`/`reap_orphans`. `SPOP`s pending requests one at a time so they're claimed atomically; one release's failure is logged and doesn't block the rest of the batch.

I'm flagging explicitly that this touches `kernel.py` and `consumer.py` (the "sacred module" set per this repo's own convention) -- I've kept the change as small and additive as I could (new methods alongside existing ones, no edits to the existing claim/steer/interrupt/reclaim logic itself), but it should get the adversarial review that convention calls for rather than a quick merge.

No CLI verb yet -- matches the current, already-shipped shape of behavior-packs config (a raw endpoint, no wrapper command). A natural follow-up, not blocking this.

## Test plan

- [x] New kernel tests: force-releasing a live route works and clears it; releasing mid-turn interrupts first; releasing a thread with no route is a no-op
- [x] New consumer tests: the maintenance tick drains a pending request and releases the sandbox; a no-op tick with nothing pending doesn't raise; one failing release in a batch doesn't block the rest
- [x] New API integration tests (real Postgres + real Valkey): the endpoint SADDs the thread key and is idempotent; a nonexistent agent 404s
- [x] `uv run pytest apps/worker/tests apps/api/tests -q` -- 487 + 413 passed (1 pre-existing, unrelated skip)
- [x] `uv run ruff check .` -- clean
- [x] `uv run mypy` -- clean
- [x] Regenerated `apps/api/openapi.json` (`test_openapi_drift` passes)

Found while getting a real agent working end-to-end against a local stack; full context in `platform/custom-agents/revenue-leak-agentos/revleak-review.md` (a sibling repo, not part of this PR).

Closes #713.