### PR TITLE
Add agentos local rebuild <service> to fix single-service credential loss

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -515,6 +515,78 @@ export const commandManifest = {
           "name": "up"
         },
         {
+          "about": "Rebuild + recreate ONE compose service (e.g. after a code change) without losing the stack's already-resolved credential/model-mode wiring",
+          "args": [
+            {
+              "global": false,
+              "help": "The compose service to rebuild, e.g. `agentos-worker`",
+              "id": "service",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Print the docker compose command and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Match how `local up` brought the stack up (core-only vs full)",
+              "id": "minimal",
+              "long": "minimal",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Match how `local up` brought the stack up (--local-model, if used)",
+              "id": "local_model",
+              "long": "local-model",
+              "num_args": {
+                "max": 1,
+                "min": 0
+              },
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Match how `local up` brought the stack up (--slack, if used)",
+              "id": "slack",
+              "long": "slack",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Rebuild + recreate ONE compose service (e.g. after a code change) without losing the stack's already-resolved credential/model-mode wiring.\n\nA raw `docker compose up --no-deps <service>` silently reverts that one service to compose's fake-model/dev-stub defaults, because compose's `${VAR-default}` substitution reads THIS invocation's shell, not what the rest of the stack is running with -- export the same credential / AGENTOS_FAKE_MODEL you want, same as `local up`.",
+          "name": "rebuild"
+        },
+        {
           "about": "Stop the dev stack (docker compose down), keeping volumes",
           "args": [
             {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -512,6 +512,78 @@
           "name": "up"
         },
         {
+          "about": "Rebuild + recreate ONE compose service (e.g. after a code change) without losing the stack's already-resolved credential/model-mode wiring",
+          "args": [
+            {
+              "global": false,
+              "help": "The compose service to rebuild, e.g. `agentos-worker`",
+              "id": "service",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override",
+              "id": "file",
+              "long": "file",
+              "positional": false,
+              "required": false,
+              "short": "f"
+            },
+            {
+              "global": false,
+              "help": "Print the docker compose command and exit without executing",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Match how `local up` brought the stack up (core-only vs full)",
+              "id": "minimal",
+              "long": "minimal",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Match how `local up` brought the stack up (--local-model, if used)",
+              "id": "local_model",
+              "long": "local-model",
+              "num_args": {
+                "max": 1,
+                "min": 0
+              },
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Match how `local up` brought the stack up (--slack, if used)",
+              "id": "slack",
+              "long": "slack",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Rebuild + recreate ONE compose service (e.g. after a code change) without losing the stack's already-resolved credential/model-mode wiring.\n\nA raw `docker compose up --no-deps <service>` silently reverts that one service to compose's fake-model/dev-stub defaults, because compose's `${VAR-default}` substitution reads THIS invocation's shell, not what the rest of the stack is running with -- export the same credential / AGENTOS_FAKE_MODEL you want, same as `local up`.",
+          "name": "rebuild"
+        },
+        {
           "about": "Stop the dev stack (docker compose down), keeping volumes",
           "args": [
             {

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -163,6 +163,12 @@ pub struct LocalDownOpts {
     pub yes: bool,
 }
 
+pub struct LocalRebuildOpts {
+    pub common: LocalOpts,
+    /// The compose service to rebuild + recreate, e.g. `agentos-worker`.
+    pub service: String,
+}
+
 // ---------------------------------------------------------------------------
 // Command builders (pure; unit-tested below)
 // ---------------------------------------------------------------------------
@@ -229,6 +235,68 @@ pub fn up_command(o: &LocalOpts) -> OpsCommand {
     // the `core`-profile collector suppression. This sits AFTER the branch
     // above, not inside it, because the `--local-model` arm does not fall
     // through to the else: `--minimal --local-model` needs suppressing too.
+    env.extend(otel_endpoint_env_override(o.minimal));
+    if !env.is_empty() {
+        cmd = cmd.with_env(env);
+    }
+    cmd
+}
+
+/// `docker compose --profile <core|full> [--profile local-model] [--profile slack]
+/// -f <file> up -d --build --force-recreate --no-deps <service>` (#714).
+///
+/// A targeted single-service rebuild -- e.g. picking up a code change to just
+/// `agentos-worker` -- carries the SAME env injection as `up_command`
+/// (credential/model-mode parity, the core-profile OTel suppression). Without
+/// it, a raw `docker compose up --no-deps <service>` silently reverts that one
+/// service to compose's fake-model/dev-stub defaults, because compose's
+/// `${VAR-default}` substitution reads the INVOKING shell's env, not whatever
+/// the rest of the stack was already running with -- exactly the footgun that
+/// cost a debugging session getting a real agent working locally. `--no-deps`
+/// keeps the blast radius to the one named service; `--build` picks up a local
+/// code change before recreating.
+pub fn rebuild_command(o: &LocalOpts, service: &str) -> OpsCommand {
+    let profile = if o.minimal { "core" } else { "full" };
+    let mut args = vec![plain("compose"), plain("--profile"), plain(profile)];
+    if o.local_model.is_some() {
+        args.push(plain("--profile"));
+        args.push(plain("local-model"));
+    }
+    if o.slack {
+        args.push(plain("--profile"));
+        args.push(plain("slack"));
+    }
+    args.extend([
+        plain("-f"),
+        plain(&o.file),
+        plain("up"),
+        plain("-d"),
+        plain("--build"),
+        plain("--force-recreate"),
+        plain("--no-deps"),
+        plain(service),
+    ]);
+    let mut cmd = OpsCommand::new("docker", args);
+    // Identical env-injection precedence to `up_command` (local-model env is
+    // mutually exclusive with the credential-driven live injection; see that
+    // function's comment for why) -- duplicated rather than shared because
+    // `up_command`'s tail differs (`--wait`, no per-service targeting) and this
+    // is the smaller, lower-risk change than reshaping a heavily-tested
+    // existing function's internals.
+    let mut env: Vec<(String, String)> = if let Some(model) = &o.local_model {
+        vec![
+            ("AGENTOS_FAKE_MODEL".into(), "0".into()),
+            (
+                "AGENTOS_MODEL_BASE_URL".into(),
+                format!("http://ollama:{OLLAMA_PORT}"),
+            ),
+            ("AGENTOS_MODEL".into(), model.clone()),
+            ("AGENTOS_DOCKER_NETWORK".into(), "agentos_runner".into()),
+            ("COMPOSE_PROJECT_NAME".into(), "agentos".into()),
+        ]
+    } else {
+        fake_model_env_override(o.model_mode).into_iter().collect()
+    };
     env.extend(otel_endpoint_env_override(o.minimal));
     if !env.is_empty() {
         cmd = cmd.with_env(env);
@@ -356,6 +424,82 @@ pub async fn up(o: LocalOpts) -> Result<LocalUpOutput> {
     Ok(LocalUpOutput::Up {
         endpoints,
         slack: o.slack,
+    })
+}
+
+/// Output of `local rebuild`: the dry-run plan, or which service was rebuilt
+/// and which model mode it came back up running (#714).
+#[derive(Debug)]
+pub enum LocalRebuildOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Rebuilt {
+        service: String,
+        model_mode: ModelMode,
+    },
+}
+
+impl crate::ui::CliOutput for LocalRebuildOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            LocalRebuildOutput::DryRun(plan) => plan.to_json(),
+            LocalRebuildOutput::Rebuilt {
+                service,
+                model_mode,
+            } => serde_json::json!({
+                "status": "rebuilt",
+                "service": service,
+                "model_mode": format!("{model_mode:?}"),
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            LocalRebuildOutput::DryRun(plan) => plan.render(ui),
+            LocalRebuildOutput::Rebuilt {
+                service,
+                model_mode,
+            } => {
+                ui.note(&format!("Rebuilt and recreated `{service}`."));
+                match model_mode {
+                    ModelMode::LiveFromCredential => ui.note(
+                        "Came back up on the LIVE model: a credential is set in your shell.",
+                    ),
+                    ModelMode::FakePinnedDespiteCredential => ui.warn(
+                        "Came back up on the FAKE model despite a credential in your shell: AGENTOS_FAKE_MODEL is pinned on.",
+                    ),
+                    ModelMode::DefaultFake => ui.note(
+                        "Came back up on the fake model (no credential set in this shell).",
+                    ),
+                }
+            }
+        }
+    }
+}
+
+/// `agentos local rebuild <service>`: rebuild + recreate ONE compose service
+/// (e.g. after a code change) without losing the stack's already-resolved
+/// credential/model-mode wiring (#714) -- see `rebuild_command`'s doc comment
+/// for the footgun this exists to close. Re-resolves `ModelMode` from THIS
+/// invocation's shell exactly as `local up` does, rather than trying to read
+/// back whatever the rest of the stack is currently running with (not
+/// generally recoverable from outside the containers) -- so the credential
+/// this rebuild applies is whatever is exported in the shell running the
+/// command, same as any other worker-restarting verb.
+pub async fn rebuild(o: LocalRebuildOpts) -> Result<LocalRebuildOutput> {
+    let cmd = rebuild_command(&o.common, &o.service);
+    if o.common.dry_run {
+        return Ok(LocalRebuildOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![cmd.display()],
+        }));
+    }
+    require_on_path("docker")?;
+    let ui = crate::ui::ui();
+    let cl = ui.checklist();
+    run_step(&cl, &format!("rebuilding {}", o.service), "rebuild", &cmd).await?;
+    Ok(LocalRebuildOutput::Rebuilt {
+        service: o.service,
+        model_mode: o.common.model_mode,
     })
 }
 
@@ -669,6 +813,70 @@ mod tests {
                 cmd.env
             );
         }
+    }
+
+    /// #714: the argv shape is `up -d --build --force-recreate --no-deps
+    /// <service>` (not `up_command`'s `up -d --wait`), and the named service
+    /// lands as the final token.
+    #[test]
+    fn rebuild_command_targets_one_service() {
+        let cmd = rebuild_command(&opts(DEFAULT_COMPOSE_FILE), "agentos-worker");
+        let display = cmd.display();
+        assert!(display.contains("up -d --build --force-recreate --no-deps agentos-worker"));
+        assert!(!display.contains("--wait"));
+    }
+
+    /// #714: the whole point -- a credential in the shell must still flip
+    /// AGENTOS_FAKE_MODEL=0 on a targeted rebuild, exactly like `local up`,
+    /// instead of the rebuilt service silently reverting to compose's fake
+    /// default.
+    #[test]
+    fn rebuild_command_carries_live_model_parity() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.model_mode = ModelMode::LiveFromCredential;
+        let cmd = rebuild_command(&o, "agentos-worker");
+        assert!(cmd
+            .env
+            .contains(&(String::from("AGENTOS_FAKE_MODEL"), String::from("0"))));
+    }
+
+    #[test]
+    fn rebuild_command_default_fake_injects_nothing() {
+        let cmd = rebuild_command(&opts(DEFAULT_COMPOSE_FILE), "agentos-worker");
+        assert!(cmd.env.is_empty(), "env={:?}", cmd.env);
+    }
+
+    #[test]
+    fn rebuild_command_carries_local_model_wiring() {
+        let cmd = rebuild_command(
+            &opts_with_local_model(DEFAULT_COMPOSE_FILE, "qwen3:4b"),
+            "agentos-worker",
+        );
+        assert!(cmd
+            .env
+            .contains(&(String::from("AGENTOS_MODEL"), String::from("qwen3:4b"))));
+        assert!(cmd
+            .env
+            .contains(&(String::from("AGENTOS_FAKE_MODEL"), String::from("0"))));
+    }
+
+    #[test]
+    fn rebuild_command_minimal_suppresses_otel_endpoint() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.minimal = true;
+        let cmd = rebuild_command(&o, "agentos-worker");
+        assert!(cmd
+            .env
+            .contains(&(String::from("OTEL_EXPORTER_OTLP_ENDPOINT"), String::new())));
+        assert!(cmd.display().contains("--profile core"));
+    }
+
+    #[test]
+    fn rebuild_command_respects_slack_profile() {
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.slack = true;
+        let display = rebuild_command(&o, "agentos-dispatcher").display();
+        assert!(display.contains("--profile slack"));
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -509,6 +509,37 @@ enum LocalAction {
         #[arg(long)]
         slack: bool,
     },
+    /// Rebuild + recreate ONE compose service (e.g. after a code change) without
+    /// losing the stack's already-resolved credential/model-mode wiring.
+    ///
+    /// A raw `docker compose up --no-deps <service>` silently reverts that one
+    /// service to compose's fake-model/dev-stub defaults, because compose's
+    /// `${VAR-default}` substitution reads THIS invocation's shell, not what the
+    /// rest of the stack is running with -- export the same credential /
+    /// AGENTOS_FAKE_MODEL you want, same as `local up`.
+    Rebuild {
+        /// The compose service to rebuild, e.g. `agentos-worker`.
+        service: String,
+        /// Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override.
+        #[arg(short = 'f', long)]
+        file: Option<String>,
+        /// Print the docker compose command and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+        /// Match how `local up` brought the stack up (core-only vs full).
+        #[arg(long)]
+        minimal: bool,
+        /// Match how `local up` brought the stack up (--local-model, if used).
+        #[arg(
+            long,
+            num_args = 0..=1,
+            default_missing_value = commands::DEFAULT_LOCAL_MODEL
+        )]
+        local_model: Option<String>,
+        /// Match how `local up` brought the stack up (--slack, if used).
+        #[arg(long)]
+        slack: bool,
+    },
     /// Stop the dev stack (docker compose down), keeping volumes.
     Down {
         /// Compose file. Default: version-pinned `compose.release.yaml` from the remote on release builds; local `compose.dev.yaml` on dev builds. Pass to override.
@@ -1427,6 +1458,30 @@ async fn run(command: Option<Command>) -> Result<()> {
                         local_model,
                         slack,
                         model_mode: local::model_mode_from_env(),
+                    })
+                    .await?,
+                )
+            }
+            LocalAction::Rebuild {
+                service,
+                file,
+                dry_run,
+                minimal,
+                local_model,
+                slack,
+            } => {
+                let file = resolve_compose_file(file, dry_run).await?;
+                emit(
+                    local::rebuild(local::LocalRebuildOpts {
+                        common: LocalOpts {
+                            file,
+                            dry_run,
+                            minimal,
+                            local_model,
+                            slack,
+                            model_mode: local::model_mode_from_env(),
+                        },
+                        service,
                     })
                     .await?,
                 )


### PR DESCRIPTION
## Summary

Rebuilding one compose service directly (`docker compose up --no-deps <service>`, e.g. to pick up a code change to `agentos-worker`) silently reverts that service to compose's fake-model/dev-stub defaults: compose's `${VAR-default}` substitution reads the *invoking shell's* env, not what the rest of the stack was already running with. This cost a real debugging session -- a manually-rebuilt worker kept answering with the fake model because the shell recreating it had no credential exported, and separately lost the real Slack wiring the same way.

`agentos local rebuild <service>` runs the same targeted `up -d --build --force-recreate --no-deps <service>`, but carries the exact same credential/model-mode/OTel-suppression env injection as `local up` -- reusing the same already-public, already-tested helpers (`fake_model_env_override`, `otel_endpoint_env_override`, `model_mode_from_env`) rather than re-deriving the decision inline, so a rebuild only regresses to a default when the invoking shell genuinely has none set, same rule as `local up`, not a silent loss.

Regenerated `cli/command-manifest.json` and `apps/ui/src/generated/commandManifest.ts` per this repo's command-surface convention (new clap subcommand).

## Test plan

- [x] New unit tests: argv shape (`--build --force-recreate --no-deps <service>`, no `--wait`), live-credential parity injects `AGENTOS_FAKE_MODEL=0`, default-fake injects nothing, `--local-model` wiring carries through, `--minimal` suppresses the OTel endpoint, `--slack` adds its profile
- [x] `cargo test` (full workspace) -- 404+ passed. Note: `chat_enqueue.rs` (unrelated to this change -- it exercises the real shared local Valkey `agentos:runs` stream) was flaky across repeated runs on this box, seemingly from accumulated stream state from an unrelated long debugging session against the same shared local stack; confirmed it's independent of this change (same flakiness reproduces with this branch's changes stashed) and passed clean on a final full run
- [x] `cargo fmt --check` -- clean
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo run -- schema` / `pnpm gen:manifest` regenerated and committed; no drift

Found while getting a real agent working end-to-end against a local stack; full context in `platform/custom-agents/revenue-leak-agentos/revleak-review.md` (a sibling repo, not part of this PR).

Closes #714.