### PR TITLE
Log claim latency separately from turn duration for diagnosability

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -664,7 +664,18 @@ class Kernel:
         # bundle + budget; on an adopt the live sandbox is already bound, so the
         # env is ignored. Then try to steer: a live turn takes the follow-up;
         # otherwise (fresh sandbox, or the finish-race 409) we open a new turn.
+        #
+        # Timed separately from the model turn itself (#718): a cold claim (no
+        # warm pool hit, a fresh `docker run`/pod create) and a slow model
+        # response present identically to an end user ("it's just slow"), but
+        # have completely different fixes (a warm pool vs. a faster/cheaper
+        # model). This is the only place that can measure claim latency at
+        # all -- the runner's own per-turn logging starts only once its
+        # process is already up, so it cannot see the wait that got it there.
+        claim_started = time.monotonic()
         handle = await self._claim_or_resume(thread, boot_env)
+        claim_ms = round((time.monotonic() - claim_started) * 1000)
+        logger.info("claim latency for %s: %d ms", thread, claim_ms)
         if await self._runner.steer(handle.base_url, event, token=handle.token or None):
             return _RouteResult(steered=True)
         turn = await self._runner.start_turn(handle.base_url, event, token=handle.token or None)

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -7,6 +7,7 @@ scriptable in-process fake runner; only Slack and the model are faked.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 import uuid
 from collections.abc import Callable
@@ -674,5 +675,32 @@ def test_release_thread_with_no_route_is_a_noop(make_harness) -> None:
         async with make_harness() as h:
             released = await h.kernel.release_thread("never-seen-thread")
             assert released is False
+
+    asyncio.run(go())
+
+
+def test_claim_latency_is_logged(make_harness, caplog) -> None:
+    """#718: the claim wait (cold sandbox boot vs. an adopted warm one) is
+    logged separately from the model turn's own duration -- the runner's own
+    per-turn logging starts only once its process is already up, so it has no
+    visibility into how long the worker waited to get it there. Both a fresh
+    claim and a steer onto a live turn go through the same timed call, so both
+    are covered by one assertion on the log line's presence and shape."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            with caplog.at_level(logging.INFO, logger="agentos_worker.kernel"):
+                await h.kernel.process_event(_qevent("hi", thread="tLatency"))
+
+            matches = [
+                r.getMessage()
+                for r in caplog.records
+                if "claim latency for tLatency" in r.getMessage()
+            ]
+            assert matches, caplog.text
+            # "claim latency for tLatency: <N> ms" -- non-negative integer duration.
+            ms = int(matches[0].rsplit(":", 1)[1].strip().split()[0])
+            assert ms >= 0
 
     asyncio.run(go())


### PR DESCRIPTION
## Summary

This is a deliberately narrow slice of #718 (reply latency). That issue names two real contributors -- no warm pool for a brand-new thread, and a mandatory `ToolSearch` round-trip before an agent's own declared tools are usable -- both of which are real feature/design work (warm-pool sizing, tool-preload architecture) that deserve their own scoping, not a same-PR fix bolted onto instrumentation. This PR only adds the "at minimum" ask from that issue: make the two contributors to perceived latency *diagnosable*.

Today, a cold sandbox claim (no warm-pool hit, a fresh `docker run`/pod create) and a slow model turn present identically to an end user -- "it's slow" -- but have completely different fixes. There was no way to tell which dominated for a given turn: the runner's own per-turn logging (`turn start`/`turn end duration_ms=N`) only starts once its process is already up, so it has no visibility into how long the worker waited to get it there.

Times the existing claim/resume call in `Kernel._route_and_start` (the one place that can see this wait) and logs it as its own line (`claim latency for <thread>: <N> ms`), distinct from the runner's own turn-duration logging.

Purely diagnostic instrumentation -- no behavior change, no new control flow, nothing that touches the four core kernel rules (steer/interrupt/lock/reclaim). I'm still flagging that this touches `kernel.py` (the "sacred module" per this repo's own convention) since even a small, additive change there is meant to get the adversarial review that convention calls for.

## Test plan

- [x] New test: after a turn completes, a log line matching `claim latency for <thread>: <N> ms` is present with a non-negative integer duration
- [x] `uv run pytest apps/worker/tests -q` -- 482 passed, 1 skipped (pre-existing, unrelated)
- [x] `uv run ruff check .` -- clean
- [x] `uv run mypy` -- clean

Found while getting a real agent working end-to-end against a local stack; full context in `platform/custom-agents/revenue-leak-agentos/revleak-review.md` (a sibling repo, not part of this PR).

Closes #718.