### PR TITLE
Render ConfirmIntent/ChoiceIntent's prompt in the Slack approval card

### DIFF
--- a/apps/worker/src/agentos_worker/blocks.py
+++ b/apps/worker/src/agentos_worker/blocks.py
@@ -78,6 +78,11 @@ class Reply:
     buttons: list[tuple[str, str]] = field(default_factory=list)
     links: list[tuple[str, str]] = field(default_factory=list)
     footer: str | None = None
+    # The question attached to `buttons` (ChoiceIntent/ConfirmIntent's `prompt`,
+    # #454) -- distinct from `text`, the reply's main body. Rendered immediately
+    # before the actions block so an approver/chooser sees the actual question
+    # next to the buttons, not just bare labels.
+    action_prompt: str | None = None
 
 
 def chunk(text: str, limit: int = _CHUNK_TARGET) -> list[str]:
@@ -147,8 +152,8 @@ def _link_button(label: str, url: str) -> dict[str, Any]:
 
 def to_blocks(reply: Reply, nav: NavPack | None = None) -> list[dict[str, Any]]:
     """Render a ``Reply`` to a Block Kit blocks array. Order: status (context) ->
-    header -> fields -> body section(s) (chunked) -> buttons (nav-leftmost) ->
-    links (URL buttons) -> footer.
+    header -> fields -> body section(s) (chunked) -> action prompt (chunked) ->
+    buttons (nav-leftmost) -> links (URL buttons) -> footer.
 
     ``nav`` is the agent's no-dead-ends hub button: when present and enabled, the
     hub button is appended to the reply's buttons (via ``ensure_hub_button``, the
@@ -175,6 +180,13 @@ def to_blocks(reply: Reply, nav: NavPack | None = None) -> list[dict[str, Any]]:
         )
     for piece in chunk(to_mrkdwn(reply.text)):
         blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": piece}})
+    # The question attached to the buttons (#454) -- rendered as its own section
+    # immediately before the actions block, never merged into `reply.text`, so a
+    # ConfirmIntent/ChoiceIntent's `prompt` reaches the approver/chooser instead
+    # of showing bare button labels with no question attached.
+    if reply.action_prompt:
+        for piece in chunk(to_mrkdwn(reply.action_prompt)):
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": piece}})
     # ``reply.buttons`` are already (label, action_id) pairs, the same (label,
     # command) shape ensure_hub_button operates on, so no conversion is needed.
     buttons = (
@@ -213,13 +225,16 @@ def _pairs(raw: Any) -> list[tuple[str, str]]:
 def _reply_from_message(message: OutboundMessage) -> Reply:
     """Project the channel-neutral contract into this Slack renderer's inputs."""
     buttons: list[tuple[str, str]] = []
+    action_prompt: str | None = None
     if isinstance(message.interaction, ChoiceIntent):
         buttons = [(option.label, option.value) for option in message.interaction.options]
+        action_prompt = message.interaction.prompt
     elif isinstance(message.interaction, ConfirmIntent):
         buttons = [
             (message.interaction.confirm.label, message.interaction.confirm.value),
             (message.interaction.cancel.label, message.interaction.cancel.value),
         ]
+        action_prompt = message.interaction.prompt
     return Reply(
         text=message.text,
         status=message.status,
@@ -228,6 +243,7 @@ def _reply_from_message(message: OutboundMessage) -> Reply:
         buttons=buttons,
         links=[(item.label, item.url) for item in message.links],
         footer=message.footer,
+        action_prompt=action_prompt,
     )
 
 

--- a/apps/worker/tests/test_blocks.py
+++ b/apps/worker/tests/test_blocks.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 
 from agentos_worker.behaviorpacks import NavPack
-from agentos_worker.blocks import Reply, chunk, parse_reply, render, to_blocks
+from agentos_worker.blocks import Reply, _reply_from_message, chunk, parse_reply, render, to_blocks
+from channel_protocol import Action, ChoiceIntent, ConfirmIntent, OutboundMessage
 
 # An enabled nav pack, same shape as tests/test_behaviorpacks.py.
 _NAV = NavPack(enabled=True, hub_label="Help", hub_command="help")
@@ -56,6 +57,73 @@ def test_to_blocks_sorts_nav_buttons_leftmost() -> None:
     actions = next(b for b in to_blocks(reply) if b["type"] == "actions")
     labels = [e["text"]["text"] for e in actions["elements"]]
     assert labels == ["← Back", "Details"]  # nav sorted to the front
+
+
+def test_confirm_intent_prompt_reaches_the_reply() -> None:
+    """#454: ConfirmIntent's `prompt` -- the actual question -- must not be
+    dropped when projecting the channel-neutral contract into this Slack
+    renderer's Reply. Before this fix, an approver saw bare Approve/Cancel
+    buttons with no question attached."""
+    message = OutboundMessage(
+        version="1.0",
+        text="Ready when you are.",
+        interaction=ConfirmIntent(
+            kind="confirm",
+            id="deploy",
+            prompt="Deploy revenue-leak to prod?",
+            confirm=Action(label="Deploy", value="deploy"),
+            cancel=Action(label="Cancel", value="cancel"),
+        ),
+    )
+    reply = _reply_from_message(message)
+    assert reply.action_prompt == "Deploy revenue-leak to prod?"
+
+
+def test_choice_intent_prompt_reaches_the_reply() -> None:
+    message = OutboundMessage(
+        version="1.0",
+        text="Pick one.",
+        interaction=ChoiceIntent(
+            kind="choice",
+            id="repo",
+            prompt="Which repository?",
+            options=[Action(label="AgentOS", value="curie-eng/agentos")],
+        ),
+    )
+    reply = _reply_from_message(message)
+    assert reply.action_prompt == "Which repository?"
+
+
+def test_choice_intent_with_no_prompt_reaches_the_reply_as_none() -> None:
+    # ChoiceIntent.prompt is optional (ConfirmIntent.prompt is not); a choice
+    # with no prompt renders no extra section, not an empty one.
+    message = OutboundMessage(
+        version="1.0",
+        text="Pick one.",
+        interaction=ChoiceIntent(
+            kind="choice",
+            id="repo",
+            options=[Action(label="AgentOS", value="curie-eng/agentos")],
+        ),
+    )
+    reply = _reply_from_message(message)
+    assert reply.action_prompt is None
+
+
+def test_action_prompt_renders_as_its_own_section_before_the_actions_block() -> None:
+    reply = Reply(
+        text="body",
+        buttons=[("Deploy", "deploy"), ("Cancel", "cancel")],
+        action_prompt="Deploy revenue-leak to prod?",
+    )
+    blocks = to_blocks(reply)
+    assert _types(blocks) == ["section", "section", "actions"]
+    assert blocks[1]["text"]["text"] == "Deploy revenue-leak to prod?"
+
+
+def test_no_action_prompt_adds_no_extra_section() -> None:
+    reply = Reply(text="body", buttons=[("Go", "go")])
+    assert _types(to_blocks(reply)) == ["section", "actions"]
 
 
 def test_chunk_splits_long_text_under_limit() -> None:


### PR DESCRIPTION
## Summary

Partial fix for #454 -- specifically the small, splittable bug the issue calls out: "the Slack renderer drops \`prompt\`, a required field on \`ConfirmIntent\` ... while the terminal renderer honors it. An agent that puts its question in \`prompt\` per the contract shows Slack approvers bare Approve and Cancel buttons with no question attached. That is worth fixing regardless of the refactor."

\`_reply_from_message\` (the Slack renderer's projection of the channel-neutral \`OutboundMessage\` contract) extracted button labels/values from both \`ChoiceIntent\` and \`ConfirmIntent\` but never read \`prompt\` -- the actual question -- from either. The terminal renderer (\`cli/src/channel.rs\`) already threads it through as a distinct \`action_prompt\`, separate from the message's main \`text\`.

Adds \`Reply.action_prompt\`, populated from both intent kinds, rendered as its own section immediately before the actions block (mirroring the terminal's "prompt belongs with the buttons" placement).

**Not included**: the larger architectural fix ADR-0020 calls for -- routing the approval card itself (\`kernel.py\`'s \`approval_card\`) through a \`Confirm\` intent instead of raw Block Kit, so every channel (not just Slack) gets an approval affordance. That's a bigger refactor across the sink Protocol surface and stays open as the rest of #454; this PR only fixes the concretely-described, independently-worth-fixing bug.

## Test plan

- [x] New tests: \`ConfirmIntent.prompt\` and \`ChoiceIntent.prompt\` both reach \`Reply.action_prompt\`; a \`ChoiceIntent\` with no prompt (it's optional) reaches \`None\`, not an empty string; the action prompt renders as its own section immediately before the actions block; no action prompt adds no extra block
- [x] \`uv run pytest apps/worker/tests -q\` -- 495 passed, 1 skipped (pre-existing, unrelated)
- [x] \`uv run ruff check .\` -- clean
- [x] \`uv run mypy\` -- clean

Found while sweeping the open-issue backlog.