### PR TITLE
Add a JavaScript dependency audit alongside the Rust/Python ones

### DIFF
--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -70,6 +70,8 @@ jobs:
           persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 9
       - uses: actions/setup-node@v7
         with:
           node-version: "22"

--- a/.github/workflows/dependency-audit.yaml
+++ b/.github/workflows/dependency-audit.yaml
@@ -60,3 +60,26 @@ jobs:
             --format requirements-txt --output-file requirements-audit.txt
       - name: pip-audit
         run: uvx pip-audit --requirement requirements-audit.txt
+
+  js-audit:
+    name: pnpm audit (apps/ui)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: apps/ui/pnpm-lock.yaml
+      - name: Install dependencies
+        working-directory: apps/ui
+        run: pnpm install --frozen-lockfile
+      # pnpm audit reads the committed lockfile and exits non-zero on any
+      # advisory, matching cargo-audit/pip-audit's fail-the-job behavior above.
+      - name: pnpm audit
+        working-directory: apps/ui
+        run: pnpm audit


### PR DESCRIPTION
## Summary

Partial fix for #632. \`dependency-audit.yaml\` ran \`cargo-audit\` and \`pip-audit\` but had no equivalent for \`apps/ui\`'s JS dependencies (item 3 of the issue's acceptance criteria), so a vulnerable npm package would ship undetected in the console build.

Adds a \`js-audit\` job that installs via the committed \`pnpm-lock.yaml\` and runs \`pnpm audit\`, mirroring the existing jobs' shape (install, then audit, fail the job on any advisory) and the pnpm setup already used in \`ci.yaml\`.

## What's NOT in this PR (and why)

This issue has four acceptance criteria; only #3 is addressed here.

- **Items 1-2** (enable secret scanning/push protection, enable Dependabot alerts/security updates) require **repo admin** settings I don't have -- confirmed via \`gh api repos/curie-eng/agentos --jq .permissions\`, which reports \`push\`-only (no \`admin\`/\`maintain\`). A maintainer needs to toggle these in repo Settings.
- **Item 4** (pin scanner images to immutable revisions) -- I deliberately did NOT touch \`gitleaks.yaml\`'s \`ghcr.io/gitleaks/gitleaks:latest\`. Its own comment explains the mutable tag is intentional (\"keeps the ruleset current, which is the desired behavior for a secret scanner\"), not an oversight. Pinning it without a companion auto-update mechanism (Dependabot/Renovate tracking the digest) would trade supply-chain pinning for a stale ruleset -- a real design tradeoff for a maintainer to weigh, not a quick pin.

## Test plan

- [x] \`pnpm audit\` run locally in \`apps/ui\` -- clean, no known vulnerabilities today
- [x] Workflow YAML validated (parses correctly, job structure matches the existing \`cargo-audit\`/\`python-audit\` jobs' shape)

Found while sweeping the open-issue backlog.