### PR TITLE
Gate the tag-triggered release pipeline on reviewed-main ancestry and green checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,9 +28,49 @@ permissions:
   packages: write
 
 jobs:
+  # Gates the ENTIRE tag-triggered publish pipeline (issue #628). A `v*` tag push
+  # proves nothing about the tagged commit on its own, so nothing below may run
+  # for one until this job says the commit is reviewed, on main, and green --
+  # see ADR-0058 for the full design and the two admin-only settings (a `v*` tag
+  # protection rule, required reviewers on the `release-publish` environment)
+  # that hardens this further once a maintainer configures them.
+  #
+  # `if:` makes this a no-op (skipped) for ordinary pushes to `main`, so the
+  # continuous sha/latest image builds below are unaffected. `environment:` has
+  # no effect until required reviewers are added to it; the day they are, every
+  # tag push pauses for approval right here, before anything else runs.
+  authorize-release:
+    name: Authorize release publication
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: release-publish
+    permissions:
+      contents: read
+      checks: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history: an ancestor commit deep in main's log must stay
+          # reachable, which a shallow clone would hide.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Tag's commit must be reviewed, on main, and fully checked
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 release/authorize.py "$GITHUB_SHA" --repo "$GITHUB_REPOSITORY"
+
   build:
     name: Build ${{ matrix.name }} image (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
+    needs: [authorize-release]
+    # `always()` overrides the default needs-propagation (which would skip this
+    # job whenever authorize-release is merely skipped, i.e. on every ordinary
+    # main push): a `skipped` authorize-release means "not a tag push, nothing to
+    # authorize" and this job proceeds; a `failure` result means an unauthorized
+    # tag, and this job -- and everything downstream of it -- does not run.
+    if: |
+      always() &&
+      (needs.authorize-release.result == 'success' || needs.authorize-release.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -245,7 +285,10 @@ jobs:
 
   cli-binaries:
     name: Build agentos CLI (${{ matrix.target }})
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [authorize-release]
+    # See build's identical condition above: proceed on the tag path only once
+    # authorize-release has actually succeeded (not merely been skipped).
+    if: startsWith(github.ref, 'refs/tags/v') && needs.authorize-release.result == 'success'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -312,7 +355,8 @@ jobs:
 
   chart:
     name: Package chart and release compose
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [authorize-release]
+    if: startsWith(github.ref, 'refs/tags/v') && needs.authorize-release.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/docs/adr/0058-tag-push-is-not-release-authority.md
+++ b/docs/adr/0058-tag-push-is-not-release-authority.md
@@ -1,0 +1,104 @@
+# 58. A pushed tag is not release authority: ancestry, checks, and an approval environment gate publication
+
+Date: 2026-07-21
+
+Status: Accepted
+
+Implements [#628](https://github.com/curie-eng/agentos/issues/628).
+
+## Context
+
+`release.yaml` triggers the full publish pipeline -- version-tagged multi-arch
+images, CLI binaries, the packaged chart, and a signed GitHub Release -- on
+`push: tags: ["v*"]`. The trigger asks nothing about the tagged commit: any
+repository write actor can create a `v*` tag on any commit reachable from any
+branch, including one that never went through review, and push it. GitHub does
+not treat a tag push as a deployment by default, so nothing paused the pipeline
+for a human decision either. Two separate gaps, one hole: the pipeline could not
+tell "this is main, reviewed, and green" from "this is a tag," and even when it
+was the former, publication needed no explicit sign-off beyond push access.
+
+ADR-0052 built the trust chain a *consumer* verifies (checksum, signature,
+provenance) once assets exist. This ADR is upstream of that: it decides whether
+the workflow run that produces those assets should have started at all.
+
+Two things this ADR does not attempt: repository-level tag protection rules
+(Settings -> Tags) and required reviewers on a GitHub Environment are both
+admin-only settings this account does not hold (`gh api repos/curie-eng/agentos
+--jq .permissions` reports `push`-only, no `admin`/`maintain`). The workflow-level
+gate below is enforceable today without that access; the two admin actions
+harden it further and are called out under Consequences as follow-ups, not
+assumed.
+
+## Decision
+
+**A gate job the whole tag-only pipeline depends on.** `authorize-release` runs
+only `if: startsWith(github.ref, 'refs/tags/v')`, checked out with full history
+(`fetch-depth: 0`), and calls `release/authorize.py`, which fails closed on
+either of:
+
+- **Ancestry**: the tagged commit is not `git merge-base --is-ancestor <sha>
+  origin/main` -- i.e. not reachable from `origin/main`. A tag on a feature
+  branch, a rebased-away commit, or anything that bypassed a merged PR is
+  refused before any image builds.
+- **Checks**: the commit's check-runs (`GET
+  /repos/{repo}/commits/{sha}/check-runs`) are not all `success` (`neutral` and
+  `skipped` also pass; anything else, or zero check-runs, fails). A commit that
+  is on main but whose CI never ran, or ran and failed, is refused the same way.
+
+Both conditions live in `release/authorize.py` as two separately-testable
+functions (`commit_is_on_reviewed_main`, `required_checks_passed`) rather than
+inline shell, so the negative case -- an unreviewed or check-less commit is
+refused -- is an ordinary pytest assertion against a constructed git fixture, not
+a manual demonstration against the real repo.
+
+**Every publishing job needs it, transitively.** `build` gains `needs:
+[authorize-release]`; every job downstream of `build` (`merge`,
+`worker-local-build`, `worker-local-merge`) already depended on it and so is
+covered without further edits. `cli-binaries` and `chart`, which have no other
+dependency, gain the same `needs:` directly. GitHub Actions treats a job whose
+`if:` evaluated false as *skipped*, not failed, so on an ordinary push to `main`
+(no tag) `authorize-release` is skipped and every dependent job proceeds exactly
+as before -- the continuous sha/latest image builds are untouched. On a tag
+push, a failed `authorize-release` skips everything beneath it: no images, no
+binaries, no chart, no release.
+
+**An environment is the hook for human approval, not a fiction.**
+`authorize-release` also declares `environment: release-publish`. A GitHub
+Environment with no protection rules configured has no effect -- the job runs
+immediately, exactly as it does today. The line is there so that the day a
+maintainer adds required reviewers to that environment (an admin-only settings
+action, not a code change), every tag push pauses for their sign-off *before*
+the ancestry/checks script even runs, with no further workflow edit. Putting the
+environment on the *first* job in the tag path, rather than on `release` at the
+end, matters: `merge` already pushes public, version-tagged image manifests to
+GHCR well before the `release` job creates anything, so gating only the last job
+would let images out while the "release" was still unapproved. Gating the entry
+point blocks the whole chain.
+
+## Consequences
+
+- A tag on a commit not reachable from `origin/main`, or reachable but lacking
+  green checks, cannot produce any published artifact -- images, binaries,
+  chart, or GitHub Release -- because every producing job is downstream of the
+  refused gate. This is directly demonstrable: tag a throwaway commit off main
+  and push it, and `authorize-release` fails before `build` starts.
+- A push straight to `main` (the continuous sha/latest image path) is
+  unaffected: `authorize-release`'s `if:` is false, so it is skipped and every
+  dependent job runs exactly as before.
+- The `environment: release-publish` line is inert until a maintainer with
+  admin access adds required reviewers to that environment in repository
+  Settings. Until then, criterion 2 of #628 (publication needs explicit release
+  authority beyond ordinary write access) is not yet met; the ancestry/checks
+  gate alone satisfies criteria 1 and 4.
+- Tag protection for `v*` (so pushing or deleting a matching tag itself requires
+  elevated permission, criterion 3) is a repository Settings -> Tags rule, also
+  admin-only, also not yet configured. Recorded here rather than silently
+  assumed. The auditable break-glass path for both admin actions is the normal
+  one: a maintainer changes the Settings page, which is itself logged in the
+  repository's audit log.
+- `release/authorize.py`'s two functions are unit-testable without network
+  access (a local temp git repo for ancestry, an in-memory check-run list for
+  checks); only the `main()` entry point that fetches real check-runs needs
+  `gh`/`GITHUB_TOKEN`, matching the `manifest`/`verify` split in
+  `release/integrity.py`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -87,4 +87,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0055 | [The fake model is a plumbing fixture, not a subject under test](0055-the-fake-model-is-a-plumbing-fixture.md) | Accepted |
 | 0056 | [An operator opt-in makes a policy gate grantable; a heuristic never does](0056-operator-opt-in-for-policy-gate-grantability.md) | Accepted |
 | 0057 | [`cluster deploy` self-plumbs a port-forward so the generated key stays off the cleartext proxy](0057-cluster-deploy-self-plumbs-port-forward-for-generated-key.md) | Accepted |
+| 0058 | [A pushed tag is not release authority: ancestry, checks, and an approval environment gate publication](0058-tag-push-is-not-release-authority.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Decide whether a pushed tag is authorized to publish a release (issue #628).
+
+`release.yaml` triggers its full publish pipeline on any `v*` tag push. A tag is
+just a ref; pushing one proves nothing about the commit it points at. This
+script is the gate `authorize-release` runs before any other job in that
+pipeline, and it fails closed on either of two questions:
+
+  ancestry  Is the tagged commit reachable from `origin/main`? A tag on a
+            feature branch, a rebased-away commit, or anything that bypassed a
+            merged PR is refused here, before any image builds.
+
+  checks    Does that commit's check-runs list show every check successful (or
+            neutral/skipped)? A commit that is on main but was never checked,
+            or was checked and failed, is refused the same way. Zero check-runs
+            is also a failure -- absence of checks is not evidence they passed.
+
+Both live as separately-testable functions so the negative case -- an
+unreviewed or check-less commit is refused -- is an ordinary pytest assertion
+against a constructed fixture, not a manual demonstration against the real
+repo. Only `main()` needs the network (`gh api` for the live check-run list);
+see `release/integrity.py` for the same manifest/verify split rationale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PASSING_CONCLUSIONS = {"success", "neutral", "skipped"}
+
+
+class AuthorizationError(Exception):
+    """A tagged commit is not authorized to publish a release."""
+
+
+def commit_is_on_reviewed_main(
+    sha: str, main_ref: str = "origin/main", *, cwd: Path | None = None
+) -> bool:
+    """Is `sha` reachable from `main_ref` in the checked-out repo at `cwd`?
+
+    Requires full history (`fetch-depth: 0` in the workflow checkout); a
+    shallow clone would make an ancestor commit unreachable and read as absent.
+    """
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", sha, main_ref],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def required_checks_passed(check_runs: list[dict[str, object]]) -> bool:
+    """Did every check-run for the commit conclude successfully?
+
+    An empty list fails: no checks having run is not the same as them passing,
+    and a commit racing ahead of its own CI must not slip through on that gap.
+    """
+    if not check_runs:
+        return False
+    return all(run.get("conclusion") in PASSING_CONCLUSIONS for run in check_runs)
+
+
+def authorize(
+    sha: str,
+    check_runs: list[dict[str, object]],
+    main_ref: str = "origin/main",
+    *,
+    cwd: Path | None = None,
+) -> None:
+    """Raise AuthorizationError unless `sha` may publish a release."""
+    if not commit_is_on_reviewed_main(sha, main_ref, cwd=cwd):
+        raise AuthorizationError(
+            f"commit {sha} is not reachable from {main_ref}. A release can only "
+            "publish from a commit that reached main through a reviewed, merged "
+            "PR; refusing to authorize this tag."
+        )
+    if not required_checks_passed(check_runs):
+        raise AuthorizationError(
+            f"commit {sha} does not have a fully successful set of check-runs "
+            f"({len(check_runs)} found). Refusing to authorize this tag until its "
+            "required checks are current and green."
+        )
+
+
+def fetch_check_runs(sha: str, repo: str) -> list[dict[str, object]]:
+    """The commit's check-runs via `gh api`, which carries GITHUB_TOKEN auth.
+
+    `per_page=100` without pagination: this repo's own CI (see release.yaml's
+    check list) runs well under 20 checks per commit, so a single page always
+    covers it, and parsing one JSON object is simpler than merging paginated
+    array-under-a-key responses (this endpoint's top level is an object, not
+    an array, so `gh api --paginate` does not auto-merge it).
+    """
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/commits/{sha}/check-runs", "-f", "per_page=100"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    runs: list[dict[str, object]] = payload["check_runs"]
+    return runs
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("sha", help="the tagged commit to authorize")
+    parser.add_argument("--repo", required=True, help="owner/name, e.g. curie-eng/agentos")
+    parser.add_argument("--main-ref", default="origin/main", help="the reviewed-main ref")
+    args = parser.parse_args(argv)
+
+    try:
+        check_runs = fetch_check_runs(args.sha, args.repo)
+        authorize(args.sha, check_runs, args.main_ref)
+    except AuthorizationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {args.sha} is reviewed, on {args.main_ref}, and checked -- authorized")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -1,0 +1,130 @@
+"""Contract tests for the release authorization gate (release/authorize.py).
+
+The gate is the deterministic check behind issue #628: a `v*` tag must not be
+able to start the publish pipeline unless its commit is reachable from
+`origin/main` and that commit's checks are all green. These tests drive both
+functions directly -- `commit_is_on_reviewed_main` against a real, disposable
+git repo (no network needed for ancestry) and `required_checks_passed` against
+constructed check-run lists -- plus `authorize()`, which combines them and is
+what `authorize-release` actually calls.
+"""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "release" / "authorize.py"
+
+
+def load_module():
+    """Import the standalone script by path (release/ is not on sys.path)."""
+    spec = importlib.util.spec_from_file_location("release_authorize", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+authorize_module = load_module()
+
+
+def run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def commit(repo: Path, name: str) -> str:
+    (repo / name).write_text(name)
+    run_git(repo, "add", name)
+    run_git(repo, "commit", "-m", f"add {name}")
+    return run_git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def git_repo(tmp_path) -> Path:
+    """A repo with a `main` branch, plus commits diverging on an unmerged branch."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_git(repo, "init", "-q", "-b", "main")
+    run_git(repo, "config", "user.email", "test@example.com")
+    run_git(repo, "config", "user.name", "Test")
+    commit(repo, "on-main.txt")
+    return repo
+
+
+CHECK_RUNS_ALL_GREEN = [
+    {"name": "CI", "conclusion": "success"},
+    {"name": "CodeQL", "conclusion": "neutral"},
+    {"name": "Secret Scan", "conclusion": "skipped"},
+]
+CHECK_RUNS_ONE_FAILED = [
+    {"name": "CI", "conclusion": "success"},
+    {"name": "Dependency Audit", "conclusion": "failure"},
+]
+
+
+class TestCommitIsOnReviewedMain:
+    def test_head_of_main_is_reachable(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+
+        assert authorize_module.commit_is_on_reviewed_main(sha, "main", cwd=git_repo)
+
+    def test_ancestor_of_main_is_reachable(self, git_repo):
+        first = run_git(git_repo, "rev-parse", "HEAD")
+        commit(git_repo, "later-on-main.txt")
+
+        assert authorize_module.commit_is_on_reviewed_main(first, "main", cwd=git_repo)
+
+    def test_commit_only_on_an_unmerged_branch_is_refused(self, git_repo):
+        run_git(git_repo, "checkout", "-q", "-b", "feature")
+        unmerged = commit(git_repo, "feature-only.txt")
+
+        assert not authorize_module.commit_is_on_reviewed_main(
+            unmerged, "main", cwd=git_repo
+        )
+
+    def test_unknown_sha_is_refused_not_raised(self, git_repo):
+        assert not authorize_module.commit_is_on_reviewed_main(
+            "0" * 40, "main", cwd=git_repo
+        )
+
+
+class TestRequiredChecksPassed:
+    def test_all_success_or_neutral_or_skipped_passes(self):
+        assert authorize_module.required_checks_passed(CHECK_RUNS_ALL_GREEN)
+
+    def test_any_failure_fails(self):
+        assert not authorize_module.required_checks_passed(CHECK_RUNS_ONE_FAILED)
+
+    def test_no_check_runs_fails(self):
+        # Absence of checks is not evidence they passed.
+        assert not authorize_module.required_checks_passed([])
+
+
+class TestAuthorize:
+    def test_reviewed_and_green_commit_is_authorized(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+
+        authorize_module.authorize(sha, CHECK_RUNS_ALL_GREEN, "main", cwd=git_repo)
+
+    def test_unreviewed_commit_is_refused_even_with_green_checks(self, git_repo):
+        run_git(git_repo, "checkout", "-q", "-b", "feature")
+        unmerged = commit(git_repo, "feature-only.txt")
+
+        with pytest.raises(authorize_module.AuthorizationError, match="not reachable"):
+            authorize_module.authorize(
+                unmerged, CHECK_RUNS_ALL_GREEN, "main", cwd=git_repo
+            )
+
+    def test_reviewed_commit_with_failed_checks_is_refused(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+
+        with pytest.raises(
+            authorize_module.AuthorizationError, match="check-runs"
+        ):
+            authorize_module.authorize(sha, CHECK_RUNS_ONE_FAILED, "main", cwd=git_repo)


### PR DESCRIPTION
Closes #628

## Summary

`release.yaml` triggers the full publish pipeline (version-tagged images, CLI
binaries, chart, signed GitHub Release) on any `v*` tag push, with no check on
the tagged commit. Any repository write actor could tag an unreviewed commit --
a feature branch, a rebased-away commit, anything that bypassed a merged PR --
and push it to start publishing.

Adds an `authorize-release` job that gates the entire tag-triggered path:

- **Ancestry**: refuses unless the tagged commit is reachable from
  `origin/main` (`git merge-base --is-ancestor`).
- **Checks**: refuses unless every check-run on that commit concluded
  `success`/`neutral`/`skipped` (zero check-runs also fails -- absence of
  checks is not evidence they passed).

Both live in `release/authorize.py` as separately-testable functions
(`commit_is_on_reviewed_main`, `required_checks_passed`), so the negative case
is an ordinary pytest assertion against a constructed git fixture rather than a
manual demonstration. `build`, `cli-binaries`, and `chart` now `needs:
[authorize-release]`; everything already downstream of those (`merge`,
`worker-local-*`, `release`, `verify-and-publish`) is covered transitively.
`build`'s condition explicitly treats `authorize-release` being *skipped* (an
ordinary push to `main`, not a tag) as fine, so continuous sha/latest image
publishing on `main` is unaffected -- only the tag path is gated.

Full design and the negative-verification story are in
[ADR-0058](docs/adr/0058-tag-push-is-not-release-authority.md).

## What's NOT in this PR (and why)

The issue has four acceptance criteria; this covers 1 and 4 in full and stages
2 and 3.

- `authorize-release` declares `environment: release-publish`. That is inert
  until a maintainer with admin access adds required reviewers to that
  environment in repo Settings -- creating/protecting an Environment needs
  `admin`/`maintain`, which this account does not have (`gh api
  repos/curie-eng/agentos --jq .permissions` reports `push`-only). Once added,
  every tag push pauses for approval right at this job with no further
  workflow edit (criterion 2).
- Tag protection for `v*` (Settings -> Tags, so pushing/deleting a matching tag
  itself needs elevated permission) is the same admin-only gap (criterion 3).
  The auditable break-glass path for both is the normal one: a Settings change
  is itself logged in the repo's audit log.

Both are called out explicitly in the ADR's Consequences section rather than
assumed done.

## Test plan

- [x] `uv run pytest release/tests/test_authorize.py -q` -- 10 passed,
      including the negative case (an unmerged branch's commit is refused even
      with all-green checks) and the checks-only negative case (reviewed
      commit, one failed check-run, refused).
- [x] `uv run ruff check` / `uv run mypy` clean on the new module.
- [x] `agentos dev docs-lint` -- regenerated `docs/adr/README.md`'s index to
      include ADR-0058, committed.
- [x] Manually traced both non-tag-push and tag-push branches through the
      `needs`/`if` chain (`build` -> `merge` -> `worker-local-*`; `cli-binaries`
      and `chart` directly) to confirm a skipped `authorize-release` (ordinary
      `main` push) doesn't block the continuous image path, and a failed one
      (unauthorized tag) skips every downstream job. Not exercised against the
      real GitHub Actions runner -- no plain way to push a throwaway
      unauthorized tag against a public repo's real release pipeline as a
      dry run.