### PR TITLE
Retire e2e.sh's cluster-verb-against-compose deploy leg

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -164,14 +164,7 @@ Scripted E2E (real runner container, fake model, fully offline):
 ```bash
 bash cli/scripts/e2e.sh
 ```
-With the compose stack + a local `apps/api` up, the same script also
-exercises the deploy leg:
-```bash
-AGENTOS_E2E_NETWORK=agentos_default \
-AGENTOS_E2E_OTEL=http://otel-collector:4318 \
-AGENTOS_E2E_API_URL=http://localhost:28000 bash cli/scripts/e2e.sh
-```
-Both require the `agentos-runner` image built once from the repo root
+Requires the `agentos-runner` image built once from the repo root
 (`docker build -f runner/Dockerfile -t agentos-runner .`).
 
 Cold-start parity ladder (issue #690, `agentos dev e2e-ladder` ->

--- a/cli/README.md
+++ b/cli/README.md
@@ -538,15 +538,10 @@ hanging.
 cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test
 ```
 
-The scripted E2E (real runner container, fake model, offline) plus an optional
-deploy leg against a locally-run apps/api:
+The scripted E2E (real runner container, fake model, offline):
 
 ```bash
 bash cli/scripts/e2e.sh
-# with the compose stack + a local API:
-AGENTOS_E2E_NETWORK=agentos_default \
-AGENTOS_E2E_OTEL=http://otel-collector:4318 \
-AGENTOS_E2E_API_URL=http://localhost:28000 bash cli/scripts/e2e.sh
 ```
 
 Requires an `agentos-runner` image (`docker build -f runner/Dockerfile -t

--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -3,9 +3,12 @@
 #
 # Round-trips a synthetic event through a real local runner container with zero
 # Slack involved: init a bundle, start the runner (fake model, offline), send a
-# message and stream the NDJSON reply, run the eval cases, stop. Optionally
-# (AGENTOS_E2E_API_URL set) also deploys the bundle to a locally-run platform
-# API.
+# message and stream the NDJSON reply, run the eval cases, stop. This is rung 1
+# (skill) of the cold-start parity ladder (issue #690,
+# cli/scripts/e2e-ladder.sh); the ladder's local rung (`local deploy` ->
+# `local message` with a real reply assertion) covers deploying a bundle
+# against a running platform API, so this script no longer does so itself
+# (issue #694).
 #
 # Requirements: docker, an agentos-runner image (build per runner/README.md),
 # and a cargo toolchain. Run from anywhere:
@@ -17,8 +20,6 @@
 #   AGENTOS_E2E_PORT      host port (default 7245)
 #   AGENTOS_E2E_NETWORK   docker network to join (e.g. agentos_default)
 #   AGENTOS_E2E_OTEL      OTLP endpoint (e.g. http://otel-collector:4318)
-#   AGENTOS_E2E_API_URL   platform API base URL; enables the deploy leg
-#   AGENTOS_E2E_API_KEY   platform API key (default agentos-dev-key)
 set -euo pipefail
 
 CLI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -123,14 +124,6 @@ echo "=== agentos skill eval (spec-scaffolded evals/cases.json) ==="
 echo
 echo "=== agentos skill eval (explicit cases file) ==="
 "$BIN" skill eval --cases evals/e2e-cases.json
-
-if [[ -n "${AGENTOS_E2E_API_URL:-}" ]]; then
-    echo
-    echo "=== agentos cluster deploy (against the platform API) ==="
-    "$BIN" cluster deploy --plugin-dir . \
-        --api-url "$AGENTOS_E2E_API_URL" \
-        --api-key "${AGENTOS_E2E_API_KEY:-agentos-dev-key}"
-fi
 
 echo
 echo "=== agentos skill down ==="


### PR DESCRIPTION
## Summary

- Removes the `AGENTOS_E2E_API_URL`-gated leg in `cli/scripts/e2e.sh` that drove a locally-run compose API through `cluster deploy --api-url`, since driving a compose-tier API with a cluster verb drifts from the target-noun namespaces established in #40.
- This leg is now duplicate, weaker coverage: the cold-start parity ladder's local rung (#690) already exercises `local deploy` -> `local message` with a real reply assertion against the same compose tier. The leg was only kept during #690 to avoid mixing streams in that PR.
- Updates `cli/README.md` and `cli/CLAUDE.md` to drop documentation of the retired leg (env knobs, invocation examples).
- Confirmed no CI workflow ever set `AGENTOS_E2E_API_URL` (searched `.github/workflows/*.yaml`), so nothing else invoked this leg.

Closes #694
Ref #690, #40

## Test plan

- [x] `bash -n cli/scripts/e2e.sh` (syntax check)
- [x] Ran `bash cli/scripts/e2e.sh` end-to-end (real runner container, fake model) and confirmed `E2E PASS` with the deploy leg gone and the container cleaned up afterward
- [x] Grepped the repo for `AGENTOS_E2E_API_URL`/`AGENTOS_E2E_API_KEY` post-change: no remaining references