### PR TITLE
Add an env-var image/tag override for compose.dev.yaml's api, migrate, and worker services

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -393,20 +393,20 @@ jobs:
   # Rung 2 brings up the `core` compose profile for real, unlike the Python
   # job above (which never starts agentos-api/worker to dodge private-registry
   # pulls). `agentos-api` and `agentos-migrate` pull
-  # `ghcr.io/curie-eng/agentos-api:latest`, a private GHCR image this workflow
-  # has no credentials for, so it is built locally first and tagged to match
-  # -- compose only pulls a tag that is absent from the local image store, so
-  # a matching local tag satisfies both services with no registry auth.
-  # `agentos-worker` builds from source at `up` time via
-  # compose/worker-local.Dockerfile, but that Dockerfile's own FROM is
+  # `ghcr.io/curie-eng/agentos-api:${AGENTOS_BASE_TAG:-latest}`, a private GHCR
+  # image this workflow has no credentials for, so it is built locally first and
+  # tagged to match. `agentos-worker` builds from source at `up` time via
+  # compose/worker-local.Dockerfile, whose own FROM is
   # `ghcr.io/curie-eng/agentos-worker:${BASE_TAG}` (default `latest`), another
-  # private pull one layer down that the compose file has no build-arg wired
-  # to override. The same local-tag trick applies: build the worker base image
-  # from source and tag it `ghcr.io/curie-eng/agentos-worker:latest` so the
-  # overlay's FROM resolves locally too. Both are the same pattern the
-  # `worker-local-image` job above already uses for its own base build, and
-  # both builds are throwaway (this runner's Docker daemon is discarded at job
-  # end; nothing here is ever pushed).
+  # private pull one layer down -- compose.dev.yaml threads the same
+  # AGENTOS_BASE_TAG through as that build stanza's BASE_TAG arg (issue #698),
+  # so one override variable drives all three. This job sets AGENTOS_BASE_TAG=
+  # ci-local (the same convention the `worker-local-image` job above already
+  # uses for its own base build) and tags its from-source builds to match,
+  # rather than retagging over whatever `:latest` meant in the local image
+  # store before this job ran -- `:latest` is not shadowed. Both builds are
+  # throwaway (this runner's Docker daemon is discarded at job end; nothing
+  # here is ever pushed).
   #
   # Rung 2's worker spawns sibling runner containers through the mounted
   # Docker socket (network_mode: host, AGENTOS_SANDBOX_SUBSTRATE=docker); the
@@ -459,11 +459,18 @@ jobs:
         run: docker build -t agentos-runner -f runner/Dockerfile .
       - name: Retag the runner image for the compose worker (AGENTOS_RUNNER_IMAGE, no registry auth)
         run: docker tag agentos-runner ghcr.io/curie-eng/agentos-runner:latest
+      # Tagged :ci-local (the worker-local-image job's own convention), not
+      # :latest -- compose.dev.yaml's AGENTOS_BASE_TAG override (set below) points
+      # agentos-api/agentos-migrate's `image:` and the worker-local overlay's
+      # BASE_TAG build arg at this tag directly, so this job no longer needs to
+      # retag its from-source builds over whatever `:latest` meant in the local
+      # Docker image store before this job ran.
       - name: Build the api image locally (satisfies agentos-api + agentos-migrate, no registry auth)
-        run: docker build -t ghcr.io/curie-eng/agentos-api:latest -f apps/api/Dockerfile .
+        run: docker build -t ghcr.io/curie-eng/agentos-api:ci-local -f apps/api/Dockerfile .
       - name: Build the worker base image locally (satisfies the worker-local overlay's FROM, no registry auth)
-        run: docker build -t ghcr.io/curie-eng/agentos-worker:latest -f apps/worker/Dockerfile .
+        run: docker build -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile .
       - name: Parity ladder (skill + local rungs, fake model, credential-free)
         env:
           AGENTOS_BIN: cli/target/release/agentos
+          AGENTOS_BASE_TAG: ci-local
         run: bash cli/scripts/e2e-ladder.sh

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -280,8 +280,17 @@ services:
   # image ships the Alembic tree but its CMD only runs uvicorn, so migrations
   # run here (mirrors the chart's api migrate init container). Migration 0001
   # creates the `agentos` schema, so this also gates on Postgres being reachable.
+  #
+  # AGENTOS_BASE_TAG overrides the tag pulled for the api image (and, below,
+  # the worker-local overlay's FROM base) in one shot. Defaults to `latest`
+  # (today's pull-based behavior, unchanged for anyone who doesn't set it). A
+  # run with no registry auth -- e.g. CI building images from source -- can set
+  # AGENTOS_BASE_TAG to a tag it built and tagged locally (the `ci-local`
+  # convention the `worker-local-image` CI job already uses) so compose
+  # resolves that local image instead of pulling, and instead of retagging the
+  # build to `:latest` and silently shadowing whatever `:latest` meant before.
   agentos-migrate:
-    image: ghcr.io/curie-eng/agentos-api:latest
+    image: ghcr.io/curie-eng/agentos-api:${AGENTOS_BASE_TAG:-latest}
     profiles: *core_profiles
     depends_on:
       postgres:
@@ -296,7 +305,9 @@ services:
   # service name. Published on host 28000 for the CLI (`agentos local deploy`, and the
   # `agentos local message` channel lookup).
   agentos-api:
-    image: ghcr.io/curie-eng/agentos-api:latest
+    # Same AGENTOS_BASE_TAG override as agentos-migrate above (both pull the
+    # same image); kept in sync deliberately, not duplicated by accident.
+    image: ghcr.io/curie-eng/agentos-api:${AGENTOS_BASE_TAG:-latest}
     profiles: *core_profiles
     # Multi-homed onto agentos_runner (#631): the runner's documented `state`
     # dependency is the API's /agents/.../state endpoints, so the API is the one
@@ -413,6 +424,15 @@ services:
     build:
       context: compose
       dockerfile: worker-local.Dockerfile
+      # Threads AGENTOS_BASE_TAG through to the overlay's own ARG BASE_TAG
+      # (compose/worker-local.Dockerfile), which pins its `FROM
+      # ghcr.io/curie-eng/agentos-worker:${BASE_TAG}` base. Without this the
+      # arg was never wired, so the Dockerfile silently fell back to its own
+      # `latest` default regardless of what the api/migrate override above was
+      # set to. Same variable, same default, so one override can drive all
+      # three services uniformly.
+      args:
+        BASE_TAG: ${AGENTOS_BASE_TAG:-latest}
     profiles: *core_profiles
     depends_on:
       postgres:

--- a/compose/generate_release_compose.py
+++ b/compose/generate_release_compose.py
@@ -16,7 +16,10 @@ via three ordered text transforms:
       the otel-collector service from the host bind-mount to that config.
 
   T3  Pin every `ghcr.io/curie-eng/agentos-*:latest` image tag to the release
-      version (this also pins the worker-local image introduced by T1).
+      version (this also pins the worker-local image introduced by T1). Also
+      collapses the `:${AGENTOS_BASE_TAG:-latest}` override form (issue #698)
+      to the same literal pin, since the release asset has no shell to resolve
+      that override in.
 
 Each transform locates its anchor explicitly and raises ValueError if it is
 missing: this runs unattended at publish time, so a silent no-op would ship a
@@ -31,6 +34,15 @@ from pathlib import Path
 WORKER_BUILD_BLOCK = """    build:
       context: compose
       dockerfile: worker-local.Dockerfile
+      # Threads AGENTOS_BASE_TAG through to the overlay's own ARG BASE_TAG
+      # (compose/worker-local.Dockerfile), which pins its `FROM
+      # ghcr.io/curie-eng/agentos-worker:${BASE_TAG}` base. Without this the
+      # arg was never wired, so the Dockerfile silently fell back to its own
+      # `latest` default regardless of what the api/migrate override above was
+      # set to. Same variable, same default, so one override can drive all
+      # three services uniformly.
+      args:
+        BASE_TAG: ${AGENTOS_BASE_TAG:-latest}
 """
 WORKER_IMAGE_LINE = "    image: ghcr.io/curie-eng/agentos-worker-local:latest\n"
 
@@ -44,7 +56,16 @@ OTEL_CONFIGS_REF = """    configs:
         target: /etc/otel/collector-config.yaml
 """
 
-AGENTOS_LATEST_RE = re.compile(r"(ghcr\.io/curie-eng/agentos-[a-z-]+):latest")
+# Matches the plain `:latest` pin AND compose.dev.yaml's
+# `:${AGENTOS_BASE_TAG:-latest}` override form (issue #698: agentos-api and
+# agentos-migrate's `image:` refs carry the override so CI/local runs can
+# repoint them at a locally built tag with no registry auth). The release
+# asset has no shell to resolve that override in, so either form collapses to
+# a plain, literal `:<version>` pin here -- same outcome the dev file's own
+# unset default already produces.
+AGENTOS_LATEST_RE = re.compile(
+    r"(ghcr\.io/curie-eng/agentos-[a-z-]+):(?:latest|\$\{AGENTOS_BASE_TAG:-latest\})"
+)
 
 DEV_COMPOSE = Path("compose.dev.yaml")
 OTEL_CONFIG = Path("otel/collector-config.yaml")


### PR DESCRIPTION
## Summary

`agentos-api` and `agentos-migrate` were pull-only `image:` refs in `compose.dev.yaml` with no override hook, and `agentos-worker`'s build stanza never passed `BASE_TAG` through to `worker-local.Dockerfile`'s `ARG BASE_TAG`. The `e2e-ladder` CI job (#690) worked around this by building all three images from source and retagging them to `:latest`, silently shadowing whatever `:latest` meant in the daemon's local image store.

This adds a single env var, `AGENTOS_BASE_TAG` (default `latest`, so behavior is unchanged for anyone who doesn't set it):

- `agentos-api` and `agentos-migrate`'s `image:` refs now interpolate `${AGENTOS_BASE_TAG:-latest}`.
- `agentos-worker`'s build stanza now passes `args: BASE_TAG: ${AGENTOS_BASE_TAG:-latest}` through to the overlay Dockerfile, matching the `ci-local` convention `worker-local-image` already uses for its own base build.

One variable now drives all three services uniformly, per the issue's ask.

- Updated the `e2e-ladder` job to build/tag its from-source images as `ci-local` and export `AGENTOS_BASE_TAG=ci-local` for the parity ladder run, instead of retagging over `:latest`.
- Updated `compose/generate_release_compose.py`'s T1 (worker build overlay -> pinned image) and T3 (pin `agentos-*:latest` tags to the release version) transforms so the release compose generator still produces a correctly pinned `compose.release.yaml` given the new build-arg block and the `${AGENTOS_BASE_TAG:-latest}` override form.

## Validation

- `docker compose --profile core -f compose.dev.yaml config -q` and `--profile full` both validate cleanly with `AGENTOS_BASE_TAG` unset (resolves to `latest`, today's behavior) and with `AGENTOS_BASE_TAG=ci-local` (resolves consistently across all three services).
- `uv run pytest compose/tests/test_generate_release_compose.py -q` passes (17 tests), including the docker-validated release-compose generation test.
- `uv run ruff check` on the touched Python files passes.

Closes #698

Ref the `worker-local-image` job (`.github/workflows/ci.yaml`), whose `ci-local` build-and-tag convention this reuses, and the `e2e-ladder` job (added in #690), which this updates to use the new override instead of shadowing `:latest`.