### PR TITLE
Wire AGENTOS_FALSE_COMPLETION_CHECK through the worker to every sandbox boot

### DIFF
--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -104,6 +104,14 @@ GRANT_TOOL_ENV = BootEnv.env_key("approval_grant_tool")
 # confers nothing -- the runner reads it only to decide whether to emit an
 # observe-only warning when the approved business action never ran.
 RESUMED_KIND_ENV = BootEnv.env_key("approval_resumed_kind")
+# #517/#669 opt-in false-completion check: a runner-local, authority-free,
+# observe-only knob, NOT a declared BootEnv field (unlike the keys above, which
+# all go through BootEnv.env_key). runner/src/agentos_runner/config.py reads
+# this as a direct env lookup rather than through the frozen ACI contract, so
+# the literal is spelled out here rather than sourced from BootEnv.env_keys().
+# Operator scope, like API_BACKEND_ENV/MODEL_ENV_KEY_ENV: forwarded from
+# WorkerConfig.false_completion_check, never per-agent.
+FALSE_COMPLETION_CHECK_ENV = "AGENTOS_FALSE_COMPLETION_CHECK"
 # the worker re-mints every turn; this only bounds a leaked-token window (ADR-0033)
 SANDBOX_TOKEN_TTL_SECONDS = 24 * 60 * 60
 
@@ -484,6 +492,14 @@ class BindingResolver:
             history_token=state_token,
             memory_token=state_token,
         )
+        # #517/#669 opt-in false-completion check: NOT a BootEnv.render_worker
+        # kwarg (it is deliberately kept out of the frozen ACI contract, see
+        # FALSE_COMPLETION_CHECK_ENV above), so it is written directly here
+        # rather than threaded through the render call above. Operator scope
+        # only, mirrored in apply_model_env for the eval lane so both boot
+        # paths agree.
+        if self._config.false_completion_check:
+            env[FALSE_COMPLETION_CHECK_ENV] = "1"
         # Deliver the agent's connector secrets (ADR-0009, #429): named secret
         # values the bundle's authed MCP servers read from the sandbox env, where
         # `.mcp.json` `${VAR}` expansion consumes them. Injected by value; the
@@ -517,6 +533,10 @@ def apply_model_env(
     (#514) come from WorkerConfig only and take no override: they select which
     wire protocol is dialed and which env var a credential is read from, so a
     lower-privileged agent author must not be able to set them.
+
+    Also layers the false-completion check (#517, #669): another operator-only,
+    no-override knob, forwarded here so the eval lane's boot env agrees with
+    ``BindingResolver.boot_env``'s direct write of the same key.
     """
     if config.fake_model:
         env[FAKE_MODEL_ENV] = "1"
@@ -531,6 +551,8 @@ def apply_model_env(
     model = model_override if model_override is not None else config.model
     if model:
         env[MODEL_ENV] = model
+    if config.false_completion_check:
+        env[FALSE_COMPLETION_CHECK_ENV] = "1"
 
 
 def inject_connector_secrets(

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -138,6 +138,18 @@ class WorkerConfig(BaseSettings):
     model_env_key: str = Field(default="", validation_alias="AGENTOS_MODEL_ENV_KEY")
     model: str = Field(default="", validation_alias="AGENTOS_MODEL")
 
+    # Opt-in false-completion check (#517, #669), operator scope like
+    # model_api_backend/model_env_key: forwarded verbatim into every boot env as
+    # AGENTOS_FALSE_COMPLETION_CHECK, never derived from the agent row. The
+    # runner reads it as a direct env var outside the frozen BootEnv contract
+    # (runner/src/agentos_runner/config.py) since it is authority-free and
+    # observe-only; this field is the missing operator-facing producer that
+    # closes the loop -- without it the runner-side read is unreachable in any
+    # deployed sandbox (#669). Default off preserves current behavior.
+    false_completion_check: Bool = Field(
+        default=False, validation_alias="AGENTOS_FALSE_COMPLETION_CHECK"
+    )
+
     # When true, clear the Slack assistant-thread status (the "shimmer" the
     # dispatcher set) once a turn ends -- editing the placeholder does not
     # auto-clear it. Off by default; pairs with the dispatcher's AGENTOS_SHIMMER.

--- a/apps/worker/tests/binding/test_model_env.py
+++ b/apps/worker/tests/binding/test_model_env.py
@@ -477,3 +477,84 @@ def test_binding_boot_env_carries_approval_required_tools() -> None:
 
     env = resolver.boot_env(_resolved(), "thread-1")
     assert APPROVAL_REQUIRED_ENV not in env
+
+
+# --- Opt-in false-completion check (#517, #669) --------------------------------
+#
+# The runner (runner/src/agentos_runner/config.py) reads AGENTOS_FALSE_COMPLETION_
+# CHECK directly (never through the frozen BootEnv contract, since the check is
+# observe-only and authority-free). Before #669 nothing set that var in any
+# deployed compose/k8s sandbox, so the #588 check was unreachable outside a
+# hand-run local runner. Mirrors model_api_backend/model_env_key's chain exactly
+# (#514): WorkerConfig field -> boot env, emitted only when truthy, operator scope
+# only (no per-agent override), and both the runs binding and the eval lane must
+# agree.
+FALSE_COMPLETION_CHECK_ENV = "AGENTOS_FALSE_COMPLETION_CHECK"
+
+
+def test_worker_config_reads_false_completion_check_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert WorkerConfig().false_completion_check is False
+    monkeypatch.setenv("AGENTOS_FALSE_COMPLETION_CHECK", "1")
+    assert WorkerConfig().false_completion_check is True
+
+
+def test_apply_model_env_forwards_false_completion_check_when_set() -> None:
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig(false_completion_check=True))
+    assert env[FALSE_COMPLETION_CHECK_ENV] == "1"
+
+
+def test_apply_model_env_omits_false_completion_check_by_default() -> None:
+    env: dict[str, str] = {}
+    apply_model_env(env, WorkerConfig())
+    assert FALSE_COMPLETION_CHECK_ENV not in env
+
+
+def test_binding_boot_env_carries_false_completion_check() -> None:
+    resolver = BindingResolver.__new__(BindingResolver)
+    resolver._config = WorkerConfig(false_completion_check=True)  # type: ignore[attr-defined]
+
+    env = resolver.boot_env(_resolved(), "thread-1")
+    assert env[FALSE_COMPLETION_CHECK_ENV] == "1"
+
+    # Default off preserves current behavior: unset until explicitly enabled.
+    resolver._config = WorkerConfig()  # type: ignore[attr-defined]
+    env = resolver.boot_env(_resolved(), "thread-1")
+    assert FALSE_COMPLETION_CHECK_ENV not in env
+
+
+def test_eval_boot_env_carries_false_completion_check() -> None:
+    # Both lanes boot the runner through apply_model_env for this knob, so the
+    # eval consumer gets the same observe-only check rather than silently
+    # running with a different boot posture than a bound run.
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(false_completion_check=True),
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    item = EvalJob(
+        agent_id=uuid.uuid4(),
+        version_id=uuid.uuid4(),
+        sha="deadbeef",
+        suite="smoke",
+        bundle_ref="bundles/x.zip",
+        requested_at="2026-07-05T00:00:00+00:00",
+    )
+
+    env = consumer._boot_env(item)
+    assert env[FALSE_COMPLETION_CHECK_ENV] == "1"
+
+
+def test_resolved_deployment_carries_no_false_completion_check_field() -> None:
+    # Operator scope is the security property, not a style choice (#514's
+    # precedent): a per-agent row must never be able to enable an observe-only
+    # runner behavior for itself. If this field ever reaches ResolvedDeployment,
+    # boot_env would have a per-agent value to forward.
+    fields = set(ResolvedDeployment.model_fields)
+    assert "false_completion_check" not in fields

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -498,6 +498,11 @@ services:
       - AGENTOS_MODEL_API_BACKEND=${AGENTOS_MODEL_API_BACKEND:-}
       - AGENTOS_MODEL_ENV_KEY=${AGENTOS_MODEL_ENV_KEY:-}
       - AGENTOS_MODEL=${AGENTOS_MODEL:-}
+      # Opt-in false-completion check (#517, #669): observe-only, so it defaults
+      # off here exactly like local up preserves every other feature's current
+      # behavior. Set AGENTOS_FALSE_COMPLETION_CHECK=1 in your shell to forward
+      # it to the worker, which forwards it into every claim's boot env.
+      - AGENTOS_FALSE_COMPLETION_CHECK=${AGENTOS_FALSE_COMPLETION_CHECK:-}
       - AGENTOS_DOCKER_NETWORK=${AGENTOS_DOCKER_NETWORK:-agentos_runner}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
     restart: unless-stopped

--- a/runner/src/agentos_runner/config.py
+++ b/runner/src/agentos_runner/config.py
@@ -91,8 +91,12 @@ class RunnerConfig:
 
         boot = BootEnv.from_env(env)
         # A runner-local read, not a BootEnv contract key (#517): the false-
-        # completion check is observe-only and has no worker producer lane, so it
-        # stays a direct env read parsed to an explicit 1/true/yes truthy.
+        # completion check is observe-only, so it stays a direct env read parsed
+        # to an explicit 1/true/yes truthy rather than a declared BootEnv field.
+        # The worker's producer lane (WorkerConfig.false_completion_check ->
+        # apps/worker/src/agentos_worker/binding.py's FALSE_COMPLETION_CHECK_ENV
+        # write, #669) forwards this same literal name, so it is no longer only
+        # reachable on a hand-run local runner.
         false_completion_raw = env.get("AGENTOS_FALSE_COMPLETION_CHECK", "")
         false_completion_check = false_completion_raw.strip().lower() in ("1", "true", "yes")
         return cls(


### PR DESCRIPTION
## Summary

The opt-in false-completion check added in #588 reads `AGENTOS_FALSE_COMPLETION_CHECK` in the runner (`runner/src/agentos_runner/config.py`), but nothing in the worker set that var into a deployed sandbox's boot env: no `WorkerConfig` field, no forwarding into the per-claim boot env, and no compose/chart production path. The feature only ever worked on a hand-run local runner.

This mirrors the `AGENTOS_MODEL_API_BACKEND` / `AGENTOS_MODEL_ENV_KEY` chain from #514 (operator scope, `WorkerConfig` field -> boot env, emitted only when truthy, no per-agent override):

- `WorkerConfig.false_completion_check` (default `False`, alias `AGENTOS_FALSE_COMPLETION_CHECK`).
- Forwarded into the per-claim boot env from both the runs binding (`BindingResolver.boot_env`) and the eval lane (`apply_model_env`), kept out of the frozen `BootEnv`/ACI contract since the check is observe-only and was deliberately declared outside it in #588.
- `compose.dev.yaml` now passes the var through to the worker container so it is settable locally without editing the compose file.
- For the Helm chart, no dedicated `values.yaml` key is needed: `worker.extraEnv` is already the production path for this class of operator-only flag (the same is true today for `AGENTOS_MODEL_API_BACKEND`/`AGENTOS_MODEL_ENV_KEY`), and both the k8s and docker sandbox substrates already forward arbitrary boot-env dict entries into the claimed sandbox, so no template change is required there.

Default stays off, preserving current behavior.

Closes #669

## Test plan
- [x] `uv run pytest apps/worker/tests -q` (501 passed, 1 skipped)
- [x] `uv run pytest runner/tests -q` (392 passed, 4 skipped)
- [x] `uv run pytest compose/tests -q` (17 passed)
- [x] `uv run ruff check` / `uv run mypy` on touched files