### PR TITLE
Add list-agents and deploy-local, plus a bundle picker for Deploy to Slack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ build/
 # Local AgentOS runner and turn state
 .agentos/
 
+# Personal, in-progress agent bundles (sibling of examples/) -- `list-agents`
+# and `deploy-local <folder>` read from here; never part of the repo proper.
+agents/
+
 # Big-plan server sidecars (belong with the .projects working copies, not the repo)
 *.snapshot
 *.comments.json

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -2857,6 +2857,88 @@ export const commandManifest = {
       ]
     },
     {
+      "about": "List locally-authored agent bundles under `agents/` (source checkout only) -- a personal, gitignored directory (sibling of `examples/`) for in-progress agent projects ready to hand to `deploy-local`. Empty, not an error, when the directory doesn't exist",
+      "hidden": false,
+      "name": "list-agents"
+    },
+    {
+      "about": "Deploy an `agents/<folder>` bundle to the local platform by name -- shorthand for `local deploy --plugin-dir agents/<folder>` (same underlying operation, just resolved by name). Local tier only; use `cluster deploy --plugin-dir agents/<folder>` for the cluster tier. (Bare `deploy` is a retired pre-tier-split verb name -- see `retired.rs` -- so this spells out the tier it targets.)",
+      "args": [
+        {
+          "global": false,
+          "help": "Bundle folder name under `agents/`",
+          "id": "folder",
+          "positional": true,
+          "required": true
+        },
+        {
+          "default_values": [
+            "http://localhost:28000"
+          ],
+          "env": "AGENTOS_API_URL",
+          "global": false,
+          "help": "Platform API base URL",
+          "id": "api_url",
+          "long": "api-url",
+          "positional": false,
+          "required": false
+        },
+        {
+          "default_values": [
+            "agentos-dev-key"
+          ],
+          "env": "AGENTOS_API_KEY",
+          "global": false,
+          "help": "Platform API key",
+          "id": "api_key",
+          "long": "api-key",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Slack channel to bind the agent to. On first create it defaults to C0LOCALDEV; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
+          "id": "slack_channel",
+          "long": "slack-channel",
+          "positional": false,
+          "required": false
+        },
+        {
+          "default_values": [
+            "dev"
+          ],
+          "global": false,
+          "help": "Target environment",
+          "id": "env",
+          "long": "env",
+          "positional": false,
+          "possible_values": [
+            "dev",
+            "prod"
+          ],
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Version label; defaults to <manifest version>-<unix time>",
+          "id": "label",
+          "long": "label",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`agentos secrets set <NAME>`) and sent to the platform. Repeatable",
+          "id": "secret",
+          "long": "secret",
+          "positional": false,
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "name": "deploy-local"
+    },
+    {
       "about": "Build the runner image locally from `runner/Dockerfile` (source checkout only)",
       "args": [
         {

--- a/cli/README.md
+++ b/cli/README.md
@@ -42,6 +42,8 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 | `agentos secrets unset <NAME>` | Remove a saved local secret. |
 | `agentos guide` | Print a self-contained primer (ADR-0021) for a coding agent driving the harness: the parity ladder, when/which decision logic, the landmines, and verify-first, to stdout. `--json` emits the same content as a structured variant (data on stdout). |
 | `agentos build` | Build the runner image locally: `docker build -f runner/Dockerfile -t agentos-runner .` from the repo root (found by walking up to `runner/Dockerfile`). `--tag` overrides the tag. Prints a clear error if Docker is not installed or if run outside a source checkout -- a release binary pulls the pinned runner image from GHCR automatically and never needs to build. |
+| `agentos list-agents` | List the plugin bundles under `agents/`, a personal, gitignored directory (sibling of `examples/`, source checkout only) for in-progress agent projects. Empty, not an error, when the directory doesn't exist. |
+| `agentos deploy-local <folder>` | Deploy `agents/<folder>` to the local platform by name -- shorthand for `agentos local deploy --plugin-dir agents/<folder>` (identical operation, same flags minus `--plugin-dir`). Local tier only; use `agentos cluster deploy --plugin-dir agents/<folder>` for the cluster tier. The interactive "How to deploy to Slack" workflow offers the same `agents/` bundles as a picker. |
 
 ### `init --from-spec` spec shape
 

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -2854,6 +2854,88 @@
       ]
     },
     {
+      "about": "List locally-authored agent bundles under `agents/` (source checkout only) -- a personal, gitignored directory (sibling of `examples/`) for in-progress agent projects ready to hand to `deploy-local`. Empty, not an error, when the directory doesn't exist",
+      "hidden": false,
+      "name": "list-agents"
+    },
+    {
+      "about": "Deploy an `agents/<folder>` bundle to the local platform by name -- shorthand for `local deploy --plugin-dir agents/<folder>` (same underlying operation, just resolved by name). Local tier only; use `cluster deploy --plugin-dir agents/<folder>` for the cluster tier. (Bare `deploy` is a retired pre-tier-split verb name -- see `retired.rs` -- so this spells out the tier it targets.)",
+      "args": [
+        {
+          "global": false,
+          "help": "Bundle folder name under `agents/`",
+          "id": "folder",
+          "positional": true,
+          "required": true
+        },
+        {
+          "default_values": [
+            "http://localhost:28000"
+          ],
+          "env": "AGENTOS_API_URL",
+          "global": false,
+          "help": "Platform API base URL",
+          "id": "api_url",
+          "long": "api-url",
+          "positional": false,
+          "required": false
+        },
+        {
+          "default_values": [
+            "agentos-dev-key"
+          ],
+          "env": "AGENTOS_API_KEY",
+          "global": false,
+          "help": "Platform API key",
+          "id": "api_key",
+          "long": "api-key",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Slack channel to bind the agent to. On first create it defaults to C0LOCALDEV; on redeploy it is only moved when you pass this flag, so omitting it leaves the deployed agent's channel untouched",
+          "id": "slack_channel",
+          "long": "slack-channel",
+          "positional": false,
+          "required": false
+        },
+        {
+          "default_values": [
+            "dev"
+          ],
+          "global": false,
+          "help": "Target environment",
+          "id": "env",
+          "long": "env",
+          "positional": false,
+          "possible_values": [
+            "dev",
+            "prod"
+          ],
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Version label; defaults to <manifest version>-<unix time>",
+          "id": "label",
+          "long": "label",
+          "positional": false,
+          "required": false
+        },
+        {
+          "global": false,
+          "help": "Bind a per-agent connector secret by NAME (ADR-0009, #429). The value is resolved from your environment or the host secret vault (`agentos secrets set <NAME>`) and sent to the platform. Repeatable",
+          "id": "secret",
+          "long": "secret",
+          "positional": false,
+          "required": false
+        }
+      ],
+      "hidden": false,
+      "name": "deploy-local"
+    },
+    {
       "about": "Build the runner image locally from `runner/Dockerfile` (source checkout only)",
       "args": [
         {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -556,6 +556,138 @@ pub async fn dev_script(rel_path: &str) -> Result<()> {
     Ok(())
 }
 
+/// `agentos list-agents`: list the plugin bundles under `agents/`, a personal,
+/// gitignored directory (sibling of `examples/`) for in-progress agent
+/// projects ready to hand to `agentos deploy-local <folder>`. A release binary has
+/// no checkout to scan, so this errors clearly outside one, same as `dev_script`.
+pub async fn list_agents() -> Result<()> {
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `agentos list-agents` \
+         from an agentos source checkout.",
+    )?;
+    let bundles = crate::discover::discover_bundles(&root.join("agents"))?;
+    crate::ui::ui().emit(&ListAgentsOutput {
+        agents: bundles
+            .into_iter()
+            .map(|b| LocalAgentSummary {
+                name: b.name,
+                description: b.description,
+                directory: b.directory.display().to_string(),
+            })
+            .collect(),
+    });
+    Ok(())
+}
+
+struct LocalAgentSummary {
+    name: String,
+    description: String,
+    directory: String,
+}
+
+/// Output of `list-agents`. Routes through the one `Ui::emit` point rather
+/// than an inline `if json()` branch (mirrors `secrets list`'s
+/// `SecretsListOutput`).
+struct ListAgentsOutput {
+    agents: Vec<LocalAgentSummary>,
+}
+
+impl crate::ui::CliOutput for ListAgentsOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "agents": self.agents.iter().map(|a| serde_json::json!({
+                "name": a.name,
+                "description": a.description,
+                "directory": a.directory,
+            })).collect::<Vec<_>>(),
+        })
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        if self.agents.is_empty() {
+            ui.note("no local agents under agents/ (none found, or the directory doesn't exist)");
+        } else {
+            let lines: Vec<String> = self
+                .agents
+                .iter()
+                .map(|a| format!("{} -- {} ({})", a.name, a.description, a.directory))
+                .collect();
+            ui.payload_plain(&lines.join("\n"));
+        }
+    }
+}
+
+/// Resolve `agents/<folder>` under the repo root to a bundle directory for
+/// `agentos deploy-local <folder>`. Errors with the available folder names (from
+/// `discover::discover_bundles`) when `folder` doesn't match one, so a typo
+/// doesn't dead-end without a next step.
+fn resolve_agent_folder(folder: &str) -> Result<std::path::PathBuf> {
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `agentos deploy-local` from \
+         an agentos source checkout.",
+    )?;
+    let agents_root = root.join("agents");
+    let dir = agents_root.join(folder);
+    if dir.join(".claude-plugin/plugin.json").is_file() {
+        return Ok(dir);
+    }
+    let available = crate::discover::discover_bundles(&agents_root)?;
+    if available.is_empty() {
+        bail!(
+            "no agent bundle named {folder:?} under agents/ (the directory has no bundles yet -- \
+             create one with `agentos init` inside agents/{folder})"
+        );
+    }
+    let names: Vec<String> = available
+        .iter()
+        .filter_map(|b| b.directory.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .collect();
+    bail!(
+        "no agent bundle named {folder:?} under agents/. Available: {}",
+        names.join(", ")
+    );
+}
+
+/// `agentos deploy-local <folder>`: shorthand for
+/// `agentos local deploy --plugin-dir agents/<folder>` -- same underlying
+/// `deploy()` call, just resolved by name instead of a hand-typed path. Local
+/// tier only: cluster deploy's API-key discovery and port-forward
+/// self-plumbing (`main.rs`'s `ClusterAction::Deploy` arm) is not duplicated
+/// here; use `agentos cluster deploy --plugin-dir agents/<folder>` directly
+/// for that tier.
+pub async fn deploy_named(folder: &str, opts: DeployNamedOpts) -> Result<DeployOutput> {
+    let plugin_dir = resolve_agent_folder(folder)?;
+    let connect_hint = format!(
+        "the platform API at {} is unreachable. Start the local stack first with `agentos local \
+         up`, then re-run (or pass --api-url if your API is elsewhere).",
+        opts.api_url
+    );
+    deploy(DeployOpts {
+        plugin_dir,
+        api_url: opts.api_url,
+        api_key: opts.api_key,
+        slack_channel: opts.slack_channel,
+        env: opts.env,
+        label: opts.label,
+        secret: opts.secret,
+        secret_binding_supported: true,
+        connect_hint,
+    })
+    .await
+}
+
+/// The `agentos deploy-local <folder>` flags, mirroring `local deploy`'s minus
+/// `plugin_dir` (resolved from `folder` instead).
+pub struct DeployNamedOpts {
+    pub api_url: String,
+    pub api_key: String,
+    pub slack_channel: Option<String>,
+    pub env: DeployEnv,
+    pub label: Option<String>,
+    pub secret: Vec<String>,
+}
+
 /// `agentos dev bump-version <X.Y.Z>`: set the release-coupled version across
 /// cli/Cargo.toml + Chart.yaml version/appVersion in one shot, so a release cut
 /// cannot leave the three out of sync (the drift the #489 consistency gate

--- a/cli/src/discover.rs
+++ b/cli/src/discover.rs
@@ -1,0 +1,103 @@
+//! Discover locally-authored plugin bundles under a directory (e.g. `agents/`),
+//! for browsing outside the hardcoded `examples/` list.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// A plugin bundle found on disk: enough to display and to hand to
+/// `skill up --plugin-dir`.
+pub struct DiscoveredBundle {
+    pub name: String,
+    pub description: String,
+    pub directory: PathBuf,
+}
+
+/// Scan `root`'s immediate subdirectories for a `.claude-plugin/plugin.json`
+/// manifest, mirroring `scripts/check-plugin-compat.sh`'s depth-3 `find`.
+///
+/// Returns an empty Vec, not an error, when `root` does not exist -- an absent
+/// scratch directory (nobody has made one yet) is the common case, not a
+/// failure.
+pub fn discover_bundles(root: &Path) -> Result<Vec<DiscoveredBundle>> {
+    if !root.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    // Sorted for a deterministic listing, same rationale as bundle.rs's
+    // archive walk.
+    let mut entries: Vec<_> = std::fs::read_dir(root)
+        .with_context(|| format!("reading {}", root.display()))?
+        .collect::<std::io::Result<_>>()?;
+    entries.sort_by_key(|e| e.file_name());
+
+    let mut bundles = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        if !path.is_dir() || !path.join(".claude-plugin/plugin.json").is_file() {
+            continue;
+        }
+        let (manifest_path, manifest) = crate::scaffold::load_manifest_json(&path)?;
+        let name = manifest
+            .get("name")
+            .and_then(|v| v.as_str())
+            .with_context(|| format!("{} has no string 'name'", manifest_path.display()))?
+            .to_string();
+        let description = manifest
+            .get("description")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        bundles.push(DiscoveredBundle {
+            name,
+            description,
+            directory: path,
+        });
+    }
+    Ok(bundles)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_when_the_directory_does_not_exist() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundles = discover_bundles(&dir.path().join("nope")).unwrap();
+        assert!(bundles.is_empty());
+    }
+
+    #[test]
+    fn finds_a_valid_bundle() {
+        let root = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(&root.path().join("deal-desk"), "deal-desk").unwrap();
+
+        let bundles = discover_bundles(root.path()).unwrap();
+        assert_eq!(bundles.len(), 1);
+        assert_eq!(bundles[0].name, "deal-desk");
+        assert_eq!(bundles[0].directory, root.path().join("deal-desk"));
+    }
+
+    #[test]
+    fn skips_a_subdirectory_with_no_manifest() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir(root.path().join("not-a-bundle")).unwrap();
+        crate::scaffold::scaffold(&root.path().join("deal-desk"), "deal-desk").unwrap();
+
+        let bundles = discover_bundles(root.path()).unwrap();
+        assert_eq!(bundles.len(), 1);
+        assert_eq!(bundles[0].name, "deal-desk");
+    }
+
+    #[test]
+    fn sorts_deterministically_by_directory_name() {
+        let root = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(&root.path().join("zeta"), "zeta").unwrap();
+        crate::scaffold::scaffold(&root.path().join("alpha"), "alpha").unwrap();
+
+        let bundles = discover_bundles(root.path()).unwrap();
+        let names: Vec<_> = bundles.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+}

--- a/cli/src/interactive.rs
+++ b/cli/src/interactive.rs
@@ -782,6 +782,12 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     ensure_secret_available(terminal, app, "SLACK_BOT_TOKEN")?;
 
     // 3. Channel id + bundle dir, prompted after the operator has completed step 1.
+    //    Resolved before the bundle-dir prompt so a picker over `agents/` bundles
+    //    can be offered instead of a bare text box.
+    let cwd = std::env::current_dir().context("reading current directory")?;
+    let repo_root = find_repo_root(cwd.clone())
+        .context("could not find AgentOS repo root; run this workflow from the source checkout")?;
+
     let Some(channel) = prompt_text(
         terminal,
         app,
@@ -794,17 +800,9 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     else {
         return Ok(());
     };
-    let plugin_dir = prompt_text(
-        terminal,
-        app,
-        "Deploy to Slack",
-        "Agent bundle directory",
-        Some("."),
-        false,
-        true,
-    )?
-    .filter(|dir| !dir.trim().is_empty())
-    .unwrap_or_else(|| ".".to_string());
+    let plugin_dir = prompt_bundle_dir(terminal, app, "Deploy to Slack", &repo_root)?
+        .filter(|dir| !dir.trim().is_empty())
+        .unwrap_or_else(|| ".".to_string());
 
     // Cluster targets a specific Helm release; prompt for its namespace/release
     // so the workflow works for a release not named the default `agentos` (the
@@ -843,10 +841,9 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
     //    ones are forwarded here.
     let secret_env = slack_secret_env()?;
 
-    // Run from the repo root (compose files / the chart are repo-relative on a dev
-    // checkout); resolve the bundle dir to an absolute path so `--plugin-dir` finds
-    // it regardless of the run cwd.
-    let cwd = std::env::current_dir().context("reading current directory")?;
+    // Resolve the bundle dir to an absolute path so `--plugin-dir` finds it
+    // regardless of the run cwd (compose files / the chart are repo-relative on
+    // a dev checkout, hence running everything from `repo_root` below).
     let plugin_abs = cwd.join(&plugin_dir);
     if !plugin_abs.join(".claude-plugin/plugin.json").is_file() {
         anyhow::bail!(
@@ -854,8 +851,6 @@ fn deploy_to_slack(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &
             plugin_abs.display()
         );
     }
-    let repo_root = find_repo_root(cwd)
-        .context("could not find AgentOS repo root; run this workflow from the source checkout")?;
 
     let mut view = RunView::new(&format!("Deploy to Slack — channel {channel}"));
     let run_result = (|| -> Result<()> {
@@ -1032,6 +1027,69 @@ fn starter_prompts(example_dir: &Path) -> Result<Vec<String>> {
         .filter(|prompt| !prompt.trim().is_empty())
         .take(10)
         .collect())
+}
+
+/// Prompt for an agent bundle directory: a picker over discovered `agents/`
+/// bundles when any exist (plus a trailing "Custom path..." choice), else the
+/// same free-text prompt as always. `Ok(None)` only when the picker/prompt
+/// itself was cancelled (Esc) -- callers keep their existing
+/// `.filter(...).unwrap_or_else(|| ".".to_string())` fallback for that case,
+/// same as an empty free-text answer.
+fn prompt_bundle_dir(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &App,
+    title: &str,
+    repo_root: &Path,
+) -> Result<Option<String>> {
+    let bundles = crate::discover::discover_bundles(&repo_root.join("agents"))?;
+    if bundles.is_empty() {
+        return prompt_text(
+            terminal,
+            app,
+            title,
+            "Agent bundle directory",
+            Some("."),
+            false,
+            true,
+        );
+    }
+
+    #[derive(Clone)]
+    enum BundleChoice {
+        Discovered(PathBuf),
+        Custom,
+    }
+
+    let mut choices: Vec<SelectChoice<BundleChoice>> = bundles
+        .into_iter()
+        .map(|b| SelectChoice {
+            label: b.name,
+            description: b.description,
+            value: BundleChoice::Discovered(b.directory),
+        })
+        .collect();
+    choices.push(SelectChoice {
+        label: "Custom path...".to_string(),
+        description: "Type a bundle directory instead (e.g. \".\" or examples/weather)".to_string(),
+        value: BundleChoice::Custom,
+    });
+
+    let Some(choice) = prompt_select(terminal, app, title, "Choose an agent bundle", choices)?
+    else {
+        return Ok(None);
+    };
+    match choice {
+        BundleChoice::Discovered(dir) => Ok(Some(dir.display().to_string())),
+        BundleChoice::Custom => prompt_text(
+            terminal,
+            app,
+            title,
+            "Agent bundle directory",
+            Some("."),
+            false,
+            true,
+        ),
+    }
 }
 
 fn example_secret_env(extra_secrets: &[&str]) -> Result<Vec<(String, String)>> {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod channel;
 pub mod chat;
 pub mod commands;
 pub mod comms;
+pub mod discover;
 pub mod docker;
 pub mod eval_init;
 pub mod evals;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -196,6 +196,47 @@ enum Command {
         #[command(subcommand)]
         action: ClusterAction,
     },
+    /// List locally-authored agent bundles under `agents/` (source checkout
+    /// only) -- a personal, gitignored directory (sibling of `examples/`) for
+    /// in-progress agent projects ready to hand to `deploy-local`. Empty, not
+    /// an error, when the directory doesn't exist.
+    ListAgents,
+    /// Deploy an `agents/<folder>` bundle to the local platform by name --
+    /// shorthand for `local deploy --plugin-dir agents/<folder>` (same
+    /// underlying operation, just resolved by name). Local tier only; use
+    /// `cluster deploy --plugin-dir agents/<folder>` for the cluster tier.
+    /// (Bare `deploy` is a retired pre-tier-split verb name -- see
+    /// `retired.rs` -- so this spells out the tier it targets.)
+    DeployLocal {
+        /// Bundle folder name under `agents/`.
+        folder: String,
+        /// Platform API base URL.
+        #[arg(
+            long,
+            default_value = message::DEFAULT_LOCAL_API_URL,
+            env = "AGENTOS_API_URL"
+        )]
+        api_url: String,
+        /// Platform API key.
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
+        api_key: String,
+        /// Slack channel to bind the agent to. On first create it defaults to
+        /// C0LOCALDEV; on redeploy it is only moved when you pass this flag, so
+        /// omitting it leaves the deployed agent's channel untouched.
+        #[arg(long)]
+        slack_channel: Option<String>,
+        /// Target environment.
+        #[arg(long, value_enum, default_value_t = DeployEnv::Dev)]
+        env: DeployEnv,
+        /// Version label; defaults to <manifest version>-<unix time>.
+        #[arg(long)]
+        label: Option<String>,
+        /// Bind a per-agent connector secret by NAME (ADR-0009, #429). The value
+        /// is resolved from your environment or the host secret vault (`agentos
+        /// secrets set <NAME>`) and sent to the platform. Repeatable.
+        #[arg(long = "secret", value_name = "NAME")]
+        secret: Vec<String>,
+    },
     /// Build the runner image locally from `runner/Dockerfile` (source checkout only).
     ///
     /// Runs `docker build -f runner/Dockerfile -t <tag> .` from the repo root. A
@@ -2276,6 +2317,29 @@ async fn run(command: Option<Command>) -> Result<()> {
                 )
             }
         },
+        Some(Command::ListAgents) => commands::list_agents().await,
+        Some(Command::DeployLocal {
+            folder,
+            api_url,
+            api_key,
+            slack_channel,
+            env,
+            label,
+            secret,
+        }) => emit(
+            commands::deploy_named(
+                &folder,
+                commands::DeployNamedOpts {
+                    api_url,
+                    api_key,
+                    slack_channel,
+                    env,
+                    label,
+                    secret,
+                },
+            )
+            .await?,
+        ),
         Some(Command::Schema) => {
             use clap::CommandFactory;
             print!("{}", agentos::schema::manifest_json(&Cli::command()));
@@ -2307,6 +2371,32 @@ mod tests {
         match cli.command {
             Some(Command::Build { tag }) => assert_eq!(tag, "my-runner:dev"),
             _ => panic!("expected build command"),
+        }
+    }
+
+    #[test]
+    fn list_agents_parses() {
+        let cli =
+            Cli::try_parse_from(["agentos", "list-agents"]).expect("list-agents should parse");
+        assert!(matches!(cli.command, Some(Command::ListAgents)));
+    }
+
+    #[test]
+    fn deploy_local_parses_the_folder_positional_and_defaults() {
+        let cli = Cli::try_parse_from(["agentos", "deploy-local", "revenue-leak"])
+            .expect("deploy-local should parse");
+        match cli.command {
+            Some(Command::DeployLocal {
+                folder,
+                slack_channel,
+                secret,
+                ..
+            }) => {
+                assert_eq!(folder, "revenue-leak");
+                assert_eq!(slack_channel, None);
+                assert!(secret.is_empty());
+            }
+            _ => panic!("expected deploy-local command"),
         }
     }
 

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -284,7 +284,7 @@ pub fn scaffold_from_spec(dir: &Path, spec: &AgentSpec) -> Result<Vec<PathBuf>> 
 /// their error messages) live in one place. Returns the resolved manifest path
 /// alongside the parsed value so callers can keep referencing it (e.g. `name`)
 /// in their own error messages.
-fn load_manifest_json(dir: &Path) -> Result<(std::path::PathBuf, serde_json::Value)> {
+pub(crate) fn load_manifest_json(dir: &Path) -> Result<(std::path::PathBuf, serde_json::Value)> {
     let path = [".claude-plugin/plugin.json", "plugin.json"]
         .iter()
         .map(|rel| dir.join(rel))


### PR DESCRIPTION
## Summary

- Adds `cli/src/discover.rs`: scans a directory's immediate subdirectories for a `.claude-plugin/plugin.json` bundle (mirrors `scripts/check-plugin-compat.sh`'s depth-3 find), returning an empty list rather than an error when the directory doesn't exist.
- `agentos list-agents`: lists the plugin bundles under `agents/`, a personal, gitignored directory (sibling of `examples/`) for in-progress agent projects. `--json` support via the standard `CliOutput`/`Ui::emit` path.
- `agentos deploy-local <folder>`: resolves `agents/<folder>` and calls the exact same `commands::deploy`/`DeployOpts` path `local deploy --plugin-dir` already uses -- a name-based shorthand, not a new deploy mechanism. Local tier only; `cluster deploy --plugin-dir agents/<folder>` remains the way to target the cluster tier. (Named `deploy-local` rather than bare `deploy` since the latter is a retired pre-tier-split verb name that redirects to `cluster deploy` -- see `retired.rs`.)
- The TUI's existing "Deploy to Slack" workflow (`Workflow::DeployToSlack`) now offers discovered `agents/` bundles as a picker (plus a "Custom path..." fallback) instead of a bare free-text prompt for the bundle directory. No other part of that workflow changed.
- `agents/` promoted from a local-only `.git/info/exclude` entry to the committed `.gitignore`, plus a couple of README lines documenting the new verbs.
- Regenerated `cli/command-manifest.json` and `apps/ui/src/generated/commandManifest.ts` for the new clap surface.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all clean (27/27 test groups pass, including the retired-verb and command-manifest-drift gates)
- [x] `agentos list-agents` / `--json` from the repo root lists the real `agents/revenue-leak-agentos` bundle; errors clearly outside a checkout
- [x] `agentos deploy-local nonexistent-folder` lists the available folder names in its error
- [x] `agentos deploy-local revenue-leak-agentos` deployed successfully end to end against a running local stack (real agent/version/deployment created)