### PR TITLE
Fix the release authorization gate so a valid tag can publish

### DIFF
--- a/release/authorize.py
+++ b/release/authorize.py
@@ -14,6 +14,9 @@ pipeline, and it fails closed on either of two questions:
             neutral/skipped)? A commit that is on main but was never checked,
             or was checked and failed, is refused the same way. Zero check-runs
             is also a failure -- absence of checks is not evidence they passed.
+            The gate's own workflow run is excluded from that list (issue
+            #732): it is itself an in-progress check-run on the tagged SHA and
+            would otherwise wait on itself forever.
 
 Both live as separately-testable functions so the negative case -- an
 unreviewed or check-less commit is refused -- is an ordinary pytest assertion
@@ -26,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -65,12 +69,37 @@ def required_checks_passed(check_runs: list[dict[str, object]]) -> bool:
     return all(run.get("conclusion") in PASSING_CONCLUSIONS for run in check_runs)
 
 
+def exclude_current_workflow_run(
+    check_runs: list[dict[str, object]], run_id: str | None
+) -> list[dict[str, object]]:
+    """Drop the check-runs belonging to the workflow run doing the asking.
+
+    On a tag push the gate's own job is itself a check-run on the tagged SHA,
+    with `status: in_progress` and `conclusion: null`, so it would refuse every
+    legitimate release by waiting on itself. Only the current run is excluded --
+    a blanket "ignore every null conclusion" would let a genuinely stuck
+    unrelated required check through, which is the opposite of failing closed.
+
+    A check-run's `details_url` is its job URL, observed live as
+    `https://github.com/curie-eng/agentos/actions/runs/<run_id>/job/<job_id>`,
+    so the run id embedded in that path is the ownership signal. An entry with
+    no `details_url` (an external app's check) can never be ours, so it stays.
+    """
+    if not run_id:
+        return check_runs
+    marker = f"/actions/runs/{run_id}/"
+    return [
+        run for run in check_runs if marker not in str(run.get("details_url") or "")
+    ]
+
+
 def authorize(
     sha: str,
     check_runs: list[dict[str, object]],
     main_ref: str = "origin/main",
     *,
     cwd: Path | None = None,
+    exclude_run_id: str | None = None,
 ) -> None:
     """Raise AuthorizationError unless `sha` may publish a release."""
     if not commit_is_on_reviewed_main(sha, main_ref, cwd=cwd):
@@ -79,11 +108,13 @@ def authorize(
             "publish from a commit that reached main through a reviewed, merged "
             "PR; refusing to authorize this tag."
         )
-    if not required_checks_passed(check_runs):
+    other_runs = exclude_current_workflow_run(check_runs, exclude_run_id)
+    if not required_checks_passed(other_runs):
         raise AuthorizationError(
             f"commit {sha} does not have a fully successful set of check-runs "
-            f"({len(check_runs)} found). Refusing to authorize this tag until its "
-            "required checks are current and green."
+            f"({len(other_runs)} found, excluding this workflow run's own). "
+            "Refusing to authorize this tag until its required checks are "
+            "current and green."
         )
 
 
@@ -95,9 +126,23 @@ def fetch_check_runs(sha: str, repo: str) -> list[dict[str, object]]:
     covers it, and parsing one JSON object is simpler than merging paginated
     array-under-a-key responses (this endpoint's top level is an object, not
     an array, so `gh api --paginate` does not auto-merge it).
+
+    `-X GET` is load-bearing, not decoration: `gh api` defaults to GET but
+    switches to POST as soon as any `-f`/`-F` flag is present, and
+    `POST /repos/{owner}/{repo}/commits/{sha}/check-runs` does not exist
+    (issue #732). The live observation pinning this is cited in
+    `release/tests/test_authorize.py::TestFetchCheckRuns`.
     """
     result = subprocess.run(
-        ["gh", "api", f"repos/{repo}/commits/{sha}/check-runs", "-f", "per_page=100"],
+        [
+            "gh",
+            "api",
+            "-X",
+            "GET",
+            f"repos/{repo}/commits/{sha}/check-runs",
+            "-f",
+            "per_page=100",
+        ],
         capture_output=True,
         text=True,
         check=True,
@@ -112,13 +157,32 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("sha", help="the tagged commit to authorize")
     parser.add_argument("--repo", required=True, help="owner/name, e.g. curie-eng/agentos")
     parser.add_argument("--main-ref", default="origin/main", help="the reviewed-main ref")
+    parser.add_argument(
+        "--run-id",
+        default=os.environ.get("GITHUB_RUN_ID"),
+        help="this workflow run's id; its own check-runs are excluded from the gate",
+    )
     args = parser.parse_args(argv)
 
     try:
         check_runs = fetch_check_runs(args.sha, args.repo)
-        authorize(args.sha, check_runs, args.main_ref)
+        authorize(args.sha, check_runs, args.main_ref, exclude_run_id=args.run_id)
     except AuthorizationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError) as exc:
+        # A lookup that did not complete is not an authorization verdict. Fail
+        # closed either way, but say which of the two happened -- an opaque
+        # traceback here is what kept issue #732's `gh api` defect unreadable.
+        detail = getattr(exc, "stderr", None)
+        suffix = f": {str(detail).strip()}" if detail else ""
+        print(
+            f"ERROR: could not retrieve check-runs for {args.sha} from "
+            f"{args.repo} -- the lookup failed with "
+            f"{type(exc).__name__}{suffix}. Refusing to authorize this tag "
+            "because its check status is unknown.",
+            file=sys.stderr,
+        )
         return 1
     print(f"OK: {args.sha} is reviewed, on {args.main_ref}, and checked -- authorized")
     return 0

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -10,6 +10,7 @@ what `authorize-release` actually calls.
 """
 
 import importlib.util
+import json
 import subprocess
 from pathlib import Path
 
@@ -66,6 +67,30 @@ CHECK_RUNS_ONE_FAILED = [
     {"name": "CI", "conclusion": "success"},
     {"name": "Dependency Audit", "conclusion": "failure"},
 ]
+
+CURRENT_RUN_ID = "29811627398"
+OTHER_RUN_ID = "29811600001"
+
+
+def check_run(name: str, conclusion: str | None, run_id: str, job_id: str) -> dict:
+    """A check-run shaped like the live API response (issue #732).
+
+    `details_url` observed live on this repo:
+    https://github.com/curie-eng/agentos/actions/runs/29811627398/job/88573652086
+    """
+    return {
+        "name": name,
+        "status": "completed" if conclusion is not None else "in_progress",
+        "conclusion": conclusion,
+        "details_url": (
+            f"https://github.com/curie-eng/agentos/actions/runs/{run_id}/job/{job_id}"
+        ),
+    }
+
+
+GATE_OWN_IN_PROGRESS = check_run(
+    "authorize-release", None, CURRENT_RUN_ID, "88573652086"
+)
 
 
 class TestCommitIsOnReviewedMain:
@@ -128,3 +153,281 @@ class TestAuthorize:
             authorize_module.AuthorizationError, match="check-runs"
         ):
             authorize_module.authorize(sha, CHECK_RUNS_ONE_FAILED, "main", cwd=git_repo)
+
+
+class TestFetchCheckRuns:
+    """`gh api` must be pinned to GET (issue #732, defect 1).
+
+    `gh api` defaults to GET but switches to POST as soon as any `-f`/`-F`
+    flag is present, and `POST /repos/{owner}/{repo}/commits/{sha}/check-runs`
+    does not exist. Verified live against curie-eng/agentos on 2026-07-21 at
+    commit 276774ff: the `-f`-only form returned
+    `{"message": "Not Found", "status": "404"}`, while adding `-X GET`
+    returned `{"total_count": 42, ...}`. Mocking `gh` here is correct: GitHub
+    is an external service.
+    """
+
+    @staticmethod
+    def _capture(monkeypatch, payload: dict) -> list:
+        captured: list = []
+
+        def fake_run(argv, **kwargs):
+            captured.append(argv)
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+        monkeypatch.setattr(authorize_module.subprocess, "run", fake_run)
+        return captured
+
+    def test_check_runs_are_fetched_with_an_explicit_get(self, monkeypatch):
+        payload = {"total_count": 1, "check_runs": [CHECK_RUNS_ALL_GREEN[0]]}
+        captured = self._capture(monkeypatch, payload)
+
+        runs = authorize_module.fetch_check_runs("deadbeef", "curie-eng/agentos")
+
+        argv = captured[0]
+        endpoint = "repos/curie-eng/agentos/commits/deadbeef/check-runs"
+        assert "-X" in argv
+        assert argv[argv.index("-X") + 1] == "GET"
+        assert argv.index("-X") < argv.index(endpoint)
+        assert "-f" in argv
+        assert argv[argv.index("-f") + 1] == "per_page=100"
+        assert runs == [CHECK_RUNS_ALL_GREEN[0]]
+
+
+class TestExcludeCurrentWorkflowRun:
+    """The gate is itself a check-run on the tagged SHA (issue #732, defect 2)."""
+
+    def test_current_run_entries_are_dropped_and_others_survive(self):
+        other = check_run("CI", "success", OTHER_RUN_ID, "88573600001")
+
+        remaining = authorize_module.exclude_current_workflow_run(
+            [GATE_OWN_IN_PROGRESS, other], CURRENT_RUN_ID
+        )
+
+        assert remaining == [other]
+
+    def test_falsy_run_id_leaves_the_list_untouched(self):
+        runs = [GATE_OWN_IN_PROGRESS, check_run("CI", "success", OTHER_RUN_ID, "1")]
+
+        assert authorize_module.exclude_current_workflow_run(runs, None) == runs
+        assert authorize_module.exclude_current_workflow_run(runs, "") == runs
+
+    def test_entries_without_details_url_are_never_dropped(self):
+        external = {"name": "External Check", "status": "completed", "conclusion": "success"}
+
+        remaining = authorize_module.exclude_current_workflow_run(
+            [GATE_OWN_IN_PROGRESS, external], CURRENT_RUN_ID
+        )
+
+        assert remaining == [external]
+
+
+class TestAuthorizeExcludesCurrentRun:
+    def test_gate_own_in_progress_entry_does_not_block_authorization(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        runs = [
+            GATE_OWN_IN_PROGRESS,
+            check_run("CI", "success", OTHER_RUN_ID, "88573600001"),
+            check_run("CodeQL", "neutral", OTHER_RUN_ID, "88573600002"),
+        ]
+
+        authorize_module.authorize(
+            sha, runs, "main", cwd=git_repo, exclude_run_id=CURRENT_RUN_ID
+        )
+
+    def test_unrelated_in_progress_check_is_still_refused(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        runs = [
+            GATE_OWN_IN_PROGRESS,
+            check_run("CI", "success", OTHER_RUN_ID, "88573600001"),
+            check_run("Integration Tests", None, OTHER_RUN_ID, "88573600003"),
+        ]
+
+        with pytest.raises(authorize_module.AuthorizationError, match="check-runs"):
+            authorize_module.authorize(
+                sha, runs, "main", cwd=git_repo, exclude_run_id=CURRENT_RUN_ID
+            )
+
+    def test_failed_check_from_another_run_is_still_refused(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        runs = [
+            GATE_OWN_IN_PROGRESS,
+            check_run("Dependency Audit", "failure", OTHER_RUN_ID, "88573600004"),
+        ]
+
+        with pytest.raises(authorize_module.AuthorizationError, match="check-runs"):
+            authorize_module.authorize(
+                sha, runs, "main", cwd=git_repo, exclude_run_id=CURRENT_RUN_ID
+            )
+
+    def test_only_current_run_checks_is_refused(self, git_repo):
+        # Nothing survives filtering, and absence of checks is not evidence
+        # they passed.
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        runs = [
+            GATE_OWN_IN_PROGRESS,
+            check_run("authorize-release setup", "success", CURRENT_RUN_ID, "88573652087"),
+        ]
+
+        with pytest.raises(authorize_module.AuthorizationError, match="check-runs"):
+            authorize_module.authorize(
+                sha, runs, "main", cwd=git_repo, exclude_run_id=CURRENT_RUN_ID
+            )
+
+
+class TestMain:
+    """`main()` must thread `GITHUB_RUN_ID` into `authorize()` as
+    `exclude_run_id` (issue #732, defect 2). Every test above drives
+    `authorize()` or `exclude_current_workflow_run()` directly, so deleting
+    `exclude_run_id=args.run_id` from `main()`'s `authorize(...)` call leaves
+    the whole suite green while restoring the bug: the gate would wait
+    forever on its own in-progress check-run. These tests invoke `main()`
+    itself so that wiring is covered at the layer where it actually lived.
+
+    `fetch_check_runs` is stubbed so no network call happens; `authorize()`
+    runs for real against `git_repo`, so `main()` is run with that repo as
+    the working directory (`main()` calls `authorize()` without a `cwd`).
+    """
+
+    @staticmethod
+    def _stub_fetch_check_runs(monkeypatch, runs: list[dict]) -> None:
+        monkeypatch.setattr(
+            authorize_module, "fetch_check_runs", lambda sha, repo: runs
+        )
+
+    @staticmethod
+    def _runs_with_gate_own_in_progress() -> list[dict]:
+        return [
+            GATE_OWN_IN_PROGRESS,
+            check_run("CI", "success", OTHER_RUN_ID, "88573600001"),
+            check_run("CodeQL", "neutral", OTHER_RUN_ID, "88573600002"),
+        ]
+
+    def test_main_authorizes_when_github_run_id_excludes_its_own_check(
+        self, git_repo, monkeypatch
+    ):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        self._stub_fetch_check_runs(monkeypatch, self._runs_with_gate_own_in_progress())
+        monkeypatch.chdir(git_repo)
+        monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
+
+        exit_code = authorize_module.main(
+            [sha, "--repo", "curie-eng/agentos", "--main-ref", "main"]
+        )
+
+        assert exit_code == 0
+
+    def test_main_refuses_when_github_run_id_is_absent(self, git_repo, monkeypatch):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        self._stub_fetch_check_runs(monkeypatch, self._runs_with_gate_own_in_progress())
+        monkeypatch.chdir(git_repo)
+        monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
+
+        exit_code = authorize_module.main(
+            [sha, "--repo", "curie-eng/agentos", "--main-ref", "main"]
+        )
+
+        assert exit_code == 1
+
+    def test_main_refuses_when_github_run_id_is_a_different_run(
+        self, git_repo, monkeypatch
+    ):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        self._stub_fetch_check_runs(monkeypatch, self._runs_with_gate_own_in_progress())
+        monkeypatch.chdir(git_repo)
+        monkeypatch.setenv("GITHUB_RUN_ID", OTHER_RUN_ID)
+
+        exit_code = authorize_module.main(
+            [sha, "--repo", "curie-eng/agentos", "--main-ref", "main"]
+        )
+
+        assert exit_code == 1
+
+
+class TestMainLookupFailures:
+    """A failed check-run lookup must refuse legibly, not traceback (#732).
+
+    Before this, `main()` caught only `AuthorizationError`, so every failure
+    inside `fetch_check_runs` escaped as an unhandled traceback. The exit code
+    was already 1, so the gate did fail closed; what was missing was any way
+    for an operator to tell an unauthorized tag from a lookup that never
+    completed -- which is exactly why the `gh api` POST/GET defect read as an
+    opaque crash. Each path below must still return 1.
+    """
+
+    @staticmethod
+    def _stub_fetch_raising(monkeypatch, exc: BaseException) -> None:
+        def raising(sha, repo):
+            raise exc
+
+        monkeypatch.setattr(authorize_module, "fetch_check_runs", raising)
+
+    @staticmethod
+    def _run_main(git_repo, monkeypatch) -> int:
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        monkeypatch.chdir(git_repo)
+        monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
+        return authorize_module.main(
+            [sha, "--repo", "curie-eng/agentos", "--main-ref", "main"]
+        )
+
+    def test_gh_api_failure_refuses_with_a_message_naming_the_lookup(
+        self, git_repo, monkeypatch, capsys
+    ):
+        self._stub_fetch_raising(
+            monkeypatch,
+            subprocess.CalledProcessError(
+                1,
+                ["gh", "api", "-X", "GET", "repos/curie-eng/agentos/commits/x/check-runs"],
+                stderr="gh: Not Found (HTTP 404)",
+            ),
+        )
+
+        exit_code = self._run_main(git_repo, monkeypatch)
+
+        assert exit_code == 1
+        stderr = capsys.readouterr().err
+        assert "ERROR: could not retrieve check-runs" in stderr
+        assert "gh: Not Found (HTTP 404)" in stderr
+
+    def test_unparseable_response_refuses_with_a_message_naming_the_lookup(
+        self, git_repo, monkeypatch, capsys
+    ):
+        self._stub_fetch_raising(
+            monkeypatch, json.JSONDecodeError("Expecting value", "not json", 0)
+        )
+
+        exit_code = self._run_main(git_repo, monkeypatch)
+
+        assert exit_code == 1
+        assert "ERROR: could not retrieve check-runs" in capsys.readouterr().err
+
+    def test_payload_without_check_runs_key_refuses_with_a_message(
+        self, git_repo, monkeypatch, capsys
+    ):
+        self._stub_fetch_raising(monkeypatch, KeyError("check_runs"))
+
+        exit_code = self._run_main(git_repo, monkeypatch)
+
+        assert exit_code == 1
+        assert "ERROR: could not retrieve check-runs" in capsys.readouterr().err
+
+    def test_lookup_failure_is_distinguishable_from_an_unauthorized_tag(
+        self, git_repo, monkeypatch, capsys
+    ):
+        # The unauthorized-tag wording must not appear on the lookup path, or
+        # an operator cannot tell the two refusals apart.
+        self._stub_fetch_raising(monkeypatch, KeyError("check_runs"))
+
+        assert self._run_main(git_repo, monkeypatch) == 1
+        lookup_stderr = capsys.readouterr().err
+
+        monkeypatch.setattr(
+            authorize_module, "fetch_check_runs", lambda sha, repo: CHECK_RUNS_ONE_FAILED
+        )
+        assert self._run_main(git_repo, monkeypatch) == 1
+        refusal_stderr = capsys.readouterr().err
+
+        assert "could not retrieve check-runs" in lookup_stderr
+        assert "could not retrieve check-runs" not in refusal_stderr
+        assert "does not have a fully successful set of check-runs" in refusal_stderr


### PR DESCRIPTION
The `authorize-release` gate added in #727 (ADR-0058) could not authorize any release. Both defects are fixed here, since fixing only the first surfaces the second.

**1. The check-run lookup always 404d.** `gh api` defaults to GET but switches to POST as soon as any `-f`/`-F` flag is present, and `POST /repos/{owner}/{repo}/commits/{sha}/check-runs` does not exist. The call now sends `-X GET`. Verified live against this repo (commit `276774ff`): the `-f`-only form returns `{"message": "Not Found", "status": "404"}`, the `-X GET` form returns `{"total_count": 42, ...}`. That observation is cited in the test that pins it.

**2. The gate evaluated its own in-progress check-run.** On a tag push, `authorize-release` is itself a check-run on the tagged SHA with `conclusion: null`, so `all(...)` refused every legitimate release. `exclude_current_workflow_run` now drops only the check-runs belonging to the current workflow run, keyed on the run id in each entry's `details_url`, before conclusions are evaluated. The run id comes from `GITHUB_RUN_ID` (a default Actions env var) via a new `--run-id` flag, which is also the injection seam the regression tests use. A blanket "ignore all null conclusions" was deliberately not used: an unrelated stuck required check must still refuse, and there is a test for that.

The gate still fails closed everywhere it did before: unreachable-from-main refuses, a failed check refuses, an unrelated in-progress check refuses, and an empty check-run list refuses.

**Intentionally bundled, flagged by the scope reviewer:** `main()` now catches `CalledProcessError`/`JSONDecodeError`/`KeyError` from the lookup and prints a clear `ERROR:` refusal instead of letting a traceback escape. This is not one of the five acceptance criteria. It is included because it is why defect 1 presented as an opaque crash for a whole release cycle, and a live reproduction during this work confirmed the traceback is still reachable (an unpushed SHA yields HTTP 422). It is purely additive: no verdict and no exit code changes.

Live demonstration of the fixed gate against the real repo:

```
$ GITHUB_RUN_ID=29811627398 python3 release/authorize.py 276774ff... --repo curie-eng/agentos --main-ref origin/main
OK: 276774ff... is reviewed, on origin/main, and checked -- authorized

$ GITHUB_RUN_ID=29811627398 python3 release/authorize.py <sha not on main> --repo curie-eng/agentos --main-ref origin/main
ERROR: could not retrieve check-runs for <sha> -- the lookup failed with CalledProcessError: gh: No commit found for SHA (HTTP 422). Refusing to authorize this tag because its check status is unknown.
exit=1
```

`.github/workflows/release.yaml` is unchanged: `GITHUB_RUN_ID` is already in the step environment.

### Done-check

- [x] Failing tests committed before implementation (`75ffe49` then `509b8fa`, squashed here)
- [x] All production edits made by delegated sub-agents; no inline driver edits
- [x] No return types broadened (the implementer reported none; the one new function is additive)
- [x] Code reviewer approved, 0 blockers, with file:line evidence
- [x] Scope reviewer: 11 of 12 hunks clear; the 12th is the error-handling block annotated above
- [x] Sibling-path parity: the gate is the single entry point for tag authorization; no sibling path
- [x] Guard demonstration: the gate was executed against the live repo in both the authorizing and refusing directions (output above), not read
- [x] Consolidation pass ran (`/simplify`): removed a redundant inequality-only test and a duplicated verification transcript; suite and lint green after; re-reviewed with no blockers
- [x] Codex review ran twice (driver-direct, headless), no blocking findings; it also executed the script end to end against the live repo
- [ ] Security reviewer: N/A, no security scale-up
- [ ] E2E tester: N/A, verified by direct live execution of the gate script
- [x] `uv run pytest release/tests -q`: 55 passed. The full workspace suite has 26 failures and 187 errors, all `apps/api`/`apps/worker` integration tests refusing to connect to Postgres on `127.0.0.1:25432` because the dev stack is not up; zero failures under `release/`, and this change touches nothing outside it
- [x] `uv run ruff check .` clean, `uv run mypy` clean (151 source files)

Closes #732