### PR TITLE
Correct the approval-gate built-in tool recognition set

### DIFF
--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -213,6 +213,19 @@ line; rewrite that `plugin:<bundle>:<server>` value into the
 `mcp__plugin_<bundle>_<server>__<tool>` prefix and append the tool name. A
 tool-call trace also shows the exact live name directly.
 
+A related trap sits on the built-in side: the bundled Claude Code CLI keeps
+an alias-to-canonical map for some of its tool names (for example `Task` to
+`Agent`, `BashOutput` to `TaskOutput`, `KillShell` to `TaskStop`,
+`ListMcpResources` to `ListMcpResourcesTool`). That map is consumed only by
+the CLI's own permission-rule parser (the settings.json allow/deny path); it
+is not in the path this gate uses. The SDK `can_use_tool` callback that
+`build_can_use_tool` compares against always reports the canonical name, so
+an operator who gates on an alias arms a literal that never matches and the
+gate silently arms nothing. Gate on the canonical name. Since #736,
+`build_approval_gate` (`runner/src/agentos_runner/approval.py`) treats alias
+names as unrecognized on purpose, so arming one still trips the existing
+"may be a silent no-op" warning.
+
 ## Implementations today
 
 **One authorizer** (`apps/api/src/agentos_api/authorizer.py`, pure policy with no Slack in

--- a/runner/src/agentos_runner/approval.py
+++ b/runner/src/agentos_runner/approval.py
@@ -63,24 +63,137 @@ logger = logging.getLogger(__name__)
 # version; a name missing from here is not an error, just an unwarned pass,
 # and a name present here that isn't actually offered in a given session is
 # similarly harmless (it just arms nothing, same as today).
+#
+# Provenance (#736): the names below are read out of the CLI the SDK actually
+# ships, not guessed. runner/pyproject.toml pins claude-agent-sdk>=0.2.115; that
+# version bundles Claude Code CLI 2.1.206 (claude_agent_sdk/_cli_version.py),
+# binary at claude_agent_sdk/_bundled/claude. Two reproducible sources:
+#
+# 1. Tool-name string constants. Note the extraction pattern must NOT anchor on
+#    "var ": the minified bundle chains declarators, e.g.
+#    var gH="CronCreate",gU="CronDelete",CVt="CronList" , so a var-anchored
+#    regex captures only the first name and silently drops its siblings (that
+#    is how CronDelete/CronList went missing on the first pass). Use:
+#      grep -ao '[A-Za-z_$][A-Za-z_$0-9]*="[A-Z][A-Za-z]*"[,;]' <binary> \
+#        | sed 's/.*="//;s/"[,;]//' | sort -u
+# 2. The alias-to-canonical map, reproducible with:
+#      grep -ao '.\{300\}BashOutputTool:"TaskOutput".\{0,400\}' <binary>
+#    which yields verbatim:
+#      {Task:"Agent",KillShell:"TaskStop",KillBash:"TaskStop",
+#       AgentOutputTool:"TaskOutput",BashOutputTool:"TaskOutput",
+#       AgentOutput:"TaskOutput",BashOutput:"TaskOutput",
+#       ListPeers:"ListAgents",Brief:"SendUserMessage",
+#       ListMcpResources:"ListMcpResourcesTool",
+#       ReadMcpResource:"ReadMcpResourceTool",
+#       ReadMcpResourceDir:"ReadMcpResourceDirTool"}
+#
+# The bound: this set holds ONLY names the SDK ``can_use_tool`` callback can
+# actually observe, which is the CANONICAL tool-name set. It is deliberately NOT
+# the CLI's whole recognition surface, because the two differ on alias keys.
+#
+# Why the alias map above is EXCLUDED rather than included. The bundled CLI
+# consumes that map through a resolver, ``R2(e){return Object.hasOwn(Hti,e)?
+# Hti[e]:e}``, and calls it only from its permission-RULE string parser
+# (``{toolName:R2(e)}``) -- the settings.json allow/deny path. AgentOS's operator
+# approval gate does not go through that path at all: ``build_approval_gate``
+# arms names verbatim into ``gate.required`` and ``build_can_use_tool`` compares
+# the SDK-reported tool name by exact equality, and the SDK reports the CANONICAL
+# name. So an operator gating an alias (``ListMcpResources``, canonical
+# ``ListMcpResourcesTool``) arms a literal that never matches: the gate silently
+# arms nothing. For this gate an alias name IS a probable no-op, so its warning
+# is a TRUE positive, not the false positive #736 set out to fix, and suppressing
+# it would be exactly the silent fail-open #712 built the warning to surface.
+# ``Task``, ``BashOutput``, and ``KillShell`` were in the historical pre-#736 set
+# and are dropped for this reason (they are alias keys for ``Agent``,
+# ``TaskOutput``, and ``TaskStop``); the canonical names stay.
+#
+# The inclusion criterion (apply this, do not re-derive it). A name is included
+# when the bundled CLI does either of:
+#   (a) declares it as a tool-name string constant AND carries a tool marker
+#       next to it: a tool description string, a userFacingName(), or an
+#       aliases:[...] registry entry, AND it is the canonical name rather than an
+#       alias key from the map above; or
+#   (b) still recognizes it in a permission-matcher list (the MultiEdit /
+#       NotebookRead case).
+# A bare capitalized string constant with no tool marker does NOT qualify, and an
+# alias key NEVER qualifies.
+#
+# Recorded exclusions, so the raw-sweep diff is pre-resolved:
+#   SlashCommand      zero occurrences of the literal in the binary.
+#   TestingPermission real registry entry, but isEnabled(){return!1}, so it is
+#                     never offered.
+#   ConnectGitHub     name constant with no tool marker next to it, fails (a).
+#   everything else the raw sweep returns (error classes, HTTP verbs,
+#   credential types, Zod types, syntax-highlighter language names) fails (a).
+#
+# MultiEdit and NotebookRead are retained without a registry entry in 2.1.206:
+# they have no tool description or name constant, but the CLI's live permission
+# matcher still lists them (filePatternTools includes NotebookRead, and the
+# write-tool deny set includes MultiEdit), so they remain legacy names the CLI
+# recognizes in permission rules and gating them is not an operator mistake.
 _KNOWN_BUILTIN_TOOLS = frozenset(
     {
-        "Task",
+        # Canonical tool names: criterion (a).
+        "Agent",
+        "Artifact",
+        "AskUserQuestion",
         "Bash",
-        "BashOutput",
-        "KillShell",
-        "Read",
-        "Write",
+        "Cd",
+        "ClaudeDesign",
+        "CronCreate",
+        "CronDelete",
+        "CronList",
+        "DesignSync",
         "Edit",
-        "MultiEdit",
+        "EndConversation",
+        "EnterPlanMode",
+        "EnterWorktree",
+        "ExitPlanMode",
+        "ExitWorktree",
         "Glob",
         "Grep",
+        "LSP",
+        "ListAgents",
+        "ListConnectors",
+        "ListMcpResourcesTool",
+        "Monitor",
+        "NotebookEdit",
+        "ObserverReport",
+        "PowerShell",
+        "Projects",
+        "PushNotification",
+        "REPL",
+        "Read",
+        "ReadMcpResourceDirTool",
+        "ReadMcpResourceTool",
+        "RemoteTrigger",
+        "ReportFindings",
+        "ScheduleWakeup",
+        "SearchMcpRegistry",
+        "SendMessage",
+        "SendUserFile",
+        "SendUserMessage",
+        "ShareOnboardingGuide",
+        "ShowOnboardingRolePicker",
+        "Skill",
+        "StructuredOutput",
+        "SuggestConnectors",
+        "TaskCreate",
+        "TaskGet",
+        "TaskList",
+        "TaskOutput",
+        "TaskStop",
+        "TaskUpdate",
+        "TodoWrite",
+        "ToolSearch",
+        "WaitForMcpServers",
         "WebFetch",
         "WebSearch",
-        "NotebookEdit",
+        "Workflow",
+        "Write",
+        # Legacy names the permission matcher still recognizes: criterion (b).
+        "MultiEdit",
         "NotebookRead",
-        "TodoWrite",
-        "ExitPlanMode",
     }
 )
 

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -2092,7 +2092,10 @@ def test_builtin_and_already_effective_operator_gates_pass_verbatim() -> None:
 
 
 def test_bare_non_builtin_operator_gate_warns_it_may_be_a_silent_no_op(caplog) -> None:
-    """#712: a bare (non-mcp__) operator gate name that ISN'T a well-known
+    """#736 also relies on this test as its anti-hollow-out guard: widening the
+    known-built-in set must not amount to deleting the check.
+
+    #712: a bare (non-mcp__) operator gate name that ISN'T a well-known
     built-in tool is still armed verbatim (unchanged behavior -- we cannot
     fail closed here without an authoritative built-in tool list), but it
     must no longer be SILENT. This is exactly the shape that bit revenue-leak:
@@ -2130,6 +2133,74 @@ def test_known_builtin_operator_gate_does_not_warn(caplog) -> None:
     assert not any(
         "does not match any well-known" in r.getMessage() for r in caplog.records
     )
+
+
+# Provenance and inclusion criterion for these names (#736): see the comment
+# above `_KNOWN_BUILTIN_TOOLS` in runner/src/agentos_runner/approval.py.
+@pytest.mark.parametrize(
+    "builtin",
+    [
+        "Skill",
+        "AskUserQuestion",
+        "ListMcpResourcesTool",
+        "ReadMcpResourceTool",
+        "MultiEdit",
+        "NotebookRead",
+        "CronDelete",
+        "CronList",
+        "StructuredOutput",
+    ],
+)
+def test_real_builtin_operator_gates_do_not_warn(caplog, builtin: str) -> None:
+    """#736: the built-in list drifted behind the bundled CLI, so correctly
+    configured gates on real built-ins (Skill, AskUserQuestion, the canonical
+    MCP-resource tools) were falsely warned as probable no-ops.
+    MultiEdit/NotebookRead have no registry entry in CLI 2.1.206 but are still
+    recognized by its permission matcher, so gating them is not an operator
+    mistake either."""
+    with caplog.at_level("WARNING"):
+        gate = build_approval_gate(
+            operator_tools=[builtin],
+            policy_routes={},
+            bundle_name="revenue-leak",
+            mcp_servers={"revenue-leak-engine"},
+        )
+    assert gate is not None
+    assert gate.required == frozenset({builtin})
+    assert not any(
+        "does not match any well-known" in r.getMessage() for r in caplog.records
+    ), caplog.text
+
+
+@pytest.mark.parametrize(
+    "alias",
+    ["Task", "BashOutput", "KillShell", "ListMcpResources"],
+)
+def test_cli_alias_operator_gates_still_warn(caplog, alias: str) -> None:
+    """#736 anti-regression guard: CLI alias names must KEEP warning.
+
+    These names live in the bundled CLI's alias-to-canonical map (Task -> Agent,
+    BashOutput -> TaskOutput, KillShell -> TaskStop, ListMcpResources ->
+    ListMcpResourcesTool). The CLI normalizes them only on its permission-RULE
+    parsing path (the settings.json allow/deny path), which this approval gate
+    does not use: build_approval_gate arms the name verbatim and
+    build_can_use_tool compares the SDK-reported tool name by exact equality,
+    and the SDK reports the CANONICAL name. So a gate armed with an alias
+    matches nothing at all, the warning is a true positive, and adding these
+    names back to _KNOWN_BUILTIN_TOOLS would restore a silent fail-open.
+    """
+    with caplog.at_level("WARNING"):
+        gate = build_approval_gate(
+            operator_tools=[alias],
+            policy_routes={},
+            bundle_name="revenue-leak",
+            mcp_servers={"revenue-leak-engine"},
+        )
+    assert gate is not None
+    assert gate.required == frozenset({alias})
+    assert any(
+        "does not match any well-known" in r.getMessage() for r in caplog.records
+    ), caplog.text
 
 
 def test_manifest_gate_half_stays_fail_closed_after_operator_normalization(


### PR DESCRIPTION
`#719` added a warning when an operator approval gate uses a bare, non-`mcp__` name that is not a recognized Claude Code built-in. The recognition set it shipped was missing real built-ins, so correct configuration got warned it was a no-op. False warnings on a security control are how true warnings get ignored.

Rebuilt `_KNOWN_BUILTIN_TOOLS` from the tool registry in the Claude Code CLI (2.1.206) bundled with the pinned `claude-agent-sdk` (0.2.115), and recorded the bound, the inclusion criterion, the exclusions, and the extraction commands in the comment so the next drift is checkable rather than guessed.

Gating logic and the warning text are untouched. The only behavior change is which names suppress the warning.

## Deviations from the acceptance criteria, for reviewer judgment

**`SlashCommand` is omitted.** It does not exist in CLI 2.1.206 (zero occurrences of the literal in the bundled binary; the only hits are unrelated identifiers like `processSlashCommand`). Independently verified by two reviewers.

**`ListMcpResources` and `ReadMcpResource` are also omitted**, despite being named in the AC, because they are CLI *aliases*. The bundled CLI keeps an alias-to-canonical map that it applies only when parsing its own permission-rule strings. The SDK `can_use_tool` callback, which is what this gate matches on, always reports the canonical name. So a gate armed with an alias matches nothing, and the warning it would have suppressed is a true positive, not the false positive this issue set out to fix. Their canonical forms `ListMcpResourcesTool` and `ReadMcpResourceTool` are in the set. This reverses an earlier revision of this branch that did include the aliases; a review pass caught the fail-open.

**`Task`, `BashOutput`, and `KillShell` are removed from the historical set** for that same reason. They are alias keys for `Agent`, `TaskOutput`, and `TaskStop`. Gating them has always armed nothing; they now warn, correctly. Their canonical forms are in the set. This is a narrowing beyond the literal AC.

**`MultiEdit` and `NotebookRead` are retained rather than removed.** Neither has a tool registry entry in 2.1.206, but both are still live in the CLI's permission-matcher lists, so gating them is not an operator mistake. The AC allows retention with an explanation; the comment carries it.

Closes #736