### PR TITLE
Bound the thread-reset interrupt so a wedged sandbox still releases

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -84,6 +84,19 @@ RETRYABLE_CLASSIFICATIONS = frozenset({"rate-limit", "runner-error"})
 # platform contract on a platform-authored turn -- not user-intent guessing.
 _EXPIRY_RESUME_MARKER = "[approval expired]"
 
+# How long an operator-requested reset waits on the courtesy interrupt before
+# giving up and releasing anyway (#739). Deliberately seconds, not minutes: the
+# runner client's own request timeout is 600s, and a wedged runner accepts the
+# TCP connect then answers nothing, so an unbounded await there blocks the whole
+# maintenance tick. A healthy runner answers an interrupt in well under a second.
+# Note the coupling this creates with `RunnerClient.connect_timeout_s` (10.0, see
+# runner_client.py): on this path 5s always fires first, so a runner that is not
+# even accepting connections surfaces as this timeout rather than as the client's
+# connect error. That is fine here because the release runs either way, but keep
+# the two in mind together -- dropping the connect timeout below this value would
+# silently change which error an operator sees in the log.
+_RESET_INTERRUPT_TIMEOUT_S = 5.0
+
 
 @dataclass
 class TurnOutcome:
@@ -468,11 +481,66 @@ class Kernel:
         not lost -- a cold-created sandbox rehydrates its transcript from the
         durable state store on claim, the same as any other fresh claim.
 
-        Any live turn is interrupted first (best-effort: `interrupt_thread`
-        already no-ops safely when nothing is live) so `release` never yanks
-        the claim out from under a running turn without at least trying to
-        stop it cleanly. True if a route existed to release."""
-        await self.interrupt_thread(thread_key, "operator requested a sandbox reset")
+        Any live turn is interrupted first so `release` never yanks the claim
+        out from under a running turn without at least trying to stop it
+        cleanly, but the interrupt is a courtesy and never a precondition
+        (#739). The case that matters is a live handle whose runner is
+        unresponsive: a wedged runner accepts the TCP connect and then answers
+        `/v1/interrupt` never, so the call rides `RunnerClient`'s own 600s
+        request timeout. That is exactly the sandbox an operator is resetting,
+        and awaiting it unbounded costs twice: the release line below is never
+        reached, and the reset request has already been SPOPped off the pending
+        set by the maintenance tick, so a raise loses it permanently rather
+        than retrying next tick. The same tick also owns stream reclaim and
+        orphan reaping, which stall for the whole window behind it.
+
+        So the interrupt is bounded to `_RESET_INTERRUPT_TIMEOUT_S` and any
+        failure (timeout, transport error, non-200) is logged and swallowed; the
+        release then runs unconditionally. `CancelledError` is deliberately not
+        swallowed, so worker shutdown still cuts through.
+
+        The failure log is an ERROR, not a warning: it is the only record that a
+        sandbox was pulled out from under a turn that may still be running, and
+        there is no retry that would produce a second, louder signal. The two
+        success shapes are logged apart from it (and from each other) so an
+        operator can tell "the live turn was killed" from "nothing was running"
+        from "we released blind".
+
+        Behavioral note for the unconditional release: when the thread really did
+        have a live turn, tearing its sandbox down mid-run drops the turn stream,
+        which `_consume` classifies as `runner-error`. That is in
+        `RETRYABLE_CLASSIFICATIONS`, so the driving loop in `_run_event` retries
+        the turn, and the retry re-claims, which cold-creates a fresh sandbox on
+        current config -- exactly the state the reset was asking for. The
+        no-auto-retry-after-side-effects rule still holds: an attempt that saw a
+        `SideEffectFlag` escalates to a human instead of replaying. So a reset of
+        a live thread is a replay on a fresh sandbox, not a lost turn, and the
+        thread is never left routeless.
+
+        True if a route existed to release."""
+        try:
+            interrupted = await asyncio.wait_for(
+                self.interrupt_thread(thread_key, "operator requested a sandbox reset"),
+                _RESET_INTERRUPT_TIMEOUT_S,
+            )
+        except Exception:
+            logger.error(
+                "reset: interrupt did not land for thread %s (timed out or errored); "
+                "releasing the sandbox anyway, so a turn that is still live loses it "
+                "mid-run and replays on a fresh sandbox",
+                thread_key,
+                exc_info=True,
+            )
+        else:
+            if interrupted:
+                logger.info(
+                    "reset: interrupted the live turn on thread %s before releasing",
+                    thread_key,
+                )
+            else:
+                logger.info(
+                    "reset: no live runner to interrupt on thread %s", thread_key
+                )
         return await asyncio.to_thread(self._substrate.release, thread_key)
 
     def attach_killswitch(self, killswitch: KillSwitch) -> None:

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 import redis.exceptions
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from agentos_dispatcher.queue import to_stream_fields
+from agentos_worker import kernel as kernel_module
 from agentos_worker.consumer import THREAD_RESET_SET, Consumer
 
 DONE = SessionStatus.DONE
@@ -244,6 +245,41 @@ def test_maintenance_tick_drains_pending_thread_reset_requests(make_harness) -> 
 
             assert h.substrate.lookup("tDrain") is None  # released
             assert await h.async_redis.scard(THREAD_RESET_SET) == 0  # popped, not left behind
+
+    asyncio.run(go())
+
+
+def test_maintenance_tick_thread_reset_is_not_stalled_by_a_wedged_runner(
+    make_harness, monkeypatch
+) -> None:
+    """#739: the maintenance tick runs stream reclaim, orphan reaping, and the
+    thread-reset drain in one pass, so a reset whose runner never answers the
+    courtesy interrupt would otherwise block all three for the runner client's
+    full 600s request timeout -- and the request is already SPOPped off the set,
+    so it is lost rather than retried on the next tick. The drain must therefore
+    finish in seconds and the sandbox must actually be gone afterwards."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", thread="tWedgedDrain"))
+            assert h.substrate.lookup("tWedgedDrain") is not None
+
+            monkeypatch.setattr(kernel_module, "_RESET_INTERRUPT_TIMEOUT_S", 0.2)
+
+            wedged = asyncio.Event()  # never set
+
+            async def never_answers(base_url: str, reason: str, token: str | None = None) -> None:
+                await wedged.wait()
+
+            monkeypatch.setattr(h.kernel._runner, "interrupt", never_answers)
+
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await h.async_redis.sadd(THREAD_RESET_SET, "tWedgedDrain")
+
+            await asyncio.wait_for(consumer._drain_thread_reset_requests(), timeout=2.0)
+
+            assert h.substrate.lookup("tWedgedDrain") is None  # the reset was not lost
 
     asyncio.run(go())
 

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -21,7 +21,9 @@ from aci_protocol import (
     SideEffectFlag,
     TextDelta,
 )
+from agentos_worker import kernel as kernel_module
 from agentos_worker.behaviorpacks import BehaviorPacks, NavPack
+from agentos_worker.runner_client import RunnerError
 
 DONE = SessionStatus.DONE
 IDLE = SessionStatus.IDLE_AWAITING_INPUT
@@ -666,6 +668,70 @@ def test_release_thread_interrupts_a_live_turn_first(make_harness) -> None:
 
             hold.set()
             await t1
+
+    asyncio.run(go())
+
+
+def test_release_thread_releases_when_the_runner_never_answers_the_interrupt(
+    make_harness, monkeypatch
+) -> None:
+    """#739: a WEDGED runner accepts the TCP connect and then never answers
+    ``/v1/interrupt``. The interrupt is a courtesy, not a precondition, so the
+    release must not be hostage to it: the sandbox is still released and the
+    route-existed answer still comes back, bounded to a few seconds rather than
+    the runner client's own 600s request timeout. Without the bound the operator
+    reset is lost entirely (the substrate release line is never reached) and the
+    maintenance tick that drove it stalls for the whole window.
+
+    The hang is injected at the runner-client seam (the external HTTP call) with
+    an event that is never set, so the wedge is deterministic rather than timing
+    dependent. The generous 10s ceiling below only has to prove the call is
+    bounded to seconds, not to pin the exact constant."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", thread="tWedged"))
+            assert h.substrate.lookup("tWedged") is not None  # the route is live
+
+            monkeypatch.setattr(kernel_module, "_RESET_INTERRUPT_TIMEOUT_S", 0.2)
+
+            wedged = asyncio.Event()  # never set: the runner answers nothing, ever
+
+            async def never_answers(base_url: str, reason: str, token: str | None = None) -> None:
+                await wedged.wait()
+
+            monkeypatch.setattr(h.kernel._runner, "interrupt", never_answers)
+
+            released = await asyncio.wait_for(h.kernel.release_thread("tWedged"), timeout=2.0)
+
+            assert released is True
+            assert h.substrate.lookup("tWedged") is None  # released despite the wedged runner
+
+    asyncio.run(go())
+
+
+def test_release_thread_releases_when_the_interrupt_raises(make_harness, monkeypatch) -> None:
+    """#739, the other half of the wedged-runner shape: the runner answers, but
+    with a transport error or a non-200. The release is an operator's explicit
+    "give me a fresh sandbox", so a failed courtesy interrupt is logged and
+    swallowed rather than aborting the release and stranding the stale sandbox."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", thread="tInterruptBoom"))
+            assert h.substrate.lookup("tInterruptBoom") is not None
+
+            async def boom(base_url: str, reason: str, token: str | None = None) -> None:
+                raise RunnerError("/v1/interrupt -> 500: runner is wedged")
+
+            monkeypatch.setattr(h.kernel._runner, "interrupt", boom)
+
+            released = await h.kernel.release_thread("tInterruptBoom")
+
+            assert released is True
+            assert h.substrate.lookup("tInterruptBoom") is None
 
     asyncio.run(go())
 


### PR DESCRIPTION
Closes #739

`Kernel.release_thread` awaited the courtesy interrupt before releasing the sandbox. A wedged runner accepts the TCP connect and then answers `/v1/interrupt` never, so that await rode `RunnerClient`'s 600s request timeout. Three costs, all in the feature's primary use case: the release line was never reached, the maintenance tick's stream reclaim and orphan reaping stalled behind it, and the reset request had already been SPOPped off the pending set so the raise lost it permanently. The operator saw a success response ten minutes earlier and retrying did the same thing.

## What changed

- The interrupt is bounded by `_RESET_INTERRUPT_TIMEOUT_S` (5.0s) and any failure is logged and swallowed. The substrate release then runs unconditionally. `CancelledError` is deliberately not swallowed so worker shutdown still cuts through.
- The interrupt outcome is logged three ways so an operator can tell "the live turn was killed" from "nothing was running" from "we released blind". The did-not-land case is an ERROR, since the request is already SPOPped and no retry will produce a second signal.
- The docstring now records the behavioral delta the unconditional release implies: tearing down a genuinely live turn classifies as `runner-error`, which is retryable, so the turn replays on a cold-created sandbox. The no-auto-retry-after-side-effects rule still holds, and the thread is never left routeless.

## Scope notes

Two things the reviewers raised are deliberately not in this diff and are filed instead:

- #742 - the bound sits at the call site because only this path has a fallback. `interrupt_agent` and the kill switch still inherit the 600s streaming-turn timeout on a control-plane POST.
- #743 - the bound is per reset request, not per maintenance tick, so N wedged resets still cost N x 5s.

## Done-check

- [x] Failing tests committed before implementation (`8d09e12` before `91d20d7`, pre-squash)
- [x] All production edits delegated to sub-agents; driver ran only git and tests
- [x] Error surface change reported and traced: `release_thread` now stops propagating interrupt exceptions. Its only non-test caller is `_drain_thread_reset_requests`, whose `except Exception` handled them before; the kernel-side ERROR log replaces that signal.
- [x] Code Reviewer: APPROVE (0 blocker, 0 major)
- [x] Scope Reviewer: PASS, 0 orphan hunks
- [x] Spec-vs-impl: all three ACs met with file:line evidence
- [x] Side-effects-detective: ship it, 0 critical
- [x] Codex heterogeneous review: no actionable findings
- [x] Sibling-path parity: unbounded siblings enumerated and filed as #742
- [x] Guard demonstration: the timeout monkeypatch was neutralized and both wedged-runner tests were executed and observed failing without it
- [x] Consolidation pass ran (one repeated docstring clause cut); suite, ruff, mypy green after
- [x] Full suite 1832 passed / 5 skipped; `ruff check .`, `mypy`, and `scripts/check-docs.sh` clean