### PR TITLE
Make the install snippets platform-aware and lead onboarding with the offline path

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -11,9 +11,16 @@ the runner container on your host Docker daemon, talking straight to the agent.
   your platform from the latest release (no Rust toolchain required):
 
   ```bash
-  # Linux (x86_64); for macOS Apple silicon swap in agentos-aarch64-apple-darwin
-  curl -L -o agentos \
-    https://github.com/curie-eng/agentos/releases/latest/download/agentos-x86_64-unknown-linux-gnu
+  # Resolve the right asset for this machine. The release ships Linux x86_64 and
+  # macOS Apple silicon; anything else builds from source (see cli/).
+  ASSET=
+  case "$(uname -s)/$(uname -m)" in
+    Linux/x86_64)                 ASSET=agentos-x86_64-unknown-linux-gnu ;;
+    Darwin/arm64|Darwin/aarch64)  ASSET=agentos-aarch64-apple-darwin ;;
+  esac
+  : "${ASSET:?no prebuilt binary for this platform; build the CLI from source in cli/}"
+  curl -fsSL -o agentos \
+    "https://github.com/curie-eng/agentos/releases/latest/download/$ASSET"
   chmod +x agentos && sudo mv agentos /usr/local/bin/
   ```
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,14 @@ release you are installing, from the
 
 ```bash
 VERSION=vX.Y.Z                            # the release you are installing
-ASSET=agentos-x86_64-unknown-linux-gnu    # macOS Apple silicon: agentos-aarch64-apple-darwin
+# Resolve the right asset for this machine. The release ships Linux x86_64 and
+# macOS Apple silicon; anything else builds from source (see cli/).
+ASSET=
+case "$(uname -s)/$(uname -m)" in
+  Linux/x86_64)                 ASSET=agentos-x86_64-unknown-linux-gnu ;;
+  Darwin/arm64|Darwin/aarch64)  ASSET=agentos-aarch64-apple-darwin ;;
+esac
+: "${ASSET:?no prebuilt binary for this platform; build the CLI from source in cli/}"
 BASE="https://github.com/curie-eng/agentos/releases/download/$VERSION"
 curl -fsSLO "$BASE/$ASSET" -O "$BASE/checksums.txt" -O "$BASE/checksums.txt.sigstore.json"
 
@@ -231,7 +238,7 @@ and the per-asset SBOMs.
 
 > **macOS: "unidentified developer"?** The release binaries are not yet
 > notarized by Apple, so a copy downloaded through a browser is quarantined and
-> Gatekeeper blocks it on first launch. The `curl -L` command above avoids this
+> Gatekeeper blocks it on first launch. The `curl` command above avoids this
 > entirely (curl does not set the quarantine flag). If you already downloaded it
 > in a browser, clear the flag once with
 > `xattr -d com.apple.quarantine ./agentos-aarch64-apple-darwin`, or right-click
@@ -282,12 +289,21 @@ image from GHCR on first run — nothing to build:
 ```bash
 agentos   # optional full-screen terminal UI for the same workflows
 agentos init my-agent && cd my-agent
-# Real model is the default. Export a credential first (forwarded into the runner
-# container): CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_API_KEY, or AGENTOS_CREDENTIALS.
+agentos skill up --fake-model    # offline scripted model, no credential
+agentos skill message "hello"
+agentos skill down
+```
+
+`agentos skill eval` runs the bundle's eval cases through the same runner
+(under `--fake-model` it checks plumbing only, not answer quality).
+
+For a real model, drop `--fake-model` and export a credential first (it is
+forwarded into the runner container): one of `CLAUDE_CODE_OAUTH_TOKEN`,
+`ANTHROPIC_API_KEY`, or `AGENTOS_CREDENTIALS`.
+
+```bash
 export CLAUDE_CODE_OAUTH_TOKEN=...
 agentos skill up
-agentos skill message "hello"
-agentos skill eval
 ```
 
 From a source checkout instead (contributor path): `cd cli && cargo build

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -15,9 +15,16 @@ Install the local path tools:
   release (no Rust toolchain needed):
 
 ```bash
-# Linux (x86_64); for macOS Apple silicon swap in agentos-aarch64-apple-darwin
-curl -L -o agentos \
-  https://github.com/curie-eng/agentos/releases/latest/download/agentos-x86_64-unknown-linux-gnu
+# Resolve the right asset for this machine. The release ships Linux x86_64 and
+# macOS Apple silicon; anything else builds from source (see cli/).
+ASSET=
+case "$(uname -s)/$(uname -m)" in
+  Linux/x86_64)                 ASSET=agentos-x86_64-unknown-linux-gnu ;;
+  Darwin/arm64|Darwin/aarch64)  ASSET=agentos-aarch64-apple-darwin ;;
+esac
+: "${ASSET:?no prebuilt binary for this platform; build the CLI from source in cli/}"
+curl -fsSL -o agentos \
+  "https://github.com/curie-eng/agentos/releases/latest/download/$ASSET"
 chmod +x agentos && sudo mv agentos /usr/local/bin/
 ```
 


### PR DESCRIPTION
Bundled because both issues touch the same three onboarding docs, so splitting them would have produced two conflicting PRs.

**#746 - install snippets hardcoded the Linux asset.** All three snippets now resolve the asset inside the snippet from `uname -s`/`uname -m`, mapping only the two binaries the release actually ships (no linux-arm64, no x86_64-darwin exist). An unmatched platform stops at a `${ASSET:?...}` guard with a clear "build from source" message instead of downloading a 404 and chmod-ing an empty operand. `ASSET=` is reset before the match so a stale value in the caller's environment cannot slip a wrong-platform binary past the guard. In QUICKSTART and the onboarding doc, curl and chmod are now separate statements, so a failed download stops a `set -e` installer instead of returning 0. The README Gatekeeper note is kept, with its reference to a `curl -L` command that no longer exists corrected.

**#748 - a credential was presented as a prerequisite for the offline path.** QUICKSTART and `docs/onboarding.md` already led with the zero-secret `--fake-model` flow on main; the README walkthrough was the remaining offender and now leads with the four-command loop `init` -> `skill up --fake-model` -> `skill message` -> `skill down`, introducing a credential afterwards only as what gates a real model. Every command and flag was checked against `agentos skill --help` on the released 0.4.2 binary; `skill eval` moved out of the first-success sequence into one prose sentence, since under `--fake-model` it reports plumbing only.

**Verification.** Both paths executed, not read: the resolver installs a working 0.4.2 binary on Linux x86_64, resolves to an HTTP 200 for macOS arm64, and exits 1 at the guard with a clear message on an unsupported pair and on a stale inherited `ASSET`. `./scripts/check-docs.sh` passes.

`docs/release-verification.md` carries the same hardcoded-asset defect and is filed separately as #752, to keep this PR to the three files both issues name.

Closes #746, #748
