### PR TITLE
Exclude venvs, caches and ignore-file entries from plugin bundles

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -112,7 +112,12 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   package the bundle as
   tar.gz and push to the platform API (find-or-create agent, create version,
   upload bundle, create deployment) authenticated via
-  `--api-key`/`AGENTOS_API_KEY`. `local message`, `local deploy`,
+  `--api-key`/`AGENTOS_API_KEY`. The packer skips a fixed set of names
+  (`.agentosignore`, `.agentos`, `.git`, `.venv`, `venv`, `node_modules`,
+  `__pycache__`, `.mypy_cache`, `.pytest_cache`) at any depth plus whatever an
+  optional root `.agentosignore` names (name-only, no globs), and still refuses
+  to pack any symlink that survives those exclusions rather than dereference it.
+  `local message`, `local deploy`,
   `cluster message`, `cluster deploy`, and every operator verb
   (`local up`, `local status`, `local down`, `local comms`, `cluster up`, `cluster status`, `cluster down`, `cluster comms`) reach a Valkey, API, or cluster by design.
 - **The operator verbs are a thin wrapper; the chart stays the source of

--- a/cli/README.md
+++ b/cli/README.md
@@ -279,6 +279,27 @@ port-forward the API yourself. They resolve `<agent>` (a name or id) to its API 
 same lookup `deploy` uses. Each takes `--dry-run` (prints the plan, makes no
 request); the destructive `kill`/`delete` also require `--yes`.
 
+### Bundle packing exclusions
+
+`local deploy` and `cluster deploy` never pack `.agentosignore`, `.agentos`,
+`.git`, `.venv`, `venv`, `node_modules`, `__pycache__`, `.mypy_cache`, or
+`.pytest_cache`, matched by name at any depth. An optional `.agentosignore`
+at the bundle root adds more patterns, one per line (`#` comments and blank
+lines skipped, surrounding whitespace and a trailing `/` stripped):
+
+```
+# .agentosignore
+scratch
+notebooks/drafts
+```
+
+A bare name matches that entry at any depth; a path containing `/` matches
+only that bundle-root-relative path and its subtree. There is no glob
+support (`*.log` never matches), and a pattern reaching outside the bundle
+(absolute, or containing `.` or `..`) is dropped. Symlinks are still a
+packing error unless excluded, by design: the packer never dereferences a
+link to upload host files from outside the bundle root.
+
 ### Artifact resolution
 
 Release builds resolve default artifacts from the binary version: `agentos local

--- a/cli/src/bundle.rs
+++ b/cli/src/bundle.rs
@@ -1,21 +1,114 @@
 //! Package a plugin bundle directory into a tar.gz archive for upload.
 //!
 //! The platform API (B2) accepts tar.gz/tar/zip, extracts, and validates via
-//! the frozen plugin-format package. Workstation state (`.agentos/`, `.git/`)
-//! never belongs in an immutable bundle, so it is excluded here.
+//! the frozen plugin-format package. Workstation state (`.agentos/`, `.git/`,
+//! virtualenvs, `node_modules`, tool caches) never belongs in an immutable
+//! bundle, so it is excluded here, and a bundle can declare its own exclusions
+//! in a root `.agentosignore` (see [`Exclusions::load`]).
 
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use flate2::write::GzEncoder;
 use flate2::Compression;
 
-const EXCLUDED_DIRS: &[&str] = &[".agentos", ".git"];
+/// Name of the optional per-bundle ignore file, read from the bundle root.
+const IGNORE_FILE: &str = ".agentosignore";
+
+/// Entry names never packed, matched against any file or directory with that
+/// name at any depth.
+const EXCLUDED_NAMES: &[&str] = &[
+    IGNORE_FILE,
+    ".agentos",
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+];
+
+/// Entries the archive skips: the built-in names plus whatever the bundle's
+/// `.agentosignore` declares.
+struct Exclusions {
+    /// Bare names, matched against any entry at any depth.
+    names: Vec<String>,
+    /// Bundle-root-relative paths, matched against the exact entry.
+    paths: Vec<PathBuf>,
+}
+
+impl Exclusions {
+    /// Read `.agentosignore` from the bundle root, if present.
+    ///
+    /// One pattern per line, with `#` comments and blank lines skipped and
+    /// surrounding whitespace plus a trailing `/` stripped. A pattern with no
+    /// `/` matches any entry with that name at any depth, the same shape as
+    /// the built-in defaults; a pattern containing `/` is a
+    /// bundle-root-relative path matching that exact entry and its subtree.
+    /// There is no glob support, so an odd pattern simply never matches, and a
+    /// pattern that could reach outside the bundle is dropped. The ignore file
+    /// is stat'd without following links, so a symlinked `.agentosignore` is
+    /// refused rather than read from outside the bundle root.
+    fn load(root: &Path) -> Result<Self> {
+        let mut exclusions = Self {
+            names: EXCLUDED_NAMES.iter().map(|n| (*n).to_string()).collect(),
+            paths: Vec::new(),
+        };
+        let ignore_path = root.join(IGNORE_FILE);
+        match std::fs::symlink_metadata(&ignore_path) {
+            Ok(meta) if meta.file_type().is_symlink() => bail!(
+                "symlinks are not supported in plugin bundles: {} (the {} file must be a regular file inside the bundle)",
+                ignore_path.display(),
+                IGNORE_FILE
+            ),
+            Ok(meta) if meta.is_file() => {
+                let text = std::fs::read_to_string(&ignore_path)
+                    .with_context(|| format!("reading {}", ignore_path.display()))?;
+                exclusions.extend_from(&text);
+            }
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err).with_context(|| format!("stat {}", ignore_path.display())),
+        }
+        Ok(exclusions)
+    }
+
+    fn extend_from(&mut self, text: &str) {
+        for line in text.lines() {
+            let pattern = line.trim().trim_end_matches('/');
+            if pattern.is_empty() || pattern.starts_with('#') {
+                continue;
+            }
+            let candidate = Path::new(pattern);
+            // Anything that is not a plain relative component (a root, a drive
+            // prefix, `.`, `..`) could reach outside the bundle, so drop it.
+            if candidate
+                .components()
+                .any(|c| !matches!(c, Component::Normal(_)))
+            {
+                continue;
+            }
+            if pattern.contains('/') {
+                self.paths.push(candidate.to_path_buf());
+            } else {
+                self.names.push(pattern.to_string());
+            }
+        }
+    }
+
+    fn is_excluded(&self, rel: &Path) -> bool {
+        let name = rel.file_name().unwrap_or_default();
+        self.names.iter().any(|n| name == std::ffi::OsStr::new(n))
+            || self.paths.iter().any(|p| rel == p)
+    }
+}
 
 fn append_dir(
     builder: &mut tar::Builder<GzEncoder<Vec<u8>>>,
     root: &Path,
     dir: &Path,
+    exclusions: &Exclusions,
 ) -> Result<()> {
     // Sorted for deterministic archives: same tree, same byte layout order.
     let mut entries: Vec<_> = std::fs::read_dir(dir)
@@ -25,8 +118,13 @@ fn append_dir(
 
     for entry in entries {
         let path = entry.path();
-        let name = entry.file_name();
         let rel = path.strip_prefix(root).expect("entry is under root");
+        // Exclusion runs before the symlink check and applies to every entry
+        // type, so an excluded dir that is itself a link is skipped, not an
+        // error. Everything that survives still hits the guard below.
+        if exclusions.is_excluded(rel) {
+            continue;
+        }
         // file_type() does not follow symlinks: a link inside the bundle would
         // otherwise be dereferenced by tar and upload host files from outside
         // the plugin root (e.g. a link into ~/.ssh). Refuse loudly instead.
@@ -35,15 +133,13 @@ fn append_dir(
             .with_context(|| format!("stat {}", path.display()))?;
         if file_type.is_symlink() {
             bail!(
-                "symlinks are not supported in plugin bundles: {}",
-                path.display()
+                "symlinks are not supported in plugin bundles: {} (if this is workstation state, exclude it by adding a line to a root {} file)",
+                path.display(),
+                IGNORE_FILE
             );
         }
         if file_type.is_dir() {
-            if EXCLUDED_DIRS.iter().any(|d| name == *d) {
-                continue;
-            }
-            append_dir(builder, root, &path)?;
+            append_dir(builder, root, &path, exclusions)?;
         } else if file_type.is_file() {
             builder
                 .append_path_with_name(&path, rel)
@@ -60,7 +156,8 @@ pub fn pack_tar_gz(dir: &Path) -> Result<Vec<u8>> {
     }
     let encoder = GzEncoder::new(Vec::new(), Compression::default());
     let mut builder = tar::Builder::new(encoder);
-    append_dir(&mut builder, dir, dir)?;
+    let exclusions = Exclusions::load(dir)?;
+    append_dir(&mut builder, dir, dir, &exclusions)?;
     let encoder = builder.into_inner().context("finalizing tar archive")?;
     encoder.finish().context("finalizing gzip stream")
 }
@@ -99,6 +196,170 @@ mod tests {
     #[test]
     fn refuses_a_missing_directory() {
         assert!(pack_tar_gz(Path::new("/nonexistent/bundle")).is_err());
+    }
+
+    #[test]
+    fn excludes_virtualenvs_caches_and_vendored_dependencies() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();
+        for excluded in [
+            "venv",
+            "node_modules",
+            "__pycache__",
+            ".mypy_cache",
+            ".pytest_cache",
+        ] {
+            std::fs::create_dir_all(dir.path().join("skills/deal-desk").join(excluded)).unwrap();
+            std::fs::write(
+                dir.path()
+                    .join("skills/deal-desk")
+                    .join(excluded)
+                    .join("junk"),
+                "junk",
+            )
+            .unwrap();
+        }
+
+        let names = entry_names(&pack_tar_gz(dir.path()).unwrap());
+        assert!(names.contains(&"skills/deal-desk/SKILL.md".to_string()));
+        assert!(
+            !names.iter().any(|n| n.contains("junk")),
+            "excluded trees leaked: {names:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn excludes_a_virtualenv_whose_entries_are_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();
+        let host = tempfile::tempdir().unwrap();
+        std::fs::write(host.path().join("python"), "binary").unwrap();
+        std::fs::create_dir_all(dir.path().join(".venv/bin")).unwrap();
+        std::os::unix::fs::symlink(
+            host.path().join("python"),
+            dir.path().join(".venv/bin/python"),
+        )
+        .unwrap();
+
+        let names = entry_names(&pack_tar_gz(dir.path()).unwrap());
+        assert!(names.contains(&"skills/deal-desk/SKILL.md".to_string()));
+        assert!(
+            !names.iter().any(|n| n.starts_with(".venv")),
+            "virtualenv leaked: {names:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn excludes_a_virtualenv_that_is_itself_a_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();
+        let host = tempfile::tempdir().unwrap();
+        std::fs::write(host.path().join("id_rsa"), "private").unwrap();
+        std::os::unix::fs::symlink(host.path(), dir.path().join(".venv")).unwrap();
+
+        let names = entry_names(&pack_tar_gz(dir.path()).unwrap());
+        assert!(!names.iter().any(|n| n.contains("id_rsa")), "{names:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_a_symlink_in_a_normal_subdirectory() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();
+        let secret = tempfile::tempdir().unwrap();
+        std::fs::write(secret.path().join("id_rsa"), "private").unwrap();
+        std::os::unix::fs::symlink(
+            secret.path().join("id_rsa"),
+            dir.path().join("skills/deal-desk/key"),
+        )
+        .unwrap();
+
+        let err = pack_tar_gz(dir.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("symlinks are not supported"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn honors_the_agentosignore_file_and_omits_it_from_the_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();
+        std::fs::create_dir_all(dir.path().join("skills/deal-desk/fixtures")).unwrap();
+        std::fs::write(dir.path().join("skills/deal-desk/fixtures/big.bin"), "x").unwrap();
+        std::fs::create_dir_all(dir.path().join("docs")).unwrap();
+        std::fs::write(dir.path().join("docs/notes.md"), "notes").unwrap();
+        std::fs::write(dir.path().join("docs/keep.md"), "keep").unwrap();
+        std::fs::write(
+            dir.path().join(".agentosignore"),
+            "# a comment\n\n  fixtures/  \ndocs/notes.md\n",
+        )
+        .unwrap();
+
+        let names = entry_names(&pack_tar_gz(dir.path()).unwrap());
+        assert!(names.contains(&"docs/keep.md".to_string()), "{names:?}");
+        assert!(!names.contains(&"docs/notes.md".to_string()), "{names:?}");
+        assert!(
+            !names.iter().any(|n| n.contains("fixtures")),
+            "bare-name pattern did not match at depth: {names:?}"
+        );
+        assert!(!names.contains(&".agentosignore".to_string()), "{names:?}");
+    }
+
+    #[test]
+    fn ignores_agentosignore_patterns_that_reach_outside_the_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();
+        std::fs::create_dir_all(dir.path().join("docs")).unwrap();
+        std::fs::write(dir.path().join("docs/keep.md"), "keep").unwrap();
+        std::fs::write(
+            dir.path().join(".agentosignore"),
+            "/etc/passwd\n../outside\n../../docs/keep.md\n./docs/keep.md\ndocs/notes.md\n",
+        )
+        .unwrap();
+
+        // Assert on the parsed exclusions, not just the archive: an escaping
+        // pattern can never match a bundle-relative entry anyway, so an
+        // archive-only assertion passes even with the guard removed.
+        let exclusions = Exclusions::load(dir.path()).unwrap();
+        assert_eq!(
+            exclusions.paths,
+            vec![PathBuf::from("docs/notes.md")],
+            "escaping patterns were not dropped: {:?}",
+            exclusions.paths
+        );
+        assert!(
+            !exclusions.names.iter().any(|n| n.contains("passwd")),
+            "{:?}",
+            exclusions.names
+        );
+
+        let names = entry_names(&pack_tar_gz(dir.path()).unwrap());
+        assert!(names.contains(&"docs/keep.md".to_string()), "{names:?}");
+        assert!(names.contains(&".mcp.json".to_string()), "{names:?}");
+        assert!(!names.iter().any(|n| n.contains("passwd")), "{names:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_an_agentosignore_that_is_a_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();
+        let host = tempfile::tempdir().unwrap();
+        std::fs::write(host.path().join("credentials"), "secret\n").unwrap();
+        std::os::unix::fs::symlink(
+            host.path().join("credentials"),
+            dir.path().join(".agentosignore"),
+        )
+        .unwrap();
+
+        let err = pack_tar_gz(dir.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("symlinks are not supported"),
+            "{err}"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
`agentos local deploy` died on any bundle carrying a virtualenv, because the packer excluded only `.agentos` and `.git` and hard-errors on every symlink, and `.venv/bin/python` is always a symlink. The only workaround was moving `.venv` aside for the duration of the deploy.

The symlink refusal is deliberate and stays: `file_type()` does not follow links so tar cannot dereference one and upload host files from outside the bundle root. The fix is exclusion, not permission.

- Default exclusions now cover `.venv`, `venv`, `node_modules`, `__pycache__`, `.mypy_cache`, `.pytest_cache` alongside `.agentos` and `.git`, matched by name at any depth.
- An optional root `.agentosignore` lets a bundle declare its own exclusions: one pattern per line, `#` comments, bare names match at any depth, a pattern with `/` is a bundle-root-relative path plus its subtree. Patterns that could reach outside the bundle are dropped. No globs. The file itself is not packed.
- Exclusion is evaluated before the symlink guard, so an excluded virtualenv packs cleanly while every surviving entry still refuses symlinks. The refusal now names `.agentosignore` so it reads as actionable rather than as a flat security denial.
- A `.agentosignore` that is itself a symlink is refused for the same reason it would be refused anywhere else in the tree.

Known limitation, called out in the docs: there is no glob support, so `*.log` never matches. Adopting real gitignore semantics would mean a new dependency and a wider behavior change than this fix warrants.

## Done-check

- [x] Code review approved, file:line spec-vs-impl evidence, 1 major and 4 minor findings all resolved
- [x] Scope review approved, 0 orphan hunks
- [x] Security review, no blocking findings; its one LOW (a symlinked `.agentosignore` being followed) is fixed here
- [x] Codex review ran, no actionable regression
- [x] Guard demonstration: the symlink refusal and the exclusion path are both executed against real filesystem symlinks by the unit tests, including a `.venv/bin/python` link to a host file, a `.venv` that is itself a link, a link in a normal subdirectory, and a symlinked `.agentosignore`
- [x] Consolidation pass ran, suite and lint green after it, applied diff re-reviewed and approved
- [x] Full suite green: 665 passed
- [x] Lint clean: `cargo fmt --check`, `cargo clippy`, `scripts/check-docs.sh`
- [n/a] Plan doc, failing-tests-first commit, sibling-path parity: quick-tier single-file change with no seam touched

Closes #750
