### PR TITLE
Record a package-shaped redesign of the harness-adapter seam

### DIFF
--- a/docs/adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md
+++ b/docs/adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md
@@ -8,6 +8,15 @@ Status: Accepted
 0036 amends the frozen-ACI posture below with semver, a reader-policy asymmetry,
 and a wire-lock gate. This ADR remains the record of the freeze itself.
 
+**Amended by [ADR-0060](0060-the-harness-is-a-declared-package.md) and
+[ADR-0061](0061-out-of-process-harness-boundary.md)**
+(back-link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+the Consequences below claim the adapter boundary keeps the door open for a
+second adapter "at zero cost". Two attempts disproved that (a synthesis tax plus
+a 517-line installer), and 0060/0061 record the actual cost and what changes to
+reduce it. The freeze itself, and the plugin shape as the distribution wedge,
+stand.
+
 ## Context
 
 Everything inside the runtime boundary is "the harness"; everything outside is "the platform." For the platform to be harness-agnostic (and for the plugin format to be the distribution wedge), the seam between them must be an explicit, versioned contract — the ACI (Agent Container Interface). The MVP harness is Anthropic's claude-agent-sdk, whose streaming-input mode is what makes Claude-Code-style steering possible server-side. The open questions were whether the SDK can be driven as a long-lived server that accepts mid-run input and interrupt, and whether the plugin format loads natively.

--- a/docs/adr/0011-opencode-second-harness.md
+++ b/docs/adr/0011-opencode-second-harness.md
@@ -1,7 +1,7 @@
 # 11. OpenCode as the second harness behind the ACI
 
 Date: 2026-07-09
-Status: Accepted (gating steer spike done — ADR-0031, #25/PR #226)
+Status: Superseded by [ADR-0060](0060-the-harness-is-a-declared-package.md) (the steer spike passed; adoption was withdrawn for other reasons, recorded there)
 
 ## Context
 

--- a/docs/adr/0031-harness-neutral-runner-seams.md
+++ b/docs/adr/0031-harness-neutral-runner-seams.md
@@ -1,7 +1,7 @@
 # 31. Harness-neutral runner seams for the second harness
 
 Date: 2026-07-11
-Status: Proposed
+Status: Superseded by [ADR-0060](0060-the-harness-is-a-declared-package.md) and [ADR-0061](0061-out-of-process-harness-boundary.md) (decisions 2/3/5 become manifest fields in 0060; decision 4 carries forward unchanged; decision 1 becomes 0061's recorded fallback)
 
 ## Context
 

--- a/docs/adr/0060-the-harness-is-a-declared-package.md
+++ b/docs/adr/0060-the-harness-is-a-declared-package.md
@@ -1,0 +1,203 @@
+# 60. The harness is a declared package, not a class
+
+Date: 2026-07-21
+
+Status: Proposed
+
+**Supersedes [ADR-0011](0011-opencode-second-harness.md)** ("OpenCode as the
+second harness behind the ACI"). Together with
+[ADR-0061](0061-out-of-process-harness-boundary.md) it replaces the Proposed
+[ADR-0031](0031-harness-neutral-runner-seams.md), whose five decisions survive
+in changed form (see Decision 4 below). Per
+[ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md),
+0011 and 0031 carry status-line pointers here rather than edited bodies, and
+[ADR-0005](0005-claude-agent-sdk-adapter-and-frozen-aci.md) carries an amendment
+banner against its "at zero cost" claim.
+
+## Context
+
+ADR-0005 drew the line: everything inside the runtime boundary is "the harness",
+everything outside is "the platform". The seam it built to hold that line is a
+class. `runner/src/agentos_runner/adapter.py:31-52` declares `ModelSession` as a
+five method Protocol (`connect`, `query`, `receive_turn`, `interrupt`, `close`)
+whose `receive_turn` returns `AsyncIterator[Any]`, documented as yielding "SDK
+messages".
+
+A harness in AgentOS is not that class. A harness is what that class implies
+about the rest of the system, and today those implications are smeared across
+nine or more files in two languages:
+
+- `runner/Dockerfile:24` installs the engine
+  (`npm install -g @anthropic-ai/claude-code`), and the surrounding comment
+  records a Claude specific non root constraint that shapes the image.
+- `cli/src/docker.rs:453` hardcodes `RUNNER_IMAGE`, consumed at
+  `cli/src/artifacts.rs:132` and `cli/src/commands.rs:462`.
+- `apps/worker/src/agentos_worker/run.py:126` picks the image again on the
+  worker side, defaulting to the same string.
+- `apps/worker/src/agentos_worker/sandbox/docker.py:310-326` builds the spawn
+  environment, carrying a hand copied mirror of the runner's credential rules.
+  The comment at `apps/worker/src/agentos_worker/sandbox/docker.py:99` admits it:
+  it is "a literal mirror of runner/src/agentos_runner/sdk_auth.py".
+- `runner/src/agentos_runner/sdk_auth.py` is 401 lines of auth plus a hard gate
+  at `runner/src/agentos_runner/sdk_auth.py:377-386` that refuses any non
+  Anthropic Messages wire because "the runner speaks the Anthropic Messages wire
+  format via claude-agent-sdk".
+- `runner/src/agentos_runner/__main__.py` encodes boot ordering,
+  `runner/src/agentos_runner/adapter.py` returns `ClaudeAgentOptions` directly
+  from `build_options`, `runner/src/agentos_runner/translate.py:84-107` is an
+  isinstance chain on SDK types, `runner/src/agentos_runner/side_effects.py:28-40`
+  hardcodes Claude Code's PascalCase read only tool names, and
+  `runner/src/agentos_runner/plugin.py` hands the bundle straight to the SDK.
+
+The concrete price of having no declarative install contract is on record. The
+withdrawn OpenCode work needed
+`runner/src/agentos_runner/opencode/installer.py` at 517 lines, plus
+`runner/src/agentos_runner/opencode/auth.py` (35 lines) and
+`runner/src/agentos_runner/opencode/__main__.py` (131 lines), none of which is
+interface work. It is packaging and wiring, reinvented because there was nowhere
+to declare it.
+
+**Omnigent is the shape we are missing.** Omnigent is Databricks' Apache 2.0
+"meta harness" (alpha, v0.5.1). A harness there ships as a pip installable
+package declaring a Python entry point:
+
+```toml
+[project.entry-points."omnigent.community.harness"]
+foo = "omnigent.community.harness.foo.plugin:get_contribution"
+```
+
+That entry point exports `get_contribution() -> HarnessContribution`, carrying
+`name`, `valid_harnesses`, `harness_modules`, `aliases`, `harness_labels`, plus
+install and auth metadata, model override environment variables, and per spawn
+environment builders. Core refuses plugins that register flat package paths or
+try to override a built in harness name. Harness selection is declarative: a
+YAML `executor: harness: claude-sdk` field or a `--harness` CLI flag. Omnigent
+also documents a scope boundary: direct and headless harnesses only, with
+community native TUI harnesses explicitly not pluggable.
+
+The insight, stated plainly: **our harness seam is a class, with everything else
+about a harness scattered through core. Omnigent's harness seam is a package
+that declares everything about itself.** The unit of a harness should be a
+package, not a class.
+
+## Decision
+
+**1. The unit of a harness is an installable package declaring a contribution
+manifest.** One object, authored in the harness package, carries: identity,
+aliases and labels; the install spec (what the image must install and how); the
+auth spec (which credential keys and env shapes the engine wants); the declared
+read only tool set; model override env keys; a per spawn environment builder;
+and a bundle compile hook. Everything the nine file scatter above encodes
+implicitly becomes a field somebody wrote down on purpose.
+
+**2. Registration is by entry point, with Omnigent's guard rules stolen
+verbatim.** Core discovers harnesses through a declared entry point group. Core
+**refuses** a plugin that registers a flat package path, and **refuses** a plugin
+that claims the name of a built in harness. Both refusals are fail closed: an
+ambiguous registry is worse than a missing harness, and silent shadowing of the
+Claude harness is the single worst failure this registry could have.
+
+**3. Harness selection becomes declarative config.** A `harness:` field plus a
+CLI flag, resolved once and carried, replacing today's baked in image assumption
+in the Rust constants (`cli/src/docker.rs:453`) and the worker's env default
+(`apps/worker/src/agentos_worker/run.py:126`). Selecting a harness stops being a
+matter of which image string three separate call sites happen to agree on.
+
+**4. ADR-0031's decisions become manifest fields, not separate ports.** Its
+decision 2 (harness declared tool identity), decision 3 (a `BundleInstaller`
+port) and decision 5 (no options abstraction) all survive, but they stop being
+three independent extractions and become three fields on one manifest. Decision
+4 (history and resume is descoped, not abstracted) carries forward unchanged: it
+still starts with an `aci-protocol` contract change and still needs its own ADR.
+Decision 1 (the runner owned `TurnEvent` union) is answered by ADR-0061 and is
+retained here only as that ADR's recorded fallback.
+
+**5. Non goal, taken from Omnigent: direct and headless harnesses only.** A
+harness that exists only as a native TUI is out of scope for this registry. This
+is the line that saves us from chasing Cursor's TUI and calling it a harness
+integration. If an engine ships a headless or server mode, it is a candidate; if
+it does not, the answer is no, and the answer does not require a spike to
+discover.
+
+**6. OpenCode as the second harness is withdrawn, and this is the record of
+why.** ADR-0011 gated adoption on a steer spike. **The spike succeeded.** A live
+`opencode serve` backed session passed the frozen conformance suite on real
+model turns with zero core changes, which is exactly what ADR-0011 asked for.
+The work was nevertheless withdrawn: all seven OpenCode PRs (#226 and #315
+through #321) were closed unmerged on 2026-07-17 and no OpenCode code exists on
+main. The reasons were the synthesis tax that ADR-0031 named (the adapter forged
+claude-agent-sdk dataclasses, including dummy `ResultMessage` fields nothing
+reads), plus two un priced workstreams: the installer and the bundle compiler.
+
+Recording this matters because ADR-0011's own escape clause only contemplated
+supersession if steer proved unreachable. Steer was reachable. Without this ADR,
+0011 reads as a still live Accepted decision with its gate satisfied, and the
+next person walks the same path and pays the same bill. Eight branches on origin
+preserve the work for mining rather than re implementation:
+`task/25-opencode-harness-spike`, `task/307-turnevent-message-model`,
+`task/308-harness-readonly-toolsets`, `task/309-bundle-installer-port`,
+`task/310-opencode-bundle-compiler`,
+`task/311-opencode-session-config-parity`, `task/312-opencode-runner-image`,
+`task/313-opencode-parity-evals`.
+
+## Alternatives considered
+
+- **Keep the nine file scatter and document it.** A `HARNESS.md` listing every
+  place a harness identity leaks costs nothing to write and catches nothing. The
+  duplicated credential mirror at
+  `apps/worker/src/agentos_worker/sandbox/docker.py:99` is already documented, in
+  a comment, at the site of the duplication, and it is still a duplication.
+- **Extract the four ADR-0031 ports individually.** This is the status quo plan
+  and it is not wrong so much as insufficient: four ports still leave the
+  install spec, the auth spec, the image selection, and the spawn env
+  unrepresented, which is where the 517 line installer actually came from.
+- **A config file per harness instead of a package.** A YAML descriptor covers
+  identity, install, and env, but not the per spawn env builder or the bundle
+  compile hook, both of which are code. Splitting a harness across a descriptor
+  and a package reintroduces the scatter at smaller scale.
+
+## Consequences
+
+**Does this shrink second harness work, or only relocate it?** ADR-0031's audit
+test, applied honestly.
+
+**It shrinks.** But not for the reason a cleaner seam usually claims. The
+evidence is against the interface story: a scripted second implementation passed
+the frozen conformance suite five times out of five in a single afternoon with
+zero core changes, which means the interface was never the bottleneck. What this
+ADR attacks is **packaging and wiring cost**, which is integration cost, not
+interface cost: the 517 line installer, the nine file identity scatter, and the
+hand copied credential mirror. Those are real, they are per harness, and a
+manifest removes them by making them declarations instead of code.
+
+**It does not shrink the bundle compiler, and it never will.** Our bundle is the
+Claude Code plugin shape verbatim, which ADR-0005 chose deliberately as the
+distribution wedge. Any non Claude engine needs a bundle to native config
+compiler, and no registry, manifest, or entry point makes that translation
+smaller. ADR-0011 said the same thing in its own words: the bundle translator,
+not the ACI server, is the bulk of the work. The manifest gives that compiler a
+declared home (the bundle compile hook) and nothing more.
+
+**It does not shrink history and resume.** ADR-0031 decision 4 carries forward
+unchanged. The consumer half exists, nothing in production produces a history
+ref, and the frozen ACI `final` frame carries no session id. That work still
+starts with an `aci-protocol` contract change under
+[ADR-0036](0036-aci-semver-and-reader-policy.md)'s semver rules and still owes
+its own ADR.
+
+**A Pydantic manifest inherits two existing gates, and one obligation.** If the
+manifest is authored as Pydantic inside a frozen package, it gets
+[ADR-0017](0017-tri-language-contract-codegen.md)'s drift gate (JSON Schema and
+the generated Rust and TS regenerate in CI, and `git diff --exit-code` fails the
+build on drift) and ADR-0036's `schema/wire.lock` enforcement (hash changed with
+version unchanged fails the build) for free. It also inherits the stop and
+escalate rule that comes with a frozen contract: every manifest field addition
+becomes a versioned contract change with tri language codegen. That is a real
+tax on a surface we expect to iterate on while the first two harnesses teach us
+its shape. **Freezing the manifest should be a deliberate choice made when the
+shape settles, not an accident of where the file was placed.**
+
+**The Rust and Python sides both have to learn the registry.** Harness selection
+crossing from a Rust CLI flag to a Python worker to a container image is exactly
+the sort of value ADR-0049's boot env contract governs, so the selected harness
+becomes a declared boot env key rather than an ad hoc string.

--- a/docs/adr/0061-out-of-process-harness-boundary.md
+++ b/docs/adr/0061-out-of-process-harness-boundary.md
@@ -1,0 +1,179 @@
+# 61. The harness boundary is an out-of-process adapter, wire-compatible with Omnigent
+
+Date: 2026-07-21
+
+Status: Proposed (gated on a spike, see Decision 5)
+
+Together with [ADR-0060](0060-the-harness-is-a-declared-package.md) this replaces
+the Proposed [ADR-0031](0031-harness-neutral-runner-seams.md). 0059 decides
+*what a harness is* (a declared package). This ADR decides *where the boundary
+sits* (a process boundary, not a Protocol). Read
+[ADR-0005](0005-claude-agent-sdk-adapter-and-frozen-aci.md) for the ACI freeze
+this ADR leaves untouched, and
+[ADR-0062](0062-harness-conformance-has-teeth.md) for the conformance
+obligations that follow from moving the boundary.
+
+## Context
+
+`runner/src/agentos_runner/adapter.py:31-52` puts the harness boundary
+in process, as a Protocol whose `receive_turn` yields `AsyncIterator[Any]`. In
+practice that `Any` is always a `claude_agent_sdk` dataclass, because everything
+downstream is written to match one:
+`runner/src/agentos_runner/translate.py:84-107` is an isinstance chain over SDK
+types.
+
+The consequence is that the cheapest way to satisfy the seam is to forge the
+Claude engine's types. The withdrawn OpenCode adapter did exactly that, and
+ADR-0031 named the cost the synthesis tax. It is not the spike's invention: the
+runner's own fake does it first and by design.
+`runner/src/agentos_runner/fake.py:1-8` says it "constructs real
+claude-agent-sdk message dataclasses with canned content, so everything above it
+runs unmodified", and `runner/src/agentos_runner/fake.py:38` hand builds a
+`ResultMessage` with `duration_ms=1`, `duration_api_ms=1`, `num_turns=1` and
+`session_id="fake-session"`: dummy fields nothing reads, which is precisely the
+tax ADR-0031 described. The spike copied our reference implementation.
+
+An in process Protocol cannot prevent this. A type annotation is advice. Even
+ADR-0031's proposed runner owned `TurnEvent` union would leave forgery merely
+discouraged rather than impossible, because nothing stops an adapter from
+importing the SDK, building an SDK object, and mapping it across.
+
+Meanwhile Omnigent has already solved the other half of the problem for engines
+we do not adapt. Each named Omnigent harness module exports
+**`create_app() -> FastAPI`**: the harness is an out of process HTTP service,
+messages and files in, text streams and tool calls out. Omnigent ships adapters
+for engines we would otherwise integrate ourselves.
+
+## Decision
+
+**1. Adopt Omnigent's `create_app() -> FastAPI` shape as the harness boundary.**
+Messages and files in, text streams and tool calls out, over HTTP. The boundary
+is deliberately wire compatible so that Omnigent's existing Codex, Cursor and Pi
+adapters are **consumable rather than reimplemented**.
+
+**2. Rationale one: the process boundary is the only mechanically enforceable
+anti forgery gate.** A `claude_agent_sdk` dataclass cannot cross HTTP. An in
+process `AsyncIterator[Any]` makes leaking SDK types the *default*; an in process
+`TurnEvent` union makes it *discouraged*; a process boundary makes it
+*impossible*. This is the same reasoning ADR-0017 applies to contract drift:
+prefer the mechanism that fails the build over the convention that asks people
+to be careful.
+
+**3. Rationale two: wire compatibility is the legitimate form of "get it for
+free".** Under Apache 2.0 we could fork Omnigent's core, and we should not: it is
+alpha software and forking buys a maintenance burden with no leverage. Landing
+on their plug shape is different. It costs one adapter surface and returns every
+adapter they write, without taking on their release cadence or their
+dependencies.
+
+**4. The ACI stays untouched and frozen. These are two boundaries with different
+jobs.** The ACI is platform to runner: versioned, semver governed under ADR-0036,
+and governance bearing (approval frames, `side_effect_flag`, budget). The harness
+boundary is runner to engine: ecosystem facing, and carrying none of that
+governance. The runner becomes a thin supervisor translating between the two.
+Nothing in this ADR touches `packages/aci-protocol`, and any proposal that
+appears to require an ACI change is out of scope here by construction.
+
+**5. This ADR is gated on a spike: run one unmodified Omnigent harness adapter
+behind our runner.** The in repo precedent for gating an adoption decision on a
+spike is ADR-0011, which gated OpenCode on a steer spike, and that gate did its
+job (the spike answered its question honestly, even though adoption was later
+withdrawn for unrelated reasons recorded in ADR-0060).
+
+The honest evidence gap: **Omnigent's `HarnessContribution` dataclass and adapter
+wire were read from its official documentation, not from its source.** Wire
+compatibility is therefore a hypothesis, not a verified fact. The spike's job is
+to convert it into one or refute it. Success is one Omnigent shipped adapter,
+unmodified, driving a real model turn through our runner and out the frozen ACI.
+
+**6. Recorded fallback if the spike fails.** ADR-0031's decision 1: an in process
+runner owned `TurnEvent` union (`AssistantText | ToolCall | RateLimit |
+TurnResult`) replacing the SDK dataclasses out of `receive_turn`, with the Claude
+adapter mapping SDK to `TurnEvent` and `translate.py`, the OTel feeds and budget
+tracking consuming `TurnEvent` only. The branch
+`origin/task/307-turnevent-message-model` is already most of that work. This
+fallback is weaker (it is unenforceable, per rationale 2, and buys no ecosystem)
+but it is real, costed, and mostly written.
+
+## Alternatives considered
+
+- **Keep the in process Protocol and add the `TurnEvent` union** (ADR-0031
+  decision 1 as the primary decision rather than the fallback). Rejected as the
+  primary because it is unenforceable: nothing stops an adapter from importing
+  the SDK and mapping across, which is what the fake already does. It also buys
+  no ecosystem, so every engine remains a from scratch supervisor.
+- **Adopt Omnigent wholesale as a dependency.** Rejected on four counts. It is
+  alpha. Its wire is unversioned where ours is frozen and semver governed
+  (ADR-0036). Its delivery model carries none of the `side_effect_flag`
+  idempotency semantics that [ADR-0013](0013-concurrency-and-delivery-model.md)'s
+  kernel depends on. And it owns no cluster substrate, which is the layer AgentOS
+  differentiates on ([ADR-0002](0002-kubernetes-agent-sandbox-as-runtime-substrate.md)).
+  Wire compatibility takes the leverage without taking the dependency.
+- **Adopt Omnigent's sandbox and policy layer (Omnibox) too.** Explicitly out of
+  scope here. AgentOS's security rails are chart defaults under
+  [ADR-0006](0006-security-rails-as-chart-defaults.md) and hardened locally under
+  [ADR-0054](0054-local-docker-runner-hardening.md); replacing that layer is a
+  separate decision with a separate blast radius. Noted as possible future work,
+  decided here as no.
+
+## Consequences
+
+**Does this shrink second harness work, or only relocate it?** It shrinks, by a
+mechanism that is worth stating precisely, because the obvious story is the wrong
+one.
+
+**It does not shrink work because the abstraction is cleaner.** A scripted second
+implementation already passed the frozen conformance suite five times out of five
+in an afternoon with zero core changes, so the interface was never the
+bottleneck. The expensive part of a second harness is the subprocess supervisor
+for a foreign out of process agent, plus the bundle compiler, plus history and
+resume bridging.
+
+**It shrinks work by letting us not write the integration at all.** For an engine
+Omnigent already adapts, wire compatibility means the supervisor (the expensive
+part) is consumed rather than authored. That is the entire saving and it is a
+large one.
+
+**The caveat, stated plainly: for an engine Omnigent does NOT adapt, this ADR
+buys close to nothing on integration cost.** We still write the supervisor. We
+write it behind HTTP instead of behind a Protocol, and we gain the anti forgery
+enforcement of rationale 2, but the work itself is the same work. Anyone
+evaluating this ADR by "will the next harness be cheaper" must first ask which
+engine.
+
+**It does not shrink the bundle compiler.** Our bundle is the Claude Code plugin
+shape verbatim, ADR-0005's deliberate distribution wedge. An off the shelf
+Omnigent adapter knows nothing about our bundle format, so the bundle to native
+config compiler is owed in full for every non Claude engine, exactly as ADR-0011
+warned and ADR-0060 restates.
+
+**It does not shrink history and resume.** Descoped under ADR-0031 decision 4 and
+carried forward by ADR-0060. It still starts with an `aci-protocol` contract
+change under ADR-0036 and still owes its own ADR.
+
+**The strategic consequence: an engine Omnigent already adapts is cheaper to ship
+than OpenCode was.** Codex, Cursor and Pi come with the supervisor attached;
+OpenCode would have to have one written. The bundle compiler is owed either way,
+so the ordering of a second harness should follow Omnigent's adapter coverage,
+not our prior familiarity with an engine.
+
+**Costs accepted.** An extra process and an extra network hop inside a security
+railed sandbox. That interacts directly with ADR-0006's chart defaults (the
+harness process needs a loopback route the NetworkPolicy must not sever) and with
+ADR-0054's local Docker runner hardening (the same rails apply to a second
+process in the same container or a second container in the same pod). Neither is
+a blocker, both are design work the spike must exercise rather than assume.
+
+The hop is not the only cost. [ADR-0059](0059-sandbox-is-a-bounded-resource-envelope.md)
+makes the sandbox an explicitly bounded resource envelope, so a second process
+inside that envelope is a claim on a ceiling that is now declared rather than
+assumed infinite: its memory, its CPU and its ephemeral storage all come out of
+the same budget the agent's own work draws on. The spike must therefore price the
+harness process against that envelope, not merely measure its latency.
+
+**Also accepted: a second failure mode.** An out of process engine can die
+independently of the runner, so the runner's supervisor gains liveness and
+restart responsibilities that an in process Protocol never had. The ACI side of
+that is already covered (a wedged turn surfaces as a terminal status), but the
+supervisor is new surface and it is where a spike is most likely to find
+trouble.

--- a/docs/adr/0062-harness-conformance-has-teeth.md
+++ b/docs/adr/0062-harness-conformance-has-teeth.md
@@ -1,0 +1,157 @@
+# 62. Harness conformance has teeth
+
+Date: 2026-07-21
+
+Status: Proposed
+
+Follows [ADR-0060](0060-the-harness-is-a-declared-package.md) (a harness is a
+declared package) and [ADR-0061](0061-out-of-process-harness-boundary.md) (the
+boundary is a process, not a Protocol). Those two decide what a harness is and
+where it plugs in. This one decides how we find out whether a harness actually
+works, because today's answer is "the conformance suite is green", and that
+sentence proves much less than it sounds like it does.
+
+**Bounds [ADR-0055](0055-the-fake-model-is-a-plumbing-fixture.md)**; it does not
+supersede or contradict it. 0055 decides what a fake *run* asserts (plumbing
+completed, never a graded content claim), and that holds unchanged. This ADR
+decides what the fake is *built out of*. A fake can be a plumbing fixture and
+still be an honest one.
+
+## Context
+
+`packages/aci-protocol/src/aci_protocol/conformance.py` asserts one thing: an
+inbound frame produces well formed NDJSON, round trips every outbound event
+type, rejects unknown protocol versions, and ends in a `final` event at a
+compatible protocol version. That is a correct and useful check of the ACI.
+
+It is also the entire check. The suite never inspects what crosses
+`ModelSession.receive_turn`, never type checks it, and asserts nothing about tool
+naming or side effect classification. So a harness passes conformance while
+being wrong in every way the ACI does not look at:
+
+- **Tool identity.** `runner/src/agentos_runner/side_effects.py:28-40` hardcodes
+  Claude Code's PascalCase read only tool names. Under an engine with lowercase
+  tool names every read only tool misclassifies as side effecting, wrongly
+  suppressing the worker's auto retry. Conformance is green throughout.
+- **Credential resolution.** `runner/src/agentos_runner/sdk_auth.py:377-386`
+  refuses any non Anthropic Messages wire outright, and
+  `apps/worker/src/agentos_worker/sandbox/docker.py:99` maintains a hand copied
+  mirror of the runner's prefix rules. A second harness can get either half
+  wrong and still emit a perfect `final` frame.
+- **Bundle compile and telemetry.** Neither is looked at by the suite at all.
+
+**The forgery is the mechanism, and our own fake teaches it.**
+`runner/src/agentos_runner/fake.py:1-8` states the design: it "constructs real
+claude-agent-sdk message dataclasses with canned content, so everything above it
+runs unmodified". `runner/src/agentos_runner/fake.py:38` hand builds a
+`ResultMessage` carrying `duration_ms=1`, `duration_api_ms=1`, `num_turns=1` and
+`session_id="fake-session"`, dummy fields nothing reads. That is exactly the
+synthesis tax ADR-0031 named, shipped as the sanctioned reference
+implementation. The withdrawn OpenCode adapter did not invent the pattern; it
+copied ours, because ours is what a new harness author reads first.
+
+The general principle this exposes: **a green conformance suite behind a
+protocol seam proves one seam and says nothing about the seams the forgery
+bypassed.** The cheapest way to pass a conformance suite is to make the new thing
+look exactly like the old thing to every downstream consumer, and that is the one
+strategy the suite is structurally unable to detect.
+
+## Decision
+
+**1. No `claude_agent_sdk` import outside the Claude harness package, enforced by
+an import linter contract in CI.** Not by review, not by prose in a README, and
+not by a comment. A forbidden import contract fails the build. This is the
+ADR-0017 pattern applied to layering: prefer the gate that breaks the build over
+the convention that asks people to remember. ADR-0061's process boundary makes
+SDK types unable to *cross* the seam; this makes them unable to be *reached* from
+the wrong side of it in the first place.
+
+**2. The fake stops forging SDK dataclasses and becomes a harness package like
+any other.** It is the reference implementation of the harness contract, so it
+must be honest about that contract. Today it demonstrates the anti pattern at the
+exact place a new harness author looks for the pattern. Under ADR-0060 the fake
+registers a contribution manifest, and under ADR-0061 it speaks the harness wire,
+which is the same thing every other harness does and therefore the same thing a
+new author should copy.
+
+This does not touch ADR-0055. The fake tier still asserts only that the turn
+completed, is still never graded, and its outcome is still `plumbing_ok`. What
+changes is that the fixture stops being built out of another harness's private
+types. A fixture whose value is "everything above it runs unmodified" keeps that
+value when it speaks the declared contract; it does not need to impersonate the
+Claude engine to deliver it.
+
+**3. Conformance extends to the adjacent seams, not just the protocol seam.** A
+harness is conformant when, in addition to today's ACI checks:
+
+- its **declared read only tool set** is present and its tools classify
+  correctly through the side effect classifier;
+- its **credential resolution** produces the expected environment for each
+  declared auth shape, including the refusal cases;
+- its **bundle compile** hook turns a validated bundle into a session config the
+  engine accepts;
+- its **telemetry** emission produces the spans and budget signals the platform
+  reads.
+
+These are the four seams ADR-0031's audit identified as implicitly Claude
+shaped. Under ADR-0060 they are manifest fields, which is what makes them
+testable in a shared suite at all: a field can be asserted about, scattered
+implicit behavior cannot.
+
+**4. Conformance is not elevation.** Passing the extended suite makes a harness
+*wireable*, not *shippable*. Parity evals remain the bar before a second harness
+is elevated past spike status. This carries forward the one genuinely good idea
+in ADR-0011, and it runs under
+[ADR-0022](0022-eval-completeness-tier-parity-and-trace-promotion.md)'s tier
+parity rule: the same evals at every tier, graded on what actually happened. Per
+ADR-0055 the fake tier contributes plumbing signal only, so harness elevation
+evidence must come from a real model tier.
+
+## Alternatives considered
+
+- **Leave conformance as is and rely on review.** This is the status quo, and the
+  status quo shipped a sanctioned forgery in the reference fake and then
+  propagated it into a spike. Review already looked at both.
+- **Assert on message types inside the existing suite.** Type checking what
+  crosses `receive_turn` would catch the forgery but leaves the other three
+  seams (credentials, bundle compile, telemetry) untested, and it would be
+  obsoleted by ADR-0061's process boundary, which makes the types unable to cross
+  at all.
+- **Keep the fake as an SDK forger and document that it is not a template.** A
+  comment saying "do not copy this" sits at the top of the file a new harness
+  author copies. We already know how that goes.
+
+## Consequences
+
+**Does this shrink second harness work, or only relocate it? Neither. It adds
+work, in the short term, deliberately.** This ADR is truth in accounting, not a
+saving. It says so plainly so that nobody prices the ADR-0060 and ADR-0061
+program on the assumption that 0062 pays for part of it.
+
+The added work is concrete: an import linter contract and its CI wiring; a
+rewrite of the fake against the declared contract; and four new conformance
+dimensions that must be authored once and then satisfied by every harness
+including the Claude one. The Claude harness will be the first thing the extended
+suite is run against, and there is no reason to assume it passes cleanly on the
+first attempt, because nothing has ever asserted these properties about it
+either.
+
+**What it buys is that a green suite starts meaning something.** Today "the
+second harness passed conformance" is compatible with every read only tool
+misclassifying, credentials resolving wrongly, and no bundle ever compiling. That
+is the state the OpenCode spike was actually in when it passed, and the passing
+was accurate: the suite asked its questions and got true answers. The questions
+were the problem.
+
+**The fake rewrite is the highest risk item, and it is not a harness risk.** The
+fake is the default in CI, in the chart's sealed pool, and in compose
+(`${AGENTOS_FAKE_MODEL:-1}`). Changing what it is built out of touches the most
+widely exercised path in the repo. ADR-0055's rules are the safety net here: the
+fake tier's one assertion is that the turn completed, so a rewrite that breaks
+plumbing fails loudly and immediately across CI rather than degrading quietly.
+
+**Not decided here.** Whether the extended conformance suite lives in
+`packages/aci-protocol` alongside the existing one or in a new harness contract
+package. That depends on where ADR-0060's manifest lands, which depends on
+whether the manifest is frozen, which ADR-0060 leaves as a deliberate later
+choice.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,7 +40,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0008 | [Multi-tenancy: one code path, pooled RLS, hard-siloed compute](0008-multi-tenancy.md) | Accepted |
 | 0009 | [Per-agent secrets and connector credentials](0009-per-agent-connector-auth.md) | Accepted |
 | 0010 | [Approval gates and human-in-the-loop](0010-approval-gates-and-human-in-the-loop.md) | Accepted |
-| 0011 | [OpenCode as the second harness behind the ACI](0011-opencode-second-harness.md) | Accepted (gating steer spike done — ADR-0031, #25/PR #226) |
+| 0011 | [OpenCode as the second harness behind the ACI](0011-opencode-second-harness.md) | Superseded by [ADR-0060](0060-the-harness-is-a-declared-package.md) (the steer spike passed; adoption was withdrawn for other reasons, recorded there) |
 | 0012 | [A substrate-agnostic worker and a channel-agnostic runner (the thin-shim thesis)](0012-substrate-and-channel-agnostic-core.md) | Accepted |
 | 0013 | [Concurrency and delivery: at-least-once streams with an idempotent, side-effect-aware kernel](0013-concurrency-and-delivery-model.md) | Accepted |
 | 0014 | [A git push is the deploy: immutable bundles, promote-not-rebuild, evals as a CI gate](0014-git-push-is-the-deploy.md) | Accepted |
@@ -60,7 +60,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0028 | [The sandbox substrate is a resilience-only fallback, not a product swap axis](0028-substrate-is-resilience-fallback-not-product-swap-axis.md) | Accepted |
 | 0029 | [The conversation-history port and its first loader: transcript replay over the durable state store](0029-conversation-history-port-and-first-loader.md) | Accepted |
 | 0030 | [A proactive within-episode memory agent over the frozen ACI injection seam](0030-proactive-within-episode-memory-agent.md) | Proposed |
-| 0031 | [Harness-neutral runner seams for the second harness](0031-harness-neutral-runner-seams.md) | Proposed |
+| 0031 | [Harness-neutral runner seams for the second harness](0031-harness-neutral-runner-seams.md) | Superseded by [ADR-0060](0060-the-harness-is-a-declared-package.md) and [ADR-0061](0061-out-of-process-harness-boundary.md) (decisions 2/3/5 become manifest fields in 0060; decision 4 carries forward unchanged; decision 1 becomes 0061's recorded fallback) |
 | 0032 | [Explicit named-provider egress, resolved at install](0032-explicit-provider-egress.md) | Accepted |
 | 0033 | [Scoped, least-privilege sandbox state token](0033-scoped-sandbox-state-token.md) | Accepted |
 | 0034 | [Approval authorizers resolve membership in the API](0034-approval-authorizers-resolve-membership-in-the-api.md) | Accepted |
@@ -89,4 +89,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0057 | [`cluster deploy` self-plumbs a port-forward so the generated key stays off the cleartext proxy](0057-cluster-deploy-self-plumbs-port-forward-for-generated-key.md) | Accepted |
 | 0058 | [A pushed tag is not release authority: ancestry, checks, and an approval environment gate publication](0058-tag-push-is-not-release-authority.md) | Accepted |
 | 0059 | [The sandbox is a bounded resource envelope; capacity is a tenant boundary](0059-sandbox-is-a-bounded-resource-envelope.md) | Accepted |
+| 0060 | [The harness is a declared package, not a class](0060-the-harness-is-a-declared-package.md) | Proposed |
+| 0061 | [The harness boundary is an out-of-process adapter, wire-compatible with Omnigent](0061-out-of-process-harness-boundary.md) | Proposed (gated on a spike, see Decision 5) |
+| 0062 | [Harness conformance has teeth](0062-harness-conformance-has-teeth.md) | Proposed |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Records a package-shaped redesign of the harness-adapter seam, modeled on the Omnigent meta-harness (Apache 2.0). Docs only, no code.

The core observation: our harness seam is a *class* (`ModelSession`), with everything else about a harness scattered across nine-plus files in two languages, including a hand-copied mirror of the credential rules in the worker. Omnigent's harness seam is a *package* that declares everything about itself. The unit of a harness should be a package, not a class.

**ADR-0059 (supersedes ADR-0011)** makes the unit of a harness an installable package declaring one contribution manifest: identity, install spec, auth spec, declared read-only tool set, model-override env keys, per-spawn env builder, bundle-compile hook. Registered by entry point with fail-closed guards, selected declaratively. ADR-0031's decisions 2, 3 and 5 become manifest fields instead of three separate ports. Non-goal taken from Omnigent: direct and headless harnesses only.

It is also the record that OpenCode-as-second-harness was withdrawn, and why. The steer spike *passed*. Adoption died on the synthesis tax plus a 517-line installer and an un-priced bundle compiler. Without that written down, ADR-0011 reads as still-live. The eight `task/25` and `task/307` through `task/313` branches on origin are named there as the mining source.

**ADR-0060 (spike-gated)** moves the harness boundary out of process behind a `create_app() -> FastAPI` shape, deliberately wire-compatible with Omnigent so its existing engine adapters are consumable rather than reimplemented. Two rationales: the process boundary is the only mechanically enforceable anti-forgery gate, since an SDK dataclass cannot cross HTTP; and wire-compatibility is the legitimate form of reuse under Apache 2.0, landing on their plug shape without forking their core. The ACI stays frozen and untouched. Gated on running one unmodified Omnigent adapter behind our runner, with the in-process `TurnEvent` union kept as the recorded fallback.

**ADR-0061** gives harness conformance teeth: an import-linter contract banning SDK imports outside the Claude harness package, an honest fake that stops forging SDK dataclasses, and conformance extended over the adjacent seams (tool identity, credentials, bundle compile, telemetry). Today `runner/src/agentos_runner/fake.py` is the sanctioned demonstration of the anti-pattern, and the OpenCode spike copied it rather than inventing it.

Every Consequences section applies ADR-0031's shrink-or-relocate test honestly. Notably: the interface was never the bottleneck, so ADR-0059 shrinks packaging and wiring cost rather than interface cost; ADR-0060 shrinks work only by letting us skip the supervisor for engines Omnigent adapts, and buys close to nothing for engines it does not; ADR-0061 adds work rather than saving it. The bundle compiler and history/resume are carved out explicitly in both 0059 and 0060.

One consequence worth surfacing: the ordering of a second harness should now follow Omnigent's adapter coverage rather than prior familiarity with an engine.

Also flips ADR-0011 and ADR-0031 status lines to Superseded and adds a second amendment banner to ADR-0005 against its "at zero cost" claim, which two attempts have now disproved.

All three ADRs are Proposed. ADR-0060 needs its spike before it is a real decision, and the evidence gap is recorded inside it: Omnigent's contribution contract and adapter wire were read from official docs, not source, so wire-compatibility is a hypothesis.

https://claude.ai/code/session_01NxcXs3eBe9cqS8zUWvSjoo
