### PR TITLE
Keep the message reply surface alive until the approval resumes

### DIFF
--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -34,7 +34,8 @@ use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 
 use crate::queue::{
-    self, entry_acked, synthetic_channel, synthetic_thread_and_placeholder, WORKER_GROUP,
+    self, entry_acked, find_entry_by_event_id, synthetic_channel, synthetic_thread_and_placeholder,
+    WORKER_GROUP,
 };
 
 pub const DEFAULT_STREAM: &str = queue::DEFAULT_STREAM;
@@ -48,6 +49,43 @@ pub const DEFAULT_LISTEN_PORT: u16 = 0;
 const ACK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// Bounded drain after the ack to catch a final edit still in flight.
 const FINAL_DRAIN: Duration = Duration::from_millis(100);
+
+/// Hard per-call budget for the ack check inside [`await_reply`]. The check is
+/// awaited in the poll arm's BODY, so while it is pending the deadline arm is not
+/// polled and a half-open Valkey could hang the CLI (and its stub) well past
+/// `--timeout-secs`. Bounding it makes an overrun read as "not acked yet" so the
+/// loop re-checks the deadline, and the budget is further capped at the time LEFT
+/// of that deadline. Four poll intervals is far beyond any healthy-latency
+/// ack check on a multiplexed connection, so it cannot produce a false negative
+/// under normal conditions.
+const ACK_CALL_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// How often the keep-alive resume wait re-scans the runs stream for the
+/// approval's resume entry (#766). Small enough to react promptly once the API
+/// enqueues it; the scan is a cheap incremental XRANGE over the same connection
+/// the enqueue already uses, and the whole wait stays bounded by the caller's
+/// `--timeout-secs` (each sleep is capped at the time left of the deadline).
+const RESUME_SCAN_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Hard per-scan budget for the resume XRANGE (#766, N3). A stalled or half-open
+/// Valkey must not block past the caller's deadline the way the removed HTTP poll
+/// could: a scan that overruns this is treated as "not found yet" and retried,
+/// so `--timeout-secs` stays a hard bound by construction rather than deferring to the
+/// OS TCP timeout. Two scan intervals is generous for a healthy multiplexed
+/// connection while still bounding a dead peer.
+const RESUME_SCAN_CALL_TIMEOUT: Duration = Duration::from_millis(400);
+
+/// After this many consecutive failing/stalling scans, warn once so a persistently
+/// unreachable Valkey is not silently reported as "approval still pending" (#766,
+/// N4): the durable approval stays resolvable, but this CLI can no longer OBSERVE
+/// its resolution, which is a different thing from "not resolved".
+const SCAN_ERROR_WARN_THRESHOLD: u32 = 5;
+
+/// Caps a per-call timeout budget at the time remaining before `deadline`, so
+/// a fixed per-call timeout can never overrun the caller's overall deadline.
+fn capped(budget: Duration, deadline: Instant) -> Duration {
+    budget.min(deadline.saturating_duration_since(Instant::now()))
+}
 
 /// The Block Kit action id on the approval card's Approve button
 /// (`agentos_dispatcher.approval_actions.APPROVE_ACTION_ID`). Its presence in a
@@ -193,6 +231,7 @@ async fn handle_call(
     Json(json!({ "ok": true, "ts": ts_out, "channel": channel, "text": text }))
 }
 
+#[derive(Debug)]
 pub enum Outcome {
     /// The worker finished the turn; the final placeholder text.
     Replied(String),
@@ -211,6 +250,22 @@ pub enum Outcome {
 /// Wait for the worker to consume and finalize the turn. Terminal signal is the
 /// XACK of our entry; the reply is the latest `chat.update` we captured. Shared
 /// by `chat` and `message` (both stand up the same stub + enqueue + ack seam).
+///
+/// The turn counts as awaiting approval on EITHER of two signals:
+///
+/// 1. An approval card was seen at this stub (the `APPROVE_ACTION_ID` in a
+///    captured call). Fastest and unambiguous, but not always present.
+/// 2. The latest placeholder text carries an authoritative trailing approval
+///    notice ([`parse_approval_id`] validates the id as a UUID).
+///
+/// Signal 2 is load-bearing because the card does not always reach this stub:
+/// the kernel posts it over the per-turn endpoint only when the approval route's
+/// channel matches the requesting channel (`in_requesting_channel` /
+/// `card_endpoint`, apps/worker/src/agentos_worker/kernel.py). With a route bound
+/// to a different channel the card rides the worker's DEFAULT transport, while
+/// the placeholder notice always uses the per-turn endpoint -- so a route-bound
+/// approval would otherwise be reported as a successful reply whose text is the
+/// "Awaiting approval (...)" notice, stranding the resumed reply (#766).
 pub async fn await_reply(
     stub: &mut SlackStub,
     conn: &mut redis::aio::MultiplexedConnection,
@@ -236,7 +291,19 @@ pub async fn await_reply(
                 }
             }
             _ = poll.tick() => {
-                if entry_acked(conn, stream, WORKER_GROUP, entry_id).await {
+                // An overrun (or a stalled connection) reads as "not acked yet",
+                // so the loop returns to the deadline arm rather than hanging.
+                // Cap the per-call budget at whatever is LEFT of the overall
+                // deadline, so a slow ack check can never push past `--timeout-secs`
+                // (a 2s fixed cap overran a short timeout by up to 2s).
+                let ack_budget = capped(ACK_CALL_TIMEOUT, deadline);
+                let acked = tokio::time::timeout(
+                    ack_budget,
+                    entry_acked(conn, stream, WORKER_GROUP, entry_id),
+                )
+                .await
+                .unwrap_or(false);
+                if acked {
                     // Drain any final edit still in flight before deciding.
                     while let Ok(Some(call)) = tokio::time::timeout(FINAL_DRAIN, stub.recv()).await {
                         awaiting_approval |= call.approval_card;
@@ -244,7 +311,12 @@ pub async fn await_reply(
                             latest = Some(text.to_string());
                         }
                     }
-                    if awaiting_approval {
+                    // Either signal parks the turn: the card seen here, or an
+                    // authoritative approval notice in the latest placeholder
+                    // text (the route-bound case, where no card reaches us).
+                    if awaiting_approval
+                        || latest.as_deref().and_then(parse_approval_id).is_some()
+                    {
                         return Outcome::AwaitingApproval(latest);
                     }
                     return latest.map_or(Outcome::CompletedNoEdit, Outcome::Replied);
@@ -254,6 +326,180 @@ pub async fn await_reply(
                 return Outcome::TimedOut;
             }
         }
+    }
+}
+
+/// Extract the approval UUID from the worker's placeholder notice.
+///
+/// Grounding (verified 2026-07-21 against this worktree,
+/// `apps/worker/src/agentos_worker/kernel.py:827-834`): the kernel builds
+/// `notice = f"Awaiting approval ({created.id}): {summary}\n" + "The session is
+/// paused and will resume once an authorized member resolves this request."` and
+/// edits the placeholder to `f"{base}\n\n{notice}"` when a prior partial answer
+/// exists, else to `notice` alone.
+///
+/// The parse is anchored to that STRUCTURE, not to a first/last occurrence of the
+/// marker. `find` let base text shadow the real id; `rfind` let the model-supplied
+/// `summary` (which FOLLOWS the id) shadow it just as easily. Instead:
+///
+/// 1. Split the text into `\n\n`-separated blocks. The authoritative notice is the
+///    appended LAST block, and it STARTS with the marker.
+/// 2. Require that block to be the only block starting with the marker: two
+///    marker-leading blocks mean the text is ambiguous (a model that emitted a
+///    whole notice-shaped block of its own), so no id is claimed.
+/// 3. When the kernel's fixed trailing sentence appears in the text at all, it
+///    must appear inside that block -- otherwise the structure is not the
+///    kernel's and no id is claimed.
+/// 4. Parse the UUID from that block's own marker.
+///
+/// Bias is deliberately toward a false negative: a WRONG id makes the CLI wait for
+/// a resume event that never arrives and strands the reply, while `None` falls
+/// back to the awaiting-approval terminal, which is truthful and retryable (#766).
+pub fn parse_approval_id(placeholder_text: &str) -> Option<String> {
+    const MARKER: &str = "Awaiting approval (";
+    /// The kernel's fixed trailing sentence, appended verbatim after the summary.
+    const NOTICE_TAIL: &str = "The session is paused and will resume once an authorized member \
+                               resolves this request.";
+
+    let blocks: Vec<&str> = placeholder_text.split("\n\n").collect();
+    let notice = blocks.last()?.trim_start();
+    // The notice is always the appended trailing block.
+    if !notice.starts_with(MARKER) {
+        return None;
+    }
+    // ...and it is the ONLY marker-leading block; anything else is ambiguous.
+    if blocks
+        .iter()
+        .filter(|b| b.trim_start().starts_with(MARKER))
+        .count()
+        != 1
+    {
+        return None;
+    }
+    // When the fixed sentence is present, it belongs to this block.
+    if placeholder_text.contains(NOTICE_TAIL) && !notice.contains(NOTICE_TAIL) {
+        return None;
+    }
+    let rest = &notice[MARKER.len()..];
+    let end = rest.find(')')?;
+    let candidate = &rest[..end];
+    // The parenthesized middle counts only when it is a real UUID; a bare token
+    // (or a notice-shaped false positive) is not an approval id.
+    uuid::Uuid::parse_str(candidate)
+        .ok()
+        .map(|_| candidate.to_string())
+}
+
+/// Keep `stub` alive after [`Outcome::AwaitingApproval`] and wait for the turn
+/// that resumes once a human resolves the approval (#766).
+///
+/// Mechanism: resolving an approval does not open a bespoke channel. The
+/// platform API appends the resume turn onto the SAME runs stream this CLI
+/// enqueued onto, under the deterministic event id `approval-<id>-resolved`
+/// (`apps/api/src/agentos_api/resumequeue.py`), replaying the original turn's
+/// placeholder and this stub's reply endpoint. So the resume is just another
+/// stream entry, and its completion is the ordinary ack-based signal:
+///
+/// 1. Scan the stream for `resume_event_id` every [`RESUME_SCAN_INTERVAL`],
+///    bounded by `timeout`. Until a human resolves, nothing matches.
+/// 2. Once the entry lands, delegate to [`await_reply`] on its stream id for the
+///    time left. That is the identical path the original turn took, so the
+///    resumed reply is reported only after the worker XACKs the entry -- i.e.
+///    after the turn FINALIZES. A booting `chat.update` or a partial streaming
+///    edit can never be printed as the final answer, and a reply that lands
+///    while the scan is between iterations is still captured, because
+///    `await_reply` tracks the latest placeholder edit continuously.
+///
+/// Carries [`await_reply`]'s [`Outcome`] verbatim (`Replied`, `CompletedNoEdit`,
+/// `AwaitingApproval` if the resumed turn hit a NEW gate, or `TimedOut`) plus
+/// `resolved`: whether the resume entry was ever observed on the stream. The flag
+/// lets the caller distinguish "resolved, but the resumed turn did not finalize
+/// before the deadline" (a plain timeout) from "never resolved" (the approval is
+/// still pending), which must be reported to the operator as different terminals.
+/// A timeout never mutates the durable `Approval` -- it stays pending and
+/// resolvable later.
+pub struct ResumeObservation {
+    pub outcome: Outcome,
+    pub resolved: bool,
+}
+
+/// The scan starts strictly AFTER `after_id` (the caller's own original turn entry
+/// id), advancing an exclusive cursor to the last-seen entry each iteration, so an
+/// ever-growing runs stream is never re-scanned from `-`. Each scan is wrapped in
+/// [`RESUME_SCAN_CALL_TIMEOUT`] and the deadline is re-checked every iteration, so
+/// a stalled Valkey cannot block past `timeout`. A failed or overrunning scan is
+/// treated as "not found yet" and retried until the deadline, so a blip cannot be
+/// misread as a resolution; a persistently failing scan warns once.
+pub async fn await_resume(
+    stub: &mut SlackStub,
+    conn: &mut redis::aio::MultiplexedConnection,
+    stream: &str,
+    resume_event_id: &str,
+    after_id: &str,
+    placeholder_ts: &str,
+    timeout: Duration,
+) -> ResumeObservation {
+    let deadline = Instant::now() + timeout;
+    let mut cursor = after_id.to_string();
+    let mut scan_errors: u32 = 0;
+    loop {
+        // Every per-op budget is capped by what is LEFT of the overall deadline, so
+        // the advertised `--timeout-secs` is a hard bound on this path too rather
+        // than being overrun by up to one fixed scan budget.
+        let scan_budget = capped(RESUME_SCAN_CALL_TIMEOUT, deadline);
+        let scan = tokio::time::timeout(
+            scan_budget,
+            find_entry_by_event_id(conn, stream, resume_event_id, &cursor),
+        )
+        .await;
+        let found = match scan {
+            Ok(Ok(scan)) => {
+                scan_errors = 0;
+                if let Some(last) = scan.last_seen {
+                    cursor = last;
+                }
+                scan.found
+            }
+            // A scan Err (Valkey blip) or an elapsed per-scan timeout (stalled
+            // Valkey) both count as "not found yet"; the overall deadline stays
+            // the hard bound.
+            Ok(Err(_)) | Err(_) => {
+                scan_errors += 1;
+                None
+            }
+        };
+        if let Some(resume_stream_id) = found {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let outcome = await_reply(
+                stub,
+                conn,
+                stream,
+                &resume_stream_id,
+                placeholder_ts,
+                remaining,
+            )
+            .await;
+            return ResumeObservation {
+                outcome,
+                resolved: true,
+            };
+        }
+        // Warn exactly once when observation has been failing for a while, so a
+        // down Valkey is not silently reported as "still pending" (N4).
+        if scan_errors == SCAN_ERROR_WARN_THRESHOLD {
+            crate::ui::ui().warn(
+                "the resume-stream scan keeps failing (Valkey slow or unreachable); the durable \
+                 approval stays resolvable, but this CLI can no longer observe its resolution",
+            );
+        }
+        if Instant::now() >= deadline {
+            return ResumeObservation {
+                outcome: Outcome::TimedOut,
+                resolved: false,
+            };
+        }
+        // Same cap on the idle sleep: never sleep past the deadline.
+        tokio::time::sleep(capped(RESUME_SCAN_INTERVAL, deadline)).await;
     }
 }
 
@@ -339,5 +585,110 @@ mod tests {
 
         assert!(line.contains("'#local-dev'"));
         assert!(line.contains("--thread 123.45"));
+    }
+
+    // --- parse_approval_id (#766 AC-2) --------------------------------------
+    // Grounding: apps/worker/src/agentos_worker/kernel.py:922 edits the
+    // placeholder to `f"Awaiting approval ({created.id}): {summary}\n..."`, and
+    // kernel.py:929 wraps it as `f"{base}\n\n{notice}"` when a prior partial
+    // answer exists. Verified 2026-07-21 against this worktree's kernel.py.
+
+    #[test]
+    fn parse_approval_id_reads_the_notice() {
+        let id = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+        let text = format!(
+            "Awaiting approval ({id}): do risky thing\n\
+             The session is paused and will resume once an authorized member \
+             resolves this request."
+        );
+        assert_eq!(parse_approval_id(&text).as_deref(), Some(id));
+    }
+
+    #[test]
+    fn parse_approval_id_survives_the_base_prefix() {
+        // The real shape when a prior answer exists: `f"{base}\n\n{notice}"`
+        // (kernel.py:929). The id must still be recovered after the prefix.
+        let id = "00000000-0000-4000-8000-000000000000";
+        let text = format!(
+            "Here is the partial answer so far.\n\n\
+             Awaiting approval ({id}): run the deploy\n\
+             The session is paused and will resume once an authorized member \
+             resolves this request."
+        );
+        assert_eq!(parse_approval_id(&text).as_deref(), Some(id));
+    }
+
+    #[test]
+    fn parse_approval_id_none_without_a_notice() {
+        assert_eq!(parse_approval_id("just a normal reply, no gate here"), None);
+    }
+
+    #[test]
+    fn parse_approval_id_rejects_a_non_uuid_middle() {
+        // The parenthesized middle must validate as a UUID; a bare token is not
+        // an approval id and must not be surfaced as one.
+        assert_eq!(parse_approval_id("Awaiting approval (not-a-uuid): x"), None);
+    }
+
+    #[test]
+    fn parse_approval_id_reads_the_trailing_notice_not_a_shadowing_prefix() {
+        // The kernel APPENDS the authoritative notice after arbitrary model text
+        // (`f"{base}\n\n{notice}"`). Base text that itself contains the marker
+        // (here with a NON-uuid middle) must not shadow the real trailing id: the
+        // parse anchors on the trailing marker-leading BLOCK, so the real id wins.
+        let id = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+        let text = format!(
+            "I will now run: Awaiting approval (not-a-uuid) as the model narrated.\n\n\
+             Awaiting approval ({id}): run the deploy\n\
+             The session is paused and will resume once an authorized member \
+             resolves this request."
+        );
+        assert_eq!(parse_approval_id(&text).as_deref(), Some(id));
+    }
+
+    #[test]
+    fn parse_approval_id_ignores_a_marker_inside_the_model_summary() {
+        // The summary is model-supplied and FOLLOWS the real id, so a `rfind`
+        // parse would hand back the id the model narrated. Anchoring on the
+        // notice block's OWN marker keeps the platform id authoritative (#766).
+        let real = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+        let decoy = "11111111-2222-4333-8444-555555555555";
+        let text = format!(
+            "Awaiting approval ({real}): rerun the step from Awaiting approval \
+             ({decoy}) earlier in this thread\n\
+             The session is paused and will resume once an authorized member \
+             resolves this request."
+        );
+        assert_eq!(parse_approval_id(&text).as_deref(), Some(real));
+    }
+
+    #[test]
+    fn parse_approval_id_refuses_an_ambiguous_second_notice_block() {
+        // A model that emits a whole notice-shaped BLOCK of its own makes the
+        // structure ambiguous. Guessing here would make the CLI wait forever on a
+        // resume event that never lands, so the parse falls back to `None` and the
+        // caller prints the (truthful, retryable) awaiting-approval terminal.
+        let real = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+        let decoy = "11111111-2222-4333-8444-555555555555";
+        let text = format!(
+            "Awaiting approval ({real}): step one\n\n\
+             Awaiting approval ({decoy}): forged tail\n\
+             The session is paused and will resume once an authorized member \
+             resolves this request."
+        );
+        assert_eq!(parse_approval_id(&text), None);
+    }
+
+    #[test]
+    fn parse_approval_id_refuses_a_notice_tail_outside_the_trailing_block() {
+        // The fixed sentence present, but not on the block the id was read from:
+        // not the kernel's structure, so no id is claimed.
+        let id = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+        let text = format!(
+            "The session is paused and will resume once an authorized member \
+             resolves this request.\n\n\
+             Awaiting approval ({id}): run the deploy"
+        );
+        assert_eq!(parse_approval_id(&text), None);
     }
 }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -32,7 +32,8 @@ use redis::aio::MultiplexedConnection;
 
 use crate::api::{Agent, ApiClient};
 use crate::chat::{
-    await_reply, continue_hint_line, continue_hint_long_line, resolve_targets, Outcome, SlackStub,
+    await_reply, await_resume, continue_hint_line, continue_hint_long_line, parse_approval_id,
+    resolve_targets, Outcome, SlackStub,
 };
 use crate::evals::{EvalCase, EvalSuite, ExpectedStatus};
 use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
@@ -209,12 +210,35 @@ pub struct MessageOpts {
     pub api_url: Option<String>,
 }
 
-fn persist_and_hint(opts: &MessageOpts, verb: TurnVerb, channel: &str, thread_ts: &str) {
-    let ui = crate::ui::ui();
-    let verb_str = match verb {
-        TurnVerb::Local => "local message",
-        TurnVerb::Cluster => "cluster message",
-    };
+/// The tier string for a [`TurnVerb`], as surfaced in the `--json` `tier` field
+/// and the human resolve hint.
+fn tier_str(verb: TurnVerb) -> &'static str {
+    match verb {
+        TurnVerb::Local => "local",
+        TurnVerb::Cluster => "cluster",
+    }
+}
+
+/// Write `.agentos/last-turn.json` for this turn WITHOUT printing the continue
+/// hint. Called before the (potentially long) approval wait so an interrupted or
+/// closed terminal still leaves a thread `message --continue` can recover (#766);
+/// the terminal paths then call [`persist_and_hint`], which rewrites the identical
+/// context and prints the hint once, at the end.
+fn persist_turn_quietly(opts: &MessageOpts, verb: TurnVerb, channel: &str, thread_ts: &str) {
+    if let Err(err) = save_turn_context(opts, verb, channel, thread_ts) {
+        crate::ui::ui().warn(&format!("could not save turn context: {err}"));
+    }
+}
+
+/// The one place the `TurnContext` is built and written. Idempotent: the same
+/// turn writes the same file, so persisting up front and again at the terminal
+/// records identical state.
+fn save_turn_context(
+    opts: &MessageOpts,
+    verb: TurnVerb,
+    channel: &str,
+    thread_ts: &str,
+) -> Result<()> {
     let ctx = TurnContext::from_turn(
         opts,
         verb,
@@ -224,18 +248,18 @@ fn persist_and_hint(opts: &MessageOpts, verb: TurnVerb, channel: &str, thread_ts
         // resolves to nothing on the next `--continue`.
         env::var("AGENTOS_API_KEY").ok().filter(|v| !v.is_empty()),
     );
+    let cwd = env::current_dir().context("resolving the current working directory")?;
+    save_turn(&cwd, &ctx)
+}
 
-    match env::current_dir().context("resolving the current working directory") {
-        Ok(cwd) => match save_turn(&cwd, &ctx) {
-            Ok(()) => ui.note(&continue_hint_line(verb_str)),
-            Err(err) => {
-                ui.warn(&format!("could not save turn context: {err}"));
-                ui.note(&continue_hint_long_line(verb_str, channel, thread_ts));
-            }
-        },
+fn persist_and_hint(opts: &MessageOpts, verb: TurnVerb, channel: &str, thread_ts: &str) {
+    let ui = crate::ui::ui();
+    let verb_str = format!("{} message", tier_str(verb));
+    match save_turn_context(opts, verb, channel, thread_ts) {
+        Ok(()) => ui.note(&continue_hint_line(&verb_str)),
         Err(err) => {
             ui.warn(&format!("could not save turn context: {err}"));
-            ui.note(&continue_hint_long_line(verb_str, channel, thread_ts));
+            ui.note(&continue_hint_long_line(&verb_str, channel, thread_ts));
         }
     }
 }
@@ -501,15 +525,29 @@ enum MessageOutcomeOutput {
     Replied { thread: String, reply: String },
     /// The worker finished the turn but never edited the placeholder.
     NoEdit { thread: String },
-    /// The turn parked awaiting human approval.
+    /// The turn parked awaiting human approval. `tier`/`agent`/`channel` shape the
+    /// human resolve hint into a copy-paste-runnable `approvals <agent> --resolve
+    /// ... --actor-channel <channel>` command (#766); none of them touch
+    /// `to_json`, which stays byte-identical.
     AwaitingApproval {
         thread: String,
         reply: Option<String>,
+        tier: &'static str,
+        agent: Option<String>,
+        channel: String,
     },
     /// The deadline elapsed with no reply. `diagnostics` carries the stream
     /// diagnostics string on the human path; it stays `None` under `--json`
     /// (which never gathers them), so no extra Valkey read happens there.
-    TimedOut { diagnostics: Option<String> },
+    /// `resume_note` (also human-only) replaces the diagnostics wording for the
+    /// resolved-but-unfinished resume case (#766): the JSON stays the byte-
+    /// identical `message_timeout_json`, but the operator is told the approval
+    /// WAS resolved and the resumed turn simply did not finish in time, rather
+    /// than being shown stream diagnostics for the wrong entry.
+    TimedOut {
+        diagnostics: Option<String>,
+        resume_note: Option<String>,
+    },
 }
 
 impl crate::ui::CliOutput for MessageOutcomeOutput {
@@ -519,7 +557,7 @@ impl crate::ui::CliOutput for MessageOutcomeOutput {
                 message_reply_json(thread, Some(reply))
             }
             MessageOutcomeOutput::NoEdit { thread } => message_reply_json(thread, None),
-            MessageOutcomeOutput::AwaitingApproval { thread, reply } => {
+            MessageOutcomeOutput::AwaitingApproval { thread, reply, .. } => {
                 message_awaiting_approval_json(thread, reply.as_deref())
             }
             MessageOutcomeOutput::TimedOut { .. } => message_timeout_json(),
@@ -535,13 +573,25 @@ impl crate::ui::CliOutput for MessageOutcomeOutput {
             MessageOutcomeOutput::NoEdit { .. } => {
                 ui.warn("the worker finished the turn but never edited the placeholder");
             }
-            MessageOutcomeOutput::AwaitingApproval { .. } => {
-                warn_approval_will_strand(ui);
+            MessageOutcomeOutput::AwaitingApproval {
+                tier,
+                agent,
+                channel,
+                ..
+            } => {
+                note_approval_pending(ui, tier, agent.as_deref(), channel);
             }
-            MessageOutcomeOutput::TimedOut { diagnostics } => {
-                ui.note("stream diagnostics:");
-                if let Some(diag) = diagnostics {
-                    ui.note(diag);
+            MessageOutcomeOutput::TimedOut {
+                diagnostics,
+                resume_note,
+            } => {
+                if let Some(note) = resume_note {
+                    ui.warn(note);
+                } else {
+                    ui.note("stream diagnostics:");
+                    if let Some(diag) = diagnostics {
+                        ui.note(diag);
+                    }
                 }
             }
         }
@@ -702,14 +752,19 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
 
     // Channel: explicit --channel, else the sole deployed agent from the compose
     // API (reached directly; routers mount at root, so the base carries no /api).
-    let channel = match opts.channel.as_deref() {
-        Some(channel) => channel.to_string(),
+    // `agent_hint` is the sole agent's NAME when we resolved it (so an approval
+    // resolve hint is copy-paste runnable), and `None` for an explicit --channel
+    // (we don't know which agent it binds) -- then the hint shows an `<AGENT>`
+    // slot (#766).
+    let (channel, agent_hint): (String, Option<String>) = match opts.channel.as_deref() {
+        Some(channel) => (channel.to_string(), None),
         None => {
             let api = ApiClient::new(&api_base, &opts.api_key)?;
             let agents = api.list_agents().await.with_context(|| {
                 format!("listing agents via {api_base} (is `agentos local up` running?)")
             })?;
-            select_channel(&agents, None)?
+            let channel = select_channel(&agents, None)?;
+            (channel, agents.first().map(|a| a.name.clone()))
         }
     };
     ui.note(&format!("routing to channel {channel}"));
@@ -739,6 +794,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
 
     let cl = ui.checklist();
     let step = cl.step("waiting for worker reply");
+    let wait_started = Instant::now();
     let outcome = await_reply(
         &mut stub,
         &mut conn,
@@ -769,12 +825,63 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
         }
         Outcome::AwaitingApproval(reply) => {
             step.done("awaiting approval");
-            ui.emit(&MessageOutcomeOutput::AwaitingApproval {
-                thread: thread_ts.clone(),
-                reply,
-            });
-            persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
-            Ok(())
+            // Persist the turn context BEFORE the (possibly full --timeout-secs)
+            // approval wait: if the operator interrupts or the terminal closes
+            // while the approval is pending, `.agentos/last-turn.json` must still
+            // hold the thread for `message --continue` (#766). The terminal paths
+            // re-persist the identical context and print the continue hint once.
+            persist_turn_quietly(&opts, TurnVerb::Local, &channel, &thread_ts);
+            // Keep the stub alive and wait for the resumed reply instead of
+            // exiting and stranding it (#766). The wait rides the Valkey
+            // connection already open for the enqueue, so the only degradation is
+            // a placeholder notice we cannot parse an approval id from -- then
+            // fall back to the terminal.
+            match parse_approval_id(reply.as_deref().unwrap_or_default()) {
+                Some(id) => {
+                    let remaining = Duration::from_secs(opts.timeout_secs)
+                        .saturating_sub(wait_started.elapsed());
+                    match resume_after_approval(
+                        &opts,
+                        TurnVerb::Local,
+                        &mut conn,
+                        &id,
+                        &mut stub,
+                        &stream_id,
+                        &placeholder_ts,
+                        &thread_ts,
+                        &channel,
+                        agent_hint.as_deref(),
+                        reply,
+                        remaining,
+                    )
+                    .await
+                    {
+                        ResumeExit::Done => Ok(()),
+                        // Still parked: the durable approval stays pending and is
+                        // resolvable later, so this is retryable. Local mode holds
+                        // no port-forward children, so exiting here leaks nothing.
+                        ResumeExit::Transient => {
+                            std::process::exit(crate::exit::ExitClass::Transient.code());
+                        }
+                    }
+                }
+                None => {
+                    // No parseable approval id, so we never entered the resume wait.
+                    // The turn is parked exactly like the timeout terminal, so exit
+                    // with the SAME transient (retryable) class rather than 0, so a
+                    // scripted caller sees one deterministic exit for "still parked"
+                    // regardless of whether the id happened to parse (#766, N5).
+                    ui.emit(&MessageOutcomeOutput::AwaitingApproval {
+                        thread: thread_ts.clone(),
+                        reply,
+                        tier: tier_str(TurnVerb::Local),
+                        agent: agent_hint.clone(),
+                        channel: channel.clone(),
+                    });
+                    persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
+                    std::process::exit(crate::exit::ExitClass::Transient.code());
+                }
+            }
         }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
@@ -785,7 +892,10 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             } else {
                 Some(diagnostics(&mut conn, &opts.stream, &stream_id).await)
             };
-            ui.emit(&MessageOutcomeOutput::TimedOut { diagnostics: diag });
+            ui.emit(&MessageOutcomeOutput::TimedOut {
+                diagnostics: diag,
+                resume_note: None,
+            });
             // A timeout is retryable (the worker may still be working, or a
             // transient stall), so it maps to the transient exit code, not failure.
             std::process::exit(crate::exit::ExitClass::Transient.code());
@@ -793,23 +903,241 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     }
 }
 
-/// The loud up-front warning a `local`/`cluster message` prints when its turn
-/// parked awaiting approval (#529): the reply stub is this process's throwaway
-/// endpoint, so the resumed reply -- delivered whenever a human approves -- has
-/// nowhere to land once the command exits (#505 dead-letters it rather than
-/// stalling the worker). Names the two ways to actually see a resumed reply.
-fn warn_approval_will_strand(ui: &crate::ui::Ui) {
+/// The one runnable `approvals --resolve` command shape, shared by the pre-wait
+/// hint and the terminal wording so the two cannot drift (#766).
+///
+/// Every flag here is load-bearing against the server:
+/// - `<AGENT>` is a REQUIRED positional on the `approvals` clap surface
+///   (`AgentTarget` flattens a mandatory `agent` arg), so omitting it made the
+///   printed hint fail with `error: the following required arguments were not
+///   provided: <AGENT>`.
+/// - `--as <user>` is required by `--resolve`, and the server blocks
+///   self-approval, so it must not be the turn's author.
+/// - `--actor-channel <channel>` is required by the DEFAULT approver set. With no
+///   `approvers` block on the route binding, the API selects
+///   `SlackChannelMembers(approval.card_channel or approval.reply_channel)`
+///   (`apps/api/src/agentos_api/slack_approvers.py`), whose `contains` admits the
+///   actor only when `actor_channel` equals that channel -- otherwise the resolve
+///   is refused 403 ("resolve this from the approval's channel"). The channel this
+///   turn routed to IS `reply_channel`, so it is the correct value in the common
+///   case; a route binding that placed the card elsewhere carries a different
+///   `card_channel`, which `approvals --list` reports. (Route bindings that
+///   declare `approvers.users`/`approvers.group` ignore the channel entirely, so
+///   passing it is harmless there.)
+fn approval_resolve_command(tier: &str, agent: Option<&str>, channel: &str, id: &str) -> String {
+    let agent = agent.unwrap_or("<AGENT>");
+    format!(
+        "agentos {tier} approvals {agent} --resolve {id} --as <user> --actor-channel '{channel}'"
+    )
+}
+
+/// The awaiting-approval terminal wording a `local`/`cluster message` prints when
+/// it did not keep the reply stub alive to receive the resumed reply -- i.e. the
+/// timeout terminal (the wait elapsed with the approval still pending) or the
+/// graceful-degradation fallback (no parseable approval id).
+///
+/// Every runtime call site is AFTER the wait ended, immediately before this
+/// command exits and drops its reply stub, so the wording says exactly that: the
+/// command is exiting, the durable `Approval` stays resolvable, and the resumed
+/// reply must be read from the agent transcript rather than waited for here.
+/// Promising that a later resolution "prints here" would strand an operator
+/// watching a terminal that is already gone (#766). It never overclaims a
+/// clickable Slack card either.
+fn note_approval_pending(ui: &crate::ui::Ui, tier: &str, agent: Option<&str>, channel: &str) {
+    let command = approval_resolve_command(tier, agent, channel, "<id>");
     ui.warn(
-        "this turn is awaiting human approval and will NOT deliver its reply here: the \
-         approval was persisted with this command's throwaway reply stub as its endpoint, and \
-         that stub dies when the command exits, so the resumed reply strands (it is \
-         dead-lettered, not lost silently).",
+        "this turn is awaiting human approval; it did not finalize, and this command is now \
+         exiting. The durable approval was persisted server-side and stays pending until someone \
+         resolves it.",
     );
-    ui.note(
-        "to demo approvals end to end, drive the turn from a durable reply surface: connect a \
-         real Slack workspace (`agentos local comms --slack` / `agentos cluster comms --slack`) \
-         and mention the agent there, or resolve the approval and read the reply in Slack.",
-    );
+    ui.note(&format!(
+        "resolve it later with `{command}` (the id is listed by `agentos {tier} approvals \
+         <AGENT> --list`, which also reports the approval's channel if its route binds one). \
+         Because this command has exited, the resumed reply does NOT print here -- read it from \
+         the agent transcript. There is no clickable Slack card unless a real workspace is \
+         connected (`agentos {tier} comms --slack`).",
+    ));
+}
+
+/// How a resume wait ended, as far as the CALLER's process lifetime is concerned.
+///
+/// The wait itself always finishes by emitting its terminal output; what the
+/// caller still owes is only the exit. This exists so the transient exit is taken
+/// by the handler that OWNS the `kubectl port-forward` guards rather than inside
+/// this helper: `std::process::exit` does not unwind, so calling it here would
+/// skip the caller's `kill_on_drop` destructors and orphan the port-forward child
+/// to init (#766). The caller drops its guards, then exits.
+enum ResumeExit {
+    /// Fully handled; the caller returns `Ok(())` and its guards drop normally.
+    Done,
+    /// The turn is still parked (the wait elapsed, or the resumed turn hit a NEW
+    /// gate). The durable `Approval` stays pending and resolvable later, so this
+    /// is retryable: the caller drops its port-forward guards and exits with the
+    /// transient class.
+    Transient,
+}
+
+/// Keep the reply stub alive after a turn parked awaiting approval and wait for
+/// the resumed reply (#766, ADR-0063).
+///
+/// Prints a per-id resolve hint and a waiting note, then waits on the runs stream
+/// via [`await_resume`]: when a human resolves the approval, the API appends the
+/// resume turn under the deterministic `approval-<id>-resolved` event id,
+/// replaying this stub's endpoint and the tracked placeholder. Completion is the
+/// worker's XACK of that entry, so the reply is reported only once the resumed
+/// turn FINALIZES -- a booting or partially-streamed edit is never printed as the
+/// answer. The wait is read-only on the approval: it never resolves, rejects, or
+/// deletes the durable record.
+///
+/// If the RESUMED turn itself parks on a NEW approval gate, this LOOPS: it parses
+/// the new approval id, recomputes `approval-<new-id>-resolved`, and keeps waiting
+/// on the fresh resume entry while the caller's overall deadline remains -- so a
+/// nested gate does not re-strand the reply the way exiting on the first gate
+/// would (that was exactly the bug this PR fixes). The loop is bounded by the
+/// deadline and, defensively, by a max iteration count.
+///
+/// Emits the terminal output for every outcome and returns what the caller still
+/// owes ([`ResumeExit`]). Shared by the local and cluster handlers so the two
+/// tiers cannot drift.
+#[allow(clippy::too_many_arguments)] // one cohesive resume-wait call; a struct would not clarify it
+async fn resume_after_approval(
+    opts: &MessageOpts,
+    verb: TurnVerb,
+    conn: &mut MultiplexedConnection,
+    id: &str,
+    stub: &mut SlackStub,
+    // The CLI's OWN original turn entry id: the exclusive lower bound for the
+    // resume scan, so it reads only entries enqueued after our turn (#766, N1).
+    after_id: &str,
+    placeholder_ts: &str,
+    thread_ts: &str,
+    channel: &str,
+    // The runnable resolve-hint agent positional: the sole deployed agent's name,
+    // or `None` (rendered `<AGENT>`) when an explicit `--channel` hid it (#766).
+    agent: Option<&str>,
+    awaiting_reply: Option<String>,
+    remaining: Duration,
+) -> ResumeExit {
+    let ui = crate::ui::ui();
+    let tier = tier_str(verb);
+    let deadline = Instant::now() + remaining;
+    // Defensive cap: the deadline is the real bound, but never spin unbounded on a
+    // pathological gate-per-resume loop.
+    const MAX_NESTED_GATES: usize = 64;
+    let mut current_id = id.to_string();
+    let mut last_reply = awaiting_reply;
+    for _ in 0..MAX_NESTED_GATES {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        ui.note(&format!(
+            "resolve it with: {}",
+            approval_resolve_command(tier, agent, channel, &current_id)
+        ));
+        ui.note(
+            "waiting for the approval to be resolved; the resumed reply lands here if it is \
+             resolved before --timeout-secs elapses...",
+        );
+        // The API's deterministic idempotency key for this approval's resume turn
+        // (`resumequeue.resume_event_id`), which is how we recognize that turn on
+        // the shared runs stream.
+        let resume_event_id = format!("approval-{current_id}-resolved");
+        let observed = await_resume(
+            stub,
+            conn,
+            &opts.stream,
+            &resume_event_id,
+            after_id,
+            placeholder_ts,
+            remaining,
+        )
+        .await;
+        match observed.outcome {
+            Outcome::Replied(reply) => {
+                ui.emit(&MessageOutcomeOutput::Replied {
+                    thread: thread_ts.to_string(),
+                    reply,
+                });
+                persist_and_hint(opts, verb, channel, thread_ts);
+                return ResumeExit::Done;
+            }
+            Outcome::CompletedNoEdit => {
+                ui.emit(&MessageOutcomeOutput::NoEdit {
+                    thread: thread_ts.to_string(),
+                });
+                persist_and_hint(opts, verb, channel, thread_ts);
+                return ResumeExit::Done;
+            }
+            Outcome::AwaitingApproval(new_reply) => {
+                // The RESUMED turn hit a NEW gate of its own. Keep waiting on ITS
+                // resume entry rather than exiting and dropping the stub -- exiting
+                // here would re-create the dead-endpoint bug for the nested gate.
+                match parse_approval_id(new_reply.as_deref().unwrap_or_default()) {
+                    Some(new_id) => {
+                        current_id = new_id;
+                        last_reply = new_reply;
+                        // Loop: wait on the nested approval's resume entry.
+                        continue;
+                    }
+                    None => {
+                        // No parseable id on the nested notice: surface the awaiting
+                        // terminal (durable + resolvable) rather than looping blind.
+                        ui.emit(&MessageOutcomeOutput::AwaitingApproval {
+                            thread: thread_ts.to_string(),
+                            reply: new_reply,
+                            tier,
+                            agent: agent.map(str::to_string),
+                            channel: channel.to_string(),
+                        });
+                        persist_and_hint(opts, verb, channel, thread_ts);
+                        return ResumeExit::Transient;
+                    }
+                }
+            }
+            Outcome::TimedOut if observed.resolved => {
+                // The approval WAS resolved (we saw the resume entry), but the
+                // resumed turn did not finalize before the deadline. That is a
+                // plain timeout, not a still-pending approval: emit the byte-
+                // identical timeout terminal with honest wording (#766, Codex P2).
+                ui.emit(&MessageOutcomeOutput::TimedOut {
+                    diagnostics: None,
+                    resume_note: Some(format!(
+                        "the approval was resolved, but the resumed turn did not finish before \
+                         --timeout-secs ({}s); read the resolved reply from the agent transcript",
+                        opts.timeout_secs
+                    )),
+                });
+                persist_and_hint(opts, verb, channel, thread_ts);
+                return ResumeExit::Transient;
+            }
+            Outcome::TimedOut => {
+                // Never resolved: the durable approval is still pending.
+                ui.emit(&MessageOutcomeOutput::AwaitingApproval {
+                    thread: thread_ts.to_string(),
+                    reply: last_reply,
+                    tier,
+                    agent: agent.map(str::to_string),
+                    channel: channel.to_string(),
+                });
+                // Persist the turn context even on the transient exit so a follow-up
+                // `--continue` still has the thread to resume against.
+                persist_and_hint(opts, verb, channel, thread_ts);
+                return ResumeExit::Transient;
+            }
+        }
+    }
+    // The deadline elapsed at a loop boundary, or the nested-gate cap was hit. The
+    // current approval is still pending and resolvable later.
+    ui.emit(&MessageOutcomeOutput::AwaitingApproval {
+        thread: thread_ts.to_string(),
+        reply: last_reply,
+        tier,
+        agent: agent.map(str::to_string),
+        channel: channel.to_string(),
+    });
+    persist_and_hint(opts, verb, channel, thread_ts);
+    ResumeExit::Transient
 }
 
 /// The shared target noun message handler.
@@ -860,9 +1188,11 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     .await?;
 
     // Channel: explicit --channel, else the sole deployed agent via a short-lived
-    // API port-forward (dropped once the lookup returns).
-    let channel = match opts.channel.as_deref() {
-        Some(channel) => channel.to_string(),
+    // API port-forward (dropped once the lookup returns). `agent_hint` carries the
+    // sole agent's name for a runnable approval-resolve hint, or `None` for an
+    // explicit --channel (rendered as an `<AGENT>` slot) (#766).
+    let (channel, agent_hint): (String, Option<String>) = match opts.channel.as_deref() {
+        Some(channel) => (channel.to_string(), None),
         None => {
             let _api_pf = start_port_forward(
                 &port_forward_command(
@@ -884,7 +1214,8 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
                 .list_agents()
                 .await
                 .context("listing agents through the api port-forward")?;
-            select_channel(&agents, None)?
+            let channel = select_channel(&agents, None)?;
+            (channel, agents.first().map(|a| a.name.clone()))
         }
     };
     ui.note(&format!("routing to channel {channel}"));
@@ -921,6 +1252,7 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
 
     let cl = ui.checklist();
     let step = cl.step("waiting for worker reply");
+    let wait_started = Instant::now();
     let outcome = await_reply(
         &mut stub,
         &mut conn,
@@ -951,12 +1283,68 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
         }
         Outcome::AwaitingApproval(reply) => {
             step.done("awaiting approval");
-            ui.emit(&MessageOutcomeOutput::AwaitingApproval {
-                thread: thread_ts.clone(),
-                reply,
-            });
-            persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
-            Ok(())
+            // Persist the turn context BEFORE the (possibly full --timeout-secs)
+            // approval wait, so an interrupted terminal still leaves a thread
+            // `message --continue` can recover (#766). Terminal paths re-persist
+            // the identical context and print the continue hint once.
+            persist_turn_quietly(&opts, TurnVerb::Cluster, &channel, &thread_ts);
+            // Keep the stub alive and wait for the resumed reply instead of
+            // exiting and stranding it (#766). The wait observes the resume turn
+            // on the runs stream over the Valkey connection already open for the
+            // enqueue, so no API port-forward is needed for it. If we cannot parse
+            // an approval id, fall back to the awaiting-approval terminal rather
+            // than hanging.
+            match parse_approval_id(reply.as_deref().unwrap_or_default()) {
+                Some(id) => {
+                    let remaining = Duration::from_secs(opts.timeout_secs)
+                        .saturating_sub(wait_started.elapsed());
+                    // `_valkey_pf` stays alive across this await, which is what
+                    // keeps `conn` usable for the resume scan.
+                    match resume_after_approval(
+                        &opts,
+                        TurnVerb::Cluster,
+                        &mut conn,
+                        &id,
+                        &mut stub,
+                        &stream_id,
+                        &placeholder_ts,
+                        &thread_ts,
+                        &channel,
+                        agent_hint.as_deref(),
+                        reply,
+                        remaining,
+                    )
+                    .await
+                    {
+                        ResumeExit::Done => Ok(()),
+                        ResumeExit::Transient => {
+                            // Drop the Valkey port-forward FIRST: `process::exit`
+                            // does not unwind, so without this explicit drop its
+                            // `kill_on_drop` guard never fires and the `kubectl
+                            // port-forward` child is orphaned to init (#766).
+                            drop(_valkey_pf);
+                            std::process::exit(crate::exit::ExitClass::Transient.code());
+                        }
+                    }
+                }
+                None => {
+                    // No parseable approval id, so we never entered the resume wait.
+                    // Same parked terminal as the timeout arm, so exit with the SAME
+                    // transient class (not 0) for a deterministic scripted contract
+                    // (#766, N5). Drop the port-forward first so its child is not
+                    // orphaned by the non-unwinding `process::exit`.
+                    ui.emit(&MessageOutcomeOutput::AwaitingApproval {
+                        thread: thread_ts.clone(),
+                        reply,
+                        tier: tier_str(TurnVerb::Cluster),
+                        agent: agent_hint.clone(),
+                        channel: channel.clone(),
+                    });
+                    persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
+                    drop(_valkey_pf);
+                    std::process::exit(crate::exit::ExitClass::Transient.code());
+                }
+            }
         }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
@@ -967,9 +1355,14 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
             } else {
                 Some(diagnostics(&mut conn, &opts.stream, &stream_id).await)
             };
-            ui.emit(&MessageOutcomeOutput::TimedOut { diagnostics: diag });
+            ui.emit(&MessageOutcomeOutput::TimedOut {
+                diagnostics: diag,
+                resume_note: None,
+            });
             // A timeout is retryable (the worker may still be working, or a
             // transient stall), so it maps to the transient exit code, not failure.
+            // Drop the Valkey port-forward FIRST for the same non-unwinding reason.
+            drop(_valkey_pf);
             std::process::exit(crate::exit::ExitClass::Transient.code());
         }
     }
@@ -1862,6 +2255,32 @@ async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The printed resolve hint must be runnable AS PRINTED. Every flag the
+    /// server requires has to be on it: the mandatory `<AGENT>` positional,
+    /// `--as`, and `--actor-channel` -- without the last one the default
+    /// channel-membership approver set
+    /// (`SlackChannelMembers.contains`, apps/api/.../slack_approvers.py) refuses
+    /// the resolve with 403 and the waiting CLI just times out (#766).
+    #[test]
+    fn the_resolve_hint_carries_every_flag_the_server_requires() {
+        let id = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+        let line = approval_resolve_command("local", Some("weather-bot"), "C-SIM-abc", id);
+        assert_eq!(
+            line,
+            format!(
+                "agentos local approvals weather-bot --resolve {id} --as <user> \
+                 --actor-channel 'C-SIM-abc'"
+            )
+        );
+
+        // With no resolved agent name the `<AGENT>` slot keeps the command shape
+        // valid so the operator sees the slot to fill, and the channel still rides.
+        let line = approval_resolve_command("cluster", None, "C-SIM-xyz", id);
+        assert!(line.contains("approvals <AGENT> --resolve"), "{line}");
+        assert!(line.contains("--actor-channel 'C-SIM-xyz'"), "{line}");
+        assert!(line.starts_with("agentos cluster approvals"), "{line}");
+    }
 
     /// The probe is only honest if it filters on the service compose actually
     /// runs the worker as. It previously matched `service=worker`, which exists

--- a/cli/src/queue.rs
+++ b/cli/src/queue.rs
@@ -122,6 +122,85 @@ pub async fn xadd(
     Ok(stream_id)
 }
 
+/// The Valkey stream id of the first entry whose decoded `QueuedTurn` carries
+/// `event_id`, or `None` when no entry matches. Each element of `entries` is a
+/// `(stream_id, payload_json)` pair as read off the stream's single
+/// [`STREAM_PAYLOAD_FIELD`]. A payload that does not decode as the frozen
+/// `QueuedTurn` is skipped rather than fatal, so one malformed row cannot hide a
+/// later matching entry. Pure, so the match is unit-testable without a Valkey.
+fn entry_stream_id_for_event_id(entries: &[(String, String)], event_id: &str) -> Option<String> {
+    entries.iter().find_map(|(stream_id, payload)| {
+        let turn: QueuedTurn = serde_json::from_str(payload).ok()?;
+        (turn.event_id == event_id).then(|| stream_id.clone())
+    })
+}
+
+/// The result of one incremental [`find_entry_by_event_id`] scan window.
+pub struct StreamScan {
+    /// Stream id of the entry whose decoded `event_id` matched, if present in
+    /// this window.
+    pub found: Option<String>,
+    /// The highest stream id observed in this window, so the caller can advance
+    /// an exclusive cursor and never re-read these rows on the next scan. `None`
+    /// when the window was empty (nothing new since the cursor).
+    pub last_seen: Option<String>,
+}
+
+/// Scan `stream` for the entry carrying `event_id`, reading only entries strictly
+/// AFTER the `after` cursor (an exclusive `(<after>` XRANGE start). Returns the
+/// matching entry's stream id (if present in this window) plus the highest stream
+/// id seen, so the caller can advance the cursor and never re-read these rows.
+///
+/// This is how the CLI observes an approval's resume turn (#766): when a human
+/// resolves a pending approval, the platform API appends a normal `QueuedTurn`
+/// onto this same runs stream under the DETERMINISTIC event id
+/// `approval-<approval_id>-resolved` (`apps/api/src/agentos_api/resumequeue.py`,
+/// `resume_event_id`), replaying the original turn's placeholder and reply
+/// endpoint. The resume entry is ALWAYS appended after the CLI's own original
+/// turn, so seeding `after` with that original entry id and advancing it each
+/// scan bounds every read to entries enqueued since our turn (typically 0-2)
+/// instead of the whole never-trimmed `agentos:runs` history. Finding the entry
+/// gives the caller a stream id it can wait on with the ordinary ack-based
+/// [`entry_acked`] completion signal.
+///
+/// Decoding goes through the generated `agentos_aci_protocol::QueuedTurn` (never
+/// a hand-mirror), so a contract rename cannot silently break the match. The
+/// XRANGE read itself needs a live Valkey; it is exercised by the Valkey-backed
+/// integration test `cli/tests/resume_wait.rs`, the same way [`entry_acked`] is
+/// exercised by `cli/tests/chat_enqueue.rs`. The pure match is
+/// [`entry_stream_id_for_event_id`].
+pub async fn find_entry_by_event_id(
+    conn: &mut MultiplexedConnection,
+    stream: &str,
+    event_id: &str,
+    after: &str,
+) -> Result<StreamScan> {
+    let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
+        .arg(stream)
+        // Exclusive start (`(<id>`, Redis/Valkey 6.2+): read only entries newer
+        // than the cursor so a monotonically-growing stream is not re-scanned.
+        .arg(format!("({after}"))
+        .arg("+")
+        .query_async(conn)
+        .await
+        .with_context(|| format!("XRANGE over {stream}"))?;
+    let last_seen = entries.last().map(|(id, _)| id.clone());
+    let decoded: Vec<(String, String)> = entries
+        .into_iter()
+        .filter_map(|(stream_id, fields)| {
+            let payload = fields
+                .into_iter()
+                .find(|(key, _)| key == STREAM_PAYLOAD_FIELD)
+                .map(|(_, value)| value)?;
+            Some((stream_id, payload))
+        })
+        .collect();
+    Ok(StreamScan {
+        found: entry_stream_id_for_event_id(&decoded, event_id),
+        last_seen,
+    })
+}
+
 /// Whether `group` has delivered `entry_id` and no longer holds it pending,
 /// i.e. the worker consumed and acked it. The worker acks only after the turn
 /// finalizes, so this is a real turn-completion signal, not a timing guess.
@@ -362,6 +441,68 @@ mod tests {
             assert_eq!(micros.len(), 6, "micros width: {ts}");
         }
         assert!(synthetic_channel().starts_with("C-SIM-"));
+    }
+
+    /// A stream row: the payload JSON of a `QueuedTurn` with the given event id.
+    fn row(stream_id: &str, event_id: &str) -> (String, String) {
+        let turn = QueuedTurn {
+            event_id: event_id.to_string(),
+            conversation_id: "1720000000.000100".into(),
+            author: "U-agentos-message".into(),
+            text: "hi".into(),
+            reply_handle: ReplyHandle {
+                channel: "C-SIM-x".into(),
+                placeholder: "1720000000.000200".into(),
+                endpoint: None,
+            },
+            received_at: "2026-07-21T00:00:00Z".into(),
+        };
+        (stream_id.to_string(), payload_json(&turn).unwrap())
+    }
+
+    #[test]
+    fn entry_stream_id_matches_the_deterministic_resume_event_id() {
+        // The API appends an approval's resume turn under the deterministic
+        // `approval-<id>-resolved` event id (apps/api/.../resumequeue.py
+        // `resume_event_id`); the CLI finds it by that id to learn which stream
+        // entry to wait on (#766).
+        let resume = "approval-3f2504e0-4f89-41d3-9a0c-0305e82c3301-resolved";
+        let entries = vec![
+            row("1000-0", "EvSIM-original"),
+            row(
+                "1001-0",
+                "approval-00000000-0000-4000-8000-000000000000-resolved",
+            ),
+            row("1002-0", resume),
+        ];
+
+        assert_eq!(
+            entry_stream_id_for_event_id(&entries, resume).as_deref(),
+            Some("1002-0"),
+            "must select the entry whose event_id matches, not merely a resume-shaped one"
+        );
+        // An event id nothing carries yields None (keep waiting), never a guess.
+        assert_eq!(
+            entry_stream_id_for_event_id(&entries, "approval-nope-resolved"),
+            None
+        );
+    }
+
+    #[test]
+    fn entry_stream_id_skips_undecodable_payloads() {
+        // One malformed row must not hide a later matching entry, and must not
+        // panic the scan.
+        let entries = vec![
+            ("1-0".to_string(), "not json at all".to_string()),
+            ("2-0".to_string(), "{\"event_id\":\"partial\"}".to_string()),
+            row("3-0", "approval-abc-resolved"),
+        ];
+
+        assert_eq!(
+            entry_stream_id_for_event_id(&entries, "approval-abc-resolved").as_deref(),
+            Some("3-0")
+        );
+        assert_eq!(entry_stream_id_for_event_id(&entries, "partial"), None);
     }
 
     #[test]

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -13,39 +13,8 @@ use agentos::chat::{resolve_targets, SlackStub};
 use agentos::queue::{diagnostics, entry_acked, synthetic_turn, xadd, WORKER_GROUP};
 use agentos_aci_protocol::QueuedTurn;
 
-const DEFAULT_VALKEY_URL: &str = "redis://:valkeypass@localhost:26379";
-
-fn valkey_url() -> String {
-    std::env::var("TEST_VALKEY_URL").unwrap_or_else(|_| DEFAULT_VALKEY_URL.to_string())
-}
-
-/// Connect and PING; return `None` (with a skip note) when Valkey is not
-/// reachable, mirroring the dispatcher's `pytest.skip`. CI does not start the
-/// compose stack, so the Valkey-backed tests skip there rather than failing.
-async fn valkey_or_skip(test: &str) -> Option<redis::aio::MultiplexedConnection> {
-    let url = valkey_url();
-    let connect = async {
-        let client = redis::Client::open(url.clone())?;
-        let mut conn = client.get_multiplexed_async_connection().await?;
-        let _: String = redis::cmd("PING").query_async(&mut conn).await?;
-        redis::RedisResult::Ok(conn)
-    };
-    match connect.await {
-        Ok(conn) => Some(conn),
-        Err(err) => {
-            eprintln!("skipping {test}: Valkey not reachable at {url}: {err}");
-            None
-        }
-    }
-}
-
-fn unique_stream() -> String {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    format!("agentos:test:chat:{nanos}")
-}
+mod support;
+use support::{unique_stream, valkey_or_skip};
 
 #[tokio::test]
 async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
@@ -53,7 +22,7 @@ async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
     else {
         return;
     };
-    let stream = unique_stream();
+    let stream = unique_stream("agentos:test:chat:");
 
     let event = synthetic_turn(
         "C-SIM-x",
@@ -130,7 +99,7 @@ async fn explicit_channel_and_thread_land_verbatim_on_the_wire() {
     else {
         return;
     };
-    let stream = unique_stream();
+    let stream = unique_stream("agentos:test:chat:");
 
     let (channel, thread_ts, placeholder_ts) =
         resolve_targets(Some("CSIM12345"), Some("1720000000.000100"));
@@ -184,7 +153,7 @@ async fn absent_channel_and_thread_fall_back_to_synthetic() {
     else {
         return;
     };
-    let stream = unique_stream();
+    let stream = unique_stream("agentos:test:chat:");
 
     let (channel, thread_ts, placeholder_ts) = resolve_targets(None, None);
     assert!(
@@ -242,7 +211,7 @@ async fn diagnostics_reports_stream_length_and_consumer_group_state() {
     else {
         return;
     };
-    let stream = unique_stream();
+    let stream = unique_stream("agentos:test:chat:");
 
     let event = synthetic_turn("C-SIM-x", "U-agentos-chat", "hi", "1.1", "1.2", None);
     let stream_id = xadd(&mut conn, &stream, &event).await.unwrap();
@@ -287,7 +256,7 @@ async fn entry_acked_tracks_the_worker_consuming_and_acking() {
     else {
         return;
     };
-    let stream = unique_stream();
+    let stream = unique_stream("agentos:test:chat:");
     let event = synthetic_turn("C-SIM-x", "U-agentos-chat", "hi", "1.1", "1.2", None);
     let stream_id = xadd(&mut conn, &stream, &event).await.unwrap();
 

--- a/cli/tests/resume_wait.rs
+++ b/cli/tests/resume_wait.rs
@@ -1,0 +1,342 @@
+//! Integration: the #766 keep-alive resume wait (`chat::await_resume`) against
+//! real Valkey plus the embedded Slack stub over real HTTP.
+//!
+//! This is the behavioral coverage the mechanism pivot lost when the injectable
+//! `await_resume_reply` seam was replaced by a concrete Valkey connection: it
+//! drives the seam the way it actually runs. No compose stack is needed -- only a
+//! reachable Valkey (the compose dev one on host port 26379 is fine) and the
+//! in-process stub. The test uses a unique test-scoped stream it deletes
+//! afterward, so it never touches the real `agentos:runs` stream. When no Valkey
+//! is reachable it SKIPS (like `chat_enqueue.rs`), so CI without the stack is
+//! unaffected; run it locally with the compose Valkey up, or point
+//! `TEST_VALKEY_URL` at another instance.
+
+use std::time::Duration;
+
+use agentos::chat::{await_reply, await_resume, parse_approval_id, Outcome, SlackStub};
+use agentos::queue::{synthetic_turn, xadd, WORKER_GROUP};
+use agentos_aci_protocol::{QueuedTurn, ReplyHandle};
+
+mod support;
+use support::{unique_stream, valkey_or_skip};
+
+const PLACEHOLDER_TS: &str = "1720000000.000200";
+
+/// A resume turn under the deterministic `approval-<id>-resolved` event id, the
+/// exact shape `resumequeue._build_turn` appends when a human resolves an
+/// approval (replaying the original placeholder + this stub's endpoint).
+fn resume_turn(resume_event_id: &str, endpoint: &str) -> QueuedTurn {
+    QueuedTurn {
+        event_id: resume_event_id.to_string(),
+        conversation_id: "1720000000.000100".into(),
+        author: "U-agentos-message".into(),
+        text: "(resumed after approval)".into(),
+        reply_handle: ReplyHandle {
+            channel: "C-SIM-x".into(),
+            placeholder: PLACEHOLDER_TS.into(),
+            endpoint: Some(endpoint.to_string()),
+        },
+        received_at: "2026-07-21T00:00:00Z".into(),
+    }
+}
+
+/// Deliver + XACK `entry_id` under the worker group so `entry_acked` sees it
+/// finalized, exactly as the worker does after finishing the turn.
+async fn deliver_and_ack(conn: &mut redis::aio::MultiplexedConnection, stream: &str) {
+    // BUSYGROUP on a second call is expected: the route-bound test acks in two
+    // phases (original turn, then the resume entry) against the same group.
+    let _: redis::RedisResult<()> = redis::cmd("XGROUP")
+        .arg("CREATE")
+        .arg(stream)
+        .arg(WORKER_GROUP)
+        .arg("0")
+        .query_async(conn)
+        .await;
+    // Deliver every pending entry to the group (advances last-delivered-id).
+    let _: redis::Value = redis::cmd("XREADGROUP")
+        .arg("GROUP")
+        .arg(WORKER_GROUP)
+        .arg("worker-1")
+        .arg("COUNT")
+        .arg(100)
+        .arg("STREAMS")
+        .arg(stream)
+        .arg(">")
+        .query_async(conn)
+        .await
+        .unwrap();
+    // XACK every entry in the stream under the worker group, exactly as the
+    // worker does after finishing each turn (`_ack` = XACK in consumer.py), so
+    // `entry_acked` sees the delivered entries as finalized rather than pending.
+    let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
+        .arg(stream)
+        .arg("-")
+        .arg("+")
+        .query_async(conn)
+        .await
+        .unwrap();
+    if !entries.is_empty() {
+        let mut xack = redis::cmd("XACK");
+        xack.arg(stream).arg(WORKER_GROUP);
+        for (id, _fields) in &entries {
+            xack.arg(id);
+        }
+        let _: i64 = xack.query_async(conn).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn await_resume_returns_the_finalized_reply_once_the_resume_entry_is_acked() {
+    let Some(mut conn) =
+        valkey_or_skip("await_resume_returns_the_finalized_reply_once_the_resume_entry_is_acked")
+            .await
+    else {
+        return;
+    };
+    let stream = unique_stream("agentos:test:resume:");
+
+    // Stand up the reply stub (the surface the resumed turn's chat.update lands on).
+    let mut stub = SlackStub::start("localhost", 0, "localhost").await.unwrap();
+    let endpoint = stub.base_api_url().to_string();
+
+    // The CLI's OWN original turn: its stream id is the exclusive scan cursor.
+    let original = synthetic_turn(
+        "C-SIM-x",
+        "U-agentos-message",
+        "do the risky thing",
+        "1720000000.000100",
+        PLACEHOLDER_TS,
+        Some(endpoint.clone()),
+    );
+    let original_id = xadd(&mut conn, &stream, &original).await.unwrap();
+
+    // The API's resume turn, appended AFTER the original under the deterministic id.
+    let resume_event_id = "approval-3f2504e0-4f89-41d3-9a0c-0305e82c3301-resolved";
+    let resume = resume_turn(resume_event_id, &endpoint);
+    xadd(&mut conn, &stream, &resume).await.unwrap();
+
+    // Simulate the worker finalizing the resumed turn: deliver+ack the entry, then
+    // post the final chat.update editing the tracked placeholder. Posting BEFORE
+    // the wait proves a reply that landed while the scan was between iterations is
+    // still captured (the stub's channel buffers it).
+    deliver_and_ack(&mut conn, &stream).await;
+    let http = reqwest::Client::new();
+    let resp: serde_json::Value = http
+        .post(format!("{endpoint}chat.update"))
+        .form(&[
+            ("channel", "C-SIM-x"),
+            ("ts", PLACEHOLDER_TS),
+            ("text", "the resolved answer"),
+        ])
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(resp["ok"], true, "stub accepted the final edit");
+
+    let observed = await_resume(
+        &mut stub,
+        &mut conn,
+        &stream,
+        resume_event_id,
+        &original_id,
+        PLACEHOLDER_TS,
+        Duration::from_secs(3),
+    )
+    .await;
+
+    let _: i64 = redis::cmd("DEL")
+        .arg(&stream)
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+
+    assert!(
+        observed.resolved,
+        "the resume entry was observed (resolved)"
+    );
+    match observed.outcome {
+        Outcome::Replied(reply) => assert_eq!(
+            reply, "the resolved answer",
+            "await_resume returns the FINALIZED placeholder text, not a booting edit"
+        ),
+        other => panic!("expected Replied, got a different terminal: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn await_resume_times_out_when_the_approval_is_never_resolved() {
+    let Some(mut conn) =
+        valkey_or_skip("await_resume_times_out_when_the_approval_is_never_resolved").await
+    else {
+        return;
+    };
+    let stream = unique_stream("agentos:test:resume:");
+
+    let mut stub = SlackStub::start("localhost", 0, "localhost").await.unwrap();
+    let endpoint = stub.base_api_url().to_string();
+
+    // Only the original turn exists; the approval is never resolved, so no resume
+    // entry is ever appended.
+    let original = synthetic_turn(
+        "C-SIM-x",
+        "U-agentos-message",
+        "do the risky thing",
+        "1720000000.000100",
+        PLACEHOLDER_TS,
+        Some(endpoint),
+    );
+    let original_id = xadd(&mut conn, &stream, &original).await.unwrap();
+
+    let resume_event_id = "approval-00000000-0000-4000-8000-000000000000-resolved";
+    let observed = await_resume(
+        &mut stub,
+        &mut conn,
+        &stream,
+        resume_event_id,
+        &original_id,
+        PLACEHOLDER_TS,
+        Duration::from_millis(400),
+    )
+    .await;
+
+    let _: i64 = redis::cmd("DEL")
+        .arg(&stream)
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+
+    assert!(
+        !observed.resolved,
+        "no resume entry was ever appended, so the approval was NOT observed as resolved"
+    );
+    assert!(
+        matches!(observed.outcome, Outcome::TimedOut),
+        "the never-resolved wait must hit the deadline as TimedOut, never a false Replied"
+    );
+}
+
+/// Post a `chat.update` editing the tracked placeholder, exactly as the worker
+/// does. Deliberately carries NO approval card: this is the notice-only path.
+async fn post_placeholder_edit(endpoint: &str, text: &str) {
+    let resp: serde_json::Value = reqwest::Client::new()
+        .post(format!("{endpoint}chat.update"))
+        .form(&[
+            ("channel", "C-SIM-x"),
+            ("ts", PLACEHOLDER_TS),
+            ("text", text),
+        ])
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(resp["ok"], true, "stub accepted the placeholder edit");
+}
+
+/// Route-bound approval (#766): when the approval route is bound to a channel
+/// other than the requesting one, the worker posts the Block Kit card over its
+/// DEFAULT transport, so NO card ever reaches this stub -- but the authoritative
+/// placeholder notice always uses the per-turn endpoint and does. Classifying on
+/// the card alone reported that notice as the final answer and stranded the
+/// resumed reply; the notice must park the turn too, and the keep-alive must
+/// then deliver the resumed reply.
+#[tokio::test]
+async fn a_notice_without_a_card_parks_the_turn_and_the_keepalive_delivers_the_resumed_reply() {
+    let Some(mut conn) = valkey_or_skip(
+        "a_notice_without_a_card_parks_the_turn_and_the_keepalive_delivers_the_resumed_reply",
+    )
+    .await
+    else {
+        return;
+    };
+    let stream = unique_stream("agentos:test:resume:");
+
+    let mut stub = SlackStub::start("localhost", 0, "localhost").await.unwrap();
+    let endpoint = stub.base_api_url().to_string();
+
+    let original = synthetic_turn(
+        "C-SIM-x",
+        "U-agentos-message",
+        "do the risky thing",
+        "1720000000.000100",
+        PLACEHOLDER_TS,
+        Some(endpoint.clone()),
+    );
+    let original_id = xadd(&mut conn, &stream, &original).await.unwrap();
+
+    // The worker parks the turn: it edits the placeholder with the authoritative
+    // notice and acks the entry. The card went elsewhere, so the stub never sees
+    // one -- the notice is the ONLY signal available here.
+    let approval_id = "3f2504e0-4f89-41d3-9a0c-0305e82c3302";
+    let notice = format!("a partial answer\n\nAwaiting approval ({approval_id}): run the tool\n");
+    post_placeholder_edit(&endpoint, &notice).await;
+    deliver_and_ack(&mut conn, &stream).await;
+
+    let outcome = await_reply(
+        &mut stub,
+        &mut conn,
+        &stream,
+        &original_id,
+        PLACEHOLDER_TS,
+        Duration::from_secs(3),
+    )
+    .await;
+
+    let parked = match outcome {
+        Outcome::AwaitingApproval(latest) => latest,
+        other => {
+            let _: i64 = redis::cmd("DEL")
+                .arg(&stream)
+                .query_async(&mut conn)
+                .await
+                .unwrap();
+            panic!("a notice-only turn must park as AwaitingApproval, got {other:?}");
+        }
+    };
+    assert_eq!(
+        parse_approval_id(parked.as_deref().unwrap_or_default()).as_deref(),
+        Some(approval_id),
+        "the parked turn carries the notice the keep-alive parses its id from"
+    );
+
+    // The keep-alive path: the API appends the resume turn, the worker finalizes
+    // it, and the resumed reply lands on this still-alive stub.
+    let resume_event_id = format!("approval-{approval_id}-resolved");
+    let resume = resume_turn(&resume_event_id, &endpoint);
+    xadd(&mut conn, &stream, &resume).await.unwrap();
+    deliver_and_ack(&mut conn, &stream).await;
+    post_placeholder_edit(&endpoint, "the resolved answer").await;
+
+    let observed = await_resume(
+        &mut stub,
+        &mut conn,
+        &stream,
+        &resume_event_id,
+        &original_id,
+        PLACEHOLDER_TS,
+        Duration::from_secs(3),
+    )
+    .await;
+
+    let _: i64 = redis::cmd("DEL")
+        .arg(&stream)
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+
+    assert!(
+        observed.resolved,
+        "the resume entry was observed (resolved)"
+    );
+    match observed.outcome {
+        Outcome::Replied(reply) => assert_eq!(
+            reply, "the resolved answer",
+            "the route-bound turn's resumed reply is delivered, not stranded"
+        ),
+        other => panic!("expected the resumed Replied, got {other:?}"),
+    }
+}

--- a/cli/tests/support/mod.rs
+++ b/cli/tests/support/mod.rs
@@ -14,6 +14,45 @@ use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+/// The compose dev Valkey (host port 26379, password `valkeypass`), used as
+/// the default target for the Valkey-backed integration tests.
+pub const DEFAULT_VALKEY_URL: &str = "redis://:valkeypass@localhost:26379";
+
+pub fn valkey_url() -> String {
+    std::env::var("TEST_VALKEY_URL").unwrap_or_else(|_| DEFAULT_VALKEY_URL.to_string())
+}
+
+/// Connect and PING; return `None` (with a skip note) when Valkey is not
+/// reachable, mirroring the dispatcher's `pytest.skip`. CI does not start the
+/// compose stack, so the Valkey-backed tests skip there rather than failing.
+pub async fn valkey_or_skip(test: &str) -> Option<redis::aio::MultiplexedConnection> {
+    let url = valkey_url();
+    let connect = async {
+        let client = redis::Client::open(url.clone())?;
+        let mut conn = client.get_multiplexed_async_connection().await?;
+        let _: String = redis::cmd("PING").query_async(&mut conn).await?;
+        redis::RedisResult::Ok(conn)
+    };
+    match connect.await {
+        Ok(conn) => Some(conn),
+        Err(err) => {
+            eprintln!("skipping {test}: Valkey not reachable at {url}: {err}");
+            None
+        }
+    }
+}
+
+/// Builds a unique test-scoped stream name under the given prefix (e.g.
+/// `"agentos:test:chat:"`), so concurrent test runs never collide and each
+/// suite keeps its own distinct stream namespace.
+pub fn unique_stream(prefix: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{prefix}{nanos}")
+}
+
 #[derive(Debug, Clone)]
 pub struct Request {
     pub method: String,

--- a/docs/adr/0063-message-driven-approval-reply-surface.md
+++ b/docs/adr/0063-message-driven-approval-reply-surface.md
@@ -1,0 +1,173 @@
+# 63. Message-driven approval reply surface
+
+Date: 2026-07-21
+Status: Accepted
+
+## Context
+
+`agentos local message` and `agentos cluster message` mint an in-process
+`SlackStub` (`cli/src/chat.rs` `SlackStub::start`) and stamp its URL as the
+turn's `reply_handle.endpoint`. When the turn is approval-gated, the worker
+persists that endpoint on the durable `Approval` record as `reply_endpoint`
+(`apps/api/src/agentos_api/resumequeue.py`), suspends the turn, and posts the
+approval card (`apps/worker/src/agentos_worker/kernel.py`, around lines
+937-953). The CLI then returns `Outcome::AwaitingApproval` and exits, which
+drops the `SlackStub` and aborts its HTTP listener.
+
+When a human later resolves the approval, the resume turn
+(`resumequeue.build_resume_turn`) replays that now-dead endpoint. With no
+connected Slack transport configured, the reply is swallowed by the
+best-effort fallback landed in #708 (`slack_sink.py`, ACK not dead-letter) and
+never reaches the operator. Issue #529 added the `warn_approval_will_strand`
+notice documenting this as expected behavior; #708 (referencing the OPEN
+parent, and #505/ADR-0039's bounded-delivery/dead-letter mechanism) made the
+undelivered case non-fatal to the worker but did not make the reply arrive.
+Issue #766 is the acute complaint: the resumed reply for a `message`-driven
+approval dead-letters instead of reaching the operator who is waiting on it.
+
+ADR-0020 established the message port as a rendering-free channel interface
+and treated the CLI stub as one adapter among several, implicitly assuming it
+is a throwaway per-turn fixture. This ADR qualifies that assumption for the
+approval-pending case: a throwaway stub cannot be the reply surface for a
+turn that pauses, because the receiver is gone before the pause resolves.
+
+## Decision
+
+**The message-driven approval reply surface is the CLI stub kept alive for
+the approval-pending window**, not a new persistent server and not (yet) the
+connected Slack transport.
+
+On `Outcome::AwaitingApproval`, `local message` and `cluster message` do not
+exit. They keep the same `SlackStub` instance running, extract the approval
+id from the worker's placeholder notice, print a resolve hint (`agentos
+<tier> approvals <agent> --resolve <id> --as <user> --actor-channel
+<channel>`), and enter a second bounded
+wait for the resumed reply on the same placeholder.
+
+That second wait reuses the SAME ack-based completion signal as the original
+turn, rather than polling approval status over HTTP. Resolving an approval
+does not open a bespoke channel: the platform API appends the resume turn
+onto the same `agentos:runs` stream the CLI already enqueued onto, under the
+deterministic event id `approval-<id>-resolved`
+(`resumequeue.resume_event_id`), replaying the original turn's placeholder
+and this stub's reply endpoint. So the CLI scans that stream (over the Valkey
+connection it already holds for the enqueue) for the resume entry, and once
+it appears delegates to the existing `await_reply` on that entry's stream id.
+Completion is therefore the worker's XACK of the resume entry -- the turn
+having FINALIZED -- exactly as for the original turn. When the resumed reply
+arrives at the still-live stub, the CLI prints it and exits 0. On timeout,
+the CLI exits with the existing transient (retryable) exit class, leaving the
+durable `Approval` record pending and resolvable later.
+
+Reusing the ack signal rather than a `GET /approvals/{id}` status poll is
+load-bearing, not incidental. A status poll observes only that the approval
+left `pending`; it carries no signal that the resumed turn has finished, so
+the first placeholder edit after resolution -- which may be a booting notice
+or a partial streaming edit -- would be printed as the final answer. It also
+needs the API reachable for the whole pending window, which at cluster tier
+would mean holding a second `kubectl port-forward` open across the wait. The
+stream scan needs neither: it reuses the connection the enqueue already
+opened and inherits `await_reply`'s finalization semantics for free.
+
+This is deliberately the CLI-side half of a two-sided contract. Durability of
+the approval itself lives in the Postgres `Approval` record, per ADR-0010,
+which explicitly rejected holding pending approval state in memory
+(alternative 4 in that ADR: "hold pending state in memory on the live
+sandbox"). The CLI keep-alive does not touch that decision or reintroduce
+in-memory approval state; it keeps alive only the reply *receiver* -- the
+stub that the resume turn's HTTP call lands on -- never the approval record
+or its resolution. No approval semantics change: resolution remains an
+explicit `approvals --resolve` call or a real card click, authorized
+server-side per ADR-0034/ADR-0035; the CLI wait loop only reads.
+
+Connected real Slack is the eventual durable, clickable-card reply surface
+for this flow, but it is explicitly deferred (see Consequences). Nothing in
+this decision blocks that path; it only fixes the zero-Slack case that #766
+reports as broken today.
+
+## Alternatives considered
+
+1. **Route the card and resumed reply through the connected Slack endpoint
+   (Option 2 in the #766/#708 framing).** This is the eventual durable
+   surface and is not rejected, only deferred. It requires the CLI to detect
+   a connected transport, diverge into a no-stub code path, rework the
+   `cluster message` `--force-wire` hijack guard, and be verified against
+   real Slack. It also requires overturning a deliberate, pinned design from
+   #451: a requesting-channel card rides the trigger's transport
+   (`kernel.py` around lines 940-945, pinned by
+   `apps/worker/tests/kernel/test_approval_lifecycle.py` lines 522-544). A
+   late resume reply to real Slack also cannot `chat.update` the synthetic
+   placeholder timestamp the offline stub uses, since that timestamp never
+   existed in real Slack, and must post top-level instead. Both are
+   sacred-kernel/`slack_sink.py` design changes that deserve their own ADR,
+   not a passenger on this one. Deferred to Follow-up A.
+2. **A new persistent/daemon reply server, independent of the CLI process.**
+   Rejected as the naive-correct answer for this slice: the stub already
+   kept alive for the pending window is a sufficient durable-enough reply
+   surface for the offline `message` loop, and a standalone server is
+   materially more infrastructure for the same result.
+3. **Hold pending approval state in memory instead of relying on the
+   Postgres `Approval` record.** Already rejected by ADR-0010 (alternative
+   4) for the platform generally; this ADR does not revisit it. The CLI
+   keep-alive is compatible with that rejection because it never holds
+   approval state, only the reply receiver.
+4. **Poll `GET /approvals/{id}` until `status != pending`, then take the next
+   placeholder edit as the resumed reply.** Rejected. This was the initial
+   design and is the more obvious one -- it reuses a client the CLI already
+   builds -- but approval status is the wrong signal. It reports that a human
+   decided, which says nothing about whether the resumed TURN has finished, so
+   the first edit after resolution (a booting notice, or a partial streaming
+   edit) gets printed as the final answer. Guarding that with "wait for the
+   edit AFTER resolution" only moves the race, because a reply landing between
+   two polls is indistinguishable from one landing before them. It also keeps
+   the API on the critical path for the whole pending window, which at cluster
+   tier means holding a second `kubectl port-forward` open across the wait. The
+   stream scan chosen above avoids all of this by construction: it reuses the
+   Valkey connection the enqueue already opened, and inherits `await_reply`'s
+   XACK-means-finalized semantics rather than approximating them.
+5. **A lighter completion signal still (text-diff on the placeholder).**
+   Rejected. Comparing successive placeholder text to guess when the answer
+   stopped changing is a timing heuristic with no terminal signal, and it
+   cannot distinguish a slow model from a finished one.
+
+## Consequences
+
+- The `message` CLI verb's reply-endpoint lifetime changes from
+  "throwaway per-turn" to "alive across the approval-pending window,"
+  qualifying ADR-0020's implicit one-throwaway-stub assumption. No other
+  consumer of `SlackStub`/`await_reply` (`agentos chat`) is affected; its
+  outcome handling is unchanged.
+- No kernel, worker, API, or dispatcher change. The endpoint value the
+  worker already persists on the `Approval` record was already correct; it
+  only needed to be *alive* when the resume posts. This keeps the change
+  entirely within `cli/src`.
+- The offline reply-surface fix does not eliminate the dead-letter case, it
+  shrinks the window in which it occurs. If the CLI's wait times out or the
+  process exits before resolution, a later resolve still falls through to
+  the pre-existing #708 best-effort swallow (transcript-only ACK, not a
+  worker dead-letter). This is unregressed and deliberate; the resume wait's
+  finalization-gated completion and its never-resolved timeout are covered by
+  the Valkey-backed integration test `cli/tests/resume_wait.rs` (skipped when
+  no Valkey is reachable, like the other `chat_enqueue.rs` seam tests), which
+  drives a real resume entry through `await_resume` and asserts a finalized
+  reply, and drives the no-resume case and asserts the timeout (never a false
+  reply). If the resumed turn parks on a NEW gate, the CLI keeps waiting on the
+  nested approval's resume entry rather than exiting and re-stranding it.
+- The awaiting/pending output (human and `--json`) must never claim a
+  durable, clickable card exists when no connected Slack transport does.
+  Offline, the durable resolution surface is the `Approval` record plus
+  `agentos <tier> approvals <agent> --resolve`, and that is what the CLI's
+  hint points at.
+- **Follow-up A -- "Route message-driven approval cards + resumed reply
+  through the connected Slack transport."** Filed as #770. Implements
+  alternative 1 above: when `message` detects a connected transport, skip
+  minting the stub so the card and resume reply post over the worker's
+  default transport to a real Slack thread, giving an actually clickable
+  card. Requires overturning the pinned #451 requesting-channel design and
+  real-Slack E2E verification.
+- **Follow-up B -- "SKILL-tier `approvals --list`/`--resolve` parity with
+  local/cluster."** Filed as #771. `skill message` talks directly to the
+  runner ACI with no dispatcher, Valkey, worker, or resume machinery, so
+  this decision's keep-alive mechanism has nothing to keep alive at that
+  tier. SKILL-tier durable approvals is a distinct, larger change and stays
+  out of scope here.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -92,4 +92,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0060 | [The harness is a declared package, not a class](0060-the-harness-is-a-declared-package.md) | Proposed |
 | 0061 | [The harness boundary is an out-of-process adapter, wire-compatible with Omnigent](0061-out-of-process-harness-boundary.md) | Proposed (gated on a spike, see Decision 5) |
 | 0062 | [Harness conformance has teeth](0062-harness-conformance-has-teeth.md) | Proposed |
+| 0063 | [Message-driven approval reply surface](0063-message-driven-approval-reply-surface.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Driving an approval through `agentos local message` or `agentos cluster message` persisted the approval against the command's in-process reply stub and then exited. The stub died with the process, so the resumed reply had nowhere to land, and the operator was told only that it would strand.

The command now parks on an awaiting-approval outcome instead of exiting, keeping the stub and its Valkey connection alive until the deterministic resume turn arrives. Completion is signalled by that entry's **ack** rather than by polling approval status, so a booting or partial edit can never be mistaken for the final answer and a reply arriving before the first scan is not missed.

Notable details:

- Parks on either signal: the approval card, or an authoritative notice in the placeholder text. The second case matters because route-bound approvals post their card with no endpoint, so no card ever reaches the stub.
- Locates the resume entry by its deterministic event id, scanning forward from the caller's own stream id with an advancing cursor.
- Parses the approval id with structural anchoring and returns no id rather than risk a wrong one.
- Persists the turn before waiting; bounds the nested-gate loop and every per-call timeout by the caller's deadline.
- Emits a resolve command that runs exactly as printed (verified by executing it).

Scope is CLI-only: no change under `apps/`, and the worker kernel's card logic is untouched. The decision is recorded in ADR-0063. Two deliberate deferrals are filed separately: #770 (route message-driven cards through the connected Slack transport, which must overturn the pinned #451 kernel design) and #771 (skill-tier `approvals --list`/`--resolve` parity).

**Verification caveat, stated plainly:** the mechanism is covered by a Valkey-backed integration test that runs against a live server, and the full CLI suite, clippy, fmt, and the docs gate are green. The plan's live-model E2E rung (`AGENTOS_E2E_LIVE=1`) was **not** run — no model credential is available in this environment. That one criterion is unverified here and worth exercising before release.

Closes #766
