### PR TITLE
Declare ephemeral-storage requests and limits on every sandbox container

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -141,6 +141,16 @@ jobs:
           set -euo pipefail
           bash charts/agentos/ci/dispatcher-api-wiring-assertions.sh
 
+      # Prove every sandbox container (runner, both bundle init containers, and
+      # the litellm sidecar when enabled) declares an ephemeral-storage request
+      # AND limit (ADR-0059 decision 1, issue #755), and that the ceiling is
+      # operator-overridable (decision 6). Before this, disk was the one
+      # resource dimension with no ceiling at all.
+      - name: helm render assertions (ephemeral-storage ceilings)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/ephemeral-storage-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/agentos/ci/ephemeral-storage-assertions.sh
+++ b/charts/agentos/ci/ephemeral-storage-assertions.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #755 (ADR-0059 decision 1: no unbounded
+# resource dimension on a sandbox container). Proves:
+#
+#   1. DEFAULT render: the runner container and both bundle init containers
+#      (bundle-fetch, bundle-extract) each carry an `ephemeral-storage`
+#      request AND limit alongside cpu/memory in `resources`.
+#   2. LITELLM render (sidecar enabled): the litellm sidecar carries its own
+#      `ephemeral-storage` request AND limit too, so every container in the
+#      sandbox pod is covered, not just the three that render by default.
+#   3. OVERRIDE: an operator `--set` on `agentSandbox.runner.resources.limits`
+#      changes the rendered ephemeral-storage limit, proving the ceiling is
+#      operator-overridable per ADR-0059 decision 6 (the `RunnerHardening`
+#      precedent), not hardcoded in the template.
+#
+# Before this issue, disk was the one resource dimension with no ceiling at
+# all: no `resources` block anywhere in the chart set `ephemeral-storage`, so
+# every pod's request was zero and the kubelet had nothing to schedule or
+# measure an overrunning pod against -- the only backstop was node-level
+# DiskPressure eviction, which degrades every co-scheduled pod before it fires.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+TPL=templates/agent-sandbox.yaml
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+DEFAULT="$TMP/default.yaml"
+LITELLM="$TMP/litellm.yaml"
+OVERRIDE="$TMP/override.yaml"
+
+echo "=== Rendering SandboxTemplate (defaults) ==="
+helm template rel "$CHART" --show-only "$TPL" > "$DEFAULT"
+
+echo "=== Rendering SandboxTemplate (litellm sidecar enabled) ==="
+helm template rel "$CHART" --show-only "$TPL" \
+  --set agentSandbox.runner.liteLLM.enabled=true \
+  --set agentSandbox.runner.liteLLM.configExistingSecret=my-litellm-cfg > "$LITELLM"
+
+echo "=== Rendering SandboxTemplate (operator override of the runner limit) ==="
+helm template rel "$CHART" --show-only "$TPL" \
+  --set agentSandbox.runner.resources.limits.ephemeral-storage=9Gi > "$OVERRIDE"
+
+ASSERT_PY="$TMP/assert.py"
+cat > "$ASSERT_PY" <<'PY'
+import sys, yaml
+
+
+def sandbox_template(path):
+    for doc in yaml.safe_load_all(open(path)):
+        if doc and doc.get("kind") == "SandboxTemplate":
+            return doc
+    raise SystemExit(f"no SandboxTemplate rendered in {path}")
+
+
+def containers(path):
+    tmpl = sandbox_template(path)
+    spec = tmpl["spec"]["podTemplate"]["spec"]
+    return (spec.get("initContainers") or []) + (spec.get("containers") or [])
+
+
+def check_present(path, expected_names):
+    found = {c["name"]: c for c in containers(path)}
+    missing = set(expected_names) - set(found)
+    if missing:
+        raise SystemExit(f"{path}: expected containers {sorted(missing)} not rendered (got {sorted(found)})")
+    for name in expected_names:
+        res = found[name].get("resources") or {}
+        requests = res.get("requests") or {}
+        limits = res.get("limits") or {}
+        if "ephemeral-storage" not in requests:
+            raise SystemExit(
+                f"{path}: container {name!r} has no ephemeral-storage REQUEST "
+                f"(ADR-0059 decision 1); got requests={requests}"
+            )
+        if "ephemeral-storage" not in limits:
+            raise SystemExit(
+                f"{path}: container {name!r} has no ephemeral-storage LIMIT "
+                f"(ADR-0059 decision 1); got limits={limits}"
+            )
+    print(f"  ok: {sorted(expected_names)} all carry an ephemeral-storage request and limit")
+
+
+def check_override(path, expected_limit):
+    found = {c["name"]: c for c in containers(path)}
+    for name in ("runner", "bundle-fetch", "bundle-extract"):
+        got = (found[name].get("resources") or {}).get("limits", {}).get("ephemeral-storage")
+        if got != expected_limit:
+            raise SystemExit(
+                f"{path}: container {name!r} ephemeral-storage limit override not honored; "
+                f"expected {expected_limit!r}, got {got!r}"
+            )
+    print(f"  ok: runner + both init containers honor the overridden ephemeral-storage limit ({expected_limit})")
+
+
+check_present(sys.argv[1], {"bundle-fetch", "bundle-extract", "runner"})
+check_present(sys.argv[2], {"bundle-fetch", "bundle-extract", "runner", "litellm"})
+check_override(sys.argv[3], "9Gi")
+PY
+
+if ! out="$(python3 "$ASSERT_PY" "$DEFAULT" "$LITELLM" "$OVERRIDE" 2>&1)"; then
+  fail "$out"
+fi
+echo "$out"
+
+echo
+echo "PASS: every sandbox container (runner, bundle-fetch, bundle-extract, and the litellm sidecar when enabled) renders an ephemeral-storage request and limit, and the ceiling is operator-overridable (ADR-0059 decisions 1 and 6)."

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -817,9 +817,17 @@ agentSandbox:
       # Extra env for the sidecar, list of {name, value} (or full env entries with
       # valueFrom.secretKeyRef for provider credentials, e.g. OPENAI_API_KEY).
       extraEnv: []
+      # ephemeral-storage alongside cpu/memory (ADR-0059 decision 1): the sidecar
+      # only reads its mounted config and proxies to an upstream model API, with
+      # no bundle/writable-path volume of its own, so its own disk footprint is
+      # just its writable layer and logs -- a small, fixed ceiling is enough.
+      # Both request (the scheduling-time floor that keeps the node from being
+      # overcommitted) and limit (the periodic-measurement backstop) are
+      # required and do different jobs (decision 2); override either for a
+      # heavier sidecar image.
       resources:
-        requests: { cpu: 50m, memory: 128Mi }
-        limits: { cpu: "1", memory: 512Mi }
+        requests: { cpu: 50m, memory: 128Mi, ephemeral-storage: 64Mi }
+        limits: { cpu: "1", memory: 512Mi, ephemeral-storage: 256Mi }
     # --- Bundle-fetch provisioning ---
     # AGENTOS_BUNDLE_REF is a MinIO object key the substrate injects per-claim
     # (bound sandboxes carry it; warm/unbound pods do not). Before the runner
@@ -839,9 +847,24 @@ agentSandbox:
       # Shared bundle volume mount point in the sandbox pod. The plugin dir the
       # worker injects (AGENTOS_PLUGIN_DIR=/bundles/current) is `<mountPath>/current`.
       mountPath: /bundles
+    # ephemeral-storage alongside cpu/memory (ADR-0059 decision 1): this same
+    # block is reused for the runner container AND both bundle init containers
+    # (bundle-fetch, bundle-extract), matching how cpu/memory already work here.
+    # Disk was previously the one resource dimension with no ceiling at all --
+    # the kubelet had no per-pod ephemeral-storage to schedule against or measure
+    # an overrunning pod against, so node-level DiskPressure eviction was the
+    # only backstop, and it ranks victims by raw usage across the WHOLE node
+    # rather than by fault. Sized to bound a runaway (an agent that clones a
+    # large repo, installs a big dependency tree, or generates large artifacts),
+    # not to constrain that same legitimate work -- a limit tight enough to
+    # break ordinary builder-agent use would be routinely overridden away and
+    # would protect nothing. Both the request (the scheduling-time floor that
+    # keeps a node from being overcommitted) and the limit (the periodic-
+    # measurement backstop) are required and do different jobs (decision 2);
+    # raise either per agent/workload via a values override.
     resources:
-      requests: { cpu: 50m, memory: 192Mi }
-      limits: { cpu: "1", memory: 768Mi }
+      requests: { cpu: 50m, memory: 192Mi, ephemeral-storage: 512Mi }
+      limits: { cpu: "1", memory: 768Mi, ephemeral-storage: 4Gi }
     # --- security rails on the runner surface ---
     # Rail 3: container hardening. non-root + read-only rootfs + dropped caps +
     # no privilege escalation + RuntimeDefault seccomp. readOnlyRootFilesystem


### PR DESCRIPTION
Implements ADR-0059 decision 1 (`docs/adr/0059-sandbox-is-a-bounded-resource-envelope.md`).

No container in the chart declared an `ephemeral-storage` request or limit. `runner.resources` set cpu and memory only, and the same block is reused for the `bundle-fetch` and `bundle-extract` init containers. Disk was therefore the one resource dimension with no ceiling: the kubelet had nothing to schedule against and could not cap or evict an overrunning pod on its own account, leaving node-level `DiskPressure` eviction (which ranks victims by raw usage across the whole node, not by fault) as the only backstop.

## Changes

- `agentSandbox.runner.resources` (shared by the runner container and the `bundle-fetch`/`bundle-extract` init containers) now declares `ephemeral-storage` alongside `cpu`/`memory`: request `512Mi`, limit `4Gi`.
- `agentSandbox.runner.liteLLM.resources` (the LiteLLM sidecar) now declares `ephemeral-storage`: request `64Mi`, limit `256Mi` — the sidecar has no bundle/writable-path volume of its own, so a small fixed ceiling covers its writable layer and logs.
- Both changes are strictly additive to the existing `requests`/`limits` maps; the template already renders `resources` via `toYaml`, so no template change was needed.
- Sizing follows the ADR's decision 6 philosophy: bound a runaway (cloning a large repo, installing a big dependency tree, generating large artifacts), not constrain that same legitimate work. Every value stays operator-overridable via the standard values mechanism (e.g. `--set agentSandbox.runner.resources.limits.ephemeral-storage=8Gi`).
- Added `charts/agentos/ci/ephemeral-storage-assertions.sh`, a render-assert proving every sandbox container (runner, both init containers, and the litellm sidecar when enabled) renders an `ephemeral-storage` request and limit, and that an operator override is honored. Wired into `.github/workflows/helm-ci.yaml` alongside the existing render-assert scripts.

## Out of scope (tracked by ADR-0059, not this issue)

Per-volume `sizeLimit` on the `bundles`/`mc-config`/`writablePaths` `emptyDir` volumes (decision 2), bundle ingestion size/ratio caps (decision 3), the tenant `ResourceQuota`/`LimitRange` (decision 4), and the sandbox `PriorityClass` (decision 5) are separate decisions under the same ADR and are not addressed here.

## Verification

```
helm lint charts/agentos
bash charts/agentos/ci/render-assertions.sh
bash charts/agentos/ci/ephemeral-storage-assertions.sh
bash charts/agentos/ci/sandbox-hardening-assertions.sh
bash charts/agentos/ci/litellm-sidecar-assertions.sh
```
All pass.

Closes #755