### PR TITLE
Set sizeLimit on every writable emptyDir in the sandbox pod

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -132,6 +132,16 @@ jobs:
           set -euo pipefail
           bash charts/agentos/ci/sandbox-hardening-assertions.sh
 
+      # Prove every writable emptyDir volume in the sandbox pod (bundles,
+      # mc-config, and one per hardening.writablePaths entry) carries an
+      # explicit sizeLimit (ADR-0059 decision 2, issue #756), and that a
+      # lengthened writablePaths list still gets one on every entry rather
+      # than only the two default paths.
+      - name: helm render assertions (sandbox emptyDir sizeLimit)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/sandbox-emptydir-sizelimit-assertions.sh
+
       # Prove the dispatcher is told where the platform API is and how to
       # authenticate to it (issue #442). Unwired, it falls back to its code
       # default http://localhost:8000 -- itself -- and every Slack Approve click

--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -315,6 +315,33 @@ Production sizing (raise every `resources` block and persistence size, supply
 real secrets) is covered in **Production sizing** above; PDBs and BYO stores are
 the availability half of the same "not sized for prod out of the box" story.
 
+## Sandbox resource envelope (ADR-0059)
+
+[ADR-0059](../../docs/adr/0059-sandbox-is-a-bounded-resource-envelope.md) treats
+sandbox capacity as a security property, not a performance-tuning afterthought:
+disk is the one resource dimension a sandbox pod could otherwise consume without
+limit. Decision 2 bounds every writable `emptyDir` in the sandbox pod with an
+explicit `sizeLimit`:
+
+| Volume | Values key | Default |
+|---|---|---|
+| `bundles` (fetched archive + extracted plugin dir) | `agentSandbox.runner.bundleFetch.sizeLimit` | `2Gi` |
+| `mc-config` (init-only mc credential dir) | `agentSandbox.runner.bundleFetch.mcConfigSizeLimit` | `16Mi` |
+| One per `agentSandbox.runner.hardening.writablePaths` entry (`/tmp`, `/home/runner` by default) | `agentSandbox.runner.hardening.writablePathSizeLimit` | `512Mi` |
+
+**This is a backstop, not an instantaneous cap.** `sizeLimit` is enforced by
+periodic kubelet measurement of the volume's usage, not a write-time quota, so a
+fast writer can briefly overshoot it before the pod is evicted. That is still a
+meaningful improvement: the offending sandbox is evicted on its own account
+rather than exhausting node disk and pushing the node into `DiskPressure`, which
+degrades every co-scheduled pod including other tenants' sandboxes. Pair it with
+the `ephemeral-storage` request/limit on `agentSandbox.runner.resources` (ADR-0059
+decision 1, tracked in issue #755) for the scheduling-time bound that keeps a node
+from being overcommitted in the first place -- the two are complementary and both
+should be set. Raise any of the values above for a legitimately disk-heavy agent
+(a large repo clone, a big dependency tree, a generated artifact); the defaults
+bound a runaway, not ordinary work.
+
 ## Security rails
 
 The security-boundary rails ship **on by default** (ADR-0006). The runner-surface

--- a/charts/agentos/ci/sandbox-emptydir-sizelimit-assertions.sh
+++ b/charts/agentos/ci/sandbox-emptydir-sizelimit-assertions.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #756 (ADR-0059 decision 2). Every writable
+# `emptyDir` volume in the sandbox pod -- the shared `bundles` volume, the
+# init-only `mc-config` volume, and one volume per `hardening.writablePaths`
+# entry -- must carry an explicit `sizeLimit` so a pod that overruns is
+# evicted on its own account instead of exhausting node disk and taking every
+# co-scheduled pod down with it (node-wide `DiskPressure`). This test pins
+# that every emptyDir volume rendered in the SandboxTemplate carries a
+# non-empty sizeLimit, on both the default `writablePaths` list and a
+# lengthened one, so the mechanism is proven generic rather than hardcoded to
+# `/tmp` and `/home/runner`.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+TPL=templates/agent-sandbox.yaml
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+DEFAULT="$TMP/default.yaml"
+EXTRA_PATH="$TMP/extra-path.yaml"
+
+echo "=== Rendering SandboxTemplate (defaults: bundles, mc-config, /tmp, /home/runner) ==="
+helm template rel "$CHART" --show-only "$TPL" > "$DEFAULT"
+
+echo "=== Rendering SandboxTemplate (a third writablePaths entry appended) ==="
+helm template rel "$CHART" --show-only "$TPL" \
+  --set agentSandbox.runner.hardening.writablePaths[0]=/tmp \
+  --set agentSandbox.runner.hardening.writablePaths[1]=/home/runner \
+  --set agentSandbox.runner.hardening.writablePaths[2]=/var/scratch \
+  --set agentSandbox.runner.hardening.writablePathSizeLimit=256Mi > "$EXTRA_PATH"
+
+ASSERT_PY="$TMP/assert.py"
+cat > "$ASSERT_PY" <<'PY'
+import sys, yaml
+
+
+def sandbox_template(path):
+    for doc in yaml.safe_load_all(open(path)):
+        if doc and doc.get("kind") == "SandboxTemplate":
+            return doc
+    raise SystemExit(f"no SandboxTemplate rendered in {path}")
+
+
+def emptydir_volumes(path):
+    tmpl = sandbox_template(path)
+    spec = tmpl["spec"]["podTemplate"]["spec"]
+    return [v for v in (spec.get("volumes") or []) if "emptyDir" in v]
+
+
+def check(path, expected_names, expected_size_limit=None):
+    volumes = emptydir_volumes(path)
+    names = {v["name"] for v in volumes}
+    missing = set(expected_names) - names
+    if missing:
+        raise SystemExit(
+            f"{path}: expected emptyDir volumes {sorted(missing)} not rendered "
+            f"(got {sorted(names)})"
+        )
+    unset = []
+    for v in volumes:
+        limit = (v.get("emptyDir") or {}).get("sizeLimit")
+        if not limit:
+            unset.append(v["name"])
+    if unset:
+        raise SystemExit(
+            f"{path}: emptyDir volume(s) {sorted(unset)} have no sizeLimit set "
+            "(ADR-0059 decision 2 requires one on every writable emptyDir)"
+        )
+    if expected_size_limit is not None:
+        wrong = {
+            v["name"]: v["emptyDir"]["sizeLimit"]
+            for v in volumes
+            if v["name"].startswith("writable-")
+            and v["emptyDir"]["sizeLimit"] != expected_size_limit
+        }
+        if wrong:
+            raise SystemExit(
+                f"{path}: writablePaths volume(s) did not honor the overridden "
+                f"writablePathSizeLimit={expected_size_limit!r}: {wrong}"
+            )
+    print(f"  ok: {sorted(names)} all carry a non-empty sizeLimit")
+
+
+# Default render: bundles, mc-config, and one writable-N per default
+# writablePaths entry (/tmp, /home/runner -> writable-0, writable-1).
+check(sys.argv[1], {"bundles", "mc-config", "writable-0", "writable-1"})
+
+# A third writablePaths entry must ALSO get a sizeLimit -- proves the
+# mechanism is generic over the list, not hardcoded to two hand-picked paths
+# -- and the overridden writablePathSizeLimit must apply to every one of them.
+check(
+    sys.argv[2],
+    {"bundles", "mc-config", "writable-0", "writable-1", "writable-2"},
+    expected_size_limit="256Mi",
+)
+PY
+
+if ! out="$(python3 "$ASSERT_PY" "$DEFAULT" "$EXTRA_PATH" 2>&1)"; then
+  fail "$out"
+fi
+echo "$out"
+
+echo
+echo "PASS: every emptyDir volume in the rendered sandbox pod (bundles, mc-config, and one per hardening.writablePaths entry, including a lengthened list) carries an explicit, operator-overridable sizeLimit."

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -175,20 +175,29 @@ spec:
         {{- end }}
         {{- if $bf.enabled }}
         # Shared bundle volume: the init pair populates <mountPath>/current, the
-        # runner reads it as AGENTOS_PLUGIN_DIR.
+        # runner reads it as AGENTOS_PLUGIN_DIR. sizeLimit is ADR-0059 decision
+        # 2 -- a fast-writer can still briefly overshoot it (kubelet enforces by
+        # periodic measurement, not a write-time cap), but it bounds an
+        # oversized or zip-bomb-shaped bundle to its own pod's eviction rather
+        # than node-wide DiskPressure.
         - name: bundles
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ $bf.sizeLimit | quote }}
         # mc writes the MinIO credential in cleartext to its config dir. Keep
         # that dir on an init-only volume the runner never mounts, so untrusted
         # agent code cannot read the store credential off the shared bundles
         # volume.
         - name: mc-config
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ $bf.mcConfigSizeLimit | quote }}
         {{- end }}
         {{- if $runner.hardening.enabled }}
         {{- range $i, $p := $runner.hardening.writablePaths }}
+        # sizeLimit is ADR-0059 decision 2 (see hardening.writablePathSizeLimit
+        # in values.yaml for the periodic-measurement caveat).
         - name: writable-{{ $i }}
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ $runner.hardening.writablePathSizeLimit | quote }}
         {{- end }}
         {{- end }}
       {{- end }}

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -839,6 +839,20 @@ agentSandbox:
       # Shared bundle volume mount point in the sandbox pod. The plugin dir the
       # worker injects (AGENTOS_PLUGIN_DIR=/bundles/current) is `<mountPath>/current`.
       mountPath: /bundles
+      # ADR-0059 decision 2: ceiling on the shared `bundles` emptyDir (the
+      # fetched archive plus the extracted plugin dir), so an oversized or
+      # zip-bomb-shaped bundle exhausts its own pod's envelope instead of node
+      # disk. Raise per-agent for a legitimately large bundle. NOTE: sizeLimit
+      # is enforced by periodic kubelet measurement, not a write-time cap -- a
+      # fast writer can overshoot it briefly before the pod is evicted. That
+      # makes it a fast, attributable backstop, not an instantaneous quota;
+      # pair it with the `runner.resources` `ephemeral-storage` request/limit
+      # (ADR-0059 decision 1, tracked in #755) for the scheduling-time bound.
+      sizeLimit: 2Gi
+      # Ceiling on the init-only `mc-config` volume, which holds nothing but
+      # the mc credential file written by the bundle-fetch init container.
+      # Small and fixed since nothing else is ever written there.
+      mcConfigSizeLimit: 16Mi
     resources:
       requests: { cpu: 50m, memory: 192Mi }
       limits: { cpu: "1", memory: 768Mi }
@@ -860,6 +874,18 @@ agentSandbox:
       # Python both write under HOME/tmp; pointing HOME at a writable emptyDir
       # keeps the root filesystem read-only.
       home: /home/runner
+      # ADR-0059 decision 2: ceiling applied to EVERY writablePaths emptyDir
+      # (one shared default rather than a per-path value, since writablePaths
+      # is a plain path list, not a list of objects -- restructuring it into
+      # {path, sizeLimit} entries just to carry one differing value per path
+      # wasn't worth the schema churn). Sized for CLI/interpreter scratch and
+      # tmp writes, not for durable output (that belongs in the `bundles`
+      # volume or an external store). Raise it for a writablePaths entry a
+      # heavy agent legitimately fills. Same periodic-measurement caveat as
+      # bundleFetch.sizeLimit above: the kubelet samples usage rather than
+      # capping writes inline, so this is a fast, attributable backstop (the
+      # offending pod is evicted, not the node degraded), not a hard quota.
+      writablePathSizeLimit: 512Mi
     # Rail 4 (gVisor kernel isolation) is controlled by security.gvisor.mode
     # below -- the effective pod runtimeClassName is computed from that tri-state,
     # not set here.


### PR DESCRIPTION
Implements ADR-0059 decision 2 (`docs/adr/0059-sandbox-is-a-bounded-resource-envelope.md`).

Every writable volume in the sandbox pod was an unbounded `emptyDir` with no `sizeLimit`: the shared `bundles` volume, the init-only `mc-config` volume, and one volume per `hardening.writablePaths` entry (`/tmp` and `/home/runner` by default), in `charts/agentos/templates/agent-sandbox.yaml`.

## Changes

- Each of those `emptyDir` volumes now sets an explicit, operator-overridable `sizeLimit`, sourced from new `values.yaml` keys:
  - `agentSandbox.runner.bundleFetch.sizeLimit` (default `2Gi`) -- the shared `bundles` volume (fetched archive + extracted plugin dir).
  - `agentSandbox.runner.bundleFetch.mcConfigSizeLimit` (default `16Mi`) -- the init-only `mc-config` volume, which holds only the mc credential file.
  - `agentSandbox.runner.hardening.writablePathSizeLimit` (default `512Mi`) -- applied to every `hardening.writablePaths` entry's volume.
- **Schema choice:** `writablePaths` stays a plain list of path strings. Rather than restructuring it into a list of `{path, sizeLimit}` objects to allow a differing ceiling per path, one shared default (`writablePathSizeLimit`) applies to every entry in the list. Both default paths (`/tmp`, `/home/runner`) are CLI/interpreter scratch with similar usage patterns, so a single ceiling reads more naturally than schema churn on an existing key, and it generalizes automatically to a lengthened `writablePaths` list without further chart changes.
- Documents the enforcement caveat -- `sizeLimit` is enforced by periodic kubelet measurement, not a write-time cap, so a fast writer can briefly overshoot it -- as comments next to each new values key, next to the template's volume definitions, and in a new "Sandbox resource envelope (ADR-0059)" section of `charts/agentos/README.md`. That section also cross-references the `ephemeral-storage` request/limit tracked separately in #755 (ADR-0059 decision 1) as the complementary scheduling-time bound, without depending on it landing first.
- Adds `charts/agentos/ci/sandbox-emptydir-sizelimit-assertions.sh`, a render-assert proving every `emptyDir` volume in a rendered `SandboxTemplate` carries a non-empty `sizeLimit`, both on the default `writablePaths` list and on a lengthened one (proving the mechanism is generic over the list rather than hardcoded to `/tmp`/`/home/runner`), and wires it into `.github/workflows/helm-ci.yaml` alongside the existing sandbox-hardening assertion.

## Verification

```
helm lint charts/agentos
helm template charts/agentos --show-only templates/agent-sandbox.yaml
bash charts/agentos/ci/sandbox-emptydir-sizelimit-assertions.sh
bash charts/agentos/ci/sandbox-hardening-assertions.sh
```

All pass. `helm template` for the default, dev, and e2e-nogvisor overlays render cleanly with the new keys.

Closes #756