### PR TITLE
Bound the thread-reset drain to a per-tick budget

### DIFF
--- a/apps/worker/src/agentos_worker/consumer.py
+++ b/apps/worker/src/agentos_worker/consumer.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import UTC, datetime
 from typing import cast
 
@@ -69,6 +70,18 @@ _CAP_SCAN_PAGE = 1000
 # administrative signal has no ordering/redelivery/dead-letter needs, so a
 # plain Valkey SET is enough.
 THREAD_RESET_SET = "agentos:thread-reset-requests"
+
+# Per-tick time budget for draining THREAD_RESET_SET (#743, follow-up to
+# #739). #739 bounded the courtesy interrupt to 5s per *request*, but the
+# drain itself is a serial `while True` over the whole set, inline in
+# `_maintenance_loop` alongside `_reclaim_once`/`reap_orphans` -- so N wedged
+# resets in one tick still cost N x the per-request bound of no stream
+# reclaim and no orphan reaping, just scaled by operator batch size instead
+# of by the runner's timeout. Once this budget is spent, the drain stops for
+# this tick; `SPOP` only removes what it actually pops, so anything still in
+# the set is picked up on the next tick rather than blocking the rest of the
+# maintenance work behind an arbitrarily large batch.
+_THREAD_RESET_DRAIN_BUDGET_S = 30.0
 
 
 class Consumer(StreamConsumer):
@@ -305,7 +318,16 @@ class Consumer(StreamConsumer):
         logged and does not block the rest of the batch; the request is
         already popped, so a release that fails needs a fresh request to
         retry -- acceptable for a manual operator action, unlike the queue's
-        own bounded-retry delivery guarantee."""
+        own bounded-retry delivery guarantee.
+
+        The loop is also bounded by ``_THREAD_RESET_DRAIN_BUDGET_S`` (#743): a
+        large operator-populated batch of wedged resets stops draining once
+        the budget is spent, rather than serially paying every request's
+        release bound inline in this tick. Members not yet popped simply stay
+        in ``THREAD_RESET_SET`` and are drained on a later tick -- safe
+        because ``SPOP`` never removes a member without this loop taking
+        ownership of it in the same step."""
+        start = time.monotonic()
         while True:
             raw = await self._valkey.spop(THREAD_RESET_SET)
             if raw is None:
@@ -325,6 +347,13 @@ class Consumer(StreamConsumer):
                 )
             except Exception:
                 logger.exception("thread reset failed for %s", thread_key)
+            if time.monotonic() - start >= _THREAD_RESET_DRAIN_BUDGET_S:
+                logger.warning(
+                    "thread reset drain: per-tick budget (%.0fs) spent; "
+                    "deferring any remaining requests to the next maintenance tick",
+                    _THREAD_RESET_DRAIN_BUDGET_S,
+                )
+                return
 
     async def _reclaim_once(self) -> int:
         """Reclaim entries pending too long from any (dead) consumer and retry.

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -97,6 +97,18 @@ _EXPIRY_RESUME_MARKER = "[approval expired]"
 # silently change which error an operator sees in the log.
 _RESET_INTERRUPT_TIMEOUT_S = 5.0
 
+# The substrate release itself (#743) runs on `asyncio.to_thread`, which is not
+# cancellable -- a hang in the K8s control plane (as opposed to a wedged
+# runner, already bounded above) would otherwise park the maintenance tick on
+# this await indefinitely, the same stall shape as an unbounded interrupt.
+# Wrapping it in `asyncio.wait_for` cannot stop the underlying thread (the
+# executor slot stays occupied until the call actually returns), but it does
+# return control to the caller so the tick is not held hostage by it; a timed
+# out release surfaces as any other release failure does -- logged by the
+# drain loop's per-request handler, with the request already popped so a
+# fresh reset request is needed to retry.
+_RESET_RELEASE_TIMEOUT_S = 5.0
+
 
 @dataclass
 class TurnOutcome:
@@ -499,6 +511,14 @@ class Kernel:
         release then runs unconditionally. `CancelledError` is deliberately not
         swallowed, so worker shutdown still cuts through.
 
+        The release itself is also bounded, to `_RESET_RELEASE_TIMEOUT_S` (#743):
+        a hang in the K8s control plane rather than the runner would otherwise
+        stall this `asyncio.to_thread` -- and therefore the whole maintenance
+        tick behind it -- indefinitely too, since `to_thread` is not
+        cancellable. A timed-out release is NOT swallowed here; it propagates
+        like any other release failure, which the drain loop's per-request
+        handler already logs and isolates from the rest of the batch.
+
         The failure log is an ERROR, not a warning: it is the only record that a
         sandbox was pulled out from under a turn that may still be running, and
         there is no retry that would produce a second, louder signal. The two
@@ -541,7 +561,10 @@ class Kernel:
                 logger.info(
                     "reset: no live runner to interrupt on thread %s", thread_key
                 )
-        return await asyncio.to_thread(self._substrate.release, thread_key)
+        return await asyncio.wait_for(
+            asyncio.to_thread(self._substrate.release, thread_key),
+            _RESET_RELEASE_TIMEOUT_S,
+        )
 
     def attach_killswitch(self, killswitch: KillSwitch) -> None:
         """Wire the kill switch after construction (it needs interrupt_agent)."""

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 import redis.exceptions
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from agentos_dispatcher.queue import to_stream_fields
+from agentos_worker import consumer as consumer_module
 from agentos_worker import kernel as kernel_module
 from agentos_worker.consumer import THREAD_RESET_SET, Consumer
 
@@ -324,5 +325,93 @@ def test_maintenance_tick_thread_reset_one_failure_does_not_block_the_rest(
             assert h.substrate.lookup("tOk") is None  # still processed despite tBoom's failure
             assert await h.async_redis.scard(THREAD_RESET_SET) == 0  # both popped either way
             assert any("tBoom" in r.getMessage() for r in caplog.records)
+
+    asyncio.run(go())
+
+
+def test_maintenance_tick_reset_drain_has_a_per_tick_budget_and_defers_the_rest(
+    make_harness, monkeypatch
+) -> None:
+    """#743: a large operator-populated batch of wedged resets must not cost
+    N x the per-request release bound inline in one maintenance tick -- that
+    re-crosses the same multi-hundred-second stall #739 set out to eliminate,
+    just scaled by batch size instead of by the runner's HTTP timeout. The
+    drain now stops once its per-tick time budget is spent and leaves
+    whatever is left in THREAD_RESET_SET for a later tick, so one call to
+    ``_drain_thread_reset_requests`` never blocks proportionally to N."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            budget_s = 0.2
+            monkeypatch.setattr(consumer_module, "_THREAD_RESET_DRAIN_BUDGET_S", budget_s)
+
+            processed: list[str] = []
+
+            async def slow_release_thread(thread_key: str) -> bool:
+                processed.append(thread_key)
+                await asyncio.sleep(0.05)  # each request "wedged" for a while
+                return True
+
+            h.kernel.release_thread = slow_release_thread  # type: ignore[method-assign]
+
+            # A batch large enough that draining it all at 0.05s/request would
+            # take roughly 1s -- five times the budget.
+            keys = [f"tBatch{i}" for i in range(20)]
+            await h.async_redis.sadd(THREAD_RESET_SET, *keys)
+
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            start = time.monotonic()
+            await asyncio.wait_for(consumer._drain_thread_reset_requests(), timeout=2.0)
+            elapsed = time.monotonic() - start
+
+            # Bounded by the budget (plus slack for the one in-flight request
+            # that pushed the check past it), not by N * per-request cost.
+            assert elapsed < 0.6
+            assert len(processed) < len(keys)  # did not drain the whole batch in one pass
+            remaining = await h.async_redis.scard(THREAD_RESET_SET)
+            assert remaining > 0  # the rest is left for the next tick, not lost
+
+            # A later tick picks up where this one left off: draining again
+            # (with the budget restored to a generous value) finishes the batch.
+            monkeypatch.setattr(consumer_module, "_THREAD_RESET_DRAIN_BUDGET_S", 30.0)
+            await asyncio.wait_for(consumer._drain_thread_reset_requests(), timeout=5.0)
+            assert await h.async_redis.scard(THREAD_RESET_SET) == 0
+            assert len(processed) == len(keys)
+
+    asyncio.run(go())
+
+
+def test_maintenance_tick_thread_reset_is_not_stalled_by_a_hanging_substrate_release(
+    make_harness, monkeypatch
+) -> None:
+    """#743: the courtesy interrupt bound (#739) only covers a wedged runner.
+    `release_thread`'s own substrate release runs on a bare `asyncio.to_thread`
+    with no timeout, so a hang in the K8s control plane -- a claim delete that
+    never returns -- would stall the tick just as unboundedly. The release
+    call must be bounded the same way the interrupt already is."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", thread="tHangRelease"))
+            assert h.substrate.lookup("tHangRelease") is not None
+
+            monkeypatch.setattr(kernel_module, "_RESET_RELEASE_TIMEOUT_S", 0.2)
+
+            def hanging_release(thread_key: str) -> bool:
+                time.sleep(5.0)  # never returns within the test's window
+                return True
+
+            monkeypatch.setattr(h.substrate, "release", hanging_release)
+
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await h.async_redis.sadd(THREAD_RESET_SET, "tHangRelease")
+
+            # Must finish well under the 5s hang, bounded instead by the
+            # (monkeypatched) release timeout.
+            await asyncio.wait_for(consumer._drain_thread_reset_requests(), timeout=2.0)
+
+            # The request was popped either way; a fresh reset is needed to retry.
+            assert await h.async_redis.scard(THREAD_RESET_SET) == 0
 
     asyncio.run(go())


### PR DESCRIPTION
## Summary

Follow-up to #739. That fix bounded the courtesy interrupt to 5s per *request*, but `Consumer._drain_thread_reset_requests` still SPOPs the whole reset set in a serial loop inline in `_maintenance_loop`, alongside `_reclaim_once` and `reap_orphans`. A large operator-populated batch of wedged resets therefore still costs N times the per-request bound of no stream reclaim and no orphan reaping in one tick, just scaled by batch size instead of by the runner's HTTP timeout.

- `_drain_thread_reset_requests` now stops draining once a per-tick time budget (`_THREAD_RESET_DRAIN_BUDGET_S`, 30s) is spent. `SPOP` only removes what it actually pops, so anything left in `THREAD_RESET_SET` is picked up on a later tick instead of blocking the rest of the maintenance work behind an arbitrarily large batch.
- `Kernel.release_thread`'s substrate-release `asyncio.to_thread` call had no timeout either, so a hang in the K8s control plane (as opposed to an unresponsive runner, already bounded) could stall the tick just as unboundedly. It is now wrapped in `asyncio.wait_for` with its own bound (`_RESET_RELEASE_TIMEOUT_S`, 5s); a timed-out release surfaces like any other release failure, already handled by the drain loop's per-request try/except.

## Sensitive module note

`kernel.py` and `consumer.py` are called out in `apps/worker/CLAUDE.md` as the sacred single-owner kernel module (correctness logic with concurrency races), so this should get a careful/adversarial review before merging, per that file's convention. The changes here are intentionally narrow: a time budget check in the existing drain loop, and one added `asyncio.wait_for` around an existing `asyncio.to_thread` call, with no changes to locking, routing, or retry semantics.

## Test plan

- Added `test_maintenance_tick_reset_drain_has_a_per_tick_budget_and_defers_the_rest`: a 20-request wedged batch does not drain in one pass once the budget is spent, and a subsequent call finishes the rest.
- Added `test_maintenance_tick_thread_reset_is_not_stalled_by_a_hanging_substrate_release`: a substrate release that hangs indefinitely no longer stalls the drain past the (monkeypatched) release timeout.
- `uv run pytest apps/worker/tests -q` -> 506 passed, 1 skipped
- `uv run ruff check apps/worker` -> all checks passed
- `uv run mypy apps/worker/src/agentos_worker/consumer.py apps/worker/src/agentos_worker/kernel.py` -> no issues

Closes #743