### PR TITLE
Add PriorityClass so platform pods outrank sandbox pods

### DIFF
--- a/charts/agentos/ci/render-assertions.sh
+++ b/charts/agentos/ci/render-assertions.sh
@@ -290,5 +290,116 @@ if check_runner_env "$MUTANT" "mutant (AGENTOS_SANDBOX_ID -> AGENTOS_SANBOX_ID)"
 fi
 echo "  ok: misspelled runner env name is rejected (the assert can fail)"
 
+echo "=== Assertion 8: priorityClassName on every control-plane pod + the sandbox (ADR-0059 decision 5, #759) ==="
+# The control plane (worker, api, dispatcher, data tier: postgres, valkey,
+# clickhouse, minio) must outrank sandbox pods for node-pressure eviction, so
+# the components that supervise, drain, and reclaim a sandbox are never
+# themselves preferred for eviction over the sandboxes they manage. Render with
+# the dispatcher enabled (it needs both Slack tokens to render at all) so every
+# control-plane pod is present in one pass.
+PRIO_OUT="$(mktemp -d -p "$TMP")"
+helm template "$CHART" --output-dir "$PRIO_OUT" \
+  --set dispatcher.slack.appToken=xapp-render-assert \
+  --set dispatcher.slack.botToken=xoxb-render-assert \
+  > /dev/null
+
+PRIO_CHECK="$TMP/check_priority_class.py"
+cat > "$PRIO_CHECK" <<'PYEOF'
+"""Assert priorityClassName on every control-plane pod template and the
+sandbox pod template.
+
+argv: <rendered-dir> <expected-platform-name> <expected-sandbox-name>
+Exits 0 on pass, 1 naming the offending workload on failure.
+"""
+import pathlib
+import sys
+
+import yaml
+
+rendered, platform_name, sandbox_name = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Deployment/StatefulSet name suffix -> expected priorityClassName. The data
+# tier (postgres/valkey/clickhouse/minio) and the three first-party services
+# (worker, api, dispatcher) are all control plane per ADR-0059 decision 5;
+# langfuse/ui/inference/otel are deliberately out of scope (not named in the
+# decision).
+EXPECTED = {
+    "-worker": platform_name,
+    "-api": platform_name,
+    "-dispatcher": platform_name,
+    "-postgres": platform_name,
+    "-valkey": platform_name,
+    "-clickhouse": platform_name,
+    "-minio": platform_name,
+}
+
+found = {}
+sandbox_found = []
+for path in sorted(pathlib.Path(rendered).rglob("*.yaml")):
+    for doc in yaml.safe_load_all(path.read_text()):
+        if not isinstance(doc, dict):
+            continue
+        kind = doc.get("kind")
+        if kind in ("Deployment", "StatefulSet"):
+            name = doc.get("metadata", {}).get("name", "")
+            spec = (
+                doc.get("spec", {})
+                .get("template", {})
+                .get("spec", {})
+            )
+            for suffix in EXPECTED:
+                if name.endswith(suffix):
+                    found[suffix] = (name, spec.get("priorityClassName"))
+        elif kind == "SandboxTemplate":
+            spec = doc.get("spec", {}).get("podTemplate", {}).get("spec", {})
+            sandbox_found.append((doc.get("metadata", {}).get("name", ""), spec.get("priorityClassName")))
+
+missing = sorted(set(EXPECTED) - set(found))
+if missing:
+    sys.stderr.write(f"render is missing expected control-plane workload(s): {missing}\n")
+    sys.exit(1)
+
+mismatched = [
+    (suffix, name, got, EXPECTED[suffix])
+    for suffix, (name, got) in found.items()
+    if got != EXPECTED[suffix]
+]
+if mismatched:
+    for suffix, name, got, want in mismatched:
+        sys.stderr.write(
+            f"workload '{name}' (matched by suffix '{suffix}') has "
+            f"priorityClassName={got!r}, expected {want!r}\n")
+    sys.exit(1)
+
+if not sandbox_found:
+    sys.stderr.write("found no SandboxTemplate in the render; the sandbox assert would pass vacuously\n")
+    sys.exit(1)
+
+sandbox_mismatched = [(n, got) for n, got in sandbox_found if got != sandbox_name]
+if sandbox_mismatched:
+    for name, got in sandbox_mismatched:
+        sys.stderr.write(
+            f"SandboxTemplate '{name}' has priorityClassName={got!r}, expected {sandbox_name!r}\n")
+    sys.exit(1)
+
+print(f"  ok: {len(found)} control-plane workloads carry priorityClassName={platform_name!r}; "
+      f"SandboxTemplate carries priorityClassName={sandbox_name!r}")
+PYEOF
+
+python3 "$PRIO_CHECK" "$PRIO_OUT" "agentos-platform" "agentos-sandbox" \
+  || fail "default render did not set the expected priorityClassName on every control-plane pod and the sandbox."
+
+echo "=== Assertion 9: priorityClassName names are operator-overridable (additive values, #759) ==="
+PRIO_OVERRIDE_OUT="$(mktemp -d -p "$TMP")"
+helm template "$CHART" --output-dir "$PRIO_OVERRIDE_OUT" \
+  --set dispatcher.slack.appToken=xapp-render-assert \
+  --set dispatcher.slack.botToken=xoxb-render-assert \
+  --set priorityClasses.platform.name=custom-platform-class \
+  --set priorityClasses.sandbox.name=custom-sandbox-class \
+  > /dev/null
+python3 "$PRIO_CHECK" "$PRIO_OVERRIDE_OUT" "custom-platform-class" "custom-sandbox-class" \
+  || fail "overriding priorityClasses.platform.name/sandbox.name did not propagate to priorityClassName on the rendered pods."
+echo "  ok: overriding priorityClasses.platform.name/sandbox.name propagates to every control-plane pod and the sandbox"
+
 echo
-echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path; every runner boot-env name is a declared contract key (proven by a failing negative control)."
+echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod and the sandbox render with the expected priorityClassName, including under operator override."

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -126,6 +126,9 @@ spec:
       serviceAccountName: {{ include "agentos.fullname" . }}-runner
       automountServiceAccountToken: {{ $runner.serviceAccount.automountToken }}
       {{- end }}
+      {{- with .Values.priorityClasses.sandbox.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- $gvisorClass := include "agentos.gvisor.runtimeClassName" . }}
       {{- if $gvisorClass }}
       # Kernel-isolation RuntimeClass from security.gvisor.mode. In `auto` this is

--- a/charts/agentos/templates/api.yaml
+++ b/charts/agentos/templates/api.yaml
@@ -36,6 +36,9 @@ spec:
       # The runner-logs proxy lists pods and reads pod logs via the K8s API, so
       # the API pod runs as its own ServiceAccount (see api-rbac.yaml).
       serviceAccountName: {{ include "agentos.fullname" . }}-api
+      {{- with .Values.priorityClasses.platform.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.api.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/agentos/templates/clickhouse.yaml
+++ b/charts/agentos/templates/clickhouse.yaml
@@ -35,6 +35,9 @@ spec:
         {{- include "agentos.labels" . | nindent 8 }}
         {{- include "agentos.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 8 }}
     spec:
+      {{- with .Values.priorityClasses.platform.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         fsGroup: {{ .Values.clickhouse.podSecurityContext.fsGroup }}
       {{- if not .Values.clickhouse.persistence.enabled }}

--- a/charts/agentos/templates/dispatcher.yaml
+++ b/charts/agentos/templates/dispatcher.yaml
@@ -25,6 +25,9 @@ spec:
         {{- include "agentos.labels" . | nindent 8 }}
         {{- include "agentos.selectorLabels" (dict "root" . "component" "dispatcher") | nindent 8 }}
     spec:
+      {{- with .Values.priorityClasses.platform.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.dispatcher.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/agentos/templates/minio.yaml
+++ b/charts/agentos/templates/minio.yaml
@@ -34,6 +34,9 @@ spec:
         {{- include "agentos.labels" . | nindent 8 }}
         {{- include "agentos.selectorLabels" (dict "root" . "component" "minio") | nindent 8 }}
     spec:
+      {{- with .Values.priorityClasses.platform.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         fsGroup: {{ .Values.minio.podSecurityContext.fsGroup }}
       {{- if not .Values.minio.persistence.enabled }}

--- a/charts/agentos/templates/postgres.yaml
+++ b/charts/agentos/templates/postgres.yaml
@@ -32,6 +32,9 @@ spec:
         {{- include "agentos.labels" . | nindent 8 }}
         {{- include "agentos.selectorLabels" (dict "root" . "component" "postgres") | nindent 8 }}
     spec:
+      {{- with .Values.priorityClasses.platform.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         fsGroup: {{ .Values.postgres.podSecurityContext.fsGroup }}
       {{- if not .Values.postgres.persistence.enabled }}

--- a/charts/agentos/templates/priorityclass.yaml
+++ b/charts/agentos/templates/priorityclass.yaml
@@ -1,0 +1,45 @@
+{{/*
+  ADR-0059 decision 5: the control plane (worker, api, dispatcher, data tier)
+  outranks sandbox pods for node-pressure eviction, so the components required
+  to supervise, drain, and reclaim a sandbox are never themselves preferred for
+  eviction over the sandboxes they manage. Priority is a ranking and preemption
+  lever, not immunity -- a node fully out of a resource (e.g. disk) can still
+  take anything down regardless of priority.
+
+  Both PriorityClasses are cluster-scoped. `priorityClasses.sandbox.name` is
+  also the intended `scopeSelector` handle for the sandbox-namespace
+  ResourceQuota (issue #758).
+*/}}
+{{- if .Values.priorityClasses.platform.create }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClasses.platform.name }}
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: priority-class
+value: {{ .Values.priorityClasses.platform.value }}
+globalDefault: false
+description: >-
+  ADR-0059 decision 5: the AgentOS control plane (worker, api, dispatcher, data
+  tier) outranks sandbox pods for node-pressure eviction, so the components
+  that supervise, drain, and reclaim a sandbox are never themselves evicted
+  ahead of it. Priority is a ranking and preemption lever, not immunity.
+{{- end }}
+{{- if .Values.priorityClasses.sandbox.create }}
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClasses.sandbox.name }}
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: priority-class
+value: {{ .Values.priorityClasses.sandbox.value }}
+globalDefault: false
+description: >-
+  ADR-0059 decision 5: AgentOS sandbox runner pods. Ranked below
+  {{ .Values.priorityClasses.platform.name }} for node-pressure eviction; also
+  the scopeSelector handle for the sandbox-namespace ResourceQuota (issue
+  #758) -- keep the two in sync if renamed.
+{{- end }}

--- a/charts/agentos/templates/valkey.yaml
+++ b/charts/agentos/templates/valkey.yaml
@@ -32,6 +32,9 @@ spec:
         {{- include "agentos.labels" . | nindent 8 }}
         {{- include "agentos.selectorLabels" (dict "root" . "component" "valkey") | nindent 8 }}
     spec:
+      {{- with .Values.priorityClasses.platform.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         fsGroup: 999
       {{- if not .Values.valkey.persistence.enabled }}

--- a/charts/agentos/templates/worker.yaml
+++ b/charts/agentos/templates/worker.yaml
@@ -70,6 +70,9 @@ spec:
       {{- if .Values.worker.serviceAccount.create }}
       serviceAccountName: {{ include "agentos.fullname" . }}-worker
       {{- end }}
+      {{- with .Values.priorityClasses.platform.name }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.worker.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -25,6 +25,36 @@ global:
   storageClass: ""
 
 # ---------------------------------------------------------------------------
+# PriorityClass (ADR-0059 decision 5): ranks the control plane -- worker, api,
+# dispatcher, and the data tier (postgres, valkey, clickhouse, minio) -- above
+# sandbox pods for node-pressure eviction, so the components that supervise,
+# drain, and reclaim a sandbox are never themselves preferred for eviction over
+# the sandboxes they manage. Priority is a ranking and preemption lever, not
+# immunity: a node fully out of a resource (e.g. disk) can still take anything
+# down regardless of priority.
+#
+# Both names are cluster-scoped (PriorityClass has no namespace), so installing
+# a second agentos release into the SAME cluster must override one release's
+# names to avoid an ownership conflict. `sandbox.name` is also the intended
+# `scopeSelector` handle for the sandbox-namespace ResourceQuota (issue #758) --
+# keep the two in sync if you rename it.
+# ---------------------------------------------------------------------------
+priorityClasses:
+  platform:
+    # Renders the PriorityClass and sets priorityClassName on every
+    # control-plane pod. Set false (and repoint `name` at an existing class) if
+    # the cluster/another release already defines an equivalent one.
+    create: true
+    name: agentos-platform
+    value: 1000000
+  sandbox:
+    # Renders the PriorityClass and sets priorityClassName on the sandbox
+    # runner pod template.
+    create: true
+    name: agentos-sandbox
+    value: 100000
+
+# ---------------------------------------------------------------------------
 # Langfuse app (web + worker). The observability + eval backbone. Its backing
 # stores (Postgres, ClickHouse, Valkey, MinIO) are the separate blocks below so
 # each can be toggled or BYO'd independently.


### PR DESCRIPTION
Closes #759

Implements ADR-0059 (`docs/adr/0059-sandbox-is-a-bounded-resource-envelope.md`) decision 5: with every pod at equal priority, the control plane competes for node-pressure eviction on equal footing with the sandboxes it is supposed to supervise, drain, and reclaim.

## Changes

- New `charts/agentos/templates/priorityclass.yaml` renders two cluster-scoped `PriorityClass` objects:
  - **`agentos-platform`** (value `1000000`) for the control plane.
  - **`agentos-sandbox`** (value `100000`) for sandbox pods.
- `priorityClassName` set on:
  - Control plane: `worker`, `api`, `dispatcher`, and the data tier (`postgres`, `valkey`, `clickhouse`, `minio`).
  - Sandbox: the `agent-sandbox.yaml` `SandboxTemplate` pod (also covers the `SandboxWarmPool`, which references the same template).
- Both names are new, additive `values.yaml` keys: `priorityClasses.platform.name` / `priorityClasses.sandbox.name` (plus a `create` flag and `value` on each), so an operator can repoint at an existing class or change the ranking without editing templates. No existing `values.yaml` keys were touched or reflowed.
- Extended `charts/agentos/ci/render-assertions.sh` with two new assertions: the default render sets `priorityClassName` on every control-plane workload and the sandbox `SandboxTemplate`, and overriding `priorityClasses.platform.name`/`priorityClasses.sandbox.name` propagates correctly.

Per the ADR: priority is a ranking and preemption lever, not immunity — a node fully out of a resource (e.g. disk) can still take anything down regardless of priority. The goal is only that platform pods are never *preferred* for eviction over sandboxes.

**Note for #758 (ResourceQuota, in parallel):** the sandbox `PriorityClass` name is `agentos-sandbox`, exposed as `priorityClasses.sandbox.name` in `values.yaml` — use that value as the `scopeSelector` handle rather than hardcoding the literal, in case it's overridden.

## Verification

```
bash charts/agentos/ci/render-assertions.sh
```
passes locally (all 9 assertions, including the 2 new ones for `priorityClassName`). Also ran `helm lint charts/agentos` (clean) and manually confirmed a negative-control mutation of one template's `priorityClassName` is caught by the new assertion before reverting it.