### PR TITLE
Ship a tenant ResourceQuota and LimitRange for the sandbox namespace

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -141,6 +141,18 @@ jobs:
           set -euo pipefail
           bash charts/agentos/ci/dispatcher-api-wiring-assertions.sh
 
+      # Prove the tenant capacity ceiling (issue #758, ADR-0059 decision 4): the
+      # ResourceQuota scopes to the sandbox PriorityClass with the published
+      # (overridable) hard ceilings, the LimitRange ships safe default-only
+      # per-container defaults, both toggle independently and with
+      # agentSandbox.deploy, and the N=1 self-host control plane stays fully
+      # self-declared on cpu/memory (so the new LimitRange defaults never
+      # engage for it).
+      - name: helm render assertions (tenant capacity: ResourceQuota + LimitRange)
+        run: |
+          set -euo pipefail
+          bash charts/agentos/ci/tenant-capacity-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -331,6 +331,7 @@ sandbox and renders whenever an in-chart store is deployed.
 | 3. Non-root / read-only rootfs | Pod + container securityContext on the runner: `runAsNonRoot`, uid 1000, `readOnlyRootFilesystem`, drop ALL caps, no privilege escalation, RuntimeDefault seccomp, plus writable emptyDir scratch (`/tmp`, `/home/runner`) and `HOME`. | `agentSandbox.runner.hardening.*` |
 | 4. gVisor kernel isolation | `runtimeClassName` on runner pods, driven by the `security.gvisor.mode` tri-state (`auto`/`require`/`off`) + a preflight that fails the install if the RuntimeClass is missing or downgraded, firing in `require` (always) and in `auto` for real-model runs + an optional RuntimeClass object. | `security.gvisor.*`, `security.gvisorPreflight.*` |
 | 5. Data-tier ingress isolation | Per deployed store (Postgres, MinIO, ClickHouse, Valkey): a default-deny-ingress NetworkPolicy plus a scoped-allow that permits ingress on the store's ports ONLY from this release's app pods (`name`+`instance` label). Blocks any co-tenant pod from opening `Postgres:5432` etc. | `security.dataTierNetworkPolicy.*` |
+| 6. Tenant capacity ceiling | A `ResourceQuota` bounding aggregate cpu/memory/ephemeral-storage and sandbox pod count, plus a `LimitRange` supplying per-container defaults so a sandbox pod created outside this chart's own templates still inherits a ceiling. Renders whenever `agentSandbox.deploy: true`. | `resourceQuota.*`, `limitRange.*` |
 
 **Fail-closed egress.** `security.networkPolicy.allowedEgress` is EMPTY by
 default: a fresh install denies all egress except DNS until the operator declares
@@ -384,6 +385,24 @@ non-enforcing CNI.
 The class name and handler live on `security.gvisor.runtimeClassName` / `.handler`;
 set `security.gvisor.installRuntimeClass=true` to have the chart create the
 RuntimeClass object (the node must still provide the runtime).
+
+**Tenant capacity ceiling (ADR-0059 decision 4).** ADR-0008 makes the namespace
+a reachability boundary (namespace-per-tenant compute); the `ResourceQuota` and
+`LimitRange` complete it with a bound on consumption, since nodes are shared
+beneath the namespace and one tenant's sandboxes can otherwise exhaust node
+capacity another tenant's sandboxes depend on. The `ResourceQuota` is scoped
+via `scopeSelector` to the sandbox `PriorityClass` name
+(`resourceQuota.sandboxPriorityClassName`, default `agentos-sandbox` -- the
+name ADR-0059 decision 5's `PriorityClass` is expected to define), so it binds
+only sandbox pods and not the control plane or data tier that, in the N=1
+self-host topology, share this same release namespace. The `LimitRange` has no
+scope (Kubernetes does not support one on `LimitRange`) and so applies
+namespace-wide, but ships `default`/`defaultRequest` only -- never `min`/`max`
+-- so it only ever fills a resource dimension a container leaves undeclared
+(today, `ephemeral-storage` everywhere in the chart) and can never reject an
+already-configured control-plane pod at admission time. Both objects are
+independently toggleable (`resourceQuota.enabled`, `limitRange.enabled`,
+each default `true`) and every ceiling is overridable, per ADR-0059 decision 6.
 
 **Verifying the rails.** The security-boundary probe suite re-runs as a `helm test`:
 

--- a/charts/agentos/ci/tenant-capacity-assertions.sh
+++ b/charts/agentos/ci/tenant-capacity-assertions.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+#
+# Render-assertion tests for the tenant capacity ceiling (#758, ADR-0059
+# decision 4): the ResourceQuota and LimitRange that complete ADR-0008's
+# namespace-per-tenant boundary with a bound on CONSUMPTION, not just
+# reachability.
+#
+#   1. Default install renders the ResourceQuota scoped (via scopeSelector) to
+#      the sandbox PriorityClass name, with the published hard ceiling values.
+#   2. Default install renders the LimitRange with the published per-container
+#      default/defaultRequest, and -- structurally -- with no min/max entry.
+#      Only default/defaultRequest can ever ADD a value where a container
+#      leaves one unset; min/max are enforced against a container's OWN
+#      declared values too, so accidentally introducing one later could reject
+#      an already-configured control-plane pod at admission time. This assert
+#      is the regression net for that invariant.
+#   3. The sandbox PriorityClass name is operator-overridable, so the #759
+#      coordination point (this chart guesses "agentos-sandbox") has a real
+#      escape hatch if the two PRs' constants land different.
+#   4. The quota's hard ceilings are operator-overridable (ADR-0059 decision 6).
+#   5. `resourceQuota.enabled: false` / `limitRange.enabled: false` each
+#      suppress just their own object.
+#   6. `agentSandbox.deploy: false` suppresses BOTH (no sandbox pods, no
+#      capacity envelope to bound).
+#   7. The N=1 self-host render (published default values.yaml -- the actual
+#      self-host topology this ADR describes: agentSandbox.deploy defaults
+#      true and every first-party service shares this one release namespace;
+#      values-dev.yaml is a DIFFERENT, offline scratch-cluster profile that
+#      turns agentSandbox.deploy off and is not the topology in question here.
+#      Dispatcher tokens are set so every control-plane Deployment renders):
+#      every control-plane container still declares its OWN cpu+memory
+#      request+limit. That is what keeps the LimitRange's defaults (assertion
+#      2) from ever engaging for the control plane -- a default only fills a
+#      dimension a container leaves unset, and this proves none of them do,
+#      for cpu/memory. If a future container lands here without its own
+#      cpu/memory, it would silently start inheriting this chart's generic
+#      sandbox-shaped LimitRange default instead of an intentional value --
+#      this assertion is the tripwire.
+#
+# NOTE ON `--output-dir`: mirrors the sibling scripts in this directory --
+# render to a directory and read the written file, never a stdout pipe (a
+# piped `helm template` has been observed to truncate silently while still
+# exiting 0 in this environment).
+#
+# Fails loudly, naming the assertion. Runnable locally and from CI.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "ASSERTION FAILED: $1" >&2
+  exit 1
+}
+
+# Render to a directory; echo the path (possibly absent) of a named template.
+render_file() {
+  # $1 = subdir name, $2 = template file under templates/, rest = extra helm args
+  local name="$1" tmpl="$2"
+  shift 2
+  local out="$TMP/$name"
+  mkdir -p "$out"
+  helm template agentos "$CHART" --output-dir "$out" "$@" >/dev/null
+  echo "$out/agentos/templates/$tmpl"
+}
+
+PYCHECK="$TMP/check.py"
+cat > "$PYCHECK" <<'PY'
+"""Structural assertions over one rendered manifest, dispatched by subcommand.
+
+argv[1] = subcommand, argv[2] = manifest/dir path, argv[3:] = subcommand args.
+Exits 0 and prints nothing on success; exits 1 with a message on failure.
+"""
+import sys
+import pathlib
+import yaml
+
+
+def load_one(path, kind):
+    docs = [d for d in yaml.safe_load_all(pathlib.Path(path).read_text()) if d]
+    matches = [d for d in docs if d.get("kind") == kind]
+    if not matches:
+        sys.exit(f"no {kind} document found in {path}")
+    if len(matches) > 1:
+        sys.exit(f"expected exactly one {kind} in {path}, found {len(matches)}")
+    return matches[0]
+
+
+cmd = sys.argv[1]
+
+if cmd == "quota-scope":
+    path, expect_name = sys.argv[2], sys.argv[3]
+    doc = load_one(path, "ResourceQuota")
+    exprs = (doc.get("spec") or {}).get("scopeSelector", {}).get("matchExpressions", [])
+    if len(exprs) != 1:
+        sys.exit(f"expected exactly one scopeSelector matchExpression, got {len(exprs)}: {exprs}")
+    e = exprs[0]
+    if e.get("scopeName") != "PriorityClass":
+        sys.exit(f"scopeName is {e.get('scopeName')!r}, expected 'PriorityClass'")
+    if e.get("operator") != "In":
+        sys.exit(f"operator is {e.get('operator')!r}, expected 'In'")
+    if e.get("values") != [expect_name]:
+        sys.exit(f"scopeSelector values are {e.get('values')!r}, expected [{expect_name!r}]")
+
+elif cmd == "quota-hard":
+    path = sys.argv[2]
+    expected = dict(arg.split("=", 1) for arg in sys.argv[3:])
+    doc = load_one(path, "ResourceQuota")
+    hard = (doc.get("spec") or {}).get("hard", {})
+    for key, want in expected.items():
+        got = str(hard.get(key))
+        if got != want:
+            sys.exit(f"hard[{key!r}] is {got!r}, expected {want!r} (full hard: {hard})")
+
+elif cmd == "limitrange-shape":
+    path = sys.argv[2]
+    expected = dict(arg.split("=", 1) for arg in sys.argv[3:])
+    doc = load_one(path, "LimitRange")
+    limits = (doc.get("spec") or {}).get("limits", [])
+    if len(limits) != 1:
+        sys.exit(f"expected exactly one limits entry, got {len(limits)}: {limits}")
+    entry = limits[0]
+    if entry.get("type") != "Container":
+        sys.exit(f"limits[0].type is {entry.get('type')!r}, expected 'Container'")
+    if "min" in entry or "max" in entry:
+        sys.exit(
+            "limits[0] declares a 'min' or 'max' -- these are enforced against a "
+            "container's OWN declared resources (not just undeclared ones) and "
+            "could reject an already-configured control-plane pod at admission "
+            f"time; only default/defaultRequest are safe here. Got: {entry}"
+        )
+    for dotted, want in expected.items():
+        section, key = dotted.split(".", 1)
+        got = str((entry.get(section) or {}).get(key))
+        if got != want:
+            sys.exit(f"{dotted} is {got!r}, expected {want!r} (full entry: {entry})")
+
+elif cmd == "controlplane-resources":
+    # Every container (non-init) across every Deployment/StatefulSet document
+    # under a rendered chart dir declares its OWN cpu+memory request+limit, so
+    # the LimitRange's default/defaultRequest can never engage for it. Scoped
+    # to the RELEASE namespace only -- the vendored agent-sandbox controller
+    # Deployment hardcodes `namespace: agent-sandbox-system` (a different,
+    # cluster-scoped namespace this chart's own tenant LimitRange never
+    # reaches), so a doc with an explicit, DIFFERENT namespace is out of scope
+    # here by construction, not a control-plane pod this assertion governs.
+    root = pathlib.Path(sys.argv[2])
+    release_ns = sys.argv[3]
+    dims = ("requests.cpu", "requests.memory", "limits.cpu", "limits.memory")
+    missing = []
+    checked = 0
+    for p in sorted(root.rglob("*.yaml")):
+        for doc in yaml.safe_load_all(p.read_text()):
+            if not isinstance(doc, dict) or doc.get("kind") not in ("Deployment", "StatefulSet"):
+                continue
+            doc_ns = doc.get("metadata", {}).get("namespace")
+            if doc_ns and doc_ns != release_ns:
+                continue
+            pod_spec = (((doc.get("spec") or {}).get("template") or {}).get("spec")) or {}
+            name = doc.get("metadata", {}).get("name")
+            for c in pod_spec.get("containers") or []:
+                checked += 1
+                res = c.get("resources") or {}
+                for dotted in dims:
+                    section, key = dotted.split(".", 1)
+                    if (res.get(section) or {}).get(key) is None:
+                        missing.append(f"{doc['kind']}/{name} container {c.get('name')!r} missing {dotted}")
+    if checked < 5:
+        sys.exit(f"only checked {checked} containers across Deployment/StatefulSet; "
+                  "expected the full control plane to be rendered (dispatcher tokens set?)")
+    if missing:
+        sys.exit(
+            "control-plane container(s) leave cpu/memory undeclared, which means the "
+            "tenant LimitRange's default/defaultRequest WOULD engage for them (a "
+            "capacity change, not a no-op) on a live cluster:\n  " + "\n  ".join(missing)
+        )
+
+else:
+    sys.exit(f"unknown subcommand {cmd!r}")
+PY
+
+check() { python3 "$PYCHECK" "$@" || fail "$*"; }
+
+echo "=== Assertion 1: default install scopes the ResourceQuota to the sandbox PriorityClass ==="
+default_quota="$(render_file default tenant-resourcequota.yaml)"
+[ -f "$default_quota" ] || fail "default install: tenant-resourcequota.yaml did not render"
+check quota-scope "$default_quota" agentos-sandbox
+echo "  ok: scopeSelector keys on PriorityClass=agentos-sandbox"
+check quota-hard "$default_quota" \
+  requests.cpu=4 requests.memory=8Gi requests.ephemeral-storage=20Gi \
+  limits.cpu=8 limits.memory=16Gi limits.ephemeral-storage=40Gi pods=50
+echo "  ok: published hard ceiling values render as documented"
+
+echo "=== Assertion 2: default install's LimitRange carries the published defaults, no min/max ==="
+# Reuses assertion 1's "default" render (--output-dir renders every template in
+# one pass, not just the one path returned), so no second `helm template` call.
+default_limitrange="$TMP/default/agentos/templates/tenant-limitrange.yaml"
+[ -f "$default_limitrange" ] || fail "default install: tenant-limitrange.yaml did not render"
+check limitrange-shape "$default_limitrange" \
+  defaultRequest.cpu=50m defaultRequest.memory=128Mi defaultRequest.ephemeral-storage=256Mi \
+  default.cpu=1 default.memory=1Gi default.ephemeral-storage=2Gi
+echo "  ok: default/defaultRequest match values.yaml, no min/max present"
+
+echo "=== Assertion 3: sandboxPriorityClassName is operator-overridable ==="
+overridden_quota="$(render_file override-name tenant-resourcequota.yaml --set resourceQuota.sandboxPriorityClassName=custom-sandbox-priority)"
+check quota-scope "$overridden_quota" custom-sandbox-priority
+echo "  ok: overriding resourceQuota.sandboxPriorityClassName is honored (the #759 coordination escape hatch)"
+
+echo "=== Assertion 4: quota hard ceilings are operator-overridable ==="
+overridden_hard="$(render_file override-hard tenant-resourcequota.yaml \
+  --set resourceQuota.hard.limitsMemory=32Gi --set resourceQuota.hard.sandboxPodCount=200)"
+check quota-hard "$overridden_hard" limits.memory=32Gi pods=200
+echo "  ok: resourceQuota.hard.* overrides are honored"
+
+echo "=== Assertion 5: each object's own 'enabled' flag suppresses only itself ==="
+out="$TMP/quota-off"
+mkdir -p "$out"
+helm template agentos "$CHART" --output-dir "$out" --set resourceQuota.enabled=false >/dev/null
+[ -f "$out/agentos/templates/tenant-resourcequota.yaml" ] && fail "resourceQuota.enabled=false: ResourceQuota still rendered"
+[ -f "$out/agentos/templates/tenant-limitrange.yaml" ] || fail "resourceQuota.enabled=false: LimitRange should still render (independent toggle)"
+echo "  ok: resourceQuota.enabled=false suppresses only the ResourceQuota"
+
+out="$TMP/limitrange-off"
+mkdir -p "$out"
+helm template agentos "$CHART" --output-dir "$out" --set limitRange.enabled=false >/dev/null
+[ -f "$out/agentos/templates/tenant-limitrange.yaml" ] && fail "limitRange.enabled=false: LimitRange still rendered"
+[ -f "$out/agentos/templates/tenant-resourcequota.yaml" ] || fail "limitRange.enabled=false: ResourceQuota should still render (independent toggle)"
+echo "  ok: limitRange.enabled=false suppresses only the LimitRange"
+
+echo "=== Assertion 6: agentSandbox.deploy=false suppresses both ==="
+out="$TMP/no-sandbox"
+mkdir -p "$out"
+helm template agentos "$CHART" --output-dir "$out" --set agentSandbox.deploy=false >/dev/null
+[ -f "$out/agentos/templates/tenant-resourcequota.yaml" ] && fail "agentSandbox.deploy=false: ResourceQuota still rendered"
+[ -f "$out/agentos/templates/tenant-limitrange.yaml" ] && fail "agentSandbox.deploy=false: LimitRange still rendered"
+echo "  ok: agentSandbox.deploy=false renders neither object"
+
+echo "=== Assertion 7: N=1 self-host render leaves the control plane's own cpu/memory untouched ==="
+# Published DEFAULT values (no -f overlay): agentSandbox.deploy defaults true
+# and every first-party service shares this one release namespace -- the
+# actual self-host N=1 topology ADR-0059 describes. values-dev.yaml is a
+# different, offline scratch-cluster profile that turns agentSandbox.deploy
+# OFF entirely (see its own comments), so it is deliberately NOT used here.
+selfhost="$TMP/selfhost"
+mkdir -p "$selfhost"
+RELEASE_NS="agentos-selfhost-assert"
+helm template agentos "$CHART" --namespace "$RELEASE_NS" --output-dir "$selfhost" \
+  --set dispatcher.slack.appToken=xapp-assert --set dispatcher.slack.botToken=xoxb-assert >/dev/null
+[ -f "$selfhost/agentos/templates/tenant-resourcequota.yaml" ] || fail "N=1 self-host render: ResourceQuota did not render"
+[ -f "$selfhost/agentos/templates/tenant-limitrange.yaml" ] || fail "N=1 self-host render: LimitRange did not render"
+check controlplane-resources "$selfhost/agentos/templates" "$RELEASE_NS"
+echo "  ok: every control-plane Deployment/StatefulSet container still declares its own cpu+memory request+limit"
+
+echo
+echo "PASS: tenant ResourceQuota scopes to the sandbox PriorityClass with the documented (and overridable) hard ceilings; the LimitRange ships safe default-only per-container defaults; both toggle independently and with agentSandbox.deploy; and the N=1 self-host control plane remains fully self-declared on cpu/memory."

--- a/charts/agentos/templates/tenant-limitrange.yaml
+++ b/charts/agentos/templates/tenant-limitrange.yaml
@@ -1,0 +1,47 @@
+{{/*
+Tenant capacity ceiling, part 2: LimitRange (ADR-0059 decision 4).
+
+Unlike the ResourceQuota above, a LimitRange has no scopeSelector -- it applies
+its per-Container default/defaultRequest to every container in the namespace
+that leaves that resource dimension undeclared, sandbox or platform alike. That
+is deliberate and is the whole point of shipping one: "a sandbox created
+outside the chart's own templates still inherits a ceiling" only holds if the
+default is namespace-wide, not sandbox-scoped.
+
+This is safe for the N=1 self-host control plane because every first-party
+component in this chart (api, worker, dispatcher, ui, postgres, valkey,
+clickhouse, minio, langfuse, the otel collector, the preflight/probe jobs, and
+the runner-prewarm DaemonSet) already declares BOTH a cpu and a memory
+request+limit of its own in values.yaml -- so this LimitRange's cpu/memory
+default/defaultRequest never overrides an already-set value for any of them;
+it only ever fills in the one dimension the chart leaves undeclared everywhere
+today, `ephemeral-storage` (the exact gap ADR-0059 opens with). Deliberately NOT
+setting `min`/`max` here: those are enforced against every container's
+DECLARED resources too (not just undeclared ones), so a `max` picked without
+perfect knowledge of every component's configured limit could reject an
+otherwise-fine control-plane pod at admission time. `default`/`defaultRequest`
+can only ever ADD a value where one is missing, never reject an existing one,
+which is what keeps this rail from being able to block the control plane from
+booting.
+*/}}
+{{- if and .Values.agentSandbox.deploy .Values.limitRange.enabled }}
+{{- $lr := .Values.limitRange.container }}
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: {{ include "agentos.fullname" . }}-tenant-limits
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tenant-capacity
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: {{ $lr.defaultRequest.cpu | quote }}
+        memory: {{ $lr.defaultRequest.memory | quote }}
+        ephemeral-storage: {{ $lr.defaultRequest.ephemeralStorage | quote }}
+      default:
+        cpu: {{ $lr.default.cpu | quote }}
+        memory: {{ $lr.default.memory | quote }}
+        ephemeral-storage: {{ $lr.default.ephemeralStorage | quote }}
+{{- end }}

--- a/charts/agentos/templates/tenant-resourcequota.yaml
+++ b/charts/agentos/templates/tenant-resourcequota.yaml
@@ -1,0 +1,61 @@
+{{/*
+Tenant capacity ceiling, part 1: ResourceQuota (ADR-0059 decision 4).
+
+ADR-0008 makes the namespace a reachability boundary (namespace-per-tenant
+compute); this completes it with a capacity boundary. Nodes are shared beneath
+the namespace, so without a namespace-level cap one tenant's sandboxes can
+exhaust node cpu/memory/disk that another tenant's sandboxes depend on -- a
+namespace alone does not stop that, because ResourceQuota is the object that
+actually bounds aggregate consumption inside it.
+
+Self-host wrinkle (ADR-0059 decision 4, and decision 5's PriorityClass): in the
+N=1 topology this release's sandboxes share the release namespace with the
+platform pods (api, worker, dispatcher, and the data tier), none of which
+declare `ephemeral-storage` today. A plain namespace-wide ResourceQuota
+would therefore bind the control plane and data tier too -- exactly what
+`resourceQuota.enabled` must NOT do. `scopeSelector` on the `PriorityClass`
+scope restricts every `hard` line in this object (including the pod count) to
+pods carrying that priority class, so only sandbox pods are counted and the
+control plane renders unconstrained by this quota.
+
+That priority class is the one decision 5 / issue #759 defines for sandbox
+pods. This template does not depend on #759's chart objects or values existing
+in this branch -- `scopeSelector` matches purely on the STRING name a pod's
+`priorityClassName` resolves to, which Kubernetes does not validate against an
+existing PriorityClass object at ResourceQuota-admission time. So this quota
+renders and behaves correctly whether #759 has landed yet or not:
+  - #759 not yet merged / no pod sets this priorityClassName: the scope simply
+    matches no pods yet (an inert-but-present quota), never an error.
+  - #759 merged with a DIFFERENT sandbox PriorityClass name than the default
+    guessed here (`resourceQuota.sandboxPriorityClassName`, default
+    "agentos-sandbox"): override this value (or align the two names) so the
+    scope actually matches; see the PR notes for the coordination point.
+*/}}
+{{- if and .Values.agentSandbox.deploy .Values.resourceQuota.enabled }}
+{{- $rq := .Values.resourceQuota }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ include "agentos.fullname" . }}-sandbox-quota
+  labels:
+    {{- include "agentos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tenant-capacity
+spec:
+  scopeSelector:
+    matchExpressions:
+      - operator: In
+        scopeName: PriorityClass
+        values:
+          - {{ $rq.sandboxPriorityClassName | quote }}
+  hard:
+    requests.cpu: {{ $rq.hard.requestsCpu | quote }}
+    requests.memory: {{ $rq.hard.requestsMemory | quote }}
+    requests.ephemeral-storage: {{ $rq.hard.requestsEphemeralStorage | quote }}
+    limits.cpu: {{ $rq.hard.limitsCpu | quote }}
+    limits.memory: {{ $rq.hard.limitsMemory | quote }}
+    limits.ephemeral-storage: {{ $rq.hard.limitsEphemeralStorage | quote }}
+    # Scoped by the same scopeSelector, so this bounds sandbox pod COUNT, not
+    # every pod in the namespace -- a tenant cannot route around the
+    # cpu/memory/disk ceiling above by simply claiming more, smaller sandboxes.
+    pods: {{ $rq.hard.sandboxPodCount | quote }}
+{{- end }}

--- a/charts/agentos/values.yaml
+++ b/charts/agentos/values.yaml
@@ -1011,3 +1011,59 @@ security:
   # and would rotate live store credentials -- pin them via `--set`/`existingSecret`
   # (or use the `helm install/upgrade` path / `agentos cluster up`) in that case.
   allowDevDefaults: false
+
+# ---------------------------------------------------------------------------
+# Tenant capacity ceiling (ADR-0059 decision 4). ADR-0008 decides
+# namespace-per-tenant compute, which bounds REACHABILITY; these two objects
+# complete it with a bound on CONSUMPTION, because nodes are shared beneath
+# the namespace boundary and one tenant's sandboxes can otherwise exhaust node
+# capacity another tenant's sandboxes depend on. See
+# docs/adr/0059-sandbox-is-a-bounded-resource-envelope.md.
+# ---------------------------------------------------------------------------
+# ResourceQuota: an aggregate cpu/memory/ephemeral-storage + sandbox pod-count
+# ceiling for the tenant namespace, so a tenant cannot exceed its allocation
+# regardless of how many sandboxes it claims.
+resourceQuota:
+  enabled: true
+  # The PriorityClass name this quota's scopeSelector keys on, so the quota
+  # binds only sandbox pods -- NOT the platform pods (api/worker/dispatcher)
+  # or the data tier, which in the N=1 self-host topology share this same
+  # release namespace. This is the sandbox PriorityClass ADR-0059 decision 5 /
+  # issue #759 defines; #759 is being implemented in parallel and this is an
+  # assumed name pending that PR landing. If #759 ships a different name,
+  # override this value (or reconcile the two constant strings) so the
+  # scopeSelector actually matches. A name that matches no pod yet (#759 not
+  # merged) makes this quota inertly present rather than an error -- Kubernetes
+  # does not validate a scopeSelector's PriorityClass name against an existing
+  # object.
+  sandboxPriorityClassName: agentos-sandbox
+  hard:
+    requestsCpu: "4"
+    requestsMemory: 8Gi
+    requestsEphemeralStorage: 20Gi
+    limitsCpu: "8"
+    limitsMemory: 16Gi
+    limitsEphemeralStorage: 40Gi
+    # Aggregate sandbox pod count, scoped by the same scopeSelector -- closes
+    # the "claim more, smaller sandboxes" route around the limits above.
+    sandboxPodCount: "50"
+# LimitRange: per-container defaults (request + limit) so a sandbox pod
+# created outside this chart's own SandboxTemplate -- and, as a floor, any
+# first-party container that omits a dimension -- still inherits a ceiling
+# rather than running unbounded. Has no scopeSelector (LimitRange does not
+# support one), so it applies namespace-wide; this is safe for the N=1
+# self-host control plane because every first-party component in this chart
+# already declares its own cpu+memory request/limit, so these defaults only
+# ever fill the one dimension nothing in the chart sets today,
+# `ephemeral-storage` -- they never override an already-declared value.
+limitRange:
+  enabled: true
+  container:
+    defaultRequest:
+      cpu: 50m
+      memory: 128Mi
+      ephemeralStorage: 256Mi
+    default:
+      cpu: "1"
+      memory: 1Gi
+      ephemeralStorage: 2Gi


### PR DESCRIPTION
Implements ADR-0059 decision 4 (`docs/adr/0059-sandbox-is-a-bounded-resource-envelope.md`).

ADR-0008 decides namespace-per-tenant compute, which bounds reachability, not capacity: nodes are shared beneath the namespace boundary, so one tenant's sandboxes could exhaust node cpu/memory/disk that another tenant's sandboxes depend on. The chart shipped no `ResourceQuota` and no `LimitRange`.

## What this ships

- `charts/agentos/templates/tenant-resourcequota.yaml`: a `ResourceQuota` bounding aggregate `cpu`, `memory`, `ephemeral-storage`, and sandbox pod count.
- `charts/agentos/templates/tenant-limitrange.yaml`: a `LimitRange` supplying per-container `default`/`defaultRequest`, so a sandbox pod created outside this chart's own templates still inherits a ceiling.
- New, additive `values.yaml` keys: `resourceQuota.*` and `limitRange.*`. No existing keys were touched or reflowed.
- `charts/agentos/ci/tenant-capacity-assertions.sh`: a new render-assert script (wired into `.github/workflows/helm-ci.yaml`) covering the quota's scope and hard values, the LimitRange's shape, independent enable/disable toggles, the `agentSandbox.deploy` gate, and a render against the default (N=1 self-host) topology proving every control-plane `Deployment`/`StatefulSet` container still declares its own cpu+memory.
- A short doc addition to `charts/agentos/README.md`'s security rails table.

## The #759 coordination point

ADR-0059 decision 4's self-host wrinkle: in the N=1 topology, sandboxes share the release namespace with the platform pods (api, worker, dispatcher, data tier), none of which declare `ephemeral-storage` today. A namespace-wide `ResourceQuota` would bind the control plane and data tier too, so the quota is scoped with a `scopeSelector` keyed on the `PriorityClass` scope, matching only pods carrying the sandbox priority class.

That `PriorityClass` is decision 5's, tracked in #759 (in progress in parallel, not merged as of this PR). This PR does not depend on #759's chart objects existing to render correctly: `scopeSelector` matches on the priority class's NAME as a string, which Kubernetes does not validate against an existing `PriorityClass` object at `ResourceQuota` admission time. So:

- If #759 hasn't merged yet, this quota renders fine and is simply inert (matches no pods) until a pod carries that priority class.
- The assumed name is `resourceQuota.sandboxPriorityClassName`, defaulted to `agentos-sandbox`. If #759 ships a different constant, override this value (or reconcile the two names) so the `scopeSelector` actually matches. A maintainer merging both PRs can align the two strings.

The `LimitRange` has no `scopeSelector` (Kubernetes doesn't support one there), so it applies namespace-wide, but ships `default`/`defaultRequest` only -- never `min`/`max` -- so it can only ever fill a dimension a container leaves undeclared (today, `ephemeral-storage`, everywhere in the chart) and can never reject an already-configured control-plane pod at admission.

## Verification

- `helm lint charts/agentos` passes.
- `bash charts/agentos/ci/render-assertions.sh` passes.
- `bash charts/agentos/ci/tenant-capacity-assertions.sh` (new) passes, including the N=1 self-host control-plane assertion.
- All other existing `charts/agentos/ci/*.sh` scripts re-verified passing.

Closes #758