### PR TITLE
Bound the interrupt RPC so it cannot hang the kill switch or interrupt_agent

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -97,6 +97,17 @@ _EXPIRY_RESUME_MARKER = "[approval expired]"
 # silently change which error an operator sees in the log.
 _RESET_INTERRUPT_TIMEOUT_S = 5.0
 
+# How long a single thread's interrupt gets during the kill switch's fan-out
+# over an agent's live threads (#742) before that thread is logged as failed
+# and the fan-out moves on. Unlike `release_thread`, there is no fallback
+# release to run afterward on this path, so a timeout here is surfaced via
+# logging rather than swallowed -- but it must still be a bound, because an
+# unbounded await on one wedged thread would otherwise leave the kill switch,
+# "the one control that is supposed to work when things are broken," unable to
+# signal the agent's other threads for as long as `RunnerClient.interrupt`'s
+# own request budget.
+_KILL_INTERRUPT_TIMEOUT_S = 5.0
+
 
 @dataclass
 class TurnOutcome:
@@ -550,12 +561,35 @@ class Kernel:
     async def interrupt_agent(self, agent_id: uuid.UUID) -> int:
         """Interrupt every live turn belonging to an agent (kill switch). Returns
         the number of turns signalled. The kill flag stays set (the API owns it),
-        so new runs are refused by the is_killed check until resume."""
+        so new runs are refused by the is_killed check until resume.
+
+        Threads are signalled concurrently, and each interrupt is individually
+        bounded to `_KILL_INTERRUPT_TIMEOUT_S` (#742): a wedged runner on one
+        thread must not delay -- let alone block -- the interrupt reaching the
+        agent's other live threads. A timed-out or otherwise failed interrupt is
+        logged and does not stop the rest of the fan-out; there is no fallback
+        release to run afterward on this path (unlike `release_thread`), so the
+        failure is surfaced via logging rather than swallowed."""
         threads = list(self._active_by_agent.get(agent_id, set()))
-        signalled = 0
-        for thread in threads:
-            if await self.interrupt_thread(thread, f"agent {agent_id} killed by operator"):
-                signalled += 1
+
+        async def _interrupt_one(thread: str) -> bool:
+            try:
+                return await asyncio.wait_for(
+                    self.interrupt_thread(thread, f"agent {agent_id} killed by operator"),
+                    _KILL_INTERRUPT_TIMEOUT_S,
+                )
+            except Exception:
+                logger.error(
+                    "kill: interrupt did not land for thread %s of agent %s (timed out "
+                    "or errored); continuing to signal its other live threads",
+                    thread,
+                    agent_id,
+                    exc_info=True,
+                )
+                return False
+
+        results = await asyncio.gather(*(_interrupt_one(thread) for thread in threads))
+        signalled = sum(results)
         logger.info("kill: interrupted %d live turn(s) for agent %s", signalled, agent_id)
         return signalled
 

--- a/apps/worker/src/agentos_worker/killswitch.py
+++ b/apps/worker/src/agentos_worker/killswitch.py
@@ -24,6 +24,16 @@ logger = logging.getLogger(__name__)
 KILL_CHANNEL = "agentos:kill-events"
 KILL_KEY_PREFIX = "agentos:kill:"
 
+# How long one kill event's dispatch to ``on_kill`` gets before the read loop
+# gives up on it and moves on to the next pubsub message (#742). ``on_kill`` is
+# `Kernel.interrupt_agent`, which already bounds and fans out over the agent's
+# individual threads concurrently, so this is a generous outer backstop, not
+# the primary bound -- it exists so a stuck handler (of any kind, not only a
+# wedged runner) can never stall this read loop and drop every kill event
+# behind it, which is exactly the failure the surrounding try/except was
+# guarding against without actually preventing.
+_ON_KILL_TIMEOUT_S = 15.0
+
 
 def kill_key(agent_id: uuid.UUID) -> str:
     return f"{KILL_KEY_PREFIX}{agent_id}"
@@ -76,11 +86,20 @@ class KillSwitch:
             return
         # A resume needs no worker action: the flag is already cleared by the API,
         # so is_killed lets new runs through. Only a kill interrupts live turns.
-        # Guard on_kill so a failed interrupt of one agent does not tear down the
-        # subscriber and miss every later kill event.
+        # Guard on_kill so a failed OR hanging interrupt of one agent does not
+        # tear down the subscriber or stall this loop and miss every later kill
+        # event (#742): a wedged handler must cost this one dispatch its timeout
+        # budget, never the read loop itself.
         if action == "kill":
             try:
-                await self._on_kill(agent_id)
+                await asyncio.wait_for(self._on_kill(agent_id), _ON_KILL_TIMEOUT_S)
+            except TimeoutError:
+                logger.error(
+                    "kill handler for agent %s did not finish within %ss; abandoning "
+                    "this dispatch and continuing to read further kill events",
+                    agent_id,
+                    _ON_KILL_TIMEOUT_S,
+                )
             except Exception:
                 logger.exception("kill handler failed for agent %s", agent_id)
 

--- a/apps/worker/src/agentos_worker/runner_client.py
+++ b/apps/worker/src/agentos_worker/runner_client.py
@@ -21,6 +21,20 @@ from types import TracebackType
 import aiohttp
 from aci_protocol import Event, Interrupt, OutboundEvent, parse_ndjson_line
 
+# The interrupt RPC is a control-plane POST, not a streaming turn (#742, a
+# follow-up to #739): it exists only to hard-stop the live turn, never to carry
+# a turn's output, so it must not inherit ``connect_timeout_s``/``total_timeout_s``,
+# which are tuned for a long-running streamed turn (default 600s). A wedged
+# runner that accepts the TCP connect and then answers nothing would otherwise
+# hang every interrupt caller for up to that streaming budget. A healthy runner
+# answers an interrupt well under a second. This bound lives here, at the RPC
+# itself, so every caller inherits it for free; each caller then layers its own
+# policy on top (``Kernel.release_thread`` swallows and releases,
+# ``Kernel.interrupt_agent`` and the kill switch surface the failure and keep
+# going) instead of re-deriving the bound -- or a coupling to this client's
+# other timeouts -- at each call site.
+_DEFAULT_INTERRUPT_TIMEOUT_S = 5.0
+
 
 def _auth_headers(token: str | None) -> dict[str, str] | None:
     """Per-call Authorization header for the per-sandbox runner token (issue #63).
@@ -74,6 +88,7 @@ class RunnerClient:
         *,
         connect_timeout_s: float = 10.0,
         total_timeout_s: float = 600.0,
+        interrupt_timeout_s: float = _DEFAULT_INTERRUPT_TIMEOUT_S,
         session: aiohttp.ClientSession | None = None,
     ) -> None:
         self._own_session = session is None
@@ -82,6 +97,11 @@ class RunnerClient:
                 total=total_timeout_s, connect=connect_timeout_s, sock_read=total_timeout_s
             )
         )
+        # A per-request override, not folded into the session default above: it
+        # replaces (not merges with) the session timeout for this one call, so
+        # ``/v1/interrupt`` gets its own short control-plane budget regardless of
+        # how the streaming timeouts above are tuned.
+        self._interrupt_timeout = aiohttp.ClientTimeout(total=interrupt_timeout_s)
 
     async def start_turn(
         self, base_url: str, event: Event, token: str | None = None
@@ -109,10 +129,21 @@ class RunnerClient:
             return True
 
     async def interrupt(self, base_url: str, reason: str, token: str | None = None) -> None:
-        """Hard-stop the live turn; its final is reclassified to idle."""
+        """Hard-stop the live turn; its final is reclassified to idle.
+
+        Bounded to ``_DEFAULT_INTERRUPT_TIMEOUT_S`` (or the constructor
+        override), never the streaming ``total_timeout_s``/``sock_read``
+        budget (#742): a wedged runner that accepts the connect and then
+        answers nothing must not cost the caller up to that streaming budget
+        just to find out. Raises ``asyncio.TimeoutError`` on expiry, same as
+        any other failure here -- callers already decide per call site whether
+        to swallow-and-fallback or surface-and-continue."""
         frame = Interrupt(reason=reason)
         async with self._session.post(
-            f"{base_url}/v1/interrupt", json=frame.model_dump(), headers=_auth_headers(token)
+            f"{base_url}/v1/interrupt",
+            json=frame.model_dump(),
+            headers=_auth_headers(token),
+            timeout=self._interrupt_timeout,
         ) as resp:
             if resp.status not in (200, 409):
                 body = await resp.text()

--- a/apps/worker/tests/binding/test_killswitch.py
+++ b/apps/worker/tests/binding/test_killswitch.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 
 import pytest
 import redis.asyncio as aredis
+from agentos_worker import killswitch as killswitch_module
 from agentos_worker.killswitch import KILL_CHANNEL, KillSwitch, kill_key
 
 _VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
@@ -95,6 +96,66 @@ def test_subscriber_invokes_on_kill_for_a_kill_event() -> None:
             await asyncio.sleep(0.3)
             assert len(killed) == 1
         finally:
+            ks.request_stop()
+            await task
+            await client.aclose()
+            await publisher.aclose()
+
+    asyncio.run(go())
+
+
+def test_wedged_on_kill_does_not_stall_the_pubsub_loop(monkeypatch) -> None:
+    """#742: on_kill (`Kernel.interrupt_agent` in production) is awaited inline
+    in the read loop. If a handler call hangs -- the shape a wedged runner
+    produces one layer down -- the loop must not stall behind it and drop
+    every kill event that arrives afterward, which is exactly the failure the
+    surrounding try/except guards against without actually preventing an
+    unbounded await. Bounding the dispatch is what actually prevents it: the
+    stuck first call times out and a second agent's kill is still dispatched
+    promptly, against the real Valkey pubsub channel (never mocked here)."""
+
+    async def go() -> None:
+        client = _client()
+        publisher = _client()
+        try:
+            await client.ping()
+        except aredis.RedisError as exc:
+            pytest.skip(f"Valkey not reachable: {exc}")
+
+        monkeypatch.setattr(killswitch_module, "_ON_KILL_TIMEOUT_S", 0.2)
+
+        wedged = asyncio.Event()  # never set: the first dispatch hangs forever
+        calls: list[uuid.UUID] = []
+
+        async def on_kill(agent_id: uuid.UUID) -> None:
+            calls.append(agent_id)
+            if len(calls) == 1:
+                await wedged.wait()
+
+        ks = KillSwitch(client, on_kill=on_kill)
+        task = asyncio.create_task(ks.run())
+        try:
+            await asyncio.sleep(0.2)  # let the subscriber finish subscribing
+            agent_a = uuid.uuid4()
+            agent_b = uuid.uuid4()
+
+            await publisher.publish(
+                KILL_CHANNEL,
+                json.dumps({"agent_id": str(agent_a), "action": "kill", "ts": "now"}),
+            )
+            await _wait_until(lambda: len(calls) >= 1)
+
+            # agent_a's dispatch is now stuck. A second kill must still reach
+            # its own handler call well before the wedge is ever released --
+            # proof the read loop kept polling instead of blocking on agent_a.
+            await publisher.publish(
+                KILL_CHANNEL,
+                json.dumps({"agent_id": str(agent_b), "action": "kill", "ts": "now"}),
+            )
+            await _wait_until(lambda: len(calls) >= 2, timeout=2.0)
+            assert calls == [agent_a, agent_b]
+        finally:
+            wedged.set()
             ks.request_stop()
             await task
             await client.aclose()

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -267,6 +267,54 @@ def test_interrupt_hard_stops_the_live_turn(make_harness) -> None:
     asyncio.run(go())
 
 
+def test_interrupt_agent_signals_other_threads_past_a_wedged_runner(
+    make_harness, monkeypatch
+) -> None:
+    """#742: interrupt_agent fans out over an agent's live threads. A single
+    wedged runner -- one that accepts the interrupt call and then never
+    answers -- must not cost the agent's other threads up to
+    `RunnerClient.interrupt`'s own request budget: the kill switch is "the one
+    control that is supposed to work when things are broken." Each thread's
+    interrupt is individually bounded and the fan-out runs concurrently, so a
+    permanently-wedged thread times out (logged, not raised) while the other
+    threads are still signalled well inside the test's own generous ceiling.
+
+    The wedge is injected at the runner-client seam with an event that is never
+    set, the same deterministic technique #739's release_thread test uses,
+    rather than racing real timing against a live HTTP hang."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            agent_id = uuid.uuid4()
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            threads = ("tKillA", "tKillB", "tKillC")
+            for thread in threads:
+                await h.kernel.process_event(_qevent("hi", thread=thread))
+            h.kernel._active_by_agent[agent_id] = set(threads)
+
+            monkeypatch.setattr(kernel_module, "_KILL_INTERRUPT_TIMEOUT_S", 0.2)
+
+            wedged = asyncio.Event()  # never set: the first thread's runner hangs forever
+            attempted: list[str] = []
+
+            async def maybe_wedge(base_url: str, reason: str, token: str | None = None) -> None:
+                attempted.append(reason)
+                if len(attempted) == 1:
+                    await wedged.wait()
+
+            monkeypatch.setattr(h.kernel._runner, "interrupt", maybe_wedge)
+
+            try:
+                signalled = await asyncio.wait_for(h.kernel.interrupt_agent(agent_id), timeout=2.0)
+            finally:
+                wedged.set()
+
+            assert len(attempted) == 3  # every thread was attempted, none blocked the rest
+            assert signalled == 2  # the wedged thread times out; the other two still land
+
+    asyncio.run(go())
+
+
 def test_duplicate_event_is_idempotent(make_harness) -> None:
     async def go() -> None:
         async with make_harness() as h:

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import pytest
 from aci_protocol import Event, Final, SessionStatus, TextDelta
 from agentos_worker.runner_client import RunnerClient
 from aiohttp import web
@@ -164,5 +165,54 @@ def test_runner_client_omits_authorization_without_token() -> None:
             finally:
                 await client.close()
                 await server.close()
+
+    asyncio.run(go())
+
+
+# --- The interrupt RPC gets its own bound, separate from the streaming ---------
+# budget (#742, a follow-up to #739 which bounded only one call site above this
+# layer). Against a REAL local server whose /v1/interrupt accepts the
+# connection and then answers nothing -- the wedged-runner shape -- so the
+# assertion is on the actual client behavior, not a mock of it.
+
+
+class _HangingInterruptRunner:
+    """A runner whose ``/v1/interrupt`` accepts the connection and never
+    answers, modelling the wedged runner #742 is about."""
+
+    def __init__(self) -> None:
+        self.app = web.Application()
+        self.app.add_routes([web.post("/v1/interrupt", self._interrupt)])
+        self.hang = asyncio.Event()  # never set by the test: the handler never returns
+
+    async def _interrupt(self, request: web.Request) -> web.Response:
+        await self.hang.wait()
+        return web.json_response({"ok": True})
+
+
+def test_interrupt_is_bounded_by_its_own_timeout_not_the_streaming_budget() -> None:
+    """The interrupt call must time out at RunnerClient's own
+    ``interrupt_timeout_s``, not the session's streaming ``total_timeout_s`` --
+    deliberately configured huge here so the test would hang for a long time
+    (rather than pass by accident) if the interrupt call fell back to
+    inheriting it."""
+
+    async def go() -> None:
+        runner = _HangingInterruptRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=30.0, interrupt_timeout_s=0.2)
+        try:
+            loop = asyncio.get_event_loop()
+            started = loop.time()
+            with pytest.raises(TimeoutError):
+                await client.interrupt(base_url, "stop")
+            elapsed = loop.time() - started
+            assert elapsed < 5.0  # nowhere near the 30s streaming budget
+        finally:
+            runner.hang.set()
+            await client.close()
+            await server.close()
 
     asyncio.run(go())


### PR DESCRIPTION
## Summary

Follow-up to #739, which bounded the interrupt call at one call site (`Kernel.release_thread`, which has a fallback: release the sandbox anyway). Every other caller of the interrupt RPC was still unbounded, riding `RunnerClient`'s streaming session timeout (connect 10s, total/sock_read 600s) even though a control-plane interrupt POST is not a streaming turn.

- `RunnerClient.interrupt` (`apps/worker/src/agentos_worker/runner_client.py`) now carries its own dedicated timeout (`interrupt_timeout_s`, default 5s) that overrides the session's streaming timeout for that one call, so every caller inherits the bound for free instead of re-deriving it (or documenting a coupling to it, as #739 had to).
- `Kernel.interrupt_agent` now fans out over an agent's live threads concurrently instead of serially, and bounds each thread's interrupt individually. A timed-out or failed interrupt on one thread is logged and does not block the rest of the fan-out.
- `KillSwitch._handle` now bounds the `on_kill` dispatch in its pubsub read loop. A stuck handler times out (logged) instead of stalling the loop and dropping every kill event behind it, which is the exact failure the existing try/except guarded against without actually preventing.
- `Kernel.release_thread`'s existing swallow-and-release behavior (#739) is unchanged.

## Tests

- `apps/worker/tests/kernel/test_runner_client.py`: the interrupt call times out at its own `interrupt_timeout_s` against a runner that accepts the connection and never answers, well short of a deliberately huge streaming budget on the same client.
- `apps/worker/tests/kernel/test_kernel.py`: `interrupt_agent` fan-out test with one permanently-wedged thread (deterministic event-based wedge, same technique as #739's release_thread test) proves the other threads are still signalled and the call returns promptly.
- `apps/worker/tests/binding/test_killswitch.py`: against the real (never-mocked) Valkey pubsub channel, a wedged `on_kill` handler for one agent times out and a second agent's kill event is still dispatched promptly, proving the read loop isn't stalled.

Full suite: `uv run pytest apps/worker/tests -q` → 507 passed, 1 skipped.

## Review note

This touches `kernel.py` and `killswitch.py`, which `apps/worker/CLAUDE.md` calls out as sacred, single-owner modules with concurrency correctness that warrants an adversarial review before merge. I did not perform that adversarial review myself; flagging it here so a human reviewer gives it that pass before merging.

Closes #742