### PR TITLE
Add a reset-thread CLI verb for forced thread sandbox release

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -1490,6 +1490,73 @@ export const commandManifest = {
           ],
           "hidden": false,
           "name": "resume"
+        },
+        {
+          "about": "Force a stuck thread's sandbox to be released (`POST /agents/{id}/threads/{thread_key}/reset`, #737). The worker's next maintenance tick deletes the thread's claim and route, so its next message cold-creates a fresh sandbox instead of adopting one that may be running stale env. Interrupts a live turn on the thread first, so it requires --yes; does not delete conversation history",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id (scopes the action; the release is thread-keyed)",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The thread key to reset (e.g. the Slack thread ts)",
+              "id": "thread_key",
+              "long": "thread-key",
+              "positional": false,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the action; it interrupts any live turn on the thread",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "reset-thread"
         }
       ]
     },
@@ -2526,6 +2593,92 @@ export const commandManifest = {
           ],
           "hidden": false,
           "name": "budget"
+        },
+        {
+          "about": "Force a stuck thread's sandbox to be released via the platform API (`POST /agents/{id}/threads/{thread_key}/reset`, #737). The worker's next maintenance tick deletes the thread's claim and route, so its next message cold-creates a fresh sandbox instead of adopting one that may be running stale env. Interrupts a live turn on the thread first, so it requires --yes; does not delete conversation history",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id (scopes the action; the release is thread-keyed)",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The thread key to reset (e.g. the Slack thread ts)",
+              "id": "thread_key",
+              "long": "thread-key",
+              "positional": false,
+              "required": true
+            },
+            {
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the action; it interrupts any live turn on the thread",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "reset-thread"
         },
         {
           "about": "Delete an agent via the platform API (`DELETE /agents/{id}`)",

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,12 +16,14 @@ disk and targets no environment.
 | Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
 |---|---|---|---|---|---|
 | `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `check` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
-| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `eval` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
-| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `eval` `deploy` `kill` `resume` `budget` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
+| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | stub by default, optional real Slack with `--slack` | none | `up` `down` `status` `comms` `message` `eval` `deploy` `reset-thread` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `comms` `message` `eval` `deploy` `kill` `resume` `budget` `reset-thread` `delete` | Operate and drive a deployed cluster release, and control its agents' lifecycle. |
 
 The universal quartet `up`/`down`/`status`/`message` is on all three targets;
 `skill` adds `eval`, while `local` and `cluster` add `comms`, `eval`, plus `deploy`; `cluster`
-further adds the agent-lifecycle verbs `kill`/`resume`/`budget`/`delete`. `eval` is on
+further adds the agent-lifecycle verbs `kill`/`resume`/`budget`/`delete`, and both `local`
+and `cluster` add `reset-thread` to force a stuck thread's sandbox to be released
+(#737). `eval` is on
 all three: it runs the SAME `evals/cases.json` with the SAME grader at each tier (the
 per-tier parity gate), so a suite that passes at `skill` can be re-asserted verbatim at
 `local` and `cluster`. The distinction
@@ -250,6 +252,7 @@ the optional Slack dispatcher.
 | `agentos local message "..."` | Drive the local compose stack end to end with zero Slack. Enqueues straight to the compose Valkey and lets the containerized worker answer. |
 | `agentos local eval` | Run the bundle's `evals/cases.json` through the compose stack's enqueue -> worker -> sandbox -> reply path (one synthetic turn per case) and grade each captured reply with the SAME grader `skill eval` uses. Prints the identical per-case table + rollup; nonzero exit on failure. `--cases` overrides the file; `--dry-run` prints the plan. `--concurrency` defaults to 1 (sequential); values above 1 are refused for now (#709). |
 | `agentos local deploy` | Package the bundle as tar.gz and push it to the compose platform API (`--api-url`, default `http://localhost:28000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
+| `agentos local reset-thread <agent> --thread-key <key> --yes` | Force a stuck thread's sandbox to be released via the compose platform API (`POST /agents/{id}/threads/{thread_key}/reset`, #737). The worker's next maintenance tick releases the thread's claim and route, so its next message cold-creates a fresh sandbox; conversation history is not deleted. Interrupts a live turn on the thread first, so it refuses without `--yes`. |
 
 ## `cluster` target: deployed Helm release
 
@@ -270,16 +273,18 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `agentos cluster kill <agent> --yes` | Kill an agent (stop its runs) via the platform API (`POST /agents/{id}/kill`). Destructive: refuses without `--yes`. |
 | `agentos cluster resume <agent>` | Resume a killed agent via the platform API (`POST /agents/{id}/resume`). |
 | `agentos cluster budget <agent> --limit <n>` | Set the agent's daily spend cap in USD via the platform API (`PUT /agents/{id}/budget`, `BudgetConfig.max_usd_per_day`); the per-run token cap is left at the platform default. |
+| `agentos cluster reset-thread <agent> --thread-key <key> --yes` | Force a stuck thread's sandbox to be released via the platform API (`POST /agents/{id}/threads/{thread_key}/reset`, #737). The worker's next maintenance tick releases the thread's claim and route, so its next message cold-creates a fresh sandbox; conversation history is not deleted. Interrupts a live turn on the thread first, so it refuses without `--yes`. |
 | `agentos cluster delete <agent> --yes` | Delete an agent via the platform API (`DELETE /agents/{id}`). Destructive and irreversible: refuses without `--yes`. |
 
-The four lifecycle verbs (`kill`, `resume`, `budget`, `delete`) act on a
-deployed release's agents through the same platform API, defaulting `--api-url`
-to `http://localhost:8000` (auth via `--api-key` or `AGENTOS_API_KEY`). Unlike
-`cluster deploy`, which self-plumbs a port-forward and auto-discovers the
-release key (ADR-0057), the lifecycle verbs do neither -- pass `--api-url` or
-port-forward the API yourself. They resolve `<agent>` (a name or id) to its API id with the
-same lookup `deploy` uses. Each takes `--dry-run` (prints the plan, makes no
-request); the destructive `kill`/`delete` also require `--yes`.
+The five lifecycle verbs (`kill`, `resume`, `budget`, `reset-thread`, `delete`)
+act on a deployed release's agents through the same platform API, defaulting
+`--api-url` to `http://localhost:8000` (auth via `--api-key` or
+`AGENTOS_API_KEY`). Unlike `cluster deploy`, which self-plumbs a port-forward
+and auto-discovers the release key (ADR-0057), the lifecycle verbs do neither
+-- pass `--api-url` or port-forward the API yourself. They resolve `<agent>`
+(a name or id) to its API id with the same lookup `deploy` uses. Each takes
+`--dry-run` (prints the plan, makes no request); the destructive
+`kill`/`reset-thread`/`delete` also require `--yes`.
 
 ### Bundle packing exclusions
 
@@ -512,7 +517,8 @@ control flow are machine-first.
 **`--json`** (global) makes every agent-facing verb emit a single
 machine-readable JSON object on **stdout** instead of empty output: the
 read/query verbs (`versions`, `memory`, `approvals`, `observability`), the
-lifecycle result verbs (`kill`, `resume`, `budget`, `delete`), and every verb's
+lifecycle result verbs (`kill`, `resume`, `budget`, `reset-thread`, `delete`),
+and every verb's
 `--dry-run` plan (uniform shape `{"dry_run": true, "plan": [<lines>]}`) all
 route through one centralized emitter. The `message` verbs keep their own,
 more specific shapes: `agentos local message` and `agentos cluster message`
@@ -546,8 +552,9 @@ parsing output:
 | 4    | unsupported | The verb was understood, but the concept it inspects does not exist at this tier by construction (`agentos skill versions`, `agentos skill memory`). No input and no retry changes that -- the same argv never succeeds here; the `fix` hint names the tier that does answer it. |
 
 **Non-interactive by default.** Every mutating command has a non-interactive
-path (`--yes` on `cluster down`/`kill`/`delete` and `local down --wipe`); none
-block on stdin. A confirmation prompt that would otherwise read stdin refuses
+path (`--yes` on `cluster down`/`kill`/`delete`/`reset-thread`, `local
+reset-thread`, and `local down --wipe`); none block on stdin. A confirmation
+prompt that would otherwise read stdin refuses
 with a usage error (exit 2) when the session is not a terminal, rather than
 hanging.
 

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -78,6 +78,11 @@
       "omissions": []
     },
     {
+      "struct": "ThreadResetState",
+      "schema": "ThreadResetState",
+      "omissions": []
+    },
+    {
       "struct": "EvalTriggerResult",
       "schema": "EvalTriggerResult",
       "omissions": [

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -1487,6 +1487,73 @@
           ],
           "hidden": false,
           "name": "resume"
+        },
+        {
+          "about": "Force a stuck thread's sandbox to be released (`POST /agents/{id}/threads/{thread_key}/reset`, #737). The worker's next maintenance tick deletes the thread's claim and route, so its next message cold-creates a fresh sandbox instead of adopting one that may be running stale env. Interrupts a live turn on the thread first, so it requires --yes; does not delete conversation history",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id (scopes the action; the release is thread-keyed)",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The thread key to reset (e.g. the Slack thread ts)",
+              "id": "thread_key",
+              "long": "thread-key",
+              "positional": false,
+              "required": true
+            },
+            {
+              "default_values": [
+                "http://localhost:28000"
+              ],
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos-dev-key"
+              ],
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the action; it interrupts any live turn on the thread",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "reset-thread"
         }
       ]
     },
@@ -2523,6 +2590,92 @@
           ],
           "hidden": false,
           "name": "budget"
+        },
+        {
+          "about": "Force a stuck thread's sandbox to be released via the platform API (`POST /agents/{id}/threads/{thread_key}/reset`, #737). The worker's next maintenance tick deletes the thread's claim and route, so its next message cold-creates a fresh sandbox instead of adopting one that may be running stale env. Interrupts a live turn on the thread first, so it requires --yes; does not delete conversation history",
+          "args": [
+            {
+              "global": false,
+              "help": "Agent name or id (scopes the action; the release is thread-keyed)",
+              "id": "agent",
+              "positional": true,
+              "required": true
+            },
+            {
+              "global": false,
+              "help": "The thread key to reset (e.g. the Slack thread ts)",
+              "id": "thread_key",
+              "long": "thread-key",
+              "positional": false,
+              "required": true
+            },
+            {
+              "env": "AGENTOS_API_URL",
+              "global": false,
+              "help": "Platform API base URL. Omit to discover the release's UI `/api` proxy",
+              "id": "api_url",
+              "long": "api-url",
+              "positional": false,
+              "required": false
+            },
+            {
+              "env": "AGENTOS_API_KEY",
+              "global": false,
+              "help": "Platform API key. Omit to read the release's `api.apiKey` from its Secret",
+              "id": "api_key",
+              "long": "api-key",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Kubernetes namespace of the release. Default: agentos",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "agentos"
+              ],
+              "global": false,
+              "help": "Helm release name. Default: agentos",
+              "id": "release",
+              "long": "release",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Confirm the action; it interrupts any live turn on the thread",
+              "id": "yes",
+              "long": "yes",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Print what would be done and exit without making a request",
+              "id": "dry_run",
+              "long": "dry-run",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "name": "reset-thread"
         },
         {
           "about": "Delete an agent via the platform API (`DELETE /agents/{id}`)",

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -139,6 +139,14 @@ pub struct KillState {
     pub killed: bool,
 }
 
+/// Whether a thread has a pending forced-sandbox-release request
+/// (`ThreadResetState` in openapi.json): the response of
+/// `POST /agents/{id}/threads/{thread_key}/reset` (#737).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ThreadResetState {
+    pub requested: bool,
+}
+
 /// The enqueued eval job's identity (`EvalTriggerResult` in openapi.json): the
 /// response of `POST /evals/trigger`. `sha` keys the run's matrix column and
 /// `model` echoes the requested model (#526) so a sweep can pair each job to the
@@ -558,6 +566,28 @@ impl ApiClient {
             .json()
             .await
             .context("decoding kill state")
+    }
+
+    /// Force a thread's sandbox to be released: `POST
+    /// /agents/{id}/threads/{thread_key}/reset` (no request body, #737). The
+    /// worker's next maintenance tick deletes the thread's claim and route, so
+    /// its next message cold-creates a fresh sandbox.
+    pub async fn reset_thread(&self, agent_id: &str, thread_key: &str) -> Result<ThreadResetState> {
+        let resp = self
+            .http
+            .post(format!(
+                "{}/agents/{agent_id}/threads/{thread_key}/reset",
+                self.base_url
+            ))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("POST /agents/{id}/threads/{thread_key}/reset")?;
+        Self::expect_ok(resp, "resetting the thread")
+            .await?
+            .json()
+            .await
+            .context("decoding thread reset state")
     }
 
     /// Set the agent budget: `PUT /agents/{id}/budget` with a `BudgetConfig` body.

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2780,6 +2780,100 @@ pub async fn budget(opts: AgentActionOpts, limit: f64) -> Result<BudgetOutput> {
     })
 }
 
+/// Output of `<tier> reset-thread <agent> --thread-key <key>`: the dry-run
+/// plan, or the resulting reset-request state. Owns its data so it outlives
+/// the `ApiClient`.
+#[derive(Debug)]
+pub enum ResetThreadOutput {
+    DryRun(crate::ui::DryRunPlan),
+    Done {
+        agent: String,
+        thread_key: String,
+        requested: bool,
+    },
+}
+
+impl crate::ui::CliOutput for ResetThreadOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            ResetThreadOutput::DryRun(plan) => plan.to_json(),
+            ResetThreadOutput::Done {
+                agent,
+                thread_key,
+                requested,
+            } => {
+                serde_json::json!({"agent": agent, "thread_key": thread_key, "requested": requested})
+            }
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        match self {
+            ResetThreadOutput::DryRun(plan) => plan.render(ui),
+            ResetThreadOutput::Done {
+                agent,
+                thread_key,
+                requested,
+            } => {
+                ui.payload(&format!(
+                    "thread {thread_key} on agent {agent} reset requested={requested}"
+                ));
+                ui.note(
+                    "The worker's next maintenance tick releases the sandbox; the next message on this thread cold-creates a fresh one.",
+                );
+            }
+        }
+    }
+}
+
+/// `agentos <tier> reset-thread <agent> --thread-key <key> --yes`: force the
+/// thread's sandbox to be released (`POST
+/// /agents/{id}/threads/{thread_key}/reset`, #737). Interrupts a live turn on
+/// the thread first, so it refuses without `--yes`, mirroring `kill`.
+/// `--dry-run` returns the plan and makes no request.
+pub async fn reset_thread(
+    opts: AgentActionOpts,
+    thread_key: String,
+    yes: bool,
+) -> Result<ResetThreadOutput> {
+    let ui = crate::ui::ui();
+    if opts.dry_run {
+        return Ok(ResetThreadOutput::DryRun(crate::ui::DryRunPlan {
+            lines: vec![format!(
+                "POST {}/agents/<id>/threads/{}/reset  (would resolve agent {:?} first)",
+                opts.api_url, thread_key, opts.agent
+            )],
+        }));
+    }
+    if !yes {
+        return Err(crate::exit::CliError::usage(format!(
+            "`agentos ... reset-thread {} --thread-key {}` interrupts any live turn on the thread; re-run with --yes to confirm",
+            opts.agent, thread_key
+        ))
+        .with_fix("re-run with --yes")
+        .into());
+    }
+    let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
+    let agent = client.find_agent(&opts.agent).await?;
+    let cl = ui.checklist();
+    let step = cl.step(&format!("resetting thread {thread_key} on {}", agent.name));
+    let state = match client.reset_thread(&agent.id, &thread_key).await {
+        Ok(state) => {
+            step.done("reset requested");
+            state
+        }
+        Err(err) => {
+            step.fail("failed");
+            return Err(err);
+        }
+    };
+    Ok(ResetThreadOutput::Done {
+        agent: agent.name,
+        thread_key,
+        requested: state.requested,
+    })
+}
+
 /// Output of `<tier> delete <agent>`: the dry-run plan, or the deleted agent's
 /// name. Owns its data so it outlives the `ApiClient`.
 #[derive(Debug)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -882,6 +882,32 @@ enum LocalAction {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Force a stuck thread's sandbox to be released (`POST
+    /// /agents/{id}/threads/{thread_key}/reset`, #737). The worker's next
+    /// maintenance tick deletes the thread's claim and route, so its next
+    /// message cold-creates a fresh sandbox instead of adopting one that may be
+    /// running stale env. Interrupts a live turn on the thread first, so it
+    /// requires --yes; does not delete conversation history.
+    ResetThread {
+        /// Agent name or id (scopes the action; the release is thread-keyed).
+        agent: String,
+        /// The thread key to reset (e.g. the Slack thread ts).
+        #[arg(long, value_name = "THREAD_KEY")]
+        thread_key: String,
+        #[arg(
+            long,
+            default_value = "http://localhost:28000",
+            env = "AGENTOS_API_URL"
+        )]
+        api_url: String,
+        #[arg(long, default_value = "agentos-dev-key", env = "AGENTOS_API_KEY", value_parser = message::api_key_or_default)]
+        api_key: String,
+        /// Confirm the action; it interrupts any live turn on the thread.
+        #[arg(long)]
+        yes: bool,
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1243,6 +1269,27 @@ enum ClusterAction {
         limit: f64,
         #[command(flatten)]
         conn: ClusterConn,
+        /// Print what would be done and exit without making a request.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Force a stuck thread's sandbox to be released via the platform API
+    /// (`POST /agents/{id}/threads/{thread_key}/reset`, #737). The worker's
+    /// next maintenance tick deletes the thread's claim and route, so its next
+    /// message cold-creates a fresh sandbox instead of adopting one that may be
+    /// running stale env. Interrupts a live turn on the thread first, so it
+    /// requires --yes; does not delete conversation history.
+    ResetThread {
+        /// Agent name or id (scopes the action; the release is thread-keyed).
+        agent: String,
+        /// The thread key to reset (e.g. the Slack thread ts).
+        #[arg(long, value_name = "THREAD_KEY")]
+        thread_key: String,
+        #[command(flatten)]
+        conn: ClusterConn,
+        /// Confirm the action; it interrupts any live turn on the thread.
+        #[arg(long)]
+        yes: bool,
         /// Print what would be done and exit without making a request.
         #[arg(long)]
         dry_run: bool,
@@ -1808,6 +1855,26 @@ async fn run(command: Option<Command>) -> Result<()> {
                 })
                 .await?,
             ),
+            LocalAction::ResetThread {
+                agent,
+                thread_key,
+                api_url,
+                api_key,
+                yes,
+                dry_run,
+            } => emit(
+                commands::reset_thread(
+                    AgentActionOpts {
+                        api_url,
+                        api_key,
+                        agent,
+                        dry_run,
+                    },
+                    thread_key,
+                    yes,
+                )
+                .await?,
+            ),
         },
         Some(Command::Cluster { action }) => match action {
             ClusterAction::Up {
@@ -2231,6 +2298,28 @@ async fn run(command: Option<Command>) -> Result<()> {
                             dry_run,
                         },
                         limit,
+                    )
+                    .await?,
+                )
+            }
+            ClusterAction::ResetThread {
+                agent,
+                thread_key,
+                conn,
+                yes,
+                dry_run,
+            } => {
+                let (api_url, api_key) = resolve_cluster_conn(conn).await?;
+                emit(
+                    commands::reset_thread(
+                        AgentActionOpts {
+                            api_url,
+                            api_key,
+                            agent,
+                            dry_run,
+                        },
+                        thread_key,
+                        yes,
                     )
                     .await?,
                 )
@@ -2925,6 +3014,73 @@ mod tests {
     }
 
     #[test]
+    fn cluster_reset_thread_parses_agent_thread_key_and_yes() {
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "cluster",
+            "reset-thread",
+            "deal-desk",
+            "--thread-key",
+            "1234.5678",
+            "--yes",
+        ])
+        .expect("cluster reset-thread should parse");
+        match cli.command {
+            Some(Command::Cluster {
+                action:
+                    ClusterAction::ResetThread {
+                        agent,
+                        thread_key,
+                        yes,
+                        ..
+                    },
+            }) => {
+                assert_eq!(agent, "deal-desk");
+                assert_eq!(thread_key, "1234.5678");
+                assert!(yes);
+            }
+            _ => panic!("expected cluster reset-thread command"),
+        }
+    }
+
+    #[test]
+    fn cluster_reset_thread_defaults_yes_and_dry_run_off() {
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "cluster",
+            "reset-thread",
+            "a",
+            "--thread-key",
+            "t1",
+        ])
+        .expect("cluster reset-thread without flags should parse");
+        match cli.command {
+            Some(Command::Cluster {
+                action:
+                    ClusterAction::ResetThread {
+                        agent,
+                        thread_key,
+                        yes,
+                        dry_run,
+                        ..
+                    },
+            }) => {
+                assert_eq!(agent, "a");
+                assert_eq!(thread_key, "t1");
+                assert!(!yes);
+                assert!(!dry_run);
+            }
+            _ => panic!("expected cluster reset-thread command"),
+        }
+    }
+
+    #[test]
+    fn cluster_reset_thread_requires_thread_key() {
+        // --thread-key has no default; omitting it must be a parse error.
+        assert!(Cli::try_parse_from(["agentos", "cluster", "reset-thread", "a", "--yes"]).is_err());
+    }
+
+    #[test]
     fn local_platform_verbs_parse() {
         // The inspection/governance verbs mirrored onto the local tier.
         assert!(matches!(
@@ -2954,6 +3110,63 @@ mod tests {
         // local budget/kill/resume are the mirrored lifecycle verbs.
         assert!(Cli::try_parse_from(["agentos", "local", "budget", "gh", "--limit", "1"]).is_ok());
         assert!(Cli::try_parse_from(["agentos", "local", "kill", "gh", "--yes"]).is_ok());
+    }
+
+    #[test]
+    fn local_reset_thread_parses_agent_thread_key_and_yes() {
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "local",
+            "reset-thread",
+            "gh",
+            "--thread-key",
+            "1234.5678",
+            "--yes",
+        ])
+        .expect("local reset-thread should parse");
+        match cli.command {
+            Some(Command::Local {
+                action:
+                    LocalAction::ResetThread {
+                        agent,
+                        thread_key,
+                        yes,
+                        dry_run,
+                        ..
+                    },
+            }) => {
+                assert_eq!(agent, "gh");
+                assert_eq!(thread_key, "1234.5678");
+                assert!(yes);
+                assert!(!dry_run);
+            }
+            _ => panic!("expected local reset-thread command"),
+        }
+    }
+
+    #[test]
+    fn local_reset_thread_dry_run_skips_yes_requirement_at_parse_time() {
+        // --dry-run parses fine without --yes; the refusal-without-yes check
+        // happens in commands::reset_thread, not at the clap layer.
+        let cli = Cli::try_parse_from([
+            "agentos",
+            "local",
+            "reset-thread",
+            "gh",
+            "--thread-key",
+            "t1",
+            "--dry-run",
+        ])
+        .expect("local reset-thread --dry-run should parse");
+        match cli.command {
+            Some(Command::Local {
+                action: LocalAction::ResetThread { dry_run, yes, .. },
+            }) => {
+                assert!(dry_run);
+                assert!(!yes);
+            }
+            _ => panic!("expected local reset-thread command"),
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/cli/tests/api_lifecycle.rs
+++ b/cli/tests/api_lifecycle.rs
@@ -1,9 +1,9 @@
-//! Integration: the agent-lifecycle verbs (`cluster kill|resume|budget|delete`,
-//! #149) against the committed platform-API contract shapes (apps/api
-//! openapi.json), served by the wire-level test server. Covers both the
-//! `ApiClient` methods (correct HTTP method + path + body) and the command
-//! handlers (`--yes` gate on the destructive verbs, `--dry-run` makes no
-//! request).
+//! Integration: the agent-lifecycle verbs (`cluster kill|resume|budget|delete|
+//! reset-thread`, #149, #737) against the committed platform-API contract
+//! shapes (apps/api openapi.json), served by the wire-level test server.
+//! Covers both the `ApiClient` methods (correct HTTP method + path + body) and
+//! the command handlers (`--yes` gate on the destructive verbs, `--dry-run`
+//! makes no request).
 
 mod support;
 
@@ -102,6 +102,26 @@ async fn set_budget_puts_the_limit_as_max_usd_per_day() {
 }
 
 #[tokio::test]
+async fn reset_thread_posts_to_reset_endpoint_with_empty_body() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("POST", p) if *p == format!("/agents/{AGENT_ID}/threads/t-1/reset") => {
+            Response::json(200, r#"{"requested":true}"#)
+        }
+        other => panic!("unexpected request: {other:?}"),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    let state = client.reset_thread(AGENT_ID, "t-1").await.unwrap();
+    assert!(state.requested);
+
+    let rec = server.recorded();
+    assert_eq!(rec.len(), 1);
+    assert_eq!(rec[0].method, "POST");
+    assert_eq!(rec[0].path, format!("/agents/{AGENT_ID}/threads/t-1/reset"));
+    assert!(rec[0].body.is_empty(), "reset sends no body");
+    assert_eq!(rec[0].header("x-api-key"), Some("k"));
+}
+
+#[tokio::test]
 async fn delete_agent_issues_a_delete() {
     let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
         ("DELETE", p) if *p == format!("/agents/{AGENT_ID}") => Response {
@@ -183,6 +203,57 @@ async fn budget_handler_resolves_then_puts_the_limit() {
 }
 
 #[tokio::test]
+async fn reset_thread_handler_resolves_by_name_then_resets() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => agent_list(),
+        ("POST", p) if *p == format!("/agents/{AGENT_ID}/threads/t-1/reset") => {
+            Response::json(200, r#"{"requested":true}"#)
+        }
+        other => panic!("unexpected request: {other:?}"),
+    });
+    commands::reset_thread(
+        opts(&server.base_url, "deal-desk", false),
+        "t-1".to_string(),
+        true,
+    )
+    .await
+    .unwrap();
+
+    let flow: Vec<(String, String)> = server
+        .recorded()
+        .iter()
+        .map(|r| (r.method.clone(), r.path.clone()))
+        .collect();
+    assert_eq!(
+        flow,
+        vec![
+            ("GET".to_string(), "/agents".to_string()),
+            (
+                "POST".to_string(),
+                format!("/agents/{AGENT_ID}/threads/t-1/reset")
+            ),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn reset_thread_without_yes_refuses_and_makes_no_request() {
+    let server = serve(|req| panic!("no request expected, got {} {}", req.method, req.path));
+    let err = commands::reset_thread(
+        opts(&server.base_url, "deal-desk", false),
+        "t-1".to_string(),
+        false,
+    )
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("--yes"), "{err}");
+    assert!(
+        server.recorded().is_empty(),
+        "a refused reset-thread must make no request"
+    );
+}
+
+#[tokio::test]
 async fn kill_without_yes_refuses_and_makes_no_request() {
     let server = serve(|req| panic!("no request expected, got {} {}", req.method, req.path));
     let err = commands::kill(opts(&server.base_url, "deal-desk", false), false)
@@ -217,6 +288,9 @@ async fn dry_run_makes_no_request_for_any_verb() {
     commands::resume(opts(base, "a", true)).await.unwrap();
     commands::budget(opts(base, "a", true), 5.0).await.unwrap();
     commands::delete(opts(base, "a", true), false)
+        .await
+        .unwrap();
+    commands::reset_thread(opts(base, "a", true), "t-1".to_string(), false)
         .await
         .unwrap();
     assert!(

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -535,7 +535,7 @@ fn cluster_comms_disconnect_dry_run_emits_plan_not_error() {
 use agentos::api::{MemoryEntry, Version};
 use agentos::commands::{
     ApprovalsOutput, BudgetOutput, DeleteOutput, InitOutput, KillOutput, MemoryOutput,
-    ResumeOutput, VersionsOutput,
+    ResetThreadOutput, ResumeOutput, VersionsOutput,
 };
 // `ObservabilityOutput` moved to the tier-aware `observability` seam (#460) so
 // both the local and cluster handlers return one type.
@@ -955,6 +955,23 @@ fn budget_output_json_shape_is_pinned() {
         }
         .to_json(),
         json!({"agent": "weather", "max_usd_per_day": null})
+    );
+}
+
+#[test]
+fn reset_thread_output_json_shape_is_pinned() {
+    assert_eq!(
+        ResetThreadOutput::DryRun(plan(&["POST <api>/agents/<id>/threads/<key>/reset"])).to_json(),
+        json!({"dry_run": true, "plan": ["POST <api>/agents/<id>/threads/<key>/reset"]})
+    );
+    assert_eq!(
+        ResetThreadOutput::Done {
+            agent: "weather".to_string(),
+            thread_key: "t-1".to_string(),
+            requested: true,
+        }
+        .to_json(),
+        json!({"agent": "weather", "thread_key": "t-1", "requested": true})
     );
 }
 


### PR DESCRIPTION
## Summary

- Issue #721 shipped `POST /agents/{agent_id}/threads/{thread_key}/reset` in `apps/api` but no CLI surface, so an operator's only path was a hand-rolled curl with an API key.
- Add `agentos local reset-thread` and `agentos cluster reset-thread`, mirroring the existing `kill`/`resume`/`budget` agent-lifecycle verbs: an `agent` positional plus a required `--thread-key`, an `--api-url`/`--api-key` surface (local defaults, cluster discovers from the release), a `--yes` gate (it interrupts any live turn on the thread), and `--dry-run` support.
- Routed through a typed `ResetThreadOutput` (`CliOutput`/`Ui::emit`), so `--json` emits `{"agent", "thread_key", "requested"}` (or the dry-run plan shape) rather than empty stdout.
- Added `ApiClient::reset_thread` + `ThreadResetState` (declared in `cli/api-mirrors.json`) to speak the endpoint's contract.
- Regenerated `cli/command-manifest.json` and `apps/ui/src/generated/commandManifest.ts` for the new clap surface.
- Documented the new verb in `cli/README.md`'s command tables.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (clap parse tests for both tiers, `ApiClient`/handler integration tests against a mocked API server, pinned `--json` output shape, manifest drift check)

Closes #737