### PR TITLE
Require an explicit allowlist of check-runs and paginate the check-run fetch

### DIFF
--- a/release/authorize.py
+++ b/release/authorize.py
@@ -10,12 +10,15 @@ pipeline, and it fails closed on either of two questions:
             feature branch, a rebased-away commit, or anything that bypassed a
             merged PR is refused here, before any image builds.
 
-  checks    Does that commit's check-runs list show every check successful (or
-            neutral/skipped)? A commit that is on main but was never checked,
-            or was checked and failed, is refused the same way. Zero check-runs
-            is also a failure -- absence of checks is not evidence they passed.
-            The gate's own workflow run is excluded from that list (issue
-            #732): it is itself an in-progress check-run on the tagged SHA and
+  checks    Does that commit's check-runs list show every REQUIRED_CHECK_NAMES
+            entry successful (or neutral/skipped)? An explicit allowlist,
+            not "some checks, all green" (issue #733): a commit with only an
+            unrelated passing check-run and no sign its real CI ever ran
+            must be refused, the same as one that is on main but was never
+            checked, or was checked and failed. Zero check-runs is also a
+            failure -- absence of checks is not evidence they passed. The
+            gate's own workflow run is excluded from that list (issue #732):
+            it is itself an in-progress check-run on the tagged SHA and
             would otherwise wait on itself forever.
 
 Both live as separately-testable functions so the negative case -- an
@@ -35,6 +38,43 @@ import sys
 from pathlib import Path
 
 PASSING_CONCLUSIONS = {"success", "neutral", "skipped"}
+
+# The check-run names that must be present and green before a tag may
+# publish (issue #733). These are the job `name:` fields from
+# `.github/workflows/ci.yaml` -- the workflow that gates every PR/push to
+# `main` -- restricted to the jobs that speak to release confidence: the
+# three language/test jobs, the generated-artifact drift checks, the
+# release-compose validation, every first-party image actually building
+# (including the worker-local overlay and the dispatcher's own import
+# smoke-test), and the two behavioral gates (eval falsifiability, the E2E
+# parity ladder) that ci.yaml's own comments describe as catching bug
+# classes no unit test does. Checks from other workflows (CodeQL, the
+# dependency/secret scanners, release.yaml's own jobs) are deliberately
+# excluded -- they matter, but are not what this gate is asserting about
+# *this* commit's CI.
+#
+# This list is a plain constant, not derived from ci.yaml at runtime -- the
+# simpler of the two options ADR-0058 left open (issue #733). A renamed or
+# removed ci.yaml job needs a matching edit here; there is no drift check
+# tying the two together yet.
+REQUIRED_CHECK_NAMES = frozenset(
+    {
+        "Python (ruff + mypy + pytest)",
+        "Rust (fmt + clippy + test)",
+        "Contracts (generated TypeScript compiles)",
+        "UI (lint + vitest + build + Playwright)",
+        "Compose (release stack validates)",
+        "Build runner image (no push)",
+        "Build api image (no push)",
+        "Build dispatcher image (no push)",
+        "Build worker image (no push)",
+        "Build ui image (no push)",
+        "Build worker-local overlay image (no push)",
+        "Dispatcher image imports resolve",
+        "Eval falsifiability gate (fake model, offline)",
+        "E2E parity ladder (skill + local, fake model)",
+    }
+)
 
 
 class AuthorizationError(Exception):
@@ -58,15 +98,47 @@ def commit_is_on_reviewed_main(
     return result.returncode == 0
 
 
-def required_checks_passed(check_runs: list[dict[str, object]]) -> bool:
-    """Did every check-run for the commit conclude successfully?
+def missing_required_checks(
+    check_runs: list[dict[str, object]],
+    required_names: frozenset[str] | None = None,
+) -> set[str]:
+    """Which `required_names` have no passing check-run for this commit?
 
-    An empty list fails: no checks having run is not the same as them passing,
-    and a commit racing ahead of its own CI must not slip through on that gap.
+    A name only counts as satisfied if some check-run with that exact `name`
+    concluded `success`/`neutral`/`skipped`; a same-named entry that is still
+    running, failed, or never ran at all leaves its name in the returned set.
+    Names outside `required_names` are ignored entirely -- an unrelated
+    check-run, passing or not, has no bearing on this gate (issue #733): the
+    point is asserting the checks that matter actually ran and passed, not
+    that everything present happened to be green.
+
+    `required_names` defaults to the module-level `REQUIRED_CHECK_NAMES`,
+    looked up here rather than bound as the parameter's default value so that
+    tests can override the module constant and have every caller (including
+    `main()`, which never passes this through explicitly) pick it up.
+    """
+    if required_names is None:
+        required_names = REQUIRED_CHECK_NAMES
+    passed_names = {
+        run.get("name") for run in check_runs if run.get("conclusion") in PASSING_CONCLUSIONS
+    }
+    return set(required_names) - passed_names
+
+
+def required_checks_passed(
+    check_runs: list[dict[str, object]],
+    required_names: frozenset[str] | None = None,
+) -> bool:
+    """Did every one of `required_names` conclude successfully for this commit?
+
+    An empty check-run list fails trivially: none of the required names can be
+    satisfied by nothing, so absence of checks is not evidence they passed. A
+    non-empty list where some unrelated check-run passed but a required one
+    never ran is the exact case issue #733 closes -- it also fails here.
     """
     if not check_runs:
         return False
-    return all(run.get("conclusion") in PASSING_CONCLUSIONS for run in check_runs)
+    return not missing_required_checks(check_runs, required_names)
 
 
 def exclude_current_workflow_run(
@@ -100,6 +172,7 @@ def authorize(
     *,
     cwd: Path | None = None,
     exclude_run_id: str | None = None,
+    required_names: frozenset[str] | None = None,
 ) -> None:
     """Raise AuthorizationError unless `sha` may publish a release."""
     if not commit_is_on_reviewed_main(sha, main_ref, cwd=cwd):
@@ -109,23 +182,35 @@ def authorize(
             "PR; refusing to authorize this tag."
         )
     other_runs = exclude_current_workflow_run(check_runs, exclude_run_id)
-    if not required_checks_passed(other_runs):
+    missing = missing_required_checks(other_runs, required_names)
+    if missing:
         raise AuthorizationError(
-            f"commit {sha} does not have a fully successful set of check-runs "
-            f"({len(other_runs)} found, excluding this workflow run's own). "
-            "Refusing to authorize this tag until its required checks are "
-            "current and green."
+            f"commit {sha} is missing {len(missing)} required check-run(s) "
+            f"({len(other_runs)} check-runs found for the commit, excluding "
+            "this workflow run's own): "
+            f"{', '.join(sorted(missing))}. Refusing to authorize this tag "
+            "until its required checks are current and green."
         )
 
 
-def fetch_check_runs(sha: str, repo: str) -> list[dict[str, object]]:
+def fetch_check_runs(
+    sha: str, repo: str, *, per_page: int = 100
+) -> list[dict[str, object]]:
     """The commit's check-runs via `gh api`, which carries GITHUB_TOKEN auth.
 
-    `per_page=100` without pagination: this repo's own CI (see release.yaml's
-    check list) runs well under 20 checks per commit, so a single page always
-    covers it, and parsing one JSON object is simpler than merging paginated
-    array-under-a-key responses (this endpoint's top level is an object, not
-    an array, so `gh api --paginate` does not auto-merge it).
+    Paginates explicitly rather than assuming one page covers it (issue
+    #733): a real commit on this repo's `main` was measured with dozens of
+    check-runs (CodeQL, dependency/secret scanners, and every ci.yaml job,
+    several of them matrixed), comfortably past the endpoint's own default
+    page size of 30, and there is no ceiling on that growing further as more
+    workflows land. `per_page=100` shrinks the common case to one request,
+    but the loop below keeps requesting subsequent pages -- using the
+    response's own `total_count` as the stopping point -- until every
+    check-run has been collected, so correctness does not depend on staying
+    under any particular count. This endpoint's top level is an object, not
+    an array (`total_count` + `check_runs`), so `gh api --paginate` would not
+    auto-merge it even if used; paging by hand and concatenating `check_runs`
+    across responses is the simpler route.
 
     `-X GET` is load-bearing, not decoration: `gh api` defaults to GET but
     switches to POST as soon as any `-f`/`-F` flag is present, and
@@ -133,22 +218,37 @@ def fetch_check_runs(sha: str, repo: str) -> list[dict[str, object]]:
     (issue #732). The live observation pinning this is cited in
     `release/tests/test_authorize.py::TestFetchCheckRuns`.
     """
-    result = subprocess.run(
-        [
-            "gh",
-            "api",
-            "-X",
-            "GET",
-            f"repos/{repo}/commits/{sha}/check-runs",
-            "-f",
-            "per_page=100",
-        ],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    payload = json.loads(result.stdout)
-    runs: list[dict[str, object]] = payload["check_runs"]
+    runs: list[dict[str, object]] = []
+    total_count: int | None = None
+    page = 1
+    while total_count is None or len(runs) < total_count:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "-X",
+                "GET",
+                f"repos/{repo}/commits/{sha}/check-runs",
+                "-f",
+                f"per_page={per_page}",
+                "-f",
+                f"page={page}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        payload = json.loads(result.stdout)
+        if total_count is None:
+            total_count = payload["total_count"]
+        page_runs = payload["check_runs"]
+        if not page_runs:
+            # A page reporting nothing ends the loop even if total_count
+            # implied more remained -- a stale/wrong total_count must not
+            # spin this forever.
+            break
+        runs.extend(page_runs)
+        page += 1
     return runs
 
 

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -2,15 +2,17 @@
 
 The gate is the deterministic check behind issue #628: a `v*` tag must not be
 able to start the publish pipeline unless its commit is reachable from
-`origin/main` and that commit's checks are all green. These tests drive both
-functions directly -- `commit_is_on_reviewed_main` against a real, disposable
-git repo (no network needed for ancestry) and `required_checks_passed` against
-constructed check-run lists -- plus `authorize()`, which combines them and is
-what `authorize-release` actually calls.
+`origin/main` and that commit's required checks are all green. These tests
+drive both functions directly -- `commit_is_on_reviewed_main` against a real,
+disposable git repo (no network needed for ancestry) and
+`required_checks_passed`/`missing_required_checks` against constructed
+check-run lists -- plus `authorize()`, which combines them and is what
+`authorize-release` actually calls.
 """
 
 import importlib.util
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -58,6 +60,13 @@ def git_repo(tmp_path) -> Path:
     return repo
 
 
+# A required-name set distinct from the real, larger production
+# REQUIRED_CHECK_NAMES (issue #733). Most tests in this file exercise the
+# *logic* of required-check matching and should not need updating every time
+# a ci.yaml job is renamed or added; the production constant itself gets its
+# own coverage in TestRequiredCheckAllowlist below.
+TEST_REQUIRED_NAMES = frozenset({"CI", "CodeQL"})
+
 CHECK_RUNS_ALL_GREEN = [
     {"name": "CI", "conclusion": "success"},
     {"name": "CodeQL", "conclusion": "neutral"},
@@ -65,7 +74,7 @@ CHECK_RUNS_ALL_GREEN = [
 ]
 CHECK_RUNS_ONE_FAILED = [
     {"name": "CI", "conclusion": "success"},
-    {"name": "Dependency Audit", "conclusion": "failure"},
+    {"name": "CodeQL", "conclusion": "failure"},
 ]
 
 CURRENT_RUN_ID = "29811627398"
@@ -120,22 +129,75 @@ class TestCommitIsOnReviewedMain:
 
 
 class TestRequiredChecksPassed:
-    def test_all_success_or_neutral_or_skipped_passes(self):
-        assert authorize_module.required_checks_passed(CHECK_RUNS_ALL_GREEN)
+    def test_all_required_names_present_and_green_passes(self):
+        assert authorize_module.required_checks_passed(
+            CHECK_RUNS_ALL_GREEN, TEST_REQUIRED_NAMES
+        )
 
-    def test_any_failure_fails(self):
-        assert not authorize_module.required_checks_passed(CHECK_RUNS_ONE_FAILED)
+    def test_a_required_name_that_concluded_failure_fails(self):
+        assert not authorize_module.required_checks_passed(
+            CHECK_RUNS_ONE_FAILED, TEST_REQUIRED_NAMES
+        )
 
     def test_no_check_runs_fails(self):
         # Absence of checks is not evidence they passed.
-        assert not authorize_module.required_checks_passed([])
+        assert not authorize_module.required_checks_passed([], TEST_REQUIRED_NAMES)
+
+    def test_a_missing_required_name_fails_even_if_everything_present_is_green(self):
+        # issue #733's core scenario: a non-empty, fully-passing list that
+        # simply never contains the name that matters.
+        only_unrelated = [{"name": "Secret Scan", "conclusion": "success"}]
+
+        assert not authorize_module.required_checks_passed(
+            only_unrelated, TEST_REQUIRED_NAMES
+        )
+
+    def test_an_unrelated_failing_check_does_not_affect_the_required_set(self):
+        # Only required names are asserted; a failing check outside
+        # `required_names` has no bearing (this is not "everything present
+        # must pass" -- that was the old, weaker behavior issue #733 replaces).
+        runs = [
+            {"name": "CI", "conclusion": "success"},
+            {"name": "CodeQL", "conclusion": "neutral"},
+            {"name": "Some Unrelated Job", "conclusion": "failure"},
+        ]
+
+        assert authorize_module.required_checks_passed(runs, TEST_REQUIRED_NAMES)
+
+
+class TestMissingRequiredChecks:
+    def test_empty_check_runs_reports_every_required_name_missing(self):
+        assert (
+            authorize_module.missing_required_checks([], TEST_REQUIRED_NAMES)
+            == TEST_REQUIRED_NAMES
+        )
+
+    def test_all_present_and_green_reports_nothing_missing(self):
+        assert (
+            authorize_module.missing_required_checks(
+                CHECK_RUNS_ALL_GREEN, TEST_REQUIRED_NAMES
+            )
+            == set()
+        )
+
+    def test_a_required_name_present_but_not_concluded_is_reported_missing(self):
+        runs = [
+            {"name": "CI", "conclusion": "success"},
+            {"name": "CodeQL", "conclusion": None},  # still in_progress
+        ]
+
+        assert authorize_module.missing_required_checks(
+            runs, TEST_REQUIRED_NAMES
+        ) == {"CodeQL"}
 
 
 class TestAuthorize:
     def test_reviewed_and_green_commit_is_authorized(self, git_repo):
         sha = run_git(git_repo, "rev-parse", "HEAD")
 
-        authorize_module.authorize(sha, CHECK_RUNS_ALL_GREEN, "main", cwd=git_repo)
+        authorize_module.authorize(
+            sha, CHECK_RUNS_ALL_GREEN, "main", cwd=git_repo, required_names=TEST_REQUIRED_NAMES
+        )
 
     def test_unreviewed_commit_is_refused_even_with_green_checks(self, git_repo):
         run_git(git_repo, "checkout", "-q", "-b", "feature")
@@ -143,16 +205,79 @@ class TestAuthorize:
 
         with pytest.raises(authorize_module.AuthorizationError, match="not reachable"):
             authorize_module.authorize(
-                unmerged, CHECK_RUNS_ALL_GREEN, "main", cwd=git_repo
+                unmerged,
+                CHECK_RUNS_ALL_GREEN,
+                "main",
+                cwd=git_repo,
+                required_names=TEST_REQUIRED_NAMES,
             )
 
-    def test_reviewed_commit_with_failed_checks_is_refused(self, git_repo):
+    def test_reviewed_commit_with_a_failed_required_check_is_refused(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+
+        with pytest.raises(authorize_module.AuthorizationError, match="required check-run"):
+            authorize_module.authorize(
+                sha,
+                CHECK_RUNS_ONE_FAILED,
+                "main",
+                cwd=git_repo,
+                required_names=TEST_REQUIRED_NAMES,
+            )
+
+
+class TestRequiredCheckAllowlist:
+    """Issue #733: a non-empty, fully-green check-run list is not enough on
+    its own -- the checks that matter must actually be among them. These use
+    the real production `REQUIRED_CHECK_NAMES` (no override), covering the
+    exact failure scenario from the issue: main's real CI never started for a
+    commit, but one unrelated check-run (e.g. a security scanner) passed on
+    that SHA.
+    """
+
+    UNRELATED_BUT_GREEN = [
+        {"name": "gitleaks (full history)", "conclusion": "success"},
+        {"name": "Analyze (python)", "conclusion": "success"},
+    ]
+
+    def test_unrelated_green_checks_alone_do_not_satisfy_required_checks_passed(self):
+        assert not authorize_module.required_checks_passed(self.UNRELATED_BUT_GREEN)
+
+    def test_missing_required_checks_lists_every_ci_yaml_job(self):
+        missing = authorize_module.missing_required_checks(self.UNRELATED_BUT_GREEN)
+
+        assert missing == authorize_module.REQUIRED_CHECK_NAMES
+
+    def test_authorize_refuses_a_commit_whose_only_checks_are_unrelated_but_green(
+        self, git_repo
+    ):
         sha = run_git(git_repo, "rev-parse", "HEAD")
 
         with pytest.raises(
-            authorize_module.AuthorizationError, match="check-runs"
+            authorize_module.AuthorizationError, match="required check-run"
         ):
-            authorize_module.authorize(sha, CHECK_RUNS_ONE_FAILED, "main", cwd=git_repo)
+            authorize_module.authorize(sha, self.UNRELATED_BUT_GREEN, "main", cwd=git_repo)
+
+    def test_every_required_check_present_and_green_authorizes(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        runs = [
+            {"name": name, "conclusion": "success"}
+            for name in authorize_module.REQUIRED_CHECK_NAMES
+        ]
+
+        authorize_module.authorize(sha, runs, "main", cwd=git_repo)
+
+    def test_a_single_missing_required_check_among_an_otherwise_full_set_is_refused(
+        self, git_repo
+    ):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        names = sorted(authorize_module.REQUIRED_CHECK_NAMES)
+        dropped, remaining = names[0], names[1:]
+        runs = [{"name": name, "conclusion": "success"} for name in remaining]
+
+        with pytest.raises(
+            authorize_module.AuthorizationError, match=re.escape(dropped)
+        ):
+            authorize_module.authorize(sha, runs, "main", cwd=git_repo)
 
 
 class TestFetchCheckRuns:
@@ -194,6 +319,102 @@ class TestFetchCheckRuns:
         assert runs == [CHECK_RUNS_ALL_GREEN[0]]
 
 
+class TestFetchCheckRunsPagination:
+    """The check-runs endpoint's default page size is 30, and a real commit
+    on this repo has been measured with several dozen check-runs across its
+    workflows (issue #733) -- comfortably past that default and past what a
+    single `per_page=100` page happened to cover historically. These tests
+    drive `fetch_check_runs`'s own pagination loop (not a stubbed
+    single-response mock) to prove it walks every page, and that a required
+    check which only fails or is only missing on a later page still causes a
+    refusal rather than being silently dropped.
+    """
+
+    @staticmethod
+    def _paged_fake_run(pages: dict, total_count: int):
+        def fake_run(argv, **kwargs):
+            page_arg = next(
+                arg for arg in argv if isinstance(arg, str) and arg.startswith("page=")
+            )
+            page = int(page_arg.split("=", 1)[1])
+            payload = {"total_count": total_count, "check_runs": pages.get(page, [])}
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+        return fake_run
+
+    def test_collects_every_page_in_order(self, monkeypatch):
+        pages = {
+            1: [
+                {"name": "CI", "conclusion": "success"},
+                {"name": "Unrelated", "conclusion": "success"},
+            ],
+            2: [{"name": "CodeQL", "conclusion": "neutral"}],
+        }
+        monkeypatch.setattr(
+            authorize_module.subprocess, "run", self._paged_fake_run(pages, total_count=3)
+        )
+
+        runs = authorize_module.fetch_check_runs("deadbeef", "curie-eng/agentos", per_page=2)
+
+        assert [run["name"] for run in runs] == ["CI", "Unrelated", "CodeQL"]
+
+    def test_a_required_check_failing_only_on_a_later_page_still_refuses(self, monkeypatch):
+        pages = {
+            1: [
+                {"name": "CI", "conclusion": "success"},
+                {"name": "Unrelated", "conclusion": "success"},
+            ],
+            2: [{"name": "CodeQL", "conclusion": "failure"}],
+        }
+        monkeypatch.setattr(
+            authorize_module.subprocess, "run", self._paged_fake_run(pages, total_count=3)
+        )
+
+        runs = authorize_module.fetch_check_runs("deadbeef", "curie-eng/agentos", per_page=2)
+
+        assert len(runs) == 3
+        assert not authorize_module.required_checks_passed(runs, TEST_REQUIRED_NAMES)
+        assert authorize_module.missing_required_checks(runs, TEST_REQUIRED_NAMES) == {
+            "CodeQL"
+        }
+
+    def test_a_required_check_only_present_on_a_later_page_still_authorizes(
+        self, git_repo, monkeypatch
+    ):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        pages = {
+            1: [{"name": "CI", "conclusion": "success"}],
+            2: [{"name": "CodeQL", "conclusion": "success"}],
+        }
+        # Scope the `gh api` stub to the fetch call only -- `authorize()` below
+        # also shells out to real `git merge-base` via the same
+        # `subprocess.run`, which must not be intercepted by this fake.
+        with monkeypatch.context() as page_fetch:
+            page_fetch.setattr(
+                authorize_module.subprocess, "run", self._paged_fake_run(pages, total_count=2)
+            )
+            runs = authorize_module.fetch_check_runs(
+                "deadbeef", "curie-eng/agentos", per_page=1
+            )
+
+        authorize_module.authorize(
+            sha, runs, "main", cwd=git_repo, required_names=TEST_REQUIRED_NAMES
+        )
+
+    def test_stops_when_a_page_reports_nothing_even_if_total_count_implied_more(
+        self, monkeypatch
+    ):
+        # A stale/wrong total_count must not spin the loop forever.
+        pages = {1: [{"name": "CI", "conclusion": "success"}], 2: []}
+        monkeypatch.setattr(
+            authorize_module.subprocess, "run", self._paged_fake_run(pages, total_count=5)
+        )
+
+        runs = authorize_module.fetch_check_runs("deadbeef", "curie-eng/agentos", per_page=1)
+
+        assert runs == [{"name": "CI", "conclusion": "success"}]
+
+
 class TestExcludeCurrentWorkflowRun:
     """The gate is itself a check-run on the tagged SHA (issue #732, defect 2)."""
 
@@ -232,32 +453,70 @@ class TestAuthorizeExcludesCurrentRun:
         ]
 
         authorize_module.authorize(
-            sha, runs, "main", cwd=git_repo, exclude_run_id=CURRENT_RUN_ID
+            sha,
+            runs,
+            "main",
+            cwd=git_repo,
+            exclude_run_id=CURRENT_RUN_ID,
+            required_names=TEST_REQUIRED_NAMES,
         )
 
-    def test_unrelated_in_progress_check_is_still_refused(self, git_repo):
+    def test_unrelated_check_present_does_not_block_when_required_checks_are_green(
+        self, git_repo
+    ):
+        # New semantics (issue #733): only the required names are asserted --
+        # an unrelated check-run, however incomplete, has no bearing.
         sha = run_git(git_repo, "rev-parse", "HEAD")
         runs = [
             GATE_OWN_IN_PROGRESS,
             check_run("CI", "success", OTHER_RUN_ID, "88573600001"),
+            check_run("CodeQL", "neutral", OTHER_RUN_ID, "88573600002"),
             check_run("Integration Tests", None, OTHER_RUN_ID, "88573600003"),
         ]
 
-        with pytest.raises(authorize_module.AuthorizationError, match="check-runs"):
-            authorize_module.authorize(
-                sha, runs, "main", cwd=git_repo, exclude_run_id=CURRENT_RUN_ID
-            )
+        authorize_module.authorize(
+            sha,
+            runs,
+            "main",
+            cwd=git_repo,
+            exclude_run_id=CURRENT_RUN_ID,
+            required_names=TEST_REQUIRED_NAMES,
+        )
 
-    def test_failed_check_from_another_run_is_still_refused(self, git_repo):
+    def test_required_check_still_in_progress_is_refused(self, git_repo):
         sha = run_git(git_repo, "rev-parse", "HEAD")
         runs = [
             GATE_OWN_IN_PROGRESS,
-            check_run("Dependency Audit", "failure", OTHER_RUN_ID, "88573600004"),
+            check_run("CI", "success", OTHER_RUN_ID, "88573600001"),
+            check_run("CodeQL", None, OTHER_RUN_ID, "88573600002"),
         ]
 
-        with pytest.raises(authorize_module.AuthorizationError, match="check-runs"):
+        with pytest.raises(authorize_module.AuthorizationError, match="required check-run"):
             authorize_module.authorize(
-                sha, runs, "main", cwd=git_repo, exclude_run_id=CURRENT_RUN_ID
+                sha,
+                runs,
+                "main",
+                cwd=git_repo,
+                exclude_run_id=CURRENT_RUN_ID,
+                required_names=TEST_REQUIRED_NAMES,
+            )
+
+    def test_required_check_that_concluded_failure_is_refused(self, git_repo):
+        sha = run_git(git_repo, "rev-parse", "HEAD")
+        runs = [
+            GATE_OWN_IN_PROGRESS,
+            check_run("CI", "success", OTHER_RUN_ID, "88573600001"),
+            check_run("CodeQL", "failure", OTHER_RUN_ID, "88573600004"),
+        ]
+
+        with pytest.raises(authorize_module.AuthorizationError, match="required check-run"):
+            authorize_module.authorize(
+                sha,
+                runs,
+                "main",
+                cwd=git_repo,
+                exclude_run_id=CURRENT_RUN_ID,
+                required_names=TEST_REQUIRED_NAMES,
             )
 
     def test_only_current_run_checks_is_refused(self, git_repo):
@@ -269,20 +528,35 @@ class TestAuthorizeExcludesCurrentRun:
             check_run("authorize-release setup", "success", CURRENT_RUN_ID, "88573652087"),
         ]
 
-        with pytest.raises(authorize_module.AuthorizationError, match="check-runs"):
+        with pytest.raises(authorize_module.AuthorizationError, match="required check-run"):
             authorize_module.authorize(
-                sha, runs, "main", cwd=git_repo, exclude_run_id=CURRENT_RUN_ID
+                sha,
+                runs,
+                "main",
+                cwd=git_repo,
+                exclude_run_id=CURRENT_RUN_ID,
+                required_names=TEST_REQUIRED_NAMES,
             )
 
 
 class TestMain:
     """`main()` must thread `GITHUB_RUN_ID` into `authorize()` as
-    `exclude_run_id` (issue #732, defect 2). Every test above drives
-    `authorize()` or `exclude_current_workflow_run()` directly, so deleting
-    `exclude_run_id=args.run_id` from `main()`'s `authorize(...)` call leaves
-    the whole suite green while restoring the bug: the gate would wait
-    forever on its own in-progress check-run. These tests invoke `main()`
-    itself so that wiring is covered at the layer where it actually lived.
+    `exclude_run_id` (issue #732, defect 2).
+
+    `main()` never passes `required_names` through explicitly, so it always
+    resolves the module-level `REQUIRED_CHECK_NAMES` at call time; these tests
+    monkeypatch that constant to the small `TEST_REQUIRED_NAMES` set so the
+    fixtures stay independent of the production ci.yaml job list.
+
+    Note on the required-check allowlist (issue #733): the gate's own
+    check-run is always named after its job (e.g. `authorize-release`), never
+    after a ci.yaml job, so it can never itself satisfy or block a required
+    name -- unlike the old "every present check-run must pass" rule, an
+    unfiltered self-entry sitting in the list with `conclusion: null` no
+    longer affects the outcome at all. What still matters, and what these
+    tests cover, is that a *wrong* run id can incorrectly filter out a
+    legitimate required check-run (mistaking another run's job for this one),
+    which must still refuse.
 
     `fetch_check_runs` is stubbed so no network call happens; `authorize()`
     runs for real against `git_repo`, so `main()` is run with that repo as
@@ -296,6 +570,10 @@ class TestMain:
         )
 
     @staticmethod
+    def _use_test_required_names(monkeypatch) -> None:
+        monkeypatch.setattr(authorize_module, "REQUIRED_CHECK_NAMES", TEST_REQUIRED_NAMES)
+
+    @staticmethod
     def _runs_with_gate_own_in_progress() -> list[dict]:
         return [
             GATE_OWN_IN_PROGRESS,
@@ -307,6 +585,7 @@ class TestMain:
         self, git_repo, monkeypatch
     ):
         sha = run_git(git_repo, "rev-parse", "HEAD")
+        self._use_test_required_names(monkeypatch)
         self._stub_fetch_check_runs(monkeypatch, self._runs_with_gate_own_in_progress())
         monkeypatch.chdir(git_repo)
         monkeypatch.setenv("GITHUB_RUN_ID", CURRENT_RUN_ID)
@@ -317,8 +596,14 @@ class TestMain:
 
         assert exit_code == 0
 
-    def test_main_refuses_when_github_run_id_is_absent(self, git_repo, monkeypatch):
+    def test_main_still_authorizes_when_github_run_id_is_absent_and_required_checks_are_green(
+        self, git_repo, monkeypatch
+    ):
+        # The gate's own check-run is never itself a required name, so
+        # leaving it unfiltered (no run id to exclude by) has no bearing on
+        # whether the real required checks (CI, CodeQL here) are satisfied.
         sha = run_git(git_repo, "rev-parse", "HEAD")
+        self._use_test_required_names(monkeypatch)
         self._stub_fetch_check_runs(monkeypatch, self._runs_with_gate_own_in_progress())
         monkeypatch.chdir(git_repo)
         monkeypatch.delenv("GITHUB_RUN_ID", raising=False)
@@ -327,12 +612,19 @@ class TestMain:
             [sha, "--repo", "curie-eng/agentos", "--main-ref", "main"]
         )
 
-        assert exit_code == 1
+        assert exit_code == 0
 
     def test_main_refuses_when_github_run_id_is_a_different_run(
         self, git_repo, monkeypatch
     ):
+        # The fixture's real "CI"/"CodeQL" entries are marked as belonging to
+        # OTHER_RUN_ID; passing that value as GITHUB_RUN_ID makes
+        # `exclude_current_workflow_run` mistake them for this run's own and
+        # strip them out, leaving only the gate's unrelated in-progress entry.
+        # A wrong run id over-excluding legitimate required checks must still
+        # refuse, not slip through.
         sha = run_git(git_repo, "rev-parse", "HEAD")
+        self._use_test_required_names(monkeypatch)
         self._stub_fetch_check_runs(monkeypatch, self._runs_with_gate_own_in_progress())
         monkeypatch.chdir(git_repo)
         monkeypatch.setenv("GITHUB_RUN_ID", OTHER_RUN_ID)
@@ -417,6 +709,7 @@ class TestMainLookupFailures:
     ):
         # The unauthorized-tag wording must not appear on the lookup path, or
         # an operator cannot tell the two refusals apart.
+        monkeypatch.setattr(authorize_module, "REQUIRED_CHECK_NAMES", TEST_REQUIRED_NAMES)
         self._stub_fetch_raising(monkeypatch, KeyError("check_runs"))
 
         assert self._run_main(git_repo, monkeypatch) == 1
@@ -430,4 +723,4 @@ class TestMainLookupFailures:
 
         assert "could not retrieve check-runs" in lookup_stderr
         assert "could not retrieve check-runs" not in refusal_stderr
-        assert "does not have a fully successful set of check-runs" in refusal_stderr
+        assert "required check-run" in refusal_stderr


### PR DESCRIPTION
## Summary

`release/authorize.py` had two hardening gaps left over from #727 (ADR-0058), separate from the two defects fixed in #732:

- It authorized a tag as soon as it found any non-empty, fully-passing check-run list, without asserting that the checks that matter actually ran. A commit whose real CI never started, but had one unrelated green check-run on the same SHA, was authorized with no CI evidence behind it.
- `fetch_check_runs` used `per_page=100` with no pagination, on the stated assumption that this repo runs "well under 20 checks per commit." Measured against `origin/main`, that assumption is false (well past the endpoint's default page size of 30 too); the code happened to still work today only because 100 was comfortably larger than the real count.

## Changes

- Added `REQUIRED_CHECK_NAMES`, an explicit allowlist of check-run names populated from the job `name:` fields in `.github/workflows/ci.yaml` (the three language/test jobs, the generated-artifact drift checks, release-compose validation, every first-party image build including the worker-local overlay and the dispatcher import smoke-test, and the eval-falsifiability/E2E-ladder behavioral gates). Checks from other workflows (CodeQL, dependency/secret scanners, release.yaml's own jobs) are intentionally out of scope for this allowlist.
- Added `missing_required_checks()` and reworked `required_checks_passed()`/`authorize()` to assert every required name is present with a passing (`success`/`neutral`/`skipped`) conclusion, rather than "some checks, all green."
- `fetch_check_runs` now paginates using the response's own `total_count`, walking every page instead of assuming one page covers it, with a safety break if a page ever reports nothing.
- Corrected the stale pagination comment: it no longer cites a specific check-run count as justification (that number will only go stale again), and instead states that the loop's correctness doesn't depend on staying under any particular count.

## Test plan

- [x] `uv run pytest release/tests/test_authorize.py -q` (40 passed), including new coverage for: a commit whose only check-runs are unrelated-but-green is refused; every required check present and green authorizes; a single missing required check among an otherwise-full set is refused; `fetch_check_runs` collects every page; a required check failing only on a later page still refuses the tag; a stale `total_count` doesn't spin the pagination loop forever.
- [x] `uv run ruff check release/` and `uv run mypy release/authorize.py`

Closes #733
Ref ADR-0058, #727