### PR TITLE
Distinguish a zero-match namespace sweep from an actual removal and aggregate the resume command's exit status

### DIFF
--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1089,10 +1089,19 @@ enum HelmOutcome {
     Failed,
 }
 
-/// Outcome of the label-scoped namespace sweep step.
+/// Outcome of the label-scoped namespace sweep step. `NoMatch` (#768) is the
+/// zero-match case: the selector's `kubectl delete` exits 0 (success) but
+/// deleted nothing, because it printed nothing to stdout. This happens by
+/// design when AgentOS was installed into a PRE-EXISTING namespace (#707
+/// deliberately leaves that namespace unlabeled, so it is never a sweep
+/// target). `NoMatch` counts as a completed step, same as `Removed`
+/// (`outstanding_steps` never re-queues it), but it is NOT the same as
+/// `Removed` for messaging: a `NoMatch` sweep stopped no compute, so
+/// `teardown_result` must not describe it as "swept".
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SweepOutcome {
     Removed,
+    NoMatch,
     Failed,
 }
 
@@ -1118,29 +1127,34 @@ fn outstanding_steps(helm: HelmOutcome, sweep: SweepOutcome) -> Vec<TeardownStep
     out
 }
 
-/// Pure builder (#767): the exact copy-pasteable resume command for the
-/// outstanding steps, mapping each back to its `down_commands(o)` entry
-/// (index 0 = HelmUninstall, 1 = NamespaceSweep).
+/// Pure builder (#767, aggregation #768): the exact copy-pasteable resume
+/// command for the outstanding steps, mapping each back to its
+/// `down_commands(o)` entry (index 0 = HelmUninstall, 1 = NamespaceSweep).
 ///
 /// When BOTH steps are outstanding the emitted ORDER matches `down()`'s own
-/// execution order: the HELM UNINSTALL FIRST, then the namespace sweep, joined
-/// with "; ". Helm first because Helm stores its release metadata as Secrets
-/// INSIDE the release namespace, and this chart owns cluster-scoped resources
+/// execution order: the HELM UNINSTALL FIRST, then the namespace sweep. Helm
+/// first because Helm stores its release metadata as Secrets INSIDE the
+/// release namespace, and this chart owns cluster-scoped resources
 /// (ClusterRole/ClusterRoleBinding). Sweeping the namespace first would destroy
 /// that metadata, the following `helm uninstall` would report "not found"
 /// (which this code reads as already-absent success), and the cluster-scoped
-/// resources would be orphaned with no cleanup path. The "; " join means the
-/// compute-stopping sweep still runs even when helm fails again, which is the
-/// ticket's core safety property.
+/// resources would be orphaned with no cleanup path.
 ///
-/// Known limitation: "; " returns only the LAST command's status, so the
-/// resume line does not aggregate the exit status of both commands. That is an
-/// accepted trade for the unconditional sweep, tracked as a follow-up.
+/// #768: a plain "; " join runs both commands unconditionally (the compute-
+/// stopping sweep is never skipped by a repeated helm failure), but a shell
+/// only returns the LAST command's exit status, so an agent or CI executing
+/// the resume line verbatim could read exit 0 even though helm failed. A
+/// naive "&&" join would fix the status but reintroduce the fail-hard hazard
+/// this whole feature exists to remove (a repeated helm failure would again
+/// skip the sweep). Instead the two-step remainder is wrapped so each
+/// command's status is captured into its own shell variable, both commands
+/// still run unconditionally, and the final expression is nonzero UNLESS both
+/// succeeded -- runs-both-aggregates-nonzero, not runs-both-or-skips-second.
 ///
 /// The argv itself comes from `down_commands`, which stays the single source of
 /// truth for the teardown commands, so the resume line cannot drift from what
 /// would actually finish the job. A single-step remainder is one command with
-/// no join; an empty remainder yields the empty string.
+/// no wrapper; an empty remainder yields the empty string.
 fn resume_command(remaining: &[TeardownStep], o: &CommonOpts) -> String {
     let cmds = down_commands(o);
     let mut steps: Vec<&TeardownStep> = remaining.iter().collect();
@@ -1149,7 +1163,7 @@ fn resume_command(remaining: &[TeardownStep], o: &CommonOpts) -> String {
         TeardownStep::HelmUninstall => 0,
         TeardownStep::NamespaceSweep => 1,
     });
-    steps
+    let lines: Vec<String> = steps
         .iter()
         .map(|step| {
             let idx = match step {
@@ -1158,8 +1172,17 @@ fn resume_command(remaining: &[TeardownStep], o: &CommonOpts) -> String {
             };
             cmds[idx].display()
         })
-        .collect::<Vec<_>>()
-        .join("; ")
+        .collect();
+    match lines.as_slice() {
+        [] => String::new(),
+        [only] => only.clone(),
+        [first, second] => {
+            format!("{first}; s1=$?; {second}; s2=$?; [ \"$s1\" -eq 0 ] && [ \"$s2\" -eq 0 ]")
+        }
+        // `remaining` only ever holds HelmUninstall and/or NamespaceSweep, so a
+        // third element is unreachable; stay defensive rather than panic.
+        _ => lines.join("; "),
+    }
 }
 
 /// Classifies whether a shelled-out `helm`/`kubectl` subprocess's stderr names a
@@ -1219,13 +1242,17 @@ fn failure_reason(stderr: &str) -> &str {
         .unwrap_or("command failed")
 }
 
-/// Pure decision (#767): turn the two teardown-step outcomes plus their stderr
-/// into the `cluster down` result. An empty remainder is success. Otherwise it is
-/// a fail-forward error carrying the exact resume command in BOTH the human
-/// Display message (P1: `main` renders Display and drops the fix) and the `fix`
-/// (for `--json`). The exit class is Transient (exit 3, safe to retry) IFF every
-/// outstanding failed step's stderr is a connectivity failure; any permanent
-/// outstanding failure makes it a plain Failure (exit 1, P2).
+/// Pure decision (#767, #768): turn the two teardown-step outcomes plus their
+/// stderr into the `cluster down` result. An empty remainder is success.
+/// Otherwise it is a fail-forward error carrying the exact resume command in
+/// BOTH the human Display message (P1: `main` renders Display and drops the
+/// fix) and the `fix` (for `--json`). The exit class is Transient (exit 3, safe
+/// to retry) IFF every outstanding failed step's stderr is a connectivity
+/// failure; any permanent outstanding failure makes it a plain Failure (exit 1,
+/// P2). #768: a `SweepOutcome::NoMatch` (the label selector matched nothing,
+/// e.g. a pre-existing namespace #707 never stamped) is a distinct case from
+/// `Removed` -- it must never be worded as having swept/removed compute, since
+/// nothing was actually deleted.
 fn teardown_result(
     helm: HelmOutcome,
     sweep: SweepOutcome,
@@ -1271,6 +1298,14 @@ fn teardown_result(
         // Sweep succeeded (compute stopped); only the stale helm record remains.
         format!(
             "helm uninstall failed ({reason}) but the run-created namespaces were swept; the release record remains. Resume with: {cmd}"
+        )
+    } else if matches!(sweep, SweepOutcome::NoMatch) {
+        // #768: the sweep's label selector matched nothing -- this release never
+        // created (or was installed into a pre-existing) namespace, so nothing
+        // was actually removed. This is NOT the swept case above: do not claim
+        // compute was stopped, since it may still be running.
+        format!(
+            "helm uninstall failed ({reason}); no run-created namespaces matched the sweep, so no compute was stopped (this release may be running in a pre-existing namespace); the release record remains. Resume with: {cmd}"
         )
     } else if transient {
         format!(
@@ -1897,9 +1932,21 @@ pub async fn down(opts: DownOpts) -> Result<ClusterDownOutput> {
     ui.plumbing(&format!("+ {}", sweep.display()));
     let step = cl.step("sweeping namespaces");
     let (ok, out, sweep_err) = run_capture(sweep).await?;
+    // #768: `--ignore-not-found` makes a zero-match selector exit 0 with EMPTY
+    // stdout (no "namespace ... deleted" line), the same exit code an actual
+    // removal gets. That is exactly the pre-existing-namespace case (#707
+    // deliberately never stamps it), so a bare `ok` check cannot tell "nothing
+    // to do" apart from "removed it"; only the stdout content can. Distinguish
+    // them into their own outcome so `teardown_result` never claims compute was
+    // stopped when the sweep matched nothing.
     let sweep_outcome = if ok {
-        step.done("removed");
-        SweepOutcome::Removed
+        if out.trim().is_empty() {
+            step.done("no matching namespaces");
+            SweepOutcome::NoMatch
+        } else {
+            step.done("removed");
+            SweepOutcome::Removed
+        }
     } else {
         step.fail("failed");
         SweepOutcome::Failed
@@ -3355,30 +3402,34 @@ mod tests {
         );
     }
 
-    // #767 fail-forward teardown. PRODUCTION SYMBOLS: two pure functions plus
-    // three small enums so `cluster down` runs both teardown steps to
-    // completion and then decides the exit from the combined result, instead
-    // of bailing the instant `helm uninstall` returns a non-"not found"
-    // nonzero exit:
+    // #767 fail-forward teardown (aggregation hardened by #768). PRODUCTION
+    // SYMBOLS: two pure functions plus three small enums so `cluster down` runs
+    // both teardown steps to completion and then decides the exit from the
+    // combined result, instead of bailing the instant `helm uninstall` returns a
+    // non-"not found" nonzero exit:
     //
     //   enum HelmOutcome { Removed, Absent, Failed }
-    //   enum SweepOutcome { Removed, Failed }
+    //   enum SweepOutcome { Removed, NoMatch, Failed }
     //   enum TeardownStep { HelmUninstall, NamespaceSweep }  // derive Debug, PartialEq, Eq
     //   fn outstanding_steps(helm: HelmOutcome, sweep: SweepOutcome) -> Vec<TeardownStep>
     //   fn resume_command(remaining: &[TeardownStep], o: &CommonOpts) -> String
     //
     // `outstanding_steps` is the pure decision function: Removed/Absent helm is
-    // done, Failed helm leaves HelmUninstall outstanding; Removed sweep is done,
-    // Failed sweep leaves NamespaceSweep outstanding; order is HelmUninstall
-    // before NamespaceSweep (matching `down_commands` order). `resume_command`
-    // maps the outstanding steps back to the matching `down_commands(o)` entries.
-    // When BOTH steps are outstanding it emits the HELM UNINSTALL FIRST, then
-    // the namespace sweep, joined with "; ": helm first because Helm's release
-    // metadata lives as Secrets inside the release namespace, so sweeping first
-    // would destroy it and orphan the chart's cluster-scoped resources; "; " so
-    // the compute-stopping sweep still runs even if helm fails again. The "; "
-    // join does not aggregate exit status, an accepted limitation tracked as a
-    // follow-up.
+    // done, Failed helm leaves HelmUninstall outstanding; Removed/NoMatch sweep
+    // is done, Failed sweep leaves NamespaceSweep outstanding; order is
+    // HelmUninstall before NamespaceSweep (matching `down_commands` order).
+    // `resume_command` maps the outstanding steps back to the matching
+    // `down_commands(o)` entries. When BOTH steps are outstanding it emits the
+    // HELM UNINSTALL FIRST, then the namespace sweep: helm first because Helm's
+    // release metadata lives as Secrets inside the release namespace, so
+    // sweeping first would destroy it and orphan the chart's cluster-scoped
+    // resources. #768: the two commands are still run unconditionally (never
+    // gated behind "&&", which would let a repeated helm failure block the
+    // sweep), but each command's own exit status is now captured into a shell
+    // variable ($?), and the resume line ends with a boolean expression that is
+    // nonzero unless BOTH captured statuses were 0 -- fixing the old "; " join's
+    // silent-exit-0-on-helm-failure bug without reintroducing the "&&" fail-hard
+    // hazard.
 
     // AC: an exact resumable cleanup command is surfaced. `resume_command`
     // renders the exact copy-pasteable line for a helm-only remainder.
@@ -3410,16 +3461,21 @@ mod tests {
         assert!(cmd.contains("--ignore-not-found"), "{cmd}");
     }
 
-    // AC + review: both steps outstanding -> the HELM UNINSTALL FIRST, then the
-    // namespace sweep, joined with "; ". Ordering rationale: Helm stores its
-    // release metadata as Secrets inside the release namespace, and the chart
-    // owns cluster-scoped resources (ClusterRole/ClusterRoleBinding); sweeping
-    // the namespace first would destroy that metadata, the subsequent helm
-    // uninstall would report "not found", and those cluster-scoped resources
-    // would be orphaned. Join rationale: "; " keeps the compute-stopping sweep
-    // unconditional so it still runs even if helm fails again. A " && " join
-    // would let a repeated helm failure block the sweep, so it is explicitly
-    // rejected. ("; " does not aggregate exit status, an accepted limitation.)
+    // AC + review (#768 aggregation): both steps outstanding -> the HELM
+    // UNINSTALL FIRST, then the namespace sweep, both run unconditionally, with
+    // each captured exit status aggregated into a nonzero-unless-both-succeeded
+    // trailing expression. Ordering rationale: Helm stores its release metadata
+    // as Secrets inside the release namespace, and the chart owns cluster-scoped
+    // resources (ClusterRole/ClusterRoleBinding); sweeping the namespace first
+    // would destroy that metadata, the subsequent helm uninstall would report
+    // "not found", and those cluster-scoped resources would be orphaned.
+    // Aggregation rationale: a plain "; " join runs both commands unconditionally
+    // but only returns the LAST command's exit status, so a helm failure
+    // followed by a successful sweep silently reads as exit 0. A " && " join
+    // would fix the status but let a repeated helm failure short-circuit and
+    // block the compute-stopping sweep, so it is explicitly rejected. The
+    // wrapper here keeps both commands unconditional and only combines their
+    // CAPTURED statuses afterward.
     #[test]
     fn resume_command_both_runs_both_steps_helm_first() {
         let o = common_distinct_release();
@@ -3427,10 +3483,14 @@ mod tests {
             &[TeardownStep::HelmUninstall, TeardownStep::NamespaceSweep],
             &o,
         );
+        let helm_cmd = "helm uninstall prod-release -n agent-ns";
+        let sweep_cmd =
+            "kubectl delete namespace -l agentos.dev/created-by=prod-release --ignore-not-found";
         assert_eq!(
             cmd,
-            "helm uninstall prod-release -n agent-ns; \
-             kubectl delete namespace -l agentos.dev/created-by=prod-release --ignore-not-found"
+            format!(
+                "{helm_cmd}; s1=$?; {sweep_cmd}; s2=$?; [ \"$s1\" -eq 0 ] && [ \"$s2\" -eq 0 ]"
+            )
         );
         // The helm uninstall must appear BEFORE the sweep, so Helm's release
         // metadata (in the release namespace) survives long enough for helm to
@@ -3441,11 +3501,19 @@ mod tests {
             helm_at < sweep_at,
             "helm uninstall must run before the sweep: {cmd}"
         );
-        // The join must NOT be " && ": a repeated helm failure would short-circuit
-        // and block the compute-stopping sweep.
+        // The two commands themselves are joined by a plain "; " immediately
+        // followed by capturing their own exit status -- NOT " && " -- so a
+        // repeated helm failure can never short-circuit and block the sweep.
         assert!(
-            !cmd.contains(" && "),
-            "join must not let a helm failure block the sweep: {cmd}"
+            cmd.starts_with(&format!("{helm_cmd}; s1=$?; {sweep_cmd}; s2=$?;")),
+            "helm and the sweep must both run unconditionally, not gated behind &&: {cmd}"
+        );
+        // The trailing "&&" combines two `[ ... -eq 0 ]` tests over the ALREADY
+        // captured statuses; it does not gate whether the sweep runs, only
+        // whether the whole line's own exit status reports both as successful.
+        assert!(
+            cmd.ends_with("[ \"$s1\" -eq 0 ] && [ \"$s2\" -eq 0 ]"),
+            "the resume line's own exit status must aggregate both captured statuses: {cmd}"
         );
         // The sweep half stays label-scoped even when combined with helm.
         assert!(cmd.contains("agentos.dev/created-by=prod-release"), "{cmd}");
@@ -3491,6 +3559,21 @@ mod tests {
         assert_eq!(
             outstanding_steps(HelmOutcome::Removed, SweepOutcome::Failed),
             vec![NamespaceSweep]
+        );
+        // #768: a zero-match sweep (pre-existing namespace, never labeled by
+        // #707) is a completed step, same as an actual removal -- there is
+        // nothing left for THIS step to do, so it must not be outstanding.
+        assert_eq!(
+            outstanding_steps(HelmOutcome::Removed, SweepOutcome::NoMatch),
+            Vec::<TeardownStep>::new()
+        );
+        // #768: helm failed and the sweep matched nothing -> only the helm
+        // record is outstanding; the sweep is done (there was nothing to sweep),
+        // but critically it did NOT stop any compute, unlike the Removed case
+        // above.
+        assert_eq!(
+            outstanding_steps(HelmOutcome::Failed, SweepOutcome::NoMatch),
+            vec![HelmUninstall]
         );
     }
 
@@ -3683,6 +3766,70 @@ mod tests {
         // ... and the fix is exactly the helm-only line for `--json`.
         let fix = fix.expect("a fail-forward teardown carries a resume command");
         assert_eq!(fix, "helm uninstall prod-release -n agent-ns");
+    }
+
+    // #768 core anti-regression: a zero-match sweep is NOT the same as an
+    // actual removal. When AgentOS was installed into a pre-existing namespace
+    // (#707 never labels it), the label-scoped sweep exits 0 with nothing
+    // matched. Before #768 this was mapped to the same `SweepOutcome::Removed`
+    // as a real deletion, so a failed helm uninstall paired with a zero-match
+    // sweep produced the exact same "the run-created namespaces were swept"
+    // message as a real removal, even though the pre-existing namespace's
+    // workloads (and the failed release's compute) may still be running. This
+    // test locks the fix: `SweepOutcome::NoMatch` must NEVER be worded as
+    // "swept", and the message must say plainly that no compute was stopped.
+    #[test]
+    fn teardown_result_zero_match_sweep_never_claims_compute_was_removed() {
+        let o = common_distinct_release();
+        let helm_err = "Kubernetes cluster unreachable: net/http: TLS handshake timeout";
+        let err = teardown_result(HelmOutcome::Failed, SweepOutcome::NoMatch, helm_err, "", &o)
+            .expect_err("a stale helm record is still an incomplete teardown");
+
+        let shown = err.to_string();
+        // The core anti-regression: must NOT claim the run-created namespaces
+        // were swept, since nothing actually matched the selector.
+        assert!(
+            !shown.contains("were swept"),
+            "a zero-match sweep must never be worded as an actual removal: {shown}"
+        );
+        // Must plainly say no compute was stopped, so an operator does not
+        // mistakenly believe the failed release's workloads are gone.
+        assert!(
+            shown.to_lowercase().contains("no compute was stopped")
+                || shown.to_lowercase().contains("no run-created namespaces matched"),
+            "the message must not imply compute was removed when the sweep matched nothing: {shown}"
+        );
+        // The sweep itself is done (nothing to sweep), so only the helm step is
+        // outstanding -- the resume command is the helm-only line, exactly like
+        // the real-removal ("swept") case, in both the message and the fix.
+        assert!(
+            shown.contains("helm uninstall prod-release -n agent-ns"),
+            "the message must carry the helm-only resume line: {shown}"
+        );
+        assert!(
+            !shown.contains("delete namespace"),
+            "a zero-match sweep has nothing outstanding, so the sweep must not be listed as a resume step: {shown}"
+        );
+        let (_, fix) = crate::exit::classify(&err);
+        let fix = fix.expect("a fail-forward teardown carries a resume command");
+        assert_eq!(fix, "helm uninstall prod-release -n agent-ns");
+    }
+
+    // #768: a zero-match sweep still counts as a COMPLETED step when helm itself
+    // succeeds -- the pre-existing namespace was correctly left untouched (#707),
+    // so `cluster down` overall succeeds exactly as it would if the release had
+    // created and then swept its own namespace.
+    #[test]
+    fn teardown_result_zero_match_sweep_with_helm_removed_is_still_success() {
+        let o = common_distinct_release();
+        let res = teardown_result(HelmOutcome::Removed, SweepOutcome::NoMatch, "", "", &o)
+            .expect("a zero-match sweep alongside a clean helm uninstall is a complete teardown");
+        assert!(matches!(
+            res,
+            ClusterDownOutput::Down {
+                release_was_absent: false
+            }
+        ));
     }
 
     // P2: permanent failures (RBAC, authz) are NOT retryable. Both steps failed

--- a/cli/tests/cluster_down_failforward.rs
+++ b/cli/tests/cluster_down_failforward.rs
@@ -1,10 +1,12 @@
-//! Integration (#767): drive the REAL `agentos::ops::down` through fake
+//! Integration (#767, #768): drive the REAL `agentos::ops::down` through fake
 //! `helm`/`kubectl` on PATH to prove the fail-forward WIRING that the ops-module
 //! unit tests cannot exercise: the namespace sweep runs UNCONDITIONALLY after a
 //! failed helm uninstall (the core anti-regression, since a revert to `bail!`
 //! skips it), the human-visible error message carries the resume command (P1),
-//! and the exit class tracks the failure kind (connectivity -> Transient exit 3,
-//! permanent RBAC -> Failure exit 1, P2).
+//! the exit class tracks the failure kind (connectivity -> Transient exit 3,
+//! permanent RBAC -> Failure exit 1, P2), a zero-match sweep is never worded as
+//! an actual removal (#768), and the emitted resume command's own exit status
+//! genuinely aggregates both steps when actually executed (#768).
 //!
 //! EVERYTHING lives in ONE test fn. `down()` resolves `helm`/`kubectl` off the
 //! process PATH, so the test mutates process-global PATH (and a SWEEP_MARKER env
@@ -114,9 +116,11 @@ async fn cluster_down_fails_forward_through_real_down() {
     );
 
     // ----- Scenario 2: permanent RBAC failure -----
-    // Fake helm fails forbidden. Fake kubectl sweeps clean (exit 0), so only the
-    // helm record remains, and a permanent failure must be a plain Failure (exit
-    // 1), not a retryable transient. The sweep still ran (marker present).
+    // Fake helm fails forbidden. Fake kubectl actually sweeps (exit 0 AND prints
+    // a "namespace ... deleted" line, so `down()` reads this as a real removal,
+    // not a #768 zero-match), so only the helm record remains, and a permanent
+    // failure must be a plain Failure (exit 1), not a retryable transient. The
+    // sweep still ran (marker present).
     let dir2 = tempfile::tempdir().expect("tempdir");
     let marker2 = dir2.path().join("sweep-ran-2");
     std::env::set_var("SWEEP_MARKER", &marker2);
@@ -130,7 +134,7 @@ async fn cluster_down_fails_forward_through_real_down() {
     write_exec(
         dir2.path(),
         "kubectl",
-        "#!/bin/sh\ntouch \"$SWEEP_MARKER\"\nexit 0\n",
+        "#!/bin/sh\ntouch \"$SWEEP_MARKER\"\necho 'namespace \"prod-release-agent-sandbox\" deleted'\nexit 0\n",
     );
     // Drop scenario 1's fakes: reset to the original PATH, then prepend dir2.
     restore_path(&original_path);
@@ -152,6 +156,148 @@ async fn cluster_down_fails_forward_through_real_down() {
     );
     assert_eq!(class.code(), 1);
     assert_ne!(class, ExitClass::Transient);
+    // The sweep really did remove something here, so the message is allowed to
+    // (and does) say "swept" -- this is the actual-removal case #768 must be
+    // distinguished FROM in scenario 3 below.
+    let shown = err.to_string();
+    assert!(
+        shown.contains("swept"),
+        "a real removal must still be worded as swept: {shown}"
+    );
+
+    // ----- Scenario 3 (#768): zero-match sweep, not an actual removal -----
+    // Fake helm fails (transient connectivity). Fake kubectl exits 0 but prints
+    // NOTHING to stdout, exactly what `kubectl delete namespace -l ...
+    // --ignore-not-found` does when the label selector matches no namespace
+    // (the pre-existing-namespace case from #707: it was never stamped, so a
+    // release's own down never touches it). Before #768 this was
+    // indistinguishable from scenario 2's real removal and produced the same
+    // "were swept" message even though nothing was actually deleted and the
+    // failed release's own compute may still be running.
+    let dir3 = tempfile::tempdir().expect("tempdir");
+    let marker3 = dir3.path().join("sweep-ran-3");
+    std::env::set_var("SWEEP_MARKER", &marker3);
+    let unreachable3 =
+        "Error: Kubernetes cluster unreachable: Get \"https://h:6443/version\": connection refused";
+    write_exec(
+        dir3.path(),
+        "helm",
+        &format!("#!/bin/sh\necho '{unreachable3}' >&2\nexit 1\n"),
+    );
+    write_exec(
+        dir3.path(),
+        "kubectl",
+        "#!/bin/sh\ntouch \"$SWEEP_MARKER\"\nexit 0\n",
+    );
+    restore_path(&original_path);
+    prepend_path(dir3.path());
+
+    let err = down(down_opts())
+        .await
+        .expect_err("a stale helm record after a zero-match sweep is still incomplete");
+
+    assert!(
+        marker3.exists(),
+        "the zero-match sweep still ran unconditionally"
+    );
+    let shown = err.to_string();
+    // The #768 anti-regression: must NOT be worded like scenario 2's real
+    // removal, since nothing actually matched the selector here.
+    assert!(
+        !shown.contains("were swept"),
+        "a zero-match sweep must never be worded as an actual removal: {shown}"
+    );
+    // Must still surface the helm-only resume command so the operator can
+    // finish teardown.
+    assert!(
+        shown.contains("helm uninstall prod-release -n agent-ns"),
+        "the message must still carry the helm-only resume command: {shown}"
+    );
+
+    // ----- Scenario 4 (#768): the resume command's own exit status aggregates
+    // BOTH steps when actually executed, even when the LAST command (the
+    // sweep) succeeds -----
+    // Both fakes fail on their FIRST invocation (so the initial `down()` call
+    // sees both steps outstanding and emits the two-step resume line), then
+    // fake helm keeps failing forever while fake kubectl SUCCEEDS on every
+    // invocation after its first. That flip means: when the emitted resume
+    // line is actually re-executed, helm fails again but the sweep (the LAST
+    // command in the line) succeeds. Under the OLD "; " join this would read
+    // as exit 0 (the last command's status) even though helm is still broken
+    // -- exactly the bug #768 reports. Each fake also appends a line to its own
+    // log file on every invocation, so the test can additionally prove BOTH
+    // commands actually ran during the re-execution (not short-circuited).
+    let dir4 = tempfile::tempdir().expect("tempdir");
+    let helm_log = dir4.path().join("helm.log");
+    let kubectl_log = dir4.path().join("kubectl.log");
+    let kubectl_switched = dir4.path().join("kubectl-switched");
+    write_exec(
+        dir4.path(),
+        "helm",
+        &format!(
+            "#!/bin/sh\necho x >> '{}'\necho 'Kubernetes cluster unreachable: connection refused' >&2\nexit 1\n",
+            helm_log.display()
+        ),
+    );
+    write_exec(
+        dir4.path(),
+        "kubectl",
+        &format!(
+            "#!/bin/sh\necho x >> '{log}'\nif [ -f '{switched}' ]; then\n  echo 'namespace \"x\" deleted'\n  exit 0\nelse\n  touch '{switched}'\n  echo 'Kubernetes cluster unreachable: connection refused' >&2\n  exit 1\nfi\n",
+            log = kubectl_log.display(),
+            switched = kubectl_switched.display(),
+        ),
+    );
+    restore_path(&original_path);
+    prepend_path(dir4.path());
+
+    let err = down(down_opts())
+        .await
+        .expect_err("both steps failing on the first pass is still an incomplete teardown");
+    let (_class, fix) = classify(&err);
+    let resume_cmd = fix.expect("a fail-forward teardown carries a resume command");
+    assert!(
+        resume_cmd.contains("helm uninstall") && resume_cmd.contains("kubectl delete namespace"),
+        "expected the two-step resume line since both steps failed on the first pass: {resume_cmd}"
+    );
+    assert_eq!(
+        fs::read_to_string(&helm_log).unwrap().lines().count(),
+        1,
+        "helm should have run exactly once so far"
+    );
+    assert_eq!(
+        fs::read_to_string(&kubectl_log).unwrap().lines().count(),
+        1,
+        "kubectl should have run exactly once so far"
+    );
+
+    // Actually EXECUTE the emitted resume command through a real shell, with the
+    // SAME fakes still on PATH, exactly as an operator pasting it or CI running
+    // the `--json` `fix` verbatim would. This time kubectl (the LAST command in
+    // the line) succeeds, while helm (the FIRST) fails again.
+    let status = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(&resume_cmd)
+        .status()
+        .expect("run the emitted resume command");
+    assert!(
+        !status.success(),
+        "helm is still broken, so the resume line's own exit status must be nonzero even \
+         though the trailing sweep succeeded (the old \"; \" join misreported exit 0 here): \
+         {resume_cmd}"
+    );
+    // Both commands must have run a SECOND time during that re-execution (not
+    // short-circuited by helm's failure, and not skipped by the aggregation).
+    assert_eq!(
+        fs::read_to_string(&helm_log).unwrap().lines().count(),
+        2,
+        "helm must run again when the resume command is re-executed"
+    );
+    assert_eq!(
+        fs::read_to_string(&kubectl_log).unwrap().lines().count(),
+        2,
+        "the sweep must still run unconditionally even though helm failed again"
+    );
 
     // Restore PATH so nothing else in this process observes the fakes.
     restore_path(&original_path);

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -89,11 +89,17 @@ installed by the chart's preflights; see `charts/agentos/README.md`).
   the `agents.x-k8s.io` CRDs are left untouched. It prompts before deleting
   unless `--yes` is passed. If `helm uninstall` fails (for example a transient
   API-server blip), teardown does not abort: the ownership-scoped namespace
-  sweep still runs so compute is not left orphaned. If teardown still cannot
+  sweep still runs so compute is not left orphaned. If the sweep's label
+  selector matches nothing (for example a pre-existing namespace, which is
+  never stamped with the ownership label), the error message says so plainly
+  rather than claiming namespaces were removed. If teardown still cannot
   complete, the command exits nonzero (exit 3 for a transient/retryable
   failure, exit 1 otherwise) and prints an exact resumable cleanup command,
   also carried in the `--json` `{error, fix}` payload, to run once the API
-  server is reachable. See ADR-0064 (`docs/adr/0064-fail-forward-cluster-teardown.md`).
+  server is reachable; when both the uninstall and the sweep are still
+  outstanding, that resumable command aggregates both steps' exit statuses so
+  re-running it verbatim cannot misreport success while the release record is
+  still stale. See ADR-0064 (`docs/adr/0064-fail-forward-cluster-teardown.md`).
 
 ## Connecting Slack
 


### PR DESCRIPTION
Two refinements deferred from #767 (fail-forward `cluster down` teardown) to keep that PR scoped.

## What changed

- **Zero-match sweep vs. actual removal.** When AgentOS is installed into a pre-existing namespace, #707 intentionally leaves that namespace unlabeled, so the ownership-scoped sweep (`kubectl delete namespace -l agentos.dev/created-by=<release> --ignore-not-found`) exits 0 with zero matches. `down()` used to map every successful sweep exit to `SweepOutcome::Removed`, so on a `(helm Failed, sweep zero-match)` combination the error message claimed "the run-created namespaces were swept; the release record remains" even though nothing was swept. The sweep step now detects the zero-match case (kubectl prints nothing to stdout when the selector matches nothing) via a new `SweepOutcome::NoMatch`, which feeds a distinct message that never claims compute was removed.
- **Aggregate the resume command's exit status.** The printed resume command joins `helm uninstall ...; kubectl delete namespace ...` with `;` (helm first, deliberately, so Helm's in-namespace release metadata survives long enough for helm to remove chart-owned cluster-scoped resources). The `;` join means the shell returns only the last command's status, so an agent or CI executing the `fix` verbatim could read exit 0 even if helm failed. A `&&` join would fix the status but reintroduce a fail-hard hazard (a repeated helm failure would skip the compute-stopping sweep). The two-step resume line now runs both commands unconditionally, captures each one's own exit status into a shell variable, and ends with a boolean expression that is nonzero unless both captured statuses were 0.

## Tests

- `cli/src/ops.rs`: unit tests over the pure `outstanding_steps`/`teardown_result`/`resume_command` functions covering the new `NoMatch` variant (decision-table entries, a message test asserting the zero-match case is never worded as "swept" while a real removal still is, and a success-path test showing a zero-match sweep alongside a clean helm uninstall still succeeds) and the new resume-command wrapper shape.
- `cli/tests/cluster_down_failforward.rs`: extended the existing fake-`helm`/`kubectl` integration test with two more scenarios: a zero-match sweep paired with a helm failure (asserting the message never says "swept"), and an exit-status aggregation scenario that actually executes the emitted resume command through a real shell with fakes that flip behavior on a second invocation, proving the aggregate exit status is nonzero when helm is still broken even though the trailing sweep command succeeds, while both commands demonstrably ran twice.

`cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` all pass; `agentos dev docs-lint` passes.

Closes #768
Ref #767