### PR TITLE
Release the local message Slack stub port on a timed-out turn

### DIFF
--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -172,7 +172,28 @@ impl SlackStub {
     pub async fn start(bind_host: &str, port: u16, advertise_host: &str) -> Result<Self> {
         let listener = TcpListener::bind(format!("{bind_host}:{port}"))
             .await
-            .with_context(|| format!("binding the Slack stub on {bind_host}:{port}"))?;
+            .with_context(|| {
+                // A bound `port` (not 0) means the caller pinned a fixed listen
+                // port, so a bind failure here is almost always "someone else is
+                // already listening there" rather than an OS-level refusal. Two
+                // things look identical from this error alone: another `local`/
+                // `cluster message` that is legitimately running right now, or a
+                // stale CLI process left over from a prior run whose stub never got
+                // torn down (the #751 leak this fixes: a timed-out turn used to
+                // exit via `std::process::exit`, which skips `Drop` and leaves the
+                // listener bound). We cannot tell those apart from here, so name
+                // both possibilities and point at how to check rather than
+                // overclaiming which one it is.
+                format!(
+                    "binding the Slack stub on {bind_host}:{port}: the port is already in use. \
+                     Either another `local message`/`cluster message` is genuinely running right \
+                     now (safe to wait for it to finish, or rerun with a different \
+                     --listen-port), or a previous invocation left a stale process still holding \
+                     the port. Find the holder with `lsof -nP -iTCP:{port} -sTCP:LISTEN` (macOS) \
+                     or `ss -ltnp 'sport = :{port}'` (Linux); if it is not a `message` invocation \
+                     you expect to still be running, kill it and retry."
+                )
+            })?;
         let addr = listener
             .local_addr()
             .context("reading the stub's local addr")?;
@@ -690,5 +711,76 @@ mod tests {
              Awaiting approval ({id}): run the deploy"
         );
         assert_eq!(parse_approval_id(&text), None);
+    }
+
+    // --- SlackStub teardown on a timed-out turn (#751) ----------------------
+    //
+    // A timed-out `local message`/`cluster message` used to hold this stub's
+    // bound port for as long as the timeout arm's post-timeout diagnostics
+    // gather took -- and that gather read straight from the SAME Valkey the
+    // worker never acked against, with no timeout of its own, so a stalled
+    // Valkey (a likely cause of the original timeout) could hang it
+    // indefinitely. The fix (`message::message_local` / `message::message`)
+    // now drops the stub's listener FIRST, before that gather even starts, so
+    // the port is released no matter how long (or whether) anything after it
+    // takes. `SlackStub::drop` aborts the server task, which is cooperative
+    // cancellation (the task actually unbinds the listener once the runtime
+    // next schedules it, not necessarily synchronously) -- this test confirms
+    // that happens promptly: start the stub, drop it exactly as the timeout
+    // arm now does immediately on detecting `Outcome::TimedOut`, then confirm
+    // the port becomes bindable again in this same process well within a
+    // fraction of a second, rather than staying held for however long a
+    // downstream diagnostics hang would otherwise last.
+
+    #[tokio::test]
+    async fn dropping_the_stub_after_a_timed_out_turn_frees_the_port_promptly() {
+        let stub = SlackStub::start("127.0.0.1", 0, "127.0.0.1")
+            .await
+            .expect("binding an ephemeral port must succeed");
+        // Recover the actually-bound port from the advertised URL (ephemeral
+        // port 0 resolves to whatever the OS assigned), the same way a real
+        // `local message` turn's stub would carry its port forward.
+        let port: u16 = stub
+            .base_api_url()
+            .rsplit_once("127.0.0.1:")
+            .and_then(|(_, rest)| rest.split('/').next())
+            .and_then(|p| p.parse().ok())
+            .expect("base_api_url carries the bound port");
+
+        // A second bind while the stub is still alive must fail -- otherwise
+        // this test would not be exercising the real OS-level port hold at all.
+        assert!(
+            TcpListener::bind(("127.0.0.1", port)).await.is_err(),
+            "the port must be genuinely held while the stub is alive"
+        );
+
+        // This is the exact first step the timeout arms now take on detecting
+        // `Outcome::TimedOut`, before the diagnostics gather that used to be
+        // able to hang: drop the stub's listener.
+        drop(stub);
+
+        // Task abortion is cooperative -- the server task unbinds the listener
+        // once the runtime schedules it, which is not guaranteed to have
+        // happened by the very next instruction. Poll for a short, bounded
+        // window rather than asserting on the first attempt; a real leak would
+        // never clear across this whole window, while the fix clears it almost
+        // immediately.
+        let deadline = std::time::Instant::now() + Duration::from_millis(500);
+        let rebound = loop {
+            match TcpListener::bind(("127.0.0.1", port)).await {
+                Ok(listener) => break Ok(listener),
+                Err(_) if std::time::Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    continue;
+                }
+                Err(err) => break Err(err),
+            }
+        };
+        assert!(
+            rebound.is_ok(),
+            "the port must become free within a fraction of a second of the stub being dropped, \
+             not leaked past a timed-out turn (#751): {:?}",
+            rebound.err()
+        );
     }
 }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -693,6 +693,35 @@ async fn wait_for_tcp(port: u16, timeout: Duration) -> Result<()> {
     }
 }
 
+/// Hard cap on the best-effort diagnostics gather run after a timeout.
+/// `diagnostics` reads straight from the SAME Valkey the worker never acked
+/// against, with no timeout of its own -- unlike every other post-deadline
+/// Valkey read on this path (`chat::ACK_CALL_TIMEOUT`,
+/// `chat::RESUME_SCAN_CALL_TIMEOUT`), which are deliberately bounded so a
+/// stalled Valkey cannot push past `--timeout-secs`. If Valkey itself is what
+/// caused the turn to time out in the first place (a stall or partition is a
+/// common cause), an unbounded diagnostics read can hang the CLI indefinitely
+/// AFTER the turn has already timed out (#751) -- the process just sits there,
+/// still alive, which is the "linger" an operator has to find and kill by
+/// hand. Capping it means the worst case is a diagnostics printout that says
+/// the read timed out, not a wedged process.
+const DIAGNOSTICS_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Best-effort stream diagnostics bounded by [`DIAGNOSTICS_TIMEOUT`] (#751).
+async fn bounded_diagnostics(
+    conn: &mut MultiplexedConnection,
+    stream: &str,
+    stream_id: &str,
+) -> String {
+    tokio::time::timeout(DIAGNOSTICS_TIMEOUT, diagnostics(conn, stream, stream_id))
+        .await
+        .unwrap_or_else(|_| {
+            format!(
+                "  diagnostics unavailable: Valkey did not respond within {DIAGNOSTICS_TIMEOUT:?}"
+            )
+        })
+}
+
 /// The `agentos local message` handler: drive the compose stack directly.
 ///
 /// The cluster path's self-plumbing (kubectl port-forwards) is cluster-specific,
@@ -859,9 +888,12 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
                         ResumeExit::Done => Ok(()),
                         // Still parked: the durable approval stays pending and is
                         // resolvable later, so this is retryable. Local mode holds
-                        // no port-forward children, so exiting here leaks nothing.
+                        // no port-forward children, but it DOES still hold the
+                        // Slack stub -- move it into `exit_after_drop` so its
+                        // listener is torn down before exit rather than leaked
+                        // (#751).
                         ResumeExit::Transient => {
-                            std::process::exit(crate::exit::ExitClass::Transient.code());
+                            exit_after_drop(crate::exit::ExitClass::Transient, stub);
                         }
                     }
                 }
@@ -879,25 +911,38 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
                         channel: channel.clone(),
                     });
                     persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
-                    std::process::exit(crate::exit::ExitClass::Transient.code());
+                    // Drop the Slack stub first so its listener is not leaked past
+                    // this non-unwinding exit (#751).
+                    exit_after_drop(crate::exit::ExitClass::Transient, stub);
                 }
             }
         }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
+            // Drop the Slack stub's listener IMMEDIATELY on timeout, before
+            // anything else -- in particular before the diagnostics gather right
+            // below, which reads from the SAME Valkey the worker never acked
+            // against and can itself stall (bounded by `DIAGNOSTICS_TIMEOUT`, but
+            // that is still seconds during which a not-yet-dropped stub would
+            // keep holding the port). Releasing the stub first means the very
+            // next `local message` can bind successfully right away regardless of
+            // how long anything after this line takes (#751).
+            drop(stub);
             // Gather diagnostics only on the human path; under `--json` the
             // timeout object carries no diagnostics, so skip the extra Valkey read.
             let diag = if ui.json() {
                 None
             } else {
-                Some(diagnostics(&mut conn, &opts.stream, &stream_id).await)
+                Some(bounded_diagnostics(&mut conn, &opts.stream, &stream_id).await)
             };
             ui.emit(&MessageOutcomeOutput::TimedOut {
                 diagnostics: diag,
                 resume_note: None,
             });
             // A timeout is retryable (the worker may still be working, or a
-            // transient stall), so it maps to the transient exit code, not failure.
+            // transient stall), so it maps to the transient exit code, not
+            // failure. The stub is already dropped above; nothing else to tear
+            // down for local mode ("Local mode holds no port-forward children").
             std::process::exit(crate::exit::ExitClass::Transient.code());
         }
     }
@@ -975,6 +1020,28 @@ enum ResumeExit {
     /// is retryable: the caller drops its port-forward guards and exits with the
     /// transient class.
     Transient,
+}
+
+/// Exit the process with `class`, after dropping `guards` first.
+///
+/// `std::process::exit` does not unwind the stack, so any `Drop` impl still in
+/// scope at the call site -- the Slack stub's listener/server task
+/// ([`SlackStub`](crate::chat::SlackStub)), a `kubectl port-forward` child --
+/// would otherwise never run, leaking whatever it holds (#751: a timed-out
+/// `local message`/`cluster message` used to leak the stub's bound port this
+/// way, wedging every subsequent turn with "Address already in use").
+///
+/// Every exit site in this module that needs to tear down a guard before
+/// exiting routes through here instead of calling `std::process::exit`
+/// directly: `guards` is taken BY VALUE, so the compiler forces the caller to
+/// move ownership in (a `SlackStub`, a `tokio::process::Child`, or a tuple of
+/// several) rather than merely borrowing it, and this function drops it before
+/// the process actually exits. That makes the guard-then-exit ordering
+/// structural rather than something a future call site has to remember to do
+/// by hand.
+fn exit_after_drop<T>(class: crate::exit::ExitClass, guards: T) -> ! {
+    drop(guards);
+    std::process::exit(class.code());
 }
 
 /// Keep the reply stub alive after a turn parked awaiting approval and wait for
@@ -1318,12 +1385,14 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
                     {
                         ResumeExit::Done => Ok(()),
                         ResumeExit::Transient => {
-                            // Drop the Valkey port-forward FIRST: `process::exit`
-                            // does not unwind, so without this explicit drop its
-                            // `kill_on_drop` guard never fires and the `kubectl
-                            // port-forward` child is orphaned to init (#766).
-                            drop(_valkey_pf);
-                            std::process::exit(crate::exit::ExitClass::Transient.code());
+                            // Drop the Slack stub AND the Valkey port-forward first:
+                            // `process::exit` does not unwind, so without dropping
+                            // them explicitly here neither the stub's listener nor
+                            // the `kill_on_drop` port-forward child guard would ever
+                            // run, leaking the stub's bound port (#751) and
+                            // orphaning the `kubectl port-forward` child to init
+                            // (#766).
+                            exit_after_drop(crate::exit::ExitClass::Transient, (stub, _valkey_pf));
                         }
                     }
                 }
@@ -1331,8 +1400,9 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
                     // No parseable approval id, so we never entered the resume wait.
                     // Same parked terminal as the timeout arm, so exit with the SAME
                     // transient class (not 0) for a deterministic scripted contract
-                    // (#766, N5). Drop the port-forward first so its child is not
-                    // orphaned by the non-unwinding `process::exit`.
+                    // (#766, N5). Drop the stub and port-forward first so neither is
+                    // leaked/orphaned by the non-unwinding `process::exit` (#751,
+                    // #766).
                     ui.emit(&MessageOutcomeOutput::AwaitingApproval {
                         thread: thread_ts.clone(),
                         reply,
@@ -1341,29 +1411,33 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
                         channel: channel.clone(),
                     });
                     persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
-                    drop(_valkey_pf);
-                    std::process::exit(crate::exit::ExitClass::Transient.code());
+                    exit_after_drop(crate::exit::ExitClass::Transient, (stub, _valkey_pf));
                 }
             }
         }
         Outcome::TimedOut => {
             step.fail(&format!("timed out after {}s", opts.timeout_secs));
+            // Drop the Slack stub's listener IMMEDIATELY on timeout, before the
+            // diagnostics gather below -- same reasoning as `message_local`'s
+            // TimedOut arm (#751). The Valkey port-forward (`_valkey_pf`) must
+            // stay alive a bit longer: `diagnostics` still needs it for `conn`.
+            drop(stub);
             // Gather diagnostics only on the human path; under `--json` the
             // timeout object carries no diagnostics, so skip the extra Valkey read.
             let diag = if ui.json() {
                 None
             } else {
-                Some(diagnostics(&mut conn, &opts.stream, &stream_id).await)
+                Some(bounded_diagnostics(&mut conn, &opts.stream, &stream_id).await)
             };
             ui.emit(&MessageOutcomeOutput::TimedOut {
                 diagnostics: diag,
                 resume_note: None,
             });
             // A timeout is retryable (the worker may still be working, or a
-            // transient stall), so it maps to the transient exit code, not failure.
-            // Drop the Valkey port-forward FIRST for the same non-unwinding reason.
-            drop(_valkey_pf);
-            std::process::exit(crate::exit::ExitClass::Transient.code());
+            // transient stall), so it maps to the transient exit code, not
+            // failure. Drop the Valkey port-forward now, for the same
+            // non-unwinding reason as the stub above (#766).
+            exit_after_drop(crate::exit::ExitClass::Transient, _valkey_pf);
         }
     }
 }


### PR DESCRIPTION
## Summary

- A timed-out `local message`/`cluster message` turn could hold its Slack stub's bound port (8155 by default) well past `--timeout-secs`, wedging every subsequent turn with "Address already in use" until the stale process was found and killed by hand.
- The real culprit: the timeout arm's post-timeout diagnostics gather read straight from the same Valkey the worker never acked against, with no timeout of its own (unlike every other Valkey read on this path). A stalled Valkey -- the likely cause of the original timeout -- could hang that gather indefinitely while the stub still held the port, since it used to be torn down only after the gather finished.
- Both `message_local` and `message` (cluster) now drop the Slack stub's listener immediately on detecting `Outcome::TimedOut`, before the diagnostics gather starts, and the gather itself is now bounded (`DIAGNOSTICS_TIMEOUT`) so the process can no longer hang indefinitely there either.
- Every remaining exit path that still holds the stub (or a `kubectl port-forward`) now routes through a small `exit_after_drop` helper that takes the guards by value and drops them before calling `std::process::exit`, so a future call site cannot reintroduce the leak by forgetting an explicit drop.
- Sharpened the stub's bind-failure error to name both possibilities (a genuinely concurrent session vs. a stale leftover process) and point at `lsof`/`ss` to find the holder, since the two look identical from the error alone.

## Test plan

- [x] Added `chat::tests::dropping_the_stub_after_a_timed_out_turn_frees_the_port_promptly`, which binds the stub, confirms the port is genuinely held, drops it exactly as the timeout arm now does, and confirms the port becomes bindable again in the same process well within a fraction of a second.
- [x] `cd cli && cargo fmt --check`
- [x] `cd cli && cargo clippy -- -D warnings`
- [x] `cd cli && cargo test` (462 lib tests + integration suites, all green)

Closes #751