### PR TITLE
Bound bundle ingestion with an upload size cap and extraction size/ratio guards

### DIFF
--- a/apps/api/src/agentos_api/bundles.py
+++ b/apps/api/src/agentos_api/bundles.py
@@ -13,6 +13,8 @@ import zipfile
 from pathlib import Path
 
 from plugin_format import (
+    DEFAULT_MAX_COMPRESSION_RATIO,
+    DEFAULT_MAX_UNCOMPRESSED_BYTES,
     MANIFEST_LOCATIONS,
     UnsupportedArchive,
     ValidationResult,
@@ -58,16 +60,29 @@ def detect_format(data: bytes) -> tuple[str, str]:
     raise UnsupportedArchive("upload is not a zip or tar(.gz) archive")
 
 
-def extract_and_validate(data: bytes, dest: Path) -> tuple[str, str, ValidationResult]:
+def extract_and_validate(
+    data: bytes,
+    dest: Path,
+    *,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+) -> tuple[str, str, ValidationResult]:
     """Detect, extract, and validate. Returns (extension, content_type, result).
 
-    Extraction (with the traversal/symlink/special-file guards) and the
-    single-wrapper-dir unwrap live in ``plugin_format``; this only adds the
-    storage-key/content-type detection the upload path needs.
+    Extraction (with the traversal/symlink/special-file and size/ratio guards)
+    and the single-wrapper-dir unwrap live in ``plugin_format``; this only adds
+    the storage-key/content-type detection the upload path needs. The size/ratio
+    caps default to ``plugin_format``'s generous fallbacks; ``deploy.py`` passes
+    the operator-configured ``Settings`` values instead.
     """
 
     extension, content_type = detect_format(data)
-    safe_extract(data, dest)
+    safe_extract(
+        data,
+        dest,
+        max_uncompressed_bytes=max_uncompressed_bytes,
+        max_compression_ratio=max_compression_ratio,
+    )
     result = validate_bundle(bundle_root(dest))
     return extension, content_type, result
 

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -55,6 +55,28 @@ class Settings(BaseSettings):
     s3_secret_key: str = "miniosecret"
     s3_region: str = "us-east-1"
     bundle_bucket: str = "agentos-bundles"
+    # Bundle ingestion bounds (ADR-0059 decision 3). Three independent caps:
+    # - bundle_upload_max_bytes gates the raw upload body, enforced before it
+    #   is fully read into memory (routers/bundles.py's `_read_bounded_upload`,
+    #   mirroring `_read_bounded_body` below). 200 MiB comfortably covers a
+    #   real plugin bundle (source, skill docs, small fixtures) while bounding
+    #   a runaway upload.
+    # - bundle_max_uncompressed_bytes and bundle_max_compression_ratio gate
+    #   `safe_extract`/`check_archive_bounds` (`plugin_format.archive`): the
+    #   total size the archive would extract to, and its overall compression
+    #   ratio. A legitimate source/text bundle rarely compresses past ~10x; a
+    #   zip-bomb-shaped archive routinely clears 1000x, so 100x sits well
+    #   above real bundles and well below a bomb. These two also gate
+    #   `deploy.revalidate_stored_bundle`'s deploy-time recheck of an
+    #   already-stored bundle against the CURRENT caps (the legacy-bundle
+    #   backward-compatibility case).
+    # Mirrored in the worker's `WorkerConfig` (apps/worker/src/agentos_worker/
+    # config.py) under the same names/defaults -- the worker's Docker-substrate
+    # bundle-fetch and the eval-stream suite loader apply the same caps to the
+    # same stored bytes, so keep the two in sync (a parity seam per AGENTS.md).
+    bundle_upload_max_bytes: int = 200 * 1024 * 1024  # 200 MiB
+    bundle_max_uncompressed_bytes: int = 1024 * 1024 * 1024  # 1 GiB
+    bundle_max_compression_ratio: float = 100.0
 
     # Git flow (J1). The webhook secret authenticates inbound GitHub events; the
     # two bot identities are the routing targets recorded on each deployment.

--- a/apps/api/src/agentos_api/deploy.py
+++ b/apps/api/src/agentos_api/deploy.py
@@ -10,9 +10,11 @@ import tempfile
 import uuid
 from pathlib import Path
 
+import plugin_format
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import bundles, crud
+from .config import Settings, get_settings
 from .models import AgentVersion
 from .schemas import BundleOut
 from .storage import ObjectStore
@@ -26,20 +28,72 @@ class BundleInvalid(Exception):
         self.errors = errors
 
 
-def validate_archive(data: bytes) -> tuple[str, str]:
+class BundleTooLarge(Exception):
+    """An already-stored bundle fails the CURRENT size/ratio caps.
+
+    Raised by ``revalidate_stored_bundle`` -- the backward-compatibility case
+    ADR-0059 decision 3 commits to: a bundle stored before these caps existed
+    (or under looser ones) must be rejected here, at deploy time, with an
+    actionable message, rather than surfacing later as an opaque
+    init-container failure or a mid-extract eviction on the node.
+    """
+
+
+def validate_archive(
+    data: bytes, settings: Settings | None = None
+) -> tuple[str, str]:
     """Validate an archive's bytes. Returns (extension, content_type).
 
     Raises ``bundles.UnsupportedArchive`` if the bytes are not a zip/tar(.gz),
-    and ``BundleInvalid`` if the plugin bundle fails validation.
+    ``BundleInvalid`` if the plugin bundle fails validation, and (via
+    ``safe_extract``) ``bundles.UnsupportedArchive`` again if the archive
+    exceeds the configured uncompressed-size or compression-ratio cap.
     """
 
+    settings = settings or get_settings()
     with tempfile.TemporaryDirectory() as tmp:
         extension, content_type, result = bundles.extract_and_validate(
-            data, Path(tmp)
+            data,
+            Path(tmp),
+            max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
+            max_compression_ratio=settings.bundle_max_compression_ratio,
         )
     if not result.valid:
         raise BundleInvalid([e.model_dump() for e in result.errors])
     return extension, content_type
+
+
+async def revalidate_stored_bundle(
+    store: ObjectStore, version: AgentVersion, settings: Settings | None = None
+) -> None:
+    """Re-check an already-stored bundle against the CURRENT size/ratio caps.
+
+    A no-op when the version carries no bundle yet. Otherwise fetches the
+    immutable bytes and reruns the same pre-scan ``safe_extract`` applies
+    (unsafe entries, uncompressed-size and compression-ratio caps) via
+    ``plugin_format.check_archive_bounds``, which extracts nothing -- cheap
+    enough to run on every deploy/promote. Called before a version becomes
+    deployable (``crud.create_deployment_row``'s callers), so a legacy bundle
+    that predates these caps, or was stored under looser ones, fails here with
+    a clear ``BundleTooLarge`` instead of only surfacing once some sandbox
+    substrate tries to fetch and extract it.
+    """
+
+    if version.bundle_ref is None:
+        return
+    settings = settings or get_settings()
+    data = await store.get(version.bundle_ref)
+    try:
+        plugin_format.check_archive_bounds(
+            data,
+            max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
+            max_compression_ratio=settings.bundle_max_compression_ratio,
+        )
+    except plugin_format.UnsupportedArchive as exc:
+        raise BundleTooLarge(
+            f"stored bundle for version {version.id} fails the current bundle "
+            f"size/ratio limits and must be rebuilt and re-uploaded: {exc}"
+        ) from exc
 
 
 async def store_bundle(

--- a/apps/api/src/agentos_api/gitflow.py
+++ b/apps/api/src/agentos_api/gitflow.py
@@ -153,7 +153,7 @@ async def process_push(
             data = await run_in_threadpool(
                 clone_and_archive, clone_url, after, settings
             )
-            extension, content_type = deploy.validate_archive(data)
+            extension, content_type = deploy.validate_archive(data, settings)
         except GitFlowError as exc:
             return WebhookResult(
                 status="rejected",
@@ -182,6 +182,21 @@ async def process_push(
     # Either the version pre-existed with a bundle, or the block above created
     # or repaired it; it is non-None from here on.
     assert version is not None
+
+    # A prod promote (bundle_built is False) reuses a bundle that may have been
+    # stored before the current size/ratio caps existed, or under looser ones --
+    # revalidate it here (ADR-0059 decision 3's backward-compat commitment). The
+    # bundle_built branch above already ran these bytes through
+    # `deploy.validate_archive` under the current caps moments ago, so re-fetching
+    # and rechecking the identical bytes here would be redundant.
+    if not bundle_built:
+        try:
+            await deploy.revalidate_stored_bundle(store, version, settings)
+        except deploy.BundleTooLarge as exc:
+            return WebhookResult(
+                status="rejected",
+                errors=[{"code": "bundle.too_large", "message": str(exc)}],
+            )
 
     deployment = await crud.create_deployment_row(
         session,

--- a/apps/api/src/agentos_api/routers/bundles.py
+++ b/apps/api/src/agentos_api/routers/bundles.py
@@ -11,9 +11,15 @@ from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile, sta
 
 from .. import bundles, crud, deploy
 from ..auth import require_api_key
+from ..config import get_settings
 from ..deps import SessionDep, StoreDep
 from ..models import AgentVersion
 from ..schemas import BundleOut
+
+# Chunk size for the bounded read below; arbitrary, just small enough that a
+# rejected oversized upload never holds more than one chunk's worth of the
+# file in memory at once.
+_UPLOAD_READ_CHUNK_BYTES = 1024 * 1024
 
 router = APIRouter(
     prefix="/agents/{agent_id}/versions/{version_id}/bundle",
@@ -45,6 +51,46 @@ def _content_type_for(key: str) -> str:
     return "application/octet-stream"
 
 
+async def _read_bounded_upload(file: UploadFile, max_bytes: int) -> bytes:
+    """Read the uploaded file's bytes, rejecting an oversized upload before it
+    is buffered into memory.
+
+    Mirrors ``_read_bounded_body`` (``routers/github.py``): the bound is
+    enforced by rejecting the moment the accumulated size crosses it, rather
+    than via a single ``await file.read()`` that materializes the whole upload
+    into one contiguous bytes object first and only then lets a caller reject
+    it -- exactly the unbounded-memory defect this closes (ADR-0059
+    decision 3). Starlette's multipart parser tracks the exact number of bytes
+    written for this part as ``file.size``, so that is checked first as a fast
+    path with no read at all; the chunked loop below is the enforcement when a
+    parser leaves ``size`` unset, and is itself bounded (never accumulates past
+    ``max_bytes`` before raising). Raises 413 on an oversized upload.
+    """
+
+    if file.size is not None:
+        if file.size > max_bytes:
+            raise HTTPException(
+                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                "bundle upload exceeds the maximum size",
+            )
+        return await file.read()
+
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await file.read(_UPLOAD_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                "bundle upload exceeds the maximum size",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 @router.put("", response_model=BundleOut, status_code=status.HTTP_201_CREATED)
 async def upload_bundle(
     agent_id: uuid.UUID,
@@ -53,6 +99,10 @@ async def upload_bundle(
     store: StoreDep,
     file: UploadFile,
 ) -> BundleOut:
+    # Enforced before touching the DB or anything else: an oversized upload is
+    # rejected on the size gate alone, not after a wasted version lookup.
+    data = await _read_bounded_upload(file, get_settings().bundle_upload_max_bytes)
+
     version = await _load_version(session, agent_id, version_id)
     if version.bundle_ref is not None:
         raise HTTPException(
@@ -60,7 +110,6 @@ async def upload_bundle(
             "bundle already stored for this version (bundles are immutable)",
         )
 
-    data = await file.read()
     try:
         extension, content_type = deploy.validate_archive(data)
     except bundles.UnsupportedArchive as exc:

--- a/apps/api/src/agentos_api/routers/deployments.py
+++ b/apps/api/src/agentos_api/routers/deployments.py
@@ -4,9 +4,9 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from .. import crud
+from .. import crud, deploy
 from ..auth import require_api_key
-from ..deps import SessionDep
+from ..deps import SessionDep, StoreDep
 from ..schemas import DeploymentCreate, DeploymentOut
 
 router = APIRouter(
@@ -18,10 +18,20 @@ router = APIRouter(
 
 @router.post("", response_model=DeploymentOut, status_code=status.HTTP_201_CREATED)
 async def create_deployment(
-    data: DeploymentCreate, session: SessionDep
+    data: DeploymentCreate, session: SessionDep, store: StoreDep
 ) -> DeploymentOut:
     if await crud.get_agent(session, data.agent_id) is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+    version = await crud.get_version(session, data.version_id)
+    if version is None or version.agent_id != data.agent_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "version not found")
+    # Revalidate the stored bundle against the CURRENT size/ratio caps before
+    # this version becomes deployable -- catches a bundle stored before these
+    # caps existed, or under looser ones (ADR-0059 decision 3).
+    try:
+        await deploy.revalidate_stored_bundle(store, version)
+    except deploy.BundleTooLarge as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
     deployment = await crud.create_deployment(session, data)
     return DeploymentOut.model_validate(deployment)
 

--- a/apps/api/tests/test_bundle_ingestion_bounds.py
+++ b/apps/api/tests/test_bundle_ingestion_bounds.py
@@ -1,0 +1,298 @@
+"""Bundle ingestion bounds (ADR-0059 decision 3, #757).
+
+Covers the three "done when" cases: an oversized upload rejected before it is
+buffered into memory, a zip-bomb-shaped archive refused with nothing written
+(the archive-level guard itself is unit-tested in
+``packages/plugin-format/tests/test_archive.py``; this file only exercises the
+API's own use of it), and an already-stored ("legacy") bundle that exceeds the
+current caps failing at deploy time with an actionable message.
+"""
+
+import asyncio
+import hashlib
+import io
+import tarfile
+import uuid
+import zipfile
+from typing import Any
+
+import pytest
+from agentos_api import crud
+from agentos_api import deploy as deploy_module
+from agentos_api.config import Settings, get_settings
+from agentos_api.routers import bundles as bundles_router
+from agentos_api.storage import BundleStore
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+MANIFEST = '{"name": "demo-plugin", "version": "0.1.0"}'
+
+
+def _tar_plain(files: dict[str, bytes], top: str = "demo-plugin") -> bytes:
+    """An UNCOMPRESSED tar so the wire size is deterministic (no gzip shrinking
+    filler content out from under a size assertion)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:") as tf:
+        for rel, content in files.items():
+            info = tarfile.TarInfo(f"{top}/{rel}")
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _create_version(client: Any, headers: dict[str, str]) -> tuple[str, str]:
+    agent = client.post(
+        "/agents",
+        json={"name": "bundle-bounds-agent", "slack_channel": "C0000BND1"},
+        headers=headers,
+    ).json()
+    version = client.post(
+        f"/agents/{agent['id']}/versions",
+        json={"version_label": "v1", "created_by": "bconn"},
+        headers=headers,
+    ).json()
+    return agent["id"], version["id"]
+
+
+# --- upload size cap, enforced before buffering --------------------------
+
+
+def test_oversized_upload_is_rejected_before_buffering(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    max_bytes = 200
+    monkeypatch.setattr(
+        bundles_router,
+        "get_settings",
+        lambda: Settings(bundle_upload_max_bytes=max_bytes),
+    )
+    agent_id, version_id = _create_version(client, auth_headers)
+
+    calls: list[uuid.UUID] = []
+    real_get_version = crud.get_version
+
+    async def _tracking_get_version(session: Any, vid: uuid.UUID) -> Any:
+        calls.append(vid)
+        return await real_get_version(session, vid)
+
+    monkeypatch.setattr(crud, "get_version", _tracking_get_version)
+
+    # An uncompressed archive carrying 2000 filler bytes: well over the 200
+    # byte cap regardless of tar's own header/padding overhead.
+    archive = _tar_plain(
+        {
+            ".claude-plugin/plugin.json": MANIFEST.encode(),
+            "big.bin": b"x" * 2000,
+        }
+    )
+    assert len(archive) > max_bytes
+
+    resp = client.put(
+        f"/agents/{agent_id}/versions/{version_id}/bundle",
+        files={"file": ("big.tar", archive)},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 413, resp.text
+
+    # The size gate ran before the version lookup: no DB work happened for a
+    # request that was always going to be rejected.
+    assert calls == []
+
+    # Nothing was stored.
+    version = client.get(
+        f"/agents/{agent_id}/versions", headers=auth_headers
+    ).json()[0]
+    assert version["bundle_ref"] is None
+
+
+def test_upload_at_the_limit_is_accepted(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    files = {
+        ".claude-plugin/plugin.json": MANIFEST.encode(),
+        "skills/greeter/SKILL.md": (
+            b"---\nname: greeter\ndescription: greets\n---\n"
+        ),
+    }
+    archive = _tar_plain(files)
+    monkeypatch.setattr(
+        bundles_router,
+        "get_settings",
+        lambda: Settings(bundle_upload_max_bytes=len(archive)),
+    )
+    agent_id, version_id = _create_version(client, auth_headers)
+
+    resp = client.put(
+        f"/agents/{agent_id}/versions/{version_id}/bundle",
+        files={"file": ("demo.tar", archive)},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _zip_bomb_shaped(size: int = 200_000) -> bytes:
+    """A single highly-compressible entry: small on the wire, huge once
+    expanded -- well under the (generous) default upload-size cap, so this
+    exercises the extraction-time ratio guard specifically, not the upload
+    body-size gate."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("zeros.bin", b"\x00" * size)
+    return buf.getvalue()
+
+
+def test_zip_bomb_upload_is_refused_with_nothing_written(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent_id, version_id = _create_version(client, auth_headers)
+    archive = _zip_bomb_shaped()
+    assert len(archive) < 2_000  # tiny on the wire; clears the upload size gate
+
+    resp = client.put(
+        f"/agents/{agent_id}/versions/{version_id}/bundle",
+        files={"file": ("bomb.zip", archive)},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400, resp.text
+    assert "compression ratio" in resp.json()["detail"]
+
+    version = client.get(
+        f"/agents/{agent_id}/versions", headers=auth_headers
+    ).json()[0]
+    assert version["bundle_ref"] is None
+
+
+# --- legacy bundle revalidated against the CURRENT caps at deploy time ---
+
+
+def _store_legacy_bundle(agent_id: str, version_id: str, data: bytes) -> None:
+    """Write bytes directly to the store and attach them to the version,
+    bypassing the upload endpoint entirely -- simulating a bundle written
+    before ADR-0059's size/ratio caps existed (or under looser ones)."""
+
+    async def _run() -> None:
+        settings = get_settings()
+        store = BundleStore(settings)
+        key = f"bundles/{agent_id}/{version_id}.tar"
+        await store.put(key, data, "application/x-tar")
+        engine = create_async_engine(settings.database_url)
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as session:
+            version = await crud.get_version(session, uuid.UUID(version_id))
+            assert version is not None
+            await crud.attach_bundle(
+                session, version, key, hashlib.sha256(data).hexdigest()
+            )
+        await engine.dispose()
+
+    asyncio.run(_run())
+
+
+def test_legacy_oversized_bundle_fails_at_deploy_time_with_actionable_message(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_id, version_id = _create_version(client, auth_headers)
+    # An entirely ordinary bundle by today's standards -- this test simulates it
+    # having been written back when the caps were looser or absent, so the
+    # CURRENT cap (set tight here) must catch it at deploy time.
+    data = _tar_plain(
+        {
+            ".claude-plugin/plugin.json": MANIFEST.encode(),
+            "big.bin": b"x" * 5000,
+        }
+    )
+    _store_legacy_bundle(agent_id, version_id, data)
+
+    monkeypatch.setattr(
+        deploy_module,
+        "get_settings",
+        lambda: Settings(bundle_max_uncompressed_bytes=1000),
+    )
+
+    resp = client.post(
+        "/deployments",
+        json={
+            "agent_id": agent_id,
+            "version_id": version_id,
+            "environment": "dev",
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert "size/ratio" in detail
+    assert version_id in detail  # actionable: names the affected version
+    assert "rebuilt and re-uploaded" in detail
+
+    # Nothing was deployed.
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert deployments == []
+
+
+def test_legacy_bundle_within_current_caps_deploys_normally(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The revalidation is a real gate, not a rubber stamp: a bundle that
+    genuinely fits under the current caps still deploys."""
+    agent_id, version_id = _create_version(client, auth_headers)
+    data = _tar_plain({".claude-plugin/plugin.json": MANIFEST.encode()})
+    _store_legacy_bundle(agent_id, version_id, data)
+
+    monkeypatch.setattr(
+        deploy_module,
+        "get_settings",
+        lambda: Settings(bundle_max_uncompressed_bytes=1_000_000),
+    )
+
+    resp = client.post(
+        "/deployments",
+        json={
+            "agent_id": agent_id,
+            "version_id": version_id,
+            "environment": "dev",
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def test_version_with_no_bundle_yet_deploys_without_revalidation(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """A version created but not yet bundled (the pre-B2 residue case) is not
+    blocked by the revalidation -- it is a no-op when bundle_ref is None."""
+    agent = client.post(
+        "/agents",
+        json={"name": "bundleless-agent", "slack_channel": "C0000BND2"},
+        headers=auth_headers,
+    ).json()
+    version = client.post(
+        f"/agents/{agent['id']}/versions",
+        json={"version_label": "v1", "created_by": "bconn"},
+        headers=auth_headers,
+    ).json()
+    assert version["bundle_ref"] is None
+
+    resp = client.post(
+        "/deployments",
+        json={
+            "agent_id": agent["id"],
+            "version_id": version["id"],
+            "environment": "dev",
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text

--- a/apps/worker/src/agentos_worker/bundle_store.py
+++ b/apps/worker/src/agentos_worker/bundle_store.py
@@ -19,7 +19,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from aci_protocol.s3 import build_s3_client
-from plugin_format import bundle_root, safe_extract
+from plugin_format import (
+    DEFAULT_MAX_COMPRESSION_RATIO,
+    DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    bundle_root,
+    safe_extract,
+)
 
 from .config import WorkerConfig
 
@@ -70,16 +75,30 @@ class BundleStore:
         return body
 
 
-def extract_bundle(data: bytes, dest: Path) -> Path:
+def extract_bundle(
+    data: bytes,
+    dest: Path,
+    *,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+) -> Path:
     """Extract ``data`` into ``dest`` and return the plugin root to mount.
 
     The returned path is ``dest`` when the archive is flat, or its single
     wrapper subdir when the manifest sits one level down -- the same root the
     API validated, so the runner reads the plugin from the expected layout.
     Extraction and unwrap route through ``plugin_format`` (the single audited
-    home for the traversal/symlink/special-file guards); an unsafe or
-    unrecognized archive raises ``plugin_format.UnsupportedArchive``, which the
-    Docker-substrate caller already treats as a fetch failure.
+    home for the traversal/symlink/special-file and size/ratio guards); an
+    unsafe, oversized, or unrecognized archive raises
+    ``plugin_format.UnsupportedArchive``, which the Docker-substrate caller
+    already treats as a fetch failure. The size/ratio caps default to
+    ``plugin_format``'s generous fallbacks; the caller passes the operator-
+    configured ``WorkerConfig`` values instead (ADR-0059 decision 3).
     """
-    safe_extract(data, dest)
+    safe_extract(
+        data,
+        dest,
+        max_uncompressed_bytes=max_uncompressed_bytes,
+        max_compression_ratio=max_compression_ratio,
+    )
     return bundle_root(dest)

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -322,6 +322,20 @@ class WorkerConfig(BaseSettings):
     s3_secret_key: str = "miniosecret"
     s3_region: str = "us-east-1"
     bundle_bucket: str = "agentos-bundles"
+    # Bundle extraction bounds (ADR-0059 decision 3), applied by the Docker
+    # substrate's claim-time bundle-fetch (`sandbox/docker.py`'s
+    # `_prepare_bundle` -> `bundle_store.extract_bundle`) and the eval-stream
+    # suite loader (`eval/stream.py`'s `load_suite_from_bundle`), both of which
+    # route through `plugin_format.safe_extract`. Mirrors the API's `Settings`
+    # field names/defaults (apps/api/src/agentos_api/config.py) -- the same
+    # stored bytes get the same caps regardless of which lane fetches them, so
+    # keep the two in sync (a parity seam per AGENTS.md). The Kubernetes
+    # substrate fetches/extracts via shell init containers, not this Python
+    # path, so this does not reach it; see ADR-0059 decision 3's note that the
+    # API-side bound is substrate-neutral, while extraction itself is not on
+    # every substrate.
+    bundle_max_uncompressed_bytes: int = 1024 * 1024 * 1024  # 1 GiB
+    bundle_max_compression_ratio: float = 100.0
     # Platform API for POST /evals/report. Defaults match the API's dev stack
     # (README serves it on :8000; its shared dev key is agentos-dev-key).
     api_base_url: str = Field(

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -42,7 +42,11 @@ from aci_protocol import (
     EvalReport,
     parse_eval_job,
 )
-from plugin_format import safe_extract
+from plugin_format import (
+    DEFAULT_MAX_COMPRESSION_RATIO,
+    DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    safe_extract,
+)
 from redis.asyncio import Redis
 
 from ..binding import (
@@ -124,14 +128,28 @@ class EvalReporter:
         return False
 
 
-def load_suite_from_bundle(data: bytes, suite_name: str) -> EvalSuite | None:
+def load_suite_from_bundle(
+    data: bytes,
+    suite_name: str,
+    *,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+) -> EvalSuite | None:
     """Extract the bundle archive and load its evals/cases.json as an EvalSuite,
     named with ``suite_name`` (the payload's authoritative name / Langfuse tag).
-    Returns None on a corrupt archive or a missing/invalid suite file."""
+    Returns None on a corrupt, unsafe, or oversized archive (ADR-0059
+    decision 3), or a missing/invalid suite file. The size/ratio caps default
+    to ``plugin_format``'s generous fallbacks; ``_load_suite`` passes the
+    operator-configured ``WorkerConfig`` values instead."""
     try:
         with tempfile.TemporaryDirectory() as tmp:
             dest = Path(tmp)
-            safe_extract(data, dest)
+            safe_extract(
+                data,
+                dest,
+                max_uncompressed_bytes=max_uncompressed_bytes,
+                max_compression_ratio=max_compression_ratio,
+            )
             cases = next((p for p in dest.rglob("cases.json") if p.parent.name == "evals"), None)
             if cases is None:
                 return None
@@ -424,7 +442,12 @@ class EvalStreamConsumer(StreamConsumer):
         except Exception:
             logger.exception("could not fetch bundle %s", item.bundle_ref)
             return None
-        return load_suite_from_bundle(data, item.suite)
+        return load_suite_from_bundle(
+            data,
+            item.suite,
+            max_uncompressed_bytes=self._config.bundle_max_uncompressed_bytes,
+            max_compression_ratio=self._config.bundle_max_compression_ratio,
+        )
 
     async def _acquire_target(self, item: EvalJob) -> tuple[str | None, str | None, str | None]:
         if item.target_url is not None:

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -133,6 +133,8 @@ def _sandbox_client(
             # the K8s runner securityContext; overridable via AGENTOS_RUNNER_*.
             hardening=RunnerHardening.from_env(env),
             environ=env,
+            bundle_max_uncompressed_bytes=config.bundle_max_uncompressed_bytes,
+            bundle_max_compression_ratio=config.bundle_max_compression_ratio,
         )
         # Prewarm the runner image once at startup so the first claim window is
         # not gated on a cold pull. Best-effort inside ensure_image.

--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -51,6 +51,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from aci_protocol import BootEnv
+from plugin_format import DEFAULT_MAX_COMPRESSION_RATIO, DEFAULT_MAX_UNCOMPRESSED_BYTES
 
 from ..binding import (
     BASE_URL_ENV,
@@ -228,6 +229,8 @@ class DockerSandboxClient:
         healthz_timeout_s: float = 0.5,
         hardening: RunnerHardening | None = None,
         environ: Mapping[str, str] | None = None,
+        bundle_max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+        bundle_max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
     ) -> None:
         self._image = image
         self._bundles = bundle_store
@@ -236,6 +239,12 @@ class DockerSandboxClient:
         self._host = host
         self._default_plugin_dir = default_plugin_dir
         self._healthz_timeout_s = healthz_timeout_s
+        # Extraction bounds (ADR-0059 decision 3), forwarded to
+        # ``extract_bundle`` at claim time below. Defaults to plugin_format's
+        # generous fallbacks; ``run.py`` passes the operator-configured
+        # ``WorkerConfig`` values instead.
+        self._bundle_max_uncompressed_bytes = bundle_max_uncompressed_bytes
+        self._bundle_max_compression_ratio = bundle_max_compression_ratio
         # Container isolation (read-only rootfs, dropped caps, no-new-privileges,
         # bounded resources). Defaults to the K8s-mirroring RunnerHardening; a
         # None means "use the on-by-default set", never "no hardening".
@@ -430,7 +439,12 @@ class DockerSandboxClient:
         data = self._bundles.get(ref)
         tmp = tempfile.mkdtemp(prefix="agentos-bundle-")
         try:
-            root = extract_bundle(data, Path(tmp))
+            root = extract_bundle(
+                data,
+                Path(tmp),
+                max_uncompressed_bytes=self._bundle_max_uncompressed_bytes,
+                max_compression_ratio=self._bundle_max_compression_ratio,
+            )
             # The mount is read-only and the runner is non-root (uid 1000), so the
             # staged bundle must be group/other readable+traversable; mkdtemp
             # defaults to 0700, which the non-root runner cannot enter.

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -405,6 +405,65 @@ def test_extract_bundle_unwraps_single_wrapper_dir() -> None:
         assert (root / ".claude-plugin" / "plugin.json").is_file()
 
 
+def _plugin_tar_gz_with_filler(size: int) -> bytes:
+    """Like ``_plugin_tar_gz`` but with an extra file of ``size`` uncompressed
+    bytes, so the archive's total declared uncompressed size is controllable."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        manifest = b'{"name": "deal-desk", "version": "0.1.0"}'
+        info = tarfile.TarInfo(".claude-plugin/plugin.json")
+        info.size = len(manifest)
+        tf.addfile(info, io.BytesIO(manifest))
+        filler = b"x" * size
+        filler_info = tarfile.TarInfo("big.bin")
+        filler_info.size = len(filler)
+        tf.addfile(filler_info, io.BytesIO(filler))
+    return buf.getvalue()
+
+
+def test_extract_bundle_rejects_a_bundle_over_the_uncompressed_cap() -> None:
+    # ADR-0059 decision 3: the Docker-substrate claim-time extraction is bound
+    # the same as the API upload path, via the same plugin_format helper.
+    import tempfile
+
+    from plugin_format import UnsupportedArchive
+
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            extract_bundle(
+                _plugin_tar_gz_with_filler(5000),
+                Path(tmp),
+                max_uncompressed_bytes=1000,
+            )
+            raise AssertionError("expected UnsupportedArchive")
+        except UnsupportedArchive as exc:
+            assert "1000 byte limit" in str(exc)
+        # Nothing was written: the bound check runs before extraction.
+        assert list(Path(tmp).iterdir()) == []
+
+
+def test_prepare_bundle_rejects_oversized_bundle_and_writes_nothing() -> None:
+    # The operator-configured cap (mirroring WorkerConfig's default) is
+    # threaded from the client constructor through to extract_bundle at
+    # claim time, so an oversized bundle fails the claim instead of silently
+    # staging an unbounded tree for the runner to bind-mount.
+    from plugin_format import UnsupportedArchive
+
+    data = _plugin_tar_gz_with_filler(5000)
+    client = _RecordingDocker(
+        image="agentos-runner",
+        bundle_store=_FakeBundleStore(data),
+        bundle_max_uncompressed_bytes=1000,
+    )
+    try:
+        client._prepare_bundle("t1", "bundles/big.tar.gz")
+        raise AssertionError("expected UnsupportedArchive")
+    except UnsupportedArchive:
+        pass
+    # The claim-scoped bundle dir was never registered (cleaned up on failure).
+    assert client._bundle_dirs == {}
+
+
 # ---------------------------------------------------------------------------
 # Container hardening (#631): every spawned runner is isolated at the container
 # level (read-only rootfs, dropped caps, no privilege escalation, bounded

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -11,7 +11,14 @@ from .approval_policy import (
     effective_operator_gate,
     grantable_routes,
 )
-from .archive import UnsupportedArchive, bundle_root, safe_extract
+from .archive import (
+    DEFAULT_MAX_COMPRESSION_RATIO,
+    DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    UnsupportedArchive,
+    bundle_root,
+    check_archive_bounds,
+    safe_extract,
+)
 from .manifest import MANIFEST_LOCATIONS, resolve_manifest
 from .models import (
     ApprovalGate,
@@ -53,6 +60,9 @@ __all__ = [
     "ValidationResult",
     "ValidationIssue",
     "safe_extract",
+    "check_archive_bounds",
+    "DEFAULT_MAX_UNCOMPRESSED_BYTES",
+    "DEFAULT_MAX_COMPRESSION_RATIO",
     "bundle_root",
     "UnsupportedArchive",
 ]

--- a/packages/plugin-format/src/plugin_format/archive.py
+++ b/packages/plugin-format/src/plugin_format/archive.py
@@ -13,6 +13,17 @@ Security model -- an entry is rejected (never extracted) when it:
     all, uniform across zip and tar. Python's ``zipfile`` would materialize a
     symlink-flagged entry as a plain file, so the zip path checks the unix mode
     in the high 16 external-attr bits explicitly (the gap #73 closes).
+
+ADR-0059 decision 3 adds two more bounds, checked in the same pre-scan pass
+before anything is written: the archive's **total uncompressed size** and its
+**compression ratio** (total uncompressed bytes / bytes of the archive itself).
+Both are a full-archive refusal, not a partial unpack -- an archive that would
+exceed either is rejected before ``extractall``/``tf.extractall`` ever runs, so
+a zip-bomb-shaped archive writes nothing to disk. The ratio is computed against
+the whole archive's byte length rather than a per-entry compressed size because
+tar(.gz) compresses the whole stream, not per-member, so per-member compressed
+sizes do not exist there; using the same denominator for zip keeps one uniform
+rule across both formats.
 """
 
 import io
@@ -22,6 +33,16 @@ import zipfile
 from pathlib import Path
 
 from .manifest import resolve_manifest
+
+# Generous defaults: they bound a runaway archive, not ordinary bundle content
+# (source, skill docs, small fixtures). Both are operator-overridable by every
+# caller (the API's Settings, the worker's WorkerConfig) rather than fixed here;
+# these are only the fallback for a caller that does not pass its own.
+DEFAULT_MAX_UNCOMPRESSED_BYTES = 1024 * 1024 * 1024  # 1 GiB
+# A legitimate source/text bundle rarely compresses past ~10x; a classic zip
+# bomb (e.g. a large run of a single repeated byte) routinely clears 1000x.
+# 100x sits well above real bundles and well below a bomb's typical ratio.
+DEFAULT_MAX_COMPRESSION_RATIO = 100.0
 
 
 class UnsupportedArchive(Exception):
@@ -34,43 +55,140 @@ def _reject_unsafe_path(name: str) -> None:
         raise UnsupportedArchive(f"unsafe path in archive: {name}")
 
 
-def _extract_zip(data: bytes, dest: Path) -> None:
-    with zipfile.ZipFile(io.BytesIO(data)) as zf:
-        for info in zf.infolist():
-            _reject_unsafe_path(info.filename)
-            # A unix symlink is encoded in the high 16 bits of external_attr;
-            # non-unix zips leave those bits 0, so this is a no-op for them.
-            if stat.S_ISLNK(info.external_attr >> 16):
-                raise UnsupportedArchive(f"link entry not allowed in archive: {info.filename}")
-        zf.extractall(dest)
+def _check_bounds(
+    total_uncompressed: int,
+    archive_bytes: int,
+    max_uncompressed_bytes: int,
+    max_compression_ratio: float,
+) -> None:
+    """Reject an archive whose declared extracted footprint or compression
+    ratio exceeds the caps. Called from the pre-scan, before any entry is
+    written, so a violation writes nothing to ``dest``."""
+    if total_uncompressed > max_uncompressed_bytes:
+        raise UnsupportedArchive(
+            f"archive would extract to {total_uncompressed} bytes, over the "
+            f"{max_uncompressed_bytes} byte limit"
+        )
+    ratio = total_uncompressed / max(archive_bytes, 1)
+    if ratio > max_compression_ratio:
+        raise UnsupportedArchive(
+            f"archive compression ratio {ratio:.1f}x (uncompressed "
+            f"{total_uncompressed} bytes from {archive_bytes} bytes on disk) "
+            f"exceeds the {max_compression_ratio}x limit"
+        )
 
 
-def _extract_tar(tf: tarfile.TarFile, dest: Path) -> None:
+def _prescan_zip(zf: zipfile.ZipFile) -> int:
+    """Reject unsafe entries; return the total declared uncompressed size."""
+    total = 0
+    for info in zf.infolist():
+        _reject_unsafe_path(info.filename)
+        # A unix symlink is encoded in the high 16 bits of external_attr;
+        # non-unix zips leave those bits 0, so this is a no-op for them.
+        if stat.S_ISLNK(info.external_attr >> 16):
+            raise UnsupportedArchive(f"link entry not allowed in archive: {info.filename}")
+        total += info.file_size
+    return total
+
+
+def _prescan_tar(tf: tarfile.TarFile) -> int:
+    """Reject unsafe entries; return the total declared uncompressed size."""
+    total = 0
     for m in tf.getmembers():
         _reject_unsafe_path(m.name)
         if m.issym() or m.islnk():
             raise UnsupportedArchive(f"link entry not allowed in archive: {m.name}")
         if not (m.isreg() or m.isdir()):
             raise UnsupportedArchive(f"special entry not allowed in archive: {m.name}")
+        total += m.size
+    return total
+
+
+def _extract_zip(
+    data: bytes, dest: Path, max_uncompressed_bytes: int, max_compression_ratio: float
+) -> None:
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        total = _prescan_zip(zf)
+        _check_bounds(total, len(data), max_uncompressed_bytes, max_compression_ratio)
+        zf.extractall(dest)
+
+
+def _extract_tar(
+    tf: tarfile.TarFile,
+    dest: Path,
+    archive_bytes: int,
+    max_uncompressed_bytes: int,
+    max_compression_ratio: float,
+) -> None:
+    total = _prescan_tar(tf)
+    _check_bounds(total, archive_bytes, max_uncompressed_bytes, max_compression_ratio)
     # filter="data" (py3.12+) is the traversal/special-file backstop; the
     # pre-scan above is the primary gate and makes "no links at all" explicit.
     tf.extractall(dest, filter="data")
 
 
-def safe_extract(data: bytes, dest: Path) -> None:
+def safe_extract(
+    data: bytes,
+    dest: Path,
+    *,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+) -> None:
     """Extract ``data`` (zip or tar(.gz)) into ``dest``, refusing unsafe entries.
 
-    Raises ``UnsupportedArchive`` on an unrecognized archive or any absolute,
-    traversing, link, or special-file entry -- nothing is written in that case
-    beyond what a rejected member's predecessors may have already unpacked.
+    Raises ``UnsupportedArchive`` on an unrecognized archive, any absolute,
+    traversing, link, or special-file entry, or an archive whose total
+    uncompressed size or compression ratio exceeds the given caps -- nothing is
+    written in that case beyond what a rejected member's predecessors may have
+    already unpacked (in practice nothing, since the whole pre-scan, including
+    the bound check, runs before extraction starts).
     """
     if zipfile.is_zipfile(io.BytesIO(data)):
-        _extract_zip(data, dest)
+        _extract_zip(data, dest, max_uncompressed_bytes, max_compression_ratio)
         return
     for mode in ("r:gz", "r:"):
         try:
             with tarfile.open(fileobj=io.BytesIO(data), mode=mode) as tf:
-                _extract_tar(tf, dest)
+                _extract_tar(
+                    tf, dest, len(data), max_uncompressed_bytes, max_compression_ratio
+                )
+            return
+        except tarfile.TarError:
+            continue
+    raise UnsupportedArchive("data is not a recognized zip or tar(.gz) archive")
+
+
+def check_archive_bounds(
+    data: bytes,
+    *,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+) -> None:
+    """Validate an archive's size/ratio bounds without extracting anything.
+
+    Runs the identical safety pre-scan ``safe_extract`` runs before unpacking
+    (unsafe paths, links, special files, uncompressed-size and
+    compression-ratio caps) but stops there -- nothing is ever written to disk,
+    so this is cheap to run against an already-stored bundle's bytes.
+
+    This is what a deploy-time revalidation of an already-stored bundle calls
+    (ADR-0059 decision 3's backward-compatibility commitment): a bundle stored
+    under a previous, looser (or absent) cap is checked against the CURRENT
+    caps before it is handed to a sandbox substrate to fetch and extract, so an
+    oversized legacy bundle fails here with a clear, actionable error instead of
+    surfacing as an opaque init-container failure or a mid-extract eviction on
+    the node.
+    """
+    if zipfile.is_zipfile(io.BytesIO(data)):
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            total = _prescan_zip(zf)
+        _check_bounds(total, len(data), max_uncompressed_bytes, max_compression_ratio)
+        return
+    for mode in ("r:gz", "r:"):
+        try:
+            with tarfile.open(fileobj=io.BytesIO(data), mode=mode) as tf:
+                total = _prescan_tar(tf)
+            _check_bounds(total, len(data), max_uncompressed_bytes, max_compression_ratio)
             return
         except tarfile.TarError:
             continue

--- a/packages/plugin-format/tests/test_archive.py
+++ b/packages/plugin-format/tests/test_archive.py
@@ -13,7 +13,12 @@ import zipfile
 from pathlib import Path
 
 import pytest
-from plugin_format import UnsupportedArchive, bundle_root, safe_extract
+from plugin_format import (
+    UnsupportedArchive,
+    bundle_root,
+    check_archive_bounds,
+    safe_extract,
+)
 
 MANIFEST = '{"name": "demo-plugin", "version": "0.1.0"}'
 
@@ -174,3 +179,81 @@ def test_flat_zip_bundle_extracts(tmp_path: Path) -> None:
 def test_non_archive_bytes_rejected(tmp_path: Path) -> None:
     with pytest.raises(UnsupportedArchive):
         safe_extract(b"not an archive", tmp_path)
+
+
+# --- ADR-0059 decision 3: size + compression-ratio bounds ----------------
+
+
+def _zip_bomb_shaped(name: str = "zeros.bin", size: int = 200_000) -> bytes:
+    """A single highly-compressible entry: small on disk, huge once expanded.
+
+    ``size`` zero bytes deflate down to a few hundred bytes, so this trips the
+    default 100x compression-ratio cap while staying nowhere near the default
+    1 GiB uncompressed-size cap -- isolating the ratio guard from the size
+    guard, at a size cheap enough to run in CI (no real multi-GB bomb needed).
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(name, b"\x00" * size)
+    return buf.getvalue()
+
+
+def test_zip_bomb_shaped_archive_is_refused_with_nothing_written(
+    tmp_path: Path,
+) -> None:
+    data = _zip_bomb_shaped()
+    # Sanity check the fixture is actually bomb-shaped before asserting the guard.
+    assert len(data) < 2_000
+    with pytest.raises(UnsupportedArchive, match="compression ratio"):
+        safe_extract(data, tmp_path)
+    # Nothing was written: the bound check runs before extractall.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_tar_gz_bomb_shaped_archive_is_refused_with_nothing_written(
+    tmp_path: Path,
+) -> None:
+    info, payload = _reg("zeros.bin", b"\x00" * 200_000)
+    data = _tar([info], {"zeros.bin": payload})
+    with pytest.raises(UnsupportedArchive, match="compression ratio"):
+        safe_extract(data, tmp_path)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_oversized_uncompressed_total_is_refused(tmp_path: Path) -> None:
+    # Random bytes barely compress, so the ratio stays near 1x and only the
+    # uncompressed-size cap (set well below the payload here) is exercised.
+    import os
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("random.bin", os.urandom(2_000))
+    data = buf.getvalue()
+
+    with pytest.raises(UnsupportedArchive, match="1000 byte limit"):
+        safe_extract(data, tmp_path, max_uncompressed_bytes=1_000)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_archive_within_bounds_is_accepted(tmp_path: Path) -> None:
+    # A normal small bundle stays well under both defaults.
+    safe_extract(_tar_files(_valid_files()), tmp_path)
+    assert (tmp_path / ".claude-plugin" / "plugin.json").is_file()
+
+
+def test_check_archive_bounds_rejects_bomb_without_extracting(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(UnsupportedArchive, match="compression ratio"):
+        check_archive_bounds(_zip_bomb_shaped())
+    # check_archive_bounds never takes a dest at all -- nothing to write.
+
+
+def test_check_archive_bounds_accepts_a_valid_bundle() -> None:
+    check_archive_bounds(_tar_files(_valid_files()))  # does not raise
+
+
+def test_check_archive_bounds_still_rejects_unsafe_entries() -> None:
+    # The size/ratio check does not bypass the existing traversal guard.
+    with pytest.raises(UnsupportedArchive):
+        check_archive_bounds(_zip({"../escape": "pwn"}))


### PR DESCRIPTION
## Summary

Implements ADR-0059 decision 3 (`docs/adr/0059-sandbox-is-a-bounded-resource-envelope.md`). Bundle ingestion was previously unbounded on both ends: the upload endpoint read the whole request body into memory with no size gate, and `safe_extract` rejected unsafe entries but enforced no uncompressed-size or compression-ratio limit.

- **Upload size cap.** `routers/bundles.py`'s upload handler now reads the file through a new `_read_bounded_upload` helper, mirroring `_read_bounded_body` (the GitHub webhook's bounded-read pattern): it checks Starlette's tracked `file.size` up front and, as a backstop, reads in chunks and rejects the moment the accumulated size crosses the bound, rather than a single unbounded `await file.read()`. Runs before the version lookup, so an oversized upload never touches the DB.
- **Extraction size/ratio guards.** `safe_extract` (`packages/plugin-format/src/plugin_format/archive.py`) now accepts `max_uncompressed_bytes` and `max_compression_ratio`, checked in the same pre-scan pass that already rejects unsafe entries, before any entry is written. A violating archive is refused outright, nothing partially unpacked. A new `check_archive_bounds` runs the identical check without extracting anything, for the deploy-time revalidation case below.
- **Deploy-time revalidation of legacy bundles.** `deploy.revalidate_stored_bundle` re-checks an already-stored bundle's bytes against the *current* caps. Wired into both places a version becomes deployable: git-flow's prod promote path (which reuses an existing `bundle_ref` without rebuilding) and the direct `POST /deployments` endpoint. A bundle stored before these caps existed now fails there with an actionable message instead of surfacing later as an opaque init-container failure or a mid-extract eviction on the node.
- **Operator-configurable.** All three limits are `Settings` fields (`bundle_upload_max_bytes`, `bundle_max_uncompressed_bytes`, `bundle_max_compression_ratio`), mirrored in the worker's `WorkerConfig` under the same names/defaults so the Docker-substrate claim-time bundle-fetch and the eval-stream suite loader apply the same bounds to the same stored bytes.

`packages/plugin-format` is a frozen-contract package; this only tightens `safe_extract`'s validation (rejects strictly more than before, via additive keyword-only parameters) and adds a new function, it does not touch the manifest schema or any existing function's required signature.

## Test plan

- [x] `uv run pytest apps/api/tests packages/plugin-format/tests apps/worker/tests -q` — 1071 passed, 1 skipped
- [x] `uv run ruff check` / `uv run mypy` on all touched source
- [x] `./scripts/check-contracts.sh` — no drift
- [x] New tests cover: an oversized upload rejected before the version lookup/buffering, a zip-bomb-shaped archive refused with nothing written (both at the `plugin_format` unit level and through the real upload endpoint), and a legacy oversized bundle failing at deploy time (both via git-flow promote reuse and direct `POST /deployments`) with an actionable message, plus a control case proving the revalidation isn't a rubber stamp

Closes #757