### PR TITLE
Share the GHA layer cache with e2e-ladder's image builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -440,6 +440,19 @@ jobs:
   # actual up/deploy/message/down round trip; `local up --wait` alone can run
   # up to compose's 300s default wait timeout if a service is slow to report
   # healthy.
+  # This job's three builds share the `images` job's gha cache store above:
+  # neither job passes an explicit `scope` to cache-from/cache-to, so both
+  # default to buildkit's own "buildkit" scope, and runner/Dockerfile,
+  # apps/api/Dockerfile, and apps/worker/Dockerfile are the same files the
+  # `images` matrix already built on this commit. There is no `needs` edge
+  # between `images` and `e2e-ladder` (this job only waits on `rust`), so the
+  # cache hit here is NOT guaranteed by job ordering -- it happens in practice
+  # because `images`'s cache-warmed builds are far quicker than `rust`'s full
+  # cargo build/test/release, so `images` has almost always finished writing
+  # its cache well before `rust` unblocks this job. If that assumption ever
+  # flips (a slower images job or a much faster rust job), the first CI run on
+  # a new commit's shas would fall back to a cold build here, same as today,
+  # and only later runs of the same shas would see the hit.
   e2e-ladder:
     name: E2E parity ladder (skill + local, fake model)
     runs-on: ubuntu-latest
@@ -448,6 +461,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Download the agentos binary built by the Rust job
         uses: actions/download-artifact@v7
         with:
@@ -456,7 +471,7 @@ jobs:
       - name: Make the binary executable
         run: chmod +x cli/target/release/agentos
       - name: Build the runner image locally
-        run: docker build -t agentos-runner -f runner/Dockerfile .
+        run: docker buildx build --load -t agentos-runner -f runner/Dockerfile --cache-from type=gha --cache-to type=gha .
       - name: Retag the runner image for the compose worker (AGENTOS_RUNNER_IMAGE, no registry auth)
         run: docker tag agentos-runner ghcr.io/curie-eng/agentos-runner:latest
       # Tagged :ci-local (the worker-local-image job's own convention), not
@@ -466,9 +481,9 @@ jobs:
       # retag its from-source builds over whatever `:latest` meant in the local
       # Docker image store before this job ran.
       - name: Build the api image locally (satisfies agentos-api + agentos-migrate, no registry auth)
-        run: docker build -t ghcr.io/curie-eng/agentos-api:ci-local -f apps/api/Dockerfile .
+        run: docker buildx build --load -t ghcr.io/curie-eng/agentos-api:ci-local -f apps/api/Dockerfile --cache-from type=gha --cache-to type=gha .
       - name: Build the worker base image locally (satisfies the worker-local overlay's FROM, no registry auth)
-        run: docker build -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile .
+        run: docker buildx build --load -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile --cache-from type=gha --cache-to type=gha .
       - name: Parity ladder (skill + local rungs, fake model, credential-free)
         env:
           AGENTOS_BIN: cli/target/release/agentos


### PR DESCRIPTION
## What

Adds `docker/setup-buildx-action` to the `e2e-ladder` job (pinned to the same version the pre-existing `images` job already uses) and switches its three plain `docker build` invocations (runner, api, worker base) to `docker buildx build --load --cache-from type=gha --cache-to type=gha`, mirroring how `images` already builds `runner/Dockerfile`, `apps/api/Dockerfile`, and `apps/worker/Dockerfile` on the same commit.

Neither job passes an explicit `scope` to `cache-from`/`cache-to`, so both land on buildkit's own default "buildkit" scope. Since `images` and `e2e-ladder` build the identical Dockerfiles on the same commit, this is the same cache store the `images` job already populated, no new scope naming needed.

Only the build mechanism for these three images changed. The rung logic, private-registry handling, and docker-in-docker paths in `e2e-ladder` are untouched.

## Job ordering caveat (please read)

There is no `needs` edge between `images` and `e2e-ladder` -- `e2e-ladder` only waits on `rust`. So the cache hit here is not guaranteed by job ordering; it works in practice because `images`'s cache-warmed docker builds are much quicker than `rust`'s full cargo build/test/release/upload, so `images` almost always finishes writing its cache well before `rust` unblocks `e2e-ladder`. If that ever flips (a slower `images` job, or a much faster `rust` job), the first CI run against a new commit's shas would still cold-build here, same as today, and the cache-hit benefit would only show up on a second run against the same shas. I did not add a `needs: images` edge to force the ordering, since that would slow down `e2e-ladder`'s start on every run to buy a guarantee that already holds in practice, and it's outside the "swap only the build mechanism" scope of this change. Flagging this so it isn't overclaimed as fully solving cold-every-time.

Closes #697
Ref #690