### PR TITLE
Give the skill-tier e2e script a live-credential mode and AGENTOS_BIN support

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -165,12 +165,17 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
 cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test
 ```
 
-Scripted E2E (real runner container, fake model, fully offline):
+Scripted E2E (real runner container, fake model, fully offline by default):
 ```bash
 bash cli/scripts/e2e.sh
 ```
 Requires the `agentos-runner` image built once from the repo root
-(`docker build -f runner/Dockerfile -t agentos-runner .`).
+(`docker build -f runner/Dockerfile -t agentos-runner .`) and a cargo
+toolchain (or `$AGENTOS_BIN` pointed at a prebuilt binary, which skips the
+`cargo build --release`). `AGENTOS_E2E_LIVE=1` drops `--fake-model` and runs
+the skill rung against a real model, requiring a credential
+(`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `AGENTOS_CREDENTIALS`) in
+the environment.
 
 Cold-start parity ladder (issue #690, `agentos dev e2e-ladder` ->
 `cli/scripts/e2e-ladder.sh`) -- an E2E test, same as the scripted E2E above, not
@@ -180,8 +185,9 @@ the falsifiability gate below it. It chains three rungs: rung 1 delegates to
 deploy` -> `cluster message` against a pre-installed release, a real round
 trip with no manual port-forward. `AGENTOS_E2E_TIERS` (default `skill,local`,
 or `all` for `skill,local,cluster`) selects rungs; `AGENTOS_E2E_LIVE` (default
-fake, `1` for live) governs the local and cluster rungs only, since the skill
-rung stays fake. One-command pre-release gate:
+fake, `1` for live) governs all three rungs -- rung 1 reads the same env var
+directly inside `e2e.sh` rather than being told by the ladder. One-command
+pre-release gate:
 ```bash
 AGENTOS_E2E_TIERS=all agentos dev e2e-ladder
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -568,14 +568,18 @@ hanging.
 cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test
 ```
 
-The scripted E2E (real runner container, fake model, offline):
+The scripted E2E (real runner container, fake model by default, offline):
 
 ```bash
 bash cli/scripts/e2e.sh
 ```
 
 Requires an `agentos-runner` image (`docker build -f runner/Dockerfile -t
-agentos-runner .` from the repo root).
+agentos-runner .` from the repo root) and a cargo toolchain, unless
+`AGENTOS_BIN` points at a prebuilt binary (skips the `cargo build --release`).
+`AGENTOS_E2E_LIVE=1` drops `--fake-model` and runs the skill rung against a
+real model, failing fast if no model credential (`ANTHROPIC_API_KEY`,
+`CLAUDE_CODE_OAUTH_TOKEN`, or `AGENTOS_CREDENTIALS`) is present.
 
 The cold-start parity ladder (`agentos dev e2e-ladder`, `cli/scripts/e2e-ladder.sh`)
 runs the same skill-tier script as rung 1, then adds a local rung (`local up
@@ -590,8 +594,8 @@ Two env knobs configure it:
   skipped.
 - `AGENTOS_E2E_LIVE` -- unset or `0` runs the fake model (credential-free, the
   default); `1` runs the live-credential variant for pre-release manual passes
-  and fails fast if no model credential is present. It governs the local and
-  cluster rungs only; the skill rung stays fake.
+  and fails fast if no model credential is present. It governs all three
+  rungs, including the skill rung: `e2e.sh` reads the same env var itself.
 
 The one-command pre-release gate:
 

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -20,10 +20,13 @@
 # belongs to another session, and so do that session's sandboxes.
 #
 # Fake model by default, so a default run is credential-free even on a box that
-# HAS credentials. Under AGENTOS_E2E_LIVE=1 the ladder runs the real model and
-# requires a credential up front. Under fake it asserts PLUMBING only -- that a
-# turn finalized and a reply came back -- never reply CONTENT (ADR-0055, #612):
-# an assertion tuned to the fake's canned reply manufactures a green.
+# HAS credentials. Under AGENTOS_E2E_LIVE=1 the ladder runs the real model on
+# every rung and requires a credential up front. Under fake, the local and
+# cluster rungs assert PLUMBING only -- that a turn finalized and a reply came
+# back -- never reply CONTENT (ADR-0055, #612): an assertion tuned to the
+# fake's canned reply manufactures a green. Rung 1 (skill) runs its own real
+# eval graders against whichever model it booted (cli/scripts/e2e.sh), fake or
+# live, since that leg is acceptance evidence for #325, not a plumbing probe.
 #
 # Requirements: docker, a cargo toolchain (or $AGENTOS_BIN), and an
 # agentos-runner image (`agentos build`). Rung 3 additionally needs a reachable
@@ -35,7 +38,9 @@
 #   AGENTOS_E2E_TIERS        comma list of rungs (default skill,local; `all` =
 #                            skill,local,cluster). A NAMED tier is REQUIRED: if
 #                            cluster is named and no release responds, exit 1.
-#   AGENTOS_E2E_LIVE         1 = real model on rungs 2 and 3 (rung 1 stays fake)
+#   AGENTOS_E2E_LIVE         1 = real model on all three rungs. Rung 1
+#                            (cli/scripts/e2e.sh) reads this same var itself
+#                            rather than being told by the ladder.
 #   AGENTOS_BIN              path to a prebuilt agentos binary (skip cargo build)
 set -euo pipefail
 
@@ -137,9 +142,12 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 # The ONE place the fake/live asymmetry is stated. There is no shared
-# fake-model control across tiers: skill takes a `--fake-model` flag, local
+# fake-model control across tiers: skill reads AGENTOS_E2E_LIVE itself (see
+# cli/scripts/e2e.sh) and derives its own `--fake-model` flag from it, local
 # reads AGENTOS_FAKE_MODEL, and cluster bakes it into the install. Keeping the
-# translation here means the seam is written down once.
+# local/cluster translation here means that seam is written down once; skill
+# is exempt because AGENTOS_E2E_LIVE is already in this process's environment
+# by the time `bash e2e.sh` is invoked below, so it needs no translation.
 apply_model_mode() {
     if [[ "$LIVE" == "1" ]]; then
         if [[ -z "${ANTHROPIC_API_KEY:-}" && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" && -z "${AGENTOS_CREDENTIALS:-}" ]]; then
@@ -150,7 +158,7 @@ apply_model_mode() {
         # Live means live: an inherited AGENTOS_FAKE_MODEL=1 would silently seal
         # a run the operator asked to be real.
         unset AGENTOS_FAKE_MODEL
-        echo "model mode: LIVE (real model on the local and cluster rungs)"
+        echo "model mode: LIVE (real model on the skill, local, and cluster rungs)"
     else
         # Exported, not merely defaulted: a developer shell that happens to carry
         # ANTHROPIC_API_KEY must still get the sealed run. That is what
@@ -158,7 +166,6 @@ apply_model_mode() {
         export AGENTOS_FAKE_MODEL=1
         echo "model mode: FAKE (sealed; AGENTOS_FAKE_MODEL=1 exported for the local rung)"
     fi
-    echo "note: the skill rung is fake either way -- cli/scripts/e2e.sh hardcodes --fake-model."
     echo "note: the cluster rung's model is a property of the installed release (cluster up --fake-model), not of this run."
 }
 

--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -2,16 +2,16 @@
 # Scripted E2E for the agentos CLI (task I1 done-when).
 #
 # Round-trips a synthetic event through a real local runner container with zero
-# Slack involved: init a bundle, start the runner (fake model, offline), send a
-# message and stream the NDJSON reply, run the eval cases, stop. This is rung 1
-# (skill) of the cold-start parity ladder (issue #690,
-# cli/scripts/e2e-ladder.sh); the ladder's local rung (`local deploy` ->
-# `local message` with a real reply assertion) covers deploying a bundle
-# against a running platform API, so this script no longer does so itself
-# (issue #694).
+# Slack involved: init a bundle, start the runner (fake model, offline by
+# default; live model under AGENTOS_E2E_LIVE=1), send a message and stream the
+# NDJSON reply, run the eval cases, stop. This is rung 1 (skill) of the
+# cold-start parity ladder (issue #690, cli/scripts/e2e-ladder.sh); the
+# ladder's local rung (`local deploy` -> `local message` with a real reply
+# assertion) covers deploying a bundle against a running platform API, so this
+# script no longer does so itself (issue #694).
 #
 # Requirements: docker, an agentos-runner image (build per runner/README.md),
-# and a cargo toolchain. Run from anywhere:
+# and a cargo toolchain (or $AGENTOS_BIN). Run from anywhere:
 #
 #   bash cli/scripts/e2e.sh
 #
@@ -20,17 +20,48 @@
 #   AGENTOS_E2E_PORT      host port (default 7245)
 #   AGENTOS_E2E_NETWORK   docker network to join (e.g. agentos_default)
 #   AGENTOS_E2E_OTEL      OTLP endpoint (e.g. http://otel-collector:4318)
+#   AGENTOS_E2E_LIVE      1 = real model, requiring a credential in the
+#                         environment (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN,
+#                         or AGENTOS_CREDENTIALS); default 0 runs the runner's
+#                         scripted fake model, offline and credential-free. This
+#                         is the SAME env var cli/scripts/e2e-ladder.sh sets for
+#                         its own local and cluster rungs, so a single
+#                         AGENTOS_E2E_LIVE=1 now runs every rung live.
+#   AGENTOS_BIN           path to a prebuilt agentos binary (skip cargo build)
 set -euo pipefail
 
 CLI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE="${AGENTOS_E2E_IMAGE:-agentos-runner}"
 PORT="${AGENTOS_E2E_PORT:-7245}"
 CONTAINER="agentos-e2e-runner"
+LIVE="${AGENTOS_E2E_LIVE:-0}"
 
-echo "=== Build the release binary ==="
-(cd "$CLI_DIR" && cargo build --release --quiet)
-BIN="$CLI_DIR/target/release/agentos"
+echo "=== Resolve the agentos binary ==="
+if [[ -n "${AGENTOS_BIN:-}" && -x "${AGENTOS_BIN:-}" ]]; then
+    # Absolutize: this script cd's into a scaffolded bundle directory before
+    # invoking the binary, so a relative $AGENTOS_BIN (as the ladder and CI
+    # pass) must be pinned to an absolute path here or it stops resolving
+    # after the cd.
+    BIN="$(cd "$(dirname "$AGENTOS_BIN")" && pwd)/$(basename "$AGENTOS_BIN")"
+    echo "using prebuilt binary: $BIN"
+else
+    (cd "$CLI_DIR" && cargo build --release --quiet)
+    BIN="$CLI_DIR/target/release/agentos"
+fi
 "$BIN" --version
+
+echo
+echo "=== Resolve model mode ==="
+if [[ "$LIVE" == "1" ]]; then
+    if [[ -z "${ANTHROPIC_API_KEY:-}" && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" && -z "${AGENTOS_CREDENTIALS:-}" ]]; then
+        echo "error: AGENTOS_E2E_LIVE=1 needs a model credential in the environment, and none is set." >&2
+        echo "fix: export ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or AGENTOS_CREDENTIALS, or drop AGENTOS_E2E_LIVE to run sealed against the fake model." >&2
+        exit 1
+    fi
+    echo "model mode: LIVE (real model; \`skill up\` forwards the ambient credential)"
+else
+    echo "model mode: FAKE (sealed; --fake-model, offline, no credential)"
+fi
 
 WORKDIR="$(mktemp -d)"
 cleanup() {
@@ -97,8 +128,19 @@ cat > evals/e2e-cases.json <<'EOF'
 EOF
 
 echo
-echo "=== agentos skill up (fake model, offline) ==="
-START_ARGS=(--plugin-dir . --image "$IMAGE" --port "$PORT" --name "$CONTAINER" --fake-model)
+if [[ "$LIVE" == "1" ]]; then
+    echo "=== agentos skill up (live model) ==="
+else
+    echo "=== agentos skill up (fake model, offline) ==="
+fi
+START_ARGS=(--plugin-dir . --image "$IMAGE" --port "$PORT" --name "$CONTAINER")
+if [[ "$LIVE" == "1" ]]; then
+    : # Real credential resolution (AGENTOS_CREDENTIALS, else the ambient SDK
+      # creds) happens inside `skill up` itself once --fake-model is omitted;
+      # see commands::select_passthrough_env.
+else
+    START_ARGS+=(--fake-model)
+fi
 if [[ -n "${AGENTOS_E2E_NETWORK:-}" ]]; then
     START_ARGS+=(--network "$AGENTOS_E2E_NETWORK")
 fi


### PR DESCRIPTION
## Summary

`cli/scripts/e2e.sh` hardcoded `--fake-model` and always ran `cargo build --release`, ignoring `AGENTOS_BIN`. That meant `AGENTOS_E2E_LIVE=1` on the cold-start parity ladder (#690) governed only the local and cluster rungs, leaving the skill rung sealed even on a pre-release live pass, and the ladder's CI job paid a full uncached release build on the exact path the downloaded artifact was meant to cover.

- `e2e.sh` now reads `AGENTOS_E2E_LIVE` itself. Under `1` it drops `--fake-model` (real credential resolution then happens inside `skill up` the same way it already does for a manual live run) and fails fast up front if none of `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `AGENTOS_CREDENTIALS` is set, mirroring the exact check `e2e-ladder.sh` already runs for its own rungs.
- `e2e.sh` now resolves `AGENTOS_BIN` before building, absolutizing a relative path the same way `eval-falsifiability.sh` already does, so a prebuilt binary skips `cargo build --release`.
- `e2e-ladder.sh`'s stale runtime note ("the skill rung is fake either way -- cli/scripts/e2e.sh hardcodes --fake-model") is removed, and its header comments/env-knob docs updated to say `AGENTOS_E2E_LIVE` now governs all three rungs, with rung 1 reading the var directly rather than being told by the ladder.
- `cli/CLAUDE.md` and `cli/README.md` updated where they documented the old fake-only, no-`AGENTOS_BIN` behavior.

## Test plan

- [x] `bash cli/scripts/e2e.sh` (no env vars) -- fake-model path unchanged, ends in `E2E PASS`.
- [x] Built the release CLI once (`cargo build --release --manifest-path cli/Cargo.toml`), then `AGENTOS_BIN=cli/target/release/agentos bash cli/scripts/e2e.sh` -- binary resolution logs `using prebuilt binary: ...`, no `cargo build` runs, ends in `E2E PASS`.
- [x] `AGENTOS_E2E_LIVE=1 bash cli/scripts/e2e.sh` with no credential in the environment -- fails fast with the expected `AGENTOS_E2E_LIVE=1 needs a model credential...` error before any container is started.
- [x] `bash -n` on both scripts.

Closes #693
Ref #690