### PR TITLE
Surface plumbing rows in the eval model-sweep report

### DIFF
--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -94,9 +94,7 @@
     {
       "struct": "EvalModelSummary",
       "schema": "EvalModelSummary",
-      "omissions": [
-        { "field": "plumbing", "why": "RISK: plumbing marks a fixture/plumbing-only row (#612/#606). The model sweep (cli/src/evals.rs) reads model/passed/total/cost_usd and cannot today distinguish a plumbing-fixture row from a real subject-under-test row. Not wired in this PR; filed as follow-up F2 (sweep scoping, #608)." }
-      ]
+      "omissions": []
     },
     {
       "struct": "EvalMatrix",

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -163,6 +163,13 @@ pub struct EvalTriggerResult {
 /// One per-model rollup of the eval matrix (`EvalModelSummary` in openapi.json):
 /// pass-rate and summed cost for a suite run under one model (#255/#526). `model`
 /// is `None` for the matrix's unlabelled column (a run with no resolved model).
+///
+/// `plumbing` counts the rows that ran but were never graded (ADR-0055, #612/#606
+/// -- the fake-model tier is plumbing-only): excluded from `passed`/`total` rather
+/// than fabricated into a pass or fail, so a model whose every row is plumbing
+/// still appears here with `total == 0` instead of vanishing from the rollup. The
+/// `--model` sweep (#700) reads this to tell a plumbing-fixture row from a real
+/// subject-under-test row rather than blending both into one pass-rate list.
 #[derive(Debug, Clone, Deserialize)]
 pub struct EvalModelSummary {
     #[serde(default)]
@@ -171,6 +178,8 @@ pub struct EvalModelSummary {
     pub total: u64,
     #[serde(default)]
     pub cost_usd: Option<f64>,
+    #[serde(default)]
+    pub plumbing: u64,
 }
 
 /// The eval matrix grid (`EvalMatrix` in openapi.json): `GET /evals/matrix`. The

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2042,6 +2042,32 @@ async fn boot_eval_runner(
     Ok(url)
 }
 
+/// One model's row in a `--model` sweep report: pass-rate, total, and how many
+/// of its rows were plumbing-only (ran but never graded, ADR-0055, #612/#606).
+/// `plumbing` is always `0` on the in-CLI skill sweep (`eval_sweep` below,
+/// which always boots a real, non-fake runner); it is populated from the
+/// platform eval matrix's `EvalModelSummary.plumbing` on the `local`/`cluster`
+/// `--model` sweep (`message.rs`'s `scoped_rows`), where a fake-model tier row
+/// can legitimately have `total == 0` and `plumbing > 0` (#700).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SweepRow {
+    pub model: String,
+    pub passed: usize,
+    pub total: usize,
+    pub plumbing: usize,
+}
+
+impl SweepRow {
+    /// A row with zero graded cases and at least one plumbing row is entirely
+    /// a fixture: every case that ran for this model was plumbing, so `passed`
+    /// and `total` carry no real signal at all (not "0% failing", but "never
+    /// graded"). Distinguishing this from a genuine 0/0 (no cases assigned)
+    /// keeps a plumbing-only model from reading as a failing real result.
+    pub fn is_plumbing_only(&self) -> bool {
+        self.total == 0 && self.plumbing > 0
+    }
+}
+
 /// Run the suite once per model in a fresh runner and report pass-rate per model.
 async fn eval_sweep(
     suite: &EvalSuite,
@@ -2063,7 +2089,7 @@ async fn eval_sweep(
         suite.cases.len()
     ));
     let cl = ui.checklist();
-    let mut rows: Vec<(String, usize, usize)> = Vec::with_capacity(models.len());
+    let mut rows: Vec<SweepRow> = Vec::with_capacity(models.len());
     for (i, model) in models.iter().enumerate() {
         let name = format!("agentos-eval-sweep-{i}");
         let port = DEFAULT_PORT + 100 + i as u16;
@@ -2077,7 +2103,8 @@ async fn eval_sweep(
         };
         let client = RunnerClient::new(&url)?;
         // `boot_eval_runner` pins `fake_model: false`, so every sweep runner is a
-        // REAL model whatever the standing dev runner is -- the sweep grades.
+        // REAL model whatever the standing dev runner is -- the sweep grades,
+        // so this in-CLI path never produces a plumbing-only row.
         let run = run_suite_cases(&client, suite, false, |_| {}).await;
         let _ = docker::remove_container(&name).await;
         let results = run?;
@@ -2086,50 +2113,78 @@ async fn eval_sweep(
             .filter(|(_, o, _, _)| *o == CaseOutcome::Pass)
             .count();
         step.done(&format!("{passed}/{}", suite.cases.len()));
-        rows.push((model.clone(), passed, suite.cases.len()));
+        rows.push(SweepRow {
+            model: model.clone(),
+            passed,
+            total: suite.cases.len(),
+            plumbing: 0,
+        });
     }
     report_sweep(&rows)
+}
+
+/// The `--json` sweep payload for one row: pure and independent of `Ui` so it
+/// is unit-testable without a process-level stdout capture. Carries the raw
+/// `plumbing` count (mirroring the API field) plus a `plumbing_only` boolean
+/// derived from `SweepRow::is_plumbing_only` for a scripted consumer to filter
+/// fixture rows out of a real model comparison (#700).
+fn sweep_json_row(row: &SweepRow) -> serde_json::Value {
+    serde_json::json!({
+        "model": row.model,
+        "passed": row.passed,
+        "total": row.total,
+        "pass_rate": if row.total > 0 { row.passed as f64 / row.total as f64 } else { 0.0 },
+        "plumbing": row.plumbing,
+        "plumbing_only": row.is_plumbing_only(),
+    })
+}
+
+/// The human table row for one sweep row: `[model, "passed/total", pass rate,
+/// plumbing count]`. A plumbing-only row (#700) is marked distinctly rather
+/// than blended into the pass-rate list: the model name gets a `(plumbing)`
+/// suffix and the rate column reads `n/a` instead of a misleading `0%`, since
+/// every case for that model was a fixture, never graded, not a real failure.
+fn sweep_table_row(row: &SweepRow) -> Vec<String> {
+    let model = if row.is_plumbing_only() {
+        format!("{} (plumbing)", row.model)
+    } else {
+        row.model.clone()
+    };
+    let rate = if row.is_plumbing_only() {
+        "n/a".to_string()
+    } else if row.total > 0 {
+        format!("{:.0}%", row.passed as f64 / row.total as f64 * 100.0)
+    } else {
+        "0%".to_string()
+    };
+    let plumbing = if row.plumbing > 0 {
+        row.plumbing.to_string()
+    } else {
+        "-".to_string()
+    };
+    vec![
+        model,
+        format!("{}/{}", row.passed, row.total),
+        rate,
+        plumbing,
+    ]
 }
 
 /// Render a model-sweep roll-up: pass-rate per model. Under `--json` the whole
 /// comparison is one payload; otherwise a table. A sweep is a comparison, not a
 /// gate, so it never exits non-zero on a model that scored below 100%.
-pub fn report_sweep(rows: &[(String, usize, usize)]) -> Result<()> {
+pub fn report_sweep(rows: &[SweepRow]) -> Result<()> {
     let ui = crate::ui::ui();
     if ui.json() {
-        let models: Vec<serde_json::Value> = rows
-            .iter()
-            .map(|(model, passed, total)| {
-                serde_json::json!({
-                    "model": model,
-                    "passed": passed,
-                    "total": total,
-                    "pass_rate": if *total > 0 { *passed as f64 / *total as f64 } else { 0.0 },
-                })
-            })
-            .collect();
+        let models: Vec<serde_json::Value> = rows.iter().map(sweep_json_row).collect();
         ui.emit_json(&serde_json::json!({ "sweep": models }));
         return Ok(());
     }
-    let table: Vec<Vec<String>> = rows
-        .iter()
-        .map(|(model, passed, total)| {
-            let rate = if *total > 0 {
-                *passed as f64 / *total as f64 * 100.0
-            } else {
-                0.0
-            };
-            vec![
-                model.clone(),
-                format!("{passed}/{total}"),
-                format!("{rate:.0}%"),
-            ]
-        })
-        .collect();
+    let table: Vec<Vec<String>> = rows.iter().map(sweep_table_row).collect();
     ui.payload_plain(&crate::ui::table(
-        &["model", "passed", "pass rate"],
+        &["model", "passed", "pass rate", "plumbing"],
         &table,
-        &[1, 2],
+        &[1, 2, 3],
     ));
     Ok(())
 }
@@ -3987,9 +4042,9 @@ mod tests {
     use super::{
         absent_container_note, merge_secret_env, parse_manifest_gates, plan_recorded_state,
         plan_recorded_teardown, plan_skill_down, replace_first_line, resolve_cases_path,
-        seed_env_if_missing, select_in_force_deployment, select_passthrough_env,
-        validate_slack_channel, ApprovalGateDecl, DownPlan, EnvSeed, RecordedStatePlan,
-        RecordedTeardown,
+        seed_env_if_missing, select_in_force_deployment, select_passthrough_env, sweep_json_row,
+        sweep_table_row, validate_slack_channel, ApprovalGateDecl, DownPlan, EnvSeed,
+        RecordedStatePlan, RecordedTeardown, SweepRow,
     };
     use serde::Deserialize;
     use std::path::{Path, PathBuf};
@@ -5405,5 +5460,88 @@ mod tests {
             fix.contains("cluster") || fix.contains("local"),
             "fix names a cross-tier alternative: {fix}"
         );
+    }
+
+    // ─── #700: plumbing rows render distinctly from real rows in a sweep ─────
+
+    fn real_row(model: &str, passed: usize, total: usize) -> SweepRow {
+        SweepRow {
+            model: model.to_string(),
+            passed,
+            total,
+            plumbing: 0,
+        }
+    }
+
+    fn plumbing_only_row(model: &str, plumbing: usize) -> SweepRow {
+        SweepRow {
+            model: model.to_string(),
+            passed: 0,
+            total: 0,
+            plumbing,
+        }
+    }
+
+    #[test]
+    fn plumbing_only_row_is_detected_and_a_real_row_is_not() {
+        assert!(plumbing_only_row("fake", 3).is_plumbing_only());
+        assert!(!real_row("opus", 3, 3).is_plumbing_only());
+        // A real row that never ran any case (no cases assigned this model, no
+        // plumbing either) is 0/0 but NOT plumbing-only -- there is nothing to
+        // distinguish it from, so it must not get the plumbing marker.
+        assert!(!real_row("idle", 0, 0).is_plumbing_only());
+    }
+
+    #[test]
+    fn sweep_json_row_carries_the_plumbing_count_and_a_filterable_boolean() {
+        let real = sweep_json_row(&real_row("opus", 2, 3));
+        assert_eq!(real["model"], "opus");
+        assert_eq!(real["passed"], 2);
+        assert_eq!(real["total"], 3);
+        assert_eq!(real["plumbing"], 0);
+        assert_eq!(real["plumbing_only"], false);
+
+        let plumbing = sweep_json_row(&plumbing_only_row("fake", 5));
+        assert_eq!(plumbing["model"], "fake");
+        assert_eq!(plumbing["passed"], 0);
+        assert_eq!(plumbing["total"], 0);
+        assert_eq!(plumbing["plumbing"], 5);
+        assert_eq!(
+            plumbing["plumbing_only"], true,
+            "a scripted consumer filters on this flag to drop fixture rows: {plumbing}"
+        );
+    }
+
+    #[test]
+    fn sweep_table_row_marks_a_plumbing_only_row_distinctly_from_a_real_one() {
+        let real = sweep_table_row(&real_row("opus", 3, 3));
+        assert_eq!(real[0], "opus");
+        assert_eq!(real[1], "3/3");
+        assert_eq!(real[2], "100%");
+        assert_eq!(real[3], "-");
+
+        let plumbing = sweep_table_row(&plumbing_only_row("fake", 4));
+        assert_eq!(
+            plumbing[0], "fake (plumbing)",
+            "the model name must be marked so it cannot be skimmed as a real row"
+        );
+        assert_eq!(plumbing[1], "0/0");
+        assert_eq!(
+            plumbing[2], "n/a",
+            "a plumbing-only row must not read as a real 0% failure"
+        );
+        assert_eq!(plumbing[3], "4");
+    }
+
+    #[test]
+    fn sweep_table_rows_for_a_mixed_sweep_stay_distinguishable_side_by_side() {
+        // A sweep containing both a plumbing row and a real row (#700 AC): the two
+        // must render differently enough that scanning the table cannot mistake
+        // one for the other.
+        let rows = [real_row("opus", 2, 3), plumbing_only_row("fake-model", 3)];
+        let table: Vec<Vec<String>> = rows.iter().map(sweep_table_row).collect();
+        assert_eq!(table[0], vec!["opus", "2/3", "67%", "-"]);
+        assert_eq!(table[1], vec!["fake-model (plumbing)", "0/0", "n/a", "3"]);
+        assert_ne!(table[0][2], table[1][2], "pass-rate columns must differ");
     }
 }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -2154,7 +2154,7 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
             let sha_present = matrix.versions.contains(&triggered_sha);
             let rows = scoped_rows(&matrix, &want);
             let ready: std::collections::BTreeSet<&str> =
-                rows.iter().map(|(m, _, _)| m.as_str()).collect();
+                rows.iter().map(|row| row.model.as_str()).collect();
             let missing = want
                 .iter()
                 .filter(|m| !ready.contains(**m))
@@ -2178,22 +2178,32 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
     }
 }
 
-/// The wanted models' current rows in the matrix (`model`, `passed`, `total`),
-/// scoped to the sweep's `--model` set and dropping empty (`total == 0`) rows.
-/// The shared filter behind both the readiness check and the timeout partial.
+/// The wanted models' current rows in the matrix, scoped to the sweep's
+/// `--model` set and dropping truly-empty rows: a row with `total == 0` is
+/// kept when `plumbing > 0` (a fake-model/plumbing-only tier row that
+/// genuinely landed, #700, #612/#606) and dropped only when it carries
+/// neither a graded case nor a plumbing one -- i.e. this model has not landed
+/// at all yet. Without the `plumbing > 0` half, a plumbing-only model's row
+/// would vanish from a report entirely instead of being surfaced as such,
+/// exactly the ambiguity #622 and this issue describe. The shared filter
+/// behind both the readiness check and the timeout partial.
 fn scoped_rows(
     matrix: &crate::api::EvalMatrix,
     want: &std::collections::BTreeSet<&str>,
-) -> Vec<(String, usize, usize)> {
+) -> Vec<crate::commands::SweepRow> {
     matrix
         .model_summaries
         .iter()
         .filter_map(|s| {
             let m = s.model.as_deref()?;
-            want.contains(m)
-                .then(|| (m.to_string(), s.passed as usize, s.total as usize))
+            want.contains(m).then(|| crate::commands::SweepRow {
+                model: m.to_string(),
+                passed: s.passed as usize,
+                total: s.total as usize,
+                plumbing: s.plumbing as usize,
+            })
         })
-        .filter(|(_, _, total)| *total > 0)
+        .filter(|row| row.total > 0 || row.plumbing > 0)
         .collect()
 }
 
@@ -2221,12 +2231,13 @@ fn sweep_ready_rows(
     matrix: &crate::api::EvalMatrix,
     triggered_sha: &str,
     want: &std::collections::BTreeSet<&str>,
-) -> Option<Vec<(String, usize, usize)>> {
+) -> Option<Vec<crate::commands::SweepRow>> {
     if !matrix.versions.iter().any(|v| v == triggered_sha) {
         return None;
     }
     let rows = scoped_rows(matrix, want);
-    let ready: std::collections::BTreeSet<&str> = rows.iter().map(|(m, _, _)| m.as_str()).collect();
+    let ready: std::collections::BTreeSet<&str> =
+        rows.iter().map(|row| row.model.as_str()).collect();
     want.iter().all(|m| ready.contains(m)).then_some(rows)
 }
 
@@ -3129,11 +3140,21 @@ mod tests {
     }
 
     fn model_summary(model: &str, passed: u64, total: u64) -> crate::api::EvalModelSummary {
+        plumbing_model_summary(model, passed, total, 0)
+    }
+
+    fn plumbing_model_summary(
+        model: &str,
+        passed: u64,
+        total: u64,
+        plumbing: u64,
+    ) -> crate::api::EvalModelSummary {
         crate::api::EvalModelSummary {
             model: Some(model.to_string()),
             passed,
             total,
             cost_usd: None,
+            plumbing,
         }
     }
 
@@ -3175,8 +3196,8 @@ mod tests {
         );
         let rows = sweep_ready_rows(&m, "new-sha", &want).expect("all models landed for the run");
         assert_eq!(rows.len(), 2);
-        assert!(rows.iter().any(|(model, _, _)| model == "opus"));
-        assert!(rows.iter().any(|(model, _, _)| model == "sonnet"));
+        assert!(rows.iter().any(|row| row.model == "opus"));
+        assert!(rows.iter().any(|row| row.model == "sonnet"));
     }
 
     #[test]
@@ -3186,6 +3207,45 @@ mod tests {
         let want: std::collections::BTreeSet<&str> = ["opus", "sonnet"].into_iter().collect();
         let m = matrix(&["new-sha"], vec![model_summary("opus", 3, 3)]);
         assert!(sweep_ready_rows(&m, "new-sha", &want).is_none());
+    }
+
+    #[test]
+    fn sweep_ready_when_a_wanted_model_is_plumbing_only() {
+        // #700: a model whose every row is a plumbing fixture (#612/#606, e.g. the
+        // fake-model tier) reports total == 0 forever -- it will never satisfy a
+        // `total > 0` readiness check. Before this fix that model's row (and the
+        // sweep it belongs to) would hang until timeout even though it landed;
+        // `plumbing > 0` alone must be enough to count as landed.
+        let want: std::collections::BTreeSet<&str> = ["opus", "fake"].into_iter().collect();
+        let m = matrix(
+            &["new-sha"],
+            vec![
+                model_summary("opus", 3, 3),
+                plumbing_model_summary("fake", 0, 0, 3),
+            ],
+        );
+        let rows = sweep_ready_rows(&m, "new-sha", &want)
+            .expect("a plumbing-only row must still count as landed");
+        assert_eq!(rows.len(), 2);
+        let fake_row = rows
+            .iter()
+            .find(|row| row.model == "fake")
+            .expect("the plumbing-only model's row must be reported, not dropped");
+        assert_eq!(fake_row.total, 0);
+        assert_eq!(fake_row.plumbing, 3);
+        assert!(fake_row.is_plumbing_only());
+        let opus_row = rows.iter().find(|row| row.model == "opus").unwrap();
+        assert!(!opus_row.is_plumbing_only());
+    }
+
+    #[test]
+    fn scoped_rows_drops_a_model_with_no_graded_and_no_plumbing_rows() {
+        // A model with a summary row but total == 0 and plumbing == 0 has not
+        // landed at all yet (distinct from a genuine plumbing-only row); it must
+        // still be dropped so readiness keeps polling for it.
+        let want: std::collections::BTreeSet<&str> = ["opus"].into_iter().collect();
+        let m = matrix(&["new-sha"], vec![model_summary("opus", 0, 0)]);
+        assert!(scoped_rows(&m, &want).is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

`EvalModelSummary.plumbing` was allowlisted as an unmirrored omission in `cli/api-mirrors.json` (#691), so the CLI's `--model` sweep could not tell a plumbing-fixture row (e.g. the fake-model tier, #612/#606) from a real subject-under-test row.

## Changes

- `cli/src/api.rs`: added `plumbing: u64` to the `EvalModelSummary` mirror struct, matching the API's field.
- `cli/api-mirrors.json`: removed the `plumbing` omission entry for `EvalModelSummary` now that it is genuinely mirrored.
- `cli/src/message.rs`: threaded `plumbing` through the local/cluster `--model` sweep's `scoped_rows`/`sweep_ready_rows` into a new `SweepRow` type (moved to `commands.rs`, shared with the report renderer). The row filter used to drop any row with `total == 0`, which silently dropped a plumbing-only model's row entirely instead of surfacing it; it now also keeps a row when `plumbing > 0`. Readiness likewise now treats a plumbing-only model as landed rather than polling until timeout waiting for a `total > 0` that will never come (sweep scoping, #608).
- `cli/src/commands.rs`: `report_sweep` marks a plumbing-only row distinctly instead of blending it into the pass-rate list -- the human table suffixes the model name with `(plumbing)` and shows `n/a` instead of a misleading `0%`, plus a dedicated `plumbing` count column; `--json` carries the raw `plumbing` count and a `plumbing_only` boolean so a scripted consumer can filter fixture rows out of a real comparison.

## Tests

- `cli/src/message.rs`: new unit tests covering a plumbing-only row's readiness (previously would hang) and that a genuinely-not-landed row (`total == 0`, `plumbing == 0`) still gets dropped.
- `cli/src/commands.rs`: new unit tests on the (now pure) `sweep_json_row`/`sweep_table_row` helpers proving a plumbing row and a real row render distinguishably in both the human table and the `--json` payload.
- `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` (including `api_field_parity`'s `real_tree_has_no_field_parity_violations`) all pass.

Closes #700
Ref #691, #606, #608