### PR TITLE
Stop the agent-sandbox controller from shadow-managing a permissive egress NetworkPolicy

### DIFF
--- a/charts/agentos/CLAUDE.md
+++ b/charts/agentos/CLAUDE.md
@@ -24,6 +24,16 @@ component and rail detail in `charts/agentos/README.md`.
   empty by default; an unset allowlist must never mean allow-all. If you add
   a new egress destination the runner needs, it goes into this allowlist
   explicitly -- never widen the default-deny baseline itself.
+- **NetworkPolicy allows are additive, never restrictive-intersecting
+  (#765, ADR-0067).** A second NetworkPolicy selecting the same pods can only
+  widen what Rail 1 permits, never narrow it -- there is no such thing as one
+  policy overriding another. This is why the runner SandboxTemplate sets
+  `spec.networkPolicyManagement: Unmanaged` whenever Rail 1 is on: it stops the
+  vendored controller from reconciling its own separately-managed, broader
+  egress policy for the same pods. Do not add any other NetworkPolicy-adjacent
+  mechanism (another controller, an operator, a second chart) that could select
+  `component: runner-sandbox` pods without checking it does not reintroduce
+  this exact union-defeats-default-deny failure mode.
 - **The preflights are mandatory Helm hooks, not advisory scripts.** The
   CPU-AVX/ClickHouse-pin check (`preflights.avxCheck`), the
   NetworkPolicy-enforcement probe (`preflights.networkPolicyProbe`), and the

--- a/charts/agentos/README.md
+++ b/charts/agentos/README.md
@@ -365,6 +365,19 @@ default: a fresh install denies all egress except DNS until the operator declare
 where the model API and MCP endpoints live (`{cidr, ports}` entries). An unset
 allowlist never means allow-all.
 
+**The controller does not get a second vote on egress (#765, ADR-0067).**
+NetworkPolicy allows are additive across objects selecting the same pods -- Rail
+1 above cannot narrow a separately-managed, broader policy, only be unioned with
+it. Left to its own default, the vendored agent-sandbox controller reconciles
+its own shared NetworkPolicy per SandboxTemplate with a built-in "allow public
+internet minus RFC1918" rule, which would silently re-open exactly what Rail 1
+was configured to close. Whenever `security.networkPolicy.enabled` is `true`
+(the default), the runner SandboxTemplate sets
+`spec.networkPolicyManagement: Unmanaged`, so the controller never creates that
+policy for this template and Rail 1 is the only NetworkPolicy in effect. With
+`security.networkPolicy.enabled: false` the field is left unset, so the
+controller's own baseline policy still applies rather than nothing.
+
 **Skill/tool web access.** The same allowlist also carries outbound web access a
 skill or tool needs (e.g. a web-search provider). `agentos cluster up --allow-web-egress
 <CIDR>` (repeatable) appends one entry per CIDR on TCP 443, additive to the model

--- a/charts/agentos/ci/render-assertions.sh
+++ b/charts/agentos/ci/render-assertions.sh
@@ -401,5 +401,73 @@ python3 "$PRIO_CHECK" "$PRIO_OVERRIDE_OUT" "custom-platform-class" "custom-sandb
   || fail "overriding priorityClasses.platform.name/sandbox.name did not propagate to priorityClassName on the rendered pods."
 echo "  ok: overriding priorityClasses.platform.name/sandbox.name propagates to every control-plane pod and the sandbox"
 
+echo "=== Assertion 10: SandboxTemplate opts the controller out of its own permissive NetworkPolicy when Rail 1 is on (#765) ==="
+# NetworkPolicy allows are additive across objects that select the same pods --
+# there is no way for the chart's own restrictive Rail 1 policies to narrow
+# what a separate, broader policy already permits. Left unset, the vendored
+# agent-sandbox controller's default "Managed" behavior reconciles its OWN
+# shared NetworkPolicy per SandboxTemplate with a built-in Secure Default
+# egress rule (public internet minus RFC1918/link-local), which silently
+# re-opens exactly the egress Rail 1's default-deny + allowlist were meant to
+# close (issue #765 packet-level evidence: a non-allowlisted host was
+# reachable from a real sandbox pod). spec.networkPolicyManagement: Unmanaged
+# tells the controller to skip creating that policy for this template
+# entirely, leaving Rail 1 as the only NetworkPolicy selecting these pods.
+NP_CHECK="$TMP/check_network_policy_management.py"
+cat > "$NP_CHECK" <<'PYEOF'
+"""Assert the rendered SandboxTemplate's spec.networkPolicyManagement.
+
+argv: <rendered-dir> <expected-value-or-"absent">
+Exits 0 on pass, 1 naming the mismatch on failure.
+"""
+import pathlib
+import sys
+
+import yaml
+
+rendered, expected = sys.argv[1], sys.argv[2]
+
+found = []
+for path in sorted(pathlib.Path(rendered).rglob("*.yaml")):
+    for doc in yaml.safe_load_all(path.read_text()):
+        if isinstance(doc, dict) and doc.get("kind") == "SandboxTemplate":
+            spec = doc.get("spec", {}) or {}
+            found.append((doc.get("metadata", {}).get("name", ""), spec.get("networkPolicyManagement")))
+
+if not found:
+    sys.stderr.write("found no SandboxTemplate in the render; the assert would pass vacuously\n")
+    sys.exit(1)
+
+for name, got in found:
+    want = None if expected == "absent" else expected
+    if got != want:
+        sys.stderr.write(
+            f"SandboxTemplate '{name}' has spec.networkPolicyManagement={got!r}, expected {want!r}\n")
+        sys.exit(1)
+
+print(f"  ok: {len(found)} SandboxTemplate(s) carry spec.networkPolicyManagement={expected!r}")
+PYEOF
+
+NP_ON_OUT="$(mktemp -d -p "$TMP")"
+helm template "$CHART" --output-dir "$NP_ON_OUT" \
+  --set agentSandbox.runner.image=agentos-runner \
+  --set agentSandbox.runner.tag=latest \
+  --set agentSandbox.runner.imagePullPolicy=Never \
+  > /dev/null
+python3 "$NP_CHECK" "$NP_ON_OUT" "Unmanaged" \
+  || fail "default render (Rail 1 on) did not set spec.networkPolicyManagement: Unmanaged on the runner SandboxTemplate."
+echo "  ok: default render (security.networkPolicy.enabled=true) sets networkPolicyManagement: Unmanaged"
+
+NP_OFF_OUT="$(mktemp -d -p "$TMP")"
+helm template "$CHART" --output-dir "$NP_OFF_OUT" \
+  --set agentSandbox.runner.image=agentos-runner \
+  --set agentSandbox.runner.tag=latest \
+  --set agentSandbox.runner.imagePullPolicy=Never \
+  --set security.networkPolicy.enabled=false \
+  > /dev/null
+python3 "$NP_CHECK" "$NP_OFF_OUT" "absent" \
+  || fail "with security.networkPolicy.enabled=false (Rail 1 off), spec.networkPolicyManagement should be left unset (default Managed) so the controller's own baseline policy still applies, but it was set."
+echo "  ok: with Rail 1 off, networkPolicyManagement is left unset (falls back to the controller's own Managed default rather than nothing)"
+
 echo
-echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod and the sandbox render with the expected priorityClassName, including under operator override."
+echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off."

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -15,6 +15,12 @@ the worker claims from, plus (optionally) the vendored upstream controller.
   substrate; envVarsInjectionPolicy Overrides makes that injection win.
 - service: true is what gives every claimed sandbox its routable
   .status.serviceFQDN (PT-1: without it no Service is created at all).
+- networkPolicyManagement: Unmanaged (issue #765, ADR-0067) stops the
+  controller from reconciling its OWN separately-managed NetworkPolicy for
+  this template. NetworkPolicy allows are additive across objects selecting
+  the same pods, so the controller's default "allow public internet"
+  behavior would otherwise silently widen (not be narrowed by) Rail 1's
+  default-deny + allowlist in security-networkpolicy.yaml.
 */}}
 {{- if .Values.agentSandbox.controller.deploy }}
 {{ .Files.Get "files/agent-sandbox/controller.yaml" }}
@@ -117,6 +123,24 @@ metadata:
 spec:
   service: true
   envVarsInjectionPolicy: {{ $runner.envVarsInjectionPolicy }}
+  {{- if .Values.security.networkPolicy.enabled }}
+  # Issue #765: NetworkPolicy is additive across objects that select the same
+  # pods -- there is no way for one policy to narrow what another already
+  # allows. Left at the default "Managed", the vendored agent-sandbox
+  # controller reconciles its OWN shared NetworkPolicy for this SandboxTemplate
+  # (name: {{ include "agentos.fullname" . }}-runner-network-policy) with its
+  # built-in Secure Default egress rule -- public internet minus RFC1918/
+  # link-local -- which UNIONS with (and silently defeats) this chart's own
+  # Rail 1 default-deny + operator allowlist below (security-networkpolicy.yaml)
+  # instead of being narrowed by it. "Unmanaged" tells the controller to skip
+  # creating that policy entirely for this template, so Rail 1 is the only
+  # NetworkPolicy selecting these pods. Gated on security.networkPolicy.enabled
+  # (not narrower) because the union defeats the default-deny baseline itself,
+  # not just a custom allowlist. When the operator has turned Rail 1 off
+  # entirely, leave this field unset (defaults to "Managed") so the
+  # controller's own baseline policy still applies rather than nothing at all.
+  networkPolicyManagement: Unmanaged
+  {{- end }}
   podTemplate:
     metadata:
       labels:

--- a/charts/agentos/templates/security-probe.yaml
+++ b/charts/agentos/templates/security-probe.yaml
@@ -5,7 +5,9 @@ The PT-3 security-boundary probe suite, re-run against the chart's rendered
 defaults as a `helm test`. Five claims:
 
   1. default-deny egress + metadata endpoint blocked, WITH a before/after control
-     that proves the CNI actually enforces (not a silent false-pass).
+     that proves the CNI actually enforces (not a silent false-pass). Claim 1c
+     additionally proves the vendored controller is not shadow-managing its own
+     permissive NetworkPolicy alongside Rail 1's (issue #765).
   2. cross-agent secret isolation via per-agent RBAC scoping.
   3. runner containers are non-root with a read-only rootfs.
   4. gVisor RuntimeClass enforced (reported testable / not-testable honestly;
@@ -226,6 +228,15 @@ spec:
               value: "app.kubernetes.io/name={{ include "agentos.name" . }},app.kubernetes.io/instance={{ .Release.Name }},agentos.io/datatier-probe=allowed"
             - name: DT_DENIED_LABELS
               value: "agentos.io/datatier-probe=denied"
+            # Claim 1c (#765): the controller-managed NetworkPolicy the runner
+            # SandboxTemplate's networkPolicyManagement: Unmanaged is meant to
+            # suppress. Only asserted when THIS release deploys that controller
+            # (agentSandbox.controller.deploy) AND Rail 1 is on -- otherwise there
+            # is nothing #765-shaped to check.
+            - name: SANDBOX_NP_NAME
+              value: {{ include "agentos.fullname" . }}-runner-network-policy
+            - name: CONTROLLER_DEPLOYED
+              value: {{ and .Values.agentSandbox.controller.deploy .Values.security.networkPolicy.enabled | quote }}
           command:
             - /bin/bash
             - -c
@@ -341,6 +352,31 @@ spec:
                 echo "RESULT: FAIL - broad-allow ext=${broad_ext} metadata=${broad_meta}"
                 echo "        (metadata=reachable means a broad allow re-opened IMDS: #70 regression.)"
                 fail=1
+              fi
+
+              # ---- Claim 1c: controller does not shadow-manage a permissive NetworkPolicy (#765) ----
+              # NetworkPolicy allows are additive: a separate, broader policy selecting
+              # the same pods cannot be narrowed by Rail 1 above, only unioned with it.
+              # The runner SandboxTemplate sets networkPolicyManagement: Unmanaged
+              # specifically so the vendored controller never reconciles its own
+              # shared NetworkPolicy for that template. Only meaningful when this
+              # release deploys that controller -- a different/external controller's
+              # behavior toward the field is not this chart's to assert.
+              echo ""
+              echo "== Claim 1c: controller does not shadow-manage a permissive NetworkPolicy (#765) =="
+              if [ "$CONTROLLER_DEPLOYED" != "true" ]; then
+                echo "SKIP: agentSandbox.controller.deploy is false, or Rail 1 (security.networkPolicy.enabled) is off -- not this chart's to assert."
+              else
+                if kubectl get networkpolicy "$SANDBOX_NP_NAME" -n "$NS" >/dev/null 2>&1; then
+                  echo "RESULT: FAIL - controller-managed NetworkPolicy '${SANDBOX_NP_NAME}' exists in ${NS}."
+                  echo "        networkPolicyManagement: Unmanaged should have suppressed it entirely; its"
+                  echo "        presence means the controller is still unioning its own permissive egress"
+                  echo "        rule with Rail 1 above, silently re-opening the allowlist (issue #765)."
+                  kubectl get networkpolicy "$SANDBOX_NP_NAME" -n "$NS" -o yaml 2>/dev/null | sed 's/^/    /'
+                  fail=1
+                else
+                  echo "RESULT: PASS - no controller-managed NetworkPolicy '${SANDBOX_NP_NAME}' exists; Rail 1 is the only policy selecting these pods."
+                fi
               fi
 
               # ================= Claim 2: cross-agent secret isolation ==============

--- a/docs/adr/0067-controller-networkpolicymanagement-unmanaged-for-rail-1.md
+++ b/docs/adr/0067-controller-networkpolicymanagement-unmanaged-for-rail-1.md
@@ -1,0 +1,131 @@
+# 67. The runner SandboxTemplate sets networkPolicyManagement: Unmanaged so Rail 1 is not additively defeated
+
+Date: 2026-07-21
+Status: Accepted
+
+## Context
+
+Issue #765 (release-blocker, security): a cluster-tier install with a tight
+egress allowlist (`--allow-web-egress <github>/32`, `--allow-egress-host
+openrouter`) did not actually get one. Packet-level evidence on a live k3s
+install of v0.4.2: the chart rendered its own containment correctly --
+`agentos-runner-default-deny-egress` (egress: none) and
+`agentos-runner-allow-egress` (TCP/443 scoped to exactly the declared /32s) --
+but the vendored agent-sandbox controller (ADR-0023) independently created
+`agentos-runner-network-policy` with a broad egress rule (`0.0.0.0/0` minus
+RFC1918/link-local, both address families). A non-allowlisted host
+(example.com) was reachable from a real sandbox pod.
+
+Kubernetes NetworkPolicy semantics are additive, not restrictive-intersecting:
+when multiple NetworkPolicy objects select the same pod for the same policy
+type, the CNI allows traffic that matches ANY of them. There is no mechanism
+for one policy to narrow what a separate, broader policy already permits. So
+the chart's own Rail 1 (`templates/security-networkpolicy.yaml`: default-deny
+egress + DNS/collector/MinIO/inference carve-outs + the operator allowlist,
+`security-networkpolicy.yaml`) cannot, by adding yet another NetworkPolicy,
+override or narrow a separately-managed permissive policy selecting the same
+pods -- the union of "deny-all + narrow allow" and "allow public internet" is
+just "allow public internet". Rail 1 was never broken; it was being silently
+unioned away by a second policy the chart does not control.
+
+### The controller's actual behavior (verified, not assumed)
+
+The vendored controller (`charts/agentos/files/agent-sandbox/controller.yaml`,
+upstream `kubernetes-sigs/agent-sandbox` v0.5.0,
+`registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.5.0`) runs with args
+`--leader-elect=true --extensions` -- no flag governs NetworkPolicy generation
+or scope (ADR-0023 already established there is no `--namespace` flag either;
+same conclusion holds for network-policy behavior: it is not a controller
+flag). The lever lives in the CRD instead: the vendored
+`sandboxtemplates.extensions.agents.x-k8s.io` CRD
+(`charts/agentos/crds/crd-sandboxtemplates.yaml`) already carries two spec
+fields on `SandboxTemplate`, present in this repo before this change but never
+set by the chart:
+
+- `spec.networkPolicyManagement`: `Managed` (default) or `Unmanaged`.
+- `spec.networkPolicy.{ingress,egress}`: a restricted subset of
+  `NetworkPolicySpec` the controller applies when Managed and the field is
+  non-nil.
+
+Upstream's doc comments (`sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1`,
+confirmed via `pkg.go.dev` and the project's own docs site,
+`agent-sandbox.sigs.k8s.io`) state the exact behavior: a single shared
+NetworkPolicy is reconciled per SandboxTemplate (not per pod, not once at
+creation -- an ongoing controller-runtime `Owns(&NetworkPolicy{})` watch, per
+ADR-0023's citation of `sandboxtemplate_controller.go:253`). When Managed and
+`spec.networkPolicy` is nil, the controller applies its own "Secure Default":
+egress to the public internet, blocking RFC1918/link-local/metadata -- exactly
+what issue #765 observed. Setting `networkPolicyManagement: Unmanaged` makes
+the controller skip creating (and reconciling) that policy for the template
+entirely.
+
+Because this is a continuous reconcile against a field on the SandboxTemplate
+object, not a one-time creation, a chart-side "delete the extra policy after
+install" hack would be fought and reverted on the controller's next reconcile
+loop. The field is the only lever; there is nothing to patch around it.
+
+### Alternatives weighed
+
+1. **Populate `spec.networkPolicy.egress` with the chart's own allowlist,
+   keep `networkPolicyManagement: Managed`.** Would also work (Managed +
+   non-nil `networkPolicy` uses the custom rules instead of the Secure
+   Default), but requires translating `security.networkPolicy.allowedEgress`
+   (chart's `{cidr, ports}` shape, plus the DNS/collector/MinIO/inference
+   carve-outs and the metadata `except` logic) into the CRD's restricted
+   `NetworkPolicyEgressRule` shape a second time. That is a second
+   representation of the same policy that can drift from Rail 1's, for no
+   benefit over Unmanaged in this chart, which already renders a complete,
+   independently-tested Rail 1. Rejected as unnecessary duplication.
+2. **Fork/patch the vendored controller image to add a scoping flag.**
+   Rejected outright: the exact anti-pattern ADR-0023 already weighed and
+   rejected for the same vendored binary -- a maintenance burden
+   (re-patch on every upstream bump) out of proportion to a chart-level
+   field that already exists for this purpose.
+3. **Leave Managed and rely on periodic deletion of the extra policy.**
+   Rejected: the controller reconciles the shared policy continuously
+   (`Owns(&NetworkPolicy{})`), so a deleted object is recreated on the next
+   reconcile. Fighting a controller loop is not a fix.
+
+## Decision
+
+The runner `SandboxTemplate` (`templates/agent-sandbox.yaml`) sets
+`spec.networkPolicyManagement: Unmanaged` whenever
+`security.networkPolicy.enabled` is true (the default). This is not narrowed
+to "only when an allowlist is configured": the additive-union defeat applies
+to Rail 1's default-deny baseline itself, with or without a populated
+`allowedEgress`, so every install with Rail 1 on needs the controller kept out
+of the way. When `security.networkPolicy.enabled` is false (the operator has
+turned Rail 1 off entirely), the field is left unset, so the CRD default
+(`Managed`) applies and the controller's own baseline Secure Default policy
+still protects the pod rather than nothing at all.
+
+A render-assertion (`ci/render-assertions.sh`, Assertion 10) pins both
+branches: the default render carries `networkPolicyManagement: Unmanaged`,
+and `--set security.networkPolicy.enabled=false` leaves the field absent. A
+live-cluster check (`templates/security-probe.yaml`, Claim 1c) asserts, when
+this release deploys the controller, that no
+`<release>-runner-network-policy` object exists in the release namespace --
+proving Unmanaged actually suppressed it, not just that the chart asked for
+it.
+
+## Consequences
+
+- Rail 1 (`security-networkpolicy.yaml`) becomes the sole NetworkPolicy
+  selecting runner-sandbox pods whenever it is enabled: no second,
+  independently-managed policy can silently widen it via the additive-union
+  behavior.
+- If a customer cluster runs agent-sandbox from a DIFFERENT release
+  (`agentSandbox.controller.deploy: false`, per the existing "one controller
+  per cluster" invariant), that external controller must also honor
+  `networkPolicyManagement` for this to hold. This is the same class of
+  cross-release version-compatibility assumption ADR-0023 already accepts for
+  the vendored CRD/controller pairing; it is not a new risk this change
+  introduces.
+- Re-vendoring a newer upstream release must re-verify `networkPolicyManagement`
+  still exists with this exact semantic (alongside the two patches already
+  called out in `controller.yaml`'s header comment and ADR-0023's verb split).
+- The existing security probe's Claim 1 (a synthetic pod carrying the chart's
+  own `runner-sandbox` selector labels) does not, by itself, exercise a real
+  Sandbox-controller-created pod; Claim 1c closes the specific gap this issue
+  exposed by checking for the controller's shadow NetworkPolicy object
+  directly, without requiring a full bound SandboxClaim in the test hook.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,4 +96,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0064 | [Fail-forward cluster teardown](0064-fail-forward-cluster-teardown.md) | Accepted |
 | 0065 | [Tag protection, not the workflow gate, binds a write actor](0065-tag-protection-not-the-workflow-gate-binds-a-write-actor.md) | Accepted |
 | 0066 | [A skip propagates through the whole ancestor graph, so every publishing job carries its own guard](0066-a-skip-propagates-through-the-whole-ancestor-graph.md) | Accepted |
+| 0067 | [The runner SandboxTemplate sets networkPolicyManagement: Unmanaged so Rail 1 is not additively defeated](0067-controller-networkpolicymanagement-unmanaged-for-rail-1.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
## Summary

Kubernetes NetworkPolicy allows are additive across every object selecting the
same pods -- one policy can never narrow what a separate, broader policy
already permits, only be unioned with it. The chart's own Rail 1
(`agentos-runner-default-deny-egress` + the operator allowlist) was correct,
but the vendored agent-sandbox controller independently reconciles its own
shared NetworkPolicy per SandboxTemplate (`<release>-runner-network-policy`),
whose default ("Managed" with no `spec.networkPolicy`) is a built-in "allow
public internet minus RFC1918/link-local" rule. That policy unioned with Rail
1's default-deny and silently re-opened arbitrary egress regardless of the
configured allowlist.

The vendored controller binary exposes no flag for this (confirmed against its
args: `--leader-elect=true --extensions`, no scoping flag, matching ADR-0023's
prior finding for the same binary). The lever instead lives on the CRD: the
already-vendored `SandboxTemplate` schema carries
`spec.networkPolicyManagement` (`Managed`/`Unmanaged`), which the chart never
set. `Unmanaged` tells the controller to skip creating (and reconciling) its
own NetworkPolicy for that template entirely, leaving the chart's own Rail 1
as the sole policy selecting runner-sandbox pods.

The runner `SandboxTemplate` now sets `networkPolicyManagement: Unmanaged`
whenever `security.networkPolicy.enabled` is `true` (the default) -- not only
when a custom allowlist is configured, since the union-defeats-default-deny
failure applies to the default-deny baseline itself. When Rail 1 is turned off
entirely, the field is left unset so the controller's own baseline policy
still protects the pod rather than nothing at all.

See ADR-0067 for the full writeup, including the alternatives considered
(populating `spec.networkPolicy.egress` under `Managed` instead of
`Unmanaged`; patching the vendored controller image) and why they were
rejected in favor of this fix.

## Changes

- `charts/agentos/templates/agent-sandbox.yaml`: set
  `spec.networkPolicyManagement: Unmanaged` on the runner SandboxTemplate,
  gated on `security.networkPolicy.enabled`.
- `charts/agentos/ci/render-assertions.sh`: Assertion 10 pins both branches --
  default render carries `Unmanaged`; `security.networkPolicy.enabled=false`
  leaves the field absent.
- `charts/agentos/templates/security-probe.yaml`: Claim 1c, a live-cluster
  check (runs under `helm test`) that no controller-managed
  `<release>-runner-network-policy` object exists when this release deploys
  the controller and Rail 1 is on -- proving `Unmanaged` actually suppressed
  it, not just that the chart asked for it.
- `docs/adr/0067-...md`: the decision record.
- `charts/agentos/README.md`, `charts/agentos/CLAUDE.md`: documented the
  additive-NetworkPolicy hazard so it isn't reintroduced by a future rail or
  controller change.

## Test plan

- [x] `helm lint charts/agentos`
- [x] `bash charts/agentos/ci/render-assertions.sh` (all 10 assertions pass,
      including the new Assertion 10)
- [x] `bash scripts/check-docs.sh` (ADR index regenerated and drift-free)
- [x] Verified the rendered `SandboxTemplate` name matches the issue's
      evidence exactly (`agentos-runner-network-policy`), confirming the fix
      targets the right object.
- [ ] Live-cluster packet-level reproduction (the issue's `curl` probe against
      a non-allowlisted host from a real bound sandbox pod, before/after this
      change) was **not** run -- I don't have a live k3s cluster available in
      this environment. Claim 1c above is the closest live-cluster proxy this
      PR adds (asserts the controller's shadow policy object is absent rather
      than re-running the exact packet probe); a maintainer with cluster
      access should re-run the issue's original repro to confirm the fix
      before closing #765 with full confidence.