### PR TITLE
Add a CI gate for _AciModel model_validate call sites

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,12 @@ jobs:
       # right after ruff/mypy and before the dev stack boots.
       - name: Interface catalog docs (generate + drift + citation lint)
         run: bash scripts/check-docs.sh
+      # _AciModel tolerant-decode gate (#625, following #492): every direct
+      # ClassName.model_validate*(...) call on an _AciModel subclass must thread
+      # READER_CONTEXT or be a declared allowlist exception. Another cheap,
+      # cluster-free static gate, so it runs alongside the docs gate.
+      - name: Wire tolerance gate (_AciModel model_validate call sites)
+        run: bash scripts/check-wire-tolerance.sh
       # Integration tests dial the real dev stack (Postgres 25432, Valkey 26379,
       # MinIO 29000, Langfuse 23000 + ClickHouse + OTel Collector). Boot it after
       # ruff/mypy so cheap failures stay fast. The first up starts the one-shot

--- a/apps/api/src/agentos_api/resumereconciler.py
+++ b/apps/api/src/agentos_api/resumereconciler.py
@@ -61,7 +61,7 @@ import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from aci_protocol import QueuedTurn
+from aci_protocol import parse_queued_turn
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -87,7 +87,11 @@ def _parse_dead_lettered_resume(
     if payload is None:
         return None
     try:
-        turn = QueuedTurn.model_validate_json(payload)
+        # Tolerant decode (#625): this reads a queue-boundary payload the
+        # worker produced, the same consumer-side case parse_queued_turn
+        # already covers, so an unknown field a newer producer added must not
+        # sink a dead-lettered row that would otherwise be recovered.
+        turn = parse_queued_turn(payload)
     except ValidationError:
         return None
     approval_id = parse_resume_event_id(turn.event_id)

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3272,6 +3272,11 @@ export const commandManifest = {
           "name": "version-check"
         },
         {
+          "about": "Assert every direct `ClassName.model_validate*(...)` call on an `_AciModel` subclass threads `READER_CONTEXT` or is a declared exception in `tools/wire-tolerance-gate/allowlist.json` (#625, following #492's forgotten-context bug, `bash scripts/check-wire-tolerance.sh`). Offline, no credential",
+          "hidden": false,
+          "name": "wire-tolerance"
+        },
+        {
           "about": "Set the release version across cli/Cargo.toml + Chart.yaml version/appVersion (and refresh the CLI lockfile) so a release cut can't leave the three out of sync. Does not commit or tag",
           "args": [
             {

--- a/cli/README.md
+++ b/cli/README.md
@@ -209,6 +209,7 @@ they error clearly -- a release binary has no dev scripts.
 | `agentos dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
 | `agentos dev e2e-ladder` | `bash cli/scripts/e2e-ladder.sh` -- the cold-start parity ladder (skill, local, cluster rungs). |
 | `agentos dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI api.rs mirror structs cover their platform API model fields (#691). |
+| `agentos dev wire-tolerance` | `bash scripts/check-wire-tolerance.sh` -- assert every direct `ClassName.model_validate*(...)` call on an `_AciModel` subclass threads `READER_CONTEXT` or is a declared exception (#625). |
 
 ## `skill` target: runner-only, fully offline
 

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3269,6 +3269,11 @@
           "name": "version-check"
         },
         {
+          "about": "Assert every direct `ClassName.model_validate*(...)` call on an `_AciModel` subclass threads `READER_CONTEXT` or is a declared exception in `tools/wire-tolerance-gate/allowlist.json` (#625, following #492's forgotten-context bug, `bash scripts/check-wire-tolerance.sh`). Offline, no credential",
+          "hidden": false,
+          "name": "wire-tolerance"
+        },
+        {
           "about": "Set the release version across cli/Cargo.toml + Chart.yaml version/appVersion (and refresh the CLI lockfile) so a release cut can't leave the three out of sync. Does not commit or tag",
           "args": [
             {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -341,6 +341,12 @@ enum DevAction {
     /// Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml
     /// version, and appVersion (`bash scripts/check-version-consistency.sh`).
     VersionCheck,
+    /// Assert every direct `ClassName.model_validate*(...)` call on an
+    /// `_AciModel` subclass threads `READER_CONTEXT` or is a declared
+    /// exception in `tools/wire-tolerance-gate/allowlist.json` (#625, following
+    /// #492's forgotten-context bug, `bash scripts/check-wire-tolerance.sh`).
+    /// Offline, no credential.
+    WireTolerance,
     /// Set the release version across cli/Cargo.toml + Chart.yaml
     /// version/appVersion (and refresh the CLI lockfile) so a release cut can't
     /// leave the three out of sync. Does not commit or tag.
@@ -1455,6 +1461,9 @@ async fn run(command: Option<Command>) -> Result<()> {
             }
             DevAction::VersionCheck => {
                 commands::dev_script("scripts/check-version-consistency.sh").await
+            }
+            DevAction::WireTolerance => {
+                commands::dev_script("scripts/check-wire-tolerance.sh").await
             }
             DevAction::BumpVersion { version, dry_run } => {
                 commands::bump_version(&version, dry_run).await

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ members = [
     "apps/worker",
     "runner",
     "tools/doclint",
+    "tools/wire-tolerance-gate",
 ]
 
 [tool.uv.sources]
@@ -37,10 +38,12 @@ agentos-dispatcher = { workspace = true }
 agentos-worker = { workspace = true }
 agentos-runner = { workspace = true }
 agentos-doclint = { workspace = true }
+agentos-wire-tolerance-gate = { workspace = true }
 
 [dependency-groups]
 dev = [
     "agentos-doclint",
+    "agentos-wire-tolerance-gate",
     "pytest>=8.3",
     "ruff>=0.15.22",
     "mypy>=2.3.0",
@@ -63,6 +66,7 @@ testpaths = [
     "release/tests",
     "examples/tests",
     "tools/doclint/tests",
+    "tools/wire-tolerance-gate/tests",
     # Only the offline harness unit tests -- NOT the whole tree: the cluster
     # scenario in test_soak_resilience.py stays out of default collection and
     # runs only under AGENTOS_SOAK=1 (#499).
@@ -98,6 +102,7 @@ mypy_path = [
     "apps/worker/src",
     "runner/src",
     "tools/doclint/src",
+    "tools/wire-tolerance-gate/src",
 ]
 files = [
     "packages/aci-protocol/src",
@@ -108,6 +113,7 @@ files = [
     "apps/worker/src",
     "runner/src",
     "tools/doclint/src",
+    "tools/wire-tolerance-gate/src",
 ]
 
 # The official kubernetes client ships no type stubs; keep its boundary typed

--- a/scripts/check-wire-tolerance.sh
+++ b/scripts/check-wire-tolerance.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# _AciModel tolerant-decode gate (issue #625, following #492). Every direct
+# ``ClassName.model_validate*(...)`` call site on an _AciModel subclass, across
+# the whole repo, must either thread READER_CONTEXT explicitly or be declared
+# in tools/wire-tolerance-gate/allowlist.json with a reason. #492 shipped a
+# forgotten-context call site four separate times before four independent
+# reviewers caught it by hand; this is the local mirror of the CI gate that
+# now catches it instead. See tools/wire-tolerance-gate/src for the scan and
+# tools/wire-tolerance-gate/tests for the negative control that proves it is
+# not vacuous.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+uv run python -m agentos_wire_tolerance_gate

--- a/tools/wire-tolerance-gate/allowlist.json
+++ b/tools/wire-tolerance-gate/allowlist.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Declared exceptions to the _AciModel tolerant-decode gate (issue #625). Every entry names a call site that decodes an _AciModel subclass without syntactically threading READER_CONTEXT, plus why it stays uncorrected here. A new call site should thread context=READER_CONTEXT instead of growing this list; an entry here is a deliberately accepted gap, not a template to copy. Check with: agentos dev wire-tolerance (bash scripts/check-wire-tolerance.sh).",
+  "entries": [
+    {
+      "path": "packages/aci-protocol/src/aci_protocol/session.py",
+      "symbol": "Budget.model_validate_json",
+      "why": "SessionConfig.from_env decodes AGENTOS_BUDGET from the runner's own boot environment, not a queue/NDJSON wire boundary with an existing parse_* helper to route through. It shares the #492 shape (a newer worker's BootEnv could add a Budget field that an older runner's from_env would then reject) and is a real pre-existing gap this gate surfaces rather than hides. Not fixed in this change: packages/aci-protocol is a frozen contract package (packages/CLAUDE.md) and a behavior change there needs its own reviewed issue/PR, not a passenger on the gate that catches it. Follow-up: thread READER_CONTEXT through SessionConfig.from_env's Budget decode in a dedicated change."
+    }
+  ]
+}

--- a/tools/wire-tolerance-gate/pyproject.toml
+++ b/tools/wire-tolerance-gate/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "agentos-wire-tolerance-gate"
+version = "0.0.0"
+description = "Static gate (#625): every model_validate*/model_validate_json call on an _AciModel subclass must thread READER_CONTEXT or be declared in the allowlist"
+requires-python = ">=3.13"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentos_wire_tolerance_gate"]

--- a/tools/wire-tolerance-gate/src/agentos_wire_tolerance_gate/__init__.py
+++ b/tools/wire-tolerance-gate/src/agentos_wire_tolerance_gate/__init__.py
@@ -1,0 +1,288 @@
+"""Static gate: every ``model_validate``/``model_validate_json``/
+``model_validate_strings`` call on an ``_AciModel`` subclass must either thread
+the reader-context flag explicitly or be named in the committed allowlist
+(issue #625, following #492 and the four independently-caught call sites it
+shipped there).
+
+``_AciModel`` (``packages/aci-protocol/src/aci_protocol/events.py``) rejects
+unknown keys on construction UNLESS the caller passes
+``context={"aci_reader": True}`` (the ``READER_CONTEXT`` mapping exported
+alongside it). A consumer decoding an untrusted wire/queue/env payload that
+forgets to thread that context gets a strict rejection instead of the intended
+tolerant decode -- exactly the #492 failure mode ("a forgotten flag silently
+422ing... on a rolling deploy"), which shipped at four call sites before four
+independent reviewers caught it by hand on that PR's review.
+
+This gate makes the mistake fail CI instead of waiting for a fifth reviewer:
+every direct ``SomeAciModel.model_validate*(...)`` call site across the repo
+must either pass ``context=READER_CONTEXT`` (matched syntactically: the call's
+``context=`` keyword must mention the reader-context name or its underlying
+key), or be declared in ``allowlist.json`` with a reason a human can audit --
+mirroring the shape of ``cli/api-mirrors.json``'s per-omission ``why``.
+
+Test files are exempt (any path with a ``tests`` directory component, or a
+``test_*.py``/``*_test.py`` filename): several intentionally exercise BOTH the
+strict and the tolerant path on purpose (see
+``packages/aci-protocol/tests/test_turn.py``, which asserts construction
+raises on an unknown field AND that ``parse_queued_turn`` tolerates it), so
+forcing a context flag onto a test asserting strict rejection would defeat the
+test it is written to be.
+
+This is a syntactic, not semantic, gate: it only resolves literal
+``ClassName.model_validate(...)`` call sites where ``ClassName`` is one of the
+statically-known ``_AciModel`` subclasses (computed by parsing class
+definitions under the frozen ``packages/aci-protocol`` package, never by
+importing/executing it). A call through a variable or parameter
+(``model.model_validate(...)``, ``cls.model_validate(...)``) is out of its
+reach by construction -- ``apps/api/src/agentos_api/wirebody.py`` uses exactly
+that shape deliberately (the FastAPI request-body seam that already threads
+``READER_CONTEXT`` from a shared generic helper, itself the fix for #492), so
+this is a known, accepted limitation rather than a gap discovered later:
+widening the gate to trace indirect call sites is real follow-up work, not
+required for this gate to do its job on the direct-call-site pattern #492
+actually repeated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "AllowlistEntry",
+    "CallSite",
+    "find_violations",
+    "main",
+]
+
+_ACI_MODEL_BASE = "_AciModel"
+_ACI_PROTOCOL_SRC_REL = "packages/aci-protocol/src/aci_protocol"
+_DEFAULT_ALLOWLIST_REL = "tools/wire-tolerance-gate/allowlist.json"
+
+_VALIDATE_METHODS = ("model_validate", "model_validate_json", "model_validate_strings")
+
+# Any of these appearing in the unparsed ``context=`` keyword value is treated
+# as "this call threads the reader context": the exported sentinel name, its
+# underlying private key, and the wire key string itself, so
+# ``context=READER_CONTEXT`` and ``context={_READER_CONTEXT_KEY: True}`` (both
+# forms used in this repo today) are both recognized without evaluating the
+# expression.
+_READER_CONTEXT_MARKERS = ("READER_CONTEXT", "_READER_CONTEXT_KEY", "aci_reader")
+
+# Directories never scanned: dependency/build/cache noise and generated code,
+# never first-party source a human wrote.
+_EXCLUDED_DIR_NAMES = frozenset(
+    {
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        "generated",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CallSite:
+    """One ``ClassName.model_validate*(...)`` call site on a known subclass."""
+
+    path: str  # repo-relative, POSIX separators
+    line: int
+    class_name: str
+    method: str
+
+    @property
+    def symbol(self) -> str:
+        return f"{self.class_name}.{self.method}"
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    path: str
+    symbol: str
+    why: str
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in sorted(root.rglob("*.py")):
+        if any(part in _EXCLUDED_DIR_NAMES for part in path.parts):
+            continue
+        files.append(path)
+    return files
+
+
+def _is_test_path(rel: str) -> bool:
+    rel_path = Path(rel)
+    if "tests" in rel_path.parts:
+        return True
+    name = rel_path.name
+    return name.startswith("test_") or name.endswith("_test.py")
+
+
+def _aci_model_subclasses(repo_root: Path, aci_protocol_src_rel: str) -> set[str]:
+    """Every class name transitively subclassing ``_AciModel``.
+
+    Computed by parsing ``class X(Y):`` headers under the frozen aci-protocol
+    package's source tree, never by importing it -- the hierarchy is small,
+    closed, and lives only in that one package (see ``packages/CLAUDE.md``), so
+    a name-based fixpoint over its own files is exact for this repo today. A
+    base outside a ``Name`` node (an aliased or dotted import) is not modeled;
+    aci-protocol declares every base as a bare name today.
+    """
+
+    known = {_ACI_MODEL_BASE}
+    src_root = repo_root / aci_protocol_src_rel
+    if not src_root.is_dir():
+        return known
+
+    bases_by_class: dict[str, set[str]] = {}
+    for path in _iter_python_files(src_root):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                base_names = {b.id for b in node.bases if isinstance(b, ast.Name)}
+                bases_by_class.setdefault(node.name, set()).update(base_names)
+
+    changed = True
+    while changed:
+        changed = False
+        for cls, bases in bases_by_class.items():
+            if cls not in known and bases & known:
+                known.add(cls)
+                changed = True
+
+    return known
+
+
+def _match_call(call: ast.Call, known_classes: set[str]) -> tuple[str, str] | None:
+    """Return ``(class_name, method)`` if ``call`` is a direct
+    ``ClassName.model_validate*(...)`` call on a known subclass, else ``None``."""
+
+    func = call.func
+    if not isinstance(func, ast.Attribute) or func.attr not in _VALIDATE_METHODS:
+        return None
+    if not isinstance(func.value, ast.Name):
+        return None
+    if func.value.id not in known_classes:
+        return None
+    return func.value.id, func.attr
+
+
+def _threads_reader_context(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg != "context":
+            continue
+        try:
+            rendered = ast.unparse(kw.value)
+        except (ValueError, TypeError):
+            rendered = ""
+        if any(marker in rendered for marker in _READER_CONTEXT_MARKERS):
+            return True
+    return False
+
+
+def _find_call_sites(repo_root: Path, known_classes: set[str]) -> list[CallSite]:
+    sites: list[CallSite] = []
+    for path in _iter_python_files(repo_root):
+        rel = path.relative_to(repo_root).as_posix()
+        if _is_test_path(rel):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            match = _match_call(node, known_classes)
+            if match is None or _threads_reader_context(node):
+                continue
+            class_name, method = match
+            sites.append(CallSite(rel, node.lineno, class_name, method))
+    return sites
+
+
+def _load_allowlist(allowlist_path: Path) -> list[AllowlistEntry]:
+    if not allowlist_path.is_file():
+        return []
+    data = json.loads(allowlist_path.read_text(encoding="utf-8"))
+    return [
+        AllowlistEntry(path=raw["path"], symbol=raw["symbol"], why=raw["why"])
+        for raw in data.get("entries", [])
+    ]
+
+
+def _is_allowlisted(site: CallSite, entries: list[AllowlistEntry]) -> bool:
+    return any(entry.path == site.path and entry.symbol == site.symbol for entry in entries)
+
+
+def find_violations(repo_root: Path, allowlist_path: Path | None = None) -> list[CallSite]:
+    """Every non-test ``model_validate*`` call site on an ``_AciModel``
+    subclass that neither threads ``READER_CONTEXT`` nor is declared in the
+    allowlist. An empty result is the passing case."""
+
+    known_classes = _aci_model_subclasses(repo_root, _ACI_PROTOCOL_SRC_REL)
+    sites = _find_call_sites(repo_root, known_classes)
+    resolved_allowlist = allowlist_path or (repo_root / _DEFAULT_ALLOWLIST_REL)
+    entries = _load_allowlist(resolved_allowlist)
+    return [site for site in sites if not _is_allowlisted(site, entries)]
+
+
+def _git_top_level() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="agentos_wire_tolerance_gate")
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root to scan; defaults to the git top-level.",
+    )
+    parser.add_argument(
+        "--allowlist",
+        default=None,
+        help="Path to the allowlist JSON; defaults to tools/wire-tolerance-gate/allowlist.json.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else _git_top_level()
+    allowlist_path = Path(args.allowlist).resolve() if args.allowlist else None
+
+    violations = find_violations(repo_root, allowlist_path)
+    for site in violations:
+        print(
+            f"{site.path}:{site.line}: {site.symbol}(...) decodes an _AciModel "
+            "subclass without threading READER_CONTEXT, and is not declared in "
+            f"{_DEFAULT_ALLOWLIST_REL} (issue #625). Either pass "
+            "context=READER_CONTEXT (see aci_protocol.ndjson.parse_queued_turn "
+            "for the sanctioned shape) or add an allowlist entry naming why this "
+            "call site is a sanctioned exception."
+        )
+
+    if violations:
+        print(f"wire-tolerance-gate: {len(violations)} violation(s)")
+    else:
+        print(
+            "wire-tolerance-gate: OK, every model_validate*/model_validate_json "
+            "call on an _AciModel subclass is tolerant or allowlisted"
+        )
+
+    return 0 if not violations else 1

--- a/tools/wire-tolerance-gate/src/agentos_wire_tolerance_gate/__main__.py
+++ b/tools/wire-tolerance-gate/src/agentos_wire_tolerance_gate/__main__.py
@@ -1,0 +1,10 @@
+"""CLI entry: ``python -m agentos_wire_tolerance_gate``."""
+
+from __future__ import annotations
+
+import sys
+
+from . import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/wire-tolerance-gate/tests/conftest.py
+++ b/tools/wire-tolerance-gate/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Keep pytest from collecting the fixture tree as real tests.
+
+``fixtures/repo/apps/fake/tests/test_something.py`` exists specifically to
+prove the gate exempts test-shaped paths; it is not a real test (its
+``Widget`` stand-in has no actual ``model_validate``) and must never be
+imported or executed by pytest itself.
+"""
+
+from __future__ import annotations
+
+collect_ignore_glob = ["fixtures/**"]

--- a/tools/wire-tolerance-gate/tests/fixtures/repo/allowlist.json
+++ b/tools/wire-tolerance-gate/tests/fixtures/repo/allowlist.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Fixture allowlist for the gate's own test suite, not the real repo allowlist.",
+  "entries": [
+    {
+      "path": "apps/fake/site_allowlisted.py",
+      "symbol": "Widget.model_validate",
+      "why": "Fixture exercising the allowlist-excuses-a-call-site path."
+    }
+  ]
+}

--- a/tools/wire-tolerance-gate/tests/fixtures/repo/apps/fake/site_allowlisted.py
+++ b/tools/wire-tolerance-gate/tests/fixtures/repo/apps/fake/site_allowlisted.py
@@ -1,0 +1,8 @@
+"""A call site with no reader context, but declared in the fixture allowlist
+(see ../../allowlist.json). Proves an allowlisted site is excused."""
+
+from packages.aci_protocol.src.aci_protocol.events import Widget
+
+
+def decode(raw: dict[str, object]) -> Widget:
+    return Widget.model_validate(raw)

--- a/tools/wire-tolerance-gate/tests/fixtures/repo/apps/fake/site_bad.py
+++ b/tools/wire-tolerance-gate/tests/fixtures/repo/apps/fake/site_bad.py
@@ -1,0 +1,10 @@
+"""The negative control: an unsanctioned decode with no reader context and no
+allowlist entry. The gate must flag this exact call site -- if it does not,
+the gate is vacuous. Also proves transitive subclass resolution: Gadget is
+two levels below _AciModel (Gadget -> Widget -> _AciModel)."""
+
+from packages.aci_protocol.src.aci_protocol.events import Gadget
+
+
+def decode(raw: dict[str, object]) -> Gadget:
+    return Gadget.model_validate(raw)

--- a/tools/wire-tolerance-gate/tests/fixtures/repo/apps/fake/site_ok.py
+++ b/tools/wire-tolerance-gate/tests/fixtures/repo/apps/fake/site_ok.py
@@ -1,0 +1,8 @@
+"""A sanctioned decode: threads READER_CONTEXT explicitly, so the gate must
+not flag it."""
+
+from packages.aci_protocol.src.aci_protocol.events import READER_CONTEXT, Widget
+
+
+def decode(raw: str) -> Widget:
+    return Widget.model_validate_json(raw, context=READER_CONTEXT)

--- a/tools/wire-tolerance-gate/tests/fixtures/repo/apps/fake/tests/test_something.py
+++ b/tools/wire-tolerance-gate/tests/fixtures/repo/apps/fake/tests/test_something.py
@@ -1,0 +1,9 @@
+"""Lives under a tests/ directory: proves the gate exempts test files, which
+legitimately exercise the strict (no reader context) construction path on
+purpose."""
+
+from packages.aci_protocol.src.aci_protocol.events import Widget
+
+
+def test_strict_construction_rejects_unknown_fields() -> None:
+    Widget.model_validate({"unexpected": True})

--- a/tools/wire-tolerance-gate/tests/fixtures/repo/packages/aci-protocol/src/aci_protocol/events.py
+++ b/tools/wire-tolerance-gate/tests/fixtures/repo/packages/aci-protocol/src/aci_protocol/events.py
@@ -1,0 +1,23 @@
+"""Minimal stand-in for the real aci_protocol.events module.
+
+Only shaped enough for the gate's class-hierarchy scan: a base class and two
+subclasses, one direct and one transitive, to prove the fixpoint walk resolves
+both. Never imported or executed by the gate -- only parsed.
+"""
+
+from collections.abc import Mapping
+from types import MappingProxyType
+
+READER_CONTEXT: Mapping[str, bool] = MappingProxyType({"aci_reader": True})
+
+
+class _AciModel:
+    pass
+
+
+class Widget(_AciModel):
+    pass
+
+
+class Gadget(Widget):
+    pass

--- a/tools/wire-tolerance-gate/tests/test_gate.py
+++ b/tools/wire-tolerance-gate/tests/test_gate.py
@@ -1,0 +1,71 @@
+"""Tests for the _AciModel tolerant-decode gate (issue #625).
+
+``fixtures/repo`` is a tiny synthetic repo shaped like the real one: a
+stand-in ``_AciModel``/``Widget``/``Gadget`` hierarchy under
+``packages/aci-protocol/src/aci_protocol/events.py`` and four call sites under
+``apps/fake`` covering the four outcomes the gate must tell apart. The
+negative-control test (``test_gate_flags_the_unsanctioned_call_site``) is the
+one that proves the gate is not vacuous: it fails the suite if the gate stops
+catching an unsanctioned call site.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentos_wire_tolerance_gate import find_violations
+
+_FIXTURE_REPO = Path(__file__).parent / "fixtures" / "repo"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _fixture_violations() -> list:
+    return find_violations(_FIXTURE_REPO, _FIXTURE_REPO / "allowlist.json")
+
+
+def test_gate_flags_the_unsanctioned_call_site() -> None:
+    """Negative control: an unsanctioned call site must be flagged, or the
+    gate is vacuous."""
+
+    flagged = {(v.path, v.symbol) for v in _fixture_violations()}
+    assert ("apps/fake/site_bad.py", "Gadget.model_validate") in flagged
+
+
+def test_gate_resolves_transitive_subclasses() -> None:
+    """Gadget is two levels below _AciModel (Gadget -> Widget -> _AciModel);
+    the fixpoint class-hierarchy walk must still catch it."""
+
+    flagged_symbols = {v.symbol for v in _fixture_violations()}
+    assert "Gadget.model_validate" in flagged_symbols
+
+
+def test_gate_passes_a_call_site_threading_reader_context() -> None:
+    flagged_paths = {v.path for v in _fixture_violations()}
+    assert "apps/fake/site_ok.py" not in flagged_paths
+
+
+def test_gate_passes_an_allowlisted_call_site() -> None:
+    flagged_paths = {v.path for v in _fixture_violations()}
+    assert "apps/fake/site_allowlisted.py" not in flagged_paths
+
+
+def test_gate_exempts_test_files() -> None:
+    flagged_paths = {v.path for v in _fixture_violations()}
+    assert "apps/fake/tests/test_something.py" not in flagged_paths
+
+
+def test_gate_flags_exactly_the_one_unsanctioned_site() -> None:
+    """Pins the fixture's total violation count so a change that widens or
+    narrows matching is caught here, not just by drift in the other tests."""
+
+    assert len(_fixture_violations()) == 1
+
+
+def test_real_repo_call_sites_all_pass() -> None:
+    """The positive-path baseline (#625): every real, current call site in this
+    repo must be either a tolerant decode (threads READER_CONTEXT) or a
+    declared allowlist exception. This is the actual CI gate, run against the
+    real repo root and its committed allowlist.json."""
+
+    violations = find_violations(_REPO_ROOT)
+    assert violations == []

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "agentos-dispatcher",
     "agentos-doclint",
     "agentos-runner",
+    "agentos-wire-tolerance-gate",
     "agentos-worker",
     "agentos-workspace",
     "plugin-format",
@@ -153,6 +154,11 @@ requires-dist = [
 ]
 
 [[package]]
+name = "agentos-wire-tolerance-gate"
+version = "0.0.0"
+source = { editable = "tools/wire-tolerance-gate" }
+
+[[package]]
 name = "agentos-worker"
 version = "0.0.0"
 source = { editable = "apps/worker" }
@@ -206,6 +212,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "agentos-doclint" },
+    { name = "agentos-wire-tolerance-gate" },
     { name = "mypy" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
@@ -228,6 +235,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "agentos-doclint", editable = "tools/doclint" },
+    { name = "agentos-wire-tolerance-gate", editable = "tools/wire-tolerance-gate" },
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29" },
     { name = "opentelemetry-sdk", specifier = ">=1.44.0" },


### PR DESCRIPTION
## Summary

Every direct `ClassName.model_validate*(...)` call on an `_AciModel` subclass must now either thread `READER_CONTEXT` explicitly or be named in a committed allowlist with a reason. `_AciModel` (`packages/aci-protocol/src/aci_protocol/events.py`) rejects unknown keys on construction unless the caller passes the reader-context flag, so a consumer decode that forgets it gets a strict rejection instead of the intended tolerant decode. #492 shipped exactly that mistake at four call sites before four independent reviewers caught it by hand; this adds a static gate that catches it instead of waiting for a fifth reviewer.

This implements the lighter of the two options #625 offered: a CI gate, not the full tolerant-by-default restructure of `_AciModel` (out of scope per the issue -- that touches every model in the frozen `packages/aci-protocol` package).

## What's here

- `tools/wire-tolerance-gate`: a new Python workspace package (mirrors `tools/doclint`'s shape). It parses (never imports/executes) `packages/aci-protocol/src/aci_protocol` to compute every class transitively subclassing `_AciModel`, then walks the whole repo's non-test `.py` files for `ClassName.model_validate`/`model_validate_json`/`model_validate_strings` calls on one of those classes. A call site passes if it syntactically threads `context=READER_CONTEXT` (or the underlying reader key), or if it is declared in `tools/wire-tolerance-gate/allowlist.json` with a `why`, mirroring `cli/api-mirrors.json`'s per-entry justification shape. Test files (any `tests/` path component, or `test_*.py`/`*_test.py`) are exempt, since several tests intentionally exercise both the strict and tolerant paths on purpose (e.g. `packages/aci-protocol/tests/test_turn.py`).
- `scripts/check-wire-tolerance.sh`: the bash wrapper, following the exact shape of `scripts/check-docs.sh`/`scripts/check-contracts.sh`.
- Wired into `agentos dev wire-tolerance` (`cli/src/main.rs`), with the committed `cli/command-manifest.json` and `apps/ui/src/generated/commandManifest.ts` regenerated to match.
- Wired into CI (`.github/workflows/ci.yaml`, the `python` job) right alongside the docs-lint gate, since both are cheap and cluster-free.
- Test suite (`tools/wire-tolerance-gate/tests`) with a synthetic fixture repo covering all four outcomes: a negative control (an unsanctioned call site the gate must flag, proving it isn't vacuous), a call site threading `READER_CONTEXT` (passes), an allowlisted call site (passes), and a test-file call site (exempt). A fifth test runs the gate against the real repo root and its real committed allowlist as the positive-path baseline.

## Bonus findings while seeding the baseline

Auditing every current `model_validate*` call site on an `_AciModel` subclass (to know what the gate must not flag) surfaced two real gaps matching the #492 shape:

- `apps/api/src/agentos_api/resumereconciler.py`'s dead-lettered-turn scan called `QueuedTurn.model_validate_json(payload)` directly instead of routing through the existing `parse_queued_turn` helper -- a live, uncaught instance of the same bug #492 fixed elsewhere. Fixed here by switching to `parse_queued_turn`.
- `packages/aci-protocol/src/aci_protocol/session.py`'s `SessionConfig.from_env` decodes `Budget` from the boot environment without threading `READER_CONTEXT`, sharing the same rolling-deploy shape. Not fixed here (that file is inside the frozen `packages/aci-protocol` package, which needs its own reviewed issue/PR for a behavior change per `packages/CLAUDE.md`) -- instead it is named in `tools/wire-tolerance-gate/allowlist.json` with a follow-up note, so the gap is visible rather than hidden.

Ref #492, #624
Closes #625

## Test plan

- [x] `bash scripts/check-wire-tolerance.sh` passes against the real repo
- [x] `uv run pytest tools/wire-tolerance-gate/tests -q` (7 tests, including the negative control)
- [x] `uv run pytest apps/api/tests/test_resume_reconciler.py -q`
- [x] `uv run ruff check .` / `uv run mypy`
- [x] `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` (including `command_manifest_matches_committed_artifact` and `clap_surface_is_valid`)
- [x] `cd apps/ui && pnpm lint && pnpm typecheck`