### PR TITLE
Add a --json emit-hop parity gate for CliOutput::to_json projections

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3267,6 +3267,11 @@ export const commandManifest = {
           "name": "field-parity"
         },
         {
+          "about": "Assert every declared `emits` projection in `cli/api-mirrors.json` -- a `CliOutput::to_json` that hand-projects a mirror struct into a `json!` literal -- covers that struct's fields (#699, one hop downstream of `field-parity`, `bash cli/scripts/check-emit-parity.sh`). Offline, no credential",
+          "hidden": false,
+          "name": "emit-parity"
+        },
+        {
           "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
           "hidden": false,
           "name": "version-check"

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -158,6 +158,18 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   `cli/api-mirrors.json`** (as a `mirrors` entry with its allowlisted field
   omissions, or a `non_mirrors` entry with a one-line reason). `agentos dev
   field-parity` is the check (#691).
+- **A `CliOutput::to_json` that hand-projects one of those mirror structs into
+  a `serde_json::json!` literal must be declared in `cli/api-mirrors.json`'s
+  `emits` array** (the `(output, struct)` pair, plus any allowlisted, justified
+  field omissions) -- the second, emit-hop seam #691 named but did not close
+  (the proof case was `VersionsOutput::to_json` dropping `Version.id`,
+  #699). `agentos dev emit-parity` is the check. Narrower than the struct-level
+  gate: it verifies every DECLARED projection stays honest but, unlike that
+  gate's `UndeclaredStruct` check, cannot discover a new projection on its own
+  (see `cli/tests/support/emit_parity.rs`'s module doc for why). A `to_json`
+  that instead delegates wholesale to a `Serialize` value
+  (`serde_json::to_value`) or a shared schema-gated builder needs no `emits`
+  entry -- it cannot drop a field by hand-picking one in the first place.
 
 ## Verify
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -38,6 +38,8 @@ dependencies = [
  "indicatif",
  "jsonschema",
  "keyring",
+ "proc-macro2",
+ "quote",
  "ratatui",
  "redis",
  "regex",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -77,3 +77,10 @@ agentos-aci-protocol = { path = "../packages/aci-protocol/generated/rust" }
 # bodies, `visit` recurses into fn/impl-body items (the method-local BundleFiles),
 # `extra-traits` gives the PartialEq the walk relies on.
 syn = { version = "2", features = ["full", "visit", "extra-traits"] }
+# Both already ride in transitively via syn; named directly for the emit-hop
+# gate (#699, `support/emit_parity.rs`), which walks a `json!` macro's raw
+# token stream (a `json!` argument is opaque to syn's AST -- it is never parsed
+# into an `Expr` tree) to recover its object-literal keys, and re-tokenizes a
+# parsed `syn::Block` (`ToTokens::to_token_stream`) to hand that walk its input.
+proc-macro2 = "1"
+quote = "1"

--- a/cli/README.md
+++ b/cli/README.md
@@ -209,6 +209,7 @@ they error clearly -- a release binary has no dev scripts.
 | `agentos dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
 | `agentos dev e2e-ladder` | `bash cli/scripts/e2e-ladder.sh` -- the cold-start parity ladder (skill, local, cluster rungs). |
 | `agentos dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI api.rs mirror structs cover their platform API model fields (#691). |
+| `agentos dev emit-parity` | `bash cli/scripts/check-emit-parity.sh` -- assert a `CliOutput::to_json` that hand-projects a mirror struct into a `json!` literal covers that struct's fields, one hop downstream of `field-parity` (#699). |
 
 ## `skill` target: runner-only, fully offline
 

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -108,5 +108,27 @@
       ]
     }
   ],
-  "non_mirrors": []
+  "non_mirrors": [],
+  "_emits_comment": "The second, emit-hop gate (#699): a CliOutput::to_json can hand-project one of the mirror structs above into a serde_json::json! literal and drop a field the struct-level gate already proved it carries (the named drift was VersionsOutput dropping Version.id, fixed in #691). Each entry below declares that a specific `output` type's to_json projects a specific mirror `struct`, and every allowlisted omission needs a consumer-derived justification just like the mirrors list above. Check with: agentos dev emit-parity. This is a narrower gate than the struct-level one: it verifies every DECLARED (output, struct) pair stays honest, but (unlike mirrors' UndeclaredStruct check) it cannot discover a NEW projection on its own -- see cli/tests/support/emit_parity.rs's module doc for why that reach is out of scope for a syntax-only check.",
+  "emits": [
+    {
+      "output": "VersionsOutput",
+      "struct": "Version",
+      "omissions": [
+        { "field": "agent_id", "why": "agent_id is carried on the struct for struct-level parity (#691) but deliberately not emitted by `versions --json`: the payload already carries `agent` (the query was agent-scoped), so echoing agent_id per version is redundant. Pinned by json_emit_contract.rs's versions_output_json_shape_is_pinned." }
+      ]
+    },
+    {
+      "output": "MemoryOutput",
+      "struct": "MemoryEntry",
+      "omissions": [
+        { "field": "version", "why": "The memory listing is read-only in the CLI today -- no verb performs a versioned mutation against a memory entry, so the log's optimistic-concurrency version (MemoryEntryOut.version) is not surfaced yet. Pinned by json_emit_contract.rs's memory_output_json_shape_is_pinned, which notes surfacing it later is a contract decision, not an oversight." }
+      ]
+    },
+    {
+      "output": "ApprovalsOutput",
+      "struct": "ApprovalRecord",
+      "omissions": []
+    }
+  ]
 }

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3264,6 +3264,11 @@
           "name": "field-parity"
         },
         {
+          "about": "Assert every declared `emits` projection in `cli/api-mirrors.json` -- a `CliOutput::to_json` that hand-projects a mirror struct into a `json!` literal -- covers that struct's fields (#699, one hop downstream of `field-parity`, `bash cli/scripts/check-emit-parity.sh`). Offline, no credential",
+          "hidden": false,
+          "name": "emit-parity"
+        },
+        {
           "about": "Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml version, and appVersion (`bash scripts/check-version-consistency.sh`)",
           "hidden": false,
           "name": "version-check"

--- a/cli/scripts/check-emit-parity.sh
+++ b/cli/scripts/check-emit-parity.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Emit-hop field-parity gate (#699): a CliOutput::to_json that hand-projects a
+# cli/src/api.rs mirror struct into a serde_json::json! literal must cover
+# every wire field of that struct per cli/api-mirrors.json's `emits` array
+# (declared projection + allowlisted, justified omissions). One hop downstream
+# of the struct-level gate (#691, check-field-parity.sh). See
+# cli/tests/api_emit_parity.rs.
+set -euo pipefail
+
+cargo test --manifest-path cli/Cargo.toml --test api_emit_parity -- --nocapture

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -338,6 +338,12 @@ enum DevAction {
     /// `cli/api-mirrors.json` and covers its API model's fields (#691,
     /// `bash cli/scripts/check-field-parity.sh`). Offline, no credential.
     FieldParity,
+    /// Assert every declared `emits` projection in `cli/api-mirrors.json` --
+    /// a `CliOutput::to_json` that hand-projects a mirror struct into a
+    /// `json!` literal -- covers that struct's fields (#699, one hop
+    /// downstream of `field-parity`, `bash cli/scripts/check-emit-parity.sh`).
+    /// Offline, no credential.
+    EmitParity,
     /// Assert the release-coupled versions agree: cli/Cargo.toml, Chart.yaml
     /// version, and appVersion (`bash scripts/check-version-consistency.sh`).
     VersionCheck,
@@ -1453,6 +1459,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             DevAction::FieldParity => {
                 commands::dev_script("cli/scripts/check-field-parity.sh").await
             }
+            DevAction::EmitParity => commands::dev_script("cli/scripts/check-emit-parity.sh").await,
             DevAction::VersionCheck => {
                 commands::dev_script("scripts/check-version-consistency.sh").await
             }

--- a/cli/tests/api_emit_parity.rs
+++ b/cli/tests/api_emit_parity.rs
@@ -1,0 +1,299 @@
+// Emit-hop field-parity gate (issue #699): a `CliOutput::to_json` that
+// hand-projects a `cli/src/api.rs` mirror struct into a `serde_json::json!`
+// literal must carry every wire field of that struct (or the omission must be
+// declared and justified in `cli/api-mirrors.json`'s `emits` array, mirroring
+// the `mirrors` array's omissions). One hop downstream of the struct-level
+// gate (#691, `cli/tests/api_field_parity.rs`) -- see the module doc on
+// `emit_parity::violations` for exactly what this narrower gate does and does
+// not catch, and why.
+
+// This binary reuses only `field_parity::walk_structs`/`CollectedStruct` (the
+// struct inventory); its own `violations`/`Violation` public surface (that
+// binary's entry point) is unused here, hence the blanket allow rather than
+// picking through the module's exports one by one.
+#[path = "support/emit_parity.rs"]
+mod emit_parity;
+#[path = "support/field_parity.rs"]
+#[allow(dead_code)]
+mod field_parity;
+
+use emit_parity::{violations, EmitViolation};
+use serde_json::Value;
+
+// ─── Loaders ─────────────────────────────────────────────────────────────────
+
+fn repo_text(rel: &str) -> String {
+    let path = format!("{}/../{}", env!("CARGO_MANIFEST_DIR"), rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn repo_json(rel: &str) -> Value {
+    let raw = repo_text(rel);
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {rel}: {e}"))
+}
+
+/// Every `cli/src/*.rs` file (flat directory, no submodules today), read as
+/// (label, contents) pairs -- the corpus the emit-hop gate scans for
+/// `CliOutput` impls and the free functions they may delegate a projection to.
+/// `cli/src/api.rs` is included too (harmless: it defines no `CliOutput` impl).
+fn cli_src_files() -> Vec<(String, String)> {
+    let dir = format!("{}/src", env!("CARGO_MANIFEST_DIR"));
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("read_dir {dir}: {e}")) {
+        let entry = entry.unwrap_or_else(|e| panic!("read_dir entry in {dir}: {e}"));
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let label = path.display().to_string();
+        let text = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {label}: {e}"));
+        out.push((label, text));
+    }
+    assert!(
+        !out.is_empty(),
+        "expected to find .rs files under {dir}; the glob is misconfigured"
+    );
+    out
+}
+
+// ─── Payload matchers (variant + payload, never message strings) ─────────────
+
+fn has_missing_field(vs: &[EmitViolation], output: &str, field: &str) -> bool {
+    vs.iter().any(|v| {
+        matches!(v, EmitViolation::MissingField { output: o, field: f, .. }
+            if o == output && f == field)
+    })
+}
+
+fn has_stale_omission(vs: &[EmitViolation], output: &str, field: &str) -> bool {
+    vs.iter().any(|v| {
+        matches!(v, EmitViolation::StaleOmission { output: o, field: f, .. }
+            if o == output && f == field)
+    })
+}
+
+fn has_output_not_found(vs: &[EmitViolation], output: &str) -> bool {
+    vs.iter()
+        .any(|v| matches!(v, EmitViolation::OutputNotFound { output: o } if o == output))
+}
+
+fn has_struct_not_found(vs: &[EmitViolation], output: &str, struct_name: &str) -> bool {
+    vs.iter().any(|v| {
+        matches!(v, EmitViolation::StructNotFound { output: o, struct_name: s }
+            if o == output && s == struct_name)
+    })
+}
+
+fn has_malformed_manifest_entry(vs: &[EmitViolation], needle: &str) -> bool {
+    vs.iter().any(
+        |v| matches!(v, EmitViolation::MalformedManifestEntry { detail } if detail.contains(needle)),
+    )
+}
+
+// ─── Real-tree assertion ──────────────────────────────────────────────────────
+
+#[test]
+fn real_tree_has_no_emit_parity_violations() {
+    let api_src = repo_text("cli/src/api.rs");
+    let cli_srcs = cli_src_files();
+    let cli_srcs_ref: Vec<(&str, &str)> = cli_srcs
+        .iter()
+        .map(|(l, s)| (l.as_str(), s.as_str()))
+        .collect();
+    let manifest = repo_json("cli/api-mirrors.json");
+
+    let vs = violations(&api_src, &cli_srcs_ref, &manifest);
+    assert!(
+        vs.is_empty(),
+        "a CliOutput::to_json has drifted from the mirror struct its `emits` entry \
+         declares. Each entry below is fixed by either emitting the field or declaring \
+         the omission (with a justification) in cli/api-mirrors.json's `emits` array:\n{vs:#?}"
+    );
+}
+
+// ─── Guard-rejects-a-violating-input demonstrations ───────────────────────────
+
+/// A synthetic `CliOutput` impl that drops `beta` from its `json!` literal, the
+/// exact shape of the proof case (`VersionsOutput` dropping `Version::id`).
+const DRIFTED_OUTPUT_SRC: &str = r#"
+pub enum DriftedOutput {
+    Done { record: crate::api::DriftedThing },
+}
+
+impl crate::ui::CliOutput for DriftedOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            DriftedOutput::Done { record } => serde_json::json!({
+                "alpha": record.alpha,
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {}
+}
+"#;
+
+const DRIFTED_STRUCT_SRC: &str = r#"
+#[derive(Debug, Clone, Deserialize)]
+pub struct DriftedThing {
+    pub alpha: String,
+    pub beta: String,
+}
+"#;
+
+fn drifted_manifest(omissions: Value) -> Value {
+    serde_json::json!({
+        "emits": [
+            { "output": "DriftedOutput", "struct": "DriftedThing", "omissions": omissions }
+        ]
+    })
+}
+
+#[test]
+fn rejects_a_dropped_field_the_deliberate_reintroduction_case() {
+    // Reintroduces the exact drift class the issue names: a struct field
+    // (`beta`) present on the mirror struct but absent from its `to_json`
+    // projection, with no declared omission.
+    let manifest = drifted_manifest(serde_json::json!([]));
+    let vs = violations(
+        DRIFTED_STRUCT_SRC,
+        &[("drifted_output.rs", DRIFTED_OUTPUT_SRC)],
+        &manifest,
+    );
+    assert!(has_missing_field(&vs, "DriftedOutput", "beta"), "{vs:#?}");
+    // The field that IS emitted must not also be flagged.
+    assert!(!has_missing_field(&vs, "DriftedOutput", "alpha"), "{vs:#?}");
+}
+
+#[test]
+fn passes_once_the_drop_is_declared_and_justified() {
+    let manifest =
+        drifted_manifest(serde_json::json!([{"field": "beta", "why": "not read by any CLI verb"}]));
+    let vs = violations(
+        DRIFTED_STRUCT_SRC,
+        &[("drifted_output.rs", DRIFTED_OUTPUT_SRC)],
+        &manifest,
+    );
+    assert!(vs.is_empty(), "{vs:#?}");
+}
+
+#[test]
+fn rejects_a_blank_omission_justification() {
+    let manifest = drifted_manifest(serde_json::json!([{"field": "beta", "why": ""}]));
+    let vs = violations(
+        DRIFTED_STRUCT_SRC,
+        &[("drifted_output.rs", DRIFTED_OUTPUT_SRC)],
+        &manifest,
+    );
+    assert!(has_stale_omission(&vs, "DriftedOutput", "beta"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_an_omission_for_a_field_the_struct_does_not_carry() {
+    let manifest =
+        drifted_manifest(serde_json::json!([{"field": "gamma", "why": "typo'd field name"}]));
+    let vs = violations(
+        DRIFTED_STRUCT_SRC,
+        &[("drifted_output.rs", DRIFTED_OUTPUT_SRC)],
+        &manifest,
+    );
+    assert!(has_stale_omission(&vs, "DriftedOutput", "gamma"), "{vs:#?}");
+    // `beta` is still genuinely missing -- the bogus omission for `gamma` must
+    // not accidentally suppress the real one.
+    assert!(has_missing_field(&vs, "DriftedOutput", "beta"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_a_stale_omission_for_a_field_that_is_actually_emitted() {
+    // `alpha` IS emitted; declaring it omitted is stale regardless of `why`.
+    let manifest = drifted_manifest(serde_json::json!([{"field": "alpha", "why": "not read"}]));
+    let vs = violations(
+        DRIFTED_STRUCT_SRC,
+        &[("drifted_output.rs", DRIFTED_OUTPUT_SRC)],
+        &manifest,
+    );
+    assert!(has_stale_omission(&vs, "DriftedOutput", "alpha"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_an_emits_entry_naming_an_output_not_found() {
+    let manifest = serde_json::json!({
+        "emits": [{ "output": "GhostOutput", "struct": "DriftedThing", "omissions": [] }]
+    });
+    let vs = violations(
+        DRIFTED_STRUCT_SRC,
+        &[("drifted_output.rs", DRIFTED_OUTPUT_SRC)],
+        &manifest,
+    );
+    assert!(has_output_not_found(&vs, "GhostOutput"), "{vs:#?}");
+}
+
+#[test]
+fn rejects_an_emits_entry_naming_a_struct_not_found() {
+    let manifest = serde_json::json!({
+        "emits": [{ "output": "DriftedOutput", "struct": "NoSuchStruct", "omissions": [] }]
+    });
+    let vs = violations(
+        DRIFTED_STRUCT_SRC,
+        &[("drifted_output.rs", DRIFTED_OUTPUT_SRC)],
+        &manifest,
+    );
+    assert!(
+        has_struct_not_found(&vs, "DriftedOutput", "NoSuchStruct"),
+        "{vs:#?}"
+    );
+}
+
+#[test]
+fn rejects_an_emits_entry_missing_a_required_key() {
+    let manifest = serde_json::json!({
+        "emits": [{ "output": "DriftedOutput", "omissions": [] }]
+    });
+    let vs = violations(
+        DRIFTED_STRUCT_SRC,
+        &[("drifted_output.rs", DRIFTED_OUTPUT_SRC)],
+        &manifest,
+    );
+    assert!(
+        has_malformed_manifest_entry(&vs, "DriftedOutput"),
+        "{vs:#?}"
+    );
+}
+
+#[test]
+fn follows_a_projection_delegated_to_a_named_free_function() {
+    // Mirrors the real `approval_record_json` pattern: `to_json` never writes
+    // the `json!` literal itself, it maps a named free fn over the collection.
+    // Reachability must follow that fn to find its `json!` literal.
+    const DELEGATING_OUTPUT_SRC: &str = r#"
+pub enum DriftedOutput {
+    Done { records: Vec<crate::api::DriftedThing> },
+}
+
+fn drifted_thing_json(r: &crate::api::DriftedThing) -> serde_json::Value {
+    serde_json::json!({
+        "alpha": r.alpha,
+        "beta": r.beta,
+    })
+}
+
+impl crate::ui::CliOutput for DriftedOutput {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            DriftedOutput::Done { records } => serde_json::json!({
+                "records": records.iter().map(drifted_thing_json).collect::<Vec<_>>(),
+            }),
+        }
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {}
+}
+"#;
+    let manifest = drifted_manifest(serde_json::json!([]));
+    let vs = violations(
+        DRIFTED_STRUCT_SRC,
+        &[("delegating_output.rs", DELEGATING_OUTPUT_SRC)],
+        &manifest,
+    );
+    assert!(vs.is_empty(), "{vs:#?}");
+}

--- a/cli/tests/support/emit_parity.rs
+++ b/cli/tests/support/emit_parity.rs
@@ -1,0 +1,434 @@
+//! Emit-hop comparator for the `--json` gate (issue #699).
+//!
+//! One hop downstream of the struct-level field-parity gate (`support/field_parity.rs`,
+//! issue #691). That gate proves a `cli/src/api.rs` mirror struct carries every
+//! field its API schema declares. It says nothing about the SECOND hop: a
+//! `CliOutput::to_json` impl in `cli/src/commands.rs` (or a sibling file) can
+//! still hand-project that struct into a `serde_json::json!` literal and drop
+//! one of its fields on the floor. The proof case was `VersionsOutput::to_json`
+//! dropping `Version::id` (fixed inline in #691's PR).
+//!
+//! ## Scope (deliberately narrower than the struct-level gate)
+//!
+//! The struct-level gate requires EVERY `Deserialize` struct in `api.rs` to be
+//! declared (its `UndeclaredStruct` violation is what gives it that reach) --
+//! that is tractable because "every `Deserialize`-deriving struct" is a
+//! syntactic property syn can enumerate exhaustively.
+//!
+//! "Every place a mirror struct gets hand-projected into a `json!` literal" is
+//! NOT a syntactic property: proving it exhaustively would mean resolving, for
+//! an arbitrary closure/iterator-adapter chain, the concrete type flowing
+//! through it (e.g. that `versions.iter().map(|v| json!({..}))`'s `v` is a
+//! `&crate::api::Version`) -- real type inference, which a syntax-only `syn`
+//! walk cannot give us. That was the risk this issue's own text flagged and
+//! asked for a spike on.
+//!
+//! So this gate takes the tractable half of the proposed shape and stops
+//! there: `cli/api-mirrors.json` gets a new `emits` array, each entry a
+//! human-DECLARED `(output, struct)` pair (analogous to `mirrors`' declared
+//! struct/schema pairs), and the gate mechanically proves that declared pair
+//! honest -- every wire field of `struct` (per the SAME struct inventory
+//! `field_parity::walk_structs` already builds from `api.rs`) appears in at
+//! least one `json!` object literal reachable from `output`'s `to_json`, or is
+//! covered by a declared, justified omission (the same allowlist shape as
+//! `mirrors`' omissions). It does NOT discover new `(output, struct)` pairs on
+//! its own the way `UndeclaredStruct` does for the struct hop -- a future
+//! projection of a mirror struct that nobody declares an `emits` entry for is a
+//! gap this gate cannot see. That gap is the honest cost of this hop being one
+//! step further from syntax and one step closer to semantics; closing it fully
+//! would need a real type-checker, not a heavier `syn` walk.
+//!
+//! ## Reachability: how "at least one `json!` literal" is found
+//!
+//! A `to_json` body is scanned for `json!`/`serde_json::json!` invocations by
+//! walking its RAW token stream (not the `syn::Expr` tree): a macro argument is
+//! opaque to syn (it is never parsed into an `Expr`), so the only way to see
+//! inside `json!({..})` at all is to look at its tokens directly. The walk is
+//! purely token-shaped -- find an `ident "json"` followed by `!` followed by a
+//! `Group`, and both recurse into that group (in case a `json!` call sits
+//! nested inside another one's tokens, e.g. inline rather than as a sibling
+//! statement) and descend into every OTHER group along the way (so a `json!`
+//! call inside a closure, a `.map(...)`, or a match arm is still found, since
+//! all of those still show up as ordinary token groups). Each `{...}`-shaped
+//! `json!` argument is then read as a flat object literal: top-level,
+//! comma-separated `"key": value` entries (nested groups inside a value are
+//! opaque and never split on their internal commas, since a `TokenTree::Group`
+//! is one token). A non-object argument (`json!(x)`, `json!([..])`) yields no
+//! keys and is not an error -- plenty of `to_json` bodies delegate to a
+//! `serde::Serialize` value wholesale (`serde_json::to_value`) or to a shared
+//! builder fn, which cannot drop a field by construction and needs no `emits`
+//! entry at all.
+//!
+//! A `to_json` body also often delegates a struct's projection to a named free
+//! function (e.g. `records.iter().map(approval_record_json)`), so the walk
+//! additionally collects every bare identifier reachable from the body and, for
+//! each one that resolves to a top-level `fn` found anywhere in the scanned
+//! sources, pulls that function's own reachable `json!` literals in too
+//! (fixpoint, cycle-guarded by name). Only free functions are followed --
+//! `self.method()` helpers are not, a scope limit noted rather than hidden.
+//!
+//! The comparator requires a single keyset (not a union across several) to
+//! cover every non-omitted wire field, so two unrelated `json!` literals in the
+//! same `to_json` cannot accidentally "cover" a struct between them.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use proc_macro2::{Delimiter, TokenStream, TokenTree};
+use quote::ToTokens;
+use serde_json::Value;
+use syn::visit::Visit;
+
+use crate::field_parity::{self, CollectedStruct};
+
+/// A single way a declared `emits` projection has drifted. Mirrors the shape of
+/// `field_parity::Violation`: the gate test matches on these variants and their
+/// payload, never on message strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmitViolation {
+    /// No single `json!` object literal reachable from `output`'s `to_json`
+    /// covers this non-omitted wire field of `struct_name`.
+    MissingField {
+        output: String,
+        struct_name: String,
+        field: String,
+    },
+    /// A declared omission is dishonest: blank/missing `why`, the struct
+    /// (per the struct-level inventory) does not actually carry the field, or
+    /// the field turns out to be covered by a reachable `json!` literal anyway.
+    StaleOmission {
+        output: String,
+        struct_name: String,
+        field: String,
+    },
+    /// An `emits` entry names an output with no `impl (crate::ui::)?CliOutput`
+    /// found for it anywhere in the scanned sources.
+    OutputNotFound { output: String },
+    /// An `emits` entry names a struct absent from the struct-level inventory.
+    StructNotFound { output: String, struct_name: String },
+    /// An `emits` entry is missing a required key (`output`/`struct`), so its
+    /// pair would silently escape comparison.
+    MalformedManifestEntry { detail: String },
+}
+
+/// Every `CliOutput` impl's `to_json` body found in the scanned sources (output
+/// type name -> its `to_json` block, re-tokenized), plus every top-level `fn`
+/// found (by name, since a delegated projection is often a free function) for
+/// the reachability fixpoint to follow.
+#[derive(Default)]
+struct OutputCollector {
+    outputs: BTreeMap<String, TokenStream>,
+    fns: BTreeMap<String, Vec<TokenStream>>,
+}
+
+impl<'ast> Visit<'ast> for OutputCollector {
+    fn visit_item_impl(&mut self, node: &'ast syn::ItemImpl) {
+        if let Some((_, path, _)) = &node.trait_ {
+            let is_cli_output = path
+                .segments
+                .last()
+                .map(|s| s.ident == "CliOutput")
+                .unwrap_or(false);
+            if is_cli_output {
+                if let syn::Type::Path(tp) = node.self_ty.as_ref() {
+                    if let Some(seg) = tp.path.segments.last() {
+                        let name = seg.ident.to_string();
+                        for item in &node.items {
+                            if let syn::ImplItem::Fn(f) = item {
+                                if f.sig.ident == "to_json" {
+                                    // First definition wins; a duplicate output
+                                    // name across files would be surprising
+                                    // enough on its own to warrant a hand look,
+                                    // and is out of scope for this gate.
+                                    self.outputs
+                                        .entry(name.clone())
+                                        .or_insert_with(|| f.block.to_token_stream());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        syn::visit::visit_item_impl(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        self.fns
+            .entry(node.sig.ident.to_string())
+            .or_default()
+            .push(node.block.to_token_stream());
+        syn::visit::visit_item_fn(self, node);
+    }
+}
+
+/// Every bare identifier reachable in `tokens`, descending into every group.
+/// Used only to find candidate free-fn names a `to_json` body might reference
+/// by value (`.map(approval_record_json)`) or by call
+/// (`approval_record_json(r)`) -- a name that happens not to resolve to a
+/// known `fn` (a local variable, a type, a keyword-shaped ident) is simply
+/// never looked up, so over-collecting here is harmless.
+fn bare_idents(tokens: TokenStream) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    collect_idents(tokens, &mut out);
+    out
+}
+
+fn collect_idents(tokens: TokenStream, out: &mut BTreeSet<String>) {
+    for tt in tokens {
+        match tt {
+            TokenTree::Ident(id) => {
+                out.insert(id.to_string());
+            }
+            TokenTree::Group(g) => collect_idents(g.stream(), out),
+            _ => {}
+        }
+    }
+}
+
+/// Split a token stream on TOP-LEVEL commas only -- a comma inside a nested
+/// group (a `{}`/`()`/`[]` in a value expression) is part of that group's one
+/// `TokenTree` and is never seen as a separate token here, so it can't be
+/// mistaken for an object-literal separator.
+fn split_top_level_commas(tokens: TokenStream) -> Vec<TokenStream> {
+    let mut chunks = Vec::new();
+    let mut current: Vec<TokenTree> = Vec::new();
+    for tt in tokens {
+        if let TokenTree::Punct(p) = &tt {
+            if p.as_char() == ',' {
+                chunks.push(current.drain(..).collect::<TokenStream>());
+                continue;
+            }
+        }
+        current.push(tt);
+    }
+    if !current.is_empty() {
+        chunks.push(current.into_iter().collect());
+    }
+    chunks
+}
+
+/// A string-literal token's value, or `None` if `text` is not a quoted string
+/// (e.g. a number, or an interpolated/computed key this gate cannot read
+/// statically -- skipped rather than guessed).
+fn strip_str_literal(text: &str) -> Option<String> {
+    if text.len() >= 2 && text.starts_with('"') && text.ends_with('"') {
+        Some(text[1..text.len() - 1].to_string())
+    } else {
+        None
+    }
+}
+
+/// If `tokens` is exactly one `{...}`-delimited group, read it as a flat
+/// object literal: each top-level comma-separated entry is `"key" : value`;
+/// `key` is collected, `value` is not interpreted further (key COVERAGE is all
+/// this gate checks, never the value expression). Returns `None` when `tokens`
+/// is not a single brace group (e.g. `json!(x)`, `json!([..])`) -- not an
+/// object literal, so it carries no keys to check.
+fn object_literal_keys(tokens: TokenStream) -> Option<BTreeSet<String>> {
+    let toks: Vec<TokenTree> = tokens.into_iter().collect();
+    if toks.len() != 1 {
+        return None;
+    }
+    let TokenTree::Group(g) = &toks[0] else {
+        return None;
+    };
+    if g.delimiter() != Delimiter::Brace {
+        return None;
+    }
+    let mut keys = BTreeSet::new();
+    for chunk in split_top_level_commas(g.stream()) {
+        let mut it = chunk.into_iter();
+        let Some(TokenTree::Literal(lit)) = it.next() else {
+            continue;
+        };
+        let Some(key) = strip_str_literal(&lit.to_string()) else {
+            continue;
+        };
+        let has_colon = matches!(it.next(), Some(TokenTree::Punct(p)) if p.as_char() == ':');
+        if has_colon {
+            keys.insert(key);
+        }
+    }
+    Some(keys)
+}
+
+/// Recursively find every `json!`/`serde_json::json!`-shaped invocation
+/// reachable in `tokens` (any qualifying path prefix -- only the segment right
+/// before the `!` is checked), returning one keyset per `{...}`-shaped
+/// argument found (a non-object argument contributes no keyset, not an
+/// error). Descends into every group along the way, both to find a `json!`
+/// call nested inside another expression's tokens and to find one hidden
+/// inside a closure, `.map(...)`, or match arm.
+fn find_json_object_keysets(tokens: TokenStream) -> Vec<BTreeSet<String>> {
+    let mut out = Vec::new();
+    let toks: Vec<TokenTree> = tokens.into_iter().collect();
+    let mut i = 0;
+    while i < toks.len() {
+        if let TokenTree::Ident(id) = &toks[i] {
+            if id == "json" && i + 2 < toks.len() {
+                if let TokenTree::Punct(bang) = &toks[i + 1] {
+                    if bang.as_char() == '!' {
+                        if let TokenTree::Group(g) = &toks[i + 2] {
+                            match object_literal_keys(g.stream()) {
+                                Some(keys) => out.push(keys),
+                                None => out.extend(find_json_object_keysets(g.stream())),
+                            }
+                            i += 3;
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+        if let TokenTree::Group(g) = &toks[i] {
+            out.extend(find_json_object_keysets(g.stream()));
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Every `json!` object-literal keyset reachable from `output`'s `to_json`,
+/// including through free functions it references by name (fixpoint,
+/// cycle-guarded).
+fn reachable_keysets(
+    output: &str,
+    outputs: &BTreeMap<String, TokenStream>,
+    fns: &BTreeMap<String, Vec<TokenStream>>,
+) -> Vec<BTreeSet<String>> {
+    let Some(body) = outputs.get(output) else {
+        return Vec::new();
+    };
+    let mut keysets = find_json_object_keysets(body.clone());
+    let mut seen_fns: BTreeSet<String> = BTreeSet::new();
+    let mut frontier: Vec<TokenStream> = vec![body.clone()];
+    while let Some(tokens) = frontier.pop() {
+        for name in bare_idents(tokens) {
+            if seen_fns.contains(&name) {
+                continue;
+            }
+            if let Some(bodies) = fns.get(&name) {
+                seen_fns.insert(name);
+                for b in bodies {
+                    keysets.extend(find_json_object_keysets(b.clone()));
+                    frontier.push(b.clone());
+                }
+            }
+        }
+    }
+    keysets
+}
+
+/// Compare each declared `emits` entry in `manifest` against the `to_json`
+/// bodies found in `cli_srcs` (every non-`api.rs` CLI source file) and the
+/// struct inventory found in `api_src` (`cli/src/api.rs`, the same walk
+/// `field_parity::violations` uses). Pure: same inputs, same output.
+pub fn violations(
+    api_src: &str,
+    cli_srcs: &[(&str, &str)],
+    manifest: &Value,
+) -> Vec<EmitViolation> {
+    let mut out = Vec::new();
+
+    let structs = field_parity::walk_structs(api_src);
+    let struct_index: BTreeMap<&str, &CollectedStruct> =
+        structs.iter().map(|s| (s.name.as_str(), s)).collect();
+
+    let mut collector = OutputCollector::default();
+    for (_, src) in cli_srcs {
+        // A file this gate cannot parse contributes nothing; a manifest entry
+        // whose output only lives there then fails closed via OutputNotFound
+        // below, the same fail-closed shape field_parity's walk relies on.
+        if let Ok(file) = syn::parse_file(src) {
+            collector.visit_file(&file);
+        }
+    }
+
+    let empty: Vec<Value> = Vec::new();
+    let entries: &[Value] = manifest
+        .get("emits")
+        .and_then(|v| v.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or(&empty);
+
+    for entry in entries {
+        let output = entry.get("output").and_then(|v| v.as_str());
+        let struct_name = entry.get("struct").and_then(|v| v.as_str());
+        let (Some(output), Some(struct_name)) = (output, struct_name) else {
+            out.push(EmitViolation::MalformedManifestEntry {
+                detail: format!("emits entry missing output or struct: {entry}"),
+            });
+            continue;
+        };
+
+        if !collector.outputs.contains_key(output) {
+            out.push(EmitViolation::OutputNotFound {
+                output: output.to_string(),
+            });
+            continue;
+        }
+        let Some(s) = struct_index.get(struct_name) else {
+            out.push(EmitViolation::StructNotFound {
+                output: output.to_string(),
+                struct_name: struct_name.to_string(),
+            });
+            continue;
+        };
+
+        let keysets = reachable_keysets(output, &collector.outputs, &collector.fns);
+
+        let mut suppressed: BTreeSet<String> = BTreeSet::new();
+        if let Some(omissions) = entry.get("omissions").and_then(|o| o.as_array()) {
+            for om in omissions {
+                let Some(field) = om.get("field").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                suppressed.insert(field.to_string());
+                let why = om.get("why").and_then(|v| v.as_str()).unwrap_or("").trim();
+                let covered_anyway = keysets.iter().any(|ks| ks.contains(field));
+                let dishonest = why.is_empty() || !s.wire_fields.contains(field) || covered_anyway;
+                if dishonest {
+                    out.push(EmitViolation::StaleOmission {
+                        output: output.to_string(),
+                        struct_name: struct_name.to_string(),
+                        field: field.to_string(),
+                    });
+                }
+            }
+        }
+
+        let non_omitted: BTreeSet<&String> = s
+            .wire_fields
+            .iter()
+            .filter(|f| !suppressed.contains(f.as_str()))
+            .collect();
+
+        // A SINGLE keyset must cover every non-omitted field -- coverage
+        // scattered across several unrelated `json!` literals in the same
+        // `to_json` does not count, since that would let two coincidentally
+        // matching key names in unrelated objects "cover" each other.
+        let best = keysets.iter().max_by_key(|ks| {
+            non_omitted
+                .iter()
+                .filter(|f| ks.contains(f.as_str()))
+                .count()
+        });
+        let missing: Vec<&String> = match best {
+            Some(ks) => non_omitted
+                .iter()
+                .filter(|f| !ks.contains(f.as_str()))
+                .copied()
+                .collect(),
+            None => non_omitted.iter().copied().collect(),
+        };
+        for field in missing {
+            out.push(EmitViolation::MissingField {
+                output: output.to_string(),
+                struct_name: struct_name.to_string(),
+                field: field.clone(),
+            });
+        }
+    }
+
+    out
+}

--- a/cli/tests/support/field_parity.rs
+++ b/cli/tests/support/field_parity.rs
@@ -79,10 +79,14 @@ pub enum Violation {
 /// One `Deserialize` struct recovered from the source: its bare name, the set of
 /// wire field names (rename/rename_all/skip applied), and whether it has a
 /// `#[serde(flatten)]` field (which makes it undecomposable).
-struct CollectedStruct {
-    name: String,
-    wire_fields: BTreeSet<String>,
-    has_flatten: bool,
+///
+/// `pub(crate)` (rather than private): the emit-hop gate (#699,
+/// `support/emit_parity.rs`) reuses this exact struct inventory as the source
+/// of truth for a mirror struct's OWN fields, one hop upstream of its check.
+pub(crate) struct CollectedStruct {
+    pub(crate) name: String,
+    pub(crate) wire_fields: BTreeSet<String>,
+    pub(crate) has_flatten: bool,
 }
 
 /// serde attributes distilled from a field's (or container's) `#[serde(...)]`
@@ -246,7 +250,7 @@ impl<'ast> Visit<'ast> for StructCollector {
     }
 }
 
-fn walk_structs(rust_src: &str) -> Vec<CollectedStruct> {
+pub(crate) fn walk_structs(rust_src: &str) -> Vec<CollectedStruct> {
     let file = match syn::parse_file(rust_src) {
         Ok(f) => f,
         // A source we cannot parse yields no structs; the real-tree test would


### PR DESCRIPTION
## What

Extends the struct-level field-parity gate (#691) one hop downstream: `#691` proves a `cli/src/api.rs` mirror struct carries every field its API schema declares, but a `CliOutput::to_json` in `cli/src/commands.rs` (or a sibling file) can still hand-project that struct into a `serde_json::json!` literal and drop a field on the floor. The proof case was `VersionsOutput::to_json` dropping `Version.id`, fixed inline in #691's PR.

## Spike first, per the issue's own risk flag

The issue explicitly asked for a spike before committing to the full mechanism, since a `json!` macro argument is opaque to `syn` (never parsed into an `Expr` tree, unlike the struct-level gate's clean `Deserialize`-struct walk). I audited every `impl (crate::ui::)?CliOutput` in the CLI (34 `to_json` bodies across 8 files) by hand first, and found the actual hand-projection sites are narrow: only `VersionsOutput` (`Version`), `MemoryOutput` (`MemoryEntry`), and `ApprovalsOutput` (`ApprovalRecord`, via a delegated free fn `approval_record_json`) hand-project a mirror struct's fields into a literal. Everything else either constructs its own ad hoc CLI-owned fields, or delegates wholesale to a `Serialize` value (`serde_json::to_value`) or a shared schema-gated builder (`status_json`, `eval_json`) -- neither of those can drop a field by hand-picking one, so they need no `emits` entry.

That scoped the spike enough to prove tractable: a raw-token-stream walk (find `json`, `!`, `{...}` sequences, descending into every group) reliably recovers a `json!` object literal's keys regardless of whether it's a sibling statement, inside a closure, or delegated to a named free function. I built the full mechanism rather than a narrower manual audit.

## Approach

`cli/api-mirrors.json` gains an `emits` array: each entry declares an `(output, struct)` pair (a `CliOutput`-implementing type and the mirror struct it projects) plus any allowlisted, justified field omissions -- the same declared-omission shape as `mirrors`' omissions, not codegen.

- `cli/tests/support/emit_parity.rs` -- the comparator: locates every `impl CliOutput for X { fn to_json ... }` and every top-level `fn`, walks a `to_json`'s raw token stream (via `ToTokens::to_token_stream()`) for `json!`-shaped invocations, reads each `{...}`-shaped argument as a flat object literal, and follows a delegated free-function reference (fixpoint, cycle-guarded) so `approval_record_json`-style delegation is still seen. Requires a SINGLE keyset (not a union across several) to cover every non-omitted wire field, so two unrelated `json!` literals in the same `to_json` can't accidentally cover a struct between them.
- `cli/tests/api_emit_parity.rs` -- real-tree assertion (all three declared entries pass with their current, already-justified omissions) plus fixture-driven rejection cases: a deliberately reintroduced dropped field, a stale omission (blank `why`, wrong field name, or a field that turns out to be emitted anyway), a malformed/dangling manifest entry, and the delegated-free-function reachability case.
- `agentos dev emit-parity` (`cli/scripts/check-emit-parity.sh`) is the contributor entry point, riding `cargo test` like `field-parity` does. Regenerated `cli/command-manifest.json` and `apps/ui/src/generated/commandManifest.ts` for the new verb.
- No live drift found: the two apparent gaps (`Version.agent_id`, `MemoryEntry.version`) were already deliberate, already pinned by `json_emit_contract.rs`'s exact-match tests with their own justifying comments -- the `emits` omissions reuse that same reasoning verbatim.

## Deliberate scope limit

This gate is narrower than the struct-level one: it verifies every DECLARED `(output, struct)` pair stays honest, but unlike that gate's `UndeclaredStruct` check, it cannot discover a NEW projection on its own -- doing so would mean resolving, for an arbitrary closure/iterator-adapter chain, which concrete mirror struct type is flowing through it, which is real type inference a syntax-only `syn` walk can't give. `cli/tests/support/emit_parity.rs`'s module doc spells this out. A future mirror-struct projection that nobody declares an `emits` entry for is a gap this gate cannot see; closing it fully would need an actual type-checker, not a heavier `syn` walk.

Closes #699
Ref #691, #548