### PR TITLE
Fail an eval model sweep row loudly when a model never completes a turn

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1229,8 +1229,13 @@
         "type": "object"
       },
       "EvalModelSummary": {
-        "description": "A per-model rollup across the suite: pass-rate and total cost.\n\nThe model dimension of the matrix (issue #255): the same suite run across\nmodels is sliceable here into ``passed/total`` pass-rate and summed\n``cost_usd`` per model, so BYO-model work can compare which models a use case\ntolerates and at what cost. ``cost_usd`` is ``None`` when no case under this\nmodel reported a cost (e.g. the fake-model path), rather than a misleading 0.\n\n``plumbing`` counts the rows that ran but were never graded (ADR-0055). They\nare excluded from ``passed``/``total``: counted as passes the fake model reads\n100% and counted as fails it reads 0%, both fabricated. The count keeps those\nrows visible instead of silently dropping them, so a model whose only rows are\nplumbing still appears with ``total == 0``.",
+        "description": "A per-model rollup across the suite: pass-rate and total cost.\n\nThe model dimension of the matrix (issue #255): the same suite run across\nmodels is sliceable here into ``passed/total`` pass-rate and summed\n``cost_usd`` per model, so BYO-model work can compare which models a use case\ntolerates and at what cost. ``cost_usd`` is ``None`` when no case under this\nmodel reported a cost (e.g. the fake-model path), rather than a misleading 0.\n\n``plumbing`` counts the rows that ran but were never graded (ADR-0055). They\nare excluded from ``passed``/``total``: counted as passes the fake model reads\n100% and counted as fails it reads 0%, both fabricated. The count keeps those\nrows visible instead of silently dropping them, so a model whose only rows are\nplumbing still appears with ``total == 0``.\n\n``completed`` counts the graded rows (within ``total``) whose turn actually\nreached a verdict, as opposed to a graded FAIL that never completed at all\n(a classified failure, a turn that ended in the wrong terminal status, or a\ntransport/runner exception -- see ``EvalCaseResult.error`` in the worker).\n``total`` alone cannot tell a real 0% (every case completed and the grader\nsaid no) apart from a model that never produced one completed turn (issue\n#622, #526 AC4): a model whose id does not resolve, or whose runner boots but\nnever answers, drives every case through the SAME classified-failure path a\nreal model's bad answer never touches. A sweep row with ``total > 0`` and\n``completed == 0`` is that distinct outcome, not a real (if unlucky) 0%.",
         "properties": {
+          "completed": {
+            "default": 0,
+            "title": "Completed",
+            "type": "integer"
+          },
           "cost_usd": {
             "anyOf": [
               {

--- a/apps/api/src/agentos_api/evals.py
+++ b/apps/api/src/agentos_api/evals.py
@@ -48,6 +48,29 @@ def _is_graded(trace: dict[str, Any]) -> bool:
     return _outcome_of(trace) in ("pass", "fail")
 
 
+def _completed(trace: dict[str, Any]) -> bool:
+    """Did this case's turn actually reach a graded verdict?
+
+    A graded ``pass`` is always a completion. A graded ``fail`` is ambiguous on
+    its own: the worker (``EvalCaseResult``) sets ``error`` on a FAIL precisely
+    when the turn never completed -- a classified failure, a terminal status
+    that did not match what the case expected, or a transport/runner exception
+    -- and leaves it unset when the turn completed cleanly and the grader simply
+    said no. Reading ``error`` is what turns "0/5 (0%)" into two distinguishable
+    outcomes: a model that answered wrong five times, and a model that never
+    answered at all (issue #622, #526 AC4). Not called for a non-graded
+    (plumbing/missing) trace, so a pre-#606 trace with no ``error`` key at all
+    (or none written) reads as completed by omission -- there is nothing in a
+    legacy trace to say otherwise.
+    """
+    outcome = _outcome_of(trace)
+    if outcome == "pass":
+        return True
+    if outcome == "fail":
+        return not (trace.get("metadata") or {}).get("error")
+    return False
+
+
 def _version_of(trace: dict[str, Any]) -> str | None:
     metadata = trace.get("metadata") or {}
     version = metadata.get("version")
@@ -192,9 +215,17 @@ def _model_summaries(
     are surfaced rather than dropped. The exclusion is per row, not per model: a
     model with real graded rows keeps its true pass-rate even when a plumbing row
     shares its label.
+
+    ``completed`` is a subset of ``total``: the graded rows whose turn actually
+    reached a verdict rather than tripping the completion gate (see
+    ``_completed``). A model with ``total > 0`` and ``completed == 0`` never
+    produced a single completed turn across the whole suite -- a categorically
+    different outcome from a real 0%, which the CLI reports distinctly and fails
+    on (issue #622).
     """
     passed: dict[str | None, int] = {}
     total: dict[str | None, int] = {}
+    completed: dict[str | None, int] = {}
     plumbing: dict[str | None, int] = {}
     cost: dict[str | None, float | None] = {}
     for (version, _case, model), trace in latest_by_model.items():
@@ -208,6 +239,8 @@ def _model_summaries(
             continue
         total[model] = total.get(model, 0) + 1
         passed[model] = passed.get(model, 0) + (1 if status == "pass" else 0)
+        if _completed(trace):
+            completed[model] = completed.get(model, 0) + 1
         case_cost = _cost_of(trace)
         if case_cost is not None:
             cost[model] = (cost.get(model) or 0.0) + case_cost
@@ -223,6 +256,7 @@ def _model_summaries(
             total=total.get(model, 0),
             cost_usd=cost.get(model),
             plumbing=plumbing.get(model, 0),
+            completed=completed.get(model, 0),
         )
         for model in keys
     ]

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -686,6 +686,17 @@ class EvalModelSummary(BaseModel):
     100% and counted as fails it reads 0%, both fabricated. The count keeps those
     rows visible instead of silently dropping them, so a model whose only rows are
     plumbing still appears with ``total == 0``.
+
+    ``completed`` counts the graded rows (within ``total``) whose turn actually
+    reached a verdict, as opposed to a graded FAIL that never completed at all
+    (a classified failure, a turn that ended in the wrong terminal status, or a
+    transport/runner exception -- see ``EvalCaseResult.error`` in the worker).
+    ``total`` alone cannot tell a real 0% (every case completed and the grader
+    said no) apart from a model that never produced one completed turn (issue
+    #622, #526 AC4): a model whose id does not resolve, or whose runner boots but
+    never answers, drives every case through the SAME classified-failure path a
+    real model's bad answer never touches. A sweep row with ``total > 0`` and
+    ``completed == 0`` is that distinct outcome, not a real (if unlucky) 0%.
     """
 
     model: str | None = None
@@ -693,6 +704,7 @@ class EvalModelSummary(BaseModel):
     total: int
     cost_usd: float | None = None
     plumbing: int = 0
+    completed: int = 0
 
     @property
     def pass_rate(self) -> float:

--- a/apps/api/tests/test_evals_unit.py
+++ b/apps/api/tests/test_evals_unit.py
@@ -156,9 +156,13 @@ def _otrace(
     outcome: str,
     model: str | None = None,
     passed: Any = ...,
+    error: str | None = None,
 ) -> dict[str, Any]:
     """A trace as the recorder writes it post-#606: an ``outcome`` alongside the
-    derived ``passed``. ``passed`` can be forced to prove which one the grid reads."""
+    derived ``passed``. ``passed`` can be forced to prove which one the grid reads.
+    ``error`` mirrors ``EvalCaseResult.error`` (#622): set on a FAIL trace whose
+    turn never completed (a classified failure, wrong terminal status, or a
+    transport/runner exception), left ``None`` for a FAIL the grader judged."""
     tags = ["eval", f"version:{version}", "suite:s"]
     if model:
         tags.append(f"model:{model}")
@@ -172,6 +176,7 @@ def _otrace(
         "outcome": outcome,
         "passed": passed,
         "model": model,
+        "error": error,
     }
     return {"id": tid, "timestamp": ts, "tags": tags, "metadata": meta}
 
@@ -280,3 +285,88 @@ def test_a_plumbing_row_does_not_dilute_its_own_model_pass_rate() -> None:
     assert opus.total == 1  # the plumbing row is not a denominator
     assert opus.pass_rate == 1.0
     assert opus.plumbing == 1
+
+
+def test_a_real_zero_percent_model_is_completed_but_not_passed() -> None:
+    """A model that answered every case wrong is still `total > 0, completed ==
+    total`: the negative control for #622. `passed == 0` alone must not be read
+    as "never completed"."""
+    traces = [
+        _otrace("o1", "shaA", "c1", "2026-07-01T00:00:00Z", "fail", "opus"),
+        _otrace("o2", "shaA", "c2", "2026-07-01T00:00:00Z", "fail", "opus"),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    opus = next(m for m in matrix.model_summaries if m.model == "opus")
+    assert opus.passed == 0
+    assert opus.total == 2
+    assert opus.completed == 2  # every case reached a verdict; it just lost
+
+
+def test_a_model_that_never_completed_a_turn_is_distinct_from_a_real_zero(
+) -> None:
+    """A FAIL whose turn never completed (classified failure, wrong terminal
+    status, a transport error) carries `error` in its metadata (issue #622).
+    `total > 0` and `completed == 0` is the "never answered" outcome the CLI
+    reports distinctly and fails on, not a real 0%."""
+    traces = [
+        _otrace(
+            "b1",
+            "shaA",
+            "c1",
+            "2026-07-01T00:00:00Z",
+            "fail",
+            "bogus-model-xyz",
+            error="runner reported a classified failure",
+        ),
+        _otrace(
+            "b2",
+            "shaA",
+            "c2",
+            "2026-07-01T00:00:00Z",
+            "fail",
+            "bogus-model-xyz",
+            error="runner reported a classified failure",
+        ),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    bogus = next(m for m in matrix.model_summaries if m.model == "bogus-model-xyz")
+    assert bogus.passed == 0
+    assert bogus.total == 2
+    assert bogus.completed == 0
+
+
+def test_a_partially_completed_model_counts_only_the_completed_rows() -> None:
+    """Mixed within one model: some cases complete (graded fail), some never do
+    (error set). `completed` counts only the former, so a model that is flaky
+    rather than wholly unresolvable is not miscategorized as never-completed."""
+    traces = [
+        _otrace("g1", "shaA", "c1", "2026-07-01T00:00:00Z", "fail", "flaky"),
+        _otrace(
+            "g2",
+            "shaA",
+            "c2",
+            "2026-07-01T00:00:00Z",
+            "fail",
+            "flaky",
+            error="turn ended classified-failure, expected status 'done'",
+        ),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    flaky = next(m for m in matrix.model_summaries if m.model == "flaky")
+    assert flaky.total == 2
+    assert flaky.completed == 1
+
+
+def test_legacy_traces_with_no_error_key_read_as_completed() -> None:
+    """A pre-#622 trace never wrote `error` at all; there is nothing in it to say
+    the turn did not complete, so it must not retroactively read as `completed ==
+    0` and trip the new outcome on historical data."""
+    traces = [_trace("t1", "shaA", "c1", "2026-07-01T00:00:00Z", passed=False)]
+    matrix = build_matrix(traces, "s", 5)
+
+    unlabelled = next(m for m in matrix.model_summaries if m.model is None)
+    assert unlabelled.total == 1
+    assert unlabelled.completed == 1

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -163,6 +163,14 @@ pub struct EvalTriggerResult {
 /// One per-model rollup of the eval matrix (`EvalModelSummary` in openapi.json):
 /// pass-rate and summed cost for a suite run under one model (#255/#526). `model`
 /// is `None` for the matrix's unlabelled column (a run with no resolved model).
+///
+/// `completed` is a subset of `total`: the graded rows whose turn actually
+/// reached a verdict, as opposed to a graded fail that never completed at all
+/// (a classified failure, the wrong terminal status, or a transport/runner
+/// exception). `total > 0 && completed == 0` is a model that never produced one
+/// completed turn across the whole suite -- distinct from a real 0%, which the
+/// sweep reports and fails on (#622, #526 AC4). `#[serde(default)]` keeps this
+/// tolerant of an API that predates the field.
 #[derive(Debug, Clone, Deserialize)]
 pub struct EvalModelSummary {
     #[serde(default)]
@@ -171,6 +179,8 @@ pub struct EvalModelSummary {
     pub total: u64,
     #[serde(default)]
     pub cost_usd: Option<f64>,
+    #[serde(default)]
+    pub completed: u64,
 }
 
 /// The eval matrix grid (`EvalMatrix` in openapi.json): `GET /evals/matrix`. The

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -16,7 +16,8 @@ use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
 use crate::bundle::pack_tar_gz;
 use crate::docker::{self, CheckSpec, StartSpec};
 use crate::evals::{
-    graded_answer, load_suite, outcome_label, rollup_line, turn_outcome, CaseOutcome, EvalSuite,
+    graded_answer, load_suite, outcome_label, rollup_line, turn_completed, turn_outcome,
+    CaseOutcome, EvalSuite,
 };
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
@@ -1902,7 +1903,10 @@ pub async fn eval(
     let client = RunnerClient::new(&url)?;
     let ui = crate::ui::ui();
     let bar = ui.progress_bar(suite.cases.len() as u64, "running evals");
-    let results = run_suite_cases(&client, &suite, fake, |_| bar.inc(1)).await?;
+    // `run_suite_cases` also tallies completion for the `--model` sweep path;
+    // the single-runner report doesn't need the count (it already reports the
+    // per-case `Fail` either way and exits on any of them), so it is discarded.
+    let (results, _completed) = run_suite_cases(&client, &suite, fake, |_| bar.inc(1)).await?;
     bar.finish();
 
     report_eval(&results)
@@ -1924,17 +1928,22 @@ fn drives_a_fake_runner(saved: Option<&state::RunnerState>, explicit_url: Option
 }
 
 /// Run every case in `suite` against a runner, returning `(id, outcome, seconds,
-/// output)` rows. `fake` says the runner is the fake model, in which case the
-/// cases are not graded at all. `on_case` is called once per completed case
-/// (progress). Shared by the single-runner path and the per-model sweep so both
-/// judge identically.
+/// output)` rows plus how many cases *completed* (reached a `final` matching
+/// `expect_status`, independent of whether the grader then agreed). `fake` says
+/// the runner is the fake model, in which case the cases are not graded at all.
+/// `on_case` is called once per completed case (progress). Shared by the
+/// single-runner path and the per-model sweep so both judge identically; the
+/// completed count is what lets the sweep tell a real 0% apart from a model
+/// that never produced one completed turn (#622, #526 AC4) -- `CaseOutcome`
+/// alone collapses both into the same `Fail`.
 async fn run_suite_cases(
     client: &RunnerClient,
     suite: &EvalSuite,
     fake: bool,
     mut on_case: impl FnMut(usize),
-) -> Result<Vec<EvalRow>> {
+) -> Result<(Vec<EvalRow>, usize)> {
     let mut results = Vec::with_capacity(suite.cases.len());
+    let mut completed = 0usize;
     for (i, case) in suite.cases.iter().enumerate() {
         // Fresh conversation by default (#550): reset the runner before a case so
         // it cannot answer from an earlier case's history instead of actually
@@ -1953,6 +1962,9 @@ async fn run_suite_cases(
             .send_event(EventType::EvalCase, &case.input, "U-eval", |_| {})
             .await?;
         let elapsed = started.elapsed().as_secs_f64();
+        if turn_completed(case, &events) {
+            completed += 1;
+        }
         // Capture the graded answer -- the exact text `turn_outcome` judged -- so
         // a red case can be diagnosed from `--json` without a manual re-run
         // (#548). A fake row carries its canned reply for the same reason.
@@ -1964,7 +1976,7 @@ async fn run_suite_cases(
         ));
         on_case(i);
     }
-    Ok(results)
+    Ok((results, completed))
 }
 
 /// Boot a throwaway runner for one model on `port`, forwarding the model
@@ -2063,7 +2075,7 @@ async fn eval_sweep(
         suite.cases.len()
     ));
     let cl = ui.checklist();
-    let mut rows: Vec<(String, usize, usize)> = Vec::with_capacity(models.len());
+    let mut rows: Vec<SweepRow> = Vec::with_capacity(models.len());
     for (i, model) in models.iter().enumerate() {
         let name = format!("agentos-eval-sweep-{i}");
         let port = DEFAULT_PORT + 100 + i as u16;
@@ -2080,58 +2092,145 @@ async fn eval_sweep(
         // REAL model whatever the standing dev runner is -- the sweep grades.
         let run = run_suite_cases(&client, suite, false, |_| {}).await;
         let _ = docker::remove_container(&name).await;
-        let results = run?;
+        let (results, completed) = run?;
         let passed = results
             .iter()
             .filter(|(_, o, _, _)| *o == CaseOutcome::Pass)
             .count();
-        step.done(&format!("{passed}/{}", suite.cases.len()));
-        rows.push((model.clone(), passed, suite.cases.len()));
+        let total = suite.cases.len();
+        // Immediate per-model feedback (#622): a model that never completed a
+        // single case is a boot/resolution problem, not a graded loss, so the
+        // checklist marks it failed rather than "done" with a misleading score.
+        if completed == 0 {
+            step.fail(&format!("0/{total} completed -- {model} never answered"));
+        } else {
+            step.done(&format!("{passed}/{total}"));
+        }
+        rows.push(SweepRow {
+            model: model.clone(),
+            passed,
+            completed,
+            total,
+        });
     }
     report_sweep(&rows)
 }
 
+/// One row of a `--model` sweep: how many of the suite's cases a model passed,
+/// how many *completed* (reached a final matching `expect_status`, whatever the
+/// grader then said -- see `evals::turn_completed`), and the suite total.
+/// `completed` is what tells a real 0% apart from a model that never produced
+/// one completed turn (issue #622, #526 AC4); `CaseOutcome` alone cannot, since
+/// `turn_outcome` collapses both into `Fail`. Shared by all three tiers: the
+/// skill sweep boots throwaway runners and grades in-CLI, local/cluster read
+/// the platform's `EvalModelSummary` -- `report_sweep` is the single point that
+/// renders and gates a sweep however its rows were produced.
+#[derive(Debug, Clone)]
+pub struct SweepRow {
+    pub model: String,
+    pub passed: usize,
+    pub completed: usize,
+    pub total: usize,
+}
+
+impl SweepRow {
+    /// A model that produced zero completed turns across the whole suite: the
+    /// distinct "never answered" outcome, not a real (if unlucky) 0%. Guarded on
+    /// `total > 0` so a row with no cases at all is never mistaken for this.
+    pub fn never_completed(&self) -> bool {
+        self.total > 0 && self.completed == 0
+    }
+
+    fn pass_rate(&self) -> f64 {
+        if self.total > 0 {
+            self.passed as f64 / self.total as f64
+        } else {
+            0.0
+        }
+    }
+}
+
 /// Render a model-sweep roll-up: pass-rate per model. Under `--json` the whole
 /// comparison is one payload; otherwise a table. A sweep is a comparison, not a
-/// gate, so it never exits non-zero on a model that scored below 100%.
-pub fn report_sweep(rows: &[(String, usize, usize)]) -> Result<()> {
+/// gate, so it never exits non-zero on a model that scored below 100% -- a real
+/// 0% still reports as `0/N (0%)` and exits `Ok`.
+///
+/// The one exception (#622, #526 AC4): a row whose model produced ZERO
+/// completed turns across the whole suite is not a comparison result at all --
+/// it means the model never answered (an unresolvable id, a missing credential,
+/// a runner that never came up for it), and reporting it as `0%` is
+/// indistinguishable from a real failing model. That row is rendered distinctly
+/// (never as a percentage) and turns the whole sweep into an `Err` naming every
+/// such model, so the caller's normal `?`-propagation exits non-zero at every
+/// tier without skipping any guard the caller still holds (a kept-alive
+/// port-forward at local/cluster) -- this function never calls
+/// `std::process::exit` itself.
+pub fn report_sweep(rows: &[SweepRow]) -> Result<()> {
     let ui = crate::ui::ui();
     if ui.json() {
         let models: Vec<serde_json::Value> = rows
             .iter()
-            .map(|(model, passed, total)| {
+            .map(|row| {
                 serde_json::json!({
-                    "model": model,
-                    "passed": passed,
-                    "total": total,
-                    "pass_rate": if *total > 0 { *passed as f64 / *total as f64 } else { 0.0 },
+                    "model": row.model,
+                    "passed": row.passed,
+                    "completed": row.completed,
+                    "total": row.total,
+                    "never_completed": row.never_completed(),
+                    // Withheld (null) rather than a fabricated 0.0 on a
+                    // never-completed row: there is no comparison to rate.
+                    "pass_rate": if row.never_completed() { None } else { Some(row.pass_rate()) },
                 })
             })
             .collect();
         ui.emit_json(&serde_json::json!({ "sweep": models }));
+    } else {
+        let table: Vec<Vec<String>> = rows
+            .iter()
+            .map(|row| {
+                let rate = if row.never_completed() {
+                    "NEVER COMPLETED".to_string()
+                } else {
+                    format!("{:.0}%", row.pass_rate() * 100.0)
+                };
+                vec![
+                    row.model.clone(),
+                    format!("{}/{}", row.passed, row.total),
+                    rate,
+                ]
+            })
+            .collect();
+        ui.payload_plain(&crate::ui::table(
+            &["model", "passed", "pass rate"],
+            &table,
+            &[1, 2],
+        ));
+    }
+
+    let never_completed: Vec<&SweepRow> = rows.iter().filter(|r| r.never_completed()).collect();
+    if never_completed.is_empty() {
         return Ok(());
     }
-    let table: Vec<Vec<String>> = rows
+    // Name the model AND the likely cause -- the whole point of #622 is that
+    // this must not read like a graded 0%, and must not point at the eval
+    // consumer the way the local/cluster sweep timeout used to (#526's AC4).
+    let detail = never_completed
         .iter()
-        .map(|(model, passed, total)| {
-            let rate = if *total > 0 {
-                *passed as f64 / *total as f64 * 100.0
-            } else {
-                0.0
-            };
-            vec![
-                model.clone(),
-                format!("{passed}/{total}"),
-                format!("{rate:.0}%"),
-            ]
-        })
-        .collect();
-    ui.payload_plain(&crate::ui::table(
-        &["model", "passed", "pass rate"],
-        &table,
-        &[1, 2],
-    ));
-    Ok(())
+        .map(|r| format!("{} (0/{} completed)", r.model, r.total))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(anyhow::Error::from(
+        crate::exit::CliError::failure(format!(
+            "{detail}: produced zero completed turns across the suite. This is not a real 0% \
+             score -- the model most likely never resolved (a typo'd or unregistered id, a \
+             missing/invalid credential, or a runner that never came up for it), so the sweep is \
+             failing loudly instead of reporting a comparison that never happened."
+        ))
+        .with_fix(
+            "verify each named model's id and credential (or its BYO endpoint registration), \
+             then re-run the sweep",
+        ),
+    ))
 }
 
 /// Render a finished eval run identically for every tier (`skill`, `local`,
@@ -3986,13 +4085,75 @@ pub fn skill_memory_unavailable() -> anyhow::Error {
 mod tests {
     use super::{
         absent_container_note, merge_secret_env, parse_manifest_gates, plan_recorded_state,
-        plan_recorded_teardown, plan_skill_down, replace_first_line, resolve_cases_path,
-        seed_env_if_missing, select_in_force_deployment, select_passthrough_env,
-        validate_slack_channel, ApprovalGateDecl, DownPlan, EnvSeed, RecordedStatePlan,
-        RecordedTeardown,
+        plan_recorded_teardown, plan_skill_down, replace_first_line, report_sweep,
+        resolve_cases_path, seed_env_if_missing, select_in_force_deployment,
+        select_passthrough_env, validate_slack_channel, ApprovalGateDecl, DownPlan, EnvSeed,
+        RecordedStatePlan, RecordedTeardown, SweepRow,
     };
     use serde::Deserialize;
     use std::path::{Path, PathBuf};
+
+    fn row(model: &str, passed: usize, completed: usize, total: usize) -> SweepRow {
+        SweepRow {
+            model: model.into(),
+            passed,
+            completed,
+            total,
+        }
+    }
+
+    #[test]
+    fn never_completed_requires_a_nonempty_row_with_zero_completions() {
+        // The distinct #622 outcome: cases ran, none completed.
+        assert!(row("bogus", 0, 0, 5).never_completed());
+        // A real 0% (every case completed and lost on the grader) is NOT this
+        // outcome -- the negative control the acceptance criteria calls out.
+        assert!(!row("opus", 0, 5, 5).never_completed());
+        // A model that completed and passed some cases is obviously not this
+        // outcome either.
+        assert!(!row("opus", 3, 5, 5).never_completed());
+        // An empty row (no cases at all) must not be misread as never-completed;
+        // there is nothing to have failed to complete.
+        assert!(!row("opus", 0, 0, 0).never_completed());
+    }
+
+    #[test]
+    fn a_real_zero_percent_model_still_exits_ok_and_reports_zero_percent() {
+        // Negative control (acceptance criterion 4): a model that legitimately
+        // scores 0% -- every case completed, the grader just disagreed -- must
+        // still report 0% and exit 0. A sweep stays a comparison, not a gate.
+        let rows = vec![row("opus", 0, 5, 5), row("sonnet", 2, 5, 5)];
+        assert!(report_sweep(&rows).is_ok());
+    }
+
+    #[test]
+    fn a_model_with_zero_completed_turns_fails_the_sweep_loudly() {
+        // The bug this issue fixes: an unresolvable model must not read as an
+        // indistinguishable 0%. `report_sweep` returns `Err` (never
+        // `std::process::exit` itself, so a caller's port-forward guard still
+        // drops via normal unwind) and the message names the model and a likely
+        // cause instead of the eval consumer.
+        let rows = vec![row("bogus-model-xyz", 0, 0, 5), row("opus", 3, 5, 5)];
+        let err = report_sweep(&rows).expect_err("a never-completed row must fail the sweep");
+        let msg = err.to_string();
+        assert!(msg.contains("bogus-model-xyz"), "{msg}");
+        assert!(!msg.contains("eval consumer"), "{msg}");
+        assert!(
+            msg.contains("never resolved") || msg.contains("zero completed turns"),
+            "{msg}"
+        );
+        let (class, _fix) = crate::exit::classify(&err);
+        assert_eq!(class, crate::exit::ExitClass::Failure);
+    }
+
+    #[test]
+    fn every_model_never_completed_still_names_every_one() {
+        let rows = vec![row("model-alpha", 0, 0, 3), row("model-beta", 0, 0, 3)];
+        let err = report_sweep(&rows).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("model-alpha"), "{msg}");
+        assert!(msg.contains("model-beta"), "{msg}");
+    }
 
     #[test]
     fn replace_clears_a_stale_record_for_the_very_container_it_replaces() {

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -213,7 +213,14 @@ pub fn turn_passes(case: &EvalCase, events: &[OutboundEvent]) -> bool {
 /// case). The one assertion the fake tier makes, and the gate the real path
 /// applies before the grader is ever consulted; a classified-failure or
 /// interrupted turn matches neither expected status, so it never completes.
-fn turn_completed(case: &EvalCase, events: &[OutboundEvent]) -> bool {
+///
+/// `pub` so a `--model` sweep can tally *completion* per case, independent of
+/// `CaseOutcome`: `turn_outcome` collapses "never completed" and "completed but
+/// graded wrong" into the same `Fail`, which is exactly the ambiguity a sweep
+/// row must not have (issue #622, #526 AC4) -- a model that produced zero
+/// completed turns across the whole suite is a categorically different outcome
+/// from one that completed turns and lost on the grader.
+pub fn turn_completed(case: &EvalCase, events: &[OutboundEvent]) -> bool {
     let Some(OutboundEvent::Final { status, .. }) = events.last() else {
         return false;
     };

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -2154,7 +2154,7 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
             let sha_present = matrix.versions.contains(&triggered_sha);
             let rows = scoped_rows(&matrix, &want);
             let ready: std::collections::BTreeSet<&str> =
-                rows.iter().map(|(m, _, _)| m.as_str()).collect();
+                rows.iter().map(|row| row.model.as_str()).collect();
             let missing = want
                 .iter()
                 .filter(|m| !ready.contains(**m))
@@ -2162,11 +2162,25 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
                 .collect::<Vec<_>>()
                 .join(", ");
             if !sha_present || rows.is_empty() {
+                // #622: this used to blame only the worker eval consumer, which
+                // pointed the operator at the wrong subsystem when the real
+                // cause is that a requested model never resolved -- an
+                // unbootable/unregistered id or a missing credential can make
+                // the worker's per-model job fail before it ever produces a
+                // single trace, so NOTHING for that model lands in the matrix
+                // at all (not even a graded "0%" row) and the sweep can only
+                // ever time out here. Name the pending model(s) and give both
+                // plausible causes; the eval consumer is one of two, not the
+                // only one.
                 bail!(
                     "timed out waiting for eval results for this run (sha {}); no requested \
-                     model landed (still pending: {missing}). Check the worker eval consumer \
-                     is running, or raise --timeout-secs.",
-                    &triggered_sha[..triggered_sha.len().min(8)]
+                     model landed within {}s (still pending: {missing}). This means either the \
+                     worker eval consumer is not running, or one or more of {missing} never \
+                     resolved (a typo'd/unregistered model id, or a missing/invalid credential) \
+                     so its job never produced a single trace. Check the eval consumer is \
+                     running, verify {missing}'s id/credential, or raise --timeout-secs.",
+                    &triggered_sha[..triggered_sha.len().min(8)],
+                    opts.timeout_secs,
                 );
             }
             ui.warn(&format!(
@@ -2184,16 +2198,24 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
 fn scoped_rows(
     matrix: &crate::api::EvalMatrix,
     want: &std::collections::BTreeSet<&str>,
-) -> Vec<(String, usize, usize)> {
+) -> Vec<crate::commands::SweepRow> {
     matrix
         .model_summaries
         .iter()
         .filter_map(|s| {
             let m = s.model.as_deref()?;
-            want.contains(m)
-                .then(|| (m.to_string(), s.passed as usize, s.total as usize))
+            want.contains(m).then(|| crate::commands::SweepRow {
+                model: m.to_string(),
+                passed: s.passed as usize,
+                // `completed` is what tells a real 0% apart from a model that
+                // never produced a completed turn (#622, #526 AC4); read
+                // straight off the platform's per-model rollup so local and
+                // cluster share the exact signal skill's in-CLI grading uses.
+                completed: s.completed as usize,
+                total: s.total as usize,
+            })
         })
-        .filter(|(_, _, total)| *total > 0)
+        .filter(|row| row.total > 0)
         .collect()
 }
 
@@ -2221,12 +2243,13 @@ fn sweep_ready_rows(
     matrix: &crate::api::EvalMatrix,
     triggered_sha: &str,
     want: &std::collections::BTreeSet<&str>,
-) -> Option<Vec<(String, usize, usize)>> {
+) -> Option<Vec<crate::commands::SweepRow>> {
     if !matrix.versions.iter().any(|v| v == triggered_sha) {
         return None;
     }
     let rows = scoped_rows(matrix, want);
-    let ready: std::collections::BTreeSet<&str> = rows.iter().map(|(m, _, _)| m.as_str()).collect();
+    let ready: std::collections::BTreeSet<&str> =
+        rows.iter().map(|row| row.model.as_str()).collect();
     want.iter().all(|m| ready.contains(m)).then_some(rows)
 }
 
@@ -3129,11 +3152,26 @@ mod tests {
     }
 
     fn model_summary(model: &str, passed: u64, total: u64) -> crate::api::EvalModelSummary {
+        // `completed` defaults to `total`: every one of these fixture rows models
+        // a normal graded run (every case reached a verdict), so it is not the
+        // #622 "never answered" outcome unless a test opts into that separately
+        // via `model_summary_never_completed`.
         crate::api::EvalModelSummary {
             model: Some(model.to_string()),
             passed,
             total,
             cost_usd: None,
+            completed: total,
+        }
+    }
+
+    fn model_summary_never_completed(model: &str, total: u64) -> crate::api::EvalModelSummary {
+        crate::api::EvalModelSummary {
+            model: Some(model.to_string()),
+            passed: 0,
+            total,
+            cost_usd: None,
+            completed: 0,
         }
     }
 
@@ -3175,8 +3213,8 @@ mod tests {
         );
         let rows = sweep_ready_rows(&m, "new-sha", &want).expect("all models landed for the run");
         assert_eq!(rows.len(), 2);
-        assert!(rows.iter().any(|(model, _, _)| model == "opus"));
-        assert!(rows.iter().any(|(model, _, _)| model == "sonnet"));
+        assert!(rows.iter().any(|row| row.model == "opus"));
+        assert!(rows.iter().any(|row| row.model == "sonnet"));
     }
 
     #[test]
@@ -3186,6 +3224,33 @@ mod tests {
         let want: std::collections::BTreeSet<&str> = ["opus", "sonnet"].into_iter().collect();
         let m = matrix(&["new-sha"], vec![model_summary("opus", 3, 3)]);
         assert!(sweep_ready_rows(&m, "new-sha", &want).is_none());
+    }
+
+    #[test]
+    fn a_local_cluster_row_for_a_model_that_never_completed_a_turn_is_ready_and_distinct() {
+        // #622 at the local/cluster tier: the platform matrix's `EvalModelSummary`
+        // for a model that never produced a completed turn reports `total > 0,
+        // completed == 0` (every case landed as a graded FAIL with `error` set --
+        // see `apps/api/src/agentos_api/evals.py::_completed`). The row still
+        // counts toward readiness (the sweep DID land, unlike the timeout path
+        // below), but `SweepRow::never_completed` reads it as the distinct
+        // outcome rather than a real 0%.
+        let want: std::collections::BTreeSet<&str> = ["bogus-model-xyz"].into_iter().collect();
+        let m = matrix(
+            &["new-sha"],
+            vec![model_summary_never_completed("bogus-model-xyz", 5)],
+        );
+        let rows = sweep_ready_rows(&m, "new-sha", &want)
+            .expect("a landed-but-all-failed row still satisfies readiness");
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].never_completed());
+        assert_eq!(rows[0].passed, 0);
+        assert_eq!(rows[0].total, 5);
+        // Feeding this row straight into the shared reporter fails the sweep
+        // loudly, exactly as the skill-tier row does -- same signal, same gate,
+        // regardless of which tier produced it.
+        let err = crate::commands::report_sweep(&rows).unwrap_err();
+        assert!(err.to_string().contains("bogus-model-xyz"));
     }
 
     #[tokio::test]

--- a/docs/adr/0067-eval-sweep-fails-loudly-on-zero-completed-turns.md
+++ b/docs/adr/0067-eval-sweep-fails-loudly-on-zero-completed-turns.md
@@ -1,0 +1,186 @@
+# 67. A `--model` sweep row with zero completed turns fails loudly instead of reporting 0%
+
+Date: 2026-07-21
+
+Status: Accepted
+
+Extends [ADR-0022](0022-eval-completeness-tier-parity-and-trace-promotion.md)
+(eval completeness) and sits alongside
+[ADR-0055](0055-the-fake-model-is-a-plumbing-fixture.md) (the fake tier's
+`plumbing_ok` third state); supersedes neither. Read
+[ADR-0041](0041-every-verb-is-answered-at-every-tier.md) for the exit-class
+boundary this ADR reuses (`Failure`, exit 1) and
+[ADR-0053](0053-expected-terminal-status-in-eval-cases.md) for the completion
+gate (`expect_status`) this decision reads without changing.
+
+Closes [#622](https://github.com/curie-eng/agentos/issues/622), the fourth
+acceptance criterion of [#526](https://github.com/curie-eng/agentos/issues/526)
+("a model that is not resolvable fails loudly rather than silently landing in
+the matrix's unlabelled column") that #526's closing commit did not actually
+implement. Related to [#606](https://github.com/curie-eng/agentos/issues/606)
+(a sealed sweep labelling fake rows with real model names) as the same family of
+defect — a sweep reporting a comparison it did not perform — but not settled
+together: #606 is the fake tier mislabelling a row; this is a real tier never
+producing one.
+
+## Context
+
+`agentos <skill|local|cluster> eval --model` runs an eval suite once per named
+model and reports a pass-rate per model (#526) so an operator can decide "can we
+move this skill to a cheaper model." There was no validation anywhere in the
+repo of whether a `--model` value names a model that actually resolves — and
+building one was explicitly the wrong fix to reach for, because the CLI cannot
+know the set of valid ids for a BYO model (#24, OpenRouter and native
+Anthropic-format endpoints). The sweep has to tell a real failing model apart
+from a typo'd one **using signal it already has**, not an allowlist.
+
+Traced for `--model bogus-model-xyz`: the runner boots and passes its health
+check (health never calls the model), so `wait_healthy` sees nothing wrong. The
+first turn then hits the SDK's model error, which `runner/src/agentos_runner/session.py`
+converts to a classified-failure `Final` **by design** — the ACI stream must
+always terminate in a final, so a raised SDK/transport error becomes a
+classified failure rather than a truncated, final-less stream. That design is
+correct and this ADR does not touch it. HTTP still returns 200, so the CLI's
+`send_event` sees success; `turn_passes`/`turn_outcome` (`cli/src/evals.rs`)
+correctly mark the case `Fail`, because the turn never reached `done`. Every
+case in the suite fails the same way, and the pre-#622 `report_sweep` rendered
+that as `bogus-model-xyz 0/5 0%` and exited 0 — by the sweep's own stated
+design, "a sweep is a comparison, not a gate, so it never exits non-zero on a
+model that scored below 100%." A typo'd model is indistinguishable from a real
+model that legitimately scored zero.
+
+At local/cluster the failure mode was worse, not better: it was a misleading
+20-interval timeout ("Check the worker eval consumer is running"). The
+platform's eval-stream consumer (`apps/worker/src/agentos_worker/eval/stream.py`,
+`_acquire_target`) provisions a fresh sandbox per triggered model; when
+provisioning itself fails (an unbootable or unregistered id, a bad credential),
+`_run_and_report` takes the `_report_failed` branch with an **empty** results
+list before `run_eval_suite`/the Langfuse recorder ever runs — so literally
+nothing is ever traced for that `(version, model)`. The CLI's poll loop
+(`cli/src/message.rs::eval_sweep`) never sees the triggered sha's row land and
+eventually times out, and the message it gave named only the eval consumer —
+the wrong subsystem when the actual cause is a model that never resolved.
+
+## Decision
+
+**A model that produced zero completed turns across the whole suite is a
+categorically distinct sweep outcome from a real (if unlucky) 0%, computed from
+completion, not from any list of valid model ids.**
+
+### 1. Completion is already a signal every tier has; it was just never carried past the per-case gate
+
+Every case is already graded through a completion gate before the grader is
+ever consulted (`turn_completed`/`_run_case`'s `expect_status` check): a case
+either reaches a `final` matching its expected status, or it does not. What
+#622 adds is *aggregating that gate's outcome per model*, across the whole
+suite, instead of discarding it once the per-case `Fail`/`Pass` verdict is
+computed:
+
+- **Skill tier** (`cli/src/commands.rs::run_suite_cases`): now returns, plus the
+  usual `(id, outcome, seconds, output)` rows, how many of the suite's cases
+  `turn_completed` (now `pub` in `cli/src/evals.rs`). `CaseOutcome` alone cannot
+  carry this: `turn_outcome` intentionally collapses "never completed" and
+  "completed but graded wrong" into the same `Fail` for the per-case report,
+  which is correct there and exactly the ambiguity a sweep row must not have.
+- **Local/cluster tier**: the worker already wrote `error` on a graded FAIL's
+  trace metadata precisely when the turn did not complete (a classified
+  failure, the wrong terminal status, or a transport/runner exception),
+  reserved and left empty for a turn that completed and simply lost on the
+  grader (`EvalCaseResult.error`, unchanged by this ADR). `apps/api/src/agentos_api/evals.py`
+  reads that pre-existing field to add a `completed` count to
+  `EvalModelSummary`/the eval matrix API — no new instrumentation in the
+  worker, only a new aggregate over data it already recorded.
+
+A row's `total > 0 && completed == 0` is the new outcome; `SweepRow` (shared
+Rust struct behind `cli/src/commands.rs::report_sweep`, the single point both
+the skill and the local/cluster `--model` sweep converge on) exposes it as
+`never_completed()`.
+
+### 2. `report_sweep` renders the outcome distinctly and fails the whole sweep, but never calls `std::process::exit` itself
+
+A never-completed row renders as `NEVER COMPLETED` (human table) or
+`"never_completed": true, "pass_rate": null` (`--json`) rather than a
+percentage — a comparison was never performed for that model, so no rate is
+printed for it, fabricated or otherwise. `report_sweep` then returns `Err`
+naming every offending model and the likely cause ("the model most likely
+never resolved: a typo'd or unregistered id, a missing/invalid credential, or a
+runner that never came up for it") instead of blaming the eval consumer, with a
+fix hint to verify the model id/credential.
+
+Returning `Err` — rather than calling `std::process::exit` the way
+`report_eval` does for a genuine per-case failure — is deliberate: `report_sweep`
+is called from both the skill-tier command (no cleanup owed) and the
+local/cluster `message::eval_sweep`, which may be holding a live `kubectl
+port-forward` guard for the whole poll. Exiting inside `report_sweep` would
+skip that guard's `Drop` the same way #751 already fixed for the approval-resume
+path. Returning `Err` lets ordinary `?`-propagation unwind through the caller,
+dropping its guards, before `main.rs`'s centralized error handler exits the
+process — `CliError::failure` (exit class `Failure`, exit 1; ADR-0021 decision
+1) is the class, since this is a genuine runtime failure, not a usage error and
+not a tier-absence.
+
+### 3. The local/cluster timeout message is fixed to name the model and both plausible causes
+
+Separately from the row-level outcome above, the pre-existing "no row landed at
+all within the timeout" bail message is rewritten to name the still-pending
+model(s) and state both causes plainly — the eval consumer not running, **or**
+one of the pending models never resolving so its job never produced a single
+trace — instead of pointing only at the eval consumer. This is the same
+underlying gap (an unresolvable model given no signal to explain itself) showing
+up as a different symptom at these two tiers, so it is fixed in the same change
+even though it is not gated by `SweepRow`/`never_completed()` (nothing landed in
+the matrix at all for this failure mode, so there is no row to compute
+`completed` from — the fix here is wording, not a new count).
+
+### 4. A real 0% is untouched
+
+A model that completed every case and lost every grader check still reports
+`0/N (0%)` and the sweep still exits 0 for it — `report_sweep`'s stated
+contract ("a sweep is a comparison, not a gate") holds for every row except the
+one this ADR carves out. No allowlist of model ids is introduced anywhere; the
+distinction is entirely a function of completion, which is why it survives a
+BYO model (#24) with no knowledge of what ids are valid.
+
+## Consequences
+
+- **A `--model` sweep that previously exited 0 on a fully-broken model now
+  exits 1**, at all three tiers, for that specific case only (`total > 0`,
+  `completed == 0` for at least one row). Any other sweep result — including a
+  real 0% — is unaffected.
+- **`EvalModelSummary` (`apps/api/src/agentos_api/schemas.py`,
+  `cli/src/api.rs`) gains a `completed: int = 0` field**, backward-compatible
+  under `#[serde(default)]`/a Pydantic default the same way `plumbing` already
+  is; an API that predates the field reads as `completed = 0` for every row,
+  which degrades toward the new "distinct outcome" reading rather than silently
+  misreporting a pass rate. This mirrors an accepted, pre-existing skew class in
+  this codebase (`plumbing`'s own default), not a new one.
+- **No `GraderKind`, no `ExpectedStatus`, no allowlist.** The frozen eval-case
+  format (ADR-0019) is untouched; this is a *result*-shape change (a new
+  aggregate field on a summary type), not a case-shape change.
+- **`#606` remains open and separate.** A sealed/fake sweep mislabelling rows
+  with real model names is a different defect (a labelling problem on a
+  non-graded row) from this one (a real-tier row that never completed); fixing
+  both in one PR was considered and rejected as scope creep once it was clear
+  neither shared an implementation once this ADR's mechanism (`SweepRow`,
+  `completed`) was in place.
+
+## Alternatives considered
+
+- **A model allowlist checked before the sweep boots.** Rejected per the issue's
+  own framing: it is brittle against BYO models (#24), where the CLI has no way
+  to know the valid id set, and it would need to be kept in sync with every
+  provider's catalog by hand.
+- **Widen `CaseOutcome` with a fourth per-case variant (e.g. `NeverCompleted`).**
+  Rejected: it would change the single-case report's shape
+  (`eval_json`/`report_eval`, the schema-gated `cli/schema/eval.schema.json`)
+  for a distinction that only matters in aggregate, across a whole suite run
+  for one model. The per-case report already correctly calls a non-completed
+  case `Fail` (ADR-0055's rule 2, "a fake turn that does not complete is still a
+  failure," generalizes the same way for a real turn); the new signal belongs at
+  the row level, not the case level.
+- **Call `std::process::exit` directly inside `report_sweep`, matching
+  `report_eval`.** Rejected: `report_sweep` is shared by the local/cluster path,
+  which may be holding a live port-forward guard for the duration of the poll
+  loop; exiting inside the shared function would skip that guard's `Drop` the
+  way #751 already had to fix once for the approval-resume path. Returning `Err`
+  keeps the guard-then-exit ordering structural.

--- a/docs/adr/0068-eval-sweep-fails-loudly-on-zero-completed-turns.md
+++ b/docs/adr/0068-eval-sweep-fails-loudly-on-zero-completed-turns.md
@@ -1,4 +1,4 @@
-# 67. A `--model` sweep row with zero completed turns fails loudly instead of reporting 0%
+# 68. A `--model` sweep row with zero completed turns fails loudly instead of reporting 0%
 
 Date: 2026-07-21
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,4 +96,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0064 | [Fail-forward cluster teardown](0064-fail-forward-cluster-teardown.md) | Accepted |
 | 0065 | [Tag protection, not the workflow gate, binds a write actor](0065-tag-protection-not-the-workflow-gate-binds-a-write-actor.md) | Accepted |
 | 0066 | [A skip propagates through the whole ancestor graph, so every publishing job carries its own guard](0066-a-skip-propagates-through-the-whole-ancestor-graph.md) | Accepted |
+| 0067 | [A `--model` sweep row with zero completed turns fails loudly instead of reporting 0%](0067-eval-sweep-fails-loudly-on-zero-completed-turns.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,5 +96,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0064 | [Fail-forward cluster teardown](0064-fail-forward-cluster-teardown.md) | Accepted |
 | 0065 | [Tag protection, not the workflow gate, binds a write actor](0065-tag-protection-not-the-workflow-gate-binds-a-write-actor.md) | Accepted |
 | 0066 | [A skip propagates through the whole ancestor graph, so every publishing job carries its own guard](0066-a-skip-propagates-through-the-whole-ancestor-graph.md) | Accepted |
-| 0067 | [A `--model` sweep row with zero completed turns fails loudly instead of reporting 0%](0067-eval-sweep-fails-loudly-on-zero-completed-turns.md) | Accepted |
+| 0068 | [A `--model` sweep row with zero completed turns fails loudly instead of reporting 0%](0068-eval-sweep-fails-loudly-on-zero-completed-turns.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
## Summary

A `--model` sweep row whose model produced zero completed turns across the whole suite used to render as an indistinguishable `0%` and exit `0`, the same as a real model that legitimately failed every case (#526 AC4). At local/cluster this additionally surfaced as a misleading 20-interval timeout blaming only the worker eval consumer.

This aggregates the completion gate every case already goes through into a per-model `completed` count, threaded through `EvalModelSummary` at the platform layer (`apps/api`) and through `run_suite_cases` at the skill tier (`cli/src/evals.rs`, `cli/src/commands.rs`), with no allowlist of model ids anywhere so BYO models keep working. A row with `total > 0 && completed == 0` is now a distinct, non-percentage outcome that fails the sweep (`report_sweep` returns `Err`, never `std::process::exit` directly, so a local/cluster caller's port-forward guard still drops via normal unwind) and names the model plus the likely cause. A real 0% (every case completed, the grader just disagreed) still reports as `0%` and still exits `0` -- a sweep stays a comparison, not a gate.

The local/cluster sweep's "nothing landed within the timeout" message is also rewritten to name the pending model(s) and state both plausible causes (the eval consumer not running, or one of the pending models never resolving) instead of pointing only at the eval consumer.

Also decided in ADR-0068 (`docs/adr/0068-eval-sweep-fails-loudly-on-zero-completed-turns.md`).

#606 (a sealed sweep labelling fake rows with real model names) is the same family of defect but a different mechanism (a labelling problem on a non-graded row vs. a real-tier row that never completes); left open and separate rather than folded in here.

## Test plan

- [x] `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` (all green, including new unit tests for `SweepRow::never_completed`, the real-0% negative control, the never-completed-row failure, and a local/cluster-tier matrix-row simulation)
- [x] `cargo test --test api_field_parity` (the new `EvalModelSummary.completed` field mirrors cleanly)
- [x] `uv run pytest apps/api/tests/test_evals_unit.py apps/api/tests/test_evals_report.py apps/api/tests/test_openapi_drift.py apps/api/tests/test_eval_case_schema_parity.py apps/api/tests/test_promote_eval_case.py -q` (new tests cover the real-0%-is-still-completed case, the never-completed case, a partially-completed model, and legacy traces with no `error` key)
- [x] `uv run pytest apps/worker/tests/eval -q` (unaffected, unmodified)
- [x] `bash scripts/check-docs.sh` (ADR index regenerated, citations resolve)
- [x] `uv run python -m agentos_api.export_openapi` (committed `openapi.json` regenerated for the new field)

Closes #622
Ref #526, #606, #24
