### PR TITLE
Gate the CLI's plugin_format hand-mirrors against the frozen schema

### DIFF
--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -158,6 +158,22 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   `cli/api-mirrors.json`** (as a `mirrors` entry with its allowlisted field
   omissions, or a `non_mirrors` entry with a one-line reason). `agentos dev
   field-parity` is the check (#691).
+- **A new `Deserialize` struct in `cli/src/commands.rs` or `cli/src/spec.rs`
+  that hand-mirrors the frozen `packages/plugin-format` manifest shape must be
+  declared in `cli/plugin-format-mirrors.json`** the same way (`mirrors` with
+  omissions, or `non_mirrors` with a reason) -- this is a SIBLING gate to the
+  one above, not the same one: the source of truth here is
+  `packages/plugin-format/schema/plugin-format.schema.json`, not
+  `apps/api/openapi.json`, since the two contracts are unrelated. `agentos dev
+  field-parity` (`cli/scripts/check-field-parity.sh`) runs both (#701). Beyond
+  the mechanical field sweep, `commands::parse_manifest_gates` additionally
+  validates a manifest that DECLARES an `approvalPolicy` against the full
+  frozen schema (`commands::validate_against_plugin_format_schema`) before
+  trusting the narrow `ManifestApprovals` read of it -- without that, a
+  manifest invalid in some unrelated modeled field (e.g. `commands: 123`)
+  would parse into the narrow shape untouched and `skill approvals` would
+  report gates as armed for a manifest the runner's own `PluginManifest`
+  parse rejects outright (closes ADR-0041's formerly-open known limitation).
 
 ## Verify
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -62,13 +62,18 @@ tokio = { version = "1", features = [
 ] }
 keyring = "4.1.5"
 rpassword = "7.5.4"
+# JSON Schema validation. Originally a test-only dependency for the agent-facing
+# `--json` contract gate (ADR-0021); promoted to a real dependency by #701 so
+# `skill_approvals` can validate a plugin manifest against the frozen
+# `packages/plugin-format` schema at runtime (`commands::parse_manifest_gates`),
+# closing the ADR-0041 known limitation without hand-mirroring every
+# `PluginManifest` field in Rust. Default features pull reqwest + a second TLS
+# stack for remote `$ref` resolution neither use case needs; the committed
+# schemas are self-contained, so keep it lean.
+jsonschema = { version = "0.48", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"
-# JSON Schema validation for the agent-facing --json contract gate (ADR-0021).
-# Default features pull reqwest + a second TLS stack for remote $ref resolution
-# we never use; the committed schemas are self-contained, so keep it lean.
-jsonschema = { version = "0.48", default-features = false }
 # The frozen ACI types are a normal dependency of the lib, but integration test
 # crates need them by name to build a SessionStatus for the status_json contract.
 agentos-aci-protocol = { path = "../packages/aci-protocol/generated/rust" }

--- a/cli/README.md
+++ b/cli/README.md
@@ -208,7 +208,7 @@ they error clearly -- a release binary has no dev scripts.
 | `agentos dev chart-check` | `bash charts/agentos/ci/render-assertions.sh` -- render-assert the Helm chart. |
 | `agentos dev e2e` | `bash cli/scripts/e2e.sh` -- the scripted CLI end-to-end test. |
 | `agentos dev e2e-ladder` | `bash cli/scripts/e2e-ladder.sh` -- the cold-start parity ladder (skill, local, cluster rungs). |
-| `agentos dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI api.rs mirror structs cover their platform API model fields (#691). |
+| `agentos dev field-parity` | `bash cli/scripts/check-field-parity.sh` -- assert CLI `api.rs` mirror structs cover their platform API model fields (#691), and CLI `commands.rs`/`spec.rs` mirror structs cover the frozen `packages/plugin-format` schema's fields (#701). |
 
 ## `skill` target: runner-only, fully offline
 

--- a/cli/plugin-format-mirrors.json
+++ b/cli/plugin-format-mirrors.json
@@ -1,0 +1,89 @@
+{
+  "_comment": "Declared hand-mirrors of the frozen packages/plugin-format schema (issue #701, the plugin_format sibling of #691's openapi.json gate; see packages/CLAUDE.md's frozen-contracts rule). Every Deserialize struct in cli/src/commands.rs and cli/src/spec.rs must appear in exactly one of mirrors or non_mirrors for its file. A mirrors entry names the plugin-format.schema.json $defs entry it mirrors and allowlists any field it deliberately does not carry, each with a why. A non_mirrors entry is a Deserialize struct that mirrors something OTHER than a plugin_format shape (a different local contract entirely) or whose field names deliberately diverge from the wire shape (an author-facing spec translated by scaffold.rs, not deserialized off a manifest), so field-by-field comparison does not apply to it. Check with: bash cli/scripts/check-field-parity.sh (rides agentos dev field-parity).",
+  "schema": "packages/plugin-format/schema/plugin-format.schema.json",
+  "mirrors": [
+    {
+      "struct": "ApprovalGateDecl",
+      "file": "cli/src/commands.rs",
+      "schema": "ApprovalGate",
+      "omissions": []
+    },
+    {
+      "struct": "ApprovalPolicyDecl",
+      "file": "cli/src/commands.rs",
+      "schema": "ApprovalPolicy",
+      "omissions": []
+    },
+    {
+      "struct": "ManifestApprovals",
+      "file": "cli/src/commands.rs",
+      "schema": "PluginManifest",
+      "omissions": [
+        { "field": "version", "why": "skill_approvals reports gate/route pairs only; the manifest's own declared version string has no output surface on this verb." },
+        { "field": "description", "why": "no approvals-verb output surfaces the bundle description." },
+        { "field": "author", "why": "no approvals-verb output surfaces manifest authorship." },
+        { "field": "homepage", "why": "no approvals-verb output surfaces a homepage URL." },
+        { "field": "repository", "why": "no approvals-verb output surfaces a source repository link." },
+        { "field": "license", "why": "no approvals-verb output surfaces a license identifier." },
+        { "field": "keywords", "why": "no approvals-verb output surfaces manifest keywords." },
+        { "field": "commands", "why": "no approvals-verb output surfaces the manifest's command list." },
+        { "field": "agents", "why": "no approvals-verb output surfaces the manifest's agent list." },
+        { "field": "hooks", "why": "hook wiring is a runner-boot concern; skill_approvals never reads or reports it." },
+        { "field": "mcpServers", "why": "declared MCP servers are surfaced by other verbs (skill check), not skill approvals." },
+        { "field": "systemPrompt", "why": "no approvals-verb output surfaces the agent's system prompt." },
+        { "field": "starterPrompts", "why": "no approvals-verb output surfaces starter prompts." },
+        { "field": "secrets", "why": "declared secret NAMES are surfaced by other verbs (skill up --secret), not skill approvals." },
+        { "field": "triggers", "why": "no approvals-verb output surfaces the manifest's trigger declarations." }
+      ]
+    },
+    {
+      "struct": "ApprovalGateSpec",
+      "file": "cli/src/spec.rs",
+      "schema": "ApprovalGate",
+      "omissions": []
+    },
+    {
+      "struct": "ApprovalPolicySpec",
+      "file": "cli/src/spec.rs",
+      "schema": "ApprovalPolicy",
+      "omissions": []
+    }
+  ],
+  "non_mirrors": [
+    {
+      "struct": "CheckReport",
+      "file": "cli/src/commands.rs",
+      "reason": "Mirrors the frozen agentos_runner.check report contract (parse_check_report), a different local contract entirely -- unrelated to plugin_format and out of scope for #701."
+    },
+    {
+      "struct": "DeclaredServer",
+      "file": "cli/src/commands.rs",
+      "reason": "A row of CheckReport.declared; same agentos_runner.check contract, not plugin_format."
+    },
+    {
+      "struct": "CheckMatch",
+      "file": "cli/src/commands.rs",
+      "reason": "A row of CheckReport.matches; same agentos_runner.check contract, not plugin_format."
+    },
+    {
+      "struct": "ForwardingVector",
+      "file": "cli/src/commands.rs",
+      "reason": "One row of the credential-forwarding cross-language test vector (#495, cli/tests/data/... fixture), unrelated to plugin_format."
+    },
+    {
+      "struct": "ForwardingVectors",
+      "file": "cli/src/commands.rs",
+      "reason": "The forwarding-vector file wrapper (#495); same unrelated fixture contract as ForwardingVector."
+    },
+    {
+      "struct": "SkillSpec",
+      "file": "cli/src/spec.rs",
+      "reason": "The agent-authoring spec's skill shape (name/description/allowed_tools/instructions). Field names are author-facing and deliberately diverge from SkillFrontmatter's wire shape (allowed_tools vs allowed-tools); scaffold.rs translates it into a SKILL.md frontmatter rather than this struct deserializing one, so it does not wire-mirror SkillFrontmatter."
+    },
+    {
+      "struct": "AgentSpec",
+      "file": "cli/src/spec.rs",
+      "reason": "The whole authored-agent spec shape (name/description/skills/connectors/secrets/approvalPolicy/evals) -- not a 1:1 mirror of any single plugin_format schema entry. Its own shape is held strict independently via #[serde(deny_unknown_fields)]."
+    }
+  ]
+}

--- a/cli/scripts/check-field-parity.sh
+++ b/cli/scripts/check-field-parity.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
-# Field-parity gate (#691): every `Deserialize` struct in cli/src/api.rs must
-# be declared in cli/api-mirrors.json (as a mirror or a non_mirror), and each
-# declared mirror struct must cover its API model's fields per
-# cli/api-mirrors.json's allowlisted omissions. See cli/tests/api_field_parity.rs.
+# Field-parity gate: every hand-mirror of a frozen contract in the CLI must be
+# declared and cover its source's fields.
+#  - cli/src/api.rs mirrors of the platform REST DTOs against the committed
+#    apps/api/openapi.json (#691, cli/api-mirrors.json,
+#    cli/tests/api_field_parity.rs).
+#  - cli/src/commands.rs + cli/src/spec.rs hand-mirrors of the frozen
+#    packages/plugin-format manifest shape (#701, the sibling seam #691
+#    explicitly did not cover: a different source of truth, the frozen
+#    package's own packages/plugin-format/schema/plugin-format.schema.json
+#    export, not openapi.json; cli/plugin-format-mirrors.json,
+#    cli/tests/plugin_format_field_parity.rs).
 set -euo pipefail
 
 cargo test --manifest-path cli/Cargo.toml --test api_field_parity -- --nocapture
+cargo test --manifest-path cli/Cargo.toml --test plugin_format_field_parity -- --nocapture

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3539,18 +3539,78 @@ struct ApprovalPolicyDecl {
 /// arms zero gates, so a narrower struct that parsed happily would report gates
 /// the runner never arms.
 ///
-/// KNOWN LIMITATION (ADR-0041): this validates only the approval-relevant subset
-/// of the manifest. The runner parses the WHOLE `PluginManifest`, so a manifest
-/// that is valid here but invalid in an unrelated modeled field (say `commands:
-/// 123`) makes `load_approval_policy` return `{}` -- the runner arms ZERO gates
-/// while this view still lists them. Closing that properly needs a shared or
-/// drift-gated manifest parser; hand-mirroring every `PluginManifest` field here
-/// would just add a second ungated mirror to drift.
+/// FORMERLY A KNOWN LIMITATION (ADR-0041), closed by #701: this struct still
+/// validates only the approval-relevant subset of the manifest -- `name` +
+/// `approvalPolicy` -- so on its own a manifest invalid in some OTHER modeled
+/// field (say `commands: 123`) would parse into it happily and report gates as
+/// armed for a manifest the runner's `PluginManifest.model_validate` rejects
+/// outright. `parse_manifest_gates` closes that gap by additionally validating
+/// the RAW manifest against the frozen `packages/plugin-format` JSON Schema
+/// (`validate_against_plugin_format_schema`) whenever `approvalPolicy` is
+/// declared -- the same condition under which the runner's
+/// `resolve_approval_policy` promotes to full-manifest validation (ADR-0041
+/// decision 1). That is schema-driven, not a hand-mirror of every
+/// `PluginManifest` field, so it tracks the frozen contract with no manual
+/// upkeep here. `cli/plugin-format-mirrors.json` + `agentos dev field-parity`
+/// (which now also runs `cli/tests/plugin_format_field_parity.rs`) separately
+/// gate that THIS struct's own fields (and its sibling mirrors in
+/// `cli/src/spec.rs`) stay honest about which `plugin_format` fields they
+/// cover.
 #[derive(Deserialize)]
 struct ManifestApprovals {
     name: Option<String>,
     #[serde(rename = "approvalPolicy")]
     approval_policy: Option<ApprovalPolicyDecl>,
+}
+
+/// The frozen `packages/plugin-format` JSON Schema (issue #701), embedded at
+/// compile time. Committed and drift-checked by `plugin-format`'s own
+/// `test_schema_compat.py` (the export is regenerated and diffed against this
+/// exact file at CI), so this constant tracks the frozen contract with zero
+/// manual upkeep on the Rust side: a schema change picks up automatically the
+/// next time the CLI is built against this checkout.
+const PLUGIN_FORMAT_SCHEMA: &str =
+    include_str!("../../packages/plugin-format/schema/plugin-format.schema.json");
+
+/// Validate a RAW parsed `.claude-plugin/plugin.json` body against the frozen
+/// `PluginManifest` schema (issue #701, sibling of #691 on the `plugin_format`
+/// seam).
+///
+/// `ManifestApprovals` deliberately reads only `name` + `approvalPolicy` (see
+/// its doc comment): hand-mirroring every `PluginManifest` field in Rust would
+/// itself be a second ungated mirror of a Python model, which is the drift
+/// class this repo already tracks elsewhere (ADR-0041). Validating the raw
+/// JSON against the committed schema instead means an invalid OTHER field
+/// (e.g. `commands: 123`) is caught here, matching the runner's
+/// `PluginManifest.model_validate` failing on the exact same input, without
+/// this Rust code needing to know that field exists at all.
+///
+/// Returns the joined validator error messages on failure so the CLI's error
+/// names the actual offending field/type rather than an approximation of one.
+fn validate_against_plugin_format_schema(
+    raw: &serde_json::Value,
+) -> std::result::Result<(), String> {
+    static VALIDATOR: std::sync::OnceLock<jsonschema::Validator> = std::sync::OnceLock::new();
+    let validator = VALIDATOR.get_or_init(|| {
+        let mut doc: serde_json::Value = serde_json::from_str(PLUGIN_FORMAT_SCHEMA).expect(
+            "packages/plugin-format/schema/plugin-format.schema.json is committed and valid JSON",
+        );
+        // The committed document's root is the bare `$defs` container (no
+        // `type`/`required` of its own); point the root at `PluginManifest`
+        // instead. Same document, same `$defs`, different entry point.
+        doc["$ref"] = serde_json::Value::String("#/$defs/PluginManifest".to_string());
+        jsonschema::validator_for(&doc)
+            .expect("plugin-format.schema.json's PluginManifest def compiles to a validator")
+    });
+    let errors: Vec<String> = validator
+        .iter_errors(raw)
+        .map(|e| format!("{e} (at instance path {})", e.instance_path()))
+        .collect();
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
 }
 
 /// Output of `skill approvals`: the bundle's declared gates, or the env
@@ -3690,15 +3750,33 @@ fn read_bundle_gates(plugin_dir: &Path) -> Result<Vec<(String, String)>> {
 /// subset, so this reports a usage error for both. `source` labels the manifest in
 /// errors. Shared by the skill tier (manifest on local disk) and the local/cluster
 /// tiers (manifest pulled from the deployed bundle over the API, #546) so both
-/// read gates identically.
+/// read gates identically. Also validates the raw manifest against the frozen
+/// `plugin_format` schema once a policy is declared (#701) -- see
+/// `validate_against_plugin_format_schema`.
 fn parse_manifest_gates(body: &str, source: &str) -> Result<Vec<(String, String)>> {
     let invalid = |problem: &str| {
         crate::exit::usage(format!(
             "invalid plugin manifest {source}: {problem}. The runner rejects this manifest and arms ZERO approval gates, including any well-formed ones"
         ))
     };
-    let manifest: ManifestApprovals =
+    let raw: serde_json::Value =
         serde_json::from_str(body).map_err(|e| invalid(&format!("not valid JSON ({e})")))?;
+    // #701: the runner only promotes to full-`PluginManifest` validation once
+    // `approvalPolicy` is actually declared (an absent or explicit-null policy
+    // returns the honest empty policy without reading the rest of the
+    // manifest, matching `resolve_approval_policy`'s early return). Mirror that
+    // gate exactly: only above this line would a manifest invalid in some
+    // OTHER field silently slip past, since `ManifestApprovals` below never
+    // looks at it.
+    if raw.get("approvalPolicy").is_some_and(|v| !v.is_null()) {
+        if let Err(detail) = validate_against_plugin_format_schema(&raw) {
+            return Err(invalid(&format!(
+                "manifest fails plugin_format schema validation ({detail})"
+            )));
+        }
+    }
+    let manifest: ManifestApprovals = serde_json::from_value(raw)
+        .map_err(|e| invalid(&format!("does not match the expected manifest shape ({e})")))?;
     if manifest.name.is_none() {
         return Err(invalid("missing the required `name` field"));
     }
@@ -4869,6 +4947,70 @@ mod tests {
                 .expect("an empty gates list is a valid declaration of no gates"),
             Vec::new()
         );
+    }
+
+    #[test]
+    fn parse_manifest_gates_refuses_a_manifest_invalid_in_an_unrelated_field() {
+        // NEGATIVE CONTROL for issue #701 (sibling of #691, ADR-0041's formerly
+        // "known limitation"). `ManifestApprovals` reads only `name` +
+        // `approvalPolicy`, so a manifest with a well-formed policy but a
+        // TYPE-INVALID unrelated modeled field (`commands` must be a string, a
+        // list of strings, or null per `plugin_format.models.PluginManifest`)
+        // used to parse straight through: this view would report `Bash` as
+        // armed while the runner's own `PluginManifest.model_validate` raises
+        // and refuses to boot with ANY of the declared gates armed -- the
+        // exact silent-drift class #691 closed on the api.rs seam, reproduced
+        // here on the plugin_format seam. Deleting
+        // `validate_against_plugin_format_schema`'s call in
+        // `parse_manifest_gates` makes this test fail (back to `Ok(vec![("Bash",
+        // "eng")])`).
+        let body = r#"{
+            "name": "deal-desk",
+            "commands": 123,
+            "approvalPolicy": {"gates": [{"gate": "Bash", "route": "eng"}]}
+        }"#;
+        let err = parse_manifest_gates(body, "test manifest").expect_err(
+            "a manifest invalid in an unrelated modeled field must not report gates as armed",
+        );
+        assert_eq!(usage_class(&err), crate::exit::ExitClass::Usage);
+    }
+
+    #[test]
+    fn parse_manifest_gates_tolerates_an_unmodeled_extra_field() {
+        // Positive control paired with the test above: `plugin_format`'s models
+        // are deliberately lenient (`extra="allow"`) so a real bundle carrying a
+        // field this schema does not model yet (e.g. a future Claude Code key)
+        // must still validate and report its gates -- the gate here is on TYPE
+        // validity of MODELED fields, never on the presence of an unmodeled one.
+        let body = r#"{
+            "name": "deal-desk",
+            "someFutureClaudeCodeKey": {"nested": true},
+            "approvalPolicy": {"gates": [{"gate": "Bash", "route": "eng"}]}
+        }"#;
+        assert_eq!(
+            parse_manifest_gates(body, "test manifest")
+                .expect("an unmodeled extra field must not be rejected"),
+            vec![("Bash".to_string(), "eng".to_string())]
+        );
+    }
+
+    #[test]
+    fn parse_manifest_gates_skips_full_validation_when_no_policy_is_declared() {
+        // A manifest with no `approvalPolicy` (or an explicit `null`) never
+        // reaches the runner's full-`PluginManifest` validation either (see
+        // `resolve_approval_policy`'s early return), so an unrelated
+        // type-invalid field must not be surfaced here -- there is no policy to
+        // falsely report as armed, so the honest answer stays the empty list.
+        for body in [
+            r#"{"name": "deal-desk", "commands": 123}"#,
+            r#"{"name": "deal-desk", "commands": 123, "approvalPolicy": null}"#,
+        ] {
+            assert_eq!(
+                parse_manifest_gates(body, "test manifest")
+                    .expect("no declared policy must not trip the full-manifest schema gate"),
+                Vec::new()
+            );
+        }
     }
 
     #[test]

--- a/cli/tests/data/plugin-format-parity/drifted-mirrors.json
+++ b/cli/tests/data/plugin-format-parity/drifted-mirrors.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Drifted fixture manifest for the plugin_format field-parity gate's rejection tests (issue #701). Paired with drifted-mirrors.rs; the real plugin-format.schema.json is reused unmodified since it is frozen and self-contained. `UndeclaredMirror` is deliberately absent from both lists below.",
+  "mirrors": [
+    {
+      "struct": "MissingFieldGate",
+      "file": "drifted-mirrors.rs",
+      "schema": "ApprovalGate",
+      "omissions": [
+        { "field": "grantableViaPolicy", "why": "fixture only exercises the MissingField case for `route`; grantableViaPolicy is allowlisted here to keep the assertion focused." }
+      ]
+    },
+    {
+      "struct": "PhantomFieldGate",
+      "file": "drifted-mirrors.rs",
+      "schema": "ApprovalGate",
+      "omissions": [
+        { "field": "grantableViaPolicy", "why": "fixture only exercises the UnknownField case for `ghost_field`; grantableViaPolicy is allowlisted here to keep the assertion focused." }
+      ]
+    }
+  ],
+  "non_mirrors": []
+}

--- a/cli/tests/data/plugin-format-parity/drifted-mirrors.rs
+++ b/cli/tests/data/plugin-format-parity/drifted-mirrors.rs
@@ -1,0 +1,30 @@
+// Fixture source for the plugin_format field-parity gate's rejection tests
+// (issue #701). Deliberately drifted from the real ApprovalGate schema so the
+// gate's assertions prove it rejects each drift class by execution, mirroring
+// how cli/tests/data/field-parity/drifted-api.rs proves the same for #691.
+
+use serde::Deserialize;
+
+/// Case 1: covers only `gate`, so the required `route` schema property is
+/// uncovered -> `MissingField`.
+#[derive(Deserialize)]
+struct MissingFieldGate {
+    gate: Option<String>,
+}
+
+/// Case 2: a `Deserialize` struct present in the source but declared in
+/// neither `mirrors` nor `non_mirrors` -> `UndeclaredStruct`.
+#[derive(Deserialize)]
+struct UndeclaredMirror {
+    name: Option<String>,
+}
+
+/// Case 3: carries a wire field (`ghost_field`) the schema does not define
+/// -> `UnknownField`. No allowlist path for this direction: a CLI field with
+/// no schema field behind it is always a bug.
+#[derive(Deserialize)]
+struct PhantomFieldGate {
+    gate: Option<String>,
+    route: Option<String>,
+    ghost_field: Option<String>,
+}

--- a/cli/tests/plugin_format_field_parity.rs
+++ b/cli/tests/plugin_format_field_parity.rs
@@ -1,0 +1,223 @@
+// Field-parity gate for the frozen `packages/plugin-format` hand-mirrors
+// (issue #701, the plugin_format sibling of #691's `cli/src/api.rs` gate --
+// #691 explicitly did not cover this seam, since it has a different source of
+// truth: the frozen package's own schema export, not `apps/api/openapi.json`).
+//
+// Reuses the EXACT SAME comparator #691 built
+// (`cli/tests/support/field_parity.rs`, included below via `#[path = ...]`,
+// same as `cli/tests/api_field_parity.rs`). That comparator is generic over
+// "a Rust source, a components.schemas-shaped Value, a mirrors/non_mirrors
+// manifest" -- so the only new work here is (a) wrapping
+// `packages/plugin-format/schema/plugin-format.schema.json`'s `$defs` into the
+// `components.schemas` shape the comparator expects, and (b) running it once
+// per source file (`cli/src/commands.rs`, `cli/src/spec.rs`), since the
+// plugin_format mirrors are split across both, filtering
+// `cli/plugin-format-mirrors.json`'s entries to each file's own slice.
+//
+// The comparator's own violation-class behavior (MissingField, StaleOmission,
+// UnsupportedShape/flatten, DuplicateStruct, MalformedManifestEntry, ...) is
+// already exhaustively fixture-tested by `cli/tests/api_field_parity.rs`; this
+// file does not re-prove that generic machinery. It proves: the real tree is
+// clean on THIS seam, the two issue-named silent-drift-prone mirror structs
+// stay fully covered, and the gate's own wiring (schema wrapping + per-file
+// manifest filtering) actually rejects a deliberately introduced drift.
+
+#[path = "support/field_parity.rs"]
+mod field_parity;
+
+use field_parity::{violations, Violation};
+use serde_json::Value;
+
+// ─── Loaders ─────────────────────────────────────────────────────────────────
+
+fn repo_text(rel: &str) -> String {
+    let path = format!("{}/../{}", env!("CARGO_MANIFEST_DIR"), rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn repo_json(rel: &str) -> Value {
+    let raw = repo_text(rel);
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {rel}: {e}"))
+}
+
+fn fixture_text(name: &str) -> String {
+    let path = format!(
+        "{}/tests/data/plugin-format-parity/{}",
+        env!("CARGO_MANIFEST_DIR"),
+        name
+    );
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+fn fixture_json(name: &str) -> Value {
+    let raw = fixture_text(name);
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {name}: {e}"))
+}
+
+/// Wrap the frozen `plugin_format` schema export's `$defs` into the
+/// `components.schemas` shape `field_parity::violations` expects (it was
+/// written against an OpenAPI doc's shape). `$defs` and `components.schemas`
+/// are structurally identical -- a map of schema name to `{properties,
+/// required, ...}` -- so no change to the shared comparator is needed.
+fn plugin_format_schema_as_components() -> Value {
+    let doc = repo_json("packages/plugin-format/schema/plugin-format.schema.json");
+    let defs = doc
+        .get("$defs")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+    serde_json::json!({ "components": { "schemas": defs } })
+}
+
+/// `cli/plugin-format-mirrors.json`'s mirrors/non_mirrors entries carry a
+/// `file` key the shared comparator does not look at (it only reads
+/// `struct`/`schema`/`reason`/`omissions`); slice the manifest down to just
+/// the entries for one source file so `violations` (which walks ONE rust
+/// source at a time) sees only the structs that could possibly be in it.
+fn manifest_for_file(manifest: &Value, file: &str) -> Value {
+    let filter = |key: &str| -> Vec<Value> {
+        manifest
+            .get(key)
+            .and_then(|v| v.as_array())
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter(|e| e.get("file").and_then(|f| f.as_str()) == Some(file))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    serde_json::json!({
+        "mirrors": filter("mirrors"),
+        "non_mirrors": filter("non_mirrors"),
+    })
+}
+
+// ─── Payload matchers (mirrors api_field_parity.rs's; variant + payload) ─────
+
+fn has_missing_field(vs: &[Violation], struct_name: &str, field: &str) -> bool {
+    vs.iter().any(|v| {
+        matches!(v, Violation::MissingField { struct_name: s, field: f, .. }
+            if s == struct_name && f == field)
+    })
+}
+
+fn has_unknown_field(vs: &[Violation], struct_name: &str, field: &str) -> bool {
+    vs.iter().any(|v| {
+        matches!(v, Violation::UnknownField { struct_name: s, field: f, .. }
+            if s == struct_name && f == field)
+    })
+}
+
+fn has_undeclared_struct(vs: &[Violation], struct_name: &str) -> bool {
+    vs.iter()
+        .any(|v| matches!(v, Violation::UndeclaredStruct { struct_name: s } if s == struct_name))
+}
+
+fn mentions_struct(vs: &[Violation], struct_name: &str) -> bool {
+    vs.iter().any(|v| match v {
+        Violation::MissingField { struct_name: s, .. }
+        | Violation::UnknownField { struct_name: s, .. }
+        | Violation::UndeclaredStruct { struct_name: s }
+        | Violation::StructNotFound { struct_name: s }
+        | Violation::StaleOmission { struct_name: s, .. }
+        | Violation::SchemaNotFound { struct_name: s, .. }
+        | Violation::DuplicateStruct { struct_name: s }
+        | Violation::UnsupportedShape { struct_name: s, .. } => s == struct_name,
+        Violation::MalformedManifestEntry { .. } => false,
+    })
+}
+
+// ─── Real-tree assertions ────────────────────────────────────────────────────
+
+#[test]
+fn commands_rs_has_no_plugin_format_field_parity_violations() {
+    let src = repo_text("cli/src/commands.rs");
+    let schema = plugin_format_schema_as_components();
+    let manifest = repo_json("cli/plugin-format-mirrors.json");
+    let scoped = manifest_for_file(&manifest, "cli/src/commands.rs");
+
+    let vs = violations(&src, &schema, &scoped);
+    assert!(
+        vs.is_empty(),
+        "cli/src/commands.rs has drifted from packages/plugin-format/schema/plugin-format.schema.json. \
+         Each entry below is fixed by either adding the field to the struct or declaring the \
+         omission (with a justification) in cli/plugin-format-mirrors.json:\n{vs:#?}"
+    );
+}
+
+#[test]
+fn spec_rs_has_no_plugin_format_field_parity_violations() {
+    let src = repo_text("cli/src/spec.rs");
+    let schema = plugin_format_schema_as_components();
+    let manifest = repo_json("cli/plugin-format-mirrors.json");
+    let scoped = manifest_for_file(&manifest, "cli/src/spec.rs");
+
+    let vs = violations(&src, &schema, &scoped);
+    assert!(
+        vs.is_empty(),
+        "cli/src/spec.rs has drifted from packages/plugin-format/schema/plugin-format.schema.json. \
+         Each entry below is fixed by either adding the field to the struct or declaring the \
+         omission (with a justification) in cli/plugin-format-mirrors.json:\n{vs:#?}"
+    );
+}
+
+#[test]
+fn approval_gate_and_policy_mirrors_stay_fully_covered() {
+    // The issue's named drift class hinges on ApprovalGate/ApprovalPolicy
+    // never silently losing coverage across BOTH mirror sites (commands.rs's
+    // runtime read path and spec.rs's authoring-write path). Checked
+    // independently of the whole-file sweep so a manifest mistake elsewhere
+    // cannot hide a regression here.
+    let schema = plugin_format_schema_as_components();
+    let manifest = repo_json("cli/plugin-format-mirrors.json");
+
+    for (file, structs) in [
+        (
+            "cli/src/commands.rs",
+            vec!["ApprovalGateDecl", "ApprovalPolicyDecl"],
+        ),
+        (
+            "cli/src/spec.rs",
+            vec!["ApprovalGateSpec", "ApprovalPolicySpec"],
+        ),
+    ] {
+        let src = repo_text(file);
+        let scoped = manifest_for_file(&manifest, file);
+        let vs = violations(&src, &schema, &scoped);
+        for name in structs {
+            assert!(
+                !mentions_struct(&vs, name),
+                "{name} in {file} does not fully mirror its ApprovalGate/ApprovalPolicy schema \
+                 (expected zero omissions, full field coverage):\n{vs:#?}"
+            );
+        }
+    }
+}
+
+// ─── Guard-rejects-a-deliberately-introduced-drift demonstration ────────────
+
+#[test]
+fn gate_rejects_a_deliberately_introduced_drift() {
+    // Proves the gate's OWN wiring (schema wrapping + per-file manifest
+    // filtering), not just the shared comparator (already exhaustively
+    // fixture-tested by cli/tests/api_field_parity.rs). The real frozen schema
+    // is reused unmodified; only the fixture Rust source + manifest drift.
+    let src = fixture_text("drifted-mirrors.rs");
+    let manifest = fixture_json("drifted-mirrors.json");
+    let schema = plugin_format_schema_as_components();
+
+    let vs = violations(&src, &schema, &manifest);
+    assert!(
+        has_missing_field(&vs, "MissingFieldGate", "route"),
+        "expected MissingField for `route`:\n{vs:#?}"
+    );
+    assert!(
+        has_undeclared_struct(&vs, "UndeclaredMirror"),
+        "expected UndeclaredStruct for a struct in neither list:\n{vs:#?}"
+    );
+    assert!(
+        has_unknown_field(&vs, "PhantomFieldGate", "ghost_field"),
+        "expected UnknownField for a wire field with no schema property behind it:\n{vs:#?}"
+    );
+}


### PR DESCRIPTION
## What

`cli/api-mirrors.json`'s field-parity gate (#691) explicitly did not cover the CLI's hand-mirrors of the frozen `packages/plugin-format` contract (`cli/src/commands.rs`, `cli/src/spec.rs`), since that seam has a different source of truth: the frozen package's own committed schema export, not `apps/api/openapi.json`.

## Approach

Reuses the exact comparator #691 built (`cli/tests/support/field_parity.rs`) unchanged. It is generic over "a Rust source, a `components.schemas`-shaped value, a mirrors/non_mirrors manifest," so the only new work is:

- `cli/plugin-format-mirrors.json` -- the declaration artifact for this seam, mirroring `cli/api-mirrors.json`'s shape. Declares every `Deserialize` struct in `cli/src/commands.rs` and `cli/src/spec.rs`: the genuine `plugin_format` mirrors (`ApprovalGateDecl`, `ApprovalPolicyDecl`, `ManifestApprovals` in `commands.rs`; `ApprovalGateSpec`, `ApprovalPolicySpec` in `spec.rs`) as `mirrors` with their allowlisted omissions, and everything else (the runner-check-report structs, the #495 credential-forwarding test vector, the author-facing `SkillSpec`/`AgentSpec` whose field names deliberately diverge from the wire shape) as `non_mirrors` with a one-line reason.
- `cli/tests/plugin_format_field_parity.rs` -- wraps `packages/plugin-format/schema/plugin-format.schema.json`'s `$defs` into the `components.schemas` shape the shared comparator expects (structurally identical), runs it once per source file (filtering the manifest to that file's own entries), and proves the real tree is clean plus that the gate's own wiring rejects a deliberately introduced drift.
- `cli/scripts/check-field-parity.sh` now runs both gates, so `agentos dev field-parity` covers both seams with no clap/command-manifest changes.

## The concrete failure the issue named

`cli/src/commands.rs`'s `ManifestApprovals` (used by `skill approvals`) only ever validated the approval-relevant slice of a manifest (`name` + `approvalPolicy`). A manifest invalid in some unrelated modeled field (e.g. `commands: 123`, which must be a string/list/null per `plugin_format.models.PluginManifest`) parsed straight through it and reported gates as armed for a manifest the runner's own `PluginManifest.model_validate` rejects outright and refuses to boot on -- the same silent-drift class #691 closed, reproduced on this seam, and previously recorded as an open "known limitation" in ADR-0041.

`parse_manifest_gates` now validates the raw manifest against the frozen schema (`validate_against_plugin_format_schema`, embedded via `include_str!` and validated with the `jsonschema` crate, promoted from a test-only to a real dependency) whenever `approvalPolicy` is actually declared -- the same condition under which the runner's `resolve_approval_policy` promotes to full-manifest validation. This is schema-driven, not a hand-mirror of every `PluginManifest` field, so it tracks the frozen contract with zero manual upkeep and avoids adding a second ungated mirror (the wrong fix the ADR called out).

New tests: a negative control reproducing the exact silent-failure manifest from the issue (now rejected), a positive control proving an unmodeled extra field still validates (the models are deliberately lenient, `extra="allow"`), and a control proving the full-manifest check only engages once a policy is declared (matching the runner's own early return for the honest "no policy" case).

## Verify

```
cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test
uv run pytest packages/plugin-format/tests -q
bash cli/scripts/check-field-parity.sh
```

Closes #701
Ref #691