### PR TITLE
Add a parity-ladder rung that runs against the generated release compose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -440,8 +440,22 @@ jobs:
   # actual up/deploy/message/down round trip; `local up --wait` alone can run
   # up to compose's 300s default wait timeout if a service is slow to report
   # healthy.
+  #
+  # Additive on top of the above: a `local-release` rung (issue #695) runs the
+  # SAME local round trip again, this time against compose/generate_release_compose.py's
+  # OUTPUT (compose.release.yaml) instead of the checked-in compose.dev.yaml --
+  # the artifact a release binary's `agentos local up` actually runs. The
+  # `compose` job elsewhere in this workflow already asserts that generated
+  # file parses and renders the right service counts; it never runs a turn
+  # through it, which is exactly the gap #545-class compose-env-wiring bugs
+  # hide in. Reuses the SAME agentos-api/agentos-worker local builds above
+  # (no second Dockerfile build for those), just tags/builds the two additional
+  # refs the DEFAULT (no --version) generation pins: agentos-api:latest (the
+  # dev file's own unset-override outcome) and the worker-local overlay image
+  # the generator's T1 substitutes for the build directive, both resolved
+  # locally so `local up` never attempts a pull against a private GHCR ref.
   e2e-ladder:
-    name: E2E parity ladder (skill + local, fake model)
+    name: E2E parity ladder (skill + local + local-release, fake model)
     runs-on: ubuntu-latest
     needs: rust
     steps:
@@ -473,4 +487,13 @@ jobs:
         env:
           AGENTOS_BIN: cli/target/release/agentos
           AGENTOS_BASE_TAG: ci-local
+        run: bash cli/scripts/e2e-ladder.sh
+      - name: Tag the api image for the generated release compose (ghcr.io/curie-eng/agentos-api:latest, no registry auth)
+        run: docker tag ghcr.io/curie-eng/agentos-api:ci-local ghcr.io/curie-eng/agentos-api:latest
+      - name: Build the worker-local overlay for the generated release compose (ghcr.io/curie-eng/agentos-worker-local:latest, no registry auth)
+        run: docker build --build-arg BASE_TAG=ci-local -t ghcr.io/curie-eng/agentos-worker-local:latest -f compose/worker-local.Dockerfile compose
+      - name: Parity ladder (local-release rung against generated compose.release.yaml, fake model, credential-free)
+        env:
+          AGENTOS_BIN: cli/target/release/agentos
+          AGENTOS_E2E_TIERS: local-release
         run: bash cli/scripts/e2e-ladder.sh

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -176,12 +176,30 @@ Cold-start parity ladder (issue #690, `agentos dev e2e-ladder` ->
 `cli/scripts/e2e-ladder.sh`) -- an E2E test, same as the scripted E2E above, not
 the falsifiability gate below it. It chains three rungs: rung 1 delegates to
 `e2e.sh` unchanged; rung 2 drives `local up --minimal` -> `local deploy` ->
-`local message` (reply asserted) -> `local down`; rung 3 drives `cluster
-deploy` -> `cluster message` against a pre-installed release, a real round
-trip with no manual port-forward. `AGENTOS_E2E_TIERS` (default `skill,local`,
-or `all` for `skill,local,cluster`) selects rungs; `AGENTOS_E2E_LIVE` (default
-fake, `1` for live) governs the local and cluster rungs only, since the skill
-rung stays fake. One-command pre-release gate:
+`local message` (reply asserted) -> `local down`, against `compose.dev.yaml`;
+rung 3 drives `cluster deploy` -> `cluster message` against a pre-installed
+release, a real round trip with no manual port-forward. A fourth,
+separately-named `local-release` rung (issue #695) repeats rung 2's exact round
+trip against `compose.release.yaml` instead -- the file
+`compose/generate_release_compose.py` derives from `compose.dev.yaml` and the
+artifact a release binary's `agentos local up` actually runs, one half of the
+`compose.dev.yaml` / generated-release-compose parity seam (AGENTS.md). It
+generates that file fresh each run, preflights that the release-pinned
+`ghcr.io/curie-eng/agentos-api` and `-worker-local` images already exist
+locally (failing with a fix hint otherwise, since the generated file has no
+build directive to fall back on and a release binary has no checkout to build
+one from), then runs the same `local up --minimal -f compose.release.yaml` ->
+`local deploy` -> `local message` (reply asserted) -> `local down -f
+compose.release.yaml` against it. Elsewhere in CI, the `compose` job already
+asserts this generated file parses and renders the right service counts but
+never runs a turn through it -- this rung is the missing half, catching the
+compose-env-wiring bug class (#545) a config-only check cannot.
+`AGENTOS_E2E_TIERS` (default `skill,local`, or `all` for `skill,local,cluster`)
+selects rungs; `local-release` is NOT folded into `all` since it needs those
+extra images built first, so name it explicitly (e.g.
+`skill,local,local-release`). `AGENTOS_E2E_LIVE` (default fake, `1` for live)
+governs the local, local-release, and cluster rungs only, since the skill rung
+stays fake. One-command pre-release gate:
 ```bash
 AGENTOS_E2E_TIERS=all agentos dev e2e-ladder
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -580,18 +580,27 @@ agentos-runner .` from the repo root).
 The cold-start parity ladder (`agentos dev e2e-ladder`, `cli/scripts/e2e-ladder.sh`)
 runs the same skill-tier script as rung 1, then adds a local rung (`local up
 --minimal` -> `local deploy` -> `local message` with the reply asserted ->
-`local down`) and a cluster rung (`cluster deploy` then `cluster message`, a
-real round trip with no manual port-forward) against a pre-installed release.
-Two env knobs configure it:
+`local down`, against `compose.dev.yaml`) and a cluster rung (`cluster deploy`
+then `cluster message`, a real round trip with no manual port-forward) against
+a pre-installed release. A `local-release` rung repeats the local rung's exact
+round trip against the generated `compose.release.yaml` instead -- the
+artifact a release binary's `agentos local up` actually runs -- so the CI
+config-only check on that file (`compose/generate_release_compose.py` +
+`docker compose config`) is not the only coverage it gets. It needs the
+release-pinned `ghcr.io/curie-eng/agentos-api` and `-worker-local` images
+already built and tagged locally (it preflights and fails with a fix hint
+otherwise). Two env knobs configure it:
 
 - `AGENTOS_E2E_TIERS` -- which rungs to run. Defaults to `skill,local`
   (credential-free, CI-safe); `all` runs `skill,local,cluster`. A tier named
   explicitly is required, and its absence fails the run; a tier not named is
-  skipped.
+  skipped. `local-release` is a fourth tier, named explicitly (e.g.
+  `skill,local,local-release`) -- it is not folded into `all` since it needs
+  the extra images built first.
 - `AGENTOS_E2E_LIVE` -- unset or `0` runs the fake model (credential-free, the
   default); `1` runs the live-credential variant for pre-release manual passes
-  and fails fast if no model credential is present. It governs the local and
-  cluster rungs only; the skill rung stays fake.
+  and fails fast if no model credential is present. It governs the local,
+  local-release, and cluster rungs only; the skill rung stays fake.
 
 The one-command pre-release gate:
 

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -5,9 +5,16 @@
 # deployment tier with the tier's own real verbs and asserts a turn actually
 # finalized. Rung 1 (skill) is the existing `cli/scripts/e2e.sh`, invoked as is
 # so the skill leg has exactly one implementation. Rung 2 (local) is
-# `local up --minimal` -> `local deploy` -> `local message` -> `local down`.
-# Rung 3 (cluster) is `cluster deploy` -> `cluster message` against a release
-# that is ALREADY installed; the ladder never installs or uninstalls one.
+# `local up --minimal` -> `local deploy` -> `local message` -> `local down`,
+# against `compose.dev.yaml`. The `local-release` mode is the same round trip
+# against `compose.release.yaml` instead -- the generated, checkout-free
+# artifact `agentos local up` runs on a release binary (issue #695), one half
+# of the `compose.dev.yaml` / generated-release-compose parity seam named in
+# AGENTS.md. CI validates that generated file today only by `docker compose
+# config` and service-count assertions (the `compose` job), never by running a
+# turn through it -- exactly the gap this mode closes. Rung 3 (cluster) is
+# `cluster deploy` -> `cluster message` against a release that is ALREADY
+# installed; the ladder never installs or uninstalls one.
 #
 # What it is NOT: it is not a compose test and not a helm test. Every step goes
 # through an `agentos` verb, because the point is to catch a tier whose verb
@@ -35,7 +42,17 @@
 #   AGENTOS_E2E_TIERS        comma list of rungs (default skill,local; `all` =
 #                            skill,local,cluster). A NAMED tier is REQUIRED: if
 #                            cluster is named and no release responds, exit 1.
-#   AGENTOS_E2E_LIVE         1 = real model on rungs 2 and 3 (rung 1 stays fake)
+#                            `local-release` is a fourth, separately-named rung
+#                            (the same local round trip against the generated
+#                            compose.release.yaml instead of compose.dev.yaml);
+#                            it is NOT folded into `all` because it needs the
+#                            release-pinned images (ghcr.io/curie-eng/agentos-api
+#                            and -worker-local) built and tagged locally first,
+#                            a step `all`'s existing skill/local/cluster rungs
+#                            don't require -- name it explicitly, e.g.
+#                            AGENTOS_E2E_TIERS=skill,local,local-release.
+#   AGENTOS_E2E_LIVE         1 = real model on rungs 2, local-release, and 3
+#                            (rung 1 stays fake)
 #   AGENTOS_BIN              path to a prebuilt agentos binary (skip cargo build)
 set -euo pipefail
 
@@ -398,6 +415,119 @@ rung_local() {
     fi
 }
 
+# local-release mode: the same local round trip as rung_local, but against the
+# GENERATED compose.release.yaml (compose/generate_release_compose.py) instead
+# of the checked-in compose.dev.yaml -- the artifact a release binary's
+# `agentos local up` actually runs, per the compose.dev.yaml / generated
+# release compose parity seam (issue #695, AGENTS.md). CI's existing `compose`
+# job already asserts this generated file parses and renders the right service
+# counts; this mode is the missing half, that a real turn survives it.
+rung_local_release() {
+    echo
+    echo "########## rung: local-release (compose, generated release artifact) ##########"
+
+    local release_compose="$WORKDIR/compose.release.yaml"
+    echo
+    echo "=== generate compose.release.yaml from compose.dev.yaml ==="
+    # No --version: same invocation as the `compose` CI job's config-only
+    # check, so this rung exercises the SAME generated text that job only
+    # parses, not a differently-pinned variant of it. Run with cwd=$REPO_ROOT:
+    # the generator reads compose.dev.yaml and otel/collector-config.yaml by
+    # relative path.
+    (cd "$REPO_ROOT" && python3 compose/generate_release_compose.py) > "$release_compose"
+
+    # The generated file has no build directives (generate_release_compose.py's
+    # T1 replaces the agentos-worker build overlay with a pinned
+    # ghcr.io/curie-eng/agentos-worker-local image, and agentos-api/-migrate
+    # were already a pull, never a build) -- every agentos-owned image it needs
+    # must already exist locally under the tag the generator pinned, or `local
+    # up` will try to pull a private GHCR image with no credentials. Check only
+    # the core profile's images (--minimal is what this rung brings up) and
+    # only the agentos-owned ones: postgres/valkey/minio are public and pulled
+    # on demand same as rung_local already assumes.
+    local missing=0 image
+    while IFS= read -r image; do
+        [[ "$image" == ghcr.io/curie-eng/agentos-* ]] || continue
+        if ! docker image inspect "$image" >/dev/null 2>&1; then
+            echo "error: image '$image' is required by compose.release.yaml's core profile and is not present locally." >&2
+            missing=1
+        fi
+    done < <(docker compose -f "$release_compose" --profile core config --images)
+    if (( missing )); then
+        echo "fix: build and tag the missing image(s) locally under the tag compose.release.yaml pins (see .github/workflows/ci.yaml's e2e-ladder job for the exact build+tag steps CI uses), then re-run." >&2
+        return 1
+    fi
+
+    assert_stub_port_free
+
+    if [[ -n "$(docker ps -q --filter 'name=agentos-api' 2>/dev/null)" ]]; then
+        # Reuse it and do NOT tear it down, matching rung_local's rule: the
+        # thread that brought a stack up owns tearing it down.
+        echo "a compose stack is already running; reusing it and leaving teardown to whoever started it"
+        if [[ "$LIVE" == "1" ]]; then
+            echo "warning: AGENTOS_E2E_LIVE=1, but the reused stack's model mode was fixed by whoever ran \`local up\` and is NOT verified here." >&2
+            echo "warning: if that stack was started with the fake model, this 'live' rung runs sealed; \`local down\` then re-run to be sure." >&2
+        fi
+    else
+        echo
+        echo "=== clear any stale volumes from a prior non-wiped teardown ==="
+        # compose.dev.yaml and compose.release.yaml pin the SAME compose
+        # project name (`agentos`), so a prior `local down` (rung_local's, kept
+        # deliberately non-destructive) can leave this rung's Postgres/Valkey
+        # state non-empty. Nothing is running (checked above), so this can only
+        # ever touch a stack this run itself would otherwise create -- never a
+        # stack this run is about to reuse. Wiping first makes this rung an
+        # actual cold start rather than one that might silently inherit state
+        # and mask the exact compose-env-wiring drift (#545) it exists to catch.
+        "$BIN" local down --wipe --yes -f "$release_compose" >/dev/null 2>&1 || true
+
+        echo
+        echo "=== agentos local up --minimal -f compose.release.yaml ==="
+        LOCAL_STACK_OWNED=1
+        "$BIN" local up --minimal -f "$release_compose"
+    fi
+
+    echo
+    echo "=== agentos local deploy (release-compose stack) ==="
+    # A separate bundle copy from rung_local's, never the same directory: deploy
+    # records state into the bundle dir, and reusing rung_local's copy here
+    # would carry over its recorded agent/version ids instead of a fresh
+    # cold-start deploy.
+    "$BIN" local deploy --plugin-dir "$WORKDIR/bundle-release"
+
+    echo
+    echo "=== agentos local message --json (release-compose stack) ==="
+    assert_stub_port_free
+    local out
+    out="$("$BIN" --json local message "$PROMPT" || true)"
+    printf '%s\n' "$out"
+    assert_finalized_reply "local-release" "$out"
+
+    if (( LOCAL_STACK_OWNED )); then
+        echo
+        echo "=== agentos local down -f compose.release.yaml ==="
+        "$BIN" local down -f "$release_compose"
+        LOCAL_STACK_OWNED=0
+
+        echo
+        echo "=== assert nothing agentos-related survived ==="
+        local survivors
+        survivors="$(docker ps --filter 'label=com.docker.compose.project=agentos' --format '{{.Names}}')"
+        if [[ -n "$survivors" ]]; then
+            echo "local down left compose services running:" >&2
+            printf '%s\n' "$survivors" >&2
+            return 1
+        fi
+        survivors="$(docker ps --filter "label=$SANDBOX_LABEL" --format '{{.Names}}')"
+        if [[ -n "$survivors" ]]; then
+            echo "sibling sandbox containers survived teardown:" >&2
+            printf '%s\n' "$survivors" >&2
+            return 1
+        fi
+        echo "no agentos containers running"
+    fi
+}
+
 # Rung 3: the deployed release. Requires one to already exist; it is never
 # installed or torn down here, because the cluster is shared.
 rung_cluster() {
@@ -456,29 +586,33 @@ if [[ "$TIERS" == "all" ]]; then
 fi
 RUN_SKILL=0
 RUN_LOCAL=0
+RUN_LOCAL_RELEASE=0
 RUN_CLUSTER=0
 IFS=',' read -r -a SELECTED <<< "$TIERS"
 for tier in "${SELECTED[@]}"; do
     case "$tier" in
         skill) RUN_SKILL=1 ;;
         local) RUN_LOCAL=1 ;;
+        local-release) RUN_LOCAL_RELEASE=1 ;;
         cluster) RUN_CLUSTER=1 ;;
         "") ;;
         *)
             echo "error: unknown tier '$tier' in AGENTOS_E2E_TIERS." >&2
-            echo "fix: use a comma list of skill, local, cluster, or the shorthand 'all'." >&2
+            echo "fix: use a comma list of skill, local, local-release, cluster, or the shorthand 'all' (skill, local, cluster)." >&2
             exit 1 ;;
     esac
 done
-if (( ! RUN_SKILL && ! RUN_LOCAL && ! RUN_CLUSTER )); then
+if (( ! RUN_SKILL && ! RUN_LOCAL && ! RUN_LOCAL_RELEASE && ! RUN_CLUSTER )); then
     echo "error: AGENTOS_E2E_TIERS selected no rungs." >&2
-    echo "fix: set it to a comma list of skill, local, cluster, or 'all'." >&2
+    echo "fix: set it to a comma list of skill, local, local-release, cluster, or 'all'." >&2
     exit 1
 fi
 
-# A throwaway COPY of the bundle: deploy records state into the bundle dir, and
-# that must never land in the tree.
+# Throwaway COPIES of the bundle: deploy records state into the bundle dir, and
+# that must never land in the tree. Separate copies for rung_local and
+# rung_local_release so neither carries the other's recorded deploy state.
 cp -r "$BUNDLE_SRC" "$WORKDIR/bundle"
+cp -r "$BUNDLE_SRC" "$WORKDIR/bundle-release"
 
 # Rungs run strictly in order and never in parallel: they share host ports, and
 # rung 1 must release its runner container before rung 2 starts.
@@ -493,6 +627,14 @@ if (( RUN_LOCAL )); then
 else
     echo
     echo "SKIPPING rung 2 (local): not named in AGENTOS_E2E_TIERS."
+fi
+if (( RUN_LOCAL_RELEASE )); then
+    rung_local_release
+else
+    echo
+    echo "SKIPPING rung (local-release): not named in AGENTOS_E2E_TIERS. Needs the"
+    echo "release-pinned images built and tagged locally first; name it explicitly,"
+    echo "e.g. AGENTOS_E2E_TIERS=skill,local,local-release."
 fi
 if (( RUN_CLUSTER )); then
     rung_cluster


### PR DESCRIPTION
## Summary

- The local rung of the cold-start parity ladder (#690) only ever ran against `compose.dev.yaml`. `compose.release.yaml` (generated by `compose/generate_release_compose.py`) is the artifact a release binary's `agentos local up` actually runs, and CI validated it only by `docker compose config` plus service-count assertions -- never by driving a real turn through it, which is exactly the compose-env-wiring bug class (#545) a config-only check misses.
- Adds a `local-release` rung to `cli/scripts/e2e-ladder.sh`, selected via a new `AGENTOS_E2E_TIERS` value (not folded into `all`, since it needs the release-pinned images built and tagged locally first): it generates `compose.release.yaml` fresh, preflights that the required `ghcr.io/curie-eng` images already exist locally (failing with a fix hint otherwise), then runs the same `local up --minimal` -> `local deploy` -> `local message` (reply asserted) -> `local down` round trip against it.
- Wires the new rung into the `e2e-ladder` CI job additively (new steps only; the existing skill+local steps are untouched) and updates `cli/CLAUDE.md` and `cli/README.md`'s parity-ladder documentation.

## Verification

- Ran `compose/tests/test_generate_release_compose.py` (17 passed, unaffected by this change).
- Verified the new rung end to end in an isolated docker-in-docker environment (to avoid touching this machine's own long-running local AgentOS stack): generated `compose.release.yaml`, built and tagged the release-pinned images the same way the new CI steps do, then ran `AGENTOS_E2E_TIERS=local-release bash cli/scripts/e2e-ladder.sh`. It brought the stack up from the generated file, deployed the example bundle, and got back a finalized reply (`{"finalized":true,"reply":"all done",...}`), then tore down cleanly with no survivors.

## Test plan

- [x] `compose/tests/test_generate_release_compose.py` passes
- [x] `local-release` rung runs a full round trip against a freshly generated `compose.release.yaml` (verified locally, isolated environment)
- [x] `bash -n cli/scripts/e2e-ladder.sh` and YAML-parse `.github/workflows/ci.yaml`

Closes #695
Ref #690, #545