### PR TITLE
Revert the e2e-ladder image builds to plain docker build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -461,21 +461,11 @@ jobs:
   # the generator's T1 substitutes for the build directive, both resolved
   # locally so `local up` never attempts a pull against a private GHCR ref.
   #
-  # The runner and api builds below share the `images` job's gha cache store
-  # above: neither job passes an explicit `scope` to cache-from/cache-to, so
-  # both default to buildkit's own "buildkit" scope, and runner/Dockerfile and
-  # apps/api/Dockerfile are the same files the `images` matrix already built
-  # on this commit. There is no `needs` edge between `images` and
-  # `e2e-ladder` (this job only waits on `rust`), so the cache hit here is NOT
-  # guaranteed by job ordering -- it happens in practice because `images`'s
-  # cache-warmed builds are far quicker than `rust`'s full cargo build/test/
-  # release, so `images` has almost always finished writing its cache well
-  # before `rust` unblocks this job. If that assumption ever flips (a slower
-  # images job or a much faster rust job), the first CI run on a new commit's
-  # shas would fall back to a cold build here, same as today, and only later
-  # runs of the same shas would see the hit. The worker base build does NOT
-  # share this cache -- see its own step comment for why it deliberately
-  # skips buildx.
+  # All three image builds here use plain `docker build`, not buildx: two of
+  # the tags are consumed as Dockerfile FROM bases by a compose-triggered build
+  # later in the same job, and a docker-container buildx builder set as the
+  # default (as docker/setup-buildx-action does) breaks that FROM resolution.
+  # See the build steps' own comment for the full history (#697/#791).
   e2e-ladder:
     name: E2E parity ladder (skill + local + local-release, fake model)
     runs-on: ubuntu-latest
@@ -484,8 +474,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Download the agentos binary built by the Rust job
         uses: actions/download-artifact@v7
         with:
@@ -493,8 +481,25 @@ jobs:
           path: cli/target/release
       - name: Make the binary executable
         run: chmod +x cli/target/release/agentos
+      # Plain `docker build`, NOT `docker buildx build`, for all three images
+      # below. Two of them (agentos-worker:ci-local, agentos-api:ci-local) are
+      # consumed as Dockerfile FROM bases by a build that `docker compose`
+      # triggers itself a few steps down (agentos-worker's service build via
+      # compose/worker-local.Dockerfile, inside `agentos local up`). #697 changed
+      # these to `docker buildx build --load` with a docker/setup-buildx-action
+      # step to share the `images` job's GHA layer cache; that made the
+      # setup-buildx-action's docker-container builder the default, and the later
+      # compose-triggered build then inherited it and could no longer resolve the
+      # locally-built `:ci-local` tags as a FROM ("failed to resolve source
+      # metadata ... not found"), reddening this job on every run since #791
+      # merged. Reverting to the pre-#697 plain-`docker build` shape (no buildx,
+      # no setup-buildx-action) is the known-good state: images land in the
+      # daemon store and the compose build, using that same daemon, resolves them.
+      # The GHA-cache speedup from #697 is the right idea but needs a mechanism
+      # that does not repoint the default builder underneath the compose build;
+      # correctness first.
       - name: Build the runner image locally
-        run: docker buildx build --load -t agentos-runner -f runner/Dockerfile --cache-from type=gha --cache-to type=gha .
+        run: docker build -t agentos-runner -f runner/Dockerfile .
       - name: Retag the runner image for the compose worker (AGENTOS_RUNNER_IMAGE, no registry auth)
         run: docker tag agentos-runner ghcr.io/curie-eng/agentos-runner:latest
       # Tagged :ci-local (the worker-local-image job's own convention), not
@@ -504,27 +509,7 @@ jobs:
       # retag its from-source builds over whatever `:latest` meant in the local
       # Docker image store before this job ran.
       - name: Build the api image locally (satisfies agentos-api + agentos-migrate, no registry auth)
-        run: docker buildx build --load -t ghcr.io/curie-eng/agentos-api:ci-local -f apps/api/Dockerfile --cache-from type=gha --cache-to type=gha .
-      # Plain `docker build`, deliberately NOT buildx: this tag is consumed as a
-      # Dockerfile FROM by a build docker compose triggers itself a few steps
-      # down (agentos-worker's service build, compose/worker-local.Dockerfile).
-      # That compose-triggered build reproducibly failed to resolve this exact
-      # tag ("failed to resolve source metadata ... not found") even though the
-      # `docker buildx build --load` step that produced it had already reported
-      # success and its "importing to docker" step had completed -- i.e. the
-      # image was in the daemon's store by every visible signal, but the LATER
-      # build (invoked by `docker compose build` from inside `agentos local up`,
-      # a few process layers removed from this shell step) could not see it. A
-      # local repro with the identical docker-container buildx driver + --load
-      # sequence did not reproduce the failure, so the exact mechanism on the
-      # GitHub-hosted runner is not fully pinned down, but every occurrence
-      # traces to this one image being BOTH built via the external buildx
-      # builder AND immediately consumed as a FROM base by a separate build
-      # invocation later in the same job. The runner and api images above don't
-      # have this shape (neither is a later Dockerfile's FROM within this job),
-      # so they keep buildx + the GHA cache; this one loses that cache to buy
-      # back the FROM resolution guarantee a same-daemon, non-buildx classic
-      # build gives for free.
+        run: docker build -t ghcr.io/curie-eng/agentos-api:ci-local -f apps/api/Dockerfile .
       - name: Build the worker base image locally (satisfies the worker-local overlay's FROM, no registry auth)
         run: docker build -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile .
       - name: Parity ladder (skill + local rungs, fake model, credential-free)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -461,19 +461,21 @@ jobs:
   # the generator's T1 substitutes for the build directive, both resolved
   # locally so `local up` never attempts a pull against a private GHCR ref.
   #
-  # This job's three builds share the `images` job's gha cache store above:
-  # neither job passes an explicit `scope` to cache-from/cache-to, so both
-  # default to buildkit's own "buildkit" scope, and runner/Dockerfile,
-  # apps/api/Dockerfile, and apps/worker/Dockerfile are the same files the
-  # `images` matrix already built on this commit. There is no `needs` edge
-  # between `images` and `e2e-ladder` (this job only waits on `rust`), so the
-  # cache hit here is NOT guaranteed by job ordering -- it happens in practice
-  # because `images`'s cache-warmed builds are far quicker than `rust`'s full
-  # cargo build/test/release, so `images` has almost always finished writing
-  # its cache well before `rust` unblocks this job. If that assumption ever
-  # flips (a slower images job or a much faster rust job), the first CI run on
-  # a new commit's shas would fall back to a cold build here, same as today,
-  # and only later runs of the same shas would see the hit.
+  # The runner and api builds below share the `images` job's gha cache store
+  # above: neither job passes an explicit `scope` to cache-from/cache-to, so
+  # both default to buildkit's own "buildkit" scope, and runner/Dockerfile and
+  # apps/api/Dockerfile are the same files the `images` matrix already built
+  # on this commit. There is no `needs` edge between `images` and
+  # `e2e-ladder` (this job only waits on `rust`), so the cache hit here is NOT
+  # guaranteed by job ordering -- it happens in practice because `images`'s
+  # cache-warmed builds are far quicker than `rust`'s full cargo build/test/
+  # release, so `images` has almost always finished writing its cache well
+  # before `rust` unblocks this job. If that assumption ever flips (a slower
+  # images job or a much faster rust job), the first CI run on a new commit's
+  # shas would fall back to a cold build here, same as today, and only later
+  # runs of the same shas would see the hit. The worker base build does NOT
+  # share this cache -- see its own step comment for why it deliberately
+  # skips buildx.
   e2e-ladder:
     name: E2E parity ladder (skill + local + local-release, fake model)
     runs-on: ubuntu-latest
@@ -503,8 +505,28 @@ jobs:
       # Docker image store before this job ran.
       - name: Build the api image locally (satisfies agentos-api + agentos-migrate, no registry auth)
         run: docker buildx build --load -t ghcr.io/curie-eng/agentos-api:ci-local -f apps/api/Dockerfile --cache-from type=gha --cache-to type=gha .
+      # Plain `docker build`, deliberately NOT buildx: this tag is consumed as a
+      # Dockerfile FROM by a build docker compose triggers itself a few steps
+      # down (agentos-worker's service build, compose/worker-local.Dockerfile).
+      # That compose-triggered build reproducibly failed to resolve this exact
+      # tag ("failed to resolve source metadata ... not found") even though the
+      # `docker buildx build --load` step that produced it had already reported
+      # success and its "importing to docker" step had completed -- i.e. the
+      # image was in the daemon's store by every visible signal, but the LATER
+      # build (invoked by `docker compose build` from inside `agentos local up`,
+      # a few process layers removed from this shell step) could not see it. A
+      # local repro with the identical docker-container buildx driver + --load
+      # sequence did not reproduce the failure, so the exact mechanism on the
+      # GitHub-hosted runner is not fully pinned down, but every occurrence
+      # traces to this one image being BOTH built via the external buildx
+      # builder AND immediately consumed as a FROM base by a separate build
+      # invocation later in the same job. The runner and api images above don't
+      # have this shape (neither is a later Dockerfile's FROM within this job),
+      # so they keep buildx + the GHA cache; this one loses that cache to buy
+      # back the FROM resolution guarantee a same-daemon, non-buildx classic
+      # build gives for free.
       - name: Build the worker base image locally (satisfies the worker-local overlay's FROM, no registry auth)
-        run: docker buildx build --load -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile --cache-from type=gha --cache-to type=gha .
+        run: docker build -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile .
       - name: Parity ladder (skill + local rungs, fake model, credential-free)
         env:
           AGENTOS_BIN: cli/target/release/agentos


### PR DESCRIPTION
## Summary

The `e2e-ladder` job has failed on every run since #791 (issue #697) merged: `agentos local up`'s `docker compose build` of `agentos-worker` (via `compose/worker-local.Dockerfile`) cannot resolve `ghcr.io/curie-eng/agentos-worker:ci-local` as its FROM base:

```
✗ `docker` failed: failed to solve: ghcr.io/curie-eng/agentos-worker:ci-local: failed to resolve source metadata for ghcr.io/curie-eng/agentos-worker:ci-local: ghcr.io/curie-eng/agentos-worker:ci-local: not found
```

## Root cause (confirmed against git history)

The known-good pre-#697 job used plain `docker build` for all three images and had no `docker/setup-buildx-action` step. #697 (merged as #791) changed the builds to `docker buildx build --load --cache-from/--cache-to type=gha` and added `setup-buildx-action` to share the `images` job's GHA layer cache.

`docker/setup-buildx-action` sets a `docker-container`-driver builder as the **default** builder. The `docker compose build` that `agentos local up` triggers a few steps later then inherits that default builder, and a `docker-container` builder cannot resolve the `--load`-ed `:ci-local` tags in the daemon's image store as a Dockerfile FROM. Hence "not found".

## Fix

Fully revert this job to its pre-#697 shape: remove the `Set up Buildx` step and build all three images (runner, api, worker base) with plain `docker build` (no buildx, no `--load`, no GHA cache). Images land in the daemon store, and the compose build -- on that same daemon -- resolves them. This is the exact configuration that passed before #697.

(An earlier revision of this PR switched only the worker image back to `docker build` while leaving `setup-buildx-action` and the other two buildx builds in place; that left the default-builder problem intact and still failed. This revision removes buildx from the job entirely.)

The GHA-cache speedup #697 aimed for is a legitimate goal, but it needs a mechanism that does not repoint the default builder underneath the compose build (e.g. a scoped/named builder used only for the explicit builds, with the default restored before the ladder runs). Filed as follow-up thinking in the code comment; correctness first.

## Test plan

- [x] Every `.github/workflows/*.yaml` parses via PyYAML
- [x] Matches the pre-#697 build shape verbatim (confirmed via `git show 9a2daa5^`)
- [ ] Confirm the `E2E parity ladder` check goes green on this PR's real CI run before merging

Note: this depends on the separate `helm-ci.yaml` YAML-syntax fix in #805 for the overall workflow set to be healthy, but the two are independent.