### PR TITLE
Quote a CI step name whose colon broke YAML parsing

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -158,7 +158,7 @@ jobs:
       # agentSandbox.deploy, and the N=1 self-host control plane stays fully
       # self-declared on cpu/memory (so the new LimitRange defaults never
       # engage for it).
-      - name: helm render assertions (tenant capacity: ResourceQuota + LimitRange)
+      - name: "helm render assertions (tenant capacity: ResourceQuota + LimitRange)"
         run: |
           set -euo pipefail
           bash charts/agentos/ci/tenant-capacity-assertions.sh


### PR DESCRIPTION
## Summary

You were right that CI itself is broken -- this is a separate, more serious bug than the e2e-ladder issue in #803. `.github/workflows/helm-ci.yaml` has been failing outright on **every run since it merged, including on `main` itself**, not just on branches with open PRs:

```
This run likely failed because of a workflow file issue.
```

The cause: a step name added by the ResourceQuota/LimitRange work --

```yaml
- name: helm render assertions (tenant capacity: ResourceQuota + LimitRange)
```

-- is an unquoted YAML scalar containing a bare `: ` (colon-space), which both PyYAML and GitHub Actions' own workflow parser read as the start of a nested mapping rather than plain text. Confirmed with `python3 -c "import yaml; yaml.safe_load(...)"`, which throws `ScannerError: mapping values are not allowed here` at that exact line.

I introduced this myself while resolving a merge conflict between two PRs that both added new steps to this file -- I validated the chart output (`helm lint`, the render-assert scripts) but never ran a YAML syntax check on the workflow file itself, so this slipped through.

## Fix

Quote the step name. Verified every file in `.github/workflows/` now parses clean with PyYAML, and re-ran `charts/agentos/ci/tenant-capacity-assertions.sh` (the script that step invokes) to confirm nothing else regressed.

## Test plan

- [x] Every `.github/workflows/*.yaml` file parses via PyYAML
- [x] `bash charts/agentos/ci/tenant-capacity-assertions.sh` passes
- [ ] Confirm `helm-ci.yaml` actually runs (not "workflow file issue") on this PR's real CI