### PR TITLE
Wait for a thread reset to actually land before reporting success

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3902,6 +3902,73 @@
       }
     },
     "/agents/{agent_id}/threads/{thread_key}/reset": {
+      "get": {
+        "description": "Poll whether a forced reset (the POST above) is still outstanding for\nthis thread (#735). ``requested`` is True from the moment the POST enqueues\nthe request until the worker's next maintenance tick drains it and releases\nthe sandbox, then False.\n\nWhy this exists: the POST returns as soon as the request is *queued*, but the\nrelease only happens on the worker's maintenance tick (up to\n``reclaim_interval_s`` -- 30s by default -- later). Without a way to observe\ncompletion, the natural operator workflow \"reset the thread, then send a\nmessage to confirm\" adopts the still-live pre-reset sandbox and reads a\nstale answer, indistinguishable from \"the reset did not work\" (#735). A\ncaller that must not adopt the pre-reset sandbox polls this until it reads\nFalse before sending the next message; the CLI ``reset-thread`` verb does\nexactly that on the operator's behalf. Mirrors ``GET .../kill``.\n\nCaveat: the worker removes the request from the drain set (atomic ``SPOP``)\nimmediately *before* it runs the release, so this can read False a few\nmilliseconds ahead of ``release_thread`` finishing the teardown. That\nresidual window is milliseconds against the up-to-30s wait this makes\nobservable; shrinking the tick latency itself (a wake nudge, like the kill\nswitch's pub/sub) is a separate follow-up.",
+        "operationId": "get_thread_reset_state_agents__agent_id__threads__thread_key__reset_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "thread_key",
+            "required": true,
+            "schema": {
+              "title": "Thread Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadResetState"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Thread Reset State",
+        "tags": [
+          "control"
+        ]
+      },
       "post": {
         "description": "Force the thread's sandbox to be released (#713): the worker's next\nmaintenance tick deletes its claim and route, so the NEXT message on this\nthread cold-creates a fresh sandbox instead of adopting one that may be\nrunning stale env (a rotated credential, an unpicked-up redeploy, a wedge\nfrom a partial local-stack upgrade). A live turn on the thread, if any, is\ninterrupted first -- see ``Kernel.release_thread``. Does not delete\nconversation history: a fresh sandbox still rehydrates from the durable\ntranscript on its next claim, same as any other cold-create.\n\n``agent_id`` scopes the action to a specific agent's registration (matching\nevery other verb on this router) but is not itself required to resolve the\nthread -- the release is purely thread-keyed, mirroring\n``SandboxSubstrate.release``.",
         "operationId": "reset_thread_agents__agent_id__threads__thread_key__reset_post",

--- a/apps/api/src/agentos_api/routers/control.py
+++ b/apps/api/src/agentos_api/routers/control.py
@@ -89,6 +89,39 @@ async def reset_thread(
     return ThreadResetState(requested=True)
 
 
+@router.get("/threads/{thread_key}/reset", response_model=ThreadResetState)
+async def get_thread_reset_state(
+    agent_id: uuid.UUID,
+    thread_key: str,
+    session: SessionDep,
+    thread_reset_requests: ThreadResetRequestsDep,
+) -> ThreadResetState:
+    """Poll whether a forced reset (the POST above) is still outstanding for
+    this thread (#735). ``requested`` is True from the moment the POST enqueues
+    the request until the worker's next maintenance tick drains it and releases
+    the sandbox, then False.
+
+    Why this exists: the POST returns as soon as the request is *queued*, but the
+    release only happens on the worker's maintenance tick (up to
+    ``reclaim_interval_s`` -- 30s by default -- later). Without a way to observe
+    completion, the natural operator workflow "reset the thread, then send a
+    message to confirm" adopts the still-live pre-reset sandbox and reads a
+    stale answer, indistinguishable from "the reset did not work" (#735). A
+    caller that must not adopt the pre-reset sandbox polls this until it reads
+    False before sending the next message; the CLI ``reset-thread`` verb does
+    exactly that on the operator's behalf. Mirrors ``GET .../kill``.
+
+    Caveat: the worker removes the request from the drain set (atomic ``SPOP``)
+    immediately *before* it runs the release, so this can read False a few
+    milliseconds ahead of ``release_thread`` finishing the teardown. That
+    residual window is milliseconds against the up-to-30s wait this makes
+    observable; shrinking the tick latency itself (a wake nudge, like the kill
+    switch's pub/sub) is a separate follow-up.
+    """
+    await _load_agent(session, agent_id)
+    return ThreadResetState(requested=await thread_reset_requests.is_pending(thread_key))
+
+
 @router.get("/budget", response_model=BudgetConfig)
 async def get_budget(agent_id: uuid.UUID, session: SessionDep) -> BudgetConfig:
     agent = await _load_agent(session, agent_id)

--- a/apps/api/tests/test_control_integration.py
+++ b/apps/api/tests/test_control_integration.py
@@ -111,14 +111,54 @@ def test_reset_thread_queues_a_pending_request(
         valkey.srem(THREAD_RESET_SET, "t-reset-1")
 
 
+def test_thread_reset_state_is_pollable_until_the_worker_drains(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+) -> None:
+    """#735: the POST only *queues* a reset; the release lands on the worker's
+    maintenance tick, up to reclaim_interval_s (30s) later. GET .../reset exposes
+    that pending state (wiring the previously-uncalled ``is_pending``) so the
+    operator workflow "reset the thread, then message to confirm" can poll to
+    completion instead of adopting the still-live pre-reset sandbox and reading a
+    stale answer. Real Valkey, real SADD/SREM, no mocking."""
+    from agentos_api.threadreset import THREAD_RESET_SET
+
+    agent_id = _make_agent(client, auth_headers)
+    thread = "t-reset-poll-1"
+    url = f"/agents/{agent_id}/threads/{thread}/reset"
+    valkey.srem(THREAD_RESET_SET, thread)
+    try:
+        # Nothing outstanding yet.
+        before = client.get(url, headers=auth_headers)
+        assert before.status_code == 200
+        assert before.json() == {"requested": False}
+
+        # POST enqueues; the poll now reports the reset as still outstanding.
+        assert client.post(url, headers=auth_headers).json() == {"requested": True}
+        pending = client.get(url, headers=auth_headers)
+        assert pending.status_code == 200
+        assert pending.json() == {"requested": True}
+
+        # Simulate the worker's maintenance tick draining THIS thread's request
+        # (it SPOPs the member, then releases the sandbox). The poll then reads
+        # False -- the signal the CLI waits on before it reports success.
+        valkey.srem(THREAD_RESET_SET, thread)
+        released = client.get(url, headers=auth_headers)
+        assert released.status_code == 200
+        assert released.json() == {"requested": False}
+    finally:
+        valkey.srem(THREAD_RESET_SET, thread)
+
+
 def test_reset_thread_requires_a_real_agent(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:
-    resp = client.post(
-        "/agents/00000000-0000-0000-0000-000000000000/threads/t-x/reset",
-        headers=auth_headers,
-    )
-    assert resp.status_code == 404
+    missing = "/agents/00000000-0000-0000-0000-000000000000/threads/t-x/reset"
+    assert client.post(missing, headers=auth_headers).status_code == 404
+    # The poll surface (#735) is scoped to a real agent the same way.
+    assert client.get(missing, headers=auth_headers).status_code == 404
 
 
 def test_budget_round_trips_through_postgres(

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -599,6 +599,34 @@ impl ApiClient {
             .context("decoding thread reset state")
     }
 
+    /// Poll whether a thread's forced reset is still outstanding: `GET
+    /// /agents/{id}/threads/{thread_key}/reset` (#735). `requested` stays true
+    /// from the POST until the worker's maintenance tick releases the sandbox,
+    /// then flips to false -- so a caller can wait for the release to actually
+    /// land (and the next message to be safe from adopting the pre-reset
+    /// sandbox) before it acts. Mirrors the POST above.
+    pub async fn thread_reset_state(
+        &self,
+        agent_id: &str,
+        thread_key: &str,
+    ) -> Result<ThreadResetState> {
+        let resp = self
+            .http
+            .get(format!(
+                "{}/agents/{agent_id}/threads/{thread_key}/reset",
+                self.base_url
+            ))
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("GET /agents/{id}/threads/{thread_key}/reset")?;
+        Self::expect_ok(resp, "polling the thread reset state")
+            .await?
+            .json()
+            .await
+            .context("decoding thread reset state")
+    }
+
     /// Set the agent budget: `PUT /agents/{id}/budget` with a `BudgetConfig` body.
     pub async fn set_budget(&self, agent_id: &str, budget: &BudgetConfig) -> Result<BudgetConfig> {
         let resp = self

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -2844,7 +2844,12 @@ pub enum ResetThreadOutput {
     Done {
         agent: String,
         thread_key: String,
+        /// The reset was accepted and queued (always true on the `Done` path).
         requested: bool,
+        /// The CLI polled `GET .../reset` and observed the worker actually
+        /// release the sandbox within the wait window (#735). False means the
+        /// release is still pending -- queued, but not yet confirmed drained.
+        released: bool,
     },
 }
 
@@ -2856,8 +2861,9 @@ impl crate::ui::CliOutput for ResetThreadOutput {
                 agent,
                 thread_key,
                 requested,
+                released,
             } => {
-                serde_json::json!({"agent": agent, "thread_key": thread_key, "requested": requested})
+                serde_json::json!({"agent": agent, "thread_key": thread_key, "requested": requested, "released": released})
             }
         }
     }
@@ -2868,18 +2874,33 @@ impl crate::ui::CliOutput for ResetThreadOutput {
             ResetThreadOutput::Done {
                 agent,
                 thread_key,
-                requested,
+                released,
+                ..
             } => {
-                ui.payload(&format!(
-                    "thread {thread_key} on agent {agent} reset requested={requested}"
-                ));
-                ui.note(
-                    "The worker's next maintenance tick releases the sandbox; the next message on this thread cold-creates a fresh one.",
-                );
+                if *released {
+                    ui.payload(&format!(
+                        "thread {thread_key} on agent {agent}: reset complete, sandbox released"
+                    ));
+                    ui.note("The next message on this thread cold-creates a fresh sandbox.");
+                } else {
+                    ui.payload(&format!(
+                        "thread {thread_key} on agent {agent}: reset queued, release still pending"
+                    ));
+                    ui.note(
+                        "The worker did not confirm the release within the wait window; its next maintenance tick will release the sandbox. Poll GET .../reset (or re-run) to confirm before the next message.",
+                    );
+                }
             }
         }
     }
 }
+
+/// How long `reset-thread` waits for the worker to actually release the sandbox
+/// before it reports the release as still pending (#735). Comfortably covers the
+/// worker's default 30s `reclaim_interval_s` drain tick.
+const RESET_RELEASE_TIMEOUT: Duration = Duration::from_secs(45);
+/// How often `reset-thread` re-polls `GET .../reset` while waiting (#735).
+const RESET_RELEASE_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 /// `agentos <tier> reset-thread <agent> --thread-key <key> --yes`: force the
 /// thread's sandbox to be released (`POST
@@ -2912,20 +2933,43 @@ pub async fn reset_thread(
     let agent = client.find_agent(&opts.agent).await?;
     let cl = ui.checklist();
     let step = cl.step(&format!("resetting thread {thread_key} on {}", agent.name));
-    let state = match client.reset_thread(&agent.id, &thread_key).await {
-        Ok(state) => {
-            step.done("reset requested");
-            state
+    if let Err(err) = client.reset_thread(&agent.id, &thread_key).await {
+        step.fail("failed");
+        return Err(err);
+    }
+    step.done("reset requested");
+
+    // The POST only *queues* the release; the worker drains it on its next
+    // maintenance tick (up to `reclaim_interval_s`, 30s by default). Poll the
+    // reset state to completion so this command -- and therefore the operator --
+    // does not move on until the sandbox has actually been released, closing the
+    // window where the next message adopts the pre-reset sandbox (#735). A poll
+    // failure never fails an already-accepted reset: it degrades to "release
+    // unconfirmed, still pending".
+    let wait = cl.step("waiting for the sandbox to be released");
+    let deadline = Instant::now() + RESET_RELEASE_TIMEOUT;
+    let released = loop {
+        match client.thread_reset_state(&agent.id, &thread_key).await {
+            Ok(state) if !state.requested => break true,
+            Ok(_) => {}
+            Err(_) => break false,
         }
-        Err(err) => {
-            step.fail("failed");
-            return Err(err);
+        if Instant::now() >= deadline {
+            break false;
         }
+        tokio::time::sleep(RESET_RELEASE_POLL_INTERVAL).await;
     };
+    if released {
+        wait.done("released");
+    } else {
+        wait.done("still pending");
+    }
+
     Ok(ResetThreadOutput::Done {
         agent: agent.name,
         thread_key,
-        requested: state.requested,
+        requested: true,
+        released,
     })
 }
 

--- a/cli/tests/api_lifecycle.rs
+++ b/cli/tests/api_lifecycle.rs
@@ -203,11 +203,16 @@ async fn budget_handler_resolves_then_puts_the_limit() {
 }
 
 #[tokio::test]
-async fn reset_thread_handler_resolves_by_name_then_resets() {
+async fn reset_thread_handler_resolves_then_resets_and_waits_for_release() {
     let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
         ("GET", "/agents") => agent_list(),
         ("POST", p) if *p == format!("/agents/{AGENT_ID}/threads/t-1/reset") => {
             Response::json(200, r#"{"requested":true}"#)
+        }
+        // #735: after the POST the handler polls this until the worker reports
+        // the release actually landed; the stub reports released on first poll.
+        ("GET", p) if *p == format!("/agents/{AGENT_ID}/threads/t-1/reset") => {
+            Response::json(200, r#"{"requested":false}"#)
         }
         other => panic!("unexpected request: {other:?}"),
     });
@@ -230,6 +235,10 @@ async fn reset_thread_handler_resolves_by_name_then_resets() {
             ("GET".to_string(), "/agents".to_string()),
             (
                 "POST".to_string(),
+                format!("/agents/{AGENT_ID}/threads/t-1/reset")
+            ),
+            (
+                "GET".to_string(),
                 format!("/agents/{AGENT_ID}/threads/t-1/reset")
             ),
         ]

--- a/cli/tests/json_emit_contract.rs
+++ b/cli/tests/json_emit_contract.rs
@@ -969,9 +969,10 @@ fn reset_thread_output_json_shape_is_pinned() {
             agent: "weather".to_string(),
             thread_key: "t-1".to_string(),
             requested: true,
+            released: true,
         }
         .to_json(),
-        json!({"agent": "weather", "thread_key": "t-1", "requested": true})
+        json!({"agent": "weather", "thread_key": "t-1", "requested": true, "released": true})
     );
 }
 


### PR DESCRIPTION
## Problem

`POST /agents/{id}/threads/{key}/reset` returns `{"requested": true}` the instant it *queues* a release, but the worker only drains the request on its next maintenance tick (`reclaim_interval_s`, 30s default). So the natural operator workflow — reset a wedged thread, then send a message to confirm — adopts the still-live pre-reset sandbox within that window, and the `200` is indistinguishable from "the reset hasn't landed yet." Because the next instinct is to reset again, it fails in the most confusing direction. The completion signal existed but was dead: `ThreadResetRequests.is_pending` had **zero callers**. (#735)

## Fix

- **API** — add `GET /agents/{id}/threads/{thread_key}/reset` returning whether a reset is still outstanding, wiring the previously-uncalled `is_pending`. This keeps the deliberate async SET design (`threadreset.py`) — it only makes completion **observable**.
- **CLI** — `reset-thread` now polls that endpoint to completion before it returns, so the operator does not move on until the sandbox is actually released. Output gains an explicit `released` boolean.

Design note: shrinking the ≤30s tick latency itself (a wake-nudge, like the kill switch's pub/sub) is deliberately left as a follow-up. This PR makes the wait **honest, bounded (~45s), and pollable** — satisfying #735's acceptance criteria without overturning the SET design.

## Behavior notes

- `reset-thread` now blocks up to ~45s (with a "waiting for release" step) — the honest cost of the async design, and far better than the silent stale-adoption it replaces.
- `reset-thread --json` gains an additive `released: bool` field; `requested` stays `true`.

## Testing

- **API**: `ruff` · `mypy` · `pytest apps/api/tests/test_control_integration.py` (10 passed, real Valkey/Postgres/MinIO) · `openapi.json` drift gate — all green. New test walks `not-pending → POST → pending → drain → released`.
- **CLI**: `cargo fmt --check` clean · `cargo clippy -- -D warnings` clean on the changed files · `api_lifecycle`, `json_emit_contract`, `command_surface`, `api_field_parity`, `json_contract` all pass — including a new poll-flow handler test asserting the `GET /agents → POST reset → GET reset` sequence.

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)
