### PR TITLE
Rationalize the README/QUICKSTART Quickstart duplication

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -161,7 +161,10 @@ when a credential is present).
 
 For the deeper ticket-verification runbook — rebuilding and redeploying a
 changed bundle, watching worker/runner logs, and driving multi-turn
-conversations — see [`docs/onboarding.md`](docs/onboarding.md).
+conversations — see [`docs/onboarding.md`](docs/onboarding.md). To hand-run the
+worker as a bare host process instead of a compose service (e.g. to attach a
+debugger while iterating on worker source), see
+[`apps/worker/README.md`](apps/worker/README.md#running-the-worker-as-a-bare-process-agentos_workerrun-docker-substrate).
 
 ### On a Kubernetes cluster (Helm)
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,6 +3,10 @@
 Welcome. This gets you from nothing to your first agent reply in about a minute,
 with no credentials, no cluster, and no Slack. It runs the `skill` target: just
 the runner container on your host Docker daemon, talking straight to the agent.
+Past that, this is also the detailed, advanced-usage doc: a real model, an
+offline local-model demo, the full local/cluster runbooks, and the contributor
+repo-checkout path. For the 30-second version, see the
+[README Quickstart](README.md#quickstart).
 
 ## Before you start
 
@@ -12,7 +16,8 @@ the runner container on your host Docker daemon, talking straight to the agent.
   [`docs/release-verification.md`](docs/release-verification.md#verify-the-cli-before-installing-it).
 
   Building the CLI from source (`cargo build --release` in `cli/`) is the
-  contributor path — see [`docs/onboarding.md`](docs/onboarding.md).
+  contributor path — see [`docs/onboarding.md`](docs/onboarding.md) and
+  [Contributor path](#contributor-path-repo-checkout) below.
 
 ## Your first agent reply
 
@@ -37,12 +42,29 @@ That is the full loop. `agentos skill up` starts the runner container,
 `agentos skill down` stops it. Edit `skills/my-agent/SKILL.md` in the bundle
 and re-run steps 2 and 3 to see your change answer.
 
+A committed first-party example lives at `examples/weather/`: `cd
+examples/weather && agentos skill up` runs it from a clean clone. For the
+"engine as an in-bundle stdio MCP server" shape — a bundle that ships its own
+tools as a stdio subprocess the harness spawns — see the template at
+[`examples/text-stats-engine/`](examples/text-stats-engine/README.md).
+
 ## Level up: a real model
 
-The fake model returns scripted replies. To get a genuine answer, bring your own
-model through OpenRouter on the same `skill` path. Set `AGENTOS_CREDENTIALS` to
-your OpenRouter key (it must arrive on that variable, not `ANTHROPIC_API_KEY`)
-and name a model slug:
+The fake model returns scripted replies. For a genuine answer, drop
+`--fake-model` and export a credential first (`agentos` forwards it into the
+runner container), then re-run `skill up`:
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN=...        # or ANTHROPIC_API_KEY=...
+agentos skill up
+agentos skill message "What's the weather in Paris? Answer in one short sentence."
+agentos skill down
+```
+
+To use a different provider or model instead of the Anthropic default, bring
+your own model through OpenRouter on the same `skill` path. Set
+`AGENTOS_CREDENTIALS` to your OpenRouter key (it must arrive on that variable,
+not `ANTHROPIC_API_KEY`) and name a model slug:
 
 ```bash
 AGENTOS_CREDENTIALS="$OPENROUTER_TOKEN" agentos skill up \
@@ -54,6 +76,56 @@ agentos skill down
 ```
 
 You should get a real answer instead of the canned loop.
+
+## Offline demo: a real local model, no Anthropic key
+
+`--local-model` is an opt-in offline path that runs a real local model through
+an Anthropic-compatible endpoint, so the demo answers for real and can drive a
+1-2 tool-call loop with no Anthropic key. This is a DEMO / dev-loop path, NOT
+the production agent path — the fake model stays the zero-dependency default.
+
+Use the flag on the CLI surface you are running:
+
+```bash
+agentos skill up --local-model
+agentos local up --local-model
+agentos cluster up --local-model
+```
+
+Bare `--local-model` uses `qwen3:4b`. Override it by passing a model name:
+
+```bash
+agentos local up --local-model qwen3-coder:30b
+```
+
+Combine `--minimal` with `--local-model` when you want the core local loop plus
+Ollama, without Langfuse or the UI:
+
+```bash
+agentos local up --minimal --local-model
+```
+
+`skill up` and `local up` run the model in a Docker container and point spawned
+runners at that endpoint. Both the `skill up --local-model` and compose paths
+persist the pulled model in a Docker volume, so a re-up is fast and does not
+re-download the model; the skill-path volume is named `<container>-ollama-data`
+(the compose path uses `ollama_data`) and can be reclaimed with
+`docker volume rm <volume>`. `cluster up` uses the in-chart inference Deployment;
+the chart renders the Ollama Service and Deployment, opens the runner egress
+carve-out automatically, and bakes `ANTHROPIC_BASE_URL` plus the inference model
+into the runner template.
+
+| Model | Loaded (Q4) | Min box | Notes |
+|---|---|---|---|
+| qwen3:4b | ~2.5GB | 8GB | demo default; clears the 1-2 tool-call bar |
+| qwen3-coder:30b | ~17-19GB | 32GB | MoE 30B/3.3B-active; real agentic-coding upgrade |
+| gemma4:e4b | ~5GB | 16GB | "4.5B effective" name understates RAM; needs Ollama >=0.31.x |
+
+Gotchas: Ollama 0.24.0 fails `gemma4` with `unknown model architecture`; qwen3
+works on 0.24.0 and gemma4 needs >=0.31.x. Gemma HF repos are gated and return
+HTTP 400 on `hf.co/google/...`; use a non-gated mirror such as
+`hf.co/unsloth/gemma-4-E4B-it-GGUF:<quant>`. RAM sizing tracks the loaded
+footprint, not the "effective params" marketing number.
 
 ## Still have time? Run your skill on your local box or on a Kubernetes cluster
 
@@ -79,9 +151,15 @@ agentos local down                    # tear it all down
 
 Watch the run land in the console UI at `http://localhost:28080/?api=1`. Like
 `skill`, the local stack runs the fake model by default, so replies are scripted
-until you wire a real model.
+until you wire a real model (`export CLAUDE_CODE_OAUTH_TOKEN=...` or
+`ANTHROPIC_API_KEY=...` before `local up`, which flips to live automatically
+when a credential is present).
 
 > The stack comes up clean; the UI answers on `:28080`.
+
+For the deeper ticket-verification runbook — a hand-started worker, watching
+logs, and driving multi-turn conversations — see
+[`docs/onboarding.md`](docs/onboarding.md).
 
 ### On a Kubernetes cluster (Helm)
 
@@ -105,3 +183,48 @@ Langfuse login, is in [`docs/operations.md`](docs/operations.md).
 
 See [`cli/README.md`](cli/README.md) for the complete command reference, and the
 [README](README.md#which-target-do-i-want) for a table to help you pick a target.
+
+## Contributor path (repo checkout)
+
+Working on AgentOS itself, rather than just building a plugin against it? Run
+from a repo checkout against the dev stack instead of the prebuilt binary:
+
+```bash
+# 1. Bring up the backing stack. The stack runs on baked defaults; copy
+#    .env.example to the gitignored .env only if you need to override anything.
+cp .env.example .env    # optional
+docker compose --profile full -f compose.dev.yaml up -d
+docker compose -f compose.dev.yaml ps    # wait for all services healthy
+
+# 2. Install the Python workspace (uv workspace: aci-protocol, plugin-format,
+#    apps/api, apps/dispatcher, apps/worker, runner)
+uv sync
+
+# 3. Run the test suite
+uv run pytest -q
+uv run ruff check .
+uv run mypy
+
+# 4. Build the CLI and the runner image
+cd cli && cargo build --release && cd -
+agentos build
+
+# 5. Boot the API server (needs the Postgres schema applied once)
+cd apps/api && uv run alembic upgrade head
+uv run uvicorn agentos_api.main:app --port 8000 &
+cd -
+
+# 6. Boot the UI (fixture mode by default; ?api=1 wires it to the running API)
+cd apps/ui && pnpm install && pnpm dev
+# open http://localhost:5173/?state=1        (fixture demo)
+# open http://localhost:5173/?api=1&state=1  (wired to apps/api on :8000)
+```
+
+`agentos local up` publishes the API on `:28000` (the compose host port); the
+hand-run `uvicorn` in step 5 uses `:8000` instead — point a hand-run `local
+deploy --api-url` at whichever one you brought up.
+
+See [`AGENTS.md`](AGENTS.md) for the full per-package verify commands and dev
+stack gotchas, [`docs/onboarding.md`](docs/onboarding.md) for a from-scratch
+walkthrough of the `skill`/`local` tiers geared at onboarding, and
+`apps/api/README.md` / `apps/ui/README.md` for the API and UI's own docs.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -52,10 +52,11 @@ tools as a stdio subprocess the harness spawns — see the template at
 
 The fake model returns scripted replies. For a genuine answer, drop
 `--fake-model` and export a credential first (`agentos` forwards it into the
-runner container), then re-run `skill up`:
+runner container), then re-run `skill up`. Any one of `CLAUDE_CODE_OAUTH_TOKEN`,
+`ANTHROPIC_API_KEY`, or `AGENTOS_CREDENTIALS` works for the Anthropic default:
 
 ```bash
-export CLAUDE_CODE_OAUTH_TOKEN=...        # or ANTHROPIC_API_KEY=...
+export CLAUDE_CODE_OAUTH_TOKEN=...        # or ANTHROPIC_API_KEY=... / AGENTOS_CREDENTIALS=...
 agentos skill up
 agentos skill message "What's the weather in Paris? Answer in one short sentence."
 agentos skill down
@@ -64,7 +65,8 @@ agentos skill down
 To use a different provider or model instead of the Anthropic default, bring
 your own model through OpenRouter on the same `skill` path. Set
 `AGENTOS_CREDENTIALS` to your OpenRouter key (it must arrive on that variable,
-not `ANTHROPIC_API_KEY`) and name a model slug:
+not `ANTHROPIC_API_KEY`, and here it selects OpenRouter specifically because
+it's paired with `--image`/`--model`) and name a model slug:
 
 ```bash
 AGENTOS_CREDENTIALS="$OPENROUTER_TOKEN" agentos skill up \
@@ -157,9 +159,9 @@ when a credential is present).
 
 > The stack comes up clean; the UI answers on `:28080`.
 
-For the deeper ticket-verification runbook — a hand-started worker, watching
-logs, and driving multi-turn conversations — see
-[`docs/onboarding.md`](docs/onboarding.md).
+For the deeper ticket-verification runbook — rebuilding and redeploying a
+changed bundle, watching worker/runner logs, and driving multi-turn
+conversations — see [`docs/onboarding.md`](docs/onboarding.md).
 
 ### On a Kubernetes cluster (Helm)
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ channel binding, and troubleshooting) see
 
 ## Quickstart
 
+This is the short version — for immediate testing. For a real model, the
+offline local-model demo, building from source, and the full local/cluster
+runbooks, see the detailed walkthrough in [`QUICKSTART.md`](QUICKSTART.md).
+
 The fastest way in — for operators and coding agents alike — is the prebuilt
 release binary. It needs no Rust toolchain and no repo checkout.
 
@@ -194,206 +198,45 @@ You are about to run a downloaded binary as root, so verify it before you instal
 it. [`docs/release-verification.md`](docs/release-verification.md#verify-the-cli-before-installing-it)
 owns the full flow: resolve the right asset for your platform, verify the signed
 `checksums.txt` with cosign (or `gh attestation`), check the binary against it, and
-install. Then, from anywhere:
+install it. Then, from a bundle directory:
 
 ```bash
-agentos cluster up
-agentos local up
-```
-
-A release binary needs no repo checkout for `agentos cluster up` or `agentos local up`.
-It pulls the pinned chart release asset and the pinned `compose.release.yaml`
-matching the binary version, then caches them under `~/.cache/agentos/`. For
-local development overrides, pass `-f <compose>`, `--chart <path>`, or
-`--image <ref>`.
-
-Contributors can still run from a repo checkout against the dev stack in
-`compose.dev.yaml` (Postgres + Valkey + Langfuse v3 + ClickHouse + MinIO + OTel
-Collector). See [`AGENTS.md`](AGENTS.md) for the ports each service binds and
-the load-bearing gotchas.
-
-```bash
-# 1. Bring up the backing stack. The stack runs on baked defaults; copy
-#    .env.example to the gitignored .env only if you need to override anything.
-cp .env.example .env    # optional
-docker compose --profile full -f compose.dev.yaml up -d
-docker compose -f compose.dev.yaml ps    # wait for all services healthy
-
-# 2. Install the Python workspace (uv workspace: aci-protocol, plugin-format,
-#    apps/api, apps/dispatcher, apps/worker, runner)
-uv sync
-
-# 3. Run the test suite
-uv run pytest -q
-uv run ruff check .
-uv run mypy
-
-# 4. Boot the API server (needs the Postgres schema applied once)
-cd apps/api && uv run alembic upgrade head
-uv run uvicorn agentos_api.main:app --port 8000 &
-cd -
-
-# 5. Boot the UI (fixture mode by default; ?api=1 wires it to the running API)
-cd apps/ui && pnpm install && pnpm dev
-# open http://localhost:5173/?state=1        (fixture demo)
-# open http://localhost:5173/?api=1&state=1  (wired to apps/api on :8000)
-```
-
-**CLI walkthrough** (no Slack, no cluster). With the prebuilt `agentos` on
-your PATH (from the Quickstart above), the binary pulls the pinned runner
-image from GHCR on first run — nothing to build:
-
-```bash
-agentos   # optional full-screen terminal UI for the same workflows
 agentos init my-agent && cd my-agent
 agentos skill up --fake-model    # offline scripted model, no credential
-agentos skill message "hello"
+agentos skill message "hello, are you there?"
 agentos skill down
 ```
 
-`agentos skill eval` runs the bundle's eval cases through the same runner
-(under `--fake-model` it checks plumbing only, not answer quality).
+That is the fastest inner loop: zero Slack, zero platform, zero cluster.
 
-For a real model, drop `--fake-model` and export a credential first (it is
-forwarded into the runner container): one of `CLAUDE_CODE_OAUTH_TOKEN`,
-`ANTHROPIC_API_KEY`, or `AGENTOS_CREDENTIALS`.
-
-```bash
-export CLAUDE_CODE_OAUTH_TOKEN=...
-agentos skill up
-```
-
-From a source checkout instead (contributor path): `cd cli && cargo build
---release`, build the runner image once with `agentos build`, then run
-`./target/release/agentos` in place of `agentos`.
-
-A committed first-party example lives at `examples/weather/`. `cd examples/weather && agentos skill up` runs it from a clean clone. `agentos init` scaffolds a generic starter skill named for your agent (plus a root `AGENTS.md` and an installable `.claude/skills/using-agentos/SKILL.md` harness primer) that you edit to build your own agent; see `examples/weather/` for a runnable example to learn from.
-
-For the "engine as an in-bundle stdio MCP server" shape — a bundle that ships
-its own tools as a stdio subprocess the harness spawns, which a hosted harness
-cannot do — see the template at [`examples/text-stats-engine/`](examples/text-stats-engine/README.md).
-
-For a fully offline round-trip (no credential, scripted replies), add
-`--fake-model` to `agentos skill up` — an explicit test-only mode that never reaches
-the Anthropic API.
-
-**One-command middle mode** (the fastest path — no host-run worker, no cluster):
+**One-command middle mode** — the same bundle through the real product path
+(queue, worker, sandbox), still no host-run worker and no cluster:
 
 ```bash
 agentos local up   # full profile: stores + API + worker + Langfuse + UI
-# or: agentos local up --minimal   # core profile: stores + API + worker only
-agentos local deploy --plugin-dir ./my-agent --slack-channel C-DEMO --api-url http://localhost:28000
+agentos local deploy --plugin-dir . --slack-channel C0123ABCD --api-url http://localhost:28000
 agentos local message "what changed in the last deploy?"
 ```
 
-`local up` runs the worker as the `agentos-worker` compose service (fake model by
-default), so there is nothing to hand-run. For a real model, export a credential
-in your shell and `local up` goes live automatically. The manual runbook
-below is the equivalent with a host-process worker, useful when iterating on the
-worker itself from source. The console UI is served at
-`http://localhost:28080/?api=1` when you use the default `full` profile.
+Watch it land in the console UI at `http://localhost:28080/?api=1`. `local up`
+runs the fake model by default; export `CLAUDE_CODE_OAUTH_TOKEN` or
+`ANTHROPIC_API_KEY` beforehand for a real model. A release binary needs no
+repo checkout for either `local` or `cluster up` — it pulls the pinned chart
+release asset and pinned `compose.release.yaml` matching the binary version,
+caching both under `~/.cache/agentos/`.
 
-**Local-model demo mode** is an opt-in offline path that runs a real local model
-through an Anthropic-compatible endpoint, so the demo answers for real and can
-drive a 1-2 tool-call loop with no Anthropic key. This is a DEMO / dev-loop path,
-NOT the production agent path. The fake model stays the zero-dependency default.
-
-Use one flag on the CLI surface you are running:
-
-```bash
-agentos skill up --local-model
-agentos local up --local-model
-agentos cluster up --local-model
-```
-
-Bare `--local-model` uses `qwen3:4b`. Override it by passing a model name:
-
-```bash
-agentos local up --local-model qwen3-coder:30b
-```
-
-Combine `--minimal` with `--local-model` when you want the core local loop plus
-Ollama, without Langfuse or the UI:
-
-```bash
-agentos local up --minimal --local-model
-```
-
-`skill up` and `local up` run the model in a Docker container and point spawned
-runners at that endpoint. Both the `skill up --local-model` and compose paths
-persist the pulled model in a Docker volume, so a re-up is fast and does not
-re-download the model; the skill-path volume is named `<container>-ollama-data`
-(the compose path uses `ollama_data`) and can be reclaimed with
-`docker volume rm <volume>`. `cluster up` uses the in-chart inference Deployment;
-the chart renders the Ollama Service and Deployment, opens the runner egress
-carve-out automatically, and bakes `ANTHROPIC_BASE_URL` plus the inference model
-into the runner template.
-
-| Model | Loaded (Q4) | Min box | Notes |
-|---|---|---|---|
-| qwen3:4b | ~2.5GB | 8GB | demo default; clears the 1-2 tool-call bar |
-| qwen3-coder:30b | ~17-19GB | 32GB | MoE 30B/3.3B-active; real agentic-coding upgrade |
-| gemma4:e4b | ~5GB | 16GB | "4.5B effective" name understates RAM; needs Ollama >=0.31.x |
-
-Gotchas: Ollama 0.24.0 fails `gemma4` with `unknown model architecture`; qwen3
-works on 0.24.0 and gemma4 needs >=0.31.x. Gemma HF repos are gated and return
-HTTP 400 on `hf.co/google/...`; use a non-gated mirror such as
-`hf.co/unsloth/gemma-4-E4B-it-GGUF:<quant>`. RAM sizing tracks the loaded
-footprint, not the "effective params" marketing number.
-
-`agentos local up` publishes the API on `:28000` (the compose host port); the
-hand-run `uvicorn` in Quickstart step 4 uses `:8000`. Point `deploy --api-url`
-at whichever one you brought up.
-
-**Local runbook** (real deployed pipeline, no Slack, no cluster — the
-backing stack from the Quickstart plus the API on :8000 and the runner image
-built as above):
-
-```bash
-# Deploy a plugin to the API (creates the agent bound to a Slack channel id).
-# This runbook hand-starts uvicorn on :8000 (Quickstart step 4), so pin
-# --api-url to it; local deploy otherwise defaults to the `local up` API on :28000.
-./target/release/agentos local deploy --plugin-dir ./my-agent --slack-channel C-DEMO \
-    --api-url http://localhost:8000 --env dev
-
-# Start a worker that claims runner containers via Docker. REAL MODEL is the
-# default: export your credential first (forwarded into each runner container).
-# AGENTOS_DOCKER_NETWORK joins each runner container to the compose network and
-# OTEL_EXPORTER_OTLP_ENDPOINT is forwarded into it; without BOTH, runs still
-# execute but emit no traces (the runner cannot resolve otel-collector).
-export CLAUDE_CODE_OAUTH_TOKEN=...        # or ANTHROPIC_API_KEY=...
-env AGENTOS_SANDBOX_SUBSTRATE=docker \
-    VALKEY_HOST=localhost VALKEY_PORT=26379 VALKEY_PASSWORD=valkeypass \
-    SLACK_API_BASE_URL=http://localhost:8155/api/ SLACK_BOT_TOKEN=xoxb-dev \
-    AGENTOS_DOCKER_NETWORK=agentos_default \
-    OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318 \
-    uv run python -m agentos_worker &
-
-# Send a message through the same path a Slack mention takes; the fake-model
-# transcript is the identical command minus the credential, plus AGENTOS_FAKE_MODEL=1.
-./target/release/agentos local message "what changed in the last deploy?" \
-    --channel C-DEMO
-```
-
-For an offline round-trip add `AGENTOS_FAKE_MODEL=1` to the worker env and drop
-the credential. Without either, the worker refuses to start.
-
-Prefer a prebuilt binary for local commands? The
-[GitHub Releases](https://github.com/curie-eng/agentos/releases) page attaches
-`agentos-<target>` binaries on every tag push (`agentos-x86_64-unknown-linux-gnu`
-and `agentos-aarch64-apple-darwin`), so `v0.1.0` onward you can download the CLI
-instead of running `cargo build` above.
-
-Each package documents its own deeper verify commands and gotchas in its own
-README (linked above) and its own scoped `CLAUDE.md` — this quickstart is
-enough to see the pieces move; it is not a substitute for those.
+See [`QUICKSTART.md`](QUICKSTART.md) for: a real model in more depth, the
+offline `--local-model` demo (Ollama, no Anthropic key), running on a
+Kubernetes cluster, the `examples/` bundles, and the contributor path for
+building AgentOS itself from a repo checkout.
 
 ## How do I develop and verify a change?
 
 - **Python packages** are one `uv` workspace (root `pyproject.toml`); ruff,
-  mypy, and pytest run across all members from the repo root (see step 3
-  above). Integration tests hit the real dev stack, never mocks of
-  Postgres/Valkey/Langfuse.
+  mypy, and pytest run across all members from the repo root
+  (`uv sync && uv run pytest -q && uv run ruff check . && uv run mypy`; see
+  [`AGENTS.md`](AGENTS.md) for the full verify command reference). Integration
+  tests hit the real dev stack, never mocks of Postgres/Valkey/Langfuse.
 - **The Rust CLI** and **the UI** are verified independently; see
   `cli/README.md` and `apps/ui/README.md` for their commands.
 - **Work on a feature branch per change**, cut from `main`; never commit to

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -295,6 +295,56 @@ from `compose.dev.yaml`, the real sandbox substrate with a fake Kubernetes clien
 sandboxes resolve to a local in-process fake runner, and a recording Slack sink.
 Only Slack and the model behind the runner are faked.
 
+### Running the worker as a bare process (`agentos_worker.run`, Docker substrate)
+
+`agentos_worker.run` is the `python -m agentos_worker` entrypoint: it reads
+`WorkerConfig`, builds the Valkey clients, the sandbox substrate, the
+`RunnerClient`, and the Slack sink, then drives the consumer until a signal
+stops it. `_sandbox_client` picks the substrate via `AGENTOS_SANDBOX_SUBSTRATE`
+(`kubernetes`, the default, claims agent-sandbox CRs; `docker` boots runner
+containers on the host Docker daemon instead -- what `agentos local up` sets
+when it runs the worker as a compose service).
+
+To hand-run the worker as a bare host process against an already-running
+`compose.dev.yaml` stack instead of letting `agentos local up` manage it as a
+compose service -- useful for attaching a debugger or iterating on worker
+source without a container rebuild -- point it at the stack's exposed ports:
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN=...        # or ANTHROPIC_API_KEY=... / AGENTOS_CREDENTIALS=...
+env AGENTOS_SANDBOX_SUBSTRATE=docker \
+    VALKEY_HOST=localhost VALKEY_PORT=26379 VALKEY_PASSWORD=valkeypass \
+    SLACK_API_BASE_URL=http://localhost:8155/api/ SLACK_BOT_TOKEN=xoxb-dev \
+    AGENTOS_DOCKER_NETWORK=agentos_default \
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318 \
+    uv run python -m agentos_worker &
+```
+
+- With the Docker substrate, `_sandbox_client` requires a model credential
+  (`AGENTOS_CREDENTIALS`, `CLAUDE_CODE_OAUTH_TOKEN`, or `ANTHROPIC_API_KEY`),
+  `AGENTOS_MODEL_BASE_URL` (local-model mode), or `AGENTOS_FAKE_MODEL=1`
+  (explicit offline opt-in) -- absent all three it raises `SystemExit` at
+  startup rather than booting a runner that fails cryptically.
+- `AGENTOS_DOCKER_NETWORK` joins each spawned runner container to the compose
+  network (`docker.py`'s `--network`); without it a runner is on the default
+  bridge network and can't reach the stack's other services (including the
+  OTel collector) by hostname.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` is forwarded into each spawned runner; unset,
+  runners still boot but just don't export traces (a warning, not a startup
+  failure).
+- `AGENTOS_RUNNER_IMAGE` overrides the runner image tag (default
+  `agentos-runner`).
+- `VALKEY_HOST`/`VALKEY_PORT`/`VALKEY_PASSWORD` and `SLACK_BOT_TOKEN` point at
+  the compose stack's exposed ports and dev bot token (see `compose.dev.yaml`);
+  `SLACK_API_BASE_URL` points at the stack's Slack stub instead of real
+  slack.com.
+
+Drive a turn the normal way once it's up (`agentos local deploy` / `agentos
+local message`, pinned at whichever API port you brought up) -- the hand-run
+worker claims runner containers on the same Docker daemon exactly as the
+compose-managed one would. For an offline round-trip, add `AGENTOS_FAKE_MODEL=1`
+to the env above and drop the credential.
+
 ## The sandbox substrate (`agentos_worker.sandbox`)
 
 The lifecycle seam between the worker kernel and kubernetes-sigs/agent-sandbox

--- a/cli/README.md
+++ b/cli/README.md
@@ -473,7 +473,7 @@ Kubernetes release, so the whole loop is one machine with no cluster:
 
 ```bash
 agentos local up
-agentos local deploy --plugin-dir <dir> --slack-channel C-DEMO --api-url http://localhost:28000
+agentos local deploy --plugin-dir <dir> --slack-channel C0123ABCD --api-url http://localhost:28000
 agentos local message "what changed in the last deploy?"
 ```
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -82,7 +82,7 @@ Use this as the verification loop for a code change:
 1. Rebuild what changed. Rebuild the runner image with
    `agentos build` if you touched runner
    code. Run
-   `agentos local deploy --plugin-dir . --slack-channel C-DEMO --api-url http://localhost:28000`
+   `agentos local deploy --plugin-dir . --slack-channel C0123ABCD --api-url http://localhost:28000`
    again to push a changed bundle.
 2. Drive a real turn with `agentos local message "..."`. It walks the full
    queue, worker, sandboxed runner, and reply path, the same path a Slack mention


### PR DESCRIPTION
## Summary

Closes #804.

- README.md's `## Quickstart` had grown into the more detailed of the two docs (cosign verification, the contributor build-from-source path, the offline `--local-model` Ollama demo, a manual worker runbook), while QUICKSTART.md stayed short - backwards from the intended split of a short README pointer plus a longer, detailed doc for advanced usage.
- Trimmed README's Quickstart to the prebuilt-binary install plus the `init`/`skill up`/`message`/`down` and `local up`/`deploy`/`message` loops, linking out to QUICKSTART.md for anything deeper.
- Moved the detailed content into QUICKSTART.md: real model via direct credential vs. OpenRouter, the offline `--local-model` demo, and a new "Contributor path (repo checkout)" section.
- Preserved the anchors other docs depend on (`README.md#quickstart`, the macOS Gatekeeper note referenced from `docs/release-verification.md`, the local-up runbook referenced from `docs/operations.md`).
- Bug found while testing: `agentos local deploy --slack-channel C-DEMO` 422s — the API's channel-ID validator requires `^[CDG][A-Z0-9]{7,}$`, which the hyphenated placeholder never matched. Replaced `C-DEMO` with `C0123ABCD` (the placeholder already used in `docs/slack-local-runbook.md` and the validator's own error message) everywhere it was copied: README.md, docs/onboarding.md, and cli/README.md.

## Test plan

Ran the documented commands end to end with the real v0.4.3 release binary, no repo checkout:
- [x] `curl` binary download per the README — confirmed no quarantine flag is set (`com.apple.provenance` only), matching the Gatekeeper note
- [x] `agentos init` / `skill up --fake-model` / `skill message` / `skill down` — full loop works, clean teardown
- [x] `agentos local up` / `local deploy --slack-channel C0123ABCD` / `local message` / `local down` — reproduced the `C-DEMO` 422, confirmed the fix resolves it, full loop works, no residual containers or volumes after teardown