### PR TITLE
Adopt an existing non-plugin bundle: init --adopt + guide + signpost error

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -86,6 +86,14 @@ export const commandManifest = {
           "long": "from-spec",
           "positional": false,
           "required": false
+        },
+        {
+          "global": false,
+          "help": "Adopt an existing non-plugin directory: scaffold the plugin skeleton INTO it (alongside your code, never overwriting existing files), deriving the name from the directory unless a NAME is given. The on-ramp for a pre-plugin (agent-ss-template) bundle; port the logic by hand afterward (docs/adopting-a-bundle.md, #745)",
+          "id": "adopt",
+          "long": "adopt",
+          "positional": false,
+          "required": false
         }
       ],
       "hidden": false,

--- a/cli/README.md
+++ b/cli/README.md
@@ -38,6 +38,7 @@ runner and ACI, so a `message` walks the same path a real Slack mention would.
 |---|---|
 | `agentos init <name>` | Scaffold a plugin bundle (Claude Code plugin shape: `.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`) plus an `evals/cases.json` seed, a root `AGENTS.md`, and an installable `.claude/skills/using-agentos/SKILL.md` harness primer. |
 | `agentos init --from-spec <path>` | Scaffold **non-interactively** from an agent-authored spec file (JSON). The bundle name comes from the spec, not a positional argument. A coding agent interviews the human, writes the spec, then this command lays down the same plugin-format shape deterministically -- zero prompts. See the spec shape below. |
+| `agentos init --adopt <dir>` | Adopt an existing non-plugin directory: scaffold the same plugin skeleton **into** it, alongside your code and never overwriting an existing file, with the bundle name derived from the directory unless a `<name>` is given. The on-ramp for a pre-plugin (`agent-ss-template`) bundle; the logic port is manual afterward -- see `docs/adopting-a-bundle.md`. |
 | `agentos` | Open the keyboard-driven terminal interface. Explicit forms: `agentos interactive`, `agentos ui`, `agentos tui`. |
 | `agentos secrets set <NAME>` | Save a local secret in AgentOS's mode-0600 credential file with hidden input. `--from-env <VAR>` reads from an existing environment variable for non-interactive use without putting the value in argv. |
 | `agentos secrets list` | List saved AgentOS secret names. Values are never printed. |

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -83,6 +83,14 @@
           "long": "from-spec",
           "positional": false,
           "required": false
+        },
+        {
+          "global": false,
+          "help": "Adopt an existing non-plugin directory: scaffold the plugin skeleton INTO it (alongside your code, never overwriting existing files), deriving the name from the directory unless a NAME is given. The on-ramp for a pre-plugin (agent-ss-template) bundle; port the logic by hand afterward (docs/adopting-a-bundle.md, #745)",
+          "id": "adopt",
+          "long": "adopt",
+          "positional": false,
+          "required": false
         }
       ],
       "hidden": false,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -21,7 +21,9 @@ use crate::evals::{
 };
 use crate::render::{boxed_summary, status_str, TurnPart, TurnPrinter};
 use crate::runner::RunnerClient;
-use crate::scaffold::{read_declared_secrets, read_manifest, scaffold, scaffold_from_spec};
+use crate::scaffold::{
+    derive_plugin_name, read_declared_secrets, read_manifest, scaffold, scaffold_from_spec,
+};
 use crate::state::{self, RunnerState};
 
 pub const DEFAULT_PORT: u16 = 7245; // the design canon's local bot port
@@ -250,7 +252,12 @@ impl crate::ui::CliOutput for CheckOutput<'_> {
     }
 }
 
-pub fn init(name: Option<String>, dir: Option<PathBuf>, from_spec: Option<PathBuf>) -> Result<()> {
+pub fn init(
+    name: Option<String>,
+    dir: Option<PathBuf>,
+    from_spec: Option<PathBuf>,
+    adopt: Option<PathBuf>,
+) -> Result<()> {
     let ui = crate::ui::ui();
 
     // Spec-file path (ADR-0021 decision 5): fully non-interactive. The bundle
@@ -289,9 +296,48 @@ pub fn init(name: Option<String>, dir: Option<PathBuf>, from_spec: Option<PathBu
         return Ok(());
     }
 
+    // Adopt an existing directory (#745, ADR-0071): scaffold the plugin skeleton
+    // INTO <dir> alongside whatever is already there, deriving the name from the
+    // directory unless an explicit NAME overrides it. The logic port is the
+    // operator's (docs/adopting-a-bundle.md); this only lays the skeleton.
+    if let Some(adopt_dir) = adopt {
+        if !adopt_dir.is_dir() {
+            bail!(
+                "--adopt {}: not a directory. Point it at the existing bundle to adopt.",
+                adopt_dir.display()
+            );
+        }
+        let name = match name {
+            Some(name) => name,
+            None => derive_plugin_name(&adopt_dir).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "could not derive a kebab-case plugin name from {}; pass one explicitly: \
+                     agentos init <name> --adopt {}",
+                    adopt_dir.display(),
+                    adopt_dir.display()
+                )
+            })?,
+        };
+        let created = scaffold(&adopt_dir, &name)?;
+        report_scaffold(
+            ui,
+            name.clone(),
+            None,
+            format!(
+                "adopted {} as plugin bundle '{name}' -- scaffolded the skeleton alongside \
+                 your existing files. Port your agent's logic into skills/{name}/SKILL.md and \
+                 .mcp.json (see docs/adopting-a-bundle.md), then run `agentos skill up`.",
+                adopt_dir.display()
+            ),
+            created,
+            &adopt_dir,
+        );
+        return Ok(());
+    }
+
     let name = match name {
         Some(name) => name,
-        None => bail!("provide a plugin NAME or --from-spec <path>"),
+        None => bail!("provide a plugin NAME, --from-spec <path>, or --adopt <dir>"),
     };
     let dir = dir.unwrap_or_else(|| PathBuf::from(&name));
     let created = scaffold(&dir, &name)?;
@@ -4025,12 +4071,7 @@ fn read_bundle_gates(plugin_dir: &Path) -> Result<Vec<(String, String)>> {
         .iter()
         .map(|loc| plugin_dir.join(loc))
         .find(|path| path.is_file())
-        .ok_or_else(|| {
-            crate::exit::usage(format!(
-                "no plugin manifest under {}: expected .claude-plugin/plugin.json or plugin.json",
-                plugin_dir.display()
-            ))
-        })?;
+        .ok_or_else(|| crate::exit::usage(crate::scaffold::no_manifest_message(plugin_dir)))?;
     let body = std::fs::read_to_string(&manifest_path)
         .with_context(|| format!("reading {}", manifest_path.display()))?;
     parse_manifest_gates(&body, &manifest_path.display().to_string())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -178,6 +178,14 @@ enum Command {
         /// Scaffold non-interactively from an agent-authored spec file (JSON). The bundle name comes from the spec.
         #[arg(long, value_name = "PATH")]
         from_spec: Option<PathBuf>,
+        /// Adopt an existing non-plugin directory: scaffold the plugin skeleton INTO it (alongside your code, never overwriting existing files), deriving the name from the directory unless a NAME is given. The on-ramp for a pre-plugin (agent-ss-template) bundle; port the logic by hand afterward (docs/adopting-a-bundle.md, #745).
+        #[arg(
+            long,
+            value_name = "DIR",
+            conflicts_with = "from_spec",
+            conflicts_with = "dir"
+        )]
+        adopt: Option<PathBuf>,
     },
     /// Work with a local runner session for a plugin bundle:
     /// `skill <up|down|status|message|eval|approvals>`. `versions` and `memory`
@@ -1448,7 +1456,8 @@ async fn run(command: Option<Command>) -> Result<()> {
             name,
             dir,
             from_spec,
-        }) => commands::init(name, dir, from_spec),
+            adopt,
+        }) => commands::init(name, dir, from_spec, adopt),
         Some(Command::Build { tag }) => commands::build(&tag).await,
         Some(Command::Install { update }) => commands::install(update).await,
         Some(Command::Update { image }) => commands::update(image).await,

--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -34,6 +34,31 @@ pub fn valid_name(name: &str) -> bool {
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
 }
 
+/// Derive a kebab-case plugin name from a directory's own name, for `init
+/// --adopt` (#745). Lowercases, turns each run of non-alphanumerics into a
+/// single hyphen, and trims leading/trailing hyphens, so the result satisfies
+/// `valid_name`. Returns None when nothing usable remains (the caller then asks
+/// for an explicit NAME).
+pub(crate) fn derive_plugin_name(dir: &Path) -> Option<String> {
+    let base = dir
+        .canonicalize()
+        .ok()
+        .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()))?;
+    let mut out = String::new();
+    let mut prev_hyphen = true; // start true to suppress any leading hyphen
+    for ch in base.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_hyphen = false;
+        } else if !prev_hyphen {
+            out.push('-');
+            prev_hyphen = true;
+        }
+    }
+    let name = out.trim_end_matches('-').to_string();
+    (!name.is_empty() && valid_name(&name)).then_some(name)
+}
+
 fn manifest(name: &str) -> String {
     serde_json::to_string_pretty(&serde_json::json!({
         "name": name,
@@ -289,12 +314,44 @@ pub(crate) fn load_manifest_json(dir: &Path) -> Result<(std::path::PathBuf, serd
         .iter()
         .map(|rel| dir.join(rel))
         .find(|p| p.is_file())
-        .with_context(|| format!("no plugin manifest under {}", dir.display()))?;
+        .ok_or_else(|| anyhow::anyhow!("{}", no_manifest_message(dir)))?;
     let body =
         std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
     let value: serde_json::Value = serde_json::from_str(&body)
         .with_context(|| format!("{} is not valid JSON", path.display()))?;
     Ok((path, value))
+}
+
+/// A directory that looks like a pre-plugin `agent-ss-template` bundle: a
+/// Python-package agent (`src/` plus a build/run file) rather than a plugin
+/// (#745). Used only to make the "no plugin manifest" error point somewhere.
+fn looks_like_pre_plugin_bundle(dir: &Path) -> bool {
+    dir.join("src").is_dir()
+        && ["Makefile", "Dockerfile", "compose.yaml", "server.py"]
+            .iter()
+            .any(|f| dir.join(f).exists())
+}
+
+/// The "no plugin manifest" error, shape-aware (#745): a pre-plugin bundle is
+/// pointed at `init --adopt` and the porting guide; anything else gets the
+/// generic scaffold hint. Shared by every manifest-read call site so the dead
+/// end always names the path forward.
+pub(crate) fn no_manifest_message(dir: &Path) -> String {
+    let d = dir.display();
+    if looks_like_pre_plugin_bundle(dir) {
+        format!(
+            "no plugin manifest under {d} -- this looks like a pre-plugin \
+             (agent-ss-template) bundle. Run `agentos init --adopt {d}` to scaffold \
+             the plugin skeleton alongside your code, then port its logic into \
+             skills/ and .mcp.json (see docs/adopting-a-bundle.md)."
+        )
+    } else {
+        format!(
+            "no plugin manifest under {d}: expected .claude-plugin/plugin.json or \
+             plugin.json. Run `agentos init <name>` to scaffold a new bundle, or \
+             `agentos init --adopt {d}` to adopt an existing directory."
+        )
+    }
 }
 
 /// Read the plugin name and version from a bundle's manifest.
@@ -336,6 +393,47 @@ pub fn read_declared_secrets(dir: &Path) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn derive_plugin_name_kebabizes_a_directory_basename() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("Revenue_Leak Agent!");
+        std::fs::create_dir(&sub).unwrap();
+        assert_eq!(
+            derive_plugin_name(&sub).as_deref(),
+            Some("revenue-leak-agent")
+        );
+    }
+
+    #[test]
+    fn derive_plugin_name_is_none_when_nothing_usable_remains() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("!!!");
+        std::fs::create_dir(&sub).unwrap();
+        assert_eq!(derive_plugin_name(&sub), None);
+    }
+
+    #[test]
+    fn no_manifest_message_points_a_pre_plugin_bundle_at_adopt() {
+        // src/ + a build/run file => looks like an agent-ss-template bundle.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("server.py"), "# flask\n").unwrap();
+        let msg = no_manifest_message(dir.path());
+        assert!(msg.contains("agent-ss-template"), "{msg}");
+        assert!(msg.contains("init --adopt"), "{msg}");
+        assert!(msg.contains("docs/adopting-a-bundle.md"), "{msg}");
+    }
+
+    #[test]
+    fn no_manifest_message_is_generic_for_a_plain_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let msg = no_manifest_message(dir.path());
+        assert!(msg.contains(".claude-plugin/plugin.json"), "{msg}");
+        assert!(!msg.contains("agent-ss-template"), "{msg}");
+        // still offers adopt as an option, just not as the lead.
+        assert!(msg.contains("init --adopt"), "{msg}");
+    }
 
     #[test]
     fn accepts_kebab_case_and_rejects_everything_else() {

--- a/docs/adopting-a-bundle.md
+++ b/docs/adopting-a-bundle.md
@@ -1,0 +1,69 @@
+# Adopting an existing agent into a plugin bundle
+
+You already have an agent — a pre-plugin (`agent-ss-template`) project: a Python
+package with `src/`, a `Makefile`, a `Dockerfile`, a `compose.yaml`, and a
+Flask/Slack `server.py`. AgentOS runs a different shape — a **plugin bundle**
+(`.claude-plugin/plugin.json`, `skills/<name>/SKILL.md`, `.mcp.json`, <!-- doclint:ignore-line -->
+`evals/cases.json`) — so `agentos skill up` on your directory dead-ends at *"no <!-- doclint:ignore-line -->
+plugin manifest"*.
+
+This guide is the supported path from the old shape to a runnable bundle. It has
+two parts: a **mechanical** step (scaffold the skeleton) and a **manual** step
+(port the logic). The logic port is deliberately manual — deciding what becomes
+a skill, an MCP tool, or the system prompt needs your judgment, not a converter
+(see [ADR-0071](adr/0071-adopting-a-pre-plugin-bundle-scaffolds-the-skeleton-not-the-logic.md)).
+
+## Step 1 — scaffold the plugin skeleton (mechanical)
+
+From anywhere, point `init --adopt` at your existing directory:
+
+```bash
+agentos init --adopt ./revenue-leak-agent
+```
+
+This creates the plugin file-set **alongside** your existing code — it never
+overwrites a file you already have, and it does not touch `src/`, your
+`Makefile`, or anything else. The bundle name is derived from the directory
+(`revenue-leak-agent`); pass an explicit name to override:
+
+```bash
+agentos init revenue-leak --adopt ./revenue-leak-agent
+```
+
+You now have, next to your old files:
+
+```
+.claude-plugin/plugin.json     # the bundle manifest
+skills/<name>/SKILL.md         # a starter skill (edit this)
+.mcp.json                      # MCP servers (empty to start)
+evals/cases.json               # a starter smoke eval
+AGENTS.md                      # harness instructions
+```
+
+## Step 2 — port the logic (manual)
+
+Move your agent's behavior from the old app into the bundle. The mapping:
+
+| In the old shape | Goes to |
+|---|---|
+| The system prompt / agent instructions | the body of `skills/<name>/SKILL.md` |
+| A deterministic tool / API call your code made (e.g. a CRM lookup) | an **MCP server** entry in `.mcp.json` (stdio `command` or `url`) — often your existing engine wrapped as a small stdio MCP server |
+| The LLM call and its loop | handled by the runner; you supply the skill + tools, not the loop |
+| `server.py`'s Slack handling | **dropped** — AgentOS owns ingress; you keep only the agent's decision logic |
+
+Your existing Python doesn't have to be rewritten — the pragmatic path is to
+expose its capabilities as an in-bundle stdio MCP server that `.mcp.json` points
+at, and let the skill drive it. Start by copying your prompt into `SKILL.md` and
+adding one MCP tool, then grow from there.
+
+## Step 3 — run it
+
+```bash
+agentos skill up --fake-model      # boots offline, no credential; proves the bundle loads
+agentos skill message "..."        # canned reply under fake model — plumbing, not a graded answer
+agentos skill down
+```
+
+Then write a **falsifiable** eval in `evals/cases.json` (one a broken agent would <!-- doclint:ignore-line -->
+fail), and re-run `agentos skill eval` with a real credential to grade it — that
+green is your promotion gate. `agentos guide` has the full authoring loop.

--- a/docs/adr/0071-adopting-a-pre-plugin-bundle-scaffolds-the-skeleton-not-the-logic.md
+++ b/docs/adr/0071-adopting-a-pre-plugin-bundle-scaffolds-the-skeleton-not-the-logic.md
@@ -1,0 +1,78 @@
+# 71. Adopting a pre-plugin bundle scaffolds the skeleton, not the logic
+
+Date: 2026-07-21
+
+Status: Accepted
+
+Sits alongside the `agentos init` scaffold (`cli/src/scaffold.rs`, which produces
+the frozen `packages/plugin-format` shape verbatim) and ADR-0021 (the CLI is a
+harness for coding agents). Supersedes nothing.
+
+Closes the code half of [#745](https://github.com/curie-eng/agentos/issues/745)
+("no adoption path for an existing non-plugin-shape bundle"), found in an
+onboarding dogfood where "stand up the demo app on the skill tier" was not
+completable because the agent already existed in the older `agent-ss-template`
+shape.
+
+## Context
+
+`agentos skill up` requires a plugin bundle: `.claude-plugin/plugin.json`,
+`skills/<name>/SKILL.md`, `.mcp.json`, `evals/cases.json`. An agent in the older
+`agent-ss-template` shape — a Python package (`src/`, `Makefile`, `Dockerfile`,
+`compose.yaml`, a Flask/Slack `server.py`) — has none of those, so `skill up`
+dead-ends at `no plugin manifest under <dir>` with no path forward. Every
+internal agent that predates the plugin format is in this position, so "point
+AgentOS at the agent I already have" has no answer today. Our own cold-start
+ladder never exercises this: every run begins with `agentos init <name>` against
+a *freshly scaffolded* bundle, so the whole adopt-an-existing-bundle journey is a
+structural blind spot.
+
+Three options were weighed:
+
+1. **A runner adapter** that consumes the old shape directly. Rejected: the old
+   shape is a standalone Flask/Slack *server app*, a fundamentally different
+   execution model from the claude-agent-sdk runner (skills + MCP). Running it
+   natively means two agent runtimes in one image. The blessed way to reuse an
+   existing engine is "engine as an in-bundle stdio MCP server" — which is
+   epic #30's territory, not a #745 adoption path.
+2. **A migration verb** that scaffolds the plugin skeleton around an existing
+   tree.
+3. **A documented hand-port guide.**
+
+The load-bearing insight: the *skeleton* is mechanizable, but the *logic port* —
+deciding what becomes a skill vs. an MCP tool vs. the system prompt — inherently
+needs human judgment. No tool can auto-convert a Flask app into the plugin
+format. So (2) and (3) are complements, not alternatives.
+
+## Decision
+
+Adopt options **2 + 3**, and reject option 1.
+
+- **`agentos init --adopt <DIR>`** scaffolds the plugin skeleton *into* an
+  existing directory: the same byte-compatible file set `init` already produces
+  (`scaffold::scaffold`), with the plugin name derived from the directory's own
+  name (kebab-sanitized; an explicit positional `NAME` overrides). It reuses the
+  existing collision-refusal discipline, so it creates the plugin files
+  *alongside* the existing `src/`/`Makefile`/etc. and never overwrites a file the
+  operator already has. It does **not** touch or interpret the existing code —
+  the logic port stays the operator's, guided by (3).
+- **A porting guide** (`docs/adopting-a-bundle.md`) is the honest destination:
+  it names the two shapes and walks the manual port (what maps to a skill, to an
+  MCP server, to the system prompt).
+- **The `no plugin manifest` error names the path forward.** When the directory
+  looks like a pre-plugin bundle (a `src/` dir plus a `Makefile`/`Dockerfile`/
+  `compose.yaml`/`server.py`), the error points at `init --adopt` and the guide
+  instead of dead-ending.
+
+## Consequences
+
+- An operator with a pre-plugin agent runs `agentos init --adopt .`, gets a
+  runnable plugin skeleton next to their code, and follows the guide to move the
+  logic in — the dogfood blocker becomes a two-step on-ramp.
+- The scaffold stays byte-identical to `init`'s (adopt reuses it verbatim), so
+  the plugin-format byte-compat obligation and its tests are unchanged.
+- The logic port is deliberately **not** automated; the guide sets that
+  expectation rather than implying a magic converter.
+- Deferred (out of scope, tracked under #745): the `revenue-leak-agent`
+  README/COMMANDS docs that drive everything through `make`/`./rl` and never
+  mention `agentos skill` — that doc fix lives in the agent's own repo.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -100,4 +100,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0068 | [A `--model` sweep row with zero completed turns fails loudly instead of reporting 0%](0068-eval-sweep-fails-loudly-on-zero-completed-turns.md) | Accepted |
 | 0069 | [The policy-gate resume reconciliation stays observe-only](0069-policy-gate-resume-reconciliation-stays-observe-only.md) | Accepted |
 | 0070 | [A bundle-local `.env` is an opt-in, lowest-priority credential source](0070-bundle-local-dotenv-is-an-opt-in-lowest-priority-credential-source.md) | Accepted |
+| 0071 | [Adopting a pre-plugin bundle scaffolds the skeleton, not the logic](0071-adopting-a-pre-plugin-bundle-scaffolds-the-skeleton-not-the-logic.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
## Problem

An agent in the older `agent-ss-template` shape — a Python package (`src/`, `Makefile`, `Dockerfile`, `compose.yaml`, a Flask/Slack `server.py`) — cannot be run by `agentos skill` at all: `skill up` dead-ends at `no plugin manifest under <dir>` with no path forward. Every pre-plugin internal agent is in this position, so "point AgentOS at the agent I already have" had no answer — an onboarding dogfood of the 0.4.0 binary could not complete because of it. (#745)

## Fix — a two-step on-ramp

**`agentos init --adopt <dir>`** scaffolds the plugin skeleton **into** an existing directory:
- The same byte-compatible file set `init` already produces, via the existing collision-refusal discipline — created *alongside* your `src/`/`Makefile`/etc., never overwriting a file.
- Bundle name derived from the directory (kebab-sanitized); a positional `NAME` overrides.
- The logic port stays manual (it inherently is) — a new **`docs/adopting-a-bundle.md`** walks it.

**The `no plugin manifest` error now names the path**: when the directory looks like a pre-plugin bundle (`src/` + a `Makefile`/`Dockerfile`/`compose.yaml`/`server.py`), it points at `init --adopt` and the guide instead of dead-ending — shared across every manifest-read call site.

## ADR

**ADR-0071** records the decision (the skeleton is mechanizable, the logic port is manual → verb + guide) and rejects the runner-adapter alternative as epic #30's *engine-as-in-bundle-MCP-server* territory.

## Verified end-to-end

Against a synthetic `agent-ss-template` dir (branch binary, real runner container):
- `skill up` → the shape-aware error naming `init --adopt` + the guide ✅
- `init --adopt .` → skeleton scaffolded, name `revenue-leak-agent` derived, existing files untouched ✅
- `skill up --fake-model` on the adopted bundle → boots healthy (`Version revenue-leak-agent @ 0.1.0`) ✅

## Testing

- `cargo fmt` clean · `cargo clippy -- -D warnings` clean on the changed code · **4 new unit tests** (`derive_plugin_name` kebab/None; shape-aware vs generic `no_manifest_message`) · manifest-drift + guide + spec-scaffold + 478 lib tests pass.
- Regenerated + gated: `command-manifest.json`, the UI mirror `commandManifest.ts`, the ADR index; `doclint` citation lint exit 0; `cli/README.md` updated.

## Scope / deferred (#745)

The `revenue-leak-agent` README/COMMANDS that drive everything through `make`/`./rl` and never mention `agentos skill` — that doc fix lives in the agent's own repo.

Refs #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)
