### PR TITLE
Guarantee a non-empty eval error on a bare timeout (#813)

### DIFF
--- a/apps/worker/src/agentos_worker/eval/runner.py
+++ b/apps/worker/src/agentos_worker/eval/runner.py
@@ -141,7 +141,9 @@ class EvalRunner:
                 outcome=EvalOutcome.FAIL,
                 output="",
                 latency_ms=_elapsed_ms(start),
-                error=str(exc),
+                # A bare asyncio.TimeoutError stringifies to "", which would
+                # otherwise read downstream as a completed turn; keep it non-empty.
+                error=str(exc) or type(exc).__name__,
             )
 
         output = final_text if final_text is not None else "".join(parts)

--- a/apps/worker/tests/eval/test_runner.py
+++ b/apps/worker/tests/eval/test_runner.py
@@ -391,3 +391,33 @@ def test_a_fake_turn_that_does_not_complete_is_a_failure_not_plumbing_ok(
             assert spy.calls == 0  # a broken turn is not graded either
 
     asyncio.run(go())
+
+
+def test_a_bare_timeout_error_records_a_nonempty_error(make_eval_harness) -> None:
+    """Issue #813: aiohttp raises a bare ``asyncio.TimeoutError`` on total/sock_read
+    expiry, and ``str(asyncio.TimeoutError())`` is empty. If ``_run_case`` recorded
+    that empty string as the error, the API's completion check (ADR-0068) would
+    read a timed-out turn as "completed" instead of the loud failure it must be.
+    The case must still FAIL, and its error must be non-empty."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            async def _timeout(*args, **kwargs):
+                # aiohttp raises a bare asyncio.TimeoutError (== builtin TimeoutError
+                # since 3.11) on timeout; its str() is empty, which is the whole bug.
+                raise TimeoutError
+
+            client.start_turn = _timeout  # type: ignore[method-assign]
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="x"))],
+            )
+            result = await EvalRunner(client).run(suite, base_url=base_url, version="v1")
+
+            case = result.results[0]
+            assert case.passed is False
+            assert case.error  # must be non-empty, not just non-None
+            assert case.error == "TimeoutError"
+            assert result.summary() == "0/1 passed"
+
+    asyncio.run(go())


### PR DESCRIPTION
## Summary
A bare `asyncio.TimeoutError` (raised by aiohttp on total/sock_read expiry) stringifies to `""`, so the eval runner recorded `error=""` on a timed-out turn. The API completion check (`_completed`) reads an empty `error` as a *completed* turn, letting a model that times out every turn slip past ADR-0068's "never completed a turn" sweep gate.

The fix falls back to the exception class name (`error=str(exc) or type(exc).__name__`) so the error stays non-empty and a timeout is distinguishable from a graded FAIL.

## Changes
- `apps/worker/src/agentos_worker/eval/runner.py`: transport-exception handler records a non-empty error.
- `apps/worker/tests/eval/test_runner.py`: regression test proving a bare timeout records a non-empty error and the case fails loudly.

## Acceptance criteria
- [x] Exception path guarantees a non-empty `error` so a timeout is distinguishable from a graded FAIL.
- [x] Test: a bare `asyncio.TimeoutError` records a non-empty error (classified "never completed", not "completed").

## Review
Code Reviewer, Scope Reviewer, and a cross-engine Codex review all approved; all three independently confirmed the fix is correct and the only follow-up (a ruff UP041 lint on the test) is applied. Worker eval + API eval unit suites green; mypy and ruff clean.

Closes #813