### PR TITLE
Give the agent-sandbox controller the platform PriorityClass (#816)

### DIFF
--- a/charts/agentos/ci/render-assertions.sh
+++ b/charts/agentos/ci/render-assertions.sh
@@ -290,13 +290,23 @@ if check_runner_env "$MUTANT" "mutant (AGENTOS_SANDBOX_ID -> AGENTOS_SANBOX_ID)"
 fi
 echo "  ok: misspelled runner env name is rejected (the assert can fail)"
 
-echo "=== Assertion 8: priorityClassName on every control-plane pod + the sandbox (ADR-0059 decision 5, #759) ==="
+echo "=== Assertion 8: priorityClassName on every control-plane pod + the sandbox controller + the sandbox (ADR-0059 decision 5, #759, #816) ==="
 # The control plane (worker, api, dispatcher, data tier: postgres, valkey,
 # clickhouse, minio) must outrank sandbox pods for node-pressure eviction, so
 # the components that supervise, drain, and reclaim a sandbox are never
 # themselves preferred for eviction over the sandboxes they manage. Render with
 # the dispatcher enabled (it needs both Slack tokens to render at all) so every
 # control-plane pod is present in one pass.
+#
+# The vendored agent-sandbox controller (#816) is control plane too: it
+# reconciles sandbox claims/releases, so it must also outrank the sandbox pods
+# it manages for node-pressure eviction. It is a static Deployment named
+# exactly `agent-sandbox-controller`, not prefixed by the chart fullname, so it
+# cannot be matched by the suffix table below and needs its own exact-name
+# lookup. This is also the tripwire for the template-layer string-injection
+# anchor silently drifting on a future upstream controller bump: if the anchor
+# stops matching, the field silently stops being set, and only an assert that
+# actually reads the rendered priorityClassName back out would catch it.
 PRIO_OUT="$(mktemp -d -p "$TMP")"
 helm template "$CHART" --output-dir "$PRIO_OUT" \
   --set dispatcher.slack.appToken=xapp-render-assert \
@@ -305,8 +315,8 @@ helm template "$CHART" --output-dir "$PRIO_OUT" \
 
 PRIO_CHECK="$TMP/check_priority_class.py"
 cat > "$PRIO_CHECK" <<'PYEOF'
-"""Assert priorityClassName on every control-plane pod template and the
-sandbox pod template.
+"""Assert priorityClassName on every control-plane pod template, the vendored
+agent-sandbox controller Deployment, and the sandbox pod template.
 
 argv: <rendered-dir> <expected-platform-name> <expected-sandbox-name>
 Exits 0 on pass, 1 naming the offending workload on failure.
@@ -333,7 +343,13 @@ EXPECTED = {
     "-minio": platform_name,
 }
 
+# Exact name, not a suffix match: `agent-sandbox-controller-extensions` and
+# `release-name-agentos-preflight-controller` also exist in the render, and a
+# loose `-controller` suffix would silently match the wrong object.
+CONTROLLER_NAME = "agent-sandbox-controller"
+
 found = {}
+controller_found = None
 sandbox_found = []
 for path in sorted(pathlib.Path(rendered).rglob("*.yaml")):
     for doc in yaml.safe_load_all(path.read_text()):
@@ -350,6 +366,8 @@ for path in sorted(pathlib.Path(rendered).rglob("*.yaml")):
             for suffix in EXPECTED:
                 if name.endswith(suffix):
                     found[suffix] = (name, spec.get("priorityClassName"))
+            if kind == "Deployment" and name == CONTROLLER_NAME:
+                controller_found = (name, spec.get("priorityClassName"))
         elif kind == "SandboxTemplate":
             spec = doc.get("spec", {}).get("podTemplate", {}).get("spec", {})
             sandbox_found.append((doc.get("metadata", {}).get("name", ""), spec.get("priorityClassName")))
@@ -371,6 +389,19 @@ if mismatched:
             f"priorityClassName={got!r}, expected {want!r}\n")
     sys.exit(1)
 
+if controller_found is None:
+    sys.stderr.write(
+        f"found no Deployment named exactly {CONTROLLER_NAME!r} in the render; "
+        "the agent-sandbox controller priorityClassName assert would pass vacuously\n")
+    sys.exit(1)
+
+controller_name, controller_got = controller_found
+if controller_got != platform_name:
+    sys.stderr.write(
+        f"controller Deployment '{controller_name}' has "
+        f"priorityClassName={controller_got!r}, expected {platform_name!r}\n")
+    sys.exit(1)
+
 if not sandbox_found:
     sys.stderr.write("found no SandboxTemplate in the render; the sandbox assert would pass vacuously\n")
     sys.exit(1)
@@ -382,12 +413,12 @@ if sandbox_mismatched:
             f"SandboxTemplate '{name}' has priorityClassName={got!r}, expected {sandbox_name!r}\n")
     sys.exit(1)
 
-print(f"  ok: {len(found)} control-plane workloads carry priorityClassName={platform_name!r}; "
-      f"SandboxTemplate carries priorityClassName={sandbox_name!r}")
+print(f"  ok: {len(found)} control-plane workloads and the agent-sandbox controller carry "
+      f"priorityClassName={platform_name!r}; SandboxTemplate carries priorityClassName={sandbox_name!r}")
 PYEOF
 
 python3 "$PRIO_CHECK" "$PRIO_OUT" "agentos-platform" "agentos-sandbox" \
-  || fail "default render did not set the expected priorityClassName on every control-plane pod and the sandbox."
+  || fail "default render did not set the expected priorityClassName on every control-plane pod, the agent-sandbox controller, and the sandbox."
 
 echo "=== Assertion 9: priorityClassName names are operator-overridable (additive values, #759) ==="
 PRIO_OVERRIDE_OUT="$(mktemp -d -p "$TMP")"
@@ -399,7 +430,7 @@ helm template "$CHART" --output-dir "$PRIO_OVERRIDE_OUT" \
   > /dev/null
 python3 "$PRIO_CHECK" "$PRIO_OVERRIDE_OUT" "custom-platform-class" "custom-sandbox-class" \
   || fail "overriding priorityClasses.platform.name/sandbox.name did not propagate to priorityClassName on the rendered pods."
-echo "  ok: overriding priorityClasses.platform.name/sandbox.name propagates to every control-plane pod and the sandbox"
+echo "  ok: overriding priorityClasses.platform.name/sandbox.name propagates to every control-plane pod, the agent-sandbox controller, and the sandbox"
 
 echo "=== Assertion 10: SandboxTemplate opts the controller out of its own permissive NetworkPolicy when Rail 1 is on (#765) ==="
 # NetworkPolicy allows are additive across objects that select the same pods --
@@ -470,4 +501,4 @@ python3 "$NP_CHECK" "$NP_OFF_OUT" "absent" \
 echo "  ok: with Rail 1 off, networkPolicyManagement is left unset (falls back to the controller's own Managed default rather than nothing)"
 
 echo
-echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off."
+echo "PASS: sealed render generates strong values for all 9 keys (encryptionKey 64-hex); dev overlay keeps published defaults; explicit override wins on the sealed path; every runner boot-env name is a declared contract key (proven by a failing negative control); every control-plane pod, the agent-sandbox controller, and the sandbox render with the expected priorityClassName, including under operator override; the runner SandboxTemplate opts the controller out of its own permissive NetworkPolicy whenever Rail 1 is on, and leaves it to the controller's default when Rail 1 is off."

--- a/charts/agentos/templates/agent-sandbox.yaml
+++ b/charts/agentos/templates/agent-sandbox.yaml
@@ -9,7 +9,11 @@ the worker claims from, plus (optionally) the vendored upstream controller.
   vendored under files/agent-sandbox/ with two AgentOS security patches (#66:
   the networkpolicies RBAC is de-scoped from cluster-wide to the release
   namespace via the Role/RoleBinding below, and the Deployment carries a
-  hardened securityContext). Cluster-scoped, one per cluster.
+  hardened securityContext). Cluster-scoped, one per cluster. A third,
+  template-layer patch injects the platform priorityClassName into the
+  controller Deployment below (issue #816, ADR-0059 decision 5) rather than
+  baking it into the vendored file, so it tracks the operator-set class name;
+  the vendored file itself still carries only the #66 securityContext patch.
 - The SandboxTemplate bakes the generic warm-pod env. Per-session env
   (AGENTOS_HISTORY_REF, AGENTOS_SESSION_ID) is injected per-claim by the
   substrate; envVarsInjectionPolicy Overrides makes that injection win.
@@ -23,7 +27,22 @@ the worker claims from, plus (optionally) the vendored upstream controller.
   default-deny + allowlist in security-networkpolicy.yaml.
 */}}
 {{- if .Values.agentSandbox.controller.deploy }}
-{{ .Files.Get "files/agent-sandbox/controller.yaml" }}
+{{/*
+ADR-0059 decision 5 / issue #816: the vendored controller carries no
+priorityClassName (priority 0), so under node Disk/Memory pressure the
+kubelet would evict it BEFORE the sandbox pods (agentos-sandbox, value
+100000) it reconciles, halting claim/release servicing exactly when the node
+is under pressure. Injecting the platform PriorityClass keeps the controller
+ranked above the sandboxes it manages. The name tracks
+.Values.priorityClasses.platform.name so an operator rename propagates; the
+vendored file stays a static .Files.Get (not tpl-ed) and this value-dependent
+patch lives in the template layer alongside the #66 RBAC patch below.
+*/}}
+{{- $controllerManifest := .Files.Get "files/agent-sandbox/controller.yaml" }}
+{{- with .Values.priorityClasses.platform.name }}
+{{- $controllerManifest = $controllerManifest | replace "      serviceAccountName: agent-sandbox-controller" (printf "      serviceAccountName: agent-sandbox-controller\n      priorityClassName: %s" .) }}
+{{- end }}
+{{ $controllerManifest }}
 ---
 {{/*
 NetworkPolicy RBAC for the vendored controller, split by verb along the


### PR DESCRIPTION
Closes #816

## Problem
#778 gave the platform Deployments (`agentos-platform`, 1000000) and sandbox pods (`agentos-sandbox`, 100000) PriorityClasses, but the vendored **agent-sandbox controller** was left with no `priorityClassName` (priority 0), below the sandboxes it reconciles. Under node Disk/Memory pressure the kubelet evicts in priority order, so the controller would be evicted before the sandbox pods it manages, halting claim/release servicing exactly when the node is under pressure.

## Fix
- `charts/agentos/templates/agent-sandbox.yaml`: inject `priorityClassName` into the controller Deployment, tracking `.Values.priorityClasses.platform.name` (the same value every other control-plane pod uses), guarded by `{{- with }}` so an empty name no-ops for parity with worker/api/dispatcher. Done via a `replace` on the static `.Files.Get` output, so the vendored `controller.yaml` stays unmodified and the value-dependent wiring lives in the template layer next to the #66 RBAC patch.
- `charts/agentos/ci/render-assertions.sh`: Assertion 8/9 now require the controller Deployment carries the platform class under both the default and operator-override renders, non-vacuously. This assertion is also the tripwire if a future upstream controller bump reindents the injection anchor and the `replace` silently no-ops.

## Done-check (quick tier)
- [x] Failing test committed before the fix (git log order preserved pre-squash)
- [x] All edits performed by delegated sub-agents; driver ran only git/tests
- [x] No broadened return types (chart-only change)
- [x] Code Reviewer APPROVE (0 findings; independently proved the anchor-drift tripwire fires)
- [x] Scope Reviewer APPROVE (0 orphan hunks; both files trace to AC1/AC2)
- [x] Sibling-path parity: the controller was the sole control-plane workload missing the field; all siblings already share the identical guard; sandbox keeps its own class by design
- [x] Guard demonstration: assertion executed failing (`priorityClassName=None`, exit 1) on the unfixed chart and passing on the fix
- [x] Codex review ran (driver-direct), no findings
- [x] `helm lint` clean; render + tenant-capacity + controller-rbac assertions all green
- [N/A] Consolidation `/simplify`: skipped, trivial code surface, zero quality findings
- [N/A] Live E2E: the change is a static rendered manifest field fully verified by the render contract test; eviction-ordering cannot be practically induced and a live install would only re-confirm the static field
