### PR TITLE
Fix four stale doc facts and consolidate duplicated getting-started content

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,18 +109,9 @@ which is what §3b describes.
 
 ### Directory ownership and language
 
-| Path | Language | Role |
-|---|---|---|
-| [`packages/aci-protocol`](packages/aci-protocol) | Python (Pydantic + codegen) | Frozen ACI session protocol + NDJSON events |
-| [`packages/plugin-format`](packages/plugin-format) | Python (Pydantic + codegen) | Frozen Claude Code plugin bundle shape |
-| [`apps/api`](apps/api) | Python (FastAPI) | Agents/versions/deployments, git-flow, evals, Langfuse proxy |
-| [`apps/dispatcher`](apps/dispatcher) | Python (Slack Bolt) | Socket Mode ingress, dedupe, placeholder, enqueue |
-| [`apps/worker`](apps/worker) | Python (redis-py) | Concurrency kernel, substrate, eval consumer |
-| [`runner`](runner) | Python (claude-agent-sdk) | ACI session server inside the sandbox |
-| [`apps/ui`](apps/ui) | React (Vite + TS) | Console: create/deploy, Runs, Metrics, Logs, Cost |
-| [`cli`](cli) | Rust (clap + tokio) | `agentos` binary: 12 top-level commands ([`cli/src/main.rs`](cli/src/main.rs)) — `init`, `skill`, `local`, `cluster`, `build`, `install`, `update`, `secrets`, `dev`, `schema`, `guide`, plus the bare-invocation `interactive` TUI |
-| [`charts/agentos`](charts/agentos) | Helm | Umbrella chart + security rails |
-| [`tests/soak`](tests/soak) | Python | Soak/chaos harness: 762 lines of Python (`wc -l tests/soak/*.py`), env-gated on `AGENTOS_SOAK=1` ([`tests/soak/conftest.py`](tests/soak/conftest.py)) — the code exists; what is outstanding is a run at N1 scale |
+The per-package directory listing — path, language, and what each package owns —
+lives in the [README Component map](README.md#component-map). It is not duplicated
+here so the two cannot drift apart.
 
 The Python packages are one **uv workspace** (root
 [`pyproject.toml`](pyproject.toml)); ruff, mypy, and pytest run across all
@@ -517,11 +508,12 @@ integration test and UI E2E runs against it.
 compose stack, runs real Alembic migrations on a virgin Postgres
 (`version_table_schema=agentos`, [`apps/api/alembic/env.py::do_run_migrations`](apps/api/alembic/env.py)),
 then the whole workspace pytest suite against the live services. It defines
-**eight** jobs: `python`, `rust`, `contracts-ts`, `ui` (lint + vitest + build +
-headless Playwright), `compose`, `images`, `worker-local-image`, and
-`dispatcher-image-smoke`. The last three are the image build gates — an operator
-reading this list to know what protects a release needs them named, since a green
-`python` says nothing about whether the images build.
+**ten** jobs: `python`, `rust`, `contracts-ts`, `ui` (lint + vitest + build +
+headless Playwright), `compose`, `images`, `worker-local-image`,
+`dispatcher-image-smoke`, `eval-falsifiability`, and `e2e-ladder`. Three of them
+(`images`, `worker-local-image`, `dispatcher-image-smoke`) are the image build
+gates — an operator reading this list to know what protects a release needs them
+named, since a green `python` says nothing about whether the images build.
 
 **Release** ([`.github/workflows/release.yaml`](.github/workflows/release.yaml))
 publishes `ghcr.io/curie-eng/agentos-{runner,api,dispatcher,worker,ui}` as

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -7,22 +7,9 @@ the runner container on your host Docker daemon, talking straight to the agent.
 ## Before you start
 
 - **Docker** running locally.
-- The **`agentos`** binary on your PATH. Download the prebuilt binary for
-  your platform from the latest release (no Rust toolchain required):
-
-  ```bash
-  # Resolve the right asset for this machine. The release ships Linux x86_64 and
-  # macOS Apple silicon; anything else builds from source (see cli/).
-  ASSET=
-  case "$(uname -s)/$(uname -m)" in
-    Linux/x86_64)                 ASSET=agentos-x86_64-unknown-linux-gnu ;;
-    Darwin/arm64|Darwin/aarch64)  ASSET=agentos-aarch64-apple-darwin ;;
-  esac
-  : "${ASSET:?no prebuilt binary for this platform; build the CLI from source in cli/}"
-  curl -fsSL -o agentos \
-    "https://github.com/curie-eng/agentos/releases/latest/download/$ASSET"
-  chmod +x agentos && sudo mv agentos /usr/local/bin/
-  ```
+- The **`agentos`** binary on your PATH. Download, verify, and install the
+  prebuilt binary for your platform by following
+  [`docs/release-verification.md`](docs/release-verification.md#verify-the-cli-before-installing-it).
 
   Building the CLI from source (`cargo build --release` in `cli/`) is the
   contributor path — see [`docs/onboarding.md`](docs/onboarding.md).

--- a/README.md
+++ b/README.md
@@ -188,61 +188,18 @@ channel binding, and troubleshooting) see
 ## Quickstart
 
 The fastest way in — for operators and coding agents alike — is the prebuilt
-release binary. It needs no Rust toolchain and no repo checkout:
+release binary. It needs no Rust toolchain and no repo checkout.
 
-You are about to run a downloaded binary as root, so verify it first. Every
-release ships a `checksums.txt` signed by the release workflow; check the
-signature, then check the binary against it, then install. Set `VERSION` to the
-release you are installing, from the
-[Releases page](https://github.com/curie-eng/agentos/releases):
+You are about to run a downloaded binary as root, so verify it before you install
+it. [`docs/release-verification.md`](docs/release-verification.md#verify-the-cli-before-installing-it)
+owns the full flow: resolve the right asset for your platform, verify the signed
+`checksums.txt` with cosign (or `gh attestation`), check the binary against it, and
+install. Then, from anywhere:
 
 ```bash
-VERSION=vX.Y.Z                            # the release you are installing
-# Resolve the right asset for this machine. The release ships Linux x86_64 and
-# macOS Apple silicon; anything else builds from source (see cli/).
-ASSET=
-case "$(uname -s)/$(uname -m)" in
-  Linux/x86_64)                 ASSET=agentos-x86_64-unknown-linux-gnu ;;
-  Darwin/arm64|Darwin/aarch64)  ASSET=agentos-aarch64-apple-darwin ;;
-esac
-: "${ASSET:?no prebuilt binary for this platform; build the CLI from source in cli/}"
-BASE="https://github.com/curie-eng/agentos/releases/download/$VERSION"
-curl -fsSLO "$BASE/$ASSET" -O "$BASE/checksums.txt" -O "$BASE/checksums.txt.sigstore.json"
-
-# 1. checksums.txt really came from this repo's release workflow, at this tag
-cosign verify-blob --bundle checksums.txt.sigstore.json \
-  --certificate-identity "https://github.com/curie-eng/agentos/.github/workflows/release.yaml@refs/tags/$VERSION" \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  checksums.txt
-# 2. the binary is the one it names (macOS: shasum -a 256 --check --ignore-missing)
-sha256sum --check --ignore-missing checksums.txt
-# 3. both OK? install it
-chmod +x "$ASSET" && sudo mv "$ASSET" /usr/local/bin/agentos
-
 agentos cluster up
 agentos local up
 ```
-
-> **Which releases can be verified?** Every release published *after* v0.4.0.
-> `checksums.txt`, the signature, the provenance, and the SBOMs are produced by
-> the release workflow, so v0.4.0 and earlier shipped bare binaries and the two
-> integrity URLs above 404 against them. Install a newer release.
-
-No cosign? `gh attestation verify $ASSET --repo curie-eng/agentos --signer-workflow
-curie-eng/agentos/.github/workflows/release.yaml --source-ref "refs/tags/$VERSION"`
-does both checks in one command. Keep `--source-ref`: without it the check passes
-for any artifact this workflow ever built, including one from a different tag.
-Either way, see [`docs/release-verification.md`](docs/release-verification.md) for
-the full story: what each asset carries, how to verify the chart and compose file,
-and the per-asset SBOMs.
-
-> **macOS: "unidentified developer"?** The release binaries are not yet
-> notarized by Apple, so a copy downloaded through a browser is quarantined and
-> Gatekeeper blocks it on first launch. The `curl` command above avoids this
-> entirely (curl does not set the quarantine flag). If you already downloaded it
-> in a browser, clear the flag once with
-> `xattr -d com.apple.quarantine ./agentos-aarch64-apple-darwin`, or right-click
-> the binary in Finder and choose Open to approve it a single time.
 
 A release binary needs no repo checkout for `agentos cluster up` or `agentos local up`.
 It pulls the pinned chart release asset and the pinned `compose.release.yaml`

--- a/docs/adr/0024-deploy-reaches-api-via-ui-proxy.md
+++ b/docs/adr/0024-deploy-reaches-api-via-ui-proxy.md
@@ -3,6 +3,14 @@
 Date: 2026-07-13
 Status: Accepted
 
+**Superseded in part by [ADR-0057](0057-cluster-deploy-self-plumbs-port-forward-for-generated-key.md)**
+(back-link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+0057 supersedes the deploy-transport decision below for the auto path (no
+`--api-url`), where `cluster deploy` now self-plumbs its own port-forward so the
+generated key stays off the cleartext proxy. The UI `/api` NodePort proxy survives
+only as the explicit-`--api-url` escape hatch, and the discovery this ADR performs
+for `cluster status` stands.
+
 Supersedes the abandoned self-plumbed port-forward approach for `cluster deploy`
 (#352 / PR #357). Implements [#359](https://github.com/curie-eng/agentos/issues/359).
 

--- a/docs/adr/0035-one-shot-post-approval-allowance.md
+++ b/docs/adr/0035-one-shot-post-approval-allowance.md
@@ -4,6 +4,12 @@ Date: 2026-07-15
 
 Status: Accepted
 
+**Superseded in part by [ADR-0046](0046-converged-approval-gates-and-durable-provenance.md)**
+(back-link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+0046 supersedes the provenance discriminator this ADR used (the summary-prefix
+sniff), replacing it with durable runner-authored provenance. The one-shot grant
+lifecycle established below is otherwise unchanged.
+
 Implements [#430](https://github.com/curie-eng/agentos/issues/430).
 
 ## Context

--- a/docs/adr/0046-converged-approval-gates-and-durable-provenance.md
+++ b/docs/adr/0046-converged-approval-gates-and-durable-provenance.md
@@ -4,6 +4,15 @@ Date: 2026-07-16
 
 Status: Accepted
 
+**Superseded in part by [ADR-0056](0056-operator-opt-in-for-policy-gate-grantability.md)**
+(back-link added under [ADR-0045](0045-the-status-line-is-the-mutable-part-of-an-immutable-adr.md)):
+0056 supersedes the "a policy gate refuses a grant outright" half of Decision C
+below — and only that half — making a policy gate grantable by explicit operator
+opt-in. Every other property this ADR established (durable
+`gate_kind`/`granted_tool` provenance, loud route resolution, observe-only resume
+reconciliation, and the convergence of the two gate paths on one lifecycle) is
+unchanged.
+
 Implements [#544](https://github.com/curie-eng/agentos/issues/544).
 Supersedes the provenance discriminator of
 [ADR-0035](0035-one-shot-post-approval-allowance.md) (the summary-prefix sniff);

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -11,22 +11,9 @@ Install the local path tools:
 - `uv`, the Python workspace manager, and Python `3.13`. The workspace requires
   `>=3.13`.
 - Docker with Compose v2, for the dev stack and the local runner container.
-- An `agentos` CLI binary. Download the prebuilt binary from the latest
-  release (no Rust toolchain needed):
-
-```bash
-# Resolve the right asset for this machine. The release ships Linux x86_64 and
-# macOS Apple silicon; anything else builds from source (see cli/).
-ASSET=
-case "$(uname -s)/$(uname -m)" in
-  Linux/x86_64)                 ASSET=agentos-x86_64-unknown-linux-gnu ;;
-  Darwin/arm64|Darwin/aarch64)  ASSET=agentos-aarch64-apple-darwin ;;
-esac
-: "${ASSET:?no prebuilt binary for this platform; build the CLI from source in cli/}"
-curl -fsSL -o agentos \
-  "https://github.com/curie-eng/agentos/releases/latest/download/$ASSET"
-chmod +x agentos && sudo mv agentos /usr/local/bin/
-```
+- An `agentos` CLI binary. Download, verify, and install the prebuilt binary for
+  your platform by following
+  [docs/release-verification.md](release-verification.md#verify-the-cli-before-installing-it).
 
 Contributors working on the CLI can instead build from source with the Rust
 stable toolchain (edition `2021`):
@@ -51,46 +38,19 @@ agentos build
 A released binary instead pulls the pinned runner image from `GHCR` on first
 run, so only source builds need this.
 
-## The Three Tiers
+## Pick a Target
 
-| Target | What runs | Slack | Kubernetes | Reach for it to |
-|---|---|---|---|---|
-| `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | Iterate a plugin/skill against a local runner, the fastest loop. |
-| `local` | The full platform via docker compose (Postgres, Valkey, API, worker, and by default Langfuse plus the UI). | stub by default | none | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. |
-| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | Operate and drive a deployed cluster release (see `docs/operations.md`). |
+The three targets (`skill`, `local`, `cluster`) and when to reach for each are
+described in the [README target guide](../README.md#which-target-do-i-want). For
+onboarding, start with `skill` for the fastest proof a bundle answers, then move
+to `local` for ticket verification — it puts the full platform in front of the
+runner with no Slack or Kubernetes. `agentos init` scaffolds a bundle and
+targets no environment.
 
-During onboarding, start with `skill` for the fastest proof that a bundle can
-answer. Move to `local` for ticket verification, because it puts the full
-platform in front of the runner without Slack or Kubernetes.
+## Fastest First Reply With `skill`
 
-The distinction that matters: `skill` is the runner only loop. It talks straight
-to the runner container's ACI HTTP surface, with no platform in front. `local`
-and `cluster` put the full platform (queue, worker, sandbox) in front of the
-identical runner, so a `message` walks the same path a real Slack mention would.
-Every environment command takes a target noun in the middle:
-`agentos <skill|local|cluster> <verb>`. `agentos init` is the exception: it
-scaffolds a bundle and targets no environment.
-
-## Step 1: Fastest First Reply With `skill`
-
-No credential, no Slack, no cluster, no compose stack:
-
-```bash
-agentos init my-agent && cd my-agent
-agentos skill up --fake-model
-agentos skill message "hello"
-agentos skill down
-```
-
-`agentos init` scaffolds a generic starter bundle: a Claude Code plugin
-(`.claude-plugin/plugin.json`, a starter `skills/<name>/SKILL.md`, `.mcp.json`, <!-- doclint:ignore-line -->
-and an `evals/cases.json` smoke seed) plus a root `AGENTS.md` and <!-- doclint:ignore-line -->
-`.claude/skills/using-agentos/SKILL.md`, the harness primer. The scaffolded eval <!-- doclint:ignore-line -->
-is a smoke test that passes out of the box; replace it with real graders as you
-build. `--fake-model` gives scripted replies with no
-Anthropic key, so this proves the loop offline. Drop `--fake-model` and export a
-credential, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, or
-`AGENTOS_CREDENTIALS`, for a real model.
+The fastest first reply — `agentos init` then `skill up`/`message`/`down` — is
+the [QUICKSTART](../QUICKSTART.md) flow.
 
 If `skill up` reports that the container name is already taken, a previous
 runner is still around: re-run with `--replace` to remove it and boot fresh. To
@@ -98,62 +58,24 @@ clear a leftover runner from a directory that has no recorded state (a bundle
 you never ran `skill up` from, or one whose state file is gone), name it
 directly with `agentos skill down --name <container>`.
 
-The reply streams to `stdout` as `NDJSON`. Abort a live turn with `Ctrl-C`.
-`agentos skill eval` runs the bundle's `evals/cases.json` the same way. <!-- doclint:ignore-line -->
+## The Real Product Loop With `local`
 
-## Step 2: The Real Product Loop With `local`
+Bringing up the full compose platform and driving a turn through it —
+`local up` / `local deploy` / `local message`, plus `--minimal` for low-RAM
+machines — is covered in the
+[README](../README.md#how-do-i-test-an-agent-the-same-way-locally-and-on-kubernetes).
+`agentos local up` flips to live automatically when a credential
+(`CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`) is present, so there is no
+manual `AGENTOS_FAKE_MODEL=0` step.
 
-Use this loop to verify tickets. It drives a message through the real queue,
-worker, sandboxed runner, and reply path with no Slack and no Kubernetes.
+For multi turn work, `local message` prints a `continue this conversation:`
+line. Use `agentos local message --continue "follow up"` to reuse the last
+turn's channel and thread from `.agentos/last-turn.json`. Send only the new <!-- doclint:ignore-line -->
+text. `--continue` reads the API key again from `$AGENTOS_API_KEY` and does not
+replay transport flags like `--listen-port`, so pass those again if you used
+custom values.
 
-```bash
-# From the bundle directory (my-agent). Bring up the full compose stack:
-agentos local up
-
-# Deploy the bundle to the compose platform API (published on host port 28000):
-agentos local deploy --plugin-dir . --slack-channel C-DEMO --api-url http://localhost:28000
-
-# Drive a turn through the real path and read the reply on stdout:
-agentos local message "what changed in the last deploy?"
-```
-
-- `agentos local up` brings up the `full` compose profile by default: the backing
-  stores (`Postgres`, `Valkey`, `MinIO`), the `API`, the `worker`, plus
-  `Langfuse` and the console UI. The console UI is served at
-  `http://localhost:28080/?api=1`. The `API` is published on host port `28000`,
-  so point
-  `local deploy --api-url` there.
-- The compose `worker` runs the fake model by default, a canned reply with no
-  credentials, so this whole loop needs zero secrets. For a real model, export a
-  credential, `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`, and set
-  `AGENTOS_FAKE_MODEL=0` in the compose environment.
-- `--slack-channel C-DEMO` binds the agent to a channel id. Pass the same value
-  to `local message --channel C-DEMO` to target it. When a single agent is
-  deployed, `local message` looks up the channel automatically, so `--channel`
-  is optional then.
-- For multi turn work, `local message` prints a `continue this conversation:`
-  line. Use `agentos local message --continue "follow up"` to reuse the last
-  turn's channel and thread from `.agentos/last-turn.json`. Send only the new <!-- doclint:ignore-line -->
-  text. `--continue` reads the API key again from `$AGENTOS_API_KEY` and does not
-  replay transport flags like `--listen-port`, so pass those again if you used
-  custom values.
-
-## Step 3: Low RAM Machines
-
-```bash
-agentos local up --minimal
-```
-
-`--minimal` brings up the smaller `core` compose profile: `Postgres`, `Valkey`,
-`MinIO`, the `API`, and the `worker` only. It drops `Langfuse`, `ClickHouse`,
-the `OTel Collector`, and the console UI, which are present only in the heavier
-`full` profile. Use it for a low RAM laptop. The `deploy` and `message` steps
-above are identical against `--minimal`; you just lose the UI and `Langfuse`
-traces.
-
-Only one local compose stack runs at a time.
-
-## Step 4: Verify a Ticket End to End
+## Verify a Ticket End to End
 
 Use this as the verification loop for a code change:
 

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -4,8 +4,9 @@ Every GitHub release publishes the `agentos` CLI binaries, the Helm chart, and
 `compose.release.yaml`. Installing the CLI means running a downloaded binary as
 root and pointing it at a cluster, so verify what you received before you run it.
 
-This page is the reference. The [README quickstart](../README.md#quickstart) has
-the short copy-paste version for the default install path.
+This page is the reference and owns the download-verify-install flow. The
+[README quickstart](../README.md#quickstart), [`QUICKSTART.md`](../QUICKSTART.md),
+and the [local dev onboarding](onboarding.md) point here for it.
 
 These artifacts are produced by the release workflow, so they exist on every
 release published *after* v0.4.0. Nothing below works against v0.4.0 or earlier,
@@ -172,7 +173,10 @@ which is a reviewed edit rather than a side effect.
 
 - **Apple notarization.** The macOS binary is unsigned and un-notarized, pending
   an Apple developer account decision. Gatekeeper quarantines a browser-downloaded
-  copy; see the [README note](../README.md#quickstart). Verify it with cosign or
+  copy; the `curl` download above avoids this (curl does not set the quarantine
+  flag), or clear it once with
+  `xattr -d com.apple.quarantine ./agentos-aarch64-apple-darwin` (or right-click
+  the binary in Finder and choose Open). Verify it with cosign or
   `gh attestation verify` as above -- that is the real check regardless.
 - **Container images.** GHCR image signing, provenance, and SBOMs are issue #62.
 - **The SBOM generator's own supply chain.** `anchore/sbom-action` is pinned to a


### PR DESCRIPTION
Fixes four stale documentation facts and removes the duplicated getting-started
content that caused one of them.

**Factual fixes**
- **ARCHITECTURE.md command count.** Deleted the "Directory ownership and
  language" table that duplicated the README Component map and carried a stale
  "12 top-level commands" claim (the clap `Command` enum in `cli/src/main.rs`
  defines 14 variants, 13 visible -- it had dropped `ListAgents` and
  `DeployLocal`). Replaced it with a pointer to the canonical README table so
  the two cannot drift again. Its only unique row (`tests/soak`) is already
  covered in section 11, so the deletion is lossless.
- **ARCHITECTURE.md CI job count.** `ci.yaml` defines ten jobs, not eight;
  added the omitted `eval-falsifiability` and `e2e-ladder` and named the three
  image-build gates explicitly (the "last three" phrasing no longer held).
- **onboarding.md fake-model step.** Removed the instruction to manually set
  `AGENTOS_FAKE_MODEL=0`; `cli/src/local.rs` injects it automatically when a
  credential is present (README already said as much).
- **ADR back-links.** ADR-0024, 0035, and 0046 are each partially superseded
  (by 0057, 0046, 0056) but lacked the back-link ADR-0045 mandates. Added only
  the back-link after each `Status:` line; `Status: Accepted` and every other
  line unchanged.

**Consolidation**
- Folded `docs/onboarding.md` down to its unique content (verify-a-ticket
  end-to-end, the `--continue` and `--replace` notes) plus pointers to the
  canonical README/QUICKSTART sections.
- Collapsed the `ASSET=` install resolver copy-pasted verbatim across README,
  QUICKSTART, and onboarding into pointers to `docs/release-verification.md`,
  which owns that flow; moved the macOS quarantine remediation into that owner
  and fixed its now-inverted back-reference.

Verified with the repo docs lint (`agentos dev docs-lint` / `scripts/check-docs.sh`):
ADR numbers unique, generated catalog drift-free, every citation resolves.
