### PR TITLE
Consolidate Valkey connect-and-skip test boilerplate into a shared helper

### DIFF
--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -38,6 +38,9 @@ from agentos_api.sandbox_token import mint
 from agentos_api.slack_approvers import SlackApproverSetSelector
 from agentos_api.slack_usergroups import SlackUserGroupClient
 from agentos_api.sweeper import run_expiry_sweeper, sweep_expired_approvals
+from agentos_test_support.valkey import (
+    connect_or_skip,
+)
 from alembic import command
 from alembic.config import Config
 from fastapi.testclient import TestClient
@@ -48,10 +51,6 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 # The migration test (18) drives alembic directly against the disposable DB the
 # conftest provisions, so it needs the same script location conftest uses.
 ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
-
-_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
-_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 
 
 @pytest.fixture
@@ -78,16 +77,7 @@ def approvals_client(_disposable_db: Any, runs_stream: str) -> Iterator[TestClie
 
 @pytest.fixture
 def valkey(runs_stream: str) -> Iterator[redis.Redis]:
-    client = redis.Redis(
-        host=_VALKEY_HOST,
-        port=_VALKEY_PORT,
-        password=_VALKEY_PW or None,
-        decode_responses=True,
-    )
-    try:
-        client.ping()
-    except redis.exceptions.RedisError as exc:
-        pytest.skip(f"Valkey not reachable: {exc}")
+    client = connect_or_skip(decode_responses=True)
     yield client
     client.delete(runs_stream)
     client.close()

--- a/apps/api/tests/test_graveyard_watcher.py
+++ b/apps/api/tests/test_graveyard_watcher.py
@@ -9,16 +9,20 @@ history, and does not double-alert or suppress across an approximate-MAXLEN trim
 from __future__ import annotations
 
 import asyncio
-import os
 import uuid
 
 import pytest
 import redis.asyncio as aioredis
 from agentos_api.graveyardwatcher import GraveyardWatcher
-
-_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
-_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
+from agentos_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
 
 
 def _client() -> aioredis.Redis:

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -33,16 +33,24 @@ from agentos_api.config import get_settings
 from agentos_api.models import Approval, ApprovalStatus
 from agentos_api.resumequeue import ResumeQueue
 from agentos_api.resumereconciler import ResumeReconciler
+from agentos_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
+from agentos_test_support.valkey import (
+    connect_or_skip,
+)
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
-
-_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
-_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 
 
 @pytest.fixture
@@ -60,16 +68,7 @@ def runs_stream() -> Iterator[str]:
 
 @pytest.fixture
 def valkey(runs_stream: str) -> Iterator[redis.Redis]:
-    client = redis.Redis(
-        host=_VALKEY_HOST,
-        port=_VALKEY_PORT,
-        password=_VALKEY_PW or None,
-        decode_responses=True,
-    )
-    try:
-        client.ping()
-    except redis.exceptions.RedisError as exc:
-        pytest.skip(f"Valkey not reachable: {exc}")
+    client = connect_or_skip(decode_responses=True)
     yield client
     client.delete(runs_stream)
     # #532's graveyard-scan tests write to the dead-letter stream too; clean it

--- a/apps/dispatcher/tests/conftest.py
+++ b/apps/dispatcher/tests/conftest.py
@@ -3,7 +3,6 @@ compose stack (per repo test discipline: never mock Valkey). Only the Slack Web
 API and socket transport are faked."""
 
 import logging
-import os
 import uuid
 from collections.abc import Iterator
 from typing import Any
@@ -11,6 +10,18 @@ from typing import Any
 import pytest
 import redis
 from agentos_dispatcher.config import DispatcherConfig
+from agentos_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
+from agentos_test_support.valkey import (
+    connect_or_skip,
+)
 from slack_bolt.authorization import AuthorizeResult
 
 
@@ -36,25 +47,12 @@ class FakeSocketClient:
     def send_socket_mode_response(self, response: Any) -> None:
         self.acked_envelope_ids.append(response.envelope_id)
 
-# Compose defaults (compose.dev.yaml maps Valkey to host port 26379, password
-# valkeypass). Overridable for CI via TEST_VALKEY_* env vars.
-_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
-_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
+# Compose defaults and connection params come from the shared agentos_test_support.valkey helper.
 
 
 @pytest.fixture
 def redis_client() -> Iterator[redis.Redis]:
-    client = redis.Redis(
-        host=_VALKEY_HOST,
-        port=_VALKEY_PORT,
-        password=_VALKEY_PW or None,
-        decode_responses=True,
-    )
-    try:
-        client.ping()
-    except redis.exceptions.RedisError as exc:
-        pytest.skip(f"Valkey not reachable at {_VALKEY_HOST}:{_VALKEY_PORT}: {exc}")
+    client = connect_or_skip(decode_responses=True)
     yield client
     client.close()
 

--- a/apps/worker/tests/binding/test_killswitch.py
+++ b/apps/worker/tests/binding/test_killswitch.py
@@ -10,19 +10,23 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import time
 import uuid
 from collections.abc import Callable
 
 import pytest
 import redis.asyncio as aredis
+from agentos_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
 from agentos_worker import killswitch as killswitch_module
 from agentos_worker.killswitch import KILL_CHANNEL, KillSwitch, kill_key
-
-_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
-_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 
 
 def _client() -> aredis.Redis:

--- a/apps/worker/tests/eval/conftest.py
+++ b/apps/worker/tests/eval/conftest.py
@@ -40,9 +40,6 @@ def eval_cases_example_path() -> Path:
     return EVAL_CASES_EXAMPLE_PATH
 
 
-_VH = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VP = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
-_VPW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 _MINIO: dict[str, object] = {
     "s3_endpoint_url": os.environ.get("TEST_S3_ENDPOINT_URL", "http://localhost:29000"),
     "s3_access_key": os.environ.get("TEST_S3_ACCESS_KEY", "minio"),

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -16,7 +16,6 @@ import asyncio
 import io
 import json
 import logging
-import os
 import tarfile
 import time
 import uuid
@@ -29,6 +28,15 @@ import httpx
 import pytest
 import redis
 from aci_protocol import STREAM_PAYLOAD_FIELD
+from agentos_test_support.valkey import (
+    VALKEY_HOST as _VH,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PORT as _VP,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PW as _VPW,
+)
 from agentos_worker.binding import BUDGET_ENV, BUNDLE_REF_ENV, MODEL_ENV
 from agentos_worker.bundle_store import BundleStore
 from agentos_worker.config import WorkerConfig
@@ -48,9 +56,6 @@ from agentos_worker.sandbox import AffinityStore, SandboxSubstrate, SubstrateCon
 from agentos_worker.sandbox.types import ClaimView, SandboxView
 from redis.asyncio import Redis as AsyncRedis
 
-_VH = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VP = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
-_VPW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 CONTAINS = GraderKind.CONTAINS
 
 

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -13,7 +13,6 @@ sync fixtures.
 from __future__ import annotations
 
 import contextlib
-import os
 import uuid
 from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass, field
@@ -22,6 +21,18 @@ import aiohttp
 import pytest
 import redis
 from aci_protocol import Final, OutboundEvent, SessionStatus
+from agentos_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from agentos_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
+from agentos_test_support.valkey import (
+    connect_or_skip,
+)
 from agentos_worker.approval_cards import ApprovalCardStore
 from agentos_worker.behaviorpacks import NavPack
 from agentos_worker.config import WorkerConfig
@@ -36,20 +47,10 @@ from aiohttp import web
 from aiohttp.test_utils import TestServer
 from redis.asyncio import Redis as AsyncRedis
 
-_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
-_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
-
 
 @pytest.fixture
 def sync_redis() -> Iterator[redis.Redis]:
-    client = redis.Redis(
-        host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW or None, decode_responses=True
-    )
-    try:
-        client.ping()
-    except redis.exceptions.RedisError as exc:
-        pytest.skip(f"Valkey not reachable: {exc}")
+    client = connect_or_skip(decode_responses=True)
     yield client
     client.close()
 

--- a/apps/worker/tests/sandbox/conftest.py
+++ b/apps/worker/tests/sandbox/conftest.py
@@ -9,13 +9,15 @@ client is exercised by the env-gated k8scratch e2e in ``test_e2e_k8scratch.py``.
 
 from __future__ import annotations
 
-import os
 import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 
 import pytest
 import redis
+from agentos_test_support.valkey import (
+    connect_or_skip,
+)
 from agentos_worker.sandbox import (
     AffinityStore,
     ClaimView,
@@ -51,23 +53,10 @@ class _RecordingDocker(DockerSandboxClient):
 def _flag_values(argv: list[str], flag: str) -> list[str]:
     return [argv[i + 1] for i, a in enumerate(argv) if a == flag and i + 1 < len(argv)]
 
-_VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
-_VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
-_VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
-
 
 @pytest.fixture
 def redis_client() -> Iterator[redis.Redis]:
-    client = redis.Redis(
-        host=_VALKEY_HOST,
-        port=_VALKEY_PORT,
-        password=_VALKEY_PW or None,
-        decode_responses=False,
-    )
-    try:
-        client.ping()
-    except redis.exceptions.RedisError as exc:
-        pytest.skip(f"Valkey not reachable at {_VALKEY_HOST}:{_VALKEY_PORT}: {exc}")
+    client = connect_or_skip(decode_responses=False)
     yield client
     client.close()
 

--- a/packages/test-support/pyproject.toml
+++ b/packages/test-support/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "agentos-test-support"
+version = "0.0.0"
+description = "AgentOS shared test-support helpers (dev/test only)"
+requires-python = ">=3.13"
+dependencies = [
+    "redis>=5.0",
+    "pytest>=8.3",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentos_test_support"]

--- a/packages/test-support/src/agentos_test_support/__init__.py
+++ b/packages/test-support/src/agentos_test_support/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test-support helpers for the AgentOS workspace (dev/test only)."""

--- a/packages/test-support/src/agentos_test_support/valkey.py
+++ b/packages/test-support/src/agentos_test_support/valkey.py
@@ -1,0 +1,38 @@
+"""Shared Valkey connect-and-skip helpers for the test suites.
+
+The three constants read the same env vars with the same compose defaults every
+test site used before consolidation (compose.dev.yaml maps Valkey to host port
+26379, password ``valkeypass``); ``connect_or_skip`` is the sync build+ping+skip
+block those sites duplicated.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import redis
+
+VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
+VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
+VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
+
+
+def connect_or_skip(*, decode_responses: bool = True) -> redis.Redis:
+    """A sync Valkey client against the compose stack, or ``pytest.skip``.
+
+    Builds a ``redis.Redis`` on the shared ``TEST_VALKEY_*`` connection params,
+    pings it, and skips the test when Valkey is unreachable. The caller owns the
+    returned client (yield it from a fixture and ``.close()`` on teardown).
+    """
+    client: redis.Redis = redis.Redis(
+        host=VALKEY_HOST,
+        port=VALKEY_PORT,
+        password=VALKEY_PW or None,
+        decode_responses=decode_responses,
+    )
+    try:
+        client.ping()
+    except redis.exceptions.RedisError as exc:
+        pytest.skip(f"Valkey not reachable at {VALKEY_HOST}:{VALKEY_PORT}: {exc}")
+    return client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ members = [
     "packages/aci-protocol",
     "packages/channel-protocol",
     "packages/plugin-format",
+    "packages/test-support",
     "apps/api",
     "apps/dispatcher",
     "apps/worker",
@@ -33,6 +34,7 @@ members = [
 aci-protocol = { workspace = true }
 agentos-channel-protocol = { workspace = true }
 plugin-format = { workspace = true }
+agentos-test-support = { workspace = true }
 agentos-api = { workspace = true }
 agentos-dispatcher = { workspace = true }
 agentos-worker = { workspace = true }
@@ -44,6 +46,7 @@ agentos-wire-tolerance-gate = { workspace = true }
 dev = [
     "agentos-doclint",
     "agentos-wire-tolerance-gate",
+    "agentos-test-support",
     "pytest>=8.3",
     "ruff>=0.15.22",
     "mypy>=2.3.0",
@@ -97,6 +100,7 @@ mypy_path = [
     "packages/aci-protocol/src",
     "packages/channel-protocol/src",
     "packages/plugin-format/src",
+    "packages/test-support/src",
     "apps/api/src",
     "apps/dispatcher/src",
     "apps/worker/src",
@@ -108,6 +112,7 @@ files = [
     "packages/aci-protocol/src",
     "packages/channel-protocol/src",
     "packages/plugin-format/src",
+    "packages/test-support/src",
     "apps/api/src",
     "apps/dispatcher/src",
     "apps/worker/src",

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "agentos-dispatcher",
     "agentos-doclint",
     "agentos-runner",
+    "agentos-test-support",
     "agentos-wire-tolerance-gate",
     "agentos-worker",
     "agentos-workspace",
@@ -154,6 +155,21 @@ requires-dist = [
 ]
 
 [[package]]
+name = "agentos-test-support"
+version = "0.0.0"
+source = { editable = "packages/test-support" }
+dependencies = [
+    { name = "pytest" },
+    { name = "redis" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "redis", specifier = ">=5.0" },
+]
+
+[[package]]
 name = "agentos-wire-tolerance-gate"
 version = "0.0.0"
 source = { editable = "tools/wire-tolerance-gate" }
@@ -212,6 +228,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "agentos-doclint" },
+    { name = "agentos-test-support" },
     { name = "agentos-wire-tolerance-gate" },
     { name = "mypy" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -235,6 +252,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "agentos-doclint", editable = "tools/doclint" },
+    { name = "agentos-test-support", editable = "packages/test-support" },
     { name = "agentos-wire-tolerance-gate", editable = "tools/wire-tolerance-gate" },
     { name = "mypy", specifier = ">=2.3.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29" },


### PR DESCRIPTION
Consolidate the duplicated Valkey connect-and-skip test boilerplate into a shared workspace helper.

## What
- New workspace member `packages/test-support` exposing `agentos_test_support.valkey`: the `TEST_VALKEY_*` constants (same env vars/defaults) and `connect_or_skip(*, decode_responses=True)` -- the sync `redis.Redis` + ping + `pytest.skip` block the suites duplicated.
- Nine test sites across `apps/api`, `apps/worker`, `apps/dispatcher` now import the shared constants (name-aliased) and route their sync fixtures through `connect_or_skip`, instead of each redefining the trio under variant names (`_VALKEY_HOST`, `_VH`).
- Dead `_VH/_VP/_VPW` in `apps/worker/tests/eval/conftest.py` removed.

## Placement
`packages/test-support` is a uv-workspace member wired into the root `pyproject.toml` (members, `[tool.uv.sources]`, dev dependency-group, mypy path/files), mirroring `tools/doclint`. It is installed editable into the single dev venv so `import agentos_test_support` resolves from every suite under `--import-mode=importlib`, and it is NOT added to any app's runtime `dependencies` -- no cross-package runtime edge.

## Behavior preservation
Pure test refactor. Fixture names, `decode_responses` values (sandbox stays `False`, the rest `True`), and skip semantics are preserved via name-aliased imports, so downstream inline async-client and config construction resolve unchanged.

## Out of scope (documented)
- `apps/worker/tests/sandbox/test_e2e_k8scratch.py` -- a module-scoped, no-skip, real-cluster e2e fixture (env-gated); different shape, unverifiable in the standard suite.
- `tests/soak/harness.py` -- `SoakConfig.from_env` config parsing, not a connect-and-skip fixture.

## Done-check
- [x] Code Reviewer approved (0 blocking; decode_responses parity + alias resolution verified)
- [x] Scope Reviewer approved (0 orphan hunks; no src/production changes)
- [~] Consolidation `/simplify` skipped -- the diff is itself a consolidation with 0 findings; its behavior-preservation rests on load-bearing import aliases a mechanical simplifier could wrongly collapse
- [x] Full api+worker+dispatcher suite unchanged vs baseline: 995 passed, 11 skipped, same 6 pre-existing environment failures (byte-identical failing set)
- [x] `ruff check` clean on all edited files; `mypy` clean across 155 source files
- [logged] Codex advisory review attempted; timed out at 2min on this box (advisory only)
- [N/A] failing-tests-first / security / E2E -- pure refactor, no new behavior or deployed surface

https://claude.ai/code/session_01UB9zhg2FfmGksSyBbmLoSe
