### PR TITLE
Consolidate ADR-0039 dead-letter machinery onto StreamConsumer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -278,7 +278,7 @@ Each has an integration test under `apps/worker/tests/`:
 1. **One live session per thread.** A Valkey thread lock (`SET NX PX`) is the routing CAS ([`apps/worker/src/agentos_worker/threadlock.py::ThreadLock`](apps/worker/src/agentos_worker/threadlock.py)).
 2. **The finish race.** A follow-up during a live turn is a steer; if the turn finished first, the runner returns 409 and the kernel opens a fresh turn on the same idle sandbox ([`apps/worker/src/agentos_worker/kernel.py::Kernel._route_and_start`](apps/worker/src/agentos_worker/kernel.py)).
 3. **No auto-retry after a side-effectful failure.** If a prior attempt flagged a side effect, the kernel escalates to a human instead of retrying ([`apps/worker/src/agentos_worker/kernel.py::Kernel.process_event`](apps/worker/src/agentos_worker/kernel.py)).
-4. **Crash recovery.** Pending stream entries are reclaimed with `XAUTOCLAIM` ([`apps/worker/src/agentos_worker/consumer.py::Consumer._reclaim_once`](apps/worker/src/agentos_worker/consumer.py)); the runs consumer group is created at `$` so a cold worker never replays ancient backlog ([`apps/worker/src/agentos_worker/consumer.py::Consumer.ensure_group`](apps/worker/src/agentos_worker/consumer.py)).
+4. **Crash recovery.** Pending stream entries are reclaimed with `XAUTOCLAIM` ([`apps/worker/src/agentos_worker/stream_consumer.py::StreamConsumer._reclaim_once`](apps/worker/src/agentos_worker/stream_consumer.py)); the runs consumer group is created at `$` so a cold worker never replays ancient backlog ([`apps/worker/src/agentos_worker/consumer.py::Consumer.ensure_group`](apps/worker/src/agentos_worker/consumer.py)).
 
 **Kill switch.** A Valkey pub/sub channel `agentos:kill-events` plus per-agent
 kill keys gate and interrupt live runs for a killed agent

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -244,7 +244,7 @@ why:
 |---|---|
 | `dl_original_id` | the entry's id on the source stream |
 | `dl_delivery_count` | deliveries made before it was given up on |
-| `dl_reason` | `max delivery exceeded`, or `unparseable` |
+| `dl_reason` | `max-delivery-exceeded`, or `unparseable` |
 | `dl_dead_lettered_at` | UTC ISO-8601 timestamp |
 
 The `dl_` prefix keeps the metadata namespaced, but the unparseable path stores

--- a/apps/worker/src/agentos_worker/consumer.py
+++ b/apps/worker/src/agentos_worker/consumer.py
@@ -39,15 +39,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from datetime import UTC, datetime
-from typing import cast
 
 from agentos_dispatcher.queue import from_stream_fields
 from redis.asyncio import Redis
 
 from .config import WorkerConfig
 from .kernel import Kernel
-from .stream_consumer import ReadLoopSpec, StreamConsumer, StreamEntry
+from .stream_consumer import DeliverySpec, ReadLoopSpec, StreamConsumer
 
 logger = logging.getLogger(__name__)
 
@@ -107,11 +105,28 @@ class Consumer(StreamConsumer):
         self._config = config
         self._sem = asyncio.Semaphore(max_concurrency)
         self._inflight: set[asyncio.Task[None]] = set()
-        # Entry ids currently being handled by THIS consumer. XAUTOCLAIM would
-        # otherwise reclaim our own long-running (still-pending) entries and
-        # re-dispatch a duplicate handler that steers the same prompt into its
-        # own live turn; skipping these ids prevents that self-reclaim.
-        self._inflight_ids: set[str] = set()
+        # The reclaim/dead-letter knobs the shared base machinery reads. Built
+        # after self._config is stored; handler is the bound self._dispatch. The
+        # over-cap reason and the success-log format string are load-bearing:
+        # dead_letter_log MUST stay byte-identical to
+        # dead_letter_alert._DEAD_LETTER_MESSAGE and logger MUST be this module's
+        # logger, or the CRITICAL dead-letter alert silently stops firing.
+        self._delivery = DeliverySpec(
+            stream=config.stream,
+            group=config.consumer_group,
+            consumer=config.consumer_name,
+            dead_letter_target=config.dead_letter_stream_name(),
+            over_cap_reason="max-delivery-exceeded",
+            max_delivery=config.max_delivery,
+            dead_letter_maxlen=config.dead_letter_maxlen,
+            reclaim_min_idle_ms=config.reclaim_min_idle_ms,
+            read_count=config.read_count,
+            cap_scan_page=_CAP_SCAN_PAGE,
+            handler=self._dispatch,
+            logger=logger,
+            dead_letter_log="dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
+            dead_letter_fail_log="dead-lettering entry %s failed; left pending, not dispatched",
+        )
 
     async def ensure_group(self) -> None:
         """Create the consumer group (and the stream) if it does not exist.
@@ -190,9 +205,6 @@ class Consumer(StreamConsumer):
             self._inflight_ids.discard(entry_id)
             self._sem.release()
 
-    async def _ack(self, entry_id: str) -> None:
-        await self._xack(self._config.stream, self._config.consumer_group, entry_id)
-
     async def _pending_delivery_count(self, entry_id: str) -> int:
         """This entry's CURRENT delivery count, read from the PEL.
 
@@ -214,82 +226,6 @@ class Consumer(StreamConsumer):
             count=1,
         )
         return int(rows[0]["times_delivered"]) if rows else 1
-
-    # -- dead letter ----------------------------------------------------------
-
-    @property
-    def _dead_letter_stream(self) -> str:
-        return self._config.dead_letter_stream_name()
-
-    async def _dead_letter(
-        self,
-        entry_id: str,
-        fields: dict[str, str] | None,
-        *,
-        reason: str,
-        delivery_count: int,
-    ) -> None:
-        """Move an entry to the graveyard and ack it off the main group.
-
-        ``fields`` are the original entry's fields, kept verbatim so a human or a
-        replay tool can inspect them; ``None`` writes a metadata-only row (the
-        entry was pending but its message had been trimmed off the stream).
-
-        The ``dl_`` prefix is a CONVENTION, not a guarantee: the unparseable path
-        accepts arbitrary malformed field maps, so an entry may already carry its
-        own ``dl_original_id``. A plain copy-then-update would let the payload
-        forge (or be silently clobbered by) the graveyard's own metadata. Original
-        keys already starting with ``dl_`` are therefore escaped by doubling the
-        prefix (``dl_reason`` -> ``dl_dl_reason``) before the metadata is written
-        last. The escape is injective -- escaped keys always start with ``dl_dl_``
-        and so can never equal a metadata key, and un-escaping strips exactly one
-        ``dl_`` -- so the metadata always wins AND the original is fully
-        recoverable.
-
-        XADD before XACK, deliberately: a crash between the two leaves the entry
-        pending, so it is re-reclaimed and re-dead-lettered -- a duplicate
-        graveyard row, which is strictly safer than the XACK-first ordering's
-        failure mode (a lost entry). Two replicas racing the same over-cap entry
-        produce the same acceptable duplicate.
-
-        The XADD is bounded by an approximate ``dead_letter_maxlen``, so
-        graveyard rows are BEST-EFFORT: under a flood the oldest rows are evicted
-        and those failures are lost. That loss is deliberate. The unparseable
-        path dead-letters per inbound entry, so a wire-format drift would grow an
-        unbounded graveyard at full ingest rate on the same Valkey that holds the
-        kernel's locks and side-effect markers -- bounded record loss is traded
-        against a platform-wide OOM. ``approximate=True`` lets Valkey trim on
-        node boundaries, so the stream is bounded at *at least* the configured
-        length, not exactly it.
-        """
-        target = self._dead_letter_stream
-        # Escape the original's own ``dl_*`` keys (see above) so the metadata
-        # written last always wins and the original stays recoverable.
-        payload: dict[str, str] = {
-            (f"dl_{k}" if k.startswith("dl_") else k): v for k, v in (fields or {}).items()
-        }
-        payload.update(
-            {
-                "dl_original_id": entry_id,
-                "dl_delivery_count": str(delivery_count),
-                "dl_reason": reason,
-                "dl_dead_lettered_at": datetime.now(UTC).isoformat(),
-            }
-        )
-        await self._redis.xadd(
-            target,
-            payload,
-            maxlen=self._config.dead_letter_maxlen,
-            approximate=True,
-        )
-        logger.error(
-            "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
-            entry_id,
-            delivery_count,
-            reason,
-            target,
-        )
-        await self._ack(entry_id)
 
     # -- maintenance loop -----------------------------------------------------
 
@@ -354,115 +290,3 @@ class Consumer(StreamConsumer):
                     _THREAD_RESET_DRAIN_BUDGET_S,
                 )
                 return
-
-    async def _reclaim_once(self) -> int:
-        """Reclaim entries pending too long from any (dead) consumer and retry.
-
-        Entries that have already exhausted their delivery budget are
-        dead-lettered first, so they are never claimed or re-dispatched again.
-        XAUTOCLAIM still claims an over-cap entry whose dead-letter failed (it is
-        still pending), so the ids it reports are skipped rather than dispatched:
-        the cap binds even when the graveyard is unwritable.
-        """
-        over_cap = await self._dead_letter_over_cap()
-        reclaimed = 0
-        cursor: str = "0-0"
-        while not self._stop.is_set():
-            raw = await self._redis.xautoclaim(
-                self._config.stream,
-                self._config.consumer_group,
-                self._config.consumer_name,
-                min_idle_time=self._config.reclaim_min_idle_ms,
-                start_id=cursor,
-                count=self._config.read_count,
-            )
-            cursor = str(raw[0])
-            entries = cast("list[StreamEntry]", raw[1])
-            for entry_id, fields in entries:
-                if entry_id in self._inflight_ids:
-                    continue  # still being processed here; not an orphan
-                if entry_id in over_cap:
-                    continue  # budget spent; never dispatch it again
-                reclaimed += 1
-                await self._dispatch(entry_id, fields)
-            if cursor in ("0-0", "0"):
-                break
-        return reclaimed
-
-    async def _dead_letter_over_cap(self) -> set[str]:
-        """Dead-letter pending entries that have exhausted their delivery budget.
-
-        Returns every over-cap id seen this pass -- including ones whose
-        dead-letter failed -- so the caller never re-dispatches them.
-
-        Read the delivery count with XPENDING *before* XAUTOCLAIM rather than
-        after, because XAUTOCLAIM increments the counter as it claims: the
-        pre-claim value is the number of deliveries ALREADY made, so an entry at
-        ``>= max_delivery`` has had its full budget and must not be claimed
-        again. Reading post-claim would fold in the current claim's own bump and
-        kill the entry one delivery early.
-
-        The scan PAGES THROUGH THE WHOLE pending list (``min`` advanced past the
-        last id seen), because XAUTOCLAIM below pages through all of it too: a
-        single ``COUNT _CAP_SCAN_PAGE`` page would cap-check only the head of the
-        list while XAUTOCLAIM happily claimed and dispatched the over-cap tail,
-        so the bound would silently not hold at backlog scale.
-
-        The IDLE filter matches XAUTOCLAIM's ``min_idle_time`` so both see the
-        same candidate set and an entry that is not yet reclaim-eligible is never
-        prematurely dead-lettered.
-
-        A failure to dead-letter ONE entry is logged and isolated: it must not
-        stop the other entries being cap-checked, nor XAUTOCLAIM, nor
-        ``reap_orphans``. This is the first await of the maintenance tick, and an
-        unguarded raise here would kill crash recovery for the whole group on
-        every tick -- #505's own stall class.
-        """
-        over_cap: set[str] = set()
-        page_size = _CAP_SCAN_PAGE
-        cursor = "-"
-        while True:
-            pending = await self._redis.xpending_range(
-                self._config.stream,
-                self._config.consumer_group,
-                min=cursor,
-                max="+",
-                count=page_size,
-                idle=self._config.reclaim_min_idle_ms,
-            )
-            if not pending:
-                break
-            for row in pending:
-                entry_id = str(row["message_id"])
-                # An entry in flight on THIS consumer is not an orphan: it is
-                # being worked right now, and its count must not be judged. This
-                # guard stays ahead of the cap check.
-                if entry_id in self._inflight_ids:
-                    continue
-                delivered = int(row["times_delivered"])
-                if delivered < self._config.max_delivery:
-                    continue
-                over_cap.add(entry_id)
-                try:
-                    await self._dead_letter_over_cap_entry(entry_id, delivered)
-                except Exception:
-                    logger.exception(
-                        "dead-lettering entry %s failed; left pending, not dispatched",
-                        entry_id,
-                    )
-            if len(pending) < page_size:
-                break
-            # Exclusive lower bound: resume after the last id of this page.
-            cursor = f"({pending[-1]['message_id']}"
-        return over_cap
-
-    async def _dead_letter_over_cap_entry(self, entry_id: str, delivered: int) -> None:
-        # XPENDING returns no fields; fetch the original payload. The id can be
-        # pending while its message was trimmed off the stream, in which case
-        # XRANGE comes back empty -> a metadata-only graveyard row, and the XACK
-        # still happens (skipping it would leave the stall in place).
-        found = await self._redis.xrange(self._config.stream, min=entry_id, max=entry_id)
-        fields = cast("list[StreamEntry]", found)[0][1] if found else None
-        await self._dead_letter(
-            entry_id, fields, reason="max delivery exceeded", delivery_count=delivered
-        )

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -32,7 +32,7 @@ import tempfile
 import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import httpx
 from aci_protocol import (
@@ -62,7 +62,7 @@ from ..bundle_store import BundleReader
 from ..config import WorkerConfig
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
-from ..stream_consumer import ReadLoopSpec, StreamConsumer, StreamEntry
+from ..stream_consumer import DeliverySpec, ReadLoopSpec, StreamConsumer
 from .models import EvalRunResult, EvalSuite
 from .recorder import LangfuseEvalRecorder
 from .run import run_eval_suite
@@ -181,10 +181,26 @@ class EvalStreamConsumer(StreamConsumer):
         self._reporter = reporter
         self._recorder = recorder
         self._repo_lookup = repo_lookup
-        # Entry ids this consumer is handling right now. XAUTOCLAIM would
-        # otherwise reclaim our own still-pending (long-running) eval and
-        # re-run it in parallel; skipping these ids prevents that self-reclaim.
-        self._inflight_ids: set[str] = set()
+        # The reclaim/dead-letter knobs the shared base machinery reads; handler
+        # is the bound self._handle. The eval-specific dead_letter_log/logger stay
+        # eval-specific (logger agentos_worker.eval.stream) so eval dead-letters
+        # remain alert-free -- they are NOT unified with the runs-lane strings.
+        self._delivery = DeliverySpec(
+            stream=config.eval_stream,
+            group=config.eval_consumer_group,
+            consumer=config.eval_consumer_name,
+            dead_letter_target=config.eval_dead_letter_stream_name(),
+            over_cap_reason="max-delivery-exceeded",
+            max_delivery=config.max_delivery,
+            dead_letter_maxlen=config.dead_letter_maxlen,
+            reclaim_min_idle_ms=config.reclaim_min_idle_ms,
+            read_count=config.read_count,
+            cap_scan_page=_EVAL_CAP_SCAN_PAGE,
+            handler=self._handle,
+            logger=logger,
+            dead_letter_log="dead-lettered eval entry %s after %d deliveries (reason=%s) -> %s",
+            dead_letter_fail_log="dead-lettering eval entry %s failed; left pending, not re-run",
+        )
 
     async def ensure_group(self) -> None:
         # Create the group at a max-age cutoff rather than the stream head ("0").
@@ -246,140 +262,6 @@ class EvalStreamConsumer(StreamConsumer):
             except Exception:
                 logger.exception("eval reclaim tick failed")
             await self._sleep_or_stop(self._config.reclaim_interval_s)
-
-    async def _reclaim_once(self) -> int:
-        """Reclaim eval entries a dead consumer left pending and re-run them.
-
-        Entries that have already spent their delivery budget are dead-lettered
-        first and then skipped, so a permanently-failing eval (an unresolvable
-        bundle, a provisioning failure) is not reclaimed and re-provisioned every
-        tick forever (#535) -- each redelivery would otherwise claim a sandbox and
-        run an LLM suite, burning money on a job that can never pass. Mirrors the
-        runs-lane cap (ADR-0039, #505) locally in the eval lane.
-        """
-        over_cap = await self._dead_letter_over_cap()
-        reclaimed = 0
-        cursor: str = "0-0"
-        while not self._stop.is_set():
-            raw = await self._redis.xautoclaim(
-                self._config.eval_stream,
-                self._config.eval_consumer_group,
-                self._config.eval_consumer_name,
-                min_idle_time=self._config.reclaim_min_idle_ms,
-                start_id=cursor,
-                count=self._config.read_count,
-            )
-            cursor = str(raw[0])
-            entries = cast("list[StreamEntry]", raw[1])
-            for entry_id, fields in entries:
-                if entry_id in self._inflight_ids:
-                    continue  # still being handled here; not an orphan
-                if entry_id in over_cap:
-                    continue  # budget spent; never re-run it again
-                reclaimed += 1
-                await self._handle(entry_id, fields)
-            if cursor in ("0-0", "0"):
-                break
-        return reclaimed
-
-    async def _dead_letter_over_cap(self) -> set[str]:
-        """Dead-letter eval entries that have exhausted their delivery budget.
-
-        Reads ``times_delivered`` from the PEL with ``XPENDING`` BEFORE
-        ``XAUTOCLAIM`` (which bumps the count on claim), so the pre-claim value is
-        the budget already spent and an entry at ``>= max_delivery`` has had its
-        full budget. Pages the whole pending list (``XAUTOCLAIM`` pages all of it
-        too), keeps the ``IDLE`` filter equal to ``XAUTOCLAIM``'s
-        ``min_idle_time``, and keeps the ``_inflight_ids`` skip ahead of the cap
-        check -- the same invariants the runs lane holds (#505). Returns every
-        over-cap id (including ones whose dead-letter failed) so the caller never
-        re-dispatches them. One entry's failure is isolated so it cannot stop the
-        reclaim tick.
-        """
-        over_cap: set[str] = set()
-        cursor = "-"
-        while True:
-            pending = await self._redis.xpending_range(
-                self._config.eval_stream,
-                self._config.eval_consumer_group,
-                min=cursor,
-                max="+",
-                count=_EVAL_CAP_SCAN_PAGE,
-                idle=self._config.reclaim_min_idle_ms,
-            )
-            if not pending:
-                break
-            for row in pending:
-                entry_id = str(row["message_id"])
-                if entry_id in self._inflight_ids:
-                    continue
-                delivered = int(row["times_delivered"])
-                if delivered < self._config.max_delivery:
-                    continue
-                over_cap.add(entry_id)
-                try:
-                    fields = await self._entry_fields(entry_id)
-                    await self._dead_letter(
-                        entry_id, fields, reason="max-delivery-exceeded", delivery_count=delivered
-                    )
-                except Exception:
-                    logger.exception(
-                        "dead-lettering eval entry %s failed; left pending, not re-run",
-                        entry_id,
-                    )
-            if len(pending) < _EVAL_CAP_SCAN_PAGE:
-                break
-            cursor = f"({pending[-1]['message_id']}"
-        return over_cap
-
-    async def _entry_fields(self, entry_id: str) -> dict[str, str] | None:
-        """The original entry's fields, or None if it was already trimmed off the
-        stream (then a metadata-only graveyard row is written)."""
-        rows = await self._redis.xrange(self._config.eval_stream, min=entry_id, max=entry_id)
-        return dict(rows[0][1]) if rows else None
-
-    async def _dead_letter(
-        self,
-        entry_id: str,
-        fields: dict[str, str] | None,
-        *,
-        reason: str,
-        delivery_count: int,
-    ) -> None:
-        """Move an eval entry to ``<eval_stream>:dead`` and ack it off the group.
-
-        XADD before XACK (a crash between costs a duplicate graveyard row, never a
-        lost entry); the XADD is bounded by an approximate ``dead_letter_maxlen``
-        so the graveyard cannot OOM. Original ``dl_*`` keys are escaped so the
-        metadata written last always wins and the original stays recoverable --
-        the same convention the runs lane uses.
-        """
-        target = self._config.eval_dead_letter_stream_name()
-        payload: dict[str, str] = {
-            (f"dl_{k}" if k.startswith("dl_") else k): v for k, v in (fields or {}).items()
-        }
-        payload.update(
-            {
-                "dl_original_id": entry_id,
-                "dl_delivery_count": str(delivery_count),
-                "dl_reason": reason,
-                "dl_dead_lettered_at": datetime.now(UTC).isoformat(),
-            }
-        )
-        await self._redis.xadd(
-            target,
-            payload,
-            maxlen=self._config.dead_letter_maxlen,
-            approximate=True,
-        )
-        logger.error(
-            "dead-lettered eval entry %s after %d deliveries (reason=%s) -> %s",
-            entry_id,
-            delivery_count,
-            reason,
-            target,
-        )
-        await self._ack(entry_id)
 
     async def _handle(self, entry_id: str, fields: dict[str, str]) -> None:
         self._inflight_ids.add(entry_id)
@@ -555,6 +437,3 @@ class EvalStreamConsumer(StreamConsumer):
                 target_url=item.target_url,
             )
         )
-
-    async def _ack(self, entry_id: str) -> None:
-        await self._xack(self._config.eval_stream, self._config.eval_consumer_group, entry_id)

--- a/apps/worker/src/agentos_worker/stream_consumer.py
+++ b/apps/worker/src/agentos_worker/stream_consumer.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import cast
 
 from redis.exceptions import (
@@ -57,6 +58,27 @@ class ReadLoopSpec:
     logger: logging.Logger
 
 
+@dataclass(frozen=True)
+class DeliverySpec:
+    """The per-consumer knobs the shared reclaim/dead-letter machinery needs;
+    passed in so each lane stays byte-identical after the extraction."""
+
+    stream: str
+    group: str
+    consumer: str
+    dead_letter_target: str
+    over_cap_reason: str
+    max_delivery: int
+    dead_letter_maxlen: int
+    reclaim_min_idle_ms: int
+    read_count: int
+    cap_scan_page: int
+    handler: EntryHandler
+    logger: logging.Logger
+    dead_letter_log: str
+    dead_letter_fail_log: str
+
+
 class StreamConsumer:
     """Base for a Valkey consumer-group reader.
 
@@ -67,13 +89,28 @@ class StreamConsumer:
     business logic.
     """
 
-    def __init__(self, redis: StreamBroker) -> None:
+    def __init__(self, redis: StreamBroker, delivery: DeliverySpec | None = None) -> None:
         # The stream broker behind the port (#284). ``redis.asyncio.Redis`` is the
         # one backing today and structurally satisfies ``StreamBroker``; a second
         # broker is a drop-in. Named ``_redis`` still so the sacred consumer.py
         # subclass (which reads ``self._redis`` for XAUTOCLAIM) is untouched.
         self._redis: StreamBroker = redis
         self._stop = asyncio.Event()
+        # Entry ids currently being handled by THIS consumer. XAUTOCLAIM would
+        # otherwise reclaim our own long-running (still-pending) entries and
+        # re-dispatch a duplicate handler that steers the same prompt into its
+        # own live turn; skipping these ids prevents that self-reclaim.
+        self._inflight_ids: set[str] = set()
+        # The reclaim/dead-letter knobs, or None for a base-only reader that
+        # exercises just ``_consume`` (no reclaim machinery).
+        self._delivery = delivery
+
+    @property
+    def _spec(self) -> DeliverySpec:
+        assert self._delivery is not None, (
+            "reclaim/dead-letter machinery used without a DeliverySpec"
+        )
+        return self._delivery
 
     def request_stop(self) -> None:
         self._stop.set()
@@ -154,3 +191,189 @@ class StreamConsumer:
 
     async def _xack(self, stream: str, group: str, entry_id: str) -> None:
         await self._redis.xack(stream, group, entry_id)
+
+    async def _ack(self, entry_id: str) -> None:
+        await self._redis.xack(self._spec.stream, self._spec.group, entry_id)
+
+    async def _entry_fields(self, entry_id: str) -> dict[str, str] | None:
+        """The original entry's fields, or None if it was already trimmed off the
+        stream (then a metadata-only graveyard row is written)."""
+        rows = await self._redis.xrange(self._spec.stream, min=entry_id, max=entry_id)
+        return dict(rows[0][1]) if rows else None
+
+    async def _dead_letter(
+        self,
+        entry_id: str,
+        fields: dict[str, str] | None,
+        *,
+        reason: str,
+        delivery_count: int,
+    ) -> None:
+        """Move an entry to the graveyard and ack it off the main group.
+
+        ``fields`` are the original entry's fields, kept verbatim so a human or a
+        replay tool can inspect them; ``None`` writes a metadata-only row (the
+        entry was pending but its message had been trimmed off the stream).
+
+        The ``dl_`` prefix is a CONVENTION, not a guarantee: the unparseable path
+        accepts arbitrary malformed field maps, so an entry may already carry its
+        own ``dl_original_id``. A plain copy-then-update would let the payload
+        forge (or be silently clobbered by) the graveyard's own metadata. Original
+        keys already starting with ``dl_`` are therefore escaped by doubling the
+        prefix (``dl_reason`` -> ``dl_dl_reason``) before the metadata is written
+        last. The escape is injective -- escaped keys always start with ``dl_dl_``
+        and so can never equal a metadata key, and un-escaping strips exactly one
+        ``dl_`` -- so the metadata always wins AND the original is fully
+        recoverable.
+
+        XADD before XACK, deliberately: a crash between the two leaves the entry
+        pending, so it is re-reclaimed and re-dead-lettered -- a duplicate
+        graveyard row, which is strictly safer than the XACK-first ordering's
+        failure mode (a lost entry). Two replicas racing the same over-cap entry
+        produce the same acceptable duplicate.
+
+        The XADD is bounded by an approximate ``dead_letter_maxlen``, so
+        graveyard rows are BEST-EFFORT: under a flood the oldest rows are evicted
+        and those failures are lost. That loss is deliberate. The unparseable
+        path dead-letters per inbound entry, so a wire-format drift would grow an
+        unbounded graveyard at full ingest rate on the same Valkey that holds the
+        kernel's locks and side-effect markers -- bounded record loss is traded
+        against a platform-wide OOM. ``approximate=True`` lets Valkey trim on
+        node boundaries, so the stream is bounded at *at least* the configured
+        length, not exactly it.
+        """
+        target = self._spec.dead_letter_target
+        # Escape the original's own ``dl_*`` keys (see above) so the metadata
+        # written last always wins and the original stays recoverable.
+        payload: dict[str, str] = {
+            (f"dl_{k}" if k.startswith("dl_") else k): v for k, v in (fields or {}).items()
+        }
+        payload.update(
+            {
+                "dl_original_id": entry_id,
+                "dl_delivery_count": str(delivery_count),
+                "dl_reason": reason,
+                "dl_dead_lettered_at": datetime.now(UTC).isoformat(),
+            }
+        )
+        await self._redis.xadd(
+            target,
+            payload,
+            maxlen=self._spec.dead_letter_maxlen,
+            approximate=True,
+        )
+        self._spec.logger.error(
+            self._spec.dead_letter_log,
+            entry_id,
+            delivery_count,
+            reason,
+            target,
+        )
+        await self._ack(entry_id)
+
+    async def _dead_letter_over_cap(self) -> set[str]:
+        """Dead-letter pending entries that have exhausted their delivery budget.
+
+        Returns every over-cap id seen this pass -- including ones whose
+        dead-letter failed -- so the caller never re-dispatches them.
+
+        Read the delivery count with XPENDING *before* XAUTOCLAIM rather than
+        after, because XAUTOCLAIM increments the counter as it claims: the
+        pre-claim value is the number of deliveries ALREADY made, so an entry at
+        ``>= max_delivery`` has had its full budget and must not be claimed
+        again. Reading post-claim would fold in the current claim's own bump and
+        kill the entry one delivery early.
+
+        The scan PAGES THROUGH THE WHOLE pending list (``min`` advanced past the
+        last id seen), because XAUTOCLAIM below pages through all of it too: a
+        single ``COUNT cap_scan_page`` page would cap-check only the head of the
+        list while XAUTOCLAIM happily claimed and dispatched the over-cap tail,
+        so the bound would silently not hold at backlog scale.
+
+        The IDLE filter matches XAUTOCLAIM's ``min_idle_time`` so both see the
+        same candidate set and an entry that is not yet reclaim-eligible is never
+        prematurely dead-lettered.
+
+        A failure to dead-letter ONE entry is logged and isolated: it must not
+        stop the other entries being cap-checked, nor XAUTOCLAIM, nor
+        ``reap_orphans``. This is the first await of the maintenance tick, and an
+        unguarded raise here would kill crash recovery for the whole group on
+        every tick -- #505's own stall class.
+        """
+        over_cap: set[str] = set()
+        page_size = self._spec.cap_scan_page
+        cursor = "-"
+        while True:
+            pending = await self._redis.xpending_range(
+                self._spec.stream,
+                self._spec.group,
+                min=cursor,
+                max="+",
+                count=page_size,
+                idle=self._spec.reclaim_min_idle_ms,
+            )
+            if not pending:
+                break
+            for row in pending:
+                entry_id = str(row["message_id"])
+                # An entry in flight on THIS consumer is not an orphan: it is
+                # being worked right now, and its count must not be judged. This
+                # guard stays ahead of the cap check.
+                if entry_id in self._inflight_ids:
+                    continue
+                delivered = int(row["times_delivered"])
+                if delivered < self._spec.max_delivery:
+                    continue
+                over_cap.add(entry_id)
+                try:
+                    fields = await self._entry_fields(entry_id)
+                    await self._dead_letter(
+                        entry_id,
+                        fields,
+                        reason=self._spec.over_cap_reason,
+                        delivery_count=delivered,
+                    )
+                except Exception:
+                    self._spec.logger.exception(
+                        self._spec.dead_letter_fail_log,
+                        entry_id,
+                    )
+            if len(pending) < page_size:
+                break
+            # Exclusive lower bound: resume after the last id of this page.
+            cursor = f"({pending[-1]['message_id']}"
+        return over_cap
+
+    async def _reclaim_once(self) -> int:
+        """Reclaim entries pending too long from any (dead) consumer and retry.
+
+        Entries that have already exhausted their delivery budget are
+        dead-lettered first, so they are never claimed or re-dispatched again.
+        XAUTOCLAIM still claims an over-cap entry whose dead-letter failed (it is
+        still pending), so the ids it reports are skipped rather than dispatched:
+        the cap binds even when the graveyard is unwritable.
+        """
+        over_cap = await self._dead_letter_over_cap()
+        reclaimed = 0
+        cursor: str = "0-0"
+        while not self._stop.is_set():
+            raw = await self._redis.xautoclaim(
+                self._spec.stream,
+                self._spec.group,
+                self._spec.consumer,
+                min_idle_time=self._spec.reclaim_min_idle_ms,
+                start_id=cursor,
+                count=self._spec.read_count,
+            )
+            cursor = str(raw[0])
+            entries = cast("list[StreamEntry]", raw[1])
+            for entry_id, fields in entries:
+                if entry_id in self._inflight_ids:
+                    continue  # still being processed here; not an orphan
+                if entry_id in over_cap:
+                    continue  # budget spent; never dispatch it again
+                reclaimed += 1
+                await self._spec.handler(entry_id, fields)
+            if cursor in ("0-0", "0"):
+                break
+        return reclaimed

--- a/apps/worker/tests/kernel/test_consumer_dead_letter.py
+++ b/apps/worker/tests/kernel/test_consumer_dead_letter.py
@@ -767,7 +767,7 @@ def test_dead_letter_is_logged_loudly_with_the_operational_facts(
                 assert any(
                     entry_id in m
                     and "2" in m
-                    and "max delivery exceeded" in m
+                    and "max-delivery-exceeded" in m
                     and dead in m
                     for m in messages
                 ), (
@@ -822,7 +822,7 @@ def test_dead_letter_emits_one_retention_independent_critical_alert(
                 assert len(alerts) == 1, f"expected one dead letter alert, got {alerts}"
                 assert alerts[0].getMessage() == (
                     f"event=agentos.dead_letter entry_id={entry_id} delivery_count=2 "
-                    f"reason=max delivery exceeded dead_stream={dead}"
+                    f"reason=max-delivery-exceeded dead_stream={dead}"
                 )
 
                 caplog.clear()
@@ -831,14 +831,14 @@ def test_dead_letter_emits_one_retention_independent_critical_alert(
                     "dead-lettered entry %s after %d deliveries reason=%s -> %s",
                     entry_id,
                     2,
-                    "max delivery exceeded",
+                    "max-delivery-exceeded",
                     dead,
                 )
                 source_logger.error(
                     "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
                     entry_id,
                     2,
-                    "max delivery exceeded",
+                    "max-delivery-exceeded",
                 )
                 assert not [
                     record
@@ -853,7 +853,7 @@ def test_dead_letter_emits_one_retention_independent_critical_alert(
                     "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
                     entry_id,
                     2,
-                    "max delivery exceeded",
+                    "max-delivery-exceeded",
                     dead,
                 )
                 assert not [
@@ -868,7 +868,7 @@ def test_dead_letter_emits_one_retention_independent_critical_alert(
                     "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
                     entry_id,
                     2,
-                    "max delivery exceeded",
+                    "max-delivery-exceeded",
                     dead,
                 )
                 assert not [
@@ -883,7 +883,7 @@ def test_dead_letter_emits_one_retention_independent_critical_alert(
                     "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
                     entry_id,
                     "two",
-                    "max delivery exceeded",
+                    "max-delivery-exceeded",
                     dead,
                 )
                 assert not [

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -183,7 +183,7 @@ def test_main_installs_dead_letter_alerting(
                 "dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
                 "1730000000000-0",
                 2,
-                "max delivery exceeded",
+                "max-delivery-exceeded",
                 "agentos:runs:dead",
             )
 

--- a/docs/interfaces/queue-stream/INTERFACE.md
+++ b/docs/interfaces/queue-stream/INTERFACE.md
@@ -51,18 +51,18 @@ A second broker must honor the stream key, the payload encoding, and the Stream 
 - **Consumer verbs** — the worker reads with `xreadgroup` over a consumer group
   (`apps/worker/src/agentos_worker/consumer.py::Consumer._read_loop`), rebuilds the model at
   `apps/worker/src/agentos_worker/consumer.py::Consumer._handle`, and acknowledges with `xack`
-  (`apps/worker/src/agentos_worker/consumer.py::Consumer._ack`). The group is
+  (`apps/worker/src/agentos_worker/stream_consumer.py::StreamConsumer._ack`). The group is
   `"agentos-workers"` (`WorkerConfig.consumer_group`, `apps/worker/src/agentos_worker/config.py::WorkerConfig`).
 - **Delivery cap and dead-letter graveyard** (#505, ADR-0039) — an entry already
   delivered `WorkerConfig.max_delivery` times (default 5, floor 2) is dead-lettered
-  instead of reclaimed again. `Consumer._dead_letter_over_cap`
-  (`apps/worker/src/agentos_worker/consumer.py::Consumer._dead_letter_over_cap`) reads
+  instead of reclaimed again. `StreamConsumer._dead_letter_over_cap`
+  (`apps/worker/src/agentos_worker/stream_consumer.py::StreamConsumer._dead_letter_over_cap`) reads
   the pending list's delivery counts with `xpending_range` before the reclaim's
   `xautoclaim` bumps them; an over-cap entry's original fields are fetched with
-  `xrange` in `Consumer._dead_letter_over_cap_entry`
-  (`apps/worker/src/agentos_worker/consumer.py::Consumer._dead_letter_over_cap_entry`)
-  and moved with `xadd` in `Consumer._dead_letter`
-  (`apps/worker/src/agentos_worker/consumer.py::Consumer._dead_letter`), then acked off
+  `xrange` in `StreamConsumer._entry_fields`
+  (`apps/worker/src/agentos_worker/stream_consumer.py::StreamConsumer._entry_fields`)
+  and moved with `xadd` in `StreamConsumer._dead_letter`
+  (`apps/worker/src/agentos_worker/stream_consumer.py::StreamConsumer._dead_letter`), then acked off
   the group. The target stream is `WorkerConfig.dead_letter_stream`
   (`apps/worker/src/agentos_worker/config.py::WorkerConfig`), defaulting to
   `"<stream>:dead"`.


### PR DESCRIPTION
Consolidates the copy-pasted ADR-0039 bounded-delivery dead-letter/reclaim machinery that was hand-maintained in both `Consumer` and `EvalStreamConsumer` onto their shared `StreamConsumer` base, via a per-lane `DeliverySpec`. Each subclass now keeps only its handler and its own loops. Net ~74 fewer lines of consumer source; the read-loop extraction (already on the base) is now joined by the reclaim/dead-letter machinery.

## Reason-string unification
The lanes had drifted: runs wrote `dl_reason="max delivery exceeded"`, eval wrote `"max-delivery-exceeded"`. Standardized on **`max-delivery-exceeded`**. The runs dead-letter ERROR log is re-emitted by `dead_letter_alert.py` as a logfmt `key=value` critical alert (`... reason=<value> dead_stream=...`); a space-separated value corrupts logfmt field parsing, so the kebab token is the correct code and matches both the sibling `unparseable` reason and the eval lane.

## Behavior preservation
Byte-identical per lane otherwise: XPENDING-before-XAUTOCLAIM, cap at `>=`, IDLE filter equal to `min_idle_time`, the `_inflight_ids` skip ahead of the cap check, XADD-before-XACK, the PEL-not-memory delivery count, whole-list paging, and the bounded graveyard are all preserved. The runs dead-letter alert coupling (exact format string plus the `agentos_worker.consumer` logger) is kept so alerting still fires; the eval lane keeps its distinct logger so eval dead-letters stay alert-free (an intended asymmetry). The detailed `dl_` field-escape docstring now lives on the shared `_dead_letter`.

## Review
Reviewed by code-reviewer, scope-creep, spec-vs-impl, and side-effects-detective (the sacred-module requirement for consumer.py), plus a Codex execution pass. All clean; Codex ran the delivery-cap tests green.

## Tests
`apps/worker/tests/kernel` 98/98; the full worker suite minus 5 environment-only failures = 506 passed; ruff + mypy clean.

The full local suite shows 6 failures: 5 are pre-existing and environmental (eval tests that need Langfuse + a runner endpoint this sandbox cannot reach, so they fail on connect). The 6th, `kernel/test_binding_integration.py::test_kill_interrupts_a_live_turn`, is a latent real-Valkey timing race in an unrelated kernel test that only trips when those 5 broken tests run before it; it passes in isolation, in kernel-only (twice), and with the 5 deselected (506 pass). side-effects-detective found no state-difference path from this refactor (the moved code reads identical config, same Valkey ops, same order, no leaked loop/connection), so it is a timing artifact, not a regression. CI with egress should not hit it.
