### PR TITLE
Keep a multi-paragraph approval summary from breaking the CLI notice parse

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -975,8 +975,16 @@ class Kernel:
             logger.warning("suspend failed for thread %s: %s", thread, exc)
 
         base = outcome.text.strip()
+        # The notice is a control string the CLI parses by splitting on blank
+        # lines and requiring the marker-leading block (cli/src/chat.rs
+        # parse_approval_id, the #766 keep-alive). A model-authored blank line or
+        # newline in ``summary`` would break that delimiter and strand the
+        # resumed reply (#817), so collapse the interpolated summary to one
+        # logical line -- the notice is always a single clean block. The durable
+        # ``Approval`` record and the Block Kit card keep the original summary.
+        notice_summary = " ".join(summary.split())
         notice = (
-            f"Awaiting approval ({created.id}): {summary}\n"
+            f"Awaiting approval ({created.id}): {notice_summary}\n"
             "The session is paused and will resume once an authorized member "
             "resolves this request."
         )

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -99,6 +99,51 @@ def test_awaiting_approval_creates_record_and_suspends(make_harness) -> None:
     asyncio.run(go())
 
 
+def test_multiparagraph_summary_yields_a_single_block_parseable_notice(
+    make_harness,
+) -> None:
+    """A model-authored multi-paragraph summary must not break the CLI notice
+    parse (#817).
+
+    The notice is a control string the CLI splits on blank lines, requiring the
+    marker-leading block (cli/src/chat.rs parse_approval_id, the #766
+    keep-alive). A blank line inside the summary would strand the resumed reply
+    (or, on the route-bound path, report the raw notice as a false success). The
+    kernel collapses the interpolated summary to one logical line, so the notice
+    stays a single block whose trailing ``\\n\\n``-split segment starts with the
+    marker -- while the durable record keeps the original summary."""
+
+    async def go() -> None:
+        approvals = RecordingApprovals()
+        async with make_harness(approvals=approvals) as h:
+            summary = "First paragraph of the summary.\n\nSecond paragraph.\nThird line."
+            h.runner.default_script = _awaiting_script(summary)
+            ev = _qevent("please discount", event_id="ev-appr-multi")
+            await h.kernel.process_event(ev)
+
+            # The durable record keeps the original multi-paragraph summary; only
+            # the notice display is collapsed.
+            assert len(approvals.requests) == 1
+            assert approvals.requests[0].summary == summary
+
+            # The placeholder notice is a single logical block: splitting on the
+            # blank-line delimiter, the trailing block is the marker-leading
+            # notice, exactly what the CLI parser anchors on.
+            text = h.sink.last_text
+            assert text is not None
+            blocks = text.split("\n\n")
+            notice = blocks[-1]
+            assert notice.startswith("Awaiting approval (appr-1)")
+            assert "The session is paused" in notice
+            # The summary's own blank line is gone; it reads as one line.
+            summary_line, _, _ = notice.partition("\n")
+            assert "First paragraph of the summary." in summary_line
+            assert "Second paragraph." in summary_line
+            assert "Third line." in summary_line
+
+    asyncio.run(go())
+
+
 def test_pending_state_survives_worker_restart_and_resumes_on_resolve(
     make_harness,
 ) -> None:

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -363,14 +363,22 @@ pub async fn await_reply(
 /// marker. `find` let base text shadow the real id; `rfind` let the model-supplied
 /// `summary` (which FOLLOWS the id) shadow it just as easily. Instead:
 ///
-/// 1. Split the text into `\n\n`-separated blocks. The authoritative notice is the
-///    appended LAST block, and it STARTS with the marker.
+/// 1. Split the text into `\n\n`-separated blocks. The authoritative notice
+///    STARTS with the marker. The kernel appends it as the trailing logical
+///    block, but rather than assuming it is the LAST block, anchor on the last
+///    marker-leading block: a model-authored blank line inside the summary can
+///    split the notice across `\n\n` boundaries, leaving a summary fragment as
+///    the true last block (#817). The kernel now collapses the summary to one
+///    line so this cannot happen in practice, but anchoring on the marker keeps
+///    the parse robust to any future notice shape rather than to a fragile
+///    "last block" assumption about its own control string.
 /// 2. Require that block to be the only block starting with the marker: two
 ///    marker-leading blocks mean the text is ambiguous (a model that emitted a
 ///    whole notice-shaped block of its own), so no id is claimed.
 /// 3. When the kernel's fixed trailing sentence appears in the text at all, it
-///    must appear inside that block -- otherwise the structure is not the
-///    kernel's and no id is claimed.
+///    must appear at or after that block (the sentence FOLLOWS the summary, so a
+///    blank-line summary can push it into a later block) -- a tail that PRECEDES
+///    the marker is not the kernel's structure and no id is claimed.
 /// 4. Parse the UUID from that block's own marker.
 ///
 /// Bias is deliberately toward a false negative: a WRONG id makes the CLI wait for
@@ -383,11 +391,16 @@ pub fn parse_approval_id(placeholder_text: &str) -> Option<String> {
                                resolves this request.";
 
     let blocks: Vec<&str> = placeholder_text.split("\n\n").collect();
-    let notice = blocks.last()?.trim_start();
-    // The notice is always the appended trailing block.
-    if !notice.starts_with(MARKER) {
-        return None;
-    }
+    // The notice STARTS with the marker; anchor on the LAST marker-leading block
+    // rather than the last block overall, so a blank-line summary that split the
+    // notice across `\n\n` boundaries cannot let a trailing summary fragment
+    // shadow it (#817).
+    let (notice_idx, notice) = blocks
+        .iter()
+        .enumerate()
+        .rev()
+        .map(|(i, b)| (i, b.trim_start()))
+        .find(|(_, b)| b.starts_with(MARKER))?;
     // ...and it is the ONLY marker-leading block; anything else is ambiguous.
     if blocks
         .iter()
@@ -397,8 +410,12 @@ pub fn parse_approval_id(placeholder_text: &str) -> Option<String> {
     {
         return None;
     }
-    // When the fixed sentence is present, it belongs to this block.
-    if placeholder_text.contains(NOTICE_TAIL) && !notice.contains(NOTICE_TAIL) {
+    // When the fixed sentence is present, it must appear at or after this block
+    // (it FOLLOWS the summary, so a blank-line summary can push it into a later
+    // block); a tail that precedes the marker is not the kernel's structure.
+    if placeholder_text.contains(NOTICE_TAIL)
+        && !blocks[notice_idx..].iter().any(|b| b.contains(NOTICE_TAIL))
+    {
         return None;
     }
     let rest = &notice[MARKER.len()..];
@@ -698,6 +715,39 @@ mod tests {
              resolves this request."
         );
         assert_eq!(parse_approval_id(&text), None);
+    }
+
+    #[test]
+    fn parse_approval_id_survives_a_blank_line_in_the_summary() {
+        // #817: a model that emits a multi-paragraph approval summary makes the
+        // notice span multiple `\n\n` blocks -- the true LAST block is then a
+        // summary fragment, not the marker-leading notice. Anchoring on the last
+        // marker-leading block (and tolerating the fixed sentence landing in a
+        // later block) recovers the id, so the CLI enters resume instead of
+        // stranding the resumed reply / reporting the notice as a false success.
+        let id = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+        let text = format!(
+            "Here is the partial answer so far.\n\n\
+             Awaiting approval ({id}): first, I will do step one.\n\n\
+             Then, in a second paragraph, step two.\n\
+             The session is paused and will resume once an authorized member \
+             resolves this request."
+        );
+        assert_eq!(parse_approval_id(&text).as_deref(), Some(id));
+    }
+
+    #[test]
+    fn parse_approval_id_survives_a_blank_line_summary_with_no_base_prefix() {
+        // The no-partial-answer shape: the placeholder is the notice alone, but
+        // the summary itself carries a blank line. The id must still parse.
+        let id = "00000000-0000-4000-8000-000000000000";
+        let text = format!(
+            "Awaiting approval ({id}): paragraph one of the summary.\n\n\
+             paragraph two of the summary.\n\
+             The session is paused and will resume once an authorized member \
+             resolves this request."
+        );
+        assert_eq!(parse_approval_id(&text).as_deref(), Some(id));
     }
 
     #[test]

--- a/cli/tests/resume_wait.rs
+++ b/cli/tests/resume_wait.rs
@@ -340,3 +340,114 @@ async fn a_notice_without_a_card_parks_the_turn_and_the_keepalive_delivers_the_r
         other => panic!("expected the resumed Replied, got {other:?}"),
     }
 }
+
+/// #817: a model that emits a multi-paragraph approval summary produces a notice
+/// whose blank line splits it across `\n\n` blocks. Before the fix the parse
+/// returned `None`, so `await_reply` fell through to `Outcome::Replied(notice)`
+/// (a FALSE SUCCESS -- the raw notice reported as the final answer, the exact
+/// regression #766 closed) and never entered resume, stranding the resumed
+/// reply. This drives the full path with that notice shape and asserts the turn
+/// parks (never `Replied`), the id parses, and the keep-alive delivers the
+/// resumed reply.
+#[tokio::test]
+async fn a_blank_line_summary_notice_parks_the_turn_and_the_keepalive_delivers_the_resumed_reply() {
+    let Some(mut conn) = valkey_or_skip(
+        "a_blank_line_summary_notice_parks_the_turn_and_the_keepalive_delivers_the_resumed_reply",
+    )
+    .await
+    else {
+        return;
+    };
+    let stream = unique_stream("agentos:test:resume:");
+
+    let mut stub = SlackStub::start("localhost", 0, "localhost").await.unwrap();
+    let endpoint = stub.base_api_url().to_string();
+
+    let original = synthetic_turn(
+        "C-SIM-x",
+        "U-agentos-message",
+        "do the risky thing",
+        "1720000000.000100",
+        PLACEHOLDER_TS,
+        Some(endpoint.clone()),
+    );
+    let original_id = xadd(&mut conn, &stream, &original).await.unwrap();
+
+    // The parked notice carries a multi-paragraph summary: the blank line inside
+    // it splits the notice across `\n\n` blocks, so the trailing block is a
+    // summary fragment rather than the marker-leading notice.
+    let approval_id = "3f2504e0-4f89-41d3-9a0c-0305e82c3303";
+    let notice = format!(
+        "a partial answer\n\n\
+         Awaiting approval ({approval_id}): first paragraph of the summary.\n\n\
+         second paragraph of the summary.\n\
+         The session is paused and will resume once an authorized member \
+         resolves this request."
+    );
+    post_placeholder_edit(&endpoint, &notice).await;
+    deliver_and_ack(&mut conn, &stream).await;
+
+    let outcome = await_reply(
+        &mut stub,
+        &mut conn,
+        &stream,
+        &original_id,
+        PLACEHOLDER_TS,
+        Duration::from_secs(3),
+    )
+    .await;
+
+    let parked = match outcome {
+        Outcome::AwaitingApproval(latest) => latest,
+        other => {
+            let _: i64 = redis::cmd("DEL")
+                .arg(&stream)
+                .query_async(&mut conn)
+                .await
+                .unwrap();
+            // A `Replied(notice)` here is the #817 false success being asserted
+            // against: a blank-line summary must never report the notice as done.
+            panic!("a blank-line summary notice must park as AwaitingApproval, got {other:?}");
+        }
+    };
+    assert_eq!(
+        parse_approval_id(parked.as_deref().unwrap_or_default()).as_deref(),
+        Some(approval_id),
+        "the id parses out of a multi-paragraph summary notice"
+    );
+
+    let resume_event_id = format!("approval-{approval_id}-resolved");
+    let resume = resume_turn(&resume_event_id, &endpoint);
+    xadd(&mut conn, &stream, &resume).await.unwrap();
+    deliver_and_ack(&mut conn, &stream).await;
+    post_placeholder_edit(&endpoint, "the resolved answer").await;
+
+    let observed = await_resume(
+        &mut stub,
+        &mut conn,
+        &stream,
+        &resume_event_id,
+        &original_id,
+        PLACEHOLDER_TS,
+        Duration::from_secs(3),
+    )
+    .await;
+
+    let _: i64 = redis::cmd("DEL")
+        .arg(&stream)
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+
+    assert!(
+        observed.resolved,
+        "the resume entry was observed (resolved)"
+    );
+    match observed.outcome {
+        Outcome::Replied(reply) => assert_eq!(
+            reply, "the resolved answer",
+            "the resumed reply is delivered, not stranded on the dead stub"
+        ),
+        other => panic!("expected the resumed Replied, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Problem

A blank line inside a model-authored approval summary breaks the CLI's approval-notice parser. The kernel builds the placeholder notice by interpolating the unsanitized summary (`kernel.py`), and the CLI parses it by splitting on `\n\n` and requiring the marker-leading block (`cli/src/chat.rs` `parse_approval_id`, the #766 keep-alive). A `\n\n` anywhere in the summary makes the trailing block a summary fragment rather than the marker-leading notice, so the parse returns `None`:

- On the message reply surface (#766 keep-alive), the turn never enters `resume_after_approval`, so the live resumed reply is stranded on the dead throwaway stub.
- On the route-bound / no-card path, `await_reply` returns `Replied(notice)` -- a false success whose text is the raw approval notice, the exact regression #766 fixed.

Introduced by commit 447aa5d ("Keep the message reply surface alive until the approval resumes").

## Fix (both halves, defense in depth)

- **Kernel (root cause, tight):** collapse the interpolated summary to a single logical line (`" ".join(summary.split())`) when building the notice, so the control string is always one clean `\n\n`-delimited block. The durable `Approval` record and the Block Kit card keep the original multi-paragraph summary. This is a surgical one-line change to the sacred kernel module -- flagged below for adversarial review.
- **CLI parser (hardening):** anchor on the *last marker-leading* block rather than the last block overall, and require the fixed platform sentence to appear *at or after* that block. This keeps the parse robust to any future notice shape rather than to a fragile "last block" assumption about its own control string, while preserving the existing anti-shadowing bias (ambiguous second notice, non-uuid middle, and tail-before-marker all still yield `None`). The UUID gate is unchanged.

## Tests

- CLI unit tests: a blank-line summary (with and without a base prefix) still parses the approval id.
- CLI integration test (`resume_wait.rs`): a blank-line-summary notice parks the turn as `AwaitingApproval` (never `Replied(notice)`) and the keep-alive delivers the resumed reply.
- Worker test: the built notice from a multi-paragraph summary is a single parseable block, while the durable record keeps the original summary.
- Existing #766 approval-resume tests and the full kernel suite stay green.

## Sacred module note

This touches `apps/worker/src/agentos_worker/kernel.py` (the sacred single-owner module). The diff is intentionally minimal: it only collapses whitespace in the already-interpolated `summary` before building the notice string -- no control-flow, locking, or side-effect changes. Please give the kernel edit the adversarial review the module requires; I have not performed that review myself.

## Verification

- `cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test` -- all green.
- `uv run pytest apps/worker/tests/kernel -q` -- 99 passed.

Closes #817
Ref #766, #770