### PR TITLE
Enforce archive member-count and incremental size caps during bundle prescan

### DIFF
--- a/apps/api/src/agentos_api/bundles.py
+++ b/apps/api/src/agentos_api/bundles.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from plugin_format import (
     DEFAULT_MAX_COMPRESSION_RATIO,
+    DEFAULT_MAX_MEMBERS,
     DEFAULT_MAX_UNCOMPRESSED_BYTES,
     MANIFEST_LOCATIONS,
     UnsupportedArchive,
@@ -66,14 +67,16 @@ def extract_and_validate(
     *,
     max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
     max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+    max_members: int = DEFAULT_MAX_MEMBERS,
 ) -> tuple[str, str, ValidationResult]:
     """Detect, extract, and validate. Returns (extension, content_type, result).
 
-    Extraction (with the traversal/symlink/special-file and size/ratio guards)
-    and the single-wrapper-dir unwrap live in ``plugin_format``; this only adds
-    the storage-key/content-type detection the upload path needs. The size/ratio
-    caps default to ``plugin_format``'s generous fallbacks; ``deploy.py`` passes
-    the operator-configured ``Settings`` values instead.
+    Extraction (with the traversal/symlink/special-file, size/ratio, and
+    member-count guards) and the single-wrapper-dir unwrap live in
+    ``plugin_format``; this only adds the storage-key/content-type detection the
+    upload path needs. The caps default to ``plugin_format``'s generous
+    fallbacks; ``deploy.py`` passes the operator-configured ``Settings`` values
+    instead.
     """
 
     extension, content_type = detect_format(data)
@@ -82,6 +85,7 @@ def extract_and_validate(
         dest,
         max_uncompressed_bytes=max_uncompressed_bytes,
         max_compression_ratio=max_compression_ratio,
+        max_members=max_members,
     )
     result = validate_bundle(bundle_root(dest))
     return extension, content_type, result
@@ -108,15 +112,30 @@ def _collect_text_files(root: Path) -> list[tuple[str, str]]:
     return sorted(files, key=lambda item: item[0])
 
 
-def read_bundle_text_files(data: bytes) -> list[tuple[str, str]]:
+def read_bundle_text_files(
+    data: bytes,
+    *,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+    max_members: int = DEFAULT_MAX_MEMBERS,
+) -> list[tuple[str, str]]:
     """Extract an archive's bytes and return its known text files.
 
     Mirrors the upload path (detect -> extract into a temp dir, guarding path
     traversal -> unwrap to the bundle root) but reads the text surfaces instead of
     validating. Returns (path, content) pairs; the caller shapes the response.
+    The caps default to ``plugin_format``'s generous fallbacks; the router passes
+    the operator-configured ``Settings`` values so this path honors the same
+    bounds as ingestion (#815) rather than the library defaults.
     """
 
     with tempfile.TemporaryDirectory() as tmp:
         dest = Path(tmp)
-        safe_extract(data, dest)
+        safe_extract(
+            data,
+            dest,
+            max_uncompressed_bytes=max_uncompressed_bytes,
+            max_compression_ratio=max_compression_ratio,
+            max_members=max_members,
+        )
         return _collect_text_files(bundle_root(dest))

--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -70,6 +70,12 @@ class Settings(BaseSettings):
     #   `deploy.revalidate_stored_bundle`'s deploy-time recheck of an
     #   already-stored bundle against the CURRENT caps (the legacy-bundle
     #   backward-compatibility case).
+    # - bundle_max_members caps the NUMBER of archive members, enforced
+    #   INCREMENTALLY during the pre-scan (#815) so a many-member archive (a
+    #   tiny tar.gz of hundreds of thousands of zero-byte members clears both
+    #   size caps yet exhausts memory building one TarInfo per member) is
+    #   refused mid-walk. A real bundle has hundreds to low thousands of files;
+    #   10_000 sits well above that and far below a member-count DoS.
     # Mirrored in the worker's `WorkerConfig` (apps/worker/src/agentos_worker/
     # config.py) under the same names/defaults -- the worker's Docker-substrate
     # bundle-fetch and the eval-stream suite loader apply the same caps to the
@@ -77,6 +83,7 @@ class Settings(BaseSettings):
     bundle_upload_max_bytes: int = 200 * 1024 * 1024  # 200 MiB
     bundle_max_uncompressed_bytes: int = 1024 * 1024 * 1024  # 1 GiB
     bundle_max_compression_ratio: float = 100.0
+    bundle_max_members: int = 10_000
 
     # Git flow (J1). The webhook secret authenticates inbound GitHub events; the
     # two bot identities are the routing targets recorded on each deployment.

--- a/apps/api/src/agentos_api/deploy.py
+++ b/apps/api/src/agentos_api/deploy.py
@@ -57,6 +57,7 @@ def validate_archive(
             Path(tmp),
             max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
             max_compression_ratio=settings.bundle_max_compression_ratio,
+            max_members=settings.bundle_max_members,
         )
     if not result.valid:
         raise BundleInvalid([e.model_dump() for e in result.errors])
@@ -88,6 +89,7 @@ async def revalidate_stored_bundle(
             data,
             max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
             max_compression_ratio=settings.bundle_max_compression_ratio,
+            max_members=settings.bundle_max_members,
         )
     except plugin_format.UnsupportedArchive as exc:
         raise BundleTooLarge(

--- a/apps/api/src/agentos_api/routers/agents.py
+++ b/apps/api/src/agentos_api/routers/agents.py
@@ -1,5 +1,6 @@
 """Agents and their versions."""
 
+import functools
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -8,6 +9,7 @@ from starlette.concurrency import run_in_threadpool
 
 from .. import bundles, crud
 from ..auth import require_api_key
+from ..config import get_settings
 from ..deps import SessionDep, StoreDep
 from ..schemas import (
     AgentCreate,
@@ -200,5 +202,12 @@ async def read_version_files(
             status.HTTP_404_NOT_FOUND, "no bundle stored for this version"
         )
     data = await store.get(version.bundle_ref)
-    files = await run_in_threadpool(bundles.read_bundle_text_files, data)
+    settings = get_settings()
+    read = functools.partial(
+        bundles.read_bundle_text_files,
+        max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
+        max_compression_ratio=settings.bundle_max_compression_ratio,
+        max_members=settings.bundle_max_members,
+    )
+    files = await run_in_threadpool(read, data)
     return BundleFiles(files=[BundleFile(path=p, content=c) for p, c in files])

--- a/apps/api/tests/test_bundle_ingestion_bounds.py
+++ b/apps/api/tests/test_bundle_ingestion_bounds.py
@@ -167,6 +167,52 @@ def test_zip_bomb_upload_is_refused_with_nothing_written(
     assert version["bundle_ref"] is None
 
 
+def _many_member_tar_gz(count: int, top: str = "demo-plugin") -> bytes:
+    """A tar.gz of ``count`` zero-byte members plus a manifest. gzip shrinks the
+    repetitive headers so the wire size stays tiny (clearing the upload gate),
+    while the declared member count is what the member-count cap must catch."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        manifest = MANIFEST.encode()
+        info = tarfile.TarInfo(f"{top}/.claude-plugin/plugin.json")
+        info.size = len(manifest)
+        tf.addfile(info, io.BytesIO(manifest))
+        for i in range(count):
+            member = tarfile.TarInfo(f"{top}/f{i}")
+            member.size = 0
+            tf.addfile(member)
+    return buf.getvalue()
+
+
+def test_many_member_upload_is_refused_by_member_count_cap(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        deploy_module,
+        "get_settings",
+        lambda: Settings(bundle_max_members=10),
+    )
+    agent_id, version_id = _create_version(client, auth_headers)
+    archive = _many_member_tar_gz(200)
+    assert len(archive) < 4_000  # tiny on the wire; clears the upload size gate
+
+    resp = client.put(
+        f"/agents/{agent_id}/versions/{version_id}/bundle",
+        files={"file": ("many.tar.gz", archive)},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400, resp.text
+    assert "member-count" in resp.json()["detail"]
+
+    version = client.get(
+        f"/agents/{agent_id}/versions", headers=auth_headers
+    ).json()[0]
+    assert version["bundle_ref"] is None
+
+
 # --- legacy bundle revalidated against the CURRENT caps at deploy time ---
 
 

--- a/apps/worker/src/agentos_worker/bundle_store.py
+++ b/apps/worker/src/agentos_worker/bundle_store.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from aci_protocol.s3 import build_s3_client
 from plugin_format import (
     DEFAULT_MAX_COMPRESSION_RATIO,
+    DEFAULT_MAX_MEMBERS,
     DEFAULT_MAX_UNCOMPRESSED_BYTES,
     bundle_root,
     safe_extract,
@@ -81,6 +82,7 @@ def extract_bundle(
     *,
     max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
     max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+    max_members: int = DEFAULT_MAX_MEMBERS,
 ) -> Path:
     """Extract ``data`` into ``dest`` and return the plugin root to mount.
 
@@ -100,5 +102,6 @@ def extract_bundle(
         dest,
         max_uncompressed_bytes=max_uncompressed_bytes,
         max_compression_ratio=max_compression_ratio,
+        max_members=max_members,
     )
     return bundle_root(dest)

--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -336,6 +336,9 @@ class WorkerConfig(BaseSettings):
     # every substrate.
     bundle_max_uncompressed_bytes: int = 1024 * 1024 * 1024  # 1 GiB
     bundle_max_compression_ratio: float = 100.0
+    # Member-count cap, enforced incrementally during the pre-scan (#815) so a
+    # many-member archive is refused mid-walk. Mirrors the API's Settings field.
+    bundle_max_members: int = 10_000
     # Platform API for POST /evals/report. Defaults match the API's dev stack
     # (README serves it on :8000; its shared dev key is agentos-dev-key).
     api_base_url: str = Field(

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -44,6 +44,7 @@ from aci_protocol import (
 )
 from plugin_format import (
     DEFAULT_MAX_COMPRESSION_RATIO,
+    DEFAULT_MAX_MEMBERS,
     DEFAULT_MAX_UNCOMPRESSED_BYTES,
     safe_extract,
 )
@@ -134,6 +135,7 @@ def load_suite_from_bundle(
     *,
     max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
     max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+    max_members: int = DEFAULT_MAX_MEMBERS,
 ) -> EvalSuite | None:
     """Extract the bundle archive and load its evals/cases.json as an EvalSuite,
     named with ``suite_name`` (the payload's authoritative name / Langfuse tag).
@@ -149,6 +151,7 @@ def load_suite_from_bundle(
                 dest,
                 max_uncompressed_bytes=max_uncompressed_bytes,
                 max_compression_ratio=max_compression_ratio,
+                max_members=max_members,
             )
             cases = next((p for p in dest.rglob("cases.json") if p.parent.name == "evals"), None)
             if cases is None:
@@ -329,6 +332,7 @@ class EvalStreamConsumer(StreamConsumer):
             item.suite,
             max_uncompressed_bytes=self._config.bundle_max_uncompressed_bytes,
             max_compression_ratio=self._config.bundle_max_compression_ratio,
+            max_members=self._config.bundle_max_members,
         )
 
     async def _acquire_target(self, item: EvalJob) -> tuple[str | None, str | None, str | None]:

--- a/apps/worker/src/agentos_worker/run.py
+++ b/apps/worker/src/agentos_worker/run.py
@@ -135,6 +135,7 @@ def _sandbox_client(
             environ=env,
             bundle_max_uncompressed_bytes=config.bundle_max_uncompressed_bytes,
             bundle_max_compression_ratio=config.bundle_max_compression_ratio,
+            bundle_max_members=config.bundle_max_members,
         )
         # Prewarm the runner image once at startup so the first claim window is
         # not gated on a cold pull. Best-effort inside ensure_image.

--- a/apps/worker/src/agentos_worker/sandbox/docker.py
+++ b/apps/worker/src/agentos_worker/sandbox/docker.py
@@ -51,7 +51,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from aci_protocol import BootEnv
-from plugin_format import DEFAULT_MAX_COMPRESSION_RATIO, DEFAULT_MAX_UNCOMPRESSED_BYTES
+from plugin_format import (
+    DEFAULT_MAX_COMPRESSION_RATIO,
+    DEFAULT_MAX_MEMBERS,
+    DEFAULT_MAX_UNCOMPRESSED_BYTES,
+)
 
 from ..binding import (
     BASE_URL_ENV,
@@ -231,6 +235,7 @@ class DockerSandboxClient:
         environ: Mapping[str, str] | None = None,
         bundle_max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
         bundle_max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+        bundle_max_members: int = DEFAULT_MAX_MEMBERS,
     ) -> None:
         self._image = image
         self._bundles = bundle_store
@@ -245,6 +250,7 @@ class DockerSandboxClient:
         # ``WorkerConfig`` values instead.
         self._bundle_max_uncompressed_bytes = bundle_max_uncompressed_bytes
         self._bundle_max_compression_ratio = bundle_max_compression_ratio
+        self._bundle_max_members = bundle_max_members
         # Container isolation (read-only rootfs, dropped caps, no-new-privileges,
         # bounded resources). Defaults to the K8s-mirroring RunnerHardening; a
         # None means "use the on-by-default set", never "no hardening".
@@ -444,6 +450,7 @@ class DockerSandboxClient:
                 Path(tmp),
                 max_uncompressed_bytes=self._bundle_max_uncompressed_bytes,
                 max_compression_ratio=self._bundle_max_compression_ratio,
+                max_members=self._bundle_max_members,
             )
             # The mount is read-only and the runner is non-root (uid 1000), so the
             # staged bundle must be group/other readable+traversable; mkdtemp

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -13,6 +13,7 @@ from .approval_policy import (
 )
 from .archive import (
     DEFAULT_MAX_COMPRESSION_RATIO,
+    DEFAULT_MAX_MEMBERS,
     DEFAULT_MAX_UNCOMPRESSED_BYTES,
     UnsupportedArchive,
     bundle_root,
@@ -63,6 +64,7 @@ __all__ = [
     "check_archive_bounds",
     "DEFAULT_MAX_UNCOMPRESSED_BYTES",
     "DEFAULT_MAX_COMPRESSION_RATIO",
+    "DEFAULT_MAX_MEMBERS",
     "bundle_root",
     "UnsupportedArchive",
 ]

--- a/packages/plugin-format/src/plugin_format/archive.py
+++ b/packages/plugin-format/src/plugin_format/archive.py
@@ -24,6 +24,15 @@ the whole archive's byte length rather than a per-entry compressed size because
 tar(.gz) compresses the whole stream, not per-member, so per-member compressed
 sizes do not exist there; using the same denominator for zip keeps one uniform
 rule across both formats.
+
+#815 adds a third bound -- a cap on the **number of members** -- and, crucially,
+enforces both it and the uncompressed-size cap INCREMENTALLY during the pre-scan
+rather than after the full member list is materialized. The tar pre-scan walks
+the stream one header at a time (``for m in tf``) instead of ``getmembers()``,
+which for a ``.tar.gz`` would decompress the entire stream up front; so a small
+archive with a huge member count, or one declaring a single huge member (a
+decompression bomb), is refused mid-walk before hundreds of MiB of TarInfo
+objects are built or the bomb's body is decompressed.
 """
 
 import io
@@ -43,6 +52,15 @@ DEFAULT_MAX_UNCOMPRESSED_BYTES = 1024 * 1024 * 1024  # 1 GiB
 # bomb (e.g. a large run of a single repeated byte) routinely clears 1000x.
 # 100x sits well above real bundles and well below a bomb's typical ratio.
 DEFAULT_MAX_COMPRESSION_RATIO = 100.0
+# A cap on the NUMBER of archive members, enforced INCREMENTALLY during the
+# pre-scan so a many-member archive (e.g. a ~5 MiB tar.gz of hundreds of
+# thousands of zero-byte members: total uncompressed 0, so it clears both the
+# size and ratio caps, yet materializing one TarInfo per member costs hundreds
+# of MiB of RSS) is refused mid-walk rather than after the whole member list is
+# built (#815). A real plugin bundle (source, skill docs, small fixtures) has
+# hundreds to low thousands of files; 10_000 sits well above that and far below
+# the hundreds-of-thousands a member-count DoS needs.
+DEFAULT_MAX_MEMBERS = 10_000
 
 
 class UnsupportedArchive(Exception):
@@ -55,6 +73,31 @@ def _reject_unsafe_path(name: str) -> None:
         raise UnsupportedArchive(f"unsafe path in archive: {name}")
 
 
+def _reject_over_size(total_uncompressed: int, max_uncompressed_bytes: int) -> None:
+    """Reject once the running (or final) uncompressed total crosses the cap.
+
+    Shared by the incremental pre-scan check and ``_check_bounds`` so both
+    raise with the identical message: ``total_uncompressed`` is the sum seen so
+    far, which is a lower bound on the full extracted footprint, so tripping it
+    mid-walk is sound (the real total can only be larger)."""
+    if total_uncompressed > max_uncompressed_bytes:
+        raise UnsupportedArchive(
+            f"archive would extract to {total_uncompressed} bytes, over the "
+            f"{max_uncompressed_bytes} byte limit"
+        )
+
+
+def _reject_over_member_count(count: int, max_members: int) -> None:
+    """Reject once the running member count crosses the cap. Called per member
+    during the pre-scan, before the next member is materialized, so a
+    many-member archive is refused mid-walk (#815)."""
+    if count > max_members:
+        raise UnsupportedArchive(
+            f"archive has more than {max_members} members, over the member-count "
+            f"limit"
+        )
+
+
 def _check_bounds(
     total_uncompressed: int,
     archive_bytes: int,
@@ -63,12 +106,10 @@ def _check_bounds(
 ) -> None:
     """Reject an archive whose declared extracted footprint or compression
     ratio exceeds the caps. Called from the pre-scan, before any entry is
-    written, so a violation writes nothing to ``dest``."""
-    if total_uncompressed > max_uncompressed_bytes:
-        raise UnsupportedArchive(
-            f"archive would extract to {total_uncompressed} bytes, over the "
-            f"{max_uncompressed_bytes} byte limit"
-        )
+    written, so a violation writes nothing to ``dest``. The size cap is also
+    enforced incrementally during the pre-scan (see ``_prescan_*``); this
+    re-checks it and adds the ratio check, which needs the final total."""
+    _reject_over_size(total_uncompressed, max_uncompressed_bytes)
     ratio = total_uncompressed / max(archive_bytes, 1)
     if ratio > max_compression_ratio:
         raise UnsupportedArchive(
@@ -78,37 +119,72 @@ def _check_bounds(
         )
 
 
-def _prescan_zip(zf: zipfile.ZipFile) -> int:
-    """Reject unsafe entries; return the total declared uncompressed size."""
+def _prescan_zip(
+    zf: zipfile.ZipFile,
+    *,
+    max_uncompressed_bytes: int,
+    max_members: int,
+) -> int:
+    """Reject unsafe entries; return the total declared uncompressed size.
+
+    The member-count and running-uncompressed-size caps are enforced INSIDE the
+    loop (before the next entry is touched), so a many-member or declared-huge
+    archive is refused mid-walk rather than after the whole list is walked."""
     total = 0
+    count = 0
     for info in zf.infolist():
+        count += 1
+        _reject_over_member_count(count, max_members)
         _reject_unsafe_path(info.filename)
         # A unix symlink is encoded in the high 16 bits of external_attr;
         # non-unix zips leave those bits 0, so this is a no-op for them.
         if stat.S_ISLNK(info.external_attr >> 16):
             raise UnsupportedArchive(f"link entry not allowed in archive: {info.filename}")
         total += info.file_size
+        _reject_over_size(total, max_uncompressed_bytes)
     return total
 
 
-def _prescan_tar(tf: tarfile.TarFile) -> int:
-    """Reject unsafe entries; return the total declared uncompressed size."""
+def _prescan_tar(
+    tf: tarfile.TarFile,
+    *,
+    max_uncompressed_bytes: int,
+    max_members: int,
+) -> int:
+    """Reject unsafe entries; return the total declared uncompressed size.
+
+    Iterates the tar as a STREAM (``for m in tf``, one member header at a time)
+    rather than ``getmembers()``, which for a ``.tar.gz`` would decompress the
+    whole stream to walk every header up front. Combined with the incremental
+    member-count and size caps, a many-member archive stops at the cap and a
+    declared-huge member (a gzip decompression bomb) trips the size cap BEFORE
+    the pre-scan advances past its header and decompresses its body (#815)."""
     total = 0
-    for m in tf.getmembers():
+    count = 0
+    for m in tf:
+        count += 1
+        _reject_over_member_count(count, max_members)
         _reject_unsafe_path(m.name)
         if m.issym() or m.islnk():
             raise UnsupportedArchive(f"link entry not allowed in archive: {m.name}")
         if not (m.isreg() or m.isdir()):
             raise UnsupportedArchive(f"special entry not allowed in archive: {m.name}")
         total += m.size
+        _reject_over_size(total, max_uncompressed_bytes)
     return total
 
 
 def _extract_zip(
-    data: bytes, dest: Path, max_uncompressed_bytes: int, max_compression_ratio: float
+    data: bytes,
+    dest: Path,
+    max_uncompressed_bytes: int,
+    max_compression_ratio: float,
+    max_members: int,
 ) -> None:
     with zipfile.ZipFile(io.BytesIO(data)) as zf:
-        total = _prescan_zip(zf)
+        total = _prescan_zip(
+            zf, max_uncompressed_bytes=max_uncompressed_bytes, max_members=max_members
+        )
         _check_bounds(total, len(data), max_uncompressed_bytes, max_compression_ratio)
         zf.extractall(dest)
 
@@ -119,8 +195,11 @@ def _extract_tar(
     archive_bytes: int,
     max_uncompressed_bytes: int,
     max_compression_ratio: float,
+    max_members: int,
 ) -> None:
-    total = _prescan_tar(tf)
+    total = _prescan_tar(
+        tf, max_uncompressed_bytes=max_uncompressed_bytes, max_members=max_members
+    )
     _check_bounds(total, archive_bytes, max_uncompressed_bytes, max_compression_ratio)
     # filter="data" (py3.12+) is the traversal/special-file backstop; the
     # pre-scan above is the primary gate and makes "no links at all" explicit.
@@ -133,24 +212,35 @@ def safe_extract(
     *,
     max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
     max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+    max_members: int = DEFAULT_MAX_MEMBERS,
 ) -> None:
     """Extract ``data`` (zip or tar(.gz)) into ``dest``, refusing unsafe entries.
 
     Raises ``UnsupportedArchive`` on an unrecognized archive, any absolute,
-    traversing, link, or special-file entry, or an archive whose total
-    uncompressed size or compression ratio exceeds the given caps -- nothing is
-    written in that case beyond what a rejected member's predecessors may have
-    already unpacked (in practice nothing, since the whole pre-scan, including
-    the bound check, runs before extraction starts).
+    traversing, link, or special-file entry, or an archive whose member count,
+    total uncompressed size, or compression ratio exceeds the given caps --
+    nothing is written in that case beyond what a rejected member's predecessors
+    may have already unpacked (in practice nothing, since the whole pre-scan,
+    including the bound checks, runs before extraction starts). The member-count
+    and uncompressed-size caps are enforced incrementally during the pre-scan,
+    so a many-member or decompression-bomb archive is refused mid-walk rather
+    than after the full member list is materialized.
     """
     if zipfile.is_zipfile(io.BytesIO(data)):
-        _extract_zip(data, dest, max_uncompressed_bytes, max_compression_ratio)
+        _extract_zip(
+            data, dest, max_uncompressed_bytes, max_compression_ratio, max_members
+        )
         return
     for mode in ("r:gz", "r:"):
         try:
             with tarfile.open(fileobj=io.BytesIO(data), mode=mode) as tf:
                 _extract_tar(
-                    tf, dest, len(data), max_uncompressed_bytes, max_compression_ratio
+                    tf,
+                    dest,
+                    len(data),
+                    max_uncompressed_bytes,
+                    max_compression_ratio,
+                    max_members,
                 )
             return
         except tarfile.TarError:
@@ -163,6 +253,7 @@ def check_archive_bounds(
     *,
     max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
     max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+    max_members: int = DEFAULT_MAX_MEMBERS,
 ) -> None:
     """Validate an archive's size/ratio bounds without extracting anything.
 
@@ -181,13 +272,21 @@ def check_archive_bounds(
     """
     if zipfile.is_zipfile(io.BytesIO(data)):
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
-            total = _prescan_zip(zf)
+            total = _prescan_zip(
+                zf,
+                max_uncompressed_bytes=max_uncompressed_bytes,
+                max_members=max_members,
+            )
         _check_bounds(total, len(data), max_uncompressed_bytes, max_compression_ratio)
         return
     for mode in ("r:gz", "r:"):
         try:
             with tarfile.open(fileobj=io.BytesIO(data), mode=mode) as tf:
-                total = _prescan_tar(tf)
+                total = _prescan_tar(
+                    tf,
+                    max_uncompressed_bytes=max_uncompressed_bytes,
+                    max_members=max_members,
+                )
             _check_bounds(total, len(data), max_uncompressed_bytes, max_compression_ratio)
             return
         except tarfile.TarError:

--- a/packages/plugin-format/src/plugin_format/archive.py
+++ b/packages/plugin-format/src/plugin_format/archive.py
@@ -62,6 +62,27 @@ DEFAULT_MAX_COMPRESSION_RATIO = 100.0
 # the hundreds-of-thousands a member-count DoS needs.
 DEFAULT_MAX_MEMBERS = 10_000
 
+# A zip is the one format whose member cap CANNOT be enforced by the in-loop
+# pre-scan alone: `zipfile.ZipFile()` parses the entire central directory and
+# builds one ZipInfo per entry at CONSTRUCTION, before `_prescan_zip` runs, so
+# a many-member zip is fully materialized (hundreds of MiB of RSS for a small
+# on-disk archive) before the loop's cap can fire (#815). The cap must be read
+# from the end-of-central-directory (EOCD) record and enforced BEFORE the
+# ZipFile is opened. These are the fixed-layout constants of that record.
+_ZIP_EOCD_SIGNATURE = b"\x50\x4b\x05\x06"  # "PK\x05\x06"
+_ZIP_EOCD_MIN_SIZE = 22  # fixed part, before any archive comment
+_ZIP_MAX_COMMENT = 0xFFFF  # the comment length field is 16 bits
+# A per-member byte budget for the central directory, used to bound the member
+# count from the EOCD's declared central-directory SIZE. zipfile parses the
+# central directory until it has consumed `size_cd` bytes (it does NOT trust
+# the declared entry count to bound that loop), so an attacker cannot evade the
+# cap by under-declaring the count -- the SIZE is what bounds zipfile's work.
+# A central-directory header is 46 fixed bytes + the file name; 512 leaves
+# generous room for long paths (a legitimate <=10k-file bundle stays well under
+# max_members*512, while a 100k+ zero-byte-member DoS blows past it), so this
+# rejects the DoS without false-rejecting a real bundle near the count cap.
+_ZIP_CENTRAL_DIR_BYTES_PER_MEMBER = 512
+
 
 class UnsupportedArchive(Exception):
     """The bytes are not a recognized zip/tar(.gz), or carry an unsafe entry."""
@@ -96,6 +117,55 @@ def _reject_over_member_count(count: int, max_members: int) -> None:
             f"archive has more than {max_members} members, over the member-count "
             f"limit"
         )
+
+
+def _reject_zip_over_member_count(data: bytes, max_members: int) -> None:
+    """Reject a zip whose central directory holds more than ``max_members``
+    entries, read from the EOCD record BEFORE ``zipfile.ZipFile`` parses and
+    materializes the whole central directory (#815).
+
+    Two signals from the EOCD, both bounded reads of the archive's tail:
+
+    - the declared entry count (precise for an honest archive), and
+    - the central-directory byte SIZE, which caps how many entries
+      ``zipfile`` will parse regardless of the (attacker-controllable, possibly
+      under-declared) count -- ``zipfile`` loops until it has consumed that many
+      bytes, so this is the signal that actually bounds its work.
+
+    A ZIP64 sentinel in either field means the true value overflows the
+    16/32-bit field, i.e. is far past any sane cap, so it is rejected. If no
+    consistent EOCD can be located the archive is left for ``zipfile`` to
+    reject with its own ``BadZipFile`` (the in-loop cap remains a backstop).
+    """
+    tail_len = _ZIP_EOCD_MIN_SIZE + _ZIP_MAX_COMMENT
+    tail = data[-tail_len:] if len(data) > tail_len else data
+    # The EOCD is the last record, followed only by its own comment; scan back
+    # for the last signature whose declared comment length lands exactly at
+    # end-of-tail, so a signature that coincidentally appears inside file data
+    # or the comment does not fool the check.
+    start = tail.rfind(_ZIP_EOCD_SIGNATURE)
+    while start != -1:
+        eocd = tail[start:]
+        if len(eocd) >= _ZIP_EOCD_MIN_SIZE:
+            comment_len = int.from_bytes(eocd[20:22], "little")
+            if start + _ZIP_EOCD_MIN_SIZE + comment_len == len(tail):
+                total_entries = int.from_bytes(eocd[10:12], "little")
+                size_cd = int.from_bytes(eocd[12:16], "little")
+                if total_entries == 0xFFFF or size_cd == 0xFFFFFFFF:
+                    raise UnsupportedArchive(
+                        f"archive declares a ZIP64 central directory, over the "
+                        f"{max_members} member-count limit"
+                    )
+                if (
+                    total_entries > max_members
+                    or size_cd > max_members * _ZIP_CENTRAL_DIR_BYTES_PER_MEMBER
+                ):
+                    raise UnsupportedArchive(
+                        f"archive has more than {max_members} members, over the "
+                        f"member-count limit"
+                    )
+                return
+        start = tail.rfind(_ZIP_EOCD_SIGNATURE, 0, start)
 
 
 def _check_bounds(
@@ -181,6 +251,9 @@ def _extract_zip(
     max_compression_ratio: float,
     max_members: int,
 ) -> None:
+    # Enforce the member cap from the EOCD BEFORE opening the ZipFile, which
+    # would otherwise materialize the entire central directory up front (#815).
+    _reject_zip_over_member_count(data, max_members)
     with zipfile.ZipFile(io.BytesIO(data)) as zf:
         total = _prescan_zip(
             zf, max_uncompressed_bytes=max_uncompressed_bytes, max_members=max_members
@@ -271,6 +344,9 @@ def check_archive_bounds(
     the node.
     """
     if zipfile.is_zipfile(io.BytesIO(data)):
+        # Same EOCD pre-check as the extract path: bound the member count before
+        # ZipFile materializes the central directory (#815).
+        _reject_zip_over_member_count(data, max_members)
         with zipfile.ZipFile(io.BytesIO(data)) as zf:
             total = _prescan_zip(
                 zf,

--- a/packages/plugin-format/tests/test_archive.py
+++ b/packages/plugin-format/tests/test_archive.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 from plugin_format import (
+    DEFAULT_MAX_MEMBERS,
     UnsupportedArchive,
     bundle_root,
     check_archive_bounds,
@@ -257,3 +258,112 @@ def test_check_archive_bounds_still_rejects_unsafe_entries() -> None:
     # The size/ratio check does not bypass the existing traversal guard.
     with pytest.raises(UnsupportedArchive):
         check_archive_bounds(_zip({"../escape": "pwn"}))
+
+
+# --- #815: member-count cap, enforced incrementally during the pre-scan ------
+
+
+def _many_member_zip(count: int) -> bytes:
+    """A zip of ``count`` zero-byte members -- the many-empty-member shape."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for i in range(count):
+            zf.writestr(f"f{i}", b"")
+    return buf.getvalue()
+
+
+def _many_member_tar_gz(count: int) -> bytes:
+    """A tar.gz of ``count`` zero-byte members. gzip compresses the repetitive
+    headers heavily, so this stays tiny on disk while declaring many members --
+    the member-count DoS shape (#815)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for i in range(count):
+            info = tarfile.TarInfo(f"f{i}")
+            info.size = 0
+            tf.addfile(info)
+    return buf.getvalue()
+
+
+def test_zip_member_count_over_cap_rejected(tmp_path: Path) -> None:
+    data = _many_member_zip(50)
+    with pytest.raises(UnsupportedArchive, match="member-count"):
+        safe_extract(data, tmp_path, max_members=10)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_tar_gz_member_count_over_cap_rejected(tmp_path: Path) -> None:
+    data = _many_member_tar_gz(50)
+    # Sanity: the archive is genuinely small on disk despite its member count,
+    # so only the member-count cap (not the size or ratio cap) can catch it.
+    assert len(data) < 4_000
+    with pytest.raises(UnsupportedArchive, match="member-count"):
+        safe_extract(data, tmp_path, max_members=10)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_tar_prescan_streams_and_never_calls_getmembers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The tar pre-scan must walk the stream one header at a time, never
+    ``getmembers()`` (which materializes every member -- and, for a .tar.gz,
+    decompresses the whole stream -- up front). Poisoning ``getmembers`` proves
+    the incremental walk does not route through it."""
+
+    def _boom(self: tarfile.TarFile) -> list[tarfile.TarInfo]:
+        raise AssertionError("getmembers() materializes the full member list")
+
+    monkeypatch.setattr(tarfile.TarFile, "getmembers", _boom)
+    # A normal small bundle still extracts (streaming iteration, no getmembers).
+    safe_extract(_tar_files(_valid_files()), tmp_path)
+    assert (tmp_path / ".claude-plugin" / "plugin.json").is_file()
+
+
+def test_tar_gz_member_cap_fires_before_materializing_all_members(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A many-member tar.gz is refused at the cap without ever building the
+    full member list: getmembers() is poisoned, so reaching the cap through the
+    streaming walk is the only way this can raise the member-count error."""
+
+    def _boom(self: tarfile.TarFile) -> list[tarfile.TarInfo]:
+        raise AssertionError("getmembers() materializes the full member list")
+
+    monkeypatch.setattr(tarfile.TarFile, "getmembers", _boom)
+    with pytest.raises(UnsupportedArchive, match="member-count"):
+        safe_extract(_many_member_tar_gz(50), tmp_path, max_members=10)
+
+
+def test_tar_gz_declared_huge_member_trips_size_cap_mid_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The uncompressed-size cap is enforced incrementally too: a member
+    declaring a huge size trips it during the streaming walk (before the walk
+    advances past the member and decompresses its body), not after a full
+    getmembers() decompress-and-materialize pass."""
+
+    def _boom(self: tarfile.TarFile) -> list[tarfile.TarInfo]:
+        raise AssertionError("getmembers() decompresses the whole stream up front")
+
+    monkeypatch.setattr(tarfile.TarFile, "getmembers", _boom)
+    info, payload = _reg("big.bin", b"\x00" * 5_000)
+    data = _tar([info], {"big.bin": payload})
+    with pytest.raises(UnsupportedArchive, match="byte limit"):
+        safe_extract(data, tmp_path, max_uncompressed_bytes=1_000)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_member_count_within_cap_is_accepted(tmp_path: Path) -> None:
+    # A few hundred legitimate members stay well under the default cap.
+    safe_extract(_many_member_tar_gz(300), tmp_path, max_members=DEFAULT_MAX_MEMBERS)
+    assert len(list(tmp_path.iterdir())) == 300
+
+
+def test_default_member_cap_is_generous_but_bounded() -> None:
+    # Documents the default: hundreds of files pass, hundreds of thousands do not.
+    assert DEFAULT_MAX_MEMBERS == 10_000
+
+
+def test_check_archive_bounds_enforces_member_cap() -> None:
+    with pytest.raises(UnsupportedArchive, match="member-count"):
+        check_archive_bounds(_many_member_tar_gz(50), max_members=10)

--- a/packages/plugin-format/tests/test_archive.py
+++ b/packages/plugin-format/tests/test_archive.py
@@ -367,3 +367,116 @@ def test_default_member_cap_is_generous_but_bounded() -> None:
 def test_check_archive_bounds_enforces_member_cap() -> None:
     with pytest.raises(UnsupportedArchive, match="member-count"):
         check_archive_bounds(_many_member_tar_gz(50), max_members=10)
+
+
+# --- #815 (verification follow-up): the zip cap must fire from the EOCD BEFORE
+# `zipfile.ZipFile` parses and materializes the whole central directory. The
+# in-loop cap in `_prescan_zip` runs only AFTER construction, so a many-member
+# zip was fully materialized (hundreds of MiB of RSS) before it could fire. ---
+
+
+def _boom_zipfile(*_args: object, **_kwargs: object) -> zipfile.ZipFile:
+    raise AssertionError("ZipFile() materializes the whole central directory")
+
+
+def test_zip_member_cap_fires_before_opening_the_zipfile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A many-member zip is refused from the EOCD record BEFORE
+    ``zipfile.ZipFile`` is constructed. Poisoning ``ZipFile`` proves the reject
+    comes from the pre-check, not the post-construction in-loop cap (the
+    module's ``is_zipfile`` detection uses ``_EndRecData``, not the class, so it
+    is unaffected)."""
+    data = _many_member_zip(50)  # build BEFORE poisoning ZipFile
+    monkeypatch.setattr(zipfile, "ZipFile", _boom_zipfile)
+    with pytest.raises(UnsupportedArchive, match="member-count"):
+        safe_extract(data, tmp_path, max_members=10)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_check_archive_bounds_zip_member_cap_fires_before_opening(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deploy-time revalidation path enforces the same pre-open cap."""
+    data = _many_member_zip(50)  # build BEFORE poisoning ZipFile
+    monkeypatch.setattr(zipfile, "ZipFile", _boom_zipfile)
+    with pytest.raises(UnsupportedArchive, match="member-count"):
+        check_archive_bounds(data, max_members=10)
+
+
+def test_zip_within_cap_still_opens_and_extracts(tmp_path: Path) -> None:
+    """No false reject: a zip whose member count is within the cap, even with
+    long paths, opens and extracts normally (the EOCD pre-check is not tripped
+    by a legitimate near-cap bundle)."""
+    entries = {f"src/deep/nested/component/module_{i}.py": "" for i in range(300)}
+    safe_extract(_zip(entries), tmp_path, max_members=DEFAULT_MAX_MEMBERS)
+    assert len(list(tmp_path.rglob("*.py"))) == 300
+
+
+def _synthetic_eocd(total_entries: int, size_cd: int, comment: bytes = b"") -> bytes:
+    """A minimal, well-formed end-of-central-directory record (no central
+    directory body needed -- the pre-check reads only the EOCD's own fields)."""
+    import struct
+
+    return (
+        struct.pack(
+            "<4sHHHHIIH",
+            b"\x50\x4b\x05\x06",  # EOCD signature
+            0,  # disk number
+            0,  # disk with central directory
+            min(total_entries, 0xFFFF),  # entries on this disk
+            min(total_entries, 0xFFFF),  # total entries
+            min(size_cd, 0xFFFFFFFF),  # central directory size
+            0,  # central directory offset
+            len(comment),
+        )
+        + comment
+    )
+
+
+def test_zip_eocd_precheck_rejects_zip64_sentinel() -> None:
+    """An entry count at the 16-bit ZIP64 sentinel (0xFFFF) means the true
+    count overflows the field -- far past any sane cap -- so it is rejected
+    without consulting the (absent) ZIP64 record."""
+    from plugin_format.archive import _reject_zip_over_member_count
+
+    with pytest.raises(UnsupportedArchive, match="ZIP64|member-count"):
+        _reject_zip_over_member_count(_synthetic_eocd(0xFFFF, 100), max_members=10_000)
+
+
+def test_zip_eocd_precheck_rejects_under_declared_count_via_size() -> None:
+    """The size guard defeats an under-declared count: an EOCD claiming only a
+    handful of entries but whose central-directory SIZE has room for far more
+    is rejected (``zipfile`` parses by size, not by the declared count, so the
+    size is the signal that actually bounds its work)."""
+    from plugin_format.archive import (
+        _ZIP_CENTRAL_DIR_BYTES_PER_MEMBER,
+        _reject_zip_over_member_count,
+    )
+
+    big_size_cd = 10_000 * _ZIP_CENTRAL_DIR_BYTES_PER_MEMBER + 1
+    with pytest.raises(UnsupportedArchive, match="member-count"):
+        _reject_zip_over_member_count(
+            _synthetic_eocd(total_entries=5, size_cd=big_size_cd), max_members=10_000
+        )
+
+
+def test_zip_eocd_precheck_allows_within_cap() -> None:
+    """A well-formed EOCD within both the count and size bounds passes."""
+    from plugin_format.archive import _reject_zip_over_member_count
+
+    _reject_zip_over_member_count(_synthetic_eocd(total_entries=42, size_cd=5_000), 10_000)
+
+
+def test_zip_eocd_precheck_ignores_a_spurious_trailing_signature() -> None:
+    """A comment that itself contains the EOCD signature bytes must not be
+    mistaken for the record: the scan requires the declared comment length to
+    land exactly at end-of-data, so the real (earlier) EOCD is the one read."""
+    from plugin_format.archive import _reject_zip_over_member_count
+
+    # Real EOCD declares 42 entries and a comment that embeds a fake signature.
+    fake = b"\x50\x4b\x05\x06" + b"\x00" * 18  # looks like an EOCD, but mid-comment
+    data = _synthetic_eocd(total_entries=42, size_cd=5_000, comment=fake)
+    # The real record (42 entries, within cap) is found, so this does NOT raise;
+    # the embedded fake (whose comment-length invariant fails) is skipped.
+    _reject_zip_over_member_count(data, max_members=10_000)


### PR DESCRIPTION
## What

The bundle-ingestion prescan enumerated every archive member (`zipfile.infolist()`, `tarfile.getmembers()`) *before* the size/ratio caps added in #785 were checked. That let a small archive with a huge member count, or a `.tar.gz` declaring one huge member, exhaust memory/CPU inside the prescan itself:

- A ~5 MiB tar.gz of hundreds of thousands of zero-byte members has `total_uncompressed == 0`, so it clears both the size cap and the ratio cap, yet `getmembers()` builds one `TarInfo` per member (hundreds of MiB of RSS).
- For a `.tar.gz`, `getmembers()` fully decompresses the stream to walk headers, so a declared-huge member forces full decompression before the ratio cap can reject it.

## Fix

Add a **member-count cap** and enforce it *and* the uncompressed-size cap **incrementally during the prescan**, before the full member list is materialized:

- The tar prescan walks the stream one header at a time (`for m in tf`) instead of `getmembers()`. A many-member archive is refused at the cap; a declared-huge member trips the size cap before the walk advances past its header and decompresses its body.
- The zip prescan tracks a running member count and uncompressed total and stops the moment either crosses its cap.

The new cap threads as an optional keyword-only `max_members` argument on `safe_extract` / `check_archive_bounds` with a generous default (`DEFAULT_MAX_MEMBERS = 10_000` — hundreds of legitimate files pass, hundreds of thousands do not), mirroring how #785 added `max_uncompressed_bytes` / `max_compression_ratio`. No public signature or manifest-schema change: `plugin-format`'s frozen contract is preserved (the new arg is keyword-only with a safe default; this is a security tightening that rejects more malicious inputs).

It is wired as an operator-configurable `bundle_max_members` setting on both the API `Settings` and the worker `WorkerConfig` (the parity seam), and passed through every extraction lane: upload validate, deploy-time revalidation, the files endpoint, the Docker-substrate bundle-fetch, and the eval-stream suite loader.

## Adjacent items (from the AC, optional)

- **Done — files endpoint honors configured caps.** `read_bundle_text_files` (`apps/api/src/agentos_api/bundles.py`) used the library-default limits; it now accepts the caps and the `/versions/{id}/files` router passes the operator-configured `Settings` values.
- **Deferred — multipart spooling.** Starlette buffers the complete multipart body into an `UploadFile` before the handler's size gate runs, so an oversized upload can consume API-node temp storage before the 413. Rejecting on `Content-Length` before the body is spooled requires an ASGI-middleware-level change (handling chunked transfer / multipart overhead correctly), not a fix inside the handler where the body is already parsed. Left out rather than half-done.

## Tests

- `packages/plugin-format/tests/test_archive.py`: member-count cap rejects a small many-member `.tar.gz` and `.zip`; the tar prescan is proved to stream (poisoning `getmembers()` and asserting a normal bundle still extracts and a many-member archive still hits the member-count error via the streaming walk); a declared-huge member trips the size cap mid-walk; a few-hundred-member archive under the default passes. #785's existing size/ratio tests stay green.
- `apps/api/tests/test_bundle_ingestion_bounds.py`: a many-member upload is refused at the API with the member-count cap.
- `uv run pytest packages/plugin-format/tests apps/api/tests -q` passes (154 + 424). Worker sandbox + eval suites and `ruff` / `mypy` also pass.

Closes #815
Ref #785