### PR TITLE
Scope eval sweep never-completed detection to the triggered sha

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1146,7 +1146,7 @@
         "type": "object"
       },
       "EvalMatrix": {
-        "description": "The eval matrix grid: rows = cases, columns = versions (most recent first).\n\n``models`` and ``model_summaries`` add the model dimension: the distinct\nmodels observed across the fetched traces, and a pass-rate + cost rollup per\nmodel for BYO-model comparison. They are additive; the version grid is\nunchanged.",
+        "description": "The eval matrix grid: rows = cases, columns = versions (most recent first).\n\n``models`` and ``model_summaries`` add the model dimension: the distinct\nmodels observed across the fetched traces, and a pass-rate + cost rollup per\nmodel for BYO-model comparison. ``model_version_summaries`` slices that same\nrollup per ``(version, model)`` so a caller can scope completion to a single\ntriggered sha rather than the blended window (#814). They are additive; the\nversion grid is unchanged.",
         "properties": {
           "cases": {
             "items": {
@@ -1161,6 +1161,14 @@
               "$ref": "#/components/schemas/EvalModelSummary"
             },
             "title": "Model Summaries",
+            "type": "array"
+          },
+          "model_version_summaries": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/EvalModelVersionSummary"
+            },
+            "title": "Model Version Summaries",
             "type": "array"
           },
           "models": {
@@ -1277,6 +1285,51 @@
           "total"
         ],
         "title": "EvalModelSummary",
+        "type": "object"
+      },
+      "EvalModelVersionSummary": {
+        "description": "A per-(version, model) rollup: the graded aggregates scoped to a single\nversion column, not rolled across the whole shown window.\n\n``EvalModelSummary`` sums ``completed`` over EVERY in-window version for a\nmodel. That blend can mask a triggered sha that lands all-incomplete (the\nmodel boots but never completes a turn on the new code) when a prior in-window\nsha completed cases for that same model: the blended ``completed`` stays ``> 0``\nfrom the old sha, so the \"never completed\" outcome the sweep must fail on\n(ADR-0068, #622) is hidden and a blended pass-rate is reported as a real\ncomparison (issue #814). This per-version breakdown exposes the\n``(version, model)`` dimension so a caller -- the CLI ``--model`` sweep, which\nknows the sha it just triggered -- can scope ``completed``/never-completed to\nthat one sha instead of the window.\n\nFields mirror the graded subset of ``EvalModelSummary`` (``cost_usd`` is not\nsliced per version, since the sweep does not compare cost per sha). It is\nadditive and defaulted the way ``completed``/``plumbing`` already are: a caller\nthat predates the field reads an empty list and degrades to the blended\nreading rather than misreporting.",
+        "properties": {
+          "completed": {
+            "default": 0,
+            "title": "Completed",
+            "type": "integer"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "passed": {
+            "title": "Passed",
+            "type": "integer"
+          },
+          "plumbing": {
+            "default": 0,
+            "title": "Plumbing",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version",
+          "passed",
+          "total"
+        ],
+        "title": "EvalModelVersionSummary",
         "type": "object"
       },
       "EvalReport": {

--- a/apps/api/src/agentos_api/evals.py
+++ b/apps/api/src/agentos_api/evals.py
@@ -11,7 +11,13 @@ pivot is unit-testable off canned data.
 
 from typing import Any, Literal
 
-from .schemas import EvalCell, EvalMatrix, EvalMatrixRow, EvalModelSummary
+from .schemas import (
+    EvalCell,
+    EvalMatrix,
+    EvalMatrixRow,
+    EvalModelSummary,
+    EvalModelVersionSummary,
+)
 
 Status = Literal["pass", "fail", "plumbing_ok", "missing"]
 
@@ -195,6 +201,9 @@ def build_matrix(
         rows=rows,
         models=[s.model for s in summaries],
         model_summaries=summaries,
+        model_version_summaries=_model_version_summaries(
+            latest_by_model, version_set
+        ),
     )
 
 
@@ -259,4 +268,61 @@ def _model_summaries(
             completed=completed.get(model, 0),
         )
         for model in keys
+    ]
+
+
+def _model_version_summaries(
+    latest_by_model: dict[tuple[str, str, str | None], dict[str, Any]],
+    version_set: set[str],
+) -> list[EvalModelVersionSummary]:
+    """The per-``(version, model)`` slice of the same rollup ``_model_summaries``
+    blends across the window.
+
+    ``_model_summaries`` accumulates ``completed`` over every ``(version, case,
+    model)`` in ``version_set`` for a model, so a model that completed on an
+    older in-window sha carries ``completed > 0`` even when its turns never
+    complete on the triggered sha -- masking the "never completed" outcome the
+    sweep must fail on (ADR-0068, #814). Keying the accumulation by
+    ``(version, model)`` instead keeps each sha's counts separate, so the CLI can
+    read the triggered sha's row alone. The per-row inclusion rules are identical
+    to ``_model_summaries`` (plumbing counted separately, missing skipped, graded
+    rows into ``total``/``passed`` with the completion gate feeding ``completed``);
+    only the aggregation key differs.
+    """
+    passed: dict[tuple[str, str | None], int] = {}
+    total: dict[tuple[str, str | None], int] = {}
+    completed: dict[tuple[str, str | None], int] = {}
+    plumbing: dict[tuple[str, str | None], int] = {}
+    for (version, _case, model), trace in latest_by_model.items():
+        if version not in version_set:
+            continue
+        key = (version, model)
+        status = _outcome_of(trace)
+        if status == "plumbing_ok":
+            plumbing[key] = plumbing.get(key, 0) + 1
+            continue
+        if status == "missing":
+            continue
+        total[key] = total.get(key, 0) + 1
+        passed[key] = passed.get(key, 0) + (1 if status == "pass" else 0)
+        if _completed(trace):
+            completed[key] = completed.get(key, 0) + 1
+
+    # Deterministic order: by version, then named models sorted, unlabelled last.
+    # The key union mirrors `_model_summaries`: a (version, model) whose every row
+    # was plumbing has no `total` entry but must still surface.
+    keys = sorted(
+        set(total) | set(plumbing),
+        key=lambda k: (k[0], k[1] is None, k[1] or ""),
+    )
+    return [
+        EvalModelVersionSummary(
+            version=version,
+            model=model,
+            passed=passed.get((version, model), 0),
+            total=total.get((version, model), 0),
+            completed=completed.get((version, model), 0),
+            plumbing=plumbing.get((version, model), 0),
+        )
+        for (version, model) in keys
     ]

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -704,13 +704,49 @@ class EvalModelSummary(BaseModel):
         return self.passed / self.total if self.total else 0.0
 
 
+class EvalModelVersionSummary(BaseModel):
+    """A per-(version, model) rollup: the graded aggregates scoped to a single
+    version column, not rolled across the whole shown window.
+
+    ``EvalModelSummary`` sums ``completed`` over EVERY in-window version for a
+    model. That blend can mask a triggered sha that lands all-incomplete (the
+    model boots but never completes a turn on the new code) when a prior in-window
+    sha completed cases for that same model: the blended ``completed`` stays ``> 0``
+    from the old sha, so the "never completed" outcome the sweep must fail on
+    (ADR-0068, #622) is hidden and a blended pass-rate is reported as a real
+    comparison (issue #814). This per-version breakdown exposes the
+    ``(version, model)`` dimension so a caller -- the CLI ``--model`` sweep, which
+    knows the sha it just triggered -- can scope ``completed``/never-completed to
+    that one sha instead of the window.
+
+    Fields mirror the graded subset of ``EvalModelSummary`` (``cost_usd`` is not
+    sliced per version, since the sweep does not compare cost per sha). It is
+    additive and defaulted the way ``completed``/``plumbing`` already are: a caller
+    that predates the field reads an empty list and degrades to the blended
+    reading rather than misreporting.
+    """
+
+    version: str
+    model: str | None = None
+    passed: int
+    total: int
+    completed: int = 0
+    plumbing: int = 0
+
+    @property
+    def pass_rate(self) -> float:
+        return self.passed / self.total if self.total else 0.0
+
+
 class EvalMatrix(BaseModel):
     """The eval matrix grid: rows = cases, columns = versions (most recent first).
 
     ``models`` and ``model_summaries`` add the model dimension: the distinct
     models observed across the fetched traces, and a pass-rate + cost rollup per
-    model for BYO-model comparison. They are additive; the version grid is
-    unchanged.
+    model for BYO-model comparison. ``model_version_summaries`` slices that same
+    rollup per ``(version, model)`` so a caller can scope completion to a single
+    triggered sha rather than the blended window (#814). They are additive; the
+    version grid is unchanged.
     """
 
     suite: str
@@ -719,6 +755,7 @@ class EvalMatrix(BaseModel):
     rows: list[EvalMatrixRow]
     models: list[str | None] = []
     model_summaries: list[EvalModelSummary] = []
+    model_version_summaries: list[EvalModelVersionSummary] = []
 
 
 class EvalTriggerRequest(BaseModel):

--- a/apps/api/tests/test_evals_unit.py
+++ b/apps/api/tests/test_evals_unit.py
@@ -370,3 +370,80 @@ def test_legacy_traces_with_no_error_key_read_as_completed() -> None:
     unlabelled = next(m for m in matrix.model_summaries if m.model is None)
     assert unlabelled.total == 1
     assert unlabelled.completed == 1
+
+
+def test_per_version_summaries_scope_completed_to_each_sha() -> None:
+    """#814: the blended `model_summaries` sums `completed` across every in-window
+    sha, so a model that completed on an OLDER in-window sha but never completes on
+    the TRIGGERED sha reads `completed > 0` in the blend -- masking the "never
+    completed" outcome the sweep must fail on. `model_version_summaries` slices the
+    same rollup per (version, model) so a caller can scope completion to one sha.
+
+    Here opus completed and passed both cases on the older `shaOld`, but on the
+    triggered `shaNew` every case landed as a graded FAIL whose turn never
+    completed (error set). The blend hides it; the per-version rows must not.
+    """
+    traces = [
+        # Older in-window sha: opus completed and passed both cases.
+        _otrace("o1", "shaOld", "c1", "2026-07-01T00:00:00Z", "pass", "opus"),
+        _otrace("o2", "shaOld", "c2", "2026-07-01T00:00:01Z", "pass", "opus"),
+        # Triggered sha: every case is a graded FAIL that never completed.
+        _otrace(
+            "n1",
+            "shaNew",
+            "c1",
+            "2026-07-02T00:00:00Z",
+            "fail",
+            "opus",
+            error="runner reported a classified failure",
+        ),
+        _otrace(
+            "n2",
+            "shaNew",
+            "c2",
+            "2026-07-02T00:00:01Z",
+            "fail",
+            "opus",
+            error="runner reported a classified failure",
+        ),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    # The blended rollup masks the outcome (completed picked up the old sha).
+    blended = next(m for m in matrix.model_summaries if m.model == "opus")
+    assert blended.total == 4
+    assert blended.completed == 2  # the two old-sha completions -- the mask
+
+    per_version = {
+        (s.version, s.model): s for s in matrix.model_version_summaries
+    }
+    # The triggered sha's own row: never completed (total > 0, completed == 0).
+    new = per_version[("shaNew", "opus")]
+    assert new.total == 2
+    assert new.completed == 0
+    assert new.passed == 0
+    # The older sha's row is unaffected: it did complete both cases.
+    old = per_version[("shaOld", "opus")]
+    assert old.total == 2
+    assert old.completed == 2
+    assert old.passed == 2
+
+
+def test_per_version_summaries_surface_a_plumbing_only_row() -> None:
+    """A (version, model) whose every row is plumbing has no graded total but must
+    still surface with `total == 0, plumbing > 0`, mirroring `_model_summaries`
+    (#700) -- the sweep reads this to tell a landed plumbing fixture apart from a
+    model that has not landed at all."""
+    traces = [
+        _otrace("f1", "shaA", "c1", "2026-07-01T00:00:00Z", "plumbing_ok", "fake"),
+        _otrace("f2", "shaA", "c2", "2026-07-01T00:00:01Z", "plumbing_ok", "fake"),
+    ]
+    matrix = build_matrix(traces, "s", 5)
+
+    per_version = {
+        (s.version, s.model): s for s in matrix.model_version_summaries
+    }
+    fake = per_version[("shaA", "fake")]
+    assert fake.total == 0
+    assert fake.plumbing == 2
+    assert fake.completed == 0

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -92,17 +92,18 @@
       ]
     },
     {
-      "struct": "EvalModelSummary",
-      "schema": "EvalModelSummary",
+      "struct": "EvalModelVersionSummary",
+      "schema": "EvalModelVersionSummary",
       "omissions": []
     },
     {
       "struct": "EvalMatrix",
       "schema": "EvalMatrix",
       "omissions": [
-        { "field": "cases", "why": "The sweep reads the per-model rollup (model_summaries) and the version columns (versions); the per-case identifiers (cases) that label the grid are not read by the CLI." },
+        { "field": "cases", "why": "The sweep reads the per-(version, model) rollup (model_version_summaries) and the version columns (versions); the per-case identifiers (cases) that label the grid are not read by the CLI." },
         { "field": "rows", "why": "The per-case pass/fail grid (rows) is carried by the endpoint but unused by the sweep, which needs only the per-model rollup; the existing doc comment on EvalMatrix already states this." },
-        { "field": "models", "why": "The model dimension the CLI acts on is model_summaries[].model; the separate models label list is not read." }
+        { "field": "models", "why": "The model dimension the CLI acts on is model_version_summaries[].model; the separate models label list is not read." },
+        { "field": "model_summaries", "why": "The window-blended per-model rollup sums completed across every in-window sha, which masks a triggered sha's zero-completed outcome (#814); the sweep reads the per-(version, model) model_version_summaries scoped to the triggered sha instead, so the blended rollup is not consumed by the CLI." }
       ]
     }
   ],

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -160,32 +160,36 @@ pub struct EvalTriggerResult {
     pub model: Option<String>,
 }
 
-/// One per-model rollup of the eval matrix (`EvalModelSummary` in openapi.json):
-/// pass-rate and summed cost for a suite run under one model (#255/#526). `model`
-/// is `None` for the matrix's unlabelled column (a run with no resolved model).
+/// One per-`(version, model)` slice of the eval matrix rollup
+/// (`EvalModelVersionSummary` in openapi.json): the graded aggregates scoped to a
+/// single version column rather than blended across the shown window. `model` is
+/// `None` for the matrix's unlabelled column (a run with no resolved model).
+///
+/// The sweep reads this rather than the window-blended `model_summaries` because
+/// `completed` there sums over EVERY in-window sha for a model, so a model that
+/// completed on an older in-window sha keeps `completed > 0` even when its turns
+/// never complete on the triggered sha -- masking the "never completed" outcome
+/// the sweep must fail on (issue #814). Scoping the row to the triggered sha (the
+/// one the sweep just enqueued) is what makes `never_completed` honest.
 ///
 /// `completed` is a subset of `total`: the graded rows whose turn actually
 /// reached a verdict, as opposed to a graded fail that never completed at all
 /// (a classified failure, the wrong terminal status, or a transport/runner
-/// exception). `total > 0 && completed == 0` is a model that never produced one
-/// completed turn across the whole suite -- distinct from a real 0%, which the
-/// sweep reports and fails on (#622, #526 AC4). `#[serde(default)]` keeps this
-/// tolerant of an API that predates the field.
-///
-/// `plumbing` counts the rows that ran but were never graded (ADR-0055, #612/#606
-/// -- the fake-model tier is plumbing-only): excluded from `passed`/`total` rather
-/// than fabricated into a pass or fail, so a model whose every row is plumbing
-/// still appears here with `total == 0` instead of vanishing from the rollup. The
-/// `--model` sweep (#700) reads this to tell a plumbing-fixture row from a real
-/// subject-under-test row rather than blending both into one pass-rate list.
+/// exception). `total > 0 && completed == 0` on the triggered sha is a model that
+/// never produced one completed turn for this run -- distinct from a real 0%,
+/// which the sweep reports and fails on (#622, #526 AC4, ADR-0068). `plumbing`
+/// counts the rows that ran but were never graded (ADR-0055, #612/#606 -- the
+/// fake-model tier is plumbing-only): excluded from `passed`/`total` rather than
+/// fabricated into a pass or fail, so a plumbing-only model's row still lands with
+/// `total == 0` (#700). `#[serde(default)]` keeps the counts tolerant of an API
+/// that predates them.
 #[derive(Debug, Clone, Deserialize)]
-pub struct EvalModelSummary {
+pub struct EvalModelVersionSummary {
+    pub version: String,
     #[serde(default)]
     pub model: Option<String>,
     pub passed: u64,
     pub total: u64,
-    #[serde(default)]
-    pub cost_usd: Option<f64>,
     #[serde(default)]
     pub completed: u64,
     #[serde(default)]
@@ -193,11 +197,14 @@ pub struct EvalModelSummary {
 }
 
 /// The eval matrix grid (`EvalMatrix` in openapi.json): `GET /evals/matrix`. The
-/// sweep reads `model_summaries` (the model dimension) plus `versions` (the shown
-/// version columns, newest first): a `--model` sweep uses `versions` to scope
-/// readiness to the run it just triggered, so a prior run's rows cannot satisfy
-/// the exit condition on the first poll (issue #608). The per-case `rows` grid is
-/// carried by the endpoint but unused here.
+/// sweep reads `model_version_summaries` (the per-`(version, model)` dimension)
+/// plus `versions` (the shown version columns, newest first): a `--model` sweep
+/// uses `versions` to scope readiness to the run it just triggered, so a prior
+/// run's rows cannot satisfy the exit condition on the first poll (issue #608),
+/// and reads the per-version rollup scoped to the triggered sha so a prior sha's
+/// completions cannot mask the triggered sha's zero-completed outcome (#814). The
+/// window-blended `model_summaries` and the per-case `rows`/`cases`/`models` grid
+/// are carried by the endpoint but unused here.
 #[derive(Debug, Clone, Deserialize)]
 pub struct EvalMatrix {
     pub suite: String,
@@ -206,7 +213,7 @@ pub struct EvalMatrix {
     #[serde(default)]
     pub versions: Vec<String>,
     #[serde(default)]
-    pub model_summaries: Vec<EvalModelSummary>,
+    pub model_version_summaries: Vec<EvalModelVersionSummary>,
 }
 
 /// The per-agent budget (`BudgetConfig` in openapi.json): the request and

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -2152,7 +2152,7 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
             // otherwise nothing for this sweep exists yet and reporting a prior
             // run's rows would be the very lie the scoping guards against (#608).
             let sha_present = matrix.versions.contains(&triggered_sha);
-            let rows = scoped_rows(&matrix, &want);
+            let rows = scoped_rows(&matrix, &want, &triggered_sha);
             let ready: std::collections::BTreeSet<&str> =
                 rows.iter().map(|row| row.model.as_str()).collect();
             let missing = want
@@ -2192,31 +2192,41 @@ async fn eval_sweep(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
     }
 }
 
-/// The wanted models' current rows in the matrix, scoped to the sweep's
-/// `--model` set and dropping truly-empty rows: a row with `total == 0` is
-/// kept when `plumbing > 0` (a fake-model/plumbing-only tier row that
+/// The wanted models' rows in the matrix for the TRIGGERED sha, scoped to the
+/// sweep's `--model` set and dropping truly-empty rows: a row with `total == 0`
+/// is kept when `plumbing > 0` (a fake-model/plumbing-only tier row that
 /// genuinely landed, #700, #612/#606) and dropped only when it carries
 /// neither a graded case nor a plumbing one -- i.e. this model has not landed
-/// at all yet. Without the `plumbing > 0` half, a plumbing-only model's row
-/// would vanish from a report entirely instead of being surfaced as such,
-/// exactly the ambiguity #622 and this issue describe. The shared filter
-/// behind both the readiness check and the timeout partial.
+/// at all yet on the triggered sha. Without the `plumbing > 0` half, a
+/// plumbing-only model's row would vanish from a report entirely instead of
+/// being surfaced as such, exactly the ambiguity #622 and #814 describe.
+///
+/// Reads `model_version_summaries` filtered to `triggered_sha`, NOT the
+/// window-blended `model_summaries`: the blended `completed` sums across every
+/// in-window sha, so a model that completed on a prior in-window sha would keep
+/// `completed > 0` and hide the triggered sha's zero-completed outcome (#814).
+/// Scoping to the triggered sha's own row is what makes `never_completed`
+/// honest. The shared filter behind both the readiness check and the timeout
+/// partial.
 fn scoped_rows(
     matrix: &crate::api::EvalMatrix,
     want: &std::collections::BTreeSet<&str>,
+    triggered_sha: &str,
 ) -> Vec<crate::commands::SweepRow> {
     matrix
-        .model_summaries
+        .model_version_summaries
         .iter()
+        .filter(|s| s.version == triggered_sha)
         .filter_map(|s| {
             let m = s.model.as_deref()?;
             want.contains(m).then(|| crate::commands::SweepRow {
                 model: m.to_string(),
                 passed: s.passed as usize,
                 // `completed` is what tells a real 0% apart from a model that
-                // never produced a completed turn (#622, #526 AC4); read
-                // straight off the platform's per-model rollup so local and
-                // cluster share the exact signal skill's in-CLI grading uses.
+                // never produced a completed turn (#622, #526 AC4); read from
+                // the triggered sha's own per-version row so a prior sha's
+                // completions cannot mask this run's zero-completed outcome
+                // (#814).
                 completed: s.completed as usize,
                 total: s.total as usize,
                 plumbing: s.plumbing as usize,
@@ -2227,25 +2237,23 @@ fn scoped_rows(
 }
 
 /// The rows to report once the triggered sweep has landed, scoped to the run just
-/// triggered (issue #608). Returns `Some(rows)` only when BOTH hold, else `None`
-/// ("keep polling"):
+/// triggered (issues #608, #814). Returns `Some(rows)` only when BOTH hold, else
+/// `None` ("keep polling"):
 ///   1. `triggered_sha` appears in the matrix's shown version columns -- i.e. at
 ///      least one trace for THIS run has landed. A change produces a new commit
 ///      sha, so a prior run's rows carry a different sha; on the first poll,
 ///      before the new traces exist, the triggered sha is absent and the prior
 ///      run cannot satisfy the exit condition (the pre-#608 gate exited here); and
-///   2. every wanted model has a summary row with `total > 0`.
+///   2. every wanted model has a row for `triggered_sha` with `total > 0` (or a
+///      plumbing-only row, #700).
 ///
-/// Residual (documented): `model_summaries` rolls the last N version columns
-/// together and does not expose the per-`(version, model)` dimension, so when a
-/// prior run for the SAME models is still in the window, the moment this run's
-/// first model lands (satisfying 1) the still-present prior rows satisfy 2 for the
-/// other models. The reported numbers are then the latest per
-/// `(version, case, model)` -- correct once every model has landed, at worst a few
-/// seconds early during the sequential per-model landing, and strictly tighter
-/// than the pre-#608 gate that exited before any trace for the run existed.
-/// Precise per-model scoping needs a matrix that keys summaries by
-/// `(version, model)`; that is a matrix API change, out of scope here.
+/// Because `scoped_rows` reads the per-`(version, model)` `model_version_summaries`
+/// filtered to `triggered_sha`, a prior in-window run for the SAME models can no
+/// longer satisfy condition 2 for a model whose triggered-sha row has not landed:
+/// each model's counts (pass-rate AND completion) are the triggered sha's own, not
+/// the blended window. This closes the residual the pre-#814 gate conceded, where
+/// a still-present prior row could stand in for a not-yet-landed model and, worse,
+/// a prior sha's completions could mask the triggered sha's zero-completed outcome.
 fn sweep_ready_rows(
     matrix: &crate::api::EvalMatrix,
     triggered_sha: &str,
@@ -2254,7 +2262,7 @@ fn sweep_ready_rows(
     if !matrix.versions.iter().any(|v| v == triggered_sha) {
         return None;
     }
-    let rows = scoped_rows(matrix, want);
+    let rows = scoped_rows(matrix, want, triggered_sha);
     let ready: std::collections::BTreeSet<&str> =
         rows.iter().map(|row| row.model.as_str()).collect();
     want.iter().all(|m| ready.contains(m)).then_some(rows)
@@ -3158,36 +3166,46 @@ mod tests {
         assert_eq!(select_agent_id(&agents[..1], None).unwrap(), "a1");
     }
 
-    fn model_summary(model: &str, passed: u64, total: u64) -> crate::api::EvalModelSummary {
+    fn model_summary(
+        version: &str,
+        model: &str,
+        passed: u64,
+        total: u64,
+    ) -> crate::api::EvalModelVersionSummary {
         // `completed` defaults to `total`: every one of these fixture rows models
         // a normal graded run (every case reached a verdict), so it is not the
         // #622 "never answered" outcome unless a test opts into that separately
         // via `model_summary_never_completed`.
-        plumbing_model_summary(model, passed, total, 0)
+        plumbing_model_summary(version, model, passed, total, 0)
     }
 
     fn plumbing_model_summary(
+        version: &str,
         model: &str,
         passed: u64,
         total: u64,
         plumbing: u64,
-    ) -> crate::api::EvalModelSummary {
-        crate::api::EvalModelSummary {
+    ) -> crate::api::EvalModelVersionSummary {
+        crate::api::EvalModelVersionSummary {
+            version: version.to_string(),
             model: Some(model.to_string()),
             passed,
             total,
-            cost_usd: None,
             completed: total,
             plumbing,
         }
     }
 
-    fn model_summary_never_completed(model: &str, total: u64) -> crate::api::EvalModelSummary {
-        crate::api::EvalModelSummary {
+    fn model_summary_never_completed(
+        version: &str,
+        model: &str,
+        total: u64,
+    ) -> crate::api::EvalModelVersionSummary {
+        crate::api::EvalModelVersionSummary {
+            version: version.to_string(),
             model: Some(model.to_string()),
             passed: 0,
             total,
-            cost_usd: None,
             completed: 0,
             plumbing: 0,
         }
@@ -3195,12 +3213,12 @@ mod tests {
 
     fn matrix(
         versions: &[&str],
-        summaries: Vec<crate::api::EvalModelSummary>,
+        summaries: Vec<crate::api::EvalModelVersionSummary>,
     ) -> crate::api::EvalMatrix {
         crate::api::EvalMatrix {
             suite: "smoke".into(),
             versions: versions.iter().map(|v| v.to_string()).collect(),
-            model_summaries: summaries,
+            model_version_summaries: summaries,
         }
     }
 
@@ -3214,7 +3232,10 @@ mod tests {
         let want: std::collections::BTreeSet<&str> = ["opus", "sonnet"].into_iter().collect();
         let m = matrix(
             &["old-sha"],
-            vec![model_summary("opus", 3, 3), model_summary("sonnet", 2, 3)],
+            vec![
+                model_summary("old-sha", "opus", 3, 3),
+                model_summary("old-sha", "sonnet", 2, 3),
+            ],
         );
         assert!(
             sweep_ready_rows(&m, "new-sha", &want).is_none(),
@@ -3227,7 +3248,10 @@ mod tests {
         let want: std::collections::BTreeSet<&str> = ["opus", "sonnet"].into_iter().collect();
         let m = matrix(
             &["new-sha", "old-sha"],
-            vec![model_summary("opus", 3, 3), model_summary("sonnet", 3, 3)],
+            vec![
+                model_summary("new-sha", "opus", 3, 3),
+                model_summary("new-sha", "sonnet", 3, 3),
+            ],
         );
         let rows = sweep_ready_rows(&m, "new-sha", &want).expect("all models landed for the run");
         assert_eq!(rows.len(), 2);
@@ -3240,7 +3264,7 @@ mod tests {
         // The triggered sha has landed, but only one of the two swept models has a
         // row yet -- keep polling rather than report a half-finished sweep.
         let want: std::collections::BTreeSet<&str> = ["opus", "sonnet"].into_iter().collect();
-        let m = matrix(&["new-sha"], vec![model_summary("opus", 3, 3)]);
+        let m = matrix(&["new-sha"], vec![model_summary("new-sha", "opus", 3, 3)]);
         assert!(sweep_ready_rows(&m, "new-sha", &want).is_none());
     }
 
@@ -3256,7 +3280,11 @@ mod tests {
         let want: std::collections::BTreeSet<&str> = ["bogus-model-xyz"].into_iter().collect();
         let m = matrix(
             &["new-sha"],
-            vec![model_summary_never_completed("bogus-model-xyz", 5)],
+            vec![model_summary_never_completed(
+                "new-sha",
+                "bogus-model-xyz",
+                5,
+            )],
         );
         let rows = sweep_ready_rows(&m, "new-sha", &want)
             .expect("a landed-but-all-failed row still satisfies readiness");
@@ -3282,8 +3310,8 @@ mod tests {
         let m = matrix(
             &["new-sha"],
             vec![
-                model_summary("opus", 3, 3),
-                plumbing_model_summary("fake", 0, 0, 3),
+                model_summary("new-sha", "opus", 3, 3),
+                plumbing_model_summary("new-sha", "fake", 0, 0, 3),
             ],
         );
         let rows = sweep_ready_rows(&m, "new-sha", &want)
@@ -3306,8 +3334,48 @@ mod tests {
         // landed at all yet (distinct from a genuine plumbing-only row); it must
         // still be dropped so readiness keeps polling for it.
         let want: std::collections::BTreeSet<&str> = ["opus"].into_iter().collect();
-        let m = matrix(&["new-sha"], vec![model_summary("opus", 0, 0)]);
-        assert!(scoped_rows(&m, &want).is_empty());
+        let m = matrix(&["new-sha"], vec![model_summary("new-sha", "opus", 0, 0)]);
+        assert!(scoped_rows(&m, &want, "new-sha").is_empty());
+    }
+
+    #[test]
+    fn never_completed_is_scoped_to_the_triggered_sha_not_the_window() {
+        // #814: a model that COMPLETED cases on an older in-window sha but never
+        // completes a turn on the TRIGGERED sha must be reported never_completed
+        // and fail the sweep. The platform matrix now exposes the per-(version,
+        // model) dimension (model_version_summaries), so `scoped_rows` reads the
+        // triggered sha's own row rather than the window-blended `completed`. With
+        // the old blended count, opus's completions on `old-sha` (completed == 5)
+        // would keep `completed > 0`, masking the zero-completed run on `new-sha`
+        // and reporting a fabricated blended pass-rate.
+        let want: std::collections::BTreeSet<&str> = ["opus"].into_iter().collect();
+        let m = matrix(
+            &["new-sha", "old-sha"],
+            vec![
+                // The triggered sha: every case landed as a graded FAIL whose turn
+                // never completed (error set) -- completed == 0.
+                model_summary_never_completed("new-sha", "opus", 5),
+                // A prior in-window sha: opus completed and passed every case.
+                model_summary("old-sha", "opus", 5, 5),
+            ],
+        );
+        let rows = sweep_ready_rows(&m, "new-sha", &want)
+            .expect("the triggered sha's row has landed for the wanted model");
+        assert_eq!(rows.len(), 1);
+        let opus = &rows[0];
+        assert_eq!(opus.model, "opus");
+        assert_eq!(opus.total, 5);
+        assert_eq!(
+            opus.completed, 0,
+            "completed must be scoped to the triggered sha (new-sha), not blended with old-sha"
+        );
+        assert!(
+            opus.never_completed(),
+            "scoped to new-sha opus never completed a turn, so the sweep must fail loudly"
+        );
+        // The shared reporter fails the sweep and names the offending model.
+        let err = crate::commands::report_sweep(&rows).unwrap_err();
+        assert!(err.to_string().contains("opus"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The eval model-sweep's zero-completed detection (ADR-0068, #798) could be masked because `completed[model]` was aggregated across every sha in the version window (`_model_summaries` accumulates over every `(version, case, model)` with `version in version_set`), not scoped to the triggered sha.

Failure scenario: the triggered sha lands all-incomplete traces (the model boots but never completes a turn on the new code), but a prior in-window sha has completed cases for that model. The blended `completed[model] > 0` from the old sha made `never_completed()` false, so the loud failure was suppressed and the blended pass-rate was reported as a real comparison.

`sweep_ready_rows`'s doc comment already conceded this residual: "Precise per-model scoping needs a matrix API change, out of scope here."

## Fix

Expose the per-`(version, model)` dimension in the matrix API so the CLI sweep can scope completion to the single sha it just triggered (it already knows that sha for the #608 readiness gate).

- **apps/api**: new `EvalModelVersionSummary` (`version, model, passed, total, completed, plumbing`) and `EvalMatrix.model_version_summaries`, built by `_model_version_summaries` — the same per-row inclusion rules as `_model_summaries`, keyed by `(version, model)` instead of blended across the window. `model_summaries` is kept unchanged (still consumed by the console). openapi.json regenerated.
- **cli**: `api.rs` mirrors the new per-version type; the now-unused blended `EvalModelSummary` mirror is dropped and declared as a justified `EvalMatrix` omission in `api-mirrors.json` (field-parity gate green). `scoped_rows` reads `model_version_summaries` filtered to the triggered sha instead of the blended `model_summaries`; the stale `sweep_ready_rows` doc comment is refreshed.

## Tests

- apps/api: `test_per_version_summaries_scope_completed_to_each_sha` — a model that completed on an older in-window sha but whose triggered-sha traces never completed reads `completed == 0` on the triggered sha's per-version row even though the blend shows `completed > 0`. Plus a plumbing-only per-version row test.
- cli: `never_completed_is_scoped_to_the_triggered_sha_not_the_window` — the same scenario end-to-end: the scoped row reports `never_completed()` and `report_sweep` fails the sweep. Existing #798/#700/#608 sweep tests stay green.

`uv run pytest apps/api/tests apps/worker/tests -q` (938 passed) and `cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo test` / `bash cli/scripts/check-field-parity.sh` all pass.

Closes #814
Ref #794, #798, ADR-0068