### PR TITLE
Add public contribution and support baseline docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,141 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at:
+
+<!-- TODO(maintainer): Decision 2 (issue #635) - conduct escalation contact.
+     Provide the reporting address or channel and who receives escalations.
+     Do not ship the placeholder below. Common choices: a dedicated conduct
+     email alias (for example conduct@your-domain), or a private form. State
+     the expected acknowledgement time if the project commits to one. -->
+
+**TODO(maintainer): conduct escalation contact** (reporting address or channel
+to be set before the public announcement).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,242 @@
+# Contributing to AgentOS
+
+Thanks for your interest in contributing. This guide covers how to prepare a
+change that fits this repository's conventions, how to run the checks CI runs,
+and how contributions are certified.
+
+Read [`AGENTS.md`](AGENTS.md) alongside this guide: it is the authoritative
+source for the build, test, and architecture conventions summarized here, and
+each area's own `CLAUDE.md` carries the rules specific to that directory.
+
+<!-- TODO(maintainer): Decision 1 (issue #635) - confirm whether outside pull
+     requests are accepted and what scope is welcome. This guide is written
+     assuming community PRs are welcome. If that holds, delete this comment and
+     the placeholder scope note below and state the accepted scope plainly
+     (for example: bug fixes and documentation freely; new connectors, CLI
+     verbs, or UI surfaces via an issue first; changes to the frozen contracts
+     never as a drive-by). If outside PRs are NOT accepted, say so here instead
+     and describe how to propose changes. -->
+
+## Scope of contributions
+
+We welcome bug reports, documentation improvements, tests, and focused feature
+work. Before starting anything larger than a bug fix or a docs tweak, please
+open a GitHub issue describing the change so a maintainer can confirm it fits
+the project's direction. This is especially important for anything that touches
+a cross-component seam or a frozen contract (see below).
+
+> TODO(maintainer): confirm the accepted contribution scope for the public
+> announcement, then finalize the paragraph above.
+
+## Before you start
+
+- **Be respectful.** All participation is governed by our
+  [Code of Conduct](CODE_OF_CONDUCT.md).
+- **Security issues do not go here.** Never open a public issue or PR for a
+  vulnerability. Follow [`SECURITY.md`](SECURITY.md) for private disclosure.
+- **Questions and usage help** belong in the support channels described in
+  [`SUPPORT.md`](SUPPORT.md), not in a pull request.
+
+## Development setup
+
+AgentOS is a multi-language monorepo: a Python
+[uv](https://docs.astral.sh/uv/) workspace (the platform services and packages),
+a Rust CLI, and a React (Vite + TS) UI, orchestrated over a Docker Compose dev
+stack. See [`README.md`](README.md) and [`QUICKSTART.md`](QUICKSTART.md) for the
+product overview and the fastest path to a running system, and
+[`ARCHITECTURE.md`](ARCHITECTURE.md) before touching a cross-component seam.
+
+Bring up the backing stack and install the workspace:
+
+```bash
+# Backing stack (Postgres + Valkey + Langfuse v3 + ClickHouse + MinIO + OTel).
+# Runs on baked defaults; copy .env.example to the gitignored .env only to override.
+cp .env.example .env    # optional
+docker compose --profile full -f compose.dev.yaml up -d
+docker compose -f compose.dev.yaml ps    # wait for all services healthy
+
+# Python workspace
+uv sync
+```
+
+Bring the stack down when you are done: `docker compose -f compose.dev.yaml
+down` (add `-v` to wipe volumes). If you brought it up, you own tearing it
+down. AGENTS.md documents the per-service host ports and the load-bearing
+gotchas.
+
+Do stack testing from a git worktree cut from `origin/main`, not the main
+checkout. Read-only runs against the current tree are fine; the moment you need
+to change code, cut a worktree.
+
+## Running the checks
+
+CI (`.github/workflows/ci.yaml`) runs the same commands below. Run the ones for
+the area you touched before opening a PR. Scope test runs to what you changed;
+CI covers the rest.
+
+**Python (all packages, from the repo root):**
+
+```bash
+uv sync                 # once, and after any dependency change
+uv run pytest -q        # workspace tests
+uv run ruff check .     # lint (auto-fix: uv run ruff check --fix .)
+uv run mypy             # type-check (strict)
+```
+
+**Rust CLI:**
+
+```bash
+cd cli
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test
+```
+
+If `cargo fmt`/`clippy` report a missing component: `rustup component add
+rustfmt clippy`.
+
+**UI:**
+
+```bash
+cd apps/ui
+pnpm install && pnpm lint && pnpm typecheck && pnpm test && pnpm e2e
+```
+
+**Docs (interface catalog):** if you edit any interface-catalog doc under
+`docs/`, regenerate and lint it with `bash scripts/check-docs.sh` (the local
+mirror of the CI docs gate) and commit the regenerated files.
+
+### Testing discipline
+
+- Test-first for behavior-bearing code. Mock only external services (Slack,
+  Anthropic, GitHub); never mock Postgres, Valkey, or Langfuse: run integration
+  tests against the dev stack above.
+- Assert real outcomes (values, state transitions, emitted events), not
+  presence. A change that passes only by weakening assertions is a regression.
+- Every behavior-bearing change must be verified end-to-end through the real
+  product loop (the `agentos` CLI, the compose services, or a real sandbox on a
+  local `kind`/`k3s` cluster), not just by unit tests.
+- If you touch one side of a known parity seam (see the registry in AGENTS.md),
+  change the sibling in the same PR, route both through a shared helper, or name
+  the sibling in the PR body with a follow-up issue.
+
+## Frozen contracts: stop and escalate
+
+`packages/aci-protocol` and `packages/plugin-format` are frozen interfaces that
+every lane compiles against across three languages. If your change needs to
+modify either package, stop: do not work around it. Open an issue or raise it in
+your PR. A contract change must land as its own reviewed, backward-compatible
+change first, before dependent lanes proceed. The same applies when an adopted
+component cannot do what a spec claims: stop and raise it with evidence rather
+than silently diverging.
+
+## Decisions: ADR vs GitHub issue
+
+Two different tools; do not conflate them.
+
+- Write an **ADR** (`docs/adr/`, Michael Nygard style, see ADR-0001) only for a
+  cross-cutting architectural decision that closes the door on alternatives. An
+  ADR must record what was decided against and why. ADRs are immutable once
+  Accepted; to change a decision, add a new ADR that supersedes the old one.
+- Write a **GitHub issue** for a feature, however large. A new CLI command, a UI
+  surface, or a connector is deletable and does not change the architecture, so
+  it is a feature, not an architectural decision. The issue carries the what and
+  the why; the how lives in the PR.
+- When in doubt, write the issue.
+
+## Branch, commit, and PR conventions
+
+- **Branch per change**, cut from the latest `origin/main`, named
+  `task/<short-description>`. Keep the slug terse. Never commit to `main`.
+- **Commit messages**: a short imperative summary line, then detail bullets.
+- **Reference the issue in the PR body** with `Closes #123` (or `Ref #123`). Do
+  not put the issue number in the PR or commit title; use a plain descriptive
+  title.
+- **No dashes or emdashes in prose; no emojis** in code or docs.
+- **Never mention any AI assistant** (or AI in general) in commit messages, and
+  never add `Co-Authored-By` lines referencing an AI.
+- Open a PR against `main`. Keep the change focused; a PR that touches unrelated
+  areas is harder to review and to revert.
+
+## Certifying your contribution
+
+<!-- TODO(maintainer): Decision 3 (issue #635) - confirm DCO vs CLA. This guide
+     recommends the Developer Certificate of Origin (DCO) as the lighter-weight,
+     lower-friction default: no paperwork, no per-contributor legal review, just
+     a per-commit sign-off. If the org instead requires a Contributor License
+     Agreement (CLA), replace this section with the CLA instructions and bot,
+     and remove the DCO sign-off requirement. -->
+
+This project uses the **Developer Certificate of Origin (DCO)**. The DCO is a
+lightweight, per-commit affirmation that you wrote the change or otherwise have
+the right to submit it under the project's license. It is the recommended
+default here because it adds no paperwork: you certify each contribution by
+signing off on your commits.
+
+> TODO(maintainer): confirm DCO vs CLA for the public launch (issue #635,
+> decision 3). If DCO stands, wire up a DCO check on pull requests.
+
+To sign off, add a `Signed-off-by` line to each commit. Git does this for you
+with the `-s` flag:
+
+```bash
+git commit -s -m "Fix the thing"
+```
+
+This appends a line using your configured `user.name` and `user.email`:
+
+```
+Signed-off-by: Jane Developer <jane@example.com>
+```
+
+Use your real name and a reachable email. By signing off you certify the
+Developer Certificate of Origin, version 1.1, reproduced in full below.
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+If you forgot to sign off, amend the most recent commit with `git commit
+--amend -s`, or for a range use `git rebase --signoff <base>`.
+
+Note on licensing: the project's open source license is a separate decision
+tracked outside this guide. The DCO certifies your right to submit under
+whatever license the project adopts; it is not itself a license grant.
+
+## Getting help while contributing
+
+If you get stuck, see [`SUPPORT.md`](SUPPORT.md) for where to ask. Thank you for
+contributing to AgentOS.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,48 @@
+# Support
+
+Thanks for using AgentOS. This page points you to the right place for the kind
+of help you need.
+
+## Before asking
+
+- Read [`README.md`](README.md) for what the product is and how to run it, and
+  [`QUICKSTART.md`](QUICKSTART.md) for the fastest path to a running system.
+- Check [`ARCHITECTURE.md`](ARCHITECTURE.md) and the area `CLAUDE.md` files if
+  your question is about how a component behaves.
+- Search existing [GitHub issues](https://github.com/curie-eng/agentos/issues)
+  in case your question is already answered or tracked.
+
+## Where to get help
+
+**Usage questions and how-to help.**
+
+<!-- TODO(maintainer): Decision 2 (issue #635) - support channel. Name where
+     ordinary support questions should go and the expected response posture.
+     Do not ship the placeholder below. Options include GitHub Discussions
+     (enable it on the repo), a community chat (Slack/Discord), or directing
+     usage questions to GitHub issues with a "question" label. State response
+     expectations plainly (for example: best-effort, no SLA) so users know
+     what to expect. -->
+
+> TODO(maintainer): support channel to be decided before the public
+> announcement (for example, enable GitHub Discussions or link a community
+> chat). Until then, open a GitHub issue with a clear title and the "question"
+> label.
+
+**Bug reports and feature requests.** Open a
+[GitHub issue](https://github.com/curie-eng/agentos/issues). For a bug, include
+the version or commit, your environment (local Docker vs Kubernetes), steps to
+reproduce, and what you expected versus what happened. For a feature, describe
+the what and the why; see [`CONTRIBUTING.md`](CONTRIBUTING.md) for how proposals
+are scoped.
+
+**Security vulnerabilities.** Do not open a public issue. Follow the private
+disclosure process in [`SECURITY.md`](SECURITY.md).
+
+**Contributing a change.** See [`CONTRIBUTING.md`](CONTRIBUTING.md) for build,
+test, and pull-request conventions, and the contribution certification process.
+
+## Conduct
+
+All support interactions are governed by our
+[Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## What

Establishes the standard open-source community health files ahead of the AgentOS public announcement, using conventional lowest-friction defaults. Every org-level decision the issue says maintainers must make first is marked inline with an explicit `TODO(maintainer): ...` rather than fabricated.

Files added:

- **CONTRIBUTING.md** - dev setup (uv workspace + compose dev stack), per-package build/test commands, testing discipline, frozen-contract escalation, the ADR-vs-issue split, and branch/commit/PR conventions, all pulled from `AGENTS.md`, `CLAUDE.md`, `cli/CLAUDE.md`, and `README.md` so they are accurate to this repo. Contribution certification uses the **DCO 1.1** (full text quoted) with a `Signed-off-by` requirement, recommended as the lighter-weight default.
- **CODE_OF_CONDUCT.md** - Contributor Covenant v2.1, verbatim.
- **SUPPORT.md** - routes usage questions, bug/feature reports, security disclosure, and contributions to the correct channel.

`SECURITY.md` already exists and already resolves the private-disclosure channel (GitHub Private Vulnerability Reporting, explicitly no published email). It is left intact and cross-referenced from the new docs; no `TODO` was added there because the decision was already made.

## Open maintainer decisions (must be resolved before the announcement)

These are the three decisions issue #635 says maintainers must make. Each is flagged inline with `TODO(maintainer)`:

1. **Whether outside PRs are accepted and the welcome scope** - CONTRIBUTING.md is written assuming community PRs are welcome; the scope paragraph and its `TODO(maintainer)` need confirmation (CONTRIBUTING.md, "Scope of contributions").
2. **Conduct/support escalation contacts and channels** - conduct reporting contact (CODE_OF_CONDUCT.md, "Enforcement") and the ordinary support channel + response expectations (SUPPORT.md, "Where to get help"). No contact was invented.
3. **DCO vs CLA** - CONTRIBUTING.md recommends DCO as the default; `TODO(maintainer)` flags the confirmation and, if DCO stands, wiring a DCO check on PRs (CONTRIBUTING.md, "Certifying your contribution").

The license choice is out of scope per the issue; CONTRIBUTING.md notes the DCO certifies the right to submit under whatever license is later adopted and is not itself a license grant.

Docs-only; no code paths changed. The `scripts/check-docs.sh` gate lints the interface catalog under `docs/` only, so these repo-root files are outside its scope.

Closes #635