### PR TITLE
Make the read-only tool set harness-declared for side-effect classification

### DIFF
--- a/runner/src/agentos_runner/__init__.py
+++ b/runner/src/agentos_runner/__init__.py
@@ -34,7 +34,12 @@ from .otel import RunTracer, build_tracer_provider
 from .plugin import PluginBundleError, load_bundle_system_prompt, load_plugins
 from .server import create_app
 from .session import SessionRunner
-from .side_effects import DEFAULT_IDEMPOTENT_TOOLS, SideEffectClassifier
+from .side_effects import (
+    CLAUDE_READONLY_TOOLS,
+    DEFAULT_IDEMPOTENT_TOOLS,
+    PLATFORM_IDEMPOTENT_TOOLS,
+    SideEffectClassifier,
+)
 
 __version__ = "0.0.0"
 
@@ -57,6 +62,8 @@ __all__ = [
     "SessionRunner",
     "SideEffectClassifier",
     "DEFAULT_IDEMPOTENT_TOOLS",
+    "CLAUDE_READONLY_TOOLS",
+    "PLATFORM_IDEMPOTENT_TOOLS",
     "MemoryStore",
     "MemoryRecord",
     "Provenance",

--- a/runner/src/agentos_runner/side_effects.py
+++ b/runner/src/agentos_runner/side_effects.py
@@ -6,26 +6,47 @@ human instead of retrying, because at-least-once delivery plus a mutating tool
 means a blind retry risks a duplicate real-world action.
 
 Design choice (documented for F1/K1): a **read-only allowlist**, deny-by-default.
-A small set of known read-only Claude Code tools is treated as idempotent; every
-other tool the harness executes is treated as potentially side-effecting and
-flags the run. This fails safe: a new or unknown tool escalates rather than
-being silently retried. The alternative, an explicit non-idempotent denylist,
-fails open (a new mutating tool would be missed) and was rejected for that
-reason. The default allowlist is replaceable by an in-process caller through the
-``idempotent_tools`` constructor argument; there is no env knob for it. The env
-override that once advertised itself here was never wired to a consumer, and an
-unwired widening knob on a deny-by-default classifier is worse than none -- it
+A harness declares which of its tools only read state; every other tool the
+harness executes is treated as potentially side-effecting and flags the run.
+This fails safe: a new or unknown tool escalates rather than being silently
+retried. The alternative, an explicit non-idempotent denylist, fails open (a new
+mutating tool would be missed) and was rejected for that reason.
+
+**The read-only set is harness-declared** (ADR-0060). Tool identifiers are
+harness-specific: the Claude Code harness names its read-only tools in PascalCase
+(``Read``, ``Grep``, ...), while a second harness such as OpenCode names the same
+capabilities in lowercase (``read``, ``grep``, ``webfetch``). The classifier
+itself stays harness-agnostic and deny-by-default; it is constructed with the
+active harness's declared read-only set. The default is the Claude adapter's
+declaration (``CLAUDE_READONLY_TOOLS``), so an unconfigured caller sees the
+historical Claude behavior unchanged. A future OpenCode adapter constructs the
+classifier with its own declaration instead. There is no env knob for this: the
+env override that once advertised itself here was never wired to a consumer, and
+an unwired widening knob on a deny-by-default classifier is worse than none -- it
 reads as an escape hatch that silently does nothing (#488).
 """
 
 from collections.abc import Iterable
 
-# Built-in Claude Code tools that only read state. Names match the SDK's tool
-# identifiers. Anything not listed here is treated as side-effecting.
-# The platform approval-request tool (ADR-0010) is explicitly allowlisted: it
-# executes no real-world action (it only marks the turn awaiting-approval), and
-# flagging it would block the no-retry rule for the very turns approvals pause.
-DEFAULT_IDEMPOTENT_TOOLS: frozenset[str] = frozenset(
+# The platform's in-process approval-request tool (ADR-0010) is idempotent under
+# EVERY harness: it executes no real-world action (it only marks the turn
+# awaiting-approval), and it is injected into every session by the platform, not
+# shipped by the harness. It is therefore always treated as idempotent,
+# independent of which harness's read-only declaration is in force -- flagging it
+# would block the no-retry rule for the very turns approvals pause, and a harness
+# declaration that happened to omit it must not be able to reintroduce that bug.
+PLATFORM_IDEMPOTENT_TOOLS: frozenset[str] = frozenset(
+    {
+        "mcp__agentos__request_approval",
+    }
+)
+
+# The Claude Code harness adapter's declared read-only tool set. Names match the
+# claude-agent-sdk tool identifiers (PascalCase). Per ADR-0060 each harness
+# declares its own read-only set; this is the Claude adapter's declaration and
+# the classifier default. A second harness (e.g. OpenCode) uses different
+# identifiers and constructs the classifier with its own declaration.
+CLAUDE_READONLY_TOOLS: frozenset[str] = frozenset(
     {
         "Read",
         "Glob",
@@ -35,20 +56,30 @@ DEFAULT_IDEMPOTENT_TOOLS: frozenset[str] = frozenset(
         "WebFetch",
         "WebSearch",
         "TodoRead",
-        "mcp__agentos__request_approval",
     }
 )
+
+# The effective idempotent set for an unconfigured (Claude) classifier: the Claude
+# adapter's declared read-only tools plus the always-idempotent platform tools.
+# Retained as the module default so existing callers and Claude behavior are
+# unchanged.
+DEFAULT_IDEMPOTENT_TOOLS: frozenset[str] = CLAUDE_READONLY_TOOLS | PLATFORM_IDEMPOTENT_TOOLS
 
 
 class SideEffectClassifier:
     """Decide whether a tool name denotes a non-idempotent (side-effecting) call."""
 
-    def __init__(self, idempotent_tools: Iterable[str] | None = None) -> None:
-        self._idempotent = (
-            frozenset(idempotent_tools)
-            if idempotent_tools is not None
-            else DEFAULT_IDEMPOTENT_TOOLS
+    def __init__(self, readonly_tools: Iterable[str] | None = None) -> None:
+        # The harness-declared read-only set (defaults to the Claude adapter's
+        # declaration) is unioned with the always-idempotent platform tools. An
+        # explicit set REPLACES the Claude declaration -- it does not inherit
+        # Claude's PascalCase names -- but the platform tools are always present.
+        declared = (
+            frozenset(readonly_tools)
+            if readonly_tools is not None
+            else CLAUDE_READONLY_TOOLS
         )
+        self._idempotent = declared | PLATFORM_IDEMPOTENT_TOOLS
 
     def is_side_effecting(self, tool_name: str) -> bool:
         """True if executing ``tool_name`` may cause a non-idempotent side effect."""

--- a/runner/tests/test_side_effects.py
+++ b/runner/tests/test_side_effects.py
@@ -1,6 +1,11 @@
-"""The side-effect classifier: read-only allowlist, deny-by-default."""
+"""The side-effect classifier: harness-declared read-only allowlist, deny-by-default."""
 
-from agentos_runner import DEFAULT_IDEMPOTENT_TOOLS, SideEffectClassifier
+from agentos_runner import (
+    CLAUDE_READONLY_TOOLS,
+    DEFAULT_IDEMPOTENT_TOOLS,
+    PLATFORM_IDEMPOTENT_TOOLS,
+    SideEffectClassifier,
+)
 
 
 def test_read_only_tools_are_idempotent() -> None:
@@ -16,8 +21,56 @@ def test_mutating_and_unknown_tools_flag() -> None:
         assert classifier.is_side_effecting(tool)
 
 
-def test_override_replaces_the_allowlist() -> None:
+def test_override_replaces_the_claude_declaration() -> None:
     classifier = SideEffectClassifier(["Bash"])
     assert not classifier.is_side_effecting("Bash")
-    # An override replaces (does not extend) the default set.
+    # An explicit harness declaration replaces (does not extend) the Claude set.
     assert classifier.is_side_effecting("Read")
+
+
+def test_platform_approval_tool_is_idempotent_under_any_harness() -> None:
+    """The platform approval tool (ADR-0010) is idempotent regardless of harness.
+
+    It is platform-injected, not harness-shipped, so even a harness declaration
+    that omits it must not be able to make the approval turn look side-effecting
+    -- flagging it would block the no-retry rule for the turns approvals pause.
+    """
+
+    approval_tool = "mcp__agentos__request_approval"
+    assert approval_tool in PLATFORM_IDEMPOTENT_TOOLS
+    # A harness declaration that omits the approval tool still classifies it safe.
+    classifier = SideEffectClassifier(["read"])
+    assert not classifier.is_side_effecting(approval_tool)
+
+
+def test_opencode_named_read_only_tools_do_not_flag() -> None:
+    """#308 regression: a second harness declares lowercase read-only names.
+
+    Under a harness like OpenCode the read-only tools are ``read``/``grep``/
+    ``webfetch`` (lowercase), not the Claude PascalCase identifiers. When the
+    classifier is constructed with that harness's declaration, those tools must
+    NOT raise side_effect_flag; an unknown tool still MUST (deny-by-default).
+    """
+
+    opencode_readonly = {"read", "grep", "glob", "list", "webfetch"}
+    classifier = SideEffectClassifier(opencode_readonly)
+
+    for tool in opencode_readonly:
+        assert not classifier.is_side_effecting(tool)
+
+    # Deny-by-default invariant holds: an unknown tool still flags. This includes
+    # the Claude PascalCase names, which are not in the OpenCode declaration.
+    for tool in ("bash", "write", "edit", "SomeBrandNewTool", "Read"):
+        assert classifier.is_side_effecting(tool)
+
+
+def test_default_is_the_claude_declaration_plus_platform_tools() -> None:
+    """AC2: the historical Claude allowlist is the Claude adapter's declaration."""
+
+    assert DEFAULT_IDEMPOTENT_TOOLS == CLAUDE_READONLY_TOOLS | PLATFORM_IDEMPOTENT_TOOLS
+    # The Claude declaration is the classifier's default when none is supplied.
+    default_classifier = SideEffectClassifier()
+    claude_classifier = SideEffectClassifier(CLAUDE_READONLY_TOOLS)
+    for tool in CLAUDE_READONLY_TOOLS:
+        assert not default_classifier.is_side_effecting(tool)
+        assert not claude_classifier.is_side_effecting(tool)


### PR DESCRIPTION
## Problem

`runner/src/agentos_runner/side_effects.py`'s read-only allowlist hardcoded Claude Code's PascalCase tool names (`Read`, `Grep`, `WebFetch`, ...). A second harness such as OpenCode names the same read-only capabilities in lowercase (`read`, `grep`, `webfetch`), so under it every read-only tool misclassified as side-effecting and `side_effect_flag` wrongly suppressed the worker's no-retry-after-side-effects auto-retry.

Per ADR-0060 Decision 4, the read-only tool set is harness-declared, not hardcoded in the classifier.

## Change

- The classifier stays harness-agnostic and deny-by-default. It is constructed with the active harness's declared read-only set (`readonly_tools`), defaulting to the Claude adapter's declaration (`CLAUDE_READONLY_TOOLS`). Claude behavior is unchanged: the existing hardcoded allowlist is now that declaration. A future OpenCode adapter constructs the classifier with its own lowercase declaration.
- The platform approval-request tool (ADR-0010) is split into `PLATFORM_IDEMPOTENT_TOOLS` and always unioned in, so it is idempotent under every harness rather than depending on each harness's declaration remembering it. A harness whose read-only set omitted it must not reintroduce the flag on the very turns approvals pause.
- The deny-by-default invariant is preserved: an unknown/unlisted tool is still treated as side-effecting.

## Tests

- `test_opencode_named_read_only_tools_do_not_flag`: lowercase `read`/`grep`/... constructed as the harness declaration do NOT flag; an unknown tool (and the Claude PascalCase names, absent from the OpenCode declaration) still DO.
- `test_platform_approval_tool_is_idempotent_under_any_harness`: approval tool stays idempotent even when a harness declaration omits it.
- `test_default_is_the_claude_declaration_plus_platform_tools`: the historical Claude allowlist is the Claude adapter's declaration and the classifier default.

`uv run pytest runner/tests -q` (404 passed, 4 skipped), `uv run ruff check runner/`, `uv run mypy` all pass.

Closes #308