### PR TITLE
Bound and sequence eval sandbox-claim creation for single-node clusters

### DIFF
--- a/apps/worker/src/agentos_worker/config.py
+++ b/apps/worker/src/agentos_worker/config.py
@@ -308,6 +308,21 @@ class WorkerConfig(BaseSettings):
         validation_alias="AGENTOS_EVAL_CONSUMER_GROUP",
     )
     eval_consumer_name: str = Field(default_factory=_default_consumer_name)
+    # Upper bound on eval SandboxClaims being created/bound CONCURRENTLY in this
+    # worker (#709). Eval jobs are handled by two coroutines racing under one
+    # gather -- the blocking read loop and the crash-recovery reclaim loop -- and
+    # each provisions its own sandbox, so without a bound they can create claims
+    # faster than a small cluster binds them. On a single-node k3s cluster that
+    # storm is the observed failure: claims never bind within claim_timeout and
+    # claim reads return 504. The default of 1 is single-node-safe (a second claim
+    # is not created until the first has bound), giving sequential-with-backpressure
+    # claim creation; a multi-node cluster raises this to admit real parallelism.
+    # The bound covers only the create/bind phase (the flood source), not the whole
+    # suite run: once a claim binds the slot frees so the next claim can begin while
+    # the bound sandbox runs its cases. Floor 1 -- 0 would create no claims at all.
+    eval_max_concurrent_claims: int = Field(
+        default=1, ge=1, validation_alias="AGENTOS_EVAL_MAX_CONCURRENT_CLAIMS"
+    )
     # On first creation the eval group starts at (now - this window) rather than
     # the stream head, so a backlog of ancient entries is not replayed en masse
     # on boot. Recent entries (younger than the window) are still delivered, so a

--- a/apps/worker/src/agentos_worker/eval/stream.py
+++ b/apps/worker/src/agentos_worker/eval/stream.py
@@ -184,6 +184,15 @@ class EvalStreamConsumer(StreamConsumer):
         self._reporter = reporter
         self._recorder = recorder
         self._repo_lookup = repo_lookup
+        # Bound concurrent in-flight SandboxClaim creation (#709). The read loop
+        # and the reclaim loop both drive _handle -> _acquire_target under one
+        # gather, so two claims can be created at once even though each loop is
+        # itself sequential; unbounded that races a small cluster's binder and
+        # produces the single-node 504/never-bind storm. This semaphore caps how
+        # many claims are being created/bound at the same time (default 1: the
+        # next claim waits until the current one binds -- sequential-with-
+        # backpressure), so a suite completes on one node instead of flooding it.
+        self._claim_slots = asyncio.Semaphore(config.eval_max_concurrent_claims)
         # The reclaim/dead-letter knobs the shared base machinery reads; handler
         # is the bound self._handle. The eval-specific dead_letter_log/logger stay
         # eval-specific (logger agentos_worker.eval.stream) so eval dead-letters
@@ -344,7 +353,15 @@ class EvalStreamConsumer(StreamConsumer):
         try:
             connector_secrets = await self._repo_lookup.secrets_for(item.agent_id)
             env = self._boot_env(item, connector_secrets)
-            handle = await asyncio.to_thread(self._substrate.claim, release_key, env=env)
+            # Hold a claim slot only across creation/binding (the flood source),
+            # not the whole suite run: the semaphore is released the moment the
+            # claim binds, so the bound sandbox runs its cases while the next
+            # claim may begin. The secrets/env prep above is cheap and does not
+            # touch the cluster, so it stays outside the slot.
+            async with self._claim_slots:
+                handle = await asyncio.to_thread(
+                    self._substrate.claim, release_key, env=env
+                )
         except SandboxError:
             logger.exception("could not provision a runner for eval %s", item.sha)
             return None, None, None

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -97,6 +97,7 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         "AGENTOS_MAX_DELIVERY",
         "AGENTOS_SLACK_NO_EDIT_STREAMING",
         "AGENTOS_EVAL_CONSUMER_GROUP",
+        "AGENTOS_EVAL_MAX_CONCURRENT_CLAIMS",
         "AGENTOS_EVAL_STREAM",
         "AGENTOS_EVAL_STREAM_MAX_AGE_HOURS",
         # The eval harness's own knobs, read by the eval entrypoint, not injected.

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -949,6 +949,89 @@ def test_eval_fake_model_install_refuses_to_label_a_model_never_called(
     assert consumer._eval_model(remote) == "claude-y"
 
 
+class _ConcurrencyProbeSubstrate:
+    """A substrate whose ``claim`` records how many claims are in flight at once.
+
+    ``claim`` is the sync substrate call the eval consumer runs via
+    ``asyncio.to_thread`` (real OS threads), so the probe uses a threading lock to
+    track the live count and the peak the semaphore ever allowed. Each claim holds
+    for a beat so overlapping callers actually contend for the slot -- without the
+    hold the calls could serialize by luck and hide an unbounded fan-out.
+    """
+
+    def __init__(self, hold_s: float = 0.05) -> None:
+        import threading
+
+        self._hold_s = hold_s
+        self._lock = threading.Lock()
+        self._live = 0
+        self.peak = 0
+        self.claims = 0
+
+    def claim(self, _key: str, *, env: dict[str, str] | None = None) -> _FakeHandle:
+        with self._lock:
+            self._live += 1
+            self.claims += 1
+            self.peak = max(self.peak, self._live)
+        time.sleep(self._hold_s)
+        with self._lock:
+            self._live -= 1
+        return _FakeHandle(base_url="http://sandbox.local:8080", token="t")
+
+    def release(self, _key: str) -> None:  # pragma: no cover - unused here
+        pass
+
+
+def test_eval_claim_creation_is_bounded_to_one_by_default() -> None:
+    """#709: the eval consumer creates SandboxClaims one at a time by default, so a
+    single-node cluster is not flooded with concurrent binds (the 504/never-bind
+    storm). Firing several provisioning calls at once must never overlap more than
+    the configured bound -- here the default of 1 -- inside ``_acquire_target``."""
+    substrate = _ConcurrencyProbeSubstrate()
+    consumer = _consumer(_cfg("s", "g"), substrate=substrate, repo_lookup=_StubRepo())
+    items = [
+        _item(suite="s", sha=f"sha{i}", bundle_ref="bundles/x.zip", target_url=None)
+        for i in range(5)
+    ]
+
+    async def go() -> None:
+        await asyncio.gather(*(consumer._acquire_target(item) for item in items))
+
+    asyncio.run(go())
+
+    assert substrate.claims == len(items)  # every job did provision
+    assert substrate.peak == 1, (
+        f"claim creation must be sequential at the default bound; saw {substrate.peak} at once"
+    )
+
+
+def test_eval_claim_creation_bound_admits_configured_parallelism() -> None:
+    """The bound is a ceiling, not a hard-coded 1: raising
+    ``eval_max_concurrent_claims`` admits that many concurrent binds (a multi-node
+    cluster opts into real parallelism) while still capping the fan-out below the
+    number of jobs in flight."""
+    substrate = _ConcurrencyProbeSubstrate()
+    consumer = _consumer(
+        _cfg("s", "g", eval_max_concurrent_claims=3),
+        substrate=substrate,
+        repo_lookup=_StubRepo(),
+    )
+    items = [
+        _item(suite="s", sha=f"sha{i}", bundle_ref="bundles/x.zip", target_url=None)
+        for i in range(8)
+    ]
+
+    async def go() -> None:
+        await asyncio.gather(*(consumer._acquire_target(item) for item in items))
+
+    asyncio.run(go())
+
+    assert substrate.claims == len(items)
+    assert 1 < substrate.peak <= 3, (
+        f"bound of 3 must admit up to 3 concurrent binds and no more; saw {substrate.peak}"
+    )
+
+
 def _consumer(cfg: WorkerConfig, **wiring: Any) -> EvalStreamConsumer:
     deps: dict[str, Any] = {
         "redis": None,

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -461,3 +461,57 @@ def test_bool_worker_rejects_on_and_falsy_tokens(
 
     assert config.shimmer is False
     assert config.fake_model is False
+
+
+# --- Eval claim-creation concurrency bound (#709) ----------------------------
+#
+# A ceiling on eval SandboxClaims created/bound concurrently, so a single-node
+# cluster is not flooded. Defaults to 1 (sequential-with-backpressure) and reads
+# only its AGENTOS_* alias; kept out of the _WORKER_OVERRIDES parity oracle since
+# it is new, not a port of the old hand-rolled from_env.
+
+
+def test_eval_max_concurrent_claims_defaults_to_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-node-safe by default: claims are created one at a time."""
+    _clear_all_config_env(monkeypatch)
+
+    config = WorkerConfig()
+
+    assert config.eval_max_concurrent_claims == 1
+
+
+def test_worker_config_reads_eval_max_concurrent_claims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_EVAL_MAX_CONCURRENT_CLAIMS", "4")
+
+    config = WorkerConfig()
+
+    assert config.eval_max_concurrent_claims == 4
+
+
+def test_eval_max_concurrent_claims_ignores_bare_field_name_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aliased like every other AGENTOS_* knob: a stray bare-name env var must not
+    leak in."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("EVAL_MAX_CONCURRENT_CLAIMS", "7")
+
+    config = WorkerConfig()
+
+    assert config.eval_max_concurrent_claims == 1
+
+
+def test_eval_max_concurrent_claims_rejects_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Floor of 1: a bound of 0 would create no claims at all (no eval could run)."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("AGENTOS_EVAL_MAX_CONCURRENT_CLAIMS", "0")
+
+    with pytest.raises(ValueError):
+        WorkerConfig()


### PR DESCRIPTION
## What

Bound concurrent in-flight eval `SandboxClaim` creation in `apps/worker` so a single-node cluster is not saturated.

The eval-stream consumer provisions one sandbox per eval job in `_acquire_target`, and the blocking read loop and the crash-recovery reclaim loop both drive that path under one `asyncio.gather`. With no bound they can create claims at the same time, and on a single-node k3s cluster that races the node's binder: claims never bind within `claim_timeout` and claim reads return `504 Gateway Timeout`.

This adds an `asyncio.Semaphore` over the claim-creation call, sized by a new `AGENTOS_EVAL_MAX_CONCURRENT_CLAIMS` knob.

## Behavior

- **Default 1, floor 1.** Single-node-safe: the next claim is not created until the current one binds (sequential-with-backpressure). A multi-node cluster raises the bound to admit real parallelism.
- **Slot held only across creation/binding** (the flood source), released the moment the claim binds -- so a bound sandbox runs its cases while the next claim may begin. The cheap secrets/env prep stays outside the slot.

## Tested

- Unit (no cluster): a threading-probe substrate asserts claim creation never overlaps beyond the configured ceiling -- peak 1 at the default, up to N at bound N -- driving several concurrent `_acquire_target` calls (`test_eval_claim_creation_is_bounded_to_one_by_default`, `test_eval_claim_creation_bound_admits_configured_parallelism`).
- Config: default / alias-read / bare-name-ignored / zero-rejected (`test_config.py`).
- Full `apps/worker/tests` suite green (520 passed, 1 skipped).

**Needs live-cluster verification:** the actual single-node k3s `504` / never-bind-within-`claim_timeout` behavior (the failure this prevents) can only be confirmed end-to-end against a real cluster; the concurrency-bound logic itself is covered in isolation above.

## CLI scope

The CLI `eval --concurrency > 1` refusal (from the #706 PR) is left as-is. This PR is worker-scoped, and there is still no CLI-side concurrent dispatch loop to honor the flag. Un-gating it is a coordinated follow-up now that the worker bounds the fan-out.

Closes #709