### PR TITLE
Serialize thread reset against turn start under the route lock

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -120,6 +120,17 @@ _KILL_INTERRUPT_TIMEOUT_S = 5.0
 # fresh reset request is needed to retry.
 _RESET_RELEASE_TIMEOUT_S = 5.0
 
+# The release runs under the same per-thread route lock the turn path holds
+# around `_route_and_start` (#734), so a reset and a turn-start on the same
+# thread cannot interleave. Acquiring that lock is bounded like the interrupt
+# and the release above, and for the same reason: a wedged or slow-cold-claiming
+# turn can hold the route lock for up to the substrate's claim timeout, and a
+# reset must not park the maintenance tick waiting on it. A lock that cannot be
+# taken in time raises, which the drain loop treats as a failed release (left in
+# the in-progress set, reported unconfirmed, retried by a fresh operator
+# request) rather than falling back to the old, unsafe lock-free release.
+_RESET_LOCK_ACQUIRE_TIMEOUT_S = 5.0
+
 
 @dataclass
 class TurnOutcome:
@@ -420,17 +431,13 @@ class Kernel:
             attempt = 0
             while True:
                 attempt += 1
-                outcome = await self._attempt(
-                    qevent, release_order, boot_env, agent_id, nav, packs
-                )
+                outcome = await self._attempt(qevent, release_order, boot_env, agent_id, nav, packs)
 
                 if outcome.status is SessionStatus.AWAITING_APPROVAL:
                     # A gate fired (ADR-0010): persist the durable record, then
                     # suspend the session until a human resolves it. The event
                     # is done -- the resolution arrives as its own queued turn.
-                    await self._pause_for_approval(
-                        qevent, outcome, agent_id, approval_routes
-                    )
+                    await self._pause_for_approval(qevent, outcome, agent_id, approval_routes)
                     await self._markers.mark_done(event_id)
                     return
 
@@ -530,6 +537,28 @@ class Kernel:
         like any other release failure, which the drain loop's per-request
         handler already logs and isolates from the rest of the batch.
 
+        The release runs under the SAME per-thread route lock the turn path
+        holds around `_route_and_start` (#734). Without it the release is
+        lock-free while a concurrent turn for this thread holds only that lock,
+        so a message arriving in the window between the interrupt above and the
+        release below can `claim()`-adopt the very sandbox this is tearing down
+        and open a turn on it -- which the release then yanks mid-run. The
+        interrupt cannot cover that turn: it fired before the turn existed, so
+        it no-oped. Taking the lock makes the two mutually exclusive. A reset
+        that wins the lock drops the route while holding it, so a turn waiting
+        to route then cold-creates a fresh sandbox (exactly the reset's intent)
+        instead of adopting the doomed one. A turn that wins the lock opens
+        first and the reset serializes behind its `_route_and_start`, then tears
+        it down as an ordinary live-thread reset (the turn replays on a fresh
+        sandbox via the `runner-error` retry path described below). Either way
+        no turn is ever left streaming on a sandbox this released out from under
+        it without the reset first having serialized against its start.
+
+        The lock hold spans only the release (interrupt-then-lock, not the
+        reverse), so the bounded-but-possibly-slow courtesy interrupt does not
+        extend the window turn-starts for this thread are blocked; the hold is
+        the release bound (a few seconds), well under the lock's TTL.
+
         The failure log is an ERROR, not a warning: it is the only record that a
         sandbox was pulled out from under a turn that may still be running, and
         there is no retry that would produce a second, louder signal. The two
@@ -569,13 +598,22 @@ class Kernel:
                     thread_key,
                 )
             else:
-                logger.info(
-                    "reset: no live runner to interrupt on thread %s", thread_key
-                )
-        return await asyncio.wait_for(
-            asyncio.to_thread(self._substrate.release, thread_key),
-            _RESET_RELEASE_TIMEOUT_S,
-        )
+                logger.info("reset: no live runner to interrupt on thread %s", thread_key)
+        # Serialize the teardown against `_route_and_start` for this thread by
+        # holding the same route lock the turn path holds (#734). Both the lock
+        # acquisition and the release run on their own bounds, so a wedged turn
+        # or control plane cannot park the maintenance tick here; a lock that
+        # cannot be taken in time propagates as a release failure, same as a
+        # timed-out release.
+        lock_key = self._config.lock_key(thread_key)
+        token = await asyncio.wait_for(self._lock.acquire(lock_key), _RESET_LOCK_ACQUIRE_TIMEOUT_S)
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(self._substrate.release, thread_key),
+                _RESET_RELEASE_TIMEOUT_S,
+            )
+        finally:
+            await self._lock.release(lock_key, token)
 
     def attach_killswitch(self, killswitch: KillSwitch) -> None:
         """Wire the kill switch after construction (it needs interrupt_agent)."""
@@ -689,9 +727,7 @@ class Kernel:
                     endpoint=qevent.reply_handle.endpoint,
                 )
             except Exception:
-                logger.warning(
-                    "booting-state update failed for %s", qevent.event_id
-                )
+                logger.warning("booting-state update failed for %s", qevent.event_id)
 
         event = self._to_event(qevent)
 
@@ -806,9 +842,7 @@ class Kernel:
         turn = await self._runner.start_turn(handle.base_url, event, token=handle.token or None)
         return _RouteResult(steered=False, handle=handle, turn=turn)
 
-    async def _claim_or_resume(
-        self, thread: str, boot_env: dict[str, str] | None
-    ) -> SandboxHandle:
+    async def _claim_or_resume(self, thread: str, boot_env: dict[str, str] | None) -> SandboxHandle:
         try:
             return await asyncio.to_thread(self._substrate.claim, thread, env=boot_env)
         except SuspendedThreadError:
@@ -859,9 +893,7 @@ class Kernel:
                 blocks=blocks,
                 endpoint=ref.endpoint,
             )
-            logger.info(
-                "disabled expired approval card for thread %s", qevent.conversation_id
-            )
+            logger.info("disabled expired approval card for thread %s", qevent.conversation_id)
         except Exception as exc:  # noqa: BLE001 - card teardown is best-effort
             logger.warning(
                 "expired approval card teardown failed for thread %s: %s",
@@ -1033,12 +1065,8 @@ class Kernel:
                         endpoint=card_endpoint,
                     )
                 except Exception as exc:  # noqa: BLE001 - best-effort memory
-                    logger.warning(
-                        "remembering approval card for %s failed: %s", created.id, exc
-                    )
-        logger.info(
-            "thread %s suspended awaiting approval %s", thread, created.id
-        )
+                    logger.warning("remembering approval card for %s failed: %s", created.id, exc)
+        logger.info("thread %s suspended awaiting approval %s", thread, created.id)
 
     async def _consume(
         self, qevent: QueuedTurn, turn: TurnStream, nav: NavPack | None = None

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import time
 import uuid
 from collections.abc import Callable
@@ -789,6 +790,69 @@ def test_release_thread_with_no_route_is_a_noop(make_harness) -> None:
         async with make_harness() as h:
             released = await h.kernel.release_thread("never-seen-thread")
             assert released is False
+
+    asyncio.run(go())
+
+
+def test_release_serializes_against_a_concurrent_turn_start(make_harness) -> None:
+    """#734: the release runs under the same per-thread route lock the turn path
+    holds around `_route_and_start`, so a reset and a message arriving for the
+    same thread cannot interleave. Without the lock the message could
+    `claim()`-adopt the sandbox the reset is tearing down and open a turn on it,
+    which the release then yanks mid-run.
+
+    The interleaving is forced deterministically rather than raced: the release
+    is gated open (via a threading.Event, because the substrate release runs on
+    `asyncio.to_thread`) so it sits IN the critical section, holding the route
+    lock, while a new turn for the same thread tries to start. That turn must
+    block on the lock -- proven by its `/v1/event` never firing while the
+    release is parked -- and, once the release drops the route and frees the
+    lock, must cold-create a FRESH sandbox (a new claim) instead of the released
+    one, and complete cleanly rather than failing on a torn-down sandbox."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="ok", status=DONE)]
+
+            # Establish a live route with a concrete, idle sandbox.
+            await h.kernel.process_event(_qevent("first", thread="tRace"))
+            old = h.substrate.lookup("tRace")
+            assert old is not None
+            old_claim = old.claim_name
+
+            # Gate the substrate release so it parks inside the critical section
+            # (route lock held) until the test lets it proceed.
+            real_release = h.substrate.release
+            release_entered = threading.Event()
+            release_gate = threading.Event()
+
+            def gated_release(thread_key: str) -> bool:
+                release_entered.set()
+                release_gate.wait(timeout=5.0)
+                return real_release(thread_key)
+
+            h.substrate.release = gated_release  # type: ignore[method-assign]
+
+            reset = asyncio.create_task(h.kernel.release_thread("tRace"))
+            await _wait_until(release_entered.is_set)  # release now holds the lock
+
+            # A new message for the same thread races the reset. It must block on
+            # the route lock the release holds, not adopt the doomed sandbox.
+            turn = asyncio.create_task(h.kernel.process_event(_qevent("second", thread="tRace")))
+            await asyncio.sleep(0.2)
+            assert h.runner.opened == ["first"], "turn started while the reset held the lock"
+
+            # Let the release finish: it drops the route and frees the lock, so
+            # the waiting turn now cold-creates a fresh sandbox.
+            release_gate.set()
+            assert await reset is True
+            await turn
+
+            assert h.runner.opened == ["first", "second"]  # the turn did run
+            fresh = h.substrate.lookup("tRace")
+            assert fresh is not None
+            assert fresh.claim_name != old_claim  # a fresh sandbox, not the released one
+            assert old_claim not in h.fake_k8s.claims  # the released claim is gone
 
     asyncio.run(go())
 


### PR DESCRIPTION
## Problem

`Kernel.release_thread` (the operator reset path, driven by the maintenance loop's `_drain_thread_reset_requests`) interrupted a thread's live turn and then released its sandbox **holding no lock**, while the turn path guards `_route_and_start` with the per-thread route lock (`self._lock.hold(lock_key(thread))`).

The race is real on current `origin/main` (post #812/#743/#739, which added the in-flight set and bounded the interrupt/release but did not add locking):

1. An operator resets a thread whose sandbox is idle.
2. `release_thread` interrupts; with no live turn the interrupt no-ops.
3. Before `release` lands, a message for the same thread acquires the route lock and `claim()`-**adopts the existing sandbox**, opening a turn on it.
4. `release` then deletes that claim and drops the route out from under the just-started turn.

The turn stream drops (`runner-error`, retried), and a turn that had emitted a `side_effect_flag` in the window escalates to a human instead of resetting cleanly. The courtesy interrupt cannot cover this turn: it fires before the turn exists.

Refutation angle checked: `reap_orphans` and `interrupt_agent` do perform unlocked work, but neither deletes a specific thread's claim in a way that races that thread's `claim()`-adopt, so this is not the established pattern. `SandboxSubstrate.release` deletes the claim (and thus the pod), so the in-flight turn does not complete harmlessly. The race stands.

## Fix

Take the **same route lock** the turn path holds around the release, so a reset and a turn-start on one thread are mutually exclusive:

- A reset that wins the lock drops the route while holding it, so a waiting turn cold-creates a **fresh** sandbox (exactly the reset's intent) instead of adopting the doomed one.
- A turn that wins the lock opens first; the reset serializes behind its `_route_and_start` and then tears it down as an ordinary live-thread reset (the turn replays on a fresh sandbox via the existing `runner-error` retry path).

Ordering is interrupt-then-lock-then-release: the courtesy interrupt stays outside the lock so a wedged runner does not extend the window turn-starts are blocked. The lock acquisition is bounded (`_RESET_LOCK_ACQUIRE_TIMEOUT_S`, 5s) exactly like the interrupt and release, so a wedged or slow cold-claiming turn cannot park the maintenance tick; a lock that cannot be taken in time propagates as a release failure (left in the in-flight set, reported unconfirmed, retried by a fresh request), preserving #743's bounding.

## Test

`test_release_serializes_against_a_concurrent_turn_start` forces the interleaving deterministically: the substrate release is gated open (via a `threading.Event`, since it runs on `asyncio.to_thread`) so it parks inside the critical section holding the lock while a new turn for the same thread tries to start. The test asserts the turn's `/v1/event` does not fire while the release holds the lock, and that once the release frees the lock the turn cold-creates a fresh claim (not the released one) and completes cleanly.

`uv run pytest apps/worker/tests -q` -> 515 passed, 1 skipped.

## Review note

This touches the sacred `kernel.py`. Per `apps/worker/CLAUDE.md` it needs the adversarial review (spec-vs-impl + side-effects-detective, minimum) before merge; I have **not** performed that review. Flagging for it. One residual, unchanged from #743: if the release itself times out, the `to_thread` keeps running after the lock is freed, so the pathological control-plane-hang case is still best-effort (the common case is fully serialized).

Closes #734