### PR TITLE
Add one-command chart runtime E2E harness and require live verification for runtime-AC tickets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,8 +267,9 @@ just that unit tests pass.
   live binary, so they cannot see the behavior the AC is about (#56, a
   credential-isolation bug in the bundle-fetch init container, was nearly shipped
   green on lint + template alone). How to apply: for chart / sandbox / bundle
-  changes, `bash scripts/chart-runtime-e2e.sh` (from repo root) is the one-command
-  way to install a trimmed slice, run the init containers, and exec-assert.
+  changes, `agentos dev chart-runtime-e2e` (implemented by
+  `scripts/chart-runtime-e2e.sh`) is the one-command way to install a trimmed
+  slice, run the init containers, and exec-assert.
 
 ## Playwright: two modes
 
@@ -285,9 +286,10 @@ just that unit tests pass.
 
 Chart, sandbox, and soak verification need a real cluster; a disposable local
 `kind` or `k3s` cluster works. The cheap default for a chart/sandbox/bundle
-change is `bash scripts/chart-runtime-e2e.sh` (from repo root): it installs a
-trimmed slice, runs the bundle-fetch init pair, and exec-asserts on the runner --
-the one-command way to satisfy a runtime AC. See
+change is `agentos dev chart-runtime-e2e` (implemented by
+`scripts/chart-runtime-e2e.sh`): it installs a trimmed slice, runs the
+bundle-fetch init pair, and exec-asserts on the runner -- the one-command way to
+satisfy a runtime AC. See
 [`charts/agentos/CLAUDE.md`](charts/agentos/CLAUDE.md) for the install and probe
 commands.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,16 @@ just that unit tests pass.
   command-surface change regenerates the committed manifest (`cli/CLAUDE.md`),
   and every wired console action maps to a real command or an explicit
   `noCliEquivalent` (`apps/ui/CLAUDE.md`). Keep both sides in the same change.
+- **A runtime acceptance criterion is not satisfied by static verification.** When
+  a ticket's AC is a runtime/observable check -- an exec command, an HTTP response,
+  a rendered-then-running behavior -- you MUST run that exact check against a
+  running cluster and paste its output; `helm lint`, `helm template`, typecheck,
+  and render do NOT count. Why: static checks never run the init container or the
+  live binary, so they cannot see the behavior the AC is about (#56, a
+  credential-isolation bug in the bundle-fetch init container, was nearly shipped
+  green on lint + template alone). How to apply: for chart / sandbox / bundle
+  changes, `bash scripts/chart-runtime-e2e.sh` (from repo root) is the one-command
+  way to install a trimmed slice, run the init containers, and exec-assert.
 
 ## Playwright: two modes
 
@@ -274,8 +284,12 @@ just that unit tests pass.
 ## Cluster verification
 
 Chart, sandbox, and soak verification need a real cluster; a disposable local
-`kind` or `k3s` cluster works. See [`charts/agentos/CLAUDE.md`](charts/agentos/CLAUDE.md)
-for the install and probe commands.
+`kind` or `k3s` cluster works. The cheap default for a chart/sandbox/bundle
+change is `bash scripts/chart-runtime-e2e.sh` (from repo root): it installs a
+trimmed slice, runs the bundle-fetch init pair, and exec-asserts on the runner --
+the one-command way to satisfy a runtime AC. See
+[`charts/agentos/CLAUDE.md`](charts/agentos/CLAUDE.md) for the install and probe
+commands.
 
 ## Branch and commit conventions
 

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -3257,6 +3257,11 @@ export const commandManifest = {
           "name": "e2e-ladder"
         },
         {
+          "about": "Runtime E2E the Helm chart on a local cluster: install a trimmed slice, seed a bundle into MinIO, run the sandbox bundle-fetch init pair, and exec-assert the runner's view -- the one-command way to satisfy a chart/sandbox runtime acceptance criterion static checks cannot (#199, `bash scripts/chart-runtime-e2e.sh`)",
+          "hidden": false,
+          "name": "chart-runtime-e2e"
+        },
+        {
           "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
           "hidden": false,
           "name": "docs-lint"

--- a/charts/agentos/CLAUDE.md
+++ b/charts/agentos/CLAUDE.md
@@ -82,7 +82,7 @@ helm template charts/agentos -f charts/agentos/values-dev.yaml   # chart-authori
 Runtime check (the cheap default for a chart/sandbox/bundle change): installs a
 trimmed slice, runs the bundle-fetch init pair, and exec-asserts on the runner:
 ```bash
-bash scripts/chart-runtime-e2e.sh                                # from repo root
+agentos dev chart-runtime-e2e            # implemented by scripts/chart-runtime-e2e.sh
 ```
 A ticket whose AC is a runtime check (like #56, the bundle-fetch credential
 isolation) is only satisfied by running this and pasting its output -- lint /

--- a/charts/agentos/CLAUDE.md
+++ b/charts/agentos/CLAUDE.md
@@ -72,10 +72,21 @@ component and rail detail in `charts/agentos/README.md`.
 
 ## Verify
 
+Static / chart-authoring checks (they render manifests but NEVER run a container,
+so they cannot catch a bug that only surfaces at runtime):
 ```bash
 helm lint charts/agentos
 helm template charts/agentos -f charts/agentos/values-dev.yaml   # chart-authoring check, no cluster contact
 ```
+
+Runtime check (the cheap default for a chart/sandbox/bundle change): installs a
+trimmed slice, runs the bundle-fetch init pair, and exec-asserts on the runner:
+```bash
+bash scripts/chart-runtime-e2e.sh                                # from repo root
+```
+A ticket whose AC is a runtime check (like #56, the bundle-fetch credential
+isolation) is only satisfied by running this and pasting its output -- lint /
+template do not exercise the init container or the live runner.
 
 Cluster verification (a disposable local cluster, `kind` or `k3s`):
 ```bash

--- a/charts/agentos/values-e2e-harness.yaml
+++ b/charts/agentos/values-e2e-harness.yaml
@@ -1,0 +1,73 @@
+# Runtime-E2E trimming overlay for scripts/chart-runtime-e2e.sh.
+#
+# COMPOSES WITH values-e2e-nogvisor.yaml (apply BOTH, nogvisor first):
+#   helm install <rel> charts/agentos -n <ns> --create-namespace --no-hooks \
+#     -f charts/agentos/values-e2e-nogvisor.yaml \
+#     -f charts/agentos/values-e2e-harness.yaml
+#
+# Purpose: stand up the SMALLEST slice of the chart that can exercise the
+# agent-sandbox bundle-fetch init pair against a real MinIO -- the runtime path
+# the #56 credential-isolation fix lives in. It disables every backing store and
+# app service that the bundle-fetch/runner path does not need (langfuse,
+# postgres, valkey, clickhouse, inference, otel collector, api, dispatcher,
+# worker, ui) and both install-time preflights, keeping ONLY MinIO (the bundle
+# store) and the agent-sandbox substrate (the SandboxTemplate whose podTemplate
+# the harness renders into a bound Pod).
+#
+# The vendored controller is OFF: the harness builds the bound sandbox Pod
+# directly from the SandboxTemplate.spec.podTemplate, so it never needs the
+# controller to bind a claim. warmPool.replicas 0 (no pre-warmed pods) and
+# fakeModel true (no model credential) keep the slice credential-free and fast.
+
+# Backing stores the bundle-fetch/runner path does not touch.
+langfuse:
+  deploy: false
+postgres:
+  deploy: false
+valkey:
+  deploy: false
+clickhouse:
+  deploy: false
+inference:
+  deploy: false
+otelCollector:
+  deploy: false
+
+# First-party app services -- none are needed to exec a bound sandbox runner.
+api:
+  deploy: false
+dispatcher:
+  deploy: false
+worker:
+  deploy: false
+ui:
+  deploy: false
+
+# Install-time preflights: skipped anyway with --no-hooks, disabled here so a
+# hooks-on install of this overlay also stays quiet.
+preflights:
+  avxCheck:
+    enabled: false
+  networkPolicyProbe:
+    enabled: false
+
+# MinIO is the bundle store under test. Keep it deployed; drop the PVC so the
+# pod schedules instantly on a scratch node with no storage provisioning wait.
+minio:
+  deploy: true
+  persistence:
+    enabled: false
+
+# Agent-sandbox substrate: keep the SandboxTemplate, skip the cluster-scoped
+# controller (already present, and the harness binds the pod itself), keep zero
+# warm replicas, and run fake-model so no model credential is required.
+agentSandbox:
+  deploy: true
+  controller:
+    deploy: false
+  warmPool:
+    replicas: 0
+  runner:
+    fakeModel: true
+    prewarm:
+      enabled: false

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -3254,6 +3254,11 @@
           "name": "e2e-ladder"
         },
         {
+          "about": "Runtime E2E the Helm chart on a local cluster: install a trimmed slice, seed a bundle into MinIO, run the sandbox bundle-fetch init pair, and exec-assert the runner's view -- the one-command way to satisfy a chart/sandbox runtime acceptance criterion static checks cannot (#199, `bash scripts/chart-runtime-e2e.sh`)",
+          "hidden": false,
+          "name": "chart-runtime-e2e"
+        },
+        {
           "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
           "hidden": false,
           "name": "docs-lint"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -334,6 +334,12 @@ enum DevAction {
     /// Run the cold-start parity ladder across the skill, local, and cluster
     /// tiers, fake model by default (#690, `bash cli/scripts/e2e-ladder.sh`).
     E2eLadder,
+    /// Runtime E2E the Helm chart on a local cluster: install a trimmed slice,
+    /// seed a bundle into MinIO, run the sandbox bundle-fetch init pair, and
+    /// exec-assert the runner's view -- the one-command way to satisfy a
+    /// chart/sandbox runtime acceptance criterion static checks cannot (#199,
+    /// `bash scripts/chart-runtime-e2e.sh`).
+    ChartRuntimeE2e,
     /// Lint the interface catalog docs (`bash scripts/check-docs.sh`).
     DocsLint,
     /// Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`).
@@ -1476,6 +1482,9 @@ async fn run(command: Option<Command>) -> Result<()> {
             }
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh").await,
             DevAction::E2eLadder => commands::dev_script("cli/scripts/e2e-ladder.sh").await,
+            DevAction::ChartRuntimeE2e => {
+                commands::dev_script("scripts/chart-runtime-e2e.sh").await
+            }
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh").await,
             DevAction::PluginCompat => commands::dev_script("scripts/check-plugin-compat.sh").await,
             DevAction::EvalFalsifiability => {
@@ -2795,6 +2804,14 @@ mod tests {
             cli.command,
             Some(Command::Dev {
                 action: DevAction::E2eLadder
+            })
+        ));
+        let cli = Cli::try_parse_from(["agentos", "dev", "chart-runtime-e2e"])
+            .expect("dev chart-runtime-e2e should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::ChartRuntimeE2e
             })
         ));
     }

--- a/scripts/chart-runtime-e2e.sh
+++ b/scripts/chart-runtime-e2e.sh
@@ -107,9 +107,27 @@ MINIO_SVC="$FULLNAME-minio"
 SECRET_NAME="$FULLNAME-secrets"
 MINIO_BUCKET="agentos-bundles"
 MINIO_USER="minio"
+# Ownership label stamped on any namespace THIS script creates. The script only
+# ever deletes a namespace carrying this label, so pointing --namespace at a
+# pre-existing namespace (e.g. `default`) can never destroy it.
+OWNED_LABEL="agentos-e2e-harness/owned"
 
 banner() { echo; echo "== $* =="; }
 fail() { echo; echo "FAIL: $*"; exit 1; }
+
+# ns_is_owned <ns> : true iff the namespace exists AND carries the ownership label.
+ns_is_owned() {
+  local ns="$1" val
+  val="$(kubectl get ns "$ns" -o "jsonpath={.metadata.labels['agentos-e2e-harness/owned']}" 2>/dev/null || echo "")"
+  [[ "$val" == "true" ]]
+}
+
+# create_owned_ns <ns> : create the namespace and stamp the ownership label on it.
+create_owned_ns() {
+  local ns="$1"
+  kubectl create ns "$ns"
+  kubectl label ns "$ns" "${OWNED_LABEL}=true" --overwrite >/dev/null
+}
 
 # --------------------------------------------------------------------------
 # Guardrails
@@ -130,7 +148,12 @@ teardown() {
   fi
   banner "TEARDOWN"
   helm uninstall "$RELEASE" -n "$NAMESPACE" --no-hooks >/dev/null 2>&1 || true
-  kubectl delete ns "$NAMESPACE" --wait=false >/dev/null 2>&1 || true
+  # Only ever delete a namespace THIS script created (carries the ownership label).
+  if ns_is_owned "$NAMESPACE"; then
+    kubectl delete ns "$NAMESPACE" --wait=false >/dev/null 2>&1 || true
+  else
+    echo "namespace $NAMESPACE not owned by this harness; leaving it in place"
+  fi
   return $rc
 }
 trap teardown EXIT
@@ -139,18 +162,32 @@ trap teardown EXIT
 # Helpers
 # --------------------------------------------------------------------------
 
-# exec_echo <label> <exec-args...> : run a kubectl exec, echo the command and its
-# raw stdout, and capture the output in the global EXEC_OUT for the caller.
+# exec_echo <label> <exec-args...> : run a kubectl exec, echo the command, its
+# exit code, and its stdout/stderr SEPARATELY. Captures stdout into the global
+# EXEC_OUT, stderr into EXEC_ERR, and the exit code into EXEC_RC for the caller.
+# Verdicts MUST key on EXEC_OUT (stdout) only -- folding stderr into the captured
+# value can make an empty result look non-empty (e.g. a "Permission denied" line)
+# and yield a false PASS.
 exec_echo() {
   local label="$1"; shift
   echo "--- $label"
   echo "\$ kubectl exec $POD_NAME -n $NAMESPACE $*"
+  local out_file err_file
+  out_file="$(mktemp /tmp/e2e-exec-out.XXXXXX)"
+  err_file="$(mktemp /tmp/e2e-exec-err.XXXXXX)"
   set +e
-  EXEC_OUT="$(kubectl exec "$POD_NAME" -n "$NAMESPACE" "$@" 2>&1)"
-  local ec=$?
+  kubectl exec "$POD_NAME" -n "$NAMESPACE" "$@" >"$out_file" 2>"$err_file"
+  EXEC_RC=$?
   set -e
-  echo "[exit $ec] output:"
+  EXEC_OUT="$(cat "$out_file")"
+  EXEC_ERR="$(cat "$err_file")"
+  rm -f "$out_file" "$err_file"
+  echo "[exit $EXEC_RC] stdout:"
   printf '%s\n' "$EXEC_OUT" | sed 's/^/    /'
+  if [[ -n "$EXEC_ERR" ]]; then
+    echo "stderr:"
+    printf '%s\n' "$EXEC_ERR" | sed 's/^/    /'
+  fi
 }
 
 # build_bound_pod : read the installed SandboxTemplate, extract its podTemplate,
@@ -272,8 +309,9 @@ run_assertions() {
   # empty config.json result below is meaningful (not a no-op fetch).
   exec_echo "positive control: bundle manifest present" \
     -c runner -- sh -c 'find /bundles/current -name plugin.json'
-  local manifest="$EXEC_OUT"
-  if [[ -z "${manifest//[[:space:]]/}" ]]; then
+  # Bundle present only if the exec succeeded AND the manifest path printed on
+  # STDOUT (stderr like "Permission denied" must never count as present).
+  if [[ "$EXEC_RC" -ne 0 || -z "${EXEC_OUT//[[:space:]]/}" ]]; then
     banner "DIAGNOSTICS (positive control failed)"
     kubectl logs "$POD_NAME" -n "$NAMESPACE" -c bundle-fetch || true
     kubectl logs "$POD_NAME" -n "$NAMESPACE" -c bundle-extract || true
@@ -321,15 +359,25 @@ run_assertions() {
 banner "PRECHECK context=$CURRENT_CTX namespace=$NAMESPACE release=$RELEASE"
 
 if kubectl get ns "$NAMESPACE" >/dev/null 2>&1; then
-  banner "namespace $NAMESPACE already exists -- cleaning up before run"
-  helm uninstall "$RELEASE" -n "$NAMESPACE" --no-hooks >/dev/null 2>&1 || true
-  kubectl delete ns "$NAMESPACE" --wait=true --timeout=120s >/dev/null 2>&1 || true
+  # Only reclaim a namespace WE created. An unlabeled pre-existing namespace
+  # (e.g. `default`, or someone else's) must never be deleted by this harness.
+  if ns_is_owned "$NAMESPACE"; then
+    banner "namespace $NAMESPACE already exists (harness-owned) -- cleaning up before run"
+    helm uninstall "$RELEASE" -n "$NAMESPACE" --no-hooks >/dev/null 2>&1 || true
+    kubectl delete ns "$NAMESPACE" --wait=true --timeout=120s >/dev/null 2>&1 || true
+  else
+    fail "namespace $NAMESPACE already exists and is NOT owned by this harness (missing label ${OWNED_LABEL}=true). Remove it manually or pick another --namespace."
+  fi
 fi
+
+# Pre-create the namespace stamped with the ownership label so teardown/cleanup
+# can only ever delete a namespace this script created.
+create_owned_ns "$NAMESPACE"
 
 banner "INSTALL trimmed chart"
 install_chart() {
   helm install "$RELEASE" "$CHART_PATH" \
-    -n "$NAMESPACE" --create-namespace --no-hooks \
+    -n "$NAMESPACE" --no-hooks \
     -f "$CHART_PATH/values-e2e-nogvisor.yaml" \
     -f "$CHART_PATH/values-e2e-harness.yaml"
 }
@@ -338,7 +386,11 @@ install_chart() {
 if ! install_chart; then
   echo "helm install failed once (likely transient API churn on shared node); retrying in 5s..."
   sleep 5
-  kubectl delete ns "$NAMESPACE" --wait=true --timeout=60s >/dev/null 2>&1 || true
+  # Recreate the labeled namespace before retrying; only ever delete our own.
+  if ns_is_owned "$NAMESPACE"; then
+    kubectl delete ns "$NAMESPACE" --wait=true --timeout=60s >/dev/null 2>&1 || true
+  fi
+  create_owned_ns "$NAMESPACE"
   install_chart || fail "helm install failed twice"
 fi
 

--- a/scripts/chart-runtime-e2e.sh
+++ b/scripts/chart-runtime-e2e.sh
@@ -1,0 +1,465 @@
+#!/usr/bin/env bash
+#
+# chart-runtime-e2e.sh -- one-command RUNTIME e2e for the AgentOS Helm chart.
+#
+# WHY THIS EXISTS
+# ---------------
+# `helm lint` and `helm template` render manifests but NEVER run a container.
+# They cannot catch a bug that only manifests when an init container executes --
+# e.g. issue #56, where the bundle-fetch init container ran `mc alias set`, which
+# writes the MinIO ROOT credential in cleartext to MC_CONFIG_DIR/config.json,
+# and that dir sat on the `bundles` emptyDir the untrusted `runner` container
+# also mounts. The acceptance criterion is a RUNTIME exec:
+#   kubectl exec <sandbox> -c runner -- find /bundles -name config.json   # empty
+# This harness makes that check one command.
+#
+# THE PATTERN (reusable -- this is NOT a #56 one-off)
+# ---------------------------------------------------
+# 1. Install a trimmed chart slice on k8scratch (MinIO + agent-sandbox only).
+# 2. Seed a real bundle object into MinIO.
+# 3. Render the SandboxTemplate.spec.podTemplate into a BOUND sandbox Pod
+#    (AGENTOS_BUNDLE_REF pointing at the seeded object) and apply it -- so the
+#    real bundle-fetch/bundle-extract init containers actually run.
+# 4. Wait for the init pair to complete and the runner container to be Running.
+# 5. `kubectl exec` into the runner and ASSERT on what it can see.
+#
+# HOW TO ADD ANOTHER RUNTIME ASSERTION
+# ------------------------------------
+# The generic seam is "render template -> bind bundle -> exec runner -> assert".
+# To add a new runtime check, add a new `kubectl exec e2e-bound-sandbox -c runner
+# -- <cmd>` inside run_assertions() and fold its result into the PASS/FAIL logic.
+# Reuse exec_echo() so the command and its raw output are auditable in the log.
+#
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Config / flags
+# --------------------------------------------------------------------------
+NAMESPACE="agentos-e2eharness"
+RELEASE="e2eharness"
+CHART="charts/agentos"
+KEEP=0
+FORCE=0
+RUNNER_IMAGE=""
+EXPECT_VULNERABLE=0
+POD_NAME="e2e-bound-sandbox"
+BUNDLE_REF="e2e/probe.tgz"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/chart-runtime-e2e.sh [options]
+
+Stands up a trimmed AgentOS chart slice on the k8scratch cluster, seeds a real
+bundle into MinIO, renders a bound agent-sandbox Pod, runs its bundle-fetch/
+extract init containers, and execs the runner to assert the #56 credential is
+NOT readable off the shared bundle volume (and the bundle really was provisioned).
+
+Options:
+  --namespace <ns>       Namespace to use (default: agentos-e2eharness)
+  --release <name>       Helm release name (default: e2eharness)
+  --chart <path>         Chart path, relative to repo root (default: charts/agentos)
+  --runner-image <img>   Override ONLY the runner container image with this image
+                         (command: sleep 3600, probes/ports stripped). Robustness
+                         fallback when the real runner image will not reach Running
+                         on the cluster; the #56 assertion only needs the runner's
+                         VIEW of the shared bundle mount. Default: real runner image.
+  --expect-vulnerable    Negative-control mode: INVERT the security assertion, so
+                         PASS means the credential IS exposed. Point at an unfixed
+                         template to prove the harness discriminates.
+  --keep                 Skip teardown (leave namespace + release for debugging).
+  --force                Allow running against a non-k8scratch kube context.
+  --help                 Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --release) RELEASE="$2"; shift 2 ;;
+    --chart) CHART="$2"; shift 2 ;;
+    --runner-image) RUNNER_IMAGE="$2"; shift 2 ;;
+    --expect-vulnerable) EXPECT_VULNERABLE=1; shift ;;
+    --keep) KEEP=1; shift ;;
+    --force) FORCE=1; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# Resolve repo root from this script's location so --chart is repo-relative.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+case "$CHART" in
+  /*) CHART_PATH="$CHART" ;;
+  *) CHART_PATH="$REPO_ROOT/$CHART" ;;
+esac
+
+# Derived resource names -- mirror the chart's `agentos.fullname` helper exactly
+# (nameOverride/fullnameOverride empty): fullname == release if it already
+# contains the chart name "agentos", else "<release>-agentos".
+if [[ "$RELEASE" == *agentos* ]]; then
+  FULLNAME="$RELEASE"
+else
+  FULLNAME="$RELEASE-agentos"
+fi
+SANDBOX_TEMPLATE="$FULLNAME-runner"
+MINIO_SVC="$FULLNAME-minio"
+SECRET_NAME="$FULLNAME-secrets"
+MINIO_BUCKET="agentos-bundles"
+MINIO_USER="minio"
+
+banner() { echo; echo "== $* =="; }
+fail() { echo; echo "FAIL: $*"; exit 1; }
+
+# --------------------------------------------------------------------------
+# Guardrails
+# --------------------------------------------------------------------------
+CURRENT_CTX="$(kubectl config current-context 2>/dev/null || echo "")"
+if [[ "$CURRENT_CTX" != "k8scratch" && "$FORCE" -ne 1 ]]; then
+  fail "kube context is '$CURRENT_CTX', not 'k8scratch'. Refusing (override with --force)."
+fi
+
+# --------------------------------------------------------------------------
+# Teardown (trap on EXIT). Leaves the cluster-scoped sandbox* CRDs alone.
+# --------------------------------------------------------------------------
+teardown() {
+  local rc=$?
+  if [[ "$KEEP" -eq 1 ]]; then
+    banner "TEARDOWN skipped (--keep); namespace $NAMESPACE left in place"
+    return $rc
+  fi
+  banner "TEARDOWN"
+  helm uninstall "$RELEASE" -n "$NAMESPACE" --no-hooks >/dev/null 2>&1 || true
+  kubectl delete ns "$NAMESPACE" --wait=false >/dev/null 2>&1 || true
+  return $rc
+}
+trap teardown EXIT
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+# exec_echo <label> <exec-args...> : run a kubectl exec, echo the command and its
+# raw stdout, and capture the output in the global EXEC_OUT for the caller.
+exec_echo() {
+  local label="$1"; shift
+  echo "--- $label"
+  echo "\$ kubectl exec $POD_NAME -n $NAMESPACE $*"
+  set +e
+  EXEC_OUT="$(kubectl exec "$POD_NAME" -n "$NAMESPACE" "$@" 2>&1)"
+  local ec=$?
+  set -e
+  echo "[exit $ec] output:"
+  printf '%s\n' "$EXEC_OUT" | sed 's/^/    /'
+}
+
+# build_bound_pod : read the installed SandboxTemplate, extract its podTemplate,
+# and emit a bound `kind: Pod` manifest on stdout. This is the generic
+# "render template -> bind bundle" step; any runtime assertion reuses the Pod.
+build_bound_pod() {
+  local template_json="$1"
+  POD_NAME="$POD_NAME" NAMESPACE="$NAMESPACE" BUNDLE_REF="$BUNDLE_REF" \
+    RUNNER_IMAGE="$RUNNER_IMAGE" python3 - "$template_json" <<'PY'
+import json, os, sys
+
+st = json.load(open(sys.argv[1]))
+pod_tmpl = st["spec"]["podTemplate"]
+spec = dict(pod_tmpl.get("spec", {}))
+
+pod_name = os.environ["POD_NAME"]
+namespace = os.environ["NAMESPACE"]
+bundle_ref = os.environ["BUNDLE_REF"]
+runner_image = os.environ.get("RUNNER_IMAGE", "")
+
+# Bind the bundle: replace any AGENTOS_BUNDLE_REF env (drop valueFrom) with the
+# seeded object key, in every container and initContainer that declares it.
+def bind_ref(container):
+    env = container.get("env")
+    if not env:
+        return
+    for e in env:
+        if e.get("name") == "AGENTOS_BUNDLE_REF":
+            e.clear()
+            e["name"] = "AGENTOS_BUNDLE_REF"
+            e["value"] = bundle_ref
+
+for c in spec.get("initContainers", []):
+    bind_ref(c)
+for c in spec.get("containers", []):
+    bind_ref(c)
+
+# Use the default ServiceAccount (avoids a missing-SA scheduling failure).
+spec.pop("serviceAccountName", None)
+spec.pop("automountServiceAccountToken", None)
+spec["restartPolicy"] = "Never"
+
+# Optional runner-image override: swap ONLY the runner container's image for a
+# trivially-runnable one. The #56 assertion depends on the runner's VIEW of the
+# shared bundle mount, not the runner binary, so this is a safe fallback when the
+# real runner image will not reach Running on the cluster.
+if runner_image:
+    for c in spec.get("containers", []):
+        if c.get("name") == "runner":
+            c["image"] = runner_image
+            c["command"] = ["/bin/sh", "-c", "sleep 3600"]
+            c.pop("readinessProbe", None)
+            c.pop("livenessProbe", None)
+            c.pop("ports", None)
+
+pod = {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "name": pod_name,
+        "namespace": namespace,
+        "labels": pod_tmpl.get("metadata", {}).get("labels", {}),
+    },
+    "spec": spec,
+}
+print(json.dumps(pod))
+PY
+}
+
+# wait_for_init_complete : block until BOTH init containers are terminated with
+# reason=Completed and the runner container is state=running (not necessarily
+# Ready -- /healthz readiness may never flip, but exec works on a Running
+# container). Dumps diagnostics and fails on timeout.
+wait_for_init_complete() {
+  local timeout=180 waited=0 interval=4
+  while true; do
+    local pod_json
+    pod_json="$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" -o json 2>/dev/null || echo '{}')"
+    local ready
+    ready="$(printf '%s' "$pod_json" | python3 -c '
+import json, sys
+p = json.load(sys.stdin)
+st = p.get("status", {})
+inits = st.get("initContainerStatuses", [])
+conts = st.get("containerStatuses", [])
+init_ok = len(inits) >= 2 and all(
+    (c.get("state", {}).get("terminated", {}) or {}).get("reason") == "Completed"
+    for c in inits
+)
+runner_running = any(
+    c.get("name") == "runner" and "running" in c.get("state", {})
+    for c in conts
+)
+print("yes" if (init_ok and runner_running) else "no")
+' 2>/dev/null || echo "no")"
+    if [[ "$ready" == "yes" ]]; then
+      return 0
+    fi
+    if [[ "$waited" -ge "$timeout" ]]; then
+      banner "DIAGNOSTICS (timeout after ${timeout}s)"
+      kubectl describe pod "$POD_NAME" -n "$NAMESPACE" || true
+      echo "--- bundle-fetch logs"
+      kubectl logs "$POD_NAME" -n "$NAMESPACE" -c bundle-fetch || true
+      echo "--- bundle-extract logs"
+      kubectl logs "$POD_NAME" -n "$NAMESPACE" -c bundle-extract || true
+      fail "bound sandbox did not reach (init Completed + runner Running) within ${timeout}s"
+    fi
+    sleep "$interval"
+    waited=$((waited + interval))
+  done
+}
+
+# run_assertions : exec the runner and evaluate the positive control + the #56
+# security assertion. Sets global RESULT to "PASS" or "FAIL".
+run_assertions() {
+  RESULT="FAIL"
+
+  # POSITIVE CONTROL: prove the bundle was actually fetched + extracted, so an
+  # empty config.json result below is meaningful (not a no-op fetch).
+  exec_echo "positive control: bundle manifest present" \
+    -c runner -- sh -c 'find /bundles/current -name plugin.json'
+  local manifest="$EXEC_OUT"
+  if [[ -z "${manifest//[[:space:]]/}" ]]; then
+    banner "DIAGNOSTICS (positive control failed)"
+    kubectl logs "$POD_NAME" -n "$NAMESPACE" -c bundle-fetch || true
+    kubectl logs "$POD_NAME" -n "$NAMESPACE" -c bundle-extract || true
+    fail "bundle not provisioned (no plugin.json under /bundles/current); test inconclusive"
+  fi
+
+  # SECURITY ASSERTION (#56): the MinIO credential must NOT be readable off the
+  # shared bundle volume from the runner's view.
+  exec_echo "security: mc config.json on shared volume" \
+    -c runner -- find /bundles -name config.json
+  local config_hits="$EXEC_OUT"
+  exec_echo "security: cleartext credential on shared volume" \
+    -c runner -- sh -c 'grep -rl miniosecret /bundles 2>/dev/null || true'
+  local cred_hits="$EXEC_OUT"
+
+  local exposed=0
+  if [[ -n "${config_hits//[[:space:]]/}" || -n "${cred_hits//[[:space:]]/}" ]]; then
+    exposed=1
+  fi
+
+  echo
+  if [[ "$EXPECT_VULNERABLE" -eq 1 ]]; then
+    # Negative control: the credential SHOULD be exposed on an unfixed template.
+    if [[ "$exposed" -eq 1 ]]; then
+      echo "negative control: credential IS exposed on shared volume (expected on unfixed template)"
+      RESULT="PASS"
+    else
+      echo "negative control: credential NOT exposed, but --expect-vulnerable expected it"
+      RESULT="FAIL"
+    fi
+  else
+    if [[ "$exposed" -eq 0 ]]; then
+      echo "security assertion clean: no config.json and no cleartext credential on shared volume"
+      RESULT="PASS"
+    else
+      echo "security assertion FAILED: MinIO credential is readable off the shared bundle volume"
+      RESULT="FAIL"
+    fi
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 1. Fresh namespace + trimmed install
+# --------------------------------------------------------------------------
+banner "PRECHECK context=$CURRENT_CTX namespace=$NAMESPACE release=$RELEASE"
+
+if kubectl get ns "$NAMESPACE" >/dev/null 2>&1; then
+  banner "namespace $NAMESPACE already exists -- cleaning up before run"
+  helm uninstall "$RELEASE" -n "$NAMESPACE" --no-hooks >/dev/null 2>&1 || true
+  kubectl delete ns "$NAMESPACE" --wait=true --timeout=120s >/dev/null 2>&1 || true
+fi
+
+banner "INSTALL trimmed chart"
+install_chart() {
+  helm install "$RELEASE" "$CHART_PATH" \
+    -n "$NAMESPACE" --create-namespace --no-hooks \
+    -f "$CHART_PATH/values-e2e-nogvisor.yaml" \
+    -f "$CHART_PATH/values-e2e-harness.yaml"
+}
+# k8scratch is shared and slightly flaky: a spurious "namespaces not found" at
+# install is usually API churn, so retry ONCE before failing.
+if ! install_chart; then
+  echo "helm install failed once (likely transient API churn on shared node); retrying in 5s..."
+  sleep 5
+  kubectl delete ns "$NAMESPACE" --wait=true --timeout=60s >/dev/null 2>&1 || true
+  install_chart || fail "helm install failed twice"
+fi
+
+# --------------------------------------------------------------------------
+# 2. Wait for MinIO Running (gate on the pod, not helm release status)
+# --------------------------------------------------------------------------
+banner "WAIT MinIO Running"
+if ! kubectl wait --for=condition=Ready pod \
+    -l app.kubernetes.io/component=minio \
+    -n "$NAMESPACE" --timeout=180s; then
+  kubectl get pods -n "$NAMESPACE" || true
+  kubectl describe pod -l app.kubernetes.io/component=minio -n "$NAMESPACE" || true
+  fail "MinIO pod did not become Ready"
+fi
+
+# --------------------------------------------------------------------------
+# 3. Seed a real bundle into MinIO
+# --------------------------------------------------------------------------
+banner "SEED bundle into MinIO"
+# Build a VALID tar.gz (bundle-extract runs `set -eu; tar -xzf`, so a malformed
+# archive fails the pod). Layout: myplugin/.claude-plugin/plugin.json.
+SEED_DIR="$(mktemp -d /tmp/e2e-bundle.XXXXXX)"
+mkdir -p "$SEED_DIR/myplugin/.claude-plugin"
+cat > "$SEED_DIR/myplugin/.claude-plugin/plugin.json" <<'JSON'
+{"name":"e2e-probe","version":"0.0.0"}
+JSON
+tar -czf "$SEED_DIR/probe.tgz" -C "$SEED_DIR" myplugin
+PROBE_B64="$(base64 -w0 "$SEED_DIR/probe.tgz" 2>/dev/null || base64 "$SEED_DIR/probe.tgz" | tr -d '\n')"
+
+# ConfigMap carrying the archive (binaryData is base64), plus a one-shot mc Job
+# that creates the bucket and uploads the object.
+cat <<EOF | kubectl apply -n "$NAMESPACE" -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: e2e-bundle-seed
+binaryData:
+  probe.tgz: $PROBE_B64
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: e2e-bundle-seed
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: seed
+          image: minio/mc
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              mc alias set src "http://$MINIO_SVC:9000" "$MINIO_USER" "\$PW"
+              mc mb -p "src/$MINIO_BUCKET"
+              mc cp /data/probe.tgz "src/$MINIO_BUCKET/$BUNDLE_REF"
+              echo "seeded $BUNDLE_REF"
+          env:
+            - name: PW
+              valueFrom:
+                secretKeyRef:
+                  name: $SECRET_NAME
+                  key: minioRootPassword
+          volumeMounts:
+            - name: bundle
+              mountPath: /data
+      volumes:
+        - name: bundle
+          configMap:
+            name: e2e-bundle-seed
+EOF
+
+if ! kubectl wait --for=condition=complete job/e2e-bundle-seed \
+    -n "$NAMESPACE" --timeout=120s; then
+  kubectl logs job/e2e-bundle-seed -n "$NAMESPACE" || true
+  fail "bundle seed Job did not complete"
+fi
+echo "bundle seeded: $BUNDLE_REF"
+
+# --------------------------------------------------------------------------
+# 4. Render + apply the bound sandbox Pod
+# --------------------------------------------------------------------------
+banner "RENDER bound sandbox Pod from SandboxTemplate $SANDBOX_TEMPLATE"
+if [[ -n "$RUNNER_IMAGE" ]]; then
+  echo "runner image override: $RUNNER_IMAGE"
+else
+  echo "runner image: real (from SandboxTemplate)"
+fi
+TEMPLATE_JSON="$(mktemp /tmp/e2e-sandboxtemplate.XXXXXX.json)"
+kubectl get sandboxtemplate "$SANDBOX_TEMPLATE" -n "$NAMESPACE" -o json > "$TEMPLATE_JSON"
+POD_JSON="$(mktemp /tmp/e2e-bound-pod.XXXXXX.json)"
+build_bound_pod "$TEMPLATE_JSON" > "$POD_JSON"
+kubectl apply -n "$NAMESPACE" -f "$POD_JSON"
+
+banner "WAIT init pair Completed + runner Running"
+wait_for_init_complete
+echo "bound sandbox ready: init containers Completed, runner Running"
+
+# --------------------------------------------------------------------------
+# 5. Assertions
+# --------------------------------------------------------------------------
+banner "ASSERT runtime security (#56)"
+run_assertions
+
+# --------------------------------------------------------------------------
+# Verdict
+# --------------------------------------------------------------------------
+echo
+if [[ "$EXPECT_VULNERABLE" -eq 1 ]]; then
+  echo "mode: negative-control (--expect-vulnerable)"
+else
+  echo "mode: default (expect secure)"
+fi
+if [[ "$RESULT" == "PASS" ]]; then
+  echo "PASS"
+  exit 0
+else
+  echo "FAIL"
+  exit 1
+fi


### PR DESCRIPTION
## What

- **`scripts/chart-runtime-e2e.sh`** plus **`agentos dev chart-runtime-e2e`** -- one command that, on a local cluster (`k8scratch`), installs a trimmed chart slice (`charts/agentos/values-e2e-harness.yaml`: MinIO + the agent-sandbox substrate only; every backing store, app service, and both preflights off; controller off; warm pool 0; fake model), seeds a real bundle into MinIO, renders the `SandboxTemplate.podTemplate` into a **bound** sandbox Pod that actually runs the `bundle-fetch`/`bundle-extract` init pair with a real `AGENTOS_BUNDLE_REF`, then execs the `runner` container and asserts the #56 credential-isolation criterion. Ships a positive control (the bundle really was provisioned) and an `--expect-vulnerable` negative-control mode. Idempotent, self-cleaning (namespace torn down on exit), refuses any non-`k8scratch` context without `--force`. The reusable seam is "render template -> bind bundle -> exec runner -> assert", so a future chart/runtime change adds a runtime assertion cheaply.
- **The rule, encoded in `AGENTS.md` + `charts/agentos/CLAUDE.md`:** a ticket whose acceptance criterion is a runtime/observable check is **not** satisfied by static verification (`helm lint`, `helm template`, typecheck, render). Run the stated check against a running cluster and paste its output; the harness is the cheap way to do it.

## Why

#56 (a MinIO root credential leaking onto the runner-visible `bundles` volume) has a runtime AC and was nearly shipped green on lint + template alone -- neither runs the init container that writes the credential file. The harness closes that gap.

## Notes

The harness itself (script, trimming overlay, and the two doc edits) is the work originally authored in the now-closed PR #201 by @TheConnMan; its first two commits are preserved verbatim with the original authorship. The one addition here brings it up to the repo's one-entry-point convention (CLAUDE.md), which hardened alongside `agentos dev e2e-ladder` (#690) after #201 was opened: the harness is now fronted as `agentos dev chart-runtime-e2e` (like every other contributor/CI verb) rather than a bare `scripts/` invocation, with the committed command manifests regenerated in the same change.

This is a distinct failure surface from the #690 parity ladder: `agentos dev e2e-ladder`'s cluster rung asserts deploy-then-message plumbing (a turn finalized, a reply came back) against an already-installed release; it never installs the chart and never exec-asserts the runner's filesystem, so a bundle-fetch credential leak would pass it. This harness is the chart-runtime-security half the ladder does not cover.

Verified: `cargo fmt --check`, `cargo clippy -- -D warnings`, the CLI parse tests, and `helm template` of the trimming overlay against current `main` all pass. The one failing `cargo test` case (`resume_wait`) is a pre-existing Valkey-dependent integration test unrelated to this change. The live on-cluster harness run remains the maintainer evidence captured on #201.

Closes #199