### PR TITLE
Own bundle credential plumbing for the compose tier and persist Slack tokens

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -546,6 +546,14 @@ export const commandManifest = {
                 "false"
               ],
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Opt-in: read a bundle-local `.env` (any dotenv path) as the LOWEST- priority model-credential source, so the compose stack boots live with no `set -a; source .env` step. Precedence: shell env > this file. Only AGENTOS_CREDENTIALS, CLAUDE_CODE_OAUTH_TOKEN, and ANTHROPIC_API_KEY are read; every other key in the file is ignored, and the value never reaches argv or logs (#749)",
+              "id": "env_file",
+              "long": "env-file",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/README.md
+++ b/cli/README.md
@@ -247,11 +247,11 @@ the optional Slack dispatcher.
 
 | Command | What it does |
 |---|---|
-| `agentos local up` | Bring the compose stack up (`docker compose --profile full up -d --wait` by default, `docker compose --profile core up -d --wait` with `--minimal`) and print URLs. Add `--slack` to append `--profile slack`. |
+| `agentos local up` | Bring the compose stack up (`docker compose --profile full up -d --wait` by default, `docker compose --profile core up -d --wait` with `--minimal`) and print URLs. Add `--slack` to append `--profile slack`. `--env-file <PATH>` reads the model credential from a bundle `.env` as a last-resort fallback (precedence: shell env > file; only `AGENTOS_CREDENTIALS`/`CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` are read, and the value never reaches argv or logs), so the stack boots live with no `set -a; source .env` step (#749). |
 | `agentos local down` | Stop the compose stack (`docker compose down`), keeping volumes. |
 | `agentos local status` | Show the compose stack's service status (`docker compose ps`). |
 | `agentos local observability` | Print the local platform's observability surfaces: AgentOS Console, Langfuse UI (traces / cost / evals), and the AgentOS API base. URLs are printed only; pass `--open` to also open the browsable ones (Console, Langfuse) in a browser. `--json` never opens a browser. |
-| `agentos local comms --slack` | Connect or disconnect a real Slack workspace for the compose stack. Reads `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN`, masks them in dry run output, starts or stops the dispatcher, and switches the worker between real Slack and the local stub. |
+| `agentos local comms --slack` | Connect or disconnect a real Slack workspace for the compose stack. Resolves `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN` with precedence `--app-token`/`--bot-token` flag > env var > a value persisted with `agentos secrets set` (so tokens saved once need no per-session re-export, #749), masks them in dry run output, starts or stops the dispatcher, and switches the worker between real Slack and the local stub. |
 | `agentos local message "..."` | Drive the local compose stack end to end with zero Slack. Enqueues straight to the compose Valkey and lets the containerized worker answer. |
 | `agentos local eval` | Run the bundle's `evals/cases.json` through the compose stack's enqueue -> worker -> sandbox -> reply path (one synthetic turn per case) and grade each captured reply with the SAME grader `skill eval` uses. Prints the identical per-case table + rollup; nonzero exit on failure. `--cases` overrides the file; `--dry-run` prints the plan. `--concurrency` defaults to 1 (sequential); values above 1 are refused for now (#709). |
 | `agentos local deploy` | Package the bundle as tar.gz and push it to the compose platform API (`--api-url`, default `http://localhost:28000`). Auth via `--api-key` or `AGENTOS_API_KEY`. |
@@ -491,17 +491,25 @@ suffix). `local message` composes with `--channel`, `--thread`, and
 `--release`, `--force-wire`, ...)
 with a clear error. The compose worker runs the fake model by default (a canned
 reply, no credentials); export a credential in your shell and `local up` or
-`local comms` goes live automatically for a real model. Set
-`AGENTOS_FAKE_MODEL=1` to force the fake model regardless of a credential
-being present.
+`local comms` goes live automatically for a real model. Instead of exporting it
+every session, point `agentos local up --env-file .env` at the bundle's own
+dotfile: the model credential is read from it as a last-resort fallback
+(precedence: shell env > file), so the stack boots live with no
+`set -a; source .env` step. Only `AGENTOS_CREDENTIALS`, `CLAUDE_CODE_OAUTH_TOKEN`,
+and `ANTHROPIC_API_KEY` are read; every other key in the file is ignored, and the
+value never reaches argv or logs. Set `AGENTOS_FAKE_MODEL=1` to force the fake
+model regardless of a credential being present.
 
 Use `agentos local comms --slack` when you want the same compose stack to talk
-to a real Slack workspace. Connect reads `SLACK_APP_TOKEN` and
-`SLACK_BOT_TOKEN`, masks them in printed commands, starts the dispatcher, and
-points the worker at real Slack, resolving the model the same way as `local up`
-(live when a credential is present, fake otherwise). `--disconnect` stops the
-dispatcher and restores the local stub. `--dry-run` prints the compose command
-only.
+to a real Slack workspace. Connect resolves `SLACK_APP_TOKEN` and
+`SLACK_BOT_TOKEN` with precedence `--app-token`/`--bot-token` flag > env var > a
+value persisted with `agentos secrets set SLACK_APP_TOKEN` /
+`agentos secrets set SLACK_BOT_TOKEN` -- so tokens saved once in AgentOS private
+storage need no per-session re-export -- masks them in printed commands, starts
+the dispatcher, and points the worker at real Slack, resolving the model the same
+way as `local up` (live when a credential is present, fake otherwise).
+`--disconnect` stops the dispatcher and restores the local stub. `--dry-run`
+prints the compose command only.
 
 Use `--continue` to reuse the last successful `local message` context from
 `.agentos/last-turn.json` in the current working directory, so only the new text

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -543,6 +543,14 @@
                 "false"
               ],
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Opt-in: read a bundle-local `.env` (any dotenv path) as the LOWEST- priority model-credential source, so the compose stack boots live with no `set -a; source .env` step. Precedence: shell env > this file. Only AGENTOS_CREDENTIALS, CLAUDE_CODE_OAUTH_TOKEN, and ANTHROPIC_API_KEY are read; every other key in the file is ignored, and the value never reaches argv or logs (#749)",
+              "id": "env_file",
+              "long": "env-file",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1010,7 +1010,7 @@ fn merge_secret_env(mut passthrough: Vec<String>, secrets: &[String]) -> Vec<Str
 /// alone reports `NAME=""` as present, which would suppress the vault fallback
 /// and forward nothing usable. Mirrors `ops.rs::resolve_up_credentials` and
 /// `interactive.rs::env_credential_present`.
-fn env_credential_present(name: &str) -> bool {
+pub(crate) fn env_credential_present(name: &str) -> bool {
     std::env::var(name).is_ok_and(|value| !value.is_empty())
 }
 
@@ -1072,7 +1072,7 @@ const MODEL_CREDENTIAL_ENV_NAMES: [&str; 3] = [
 /// dropping every other key. An empty value is absent, not supplied (issue
 /// #540), so it is dropped too. A missing/unreadable file is a hard error --
 /// `--env-file` is an explicit opt-in, so pointing it at nothing is a mistake.
-fn parse_credential_env_file(path: &Path) -> Result<Vec<(String, String)>> {
+pub(crate) fn parse_credential_env_file(path: &Path) -> Result<Vec<(String, String)>> {
     let mut found = Vec::new();
     for item in dotenvy::from_path_iter(path)
         .with_context(|| format!("reading --env-file {}", path.display()))?
@@ -1092,7 +1092,7 @@ fn parse_credential_env_file(path: &Path) -> Result<Vec<(String, String)>> {
 /// process env. Mirrors `load_model_credentials_from_secret_store`'s shape:
 /// `AGENTOS_CREDENTIALS` dominates and suppresses the SDK pair, matching
 /// `select_passthrough_env`'s byo branch.
-fn resolve_env_file_credentials(
+pub(crate) fn resolve_env_file_credentials(
     parsed: &[(String, String)],
     is_present: &dyn Fn(&str) -> bool,
 ) -> Vec<(String, String)> {

--- a/cli/src/comms.rs
+++ b/cli/src/comms.rs
@@ -222,6 +222,49 @@ pub fn require_connect_tokens(disconnect: bool, app_token: &str, bot_token: &str
     Ok(())
 }
 
+/// Decide a Slack token from the two candidate sources, highest wins: the
+/// clap-merged `--flag`/env value, then a value persisted via `agentos secrets
+/// set` (#749). `cli_value` is empty when neither the flag nor the env var was
+/// supplied; `saved` is `None` when the vault has no entry. Returns the empty
+/// string when nothing is available, which `require_connect_tokens` then rejects
+/// on connect. Pure so the precedence (flag/env > saved vault) is unit-testable
+/// without touching the vault or the process env.
+pub fn resolve_slack_token(cli_value: &str, saved: Option<String>) -> String {
+    if !cli_value.is_empty() {
+        return cli_value.to_string();
+    }
+    saved.unwrap_or_default()
+}
+
+/// Resolve a `local comms` Slack token from the live vault, so a token persisted
+/// once with `agentos secrets set SLACK_APP_TOKEN`/`SLACK_BOT_TOKEN` survives
+/// across sessions and `--slack` needs no per-session re-export (#749).
+/// Precedence: the clap-merged `--flag`/env `cli_value` wins; only when it is
+/// empty is the vault consulted. The vault is never read on `--disconnect`
+/// (which needs no tokens) or when a value was already supplied, so an unrelated
+/// run never opens the credential store. Emits a masked "loaded from storage"
+/// note, never the value; the resolved token still travels only through the
+/// masked `secret_env` channel downstream.
+pub fn resolve_local_slack_token(name: &str, cli_value: &str, disconnect: bool) -> Result<String> {
+    if !cli_value.is_empty() || disconnect {
+        return Ok(cli_value.to_string());
+    }
+    let saved = if crate::secrets::is_saved(name)? {
+        match crate::secrets::get_value(name)? {
+            Some(value) => {
+                crate::ui::ui().note(&format!(
+                    "{name}: loaded from AgentOS private storage for this run"
+                ));
+                Some(value)
+            }
+            None => None,
+        }
+    } else {
+        None
+    };
+    Ok(resolve_slack_token(cli_value, saved))
+}
+
 /// Output of `<tier> comms`: the dry-run plan, or the resulting Slack wiring
 /// state. `--json` emits a JSON object; the real path formerly emitted only
 /// stderr notes, so `comms --json` on success exited 0 with empty stdout (#485).
@@ -368,6 +411,26 @@ mod tests {
         assert!(require_provider(true).is_ok());
         let err = require_provider(false).unwrap_err().to_string();
         assert!(err.contains("specify a chat surface"), "{err}");
+    }
+
+    /// #749 token resolution precedence: the clap-merged `--flag`/env value wins;
+    /// only when it is empty does the saved vault value apply; empty + no saved
+    /// value yields the empty string (which `require_connect_tokens` rejects on
+    /// connect).
+    #[test]
+    fn resolve_slack_token_prefers_flag_env_then_saved_vault() {
+        // Flag/env supplied: wins even when a vault value also exists.
+        assert_eq!(
+            resolve_slack_token("xapp-flag", Some("xapp-saved".to_string())),
+            "xapp-flag"
+        );
+        // Flag/env empty: fall back to the saved vault value.
+        assert_eq!(
+            resolve_slack_token("", Some("xapp-saved".to_string())),
+            "xapp-saved"
+        );
+        // Nothing anywhere: empty (rejected downstream on connect).
+        assert_eq!(resolve_slack_token("", None), "");
     }
 
     #[test]
@@ -680,6 +743,7 @@ mod tests {
                 local_model: None,
                 slack: false,
                 model_mode: mode,
+                env_file: None,
             })
             .env;
             let connect_env = local_connect_commands(&local_comms_opts(false, mode))[0]
@@ -714,6 +778,7 @@ mod tests {
                 local_model: None,
                 slack: false,
                 model_mode: mode,
+                env_file: None,
             })
             .env;
             let disconnect_env = local_disconnect_commands(&local_comms_opts(true, mode))[1]
@@ -747,6 +812,7 @@ mod tests {
                 local_model: None,
                 slack: false,
                 model_mode: ModelMode::DefaultFake,
+                env_file: None,
             })
             .env;
             let connect_env = local_connect_commands(&local_comms_opts_with(
@@ -783,6 +849,7 @@ mod tests {
                 local_model: None,
                 slack: false,
                 model_mode: ModelMode::DefaultFake,
+                env_file: None,
             })
             .env;
             let disconnect_env = local_disconnect_commands(&local_comms_opts_with(

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -6,6 +6,8 @@
 //! (or the `--dry-run` printer) consumes it, so argv construction stays
 //! unit-testable with no Docker daemon.
 
+use std::path::Path;
+
 use anyhow::{bail, Result};
 
 use crate::commands::OLLAMA_PORT;
@@ -134,13 +136,76 @@ pub fn otel_endpoint_env_override(minimal: bool) -> Option<(String, String)> {
 /// empty-string-is-not-a-credential rule); a credential is any non-empty
 /// CREDENTIAL_ENV_VARS value.
 pub fn model_mode_from_env() -> ModelMode {
+    model_mode_from_env_with_file_credential(false)
+}
+
+/// The shell parity decision, folding in whether an opt-in `.env` supplied a
+/// model credential the shell did not (#749). `file_has_credential` makes the
+/// stack go live exactly like a shell credential would, unless the shell pins
+/// `AGENTOS_FAKE_MODEL` truthy -- in which case the pin still wins
+/// (`FakePinnedDespiteCredential`). Reads the shell for the pin and for its own
+/// credentials; a `.env`-only credential is the sole extra input.
+pub fn model_mode_from_env_with_file_credential(file_has_credential: bool) -> ModelMode {
     let explicit = std::env::var("AGENTOS_FAKE_MODEL")
         .ok()
         .filter(|s| !s.is_empty());
-    let has_credential = CREDENTIAL_ENV_VARS
-        .iter()
-        .any(|v| std::env::var(v).map(|s| !s.is_empty()).unwrap_or(false));
+    let has_credential = file_has_credential
+        || CREDENTIAL_ENV_VARS
+            .iter()
+            .any(|v| std::env::var(v).map(|s| !s.is_empty()).unwrap_or(false));
     resolve_model_mode(explicit.as_deref(), has_credential)
+}
+
+/// Resolve the opt-in bundle `.env` plan for `local up` (#749, ADR-0070): the
+/// model credentials to inject into the compose child, plus the effective model
+/// mode. Pure -- the shell-presence predicate and the explicit `AGENTOS_FAKE_MODEL`
+/// pin are injected -- so both the precedence (shell env wins over `.env`) and
+/// the "a `.env`-only credential still boots live" rule are unit-testable without
+/// touching the process environment.
+///
+/// `parsed` is the recognized model-credential names read from the file;
+/// `shell_present(name)` is whether the shell already exports it non-empty (a
+/// shell value always wins, so a present name is never taken from the file);
+/// `explicit_fake_model` / `shell_has_credential` are the shell inputs to the
+/// parity decision. The returned credentials are only those absent from the
+/// shell, ready to be attached as masked `secret_env` (never argv).
+pub fn resolve_env_file_up_plan(
+    parsed: &[(String, String)],
+    shell_present: &dyn Fn(&str) -> bool,
+    explicit_fake_model: Option<&str>,
+    shell_has_credential: bool,
+) -> (Vec<(String, String)>, ModelMode) {
+    let creds = crate::commands::resolve_env_file_credentials(parsed, shell_present);
+    let has_credential = shell_has_credential || !creds.is_empty();
+    let mode = resolve_model_mode(explicit_fake_model, has_credential);
+    (creds, mode)
+}
+
+/// Read the opt-in bundle `.env` and resolve the credentials `local up` should
+/// inject plus the effective model mode, from the live process environment. A
+/// `None` path means no file is read (returns no credentials and the shell-only
+/// mode). Thin IO wrapper over the pure [`resolve_env_file_up_plan`]; the file
+/// is parsed for the recognized model-credential names only, every other key
+/// ignored.
+pub fn load_env_file_up_plan(
+    env_file: Option<&Path>,
+) -> Result<(Vec<(String, String)>, ModelMode)> {
+    let Some(path) = env_file else {
+        return Ok((Vec::new(), model_mode_from_env()));
+    };
+    let parsed = crate::commands::parse_credential_env_file(path)?;
+    let explicit = std::env::var("AGENTOS_FAKE_MODEL")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let shell_has_credential = CREDENTIAL_ENV_VARS
+        .iter()
+        .any(|v| crate::commands::env_credential_present(v));
+    Ok(resolve_env_file_up_plan(
+        &parsed,
+        &|name| crate::commands::env_credential_present(name),
+        explicit.as_deref(),
+        shell_has_credential,
+    ))
 }
 
 /// Flags shared by every `local` verb.
@@ -153,6 +218,11 @@ pub struct LocalOpts {
     /// Model mode resolved from the shell (skill-tier parity). Only `up`
     /// consumes it; `down`/`status` set `DefaultFake`.
     pub model_mode: ModelMode,
+    /// Opt-in bundle-local `.env` path (#749, ADR-0070): the LOWEST-priority
+    /// model-credential source for the compose stack, so a bundle boots live
+    /// with no `set -a; source .env` step. `None` means no file is read. Only
+    /// `up` consumes it; the other verbs set `None`.
+    pub env_file: Option<std::path::PathBuf>,
 }
 
 pub struct LocalDownOpts {
@@ -388,9 +458,31 @@ impl crate::ui::CliOutput for LocalUpOutput {
     }
 }
 
-pub async fn up(o: LocalOpts) -> Result<LocalUpOutput> {
+pub async fn up(mut o: LocalOpts) -> Result<LocalUpOutput> {
     let ui = crate::ui::ui();
-    let cmd = up_command(&o);
+    // #749/ADR-0070: an opt-in bundle `.env` is the LOWEST-priority model
+    // credential source. A name exported in the shell always wins; only a name
+    // absent from the shell is taken from the file. The value is injected into
+    // the compose child as masked `secret_env` (never argv/logs), and a
+    // `.env`-only credential still flips the stack live -- so the model mode is
+    // recomputed with the file credential folded in.
+    let (env_creds, env_file_mode) = load_env_file_up_plan(o.env_file.as_deref())?;
+    if o.env_file.is_some() {
+        o.model_mode = env_file_mode;
+        for (name, _) in &env_creds {
+            ui.note(&format!(
+                "{name}: loaded from --env-file {} for this run",
+                o.env_file
+                    .as_deref()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_default()
+            ));
+        }
+    }
+    let mut cmd = up_command(&o);
+    if !env_creds.is_empty() {
+        cmd = cmd.with_secret_env(env_creds);
+    }
     if o.dry_run {
         return Ok(LocalUpOutput::DryRun(crate::ui::DryRunPlan {
             lines: vec![cmd.display()],
@@ -678,6 +770,7 @@ mod tests {
             local_model: None,
             slack: false,
             model_mode: ModelMode::DefaultFake,
+            env_file: None,
         }
     }
 
@@ -689,6 +782,7 @@ mod tests {
             local_model: Some(model.into()),
             slack: false,
             model_mode: ModelMode::DefaultFake,
+            env_file: None,
         }
     }
 
@@ -877,6 +971,99 @@ mod tests {
         o.slack = true;
         let display = rebuild_command(&o, "agentos-dispatcher").display();
         assert!(display.contains("--profile slack"));
+    }
+
+    /// #749/ADR-0070 precedence: a credential exported in the SHELL always wins
+    /// over the same name in the opt-in `.env`, so a shell-present name is never
+    /// taken from the file. Here the shell already has `ANTHROPIC_API_KEY`, so the
+    /// file copy is dropped; nothing is injected and the mode stays whatever the
+    /// shell dictated (live, since the shell has the credential).
+    #[test]
+    fn env_file_up_plan_shell_env_wins_over_dotenv() {
+        let parsed = vec![("ANTHROPIC_API_KEY".to_string(), "from-file".to_string())];
+        let (creds, mode) = resolve_env_file_up_plan(
+            &parsed,
+            &|name| name == "ANTHROPIC_API_KEY", // shell already exports it
+            None,
+            true, // shell has the credential
+        );
+        assert!(
+            creds.is_empty(),
+            "a shell-present credential must not be taken from the file; got {creds:?}"
+        );
+        assert_eq!(mode, ModelMode::LiveFromCredential);
+    }
+
+    /// A credential present ONLY in the `.env` (absent from the shell) is
+    /// injected and still flips the stack live, so a bundle boots on the real
+    /// model with no `source` step.
+    #[test]
+    fn env_file_up_plan_dotenv_only_credential_boots_live() {
+        let parsed = vec![("ANTHROPIC_API_KEY".to_string(), "sk-from-file".to_string())];
+        let (creds, mode) = resolve_env_file_up_plan(
+            &parsed,
+            &|_| false, // shell exports nothing
+            None,
+            false,
+        );
+        assert_eq!(
+            creds,
+            vec![("ANTHROPIC_API_KEY".to_string(), "sk-from-file".to_string())]
+        );
+        assert_eq!(mode, ModelMode::LiveFromCredential);
+    }
+
+    /// The shell's `AGENTOS_FAKE_MODEL` pin still wins over a `.env` credential:
+    /// the operator explicitly asked for the fake model, so a file credential
+    /// does not silently override it (parity with a shell credential).
+    #[test]
+    fn env_file_up_plan_shell_fake_pin_beats_dotenv_credential() {
+        let parsed = vec![("ANTHROPIC_API_KEY".to_string(), "sk-from-file".to_string())];
+        let (creds, mode) = resolve_env_file_up_plan(&parsed, &|_| false, Some("1"), false);
+        // The credential is still injected (present for the runner), but the mode
+        // honors the pin.
+        assert_eq!(creds.len(), 1);
+        assert_eq!(mode, ModelMode::FakePinnedDespiteCredential);
+    }
+
+    /// The injected `.env` credential travels as masked `secret_env`: its raw
+    /// value never appears in the argv or the printed command line, only a masked
+    /// prefix. This is the leak-prevention property (cli/CLAUDE.md: credentials
+    /// masked, never printed).
+    #[test]
+    fn env_file_credential_is_masked_never_printed() {
+        let secret = "sk-ant-supersecretvalue";
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.model_mode = ModelMode::LiveFromCredential;
+        let cmd = up_command(&o)
+            .with_secret_env(vec![("ANTHROPIC_API_KEY".to_string(), secret.to_string())]);
+        let display = cmd.display();
+        assert!(
+            display.contains("ANTHROPIC_API_KEY=sk-ant-s***"),
+            "the token must be masked in the printed command line; got {display}"
+        );
+        assert!(
+            !display.contains(secret),
+            "the raw token leaked into the printed command line: {display}"
+        );
+        assert!(
+            !cmd.argv().iter().any(|a| a.contains(secret)),
+            "the raw token leaked into argv: {:?}",
+            cmd.argv()
+        );
+        // The credential rides secret_env, not the plain env vec.
+        assert!(cmd.env.iter().all(|(k, _)| k != "ANTHROPIC_API_KEY"));
+        assert!(cmd
+            .secret_env
+            .contains(&("ANTHROPIC_API_KEY".to_string(), secret.to_string())));
+    }
+
+    /// No `--env-file` means no file read and no injected credentials -- the
+    /// mode is the shell-only decision.
+    #[test]
+    fn load_env_file_up_plan_none_reads_nothing() {
+        let (creds, _mode) = load_env_file_up_plan(None).unwrap();
+        assert!(creds.is_empty());
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -587,6 +587,14 @@ enum LocalAction {
         /// Also start the optional Slack dispatcher (adds --profile slack).
         #[arg(long)]
         slack: bool,
+        /// Opt-in: read a bundle-local `.env` (any dotenv path) as the LOWEST-
+        /// priority model-credential source, so the compose stack boots live
+        /// with no `set -a; source .env` step. Precedence: shell env > this
+        /// file. Only AGENTOS_CREDENTIALS, CLAUDE_CODE_OAUTH_TOKEN, and
+        /// ANTHROPIC_API_KEY are read; every other key in the file is ignored,
+        /// and the value never reaches argv or logs (#749).
+        #[arg(long = "env-file", value_name = "PATH")]
+        env_file: Option<PathBuf>,
     },
     /// Rebuild + recreate ONE compose service (e.g. after a code change) without
     /// losing the stack's already-resolved credential/model-mode wiring.
@@ -1587,6 +1595,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 minimal,
                 local_model,
                 slack,
+                env_file,
             } => {
                 let file = resolve_compose_file(file, dry_run).await?;
                 emit(
@@ -1597,6 +1606,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         local_model,
                         slack,
                         model_mode: local::model_mode_from_env(),
+                        env_file,
                     })
                     .await?,
                 )
@@ -1619,6 +1629,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             local_model,
                             slack,
                             model_mode: local::model_mode_from_env(),
+                            env_file: None,
                         },
                         service,
                     })
@@ -1641,6 +1652,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             local_model: None,
                             slack: false,
                             model_mode: local::ModelMode::DefaultFake,
+                            env_file: None,
                         },
                         wipe,
                         yes,
@@ -1658,6 +1670,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                         local_model: None,
                         slack: false,
                         model_mode: local::ModelMode::DefaultFake,
+                        env_file: None,
                     })
                     .await?,
                 )
@@ -1673,6 +1686,14 @@ async fn run(command: Option<Command>) -> Result<()> {
             } => {
                 comms::require_provider(slack)?;
                 let resolved_file = resolve_compose_file(file, dry_run).await?;
+                // #749: fall back to Slack tokens persisted via `agentos secrets
+                // set` when neither a flag nor an env var supplied one, so
+                // `--slack` needs no per-session re-export. Precedence: flag/env
+                // > saved vault.
+                let app_token =
+                    comms::resolve_local_slack_token("SLACK_APP_TOKEN", &app_token, disconnect)?;
+                let bot_token =
+                    comms::resolve_local_slack_token("SLACK_BOT_TOKEN", &bot_token, disconnect)?;
                 emit(
                     comms::local_comms(LocalCommsOpts {
                         file: resolved_file,


### PR DESCRIPTION
Completes the two follow-ups ADR-0070 deferred under #749, applying the precedence that ADR decided (shell env > vault > file) to the compose tier. Ref ADR-0070.

## `agentos local up --env-file <PATH>`
Opt-in read of a bundle-local `.env` as the lowest-priority model-credential source, mirroring `skill up`, so the compose stack boots live with no `set -a; source .env` step.

- Only `AGENTOS_CREDENTIALS` / `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` are read; every other key in the file is ignored.
- Precedence: shell env > file. A name exported in the shell always wins; only a name absent from the shell is taken from the file.
- A `.env`-only credential still flips the stack live (the model mode is recomputed with the file credential folded in), so it does not silently boot fake.
- The value is injected into the compose child as masked `secret_env`, so it never reaches argv or any printed command line.
- Scope note: `local up` has never hydrated the model credential from the vault, so that middle layer is deliberately left out for the compose tier rather than half-wired (injecting a vault-presence check without vault injection would suppress the `.env` fallback while supplying nothing). Full vault hydration for `local up`'s model credential can be a later follow-up.

## `agentos local comms --slack` token persistence
Falls back to `SLACK_APP_TOKEN` / `SLACK_BOT_TOKEN` persisted with `agentos secrets set` when neither a flag nor an env var supplied one, so tokens saved once need no per-session re-export.

- Precedence: `--app-token`/`--bot-token` flag > env var > saved vault.
- The vault is read only when a value is missing, and never on `--disconnect` (which needs no tokens).
- The resolved token still travels only through the existing masked `secret_env` channel; nothing new is printed.

## Other
- Promotes the dotenv precedence helpers (`parse_credential_env_file`, `resolve_env_file_credentials`, `env_credential_present`) to `pub(crate)` and reuses them rather than duplicating.
- Regenerates the committed command manifest (`cli/command-manifest.json` + `apps/ui/src/generated/commandManifest.ts`) for the new `--env-file` flag on `local up`.
- Updates `cli/README.md` where it documented the manual export steps.

## Tests
New unit tests: dotenv up-plan precedence (shell env wins over `.env`; a `.env`-only credential boots live; a shell `AGENTOS_FAKE_MODEL` pin still wins), the injected credential is masked and never printed/in argv, and `local comms` token resolution precedence (flag/env > saved vault). `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass.

## Note on framing
The task summary said "auto-load `.env` if present," but issue #749 itself specifies "Opt-in rather than implicit, since silently absorbing a dotfile into a process environment deserves an explicit gesture," and accepted ADR-0070 encodes that fail-closed posture. This PR follows the issue + ADR: opt-in via `--env-file`, matching `skill up`.

Closes #749