### PR TITLE
Add tool_called eval grader kind (ADR-0022 Phase 1)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1535,7 +1535,8 @@
             "enum": [
               "exact",
               "contains",
-              "regex"
+              "regex",
+              "tool_called"
             ],
             "title": "Kind",
             "type": "string"

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -405,7 +405,7 @@ class GraderOut(BaseModel):
     (`apps/worker/schema/eval-cases.schema.json`). Do not let this drift from the
     worker's `Grader` model."""
 
-    kind: Literal["exact", "contains", "regex"]
+    kind: Literal["exact", "contains", "regex", "tool_called"]
     expected: str
     case_sensitive: bool = False
 

--- a/apps/api/tests/test_eval_case_schema_parity.py
+++ b/apps/api/tests/test_eval_case_schema_parity.py
@@ -42,7 +42,7 @@ def _validator_for(def_name: str) -> Draft202012Validator:
     return Draft202012Validator({"$ref": f"#/$defs/{def_name}", "$defs": schema["$defs"]})
 
 
-@pytest.mark.parametrize("kind", ["exact", "contains", "regex"])
+@pytest.mark.parametrize("kind", ["exact", "contains", "regex", "tool_called"])
 def test_emitted_eval_case_validates_against_the_frozen_schema(kind: str) -> None:
     case = EvalCaseOut(
         id="c1",

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -66,7 +66,7 @@ export type RawTrace = Record<string, unknown>;
 // An eval case in the frozen eval-case format (#8/#259): an input prompt plus a
 // deterministic grader. Returned by promoteTraceToEvalCase.
 export interface GraderOut {
-  kind: "exact" | "contains" | "regex";
+  kind: "exact" | "contains" | "regex" | "tool_called";
   expected: string;
   case_sensitive: boolean;
 }

--- a/apps/ui/src/state/types.ts
+++ b/apps/ui/src/state/types.ts
@@ -70,7 +70,11 @@ export interface AppState {
 export interface PromotedEvalCase {
   id: string;
   input: string;
-  grader: { kind: "exact" | "contains" | "regex"; expected: string; case_sensitive: boolean };
+  grader: {
+    kind: "exact" | "contains" | "regex" | "tool_called";
+    expected: string;
+    case_sensitive: boolean;
+  };
 }
 
 export type Action =

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -50,7 +50,8 @@ and PR check read.
 EvalSuite (cases: input + grader)
    -> EvalRunner: deliver each case as an ACI `eval_case` event over the runner's
       HTTP channel (the kernel's RunnerClient), take the `final` text as the answer
-   -> Grader: exact | contains | regex -> pass/fail (deny-by-default; a case must
+   -> Grader: exact | contains | regex (on the answer text) | tool_called (on the
+      turn's tool-call trajectory) -> pass/fail (deny-by-default; a case must
       name a grader)
    -> EvalRunResult: per-case rows + the "N/M passed" summary
    -> LangfuseEvalRecorder: a trace + `eval_pass` score per case, tagged

--- a/apps/worker/schema/eval-cases.schema.json
+++ b/apps/worker/schema/eval-cases.schema.json
@@ -65,7 +65,7 @@
       "type": "string"
     },
     "Grader": {
-      "description": "A single deterministic grader. MVP scope: string-shaped checks only.\n\n(An LLM-judge grader is a later addition; keeping these deterministic makes\neval results reproducible, which is the whole point of eval-as-CI.)",
+      "description": "A single deterministic grader.\n\nFor the text matchers (``exact``/``contains``/``regex``) ``expected`` is the\nstring to match against the answer text. For ``tool_called`` ``expected`` is\ninstead the *tool name* that must have been invoked during the turn; the\ngrader then reads the observed tool-call trajectory rather than the answer\ntext. Reusing ``expected`` as the tool name keeps this an additive enum value\nwith no new field -- the smallest possible touch to the frozen eval-case\nschema (ADR-0022 Phase 1).\n\n(An LLM-judge grader is a later addition governed by ADR-0042; keeping these\ndeterministic makes eval results reproducible, which is the whole point of\neval-as-CI.)",
       "properties": {
         "case_sensitive": {
           "default": false,
@@ -88,11 +88,12 @@
       "type": "object"
     },
     "GraderKind": {
-      "description": "How a case's expected value is compared against the agent's output.",
+      "description": "How a case's expected value is compared against the agent's output.\n\nThe three text matchers (``exact``/``contains``/``regex``) grade the turn's\nfinal answer TEXT. ``tool_called`` is the ADR-0022 Phase 1 addition: it grades\nthe turn's tool-call TRAJECTORY instead, asserting a named tool was actually\ninvoked during the turn. This closes the \"grade the last sentence\" gap -- a\ntext grader can confirm a version-shaped string appears in the reply but never\nthat the tool which was supposed to produce it ever ran. Reading the observed\ntrajectory (not the final text) is the whole point: grepping the answer for\nthe tool's name would be the mechanically-easy false green ADR-0022 warns\nagainst.",
       "enum": [
         "exact",
         "contains",
-        "regex"
+        "regex",
+        "tool_called"
       ],
       "title": "GraderKind",
       "type": "string"

--- a/apps/worker/src/agentos_worker/eval/models.py
+++ b/apps/worker/src/agentos_worker/eval/models.py
@@ -17,6 +17,7 @@ the eval matrix records per version.
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from enum import StrEnum
 
 from pydantic import (
@@ -30,11 +31,23 @@ from pydantic import (
 
 
 class GraderKind(StrEnum):
-    """How a case's expected value is compared against the agent's output."""
+    """How a case's expected value is compared against the agent's output.
+
+    The three text matchers (``exact``/``contains``/``regex``) grade the turn's
+    final answer TEXT. ``tool_called`` is the ADR-0022 Phase 1 addition: it grades
+    the turn's tool-call TRAJECTORY instead, asserting a named tool was actually
+    invoked during the turn. This closes the "grade the last sentence" gap -- a
+    text grader can confirm a version-shaped string appears in the reply but never
+    that the tool which was supposed to produce it ever ran. Reading the observed
+    trajectory (not the final text) is the whole point: grepping the answer for
+    the tool's name would be the mechanically-easy false green ADR-0022 warns
+    against.
+    """
 
     EXACT = "exact"
     CONTAINS = "contains"
     REGEX = "regex"
+    TOOL_CALLED = "tool_called"
 
 
 class ExpectedStatus(StrEnum):
@@ -52,10 +65,19 @@ class ExpectedStatus(StrEnum):
 
 
 class Grader(BaseModel):
-    """A single deterministic grader. MVP scope: string-shaped checks only.
+    """A single deterministic grader.
 
-    (An LLM-judge grader is a later addition; keeping these deterministic makes
-    eval results reproducible, which is the whole point of eval-as-CI.)
+    For the text matchers (``exact``/``contains``/``regex``) ``expected`` is the
+    string to match against the answer text. For ``tool_called`` ``expected`` is
+    instead the *tool name* that must have been invoked during the turn; the
+    grader then reads the observed tool-call trajectory rather than the answer
+    text. Reusing ``expected`` as the tool name keeps this an additive enum value
+    with no new field -- the smallest possible touch to the frozen eval-case
+    schema (ADR-0022 Phase 1).
+
+    (An LLM-judge grader is a later addition governed by ADR-0042; keeping these
+    deterministic makes eval results reproducible, which is the whole point of
+    eval-as-CI.)
     """
 
     model_config = ConfigDict(frozen=True)
@@ -66,24 +88,42 @@ class Grader(BaseModel):
 
     @field_validator("expected")
     @classmethod
-    def _regex_compiles(cls, value: str, info: ValidationInfo) -> str:
-        """Reject an uncompilable pattern eagerly when the grader is a regex.
+    def _expected_is_well_formed(cls, value: str, info: ValidationInfo) -> str:
+        """Reject an ill-formed ``expected`` eagerly, by grader kind.
 
         ``kind`` is declared before ``expected``, so it is already validated and
-        available in ``info.data`` here. Note that Python ``re`` accepts a wider
-        dialect than the CLI's Rust ``regex`` engine (lookaround, backreferences):
-        a pattern valid here may still be rejected by the local CLI. See
-        docs/adr/0019-freeze-eval-case-format.md.
+        available in ``info.data`` here. A ``regex`` grader must compile (note that
+        Python ``re`` accepts a wider dialect than the CLI's Rust ``regex`` engine
+        -- lookaround, backreferences -- so a pattern valid here may still be
+        rejected by the local CLI; see docs/adr/0019-freeze-eval-case-format.md). A
+        ``tool_called`` grader's ``expected`` is a tool name, which must be
+        non-empty: an empty tool name would match no tool and can never be
+        satisfied, so it is a suite-authoring mistake rather than a valid case.
         """
-        if info.data.get("kind") is GraderKind.REGEX:
+        kind = info.data.get("kind")
+        if kind is GraderKind.REGEX:
             try:
                 re.compile(value)
             except re.error as exc:
                 raise ValueError(f"invalid regex pattern: {exc}") from exc
+        elif kind is GraderKind.TOOL_CALLED and not value.strip():
+            raise ValueError("tool_called grader requires a non-empty tool name in `expected`")
         return value
 
-    def grade(self, output: str) -> bool:
-        """True if ``output`` satisfies this grader."""
+    def grade(self, output: str, trajectory: Sequence[str] = ()) -> bool:
+        """True if the turn satisfies this grader.
+
+        ``output`` is the graded answer text; ``trajectory`` is the ordered tool
+        names the turn invoked (the ``tool`` field of each ``tool_note`` frame, in
+        emission order). The text matchers judge ``output`` and ignore
+        ``trajectory``; ``tool_called`` judges ``trajectory`` and ignores
+        ``output``. Tool names are exact identifiers, so ``tool_called`` compares
+        them exactly and does not fold case (the ``case_sensitive`` flag is a
+        text-matcher concern and does not apply).
+        """
+        if self.kind is GraderKind.TOOL_CALLED:
+            return self.expected in trajectory
+
         if self.kind is GraderKind.REGEX:
             flags = 0 if self.case_sensitive else re.IGNORECASE
             return re.search(self.expected, output, flags) is not None

--- a/apps/worker/src/agentos_worker/eval/scorer.py
+++ b/apps/worker/src/agentos_worker/eval/scorer.py
@@ -63,16 +63,17 @@ class Scorer(Protocol):
 
 
 class GraderScorer:
-    """Default scorer: apply the case's frozen :class:`Grader` to the answer text.
+    """Default scorer: apply the case's frozen :class:`Grader` to the turn.
 
-    Behavior-preserving -- this is exactly the ``case.grader.grade(output)`` the
-    runner used inline, now expressed through the seam so it is one swappable
-    implementation among several.
+    Passes both the answer text and the observed tool-call trajectory to the
+    grader; the grader uses whichever its ``kind`` needs (the text matchers judge
+    the text, ``tool_called`` judges the trajectory). This is the same
+    ``case.grader.grade(...)`` the runner used inline, now expressed through the
+    seam so it is one swappable implementation among several.
     """
 
     def score(self, case: EvalCase, output: str, trajectory: Sequence[str]) -> ScoreResult:
-        del trajectory  # text grader: the tool-call sequence is irrelevant
-        passed = case.grader.grade(output)
+        passed = case.grader.grade(output, trajectory)
         return ScoreResult(passed=passed, detail=None if passed else "grader did not match")
 
 

--- a/apps/worker/tests/eval/test_models.py
+++ b/apps/worker/tests/eval/test_models.py
@@ -36,6 +36,27 @@ def test_regex_grader() -> None:
     assert g.grade("result: 42") is False
 
 
+def test_tool_called_grader_reads_the_trajectory_not_the_text() -> None:
+    # ADR-0022 Phase 1: a tool_called grader asserts a named tool was invoked,
+    # read from the observed trajectory -- NOT grepped from the answer text.
+    g = Grader(kind=GraderKind.TOOL_CALLED, expected="DeterministicEngine")
+    # GREEN: the tool appears in the trajectory.
+    assert g.grade("", ["DeterministicEngine"]) is True
+    assert g.grade("", ["Bash", "DeterministicEngine", "Read"]) is True
+    # RED: the tool was never called, whatever the final text claims.
+    assert g.grade("I ran the DeterministicEngine tool", []) is False
+    assert g.grade("DeterministicEngine", ["Bash", "Read"]) is False
+    # Tool names are exact identifiers; the case_sensitive flag does not fold them.
+    assert Grader(kind=GraderKind.TOOL_CALLED, expected="Bash").grade("", ["bash"]) is False
+
+
+def test_tool_called_grader_rejects_an_empty_tool_name() -> None:
+    # An empty tool name can never be satisfied, so it is a suite-authoring
+    # mistake rejected at construction (deny-by-default).
+    with pytest.raises(ValidationError):
+        Grader(kind=GraderKind.TOOL_CALLED, expected="  ")
+
+
 def test_case_sensitivity_is_honored() -> None:
     insensitive = Grader(kind=GraderKind.CONTAINS, expected="PARIS")
     assert insensitive.grade("paris") is True

--- a/apps/worker/tests/eval/test_runner.py
+++ b/apps/worker/tests/eval/test_runner.py
@@ -297,6 +297,67 @@ def test_all_passed_suite(make_eval_harness) -> None:
     asyncio.run(go())
 
 
+def test_tool_called_grader_greens_on_the_tool_note_and_reds_without_it(
+    make_eval_harness,
+) -> None:
+    """The #621 acceptance, end to end through the real stream path: a case
+    asserting a tool was called GREENs when the runner emits that tool_note and
+    REDs when it does not -- and a turn that calls no tool at all fails it, so
+    the grader is falsifiable (a do-nothing agent cannot pass)."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            # Same input for all three cases; the fake emits a per-input tool_note
+            # trajectory, so the grader is judged on what the turn actually did.
+            fake.responses = {
+                "run it": "I used the DeterministicEngine",
+                "narrate": "I used the DeterministicEngine tool, promise",
+                "idle": "nothing happened",
+            }
+            fake.tool_calls = {
+                "run it": ["Bash", "DeterministicEngine"],  # tool really called
+                "narrate": ["Bash"],  # only claims it in text
+                # "idle" emits no tool_note at all
+            }
+            suite = EvalSuite(
+                name="tool-calls",
+                cases=[
+                    EvalCase(
+                        id="called",
+                        input="run it",
+                        grader=Grader(
+                            kind=GraderKind.TOOL_CALLED, expected="DeterministicEngine"
+                        ),
+                    ),
+                    EvalCase(
+                        id="only-narrated",
+                        input="narrate",
+                        grader=Grader(
+                            kind=GraderKind.TOOL_CALLED, expected="DeterministicEngine"
+                        ),
+                    ),
+                    EvalCase(
+                        id="did-nothing",
+                        input="idle",
+                        grader=Grader(
+                            kind=GraderKind.TOOL_CALLED, expected="DeterministicEngine"
+                        ),
+                    ),
+                ],
+            )
+            result = await EvalRunner(client).run(suite, base_url=base_url, version="v1")
+            by_id = {r.case_id: r for r in result.results}
+            # GREEN only when the tool_note is on the wire.
+            assert by_id["called"].passed is True
+            # RED when the agent merely claims it in text (grader reads trajectory).
+            assert by_id["only-narrated"].passed is False
+            # RED when no tool ran at all -- the falsifiability floor.
+            assert by_id["did-nothing"].passed is False
+            assert result.summary() == "1/3 passed"
+
+    asyncio.run(go())
+
+
 class _SpyScorer:
     """A scorer that would pass ANYTHING, and counts the times it was consulted.
 

--- a/apps/worker/tests/eval/test_scorer.py
+++ b/apps/worker/tests/eval/test_scorer.py
@@ -97,6 +97,20 @@ def test_grader_scorer_matches_the_frozen_grader() -> None:
     assert scorer.score(case, "The capital is Berlin.", []).passed is False
 
 
+def test_grader_scorer_threads_the_trajectory_to_a_tool_called_grader() -> None:
+    # The default scorer now passes the observed trajectory to the grader, so a
+    # frozen tool_called grader is judged on what the turn did, not its text.
+    scorer = GraderScorer()
+    case = EvalCase(
+        id="c",
+        input="q",
+        grader=Grader(kind=GraderKind.TOOL_CALLED, expected="DeterministicEngine"),
+    )
+    # Text is unrelated; only the trajectory decides.
+    assert scorer.score(case, "unrelated text", ["Bash", "DeterministicEngine"]).passed is True
+    assert scorer.score(case, "I used the DeterministicEngine", []).passed is False
+
+
 def test_scorers_satisfy_the_protocol() -> None:
     # runtime_checkable Protocol: both shipped scorers are structural Scorers.
     assert isinstance(GraderScorer(), Scorer)

--- a/cli/src/eval_init.rs
+++ b/cli/src/eval_init.rs
@@ -140,23 +140,25 @@ pub fn interview<R: BufRead, W: Write>(
     Ok(EvalSuite { name, cases })
 }
 
-/// Ask for a grader: kind (exact/contains/regex), the expected string, and
-/// case-sensitivity. Re-prompts on an unrecognized kind rather than guessing.
+/// Ask for a grader: kind (exact/contains/regex/tool_called), the expected
+/// string, and case-sensitivity. Re-prompts on an unrecognized kind rather than
+/// guessing.
 fn ask_grader<R: BufRead, W: Write>(r: &mut R, w: &mut W) -> Result<Grader> {
     let kind = loop {
         let raw = ask_default(
             r,
             w,
-            "  Grader kind (exact/contains/regex) [contains]: ",
+            "  Grader kind (exact/contains/regex/tool_called) [contains]: ",
             "contains",
         )?;
         match raw.to_lowercase().as_str() {
             "exact" => break GraderKind::Exact,
             "contains" => break GraderKind::Contains,
             "regex" => break GraderKind::Regex,
+            "tool_called" => break GraderKind::ToolCalled,
             other => writeln!(
                 w,
-                "  '{other}' is not a grader kind; choose exact, contains, or regex."
+                "  '{other}' is not a grader kind; choose exact, contains, regex, or tool_called."
             )?,
         }
     };
@@ -166,6 +168,11 @@ fn ask_grader<R: BufRead, W: Write>(r: &mut R, w: &mut W) -> Result<Grader> {
         GraderKind::Exact => ask_required(r, w, "  Expected (exact answer, trimmed): ")?,
         GraderKind::Contains => {
             ask_required(r, w, "  Expected (substring the answer must contain): ")?
+        }
+        // tool_called grades the tool-call trajectory, so `expected` is the name
+        // of the tool that must have been invoked during the turn.
+        GraderKind::ToolCalled => {
+            ask_required(r, w, "  Expected (name of the tool that must be called): ")?
         }
     };
     let case_sensitive = ask_yes_no(r, w, "  Case-sensitive? [y/N]: ", false)?;

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -2,8 +2,11 @@
 //!
 //! Cases live in `evals/cases.json` (seeded by `agentos init`): a suite OBJECT
 //! `{name, cases: [{id, input, grader}]}`, where each grader is one of
-//! `kind: exact | contains | regex` with an `expected` string and an optional
-//! `case_sensitive` flag. This shape hand-mirrors the frozen canonical eval-case
+//! `kind: exact | contains | regex | tool_called` with an `expected` string and
+//! an optional `case_sensitive` flag. The three text matchers grade the final
+//! answer text; `tool_called` grades the turn's tool-call trajectory, asserting
+//! the tool named in `expected` was actually invoked (ADR-0022 Phase 1). This
+//! shape hand-mirrors the frozen canonical eval-case
 //! format owned by the worker (`apps/worker/schema/eval-cases.schema.json`, the
 //! Pydantic `EvalSuite`); a shape change lands in the same reviewed change as the
 //! Python models. Grading semantics mirror the platform's `Grader.grade`. This is
@@ -27,6 +30,12 @@ pub enum GraderKind {
     Exact,
     Contains,
     Regex,
+    /// Assert a named tool was invoked during the turn (graded against the
+    /// tool-call trajectory, not the answer text). The wire token is snake_case
+    /// `tool_called`, so it is renamed explicitly rather than by the container's
+    /// `lowercase` rule (which would emit `toolcalled`).
+    #[serde(rename = "tool_called")]
+    ToolCalled,
 }
 
 /// The terminal session status an eval case asserts. Mirrors the frozen
@@ -56,7 +65,9 @@ impl ExpectedStatus {
     }
 }
 
-/// A single deterministic grader mirroring the worker's `Grader`.
+/// A single deterministic grader mirroring the worker's `Grader`. For the text
+/// matchers `expected` is the string to match against the answer; for
+/// `tool_called` it is instead the tool NAME that must have been invoked.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Grader {
     pub kind: GraderKind,
@@ -66,11 +77,20 @@ pub struct Grader {
 }
 
 impl Grader {
-    /// True if `output` satisfies this grader. Mirrors the platform's
-    /// `Grader.grade`: exact compares whitespace-trimmed values, contains is a
-    /// substring test, regex is a search; all case-fold both sides unless
-    /// `case_sensitive` (regex uses the engine's case-insensitive flag).
-    pub fn grade(&self, output: &str) -> bool {
+    /// True if the turn satisfies this grader. `output` is the graded answer
+    /// text; `trajectory` is the ordered tool names the turn invoked (each
+    /// `tool_note` frame's `tool`, in emission order). Mirrors the platform's
+    /// `Grader.grade`: the text matchers judge `output` (exact compares
+    /// whitespace-trimmed values, contains is a substring test, regex is a
+    /// search; all case-fold both sides unless `case_sensitive`) and ignore the
+    /// trajectory; `tool_called` judges the trajectory and ignores `output`.
+    /// Tool names are exact identifiers, so `tool_called` compares them exactly
+    /// and does not fold case (the `case_sensitive` flag is a text-matcher
+    /// concern here).
+    pub fn grade(&self, output: &str, trajectory: &[&str]) -> bool {
+        if self.kind == GraderKind::ToolCalled {
+            return trajectory.contains(&self.expected.as_str());
+        }
         if self.kind == GraderKind::Regex {
             return match RegexBuilder::new(&self.expected)
                 .case_insensitive(!self.case_sensitive)
@@ -152,6 +172,15 @@ pub fn validate_suite(name: &str, cases: &[EvalCase]) -> Result<()> {
                     )
                 })?;
         }
+        // A tool_called grader's `expected` is a tool name; an empty one matches
+        // no tool and can never be satisfied, so reject it at load exactly as the
+        // platform's Grader validator does.
+        if case.grader.kind == GraderKind::ToolCalled && case.grader.expected.trim().is_empty() {
+            bail!(
+                "case {:?} has a tool_called grader with an empty tool name in `expected`",
+                case.id
+            );
+        }
     }
     Ok(())
 }
@@ -199,13 +228,32 @@ pub fn graded_answer(events: &[OutboundEvent]) -> String {
     }
 }
 
+/// The ordered tool-call trajectory of a turn: the `tool` field of every
+/// `tool_note` frame, in emission order. This is the observed record a
+/// `tool_called` grader asserts against -- read from the trajectory the runner
+/// emitted, never inferred from the answer text (ADR-0022). Mirrors the platform
+/// runner, which accumulates the same list off the `ToolNote` frames.
+pub fn trajectory(events: &[OutboundEvent]) -> Vec<&str> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            OutboundEvent::ToolNote { tool: Some(t), .. } => Some(t.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Full pass condition for a turn: it must end in a `final` whose status equals
 /// the case's `expect_status` (default `done`, or `awaiting-approval` for a
-/// gate-blocked case) AND the grader must match the graded answer. A
-/// classified-failure or interrupted turn still never passes, because those
-/// statuses match neither `done` nor `awaiting-approval`.
+/// gate-blocked case) AND the grader must match the turn. A text grader matches
+/// the graded answer; a `tool_called` grader matches the observed tool-call
+/// trajectory. A classified-failure or interrupted turn still never passes,
+/// because those statuses match neither `done` nor `awaiting-approval`.
 pub fn turn_passes(case: &EvalCase, events: &[OutboundEvent]) -> bool {
-    turn_completed(case, events) && case.grader.grade(&graded_answer(events))
+    turn_completed(case, events)
+        && case
+            .grader
+            .grade(&graded_answer(events), &trajectory(events))
 }
 
 /// True when the turn ended in a `final` frame whose status matches the case's
@@ -267,7 +315,10 @@ pub fn turn_outcome(case: &EvalCase, events: &[OutboundEvent], fake: bool) -> Ca
     if fake {
         return CaseOutcome::PlumbingOk;
     }
-    if case.grader.grade(&graded_answer(events)) {
+    if case
+        .grader
+        .grade(&graded_answer(events), &trajectory(events))
+    {
         CaseOutcome::Pass
     } else {
         CaseOutcome::Fail
@@ -353,6 +404,14 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+        }
+    }
+
+    fn tool_note(tool: &str) -> OutboundEvent {
+        OutboundEvent::ToolNote {
+            version: PROTOCOL_VERSION.into(),
+            text: format!("calling {tool}"),
+            tool: Some(tool.into()),
         }
     }
 
@@ -450,24 +509,95 @@ mod tests {
 
     #[test]
     fn exact_grader_trims_and_case_folds() {
-        assert!(grader(GraderKind::Exact, "  Done  ", false).grade("done"));
-        assert!(!grader(GraderKind::Exact, "done", true).grade("Done"));
-        assert!(grader(GraderKind::Exact, "done", true).grade("  done  "));
-        assert!(!grader(GraderKind::Exact, "done", false).grade("all done"));
+        assert!(grader(GraderKind::Exact, "  Done  ", false).grade("done", &[]));
+        assert!(!grader(GraderKind::Exact, "done", true).grade("Done", &[]));
+        assert!(grader(GraderKind::Exact, "done", true).grade("  done  ", &[]));
+        assert!(!grader(GraderKind::Exact, "done", false).grade("all done", &[]));
     }
 
     #[test]
     fn contains_grader_case_folds_unless_flagged() {
-        assert!(grader(GraderKind::Contains, "WEATHER", false).grade("the weather today"));
-        assert!(!grader(GraderKind::Contains, "WEATHER", true).grade("the weather today"));
-        assert!(grader(GraderKind::Contains, "weather", true).grade("the weather today"));
+        assert!(grader(GraderKind::Contains, "WEATHER", false).grade("the weather today", &[]));
+        assert!(!grader(GraderKind::Contains, "WEATHER", true).grade("the weather today", &[]));
+        assert!(grader(GraderKind::Contains, "weather", true).grade("the weather today", &[]));
     }
 
     #[test]
     fn regex_grader_searches_with_optional_case_flag() {
-        assert!(grader(GraderKind::Regex, "wea.her", false).grade("The WEATHER"));
-        assert!(!grader(GraderKind::Regex, "WEA.HER", true).grade("the weather"));
-        assert!(grader(GraderKind::Regex, "^done$", false).grade("DONE"));
+        assert!(grader(GraderKind::Regex, "wea.her", false).grade("The WEATHER", &[]));
+        assert!(!grader(GraderKind::Regex, "WEA.HER", true).grade("the weather", &[]));
+        assert!(grader(GraderKind::Regex, "^done$", false).grade("DONE", &[]));
+    }
+
+    #[test]
+    fn tool_called_grader_reads_the_trajectory_not_the_text() {
+        let g = grader(GraderKind::ToolCalled, "DeterministicEngine", false);
+        // GREEN: the tool appears in the observed trajectory.
+        assert!(g.grade("", &["DeterministicEngine"]));
+        assert!(g.grade("", &["Bash", "DeterministicEngine", "Read"]));
+        // RED: the tool was never called, no matter what the answer text says --
+        // grading must read the trajectory, not grep the final text (ADR-0022).
+        assert!(!g.grade("I ran the DeterministicEngine tool", &[]));
+        assert!(!g.grade("DeterministicEngine", &["Bash", "Read"]));
+        // The case_sensitive flag is a text-matcher concern; tool names match
+        // exactly regardless of it.
+        assert!(!grader(GraderKind::ToolCalled, "Bash", false).grade("", &["bash"]));
+    }
+
+    #[test]
+    fn tool_called_case_greens_when_the_tool_note_is_present_and_reds_when_absent() {
+        // The #621 acceptance, at the turn level: a case asserting a tool was
+        // called GREENs when the trajectory carries that tool_note and REDs when
+        // it does not -- and a do-nothing turn that calls no tool fails it, so the
+        // grader is falsifiable.
+        let c = case(grader(GraderKind::ToolCalled, "DeterministicEngine", false));
+        let called = vec![
+            tool_note("DeterministicEngine"),
+            final_event("done", SessionStatus::Done),
+        ];
+        let not_called = vec![
+            tool_note("Bash"),
+            final_event("I used the DeterministicEngine", SessionStatus::Done),
+        ];
+        let did_nothing = vec![final_event("all done", SessionStatus::Done)];
+        assert!(turn_passes(&c, &called));
+        assert!(!turn_passes(&c, &not_called));
+        assert!(!turn_passes(&c, &did_nothing));
+    }
+
+    #[test]
+    fn trajectory_collects_tool_note_names_in_order() {
+        let events = vec![
+            tool_note("Bash"),
+            delta("thinking"),
+            tool_note("Read"),
+            final_event("done", SessionStatus::Done),
+        ];
+        assert_eq!(trajectory(&events), vec!["Bash", "Read"]);
+    }
+
+    #[test]
+    fn loads_a_tool_called_grader_and_rejects_an_empty_tool_name() {
+        let (_dir, path) = write(
+            r#"{"name":"s","cases":[{"id":"a","input":"b","grader":{"kind":"tool_called","expected":"DeterministicEngine"}}]}"#,
+        );
+        let suite = load_suite(&path).unwrap();
+        assert_eq!(suite.cases[0].grader.kind, GraderKind::ToolCalled);
+        assert_eq!(suite.cases[0].grader.expected, "DeterministicEngine");
+        // An empty tool name can never be satisfied, so the loader rejects it.
+        let (_dir2, path2) = write(
+            r#"{"name":"s","cases":[{"id":"a","input":"b","grader":{"kind":"tool_called","expected":"  "}}]}"#,
+        );
+        let err = load_suite(&path2).unwrap_err().to_string();
+        assert!(err.contains("empty tool name"), "{err}");
+    }
+
+    #[test]
+    fn tool_called_round_trips_through_serialize() {
+        // The scaffold/spec re-emit path serializes a Grader; the tool_called kind
+        // must write the snake_case wire token load_suite reads back.
+        let json = serde_json::to_string(&grader(GraderKind::ToolCalled, "Bash", false)).unwrap();
+        assert!(json.contains(r#""kind":"tool_called""#), "got: {json}");
     }
 
     #[test]
@@ -580,14 +710,17 @@ mod tests {
         let body = include_str!("../../examples/weather/evals/cases.json");
         let (_dir, path) = write(body);
         let grader = &load_suite(&path).unwrap().cases[0].grader;
-        assert!(grader.grade("68°"), "glyph form must pass");
-        assert!(grader.grade("68 deg F"), "abbreviated unit must pass");
+        assert!(grader.grade("68°", &[]), "glyph form must pass");
+        assert!(grader.grade("68 deg F", &[]), "abbreviated unit must pass");
         assert!(
-            grader.grade("The high in San Francisco today is 68 degrees Fahrenheit"),
+            grader.grade(
+                "The high in San Francisco today is 68 degrees Fahrenheit",
+                &[]
+            ),
             "spelled-out unit must pass"
         );
         assert!(
-            !grader.grade("I could not confirm a current forecast"),
+            !grader.grade("I could not confirm a current forecast", &[]),
             "a refusal with no temperature figure must still fail"
         );
     }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1612,7 +1612,11 @@ pub fn reply_passes(case: &EvalCase, outcome: &Outcome) -> bool {
     match case.expect_status {
         // Default: the turn must have finalized WITH reply text and satisfy the grader.
         ExpectedStatus::Done => match outcome {
-            Outcome::Replied(reply) => case.grader.grade(reply),
+            // The message-relay path observes only the reply text, not the turn's
+            // tool-call trajectory, so a tool_called grader has nothing to read
+            // here and fails closed. The trajectory-aware grade lives on the
+            // `skill eval` path (`turn_passes`) and the server-side eval matrix.
+            Outcome::Replied(reply) => case.grader.grade(reply, &[]),
             Outcome::CompletedNoEdit | Outcome::AwaitingApproval(_) | Outcome::TimedOut => false,
         },
         // Gate-blocked assertion: the turn must have parked awaiting approval, and
@@ -1621,7 +1625,7 @@ pub fn reply_passes(case: &EvalCase, outcome: &Outcome) -> bool {
         // asserts purely on the gate holding.
         ExpectedStatus::AwaitingApproval => match outcome {
             Outcome::AwaitingApproval(reply) => {
-                case.grader.grade(reply.as_deref().unwrap_or_default())
+                case.grader.grade(reply.as_deref().unwrap_or_default(), &[])
             }
             Outcome::Replied(_) | Outcome::CompletedNoEdit | Outcome::TimedOut => false,
         },

--- a/cli/tests/fake_tier_plumbing.rs
+++ b/cli/tests/fake_tier_plumbing.rs
@@ -247,7 +247,7 @@ fn the_scaffold_seeds_a_falsifiable_grader_the_fake_reply_does_not_satisfy() {
     assert_eq!(case.grader.kind, GraderKind::Contains);
     assert_eq!(case.grader.expected, BUNDLE);
     assert!(
-        !case.grader.grade("all done"),
+        !case.grader.grade("all done", &[]),
         "the seed must stay falsifiable: the fake's canned reply must NOT satisfy it, \
          which is precisely why the fake tier cannot be graded"
     );
@@ -289,7 +289,7 @@ fn a_completed_fake_turn_is_plumbing_ok_even_when_the_grader_would_fail_it() {
     let case = case_requiring(BUNDLE);
     let events = vec![final_event("all done", SessionStatus::Done)];
     assert!(
-        !case.grader.grade("all done"),
+        !case.grader.grade("all done", &[]),
         "precondition: this grader fails the fake's canned text"
     );
     assert_eq!(
@@ -307,7 +307,7 @@ fn a_completed_fake_turn_is_plumbing_ok_even_when_the_grader_would_fail_it() {
 fn a_completed_fake_turn_the_grader_would_pass_is_still_plumbing_ok() {
     let case = case_requiring("all done");
     let events = vec![final_event("all done", SessionStatus::Done)];
-    assert!(case.grader.grade("all done"), "precondition");
+    assert!(case.grader.grade("all done", &[]), "precondition");
     assert_eq!(
         turn_outcome(&case, &events, true),
         CaseOutcome::PlumbingOk,

--- a/cli/tests/spec_scaffold.rs
+++ b/cli/tests/spec_scaffold.rs
@@ -435,15 +435,15 @@ fn a_spec_scaffolded_grader_is_not_satisfied_by_the_fake_models_canned_reply() {
     let grader = &suite.cases[0].grader;
     // "all done" is `fake.py::default_turn()`'s final text, whatever the input.
     assert!(
-        !grader.grade("all done"),
+        !grader.grade("all done", &[]),
         "a spec-scaffolded grader must judge the real work, not the fake's canned text"
     );
     assert!(
-        !grader.grade(""),
+        !grader.grade("", &[]),
         "an empty turn must never satisfy a scaffolded grader"
     );
     assert!(
-        grader.grade("The deal-desk agent quotes 20% off for Acme."),
+        grader.grade("The deal-desk agent quotes 20% off for Acme.", &[]),
         "an on-topic answer must still pass"
     );
 }


### PR DESCRIPTION
## What

Adds a `tool_called` grader kind to the frozen eval-case taxonomy (previously `exact | contains | regex`). It asserts that a named tool was actually **invoked** during the turn, graded against the observed tool-call **trajectory** rather than the final answer text.

This is ADR-0022 Phase 1, "the credibility floor": today no grader can confirm the tool that was supposed to produce an answer ever ran, so a green eval means "a string appeared in the reply", not "the agent did the work". `tool_called` closes that gap and retires the dogfood proof-token workaround.

## Grader shape

```json
{ "kind": "tool_called", "expected": "DeterministicEngine" }
```

`expected` is reused as the tool name, so the change is **purely additive on the wire**: `GraderKind` gains one enum value and no new field touches the frozen schema. This is the smallest possible contract change, which is exactly why ADR-0022 sequences tool-call assertion first: `tool_note` already carries the tool name and the eval runner already accumulates the trajectory, so **no ACI/protocol change is required** (no `PROTOCOL_VERSION` bump).

Semantics: passes iff the observed trajectory contains `expected` at least once. Tool names are exact identifiers, so the match is exact and `case_sensitive` (a text-matcher concern) does not apply. Grading reads the trajectory, **never** greps the final text — the false-green ADR-0022 explicitly warns against.

## Wired through every mirror of the frozen shape

- **worker** (`eval/models.py`): `Grader.grade(output, trajectory)` dispatches `tool_called` onto the trajectory; `GraderScorer` threads the trajectory through; empty tool name rejected at construction. Regenerated `eval-cases.schema.json`.
- **CLI mirror** (`evals.rs`): `GraderKind::ToolCalled`, trajectory extracted from the event stream and threaded into `turn_passes`/`turn_outcome`, load-time validation, and the guided `eval-init` prompt.
- **API** (`GraderOut` literal) + regenerated `openapi.json`; UI TS mirrors (`client.ts`, `types.ts`).

## Acceptance / falsifiability

Tests on both worker and CLI sides prove a case asserting a tool was called **GREENs when the trajectory carries that `tool_note` and REDs when it does not** — including that a turn which only *narrates* calling the tool, or calls no tool at all, fails. The worker test drives this end to end through the fake-runner stream. The committed suites are untouched, so the falsifiability gate stays green (the schema-driven `every_schema_grader_kind_deserializes` and API parity gates now cover the new kind automatically).

Verified: `uv run pytest apps/worker/tests apps/api/tests -q` (947 passed, 1 skipped); `cargo fmt --check` + `cargo clippy -D warnings` + `cargo test` (all green).

Closes #621
Ref ADR-0022