### PR TITLE
Render the approval card below the channel-interaction seam

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -44,6 +44,12 @@ from aci_protocol import (
     TextDelta,
     ToolNote,
 )
+from channel_protocol import (
+    MESSAGE_VERSION,
+    Action,
+    ConfirmIntent,
+    OutboundMessage,
+)
 from pydantic import ValidationError
 
 from .approval_cards import ApprovalCardStore
@@ -57,7 +63,6 @@ from .behaviorpacks import (
     sample_tip,
 )
 from .binding import GRANT_TOOL_ENV, RESUMED_KIND_ENV, BindingResolver
-from .blocks import approval_card, expired_approval_card
 from .config import WorkerConfig
 from .killswitch import KillSwitch
 from .markers import Markers
@@ -851,12 +856,12 @@ class Kernel:
             ref = await self._card_store.pop(qevent.conversation_id)
             if ref is None or not qevent.text.startswith(_EXPIRY_RESUME_MARKER):
                 return
-            fallback, blocks = expired_approval_card(summary=ref.summary)
+            # Emit the channel-neutral summary (ADR-0020); the adapter renders the
+            # settled, buttonless expired card below the seam.
             await self._sink.update_message(
                 channel=ref.channel,
                 ts=ref.ts,
-                text=fallback,
-                blocks=blocks,
+                message=OutboundMessage(version=MESSAGE_VERSION, text=ref.summary),
                 endpoint=ref.endpoint,
             )
             logger.info(
@@ -995,24 +1000,37 @@ class Kernel:
             endpoint=qevent.reply_handle.endpoint,
         )
 
-        # The Block Kit approval card (#246): Approve/Reject buttons routed to
-        # the approval's channel, in this thread; the dispatcher resolves a
-        # click through the API's server-side authorizer. Best-effort -- the
-        # record and the API resolve path stand with or without the card.
-        fallback, card_blocks = approval_card(
-            approval_id=created.id, summary=summary, requested_by=qevent.author
-        )
         # In the requesting channel the card joins the thread and rides the
         # trigger's transport; a route-bound channel has no such thread and is
         # policy, not a per-turn reply, so it posts top-level over the worker's
         # default Slack transport.
         in_requesting_channel = card_channel == qevent.reply_handle.channel
         card_endpoint = qevent.reply_handle.endpoint if in_requesting_channel else None
+        # The approval interaction (#246, ADR-0010/0020): a channel-neutral
+        # Confirm intent (Approve/Reject) emitted WITHOUT any Block Kit -- the
+        # Slack adapter renders it into the approval card's buttons below the
+        # seam. The confirm/cancel actions carry the durable record id so a click
+        # resolves exactly this approval through the API's server-side authorizer.
+        # Building the message is inside the best-effort try (the channel-neutral
+        # models validate on construction, unlike the old blocks builder) so the
+        # pause -- the durable record and the resume path -- stands with or without
+        # the card, exactly as before.
         try:
+            card_message = OutboundMessage(
+                version=MESSAGE_VERSION,
+                text=summary,
+                interaction=ConfirmIntent(
+                    kind="confirm",
+                    id=created.id,
+                    prompt=summary,
+                    confirm=Action(label="Approve", value=created.id),
+                    cancel=Action(label="Reject", value=created.id),
+                ),
+            )
             card_ts = await self._sink.post(
                 channel=card_channel,
-                text=fallback,
-                blocks=card_blocks,
+                message=card_message,
+                requested_by=qevent.author,
                 thread_ts=thread if in_requesting_channel else None,
                 endpoint=card_endpoint,
             )

--- a/apps/worker/src/agentos_worker/slack_sink.py
+++ b/apps/worker/src/agentos_worker/slack_sink.py
@@ -14,12 +14,13 @@ from collections.abc import Awaitable, Callable
 from typing import Protocol, TypeVar, cast
 
 import aiohttp
+from channel_protocol import ConfirmIntent, OutboundMessage
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 from slack_sdk.web.async_slack_response import AsyncSlackResponse
 
 from .behaviorpacks import NavPack
-from .blocks import render
+from .blocks import approval_card, expired_approval_card, render
 
 logger = logging.getLogger(__name__)
 
@@ -74,16 +75,22 @@ class SlackSink(Protocol):
         self,
         *,
         channel: str,
-        text: str,
-        blocks: list[dict[str, object]] | None = None,
+        message: OutboundMessage,
+        requested_by: str,
         thread_ts: str | None = None,
         endpoint: str | None = None,
     ) -> str | None:
         """Post a NEW message (the approval card, #246), returning its ts.
 
-        Distinct from ``update``: the placeholder-edit reply model stays the
-        norm; posting is reserved for platform-owned messages like the
-        approval card. Raises on failure so the caller decides best-effort."""
+        The kernel hands a channel-neutral ``OutboundMessage`` carrying a
+        ``Confirm`` intent (ADR-0020); the adapter renders it into whatever
+        widget the channel supports (Slack: the Block Kit approval card with
+        Approve/Reject buttons). No channel-native markup crosses this seam.
+        ``requested_by`` is the semantic actor id the adapter renders (Slack: a
+        ``<@id>`` mention). Distinct from ``update``: the placeholder-edit reply
+        model stays the norm; posting is reserved for platform-owned messages
+        like the approval card. Raises on failure so the caller decides
+        best-effort."""
         ...
 
     async def update_message(
@@ -91,16 +98,17 @@ class SlackSink(Protocol):
         *,
         channel: str,
         ts: str,
-        text: str,
-        blocks: list[dict[str, object]],
+        message: OutboundMessage,
         endpoint: str | None = None,
     ) -> None:
-        """Edit an already-posted platform message's blocks in place (disabling
-        the expired approval card, #419).
+        """Edit an already-posted platform message in place (disabling the
+        expired approval card, #419).
 
-        Distinct from ``update`` (which renders reply Markdown through
-        ``render``) and ``post`` (a brand-new message): this replaces a known
-        message's blocks verbatim. Best-effort at the call site."""
+        Like ``post``, the kernel hands a channel-neutral ``OutboundMessage``
+        (ADR-0020) and the adapter renders the settled form (Slack: the expired
+        approval card, its buttons gone). Distinct from ``update`` (which renders
+        streamed reply Markdown): this replaces a known platform message.
+        Best-effort at the call site."""
         ...
 
 
@@ -271,11 +279,23 @@ class AsyncSlackSink:
         self,
         *,
         channel: str,
-        text: str,
-        blocks: list[dict[str, object]] | None = None,
+        message: OutboundMessage,
+        requested_by: str,
         thread_ts: str | None = None,
         endpoint: str | None = None,
     ) -> str | None:
+        # Render the channel-neutral message into Block Kit HERE, below the seam
+        # (ADR-0020): the kernel emits a Confirm intent, the Slack adapter turns it
+        # into the approval card's Approve/Reject buttons. A message with no
+        # interaction degrades to a plain text post (the mandatory text fallback).
+        intent = message.interaction
+        if isinstance(intent, ConfirmIntent):
+            text, blocks = approval_card(
+                approval_id=intent.id, summary=message.text, requested_by=requested_by
+            )
+        else:
+            text, blocks = message.text, None
+
         # A rejected Block Kit payload falls back to text-only, mirroring
         # ``update``: the card is the resolve UI, but a plain-text notice still
         # beats losing the message (the API resolve path works regardless).
@@ -309,10 +329,14 @@ class AsyncSlackSink:
         *,
         channel: str,
         ts: str,
-        text: str,
-        blocks: list[dict[str, object]],
+        message: OutboundMessage,
         endpoint: str | None = None,
     ) -> None:
+        # Render the settled (expired) approval card HERE, below the seam
+        # (ADR-0020): the kernel hands the channel-neutral summary, the adapter
+        # rebuilds the buttonless expired form.
+        text, blocks = expired_approval_card(summary=message.text)
+
         # A rejected Block Kit payload falls back to text-only, mirroring
         # ``post``/``update``: disabling the card is best-effort, but a plain-text
         # expiry notice still beats leaving live-looking buttons.

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -45,6 +45,7 @@ from agentos_worker.slack_sink import SlackSink
 from agentos_worker.threadlock import ThreadLock
 from aiohttp import web
 from aiohttp.test_utils import TestServer
+from channel_protocol import OutboundMessage
 from redis.asyncio import Redis as AsyncRedis
 
 
@@ -110,17 +111,22 @@ class FakeSink(SlackSink):
         self.update_endpoints: list[str | None] = []
         self.status_sets: list[tuple[str, str, str]] = []
         self.status_clears: list[tuple[str, str]] = []
-        # New messages posted by the kernel (the approval card, #246):
-        # (channel, text, blocks, thread_ts, endpoint) per post. The endpoint is
-        # the transport the post is delivered through (#451): None means the
-        # worker's default Slack transport.
+        # New messages posted by the kernel (the approval card, #246): the
+        # channel-neutral OutboundMessage the kernel emits (ADR-0020) plus its
+        # framing -- (channel, message, requested_by, thread_ts, endpoint) per
+        # post. Block Kit rendering is the adapter's job (see test_slack_sink.py),
+        # so this double records the intent, not blocks. The endpoint is the
+        # transport the post is delivered through (#451): None means the worker's
+        # default Slack transport.
         self.posts: list[
-            tuple[str, str, list[dict[str, object]] | None, str | None, str | None]
+            tuple[str, OutboundMessage, str, str | None, str | None]
         ] = []
-        # In-place block edits of an already-posted message (the expired approval
-        # card, #419): (channel, ts, text, blocks, endpoint) per update_message.
+        # In-place edits of an already-posted message (the expired approval card,
+        # #419): (channel, ts, message, endpoint) per update_message. Like posts,
+        # the recorded value is the channel-neutral message; the adapter renders
+        # the buttonless expired card below the seam.
         self.card_updates: list[
-            tuple[str, str, str, list[dict[str, object]], str | None]
+            tuple[str, str, OutboundMessage, str | None]
         ] = []
         # #708 test infra: endpoints whose HOST is dead (a CLI stub that exited).
         # A reply-delivery ``update`` to one models the pure-offline local loop --
@@ -166,12 +172,12 @@ class FakeSink(SlackSink):
         self,
         *,
         channel: str,
-        text: str,
-        blocks: list[dict[str, object]] | None = None,
+        message: OutboundMessage,
+        requested_by: str,
         thread_ts: str | None = None,
         endpoint: str | None = None,
     ) -> str | None:
-        self.posts.append((channel, text, blocks, thread_ts, endpoint))
+        self.posts.append((channel, message, requested_by, thread_ts, endpoint))
         return f"posted-{len(self.posts)}"
 
     async def update_message(
@@ -179,11 +185,10 @@ class FakeSink(SlackSink):
         *,
         channel: str,
         ts: str,
-        text: str,
-        blocks: list[dict[str, object]],
+        message: OutboundMessage,
         endpoint: str | None = None,
     ) -> None:
-        self.card_updates.append((channel, ts, text, blocks, endpoint))
+        self.card_updates.append((channel, ts, message, endpoint))
 
     @property
     def last_text(self) -> str | None:

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -17,6 +17,7 @@ import pytest
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from agentos_worker.approvals import ApprovalBackendError, ApprovalRequest, CreatedApproval
 from agentos_worker.sandbox.types import RouteState
+from channel_protocol import ConfirmIntent
 
 DONE = SessionStatus.DONE
 AWAITING = SessionStatus.AWAITING_APPROVAL
@@ -379,9 +380,11 @@ def test_unknown_gate_kind_escalates_instead_of_stranding_the_turn(make_harness)
     asyncio.run(go())
 
 
-def test_pause_posts_the_approval_card(make_harness) -> None:
-    """#246: pausing posts a Block Kit card into the approval's thread whose
-    buttons carry the record id, alongside the placeholder notice."""
+def test_pause_emits_a_confirm_intent_for_the_approval_card(make_harness) -> None:
+    """#246, ADR-0020: pausing emits a channel-neutral Confirm intent into the
+    approval's thread whose confirm/cancel actions carry the record id (the Slack
+    adapter renders it into Block Kit buttons -- see test_slack_sink.py), alongside
+    the placeholder notice. The kernel never builds Block Kit itself."""
 
     async def go() -> None:
         approvals = RecordingApprovals()
@@ -391,14 +394,21 @@ def test_pause_posts_the_approval_card(make_harness) -> None:
             await h.kernel.process_event(ev)
 
             assert len(h.sink.posts) == 1
-            channel, fallback, blocks, thread_ts, _endpoint = h.sink.posts[0]
+            channel, message, requested_by, thread_ts, _endpoint = h.sink.posts[0]
             assert channel == "C1"
             assert thread_ts == "th-card"
-            assert "Give ACME a 20% discount" in fallback
-            assert blocks is not None
-            actions = blocks[-1]
-            assert actions["type"] == "actions"
-            assert [e["value"] for e in actions["elements"]] == ["appr-1", "appr-1"]
+            assert requested_by == "U1"
+            # The mandatory text fallback carries the summary; the adapter derives
+            # the "Approval required: ..." card fallback from it below the seam.
+            assert message.text == "Give ACME a 20% discount"
+            # A Confirm intent, not buttons: the record id rides both actions so a
+            # click resolves exactly this approval.
+            intent = message.interaction
+            assert isinstance(intent, ConfirmIntent)
+            assert intent.id == "appr-1"
+            assert intent.confirm.value == "appr-1"
+            assert intent.cancel.value == "appr-1"
+            assert (intent.confirm.label, intent.cancel.label) == ("Approve", "Reject")
 
     asyncio.run(go())
 
@@ -479,10 +489,10 @@ def test_routed_approval_cards_go_to_the_bound_channel(make_harness) -> None:
             assert req.route == "managers"
             assert req.card_channel == "C_MGRS"
             # Card posted to the bound channel, top-level (no thread there).
-            channel, _fallback, blocks, thread_ts, endpoint = h.sink.posts[0]
+            channel, message, _requested_by, thread_ts, endpoint = h.sink.posts[0]
             assert channel == "C_MGRS"
             assert thread_ts is None
-            assert blocks is not None
+            assert isinstance(message.interaction, ConfirmIntent)
             assert endpoint is None
 
     asyncio.run(go())
@@ -556,7 +566,7 @@ def test_routed_card_ignores_the_triggering_turns_endpoint(make_harness) -> None
                 _qevent("discount?", thread="th-cli-routed", endpoint=_CLI_STUB)
             )
 
-            channel, _f, _b, thread_ts, endpoint = h.sink.posts[0]
+            channel, _message, _requested_by, thread_ts, endpoint = h.sink.posts[0]
             assert channel == "C_MGRS"
             assert thread_ts is None
             assert endpoint is None
@@ -581,7 +591,7 @@ def test_card_routed_to_requesting_channel_keeps_the_trigger_endpoint(
                 _qevent("ship?", thread="th-self-routed", endpoint=_CLI_STUB)
             )
 
-            channel, _f, _b, thread_ts, endpoint = h.sink.posts[0]
+            channel, _message, _requested_by, thread_ts, endpoint = h.sink.posts[0]
             assert channel == "C1"
             assert thread_ts == "th-self-routed"
             assert endpoint == _CLI_STUB
@@ -640,15 +650,15 @@ def test_expiry_resume_disables_the_approval_card(make_harness) -> None:
                 )
             )
 
-            # The card was edited in place: same ts, no actions block, an expiry
-            # line where the Approve/Reject buttons were.
+            # The card was edited in place: same ts, and a channel-neutral message
+            # carrying the remembered summary. The buttonless expired-card render
+            # (no actions block, an expiry line) is the adapter's job below the
+            # seam -- asserted in test_slack_sink.py.
             assert len(h.sink.card_updates) == 1
-            channel, ts, text, blocks, endpoint = h.sink.card_updates[0]
+            channel, ts, message, endpoint = h.sink.card_updates[0]
             assert (channel, ts) == ("C1", card_ts)
             assert endpoint is None
-            assert all(b.get("type") != "actions" for b in blocks)
-            assert "expired" in text.lower()
-            assert any("expired" in str(b).lower() for b in blocks)
+            assert message.text == "Give ACME a 20% discount"
 
             # The memory was consumed (GETDEL), so a redelivery no-ops.
             assert not await h.async_redis.exists(h.config.approval_card_key(thread))

--- a/apps/worker/tests/test_slack_sink.py
+++ b/apps/worker/tests/test_slack_sink.py
@@ -9,6 +9,12 @@ import aiohttp
 import pytest
 from agentos_worker.config import WorkerConfig
 from agentos_worker.slack_sink import AsyncSlackSink
+from channel_protocol import (
+    MESSAGE_VERSION,
+    Action,
+    ConfirmIntent,
+    OutboundMessage,
+)
 from slack_sdk.errors import SlackApiError
 
 
@@ -410,6 +416,132 @@ def test_best_effort_stays_loud_when_default_transport_is_the_dead_target() -> N
                 best_effort_unreachable=True,
             )
         )
+
+
+# --- #454: the approval card renders BELOW the seam (ADR-0020) ----------------
+# The kernel emits a channel-neutral Confirm intent; the Slack adapter's post()
+# renders it into the same Block Kit approval card that used to be built in the
+# kernel. These tests are where the byte-identical card contract lives now (the
+# builders themselves are unit-tested in test_blocks.py).
+
+
+def _approval_message(approval_id: str, summary: str) -> OutboundMessage:
+    return OutboundMessage(
+        version=MESSAGE_VERSION,
+        text=summary,
+        interaction=ConfirmIntent(
+            kind="confirm",
+            id=approval_id,
+            prompt=summary,
+            confirm=Action(label="Approve", value=approval_id),
+            cancel=Action(label="Reject", value=approval_id),
+        ),
+    )
+
+
+def test_post_renders_the_approval_card_from_a_confirm_intent() -> None:
+    # The adapter turns a Confirm intent into the Block Kit approval card: header,
+    # the summary section, a "Requested by" context line, and Approve/Reject
+    # buttons carrying the dispatcher's action ids + the record id as value.
+    from agentos_dispatcher.approval_actions import APPROVE_ACTION_ID, REJECT_ACTION_ID
+
+    sink = AsyncSlackSink("xoxb-test")
+    captured: dict[str, object] = {}
+
+    async def _fake_post(**kwargs: object):
+        captured.update(kwargs)
+        return {"ok": True, "ts": "9.9"}
+
+    sink._client_for(None).chat_postMessage = _fake_post  # type: ignore[method-assign]
+
+    ts = asyncio.run(
+        sink.post(
+            channel="C1",
+            message=_approval_message("appr-1", "Give ACME a 20% discount"),
+            requested_by="U_AE",
+            thread_ts="th-card",
+        )
+    )
+
+    assert ts == "9.9"
+    assert captured["channel"] == "C1"
+    assert captured["thread_ts"] == "th-card"
+    assert "Give ACME a 20% discount" in captured["text"]  # accessibility fallback
+    blocks = captured["blocks"]
+    assert isinstance(blocks, list)
+    assert blocks[0]["type"] == "header"  # type: ignore[index]
+    assert "Give ACME a 20% discount" in blocks[1]["text"]["text"]  # type: ignore[index]
+    assert "<@U_AE>" in blocks[2]["elements"][0]["text"]  # type: ignore[index]
+    actions = blocks[-1]  # type: ignore[index]
+    assert actions["type"] == "actions"
+    approve, reject = actions["elements"]
+    assert approve["action_id"] == APPROVE_ACTION_ID
+    assert approve["value"] == "appr-1"
+    assert approve["style"] == "primary"
+    assert reject["action_id"] == REJECT_ACTION_ID
+    assert reject["value"] == "appr-1"
+    assert reject["style"] == "danger"
+
+
+def test_post_falls_back_to_text_only_when_card_blocks_rejected() -> None:
+    # Mirrors update(): a rejected Block Kit payload retries text-only so the
+    # notice still lands rather than losing the message (the API resolve path
+    # stands regardless).
+    sink = AsyncSlackSink("xoxb-test")
+    calls: list[dict[str, object]] = []
+
+    async def _fake_post(**kwargs: object):
+        calls.append(kwargs)
+        if "blocks" in kwargs:
+            raise SlackApiError("invalid_blocks", {"ok": False, "error": "invalid_blocks"})
+        return {"ok": True, "ts": "9.9"}
+
+    sink._client_for(None).chat_postMessage = _fake_post  # type: ignore[method-assign]
+
+    ts = asyncio.run(
+        sink.post(
+            channel="C1",
+            message=_approval_message("appr-1", "Discount ACME"),
+            requested_by="U1",
+        )
+    )
+
+    assert ts == "9.9"
+    assert len(calls) == 2
+    assert "blocks" not in calls[1]  # the retry is text-only
+    assert "Discount ACME" in calls[1]["text"]
+
+
+def test_update_message_renders_the_expired_card() -> None:
+    # The adapter rebuilds the settled expired card from the channel-neutral
+    # summary: the summary stays, the Approve/Reject actions block is gone, and an
+    # expiry line takes its place so the card can no longer be clicked.
+    sink = AsyncSlackSink("xoxb-test")
+    captured: dict[str, object] = {}
+
+    async def _fake_update(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    sink._client_for(None).chat_update = _fake_update  # type: ignore[method-assign]
+
+    asyncio.run(
+        sink.update_message(
+            channel="C1",
+            ts="9.9",
+            message=OutboundMessage(
+                version=MESSAGE_VERSION, text="Give ACME a 20% discount"
+            ),
+        )
+    )
+
+    assert captured["channel"] == "C1"
+    assert captured["ts"] == "9.9"
+    assert "expired" in str(captured["text"]).lower()
+    blocks = captured["blocks"]
+    assert isinstance(blocks, list)
+    assert "Give ACME a 20% discount" in blocks[1]["text"]["text"]  # type: ignore[index]
+    assert all(b.get("type") != "actions" for b in blocks)  # type: ignore[union-attr]
+    assert any("expired" in str(b).lower() for b in blocks)
 
 
 def test_best_effort_still_falls_back_to_default_when_present() -> None:

--- a/docs/interfaces/channel-interaction/INTERFACE.md
+++ b/docs/interfaces/channel-interaction/INTERFACE.md
@@ -108,6 +108,13 @@ back into the contract:
    degrades to plain text, so a half-streamed block never shows raw JSON. Slack's
    3000-char section cap is absorbed here by
    `apps/worker/src/agentos_worker/blocks.py::chunk`, not pushed onto the agent.
+   The approval card (ADR-0010) travels the same seam: the kernel emits a
+   `confirm` intent and the adapter renders it below the line via
+   `apps/worker/src/agentos_worker/blocks.py::approval_card` inside
+   `apps/worker/src/agentos_worker/slack_sink.py::AsyncSlackSink.post` (its
+   settled/expired form via
+   `apps/worker/src/agentos_worker/blocks.py::expired_approval_card`), so no Block
+   Kit is built above the seam.
 2. **Terminal (TUI selector)** — `cli/src/channel.rs`. It parses the same fence
    (`REPLY_FENCE`) into a `TerminalMessage` of plain lines plus actions, which the
    TUI renders as a numbered selector per the TUI behavior above.


### PR DESCRIPTION
## What

The approval card bypassed the channel-interaction port (ADR-0020 violation). `kernel.py` imported the Block Kit builders (`approval_card`, `expired_approval_card`), built Slack `blocks`, and passed them through the sink; `blocks` was typed into the `SlackSink` Protocol's `post()`/`update_message()`. That made approval presentation Slack-only and forced every sink to accept Block Kit, the exact coupling ADR-0020 forbids (no channel-native markup above the seam), and the approval interface is the worked example ADR-0020 names for building on a `Confirm`/`Choice` intent (ADR-0010).

## Seam design

- The kernel now emits a channel-neutral `OutboundMessage` carrying a `confirm` intent (Approve/Reject, with the durable record id on both actions and as the intent id). It builds no Block Kit and imports no channel renderer.
- The Slack adapter (`AsyncSlackSink`) renders that intent into the identical approval card below the seam, via the existing `approval_card` builder in `blocks.py`; the settled/expired teardown renders via `expired_approval_card`.
- The `SlackSink` Protocol no longer mentions Block Kit: `post()` and `update_message()` take an `OutboundMessage` (plus `requested_by` for the actor mention). This is the same channel-protocol contract the streamed-reply path already uses.

The end-to-end Slack card is byte-identical: same header, summary section, "Requested by" context line, Approve/Reject action ids, per-button `value` (the record id), and primary/danger styles. The dispatcher click-to-resolve contract (`APPROVE_ACTION_ID`/`REJECT_ACTION_ID`, the resolved-card edit) is untouched.

## Tests

- The block-level card assertions moved from the kernel suite to `apps/worker/tests/test_slack_sink.py`, where the adapter render is now proven byte-for-byte (header, summary, requested-by, action ids, values, styles; expired form drops the actions block). The `blocks.py` builder unit tests in `test_blocks.py` are unchanged.
- The kernel suite (`test_approval_lifecycle.py`, pinning #451/#544/#766) now asserts the emitted `confirm` intent and transport framing instead of blocks; all stay green.
- `uv run pytest apps/worker/tests -q` -> 517 passed, 1 skipped. `uv run mypy` clean. `uv run ruff check` clean. `agentos dev docs-lint` clean (added a note to the channel-interaction INTERFACE.md that the approval card travels this seam).

## Sacred-module change: needs adversarial review

`apps/worker/src/agentos_worker/kernel.py` is the sacred single-owner module. The diff is deliberately surgical: it swaps the two Block-Kit call sites (`_pause_for_approval`, `_finalize_expired_card`) to emit an `OutboundMessage`/`ConfirmIntent`, and removes the `blocks` import. No concurrency, retry/escalate, marker, suspend/resume, or transport-selection logic changed.

Two points flagged for the required spec-vs-impl + side-effects review (I have NOT performed that review):
1. The `OutboundMessage`/`ConfirmIntent` models validate on construction, unlike the old builder which never raised. To keep the "the pause stands with or without the card" invariant, the message construction was moved inside the existing best-effort `try` around the card post, so a validation error is swallowed exactly like a post failure (the durable record and resume path still stand, the event is still marked done). Worth confirming this is the intended failure posture.
2. The record id flows into `Action.value`/`ConfirmIntent.id`, which have `min_length=1`/`max_length=255`. Server-minted approval ids (UUIDs) are always within bounds, so this cannot fire in practice, but it is a new validation surface on the pause path.

## Not in this PR: #770

#770 (route message-driven approval cards through the connected Slack transport) overturns the pinned `in_requesting_channel` transport-selection design in `_pause_for_approval`. That logic is orthogonal to this rendering-seam refactor (it decides *which endpoint* the card posts through, not *what* is posted), so #454 does not make #770 natural. Left as a documented follow-up rather than forcing a risky, test-pinned change onto the sacred module in the same pass.