### PR TITLE
Populate eval cost_usd from token usage and add variance-aware grading

### DIFF
--- a/apps/worker/src/agentos_worker/eval/__init__.py
+++ b/apps/worker/src/agentos_worker/eval/__init__.py
@@ -19,6 +19,7 @@ from .models import (
 from .recorder import SCORE_NAME, IngestionError, LangfuseEvalRecorder
 from .run import load_suite, run_eval_suite
 from .runner import EvalRunner
+from .sampling import AggregationPolicy, SampleConfig, aggregate
 from .scorer import (
     GraderScorer,
     Scorer,
@@ -38,6 +39,7 @@ from .stream import (
 
 __all__ = [
     "SCORE_NAME",
+    "AggregationPolicy",
     "EvalCase",
     "EvalCaseResult",
     "EvalJob",
@@ -54,11 +56,13 @@ __all__ = [
     "GraderScorer",
     "IngestionError",
     "LangfuseEvalRecorder",
+    "SampleConfig",
     "Scorer",
     "ScoreResult",
     "TrajectoryMode",
     "TrajectoryScorer",
     "TrajectorySpec",
+    "aggregate",
     "load_suite",
     "load_suite_from_bundle",
     "match_trajectory",

--- a/apps/worker/src/agentos_worker/eval/pricing.py
+++ b/apps/worker/src/agentos_worker/eval/pricing.py
@@ -1,0 +1,95 @@
+"""Per-model token pricing for attributing a dollar cost to an eval turn (#390).
+
+The eval runner knows a turn's token usage (carried on the ACI ``final`` event)
+and the model it ran under; this module is the third input -- the price of those
+tokens. Pricing lives here, on the consumer side, not on the wire: the ACI wire
+carries raw usage, and what a token costs is a billing concern the recorder/matrix
+own, not a property of the protocol.
+
+The table is deny-by-default: a model id with no entry prices to ``None`` (cost
+unknown) rather than to a guessed number, so a run under an unpriced model simply
+falls out of the matrix's cost rollup instead of polluting it. That is also why
+the fake-model path never gets a cost -- ``AGENTOS_FAKE_MODEL`` is not a real
+model and is deliberately absent from the table.
+
+Prices are USD per one million tokens, split input/output, matching Anthropic's
+published list pricing (https://www.anthropic.com/pricing, list as of 2026-07).
+Keep this list-price-only: eval cost is a coarse comparison signal across models,
+not a billing ledger, so it does not model prompt-cache discounts, batch pricing,
+or per-region multipliers.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class _Price(NamedTuple):
+    """USD per one million tokens, input and output."""
+
+    input_per_mtok: float
+    output_per_mtok: float
+
+
+# Keyed by a canonical model-family substring so a fully-qualified id -- a bare
+# ``claude-opus-4-8`` or a platform-prefixed/dated ``anthropic.claude-opus-4-1-...``
+# -- resolves to the same price via containment (see ``_price_for``). Ordered
+# longest-key-first there so a more specific family wins over a prefix of it.
+_PRICES: dict[str, _Price] = {
+    # Anthropic list pricing, USD per 1M tokens (input / output).
+    "claude-fable-5": _Price(10.0, 50.0),
+    "claude-mythos-5": _Price(10.0, 50.0),
+    "claude-opus-4-8": _Price(5.0, 25.0),
+    "claude-opus-4-7": _Price(5.0, 25.0),
+    "claude-opus-4-6": _Price(5.0, 25.0),
+    "claude-opus-4-5": _Price(5.0, 25.0),
+    "claude-opus-4-1": _Price(15.0, 75.0),
+    "claude-opus-4": _Price(15.0, 75.0),
+    "claude-sonnet-5": _Price(3.0, 15.0),
+    "claude-sonnet-4-6": _Price(3.0, 15.0),
+    "claude-sonnet-4-5": _Price(3.0, 15.0),
+    "claude-sonnet-4": _Price(3.0, 15.0),
+    "claude-haiku-4-5": _Price(1.0, 5.0),
+}
+
+# Longest key first: ``claude-opus-4-8`` must be tried before ``claude-opus-4``
+# so a specific family is never shadowed by a shorter prefix of itself.
+_PRICE_KEYS: tuple[str, ...] = tuple(sorted(_PRICES, key=len, reverse=True))
+
+
+def _price_for(model: str | None) -> _Price | None:
+    """The price for ``model``, or ``None`` when the model is unknown/unset.
+
+    Matches by family containment so an exact id, a platform-prefixed id
+    (``anthropic.claude-...``), or a dated snapshot all resolve to one entry. An
+    unrecognized id returns ``None`` -- cost stays unknown rather than guessed.
+    """
+    if not model:
+        return None
+    for key in _PRICE_KEYS:
+        if key in model:
+            return _PRICES[key]
+    return None
+
+
+def cost_usd(
+    model: str | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+) -> float | None:
+    """Dollar cost of one turn's token usage under ``model``, or ``None``.
+
+    Returns ``None`` -- cost unknown, keeping the turn out of the matrix's cost
+    rollup rather than counting it as free -- when the model is unpriced, or when
+    neither token count was reported (an unpriced model, the fake tier, or a
+    provider that reported no usage). A reported count that is ``None`` is treated
+    as zero once at least one side is known, so a turn with only output tokens
+    still prices.
+    """
+    price = _price_for(model)
+    if price is None or (input_tokens is None and output_tokens is None):
+        return None
+    return (
+        (input_tokens or 0) * price.input_per_mtok
+        + (output_tokens or 0) * price.output_per_mtok
+    ) / 1_000_000

--- a/apps/worker/src/agentos_worker/eval/run.py
+++ b/apps/worker/src/agentos_worker/eval/run.py
@@ -28,6 +28,7 @@ from ..runner_client import RunnerClient
 from .models import EvalRunResult, EvalSuite
 from .recorder import LangfuseEvalRecorder
 from .runner import EvalRunner
+from .sampling import AggregationPolicy, SampleConfig
 
 
 def load_suite(path: str | Path) -> EvalSuite:
@@ -43,16 +44,19 @@ async def run_eval_suite(
     token: str | None = None,
     model: str | None = None,
     fake: bool = False,
+    samples: SampleConfig | None = None,
 ) -> EvalRunResult:
     """Run a suite against a runner endpoint and, if configured, record it.
 
     ``model`` is the model id the suite is being run under; it is threaded onto
     the ``EvalRunResult`` so the recorder can tag the model dimension and the
     eval matrix can slice pass-rate/cost by model. ``fake`` says that runner is
-    the fake model, whose turns are never graded (ADR-0055).
+    the fake model, whose turns are never graded (ADR-0055). ``samples`` is the
+    multi-sample / variance-aware-grading policy (#332); the default (``None`` ->
+    ``n=1``) runs each case once, unchanged.
     """
     async with RunnerClient() as runner:
-        result = await EvalRunner(runner).run(
+        result = await EvalRunner(runner, samples=samples).run(
             suite,
             base_url=base_url,
             version=version,
@@ -65,6 +69,20 @@ async def run_eval_suite(
     return result
 
 
+def _sample_config_from_env(env: Mapping[str, str]) -> SampleConfig:
+    """Build the multi-sample policy from the eval Job's env (#332).
+
+    ``AGENTOS_EVAL_SAMPLES`` (default 1) sets N; ``AGENTOS_EVAL_AGGREGATION``
+    (``majority`` | ``pass_at_k``, default ``majority``) the policy; and
+    ``AGENTOS_EVAL_PASS_AT_K`` (default 1) the pass@k threshold. Absent/unset
+    keys yield the backward-compatible ``n=1`` default.
+    """
+    n = int(env.get("AGENTOS_EVAL_SAMPLES", "1"))
+    policy = AggregationPolicy(env.get("AGENTOS_EVAL_AGGREGATION", AggregationPolicy.MAJORITY))
+    k = int(env.get("AGENTOS_EVAL_PASS_AT_K", "1"))
+    return SampleConfig(n=n, policy=policy, k=k)
+
+
 async def _main_async(env: Mapping[str, str]) -> int:
     suite = load_suite(env["AGENTOS_EVAL_SUITE"])
     base_url = env["AGENTOS_EVAL_TARGET_URL"]
@@ -73,6 +91,7 @@ async def _main_async(env: Mapping[str, str]) -> int:
     # (the same AGENTOS_MODEL the runner authenticates from). Empty/unset means
     # "model unknown", recorded as no model tag.
     model = env.get("AGENTOS_MODEL") or None
+    samples = _sample_config_from_env(env)
 
     lf_keys = ("LANGFUSE_HOST", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY")
     if all(k in env for k in lf_keys):
@@ -84,11 +103,12 @@ async def _main_async(env: Mapping[str, str]) -> int:
                 client=client,
             )
             result = await run_eval_suite(
-                suite, base_url=base_url, version=version, recorder=recorder, model=model
+                suite, base_url=base_url, version=version, recorder=recorder,
+                model=model, samples=samples,
             )
     else:
         result = await run_eval_suite(
-            suite, base_url=base_url, version=version, model=model
+            suite, base_url=base_url, version=version, model=model, samples=samples
         )
 
     print(result.model_dump_json())

--- a/apps/worker/src/agentos_worker/eval/runner.py
+++ b/apps/worker/src/agentos_worker/eval/runner.py
@@ -29,6 +29,8 @@ from aci_protocol import ErrorEvent, Event, Final, SessionStatus, TextDelta, Too
 
 from ..runner_client import RunnerClient, RunnerError
 from .models import EvalCase, EvalCaseResult, EvalOutcome, EvalRunResult, EvalSuite
+from .pricing import cost_usd
+from .sampling import SampleConfig, aggregate
 from .scorer import GraderScorer, Scorer
 
 
@@ -45,9 +47,21 @@ class EvalRunner:
     skips the scorer entirely (see :meth:`run`).
     """
 
-    def __init__(self, runner: RunnerClient, *, scorer: Scorer | None = None) -> None:
+    def __init__(
+        self,
+        runner: RunnerClient,
+        *,
+        scorer: Scorer | None = None,
+        samples: SampleConfig | None = None,
+    ) -> None:
         self._runner = runner
         self._scorer: Scorer = scorer if scorer is not None else GraderScorer()
+        # Multi-sample policy (#332). Default n=1 is a no-op: each case runs once
+        # and its single result is returned unchanged, so existing suites behave
+        # exactly as before. n>1 runs the case n times and reduces the verdicts by
+        # the configured policy (majority / pass@k) -- variance-aware grading
+        # around the frozen case + scorer.
+        self._samples: SampleConfig = samples if samples is not None else SampleConfig()
 
     async def run(
         self,
@@ -64,33 +78,54 @@ class EvalRunner:
         ``fake`` says the runner behind ``base_url`` is the fake model, whose
         canned replies no grader can meaningfully judge (ADR-0055). It is not a
         scoring mode: the scorer is not consulted at all on a completed fake turn.
+
+        Each case is run :attr:`SampleConfig.n` times and the per-sample verdicts
+        are reduced to one by the configured aggregation policy (#332). With the
+        default ``n=1`` the case runs once and its result is returned unchanged.
         """
         results: list[EvalCaseResult] = []
         for case in suite.cases:
-            # Fresh conversation by default (#550): reset the runner before a case
-            # so it cannot inherit an earlier case's history. A shared_history
-            # case skips the reset and deliberately chains onto what preceded it.
-            if not case.shared_history:
-                isolation_error = await self._isolate(base_url, token)
-                if isolation_error is not None:
-                    # Could not establish isolation: fail the case rather than run
-                    # it against a possibly-leaked conversation (a false green is
-                    # exactly what #550 removes). One bad reset never aborts the
-                    # suite, matching the per-case error handling in _run_case.
-                    results.append(
-                        EvalCaseResult(
-                            case_id=case.id,
-                            outcome=EvalOutcome.FAIL,
-                            output="",
-                            latency_ms=0.0,
-                            error=isolation_error,
-                        )
-                    )
-                    continue
-            results.append(await self._run_case(case, base_url, token, fake=fake))
+            samples = [
+                await self._sample_case(case, base_url, token, model=model, fake=fake)
+                for _ in range(self._samples.n)
+            ]
+            results.append(aggregate(case.id, samples, self._samples))
         return EvalRunResult(
             version=version, suite=suite.name, results=results, model=model
         )
+
+    async def _sample_case(
+        self,
+        case: EvalCase,
+        base_url: str,
+        token: str | None,
+        *,
+        model: str | None,
+        fake: bool,
+    ) -> EvalCaseResult:
+        """Run one sample of a case: establish isolation, then run and score it.
+
+        Isolation is re-established before *every* sample (not once per case): two
+        samples of the same fresh-conversation case must each start clean, or the
+        second would inherit the first's turn and the samples would not be
+        independent draws. A ``shared_history`` case still skips the reset and
+        chains, matching its per-case semantics.
+        """
+        if not case.shared_history:
+            isolation_error = await self._isolate(base_url, token)
+            if isolation_error is not None:
+                # Could not establish isolation: fail the sample rather than run
+                # it against a possibly-leaked conversation (a false green is
+                # exactly what #550 removes). One bad reset never aborts the
+                # suite, matching the per-case error handling in _run_case.
+                return EvalCaseResult(
+                    case_id=case.id,
+                    outcome=EvalOutcome.FAIL,
+                    output="",
+                    latency_ms=0.0,
+                    error=isolation_error,
+                )
+        return await self._run_case(case, base_url, token, model=model, fake=fake)
 
     async def _isolate(self, base_url: str, token: str | None) -> str | None:
         """Reset the runner's conversation; return an error string on failure.
@@ -111,6 +146,7 @@ class EvalRunner:
         base_url: str,
         token: str | None = None,
         *,
+        model: str | None = None,
         fake: bool = False,
     ) -> EvalCaseResult:
         start = time.monotonic()
@@ -119,6 +155,8 @@ class EvalRunner:
         trajectory: list[str] = []
         final_text: str | None = None
         final_status: SessionStatus | None = None
+        input_tokens: int | None = None
+        output_tokens: int | None = None
         error_detail: str | None = None
         try:
             turn = await self._runner.start_turn(base_url, event, token=token)
@@ -133,6 +171,10 @@ class EvalRunner:
                     elif isinstance(frame, Final):
                         final_text = frame.text
                         final_status = frame.status
+                        # Token usage the runner stamped on the successful final
+                        # (#390); priced into cost_usd below for a graded turn.
+                        input_tokens = frame.input_tokens
+                        output_tokens = frame.output_tokens
                     elif isinstance(frame, ErrorEvent):
                         error_detail = frame.classification or frame.message
         except (RunnerError, aiohttp.ClientError, TimeoutError) as exc:
@@ -197,6 +239,10 @@ class EvalRunner:
             outcome=EvalOutcome.PASS if verdict.passed else EvalOutcome.FAIL,
             output=output,
             latency_ms=_elapsed_ms(start),
+            # Real token usage x model pricing (#390). None when the model is
+            # unpriced or the runner reported no usage, so the matrix omits this
+            # case from the model's cost rollup rather than counting it as free.
+            cost_usd=cost_usd(model, input_tokens, output_tokens),
         )
 
 

--- a/apps/worker/src/agentos_worker/eval/sampling.py
+++ b/apps/worker/src/agentos_worker/eval/sampling.py
@@ -1,0 +1,142 @@
+"""Multi-sample runs with variance-aware grading (#332).
+
+A single run grades noise: an agent that passes a case 2 times out of 3 is graded
+GREEN or RED depending on which run the CI happened to catch. This module is the
+*aggregation layer* around the frozen case + scorer: a case is run ``n`` times and
+the ``n`` per-sample verdicts are reduced to one, by **majority vote** or
+**pass@k**. The eval-case schema and the scorer are untouched -- sampling is a
+run-layer policy (like the trajectory-spec mapping), supplied above the port, not
+a field on the frozen ``EvalCase``.
+
+Backward compatible by construction: the default is ``n=1``, and the runner
+short-circuits a single-sample run to the exact one-shot result it produced
+before this module existed. Only ``n>1`` engages aggregation.
+
+Aggregation operates on the per-sample :class:`~.models.EvalCaseResult` list the
+runner already produces, so it is a pure, testable reduction with no runner or
+network dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .models import EvalCaseResult, EvalOutcome
+
+
+class AggregationPolicy(StrEnum):
+    """How ``n`` per-sample verdicts reduce to one.
+
+    ``MAJORITY`` -- GREEN when a strict majority of the graded samples passed
+    (ties fail, deny-by-default: a 1-of-2 split is not a pass). ``PASS_AT_K`` --
+    GREEN when at least ``k`` of the graded samples passed (the eval ``pass@k``:
+    with ``k=1`` a case is green if it passed even once, the loosest useful bar).
+    """
+
+    MAJORITY = "majority"
+    PASS_AT_K = "pass_at_k"
+
+
+@dataclass(frozen=True)
+class SampleConfig:
+    """How many times to run each case and how to reduce the verdicts.
+
+    ``n=1`` (the default) is a no-op: the runner returns the single sample
+    unchanged, so existing suites behave exactly as before. ``k`` is only read by
+    :data:`AggregationPolicy.PASS_AT_K` and is clamped into ``1..n``.
+    """
+
+    n: int = 1
+    policy: AggregationPolicy = AggregationPolicy.MAJORITY
+    k: int = 1
+
+    def __post_init__(self) -> None:
+        if self.n < 1:
+            raise ValueError(f"samples n must be >= 1, got {self.n}")
+        if self.k < 1:
+            raise ValueError(f"pass@k k must be >= 1, got {self.k}")
+
+    @property
+    def effective_k(self) -> int:
+        """``k`` clamped to ``1..n`` -- a k larger than n can never be met."""
+        return min(self.k, self.n)
+
+
+def _representative(samples: list[EvalCaseResult], outcome: EvalOutcome) -> EvalCaseResult:
+    """The first sample whose outcome matches the aggregate (fallback: first).
+
+    Used to source the aggregated row's ``output`` so a GREEN aggregate shows a
+    passing sample's answer and a RED one shows a failing sample's, rather than an
+    arbitrary sample that disagrees with the verdict.
+    """
+    for sample in samples:
+        if sample.outcome is outcome:
+            return sample
+    return samples[0]
+
+
+def _summed_cost(samples: list[EvalCaseResult]) -> float | None:
+    """Total cost across samples; None only when no sample reported a cost.
+
+    Summing (not averaging) keeps the matrix's per-model rollup counting the real
+    dollars ``n`` samples spent -- running a case 3x costs 3x, and the rollup
+    should say so.
+    """
+    known = [s.cost_usd for s in samples if s.cost_usd is not None]
+    return sum(known) if known else None
+
+
+def aggregate(
+    case_id: str, samples: list[EvalCaseResult], config: SampleConfig
+) -> EvalCaseResult:
+    """Reduce ``n`` per-sample results for one case to a single verdict.
+
+    Never called with an empty ``samples`` (the runner always produces at least
+    one). A single sample is returned unchanged so ``n=1`` is bit-for-bit the
+    pre-#332 behavior. All-plumbing (the fake tier) stays non-graded: there is no
+    verdict to vote on.
+    """
+    if len(samples) == 1:
+        return samples[0]
+
+    total_latency = round(sum(s.latency_ms for s in samples), 2)
+    cost = _summed_cost(samples)
+
+    # The fake tier is never graded, so an all-plumbing set has no verdict to
+    # aggregate -- it stays PLUMBING_OK. (fake runs are per-run, so a set is
+    # either all plumbing or none.)
+    if all(s.outcome is EvalOutcome.PLUMBING_OK for s in samples):
+        rep = samples[0]
+        return EvalCaseResult(
+            case_id=case_id,
+            outcome=EvalOutcome.PLUMBING_OK,
+            output=rep.output,
+            latency_ms=total_latency,
+            cost_usd=cost,
+        )
+
+    graded = [s for s in samples if s.outcome is not EvalOutcome.PLUMBING_OK]
+    passes = sum(1 for s in graded if s.outcome is EvalOutcome.PASS)
+    graded_count = len(graded)
+
+    if config.policy is AggregationPolicy.PASS_AT_K:
+        green = passes >= config.effective_k
+        bar = f"pass@{config.effective_k}"
+    else:  # MAJORITY
+        green = passes * 2 > graded_count
+        bar = "majority"
+
+    outcome = EvalOutcome.PASS if green else EvalOutcome.FAIL
+    variance = f"{passes}/{graded_count} samples passed ({bar})"
+    # Variance rides `error` only on a RED aggregate, matching the runner's
+    # convention that `error` explains why a case is not green; a flaky-but-green
+    # case (e.g. 2/3 under majority) reports GREEN and leaves `error` clear.
+    return EvalCaseResult(
+        case_id=case_id,
+        outcome=outcome,
+        output=_representative(samples, outcome).output,
+        latency_ms=total_latency,
+        error=None if green else f"variance-aware grading failed: {variance}",
+        cost_usd=cost,
+    )

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -103,6 +103,11 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         "AGENTOS_EVAL_SUITE",
         "AGENTOS_EVAL_TARGET_URL",
         "AGENTOS_EVAL_VERSION",
+        # Multi-sample / variance-aware grading policy (#332), read by the eval
+        # entrypoint (run.py::_sample_config_from_env), not a sandbox boot key.
+        "AGENTOS_EVAL_SAMPLES",
+        "AGENTOS_EVAL_AGGREGATION",
+        "AGENTOS_EVAL_PASS_AT_K",
         # Substrate wiring: how the worker provisions sandboxes, not what it puts
         # inside one. SubstrateConfig reads these from the worker's env.
         "AGENTOS_CLAIM_TIMEOUT_SECONDS",

--- a/apps/worker/tests/eval/conftest.py
+++ b/apps/worker/tests/eval/conftest.py
@@ -84,6 +84,15 @@ class FakeEvalRunner:
         # tool_note frames before the final, so scorer-seam tests can drive the
         # tool-call sequence a turn produced.
         self.tool_calls: dict[str, list[str]] = {}
+        # Per-input token usage stamped on the final ((input_tokens, output_tokens)),
+        # so cost-attribution tests (#390) can drive a turn's usage. Absent inputs
+        # emit a final with no usage, modelling a provider that reported none.
+        self.usage: dict[str, tuple[int, int]] = {}
+        # Per-input output sequence consumed one entry per delivery (clamped to the
+        # last), so multi-sample tests (#332) can drive a flaky case that answers
+        # differently across samples. Takes precedence over ``responses``.
+        self.output_sequence: dict[str, list[str]] = {}
+        self._sequence_calls: dict[str, int] = {}
         self.default_output = ""
         self.seen: list[dict[str, str]] = []
         # The accumulated conversation: every delivered input, cleared by reset.
@@ -114,9 +123,15 @@ class FakeEvalRunner:
         if text in self.fail_inputs:
             return web.json_response({"error": "boom"}, status=500)
         # A recall input answers from the conversation so far (the history that a
-        # reset would have cleared); otherwise fall back to the canned response.
+        # reset would have cleared); otherwise a per-sample output sequence (#332),
+        # else the canned response.
         if text in self.recall_inputs:
             output = " | ".join(self.history)
+        elif text in self.output_sequence:
+            seq = self.output_sequence[text]
+            idx = min(self._sequence_calls.get(text, 0), len(seq) - 1)
+            self._sequence_calls[text] = idx + 1
+            output = seq[idx]
         else:
             output = self.responses.get(text, self.default_output)
         self.history.append(text)
@@ -133,7 +148,13 @@ class FakeEvalRunner:
         for tool in self.tool_calls.get(text, []):
             note = ToolNote(text=f"calling {tool}", tool=tool)
             await resp.write((note.model_dump_json() + "\n").encode("utf-8"))
-        frame = Final(text=output, status=status)
+        usage = self.usage.get(text)
+        frame = Final(
+            text=output,
+            status=status,
+            input_tokens=usage[0] if usage else None,
+            output_tokens=usage[1] if usage else None,
+        )
         await resp.write((frame.model_dump_json() + "\n").encode("utf-8"))
         await resp.write_eof()
         return resp

--- a/apps/worker/tests/eval/test_pricing.py
+++ b/apps/worker/tests/eval/test_pricing.py
@@ -1,0 +1,43 @@
+"""Pricing table tests: real token usage x model price -> dollar cost (#390)."""
+
+from __future__ import annotations
+
+import pytest
+from agentos_worker.eval.pricing import cost_usd
+
+
+def test_prices_known_model_from_input_and_output_tokens() -> None:
+    # claude-opus-4-8: $5/1M input, $25/1M output.
+    # 1M input + 200k output = 5.0 + 5.0 = 10.0
+    assert cost_usd("claude-opus-4-8", 1_000_000, 200_000) == pytest.approx(10.0)
+
+
+def test_resolves_family_from_prefixed_or_dated_model_id() -> None:
+    # A platform-prefixed / dated id resolves to the same family price by
+    # containment, so a Bedrock-style id is not silently unpriced.
+    exact = cost_usd("claude-sonnet-4-5", 1_000_000, 0)
+    prefixed = cost_usd("anthropic.claude-sonnet-4-5-20250929", 1_000_000, 0)
+    assert exact == prefixed == pytest.approx(3.0)
+
+
+def test_specific_family_wins_over_shorter_prefix() -> None:
+    # claude-opus-4-1 is $15/1M input; the shorter claude-opus-4 prefix must not
+    # shadow it (longest key wins).
+    assert cost_usd("claude-opus-4-1-20250805", 1_000_000, 0) == pytest.approx(15.0)
+
+
+def test_unknown_model_is_none_not_guessed() -> None:
+    assert cost_usd("some-unpriced-model", 1_000_000, 200_000) is None
+
+
+def test_none_model_is_none() -> None:
+    assert cost_usd(None, 1_000_000, 200_000) is None
+
+
+def test_no_usage_at_all_is_none() -> None:
+    assert cost_usd("claude-opus-4-8", None, None) is None
+
+
+def test_partial_usage_prices_the_known_side() -> None:
+    # Only output reported: input treated as zero once one side is known.
+    assert cost_usd("claude-opus-4-8", None, 1_000_000) == pytest.approx(25.0)

--- a/apps/worker/tests/eval/test_runner.py
+++ b/apps/worker/tests/eval/test_runner.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 
 import pytest
 from agentos_worker.eval import (
+    AggregationPolicy,
     EvalCase,
     EvalOutcome,
     EvalRunner,
@@ -14,6 +15,7 @@ from agentos_worker.eval import (
     ExpectedStatus,
     Grader,
     GraderKind,
+    SampleConfig,
     ScoreResult,
 )
 
@@ -389,6 +391,182 @@ def test_a_fake_turn_that_does_not_complete_is_a_failure_not_plumbing_ok(
             assert case.passed is False
             assert case.error is not None  # the breakage reason is recorded
             assert spy.calls == 0  # a broken turn is not graded either
+
+    asyncio.run(go())
+
+
+def test_majority_vote_greens_a_case_that_passes_two_of_three_samples(make_eval_harness) -> None:
+    """#332: with n=3 majority, a case whose runner answers correctly 2 of 3 times
+    is GREEN, and the runner is reset before every sample so the draws are
+    independent (fresh conversation each time)."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            # 2 passing answers, 1 wrong -> 2/3 under majority.
+            fake.output_sequence = {"q": ["the answer is 4", "still 4", "nope"]}
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(client, samples=SampleConfig(n=3)).run(
+                suite, base_url=base_url, version="v1"
+            )
+
+            case = result.results[0]
+            assert case.passed is True
+            assert result.summary() == "1/1 passed"
+            # Reset ran before each of the 3 samples (independent fresh draws).
+            assert fake.resets == 3
+
+    asyncio.run(go())
+
+
+def test_flaky_case_that_passes_one_of_three_is_red_with_variance(make_eval_harness) -> None:
+    """A flaky case that passes only 1 of 3 samples is RED under majority and is
+    reported with its variance (the pass count)."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.output_sequence = {"q": ["the answer is 4", "nope", "wrong"]}
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(client, samples=SampleConfig(n=3)).run(
+                suite, base_url=base_url, version="v1"
+            )
+
+            case = result.results[0]
+            assert case.passed is False
+            assert case.error is not None and "1/3 samples passed" in case.error
+
+    asyncio.run(go())
+
+
+def test_pass_at_k_greens_a_case_that_passes_once(make_eval_harness) -> None:
+    """Under pass@1 the same 1-of-3 flaky case is GREEN (passed at least once)."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.output_sequence = {"q": ["nope", "the answer is 4", "wrong"]}
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(
+                client, samples=SampleConfig(n=3, policy=AggregationPolicy.PASS_AT_K, k=1)
+            ).run(suite, base_url=base_url, version="v1")
+
+            assert result.results[0].passed is True
+
+    asyncio.run(go())
+
+
+def test_default_single_sample_matches_pre_sampling_behavior(make_eval_harness) -> None:
+    """The default n=1 runs each case exactly once (one reset, one turn) -- the
+    backward-compatible no-op path."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "the answer is 4"}
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(client).run(suite, base_url=base_url, version="v1")
+
+            assert result.results[0].passed is True
+            assert fake.resets == 1  # one sample, one reset
+            assert len(fake.seen) == 1  # one turn delivered
+
+    asyncio.run(go())
+
+
+def test_cost_usd_is_priced_from_real_usage_for_a_known_model(make_eval_harness) -> None:
+    """#390: a graded turn with reported usage carries a dollar cost computed from
+    real token usage x the model's price, so the matrix's per-model cost rollup is
+    non-null after a real run. claude-opus-4-8 is $5/1M input, $25/1M output."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "the answer is 4"}
+            fake.usage = {"q": (1_000_000, 200_000)}  # 1M input, 200k output
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(client).run(
+                suite, base_url=base_url, version="v1", model="claude-opus-4-8"
+            )
+
+            case = result.results[0]
+            assert case.passed is True
+            # 1M * $5/1M + 200k * $25/1M = 5.0 + 5.0 = 10.0
+            assert case.cost_usd == pytest.approx(10.0)
+
+    asyncio.run(go())
+
+
+def test_cost_usd_is_none_for_an_unpriced_model(make_eval_harness) -> None:
+    """An unknown/unpriced model leaves cost None rather than guessing, so the
+    case drops out of the cost rollup instead of counting as free."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "the answer is 4"}
+            fake.usage = {"q": (1_000_000, 200_000)}
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(client).run(
+                suite, base_url=base_url, version="v1", model="some-unpriced-model"
+            )
+
+            assert result.results[0].passed is True
+            assert result.results[0].cost_usd is None
+
+    asyncio.run(go())
+
+
+def test_fake_model_run_leaves_cost_none_even_with_usage(make_eval_harness) -> None:
+    """A fake-tier run is never graded and never priced (#390 AC): even when the
+    fake reports usage, the turn returns PLUMBING_OK before cost is computed, so
+    cost stays None (no pricing)."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "all done"}
+            fake.usage = {"q": (1_000_000, 200_000)}
+            result = await EvalRunner(client).run(
+                _one_case_suite(), base_url=base_url, version="v1",
+                model="claude-opus-4-8", fake=True,
+            )
+
+            case = result.results[0]
+            assert case.outcome is EvalOutcome.PLUMBING_OK
+            assert case.cost_usd is None
+
+    asyncio.run(go())
+
+
+def test_cost_usd_is_none_when_the_runner_reports_no_usage(make_eval_harness) -> None:
+    """A priced model but no reported usage (an older runner, or a provider that
+    reports none) leaves cost None rather than pricing it as zero."""
+
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"q": "the answer is 4"}  # no fake.usage entry
+            suite = EvalSuite(
+                name="s",
+                cases=[EvalCase(id="c", input="q", grader=Grader(kind=CONTAINS, expected="4"))],
+            )
+            result = await EvalRunner(client).run(
+                suite, base_url=base_url, version="v1", model="claude-opus-4-8"
+            )
+
+            assert result.results[0].passed is True
+            assert result.results[0].cost_usd is None
 
     asyncio.run(go())
 

--- a/apps/worker/tests/eval/test_sampling.py
+++ b/apps/worker/tests/eval/test_sampling.py
@@ -1,0 +1,96 @@
+"""Multi-sample aggregation: majority vote / pass@k over per-sample results (#332)."""
+
+from __future__ import annotations
+
+import pytest
+from agentos_worker.eval.models import EvalCaseResult, EvalOutcome
+from agentos_worker.eval.sampling import AggregationPolicy, SampleConfig, aggregate
+
+
+def _result(outcome: EvalOutcome, *, output: str = "", latency: float = 1.0,
+            cost: float | None = None) -> EvalCaseResult:
+    return EvalCaseResult(
+        case_id="c", outcome=outcome, output=output, latency_ms=latency, cost_usd=cost
+    )
+
+
+def _samples(passes: int, fails: int) -> list[EvalCaseResult]:
+    return (
+        [_result(EvalOutcome.PASS, output="ok") for _ in range(passes)]
+        + [_result(EvalOutcome.FAIL, output="no") for _ in range(fails)]
+    )
+
+
+def test_single_sample_is_returned_unchanged() -> None:
+    # n=1 must be a bit-for-bit no-op: the exact pre-#332 result.
+    one = _result(EvalOutcome.PASS, output="answer", latency=12.5, cost=0.5)
+    assert aggregate("c", [one], SampleConfig(n=1)) is one
+
+
+def test_majority_two_of_three_is_green() -> None:
+    agg = aggregate("c", _samples(2, 1), SampleConfig(n=3, policy=AggregationPolicy.MAJORITY))
+    assert agg.passed is True
+    assert agg.error is None
+    assert agg.output == "ok"  # representative is a passing sample
+
+
+def test_majority_one_of_three_is_red_and_reports_variance() -> None:
+    agg = aggregate("c", _samples(1, 2), SampleConfig(n=3, policy=AggregationPolicy.MAJORITY))
+    assert agg.passed is False
+    assert agg.error is not None and "1/3 samples passed" in agg.error
+    assert agg.output == "no"  # representative is a failing sample
+
+
+def test_majority_tie_fails_deny_by_default() -> None:
+    agg = aggregate("c", _samples(1, 1), SampleConfig(n=2, policy=AggregationPolicy.MAJORITY))
+    assert agg.passed is False  # 1-of-2 is not a strict majority
+
+
+def test_pass_at_k_one_of_three_is_green() -> None:
+    agg = aggregate(
+        "c", _samples(1, 2), SampleConfig(n=3, policy=AggregationPolicy.PASS_AT_K, k=1)
+    )
+    assert agg.passed is True
+
+
+def test_pass_at_k_threshold_not_met_is_red() -> None:
+    agg = aggregate(
+        "c", _samples(1, 2), SampleConfig(n=3, policy=AggregationPolicy.PASS_AT_K, k=2)
+    )
+    assert agg.passed is False
+    assert agg.error is not None and "pass@2" in agg.error
+
+
+def test_summed_cost_across_samples() -> None:
+    samples = [
+        _result(EvalOutcome.PASS, cost=0.10),
+        _result(EvalOutcome.PASS, cost=0.20),
+        _result(EvalOutcome.FAIL, cost=None),
+    ]
+    agg = aggregate("c", samples, SampleConfig(n=3))
+    assert agg.cost_usd == pytest.approx(0.30)
+    assert agg.latency_ms == pytest.approx(3.0)
+
+
+def test_cost_none_when_no_sample_reported_cost() -> None:
+    agg = aggregate("c", _samples(2, 1), SampleConfig(n=3))
+    assert agg.cost_usd is None
+
+
+def test_all_plumbing_samples_stay_non_graded() -> None:
+    samples = [_result(EvalOutcome.PLUMBING_OK, output="all done") for _ in range(3)]
+    agg = aggregate("c", samples, SampleConfig(n=3))
+    assert agg.outcome is EvalOutcome.PLUMBING_OK
+    assert agg.passed is None
+    assert agg.error is None
+
+
+def test_config_rejects_nonpositive_n_and_k() -> None:
+    with pytest.raises(ValueError):
+        SampleConfig(n=0)
+    with pytest.raises(ValueError):
+        SampleConfig(k=0)
+
+
+def test_effective_k_clamps_to_n() -> None:
+    assert SampleConfig(n=3, k=5).effective_k == 3

--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -353,6 +353,8 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            input_tokens: None,
+            output_tokens: None,
         }
     }
 

--- a/cli/src/ndjson.rs
+++ b/cli/src/ndjson.rs
@@ -84,6 +84,8 @@ mod tests {
                 approval_route: None,
                 approval_gate_kind: None,
                 approval_granted_tool: None,
+                input_tokens: None,
+                output_tokens: None,
             }
         );
     }

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -156,6 +156,8 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            input_tokens: None,
+            output_tokens: None,
         };
         // A delta routes to stdout as a raw token.
         assert!(matches!(printer.part_for(&delta), Some(TurnPart::Token(t)) if t == "all done"));
@@ -176,6 +178,8 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            input_tokens: None,
+            output_tokens: None,
         };
         // The caller prints this token to stdout, then appends the status trailer.
         assert!(
@@ -194,6 +198,8 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            input_tokens: None,
+            output_tokens: None,
         };
         assert!(
             matches!(printer.part_for(&final_frame), Some(TurnPart::Status(s)) if s == "-- final (done)")

--- a/cli/tests/eval_falsifiability.rs
+++ b/cli/tests/eval_falsifiability.rs
@@ -106,6 +106,8 @@ fn done_turn(text: &str) -> Vec<OutboundEvent> {
         approval_route: None,
         approval_gate_kind: None,
         approval_granted_tool: None,
+        input_tokens: None,
+        output_tokens: None,
     }]
 }
 

--- a/cli/tests/fake_tier_plumbing.rs
+++ b/cli/tests/fake_tier_plumbing.rs
@@ -278,6 +278,8 @@ fn final_event(text: &str, status: SessionStatus) -> OutboundEvent {
         approval_route: None,
         approval_gate_kind: None,
         approval_granted_tool: None,
+        input_tokens: None,
+        output_tokens: None,
     }
 }
 

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.2.3";
+pub const PROTOCOL_VERSION: &str = "0.2.4";
 
 pub const RUNS_STREAM_DEFAULT: &str = "agentos:runs";
 
@@ -312,6 +312,10 @@ pub enum OutboundEvent {
         approval_gate_kind: Option<String>,
         #[serde(default)]
         approval_granted_tool: Option<String>,
+        #[serde(default)]
+        input_tokens: Option<i64>,
+        #[serde(default)]
+        output_tokens: Option<i64>,
     },
     #[serde(rename = "error")]
     ErrorEvent {
@@ -346,6 +350,8 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            input_tokens: None,
+            output_tokens: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -362,6 +368,8 @@ mod tests {
             approval_route: Some("managers".to_string()),
             approval_gate_kind: Some("policy".to_string()),
             approval_granted_tool: None,
+            input_tokens: None,
+            output_tokens: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -85,6 +85,8 @@ export type ApprovalGateKind = string | null;
 export type ApprovalGrantedTool = string | null;
 export type ApprovalRoute = string | null;
 export type ApprovalSummary = string | null;
+export type InputTokens = number | null;
+export type OutputTokens = number | null;
 /**
  * Terminal or awaiting status of a session, from the output contract.
  *
@@ -96,14 +98,14 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
@@ -132,12 +134,12 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 
-export interface ACIProtocolV023 {
+export interface ACIProtocolV024 {
   [k: string]: unknown;
 }
 /**
@@ -152,7 +154,7 @@ export interface ACIProtocolV023 {
  * provenance (#544, Decision C) written by the runner; both stay optional for
  * the rolling-deploy window.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -197,7 +199,7 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
@@ -229,7 +231,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -248,7 +250,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -264,7 +266,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -276,7 +278,7 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -293,7 +295,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -313,7 +315,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -327,7 +329,7 @@ export interface EvalReport {
 /**
  * An inbound event delivered into a live session (initial or follow-up).
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -362,7 +364,17 @@ export interface Event {
  * Both ``None`` on every other status, and ``None`` from an older runner that
  * predates these fields (the worker falls back to the prefix parse then).
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * ``input_tokens``/``output_tokens`` carry the turn's model token usage when
+ * the harness reported it (#390): the runner stamps them from the SDK result's
+ * ``usage`` so a consumer can attribute a dollar cost to the turn (model
+ * pricing lives with the consumer, not on the wire). Both ``None`` when usage
+ * was unavailable -- the fake-model path, a provider that reports no usage, or
+ * an older runner that predates these fields -- so a consumer computing cost
+ * leaves it unknown rather than counting the turn as free. Additive optional
+ * scalars: a tolerant consumer decoding an older producer's ``final`` simply
+ * sees them absent.
+ *
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
@@ -370,6 +382,8 @@ export interface Final {
   approval_granted_tool?: ApprovalGrantedTool;
   approval_route?: ApprovalRoute;
   approval_summary?: ApprovalSummary;
+  input_tokens?: InputTokens;
+  output_tokens?: OutputTokens;
   status?: SessionStatus;
   text: Text1;
   type: Type2;
@@ -379,7 +393,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -390,7 +404,7 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -402,7 +416,7 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -418,7 +432,7 @@ export interface ToolNote {
  * Its presence gates the no-retry-after-side-effects rule (section 2b): a
  * failed run carrying this flag escalates to a human instead of retrying.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
@@ -436,7 +450,7 @@ export interface SideEffectFlag {
  * stream-encoding helpers live with the producer (the dispatcher), not on this
  * frozen model, so the contract stays transport-agnostic.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -465,7 +479,7 @@ export interface QueuedTurn {
  * (its ``slack_api_base_url``, i.e. real Slack), so a producer that does not set
  * it keeps the pre-#19 behavior.
  *
- * This interface was referenced by `ACIProtocolV023`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV024`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -663,7 +663,7 @@
       "type": "object"
     },
     "Final": {
-      "description": "The terminal response event, carrying the session status.\n\n``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):\nthe human-readable statement of what needs approval, captured from the\nrun's approval request so the platform can persist it on the durable\n``Approval`` record and show it to the approver. ``approval_route`` names\nthe approval route the request targets (#247): declared in the bundle\nmanifest's ``approvalPolicy`` (versioned with the agent), bound to a\nworkspace channel per deployment by the worker. Both ``None`` on every\nother status; ``approval_route`` also ``None`` when the request named no\nroute (the platform falls back to the requesting channel).\n\n``approval_gate_kind`` records which gate produced the request (#544):\n``'permission'`` when the runner's tool-permission gate denied a real tool\ncall, ``'policy'`` when the model asked for a business-decision approval.\nIt is the durable provenance the worker branches on instead of sniffing the\nsummary prefix. ``approval_granted_tool`` carries the tool name the\npermission gate denied -- the trusted ``can_use_tool`` value the resume-turn\ngrant is bound to -- and is only ever set for ``approval_gate_kind =\n'permission'``; a policy gate never authorizes a tool, so it stays ``None``.\nBoth ``None`` on every other status, and ``None`` from an older runner that\npredates these fields (the worker falls back to the prefix parse then).",
+      "description": "The terminal response event, carrying the session status.\n\n``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):\nthe human-readable statement of what needs approval, captured from the\nrun's approval request so the platform can persist it on the durable\n``Approval`` record and show it to the approver. ``approval_route`` names\nthe approval route the request targets (#247): declared in the bundle\nmanifest's ``approvalPolicy`` (versioned with the agent), bound to a\nworkspace channel per deployment by the worker. Both ``None`` on every\nother status; ``approval_route`` also ``None`` when the request named no\nroute (the platform falls back to the requesting channel).\n\n``approval_gate_kind`` records which gate produced the request (#544):\n``'permission'`` when the runner's tool-permission gate denied a real tool\ncall, ``'policy'`` when the model asked for a business-decision approval.\nIt is the durable provenance the worker branches on instead of sniffing the\nsummary prefix. ``approval_granted_tool`` carries the tool name the\npermission gate denied -- the trusted ``can_use_tool`` value the resume-turn\ngrant is bound to -- and is only ever set for ``approval_gate_kind =\n'permission'``; a policy gate never authorizes a tool, so it stays ``None``.\nBoth ``None`` on every other status, and ``None`` from an older runner that\npredates these fields (the worker falls back to the prefix parse then).\n\n``input_tokens``/``output_tokens`` carry the turn's model token usage when\nthe harness reported it (#390): the runner stamps them from the SDK result's\n``usage`` so a consumer can attribute a dollar cost to the turn (model\npricing lives with the consumer, not on the wire). Both ``None`` when usage\nwas unavailable -- the fake-model path, a provider that reports no usage, or\nan older runner that predates these fields -- so a consumer computing cost\nleaves it unknown rather than counting the turn as free. Additive optional\nscalars: a tolerant consumer decoding an older producer's ``final`` simply\nsees them absent.",
       "properties": {
         "approval_gate_kind": {
           "anyOf": [
@@ -712,6 +712,30 @@
           ],
           "default": null,
           "title": "Approval Summary"
+        },
+        "input_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Input Tokens"
+        },
+        "output_tokens": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Output Tokens"
         },
         "status": {
           "$ref": "#/$defs/SessionStatus",
@@ -1107,6 +1131,6 @@
   },
   "$id": "https://curie.tech/agentos/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.2.3",
-  "title": "ACI Protocol v0.2.3"
+  "protocolVersion": "0.2.4",
+  "title": "ACI Protocol v0.2.4"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.2.3",
-  "wire_sha256": "13a79cc1e5be541658785911bfd3fbb51600c0f7b93d073772f77f211a49a1d3"
+  "protocol_version": "0.2.4",
+  "wire_sha256": "3546742a903c27e6d8e57939035a1a6815a8c411018f777c79ef0e4b643a7255"
 }

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -156,6 +156,16 @@ class Final(_OutboundBase):
     'permission'``; a policy gate never authorizes a tool, so it stays ``None``.
     Both ``None`` on every other status, and ``None`` from an older runner that
     predates these fields (the worker falls back to the prefix parse then).
+
+    ``input_tokens``/``output_tokens`` carry the turn's model token usage when
+    the harness reported it (#390): the runner stamps them from the SDK result's
+    ``usage`` so a consumer can attribute a dollar cost to the turn (model
+    pricing lives with the consumer, not on the wire). Both ``None`` when usage
+    was unavailable -- the fake-model path, a provider that reports no usage, or
+    an older runner that predates these fields -- so a consumer computing cost
+    leaves it unknown rather than counting the turn as free. Additive optional
+    scalars: a tolerant consumer decoding an older producer's ``final`` simply
+    sees them absent.
     """
 
     type: Literal["final"] = "final"
@@ -165,6 +175,8 @@ class Final(_OutboundBase):
     approval_route: str | None = None
     approval_gate_kind: str | None = None
     approval_granted_tool: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
 
 class ErrorEvent(_OutboundBase):

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -287,6 +287,8 @@ mod tests {
             approval_route: None,
             approval_gate_kind: None,
             approval_granted_tool: None,
+            input_tokens: None,
+            output_tokens: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -303,6 +305,8 @@ mod tests {
             approval_route: Some("managers".to_string()),
             approval_gate_kind: Some("policy".to_string()),
             approval_granted_tool: None,
+            input_tokens: None,
+            output_tokens: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.2.3"
+PROTOCOL_VERSION: Final = "0.2.4"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/runner/src/agentos_runner/translate.py
+++ b/runner/src/agentos_runner/translate.py
@@ -15,6 +15,7 @@ translation serve both the live HTTP turn and the conformance producer.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from aci_protocol import (
@@ -190,4 +191,36 @@ def _translate_result(
     # so a reasoning model whose result-extraction returned empty (issue #107)
     # still delivers its answer. Provider-agnostic: it only fires when result is
     # empty, so non-reasoning models and the fake-model path are unaffected.
-    return [Final(text=message.result or state.assistant_text, status=SessionStatus.DONE)]
+    #
+    # Stamp the turn's token usage on the successful final (#390) so a consumer
+    # (the eval runner) can attribute a dollar cost to the turn. Only the clean
+    # DONE final carries usage: a classified failure never grades, and the
+    # interrupt/approval overrides in the session reconstruct their own final.
+    input_tokens, output_tokens = _usage_tokens(message.usage)
+    return [
+        Final(
+            text=message.result or state.assistant_text,
+            status=SessionStatus.DONE,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+    ]
+
+
+def _usage_tokens(usage: object) -> tuple[int | None, int | None]:
+    """Read ``input_tokens``/``output_tokens`` off the SDK result's usage block.
+
+    The SDK reports usage as a mapping (the Anthropic wire shape); a missing
+    block or a non-integer value yields ``None`` so the wire never carries a
+    fabricated count. Cache-token fields are deliberately not surfaced here --
+    the eval cost model prices prompt/completion tokens only, and each eval case
+    runs a fresh conversation (little cache benefit to attribute).
+    """
+    if not isinstance(usage, Mapping):
+        return None, None
+
+    def _int(key: str) -> int | None:
+        value = usage.get(key)
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+    return _int("input_tokens"), _int("output_tokens")

--- a/runner/tests/test_translate.py
+++ b/runner/tests/test_translate.py
@@ -59,6 +59,44 @@ def test_result_success_is_final_done() -> None:
     assert events[0].text == "answer"
 
 
+def test_success_final_carries_token_usage() -> None:
+    # #390: usage from the SDK result rides the successful final so a consumer
+    # can attribute a dollar cost to the turn.
+    msg = ResultMessage(
+        subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
+        num_turns=1, session_id="s", result="answer",
+        usage={"input_tokens": 1200, "output_tokens": 88},
+    )
+    events = _translate(msg)
+    assert events[0].input_tokens == 1200
+    assert events[0].output_tokens == 88
+
+
+def test_success_final_has_no_usage_when_result_reports_none() -> None:
+    # A result with no usage block leaves the wire counts None (never a
+    # fabricated zero), so a consumer reads "cost unknown".
+    msg = ResultMessage(
+        subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
+        num_turns=1, session_id="s", result="answer", usage=None,
+    )
+    events = _translate(msg)
+    assert events[0].input_tokens is None
+    assert events[0].output_tokens is None
+
+
+def test_failure_final_carries_no_usage() -> None:
+    # A classified-failure final is never graded, so it carries no cost signal.
+    msg = ResultMessage(
+        subtype="error", duration_ms=1, duration_api_ms=1, is_error=True,
+        num_turns=1, session_id="s", result="boom",
+        usage={"input_tokens": 10, "output_tokens": 2},
+    )
+    events = _translate(msg)
+    final = next(e for e in events if e.type == "final")
+    assert final.input_tokens is None
+    assert final.output_tokens is None
+
+
 def test_reasoning_model_empty_result_falls_back_to_assistant_text() -> None:
     # A reasoning model routed through OpenRouter (e.g. z-ai/glm-5.2) streams the
     # answer as a TextBlock but the terminal ResultMessage reports success with an


### PR DESCRIPTION
Two folded eval-runner changes that both touch the run loop (kept on one branch to avoid a merge conflict in `runner.py`).

## Cost attribution (#390)
`EvalCaseResult.cost_usd` was declared and read by the recorder and matrix rollup but never set, so every per-model cost rollup was null.

- The runner now stamps the turn's model token usage on the successful ACI `final` (new optional `input_tokens`/`output_tokens` scalars on `Final`). This is a backward-compatible new-optional-field patch bump of the wire (`0.2.3` -> `0.2.4`), with the JSON schema, generated Rust, generated TS, and wire lock regenerated. This is the usage-source threading the evals INTERFACE doc named as the deliberate follow-up for this field.
- A new consumer-side per-model price map (`apps/worker/src/agentos_worker/eval/pricing.py`, Anthropic list pricing, USD per 1M tokens) prices that usage. Pricing lives with the consumer, not on the wire.
- `EvalRunner._run_case` sets `cost_usd` on graded turns. Unknown/unpriced models, the fake tier, and turns with no reported usage stay `None` (deny-by-default) rather than counting as free, so `GET /matrix?suite=<name>` returns non-null per-model `cost_usd` after a real run and fake-model runs stay `None`.

## Variance-aware grading (#332)
Single runs grade noise. A run-layer sampling policy (`apps/worker/src/agentos_worker/eval/sampling.py`) runs each case `n` times and reduces the per-sample verdicts by **majority vote** or **pass@k**.

- Aggregation layer around the frozen case + scorer; neither is changed, and no field is added to the frozen eval-case schema.
- Per-case isolation (the #550 fresh-conversation reset) is re-established before every sample, so the draws are independent.
- Default `n=1` is a bit-for-bit no-op, so existing suites are unchanged. Configurable per eval Job via `AGENTOS_EVAL_SAMPLES` / `AGENTOS_EVAL_AGGREGATION` / `AGENTOS_EVAL_PASS_AT_K`.
- A 2/3 case is GREEN under majority; a flaky case reports its variance (the pass count) in `error`.

## Tests
`uv run pytest apps/worker/tests apps/api/tests -q` -> 968 passed, 1 skipped. Runner + aci-protocol suites green; `ruff` and `mypy` clean; contract artifacts regenerated (Rust `cargo check` and TS `tsc` pass).

Closes #390
Closes #332