### PR TITLE
Add harness contribution manifest and entry-point registry

### DIFF
--- a/runner/pyproject.toml
+++ b/runner/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "anyio>=4.6",
 ]
 
+[project.entry-points."agentos.harness"]
+claude = "agentos_runner.harness.claude:get_contribution"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/runner/src/agentos_runner/__init__.py
+++ b/runner/src/agentos_runner/__init__.py
@@ -14,6 +14,7 @@ from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .config import RunnerConfig
 from .conformance import conformance_producer
 from .fake import FakeModelSession
+from .harness import HarnessContribution, discover_contributions, resolve_harness
 from .hooks import load_bundle_hooks
 from .memory import (
     ConsolidationResult,
@@ -77,4 +78,7 @@ __all__ = [
     "consolidate_memory",
     "consolidate_records",
     "merge_provenance",
+    "HarnessContribution",
+    "discover_contributions",
+    "resolve_harness",
 ]

--- a/runner/src/agentos_runner/harness/__init__.py
+++ b/runner/src/agentos_runner/harness/__init__.py
@@ -1,0 +1,29 @@
+"""The harness contribution manifest and its entry-point registry (ADR-0060)."""
+
+from .claude import CLAUDE_CONTRIBUTION, get_contribution
+from .contribution import AuthSpec, BundleCompileResult, HarnessContribution, InstallSpec
+from .registry import (
+    BUILTIN_HARNESS_CANONICAL_PATHS,
+    ENTRY_POINT_GROUP,
+    FlatHarnessPackageError,
+    HarnessNameCollisionError,
+    UnknownHarnessError,
+    discover_contributions,
+    resolve_harness,
+)
+
+__all__ = [
+    "HarnessContribution",
+    "InstallSpec",
+    "AuthSpec",
+    "BundleCompileResult",
+    "CLAUDE_CONTRIBUTION",
+    "get_contribution",
+    "ENTRY_POINT_GROUP",
+    "BUILTIN_HARNESS_CANONICAL_PATHS",
+    "FlatHarnessPackageError",
+    "HarnessNameCollisionError",
+    "UnknownHarnessError",
+    "discover_contributions",
+    "resolve_harness",
+]

--- a/runner/src/agentos_runner/harness/claude.py
+++ b/runner/src/agentos_runner/harness/claude.py
@@ -1,0 +1,49 @@
+"""The Claude harness's own contribution manifest (ADR-0060).
+
+Wraps the already-landed ``side_effects.py``, ``sdk_auth.py``, and
+``plugin.py`` -- this module declares no new behavior, it just names what
+already exists so a second harness has something to register alongside. This
+is the built-in registered under ``registry.BUILTIN_HARNESS_CANONICAL_PATHS``,
+so any third-party entry point claiming the name ``"claude"`` under a
+different module path is refused by the registry's guard rules.
+"""
+
+from __future__ import annotations
+
+from .. import sdk_auth, side_effects
+from ..plugin import load_bundle_system_prompt, load_plugins
+from .contribution import AuthSpec, BundleCompileResult, HarnessContribution, InstallSpec
+
+
+def _compile_bundle(plugin_dir: str | None) -> BundleCompileResult:
+    return BundleCompileResult(
+        plugins=load_plugins(plugin_dir),
+        system_prompt=load_bundle_system_prompt(plugin_dir),
+    )
+
+
+CLAUDE_CONTRIBUTION = HarnessContribution(
+    name="claude",
+    aliases=frozenset({"claude-sdk", "claude-code"}),
+    image="agentos-runner",
+    install=InstallSpec(
+        packages=("@anthropic-ai/claude-code",),
+        notes="runs as a non-root user; see runner/Dockerfile",
+    ),
+    auth=AuthSpec(
+        credential_env_keys=sdk_auth.DEFAULT_CREDENTIAL_ENV_KEYS,
+        oauth_token_prefix=sdk_auth.OAUTH_TOKEN_PREFIX,
+    ),
+    readonly_tools=side_effects.CLAUDE_READONLY_TOOLS,
+    model_override_env_keys=(
+        sdk_auth.MODEL_BASE_URL_ENV,
+        sdk_auth.API_BACKEND_ENV,
+        sdk_auth.MODEL_ENV_KEY_ENV,
+    ),
+    build_spawn_env=sdk_auth.resolve_sdk_env,
+    compile_bundle=_compile_bundle,
+)
+
+
+def get_contribution() -> HarnessContribution:
+    return CLAUDE_CONTRIBUTION

--- a/runner/src/agentos_runner/harness/contribution.py
+++ b/runner/src/agentos_runner/harness/contribution.py
@@ -1,0 +1,63 @@
+"""The harness contribution manifest (ADR-0060).
+
+A harness is not the ``ModelSession`` class (``adapter.py``) alone -- it is
+everything the rest of the runner assumes about the engine that class drives:
+what the image must install, which credential shapes it accepts, which of its
+tools are safe to retry, which env vars carry a model override, and how a
+mounted bundle becomes that engine's native session config. Today those facts
+are scattered across ``sdk_auth.py``, ``side_effects.py``, and ``plugin.py`` as
+free functions and module-level constants with no single name tying them
+together. ``HarnessContribution`` is that name: one declared object per
+harness, discovered via ``registry.py``.
+
+These are plain, unfrozen dataclasses (matching ``config.py``'s
+``RunnerConfig``), not a ``packages/`` contract type. Freezing this shape with
+tri-language codegen is a deliberate later choice once a second harness has
+exercised it, not an accident of where the file lives.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, MutableMapping
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class InstallSpec:
+    """What the runner image must install for this harness to run."""
+
+    packages: tuple[str, ...] = ()
+    notes: str | None = None
+
+
+@dataclass(frozen=True)
+class AuthSpec:
+    """Which credential shapes this harness's auth resolution accepts."""
+
+    credential_env_keys: tuple[str, ...]
+    oauth_token_prefix: str | None
+
+
+@dataclass(frozen=True)
+class BundleCompileResult:
+    """A mounted bundle translated into this harness's native session config."""
+
+    plugins: list[Any]
+    system_prompt: str | None
+
+
+@dataclass(frozen=True)
+class HarnessContribution:
+    """Everything the runner needs to know about one harness, declared once."""
+
+    name: str
+    image: str
+    install: InstallSpec
+    auth: AuthSpec
+    readonly_tools: frozenset[str]
+    model_override_env_keys: tuple[str, ...]
+    build_spawn_env: Callable[[MutableMapping[str, str]], dict[str, str] | None]
+    compile_bundle: Callable[[str | None], BundleCompileResult]
+    aliases: frozenset[str] = field(default_factory=frozenset)
+    labels: frozenset[str] = field(default_factory=frozenset)

--- a/runner/src/agentos_runner/harness/registry.py
+++ b/runner/src/agentos_runner/harness/registry.py
@@ -1,0 +1,109 @@
+"""Entry-point discovery for harness contributions (ADR-0060).
+
+Modeled on Databricks' Omnigent (Apache 2.0): a harness registers a Python
+entry point under ``ENTRY_POINT_GROUP`` whose value points at a
+``get_contribution() -> HarnessContribution`` callable. Two fail-closed guard
+rules are ported from Omnigent verbatim, both evaluated on entry-point
+*metadata* -- before ``ep.load()`` ever executes a line of the plugin's code,
+so an adversarial or merely-broken plugin cannot forge its way past a check by
+being expensive or side-effecting to import:
+
+1. **Flat package path refusal.** A registered ``value`` must dot into a real
+   package (``agentos_runner.harness.claude:get_contribution``), not a bare
+   top-level module (``claude:get_contribution``). A flat path is exactly the
+   shape most likely to collide with something else importable on the path,
+   and it is a namespacing smell a legitimate harness package never has a
+   reason to produce.
+2. **Built-in name collision refusal.** A registered *key* that matches a
+   name in ``BUILTIN_HARNESS_CANONICAL_PATHS`` is refused unless its ``value``
+   is that name's own canonical path. Silently shadowing the Claude harness
+   is the single worst failure this registry could produce, so an ambiguous
+   registration is refused rather than resolved by load order.
+
+Both refusals are fail-closed by design: an ambiguous or malformed registry
+entry is worse than a missing harness.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from importlib.metadata import EntryPoint
+from importlib.metadata import entry_points as _iter_entry_points
+
+from .contribution import HarnessContribution
+
+ENTRY_POINT_GROUP = "agentos.harness"
+
+# Canonical "module:attr" path for each built-in harness's own self-registration.
+# A third-party entry point may not claim one of these keys under any other path.
+BUILTIN_HARNESS_CANONICAL_PATHS: dict[str, str] = {
+    "claude": "agentos_runner.harness.claude:get_contribution",
+}
+
+
+class FlatHarnessPackageError(RuntimeError):
+    """Raised when a harness entry point registers a flat (unpackaged) module path."""
+
+
+class HarnessNameCollisionError(RuntimeError):
+    """Raised when a harness entry point claims a built-in harness's name."""
+
+
+class UnknownHarnessError(RuntimeError):
+    """Raised when a requested harness name (or alias) is not registered."""
+
+
+def _check_guards(ep: EntryPoint) -> None:
+    module_path = ep.value.split(":", 1)[0]
+    if "." not in module_path:
+        raise FlatHarnessPackageError(
+            f"harness entry point {ep.name!r} registers a flat package path "
+            f"{ep.value!r}; a harness must live in a real package, not a "
+            "top-level module."
+        )
+    canonical = BUILTIN_HARNESS_CANONICAL_PATHS.get(ep.name)
+    if canonical is not None and ep.value != canonical:
+        raise HarnessNameCollisionError(
+            f"harness entry point {ep.name!r} claims a built-in harness name "
+            f"but registers {ep.value!r}, not the built-in's canonical path "
+            f"{canonical!r}."
+        )
+
+
+def discover_contributions(
+    *, entry_points: Iterable[EntryPoint] | None = None
+) -> dict[str, HarnessContribution]:
+    """Discover every registered harness, keyed by its declared name and aliases.
+
+    Guard failures raise rather than silently skipping the offending entry
+    point: a malformed or colliding registration is a configuration error the
+    operator must fix, not a harness that quietly fails to appear.
+    """
+
+    eps = (
+        entry_points
+        if entry_points is not None
+        else _iter_entry_points(group=ENTRY_POINT_GROUP)
+    )
+    contributions: dict[str, HarnessContribution] = {}
+    for ep in eps:
+        _check_guards(ep)
+        get_contribution = ep.load()
+        contribution = get_contribution()
+        for key in (contribution.name, *contribution.aliases):
+            contributions[key] = contribution
+    return contributions
+
+
+def resolve_harness(
+    name: str, *, contributions: dict[str, HarnessContribution] | None = None
+) -> HarnessContribution:
+    """Resolve a harness by its declared name or one of its aliases."""
+
+    available = contributions if contributions is not None else discover_contributions()
+    try:
+        return available[name]
+    except KeyError:
+        raise UnknownHarnessError(
+            f"no harness registered under {name!r} (known: {sorted(available)})"
+        ) from None

--- a/runner/tests/test_harness_contribution.py
+++ b/runner/tests/test_harness_contribution.py
@@ -1,0 +1,68 @@
+"""The Claude harness's contribution wraps the existing modules, verbatim.
+
+Every assertion here checks equivalence (or identity) against the module the
+contribution wraps, not new behavior -- the contribution is a name for facts
+that already exist in ``side_effects.py``, ``sdk_auth.py``, and ``plugin.py``.
+"""
+
+from pathlib import Path
+
+import pytest
+from agentos_runner import CLAUDE_READONLY_TOOLS, load_bundle_system_prompt, load_plugins
+from agentos_runner.harness import get_contribution
+from agentos_runner.sdk_auth import (
+    API_BACKEND_ENV,
+    CREDENTIALS_ENV,
+    MODEL_BASE_URL_ENV,
+    MODEL_ENV_KEY_ENV,
+    UnsupportedApiBackendError,
+    resolve_sdk_env,
+)
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "packages/plugin-format/tests/fixtures"
+
+
+def test_claude_contribution_wraps_readonly_tools() -> None:
+    assert get_contribution().readonly_tools is CLAUDE_READONLY_TOOLS
+
+
+def test_claude_contribution_image_identity() -> None:
+    assert get_contribution().image == "agentos-runner"
+
+
+def test_claude_contribution_model_override_env_keys() -> None:
+    assert get_contribution().model_override_env_keys == (
+        MODEL_BASE_URL_ENV,
+        API_BACKEND_ENV,
+        MODEL_ENV_KEY_ENV,
+    )
+
+
+def test_build_spawn_env_matches_resolve_sdk_env_plain_credential() -> None:
+    build_spawn_env = get_contribution().build_spawn_env
+    env_a = {CREDENTIALS_ENV: "sk-ant-PLACEHOLDER"}
+    env_b = dict(env_a)
+    assert build_spawn_env(env_a) == resolve_sdk_env(env_b)
+    assert env_a == env_b
+
+
+def test_build_spawn_env_matches_resolve_sdk_env_chat_completions_refusal() -> None:
+    build_spawn_env = get_contribution().build_spawn_env
+    env = {CREDENTIALS_ENV: "sk-ant-PLACEHOLDER", API_BACKEND_ENV: "chat_completions"}
+    with pytest.raises(UnsupportedApiBackendError):
+        build_spawn_env(dict(env))
+    with pytest.raises(UnsupportedApiBackendError):
+        resolve_sdk_env(dict(env))
+
+
+def test_compile_bundle_matches_existing_loaders() -> None:
+    bundle = _FIXTURES / "valid_bundle"
+    result = get_contribution().compile_bundle(str(bundle))
+    assert result.plugins == load_plugins(str(bundle))
+    assert result.system_prompt == load_bundle_system_prompt(str(bundle))
+
+
+def test_compile_bundle_no_plugin_dir() -> None:
+    result = get_contribution().compile_bundle(None)
+    assert result.plugins == []
+    assert result.system_prompt is None

--- a/runner/tests/test_harness_registry.py
+++ b/runner/tests/test_harness_registry.py
@@ -1,0 +1,55 @@
+"""The harness entry-point registry and its two fail-closed guard rules (ADR-0060)."""
+
+from importlib.metadata import EntryPoint
+
+import pytest
+from agentos_runner import CLAUDE_READONLY_TOOLS
+from agentos_runner.harness.registry import (
+    ENTRY_POINT_GROUP,
+    FlatHarnessPackageError,
+    HarnessNameCollisionError,
+    UnknownHarnessError,
+    discover_contributions,
+    resolve_harness,
+)
+
+
+def _entry_point(name: str, value: str) -> EntryPoint:
+    return EntryPoint(name=name, value=value, group=ENTRY_POINT_GROUP)
+
+
+def test_discovers_claude_via_real_entry_point() -> None:
+    contributions = discover_contributions()
+    claude = contributions["claude"]
+    assert claude.readonly_tools == CLAUDE_READONLY_TOOLS
+
+
+def test_flat_package_path_refused() -> None:
+    with pytest.raises(FlatHarnessPackageError):
+        discover_contributions(entry_points=[_entry_point("evil", "evil:get_contribution")])
+
+
+def test_builtin_name_collision_refused() -> None:
+    with pytest.raises(HarnessNameCollisionError):
+        discover_contributions(
+            entry_points=[_entry_point("claude", "some.impostor.module:get_contribution")]
+        )
+
+
+def test_claudes_own_registration_is_not_flagged_as_collision() -> None:
+    contributions = discover_contributions(
+        entry_points=[_entry_point("claude", "agentos_runner.harness.claude:get_contribution")]
+    )
+    assert contributions["claude"].name == "claude"
+
+
+def test_resolve_harness_by_alias() -> None:
+    contributions = discover_contributions()
+    assert resolve_harness("claude-code", contributions=contributions) is resolve_harness(
+        "claude", contributions=contributions
+    )
+
+
+def test_resolve_unknown_harness_raises() -> None:
+    with pytest.raises(UnknownHarnessError):
+        resolve_harness("nonexistent", contributions={})


### PR DESCRIPTION
## What

First slice of ADR-0060 ("the harness is a declared package, not a class"): a `HarnessContribution` dataclass declaring a harness's install spec, auth spec, declared read-only tool set, model-override env keys, spawn-env builder, and bundle-compile hook, discovered via an `agentos.harness` entry point.

Both of Omnigent's fail-closed guard rules are ported, checked on entry-point metadata alone (before `ep.load()` ever runs a line of plugin code):
- **Flat package path refusal** — a registered entry point must dot into a real package, not a bare top-level module.
- **Built-in name collision refusal** — an entry point can't claim the name `claude` unless it's Claude's own canonical registration.

Claude's own contribution (`harness/claude.py`) wraps the already-landed `side_effects.CLAUDE_READONLY_TOOLS`, `sdk_auth.resolve_sdk_env`, and `plugin.load_plugins`/`load_bundle_system_prompt` — no reimplementation, no behavior change.

## What this deliberately does not do

- Does not touch `__main__.py`/`build_runner()` — the widest-blast-radius path in the repo (CI, `agentos skill up`, the chart's default pool per `runner/CLAUDE.md`). Wiring the boot path to resolve through the registry is a small, mechanical follow-up once this lands, so entry-point discovery (new to this codebase) proves itself unwired first.
- Does not touch the Rust CLI or the worker — declarative harness selection across that language boundary is ADR-0060 decision 3, a separate PR.
- Does not touch ADR-0061 (out-of-process boundary, gated on its own spike) or ADR-0062 (import-linter contract, `fake.py` rewrite, extended conformance).

`HarnessContribution` is a plain `@dataclass(frozen=True)` (matching `config.py`'s `RunnerConfig`), not a `packages/` frozen contract type — freezing this shape is a deliberate later choice once a second harness has exercised it.

## Testing

- `runner/tests/test_harness_registry.py` — both guard rules, alias resolution, real entry-point discovery.
- `runner/tests/test_harness_contribution.py` — the Claude contribution's fields checked for equivalence/identity against the modules it wraps.
- Full `runner/tests` suite: 436 passed, 4 skipped (unchanged from before this PR). `ruff check` and `mypy` clean.

Ref #844. ADR-0060/0061/0062.