### PR TITLE
Wire build_runner to the harness contribution registry

### DIFF
--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -26,6 +26,8 @@ from .approval import (
 )
 from .config import RunnerConfig
 from .fake import FakeModelSession
+from .harness.contribution import HarnessContribution
+from .harness.registry import UnknownHarnessError, resolve_harness
 from .history import (
     DEFAULT_PREAMBLE_MAX_BYTES,
     DEFAULT_PREAMBLE_MAX_TURNS,
@@ -37,15 +39,36 @@ from .history import (
 from .hooks import load_bundle_hooks
 from .memory import MemoryRecord, MemoryStore, format_memory_preamble, resolve_memory
 from .otel import RunTracer, build_tracer_provider
-from .plugin import load_bundle_system_prompt, load_plugins
 from .redact import install_stdout_redaction
-from .sdk_auth import UnsupportedCredentialError, resolve_sdk_env
+from .sdk_auth import UnsupportedCredentialError
 from .server import create_app
 from .session import SessionRunner
 from .side_effects import SideEffectClassifier
 from .state import STATE_SERVER_NAME, build_state_server, resolve_state_client
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_HARNESS = "claude"
+
+
+def _resolve_harness(name: str = DEFAULT_HARNESS) -> HarnessContribution:
+    """Resolve the active harness's contribution manifest (ADR-0060).
+
+    The built-in Claude harness must always be available, so if entry-point
+    metadata is somehow absent in this environment this falls back to its direct
+    import -- the critical boot path never depends on packaging metadata for the
+    built-in. A non-built-in name that isn't registered still raises, so an
+    operator who selects a harness that isn't installed fails loud, not silent.
+    """
+
+    try:
+        return resolve_harness(name)
+    except UnknownHarnessError:
+        if name == DEFAULT_HARNESS:
+            from .harness.claude import get_contribution
+
+            return get_contribution()
+        raise
 
 
 def _compose_system_prompt(
@@ -74,21 +97,32 @@ def build_runner(
     memory_preamble: str | None = None,
     history_store: TranscriptStore | None = None,
     conversation_preamble: str | None = None,
+    harness: HarnessContribution | None = None,
 ) -> SessionRunner:
-    """Wire a SessionRunner backed by a real claude-agent-sdk session.
+    """Wire a SessionRunner backed by the active harness's model session.
 
     ``fake_model`` (env ``AGENTOS_FAKE_MODEL``) swaps in the scripted fake session
     so the image can round-trip a synthetic event with no model credential or
     network -- used for the container smoke and any offline exercise of the wiring
     (OTel export included). It never reaches the Anthropic API.
+
+    ``harness`` is the resolved contribution manifest (ADR-0060) whose fields
+    drive the read-only tool set and bundle compile; it defaults to the built-in
+    Claude harness so existing callers are unaffected.
     """
 
-    # The effective system prompt is the ``systemPrompt`` shipped in the bundle
-    # manifest, versioned with the agent (epic #30). It is the declared surface
-    # and always wins: an env override let an operator silently replace the
-    # prompt the bundle ships, so the bundle said one thing and the sandbox ran
-    # another (#488).
-    system_prompt = load_bundle_system_prompt(config.session.plugin_dir)
+    # Resolve the active harness's contribution (ADR-0060): its manifest is the
+    # single source for the read-only tool classification and how a bundle
+    # compiles into session inputs, replacing the direct module imports these
+    # used to be. Defaults to the built-in Claude harness.
+    harness = harness or _resolve_harness()
+    # The bundle compiles once into this harness's native inputs (compile_bundle):
+    # the ``systemPrompt`` shipped in the manifest (versioned with the agent, epic
+    # #30) is the declared surface and always wins -- an env override let an
+    # operator silently replace the prompt the bundle ships (#488) -- and the
+    # bundle's plugins feed the session factory below.
+    compiled = harness.compile_bundle(config.session.plugin_dir)
+    system_prompt = compiled.system_prompt
     # Prior memory (#264) and this thread's recovered conversation (#20), both
     # loaded from outside the sandbox, lead the system prompt so the model sees
     # learned lessons and the prior exchange as durable context.
@@ -151,7 +185,7 @@ def build_runner(
                 # route through the real decision table on the offline tier (#561).
                 approval_gate=approval_gate,
             )
-        plugins = load_plugins(config.session.plugin_dir)
+        plugins = compiled.plugins
         options = build_options(
             plugins=plugins,
             model=config.model,
@@ -194,7 +228,7 @@ def build_runner(
         session_factory=factory,
         ceiling=config.ceiling,
         tracer=RunTracer(provider),
-        classifier=SideEffectClassifier(),
+        classifier=SideEffectClassifier(readonly_tools=harness.readonly_tools),
         trace_name=f"agentos-run:{config.session.session_id}",
         session_id=config.session.session_id,
         model=config.model,
@@ -296,14 +330,20 @@ def main() -> None:
         "yes",
     )
     logger.info("runner starting fake_model=%s", fake_model)
-    # A real session authenticates from the SDK's own credential env; map the
-    # forwarded ACI AGENTOS_CREDENTIALS reference onto it (a no-op for a fake
-    # run, which needs no credential). Raises on an unsupported credential so the
-    # process fails visibly before the port is up rather than after a real call.
+    # The active harness (ADR-0060). Its manifest supplies the per-spawn env
+    # builder used just below and is threaded into build_runner so the read-only
+    # tool set and bundle compile come from the same declaration. Defaults to the
+    # built-in Claude harness (declarative harness selection is a later step).
+    harness = _resolve_harness()
+    # A real session authenticates from the SDK's own credential env; the
+    # harness's per-spawn env builder maps the forwarded ACI AGENTOS_CREDENTIALS
+    # reference onto it (a no-op for a fake run, which needs no credential).
+    # Raises on an unsupported credential so the process fails visibly before the
+    # port is up rather than after a real call.
     override = None
     if not fake_model:
         try:
-            override = resolve_sdk_env(os.environ)
+            override = harness.build_spawn_env(os.environ)
         except UnsupportedCredentialError as exc:
             logger.error("credential resolution failed: %s", exc)
             raise
@@ -324,6 +364,7 @@ def main() -> None:
         memory_preamble=memory_preamble,
         history_store=history_store,
         conversation_preamble=conversation_preamble,
+        harness=harness,
     )
     app = create_app(runner, token=config.runner_token)
 

--- a/runner/tests/test_harness_boot_wiring.py
+++ b/runner/tests/test_harness_boot_wiring.py
@@ -1,0 +1,106 @@
+"""build_runner routes its harness-shaped behavior through the resolved
+HarnessContribution (ADR-0060, #844 phase 1) rather than through hardcoded
+Claude imports. These drive the real boot path (``fake_model=True``) and assert
+that the harness's declared fields are what the boot path actually consumes.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from agentos_runner import __main__ as boot
+from agentos_runner.__main__ import DEFAULT_HARNESS, _resolve_harness, build_runner
+from agentos_runner.config import RunnerConfig
+from agentos_runner.harness.contribution import (
+    AuthSpec,
+    BundleCompileResult,
+    HarnessContribution,
+    InstallSpec,
+)
+from agentos_runner.harness.registry import UnknownHarnessError
+
+_BUDGET = '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+
+
+def _config(tmp_path) -> RunnerConfig:
+    plugin = tmp_path / ".claude-plugin"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.json").write_text(json.dumps({"name": "wiring"}))
+    return RunnerConfig.from_env(
+        {
+            "AGENTOS_PLUGIN_DIR": str(tmp_path),
+            "AGENTOS_SESSION_ID": "s-wire",
+            "AGENTOS_SANDBOX_ID": "b-wire",
+            "AGENTOS_BUDGET": _BUDGET,
+        }
+    )
+
+
+def _harness(**overrides) -> HarnessContribution:
+    """A minimal, non-Claude contribution so the assertions can tell whether the
+    boot path read from THIS manifest or fell back to hardcoded Claude values."""
+    defaults: dict = dict(
+        name="test-harness",
+        image="test-image",
+        install=InstallSpec(),
+        auth=AuthSpec(credential_env_keys=(), oauth_token_prefix=None),
+        readonly_tools=frozenset({"CustomReadOnly"}),
+        model_override_env_keys=(),
+        build_spawn_env=lambda env: None,
+        compile_bundle=lambda plugin_dir: BundleCompileResult(
+            plugins=[], system_prompt=None
+        ),
+    )
+    defaults.update(overrides)
+    return HarnessContribution(**defaults)
+
+
+def test_build_runner_uses_the_harness_readonly_set(tmp_path) -> None:
+    # The side-effect classifier is built from the HARNESS's declared read-only
+    # set, not a hardcoded Claude one: this harness's own tool is idempotent, and
+    # Claude's "Read" -- absent from this set -- reads as side-effecting.
+    runner = build_runner(_config(tmp_path), fake_model=True, harness=_harness())
+    assert runner._classifier.is_side_effecting("CustomReadOnly") is False
+    assert runner._classifier.is_side_effecting("Read") is True
+
+
+def test_build_runner_default_harness_is_claude(tmp_path) -> None:
+    # With no harness passed, the default resolves the built-in Claude harness,
+    # whose read-only set contains "Read" (so it is not side-effecting).
+    runner = build_runner(_config(tmp_path), fake_model=True)
+    assert runner._classifier.is_side_effecting("Read") is False
+
+
+def test_build_runner_routes_bundle_compile_through_the_harness(tmp_path) -> None:
+    # The bundle is compiled via the harness's compile_bundle hook, called once
+    # with the config's plugin dir -- not via a direct load_plugins import.
+    calls: list[str | None] = []
+
+    def spy(plugin_dir: str | None) -> BundleCompileResult:
+        calls.append(plugin_dir)
+        return BundleCompileResult(plugins=[], system_prompt=None)
+
+    config = _config(tmp_path)
+    build_runner(config, fake_model=True, harness=_harness(compile_bundle=spy))
+    assert calls == [config.session.plugin_dir]
+
+
+def test_resolve_harness_default_alias_and_unknown() -> None:
+    assert _resolve_harness().name == "claude"
+    assert _resolve_harness("claude-sdk").name == "claude"  # an alias resolves
+    with pytest.raises(UnknownHarnessError):
+        _resolve_harness("no-such-harness")
+
+
+def test_resolve_harness_falls_back_to_builtin_when_registry_misses(monkeypatch) -> None:
+    # If entry-point discovery somehow cannot surface the built-in, the default
+    # falls back to its direct import so the boot path never loses Claude. A
+    # non-built-in name still raises rather than silently falling back.
+    def miss(name: str, **kwargs: object) -> HarnessContribution:
+        raise UnknownHarnessError(name)
+
+    monkeypatch.setattr(boot, "resolve_harness", miss)
+    assert _resolve_harness(DEFAULT_HARNESS).name == "claude"
+    with pytest.raises(UnknownHarnessError):
+        _resolve_harness("other")


### PR DESCRIPTION
Phase 1 of #844 continued: make the ADR-0060 harness manifest load-bearing in the runner boot path.

## What
[PR #845](https://github.com/curie-eng/agentos/pull/845) landed the `HarnessContribution` manifest, the entry-point registry, and Claude's own contribution — but nothing consumed them. This wires `build_runner` (and `main`) to resolve the active harness and drive their harness-shaped behavior from its manifest fields instead of reaching for `side_effects`/`sdk_auth`/`plugin` directly:

- **read-only tool set** → `harness.readonly_tools` (feeds `SideEffectClassifier`; still deny-by-default — the classifier unions the platform tools regardless);
- **per-spawn credential env** → `harness.build_spawn_env`;
- **bundle compile** → one `harness.compile_bundle` call yields plugins + `systemPrompt` (replacing the direct `load_plugins` / `load_bundle_system_prompt`).

Behavior is unchanged for the built-in Claude harness (its contribution wraps exactly those functions) — this is a **routing change, not a semantics change**.

`_resolve_harness` defaults to the built-in Claude harness and falls back to its direct import if entry-point metadata is somehow absent, so the critical boot path never depends on packaging metadata for the built-in. A non-built-in name that isn't registered still raises (fail loud, not silent).

## Not in this PR
Declarative harness **selection** — a `harness:` config field + CLI flag threaded across the Rust CLI/worker — is the next Phase 1 step; the default built-in is used for now. Phase 2 (ADR-0062 conformance teeth) and the Phase 0 ADR-0061 spike remain tracked in #844.

## Verification
- 5 new tests (`runner/tests/test_harness_boot_wiring.py`) prove the boot path *consumes* the manifest: the classifier reflects a custom harness's read-only set; the default resolves Claude; `compile_bundle` is the bundle path (called once with the plugin dir); the built-in fallback fires when discovery misses.
- Full runner suite: **441 passed, 4 skipped** (incl. conformance); `ruff` + `mypy` clean.
- No `packages/aci-protocol` change (frozen per ADR-0005 / ADR-0061 Decision 4).

Ref #844, ADR-0060.