### PR TITLE
Make the runner honor a declarative harness selection

### DIFF
--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -149,6 +149,10 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # runner-local false-completion knob; read by the runner from its own env,
         # not a boot contract key.
         "AGENTOS_FALSE_COMPLETION_CHECK",
+        # runner-local harness selection (ADR-0060, #844); read by the runner from
+        # its own env to pick the active harness, unset selects the built-in
+        # Claude. Not a boot contract key.
+        "AGENTOS_HARNESS",
     }
 )
 

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -27,7 +27,7 @@ from .approval import (
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .harness.contribution import HarnessContribution
-from .harness.registry import UnknownHarnessError, resolve_harness
+from .harness.registry import DEFAULT_HARNESS, UnknownHarnessError, resolve_harness
 from .history import (
     DEFAULT_PREAMBLE_MAX_BYTES,
     DEFAULT_PREAMBLE_MAX_TURNS,
@@ -47,8 +47,6 @@ from .side_effects import SideEffectClassifier
 from .state import STATE_SERVER_NAME, build_state_server, resolve_state_client
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_HARNESS = "claude"
 
 
 def _resolve_harness(name: str = DEFAULT_HARNESS) -> HarnessContribution:
@@ -330,11 +328,20 @@ def main() -> None:
         "yes",
     )
     logger.info("runner starting fake_model=%s", fake_model)
-    # The active harness (ADR-0060). Its manifest supplies the per-spawn env
-    # builder used just below and is threaded into build_runner so the read-only
-    # tool set and bundle compile come from the same declaration. Defaults to the
-    # built-in Claude harness (declarative harness selection is a later step).
-    harness = _resolve_harness()
+    config = RunnerConfig.from_env(os.environ)
+    logger.info(
+        "runner configured session=%s model=%s port=%d harness=%s",
+        config.session.session_id,
+        config.model,
+        config.port,
+        config.harness,
+    )
+    # The active harness (ADR-0060), SELECTED by config (AGENTOS_HARNESS, default
+    # the built-in Claude). Its manifest supplies the per-spawn env builder used
+    # just below and is threaded into build_runner so the read-only tool set and
+    # bundle compile come from the same declaration. An unregistered selection
+    # raises here, so a misconfigured harness fails visibly before the port is up.
+    harness = _resolve_harness(config.harness)
     # A real session authenticates from the SDK's own credential env; the
     # harness's per-spawn env builder maps the forwarded ACI AGENTOS_CREDENTIALS
     # reference onto it (a no-op for a fake run, which needs no credential).
@@ -347,13 +354,6 @@ def main() -> None:
         except UnsupportedCredentialError as exc:
             logger.error("credential resolution failed: %s", exc)
             raise
-    config = RunnerConfig.from_env(os.environ)
-    logger.info(
-        "runner configured session=%s model=%s port=%d",
-        config.session.session_id,
-        config.model,
-        config.port,
-    )
     memory_store, memory_preamble = _load_memory(config)
     history_store, conversation_preamble = _load_history(config)
     runner = build_runner(

--- a/runner/src/agentos_runner/config.py
+++ b/runner/src/agentos_runner/config.py
@@ -19,11 +19,19 @@ from dataclasses import dataclass
 
 from aci_protocol import BootEnv, SessionConfig
 
+from .harness.registry import DEFAULT_HARNESS
+
 
 @dataclass(frozen=True)
 class RunnerConfig:
     session: SessionConfig
     model: str | None
+    # The harness whose contribution manifest drives this runner (ADR-0060,
+    # #844): read from the runner-local AGENTOS_HARNESS knob (default the
+    # built-in Claude), NOT a BootEnv contract key -- the same runner-local read
+    # pattern as false_completion_check below. ``__main__`` resolves this name
+    # through the harness registry; an unregistered selection fails the boot.
+    harness: str
     max_turns: int
     history_ref: str | None
     # Tool names whose calls require human approval (#245, ADR-0010). The
@@ -99,9 +107,13 @@ class RunnerConfig:
         # reachable on a hand-run local runner.
         false_completion_raw = env.get("AGENTOS_FALSE_COMPLETION_CHECK", "")
         false_completion_check = false_completion_raw.strip().lower() in ("1", "true", "yes")
+        # Runner-local harness selection (ADR-0060, #844), not a BootEnv key:
+        # empty/unset selects the built-in Claude harness.
+        harness = env.get("AGENTOS_HARNESS", "").strip() or DEFAULT_HARNESS
         return cls(
             session=boot.session,
             model=boot.model,
+            harness=harness,
             max_turns=boot.max_turns if boot.max_turns is not None else 20,
             history_ref=boot.history_ref,
             approval_required_tools=boot.approval_required_tools,

--- a/runner/src/agentos_runner/harness/registry.py
+++ b/runner/src/agentos_runner/harness/registry.py
@@ -40,6 +40,11 @@ BUILTIN_HARNESS_CANONICAL_PATHS: dict[str, str] = {
     "claude": "agentos_runner.harness.claude:get_contribution",
 }
 
+# The harness selected when none is named (``AGENTOS_HARNESS`` unset): the
+# built-in Claude harness. Single source shared by the runner config and the
+# boot path so the default name is declared exactly once.
+DEFAULT_HARNESS = "claude"
+
 
 class FlatHarnessPackageError(RuntimeError):
     """Raised when a harness entry point registers a flat (unpackaged) module path."""

--- a/runner/tests/test_config.py
+++ b/runner/tests/test_config.py
@@ -19,6 +19,22 @@ def test_parses_budget_and_defaults() -> None:
     assert config.history_ref is None
 
 
+def test_harness_defaults_to_claude_when_unset() -> None:
+    # AGENTOS_HARNESS is a runner-local knob; unset selects the built-in Claude.
+    assert RunnerConfig.from_env(dict(_BASE)).harness == "claude"
+
+
+def test_harness_selection_is_read_from_env() -> None:
+    env = dict(_BASE, AGENTOS_HARNESS="claude-code")
+    assert RunnerConfig.from_env(env).harness == "claude-code"
+
+
+def test_harness_selection_is_stripped_and_empty_falls_back() -> None:
+    assert RunnerConfig.from_env(dict(_BASE, AGENTOS_HARNESS="  opencode ")).harness == "opencode"
+    # A whitespace-only (or empty) value is not a selection -- fall back to the default.
+    assert RunnerConfig.from_env(dict(_BASE, AGENTOS_HARNESS="   ")).harness == "claude"
+
+
 def test_history_ref_is_not_derived_from_memory_ref() -> None:
     # A memory ref is an externalized-memory pointer, not an SDK resume id, so it
     # must not become the rehydrate ref.

--- a/runner/tests/test_harness_boot_wiring.py
+++ b/runner/tests/test_harness_boot_wiring.py
@@ -93,6 +93,24 @@ def test_resolve_harness_default_alias_and_unknown() -> None:
         _resolve_harness("no-such-harness")
 
 
+def test_config_selected_unregistered_harness_fails_loud() -> None:
+    # End to end: a config-selected harness that isn't registered raises through
+    # the same _resolve_harness(config.harness) call main() makes -- no silent
+    # fallback for a non-built-in name, so a misconfigured harness fails visibly.
+    cfg = RunnerConfig.from_env(
+        {
+            "AGENTOS_PLUGIN_DIR": "/b",
+            "AGENTOS_SESSION_ID": "s",
+            "AGENTOS_SANDBOX_ID": "b",
+            "AGENTOS_BUDGET": _BUDGET,
+            "AGENTOS_HARNESS": "no-such-harness",
+        }
+    )
+    assert cfg.harness == "no-such-harness"
+    with pytest.raises(UnknownHarnessError):
+        _resolve_harness(cfg.harness)
+
+
 def test_resolve_harness_falls_back_to_builtin_when_registry_misses(monkeypatch) -> None:
     # If entry-point discovery somehow cannot surface the built-in, the default
     # falls back to its direct import so the boot path never loses Claude. A


### PR DESCRIPTION
Phase 1c (runner side) of #844, building on #846 (merged): harness selection becomes a declarative config value instead of three call sites implicitly agreeing on an image string.

## What
- `RunnerConfig` gains a `harness` field, read from the runner-local `AGENTOS_HARNESS` knob (default `"claude"`) — the same runner-local-read pattern as `false_completion_check`, **not** a BootEnv contract key, so `packages/aci-protocol` stays frozen.
- `main()` now loads config first, then resolves `_resolve_harness(config.harness)`. An unregistered selection raises before the port is up (a non-built-in name gets no fallback — fail loud). The boot log records the selected harness.
- The default-harness name is single-sourced as `registry.DEFAULT_HARNESS`, shared by `config.py` and the boot path.

## Not in this PR (the cross-language half)
A Rust CLI `--harness` flag and the worker/`Dockerfile` image call sites resolving *from* the selection. With one harness whose image is already the default, doing that correctly needs a **generated name→image manifest** (to avoid the Rust/Python drift ADR-0060 exists to eliminate) — its own PR, tracked in #844.

## Verification
- 4 new tests: `AGENTOS_HARNESS` parses/strips/defaults; a config-selected *unregistered* harness fails loud through the same `_resolve_harness(config.harness)` call `main()` makes.
- Full runner suite **445 passed / 4 skipped** (incl. conformance); `ruff` + `mypy` clean. No `aci-protocol` change.

Ref #844, ADR-0060.