### PR TITLE
Make LockAcquireTimeout retryable on the turn path

### DIFF
--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -611,6 +611,11 @@ class Kernel:
         # cannot be taken in time propagates as a release failure, same as a
         # timed-out release.
         lock_key = self._config.lock_key(thread_key)
+        # This outer bound shadows `acquire`'s own configured
+        # `lock_acquire_timeout_s` (45s by default): whichever fires first wins,
+        # and `_RESET_LOCK_ACQUIRE_TIMEOUT_S` is the shorter one, so it is the
+        # effective bound on the reset path. Both raise `TimeoutError` (the
+        # inner one as `LockAcquireTimeout`), so the caller sees one shape.
         token = await asyncio.wait_for(self._lock.acquire(lock_key), _RESET_LOCK_ACQUIRE_TIMEOUT_S)
         try:
             return await asyncio.wait_for(
@@ -746,11 +751,12 @@ class Kernel:
                 route = await self._route_and_start(thread, event, boot_env, packs)
         except (RunnerError, aiohttp.ClientError, TimeoutError, SandboxError) as exc:
             # The turn was never accepted (transient runner 5xx, runner not ready,
-            # claim timeout). Convert to a retryable outcome so process_event backs
-            # off and retries within max_attempts, instead of letting the entry
-            # escape to the consumer and sit pending for the whole reclaim window.
+            # claim timeout, route-lock acquire timeout). Convert to a retryable
+            # outcome so process_event backs off and retries within max_attempts,
+            # instead of letting the entry escape to the consumer and sit pending
+            # for the whole reclaim window.
             release_order()
-            logger.warning("turn start failed for %s: %s", qevent.event_id, exc)
+            logger.warning("turn start failed for %s: %r", qevent.event_id, exc)
             return TurnOutcome(terminal_ok=False, classification="runner-error")
         release_order()
 

--- a/apps/worker/src/agentos_worker/threadlock.py
+++ b/apps/worker/src/agentos_worker/threadlock.py
@@ -32,8 +32,19 @@ end
 """
 
 
-class LockAcquireTimeout(Exception):
-    """The per-thread lock was not acquired within the configured timeout."""
+class LockAcquireTimeout(TimeoutError):
+    """The per-thread lock was not acquired within the configured timeout.
+
+    A ``TimeoutError`` subclass on purpose (#849): it genuinely is a timeout, and
+    the kernel's turn path treats a failed turn start as a retryable outcome by
+    catching ``TimeoutError`` among the transient errors. As a plain
+    ``Exception`` this escaped that catch, so a contended lock left the stream
+    entry pending for the whole reclaim window instead of retrying in process.
+    Subclassing also makes the turn path uniform with the reset path, where the
+    outer ``asyncio.wait_for`` bound already raises ``TimeoutError``. Note that
+    since builtin ``TimeoutError`` subclasses ``OSError``, this exception is now
+    also an ``OSError``.
+    """
 
 
 class ThreadLock:

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -882,3 +882,70 @@ def test_claim_latency_is_logged(make_harness, caplog) -> None:
             assert ms >= 0
 
     asyncio.run(go())
+
+
+def test_lock_acquire_timeout_is_a_retryable_turn_start_failure(make_harness) -> None:
+    """#849, the sibling of the runner-500 turn-start failure above: the turn
+    never starts because the per-thread route lock cannot be taken in time.
+
+    The contention is real -- another holder squats the exact Valkey lock key,
+    so `acquire` polls to its deadline -- and the failure must come back as the
+    same retryable outcome the other transient turn-start failures do, not
+    escape `_attempt` to the consumer. The order lock must be released too, or
+    the next same-thread event would never route."""
+
+    async def go() -> None:
+        async with make_harness(lock_acquire_timeout_s=0.2) as h:
+            thread = "tLockTimeout"
+            # A foreign holder of the route lock, outliving the acquire deadline.
+            await h.async_redis.set(h.config.lock_key(thread), "another-worker", nx=True, px=60000)
+
+            released: list[bool] = []
+
+            def release_order() -> None:
+                released.append(True)
+
+            outcome = await h.kernel._attempt(_qevent("go", thread=thread), release_order)
+
+            assert outcome.terminal_ok is False
+            assert outcome.classification == "runner-error"  # retryable
+            assert h.runner.opened == []  # the turn was never started
+            assert released, "the order lock was not released on the failed start"
+
+    asyncio.run(go())
+
+
+def test_lock_acquire_timeout_retries_in_process(make_harness) -> None:
+    """#849: a route-lock acquire timeout is retried inside `process_event`,
+    within `max_attempts`, instead of escaping to the consumer and leaving the
+    stream entry pending for the whole reclaim window.
+
+    Attempt 1 finds the lock squatted by a foreign holder and times out without
+    ever reaching the runner; the squatter goes away once attempt 2 has begun,
+    so attempt 2 opens the turn and completes. `opened == ["go"]` is what
+    separates this from the runner-500 shape: the retry was caused by the lock,
+    not by a failed turn start at the runner."""
+
+    async def go() -> None:
+        async with make_harness(lock_acquire_timeout_s=0.2, max_attempts=3) as h:
+            thread = "tLockRetry"
+            lock_key = h.config.lock_key(thread)
+            await h.async_redis.set(lock_key, "another-worker", nx=True, px=60000)
+            h.runner.default_script = [Final(text="recovered", status=DONE)]
+
+            async def unsquat() -> None:
+                # Each attempt opens with a "booting" edit before it touches the
+                # lock, so a second one means attempt 1 already gave up.
+                await _wait_until(lambda: len(h.sink.updates) >= 2)
+                await h.async_redis.delete(lock_key)
+
+            freeing = asyncio.create_task(unsquat())
+            ev = _qevent("go", thread=thread)
+            await h.kernel.process_event(ev)
+            await freeing
+
+            assert h.runner.opened == ["go"]  # attempt 1 never reached the runner
+            assert h.sink.last_text == "recovered"
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())


### PR DESCRIPTION
`LockAcquireTimeout` was a plain `Exception`, so it fell outside the turn path's retryable tuple at `kernel.py`. A route-lock acquire timeout escaped `_attempt` and `process_event`, landed in the consumer's broad handler, and the stream entry was left pending for the full 15-minute `reclaim_min_idle_ms` window instead of retrying in-process within `max_attempts` and escalating. The Slack placeholder sat on "booting" for that whole window and the delivery burned one of `max_delivery: 5`.

It now subclasses `TimeoutError`, which the tuple already catches. That was chosen over extending the tuple because the failure genuinely is a timeout, it makes the turn path uniform with the reset path (where `asyncio.wait_for` already raises `TimeoutError`), and future catch sites get it for free. A repo-wide sweep found no `except TimeoutError` site whose behavior this changes: `ThreadLock` has exactly two call sites, and the reset path's caller already catches broadly.

Two smaller items ride along, both named by the issue or forced by the fix:
- The turn-start warning now formats the exception with `%r`. `LockAcquireTimeout` stringifies to the bare lock key and `asyncio.TimeoutError` to the empty string, so the log could not say which failure fired (same class of bug as #813).
- A comment at the reset-path acquire noting its 5s outer bound shadows the configured 45s `lock_acquire_timeout_s`, which the issue explicitly asked for.

Both regression tests induce real Valkey lock contention (a foreign token squatting the key) rather than asserting on the `except` clause. Verified failing on the pre-fix code with `LockAcquireTimeout` propagating out, and passing after.

Closes #849
