### PR TITLE
Wire the console Evals tab to the live evals matrix API

### DIFF
--- a/apps/ui/CLAUDE.md
+++ b/apps/ui/CLAUDE.md
@@ -15,10 +15,12 @@ structure and wiring detail in `apps/ui/README.md`.
   a fresh workspace degrades honestly (empty lists, zero metrics).
 - **Not everything is wired yet, but unwired surfaces are honest stubs, never
   demo data.** Create-agent + Deploy, Agents/Fleet, Runs/Traces, Metrics, Logs,
-  Cost, Memory, and Versions call the real API. Evals, Usage, and Settings render
-  a `ComingSoon` placeholder (`src/views/wired/WiredStubs.tsx`). Before wiring one
-  of these, check `apps/ui/README.md`'s "Not wired yet" list; when the endpoint
-  does not exist yet, keep the honest stub rather than inventing data.
+  Cost, Memory, Versions, and Evals call the real API (Evals reads
+  `GET /evals/matrix` in `src/views/wired/WiredEvals.tsx`). Usage and Settings
+  render a `ComingSoon` placeholder (`src/views/wired/WiredStubs.tsx`). Before
+  wiring one of these, check `apps/ui/README.md`'s "Not wired yet" list; when
+  the endpoint does not exist yet, keep the honest stub rather than inventing
+  data.
 - **All API calls are same-origin `/api`, proxied by Vite.** `apps/api` has
   no CORS middleware on purpose -- the browser must reach it same-origin.
   `vite.config.ts` proxies `/api` to `AGENTOS_API_TARGET` and strips the

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -32,7 +32,7 @@ production build on http://localhost:4173 (what Playwright drives).
 - `src/components/` — app chrome (Sidebar, Topbar, Confetti) and the create-agent
   modal (`modals/`).
 - `src/views/` — the wired views: `wired/*` (Overview, Agents, AgentDetail,
-  Versions, and the `ComingSoon`/stub views in `WiredStubs.tsx`), `Observability.tsx`
+  Versions, Evals, and the `ComingSoon`/stub views in `WiredStubs.tsx`), `Observability.tsx`
   and its `obs/*` panels (RealTraces, RealMetrics, RealLogs, RealCost, RealMemory).
 - `e2e/` — Playwright specs. `design-review/` — committed side-by-side fidelity
   screenshots (impl vs the design canon).
@@ -40,7 +40,7 @@ production build on http://localhost:4173 (what Playwright drives).
 ## Backend wiring
 
 Every view is backed by the live API. Surfaces without a backend yet render an
-honest `ComingSoon` stub (Evals, Usage, Settings).
+honest `ComingSoon` stub (Usage, Settings).
 
 **Wired (real API):**
 - Create agent + Deploy: the create-agent modal POSTs `/agents` and
@@ -84,7 +84,7 @@ descriptor) and shows only the five API-backed metrics. The per-agent filter is 
 trace-name substring server-side, so it is presented as a plain "name contains"
 filter, not exact matching.
 
-**Not wired yet (honest stubs, no demo data):** Evals, Usage, and Settings
+**Not wired yet (honest stubs, no demo data):** Usage and Settings
 render a `ComingSoon` placeholder (`src/views/wired/WiredStubs.tsx`). These state
 plainly what is not wired yet rather than showing fictional data.
 
@@ -135,7 +135,7 @@ Config reference: `.env.example`.
 
 ## Wiring the rest
 
-- The remaining `ComingSoon` stubs (Evals, Usage, Settings) each bind to their
+- The remaining `ComingSoon` stubs (Usage, Settings) each bind to their
   API endpoint once it exists; until then they must stay honest stubs, never
   demo data.
 - The Runs path renders the API's `ObservationNode` tree directly.

--- a/apps/ui/e2e/cold-start-wired.spec.ts
+++ b/apps/ui/e2e/cold-start-wired.spec.ts
@@ -44,6 +44,11 @@ async function stubBackend(page: Page) {
   );
   await page.route("**/api/observability/metrics/summary*", (route) => route.fulfill(json(200, SUMMARY)));
   await page.route("**/api/langfuse/traces*", (route) => route.fulfill(json(200, [])));
+  // A fresh workspace has no eval runs: the matrix comes back empty, so the
+  // wired Evals view degrades to its honest empty state (no fixture cases).
+  await page.route("**/api/evals/matrix*", (route) =>
+    route.fulfill(json(200, { suite: "default", versions: [], cases: [], rows: [], models: [], model_summaries: [] })),
+  );
   return { agents, posted };
 }
 

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -11,7 +11,8 @@ import { Observability } from "./views/Observability";
 import { WiredOverview } from "./views/wired/WiredOverview";
 import { WiredAgents } from "./views/wired/WiredAgents";
 import { WiredAgentDetail } from "./views/wired/WiredAgentDetail";
-import { WiredEvals, WiredConnections, WiredSettings } from "./views/wired/WiredStubs";
+import { WiredConnections, WiredSettings } from "./views/wired/WiredStubs";
+import { WiredEvals } from "./views/wired/WiredEvals";
 import { WiredVersions } from "./views/wired/WiredVersions";
 
 // The console is always backed by the live API. Each nav renders its

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -222,6 +222,57 @@ export async function promoteTraceToEvalCase(traceId: string): Promise<EvalCaseO
   return jsonOrThrow<EvalCaseOut>(resp);
 }
 
+// ---- K1: the eval matrix — cases × versions grid + per-model rollup ----
+
+// One cell of the eval matrix: a case's outcome on a version column.
+// `plumbing_ok` means the case ran to completion but no grader judged it (the
+// fake-model tier); it is neither a pass nor a fail and must never read green.
+export type EvalStatus = "pass" | "fail" | "plumbing_ok" | "missing";
+
+export interface EvalCell {
+  version: string;
+  status: EvalStatus;
+  // The model the result was produced under, or null when the run was unlabelled.
+  model: string | null;
+}
+
+export interface EvalMatrixRow {
+  case_id: string;
+  cells: EvalCell[];
+}
+
+// A per-model rollup across the suite. `passed`/`total` exclude non-graded
+// (plumbing) rows, counted separately in `plumbing`; `completed` (⊆ `total`) is
+// the graded rows whose turn actually reached a verdict, so `total > 0` with
+// `completed === 0` is a model that never answered — distinct from a real 0%.
+export interface EvalModelSummary {
+  model: string | null;
+  passed: number;
+  total: number;
+  cost_usd: number | null;
+  plumbing: number;
+  completed: number;
+}
+
+export interface EvalMatrix {
+  suite: string;
+  // Version columns, most-recently-exercised first, capped at the requested N.
+  versions: string[];
+  cases: string[];
+  rows: EvalMatrixRow[];
+  models: (string | null)[];
+  model_summaries: EvalModelSummary[];
+}
+
+// Read the eval matrix for a suite. The matrix is filtered by suite (the real
+// dimension on eval traces); `versions` caps the number of version columns.
+export async function getEvalMatrix(suite: string, versions = 5): Promise<EvalMatrix> {
+  const resp = await fetch(url(`/evals/matrix${query({ suite, versions })}`), {
+    headers: headers(),
+  });
+  return jsonOrThrow<EvalMatrix>(resp);
+}
+
 // ---- observability (OB1): Langfuse-backed metrics + runner-pod log proxy ----
 
 export type MetricKey = "runs" | "latency_p95_ms" | "tokens" | "cost_usd" | "error_rate";

--- a/apps/ui/src/api/hooks.ts
+++ b/apps/ui/src/api/hooks.ts
@@ -6,6 +6,7 @@ import {
   getMetricSeries,
   getAgents,
   getCost,
+  getEvalMatrix,
   listVersions,
   listDeployments,
   listAllDeployments,
@@ -20,6 +21,7 @@ import {
   type MetricFilter,
   type AgentOut,
   type CostReport,
+  type EvalMatrix,
   type VersionOut,
   type DeploymentOut,
   type BundleFile,
@@ -106,6 +108,18 @@ export function useAllDeployments(enabled: boolean): Async<DeploymentOut[]> {
     queryFn: () => listAllDeployments(),
   });
   return asyncFrom(enabled, query);
+}
+
+// Fetch the eval matrix for a suite (K1). Keyed on suite + version count so a
+// suite change refetches; gated on a non-empty suite (the endpoint requires it).
+export function useEvalMatrix(suite: string, versions = 5): Async<EvalMatrix> {
+  const gate = suite.trim().length > 0;
+  const query = useQuery({
+    queryKey: ["evalMatrix", suite, versions],
+    enabled: gate,
+    queryFn: () => getEvalMatrix(suite, versions),
+  });
+  return asyncFrom(gate, query);
 }
 
 // Fetch the per-agent cost report (total + daily points).

--- a/apps/ui/src/primitives/CliHint.parity.test.tsx
+++ b/apps/ui/src/primitives/CliHint.parity.test.tsx
@@ -20,6 +20,7 @@ const EXPECTED_COMMAND_IDS = [
   "local.status",
 ] as const;
 const EXPECTED_NO_CLI_ACTION_IDS = [
+  "eval-matrix",
   "memory-delete",
   "memory-edit",
 ] as const satisfies readonly WiredActionId[];

--- a/apps/ui/src/primitives/parity.ts
+++ b/apps/ui/src/primitives/parity.ts
@@ -68,6 +68,11 @@ export const WIRED_ACTIONS = [
   // CLI verb exists yet, so both render the honest amber gap glyph.
   { id: "memory-edit", label: "Edit a learned memory entry", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
   { id: "memory-delete", label: "Delete a learned memory entry", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
+
+  // WiredEvals (#868) — the eval matrix is read from GET /evals/matrix. There is
+  // no top-level `agentos` verb that just reads the matrix (the CLI polls it
+  // internally during a model sweep), so the view renders the honest amber gap.
+  { id: "eval-matrix", label: "View the eval matrix", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
 ] as const satisfies readonly WiredAction[];
 
 export type WiredActionId = (typeof WIRED_ACTIONS)[number]["id"];

--- a/apps/ui/src/views/wired/WiredEvals.test.tsx
+++ b/apps/ui/src/views/wired/WiredEvals.test.tsx
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { StoreProvider } from "../../state/store";
+import { WiredEvals } from "./WiredEvals";
+import { getEvalMatrix, type EvalMatrix } from "../../api/client";
+
+// Mock the eval-matrix data-layer call only; the real useEvalMatrix hook runs
+// against the stub so the component + hook wiring is exercised end to end.
+vi.mock("../../api/client", async (importActual) => {
+  const actual = await importActual<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    getEvalMatrix: vi.fn(),
+  };
+});
+
+const MATRIX: EvalMatrix = {
+  suite: "default",
+  versions: ["abc1234def", "def5678abc"],
+  cases: ["approver-from-policy", "deal-data-not-slack"],
+  rows: [
+    {
+      case_id: "approver-from-policy",
+      cells: [
+        { version: "abc1234def", status: "pass", model: "claude-sonnet-4.5" },
+        { version: "def5678abc", status: "pass", model: "claude-sonnet-4.5" },
+      ],
+    },
+    {
+      case_id: "deal-data-not-slack",
+      cells: [
+        { version: "abc1234def", status: "fail", model: "claude-sonnet-4.5" },
+        { version: "def5678abc", status: "missing", model: null },
+      ],
+    },
+  ],
+  models: ["claude-sonnet-4.5", "fake"],
+  model_summaries: [
+    { model: "claude-sonnet-4.5", passed: 3, total: 4, cost_usd: 0.0123, plumbing: 0, completed: 4 },
+    { model: "fake", passed: 0, total: 2, cost_usd: null, plumbing: 1, completed: 0 },
+  ],
+};
+
+// A fresh client per render with retry off, mirroring main.tsx, so the wired
+// hook resolves on the first response instead of retrying.
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={client}>
+        <StoreProvider>{children}</StoreProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function renderView() {
+  return render(<WiredEvals />, { wrapper: wrapper() });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("WiredEvals (#868)", () => {
+  it("renders the matrix grid: one row per case, cells per version", async () => {
+    vi.mocked(getEvalMatrix).mockResolvedValue(MATRIX);
+    renderView();
+
+    // Reads the matrix from the live API for the default suite.
+    await waitFor(() => expect(getEvalMatrix).toHaveBeenCalledWith("default", 5));
+
+    const rows = await screen.findAllByTestId("matrix-row");
+    expect(rows).toHaveLength(2);
+    expect(within(rows[0]).getByText("approver-from-policy")).toBeInTheDocument();
+    // Version columns render short shas in the header.
+    const header = screen.getByTestId("matrix-header");
+    expect(within(header).getByText("abc1234")).toBeInTheDocument();
+    expect(within(header).getByText("def5678")).toBeInTheDocument();
+  });
+
+  it("distinguishes pass / fail / missing cells by status", async () => {
+    vi.mocked(getEvalMatrix).mockResolvedValue(MATRIX);
+    renderView();
+
+    const rows = await screen.findAllByTestId("matrix-row");
+    const failRow = rows[1];
+    const cells = within(failRow).getAllByTestId("eval-cell");
+    expect(cells[0]).toHaveAttribute("data-status", "fail");
+    expect(cells[1]).toHaveAttribute("data-status", "missing");
+    const passCells = within(rows[0]).getAllByTestId("eval-cell");
+    expect(passCells[0]).toHaveAttribute("data-status", "pass");
+  });
+
+  it("renders the per-model rollup, flagging a model that never completed", async () => {
+    vi.mocked(getEvalMatrix).mockResolvedValue(MATRIX);
+    renderView();
+
+    const modelRows = await screen.findAllByTestId("model-summary-row");
+    expect(modelRows).toHaveLength(2);
+    // Real model: pass-rate + passed/total + cost.
+    expect(within(modelRows[0]).getByText("claude-sonnet-4.5")).toBeInTheDocument();
+    expect(within(modelRows[0]).getByText("75%")).toBeInTheDocument();
+    expect(within(modelRows[0]).getByText("$0.0123")).toBeInTheDocument();
+    // The fake tier has total > 0 but completed 0: flagged as never-run, not 0%.
+    expect(within(modelRows[1]).getByText("never ran")).toBeInTheDocument();
+    expect(within(modelRows[1]).getByText(/not graded/)).toBeInTheDocument();
+  });
+
+  it("refetches when the suite is changed", async () => {
+    vi.mocked(getEvalMatrix).mockResolvedValue(MATRIX);
+    renderView();
+    await waitFor(() => expect(getEvalMatrix).toHaveBeenCalledWith("default", 5));
+
+    const input = screen.getByTestId("eval-suite-input");
+    await userEvent.clear(input);
+    await userEvent.type(input, "deal-desk{Enter}");
+
+    await waitFor(() => expect(getEvalMatrix).toHaveBeenCalledWith("deal-desk", 5));
+  });
+
+  it("shows an honest empty state for a suite with no runs", async () => {
+    vi.mocked(getEvalMatrix).mockResolvedValue({
+      ...MATRIX,
+      versions: [],
+      cases: [],
+      rows: [],
+      model_summaries: [],
+    });
+    renderView();
+    expect(await screen.findByText(/No eval runs yet/i)).toBeInTheDocument();
+  });
+
+  it("surfaces a load error without leaking demo data", async () => {
+    vi.mocked(getEvalMatrix).mockRejectedValue(new Error("boom"));
+    renderView();
+    expect(await screen.findByText(/eval matrix is not available/i)).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/views/wired/WiredEvals.tsx
+++ b/apps/ui/src/views/wired/WiredEvals.tsx
@@ -1,0 +1,292 @@
+import { useState, type ReactNode } from "react";
+import { C } from "../../tokens";
+import { Card, SectionTitle, Chip, Notice, CliHint, PARITY_TRACKING_ISSUE } from "../../primitives";
+import { useEvalMatrix } from "../../api/hooks";
+import type { EvalStatus, EvalModelSummary } from "../../api/client";
+import { ComingSoon } from "./WiredStubs";
+
+// The wired Evals view (#868): renders the eval matrix from GET /evals/matrix
+// over the same-origin /api proxy. Rows = fixed eval cases, columns = the most
+// recently exercised versions (newest first), cells = each case's outcome on
+// that version. A per-model rollup (pass-rate, completion, cost) surfaces the
+// matrix's model dimension below the grid.
+//
+// The matrix is filtered by SUITE (the real dimension on eval traces), so the
+// view carries a suite selector defaulting to the platform default suite. A
+// fresh workspace with no eval runs degrades honestly to an empty state rather
+// than showing demo data (#542). There is no top-level CLI verb that just reads
+// the matrix, so the header shows the honest amber no-equivalent glyph.
+
+const DEFAULT_SUITE = "default";
+const VERSION_COLUMNS = 5;
+
+// Short, mono-friendly version label: a commit sha renders as its first 7 chars.
+function shortVersion(version: string): string {
+  return version.length > 7 ? version.slice(0, 7) : version;
+}
+
+// One matrix cell's glyph + color. `plumbing_ok` is deliberately amber, not
+// green: the case ran but no grader judged it, so it carries no pass/fail
+// signal and must never read as a green promotion gate.
+function cellPresentation(status: EvalStatus): { glyph: string; color: string; label: string } {
+  switch (status) {
+    case "pass":
+      return { glyph: "✓", color: C.success, label: "pass" };
+    case "fail":
+      return { glyph: "✕", color: C.destructive, label: "fail" };
+    case "plumbing_ok":
+      return { glyph: "◇", color: C.warn, label: "ran, not graded" };
+    case "missing":
+      return { glyph: "·", color: C.muted, label: "not run" };
+  }
+}
+
+function StatusCell({ status }: { status: EvalStatus }) {
+  const { glyph, color, label } = cellPresentation(status);
+  return (
+    <div
+      data-testid="eval-cell"
+      data-status={status}
+      title={label}
+      style={{ textAlign: "center", color, fontFamily: C.mono, fontSize: 14 }}
+    >
+      {glyph}
+    </div>
+  );
+}
+
+function formatPassRate(s: EvalModelSummary): string {
+  if (s.total === 0) return "—";
+  return `${Math.round((s.passed / s.total) * 100)}%`;
+}
+
+function Matrix({ suite }: { suite: string }) {
+  const { data, loading, error } = useEvalMatrix(suite, VERSION_COLUMNS);
+
+  if (error) {
+    return (
+      <ComingSoon
+        title="The eval matrix is not available"
+        body={`Could not load the matrix from the backend: ${error}`}
+      />
+    );
+  }
+  if (loading || !data) return <Notice padding="40px 20px">Loading the eval matrix…</Notice>;
+  if (data.cases.length === 0 || data.versions.length === 0) {
+    return (
+      <ComingSoon
+        title="No eval runs yet"
+        body={`No graded eval traces for suite “${suite}”. Trigger an eval run or push to a connected git branch, and the case-by-version matrix lights up here.`}
+      />
+    );
+  }
+
+  // rows = cases, columns = versions. First column is the case id; the rest are
+  // one per version, newest first (the order the API returns them in).
+  const grid = `minmax(180px, 1.6fr) repeat(${data.versions.length}, minmax(72px, 1fr))`;
+  const headers: ReactNode[] = [
+    <span key="case" style={{ fontSize: 12, color: C.muted }}>
+      Case
+    </span>,
+    ...data.versions.map((v) => (
+      <span
+        key={v}
+        title={v}
+        style={{ fontFamily: C.mono, fontSize: 11.5, color: C.muted, textAlign: "center" }}
+      >
+        {shortVersion(v)}
+      </span>
+    )),
+  ];
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <Card>
+        <div style={{ overflowX: "auto" }}>
+          <div style={{ minWidth: 520 }}>
+            <div
+              data-testid="matrix-header"
+              style={{
+                display: "grid",
+                gridTemplateColumns: grid,
+                gap: 12,
+                padding: "0 0 12px",
+                borderBottom: "1px solid " + C.border,
+                alignItems: "center",
+              }}
+            >
+              {headers.map((h, i) => (
+                <div key={i} style={{ textAlign: i === 0 ? "left" : "center" }}>
+                  {h}
+                </div>
+              ))}
+            </div>
+            {data.rows.map((row) => (
+              <div
+                key={row.case_id}
+                data-testid="matrix-row"
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: grid,
+                  gap: 12,
+                  padding: "12px 0",
+                  alignItems: "center",
+                  borderBottom: "1px solid " + C.border,
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: C.mono,
+                    fontSize: 12.5,
+                    color: C.text,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {row.case_id}
+                </span>
+                {row.cells.map((cell) => (
+                  <StatusCell key={cell.version} status={cell.status} />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 16, marginTop: 14, fontSize: 11.5, color: C.muted }}>
+          {(["pass", "fail", "plumbing_ok", "missing"] as const).map((s) => {
+            const { glyph, color, label } = cellPresentation(s);
+            return (
+              <span key={s} style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+                <span style={{ color, fontFamily: C.mono }}>{glyph}</span>
+                {label}
+              </span>
+            );
+          })}
+        </div>
+      </Card>
+
+      {data.model_summaries.length > 0 ? (
+        <Card>
+          <div style={{ fontSize: 13, fontWeight: 500, color: C.text, marginBottom: 4 }}>By model</div>
+          <div style={{ fontSize: 12, color: C.muted, marginBottom: 14 }}>
+            Pass-rate and cost per model across the shown versions. A model with runs but zero completed turns never
+            produced an answer — distinct from a real 0%.
+          </div>
+          <ModelSummaryTable summaries={data.model_summaries} />
+        </Card>
+      ) : null}
+    </div>
+  );
+}
+
+function ModelSummaryTable({ summaries }: { summaries: EvalModelSummary[] }) {
+  const grid = "1.4fr 0.8fr 0.9fr 0.9fr 0.9fr";
+  return (
+    <div>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: grid,
+          gap: 12,
+          padding: "0 0 10px",
+          fontSize: 12,
+          color: C.muted,
+          borderBottom: "1px solid " + C.border,
+        }}
+      >
+        {["Model", "Pass-rate", "Passed", "Completed", "Cost"].map((h) => (
+          <div key={h}>{h}</div>
+        ))}
+      </div>
+      {summaries.map((s, i) => {
+        const neverCompleted = s.total > 0 && s.completed === 0;
+        return (
+          <div
+            key={s.model ?? `unlabelled-${i}`}
+            data-testid="model-summary-row"
+            style={{
+              display: "grid",
+              gridTemplateColumns: grid,
+              gap: 12,
+              padding: "12px 0",
+              alignItems: "center",
+              borderBottom: "1px solid " + C.border,
+              fontSize: 13,
+            }}
+          >
+            <span style={{ fontFamily: C.mono, fontSize: 12.5, color: C.text, display: "flex", alignItems: "center", gap: 8 }}>
+              {s.model ?? "unlabelled"}
+              {s.plumbing > 0 ? (
+                <Chip color={C.warn} border="rgba(191,135,0,.4)">
+                  {s.plumbing} not graded
+                </Chip>
+              ) : null}
+            </span>
+            <span style={{ color: neverCompleted ? C.warn : C.text2, fontFamily: C.mono, fontSize: 12.5 }}>
+              {neverCompleted ? "never ran" : formatPassRate(s)}
+            </span>
+            <span style={{ color: C.text2, fontFamily: C.mono, fontSize: 12.5 }}>
+              {s.passed}/{s.total}
+            </span>
+            <span style={{ color: C.text2, fontFamily: C.mono, fontSize: 12.5 }}>
+              {s.completed}/{s.total}
+            </span>
+            <span style={{ color: C.text2, fontFamily: C.mono, fontSize: 12.5 }}>
+              {s.cost_usd == null ? "—" : `$${s.cost_usd.toFixed(4)}`}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function WiredEvals() {
+  const [suite, setSuite] = useState(DEFAULT_SUITE);
+  const [applied, setApplied] = useState(DEFAULT_SUITE);
+
+  const apply = () => {
+    const trimmed = suite.trim();
+    if (trimmed) setApplied(trimmed);
+  };
+
+  return (
+    <div>
+      <SectionTitle
+        title="Evals"
+        sub="Fixed test cases run against a version + model, on demand and on every PR. This is not live traffic (see Observability)."
+        right={<CliHint noCliEquivalent={PARITY_TRACKING_ISSUE} actionIds={["eval-matrix"]} label="No CLI equivalent" />}
+      />
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          apply();
+        }}
+        style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 18 }}
+      >
+        <label htmlFor="eval-suite" style={{ fontSize: 12.5, color: C.muted }}>
+          Suite
+        </label>
+        <input
+          id="eval-suite"
+          data-testid="eval-suite-input"
+          value={suite}
+          onChange={(e) => setSuite(e.target.value)}
+          spellCheck={false}
+          style={{
+            background: C.input,
+            border: "1px solid " + C.borderStrong,
+            borderRadius: 7,
+            padding: "7px 10px",
+            color: C.text,
+            fontFamily: C.mono,
+            fontSize: 13,
+            minWidth: 200,
+          }}
+        />
+      </form>
+      <Matrix key={applied} suite={applied} />
+    </div>
+  );
+}

--- a/apps/ui/src/views/wired/WiredStubs.tsx
+++ b/apps/ui/src/views/wired/WiredStubs.tsx
@@ -43,18 +43,6 @@ export function ComingSoon({ title, body }: { title: string; body: string }) {
   );
 }
 
-export function WiredEvals() {
-  return (
-    <div>
-      <SectionTitle title="Evals" sub="Fixed test cases run against a version + model, on every PR." />
-      <ComingSoon
-        title="No eval runs yet"
-        body="Eval suites and the version matrix light up here once the eval runner is connected. Nothing to show for a fresh workspace."
-      />
-    </div>
-  );
-}
-
 export function WiredUsage() {
   return (
     <ComingSoon


### PR DESCRIPTION
## What

The console Evals tab rendered a `ComingSoon` stub (left that way when the fixture/demo world was removed in #542). The evals matrix backend (`GET /evals/matrix`) is live, so this replaces the stub with a real wired view that reads and renders the matrix — no backend work.

## Changes

- **API client** (`apps/ui/src/api/client.ts`): `EvalMatrix`/`EvalCell`/`EvalMatrixRow`/`EvalModelSummary` types + `getEvalMatrix(suite, versions)`, same-origin `/api` like every other call.
- **Hook** (`apps/ui/src/api/hooks.ts`): `useEvalMatrix`, react-query keyed on `suite` + version count (refetches on suite change), gated on a non-empty suite (the endpoint requires it).
- **New view** (`apps/ui/src/views/wired/WiredEvals.tsx`): the cases × versions grid (columns = most-recent versions, newest first; cells = `pass`/`fail`/`plumbing_ok`/`missing` with an honest legend — `plumbing_ok` is amber, never a green promotion gate), a suite selector defaulting to the platform default suite, and the per-model rollup surfacing pass-rate, cost, and the never-completed vs. real-0% distinction. Honest loading/empty/error states; a fresh workspace degrades to an empty state, never demo data.
- **Parity**: new `eval-matrix` `noCliEquivalent` entry (the matrix has no top-level `agentos` verb — the CLI polls it internally during a model sweep), so the header shows the honest amber glyph.
- **Docs**: `apps/ui/README.md` + `apps/ui/CLAUDE.md` move Evals from "not wired" to wired.
- **E2E**: cold-start spec stubs `/evals/matrix` (empty matrix) so the nav sweep stays deterministic now that Evals fetches.

## Verified

`apps/ui` full CI job, all green:
- `pnpm lint` (zero warnings), `pnpm typecheck`, `pnpm build`
- `pnpm test` — 121 tests pass (6 new in `WiredEvals.test.tsx`: grid, cell-status distinction, per-model rollup incl. never-completed flag, suite-change refetch, empty state, load error)
- `pnpm exec playwright test cold-start-wired --project=chromium` — 6 pass (incl. the "no fixture leaks" nav sweep that now visits the live Evals view)

Frontend-only; no backend change.

Closes #868