### PR TITLE
Add console operator control for thread reset

### DIFF
--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -347,6 +347,14 @@ export interface KillState {
   killed: boolean;
 }
 
+// The forced-thread-reset state (#737/#735). `requested` is true from the moment
+// the POST enqueues a reset until the worker's maintenance tick has actually
+// released the thread's sandbox, then false. Operators poll it to know the
+// release landed (mirrors the CLI reset-thread verb's wait loop).
+export interface ThreadResetState {
+  requested: boolean;
+}
+
 export async function getAgents(): Promise<AgentOut[]> {
   const resp = await fetch(url("/agents"), { headers: headers() });
   return jsonOrThrow<AgentOut[]>(resp);
@@ -589,4 +597,33 @@ export async function killAgent(agentId: string): Promise<KillState> {
 export async function resumeAgent(agentId: string): Promise<KillState> {
   const resp = await fetch(url(`/agents/${agentId}/resume`), { method: "POST", headers: headers() });
   return jsonOrThrow<KillState>(resp);
+}
+
+// Force a thread's sandbox to be released (#737): the worker's next maintenance
+// tick deletes the thread's claim/route, so the next message cold-creates a
+// fresh sandbox. Interrupts a live turn on the thread; does not delete
+// conversation history. `agent_id` scopes the action; the release is
+// thread-keyed. The POST only *queues* the release — poll getThreadResetState to
+// confirm it landed. The thread key is arbitrary (e.g. a Slack thread ts), so it
+// is URL-encoded into the path.
+export async function resetThread(agentId: string, threadKey: string): Promise<ThreadResetState> {
+  const resp = await fetch(
+    url(`/agents/${agentId}/threads/${encodeURIComponent(threadKey)}/reset`),
+    { method: "POST", headers: headers() },
+  );
+  return jsonOrThrow<ThreadResetState>(resp);
+}
+
+// Poll whether a forced reset (the POST above) is still outstanding for this
+// thread (#735). Stays true across the whole release and flips to false only
+// once the sandbox has actually been released.
+export async function getThreadResetState(
+  agentId: string,
+  threadKey: string,
+): Promise<ThreadResetState> {
+  const resp = await fetch(
+    url(`/agents/${agentId}/threads/${encodeURIComponent(threadKey)}/reset`),
+    { headers: headers() },
+  );
+  return jsonOrThrow<ThreadResetState>(resp);
 }

--- a/apps/ui/src/primitives/CliHint.parity.test.tsx
+++ b/apps/ui/src/primitives/CliHint.parity.test.tsx
@@ -12,9 +12,11 @@ import { StoreProvider } from "../state/store";
 const PRODUCTION_ROOT = join(process.cwd(), "src");
 const EXPECTED_COMMAND_IDS = [
   "cluster.deploy",
+  "cluster.reset-thread",
   "cluster.status",
   "init",
   "local.deploy",
+  "local.reset-thread",
   "local.status",
 ] as const;
 const EXPECTED_NO_CLI_ACTION_IDS = [

--- a/apps/ui/src/primitives/parity.ts
+++ b/apps/ui/src/primitives/parity.ts
@@ -53,6 +53,12 @@ export const WIRED_ACTIONS = [
   { id: "budget", label: "Set budget", mapping: { command: "cluster.budget" } },
   { id: "delete", label: "Delete an agent", mapping: { command: "cluster.delete" } },
 
+  // WiredThreadReset (#871) — force a thread's sandbox to be released. Env-scoped
+  // in the UI (prod -> cluster, dev -> local), mirroring deploy; both tiers are
+  // listed so the parity gate covers each concrete command the surface emits.
+  { id: "reset-thread-cluster", label: "Reset a thread (prod)", mapping: { command: "cluster.reset-thread" } },
+  { id: "reset-thread-local", label: "Reset a thread (dev)", mapping: { command: "local.reset-thread" } },
+
   // Genuinely-unmapped actions: no dedicated CLI verb exists yet. These render
   // the honest amber glyph linking to the parity epic instead of a command.
   { id: "rollback", label: "Roll back to an earlier version", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },

--- a/apps/ui/src/views/wired/WiredAgentDetail.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.tsx
@@ -4,6 +4,7 @@ import { Button, Card, Chip, CliHint, Dot, Notice, cliCommand } from "../../prim
 import { SkillEditor } from "../../components/SkillEditor";
 import { WiredAgentMemory } from "./WiredAgentMemory";
 import { WiredAgentState } from "./WiredAgentState";
+import { WiredThreadReset } from "./WiredThreadReset";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
 import { useAgentVersions, useVersionFiles } from "../../api/hooks";
@@ -536,6 +537,12 @@ export function WiredAgentDetail() {
       {agentId ? (
         <div style={{ marginTop: 16 }}>
           <WiredAgentState agentId={agentId} />
+        </div>
+      ) : null}
+
+      {agentId ? (
+        <div style={{ marginTop: 16 }}>
+          <WiredThreadReset agentId={agentId} agentName={agent.name} />
         </div>
       ) : null}
     </div>

--- a/apps/ui/src/views/wired/WiredThreadReset.test.tsx
+++ b/apps/ui/src/views/wired/WiredThreadReset.test.tsx
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StoreProvider } from "../../state/store";
+import { WiredThreadReset } from "./WiredThreadReset";
+import { resetThread, getThreadResetState, ApiError } from "../../api/client";
+
+// Mock only the thread-reset data-layer calls; keep everything else real.
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    resetThread: vi.fn(),
+    getThreadResetState: vi.fn(),
+  };
+});
+
+function renderPanel() {
+  return render(
+    <StoreProvider>
+      <WiredThreadReset agentId="a1" agentName="deal-desk" />
+    </StoreProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("WiredThreadReset (#871)", () => {
+  it("gates the destructive reset behind a confirm step", async () => {
+    renderPanel();
+    // The start button is disabled until a thread key is entered.
+    expect(screen.getByTestId("thread-reset-start")).toBeDisabled();
+
+    await userEvent.type(screen.getByTestId("thread-reset-key"), "1699.0012");
+    await userEvent.click(screen.getByTestId("thread-reset-start"));
+
+    // Confirm affordance appears; no request has fired yet.
+    expect(screen.getByTestId("thread-reset-confirm")).toBeInTheDocument();
+    expect(resetThread).not.toHaveBeenCalled();
+
+    // Cancel backs out without firing.
+    await userEvent.click(screen.getByTestId("thread-reset-cancel"));
+    expect(screen.getByTestId("thread-reset-start")).toBeInTheDocument();
+    expect(resetThread).not.toHaveBeenCalled();
+  });
+
+  it("requests the reset and polls to a released outcome", async () => {
+    vi.mocked(resetThread).mockResolvedValue({ requested: true });
+    // First poll already reads released (requested false).
+    vi.mocked(getThreadResetState).mockResolvedValue({ requested: false });
+
+    renderPanel();
+    await userEvent.type(screen.getByTestId("thread-reset-key"), "1699.0012");
+    await userEvent.click(screen.getByTestId("thread-reset-start"));
+    await userEvent.click(screen.getByTestId("thread-reset-confirm"));
+
+    expect(resetThread).toHaveBeenCalledWith("a1", "1699.0012");
+    const released = await screen.findByTestId("thread-reset-released");
+    expect(released).toHaveTextContent("1699.0012");
+    expect(getThreadResetState).toHaveBeenCalledWith("a1", "1699.0012");
+  });
+
+  it("reports the release as still pending when polling cannot confirm it", async () => {
+    vi.mocked(resetThread).mockResolvedValue({ requested: true });
+    // A poll failure degrades to "still pending", never fails the accepted reset.
+    vi.mocked(getThreadResetState).mockRejectedValue(new Error("gone"));
+
+    renderPanel();
+    await userEvent.type(screen.getByTestId("thread-reset-key"), "1699.0012");
+    await userEvent.click(screen.getByTestId("thread-reset-start"));
+    await userEvent.click(screen.getByTestId("thread-reset-confirm"));
+
+    expect(await screen.findByTestId("thread-reset-pending")).toBeInTheDocument();
+  });
+
+  it("surfaces a request error without leaving the confirm state stuck", async () => {
+    vi.mocked(resetThread).mockRejectedValue(new ApiError(404, "agent not found"));
+
+    renderPanel();
+    await userEvent.type(screen.getByTestId("thread-reset-key"), "nope");
+    await userEvent.click(screen.getByTestId("thread-reset-start"));
+    await userEvent.click(screen.getByTestId("thread-reset-confirm"));
+
+    expect(await screen.findByTestId("thread-reset-error")).toHaveTextContent("agent not found");
+    // Back to the entry state, not stuck mid-request.
+    expect(screen.getByTestId("thread-reset-start")).toBeInTheDocument();
+    expect(getThreadResetState).not.toHaveBeenCalled();
+  });
+
+  it("offers a copyable env-scoped reset-thread CLI command", async () => {
+    renderPanel();
+    await userEvent.type(screen.getByTestId("thread-reset-key"), "1699.0012");
+    // Default env is prod -> cluster reset-thread, carrying the entered key and --yes.
+    expect(
+      screen.getByRole("button", {
+        name: "Copy command: agentos cluster reset-thread deal-desk --thread-key 1699.0012 --yes",
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/views/wired/WiredThreadReset.tsx
+++ b/apps/ui/src/views/wired/WiredThreadReset.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from "react";
+import { C } from "../../tokens";
+import { Button, Card, CliHint, cliCommand } from "../../primitives";
+import { useStore } from "../../state/store";
+import { resetThread, getThreadResetState, ApiError } from "../../api/client";
+
+// How long we wait for the worker to actually release the sandbox before we
+// report the release as still pending, and how often we re-poll. Mirrors the
+// CLI reset-thread verb's wait loop (RESET_RELEASE_TIMEOUT / _POLL_INTERVAL):
+// comfortably covers the worker's default 30s reclaim tick.
+const RELEASE_TIMEOUT_MS = 45_000;
+const POLL_INTERVAL_MS = 1_000;
+
+type Phase = "idle" | "confirm" | "requesting" | "waiting" | "released" | "pending";
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// The wired "reset a thread" operator control (#871). Thread reset exists as a
+// backend operation + CLI verb (#737) but had no console affordance; this closes
+// the drift. An operator enters the thread key (e.g. the Slack thread ts) and
+// forces its sandbox to be released, so the thread's next message cold-creates a
+// fresh sandbox instead of adopting one running stale env. It interrupts any
+// live turn on the thread, so — mirroring the kill switch and the CLI verb's
+// --yes gate — it takes a confirm step before firing.
+//
+// The POST only queues the release (the worker drains it on its next
+// maintenance tick, up to ~30s later), so after the request we poll the reset
+// state to completion, exactly as the CLI does, and report "released" vs. "still
+// pending" honestly. Does not delete conversation history.
+export function WiredThreadReset({ agentId, agentName }: { agentId: string; agentName: string }) {
+  const { state, dispatch } = useStore();
+  const [threadKey, setThreadKey] = useState("");
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [resetKey, setResetKey] = useState<string | null>(null);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const key = threadKey.trim();
+  const blank = key === "";
+  const busy = phase === "requesting" || phase === "waiting";
+
+  const run = async () => {
+    if (blank || busy) return;
+    setPhase("requesting");
+    setError(null);
+    setResetKey(key);
+    try {
+      await resetThread(agentId, key);
+    } catch (e) {
+      if (!mounted.current) return;
+      setError(e instanceof ApiError ? e.message : e instanceof Error ? e.message : String(e));
+      setPhase("idle");
+      return;
+    }
+    if (!mounted.current) return;
+    setPhase("waiting");
+    // Poll the reset state to completion so the operator does not move on until
+    // the sandbox has actually been released, closing the window where the next
+    // message adopts the pre-reset sandbox (#735). A poll failure never fails an
+    // already-accepted reset: it degrades to "release unconfirmed, still
+    // pending", same as the CLI.
+    const deadline = Date.now() + RELEASE_TIMEOUT_MS;
+    let released = false;
+    for (;;) {
+      try {
+        const st = await getThreadResetState(agentId, key);
+        if (!st.requested) {
+          released = true;
+          break;
+        }
+      } catch {
+        break;
+      }
+      if (Date.now() >= deadline) break;
+      await sleep(POLL_INTERVAL_MS);
+      if (!mounted.current) return;
+    }
+    if (!mounted.current) return;
+    setPhase(released ? "released" : "pending");
+    dispatch({
+      type: "toast",
+      message: released
+        ? `Thread ${key} reset: sandbox released`
+        : `Thread ${key} reset queued; release still pending`,
+    });
+  };
+
+  // Reset the control back to the entry state for a fresh reset.
+  const clear = () => {
+    setPhase("idle");
+    setError(null);
+    setResetKey(null);
+  };
+
+  return (
+    <Card>
+      <div data-testid="agent-thread-reset" style={{ padding: "4px 4px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
+          <div style={{ fontWeight: 600, fontSize: 14, color: C.text2 }}>Reset a thread</div>
+          <CliHint
+            command={cliCommand(
+              state.env === "prod" ? "cluster.reset-thread" : "local.reset-thread",
+              { agent: agentName, "thread-key": key || undefined, yes: true },
+            )}
+          />
+        </div>
+        <div style={{ color: C.muted, fontSize: 12.5, marginBottom: 12, maxWidth: 620, lineHeight: 1.5 }}>
+          Forces the thread's sandbox to be released, so its next message cold-creates a fresh
+          sandbox instead of adopting one running stale env (a rotated credential, an unpicked-up
+          redeploy, a wedge). Interrupts any live turn on the thread. Does not delete conversation
+          history — a fresh sandbox still rehydrates from the durable transcript.
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <input
+            data-testid="thread-reset-key"
+            value={threadKey}
+            onChange={(e) => {
+              setThreadKey(e.target.value);
+              if (phase !== "requesting" && phase !== "waiting") clear();
+            }}
+            disabled={busy || phase === "confirm"}
+            placeholder="thread key, e.g. 1699912345.001200"
+            aria-label="thread key"
+            style={{
+              background: C.input,
+              border: "1px solid " + C.borderStrong,
+              borderRadius: 7,
+              padding: "6px 10px",
+              color: C.text,
+              fontFamily: C.mono,
+              fontSize: 12.5,
+              width: 280,
+            }}
+          />
+          {phase === "confirm" ? (
+            <>
+              <span style={{ fontSize: 12.5, color: C.text2, fontFamily: C.mono }}>
+                Reset this thread? It interrupts any live turn.
+              </span>
+              <Button label="Cancel" variant="ghost" size="sm" testId="thread-reset-cancel" onClick={clear} />
+              <Button
+                label="Confirm reset"
+                variant="danger"
+                size="sm"
+                testId="thread-reset-confirm"
+                onClick={() => void run()}
+              />
+            </>
+          ) : (
+            <Button
+              label={
+                phase === "requesting"
+                  ? "Requesting…"
+                  : phase === "waiting"
+                    ? "Waiting for release…"
+                    : "Reset thread"
+              }
+              variant="danger"
+              size="sm"
+              testId="thread-reset-start"
+              disabled={blank || busy}
+              title={blank ? "Enter the thread key first" : undefined}
+              onClick={() => {
+                setError(null);
+                setPhase("confirm");
+              }}
+            />
+          )}
+        </div>
+
+        {error ? (
+          <div
+            data-testid="thread-reset-error"
+            style={{ color: C.destructive, fontSize: 12.5, marginTop: 10, fontFamily: C.mono }}
+          >
+            Reset failed: {error}
+          </div>
+        ) : phase === "released" ? (
+          <div
+            data-testid="thread-reset-released"
+            style={{ color: C.brand, fontSize: 12.5, marginTop: 10, fontFamily: C.mono }}
+          >
+            ✓ Thread {resetKey} reset — sandbox released.
+          </div>
+        ) : phase === "pending" ? (
+          <div
+            data-testid="thread-reset-pending"
+            style={{ color: C.warn, fontSize: 12.5, marginTop: 10, fontFamily: C.mono }}
+          >
+            Reset queued for {resetKey}; release still pending — the worker will drain it on its next
+            maintenance tick.
+          </div>
+        ) : phase === "waiting" ? (
+          <div
+            data-testid="thread-reset-waiting"
+            style={{ color: C.muted, fontSize: 12.5, marginTop: 10, fontFamily: C.mono }}
+          >
+            Reset requested for {resetKey}; waiting for the sandbox to be released…
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}


### PR DESCRIPTION
## What

Thread reset exists as a backend operation and CLI verb (#737) but had no operator affordance in `apps/ui`, leaving a console/CLI parity gap. This adds a wired operator control on the agent detail view that consumes the **existing** API — no new backend.

## The control

`WiredThreadReset` renders a section on `WiredAgentDetail` (alongside memory and state). An operator enters the thread key (e.g. the Slack thread ts) and forces its sandbox to be released so the thread's next message cold-creates a fresh sandbox instead of adopting one running stale env.

- **Confirm step**: the reset interrupts any live turn on the thread, so it is gated behind an inline confirm (Cancel / Confirm reset), mirroring the CLI verb's `--yes` gate and the existing promote/kill mutation pattern in the console.
- **Polls to completion**: the POST only *queues* the release (the worker drains it on its next maintenance tick, up to ~30s later), so after the request the control polls the reset state to completion — exactly as the CLI `reset-thread` verb does — and reports "released" vs. "still pending" honestly rather than claiming success early. A poll failure degrades to "still pending", never failing an already-accepted reset.
- Does not delete conversation history (the fresh sandbox rehydrates from the durable transcript).

## API consumed

- `POST /agents/{id}/threads/{thread_key}/reset` (force release)
- `GET  /agents/{id}/threads/{thread_key}/reset` (poll `requested`)

Both added to the typed `apps/ui/src/api/client.ts` with a `ThreadResetState` type.

## Console/CLI parity

The CLI hint resolves the env-scoped `reset-thread` verb directly from the committed manifest (`cluster.reset-thread` in prod, `local.reset-thread` in dev), registered in `parity.ts` and covered by the parity gate.

## Verification

Full `apps/ui` CI job, all green:

- `pnpm lint` — clean (zero warnings)
- `pnpm typecheck` — clean
- `pnpm test` — 120 passed (21 files), including 5 new `WiredThreadReset` tests asserting outcomes: confirm gate, requested->released, poll-failure->pending, request error recovery, and the env-scoped CLI hint
- `pnpm build` — succeeds
- `pnpm e2e` (stackless Playwright) — 30 passed, no regression

Interactive browser verification of the rendered control was not performed: the surface only populates with a live API + a created agent, which needs the full compose stack. Behavior is covered by the unit tests driving the real component against mocked API responses.

Closes #871