### PR TITLE
Add console Approvals surface consuming the approvals API

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -33,7 +33,8 @@ production build on http://localhost:4173 (what Playwright drives).
   modal (`modals/`).
 - `src/views/` — the wired views: `wired/*` (Overview, Agents, AgentDetail,
   Versions, Evals, and the `ComingSoon`/stub views in `WiredStubs.tsx`), `Observability.tsx`
-  and its `obs/*` panels (RealTraces, RealMetrics, RealLogs, RealCost, RealMemory).
+  and its `obs/*` panels (RealTraces, RealMetrics, RealLogs, RealCost,
+  RealApprovals, RealMemory).
 - `e2e/` — Playwright specs. `design-review/` — committed side-by-side fidelity
   screenshots (impl vs the design canon).
 
@@ -74,6 +75,15 @@ honest `ComingSoon` stub (Usage, Settings).
   one with `DELETE /agents/{id}/memory/{index}`; edits/deletes take effect at the
   agent's next session boot. Reuses the same `WiredAgentMemory` panel the agent
   detail page consumes (the endpoint was already live and consumed there).
+- Approvals tab (Observability > Approvals): the operator visibility + resolve
+  surface for durable approvals (#867). Lists approvals (pending by default,
+  with a status filter) from `GET /approvals`; a row opens a detail with the
+  audit trail (`GET /approvals/{id}/audit`) and, for a pending record, drives
+  the resolve-once route (`POST /approvals/{id}/resolve`) with Approve/Reject,
+  a required resolver identity, and optional actor-channel/note. The resolve
+  route's designed failure statuses are surfaced distinctly (403 not
+  authorized/self-approval, 409 already resolved, 410 expired). Read + resolve
+  only -- it never creates approvals (that is the worker's job).
 
 **Metrics divergence (deliberate).** The design canon's Metrics tab is a
 Prometheus/PromQL surface (a `rate(...)` query bar, a request-rate hero, and
@@ -104,8 +114,8 @@ and the cost calls `getCost`/`getBudget`/`putBudget`/`getKillState`/`killAgent`/
 `useMetricSeries`/`useAgents`/`useCost`), `config.ts` (API key + prefix). Deploy
 failures flow through the store reducer actions `deployFailedValidation` /
 `deployFailed`. Observability lives in `src/views/obs/Real*.tsx`
-(`RealTraces`, `RealMetrics`, `RealLogs`, `RealCost`), dispatched by tab in
-`Observability.tsx`.
+(`RealTraces`, `RealMetrics`, `RealLogs`, `RealCost`, `RealApprovals`),
+dispatched by tab in `Observability.tsx`.
 
 **Integration E2E (needs the live stack).** With the compose dev stack up and
 apps/api on 8000:
@@ -127,7 +137,9 @@ The wired Metrics/Logs are covered in the **stackless** suite
 (`e2e/observability-wired.spec.ts`) by running the app in `?api=1` mode and
 stubbing the observability endpoints with real-shaped responses via Playwright
 route interception (200 metrics, 503 no-cluster logs, 200 logs) — no backend
-needed. Against a real API on the dev box, runner-logs returns 502 rather than
+needed. Approvals are covered the same way (`e2e/approvals-wired.spec.ts`):
+stubbed `GET /approvals`/`/audit` and a `POST /resolve` interceptor asserting
+the list, detail, resolve payload, and the 409 conflict state. Against a real API on the dev box, runner-logs returns 502 rather than
 503 because a kubeconfig is present (the 401-rejecting cluster), which the UI
 renders as the "Cluster error" state.
 

--- a/apps/ui/e2e/approvals-wired.spec.ts
+++ b/apps/ui/e2e/approvals-wired.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Wired Approvals (#867) in the stackless suite: the app is served with the
+// approvals API stubbed with real-shaped responses via route interception, so
+// these run headless with no backend. Consumes GET /approvals,
+// GET /approvals/{id}/audit, and POST /approvals/{id}/resolve.
+
+function approval(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "ap-1",
+    agent_id: "ag-1",
+    conversation_id: "C-thread-1",
+    author: "U-alice",
+    summary: "Refund $4,200 to ACME Corp",
+    reply_channel: "C0DEALS",
+    reply_placeholder: "ts-1",
+    reply_endpoint: null,
+    dedupe_key: "dk-1",
+    route: "managers",
+    card_channel: "C0MANAGERS",
+    gate_kind: "permission",
+    granted_tool: "issue_refund",
+    status: "pending",
+    expires_at: "2026-07-24T00:00:00+00:00",
+    resolved_by: null,
+    resolution_note: null,
+    created_at: "2026-07-23T00:00:00+00:00",
+    resolved_at: null,
+    ...overrides,
+  };
+}
+
+// Stub the approvals list; the audit endpoint (more specific path) is stubbed
+// first so the list matcher does not swallow it.
+async function stubApprovals(page: Page, rows: object[]) {
+  await page.route("**/api/approvals/*/audit*", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([]) }),
+  );
+  await page.route(
+    (url) => url.pathname.endsWith("/api/approvals"),
+    (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(rows) }),
+  );
+}
+
+async function openApprovalsTab(page: Page) {
+  await page.goto("/?api=1");
+  await page.getByRole("navigation").getByText("Observability", { exact: true }).click();
+  await page.getByRole("button", { name: "Approvals" }).click();
+}
+
+test("lists pending approvals and opens the detail with its audit trail", async ({ page }) => {
+  await stubApprovals(page, [approval()]);
+  await openApprovalsTab(page);
+
+  await expect(page.getByTestId("approval-summary")).toContainText("Refund $4,200 to ACME Corp");
+  await page.getByTestId("approval-summary").click();
+
+  const detail = page.getByTestId("approval-detail");
+  await expect(detail).toBeVisible();
+  await expect(detail).toContainText("managers");
+  await expect(detail).toContainText("issue_refund");
+});
+
+test("resolves a pending approval as approved through POST /resolve", async ({ page }) => {
+  await stubApprovals(page, [approval()]);
+
+  let resolveBody: Record<string, unknown> | null = null;
+  await page.route("**/api/approvals/*/resolve", (route) => {
+    resolveBody = JSON.parse(route.request().postData() ?? "{}");
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(approval({ status: "approved", resolved_by: "you@x.com" })),
+    });
+  });
+
+  await openApprovalsTab(page);
+  await page.getByTestId("approval-summary").click();
+  await page.getByLabel("resolved by").fill("you@x.com");
+  await page.getByTestId("approve-btn").click();
+
+  await expect.poll(() => resolveBody && (resolveBody as { decision?: string }).decision).toBe("approved");
+  await expect.poll(() => resolveBody && (resolveBody as { resolved_by?: string }).resolved_by).toBe("you@x.com");
+});
+
+test("surfaces a 409 already-resolved conflict from the resolve route", async ({ page }) => {
+  await stubApprovals(page, [approval()]);
+  await page.route("**/api/approvals/*/resolve", (route) =>
+    route.fulfill({
+      status: 409,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "already resolved by U-bob (approved)" }),
+    }),
+  );
+
+  await openApprovalsTab(page);
+  await page.getByTestId("approval-summary").click();
+  await page.getByLabel("resolved by").fill("you@x.com");
+  await page.getByTestId("reject-btn").click();
+
+  await expect(page.getByTestId("resolve-error")).toContainText("Already resolved: already resolved by U-bob");
+});
+
+test("shows the pending empty state for a fresh workspace", async ({ page }) => {
+  await stubApprovals(page, []);
+  await openApprovalsTab(page);
+  await expect(page.getByTestId("approvals")).toContainText("No pending approvals");
+});

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -678,3 +678,108 @@ export async function getThreadResetState(
   );
   return jsonOrThrow<ThreadResetState>(resp);
 }
+
+// ---- Durable approvals: operator visibility + resolve-once (#867, ADR-0010) ----
+
+// A durable approval record (mirrors ApprovalOut). The worker creates one when a
+// run pauses on a permission/policy gate and suspends the session; an operator
+// resolves it here or from the Slack card. `status` is one of
+// pending/approved/rejected/expired.
+export interface ApprovalOut {
+  id: string;
+  agent_id: string | null;
+  conversation_id: string;
+  author: string;
+  summary: string;
+  reply_channel: string;
+  reply_placeholder: string;
+  reply_endpoint: string | null;
+  dedupe_key: string;
+  route: string | null;
+  card_channel: string | null;
+  // Gate provenance (#544): which gate fired, and the tool a grant is bound to.
+  gate_kind: string | null;
+  granted_tool: string | null;
+  status: string;
+  expires_at: string | null;
+  resolved_by: string | null;
+  resolution_note: string | null;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+// One audit-trail entry for an approval (mirrors ApprovalAuditOut, #247): each
+// resolution attempt with the authorizer snapshot that counted or refused it.
+export interface ApprovalAudit {
+  id: string;
+  approval_id: string;
+  action: string;
+  actor: string;
+  actor_channel: string | null;
+  decision: string;
+  authorizer: string;
+  authorized: boolean;
+  reason: string | null;
+  evidence: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export interface ApprovalListQuery {
+  // Passed as the `status_filter` query param; omit for all statuses.
+  status?: string;
+  agentId?: string;
+  conversationId?: string;
+  limit?: number;
+}
+
+// List approvals, newest first (server clamps limit to 1..200). Without a status
+// filter, every status is returned; the operator surface defaults to pending.
+export async function listApprovals(opts: ApprovalListQuery = {}): Promise<ApprovalOut[]> {
+  const resp = await fetch(
+    url(
+      `/approvals${query({
+        status_filter: opts.status,
+        agent_id: opts.agentId,
+        conversation_id: opts.conversationId,
+        limit: opts.limit,
+      })}`,
+    ),
+    { headers: headers() },
+  );
+  return jsonOrThrow<ApprovalOut[]>(resp);
+}
+
+export async function getApproval(approvalId: string): Promise<ApprovalOut> {
+  const resp = await fetch(url(`/approvals/${encodeURIComponent(approvalId)}`), { headers: headers() });
+  return jsonOrThrow<ApprovalOut>(resp);
+}
+
+// The approval's audit trail, oldest first (empty until the first resolution
+// attempt). A 404 (approval gone) surfaces via the thrown ApiError.
+export async function getApprovalAudit(approvalId: string): Promise<ApprovalAudit[]> {
+  const resp = await fetch(url(`/approvals/${encodeURIComponent(approvalId)}/audit`), { headers: headers() });
+  return jsonOrThrow<ApprovalAudit[]>(resp);
+}
+
+export interface ApprovalResolveInput {
+  decision: "approved" | "rejected";
+  // Who is resolving (server requires non-empty); the authorizer blocks
+  // self-approval against the record's author.
+  resolved_by: string;
+  note?: string;
+  // The channel the resolution is asserted from; an API-key operator asserts it
+  // explicitly so the channel-membership authorizer can count them.
+  actor_channel?: string;
+}
+
+// Resolve an approval (resolve-once compare-and-set). The server-side authorizer
+// runs first; distinct failure statuses carried on the thrown ApiError: 403
+// (not authorized / self-approval), 409 (already resolved), 410 (expired).
+export async function resolveApproval(approvalId: string, input: ApprovalResolveInput): Promise<ApprovalOut> {
+  const resp = await fetch(url(`/approvals/${encodeURIComponent(approvalId)}/resolve`), {
+    method: "POST",
+    headers: headers({ "Content-Type": "application/json" }),
+    body: JSON.stringify(input),
+  });
+  return jsonOrThrow<ApprovalOut>(resp);
+}

--- a/apps/ui/src/state/types.ts
+++ b/apps/ui/src/state/types.ts
@@ -9,7 +9,7 @@ export type Nav =
 
 export type Env = "prod" | "dev";
 
-export type ObsTab = "traces" | "metrics" | "logs" | "memory" | "usage" | "cost";
+export type ObsTab = "traces" | "metrics" | "logs" | "memory" | "usage" | "cost" | "approvals";
 export type ModalKind = "new-agent";
 
 // A plugin-format validator issue, surfaced inline when a wired deploy is

--- a/apps/ui/src/views/Observability.tsx
+++ b/apps/ui/src/views/Observability.tsx
@@ -6,12 +6,14 @@ import { RealMetrics } from "./obs/RealMetrics";
 import { RealLogs } from "./obs/RealLogs";
 import { RealCost } from "./obs/RealCost";
 import { RealMemory } from "./obs/RealMemory";
+import { RealApprovals } from "./obs/RealApprovals";
 import { WiredUsage } from "./wired/WiredStubs";
 
 const TABS: [ObsTab, string][] = [
   ["traces", "Traces"],
   ["metrics", "Metrics"],
   ["logs", "Logs"],
+  ["approvals", "Approvals"],
   ["memory", "Memory"],
   ["usage", "Usage"],
   ["cost", "Cost"],
@@ -40,6 +42,9 @@ export function Observability() {
       break;
     case "cost":
       content = <RealCost />;
+      break;
+    case "approvals":
+      content = <RealApprovals />;
       break;
   }
 

--- a/apps/ui/src/views/obs/RealApprovals.test.tsx
+++ b/apps/ui/src/views/obs/RealApprovals.test.tsx
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StoreProvider } from "../../state/store";
+import { RealApprovals } from "./RealApprovals";
+import {
+  ApiError,
+  getApprovalAudit,
+  listApprovals,
+  resolveApproval,
+  type ApprovalAudit,
+  type ApprovalOut,
+} from "../../api/client";
+
+// Mock only the approvals data-layer calls; keep everything else (ApiError, the
+// store, primitives) real.
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    listApprovals: vi.fn(),
+    getApprovalAudit: vi.fn(),
+    resolveApproval: vi.fn(),
+  };
+});
+
+function approval(overrides: Partial<ApprovalOut> = {}): ApprovalOut {
+  return {
+    id: "ap-1",
+    agent_id: "ag-1",
+    conversation_id: "C-thread-1",
+    author: "U-alice",
+    summary: "Refund $4,200 to ACME Corp",
+    reply_channel: "C0DEALS",
+    reply_placeholder: "ts-1",
+    reply_endpoint: null,
+    dedupe_key: "dk-1",
+    route: "managers",
+    card_channel: "C0MANAGERS",
+    gate_kind: "permission",
+    granted_tool: "issue_refund",
+    status: "pending",
+    expires_at: "2026-07-24T00:00:00+00:00",
+    resolved_by: null,
+    resolution_note: null,
+    created_at: "2026-07-23T00:00:00+00:00",
+    resolved_at: null,
+    ...overrides,
+  };
+}
+
+function renderView() {
+  return render(
+    <StoreProvider>
+      <RealApprovals />
+    </StoreProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getApprovalAudit).mockResolvedValue([]);
+  try {
+    window.localStorage.clear();
+  } catch {
+    // ignore
+  }
+});
+
+describe("RealApprovals (#867)", () => {
+  it("lists pending approvals by default and requests the pending status", async () => {
+    vi.mocked(listApprovals).mockResolvedValue([approval()]);
+    renderView();
+
+    expect(await screen.findByText("Refund $4,200 to ACME Corp")).toBeInTheDocument();
+    expect(screen.getByText("U-alice")).toBeInTheDocument();
+    expect(listApprovals).toHaveBeenCalledWith({ status: "pending" });
+  });
+
+  it("shows the pending empty state when nothing is waiting", async () => {
+    vi.mocked(listApprovals).mockResolvedValue([]);
+    renderView();
+    expect(await screen.findByText(/No pending approvals/i)).toBeInTheDocument();
+  });
+
+  it("refetches with the chosen status filter (all sends no status)", async () => {
+    vi.mocked(listApprovals).mockResolvedValue([]);
+    renderView();
+    await screen.findByText(/No pending approvals/i);
+
+    await userEvent.selectOptions(screen.getByTestId("approvals-status-filter"), "all");
+    await waitFor(() => expect(listApprovals).toHaveBeenLastCalledWith({ status: undefined }));
+  });
+
+  it("surfaces a load error", async () => {
+    vi.mocked(listApprovals).mockRejectedValue(new Error("boom"));
+    renderView();
+    expect(await screen.findByTestId("approvals-error")).toHaveTextContent("boom");
+  });
+
+  it("opens a detail modal with the audit trail on row click", async () => {
+    vi.mocked(listApprovals).mockResolvedValue([approval()]);
+    const audit: ApprovalAudit[] = [
+      {
+        id: "au-1",
+        approval_id: "ap-1",
+        action: "denied",
+        actor: "U-alice",
+        actor_channel: "C0DEALS",
+        decision: "approved",
+        authorizer: "self-approval-block",
+        authorized: false,
+        reason: "author may not self-approve",
+        evidence: null,
+        created_at: "2026-07-23T01:00:00+00:00",
+      },
+    ];
+    vi.mocked(getApprovalAudit).mockResolvedValue(audit);
+    renderView();
+
+    await userEvent.click(await screen.findByText("Refund $4,200 to ACME Corp"));
+    const detail = await screen.findByTestId("approval-detail");
+    expect(within(detail).getByText("managers")).toBeInTheDocument();
+    expect(await within(detail).findByTestId("approval-audit-entry")).toHaveTextContent("author may not self-approve");
+  });
+
+  it("resolves an approval as approved and refreshes the list", async () => {
+    vi.mocked(listApprovals).mockResolvedValue([approval()]);
+    vi.mocked(resolveApproval).mockResolvedValue(approval({ status: "approved", resolved_by: "you@x.com" }));
+    renderView();
+
+    await userEvent.click(await screen.findByText("Refund $4,200 to ACME Corp"));
+    await screen.findByTestId("approval-detail");
+    await userEvent.type(screen.getByLabelText("resolved by"), "you@x.com");
+    await userEvent.click(screen.getByTestId("approve-btn"));
+
+    await waitFor(() =>
+      expect(resolveApproval).toHaveBeenCalledWith("ap-1", {
+        decision: "approved",
+        resolved_by: "you@x.com",
+        note: undefined,
+        actor_channel: undefined,
+      }),
+    );
+    // Refetch fired after resolve (initial load + reload).
+    await waitFor(() => expect(listApprovals).toHaveBeenCalledTimes(2));
+  });
+
+  it("blocks resolve until an identity is entered", async () => {
+    vi.mocked(listApprovals).mockResolvedValue([approval()]);
+    renderView();
+
+    await userEvent.click(await screen.findByText("Refund $4,200 to ACME Corp"));
+    await screen.findByTestId("approval-detail");
+    await userEvent.click(screen.getByTestId("approve-btn"));
+
+    expect(await screen.findByTestId("resolve-error")).toHaveTextContent(/who is resolving/i);
+    expect(resolveApproval).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 409 already-resolved conflict distinctly", async () => {
+    vi.mocked(listApprovals).mockResolvedValue([approval()]);
+    vi.mocked(resolveApproval).mockRejectedValue(new ApiError(409, "already resolved by U-bob (approved)"));
+    renderView();
+
+    await userEvent.click(await screen.findByText("Refund $4,200 to ACME Corp"));
+    await screen.findByTestId("approval-detail");
+    await userEvent.type(screen.getByLabelText("resolved by"), "you@x.com");
+    await userEvent.click(screen.getByTestId("reject-btn"));
+
+    expect(await screen.findByTestId("resolve-error")).toHaveTextContent("Already resolved: already resolved by U-bob");
+  });
+
+  it("hides the resolve controls for an already-resolved approval", async () => {
+    vi.mocked(listApprovals).mockResolvedValue([
+      approval({ status: "approved", resolved_by: "U-bob", resolution_note: "ok" }),
+    ]);
+    renderView();
+
+    await userEvent.click(await screen.findByText("Refund $4,200 to ACME Corp"));
+    await screen.findByTestId("approval-detail");
+    expect(screen.queryByTestId("approve-btn")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/views/obs/RealApprovals.tsx
+++ b/apps/ui/src/views/obs/RealApprovals.tsx
@@ -1,0 +1,455 @@
+import { useCallback, useEffect, useState } from "react";
+import { C } from "../../tokens";
+import { Button, Card, Chip, Dot, Modal, Notice, Table } from "../../primitives";
+import { useStore } from "../../state/store";
+import {
+  ApiError,
+  getApprovalAudit,
+  listApprovals,
+  resolveApproval,
+  type ApprovalAudit,
+  type ApprovalOut,
+} from "../../api/client";
+
+// The operator visibility + resolve surface for durable approvals (#867,
+// ADR-0010). The worker creates an approval when a run pauses on a
+// permission/policy gate and suspends the session; today the only place to see
+// or act on one is the Slack card. This tab lists them (pending by default) and
+// drives the resolve-once route from the console, so an operator has visibility
+// and control outside Slack. Read + resolve only; it never creates approvals
+// (that is the worker's job). Backed by the real API over the same-origin /api
+// proxy (GET /approvals, GET /approvals/{id}/audit, POST /approvals/{id}/resolve).
+
+// The status filter options; "all" sends no status_filter so every status
+// returns. Pending is the default — the queue an operator acts on.
+const STATUS_FILTERS: [string, string][] = [
+  ["pending", "Pending"],
+  ["approved", "Approved"],
+  ["rejected", "Rejected"],
+  ["expired", "Expired"],
+  ["all", "All"],
+];
+
+// Persist the resolving operator's identity so they need not retype it each
+// time; resolved_by is required server-side and gates self-approval.
+const OPERATOR_KEY = "agentos.approvalOperator";
+
+function loadOperator(): string {
+  try {
+    return window.localStorage.getItem(OPERATOR_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function saveOperator(value: string): void {
+  try {
+    window.localStorage.setItem(OPERATOR_KEY, value);
+  } catch {
+    // Non-fatal: a private-mode / disabled localStorage just means no memory.
+  }
+}
+
+function statusColor(status: string): string {
+  switch (status) {
+    case "pending":
+      return C.warn;
+    case "approved":
+      return C.success;
+    case "rejected":
+      return C.failure;
+    case "expired":
+      return C.mutedStatus;
+    default:
+      return C.mutedStatus;
+  }
+}
+
+function StatusChip({ status }: { status: string }) {
+  const color = statusColor(status);
+  return (
+    <Chip color={color} border={C.border} pre={<Dot color={color} size={7} />}>
+      {status}
+    </Chip>
+  );
+}
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+// Compact relative age, e.g. "3m ago", "2h ago", "5d ago"; "just now" under a
+// minute, and a friendly future form for an expiry that has not passed yet.
+function relativeAge(iso: string | null): string {
+  if (!iso) return "—";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const deltaMs = Date.now() - then;
+  const future = deltaMs < 0;
+  const secs = Math.abs(deltaMs) / 1000;
+  const label =
+    secs < 60
+      ? "just now"
+      : secs < 3600
+        ? `${Math.floor(secs / 60)}m`
+        : secs < 86400
+          ? `${Math.floor(secs / 3600)}h`
+          : `${Math.floor(secs / 86400)}d`;
+  if (label === "just now") return label;
+  return future ? `in ${label}` : `${label} ago`;
+}
+
+function ApprovalDetail({
+  approval,
+  onClose,
+  onResolved,
+}: {
+  approval: ApprovalOut;
+  onClose: () => void;
+  onResolved: () => void;
+}) {
+  const { dispatch } = useStore();
+  const [audit, setAudit] = useState<ApprovalAudit[] | null>(null);
+  const [auditError, setAuditError] = useState<string | null>(null);
+  const [resolvedBy, setResolvedBy] = useState(loadOperator);
+  const [actorChannel, setActorChannel] = useState("");
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState<"approved" | "rejected" | null>(null);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+
+  const pending = approval.status === "pending";
+
+  useEffect(() => {
+    let live = true;
+    getApprovalAudit(approval.id)
+      .then((rows) => {
+        if (live) setAudit(rows);
+      })
+      .catch((e) => {
+        if (live) setAuditError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      live = false;
+    };
+  }, [approval.id]);
+
+  const resolve = async (decision: "approved" | "rejected") => {
+    const who = resolvedBy.trim();
+    if (!who) {
+      setResolveError("Enter who is resolving this approval.");
+      return;
+    }
+    setBusy(decision);
+    setResolveError(null);
+    try {
+      await resolveApproval(approval.id, {
+        decision,
+        resolved_by: who,
+        note: note.trim() || undefined,
+        actor_channel: actorChannel.trim() || undefined,
+      });
+      saveOperator(who);
+      dispatch({ type: "toast", message: `Approval ${decision}` });
+      onResolved();
+    } catch (e) {
+      // The resolve route has designed failure statuses; surface each honestly
+      // rather than a bare "failed" (403 self-approval/not-authorized, 409 lost
+      // the race, 410 expired past its SLA).
+      const msg =
+        e instanceof ApiError
+          ? e.status === 403
+            ? `Not authorized: ${e.message}`
+            : e.status === 409
+              ? `Already resolved: ${e.message}`
+              : e.status === 410
+                ? `Expired: ${e.message}`
+                : `${e.status}: ${e.message}`
+          : e instanceof Error
+            ? e.message
+            : String(e);
+      setResolveError(msg);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const inputStyle = {
+    background: C.input,
+    border: "1px solid " + C.borderStrong,
+    borderRadius: 7,
+    padding: "8px 11px",
+    color: C.text,
+    fontSize: 13,
+    width: "100%",
+    boxSizing: "border-box" as const,
+  };
+
+  return (
+    <Modal onClose={onClose}>
+      <div
+        data-testid="approval-detail"
+        style={{
+          width: "min(680px, 90vw)",
+          maxHeight: "85vh",
+          overflowY: "auto",
+          background: C.card,
+          border: "1px solid " + C.borderStrong,
+          borderRadius: 14,
+          padding: 22,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 12, marginBottom: 14 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 15, fontWeight: 600, color: C.text, marginBottom: 6 }}>{approval.summary}</div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+              <StatusChip status={approval.status} />
+              {approval.gate_kind ? (
+                <Chip color={C.text2} border={C.border}>{`gate: ${approval.gate_kind}`}</Chip>
+              ) : null}
+              {approval.granted_tool ? (
+                <Chip color={C.text2} border={C.border}>{approval.granted_tool}</Chip>
+              ) : null}
+            </div>
+          </div>
+          <Button label="Close" variant="ghost" size="sm" onClick={onClose} />
+        </div>
+
+        <dl
+          style={{
+            display: "grid",
+            gridTemplateColumns: "auto 1fr",
+            gap: "6px 14px",
+            margin: 0,
+            fontSize: 12.5,
+            marginBottom: 16,
+          }}
+        >
+          {(
+            [
+              ["Author", approval.author],
+              ["Route", approval.route ?? "— (requesting channel)"],
+              ["Card channel", approval.card_channel ?? "—"],
+              ["Conversation", approval.conversation_id],
+              ["Created", formatWhen(approval.created_at)],
+              ["Expires", approval.expires_at ? `${formatWhen(approval.expires_at)} (${relativeAge(approval.expires_at)})` : "—"],
+              ["Resolved by", approval.resolved_by ?? "—"],
+              ["Resolution note", approval.resolution_note ?? "—"],
+            ] as [string, string][]
+          ).map(([k, v]) => (
+            <div key={k} style={{ display: "contents" }}>
+              <dt style={{ color: C.muted }}>{k}</dt>
+              <dd style={{ margin: 0, color: C.text2, fontFamily: C.mono, wordBreak: "break-word" }}>{v}</dd>
+            </div>
+          ))}
+        </dl>
+
+        {pending ? (
+          <div
+            style={{
+              borderTop: "1px solid " + C.border,
+              paddingTop: 14,
+              marginBottom: 16,
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+            }}
+          >
+            <div style={{ fontWeight: 600, fontSize: 13, color: C.text2 }}>Resolve</div>
+            <input
+              aria-label="resolved by"
+              value={resolvedBy}
+              onChange={(e) => setResolvedBy(e.target.value)}
+              placeholder="Your identity (e.g. you@example.com)"
+              style={inputStyle}
+            />
+            <input
+              aria-label="actor channel"
+              value={actorChannel}
+              onChange={(e) => setActorChannel(e.target.value)}
+              placeholder="Actor channel (optional, e.g. C0123ABCD)"
+              style={inputStyle}
+            />
+            <textarea
+              aria-label="note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Note (optional)"
+              rows={2}
+              style={{ ...inputStyle, resize: "vertical", fontFamily: C.sans }}
+            />
+            {resolveError ? (
+              <div data-testid="resolve-error" style={{ color: C.destructive, fontSize: 12.5, fontFamily: C.mono }}>
+                {resolveError}
+              </div>
+            ) : null}
+            <div style={{ display: "flex", gap: 10 }}>
+              <Button
+                label={busy === "approved" ? "Approving…" : "Approve"}
+                variant="primary"
+                testId="approve-btn"
+                disabled={busy !== null}
+                onClick={() => void resolve("approved")}
+              />
+              <Button
+                label={busy === "rejected" ? "Rejecting…" : "Reject"}
+                variant="danger"
+                testId="reject-btn"
+                disabled={busy !== null}
+                onClick={() => void resolve("rejected")}
+              />
+            </div>
+          </div>
+        ) : null}
+
+        <div style={{ borderTop: "1px solid " + C.border, paddingTop: 14 }}>
+          <div style={{ fontWeight: 600, fontSize: 13, color: C.text2, marginBottom: 8 }}>Audit trail</div>
+          {auditError ? (
+            <div data-testid="audit-error" style={{ color: C.destructive, fontSize: 12.5, fontFamily: C.mono }}>
+              {auditError}
+            </div>
+          ) : audit === null ? (
+            <Notice padding="16px">Loading audit…</Notice>
+          ) : audit.length === 0 ? (
+            <Notice padding="16px">No resolution attempts yet.</Notice>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {audit.map((entry) => (
+                <div
+                  key={entry.id}
+                  data-testid="approval-audit-entry"
+                  style={{ border: "1px solid " + C.border, borderRadius: 6, padding: "8px 10px", background: C.darkest }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12.5 }}>
+                    <span style={{ fontFamily: C.mono, color: C.text }}>{entry.action}</span>
+                    <Chip color={entry.authorized ? C.success : C.failure} border={C.border}>
+                      {entry.authorized ? "authorized" : "denied"}
+                    </Chip>
+                    <span style={{ marginLeft: "auto", color: C.muted, fontSize: 11, fontFamily: C.mono }}>
+                      {formatWhen(entry.created_at)}
+                    </span>
+                  </div>
+                  <div style={{ color: C.text2, fontSize: 12, marginTop: 4 }}>
+                    {entry.actor} · {entry.decision} · via {entry.authorizer}
+                    {entry.reason ? ` — ${entry.reason}` : ""}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export function RealApprovals() {
+  const [status, setStatus] = useState("pending");
+  const [approvals, setApprovals] = useState<ApprovalOut[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await listApprovals({ status: status === "all" ? undefined : status });
+      setApprovals(rows);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [status]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const open = approvals?.find((a) => a.id === openId) ?? null;
+
+  const inputStyle = {
+    background: C.input,
+    border: "1px solid " + C.borderStrong,
+    borderRadius: 7,
+    padding: "7px 10px",
+    color: C.text,
+    fontSize: 12.5,
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
+        <select
+          data-testid="approvals-status-filter"
+          aria-label="status filter"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          style={inputStyle}
+        >
+          {STATUS_FILTERS.map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <div style={{ color: C.muted, fontSize: 12.5, flex: 1 }}>
+          Human approval gates that paused a run. Resolve here or from the Slack card.
+        </div>
+        <Button label="Refresh" variant="ghost" size="sm" onClick={() => void load()} />
+      </div>
+
+      {error ? (
+        <div data-testid="approvals-error" style={{ color: C.destructive, fontSize: 12.5, marginBottom: 10, fontFamily: C.mono }}>
+          {error}
+        </div>
+      ) : null}
+
+      <Card>
+        <div data-testid="approvals">
+          {loading ? (
+            <Notice padding="28px 20px">Loading approvals…</Notice>
+          ) : !approvals || approvals.length === 0 ? (
+            <Notice padding="28px 20px">
+              {status === "pending"
+                ? "No pending approvals. Nothing is waiting on a human decision."
+                : `No ${status === "all" ? "" : status + " "}approvals to show.`}
+            </Notice>
+          ) : (
+            <Table
+              columns="minmax(0,2fr) minmax(0,1fr) minmax(0,1fr) auto auto"
+              headers={["Summary", "Author", "Route", "Status", "Age"]}
+              rows={approvals.map((a) => ({
+                key: a.id,
+                onClick: () => setOpenId(a.id),
+                accent: a.status === "pending" ? C.warn : undefined,
+                cells: [
+                  <span data-testid="approval-summary" style={{ color: C.text, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", display: "block" }}>
+                    {a.summary}
+                  </span>,
+                  <span style={{ color: C.text2, fontFamily: C.mono, fontSize: 12 }}>{a.author}</span>,
+                  <span style={{ color: C.muted, fontFamily: C.mono, fontSize: 12 }}>{a.route ?? "—"}</span>,
+                  <StatusChip status={a.status} />,
+                  <span style={{ color: C.muted, fontFamily: C.mono, fontSize: 12 }}>{relativeAge(a.created_at)}</span>,
+                ],
+              }))}
+            />
+          )}
+        </div>
+      </Card>
+
+      {open ? (
+        <ApprovalDetail
+          approval={open}
+          onClose={() => setOpenId(null)}
+          onResolved={() => {
+            setOpenId(null);
+            void load();
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

The approvals API (`apps/api/.../routers/approvals.py`) has five routes and had **zero frontend** — the console never called any of them (#867). This adds the missing console surface: a wired **Observability > Approvals** tab.

## Surface

- **List** (`GET /approvals`): pending by default, with a status filter (pending/approved/rejected/expired/all). Fresh workspaces degrade honestly to an empty state.
- **Detail** (row → modal): full record plus the audit trail (`GET /approvals/{id}/audit`).
- **Resolve** (`POST /approvals/{id}/resolve`): Approve / Reject for a pending record, with a required resolver identity (remembered via localStorage), optional actor-channel, and note. The route's designed failure statuses are surfaced distinctly — 403 (not authorized / self-approval), 409 (already resolved), 410 (expired).

Read + resolve only — the console never **creates** approvals (that is the worker's job). Follows the existing wired-view pattern (same-origin `/api`, no fixture/demo mode, honest loading/empty/error states). Added as an Observability tab, matching how Memory/Usage/Cost operator surfaces were added.

## API routes consumed

`GET /approvals`, `GET /approvals/{id}`, `GET /approvals/{id}/audit`, `POST /approvals/{id}/resolve`. No backend changes.

## Tests

- Unit: `src/views/obs/RealApprovals.test.tsx` (9 tests) — list/empty/filter/error, detail + audit, resolve success + refresh, identity gate, 409 conflict, resolve controls hidden when already resolved.
- E2E (stackless, route-stubbed): `e2e/approvals-wired.spec.ts` (4 tests) — list+detail, resolve payload, 409 state, empty state.

Verified: `pnpm lint` (clean), `pnpm typecheck` (clean), `pnpm test` (124 passed), `pnpm build`, `pnpm exec playwright test` (34 passed). Command manifest unchanged (no CLI surface touched).

Closes #867
