### PR TITLE
Add console behavior-packs panel (GET + PUT)

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -48,6 +48,13 @@ honest `ComingSoon` stub (Usage, Settings).
   `/agents/{id}/versions`, packages the editor's skill.md into a plugin bundle
   client-side (jszip), and PUTs it to `/agents/{id}/versions/{vid}/bundle`. The
   bundle validator's 422 `errors[]` render inline under the editor.
+- Agent detail > Behavior packs: a settings-style panel over
+  `GET/PUT /agents/{id}/behavior-packs` (#870). Toggles each opt-in pack (load
+  lines, tips, greeting/help short-circuits, the nav hub button) and edits its
+  content, then PUTs the full config (the API takes the whole object, no partial
+  patch). The declarative settings pack is schema-only today, so its declared
+  knobs are shown read-only and round-tripped unchanged. Edits apply at the
+  agent's next bind, not mid-turn.
 - Runs tab (Observability > Traces): reads `GET /langfuse/traces` and
   `/langfuse/traces/{id}` through the proxy and renders the real span tree.
 - Metrics tab (Observability > Metrics): summary stat cards from
@@ -109,7 +116,8 @@ plainly what is not wired yet rather than showing fictional data.
 **Client layer.** `src/api/`: `client.ts` (typed calls + `BundleValidationError`,
 the observability calls `getMetricsSummary`/`getMetricSeries`/`getRunnerLogs`,
 and the cost calls `getCost`/`getBudget`/`putBudget`/`getKillState`/`killAgent`/
-`resumeAgent`/`getAgents`), `bundle.ts` (jszip packaging + the testable
+`resumeAgent`/`getAgents`, and the behavior-packs calls
+`getBehaviorPacks`/`putBehaviorPacks`), `bundle.ts` (jszip packaging + the testable
 `bundleFileTree`), `hooks.ts` (`useTraces`/`useTrace`/`useMetricsSummary`/
 `useMetricSeries`/`useAgents`/`useCost`), `config.ts` (API key + prefix). Deploy
 failures flow through the store reducer actions `deployFailedValidation` /

--- a/apps/ui/e2e/behavior-packs-wired.spec.ts
+++ b/apps/ui/e2e/behavior-packs-wired.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+// #870: the wired behavior-packs panel on the agent-detail page. Open an agent,
+// toggle a pack + edit a load line, Save, and assert the PUT carried the full
+// config with the edit applied. Backend stubbed with real-shaped responses, so
+// this runs stackless (chromium project).
+
+const AGENT = { id: "a1", name: "deal-desk", slack_channel: "C0123ABCD", model: null, created_at: "2026-07-01T00:00:00Z" };
+
+const DEFAULT_PACKS = {
+  load: { enabled: false, lines: [] as string[] },
+  tips: { enabled: false, tips: [] as string[] },
+  greeting: { enabled: false, phrases: [] as string[], reply: "" },
+  help: { enabled: false, phrases: [] as string[], reply: "" },
+  settings: { enabled: false, settings: [] as unknown[] },
+  nav: { enabled: false, hub_label: "", hub_command: "" },
+};
+
+interface Recorder {
+  putBody: Record<string, unknown> | null;
+}
+
+async function stub(page: Page, rec: Recorder) {
+  const json = (route: Route, status: number, body: unknown) =>
+    route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+
+  // Minimal agent-detail scaffolding so the page renders down to the panel.
+  await page.route("**/api/agents/*/versions/*/files*", (route) =>
+    json(route, 200, { files: [{ path: "skills/deal-desk/SKILL.md", content: "# Policy" }] }),
+  );
+  await page.route("**/api/agents/*/versions", (route) =>
+    json(route, 200, [
+      { id: "v1", agent_id: "a1", version_label: "v0.1.0", bundle_ref: "b", bundle_sha256: "s", commit_sha: null, created_by: "ui", created_at: "2026-07-01T00:00:00Z" },
+    ]),
+  );
+  await page.route("**/api/deployments*", (route) =>
+    json(route, 200, [
+      { id: "d1", agent_id: "a1", version_id: "v1", environment: "prod", commit_sha: null, status: "active", deployed_at: "2026-07-01T00:00:00Z" },
+    ]),
+  );
+
+  // The read/inspect sibling panels: empty is fine, they must not error the page.
+  await page.route("**/api/agents/*/memory*", (route) => json(route, 200, []));
+  await page.route("**/api/agents/*/state", (route) => json(route, 200, []));
+
+  // The subject under test: GET returns the all-off default; PUT echoes the body.
+  await page.route("**/api/agents/*/behavior-packs", (route) => {
+    if (route.request().method() === "PUT") {
+      rec.putBody = JSON.parse(route.request().postData() ?? "{}");
+      return json(route, 200, rec.putBody);
+    }
+    return json(route, 200, DEFAULT_PACKS);
+  });
+
+  await page.route("**/api/agents", (route) => json(route, 200, [AGENT]));
+}
+
+test("view and save an agent's behavior packs", async ({ page }) => {
+  const rec: Recorder = { putBody: null };
+  await stub(page, rec);
+
+  await page.goto("/?api=1");
+  await page.getByRole("navigation").getByText("Agents", { exact: true }).click();
+  await page.getByTestId("agent-card-name").click();
+
+  const panel = page.getByTestId("agent-behavior-packs");
+  await expect(panel).toBeVisible();
+
+  // Save is gated until an edit makes the panel dirty.
+  const save = page.getByTestId("behavior-packs-save");
+  await expect(save).toBeDisabled();
+
+  // Enable the load pack and add a rotating line.
+  await panel.getByTestId("pack-toggle-load").check();
+  await panel.getByTestId("load-lines").fill("crunching numbers…");
+  await expect(save).toBeEnabled();
+
+  await save.click();
+
+  // Success indicator, and the PUT carried the full config with the edit applied.
+  await expect(page.getByTestId("behavior-packs-saved")).toHaveText(/Saved/);
+  expect(rec.putBody?.load).toEqual({ enabled: true, lines: ["crunching numbers…"] });
+  // Untouched packs are round-tripped intact.
+  expect(rec.putBody?.nav).toEqual({ enabled: false, hub_label: "", hub_command: "" });
+});

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -783,3 +783,91 @@ export async function resolveApproval(approvalId: string, input: ApprovalResolve
   });
   return jsonOrThrow<ApprovalOut>(resp);
 }
+
+// ---- Behavior packs: per-agent opt-in deterministic behaviors (#870) ----
+//
+// Shapes mirror apps/api schemas.BehaviorPacksConfig verbatim. The packs ride on
+// the agent's stored config (like BudgetConfig mirrors the ACI Budget), so the
+// shape is duplicated here rather than shared. A NULL agent row reads back as the
+// all-off default; the API always returns the fully-defaulted object.
+
+export interface LoadPack {
+  enabled: boolean;
+  // Rotating "working…" load lines shown while the agent is thinking.
+  lines: string[];
+}
+
+export interface TipsPack {
+  enabled: boolean;
+  // Rotating capability tips (what the agent CAN do, vs. what it is doing now).
+  tips: string[];
+}
+
+export interface GreetingPack {
+  enabled: boolean;
+  // Trigger phrases that short-circuit to the deterministic reply below.
+  phrases: string[];
+  reply: string;
+}
+
+export interface HelpPack {
+  enabled: boolean;
+  // Trigger phrases (e.g. "what can you do") that short-circuit to the reply.
+  phrases: string[];
+  reply: string;
+}
+
+// One declared user-editable runtime knob. The settings pack is schema-only today
+// (the override store + per-user edit UI are a deferred runtime), so the console
+// surfaces the declared knobs read-only and round-trips them unchanged.
+export interface SettingConfig {
+  key: string;
+  label: string;
+  kind: string;
+  default: string;
+  help: string;
+  choices: string[];
+  applies_live: boolean;
+}
+
+export interface SettingsPack {
+  enabled: boolean;
+  settings: SettingConfig[];
+}
+
+export interface NavPack {
+  enabled: boolean;
+  // The no-dead-ends hub button label + command for this agent.
+  hub_label: string;
+  hub_command: string;
+}
+
+export interface BehaviorPacksConfig {
+  load: LoadPack;
+  tips: TipsPack;
+  greeting: GreetingPack;
+  help: HelpPack;
+  settings: SettingsPack;
+  nav: NavPack;
+}
+
+export async function getBehaviorPacks(agentId: string): Promise<BehaviorPacksConfig> {
+  const resp = await fetch(url(`/agents/${agentId}/behavior-packs`), { headers: headers() });
+  return jsonOrThrow<BehaviorPacksConfig>(resp);
+}
+
+// PUT the full behavior-packs config (the API validates + persists the whole
+// object; there is no partial patch). A validation failure 422s server-side and
+// the ApiError message carries the field-level reason for inline display. The
+// change is read by the worker at the agent's next bind, not mid-turn.
+export async function putBehaviorPacks(
+  agentId: string,
+  config: BehaviorPacksConfig,
+): Promise<BehaviorPacksConfig> {
+  const resp = await fetch(url(`/agents/${agentId}/behavior-packs`), {
+    method: "PUT",
+    headers: headers({ "Content-Type": "application/json" }),
+    body: JSON.stringify(config),
+  });
+  return jsonOrThrow<BehaviorPacksConfig>(resp);
+}

--- a/apps/ui/src/primitives/CliHint.parity.test.tsx
+++ b/apps/ui/src/primitives/CliHint.parity.test.tsx
@@ -20,6 +20,7 @@ const EXPECTED_COMMAND_IDS = [
   "local.status",
 ] as const;
 const EXPECTED_NO_CLI_ACTION_IDS = [
+  "behavior-packs-edit",
   "eval-matrix",
   "memory-delete",
   "memory-edit",

--- a/apps/ui/src/primitives/parity.ts
+++ b/apps/ui/src/primitives/parity.ts
@@ -73,6 +73,11 @@ export const WIRED_ACTIONS = [
   // no top-level `agentos` verb that just reads the matrix (the CLI polls it
   // internally during a model sweep), so the view renders the honest amber gap.
   { id: "eval-matrix", label: "View the eval matrix", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
+
+  // WiredAgentBehaviorPacks (#870) — view/edit the agent's opt-in behavior packs.
+  // No CLI path reads or writes behavior_packs (see cli/api-mirrors.json), so the
+  // save action renders the honest amber gap glyph linking to the parity epic.
+  { id: "behavior-packs-edit", label: "Edit an agent's behavior packs", mapping: { noCliEquivalent: PARITY_TRACKING_ISSUE } },
 ] as const satisfies readonly WiredAction[];
 
 export type WiredActionId = (typeof WIRED_ACTIONS)[number]["id"];

--- a/apps/ui/src/views/wired/WiredAgentBehaviorPacks.test.tsx
+++ b/apps/ui/src/views/wired/WiredAgentBehaviorPacks.test.tsx
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StoreProvider } from "../../state/store";
+import { WiredAgentBehaviorPacks } from "./WiredAgentBehaviorPacks";
+import {
+  getBehaviorPacks,
+  putBehaviorPacks,
+  ApiError,
+  type BehaviorPacksConfig,
+} from "../../api/client";
+
+// Mock only the behavior-packs data-layer calls; keep everything else real.
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    getBehaviorPacks: vi.fn(),
+    putBehaviorPacks: vi.fn(),
+  };
+});
+
+function makeConfig(overrides: Partial<BehaviorPacksConfig> = {}): BehaviorPacksConfig {
+  return {
+    load: { enabled: false, lines: [] },
+    tips: { enabled: false, tips: [] },
+    greeting: { enabled: false, phrases: [], reply: "" },
+    help: { enabled: false, phrases: [], reply: "" },
+    settings: { enabled: false, settings: [] },
+    nav: { enabled: false, hub_label: "", hub_command: "" },
+    ...overrides,
+  };
+}
+
+function renderPanel() {
+  return render(
+    <StoreProvider>
+      <WiredAgentBehaviorPacks agentId="a1" />
+    </StoreProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("WiredAgentBehaviorPacks (#870)", () => {
+  it("renders every pack with its enabled state from the GET", async () => {
+    vi.mocked(getBehaviorPacks).mockResolvedValue(
+      makeConfig({ load: { enabled: true, lines: ["thinking…"] } }),
+    );
+    renderPanel();
+
+    expect(await screen.findByTestId("pack-load")).toBeInTheDocument();
+    for (const name of ["load", "tips", "greeting", "help", "nav", "settings"]) {
+      expect(screen.getByTestId(`pack-${name}`)).toBeInTheDocument();
+    }
+    // load is on; the rest are off.
+    expect(screen.getByTestId("pack-toggle-load")).toBeChecked();
+    expect(screen.getByTestId("pack-toggle-tips")).not.toBeChecked();
+    expect(screen.getByTestId("load-lines")).toHaveValue("thinking…");
+  });
+
+  it("Save is gated until an edit makes the panel dirty", async () => {
+    vi.mocked(getBehaviorPacks).mockResolvedValue(makeConfig());
+    renderPanel();
+
+    const save = await screen.findByTestId("behavior-packs-save");
+    expect(save).toBeDisabled();
+    expect(screen.getByText("no changes")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("pack-toggle-tips"));
+    expect(save).toBeEnabled();
+    expect(screen.getByText("unsaved changes")).toBeInTheDocument();
+  });
+
+  it("toggling a pack and saving PUTs the full config with the flag flipped", async () => {
+    const initial = makeConfig();
+    vi.mocked(getBehaviorPacks).mockResolvedValue(initial);
+    vi.mocked(putBehaviorPacks).mockImplementation(async (_id, cfg) => cfg);
+    renderPanel();
+
+    await userEvent.click(await screen.findByTestId("pack-toggle-greeting"));
+    await userEvent.click(screen.getByTestId("behavior-packs-save"));
+
+    await waitFor(() => expect(putBehaviorPacks).toHaveBeenCalledTimes(1));
+    const [id, sent] = vi.mocked(putBehaviorPacks).mock.calls[0];
+    expect(id).toBe("a1");
+    expect(sent.greeting.enabled).toBe(true);
+    // The rest of the config is round-tripped untouched.
+    expect(sent.load.enabled).toBe(false);
+    expect(await screen.findByTestId("behavior-packs-saved")).toHaveTextContent("Saved");
+  });
+
+  it("edits list content and drops blank lines on save", async () => {
+    vi.mocked(getBehaviorPacks).mockResolvedValue(makeConfig({ load: { enabled: true, lines: [] } }));
+    vi.mocked(putBehaviorPacks).mockImplementation(async (_id, cfg) => cfg);
+    renderPanel();
+
+    const lines = await screen.findByTestId("load-lines");
+    await userEvent.clear(lines);
+    // A blank middle line must not survive to the PUT body.
+    await userEvent.type(lines, "one\n\ntwo");
+    await userEvent.click(screen.getByTestId("behavior-packs-save"));
+
+    await waitFor(() => expect(putBehaviorPacks).toHaveBeenCalledTimes(1));
+    const [, sent] = vi.mocked(putBehaviorPacks).mock.calls[0];
+    expect(sent.load.lines).toEqual(["one", "two"]);
+  });
+
+  it("round-trips the read-only settings pack unchanged", async () => {
+    const declared = {
+      enabled: true,
+      settings: [
+        { key: "tone", label: "Tone", kind: "str", default: "formal", help: "", choices: [], applies_live: true },
+      ],
+    };
+    vi.mocked(getBehaviorPacks).mockResolvedValue(makeConfig({ settings: declared }));
+    vi.mocked(putBehaviorPacks).mockImplementation(async (_id, cfg) => cfg);
+    renderPanel();
+
+    // The declared knob is surfaced read-only.
+    expect(await screen.findByTestId("settings-knob")).toHaveTextContent("tone");
+
+    // Make an unrelated edit, save, and confirm settings survived verbatim.
+    await userEvent.click(screen.getByTestId("pack-toggle-tips"));
+    await userEvent.click(screen.getByTestId("behavior-packs-save"));
+
+    await waitFor(() => expect(putBehaviorPacks).toHaveBeenCalledTimes(1));
+    const [, sent] = vi.mocked(putBehaviorPacks).mock.calls[0];
+    expect(sent.settings).toEqual(declared);
+  });
+
+  it("Reset reverts edits back to the last-saved baseline", async () => {
+    vi.mocked(getBehaviorPacks).mockResolvedValue(makeConfig());
+    renderPanel();
+
+    await userEvent.click(await screen.findByTestId("pack-toggle-nav"));
+    expect(screen.getByTestId("pack-toggle-nav")).toBeChecked();
+
+    await userEvent.click(screen.getByRole("button", { name: "Reset" }));
+    expect(screen.getByTestId("pack-toggle-nav")).not.toBeChecked();
+    expect(screen.getByText("no changes")).toBeInTheDocument();
+  });
+
+  it("surfaces a load error", async () => {
+    vi.mocked(getBehaviorPacks).mockRejectedValue(new Error("boom"));
+    renderPanel();
+    expect(await screen.findByTestId("behavior-packs-error")).toHaveTextContent("boom");
+  });
+
+  it("surfaces a save error and leaves edits intact", async () => {
+    vi.mocked(getBehaviorPacks).mockResolvedValue(makeConfig());
+    vi.mocked(putBehaviorPacks).mockRejectedValue(new ApiError(422, "settings.key: invalid"));
+    renderPanel();
+
+    await userEvent.click(await screen.findByTestId("pack-toggle-load"));
+    await userEvent.click(screen.getByTestId("behavior-packs-save"));
+
+    expect(await screen.findByTestId("behavior-packs-save-error")).toHaveTextContent("settings.key: invalid");
+    // The edit is still pending (not lost) so the operator can correct + retry.
+    expect(screen.getByTestId("pack-toggle-load")).toBeChecked();
+  });
+});

--- a/apps/ui/src/views/wired/WiredAgentBehaviorPacks.tsx
+++ b/apps/ui/src/views/wired/WiredAgentBehaviorPacks.tsx
@@ -1,0 +1,447 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { C } from "../../tokens";
+import { Button, Card, CliHint, Notice, PARITY_TRACKING_ISSUE } from "../../primitives";
+import {
+  getBehaviorPacks,
+  putBehaviorPacks,
+  ApiError,
+  type BehaviorPacksConfig,
+} from "../../api/client";
+
+// The wired "behavior packs" surface (#870): a small settings-style panel on the
+// agent detail page that reads GET /agents/{id}/behavior-packs and writes the
+// whole config back with PUT. Behavior packs are per-agent opt-in deterministic
+// behaviors (rotating load lines, capability tips, a greeting/help short-circuit,
+// a declarative editable-settings allowlist, and the no-dead-ends nav button).
+//
+// The API takes the FULL config on write (no partial patch), so this panel loads
+// the current config, edits a working copy in place, and PUTs the whole object on
+// Save. The settings pack is schema-only today (the per-user override store is a
+// deferred runtime), so its declared knobs are shown read-only and round-tripped
+// unchanged. No CLI verb reads/writes behavior_packs (cli/api-mirrors.json), so
+// Save carries the honest amber CliHint gap (parity id behavior-packs-edit).
+
+// A pack's edits are read by the worker at the agent's next bind, not mid-turn.
+const APPLIES_NOTE =
+  "Behavior packs are read at the agent's next bind (a fresh mention), not mid-conversation.";
+
+// A textarea's text is kept as one entry per line while editing (empties and
+// all), so multi-line typing works — a freshly-typed newline leaves a transient
+// blank line the operator is about to fill. Blank/whitespace-only lines are only
+// dropped at save time (cleanList), so the worker never renders a "" load line.
+function toEditLines(text: string): string[] {
+  return text.split("\n");
+}
+
+function cleanList(lines: string[]): string[] {
+  return lines.map((l) => l.trim()).filter((l) => l.length > 0);
+}
+
+// The exact object PUT on save: every list field trimmed + blank-stripped, the
+// rest (nav strings, replies, the read-only settings pack) carried verbatim.
+function cleanConfig(config: BehaviorPacksConfig): BehaviorPacksConfig {
+  return {
+    ...config,
+    load: { ...config.load, lines: cleanList(config.load.lines) },
+    tips: { ...config.tips, tips: cleanList(config.tips.tips) },
+    greeting: { ...config.greeting, phrases: cleanList(config.greeting.phrases) },
+    help: { ...config.help, phrases: cleanList(config.help.phrases) },
+  };
+}
+
+function ListField({
+  label,
+  help,
+  value,
+  onChange,
+  testId,
+}: {
+  label: string;
+  help: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+  testId: string;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <div style={{ fontSize: 12, color: C.text2, fontFamily: C.mono }}>{label}</div>
+      <div style={{ fontSize: 11, color: C.muted }}>{help}</div>
+      <textarea
+        aria-label={label}
+        data-testid={testId}
+        value={value.join("\n")}
+        onChange={(e) => onChange(toEditLines(e.target.value))}
+        rows={3}
+        style={{
+          width: "100%",
+          background: C.input,
+          color: C.text,
+          border: "1px solid " + C.border,
+          borderRadius: 4,
+          fontFamily: C.mono,
+          fontSize: 12.5,
+          padding: 8,
+          resize: "vertical",
+        }}
+      />
+    </div>
+  );
+}
+
+function TextField({
+  label,
+  value,
+  onChange,
+  testId,
+  multiline,
+}: {
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  testId: string;
+  multiline?: boolean;
+}) {
+  const shared = {
+    "aria-label": label,
+    "data-testid": testId,
+    value,
+    onChange: (e: { target: { value: string } }) => onChange(e.target.value),
+    style: {
+      width: "100%",
+      background: C.input,
+      color: C.text,
+      border: "1px solid " + C.border,
+      borderRadius: 4,
+      fontFamily: C.mono,
+      fontSize: 12.5,
+      padding: 8,
+    } as const,
+  };
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <div style={{ fontSize: 12, color: C.text2, fontFamily: C.mono }}>{label}</div>
+      {multiline ? (
+        <textarea {...shared} rows={2} style={{ ...shared.style, resize: "vertical" }} />
+      ) : (
+        <input {...shared} type="text" />
+      )}
+    </div>
+  );
+}
+
+function PackSection({
+  name,
+  title,
+  description,
+  enabled,
+  onToggle,
+  children,
+}: {
+  name: string;
+  title: string;
+  description: string;
+  enabled: boolean;
+  onToggle: (next: boolean) => void;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      data-testid={`pack-${name}`}
+      style={{
+        border: "1px solid " + C.border,
+        borderRadius: 6,
+        padding: "10px 12px",
+        background: C.darkest,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <label style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer" }}>
+        <input
+          type="checkbox"
+          data-testid={`pack-toggle-${name}`}
+          checked={enabled}
+          onChange={(e) => onToggle(e.target.checked)}
+          style={{ cursor: "pointer" }}
+        />
+        <span style={{ fontFamily: C.mono, fontSize: 13, color: C.text }}>{title}</span>
+        <span style={{ marginLeft: "auto", fontSize: 11, color: enabled ? C.brand : C.muted, fontFamily: C.mono }}>
+          {enabled ? "on" : "off"}
+        </span>
+      </label>
+      <div style={{ fontSize: 11.5, color: C.muted, lineHeight: 1.4 }}>{description}</div>
+      {children ? <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>{children}</div> : null}
+    </div>
+  );
+}
+
+export function WiredAgentBehaviorPacks({ agentId }: { agentId: string }) {
+  const [config, setConfig] = useState<BehaviorPacksConfig | null>(null);
+  const [baseline, setBaseline] = useState<BehaviorPacksConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const cfg = await getBehaviorPacks(agentId);
+      setConfig(cfg);
+      setBaseline(cfg);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Serialize for dirty-tracking: the working copy differs from the last-saved
+  // baseline. Cheap and exact for this small object.
+  const dirty = useMemo(
+    () => !!config && !!baseline && JSON.stringify(config) !== JSON.stringify(baseline),
+    [config, baseline],
+  );
+
+  // Typed patch helper: mutate one pack's slice, clear the transient saved flag.
+  const patch = useCallback((next: Partial<BehaviorPacksConfig>) => {
+    setSaved(false);
+    setSaveError(null);
+    setConfig((prev) => (prev ? { ...prev, ...next } : prev));
+  }, []);
+
+  const save = async () => {
+    if (!config || saving || !dirty) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      // Send the cleaned config (blank list lines stripped); adopt the server's
+      // echo as the new working copy + baseline so the panel reflects exactly
+      // what persisted (and pending blank lines collapse in the editor).
+      const updated = await putBehaviorPacks(agentId, cleanConfig(config));
+      setConfig(updated);
+      setBaseline(updated);
+      setSaved(true);
+    } catch (e) {
+      setSaveError(e instanceof ApiError ? e.message : e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reset = () => {
+    if (baseline) setConfig(baseline);
+    setSaved(false);
+    setSaveError(null);
+  };
+
+  return (
+    <Card>
+      <div data-testid="agent-behavior-packs" style={{ padding: "4px 4px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
+          <div style={{ fontWeight: 600, fontSize: 14, color: C.text2 }}>Behavior packs</div>
+          <CliHint
+            noCliEquivalent={PARITY_TRACKING_ISSUE}
+            actionIds={["behavior-packs-edit"]}
+            label="No CLI equivalent"
+          />
+          <div style={{ marginLeft: "auto" }}>
+            <Button label="Refresh" variant="ghost" size="sm" onClick={() => void load()} />
+          </div>
+        </div>
+        <div style={{ color: C.muted, fontSize: 12.5, marginBottom: 12 }}>
+          Opt-in deterministic behaviors for this agent. {APPLIES_NOTE}
+        </div>
+
+        {error ? (
+          <div
+            data-testid="behavior-packs-error"
+            style={{ color: C.destructive, fontSize: 12.5, marginBottom: 10, fontFamily: C.mono }}
+          >
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <Notice padding="28px 20px">Loading behavior packs…</Notice>
+        ) : !config ? (
+          <Notice padding="28px 20px">No behavior-pack config available.</Notice>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            <PackSection
+              name="load"
+              title="load"
+              description="Rotating “working…” lines shown while the agent is thinking."
+              enabled={config.load.enabled}
+              onToggle={(enabled) => patch({ load: { ...config.load, enabled } })}
+            >
+              <ListField
+                label="Load lines"
+                help="One line per row; shown in rotation. Blank lines are dropped."
+                value={config.load.lines}
+                onChange={(lines) => patch({ load: { ...config.load, lines } })}
+                testId="load-lines"
+              />
+            </PackSection>
+
+            <PackSection
+              name="tips"
+              title="tips"
+              description="Rotating capability tips — what the agent can do, vs. what it is doing now."
+              enabled={config.tips.enabled}
+              onToggle={(enabled) => patch({ tips: { ...config.tips, enabled } })}
+            >
+              <ListField
+                label="Tips"
+                help="One tip per row; shown in rotation. Blank lines are dropped."
+                value={config.tips.tips}
+                onChange={(tips) => patch({ tips: { ...config.tips, tips } })}
+                testId="tips-tips"
+              />
+            </PackSection>
+
+            <PackSection
+              name="greeting"
+              title="greeting"
+              description="Deterministic reply that short-circuits a matching greeting."
+              enabled={config.greeting.enabled}
+              onToggle={(enabled) => patch({ greeting: { ...config.greeting, enabled } })}
+            >
+              <ListField
+                label="Trigger phrases"
+                help="Messages matching one of these short-circuit to the reply below."
+                value={config.greeting.phrases}
+                onChange={(phrases) => patch({ greeting: { ...config.greeting, phrases } })}
+                testId="greeting-phrases"
+              />
+              <TextField
+                label="Reply"
+                value={config.greeting.reply}
+                onChange={(reply) => patch({ greeting: { ...config.greeting, reply } })}
+                testId="greeting-reply"
+                multiline
+              />
+            </PackSection>
+
+            <PackSection
+              name="help"
+              title="help"
+              description="Deterministic reply to a “what can you do” style message."
+              enabled={config.help.enabled}
+              onToggle={(enabled) => patch({ help: { ...config.help, enabled } })}
+            >
+              <ListField
+                label="Trigger phrases"
+                help="Messages matching one of these short-circuit to the reply below."
+                value={config.help.phrases}
+                onChange={(phrases) => patch({ help: { ...config.help, phrases } })}
+                testId="help-phrases"
+              />
+              <TextField
+                label="Reply"
+                value={config.help.reply}
+                onChange={(reply) => patch({ help: { ...config.help, reply } })}
+                testId="help-reply"
+                multiline
+              />
+            </PackSection>
+
+            <PackSection
+              name="nav"
+              title="nav"
+              description="The no-dead-ends hub button offered when the agent has nothing else to say."
+              enabled={config.nav.enabled}
+              onToggle={(enabled) => patch({ nav: { ...config.nav, enabled } })}
+            >
+              <TextField
+                label="Hub label"
+                value={config.nav.hub_label}
+                onChange={(hub_label) => patch({ nav: { ...config.nav, hub_label } })}
+                testId="nav-hub-label"
+              />
+              <TextField
+                label="Hub command"
+                value={config.nav.hub_command}
+                onChange={(hub_command) => patch({ nav: { ...config.nav, hub_command } })}
+                testId="nav-hub-command"
+              />
+            </PackSection>
+
+            <PackSection
+              name="settings"
+              title="settings"
+              description="Declarative allowlist of user-editable runtime knobs. Schema-only today (the per-user override store is a deferred runtime), so the declared knobs are shown read-only here."
+              enabled={config.settings.enabled}
+              onToggle={(enabled) => patch({ settings: { ...config.settings, enabled } })}
+            >
+              {config.settings.settings.length === 0 ? (
+                <div style={{ fontSize: 11.5, color: C.muted, fontFamily: C.mono }}>No settings declared.</div>
+              ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                  {config.settings.settings.map((s) => (
+                    <div
+                      key={s.key}
+                      data-testid="settings-knob"
+                      style={{
+                        border: "1px solid " + C.border,
+                        borderRadius: 4,
+                        padding: "6px 8px",
+                        background: C.input,
+                        fontFamily: C.mono,
+                        fontSize: 11.5,
+                        color: C.text2,
+                      }}
+                    >
+                      <span style={{ color: C.text }}>{s.key}</span>
+                      <span style={{ color: C.muted }}>{` · ${s.kind}`}</span>
+                      {s.default ? <span style={{ color: C.muted }}>{` · default ${s.default}`}</span> : null}
+                      {s.label ? <span style={{ color: C.muted }}>{` — ${s.label}`}</span> : null}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </PackSection>
+
+            <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 2 }}>
+              {saved ? (
+                <span data-testid="behavior-packs-saved" style={{ fontSize: 12.5, color: C.brand, fontFamily: C.mono }}>
+                  ✓ Saved
+                </span>
+              ) : (
+                <span style={{ fontSize: 12, color: C.muted, fontFamily: C.mono }}>
+                  {dirty ? "unsaved changes" : "no changes"}
+                </span>
+              )}
+              {saveError ? (
+                <span
+                  data-testid="behavior-packs-save-error"
+                  style={{ fontSize: 12, color: C.destructive, fontFamily: C.mono }}
+                >
+                  Save failed: {saveError}
+                </span>
+              ) : null}
+              <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
+                <Button label="Reset" variant="ghost" size="sm" disabled={!dirty || saving} onClick={reset} />
+                <Button
+                  label={saving ? "Saving…" : "Save"}
+                  variant="primary"
+                  size="sm"
+                  testId="behavior-packs-save"
+                  disabled={!dirty || saving}
+                  onClick={() => void save()}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/apps/ui/src/views/wired/WiredAgentDetail.tsx
+++ b/apps/ui/src/views/wired/WiredAgentDetail.tsx
@@ -5,6 +5,7 @@ import { SkillEditor } from "../../components/SkillEditor";
 import { WiredAgentMemory } from "./WiredAgentMemory";
 import { WiredAgentState } from "./WiredAgentState";
 import { WiredThreadReset } from "./WiredThreadReset";
+import { WiredAgentBehaviorPacks } from "./WiredAgentBehaviorPacks";
 import { useStore } from "../../state/store";
 import { useWired } from "../../state/wired";
 import { useAgentVersions, useVersionFiles } from "../../api/hooks";
@@ -543,6 +544,12 @@ export function WiredAgentDetail() {
       {agentId ? (
         <div style={{ marginTop: 16 }}>
           <WiredThreadReset agentId={agentId} agentName={agent.name} />
+        </div>
+      ) : null}
+
+      {agentId ? (
+        <div style={{ marginTop: 16 }}>
+          <WiredAgentBehaviorPacks agentId={agentId} />
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## What

Surfaces the existing `GET`/`PUT /agents/{id}/behavior-packs` control-plane endpoints (`apps/api/.../routers/control.py`) in the console. Adds a settings-style panel on the agent detail page to view and edit an agent's opt-in behavior packs. Frontend only; no backend change.

## The API consumed

- `GET /agents/{id}/behavior-packs` -> `BehaviorPacksConfig` (a NULL agent row reads back as the all-off default).
- `PUT /agents/{id}/behavior-packs` (full config; the API takes the whole object, no partial patch).

## Changes

- **`apps/ui/src/api/client.ts`**: `getBehaviorPacks` / `putBehaviorPacks` and the `BehaviorPacksConfig` types (load / tips / greeting / help / settings / nav), mirroring the `apps/api` schemas verbatim.
- **`WiredAgentBehaviorPacks.tsx`**: a self-contained panel (sibling of the memory / durable-state panels), mounted at the bottom of `WiredAgentDetail`. Toggles each pack's `enabled` and edits its content; the schema-only `settings` pack is shown read-only and round-tripped unchanged. Save PUTs the full config (list fields blank-stripped at save, so a stray empty line never persists); Reset reverts to the last-saved baseline; load / save errors surface inline. Wired-only, no fixture data.
- **`parity.ts` + parity test**: `behavior-packs-edit` registered as a `noCliEquivalent` gap linking the parity epic. No CLI path reads or writes `behavior_packs` (see `cli/api-mirrors.json`), so the honest amber glyph is correct rather than a copyable command.
- **Tests**: unit tests (`WiredAgentBehaviorPacks.test.tsx`) covering render / dirty-gating / toggle-and-PUT / list-cleaning / read-only-settings round-trip / reset / load + save errors, and a stackless Playwright spec (`behavior-packs-wired.spec.ts`) asserting the PUT body.
- **README**: documents the new wired surface and client calls.

## Verification

Full `apps/ui` CI job, all green:
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 123 passed (21 files; 9 new behavior-pack tests + 1 parity update)
- `pnpm build` — ok
- `pnpm e2e` — 31 passed (stackless), including the new `behavior-packs-wired` spec

Closes #870