### PR TITLE
Speed up the e2e parity ladder: cache Rust + split the binary build + split the ladder

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,15 @@ jobs:
           persist-credentials: false
       - name: Toolchain
         run: rustup component add rustfmt clippy
+      # Cache the cargo registry + build artifacts keyed on the lockfiles + rustc
+      # so a run recompiles only what changed, not the whole dependency tree from
+      # scratch (the dominant cost of this job).
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            cli
+            packages/aci-protocol/generated/rust
       # The release-coupled versions (cli/Cargo.toml, Chart.yaml version +
       # appVersion) must agree on every PR, so a bump that forgets one field
       # fails here rather than shipping a chart that pulls the wrong image (#489).
@@ -138,8 +147,31 @@ jobs:
       - name: Generated ACI protocol crate compiles
         working-directory: packages/aci-protocol/generated/rust
         run: cargo test --locked
-      # Continuously prove the release build (the artifact a cold user downloads)
-      # and publish it as a sha-addressable workflow artifact every run.
+
+  # The release binary the e2e ladder + falsifiability gate consume, split out of
+  # the quality job above so those downstream jobs start as soon as the binary
+  # COMPILES -- in parallel with fmt/clippy/test rather than waiting for them
+  # (they no longer gate the ladder; a real test/clippy failure still blocks the
+  # merge via the required "Rust (fmt + clippy + test)" check). The release-build
+  # compile check now lives here; if it should stay merge-blocking, add this job
+  # ("Build the agentos release binary") to the branch ruleset's required checks
+  # (today the required set is Compose/Contracts/Python/Rust/UI).
+  rust-build:
+    name: Build the agentos release binary
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        run: rustc --version
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cli
       - name: Release build
         run: cargo build --release --locked
       - name: Upload agentos binary
@@ -357,7 +389,7 @@ jobs:
   eval-falsifiability:
     name: Eval falsifiability gate (fake model, offline)
     runs-on: ubuntu-latest
-    needs: rust
+    needs: rust-build
     steps:
       - uses: actions/checkout@v7
         with:
@@ -470,14 +502,14 @@ jobs:
   # default (as docker/setup-buildx-action does) breaks that FROM resolution.
   # See the build steps' own comment for the full history (#697/#791).
   e2e-ladder:
-    name: E2E parity ladder (skill + local + local-release, fake model)
+    name: E2E parity ladder (skill + local, fake model)
     runs-on: ubuntu-latest
-    needs: rust
+    needs: rust-build
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - name: Download the agentos binary built by the Rust job
+      - name: Download the agentos binary built by the release-build job
         uses: actions/download-artifact@v7
         with:
           name: agentos-x86_64-linux-${{ github.sha }}
@@ -520,6 +552,39 @@ jobs:
           AGENTOS_BIN: cli/target/release/agentos
           AGENTOS_BASE_TAG: ci-local
         run: bash cli/scripts/e2e-ladder.sh
+  # local-release runs the same round trip as the local rung but against the
+  # GENERATED compose.release.yaml + release-pinned images. Split into its own
+  # job so it runs IN PARALLEL with the skill+local rungs above instead of after
+  # them. Tradeoff: a fresh runner shares no Docker daemon with the e2e-ladder
+  # job, so it rebuilds the same :ci-local base images -- extra image-build
+  # compute in exchange for the wall-clock overlap. Because the combined job was
+  # already short, that trade is marginal; keep or drop this split on review.
+  e2e-ladder-release:
+    name: E2E parity ladder (local-release, fake model)
+    runs-on: ubuntu-latest
+    needs: rust-build
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Download the agentos binary built by the release-build job
+        uses: actions/download-artifact@v7
+        with:
+          name: agentos-x86_64-linux-${{ github.sha }}
+          path: cli/target/release
+      - name: Make the binary executable
+        run: chmod +x cli/target/release/agentos
+      # Plain `docker build` (not buildx) for the same FROM-resolution reason the
+      # e2e-ladder job documents (#697/#791): a buildx docker-container builder as
+      # the default breaks the compose-triggered FROM lookup of the :ci-local tags.
+      - name: Build the runner image locally
+        run: docker build -t agentos-runner -f runner/Dockerfile .
+      - name: Retag the runner image for the compose worker (AGENTOS_RUNNER_IMAGE, no registry auth)
+        run: docker tag agentos-runner ghcr.io/curie-eng/agentos-runner:latest
+      - name: Build the api image locally (satisfies agentos-api + agentos-migrate, no registry auth)
+        run: docker build -t ghcr.io/curie-eng/agentos-api:ci-local -f apps/api/Dockerfile .
+      - name: Build the worker base image locally (satisfies the worker-local overlay's FROM, no registry auth)
+        run: docker build -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile .
       - name: Tag the api image for the generated release compose (ghcr.io/curie-eng/agentos-api:latest, no registry auth)
         run: docker tag ghcr.io/curie-eng/agentos-api:ci-local ghcr.io/curie-eng/agentos-api:latest
       - name: Build the worker-local overlay for the generated release compose (ghcr.io/curie-eng/agentos-worker-local:latest, no registry auth)
@@ -614,7 +679,7 @@ jobs:
   e2e-ladder-cluster:
     name: E2E parity ladder (cluster rung on kind, fake model)
     runs-on: ubuntu-latest
-    needs: [rust, changes]
+    needs: [rust-build, changes]
     if: needs.changes.outputs.cluster == 'true'
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
**Do not merge yet — for review.** Addresses "why does the parity ladder take so long?"

## Diagnosis (from a recent CI run)
The ladder job itself is **138s**, but it `needs: rust` (**350s**) just to receive the compiled `agentos` binary → ~**8 min** end-to-end. The `rust` job is slow because it has **no cargo caching** (full dep-tree recompile every run), compiles the tree **twice** (debug for tests + release for the artifact), and the ladder waits for fmt+clippy+test even though it only needs the binary.

## Three changes
1. **Cache cargo** in the `rust` job (`Swatinem/rust-cache@v2`) → warm runs recompile only what changed (~350s → est ~120–180s).
2. **Split the release binary into a dedicated cached `rust-build` job** that the ladder / falsifiability / cluster jobs depend on → they start as soon as the binary *compiles*, in parallel with fmt/clippy/test → ladder end-to-end est **~8 min → ~4 min**.
3. **Split the `local-release` rung into a parallel `e2e-ladder-release` job** so it overlaps skill+local.

## Can't break other PRs (same audit as #843)
- `actionlint` clean; every `needs:` resolves.
- The required-check **`Rust (fmt + clippy + test)`** keeps its exact name and still gates merges on test/clippy failure.
- The two new jobs (`rust-build`, `e2e-ladder-release`) are **not** in the ruleset's required set (Compose/Contracts/Python/Rust/UI), and nothing required `needs:` them → they can't block a merge.
- Binary artifact uploaded once (in `rust-build`), downloaded by all four consumers under the same name.

## Honest caveats / decisions for you
- **Not yet run on real CI** — a workflow edit only proves out on the first run. #1 speeds only *warm* runs (first run populates the cache).
- **#2 gating change:** the release-build *compile* check moves from the required `rust` job to the non-required `rust-build`. If a release-only compile break should stay merge-blocking, add **`Build the agentos release binary`** to the ruleset's required checks.
- **#3 is marginal:** a fresh runner shares no Docker daemon with `e2e-ladder`, so `e2e-ladder-release` rebuilds the same `:ci-local` images — extra build compute for a small wall-clock overlap, since the combined job was already short. **Recommend keeping #1+#2 and dropping #3** unless you want the overlap.