### PR TITLE
Cache cargo in the Rust CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,15 @@ jobs:
           persist-credentials: false
       - name: Toolchain
         run: rustup component add rustfmt clippy
+      # Cache the cargo registry + build artifacts keyed on the lockfiles + rustc
+      # so a run recompiles only what changed, not the whole dependency tree from
+      # scratch (the dominant cost of this job).
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            cli
+            packages/aci-protocol/generated/rust
       # The release-coupled versions (cli/Cargo.toml, Chart.yaml version +
       # appVersion) must agree on every PR, so a bump that forgets one field
       # fails here rather than shipping a chart that pulls the wrong image (#489).


### PR DESCRIPTION
**1 of 3** splitting the ladder-speedup work (was combined in #884). Independent — merge in any order.

The Rust job (~350s) has no cargo caching, so every run recompiles the whole dependency tree from scratch. Since the e2e ladder `needs: rust`, that's the biggest reason the ladder's signal takes ~8 min end-to-end.

Adds `Swatinem/rust-cache@v2` (keyed on the lockfiles + rustc) so a run recompiles only changed crates → est ~350s → ~120–180s on **warm** runs (the first run after merge populates the cache).

Safe: a cache hit/miss only changes timing, never outcome; no job-graph or required-check change. `actionlint` clean.