### PR TITLE
Split the local-release ladder rung into a parallel CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -493,14 +493,14 @@ jobs:
   # default (as docker/setup-buildx-action does) breaks that FROM resolution.
   # See the build steps' own comment for the full history (#697/#791).
   e2e-ladder:
-    name: E2E parity ladder (skill + local + local-release, fake model)
+    name: E2E parity ladder (skill + local, fake model)
     runs-on: ubuntu-latest
     needs: rust-build
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - name: Download the agentos binary built by the Rust job
+      - name: Download the agentos binary built by the release-build job
         uses: actions/download-artifact@v7
         with:
           name: agentos-x86_64-linux-${{ github.sha }}
@@ -543,6 +543,39 @@ jobs:
           AGENTOS_BIN: cli/target/release/agentos
           AGENTOS_BASE_TAG: ci-local
         run: bash cli/scripts/e2e-ladder.sh
+  # local-release runs the same round trip as the local rung but against the
+  # GENERATED compose.release.yaml + release-pinned images. Split into its own
+  # job so it runs IN PARALLEL with the skill+local rungs above instead of after
+  # them. Tradeoff: a fresh runner shares no Docker daemon with the e2e-ladder
+  # job, so it rebuilds the same :ci-local base images -- extra image-build
+  # compute in exchange for the wall-clock overlap. Because the combined job was
+  # already short, that trade is marginal; keep or drop this split on review.
+  e2e-ladder-release:
+    name: E2E parity ladder (local-release, fake model)
+    runs-on: ubuntu-latest
+    needs: rust-build
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Download the agentos binary built by the release-build job
+        uses: actions/download-artifact@v7
+        with:
+          name: agentos-x86_64-linux-${{ github.sha }}
+          path: cli/target/release
+      - name: Make the binary executable
+        run: chmod +x cli/target/release/agentos
+      # Plain `docker build` (not buildx) for the same FROM-resolution reason the
+      # e2e-ladder job documents (#697/#791): a buildx docker-container builder as
+      # the default breaks the compose-triggered FROM lookup of the :ci-local tags.
+      - name: Build the runner image locally
+        run: docker build -t agentos-runner -f runner/Dockerfile .
+      - name: Retag the runner image for the compose worker (AGENTOS_RUNNER_IMAGE, no registry auth)
+        run: docker tag agentos-runner ghcr.io/curie-eng/agentos-runner:latest
+      - name: Build the api image locally (satisfies agentos-api + agentos-migrate, no registry auth)
+        run: docker build -t ghcr.io/curie-eng/agentos-api:ci-local -f apps/api/Dockerfile .
+      - name: Build the worker base image locally (satisfies the worker-local overlay's FROM, no registry auth)
+        run: docker build -t ghcr.io/curie-eng/agentos-worker:ci-local -f apps/worker/Dockerfile .
       - name: Tag the api image for the generated release compose (ghcr.io/curie-eng/agentos-api:latest, no registry auth)
         run: docker tag ghcr.io/curie-eng/agentos-api:ci-local ghcr.io/curie-eng/agentos-api:latest
       - name: Build the worker-local overlay for the generated release compose (ghcr.io/curie-eng/agentos-worker-local:latest, no registry auth)


### PR DESCRIPTION
**3 of 3** splitting the ladder-speedup work (was combined in #884). **Stacked on #893** (base `task/ci-split-release-build`) because the new job `needs: rust-build`, which #893 creates — review/merge #893 first (GitHub retargets this to `main` on merge).

Moves the `local-release` rung out of the combined `e2e-ladder` job into a parallel `e2e-ladder-release` job so it overlaps skill+local instead of running after them.

**Honest recommendation — this is the marginal one.** A fresh runner shares no Docker daemon with `e2e-ladder`, so `e2e-ladder-release` rebuilds the same `:ci-local` base images: extra build compute for a small wall-clock overlap, and the combined job was already short (~138s). The real wins are #885 (cache) and #893 (decouple from the 350s quality job). **Fine to close this unmerged** if the trade isn't worth it — it's isolated here.

Verified: `actionlint` clean; new job `needs: rust-build`; the `local-release` rung runs in exactly one job. Not yet run on real CI.