### PR TITLE
Add export-time validator dropping non-schema keys and unscrubbed secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,7 @@ VALKEY_PASSWORD=valkeypass
 #   substrate the chart / docker substrate
 #   operator  you, via chart runner.extraEnv or docker -e
 #
+# AGENTOS_APPROVAL_DECISION        producers: kernel
 # AGENTOS_APPROVAL_GRANT_TOOL      producers: kernel
 # AGENTOS_APPROVAL_REQUIRED_TOOLS  producers: worker
 # AGENTOS_APPROVAL_RESUMED_KIND    producers: kernel

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2240,6 +2240,17 @@
       "TraceTree": {
         "description": "A trace plus its reconstructed observation tree.",
         "properties": {
+          "approval_decision": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Decision"
+          },
           "sandbox_id": {
             "anyOf": [
               {

--- a/apps/api/src/agentos_api/langfuse.py
+++ b/apps/api/src/agentos_api/langfuse.py
@@ -46,14 +46,20 @@ def matching_traces(
 # attributable to the concrete sandbox that served it.
 _SANDBOX_ATTR = "agentos.sandbox_id"
 
+# The OTel span attribute the runner stamps on the root agent.run span (ADR-0076
+# Stone 3, #889) when a turn resumes a resolved approval.
+_APPROVAL_DECISION_ATTR = "gen_ai.approval.decision"
 
-def _probe_sandbox_attr(bag: Any) -> str | None:
-    """Return a non-empty `agentos.sandbox_id` from one attribute bag, or None.
+
+def _probe_attr(bag: Any, key: str, *, bare_key: str | None = None) -> str | None:
+    """Return a non-empty string attribute from one attribute bag, or None.
 
     Checks the bag itself plus the common keys Langfuse uses to carry OTel
-    resource/metadata attributes (``metadata`` / ``resourceAttributes`` /
-    ``resource``, each optionally wrapping an ``attributes`` sub-dict). The bare
-    ``sandbox_id`` key is accepted too. Non-string / empty values are ignored.
+    span/resource attributes (``metadata`` / ``resourceAttributes`` /
+    ``resource``, each optionally wrapping an ``attributes`` sub-dict).
+    ``bare_key``, when given, is accepted as a shorter alias (e.g. the bare
+    ``sandbox_id`` for ``agentos.sandbox_id``). Non-string / empty values are
+    ignored.
     """
 
     if not isinstance(bag, dict):
@@ -67,7 +73,7 @@ def _probe_sandbox_attr(bag: Any) -> str | None:
             if isinstance(inner, dict):
                 candidates.append(inner)
     for cand in candidates:
-        hit = cand.get(_SANDBOX_ATTR) or cand.get("sandbox_id")
+        hit = cand.get(key) or (cand.get(bare_key) if bare_key else None)
         if isinstance(hit, str) and hit.strip():
             return hit
     return None
@@ -85,11 +91,33 @@ def hoist_sandbox_id(
     invented.
     """
 
-    hit = _probe_sandbox_attr(trace)
+    hit = _probe_attr(trace, _SANDBOX_ATTR, bare_key="sandbox_id")
     if hit:
         return hit
     if observations:
-        return _probe_sandbox_attr(observations[0])
+        return _probe_attr(observations[0], _SANDBOX_ATTR, bare_key="sandbox_id")
+    return None
+
+
+def hoist_approval_decision(
+    trace: dict[str, Any], observations: list[dict[str, Any]]
+) -> str | None:
+    """Lift the runner's approval-gate decision out of a trace, or None.
+
+    Mirrors ``hoist_sandbox_id``'s trace-then-first-observation probe. The
+    attribute is stamped on the root ``agent.run`` span rather than as a
+    provider-wide resource attribute (ADR-0076 Stone 3, #889), so it is
+    ordinarily trace-level; the observation fallback stays for the same
+    reason ``hoist_sandbox_id`` keeps it -- Langfuse's OTLP ingestion doesn't
+    guarantee which level surfaces a given span attribute. Absent for the
+    ordinary case (no approval gate was resumed this turn); no value invented.
+    """
+
+    hit = _probe_attr(trace, _APPROVAL_DECISION_ATTR)
+    if hit:
+        return hit
+    if observations:
+        return _probe_attr(observations[0], _APPROVAL_DECISION_ATTR)
     return None
 
 

--- a/apps/api/src/agentos_api/routers/runs.py
+++ b/apps/api/src/agentos_api/routers/runs.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from ..auth import require_api_key
 from ..deps import LangfuseDep
 from ..evalcase import trace_to_eval_case
-from ..langfuse import build_tree, hoist_sandbox_id
+from ..langfuse import build_tree, hoist_approval_decision, hoist_sandbox_id
 from ..metrics import agent_trace_filter
 from ..schemas import EvalCaseOut, TraceTree
 
@@ -49,6 +49,7 @@ async def get_trace(trace_id: str, lf: LangfuseDep) -> TraceTree:
         trace=trace,
         tree=build_tree(observations),
         sandbox_id=hoist_sandbox_id(trace, observations),
+        approval_decision=hoist_approval_decision(trace, observations),
     )
 
 

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -590,6 +590,10 @@ class TraceTree(BaseModel):
     # The runner's sandbox id (agentos.sandbox_id), hoisted out of the trace/
     # observation resource attributes; None when the trace predates the attr.
     sandbox_id: str | None = None
+    # The resolved approval-gate decision (approved/rejected/expired) this turn
+    # resumed from (ADR-0076 Stone 3, #889), hoisted out of the trace/
+    # observation attributes; None for a turn that resumed no approval.
+    approval_decision: str | None = None
 
 
 class MetricsSummary(BaseModel):

--- a/apps/api/tests/test_approval_decision_hoist.py
+++ b/apps/api/tests/test_approval_decision_hoist.py
@@ -1,0 +1,57 @@
+"""Unit tests for hoisting the resolved approval decision out of a Langfuse trace.
+
+The runner stamps `gen_ai.approval.decision` as an OTel span attribute on the
+root agent.run span (ADR-0076 Stone 3, #889) rather than a resource attribute,
+but Langfuse's OTLP ingestion still may surface it on the trace's metadata or
+only on the observations, so the hoist probes both -- mirroring
+`hoist_sandbox_id` (see test_sandbox_hoist.py). These tests fake both payload
+shapes; the real propagation is exercised only against a live Langfuse.
+"""
+
+from typing import Any
+
+from agentos_api.langfuse import hoist_approval_decision
+
+
+def test_hoist_from_trace_metadata() -> None:
+    trace = {"id": "t1", "metadata": {"gen_ai.approval.decision": "approved"}}
+    assert hoist_approval_decision(trace, []) == "approved"
+
+
+def test_hoist_from_trace_resource_attributes() -> None:
+    trace = {
+        "id": "t1",
+        "resourceAttributes": {"attributes": {"gen_ai.approval.decision": "rejected"}},
+    }
+    assert hoist_approval_decision(trace, []) == "rejected"
+
+
+def test_hoist_from_first_observation_when_trace_lacks_it() -> None:
+    trace = {"id": "t1", "metadata": {"other": "x"}}
+    observations: list[dict[str, Any]] = [
+        {
+            "id": "root",
+            "type": "SPAN",
+            "resourceAttributes": {"gen_ai.approval.decision": "expired"},
+        },
+        {"id": "child", "type": "SPAN"},
+    ]
+    assert hoist_approval_decision(trace, observations) == "expired"
+
+
+def test_hoist_prefers_trace_over_observation() -> None:
+    trace = {"id": "t1", "metadata": {"gen_ai.approval.decision": "approved"}}
+    observations = [{"id": "root", "metadata": {"gen_ai.approval.decision": "rejected"}}]
+    assert hoist_approval_decision(trace, observations) == "approved"
+
+
+def test_hoist_returns_none_for_an_ordinary_turn() -> None:
+    # No approval was resumed this turn -- the ordinary, most common case.
+    trace = {"id": "t1", "metadata": {"other": "x"}}
+    observations = [{"id": "root", "type": "SPAN"}]
+    assert hoist_approval_decision(trace, observations) is None
+
+
+def test_hoist_ignores_empty_value() -> None:
+    trace = {"id": "t1", "metadata": {"gen_ai.approval.decision": ""}}
+    assert hoist_approval_decision(trace, []) is None

--- a/apps/api/tests/test_runs_proxy.py
+++ b/apps/api/tests/test_runs_proxy.py
@@ -88,6 +88,36 @@ def test_get_trace_sandbox_id_null_when_absent(
     assert resp.json()["sandbox_id"] is None
 
 
+def test_get_trace_surfaces_approval_decision_from_observation(
+    auth_headers: dict[str, str],
+) -> None:
+    # Same hoist shape as sandbox_id, for the ADR-0076 Stone 3 (#889) attribute.
+    observations = [
+        {
+            "id": "r",
+            "type": "SPAN",
+            "name": "agent.run",
+            "startTime": "1",
+            "metadata": {"gen_ai.approval.decision": "approved"},
+        },
+    ]
+    with _app_with(observations) as client:
+        resp = client.get("/langfuse/traces/abc", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["approval_decision"] == "approved"
+
+
+def test_get_trace_approval_decision_null_when_absent(
+    auth_headers: dict[str, str],
+) -> None:
+    # The ordinary case: no approval was resumed this turn.
+    observations = [{"id": "r", "type": "SPAN", "name": "agent.run", "startTime": "1"}]
+    with _app_with(observations) as client:
+        resp = client.get("/langfuse/traces/abc", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["approval_decision"] is None
+
+
 def test_get_trace_404_when_no_observations(
     auth_headers: dict[str, str],
 ) -> None:

--- a/apps/worker/src/agentos_worker/binding.py
+++ b/apps/worker/src/agentos_worker/binding.py
@@ -104,6 +104,12 @@ GRANT_TOOL_ENV = BootEnv.env_key("approval_grant_tool")
 # confers nothing -- the runner reads it only to decide whether to emit an
 # observe-only warning when the approved business action never ran.
 RESUMED_KIND_ENV = BootEnv.env_key("approval_resumed_kind")
+# ADR-0076 Stone 3 (#889, epic #512): the resolved terminal decision
+# ('approved'/'rejected'/'expired') of the approval this resume boot is
+# resuming from, so the runner can stamp it on the turn's OTel span and close
+# the "did an approval get requested" gap ADR-0038 named open. Also an
+# authority-free FACT, like RESUMED_KIND_ENV -- confers nothing.
+DECISION_ENV = BootEnv.env_key("approval_decision")
 # #517/#669 opt-in false-completion check: a runner-local, authority-free,
 # observe-only knob, NOT a declared BootEnv field (unlike the keys above, which
 # all go through BootEnv.env_key). runner/src/agentos_runner/config.py reads
@@ -380,6 +386,45 @@ class BindingResolver:
             return None
         kind: str | None = row["gate_kind"]
         return kind or None
+
+    async def approval_decision(self, event_id: str, agent_id: uuid.UUID) -> str | None:
+        """The resolved terminal decision of the approval a resume turn is
+        resuming from (ADR-0076 Stone 3, #889), or None.
+
+        An authority-free FACT for the runner's OTel span, exactly like
+        ``approval_resumed_kind`` -- it confers nothing, it only reports an
+        outcome the worker already resolved. Unlike ``approval_resumed_kind``
+        (approved-only, since only an approved resume owes a business action)
+        this reports all three terminal statuses -- ``approved``, ``rejected``,
+        and ``expired`` -- so a rejected or expired gate is observable from the
+        trace too, closing the "did an approval get requested" gap ADR-0038
+        named open. ``pending`` is not terminal and is never returned.
+
+        Agent-bound identically to the grant and the resumed-kind marker, so it
+        never leaks across a channel rebind. A non-approval event id, an
+        unknown or other-agent approval, or a still-pending approval all
+        return None.
+        """
+        approval_id = _parse_resume_event_id(event_id)
+        if approval_id is None:
+            return None
+        sql = text(
+            f"SELECT status, agent_id FROM {self._config.db_schema}.approvals WHERE id = :id"
+        )
+        async with self._engine.connect() as conn:
+            result = await conn.execute(sql, {"id": approval_id})
+            row = result.mappings().first()
+        if row is None:
+            return None
+        row_agent_id = row["agent_id"]
+        if row_agent_id is None or row_agent_id != agent_id:
+            return None
+        # Literal status compare: the worker must not import the API's
+        # ApprovalStatus.
+        status: str = row["status"]
+        if status not in ("approved", "rejected", "expired"):
+            return None
+        return status
 
     async def secrets_for(self, agent_id: uuid.UUID) -> dict[str, str] | None:
         """The agent's connector secrets (#429), for lanes that boot by agent_id

--- a/apps/worker/src/agentos_worker/kernel.py
+++ b/apps/worker/src/agentos_worker/kernel.py
@@ -62,7 +62,7 @@ from .behaviorpacks import (
     sample_load,
     sample_tip,
 )
-from .binding import GRANT_TOOL_ENV, RESUMED_KIND_ENV, BindingResolver
+from .binding import DECISION_ENV, GRANT_TOOL_ENV, RESUMED_KIND_ENV, BindingResolver
 from .config import WorkerConfig
 from .killswitch import KillSwitch
 from .markers import Markers
@@ -419,6 +419,21 @@ class Kernel:
                 )
                 if resumed_kind:
                     boot_env[RESUMED_KIND_ENV] = resumed_kind
+                # ADR-0076 Stone 3 (#889, epic #512): the resolved terminal
+                # decision (approved/rejected/expired), authority-free like the
+                # marker above, so the runner can stamp it on the turn's OTel
+                # span. Reports all three terminal statuses, not just approved
+                # (contrast resumed_kind), closing the "did an approval get
+                # requested" gap ADR-0038 named open. getattr-tolerant of
+                # binding doubles that do not carry the method, like the two above.
+                decision_fn = getattr(self._binding, "approval_decision", None)
+                decision = (
+                    await decision_fn(qevent.event_id, resolved.agent_id)
+                    if decision_fn is not None
+                    else None
+                )
+                if decision:
+                    boot_env[DECISION_ENV] = decision
                 # Resolve the agent's packs once here (a pure parse, no I/O) and
                 # reuse: the nav pack is threaded to the final render, the same
                 # packs feed the shimmer below.

--- a/apps/worker/tests/binding/test_approval_grant.py
+++ b/apps/worker/tests/binding/test_approval_grant.py
@@ -606,6 +606,108 @@ def test_resumed_kind_only_for_approved_approvals() -> None:
     asyncio.run(go())
 
 
+def test_approval_decision_reports_all_three_terminal_statuses() -> None:
+    # ADR-0076 Stone 3 (#889): unlike approval_resumed_kind (approved-only),
+    # approval_decision reports every terminal status so a rejected or expired
+    # gate is observable from the trace too. pending is not terminal and never
+    # yields a decision.
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            await _skip_if_unreachable(engine)
+            agent_id = uuid.uuid4()
+            await _seed_agent(engine, agent_id)
+            try:
+                resolver = _resolver(engine)
+                for status in ("approved", "rejected", "expired"):
+                    approval_id = uuid.uuid4()
+                    await _seed_approval(
+                        engine,
+                        approval_id=approval_id,
+                        status=status,
+                        summary="Give ACME a 20% discount",
+                        agent_id=agent_id,
+                        gate_kind="policy",
+                    )
+                    assert (
+                        await resolver.approval_decision(
+                            resume_event_id(approval_id), agent_id
+                        )
+                        == status
+                    )
+
+                pending_id = uuid.uuid4()
+                await _seed_approval(
+                    engine,
+                    approval_id=pending_id,
+                    status="pending",
+                    summary="Give ACME a 20% discount",
+                    agent_id=agent_id,
+                    gate_kind="policy",
+                )
+                assert (
+                    await resolver.approval_decision(resume_event_id(pending_id), agent_id)
+                    is None
+                )
+            finally:
+                await _cleanup_agents(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_approval_decision_is_agent_bound() -> None:
+    # Same cross-agent guard as the grant and the resumed-kind marker: a
+    # decision resolves only for the agent the approval belongs to.
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            await _skip_if_unreachable(engine)
+            owner_id = uuid.uuid4()
+            other_id = uuid.uuid4()
+            approval_id = uuid.uuid4()
+            await _seed_agent(engine, owner_id)
+            await _seed_approval(
+                engine,
+                approval_id=approval_id,
+                status="approved",
+                summary="Give ACME a 20% discount",
+                agent_id=owner_id,
+                gate_kind="policy",
+            )
+            try:
+                resolver = _resolver(engine)
+                event = resume_event_id(approval_id)
+                assert await resolver.approval_decision(event, other_id) is None
+                assert await resolver.approval_decision(event, owner_id) == "approved"
+            finally:
+                await _cleanup_agents(engine, [owner_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_approval_decision_returns_none_without_db_hit_for_non_approval_event_id() -> None:
+    # Same fast-return guarantee as approval_grant_tool: a non-approval event id
+    # must not touch the DB at all.
+    async def go() -> None:
+        bad_engine = create_async_engine(
+            "postgresql+asyncpg://invalid:invalid@127.0.0.1:1/none"
+        )
+        try:
+            resolver = BindingResolver(bad_engine, WorkerConfig(db_schema=_SCHEMA))
+            decision = await resolver.approval_decision(
+                "ev-slack-1699999999.123456", uuid.uuid4()
+            )
+            assert decision is None
+        finally:
+            await bad_engine.dispose()
+
+    asyncio.run(go())
+
+
 def test_pins_summarize_tool_call_format() -> None:
     # Pinning: the worker summary-parser recovers exactly the tool name that
     # summarize_tool_call (the runner producer) writes into the summary. Guards

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.2.5";
+pub const PROTOCOL_VERSION: &str = "0.2.6";
 
 pub const RUNS_STREAM_DEFAULT: &str = "agentos:runs";
 
@@ -152,6 +152,8 @@ pub struct BootEnv {
     #[serde(default)]
     pub approval_resumed_kind: Option<String>,
     #[serde(default)]
+    pub approval_decision: Option<String>,
+    #[serde(default)]
     pub connector_secret_keys: Option<Vec<String>>,
     #[serde(default)]
     pub port: Option<i64>,
@@ -173,6 +175,7 @@ pub struct BootEnv {
 /// The env key is the contract; the Rust CLI and the chart render-assert
 /// pin against these instead of retyping the literals.
 pub mod env_keys {
+    pub const AGENTOS_APPROVAL_DECISION: &str = "AGENTOS_APPROVAL_DECISION";
     pub const AGENTOS_APPROVAL_GRANT_TOOL: &str = "AGENTOS_APPROVAL_GRANT_TOOL";
     pub const AGENTOS_APPROVAL_REQUIRED_TOOLS: &str = "AGENTOS_APPROVAL_REQUIRED_TOOLS";
     pub const AGENTOS_APPROVAL_RESUMED_KIND: &str = "AGENTOS_APPROVAL_RESUMED_KIND";

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -31,6 +31,7 @@ export type ReplyPlaceholder = string;
 export type Route = string | null;
 export type Summary = string;
 export type ApiBackend = string | null;
+export type ApprovalDecision = string | null;
 export type ApprovalGrantTool = string | null;
 export type ApprovalRequiredTools = string[] | null;
 export type ApprovalResumedKind = string | null;
@@ -100,14 +101,14 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
@@ -136,12 +137,12 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
 
-export interface ACIProtocolV025 {
+export interface ACIProtocolV026 {
   [k: string]: unknown;
 }
 /**
@@ -156,7 +157,7 @@ export interface ACIProtocolV025 {
  * provenance (#544, Decision C) written by the runner; both stay optional for
  * the rolling-deploy window.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -201,11 +202,12 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
   api_backend?: ApiBackend;
+  approval_decision?: ApprovalDecision;
   approval_grant_tool?: ApprovalGrantTool;
   approval_required_tools?: ApprovalRequiredTools;
   approval_resumed_kind?: ApprovalResumedKind;
@@ -235,7 +237,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -254,7 +256,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -270,7 +272,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -282,7 +284,7 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -299,7 +301,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -319,7 +321,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -333,7 +335,7 @@ export interface EvalReport {
 /**
  * An inbound event delivered into a live session (initial or follow-up).
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -378,7 +380,7 @@ export interface Event {
  * scalars: a tolerant consumer decoding an older producer's ``final`` simply
  * sees them absent.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
@@ -397,7 +399,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -408,7 +410,7 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -420,7 +422,7 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -436,7 +438,7 @@ export interface ToolNote {
  * Its presence gates the no-retry-after-side-effects rule (section 2b): a
  * failed run carrying this flag escalates to a human instead of retrying.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
@@ -454,7 +456,7 @@ export interface SideEffectFlag {
  * stream-encoding helpers live with the producer (the dispatcher), not on this
  * frozen model, so the contract stays transport-agnostic.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -483,7 +485,7 @@ export interface QueuedTurn {
  * (its ``slack_api_base_url``, i.e. real Slack), so a producer that does not set
  * it keeps the pre-#19 behavior.
  *
- * This interface was referenced by `ACIProtocolV025`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV026`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -149,6 +149,22 @@
           ],
           "title": "Api Backend"
         },
+        "approval_decision": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "env": "AGENTOS_APPROVAL_DECISION",
+          "producer": [
+            "kernel"
+          ],
+          "title": "Approval Decision"
+        },
         "approval_grant_tool": {
           "anyOf": [
             {
@@ -1163,6 +1179,6 @@
   },
   "$id": "https://curie.tech/agentos/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.2.5",
-  "title": "ACI Protocol v0.2.5"
+  "protocolVersion": "0.2.6",
+  "title": "ACI Protocol v0.2.6"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.2.5",
-  "wire_sha256": "17a967d6315f6267c159bf784b80ea7d09d3003002ef8cdc73200bdaa4a1001f"
+  "protocol_version": "0.2.6",
+  "wire_sha256": "1c0847e417ea4df4f434032d71d11327ccfb26c0a8a8277a7cd5442498ab2daa"
 }

--- a/packages/aci-protocol/src/aci_protocol/session.py
+++ b/packages/aci-protocol/src/aci_protocol/session.py
@@ -340,6 +340,15 @@ class BootEnv(_AciModel):
     approval_resumed_kind: str | None = Field(
         default=None, json_schema_extra=_env("AGENTOS_APPROVAL_RESUMED_KIND", "kernel")
     )
+    # ADR-0076 Stone 3 (#889, epic #512): the resolved terminal decision
+    # ('approved'/'rejected'/'expired') of the approval this resume boot is
+    # resuming from, so the runner can stamp it onto the turn's OTel span and
+    # close the "did an approval get requested" gap ADR-0038 named open. Also
+    # an authority-free fact, like approval_resumed_kind -- it confers no
+    # capability, it only reports an outcome the worker already resolved.
+    approval_decision: str | None = Field(
+        default=None, json_schema_extra=_env("AGENTOS_APPROVAL_DECISION", "kernel")
+    )
     # Names which boot keys are per-agent connector secrets (ADR-0009, #429), so
     # the k8s substrate strips those plaintext values off the claim CR. Declared
     # here so the key is typed, exported, and parseable, but the worker's
@@ -577,6 +586,8 @@ class BootEnv(_AciModel):
             env[self.env_key("approval_grant_tool")] = self.approval_grant_tool
         if self.approval_resumed_kind is not None:
             env[self.env_key("approval_resumed_kind")] = self.approval_resumed_kind
+        if self.approval_decision is not None:
+            env[self.env_key("approval_decision")] = self.approval_decision
         if self.connector_secret_keys:
             env[self.env_key("connector_secret_keys")] = ",".join(self.connector_secret_keys)
         if self.port is not None:
@@ -624,6 +635,7 @@ class BootEnv(_AciModel):
             approval_required_tools=_list_or_none(env.get("AGENTOS_APPROVAL_REQUIRED_TOOLS")),
             approval_grant_tool=_stripped_or_none(env.get("AGENTOS_APPROVAL_GRANT_TOOL")),
             approval_resumed_kind=_stripped_or_none(env.get("AGENTOS_APPROVAL_RESUMED_KIND")),
+            approval_decision=_stripped_or_none(env.get("AGENTOS_APPROVAL_DECISION")),
             connector_secret_keys=_list_or_none(env.get("AGENTOS_CONNECTOR_SECRET_KEYS")),
             port=_required_int(env.get("AGENTOS_RUNNER_PORT")),
             base_url=_str_or_none(env.get("ANTHROPIC_BASE_URL")),

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.2.5"
+PROTOCOL_VERSION: Final = "0.2.6"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/packages/aci-protocol/tests/test_session.py
+++ b/packages/aci-protocol/tests/test_session.py
@@ -472,16 +472,18 @@ def test_render_worker_emits_exactly_the_worker_owned_key_subset() -> None:
 # --- Golden 3: the kernel resume overlay. ------------------------------------
 
 
-def test_the_kernel_owns_exactly_the_two_approval_resume_keys() -> None:
-    """kernel.py:317,334 layer these onto binding.boot_env's dict after the fact.
+def test_the_kernel_owns_exactly_the_three_approval_resume_keys() -> None:
+    """kernel.py layers these onto binding.boot_env's dict after the fact.
 
     They are a distinct producer: same process, different code path, rendered
     independently. The kernel sets them via the exported constants, so the
-    producer map is what pins the overlay's exact extent.
+    producer map is what pins the overlay's exact extent. ADR-0076/#889 added
+    ``AGENTOS_APPROVAL_DECISION`` alongside the original two.
     """
     assert set(BootEnv.env_keys(producer="kernel")) == {
         "AGENTOS_APPROVAL_GRANT_TOOL",
         "AGENTOS_APPROVAL_RESUMED_KIND",
+        "AGENTOS_APPROVAL_DECISION",
     }
 
 
@@ -490,6 +492,7 @@ def test_the_kernel_overlay_keys_are_not_worker_rendered() -> None:
     env = _worker_env(approval_required_tools=["Bash"])
     assert "AGENTOS_APPROVAL_GRANT_TOOL" not in env
     assert "AGENTOS_APPROVAL_RESUMED_KIND" not in env
+    assert "AGENTOS_APPROVAL_DECISION" not in env
 
 
 # --- Golden 4: the consumer parse. -------------------------------------------
@@ -690,6 +693,7 @@ def test_env_keys_declares_the_whole_flattened_boot_surface() -> None:
         "AGENTOS_APPROVAL_REQUIRED_TOOLS",
         "AGENTOS_APPROVAL_GRANT_TOOL",
         "AGENTOS_APPROVAL_RESUMED_KIND",
+        "AGENTOS_APPROVAL_DECISION",
         "AGENTOS_CONNECTOR_SECRET_KEYS",
         "AGENTOS_RUNNER_PORT",
         "ANTHROPIC_BASE_URL",

--- a/runner/schema/otel-attributes.schema.json
+++ b/runner/schema/otel-attributes.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://schemas.agentos.dev/runner/otel-attributes/v1.json",
+  "schema_version": "v1",
+  "keys": [
+    "agentos.sandbox_id",
+    "agentos.session_id",
+    "gen_ai.approval.decision",
+    "gen_ai.operation.name",
+    "gen_ai.request.model",
+    "gen_ai.tool.name",
+    "gen_ai.usage.cache_creation_input_tokens",
+    "gen_ai.usage.cache_read_input_tokens",
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.output_tokens",
+    "langfuse.session.id",
+    "langfuse.trace.name",
+    "langfuse.user.id",
+    "model",
+    "schema.version",
+    "service.name"
+  ]
+}

--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -234,6 +234,7 @@ def build_runner(
         history_store=history_store,
         approval_gate=approval_gate,
         approval_resumed_kind=config.approval_resumed_kind,
+        approval_decision=config.approval_decision,
         false_completion_check=config.false_completion_check,
     )
 

--- a/runner/src/agentos_runner/config.py
+++ b/runner/src/agentos_runner/config.py
@@ -54,6 +54,13 @@ class RunnerConfig:
     # the past, used only to emit an observe-only warning when a resumed policy
     # turn takes no action. It must never influence can_use_tool.
     approval_resumed_kind: str | None
+    # ADR-0076 Stone 3 (#889, epic #512): the resolved terminal decision
+    # (approved/rejected/expired) of the approval this resume boot is resuming
+    # from. Authority-free like approval_resumed_kind -- it confers nothing,
+    # it is stamped onto the turn's OTel span so an operator can see whether
+    # (and how) an approval gate was resolved from the trace, closing the
+    # "did an approval get requested" gap ADR-0038 named open.
+    approval_decision: str | None
     # Opt-in false-completion check (#517), authority-free and observe-only. When
     # AGENTOS_FALSE_COMPLETION_CHECK is truthy, a turn that ends DONE with a
     # substantive answer but ZERO tool calls emits a non-terminal warning frame.
@@ -119,6 +126,7 @@ class RunnerConfig:
             approval_required_tools=boot.approval_required_tools,
             approval_grant_tool=boot.approval_grant_tool,
             approval_resumed_kind=boot.approval_resumed_kind,
+            approval_decision=boot.approval_decision,
             false_completion_check=false_completion_check,
             port=boot.port if boot.port is not None else 8080,
             runner_token=boot.runner_token,

--- a/runner/src/agentos_runner/otel.py
+++ b/runner/src/agentos_runner/otel.py
@@ -59,6 +59,12 @@ class SpanAttributeKey(StrEnum):
     TRACE_NAME = "langfuse.trace.name"
     SESSION_ID = "langfuse.session.id"
     USER_ID = "langfuse.user.id"
+    # ADR-0076 Stone 3 (#889, epic #512): the resolved terminal decision
+    # (approved/rejected/expired) of the approval a resume turn is resuming
+    # from, threaded in from the worker's authority-free AGENTOS_APPROVAL_DECISION
+    # boot-env fact. Closes the "did an approval get requested" gap ADR-0038
+    # named open, on the existing span stream.
+    APPROVAL_DECISION = "gen_ai.approval.decision"
     REQUEST_MODEL = "gen_ai.request.model"
     MODEL = "model"
     USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
@@ -194,6 +200,7 @@ class RunTracer:
         model: str | None,
         session_id: str | None = None,
         user_id: str | None = None,
+        approval_decision: str | None = None,
     ) -> Iterator[_GenerationSpan]:
         """Open the root ``agent.run`` span and its child ``llm.generation`` span.
 
@@ -203,6 +210,11 @@ class RunTracer:
         Langfuse reads these from the trace-root span, exactly as it does
         ``langfuse.trace.name``; an empty or absent value is omitted rather than
         stamped, so a turn with no event user (eval runs etc.) carries no user id.
+
+        ``approval_decision`` (ADR-0076 Stone 3, #889) is the authority-free
+        AGENTOS_APPROVAL_DECISION fact -- present only when this turn is
+        resuming a resolved approval -- stamped unconditionally when given so
+        an operator can see the outcome from the trace.
         """
 
         with self._tracer.start_as_current_span("agent.run", kind=SpanKind.SERVER) as root:
@@ -211,6 +223,8 @@ class RunTracer:
                 _set(root, SpanAttributeKey.SESSION_ID, session_id)
             if user_id:
                 _set(root, SpanAttributeKey.USER_ID, user_id)
+            if approval_decision:
+                _set(root, SpanAttributeKey.APPROVAL_DECISION, approval_decision)
             with self._tracer.start_as_current_span("llm.generation") as gen:
                 span = _GenerationSpan(self._tracer, gen)
                 # Stamp the configured model at span open when AGENTOS_MODEL is

--- a/runner/src/agentos_runner/otel.py
+++ b/runner/src/agentos_runner/otel.py
@@ -27,17 +27,18 @@ from __future__ import annotations
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from enum import StrEnum
-from typing import Any
+from typing import Any, cast
 
 from aci_protocol import OtelConfig
 from opentelemetry import trace
+from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import SpanKind, Tracer
 
-from .redact import redact_span_attribute
+from .redact import redact_span_attribute, redact_text
 
 _SERVICE_NAME = "agentos-runner"
 
@@ -94,6 +95,50 @@ def _set(span: Any, key: SpanAttributeKey, value: object) -> None:
     span.set_attribute(key.value, redact_span_attribute(value))
 
 
+class _SchemaValidatingSpanProcessor(SpanProcessor):
+    """Fail-closed export-time backstop (ADR-0076 decision 3).
+
+    ``_set()`` already gates every attribute this module attaches through the
+    closed ``SpanAttributeKey`` enum and the ``redact.py`` scrub; this processor
+    exists for the call site that bypasses both by calling ``span.set_attribute``
+    directly. On each span ending, it strips (does not replace) any attribute
+    whose key is outside the closed schema, or whose string value still matches
+    an unscrubbed-secret pattern after the existing redaction pass — dropping the
+    offending attribute rather than the whole span, so one bad key costs a single
+    field of trace data rather than the whole record.
+
+    Must be registered on the provider ahead of the exporting processor
+    (``TracerProvider.add_span_processor`` invokes processors in registration
+    order); it mutates the span's attributes in place so the exporter that runs
+    after it sees the cleaned set.
+    """
+
+    _ALLOWED_KEYS = frozenset(member.value for member in SpanAttributeKey)
+
+    def on_end(self, span: ReadableSpan) -> None:
+        # ReadableSpan.attributes is a read-only MappingProxyType view; the
+        # underlying BoundedAttributes (span._attributes) is the same object the
+        # concrete Span held, flagged immutable at Span.end() (see the SDK's own
+        # `self._attributes._immutable = True` in Span.end()). Toggling that
+        # private flag to mutate here mirrors the SDK's own pattern. Always a
+        # BoundedAttributes at runtime (Span.__init__ constructs it directly);
+        # the cast narrows past the Mapping-typed private attribute.
+        raw = span._attributes  # noqa: SLF001
+        if raw is None:
+            return
+        attributes = cast(BoundedAttributes, raw)
+        was_immutable = attributes._immutable  # noqa: SLF001
+        attributes._immutable = False  # noqa: SLF001
+        try:
+            for key in list(attributes.keys()):
+                value = attributes[key]
+                still_leaks = isinstance(value, str) and redact_text(value) != value
+                if key not in self._ALLOWED_KEYS or still_leaks:
+                    del attributes[key]
+        finally:
+            attributes._immutable = was_immutable  # noqa: SLF001
+
+
 def build_tracer_provider(
     otel: OtelConfig, session_id: str, sandbox_id: str | None = None
 ) -> TracerProvider | None:
@@ -118,6 +163,9 @@ def build_tracer_provider(
         attributes[SpanAttributeKey.AGENTOS_SANDBOX_ID.value] = sandbox_id
     resource = Resource.create(attributes)
     provider = TracerProvider(resource=resource)
+    # The validator must run before the exporting processor (registration order)
+    # so the exporter only ever sees attributes the closed schema allows.
+    provider.add_span_processor(_SchemaValidatingSpanProcessor())
     # The exporter reads OTEL_EXPORTER_OTLP_ENDPOINT / _HEADERS / _PROTOCOL from
     # the environment itself; SessionConfig.otel is the typed view of the same
     # vars, so an argument-free exporter and the config agree by construction.

--- a/runner/src/agentos_runner/session.py
+++ b/runner/src/agentos_runner/session.py
@@ -135,6 +135,7 @@ class SessionRunner:
         history_store: TranscriptStore | None = None,
         approval_gate: ApprovalGate | None = None,
         approval_resumed_kind: str | None = None,
+        approval_decision: str | None = None,
         false_completion_check: bool = False,
     ) -> None:
         self._factory = session_factory
@@ -161,6 +162,11 @@ class SessionRunner:
         # this boot is resuming from a policy-gate approval. It confers no
         # capability -- it only arms the observe-only turn-end reconciliation.
         self._approval_resumed_kind = approval_resumed_kind
+        # ADR-0076 Stone 3 (#889, epic #512): the resolved terminal decision
+        # (approved/rejected/expired) of the approval this resume boot is
+        # resuming from, stamped onto the turn's OTel span. Authority-free,
+        # like approval_resumed_kind -- it confers no capability.
+        self._approval_decision = approval_decision
         # Opt-in, observe-only false-completion check (#517): warn when a turn
         # ends DONE with a substantive answer but zero tool calls. Off by default.
         self._false_completion_check = false_completion_check
@@ -381,7 +387,11 @@ class SessionRunner:
             tracker = BudgetTracker(ceiling=self._ceiling)
 
             with self._tracer.run_span(
-                self._trace_name, self._model, self._session_id, event.user
+                self._trace_name,
+                self._model,
+                self._session_id,
+                event.user,
+                approval_decision=self._approval_decision,
             ) as gen:
                 try:
                     async for line in self._drive_turn(event, state, tracker, gen):

--- a/runner/tests/test_otel.py
+++ b/runner/tests/test_otel.py
@@ -133,6 +133,62 @@ def test_run_omits_langfuse_user_id_when_event_user_empty() -> None:
     assert root.attributes["langfuse.session.id"] == "agent-abc-thread-123"
 
 
+def test_run_stamps_approval_decision_when_resuming_a_resolved_approval() -> None:
+    # ADR-0076 Stone 3 (#889): the authority-free AGENTOS_APPROVAL_DECISION fact
+    # threaded from the worker lands on the root span, so an operator can see
+    # the outcome of an approval gate from the trace.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    runner = SessionRunner(
+        session_factory=FakeModelSession,
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name="agentos-run:test",
+        model="fake-model",
+        approval_decision="rejected",
+    )
+
+    async def go() -> None:
+        await runner.start()
+        async for _ in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            pass
+
+    anyio.run(go)
+
+    root = {s.name: s for s in exporter.get_finished_spans()}["agent.run"]
+    assert root.attributes["gen_ai.approval.decision"] == "rejected"
+
+
+def test_run_omits_approval_decision_on_an_ordinary_turn() -> None:
+    # No approval was resumed, so the attribute is absent rather than stamped
+    # empty or None -- the ordinary-turn default posture.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    runner = SessionRunner(
+        session_factory=FakeModelSession,
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name="agentos-run:test",
+        model="fake-model",
+    )
+
+    async def go() -> None:
+        await runner.start()
+        async for _ in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            pass
+
+    anyio.run(go)
+
+    root = {s.name: s for s in exporter.get_finished_spans()}["agent.run"]
+    assert "gen_ai.approval.decision" not in root.attributes
+
+
 def test_tracer_provider_none_without_endpoint() -> None:
     otel = OtelConfig()
     assert build_tracer_provider(otel, "s1") is None

--- a/runner/tests/test_otel.py
+++ b/runner/tests/test_otel.py
@@ -4,6 +4,7 @@ import anyio
 from aci_protocol import Event, OtelConfig
 from agentos_runner import RunTracer, SideEffectClassifier, build_tracer_provider
 from agentos_runner.fake import FakeModelSession
+from agentos_runner.otel import _SchemaValidatingSpanProcessor
 from agentos_runner.session import SessionRunner
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -175,3 +176,51 @@ def test_resource_stamps_schema_version() -> None:
     assert provider is not None
     assert provider.resource.attributes["schema.version"] == "v1"
     provider.shutdown()
+
+
+def _validated_exporter() -> tuple[TracerProvider, InMemorySpanExporter]:
+    # The validator only strips attributes on export; wire it ahead of an
+    # in-memory exporter so tests can assert on what actually got through.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(_SchemaValidatingSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def test_validator_strips_attribute_key_outside_the_closed_schema() -> None:
+    # A call site bypassing _set() (e.g. a future span.set_attribute call) must
+    # not reach the exporter with an unlisted key (ADR-0076 decision 3).
+    provider, exporter = _validated_exporter()
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("agent.run") as span:
+        span.set_attribute("langfuse.trace.name", "ok")
+        span.set_attribute("some.unlisted.key", "should not survive export")
+
+    (finished,) = exporter.get_finished_spans()
+    assert finished.attributes["langfuse.trace.name"] == "ok"
+    assert "some.unlisted.key" not in finished.attributes
+
+
+def test_validator_strips_value_still_matching_an_unscrubbed_secret() -> None:
+    # A value that reaches set_attribute without going through redact_span_attribute
+    # (bypassing _set()) is caught at export time even though its key is allowed.
+    provider, exporter = _validated_exporter()
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("agent.run") as span:
+        span.set_attribute("langfuse.trace.name", "sk-abcdefghijklmnopqrstuvwx")
+
+    (finished,) = exporter.get_finished_spans()
+    assert "langfuse.trace.name" not in finished.attributes
+
+
+def test_validator_leaves_clean_allowed_attributes_untouched() -> None:
+    provider, exporter = _validated_exporter()
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("agent.run") as span:
+        span.set_attribute("langfuse.trace.name", "agentos-run:test")
+        span.set_attribute("gen_ai.usage.input_tokens", 12)
+
+    (finished,) = exporter.get_finished_spans()
+    assert finished.attributes["langfuse.trace.name"] == "agentos-run:test"
+    assert finished.attributes["gen_ai.usage.input_tokens"] == 12

--- a/runner/tests/test_otel_schema_drift.py
+++ b/runner/tests/test_otel_schema_drift.py
@@ -1,0 +1,96 @@
+"""CI drift gate on the closed OTel attribute schema (ADR-0076 Stone 5, #891).
+
+Mirrors ADR-0074's committed-artifact-plus-CI-gate discipline for the CLI's
+``--json`` schemas, adapted for this Python-only surface: ``SpanAttributeKey``
+(``otel.py``) is the single source of truth in code, this file's committed
+mirror (``runner/schema/otel-attributes.schema.json``) is the reviewed
+artifact, and the tests below fail loudly if the two diverge -- catching a
+new attribute key (or a bumped ``SCHEMA_VERSION``) that lands without an
+accompanying schema update. A real emitted-attribute contract test closes the
+loop by proving a live run's span attributes never escape the committed set.
+
+Regenerate the committed file after a deliberate schema change by running, from
+the repo root: import ``json``, ``SCHEMA_VERSION`` and ``SpanAttributeKey``
+from ``agentos_runner.otel``, then write
+``{"id": "https://schemas.agentos.dev/runner/otel-attributes/v1.json",
+"schema_version": SCHEMA_VERSION, "keys": sorted(m.value for m in
+SpanAttributeKey)}`` as indented JSON to
+``runner/schema/otel-attributes.schema.json``.
+"""
+
+import json
+from pathlib import Path
+
+import anyio
+from aci_protocol import Event
+from agentos_runner import RunTracer, SideEffectClassifier
+from agentos_runner.fake import FakeModelSession
+from agentos_runner.otel import SCHEMA_VERSION, SpanAttributeKey
+from agentos_runner.session import SessionRunner
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+_SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "otel-attributes.schema.json"
+
+
+def _committed_schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text())
+
+
+def test_committed_schema_matches_the_enum() -> None:
+    committed_keys = set(_committed_schema()["keys"])
+    code_keys = {member.value for member in SpanAttributeKey}
+    assert code_keys == committed_keys, (
+        "SpanAttributeKey (otel.py) and the committed schema "
+        f"({_SCHEMA_PATH}) have diverged -- a key was added or removed on one "
+        "side but not the other. Regenerate the committed file (see this "
+        "module's docstring) and commit it alongside the code change."
+    )
+
+
+def test_committed_schema_version_matches_the_code() -> None:
+    committed_version = _committed_schema()["schema_version"]
+    assert committed_version == SCHEMA_VERSION, (
+        "SCHEMA_VERSION (otel.py) and the committed schema's schema_version "
+        f"({_SCHEMA_PATH}) disagree. Per ADR-0076, bump both together only "
+        "for a removed/renamed/retyped key -- a new optional key is additive "
+        "and must not bump either."
+    )
+
+
+def test_a_real_run_only_emits_attributes_within_the_committed_schema() -> None:
+    # The contract half: proves the enum's closure actually holds on the wire,
+    # not just in the committed inventory. Drives a real turn (permission gate
+    # + tool call + usage, the FakeModelSession default script) and asserts
+    # every attribute key on every emitted span is in the committed set.
+    committed_keys = set(_committed_schema()["keys"])
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    runner = SessionRunner(
+        session_factory=FakeModelSession,
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name="agentos-run:test",
+        session_id="s1",
+        model="fake-model",
+    )
+
+    async def go() -> None:
+        await runner.start()
+        async for _ in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            pass
+
+    anyio.run(go)
+
+    spans = exporter.get_finished_spans()
+    assert spans, "expected at least one emitted span to check"
+    for span in spans:
+        emitted_keys = set(span.attributes)
+        assert emitted_keys <= committed_keys, (
+            f"span {span.name!r} emitted attribute key(s) outside the "
+            f"committed schema: {emitted_keys - committed_keys}"
+        )


### PR DESCRIPTION
Implements Stone 2 of #512 per ADR-0076 (#895).

**Stacked on #896 (Stone 1's enum) — base branch is `task/887-telemetry-attribute-enum`, not `main`. Retarget to `main` once #896 merges; the diff here is additive on top of it.**

Adds `_SchemaValidatingSpanProcessor`, registered ahead of the OTLP-exporting processor in `build_tracer_provider`. On each span ending it strips (not replaces) any attribute whose key falls outside `SpanAttributeKey`, or whose string value still matches one of `redact.py`'s `REDACTION_RULES` after the existing scrub — dropping the single offending attribute rather than the whole span or batch, per ADR-0076 decision 3.

This is a defense-in-depth backstop: `_set()` already gates every attribute this module attaches today. The processor exists for a future call site that bypasses `_set()` by calling `span.set_attribute()` directly.

Implementation note: `ReadableSpan._attributes` is the same `BoundedAttributes` object the concrete `Span` held, flagged immutable at `Span.end()`. Mutating it via a private-attribute toggle mirrors the SDK's own internal pattern (`Span.end()` itself does `self._attributes._immutable = True`).

Closes #888
Ref #512