### PR TITLE
Surface the resolved approval decision through the Langfuse read proxy

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2240,6 +2240,17 @@
       "TraceTree": {
         "description": "A trace plus its reconstructed observation tree.",
         "properties": {
+          "approval_decision": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Approval Decision"
+          },
           "sandbox_id": {
             "anyOf": [
               {

--- a/apps/api/src/agentos_api/langfuse.py
+++ b/apps/api/src/agentos_api/langfuse.py
@@ -46,14 +46,20 @@ def matching_traces(
 # attributable to the concrete sandbox that served it.
 _SANDBOX_ATTR = "agentos.sandbox_id"
 
+# The OTel span attribute the runner stamps on the root agent.run span (ADR-0076
+# Stone 3, #889) when a turn resumes a resolved approval.
+_APPROVAL_DECISION_ATTR = "gen_ai.approval.decision"
 
-def _probe_sandbox_attr(bag: Any) -> str | None:
-    """Return a non-empty `agentos.sandbox_id` from one attribute bag, or None.
+
+def _probe_attr(bag: Any, key: str, *, bare_key: str | None = None) -> str | None:
+    """Return a non-empty string attribute from one attribute bag, or None.
 
     Checks the bag itself plus the common keys Langfuse uses to carry OTel
-    resource/metadata attributes (``metadata`` / ``resourceAttributes`` /
-    ``resource``, each optionally wrapping an ``attributes`` sub-dict). The bare
-    ``sandbox_id`` key is accepted too. Non-string / empty values are ignored.
+    span/resource attributes (``metadata`` / ``resourceAttributes`` /
+    ``resource``, each optionally wrapping an ``attributes`` sub-dict).
+    ``bare_key``, when given, is accepted as a shorter alias (e.g. the bare
+    ``sandbox_id`` for ``agentos.sandbox_id``). Non-string / empty values are
+    ignored.
     """
 
     if not isinstance(bag, dict):
@@ -67,7 +73,7 @@ def _probe_sandbox_attr(bag: Any) -> str | None:
             if isinstance(inner, dict):
                 candidates.append(inner)
     for cand in candidates:
-        hit = cand.get(_SANDBOX_ATTR) or cand.get("sandbox_id")
+        hit = cand.get(key) or (cand.get(bare_key) if bare_key else None)
         if isinstance(hit, str) and hit.strip():
             return hit
     return None
@@ -85,11 +91,33 @@ def hoist_sandbox_id(
     invented.
     """
 
-    hit = _probe_sandbox_attr(trace)
+    hit = _probe_attr(trace, _SANDBOX_ATTR, bare_key="sandbox_id")
     if hit:
         return hit
     if observations:
-        return _probe_sandbox_attr(observations[0])
+        return _probe_attr(observations[0], _SANDBOX_ATTR, bare_key="sandbox_id")
+    return None
+
+
+def hoist_approval_decision(
+    trace: dict[str, Any], observations: list[dict[str, Any]]
+) -> str | None:
+    """Lift the runner's approval-gate decision out of a trace, or None.
+
+    Mirrors ``hoist_sandbox_id``'s trace-then-first-observation probe. The
+    attribute is stamped on the root ``agent.run`` span rather than as a
+    provider-wide resource attribute (ADR-0076 Stone 3, #889), so it is
+    ordinarily trace-level; the observation fallback stays for the same
+    reason ``hoist_sandbox_id`` keeps it -- Langfuse's OTLP ingestion doesn't
+    guarantee which level surfaces a given span attribute. Absent for the
+    ordinary case (no approval gate was resumed this turn); no value invented.
+    """
+
+    hit = _probe_attr(trace, _APPROVAL_DECISION_ATTR)
+    if hit:
+        return hit
+    if observations:
+        return _probe_attr(observations[0], _APPROVAL_DECISION_ATTR)
     return None
 
 

--- a/apps/api/src/agentos_api/routers/runs.py
+++ b/apps/api/src/agentos_api/routers/runs.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from ..auth import require_api_key
 from ..deps import LangfuseDep
 from ..evalcase import trace_to_eval_case
-from ..langfuse import build_tree, hoist_sandbox_id
+from ..langfuse import build_tree, hoist_approval_decision, hoist_sandbox_id
 from ..metrics import agent_trace_filter
 from ..schemas import EvalCaseOut, TraceTree
 
@@ -49,6 +49,7 @@ async def get_trace(trace_id: str, lf: LangfuseDep) -> TraceTree:
         trace=trace,
         tree=build_tree(observations),
         sandbox_id=hoist_sandbox_id(trace, observations),
+        approval_decision=hoist_approval_decision(trace, observations),
     )
 
 

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -590,6 +590,10 @@ class TraceTree(BaseModel):
     # The runner's sandbox id (agentos.sandbox_id), hoisted out of the trace/
     # observation resource attributes; None when the trace predates the attr.
     sandbox_id: str | None = None
+    # The resolved approval-gate decision (approved/rejected/expired) this turn
+    # resumed from (ADR-0076 Stone 3, #889), hoisted out of the trace/
+    # observation attributes; None for a turn that resumed no approval.
+    approval_decision: str | None = None
 
 
 class MetricsSummary(BaseModel):

--- a/apps/api/tests/test_approval_decision_hoist.py
+++ b/apps/api/tests/test_approval_decision_hoist.py
@@ -1,0 +1,57 @@
+"""Unit tests for hoisting the resolved approval decision out of a Langfuse trace.
+
+The runner stamps `gen_ai.approval.decision` as an OTel span attribute on the
+root agent.run span (ADR-0076 Stone 3, #889) rather than a resource attribute,
+but Langfuse's OTLP ingestion still may surface it on the trace's metadata or
+only on the observations, so the hoist probes both -- mirroring
+`hoist_sandbox_id` (see test_sandbox_hoist.py). These tests fake both payload
+shapes; the real propagation is exercised only against a live Langfuse.
+"""
+
+from typing import Any
+
+from agentos_api.langfuse import hoist_approval_decision
+
+
+def test_hoist_from_trace_metadata() -> None:
+    trace = {"id": "t1", "metadata": {"gen_ai.approval.decision": "approved"}}
+    assert hoist_approval_decision(trace, []) == "approved"
+
+
+def test_hoist_from_trace_resource_attributes() -> None:
+    trace = {
+        "id": "t1",
+        "resourceAttributes": {"attributes": {"gen_ai.approval.decision": "rejected"}},
+    }
+    assert hoist_approval_decision(trace, []) == "rejected"
+
+
+def test_hoist_from_first_observation_when_trace_lacks_it() -> None:
+    trace = {"id": "t1", "metadata": {"other": "x"}}
+    observations: list[dict[str, Any]] = [
+        {
+            "id": "root",
+            "type": "SPAN",
+            "resourceAttributes": {"gen_ai.approval.decision": "expired"},
+        },
+        {"id": "child", "type": "SPAN"},
+    ]
+    assert hoist_approval_decision(trace, observations) == "expired"
+
+
+def test_hoist_prefers_trace_over_observation() -> None:
+    trace = {"id": "t1", "metadata": {"gen_ai.approval.decision": "approved"}}
+    observations = [{"id": "root", "metadata": {"gen_ai.approval.decision": "rejected"}}]
+    assert hoist_approval_decision(trace, observations) == "approved"
+
+
+def test_hoist_returns_none_for_an_ordinary_turn() -> None:
+    # No approval was resumed this turn -- the ordinary, most common case.
+    trace = {"id": "t1", "metadata": {"other": "x"}}
+    observations = [{"id": "root", "type": "SPAN"}]
+    assert hoist_approval_decision(trace, observations) is None
+
+
+def test_hoist_ignores_empty_value() -> None:
+    trace = {"id": "t1", "metadata": {"gen_ai.approval.decision": ""}}
+    assert hoist_approval_decision(trace, []) is None

--- a/apps/api/tests/test_runs_proxy.py
+++ b/apps/api/tests/test_runs_proxy.py
@@ -88,6 +88,36 @@ def test_get_trace_sandbox_id_null_when_absent(
     assert resp.json()["sandbox_id"] is None
 
 
+def test_get_trace_surfaces_approval_decision_from_observation(
+    auth_headers: dict[str, str],
+) -> None:
+    # Same hoist shape as sandbox_id, for the ADR-0076 Stone 3 (#889) attribute.
+    observations = [
+        {
+            "id": "r",
+            "type": "SPAN",
+            "name": "agent.run",
+            "startTime": "1",
+            "metadata": {"gen_ai.approval.decision": "approved"},
+        },
+    ]
+    with _app_with(observations) as client:
+        resp = client.get("/langfuse/traces/abc", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["approval_decision"] == "approved"
+
+
+def test_get_trace_approval_decision_null_when_absent(
+    auth_headers: dict[str, str],
+) -> None:
+    # The ordinary case: no approval was resumed this turn.
+    observations = [{"id": "r", "type": "SPAN", "name": "agent.run", "startTime": "1"}]
+    with _app_with(observations) as client:
+        resp = client.get("/langfuse/traces/abc", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["approval_decision"] is None
+
+
 def test_get_trace_404_when_no_observations(
     auth_headers: dict[str, str],
 ) -> None:


### PR DESCRIPTION
Implements Stone 4 of #512 per ADR-0076 (#895).

**Stacked on #898 (Stone 3) — base branch is `task/889-telemetry-approval-decision`, not `main`. Retarget to `main` once #896/#897/#898 merge.**

`hoist_approval_decision(trace, observations)` mirrors `hoist_sandbox_id`'s trace-then-first-observation attribute probe (I refactored the shared probing logic into `_probe_attr` since there are now two real call sites, rather than a hypothetical one). `TraceTree` gains an `approval_decision` field, populated in `GET /langfuse/traces/{trace_id}` right alongside `sandbox_id` — no new store, no new route, consistent with `apps/api/CLAUDE.md`'s "observability endpoints are read-only proxies, not new stores" invariant.

Regenerated `openapi.json` for the schema change (`test_openapi_drift.py`).

Closes #890
Ref #512