### PR TITLE
Report skill-tier approvals --list/--resolve as unavailable, not absent

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -309,6 +309,46 @@ export const commandManifest = {
                 "false"
               ],
               "required": false
+            },
+            {
+              "global": false,
+              "help": "List pending approval RECORDS (not gate config). Accepted so it can be DECLINED with a reason at this tier rather than error like a typo: the skill tier's local runner keeps no durable approval store (ADR-0063, ADR-0077). Use `agentos local/cluster approvals --list`",
+              "id": "list",
+              "long": "list",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Resolve the approval with this id. Not available at the skill tier for the same reason as --list; declined with that reason",
+              "id": "resolve",
+              "long": "resolve",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "The actor resolving the approval (paired with --resolve on local/cluster). Accepted here only so a local/cluster-style resolve invocation is declined cleanly, not rejected as an unknown flag",
+              "id": "as_actor",
+              "long": "as",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Reject instead of approve (paired with --resolve). Accepted only to be declined cleanly at this tier",
+              "id": "reject",
+              "long": "reject",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -306,6 +306,46 @@
                 "false"
               ],
               "required": false
+            },
+            {
+              "global": false,
+              "help": "List pending approval RECORDS (not gate config). Accepted so it can be DECLINED with a reason at this tier rather than error like a typo: the skill tier's local runner keeps no durable approval store (ADR-0063, ADR-0077). Use `agentos local/cluster approvals --list`",
+              "id": "list",
+              "long": "list",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Resolve the approval with this id. Not available at the skill tier for the same reason as --list; declined with that reason",
+              "id": "resolve",
+              "long": "resolve",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "The actor resolving the approval (paired with --resolve on local/cluster). Accepted here only so a local/cluster-style resolve invocation is declined cleanly, not rejected as an unknown flag",
+              "id": "as_actor",
+              "long": "as",
+              "positional": false,
+              "required": false
+            },
+            {
+              "global": false,
+              "help": "Reject instead of approve (paired with --resolve). Accepted only to be declined cleanly at this tier",
+              "id": "reject",
+              "long": "reject",
+              "positional": false,
+              "possible_values": [
+                "true",
+                "false"
+              ],
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4403,6 +4403,28 @@ pub fn skill_memory_unavailable() -> anyhow::Error {
     crate::exit::unsupported("memory", MEMORY_REASON, MEMORY_ALT)
 }
 
+/// Why `skill approvals --list`/`--resolve` cannot be answered at this tier.
+pub const APPROVALS_LIST_REASON: &str =
+    "`skill message` talks straight to the local runner, bypassing the worker, Valkey, and the durable-Approval + resume machinery (ADR-0063), so the skill tier keeps no durable approval record to list or resolve";
+/// Where to list/resolve durable approvals instead.
+pub const APPROVALS_LIST_ALT: &str =
+    "use `agentos local approvals <agent> --list`/`--resolve` or `agentos cluster approvals <agent> --list`/`--resolve` for a deployed agent, or resolve the gate within the same `skill message` session";
+
+/// `skill approvals --list`/`--resolve`: answered, but unavailable at this tier
+/// by construction (ADR-0077). The bundle's gate config (view/set/clear) still
+/// works; only the durable pending-record list/resolve the local+cluster tiers
+/// gained (#506/#736) has no meaning where there is no durable Approval store or
+/// resume path (#766). The flags are accepted so this reports WHY (exit 4) rather
+/// than erroring like an unknown-flag typo, matching `cluster deploy --secret`'s
+/// decline-with-reason (issue #771, ADR-0041, ADR-0077).
+pub fn skill_approvals_list_unavailable() -> anyhow::Error {
+    crate::exit::unsupported(
+        "approvals --list/--resolve",
+        APPROVALS_LIST_REASON,
+        APPROVALS_LIST_ALT,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -5500,6 +5522,24 @@ mod tests {
                 Vec::new()
             );
         }
+    }
+
+    #[test]
+    fn skill_approvals_list_resolve_reported_unavailable_not_absent() {
+        // ADR-0077 / ADR-0041: --list/--resolve are answered-as-unavailable at
+        // the skill tier (exit 4, carrying a cross-tier fix), with the reason and
+        // the local/cluster alternative -- not silently broken.
+        let err = super::skill_approvals_list_unavailable();
+        let (class, fix) = crate::exit::classify(&err);
+        assert_eq!(class, crate::exit::ExitClass::Unsupported);
+        assert!(
+            fix.expect("an unsupported error carries the cross-tier fix")
+                .contains("approvals"),
+            "the fix must point at the local/cluster alternative"
+        );
+        let shown = format!("{err:#}");
+        assert!(shown.contains("durable approval record"), "reason: {shown}");
+        assert!(shown.contains("cluster approvals"), "alternative: {shown}");
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -496,6 +496,25 @@ enum SkillAction {
         /// Print the assignment that clears the env override.
         #[arg(long)]
         clear: bool,
+        /// List pending approval RECORDS (not gate config). Accepted so it can be
+        /// DECLINED with a reason at this tier rather than error like a typo: the
+        /// skill tier's local runner keeps no durable approval store (ADR-0063,
+        /// ADR-0077). Use `agentos local/cluster approvals --list`.
+        #[arg(long)]
+        list: bool,
+        /// Resolve the approval with this id. Not available at the skill tier for
+        /// the same reason as --list; declined with that reason.
+        #[arg(long, value_name = "APPROVAL_ID")]
+        resolve: Option<String>,
+        /// The actor resolving the approval (paired with --resolve on
+        /// local/cluster). Accepted here only so a local/cluster-style resolve
+        /// invocation is declined cleanly, not rejected as an unknown flag.
+        #[arg(long = "as", value_name = "USER")]
+        as_actor: Option<String>,
+        /// Reject instead of approve (paired with --resolve). Accepted only to be
+        /// declined cleanly at this tier.
+        #[arg(long)]
+        reject: bool,
     },
     // The about text is composed from the same consts the runtime `{error, fix}`
     // payload uses, so the discovery surface cannot drift from the answer
@@ -1578,7 +1597,20 @@ async fn run(command: Option<Command>) -> Result<()> {
                 plugin_dir,
                 gate,
                 clear,
-            } => emit(commands::skill_approvals(plugin_dir, gate, clear).await?),
+                list,
+                resolve,
+                ..
+            } => {
+                // Answered, not absent (ADR-0041, ADR-0077): the durable
+                // list/resolve the local+cluster tiers have does not exist here,
+                // so the verb reports why and exits 4 rather than erroring like a
+                // typo. Gate config (view/set/clear) is unchanged.
+                if list || resolve.is_some() {
+                    Err(commands::skill_approvals_list_unavailable())
+                } else {
+                    emit(commands::skill_approvals(plugin_dir, gate, clear).await?)
+                }
+            }
             // Answered, not absent: the concept does not exist at this tier, so
             // the verb reports why and exits 4 (issue #459, ADR-0041).
             SkillAction::Versions => Err(commands::skill_versions_unavailable()),
@@ -2597,6 +2629,24 @@ mod tests {
     #[test]
     fn clap_surface_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn skill_approvals_accepts_list_and_resolve_to_decline_them() {
+        // The flags exist so the skill tier DECLINES them with a reason
+        // (ADR-0077), not clap-erroring like an unknown-flag typo.
+        Cli::try_parse_from(["agentos", "skill", "approvals", "--list"])
+            .expect("skill approvals --list should parse");
+        Cli::try_parse_from([
+            "agentos",
+            "skill",
+            "approvals",
+            "--resolve",
+            "abc",
+            "--as",
+            "u",
+        ])
+        .expect("skill approvals --resolve --as should parse");
     }
 
     #[test]

--- a/docs/adr/0077-skill-tier-durable-approvals-stay-unavailable.md
+++ b/docs/adr/0077-skill-tier-durable-approvals-stay-unavailable.md
@@ -1,0 +1,70 @@
+# 77. Skill-tier durable approvals stay unavailable, reported not absent
+
+Date: 2026-07-23
+
+Status: Accepted
+
+Implements [#771](https://github.com/curie-eng/agentos/issues/771).
+Follows [#766](https://github.com/curie-eng/agentos/issues/766) and
+[ADR-0063](0063-message-driven-approval-reply-surface.md); applies the tier
+answer-or-report rule of [ADR-0041](0041-every-verb-is-answered-at-every-tier.md).
+
+## Context
+
+`local approvals` and `cluster approvals` gained `--list` and `--resolve --as`
+(#506/#736): they read and resolve the durable `Approval` records the API
+persists and the worker resumes against. `skill approvals` never grew them; it
+takes only gate-config arguments (view/set the bundle's declared gates).
+
+`skill message` talks straight to the local runner's ACI surface, bypassing the
+dispatcher, Valkey, worker, and the whole resume path by design — that is the
+point of the tier (zero cluster, zero platform, the bundle bytes on disk). So
+there is no durable `Approval` record at this tier and no resume machinery: the
+#766 keep-alive fix has nothing to keep alive here. Closing the gap means
+*deciding what durable approval state means at the skill tier*, which is a design
+question, not a parity patch.
+
+## Decision
+
+**Do not implement durable approvals at the skill tier. Report the two verbs as
+explicitly unavailable, with a reason and the cross-tier alternative.**
+
+`skill approvals` accepts `--list` and `--resolve` (plus the paired `--as` /
+`--reject`) so a `local`/`cluster`-shaped invocation is **declined with a
+reason** rather than rejected as an unknown-flag typo — the same accept-to-decline
+shape `cluster deploy --secret` uses for its not-yet-delivered capability
+(ADR-0009). Using either flag returns an `unsupported` error (exit 4) whose
+`{error, fix}` payload names why (no durable store or resume path here) and where
+to go instead (`local`/`cluster approvals`, or resolve the gate within the same
+`skill message` session). The reason/alt strings are single-sourced in
+`cli/src/commands.rs` (`APPROVALS_LIST_REASON`/`APPROVALS_LIST_ALT`), so the help
+text and the runtime answer cannot drift (#459). The existing gate-config path
+(view/set/clear) is unchanged.
+
+This satisfies ADR-0041's promise — a verb is either implemented or explicitly
+reported unavailable at a tier — which today it silently breaks: `skill approvals
+--list` currently fails as an unknown flag, indistinguishable from a typo.
+
+## Alternatives considered
+
+- **Implement it via the live runner container** — hold pending approvals in the
+  long-lived runner and expose list/resolve over its ACI surface, treating
+  "durable" as "as long as the container is up." **Rejected.** It bolts a resume
+  path onto a tier #766 deliberately left without one, expands the runner's
+  approval lifecycle, and redefines "durable" to something weaker than the
+  local/cluster guarantee — a lot of surface and a sacred-`kernel.py`-adjacent
+  approval-flow change to make a dev-loop tier imitate a capability it exists to
+  do without. The tier's honest shape is: raise a gate, resolve it in-session, or
+  move to `local`/`cluster` for durable review. If a concrete need for
+  container-lifetime skill approvals appears later, a new ADR supersedes this one.
+
+## Consequences
+
+- The skill tier's approval surface is now honest under ADR-0041: gate config is
+  answered; durable list/resolve is reported unavailable with a reason and an
+  alternative, not a typo-shaped error.
+- No new durable-state or resume code at the skill tier; the runner's approval
+  lifecycle is untouched.
+- If the local/cluster `approvals` flag surface grows, the skill decline should
+  keep accepting the same flags (to decline, not error) — a small maintenance tie
+  between the tiers, the deliberate cost of the accept-to-decline shape.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -105,4 +105,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0073 | [The durable state store reaches bundle code as an auto-mounted MCP server, not a bundle-shipped one](0073-agentos-state-mcp-server-and-state-boot-env.md) | Accepted |
 | 0074 | [Versioned JSON Schemas for every agent-facing CLI result](0074-versioned-json-schemas-for-cli-results.md) | Accepted |
 | 0076 | [A closed, versioned attribute schema for the runner's OTel span stream](0076-closed-typed-telemetry-attribute-schema.md) | Accepted |
+| 0077 | [Skill-tier durable approvals stay unavailable, reported not absent](0077-skill-tier-durable-approvals-stay-unavailable.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Closes #771.

## Decision (ADR-0077)
`local`/`cluster approvals` have durable `--list`/`--resolve`; `skill approvals` doesn't, and today `skill approvals --list` fails as an **unknown flag** — indistinguishable from a typo, silently breaking ADR-0041's "implemented OR explicitly reported unavailable" promise.

The skill tier bypasses the worker/Valkey/API and resume path **by design** (ADR-0063), so there's no durable `Approval` store to list or resolve. You picked (via the design fork) **declare it unavailable** rather than bolt a resume path onto a tier deliberately built without one (#766).

## What this does
- `skill approvals` now **accepts** `--list`/`--resolve` (+ paired `--as`/`--reject`) and **declines** them with a reason + the local/cluster alternative (exit 4) — the same accept-to-decline shape as `cluster deploy --secret` (ADR-0009). Not a clap "unknown flag" error.
- Gate config (`--gate`/`--clear`/view) is unchanged.
- Reason/alt strings single-sourced in `commands.rs` so help text and the runtime answer can't drift (#459).
- **ADR-0077** records the decision + the rejected "live-container approvals" alternative.
- Command manifest regenerated (JSON + committed TS).

## Verification
- 2 new tests: the decline classifies as `unsupported` (exit 4) with the reason + cross-tier alternative; `skill approvals --list` and `--resolve X --as Y` **parse** (so they decline, not error).
- `cargo fmt --check`, `clippy -D warnings`, `cargo test` green. The one failing binary — `chat_enqueue` — is a pre-existing parallel-Valkey-state flake (passes in isolation), untouched by this change (diff is skill approvals + manifest + ADR).

Ref ADR-0077, ADR-0041, ADR-0063. This is skill-tier/CLI only — no `kernel.py` / worker changes, so it doesn't touch the telemetry stack's sacred-module area.