### PR TITLE
Skip the whole e2e parity ladder on PRs that can't affect it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -504,7 +504,12 @@ jobs:
   e2e-ladder:
     name: E2E parity ladder (skill + local + local-release, fake model)
     runs-on: ubuntu-latest
-    needs: rust-build
+    needs: [rust-build, changes]
+    # Skip on PRs that can't affect what the ladder tests (docs, UI-only, gtools,
+    # non-ladder CI). Not a required check, so skipping never blocks a merge; it
+    # just stops paying the ~2min image-build + rung cost when nothing it
+    # exercises changed. Always runs on push to main (the changes job forces it).
+    if: needs.changes.outputs.ladder == 'true'
     steps:
       - uses: actions/checkout@v7
         with:
@@ -610,18 +615,20 @@ jobs:
   # treat the kind/reachability path as unverified rather than assuming the
   # theory above is right. Kept a SEPARATE job from `e2e-ladder` on purpose: the
   # skill/local signal must never be reddened by a kind or Helm flake.
-  # Gate the expensive kind rung so it runs ONLY when a change could affect the
-  # cluster deploy-then-message path (charts / cli / app+runner images / the ACI
-  # wire / this workflow), and always on push to main. An unrelated PR (docs,
-  # etc.) skips it entirely -- no red check, no kind-cluster minutes. Pure
-  # git-diff, no third-party action. (It is not a required check either way --
-  # the ruleset requires only Compose/Contracts/Python/Rust/UI -- so it can never
-  # block a merge; this just keeps it off PRs it has no bearing on.)
+  # Gate the expensive e2e parity ladder rungs so they run ONLY when a change
+  # could affect the build/deploy/message path any rung exercises (charts / cli /
+  # app+runner images / the ACI wire / this workflow), and always on push to
+  # main. An unrelated PR (docs, UI-only, gtools, etc.) skips every ladder rung
+  # entirely -- the ladder's image builds + rungs are ~2min it need not pay when
+  # nothing it tests changed. Pure git-diff, no third-party action. (No ladder
+  # rung is a required check anyway -- the ruleset requires only
+  # Compose/Contracts/Python/Rust/UI -- so this only trims wasted runs, never
+  # blocks a merge.)
   changes:
-    name: Detect cluster-relevant changes
+    name: Detect ladder-relevant changes
     runs-on: ubuntu-latest
     outputs:
-      cluster: ${{ steps.filter.outputs.cluster }}
+      ladder: ${{ steps.filter.outputs.ladder }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -631,23 +638,23 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
-            echo "cluster=true" >> "$GITHUB_OUTPUT"   # post-merge gate on main
+            echo "ladder=true" >> "$GITHUB_OUTPUT"   # post-merge gate on main
             exit 0
           fi
           base="${{ github.base_ref }}"
           git fetch --quiet origin "$base"
           if git diff --name-only "origin/$base...HEAD" \
               | grep -qE '^(charts/|cli/|apps/|runner/|packages/aci-protocol/|\.github/workflows/ci\.yaml)'; then
-            echo "cluster=true" >> "$GITHUB_OUTPUT"
+            echo "ladder=true" >> "$GITHUB_OUTPUT"
           else
-            echo "cluster=false" >> "$GITHUB_OUTPUT"
+            echo "ladder=false" >> "$GITHUB_OUTPUT"
           fi
 
   e2e-ladder-cluster:
     name: E2E parity ladder (cluster rung on kind, fake model)
     runs-on: ubuntu-latest
     needs: [rust-build, changes]
-    if: needs.changes.outputs.cluster == 'true'
+    if: needs.changes.outputs.ladder == 'true'
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Follow-up to the ladder-speedup work (#885/#893 merged). Addresses "the ladder is still super long — what else can we do?"

## Why
With the Rust cache + rust-build decouple live, the ladder's remaining cost is its **own ~2min**, and ~55% of that is image builds rebuilt from scratch each run (runner image ≈ 42s). Today the skill+local rung pays that on **every PR** — docs, UI-only, gtools, non-ladder CI — none of which can affect what it tests.

## What
Generalize the cluster-rung path gate from #843: the `changes` job's filter (`charts/ cli/ apps/ runner/ packages/aci-protocol/ .github/workflows/ci.yaml`) is exactly the ladder-relevant path set. Rename its output `cluster` → `ladder` and gate **both** the skill+local rung and the cluster rung on it. An unrelated PR now **skips every ladder rung** (neutral check, not red); it still runs on every `push` to main and on any PR touching the tested surface.

## Safety
- No ladder rung is a **required** check (the ruleset requires only Compose/Contracts/Python/Rust/UI), so skipping can never block a merge — same reasoning as #843.
- `actionlint` clean; the `cluster`→`ladder` rename is fully consistent (no stale references); both rungs `needs: [rust-build, changes]`, `if: needs.changes.outputs.ladder == 'true'`.

## Note
This attacks a different axis than the split (#894, which parallelizes local-release): here we stop paying the ladder's runtime *at all* when nothing it exercises changed. **#894's `e2e-ladder-release` should gain the same `if: needs.changes.outputs.ladder` gate** when it merges — I'll update that branch. And the biggest remaining *runtime* lever (for PRs that DO run it) is a docker layer cache for the image builds, done without repointing the default builder (the #697/#803 landmine) — a separate, careful follow-up.