### PR TITLE
Percent-encode state key/namespace so '#'/'?' can't collide keys

### DIFF
--- a/runner/src/agentos_runner/state.py
+++ b/runner/src/agentos_runner/state.py
@@ -34,6 +34,7 @@ import json
 import logging
 from collections.abc import Mapping
 from typing import Any
+from urllib.parse import quote
 
 import aiohttp
 from aci_protocol import BootEnv
@@ -104,10 +105,16 @@ class StateApiClient:
         self._token = token
 
     def _key_url(self, namespace: str, key: str) -> str:
-        return f"{self._base}/{namespace}/{key}"
+        # Percent-encode both path segments (#851). An unescaped '#' or '?' in a
+        # key (or, since #840, an arbitrary namespace) is URL syntax to
+        # aiohttp/yarl -- the fragment/query -- which silently truncates the path
+        # so two distinct keys ("config" and "config#draft") collide on one slot
+        # with no error. `safe=""` also encodes '/' so a key never spills into an
+        # extra path segment. Mirrors binding.py's own `quote(..., safe="")`.
+        return f"{self._base}/{quote(namespace, safe='')}/{quote(key, safe='')}"
 
     def _namespace_url(self, namespace: str) -> str:
-        return f"{self._base}/{namespace}"
+        return f"{self._base}/{quote(namespace, safe='')}"
 
     def _headers(self, *, json_body: bool = False) -> dict[str, str]:
         headers: dict[str, str] = {}

--- a/runner/tests/test_state.py
+++ b/runner/tests/test_state.py
@@ -142,6 +142,40 @@ def test_set_then_get_round_trip() -> None:
     anyio.run(go)
 
 
+def test_keys_with_url_special_chars_do_not_collide() -> None:
+    # #851: '#'/'?'/space in a key are URL syntax to aiohttp -- without escaping,
+    # "config#draft" truncates to "config" and the two silently share one slot.
+    # Faithful round trip: aiohttp's real client URL handling + a router that
+    # decodes path params exactly as the FastAPI state route does.
+    app, store = _fake_state_app()
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            client = StateApiClient(_base(server), token="k")
+            specials = ["config#draft", "report?v=2", "with space"]
+            for key in specials:
+                await client.set("prefs", key, {"k": key}, expected_version=None)
+            # A distinct plain key must NOT read back a special-char key's value.
+            await client.set("prefs", "config", {"k": "plain"}, expected_version=None)
+            assert (await client.get("prefs", "config#draft"))["value"] == {"k": "config#draft"}
+            assert (await client.get("prefs", "config"))["value"] == {"k": "plain"}
+            # Every key landed in its own row, none clobbered.
+            for key in [*specials, "config"]:
+                assert ("prefs", key) in store
+
+    anyio.run(go)
+
+
+def test_key_url_percent_encodes_both_segments() -> None:
+    # Unit guard (#851): special chars become %-escapes (incl. '/'), and two keys
+    # that would have collided now compose distinct URLs.
+    client = StateApiClient("http://api/agents/A/state", token=None)
+    url = client._key_url("ns#x", "config#draft")
+    assert url == "http://api/agents/A/state/ns%23x/config%23draft"
+    assert "%2F" in client._key_url("ns", "a/b")
+    assert client._key_url("ns", "config#draft") != client._key_url("ns", "config")
+
+
 def test_get_missing_key_is_none() -> None:
     app, _ = _fake_state_app()
 


### PR DESCRIPTION
## Problem

The runner's state client built request URLs by string interpolation:

```python
def _key_url(self, namespace, key):
    return f"{self._base}/{namespace}/{key}"   # no escaping
```

The client is `aiohttp`, whose `yarl` URLs treat `#` as a *fragment* and `?` as a *query* — both cut off the path. So a key like `config#draft` truncated to `config`: **two distinct keys silently shared one slot** — a write landed on the wrong key, a read returned someone else's value, and nothing errored. #840 made namespaces arbitrary model-supplied strings too, widening the blast radius. (The worker's `binding.py:496` already `quote(..., safe="")`s its own path segment; the state client just didn't.)

## Fix

`quote(..., safe="")` both path segments — also encoding `/` so a key can't spill into an extra path segment. FastAPI (and aiohttp's router) decode path params, so the server still stores under the real key.

```python
return f"{self._base}/{quote(namespace, safe='')}/{quote(key, safe='')}"
```

## Testing

- **Round-trip test** through aiohttp's real client + a param-decoding fake router: `config#draft`, `report?v=2`, and `with space` each land in their own row and don't clobber a plain `config`.
- **Unit guard** pins the encoding (`%23`, `%2F`, distinctness).
- **Verified both tests fail without the fix** (negative check), so they're real regression guards.
- `ruff` + `mypy` clean; full `test_state.py` green (18 passed).

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
