### PR TITLE
QUICKSTART: split quick path from advanced usage, fix stale UI refs

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -3,10 +3,9 @@
 Welcome. This gets you from nothing to your first agent reply in about a minute,
 with no credentials, no cluster, and no Slack. It runs the `skill` target: just
 the runner container on your host Docker daemon, talking straight to the agent.
-Past that, this is also the detailed, advanced-usage doc: a real model, an
-offline local-model demo, the full local/cluster runbooks, and the contributor
-repo-checkout path. For the 30-second version, see the
-[README Quickstart](README.md#quickstart).
+For the 30-second version, see the [README Quickstart](README.md#quickstart). To
+go further — a real local model, the full local/cluster runbooks, or working on
+AgentOS itself — see [Where to go next](#where-to-go-next).
 
 ## Before you start
 
@@ -22,10 +21,9 @@ repo-checkout path. For the 30-second version, see the
   PATH (`AGENTOS_REQUIRE_COSIGN=1` requires it). To run the download-verify-install
   steps by hand instead, see
   [`docs/release-verification.md`](docs/release-verification.md#verify-the-cli-before-installing-it).
-
-  Building the CLI from source (`cargo build --release` in `cli/`) is the
-  contributor path — see [`docs/onboarding.md`](docs/onboarding.md) and
-  [Contributor path](#contributor-path-repo-checkout) below.
+  Working on AgentOS itself? Run that same script from a source checkout and it
+  builds the CLI instead of downloading it — see
+  [Where to go next](#where-to-go-next).
 
 ## Your first agent reply
 
@@ -87,157 +85,28 @@ agentos skill down
 
 You should get a real answer instead of the canned loop.
 
-## Offline demo: a real local model, no Anthropic key
+## Where to go next
 
-`--local-model` is an opt-in offline path that runs a real local model through
-an Anthropic-compatible endpoint, so the demo answers for real and can drive a
-1-2 tool-call loop with no Anthropic key. This is a DEMO / dev-loop path, NOT
-the production agent path — the fake model stays the zero-dependency default.
+The `skill` loop is just the runner container. From here:
 
-Use the flag on the CLI surface you are running:
-
-```bash
-agentos skill up --local-model
-agentos local up --local-model
-agentos cluster up --local-model
-```
-
-Bare `--local-model` uses `qwen3:4b`. Override it by passing a model name:
-
-```bash
-agentos local up --local-model qwen3-coder:30b
-```
-
-Combine `--minimal` with `--local-model` when you want the core local loop plus
-Ollama, without Langfuse or the UI:
-
-```bash
-agentos local up --minimal --local-model
-```
-
-`skill up` and `local up` run the model in a Docker container and point spawned
-runners at that endpoint. Both the `skill up --local-model` and compose paths
-persist the pulled model in a Docker volume, so a re-up is fast and does not
-re-download the model; the skill-path volume is named `<container>-ollama-data`
-(the compose path uses `ollama_data`) and can be reclaimed with
-`docker volume rm <volume>`. `cluster up` uses the in-chart inference Deployment;
-the chart renders the Ollama Service and Deployment, opens the runner egress
-carve-out automatically, and bakes `ANTHROPIC_BASE_URL` plus the inference model
-into the runner template.
-
-| Model | Loaded (Q4) | Min box | Notes |
-|---|---|---|---|
-| qwen3:4b | ~2.5GB | 8GB | demo default; clears the 1-2 tool-call bar |
-| qwen3-coder:30b | ~17-19GB | 32GB | MoE 30B/3.3B-active; real agentic-coding upgrade |
-| gemma4:e4b | ~5GB | 16GB | "4.5B effective" name understates RAM; needs Ollama >=0.31.x |
-
-Gotchas: Ollama 0.24.0 fails `gemma4` with `unknown model architecture`; qwen3
-works on 0.24.0 and gemma4 needs >=0.31.x. Gemma HF repos are gated and return
-HTTP 400 on `hf.co/google/...`; use a non-gated mirror such as
-`hf.co/unsloth/gemma-4-E4B-it-GGUF:<quant>`. RAM sizing tracks the loaded
-footprint, not the "effective params" marketing number.
-
-## Still have time? Run your skill on your local box or on a Kubernetes cluster
-
-The `skill` loop is just the runner container. To see your skill run through the
-real product path (queue, worker, sandbox, traces), the same way a Slack mention
-would, put the full platform in front of it. Two options, lightest first.
-
-### On your local box (Docker stack)
-
-`local` brings up the platform with docker compose and runs your skill through
-it. `agentos local up` uses the `full` profile, which includes Langfuse and the
-console UI. `agentos local up --minimal` boots only the 7 core services for low
-RAM machines and the CLI turn path. Same runner, now with the queue and worker
-in front, all on your machine. Run these from your bundle directory:
-
-```bash
-agentos local up                      # full profile
-# or: agentos local up --minimal      # core profile
-agentos local deploy --plugin-dir .   # push the bundle to the local API on :28000
-agentos local message "What's the weather in Paris?"
-agentos local down                    # tear it all down
-```
-
-Watch the run land in the console UI at `http://localhost:28080/?api=1`. Like
-`skill`, the local stack runs the fake model by default, so replies are scripted
-until you wire a real model (`export CLAUDE_CODE_OAUTH_TOKEN=...` or
-`ANTHROPIC_API_KEY=...` before `local up`, which flips to live automatically
-when a credential is present).
-
-> The stack comes up clean; the UI answers on `:28080`.
-
-For the deeper ticket-verification runbook — rebuilding and redeploying a
-changed bundle, watching worker/runner logs, and driving multi-turn
-conversations — see [`docs/onboarding.md`](docs/onboarding.md). To hand-run the
-worker as a bare host process instead of a compose service (e.g. to attach a
-debugger while iterating on worker source), see
-[`apps/worker/README.md`](apps/worker/README.md#running-the-worker-as-a-bare-process-agentos_workerrun-docker-substrate).
-
-### On a Kubernetes cluster (Helm)
-
-`cluster` installs the platform as a Helm release and drives your skill on real
-Kubernetes, with runs traced in Langfuse. The short arc:
-
-```bash
-agentos cluster up                    # install the platform (Helm release)
-agentos cluster status                # prints the UI URL, e.g. http://<node>:30080
-# The UI reverse-proxies /api to the in-cluster API, so deploy through it -- no
-# port-forward. Use the UI URL from `cluster status` with a /api suffix:
-agentos cluster deploy --plugin-dir . --api-url http://<node>:30080/api
-agentos cluster message "What's the weather in Paris?"
-agentos cluster down --yes            # uninstall
-```
-
-For a real model on the cluster, the runner model key is
-`--set agentSandbox.runner.model=<slug>` (not `runner.model`, which silently
-no-ops). The full cluster runbook, including credentials, web egress, and the
-Langfuse login, is in [`docs/operations.md`](docs/operations.md).
-
-See [`cli/README.md`](cli/README.md) for the complete command reference, and the
-[README](README.md#which-target-do-i-want) for a table to help you pick a target.
-
-## Contributor path (repo checkout)
-
-Working on AgentOS itself, rather than just building a plugin against it? Run
-from a repo checkout against the dev stack instead of the prebuilt binary:
-
-```bash
-# 1. Bring up the backing stack. The stack runs on baked defaults; copy
-#    .env.example to the gitignored .env only if you need to override anything.
-cp .env.example .env    # optional
-docker compose --profile full -f compose.dev.yaml up -d
-docker compose -f compose.dev.yaml ps    # wait for all services healthy
-
-# 2. Install the Python workspace (uv workspace: aci-protocol, plugin-format,
-#    apps/api, apps/dispatcher, apps/worker, runner)
-uv sync
-
-# 3. Run the test suite
-uv run pytest -q
-uv run ruff check .
-uv run mypy
-
-# 4. Build the CLI and the runner image
-cd cli && cargo build --release && cd -
-agentos build
-
-# 5. Boot the API server (needs the Postgres schema applied once)
-cd apps/api && uv run alembic upgrade head
-uv run uvicorn agentos_api.main:app --port 8000 &
-cd -
-
-# 6. Boot the UI (fixture mode by default; ?api=1 wires it to the running API)
-cd apps/ui && pnpm install && pnpm dev
-# open http://localhost:5173/?state=1        (fixture demo)
-# open http://localhost:5173/?api=1&state=1  (wired to apps/api on :8000)
-```
-
-`agentos local up` publishes the API on `:28000` (the compose host port); the
-hand-run `uvicorn` in step 5 uses `:8000` instead — point a hand-run `local
-deploy --api-url` at whichever one you brought up.
-
-See [`AGENTS.md`](AGENTS.md) for the full per-package verify commands and dev
-stack gotchas, [`docs/onboarding.md`](docs/onboarding.md) for a from-scratch
-walkthrough of the `skill`/`local` tiers geared at onboarding, and
-`apps/api/README.md` / `apps/ui/README.md` for the API and UI's own docs.
+- **A real local model, no Anthropic key** — the opt-in offline `--local-model`
+  demo (a real model in a container over an Anthropic-compatible endpoint, model
+  sizing, and gotchas): [`docs/local-model.md`](docs/local-model.md).
+- **Run your bundle on the full local platform** — the queue, worker, sandbox,
+  and traces, the same path a Slack mention takes, via docker compose
+  (`agentos local up` → `local deploy` → `local message`). Walkthrough and the
+  ticket-verification loop in
+  [`docs/onboarding.md`](docs/onboarding.md#the-real-product-loop-with-local).
+- **Run it on Kubernetes** — the platform as a Helm release
+  (`agentos cluster up` → `cluster deploy` → `cluster message`). Full runbook,
+  including credentials, web egress, and the Langfuse login, in
+  [`docs/operations.md`](docs/operations.md).
+- **Working on AgentOS itself** — the repo-checkout dev stack, tests, and
+  from-scratch walkthrough in [`docs/onboarding.md`](docs/onboarding.md) and
+  [`AGENTS.md`](AGENTS.md). One-command bootstrap from a clone:
+  `./get-agentos.sh` (builds the CLI, then runs `agentos install` for deps and
+  the runner image).
+- **Every command and flag** — the complete reference in
+  [`cli/README.md`](cli/README.md); the
+  [README target guide](README.md#which-target-do-i-want) has a table to help
+  you pick `skill` vs `local` vs `cluster`.

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -1,0 +1,54 @@
+# Offline demo: a real local model (no Anthropic key)
+
+`--local-model` is an opt-in offline path that runs a real local model through an
+Anthropic-compatible endpoint, so the demo answers for real and can drive a 1-2
+tool-call loop with no Anthropic key. This is a DEMO / dev-loop path, NOT the
+production agent path — the built-in fake model stays the zero-dependency default
+(see the [QUICKSTART](../QUICKSTART.md)).
+
+Use the flag on whichever target you are running:
+
+```bash
+agentos skill up --local-model
+agentos local up --local-model
+agentos cluster up --local-model
+```
+
+Bare `--local-model` uses `qwen3:4b`. Override it by passing a model name:
+
+```bash
+agentos local up --local-model qwen3-coder:30b
+```
+
+Combine `--minimal` with `--local-model` when you want the core local loop plus
+Ollama, without Langfuse or the UI:
+
+```bash
+agentos local up --minimal --local-model
+```
+
+## How it runs
+
+`skill up` and `local up` run the model in a Docker container and point spawned
+runners at that endpoint. Both the `skill up --local-model` and compose paths
+persist the pulled model in a Docker volume, so a re-up is fast and does not
+re-download the model; the skill-path volume is named `<container>-ollama-data`
+(the compose path uses `ollama_data`) and can be reclaimed with
+`docker volume rm <volume>`. `cluster up` uses the in-chart inference Deployment;
+the chart renders the Ollama Service and Deployment, opens the runner egress
+carve-out automatically, and bakes `ANTHROPIC_BASE_URL` plus the inference model
+into the runner template.
+
+## Choosing a model
+
+| Model | Loaded (Q4) | Min box | Notes |
+|---|---|---|---|
+| qwen3:4b | ~2.5GB | 8GB | demo default; clears the 1-2 tool-call bar |
+| qwen3-coder:30b | ~17-19GB | 32GB | MoE 30B/3.3B-active; real agentic-coding upgrade |
+| gemma4:e4b | ~5GB | 16GB | "4.5B effective" name understates RAM; needs Ollama >=0.31.x |
+
+Gotchas: Ollama 0.24.0 fails `gemma4` with `unknown model architecture`; qwen3
+works on 0.24.0 and gemma4 needs >=0.31.x. Gemma HF repos are gated and return
+HTTP 400 on `hf.co/google/...`; use a non-gated mirror such as
+`hf.co/unsloth/gemma-4-E4B-it-GGUF:<quant>`. RAM sizing tracks the loaded
+footprint, not the "effective params" marketing number.

--- a/llms.txt
+++ b/llms.txt
@@ -35,4 +35,5 @@ The point of the three targets (`skill` in-process, `local` via docker compose, 
 - [SECURITY.md](SECURITY.md): the security posture and reporting process.
 - [docs/behavior-packs.md](docs/behavior-packs.md): reusable behavior packs for bundles.
 - [docs/onboarding.md](docs/onboarding.md): the end-to-end onboarding walkthrough.
+- [docs/local-model.md](docs/local-model.md): the offline `--local-model` demo (Ollama in a container), model sizing, and gotchas.
 - [docs/slack-local-runbook.md](docs/slack-local-runbook.md): exercising real Slack routing against the local compose stack.


### PR DESCRIPTION
Follow-on to the installer condense. QUICKSTART had grown into a 244-line doc doing double duty — the one-minute quickstart *and* the advanced/runbook doc (its own intro said so). Split it.

## What changed
- **QUICKSTART is now genuinely quick** (244 → 112 lines): install → first reply → a real model → a compact **Where to go next** that points at the docs which already own the advanced material:
  - local product loop + ticket verification + contributor dev-stack → [`docs/onboarding.md`](docs/onboarding.md)
  - cluster runbook → [`docs/operations.md`](docs/operations.md)
- **New [`docs/local-model.md`](docs/local-model.md)** — the offline `--local-model` demo (Ollama-in-a-container, the model-sizing table, the Ollama/Gemma gotchas) had no existing home, so it moves there verbatim, linked from QUICKSTART and `llms.txt`.

## Rot fixed
- The **`?state=1` fixture-demo mode** QUICKSTART told contributors to open **no longer exists** — the fixtures + the `?state=N`/`?dev=1` switcher were removed (`apps/ui/CLAUDE.md`: the console is always live-API-backed now). Those lines were in the contributor section that's now a pointer, so they're gone.
- The manual contributor bootstrap (`cargo build` + `agentos build`) is folded into the one-command `./get-agentos.sh` source mode.

## Deliberately *not* touched
`?api=1` in README/operations.md is **not** rot to fix here — the CLI still *emits* those URLs (ADR-0038), the UI just ignores the param. Stripping it from the docs would desync them from actual CLI output; that's a separate CLI cleanup.

## Verify
`scripts/check-docs.sh` clean — every citation resolves, catalog drift-free. All cross-links checked to resolve (incl. the `onboarding.md#the-real-product-loop-with-local` anchor).