### PR TITLE
Make QUICKSTART shell blocks paste-safe on zsh (#801)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -27,21 +27,32 @@ AgentOS itself — see [Where to go next](#where-to-go-next).
 
 ## Your first agent reply
 
-```bash
-# 1. Scaffold a bundle. This creates a starter skill named for your agent, plus
-#    an AGENTS.md and a using-agentos harness-primer skill, that you edit next.
-agentos init my-agent
-cd my-agent
+1. **Scaffold a bundle.** This creates a starter skill named for your agent,
+   plus an `AGENTS.md` and a `using-agentos` harness-primer skill, that you edit
+   next.
 
-# 2. Boot the runner with the built-in fake model (offline, instant, no key).
-agentos skill up --fake-model
+   ```bash
+   agentos init my-agent
+   cd my-agent
+   ```
 
-# 3. Ask it something and watch the reply stream back.
-agentos skill message "hello, are you there?"
+2. **Boot the runner** with the built-in fake model — offline, instant, no key.
 
-# 4. Done. Tear the runner down.
-agentos skill down
-```
+   ```bash
+   agentos skill up --fake-model
+   ```
+
+3. **Ask it something** and watch the reply stream back.
+
+   ```bash
+   agentos skill message "hello, are you there?"
+   ```
+
+4. **Done.** Tear the runner down.
+
+   ```bash
+   agentos skill down
+   ```
 
 That is the full loop. `agentos skill up` starts the runner container,
 `agentos skill message` sends a synthetic event and streams the reply, and
@@ -62,11 +73,14 @@ runner container), then re-run `skill up`. Any one of `CLAUDE_CODE_OAUTH_TOKEN`,
 `ANTHROPIC_API_KEY`, or `AGENTOS_CREDENTIALS` works for the Anthropic default:
 
 ```bash
-export CLAUDE_CODE_OAUTH_TOKEN=...        # or ANTHROPIC_API_KEY=... / AGENTOS_CREDENTIALS=...
+export CLAUDE_CODE_OAUTH_TOKEN=...
 agentos skill up
 agentos skill message "What's the weather in Paris? Answer in one short sentence."
 agentos skill down
 ```
+
+(`ANTHROPIC_API_KEY` or `AGENTOS_CREDENTIALS` work in place of
+`CLAUDE_CODE_OAUTH_TOKEN`, as noted above.)
 
 To use a different provider or model instead of the Anthropic default, bring
 your own model through OpenRouter on the same `skill` path. Set


### PR DESCRIPTION
Fixes #801.

## Problem

macOS's default shell is zsh, which does **not** enable `INTERACTIVE_COMMENTS`. Pasting a QUICKSTART code block that carries `#` annotations therefore fails:

- `#` lines raise `zsh: command not found: #`
- unquoted parentheses inside those comments (e.g. `(offline, instant, no key).`) trip zsh globbing with `zsh: no matches found`

Both are reproduced verbatim in the issue.

## Fix

Move every annotation out of the runnable code fences and into surrounding prose, so each `bash` block contains **only commands**:

- **"Your first agent reply"** and **"Contributor path"** become numbered lists with one clean command block per step (these had the worst hazards — `#` comments *and* glob-triggering parens).
- The inline `# ...` notes in the **real-model**, **local box**, and **Kubernetes cluster** blocks move to sentences alongside the block.

No commands or guidance are lost; the important context (the `--minimal` alternative, the `/api` deploy suffix, the credential alternatives, the UI URLs) is all preserved in prose.

## Verification

- Scanned every `bash` fence in the file: zero `#` comments and zero parentheses remain inside code blocks.
- Blocks now paste cleanly into zsh (and any other shell).
- Only `QUICKSTART.md` changed; no lint gate references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)