### PR TITLE
Sync runner Dockerfile SDK/OTel pins to uv.lock (#873)

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -52,10 +52,10 @@ RUN python3 -m venv /app/.venv \
     && /app/.venv/bin/pip install --no-cache-dir ./packages/aci-protocol ./packages/plugin-format \
     && /app/.venv/bin/pip install --no-cache-dir --no-deps ./runner \
     && /app/.venv/bin/pip install --no-cache-dir \
-        "claude-agent-sdk==0.2.110" \
+        "claude-agent-sdk==0.2.115" \
         "aiohttp==3.14.1" \
-        "opentelemetry-sdk==1.43.0" \
-        "opentelemetry-exporter-otlp-proto-http==1.43.0" \
+        "opentelemetry-sdk==1.44.0" \
+        "opentelemetry-exporter-otlp-proto-http==1.44.0" \
         "anyio==4.14.1"
 
 # Run as a non-root user. The claude-agent-sdk spawns


### PR DESCRIPTION
Fixes #873.

## Problem

`agentos build` warned that the runner image installs `claude-agent-sdk 0.2.110` while the lock requires `>=0.2.115`. The Dockerfile carries exact `==` pins that its own comment says must stay "in lockstep with `uv.lock`", but three had drifted behind the lock.

The SDK warning comes from pip, not the CLI: the Dockerfile installs `./runner` with `--no-deps`, then the explicit pin installs `0.2.110`, which pip's resolver flags as incompatible with `runner`'s `>=0.2.115` metadata.

## Fix — align every drifted pin to the lock's resolved version

| Package | Was | Now (uv.lock) |
|---|---|---|
| `claude-agent-sdk` | 0.2.110 | **0.2.115** |
| `opentelemetry-sdk` | 1.43.0 | **1.44.0** |
| `opentelemetry-exporter-otlp-proto-http` | 1.43.0 | **1.44.0** |

`opentelemetry-sdk==1.43.0` also violated the runner's own `pyproject.toml` (`>=1.44.0`), so it was drift of the same class and is corrected here too. `aiohttp` (3.14.1) and `anyio` (4.14.1) already matched the lock and are unchanged.

## Verification

Full `docker build -f runner/Dockerfile -t agentos-runner .` from the repo root:

- The pip dependency-conflict warning is **gone** (grepped the build log: no `incompatible` / `dependency resolver` / `0.2.110`).
- `pip show` inside the built image confirms `claude-agent-sdk 0.2.115`, `opentelemetry-sdk 1.44.0`, `opentelemetry-exporter-otlp-proto-http 1.44.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)