### PR TITLE
Thread --env-file through local rebuild for up-parity wiring (#853)

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -666,6 +666,14 @@ export const commandManifest = {
                 "false"
               ],
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Match how `local up` brought the stack up (--env-file, if used): read a bundle-local `.env` as the LOWEST-priority model-credential source so the rebuilt service comes back on the SAME model as the rest of the stack, instead of reverting to compose's fake default (#853). Precedence (shell env > this file), the recognized keys, and the never-in-argv/logs masking are identical to `local up --env-file`",
+              "id": "env_file",
+              "long": "env-file",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -663,6 +663,14 @@
                 "false"
               ],
               "required": false
+            },
+            {
+              "global": false,
+              "help": "Match how `local up` brought the stack up (--env-file, if used): read a bundle-local `.env` as the LOWEST-priority model-credential source so the rebuilt service comes back on the SAME model as the rest of the stack, instead of reverting to compose's fake default (#853). Precedence (shell env > this file), the recognized keys, and the never-in-argv/logs masking are identical to `local up --env-file`",
+              "id": "env_file",
+              "long": "env-file",
+              "positional": false,
+              "required": false
             }
           ],
           "hidden": false,

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -458,14 +458,21 @@ impl crate::ui::CliOutput for LocalUpOutput {
     }
 }
 
-pub async fn up(mut o: LocalOpts) -> Result<LocalUpOutput> {
-    let ui = crate::ui::ui();
-    // #749/ADR-0070: an opt-in bundle `.env` is the LOWEST-priority model
-    // credential source. A name exported in the shell always wins; only a name
-    // absent from the shell is taken from the file. The value is injected into
-    // the compose child as masked `secret_env` (never argv/logs), and a
-    // `.env`-only credential still flips the stack live -- so the model mode is
-    // recomputed with the file credential folded in.
+/// Apply the opt-in bundle `.env` plan (#749, ADR-0070) to a worker-starting
+/// verb's options, in place: fold a file-only model credential into the model
+/// mode so the stack boots live exactly as a shell credential would, emit a
+/// per-credential "loaded from --env-file" note, and return the credentials to
+/// attach as masked `secret_env` (never argv/logs). Shared by `local up` and
+/// `local rebuild` so a targeted rebuild comes back with the SAME
+/// credential/model-mode wiring the original `up` resolved from identical
+/// inputs (shell env + the same `--env-file`), rather than the fake-model revert
+/// #853 describes. A `None` env_file leaves the shell-resolved mode untouched
+/// and returns no credentials.
+fn apply_env_file_plan(o: &mut LocalOpts, ui: &crate::ui::Ui) -> Result<Vec<(String, String)>> {
+    // A name exported in the shell always wins; only a name absent from the
+    // shell is taken from the file. A `.env`-only credential still flips the
+    // stack live, so the model mode is recomputed with the file credential
+    // folded in.
     let (env_creds, env_file_mode) = load_env_file_up_plan(o.env_file.as_deref())?;
     if o.env_file.is_some() {
         o.model_mode = env_file_mode;
@@ -479,6 +486,14 @@ pub async fn up(mut o: LocalOpts) -> Result<LocalUpOutput> {
             ));
         }
     }
+    Ok(env_creds)
+}
+
+pub async fn up(mut o: LocalOpts) -> Result<LocalUpOutput> {
+    let ui = crate::ui::ui();
+    // #749/ADR-0070: an opt-in bundle `.env` is the LOWEST-priority model
+    // credential source, injected into the compose child as masked `secret_env`.
+    let env_creds = apply_env_file_plan(&mut o, ui)?;
     let mut cmd = up_command(&o);
     if !env_creds.is_empty() {
         cmd = cmd.with_secret_env(env_creds);
@@ -573,20 +588,30 @@ impl crate::ui::CliOutput for LocalRebuildOutput {
 /// (e.g. after a code change) without losing the stack's already-resolved
 /// credential/model-mode wiring (#714) -- see `rebuild_command`'s doc comment
 /// for the footgun this exists to close. Re-resolves `ModelMode` from THIS
-/// invocation's shell exactly as `local up` does, rather than trying to read
-/// back whatever the rest of the stack is currently running with (not
-/// generally recoverable from outside the containers) -- so the credential
-/// this rebuild applies is whatever is exported in the shell running the
-/// command, same as any other worker-restarting verb.
-pub async fn rebuild(o: LocalRebuildOpts) -> Result<LocalRebuildOutput> {
-    let cmd = rebuild_command(&o.common, &o.service);
+/// invocation's inputs exactly as `local up` does -- the shell AND the same
+/// opt-in `--env-file` (#853) -- rather than trying to read back whatever the
+/// rest of the stack is currently running with (not generally recoverable from
+/// outside the containers). So given the same shell and the same `--env-file`
+/// the original `up` used, the rebuilt service comes back on the identical
+/// model/credential wiring; drop `--env-file` on a stack that was brought up
+/// with one and the rebuilt service silently reverts to compose's fake default,
+/// which is exactly the regression #853 reports.
+pub async fn rebuild(mut o: LocalRebuildOpts) -> Result<LocalRebuildOutput> {
+    let ui = crate::ui::ui();
+    // The same opt-in bundle `.env` plan `local up` applies: fold a file-only
+    // credential into the model mode and inject it as masked `secret_env`, so
+    // the resolved plan matches `up`'s for identical inputs (#853).
+    let env_creds = apply_env_file_plan(&mut o.common, ui)?;
+    let mut cmd = rebuild_command(&o.common, &o.service);
+    if !env_creds.is_empty() {
+        cmd = cmd.with_secret_env(env_creds);
+    }
     if o.common.dry_run {
         return Ok(LocalRebuildOutput::DryRun(crate::ui::DryRunPlan {
             lines: vec![cmd.display()],
         }));
     }
     require_on_path("docker")?;
-    let ui = crate::ui::ui();
     let cl = ui.checklist();
     run_step(&cl, &format!("rebuilding {}", o.service), "rebuild", &cmd).await?;
     Ok(LocalRebuildOutput::Rebuilt {
@@ -1052,6 +1077,72 @@ mod tests {
             cmd.argv()
         );
         // The credential rides secret_env, not the plain env vec.
+        assert!(cmd.env.iter().all(|(k, _)| k != "ANTHROPIC_API_KEY"));
+        assert!(cmd
+            .secret_env
+            .contains(&("ANTHROPIC_API_KEY".to_string(), secret.to_string())));
+    }
+
+    /// #853: given the SAME inputs a `local up --env-file` resolved -- a
+    /// file-only credential folded into `LiveFromCredential`, plus that
+    /// credential to inject as masked `secret_env` -- `local rebuild` builds the
+    /// identical model/credential wiring, so the rebuilt service comes back LIVE
+    /// rather than reverting to compose's fake default. Asserted on the resolved
+    /// plan (the env and secret_env of the built command), not on flag presence.
+    /// Both verbs share `apply_env_file_plan`, so identical inputs cannot diverge.
+    #[test]
+    fn rebuild_matches_up_env_file_wiring() {
+        let secret = "sk-ant-fromfile";
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        // The mode a `.env`-only credential resolves to (see
+        // env_file_up_plan_dotenv_only_credential_boots_live).
+        o.model_mode = ModelMode::LiveFromCredential;
+        let creds = vec![("ANTHROPIC_API_KEY".to_string(), secret.to_string())];
+
+        let up = up_command(&o).with_secret_env(creds.clone());
+        let rebuilt = rebuild_command(&o, "agentos-worker").with_secret_env(creds.clone());
+
+        // The live-model flip is present on both, and the plain env + masked
+        // credential wiring match exactly across the two verbs.
+        assert!(up
+            .env
+            .contains(&(String::from("AGENTOS_FAKE_MODEL"), String::from("0"))));
+        assert_eq!(up.env, rebuilt.env, "rebuild env drifted from up env");
+        assert_eq!(
+            up.secret_env, rebuilt.secret_env,
+            "rebuild secret_env drifted from up secret_env"
+        );
+        assert!(rebuilt
+            .secret_env
+            .contains(&("ANTHROPIC_API_KEY".to_string(), secret.to_string())));
+    }
+
+    /// #853: the `--env-file` credential a rebuild injects is masked in the
+    /// printed command line and never lands in argv -- the same leak-prevention
+    /// property `env_file_credential_is_masked_never_printed` proves for `up`
+    /// must hold on the rebuild path too (cli/CLAUDE.md: credentials masked,
+    /// never printed).
+    #[test]
+    fn rebuild_env_file_credential_is_masked_never_printed() {
+        let secret = "sk-ant-supersecretvalue";
+        let mut o = opts(DEFAULT_COMPOSE_FILE);
+        o.model_mode = ModelMode::LiveFromCredential;
+        let cmd = rebuild_command(&o, "agentos-worker")
+            .with_secret_env(vec![("ANTHROPIC_API_KEY".to_string(), secret.to_string())]);
+        let display = cmd.display();
+        assert!(
+            display.contains("ANTHROPIC_API_KEY=sk-ant-s***"),
+            "the token must be masked in the printed command line; got {display}"
+        );
+        assert!(
+            !display.contains(secret),
+            "the raw token leaked into the printed command line: {display}"
+        );
+        assert!(
+            !cmd.argv().iter().any(|a| a.contains(secret)),
+            "the raw token leaked into argv: {:?}",
+            cmd.argv()
+        );
         assert!(cmd.env.iter().all(|(k, _)| k != "ANTHROPIC_API_KEY"));
         assert!(cmd
             .secret_env

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -663,6 +663,14 @@ enum LocalAction {
         /// Match how `local up` brought the stack up (--slack, if used).
         #[arg(long)]
         slack: bool,
+        /// Match how `local up` brought the stack up (--env-file, if used):
+        /// read a bundle-local `.env` as the LOWEST-priority model-credential
+        /// source so the rebuilt service comes back on the SAME model as the
+        /// rest of the stack, instead of reverting to compose's fake default
+        /// (#853). Precedence (shell env > this file), the recognized keys, and
+        /// the never-in-argv/logs masking are identical to `local up --env-file`.
+        #[arg(long = "env-file", value_name = "PATH")]
+        env_file: Option<PathBuf>,
     },
     /// Stop the dev stack (docker compose down), keeping volumes.
     Down {
@@ -1671,6 +1679,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 minimal,
                 local_model,
                 slack,
+                env_file,
             } => {
                 let file = resolve_compose_file(file, dry_run).await?;
                 emit(
@@ -1682,7 +1691,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             local_model,
                             slack,
                             model_mode: local::model_mode_from_env(),
-                            env_file: None,
+                            env_file,
                         },
                         service,
                     })


### PR DESCRIPTION
Fixes #853.

## Problem

`LocalAction::Rebuild` had no `--env-file` flag and the handler hardcoded `env_file: None` ([cli/src/main.rs](../blob/main/cli/src/main.rs)), while its own help text promises rebuild recreates a service *"without losing the stack's already-resolved credential/model-mode wiring."*

Failure scenario (from the issue):

1. `agentos local up --env-file bundle/.env` — the stack boots live off a credential present only in that `.env` (the whole point of #749: no manual `source`).
2. Operator edits worker code and runs the documented per-change loop: `agentos local rebuild agentos-worker`.
3. `load_env_file_up_plan(None)` returns no credentials; the mode re-resolves to `DefaultFake`; no `secret_env` is attached.
4. **The rebuilt worker comes back on the fake model inside an otherwise-live stack** — reopening the #749 footgun on the loop that runs most often.

## Fix

- Give `rebuild` the same `--env-file` flag as `up`, threaded through the handler (`env_file: None` → `env_file`).
- Factor the env-file plan application into a shared helper `apply_env_file_plan`, called by **both** `up` and `rebuild`. Given the same shell env and the same `--env-file`, the two verbs now resolve an **identical** `(credentials, ModelMode)` plan by construction — rebuild folds a file-only credential into the model mode and injects it as masked `secret_env`, exactly as `up` does.

Per the AC's "better" option: rebuild re-resolves from *this invocation's inputs* (the shell + the same `--env-file`), matching every other worker-restarting verb, rather than reading back container state that is not recoverable from outside the containers. Passing the same `--env-file` the original `up` used is what keeps the wiring identical.

## Acceptance criteria

- [x] `local rebuild` accepts `--env-file` with the same semantics as `local up`.
- [x] rebuild reuses the resolved wiring via the shared `apply_env_file_plan` helper, matching the help text.
- [x] Test asserts the **resolved plan** (not flag presence): `rebuild_matches_up_env_file_wiring` proves rebuild's `env` and masked `secret_env` match up's for identical inputs, both carrying the live-model flip.
- [x] Credential stays masked in `cmd.display()`: `rebuild_env_file_credential_is_masked_never_printed` proves it on the rebuild path; the existing `env_file_credential_is_masked_never_printed` (up path) still holds.

## Verification

- `cargo fmt`, `cargo clippy -- -D warnings`: clean.
- `local` module unit tests: **71 passed** (incl. the two new tests, confirmed by name).
- `command_surface` integration tests: **11 passed** — the manifest drift gate confirms the regenerated `cli/command-manifest.json` matches the CLI grammar.
- Regenerated the committed `apps/ui/src/generated/commandManifest.ts` via `pnpm gen:manifest`; `pnpm typecheck` shows no error from this change (the only local errors are a pre-existing missing `@tanstack/react-query` dep, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)