### PR TITLE
Attribute eval cost_usd on failing real-model turns, not just graded ones

### DIFF
--- a/apps/worker/src/agentos_worker/eval/runner.py
+++ b/apps/worker/src/agentos_worker/eval/runner.py
@@ -186,6 +186,9 @@ class EvalRunner:
                 # A bare asyncio.TimeoutError stringifies to "", which would
                 # otherwise read downstream as a completed turn; keep it non-empty.
                 error=str(exc) or type(exc).__name__,
+                # Attribute whatever usage the turn stamped before it failed
+                # (#854); None on a fake run or when no Final was seen.
+                cost_usd=None if fake else cost_usd(model, input_tokens, output_tokens),
             )
 
         output = final_text if final_text is not None else "".join(parts)
@@ -199,6 +202,9 @@ class EvalRunner:
                 output=output,
                 latency_ms=_elapsed_ms(start),
                 error=error_detail or "runner reported a classified failure",
+                # A classified-failure turn (budget/model error) can burn heavy
+                # input tokens before it fails -- attribute that cost (#854).
+                cost_usd=None if fake else cost_usd(model, input_tokens, output_tokens),
             )
         # Gate on the case's expected terminal status. A case asserts its terminal
         # status (default ``done``, or ``awaiting-approval`` for a gate-blocked
@@ -215,6 +221,9 @@ class EvalRunner:
                 output=output,
                 latency_ms=_elapsed_ms(start),
                 error=f"turn ended {final_status}, expected status {expected.value!r}",
+                # A wrong-terminal-status turn still ran the model and stamped
+                # usage on its Final -- attribute that cost too (#854).
+                cost_usd=None if fake else cost_usd(model, input_tokens, output_tokens),
             )
         # The turn completed, which on the fake tier is the whole assertion: the
         # fake answers from a canned script, so grading its text measures the
@@ -229,6 +238,8 @@ class EvalRunner:
                 outcome=EvalOutcome.PLUMBING_OK,
                 output=output,
                 latency_ms=_elapsed_ms(start),
+                # No cost_usd on purpose: the fake tier has no real spend, so
+                # pricing it would fabricate a cost (#854).
             )
         # The turn completed cleanly, so a negative verdict is the scorer saying
         # "no", not a runner/turn error -- keep `error` reserved for the latter

--- a/apps/worker/tests/eval/test_runner.py
+++ b/apps/worker/tests/eval/test_runner.py
@@ -97,6 +97,43 @@ def test_classified_failure_final_fails_even_if_text_matches(make_eval_harness) 
     asyncio.run(go())
 
 
+def test_cost_is_attributed_on_failing_real_model_turns(make_eval_harness) -> None:
+    # #854: a real-model turn that ends in a classified failure -- or the wrong
+    # terminal status -- still burned tokens on its Final, and those failing runs
+    # are often the most expensive. Their cost must be attributed, not dropped as
+    # unknown. A fake run stays None: it has no real spend to price.
+    async def go() -> None:
+        async with make_eval_harness() as (base_url, fake, client):
+            fake.responses = {"boom": "burned then failed", "wrong": "answered early"}
+            fake.usage = {"boom": (1_000_000, 0), "wrong": (1_000_000, 0)}  # 1M input tokens
+            fake.classified_failure_inputs = {"boom"}  # -> classified-failure return
+            fake.awaiting_approval_inputs = {"wrong"}  # ends != the default expected 'done'
+            suite = EvalSuite(
+                name="cost",
+                cases=[
+                    EvalCase(id="cf", input="boom", grader=Grader(kind=CONTAINS, expected="")),
+                    EvalCase(id="ws", input="wrong", grader=Grader(kind=CONTAINS, expected="")),
+                ],
+            )
+
+            real = await EvalRunner(client).run(
+                suite, base_url=base_url, version="v1", model="claude-sonnet-5"
+            )
+            by_id = {r.case_id: r for r in real.results}
+            # Both failed; both burned 1M input tokens @ $3/Mtok (claude-sonnet-5) = $3.00.
+            assert by_id["cf"].outcome is EvalOutcome.FAIL
+            assert by_id["cf"].cost_usd == pytest.approx(3.0)
+            assert by_id["ws"].cost_usd == pytest.approx(3.0)
+
+            # The identical failing turns on the fake tier attribute no cost.
+            faked = await EvalRunner(client).run(
+                suite, base_url=base_url, version="v1", model="claude-sonnet-5", fake=True
+            )
+            assert {r.cost_usd for r in faked.results} == {None}
+
+    asyncio.run(go())
+
+
 def test_idle_awaiting_input_final_fails_even_if_text_matches(make_eval_harness) -> None:
     async def go() -> None:
         async with make_eval_harness() as (base_url, fake, client):


### PR DESCRIPTION
## Problem

`_run_case` (`apps/worker/.../eval/runner.py`) populated `cost_usd` at **only one** of its result-construction sites — the graded path. A turn that ended in a **classified failure** (budget/model error) or the **wrong terminal status** returned with `cost_usd=None`, even though its `Final` frame carried the token usage. So the runs that most need cost attribution — the ones that burned a lot of input tokens and then failed — reported cost *unknown* and fell out of the per-model cost rollup entirely.

```python
# graded path (had it):
cost_usd=cost_usd(model, input_tokens, output_tokens)
# classified-failure / wrong-status / transport-error returns: nothing -> None
```

## Fix

Attribute cost at the classified-failure, wrong-status, and transport-exception returns — the tokens are already in scope at each. Guarded on `not fake`, so a fake run never fabricates a cost; the plumbing (fake) path stays `None` deliberately (the fake tier has no real spend).

```python
cost_usd=None if fake else cost_usd(model, input_tokens, output_tokens),
```

## Testing

- New test drives a **1M-input-token classified-failure** turn and a **wrong-status** turn under `claude-sonnet-5` ($3/Mtok) and asserts both land **$3.00** — and that the identical failing turns on the fake tier stay `None`.
- **Verified it fails without the fix** (`Obtained: None, Expected: 3.0`), so it's a real regression guard.
- `ruff` + `mypy` clean; full `test_runner.py` green (25 passed).

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)
