### PR TITLE
Filter reserved namespaces from state enumeration for the app token

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3608,7 +3608,7 @@
     },
     "/agents/{agent_id}/state": {
       "get": {
-        "description": "List the namespaces an agent has stored, each with its key count and the\nmost recent write time (#250). This is the enumeration the operator's\nread/inspect surface needs on top of get-by-key + list-by-namespace; it stays\nwithin the store's non-goals (no query language, just a grouped summary).\nNamespaces are returned most-recently-written first.",
+        "description": "List the namespaces an agent has stored, each with its key count and the\nmost recent write time (#250). This is the enumeration the operator's\nread/inspect surface needs on top of get-by-key + list-by-namespace; it stays\nwithin the store's non-goals (no query language, just a grouped summary).\nNamespaces are returned most-recently-written first.\n\nThis route has no ``namespace`` path param, so ``forbid_reserved_namespace``\ncannot gate it; instead the reserved namespaces are filtered out for the\nnarrow app (bundle) token (#856), the enumeration equivalent of that guard.\nThe platform key (the UI inspector) and the broad ``state`` loaders keep full\nreach. ``require_state_access`` is a router-level dependency, so re-declaring\nit here only surfaces the already-resolved caller (FastAPI caches it).",
         "operationId": "list_namespaces_agents__agent_id__state_get",
         "parameters": [
           {

--- a/apps/api/src/agentos_api/routers/state.py
+++ b/apps/api/src/agentos_api/routers/state.py
@@ -265,13 +265,22 @@ async def append_state(
 
 @router.get("/{agent_id}/state", response_model=list[StateNamespaceOut])
 async def list_namespaces(
-    agent_id: uuid.UUID, session: SessionDep
+    agent_id: uuid.UUID,
+    session: SessionDep,
+    caller: Annotated[StateCaller, Depends(require_state_access)],
 ) -> list[StateNamespaceOut]:
     """List the namespaces an agent has stored, each with its key count and the
     most recent write time (#250). This is the enumeration the operator's
     read/inspect surface needs on top of get-by-key + list-by-namespace; it stays
     within the store's non-goals (no query language, just a grouped summary).
     Namespaces are returned most-recently-written first.
+
+    This route has no ``namespace`` path param, so ``forbid_reserved_namespace``
+    cannot gate it; instead the reserved namespaces are filtered out for the
+    narrow app (bundle) token (#856), the enumeration equivalent of that guard.
+    The platform key (the UI inspector) and the broad ``state`` loaders keep full
+    reach. ``require_state_access`` is a router-level dependency, so re-declaring
+    it here only surfaces the already-resolved caller (FastAPI caches it).
     """
     rows = await session.execute(
         select(
@@ -290,6 +299,10 @@ async def list_namespaces(
             last_updated=row.last_updated,
         )
         for row in rows
+        # The narrow app (bundle) token must not even learn the reserved
+        # namespaces exist -- their key counts and write times are exactly what
+        # the state.app scope fences off (#856).
+        if not (caller is StateCaller.APP and row.namespace in RESERVED_NAMESPACES)
     ]
 
 

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -158,6 +158,36 @@ def test_app_scoped_token_is_refused_on_reserved_namespaces(
         assert client.delete(f"/agents/{aid}/state/{ns}/k", headers=headers).status_code == 403
 
 
+def test_namespace_enumeration_hides_reserved_from_the_app_token(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # #856: the enumeration route (GET .../state) has no namespace path param, so
+    # forbid_reserved_namespace cannot gate it. The narrow state.app token must
+    # still not learn the reserved namespaces exist -- their key counts and write
+    # times are exactly what that scope fences off. The platform key (the UI
+    # inspector) keeps full reach.
+    aid = _agent(client, auth_headers)
+    # Seed both reserved namespaces and a normal one via the unrestricted key.
+    for ns, key in (("memory", "m1"), ("transcript", "t1"), ("workflow", "w1")):
+        put = client.put(
+            f"/agents/{aid}/state/{ns}/{key}", json={"value": {"n": 1}}, headers=auth_headers
+        )
+        assert put.status_code == 200, f"{ns}: {put.text}"
+
+    app = mint(get_settings().api_key, agent=aid, scope="state.app", exp=_FAR_FUTURE)
+    app_names = {
+        row["namespace"]
+        for row in client.get(f"/agents/{aid}/state", headers={"X-API-Key": app}).json()
+    }
+    assert app_names == {"workflow"}, app_names
+
+    platform_names = {
+        row["namespace"]
+        for row in client.get(f"/agents/{aid}/state", headers=auth_headers).json()
+    }
+    assert platform_names == {"memory", "transcript", "workflow"}, platform_names
+
+
 def test_app_scoped_token_works_on_a_non_reserved_namespace(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:


### PR DESCRIPTION
## Problem

`GET /agents/{id}/state` (the namespace enumeration, #250) has **no `namespace` path param**, so `forbid_reserved_namespace` can't gate it — and it gained no equivalent filter (introduced by #842). A bundle holding the narrow `state.app` token could enumerate the agent and receive metadata for the very namespaces that scope exists to hide:

```json
[{"namespace": "memory", "key_count": 47, "last_updated": "..."},
 {"namespace": "transcript", "key_count": 1203, "last_updated": "..."}]
```

How many memories the agent holds, how large its transcript is, when each was last written. **Values are not exposed** (reading a reserved namespace still `403`s) — metadata only, hence low severity, but it's exactly the fencing the `state.app` scope is for.

## Fix

Inject the already-resolved caller — `require_state_access` is a **router-level** dependency, so re-declaring it on this route just surfaces the cached value — and filter the reserved namespaces out for `StateCaller.APP`:

```python
... for row in rows
    if not (caller is StateCaller.APP and row.namespace in RESERVED_NAMESPACES)
```

The platform key (`StateCaller.PLATFORM`, the UI inspector) and the broad `state` loaders keep full reach.

## Testing

- New test seeds `memory`, `transcript`, and a normal namespace, then asserts a `state.app` token enumerates **only** the normal one while the platform key sees all three.
- **Verified it fails without the fix** (the app token saw all three), so it's a real regression guard.
- `ruff` + `mypy` clean; full `test_state.py` green (21 passed).

Cross-agent / cross-tenant isolation on this route was already sound (`require_state_access` binds the token to the path `agent_id`); this is only reserved-namespace fencing within the correct agent.

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)
