### PR TITLE
Correct two stale seam-catalog claims (#858)

### DIFF
--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -83,15 +83,21 @@ Nine, all in the CLI crate:
 
 ## Known leakage
 
-- **The trait is not the whole `--json` surface.** `CliOutput` governs the
-  success path of the verbs that were converted. It cannot, by construction, prove
-  that *every* verb returns an output rather than printing directly — that is a
-  convention plus review, not a compile-time guarantee. A new handler can still call
-  a stdout emitter and bypass the seam; nothing fails the build if it does.
-- **No machine-readable schema.** Each `to_json` hand-builds its object with
-  `serde_json::json!`. There is no committed JSON Schema and no drift gate, unlike
-  the ACI (`packages/aci-protocol`, ADR-0017) or the channel protocol. An agent
-  parsing this output is coupled to shapes that are only enforced by tests.
+- **The trait is not the whole `--json` surface, but a new raw emitter now fails
+  the build (since #841).** `CliOutput` governs the success path of the verbs that
+  were converted. `schema_inventory.rs` pins the per-file `.emit_json(` call-site
+  count and raises `UnexpectedRawEmitter` when a new direct emitter appears, so a
+  handler that bypasses the seam and prints to stdout directly breaks CI rather
+  than sliding through on convention alone. The residual is that this is a
+  syntactic call-site inventory, not a type-level proof that *every* verb returns
+  a `CliOutput`.
+- **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
+  longer schema-free: there are 32 committed schemas under `cli/schema/` with an
+  index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
+  CliOutput`, and per-family output validation — all 32 are validated against real
+  `to_json()` output across 44 tests in `cli/tests/json_contract.rs`. An agent
+  parsing this output is now coupled to shapes enforced by committed schemas and a
+  drift gate, like the ACI (`packages/aci-protocol`, ADR-0017), not by tests alone.
 - **Not separately graded.** This is not one of the six swap-readiness Jobs in the
   vision doc: the "second implementation" here would be a second *output format*
   (YAML, a table protocol), which nobody has asked for. Per the governing restraint,
@@ -102,5 +108,6 @@ Nine, all in the CLI crate:
 
 - **Issue:** [#456](https://github.com/curie-eng/agentos/issues/456) — the `--json` contract broke per-command; `Ui::emit` + `CliOutput` + `DryRunPlan` are its fix
 - **Issue:** [#460](https://github.com/curie-eng/agentos/issues/460) — the observability twin, whose local/cluster tiers share one `CliOutput`
+- **Issue:** [#841](https://github.com/curie-eng/agentos/issues/841) — added the committed `cli/schema/` JSON Schemas, the `schema_inventory` build gate, and the `json_contract` output validation this seam now relies on
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — CLI output is not one of the six swap-readiness Jobs; not separately graded
 - **ADR(s):** [ADR-0021](../../adr/0021-agentos-is-a-harness-for-coding-agents.md) — AgentOS is a harness for coding agents: the CLI's primary user is Claude Code (this seam is decision 1's enforcement); [ADR-0038](../../adr/0038-observability-cli-helper-for-the-agent-dev-loop.md) — the observability CLI is a thin client over the API proxy, not a second backend

--- a/docs/interfaces/harness-modelsession/INTERFACE.md
+++ b/docs/interfaces/harness-modelsession/INTERFACE.md
@@ -23,9 +23,9 @@ epic_note: folds into
 Inside the runner the model harness is reached through one in-process port: the
 `ModelSession` Protocol. Everything above it (ACI translation, budget, side-effect
 flagging, NDJSON, the HTTP layer) is written against the Protocol. The port itself is
-CLEAN, but the SDK is not yet confined to one module: eight runner modules still import
+CLEAN, but the SDK is not yet confined to one module: nine runner modules still import
 `claude_agent_sdk` today (`check.py`, `session.py`, `hooks.py`, `adapter.py`, `fake.py`,
-`approval.py`, `translate.py`, `plugin.py`), and the value that crosses the port is
+`approval.py`, `translate.py`, `plugin.py`, `state.py`), and the value that crosses the port is
 currently the raw SDK message union rather than a runner-owned neutral type. The
 runner-owned `TurnEvent` model that would draw that line is pending (#307/#315, both
 open); until it lands, a second harness must emit objects the SDK-shaped translation
@@ -80,7 +80,7 @@ The port is CLEAN as a code interface but leaks harness shape where the SDK is n
 walled off, called out in vision-doc Job 1:
 
 - **SDK-shaped message payload.** The value crossing the port is the concrete
-  `claude_agent_sdk` message union, and `claude_agent_sdk` is imported across eight
+  `claude_agent_sdk` message union, and `claude_agent_sdk` is imported across nine
   runner modules rather than one adapter. The runner-owned `TurnEvent` model that draws
   the neutral line is #307/#315 (open); until it merges, a second harness emits SDK-shaped
   dataclasses that `translate_message` understands.


### PR DESCRIPTION
Fixes #858.

The generated seam catalog (`docs/interfaces/`) is the system of record for what each seam guarantees (ADR-0043), but the doc-lint gate lints **structure**, not **claims** — so two entries stated the opposite of the truth.

## 1. `cli-output/INTERFACE.md` — two claims stale after #841

- **"No machine-readable schema … no committed JSON Schema and no drift gate"** → false. Verified: **32** committed schemas under `cli/schema/`, an index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl CliOutput`, and per-family output validation across **44** tests in `cli/tests/json_contract.rs`.
- **"A new handler can bypass the seam; nothing fails the build"** → false. `schema_inventory.rs` pins per-file `.emit_json(` call-site counts and raises `UnexpectedRawEmitter` when a new direct emitter appears, so the build **does** fail. Reworded to keep the honest residual (a syntactic call-site inventory, not a type-level proof that every verb returns a `CliOutput`). Added #841 to cross-links.

## 2. `harness-modelsession/INTERFACE.md` — count stale after #840

`claude_agent_sdk` is imported across **nine** runner modules, not eight — #840 added `state.py` as the ninth. Verified:

```
$ git grep -l claude_agent_sdk -- runner/src
adapter.py approval.py check.py fake.py hooks.py plugin.py session.py state.py translate.py   # = 9
```

Updated both the count and the module list in the two places it appears (`## The black line` and `## Known leakage`).

## Verification

- `bash scripts/check-docs.sh` passes post-commit: *"the interface catalog is generated, drift-free, and every citation resolves."*
- Only non-generated prose changed — `agentos_doclint --write` regenerates no catalog region from this edit (front-matter untouched), and the citation lint is clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)