### PR TITLE
Resolve the built-in harness without scanning entry points (#865)

### DIFF
--- a/runner/src/agentos_runner/__main__.py
+++ b/runner/src/agentos_runner/__main__.py
@@ -27,7 +27,11 @@ from .approval import (
 from .config import RunnerConfig
 from .fake import FakeModelSession
 from .harness.contribution import HarnessContribution
-from .harness.registry import DEFAULT_HARNESS, UnknownHarnessError, resolve_harness
+from .harness.registry import (
+    BUILTIN_HARNESS_CANONICAL_PATHS,
+    DEFAULT_HARNESS,
+    resolve_harness,
+)
 from .history import (
     DEFAULT_PREAMBLE_MAX_BYTES,
     DEFAULT_PREAMBLE_MAX_TURNS,
@@ -52,21 +56,30 @@ logger = logging.getLogger(__name__)
 def _resolve_harness(name: str = DEFAULT_HARNESS) -> HarnessContribution:
     """Resolve the active harness's contribution manifest (ADR-0060).
 
-    The built-in Claude harness must always be available, so if entry-point
-    metadata is somehow absent in this environment this falls back to its direct
-    import -- the critical boot path never depends on packaging metadata for the
-    built-in. A non-built-in name that isn't registered still raises, so an
-    operator who selects a harness that isn't installed fails loud, not silent.
+    The built-in Claude harness must always be available, so a built-in name --
+    its declared name or any alias in ``BUILTIN_HARNESS_CANONICAL_PATHS`` -- is
+    resolved from its direct import and never through entry-point discovery.
+    That keeps the critical boot path independent of packaging metadata
+    entirely: a malformed, colliding, or import-crashing *sibling* entry point
+    makes ``discover_contributions`` raise (a guard error such as
+    ``FlatHarnessPackageError``/``HarnessNameCollisionError``/
+    ``MalformedHarnessContributionError``, none of them ``UnknownHarnessError``),
+    and none of that may take down the built-in (#865). The registry already
+    refuses any third party that claims a built-in key, so a built-in name can
+    only ever mean the built-in -- resolving it directly is equivalent for a
+    well-formed registry and strictly safer for a broken one.
+
+    A non-built-in name goes through the registry and still fails loud (an
+    ``UnknownHarnessError`` if unregistered, or a guard error if the registry is
+    malformed), so an operator who selects a harness that isn't installed fails
+    visibly, not silently.
     """
 
-    try:
-        return resolve_harness(name)
-    except UnknownHarnessError:
-        if name == DEFAULT_HARNESS:
-            from .harness.claude import get_contribution
+    if name in BUILTIN_HARNESS_CANONICAL_PATHS:
+        from .harness.claude import get_contribution
 
-            return get_contribution()
-        raise
+        return get_contribution()
+    return resolve_harness(name)
 
 
 def _compose_system_prompt(

--- a/runner/tests/test_harness_boot_wiring.py
+++ b/runner/tests/test_harness_boot_wiring.py
@@ -18,7 +18,10 @@ from agentos_runner.harness.contribution import (
     HarnessContribution,
     InstallSpec,
 )
-from agentos_runner.harness.registry import UnknownHarnessError
+from agentos_runner.harness.registry import (
+    MalformedHarnessContributionError,
+    UnknownHarnessError,
+)
 
 _BUDGET = '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
 
@@ -121,4 +124,21 @@ def test_resolve_harness_falls_back_to_builtin_when_registry_misses(monkeypatch)
     monkeypatch.setattr(boot, "resolve_harness", miss)
     assert _resolve_harness(DEFAULT_HARNESS).name == "claude"
     with pytest.raises(UnknownHarnessError):
+        _resolve_harness("other")
+
+
+def test_default_harness_survives_a_malformed_sibling(monkeypatch) -> None:
+    # #865: a malformed / colliding / import-crashing sibling entry point makes
+    # discover_contributions raise a GUARD error (not UnknownHarnessError), which
+    # the old code let propagate past the fallback and take the built-in down with
+    # it. The built-in must never depend on that scan, so a built-in name -- its
+    # declared name AND every alias -- still resolves to Claude. A non-built-in
+    # name still surfaces the guard error loudly rather than silently falling back.
+    def boom(name: str, **kwargs: object) -> HarnessContribution:
+        raise MalformedHarnessContributionError("a sibling entry point is broken")
+
+    monkeypatch.setattr(boot, "resolve_harness", boom)
+    assert _resolve_harness(DEFAULT_HARNESS).name == "claude"
+    assert _resolve_harness("claude-sdk").name == "claude"  # aliases protected too
+    with pytest.raises(MalformedHarnessContributionError):
         _resolve_harness("other")


### PR DESCRIPTION
Fixes #865.

## Problem

`_resolve_harness` ([runner/src/agentos_runner/__main__.py](../blob/main/runner/src/agentos_runner/__main__.py)) caught only `UnknownHarnessError` before falling back to the built-in's direct import. But `resolve_harness(DEFAULT_HARNESS)` calls `discover_contributions()`, which iterates **every** installed entry point and runs `_check_guards`. A malformed / colliding / (post-`ep.load`) import-crashing **sibling** raises `FlatHarnessPackageError`, `HarnessNameCollisionError`, or `MalformedHarnessContributionError` — none of them `UnknownHarnessError` — so it propagated past the fallback and took the built-in Claude boot down with it.

The docstring promised the critical boot path never depends on packaging metadata for the built-in; it did. Risk is zero today (one entry point registered) and becomes real the moment harnesses are independently installable (ADR-0060 Phase 1 selection).

## Fix

Took the issue's **second, more robust option**: a built-in name — its declared name **or any alias** in `BUILTIN_HARNESS_CANONICAL_PATHS` (`claude`, `claude-sdk`, `claude-code`) — is resolved from its direct import and **never** through entry-point discovery.

- The critical boot path no longer depends on packaging metadata at all — no sibling (malformed, colliding, or one whose `get_contribution()` raises anything) can break the built-in.
- The registry already refuses any third party that claims a built-in key, so a built-in name can only ever mean the built-in: resolving it directly is **equivalent** for a well-formed registry and **strictly safer** for a broken one. It also avoids executing an untrusted sibling's `ep.load()` on the default boot.
- A **non-built-in** name still goes through the registry and fails loud (unknown → `UnknownHarnessError`; malformed registry → the guard error), so a mis-selected harness is never silently swallowed.

This also fixes a gap the issue's *first* option would have left: a sibling whose `get_contribution()` raises a non-guard exception would still crash a default boot under option 1, but cannot under this approach.

## Test

`test_default_harness_survives_a_malformed_sibling` monkeypatches `resolve_harness` to raise a guard error and asserts the built-in default **and an alias** still resolve to Claude, while a non-built-in name still surfaces the guard error. It fails on the old code (the guard error escaped `except UnknownHarnessError`).

## Verification

- `uv run pytest runner/tests/test_harness_boot_wiring.py runner/tests/test_harness_registry.py -q` → **23 passed**.
- `uv run ruff check runner/` clean; `uv run mypy` clean.
- Full `uv run pytest runner/tests` → **470 passed, 1 skipped**, and one **pre-existing, unrelated** failure: `test_live.py::test_live_permission_gate_pauses_awaiting_approval` (a `@live` real-model test) fails **identically on clean `main`** without this change (`AttributeError: 'list' object has no attribute 'type'`), so it is not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)