### PR TITLE
Tighten the zip central-directory per-member budget (#861)

### DIFF
--- a/packages/plugin-format/src/plugin_format/archive.py
+++ b/packages/plugin-format/src/plugin_format/archive.py
@@ -87,11 +87,25 @@ _ZIP64_EOCD_LOCATOR_SIZE = 20
 # central directory until it has consumed `size_cd` bytes (it does NOT trust
 # the declared entry count to bound that loop), so an attacker cannot evade the
 # cap by under-declaring the count -- the SIZE is what bounds zipfile's work.
-# A central-directory header is 46 fixed bytes + the file name; 512 leaves
-# generous room for long paths (a legitimate <=10k-file bundle stays well under
-# max_members*512, while a 100k+ zero-byte-member DoS blows past it), so this
-# rejects the DoS without false-rejecting a real bundle near the count cap.
-_ZIP_CENTRAL_DIR_BYTES_PER_MEMBER = 512
+#
+# A central-directory header is 46 FIXED bytes + the file name (+ extra field +
+# file comment, both 0 in a normal bundle), so 46 is the smallest a real entry
+# can be and `size_cd / 46` is the most entries zipfile can materialize from
+# `size_cd` bytes. The old 512 budget (a ~466-byte filename allowance) let a
+# compact real central directory of short-named headers pack ~size_cd/46 real
+# entries under a size_cd/512 cap -- roughly an 11x entry-count amplification
+# over max_members, so a caller could still be pushed to materialize ~106k
+# ZipInfos at the default cap by under-declaring the EOCD count (#861).
+# Tightening to 128 (the 46-byte minimum header + an 82-byte modest filename
+# allowance) cuts the worst case to ~2.8x while still clearing a full
+# max_members-file bundle whose paths average up to ~82 chars -- the realistic
+# ceiling for nested plugin-bundle paths. The bare 46-byte minimum would close
+# the amplification entirely but false-reject realistic medium bundles with
+# nested paths, so this keeps the modest allowance the header shape genuinely
+# needs (the issue's option 1); max_members is operator-overridable for a bundle
+# that legitimately needs more headroom, and size_cd is bounded by the upload
+# cap regardless, so the residual amplification stays bounded.
+_ZIP_CENTRAL_DIR_BYTES_PER_MEMBER = 128
 
 
 class UnsupportedArchive(Exception):

--- a/packages/plugin-format/tests/test_archive.py
+++ b/packages/plugin-format/tests/test_archive.py
@@ -469,6 +469,30 @@ def test_zip_eocd_precheck_allows_within_cap() -> None:
     _reject_zip_over_member_count(_synthetic_eocd(total_entries=42, size_cd=5_000), 10_000)
 
 
+def test_zip_eocd_precheck_closes_bounded_count_amplification() -> None:
+    """#861: an under-declared count (1) paired with a central-directory SIZE
+    that would let ``zipfile`` materialize far more than ``max_members``
+    minimum-size (46-byte) headers is rejected. The size sits just over the
+    tightened per-member budget yet well under the old 512-byte budget, so it
+    would have slipped past the pre-#861 guard while ``zipfile`` parsed
+    ``size_cd / 46`` (~2.8x the cap here) real headers regardless of the tiny
+    declared count. The tightened budget is what closes that window."""
+    from plugin_format.archive import (
+        _ZIP_CENTRAL_DIR_BYTES_PER_MEMBER,
+        _reject_zip_over_member_count,
+    )
+
+    max_members = 10_000
+    size_cd = max_members * _ZIP_CENTRAL_DIR_BYTES_PER_MEMBER + 1
+    # The window this fix closes: rejected now, but under the old 512-byte budget
+    # this same size_cd was accepted while holding ~size_cd/46 real headers.
+    assert size_cd < max_members * 512
+    with pytest.raises(UnsupportedArchive, match="member-count"):
+        _reject_zip_over_member_count(
+            _synthetic_eocd(total_entries=1, size_cd=size_cd), max_members=max_members
+        )
+
+
 def test_zip_eocd_precheck_ignores_a_spurious_trailing_signature() -> None:
     """A later byte run that itself starts with the EOCD signature is the record
     ``rfind`` now locates (matching CPython, which rfinds the LAST signature in


### PR DESCRIPTION
Fixes #861.

## Problem

`_reject_zip_over_member_count` bounds `zipfile`'s pre-open work by the declared central-directory **size** (`size_cd`) — the right signal, since `zipfile` parses the central directory until it has consumed `size_cd` bytes and does **not** trust the declared entry count. But the per-member byte budget was **512** (a ~466-byte filename allowance), while a real central-directory header is only **46 fixed bytes** + the file name.

So an attacker who under-declares the EOCD `total_entries` (e.g. to 1) while shipping a compact directory of short-named (~46–48-byte) headers packs `~size_cd/46` real entries under a `size_cd/512` cap — roughly **11x** the member cap. At the default `max_members=10_000` that is ~106k `ZipInfo`s materialized. It is *bounded* (the upload cap bounds `size_cd`), but a real amplification, and `size_cd`/512 is unchanged by #848.

## Fix

Tighten `_ZIP_CENTRAL_DIR_BYTES_PER_MEMBER` **512 → 128** = the 46-byte minimum header + an 82-byte **modest filename allowance** (the issue's option 1).

- Cuts the worst case from ~11x to **~2.8x**.
- Still clears a full `max_members`-file bundle whose paths average up to ~82 chars — the realistic ceiling for nested plugin-bundle paths (existing `test_zip_within_cap_still_opens_and_extracts` and a 10k-file bundle both stay well under).
- The bare 46-byte minimum (option 2) would close the amplification entirely but false-reject realistic medium bundles with nested paths, so this keeps the allowance the header shape genuinely needs. `max_members` remains operator-overridable, and `size_cd` is bounded by the upload cap, so the residual stays bounded.

## Test

`test_zip_eocd_precheck_closes_bounded_count_amplification`: an under-declared count (1) with a `size_cd` just over the tightened budget but **well under the old 512-byte budget** (asserted) — the exact window this closes — is now rejected.

## Verification

- `uv run pytest packages/plugin-format/tests/test_archive.py -q` → **49 passed**.
- `uv run ruff check packages/` clean; `uv run mypy` → **Success (161 files)**.
- **Frozen contract untouched**: `bash scripts/check-contracts.sh` → *"all committed contract artifacts are current."* This changes only archive-extraction logic, not any Pydantic model / JSON Schema / generated Rust/TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)