### PR TITLE
Cap the number of namespaces an agent can create in durable state

### DIFF
--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -219,6 +219,13 @@ class Settings(BaseSettings):
     # namespace are both bounded. Sizes are the serialized-JSON byte length.
     state_max_value_bytes: int = 64 * 1024  # 64 KiB per value
     state_max_namespace_bytes: int = 1024 * 1024  # 1 MiB per (agent, namespace)
+    # Per-agent cap on the NUMBER of namespaces (#852). #840 made the namespace an
+    # arbitrary model-supplied string, so without this a single sandbox could
+    # create unbounded namespaces -- each under the byte caps -- bloating the
+    # shared store and permanently enlarging the enumeration GROUP BY. Only
+    # creating a NEW namespace past the cap is refused; existing-namespace writes
+    # are unaffected.
+    state_max_namespaces: int = 256
     # The namespace the runner sandboxes run in, and the label selector that
     # identifies them (the chart labels sandbox pods
     # app.kubernetes.io/component=runner-sandbox). Used by the pod-list endpoint

--- a/apps/api/src/agentos_api/routers/state.py
+++ b/apps/api/src/agentos_api/routers/state.py
@@ -155,6 +155,32 @@ async def _enforce_caps(
             f"{settings.state_max_namespace_bytes}-byte per-namespace cap",
         )
 
+    # Per-agent namespace-count cap (#852): refuse only a NEW namespace, and only
+    # once the agent is at its limit -- writes to an existing namespace never hit
+    # this. Without it a sandbox could loop creating unbounded namespaces, each
+    # under the byte caps, after #840 made the namespace agent-chosen.
+    namespace_exists = await session.scalar(
+        select(WorkflowStateEntry.namespace)
+        .where(
+            WorkflowStateEntry.agent_id == agent_id,
+            WorkflowStateEntry.namespace == namespace,
+        )
+        .limit(1)
+    )
+    if namespace_exists is None:
+        namespace_count = await session.scalar(
+            select(func.count(func.distinct(WorkflowStateEntry.namespace))).where(
+                WorkflowStateEntry.agent_id == agent_id
+            )
+        )
+        if (namespace_count or 0) >= settings.state_max_namespaces:
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                f"agent is at its {settings.state_max_namespaces}-namespace cap; "
+                f"delete a namespace or reuse an existing one before creating "
+                f"{namespace!r}",
+            )
+
 
 async def _get_entry(
     session: AsyncSession, agent_id: uuid.UUID, namespace: str, key: str

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -400,6 +400,34 @@ def test_namespace_over_the_per_namespace_cap_is_rejected(
         get_settings.cache_clear()
 
 
+def test_namespace_count_over_the_per_agent_cap_is_rejected(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # #852: a per-agent cap on the NUMBER of namespaces refuses a NEW namespace
+    # once the agent is at its limit, so a sandbox cannot loop creating unbounded
+    # namespaces (each under the byte caps). Writes to an existing namespace are
+    # unaffected. Same lru_cache mutate-and-reset pattern as the byte-cap tests.
+    aid = _agent(client, auth_headers)
+
+    def put(ns: str, key: str = "k") -> Any:
+        return client.put(
+            f"/agents/{aid}/state/{ns}/{key}", json={"value": 1}, headers=auth_headers
+        )
+
+    get_settings().state_max_namespaces = 2
+    try:
+        assert put("ns1").status_code == 200
+        assert put("ns2").status_code == 200
+        # A third, NEW namespace is refused with a clear 4xx, not a 500.
+        over = put("ns3")
+        assert over.status_code == 403, over.text
+        assert "cap" in over.text.lower() and "namespace" in over.text.lower()
+        # More keys in an EXISTING namespace still succeed (not a new namespace).
+        assert put("ns1", "k2").status_code == 200
+    finally:
+        get_settings.cache_clear()
+
+
 def test_list_namespaces_summarizes_the_store_recent_first(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:


### PR DESCRIPTION
## Problem

The durable state store caps a single **value** (64 KiB) and a single **namespace** (1 MiB), but nothing caps how many namespaces an agent may create. #840 made the namespace an **arbitrary model-supplied string**, so a buggy or adversarial skill could loop:

```python
for i in range(20000):
    mcp__agentos-state__set(namespace=f"n{i}", key="k", value="x" * 65000)
```

Each write is under the value cap; each namespace holds one key, under the namespace cap. Nothing refuses any single call, yet ~1.3 GB lands in the shared Postgres from one sandbox — and every namespace permanently enlarges the `list_namespaces` GROUP BY. The store's non-goal was "no query language," not "no total bound." (ADR-0073)

## Fix

Add a per-agent **namespace-count** cap (`state_max_namespaces`, default 256, configurable alongside the byte caps), enforced in `_enforce_caps`:

- Creating a **new** namespace past the cap is refused with a clear **403** (not a 500).
- Writes to an **existing** namespace are unaffected (they don't grow the namespace count).

## Testing

- New test asserts the bound **by execution**: with the cap set to 2, two namespaces succeed, a third *new* one is refused (403, "namespace … cap"), and an existing-namespace write still succeeds.
- **Verified it fails without the enforcement** (the 3rd namespace was allowed), so it's a real regression guard.
- `ruff` + `mypy` clean; `test_state.py` + the `openapi.json` drift gate green (23 passed).

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)
