### PR TITLE
Add connected-transport Slack primitives for the message path

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -32,6 +32,7 @@ pub mod scaffold;
 pub mod schema;
 pub mod schemas;
 pub mod secrets;
+pub mod slack;
 pub mod spec;
 pub mod state;
 pub mod ui;

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -2188,6 +2188,34 @@ pub async fn discover_valkey_password(namespace: &str, release: &str) -> Result<
         })
 }
 
+/// A usage error whose fix hint points at the Slack bot-token escape hatch.
+fn slack_bot_token_usage_err(msg: impl Into<String>) -> anyhow::Error {
+    crate::exit::CliError::usage(msg)
+        .with_fix("set AGENTOS_SLACK_BOT_TOKEN, or connect the workspace with `agentos cluster comms --slack`")
+        .into()
+}
+
+/// Discover a Helm release's Slack bot token from the same chart Secret
+/// (`<release>-secrets`, data key `slackBotToken`). In connected mode
+/// `cluster message` posts a real placeholder to the workspace with this token so
+/// the approval card and resumed reply ride the connected transport, instead of
+/// the throwaway stub (#770/ADR-0078). Only reached when a `<release>-dispatcher`
+/// is present (a workspace IS connected), so the token is expected to be set; an
+/// empty or unreadable value is an actionable error. The value is never printed
+/// -- it flows only into the `chat.postMessage` auth header.
+pub async fn discover_slack_bot_token(namespace: &str, release: &str) -> Result<String> {
+    read_release_secret(namespace, release, "slackBotToken")
+        .await
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| {
+            slack_bot_token_usage_err(format!(
+                "could not read a Slack bot token from secret {release}-secrets in namespace \
+                 {namespace}; the workspace may not be connected (run `agentos cluster comms \
+                 --slack`), or set AGENTOS_SLACK_BOT_TOKEN"
+            ))
+        })
+}
+
 /// Read one data key out of a release's chart Secret, decoded server-side by
 /// kubectl's `base64decode` so the plaintext never lands in argv (#524). `None`
 /// when the Secret, the key, or the cluster is unreachable; the caller turns

--- a/cli/src/slack.rs
+++ b/cli/src/slack.rs
@@ -1,0 +1,92 @@
+//! A minimal Slack Web API client for the connected-transport `message` path
+//! (#770/ADR-0078).
+//!
+//! `local`/`cluster message` normally mint a throwaway in-process reply stub.
+//! When a real workspace is connected, we instead post a real placeholder
+//! message to the channel over the workspace bot token and enqueue the turn
+//! against its real `ts`, so the worker edits that message in place and the
+//! approval card threads under it -- the card and the resumed reply ride the
+//! connected transport with no stub. This module owns just that one outbound
+//! call.
+
+use anyhow::{Context, Result};
+
+/// The Slack Web API base. `SLACK_API_BASE_URL` overrides it (a test/stub base,
+/// the same env the worker's own sink honours), else real Slack.
+fn api_base() -> String {
+    std::env::var("SLACK_API_BASE_URL")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "https://slack.com/api".to_string())
+}
+
+/// Post `text` to `channel` as the bot, returning the created message `ts` (the
+/// placeholder the worker then edits in place). The token is sent only in the
+/// Authorization header; it is never logged.
+pub async fn post_placeholder(bot_token: &str, channel: &str, text: &str) -> Result<String> {
+    let base = api_base();
+    let resp = reqwest::Client::new()
+        .post(format!("{base}/chat.postMessage"))
+        .bearer_auth(bot_token)
+        .json(&serde_json::json!({ "channel": channel, "text": text }))
+        .send()
+        .await
+        .context("posting the approval-turn placeholder to Slack")?
+        .json::<serde_json::Value>()
+        .await
+        .context("decoding the Slack chat.postMessage response")?;
+    parse_ts(&resp)
+}
+
+/// Extract the created message `ts` from a `chat.postMessage` response, turning
+/// an `{"ok": false, "error": ...}` body into an actionable error. Pure, so it
+/// is unit tested without a network round trip.
+fn parse_ts(resp: &serde_json::Value) -> Result<String> {
+    if resp.get("ok").and_then(serde_json::Value::as_bool) != Some(true) {
+        let err = resp
+            .get("error")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown error");
+        anyhow::bail!("Slack chat.postMessage failed: {err}");
+    }
+    resp.get("ts")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .context("Slack chat.postMessage returned ok but no message ts")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_ts_returns_the_ts_on_ok() {
+        assert_eq!(
+            parse_ts(&json!({"ok": true, "ts": "1717171717.001900"})).unwrap(),
+            "1717171717.001900"
+        );
+    }
+
+    #[test]
+    fn parse_ts_surfaces_the_slack_error_on_not_ok() {
+        let err = parse_ts(&json!({"ok": false, "error": "channel_not_found"})).unwrap_err();
+        assert!(err.to_string().contains("channel_not_found"), "{err}");
+    }
+
+    #[test]
+    fn parse_ts_errors_when_ok_but_no_ts() {
+        assert!(parse_ts(&json!({"ok": true})).is_err());
+    }
+
+    #[test]
+    fn api_base_defaults_to_real_slack_and_honours_the_override() {
+        // No override -> real Slack. (Set/removed in-process; keep the assertions
+        // tolerant of a pre-set env by asserting the shape, not a fixed value.)
+        std::env::remove_var("SLACK_API_BASE_URL");
+        assert_eq!(api_base(), "https://slack.com/api");
+        std::env::set_var("SLACK_API_BASE_URL", "http://stub:9/api");
+        assert_eq!(api_base(), "http://stub:9/api");
+        std::env::remove_var("SLACK_API_BASE_URL");
+    }
+}


### PR DESCRIPTION
Groundwork for #770 (route approval cards through the connected Slack transport), per **ADR-0078** (#923). **Additive, no behavior change** — this is PR 1 of 2; the wiring PR that changes `message` behavior follows and will `Closes #770`.

## What
- **`ops::discover_slack_bot_token`** — reads the workspace bot token from `<release>-secrets` (data key `slackBotToken`), mirroring the existing `discover_api_key` / `discover_valkey_password`. Empty/unreadable → actionable error; never printed.
- **`cli/src/slack.rs`** — a minimal Slack Web API client: `post_placeholder` → `chat.postMessage`, returning the created message `ts`, with a **pure, unit-tested** response parser (ok→ts, `ok:false`→error, missing ts→error) and the `SLACK_API_BASE_URL` stub override the worker's own sink already honours.

## Why (the design, briefly)
The connected-transport `message` path posts a **real** placeholder over the workspace bot token and enqueues the turn against its **real ts** — so the worker edits it in place and the approval card threads under it, all on the existing kernel/sink paths. That's what avoids a sacred-kernel change and a frozen-contract change (an empty-placeholder sentinel is a `packages/aci-protocol` `min_length=1` violation — see ADR-0078 Alternatives). These two primitives are the reusable pieces; the next PR wires them in.

## Verify
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the 4 new `slack::` unit tests all clean. No clap-surface change (no manifest regen).