### PR TITLE
message: post a real placeholder over the connected Slack transport

### DIFF
--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -609,6 +609,11 @@ enum MessageOutcomeOutput {
         diagnostics: Option<String>,
         resume_note: Option<String>,
     },
+    /// Connected-transport mode (#770/ADR-0078): the turn was enqueued and its
+    /// reply, approval card, and any resumed reply land in the connected Slack
+    /// workspace, not here. The CLI cannot observe a Slack-side reply, so it
+    /// confirms the enqueue and points the operator at the channel.
+    Enqueued { channel: String, thread: String },
 }
 
 impl crate::ui::CliOutput for MessageOutcomeOutput {
@@ -622,6 +627,11 @@ impl crate::ui::CliOutput for MessageOutcomeOutput {
                 message_awaiting_approval_json(thread, reply.as_deref())
             }
             MessageOutcomeOutput::TimedOut { .. } => message_timeout_json(),
+            MessageOutcomeOutput::Enqueued { channel, thread } => serde_json::json!({
+                "status": "enqueued",
+                "channel": channel,
+                "thread": thread,
+            }),
         }
     }
 
@@ -654,6 +664,13 @@ impl crate::ui::CliOutput for MessageOutcomeOutput {
                         ui.note(diag);
                     }
                 }
+            }
+            MessageOutcomeOutput::Enqueued { channel, thread } => {
+                ui.note(&format!(
+                    "enqueued; the agent is replying in {channel} (thread {thread}). \
+                     Watch Slack for the reply and any approval card -- in connected mode \
+                     the reply lands in the workspace, not here."
+                ));
             }
         }
     }
@@ -1303,6 +1320,117 @@ async fn resume_after_approval(
 }
 
 /// The shared target noun message handler.
+/// Resolve the target channel (and the sole-agent hint for resolve messages) for
+/// a cluster turn: an explicit `--channel`, else the sole deployed agent via a
+/// short-lived API port-forward (dropped once the lookup returns). Shared by the
+/// stub path and the connected-transport path.
+async fn resolve_cluster_channel(opts: &MessageOpts) -> Result<(String, Option<String>)> {
+    match opts.channel.as_deref() {
+        Some(channel) => Ok((channel.to_string(), None)),
+        None => {
+            let _api_pf = start_port_forward(
+                &port_forward_command(
+                    &opts.namespace,
+                    &opts.release,
+                    "api",
+                    opts.api_local_port,
+                    API_REMOTE_PORT,
+                ),
+                opts.api_local_port,
+                "api",
+            )
+            .await?;
+            let api = ApiClient::new(
+                &format!("http://localhost:{}", opts.api_local_port),
+                &opts.api_key,
+            )?;
+            let agents = api
+                .list_agents()
+                .await
+                .context("listing agents through the api port-forward")?;
+            let channel = select_channel(&agents, None)?;
+            Ok((channel, agents.first().map(|a| a.name.clone())))
+        }
+    }
+}
+
+/// The connected-transport `cluster message` path (#770/ADR-0078). A real Slack
+/// workspace is connected, so instead of a throwaway stub we post a real
+/// placeholder to the channel over the workspace bot token and enqueue the turn
+/// against its real ts with no per-turn endpoint. The worker then edits that
+/// message in place and the approval card threads under it -- the card and any
+/// resumed reply ride the connected transport. The CLI cannot observe a reply
+/// that lands in Slack, so it enqueues and points the operator there rather than
+/// waiting on a (nonexistent) stub.
+async fn message_connected(opts: MessageOpts) -> Result<()> {
+    let ui = crate::ui::ui();
+
+    // Valkey port-forward for the enqueue (killed on drop at fn end).
+    let _valkey_pf = start_port_forward(
+        &port_forward_command(
+            &opts.namespace,
+            &opts.release,
+            "valkey",
+            opts.valkey_local_port,
+            VALKEY_REMOTE_PORT,
+        ),
+        opts.valkey_local_port,
+        "valkey",
+    )
+    .await?;
+
+    let (channel, _agent_hint) = resolve_cluster_channel(&opts).await?;
+    ui.note(&format!(
+        "routing to channel {channel} over the connected Slack transport"
+    ));
+
+    // Bot token: explicit AGENTOS_SLACK_BOT_TOKEN override, else the release
+    // Secret. Never printed; used only to post the placeholder.
+    let bot_token = match std::env::var("AGENTOS_SLACK_BOT_TOKEN")
+        .ok()
+        .filter(|value| !value.is_empty())
+    {
+        Some(token) => token,
+        None => crate::ops::discover_slack_bot_token(&opts.namespace, &opts.release).await?,
+    };
+
+    let (channel, thread_ts, _synthetic) = resolve_targets(Some(&channel), opts.thread.as_deref());
+
+    // Post the real placeholder the worker edits in place; its ts anchors the
+    // turn (the approval card threads under it). No per-turn endpoint => the turn
+    // rides the worker's default (connected) transport, like a real mention.
+    let placeholder_ts = crate::slack::post_placeholder(&bot_token, &channel, "\u{2026}")
+        .await
+        .context("posting the placeholder to the connected Slack workspace")?;
+
+    let valkey_url = format!(
+        "redis://:{}@localhost:{}",
+        opts.valkey_password, opts.valkey_local_port
+    );
+    let mut conn = connect(&valkey_url).await?;
+    let event = synthetic_turn(
+        &channel,
+        &opts.user,
+        &opts.text,
+        &thread_ts,
+        &placeholder_ts,
+        None,
+    );
+    let stream_id = xadd(&mut conn, &opts.stream, &event).await?;
+    ui.note(&format!(
+        "enqueued {} on {} as {stream_id}",
+        event.event_id, opts.stream
+    ));
+
+    // The reply, approval card, and any resumed reply land in Slack, not here.
+    persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
+    ui.emit(&MessageOutcomeOutput::Enqueued {
+        channel,
+        thread: thread_ts,
+    });
+    Ok(())
+}
+
 pub async fn message(opts: MessageOpts) -> Result<()> {
     if opts.local {
         return message_local(opts).await;
@@ -1324,6 +1452,15 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     }
 
     require_on_path("kubectl")?;
+
+    // Connected-transport path (#770/ADR-0078): when a real workspace is
+    // connected (a running dispatcher), post a real placeholder and enqueue
+    // against its ts with no per-turn endpoint, so the approval card and any
+    // resumed reply ride the connected transport -- no throwaway stub. A kubectl
+    // failure reads as NOT connected, so this falls through to the stub path.
+    if crate::ops::dispatcher_connected(&opts.namespace, &opts.release).await {
+        return message_connected(opts).await;
+    }
 
     // Advertise a host the in-cluster worker can reach, then bind the stub on
     // 0.0.0.0 so it is reachable off-box. Take the URL from the started stub so an
@@ -1349,37 +1486,9 @@ pub async fn message(opts: MessageOpts) -> Result<()> {
     )
     .await?;
 
-    // Channel: explicit --channel, else the sole deployed agent via a short-lived
-    // API port-forward (dropped once the lookup returns). `agent_hint` carries the
-    // sole agent's name for a runnable approval-resolve hint, or `None` for an
-    // explicit --channel (rendered as an `<AGENT>` slot) (#766).
-    let (channel, agent_hint): (String, Option<String>) = match opts.channel.as_deref() {
-        Some(channel) => (channel.to_string(), None),
-        None => {
-            let _api_pf = start_port_forward(
-                &port_forward_command(
-                    &opts.namespace,
-                    &opts.release,
-                    "api",
-                    opts.api_local_port,
-                    API_REMOTE_PORT,
-                ),
-                opts.api_local_port,
-                "api",
-            )
-            .await?;
-            let api = ApiClient::new(
-                &format!("http://localhost:{}", opts.api_local_port),
-                &opts.api_key,
-            )?;
-            let agents = api
-                .list_agents()
-                .await
-                .context("listing agents through the api port-forward")?;
-            let channel = select_channel(&agents, None)?;
-            (channel, agents.first().map(|a| a.name.clone()))
-        }
-    };
+    // Channel: explicit --channel, else the sole deployed agent via a
+    // short-lived API port-forward (#766). Shared with the connected path.
+    let (channel, agent_hint) = resolve_cluster_channel(&opts).await?;
     ui.note(&format!("routing to channel {channel}"));
 
     // Enqueue the exact event the dispatcher would produce and wait for the ack.

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -474,6 +474,7 @@ pub fn dry_run_lines(opts: &MessageOpts, advertise_host: &str) -> Vec<String> {
          on stream {}",
         opts.stream
     ));
+    lines.push(connected_transport_dry_run_note());
     lines
 }
 
@@ -860,6 +861,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             format!("stub advertised at {reply_endpoint}"),
             channel_line,
             format!("enqueue a synthetic QueuedTurn on stream {}", opts.stream),
+            connected_transport_dry_run_note(),
         ];
         ui.emit(&MessageDryRunOutput {
             target: "local",
@@ -873,6 +875,35 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
 
     // Connect Valkey up front so a down stack fails fast, before the stub binds.
     let mut conn = connect(&valkey_url).await?;
+
+    // Connected-transport path (#770/ADR-0078): when a real workspace is wired up
+    // (`local comms --slack` set a genuine bot token, not the `xoxb-dev` stub
+    // sentinel), post a real placeholder and enqueue against its ts with no
+    // per-turn endpoint so the reply and any approval card ride that transport.
+    // Resolving the channel first keeps the behavior identical to the stub path.
+    if let Some(bot_token) = local_connected_bot_token() {
+        let channel = match opts.channel.as_deref() {
+            Some(channel) => channel.to_string(),
+            None => {
+                let api = ApiClient::new(&api_base, &opts.api_key)?;
+                let agents = api.list_agents().await.with_context(|| {
+                    format!("listing agents via {api_base} (is `curie local up` running?)")
+                })?;
+                select_channel(&agents, None)?
+            }
+        };
+        ui.note(&format!(
+            "routing to channel {channel} over the connected Slack transport"
+        ));
+        return enqueue_over_connected_transport(
+            &opts,
+            &mut conn,
+            TurnVerb::Local,
+            &channel,
+            &bot_token,
+        )
+        .await;
+    }
 
     // Bind the stub and advertise the reply endpoint so the compose worker can
     // reach it. Native-Linux host networking shares the host loopback, so bind
@@ -1320,6 +1351,98 @@ async fn resume_after_approval(
 }
 
 /// The shared target noun message handler.
+/// The local stub's sentinel bot token (`comms::LOCAL_SLACK_STUB_BOT_TOKEN`).
+/// `local comms --disconnect` restores this value, so seeing it means the compose
+/// dispatcher is wired to the local stub -- NOT a real workspace.
+const LOCAL_STUB_BOT_TOKEN: &str = "xoxb-dev";
+
+/// The workspace bot token that means "a real Slack workspace is connected" at
+/// local tier, or `None` when this is the stub/disconnected setup. Candidates are
+/// tried in precedence order (`CURIE_SLACK_BOT_TOKEN`, `SLACK_BOT_TOKEN`, the
+/// persisted secret); the first CONFIGURED one decides, and if that is the stub
+/// sentinel the answer is "not connected" rather than falling through to a
+/// staler value -- the effective config wins, so a deliberate `--disconnect`
+/// is never overridden by a leftover persisted token. Pure, so the precedence
+/// and the sentinel rejection are unit-testable without env or a secrets store.
+fn connected_local_bot_token(candidates: [Option<String>; 3]) -> Option<String> {
+    let configured = candidates
+        .into_iter()
+        .flatten()
+        .map(|token| token.trim().to_string())
+        .find(|token| !token.is_empty())?;
+    (configured != LOCAL_STUB_BOT_TOKEN).then_some(configured)
+}
+
+/// Process-level wrapper over [`connected_local_bot_token`] reading the real env
+/// and the persisted secret store (#749). A secrets-store read failure is treated
+/// as "absent" rather than fatal: it only means we fall back to the stub path.
+fn local_connected_bot_token() -> Option<String> {
+    let env_var = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
+    connected_local_bot_token([
+        env_var("CURIE_SLACK_BOT_TOKEN"),
+        env_var("SLACK_BOT_TOKEN"),
+        crate::secrets::get_value("SLACK_BOT_TOKEN").ok().flatten(),
+    ])
+}
+
+/// The human dry-run line noting that a connected workspace changes the plan
+/// (#770/ADR-0078). `--dry-run` never touches the network, so it cannot probe for
+/// a dispatcher; it states the conditional instead of guessing.
+fn connected_transport_dry_run_note() -> String {
+    "if a Slack workspace is connected, the plan changes: no stub is bound -- \
+     the CLI posts a real placeholder to the channel over the workspace bot token \
+     and enqueues against its ts with no per-turn endpoint, so the reply and any \
+     approval card ride the connected transport"
+        .to_string()
+}
+
+/// Post a real placeholder over the connected transport and enqueue the turn
+/// against its ts with NO per-turn endpoint (#770/ADR-0078), then report where the
+/// reply will land. Shared by both tiers: the caller supplies an open Valkey
+/// connection, the resolved channel, and the workspace bot token.
+///
+/// Because the placeholder is a real Slack message, the worker edits it in place
+/// and the requesting-channel approval card threads under it on the EXISTING
+/// kernel/sink paths -- no per-turn endpoint means the turn rides the worker's
+/// default (connected) transport, exactly like a real mention.
+async fn enqueue_over_connected_transport(
+    opts: &MessageOpts,
+    conn: &mut MultiplexedConnection,
+    verb: TurnVerb,
+    channel: &str,
+    bot_token: &str,
+) -> Result<()> {
+    let ui = crate::ui::ui();
+    let (channel, thread_ts, _synthetic_placeholder) =
+        resolve_targets(Some(channel), opts.thread.as_deref());
+
+    let placeholder_ts = crate::slack::post_placeholder(bot_token, &channel, "\u{2026}")
+        .await
+        .context("posting the placeholder to the connected Slack workspace")?;
+
+    let event = synthetic_turn(
+        &channel,
+        &opts.user,
+        &opts.text,
+        &thread_ts,
+        &placeholder_ts,
+        None,
+    );
+    let stream_id = xadd(conn, &opts.stream, &event).await?;
+    ui.note(&format!(
+        "enqueued {} on {} as {stream_id}",
+        event.event_id, opts.stream
+    ));
+
+    // The reply, approval card, and any resumed reply land in Slack, not here.
+    persist_and_hint(opts, verb, &channel, &thread_ts);
+    ui.emit(&MessageOutcomeOutput::Enqueued {
+        channel,
+        thread: thread_ts,
+    });
+    Ok(())
+}
+
 /// Resolve the target channel (and the sole-agent hint for resolve messages) for
 /// a cluster turn: an explicit `--channel`, else the sole deployed agent via a
 /// short-lived API port-forward (dropped once the lookup returns). Shared by the
@@ -1384,9 +1507,9 @@ async fn message_connected(opts: MessageOpts) -> Result<()> {
         "routing to channel {channel} over the connected Slack transport"
     ));
 
-    // Bot token: explicit AGENTOS_SLACK_BOT_TOKEN override, else the release
+    // Bot token: explicit CURIE_SLACK_BOT_TOKEN override, else the release
     // Secret. Never printed; used only to post the placeholder.
-    let bot_token = match std::env::var("AGENTOS_SLACK_BOT_TOKEN")
+    let bot_token = match std::env::var("CURIE_SLACK_BOT_TOKEN")
         .ok()
         .filter(|value| !value.is_empty())
     {
@@ -1394,41 +1517,13 @@ async fn message_connected(opts: MessageOpts) -> Result<()> {
         None => crate::ops::discover_slack_bot_token(&opts.namespace, &opts.release).await?,
     };
 
-    let (channel, thread_ts, _synthetic) = resolve_targets(Some(&channel), opts.thread.as_deref());
-
-    // Post the real placeholder the worker edits in place; its ts anchors the
-    // turn (the approval card threads under it). No per-turn endpoint => the turn
-    // rides the worker's default (connected) transport, like a real mention.
-    let placeholder_ts = crate::slack::post_placeholder(&bot_token, &channel, "\u{2026}")
-        .await
-        .context("posting the placeholder to the connected Slack workspace")?;
-
     let valkey_url = format!(
         "redis://:{}@localhost:{}",
         opts.valkey_password, opts.valkey_local_port
     );
     let mut conn = connect(&valkey_url).await?;
-    let event = synthetic_turn(
-        &channel,
-        &opts.user,
-        &opts.text,
-        &thread_ts,
-        &placeholder_ts,
-        None,
-    );
-    let stream_id = xadd(&mut conn, &opts.stream, &event).await?;
-    ui.note(&format!(
-        "enqueued {} on {} as {stream_id}",
-        event.event_id, opts.stream
-    ));
-
-    // The reply, approval card, and any resumed reply land in Slack, not here.
-    persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
-    ui.emit(&MessageOutcomeOutput::Enqueued {
-        channel,
-        thread: thread_ts,
-    });
-    Ok(())
+    enqueue_over_connected_transport(&opts, &mut conn, TurnVerb::Cluster, &channel, &bot_token)
+        .await
 }
 
 pub async fn message(opts: MessageOpts) -> Result<()> {
@@ -2974,6 +3069,57 @@ mod tests {
         assert_eq!(
             resolve_local_stub_binding(Some(String::new()), true),
             resolve_local_stub_binding(None, true),
+        );
+    }
+
+    #[test]
+    fn connected_local_bot_token_precedence_and_stub_sentinel() {
+        let t = |s: &str| Some(s.to_string());
+        // Precedence: CURIE_ override, then SLACK_BOT_TOKEN, then the secret.
+        assert_eq!(
+            connected_local_bot_token([t("xoxb-a"), t("xoxb-b"), t("xoxb-c")]).as_deref(),
+            Some("xoxb-a")
+        );
+        assert_eq!(
+            connected_local_bot_token([None, t("xoxb-b"), t("xoxb-c")]).as_deref(),
+            Some("xoxb-b")
+        );
+        assert_eq!(
+            connected_local_bot_token([None, None, t("xoxb-c")]).as_deref(),
+            Some("xoxb-c")
+        );
+        // Nothing configured -> not connected (stub path).
+        assert_eq!(connected_local_bot_token([None, None, None]), None);
+        // Empty is unset, not a token (#540's empty-is-unset rule).
+        assert_eq!(
+            connected_local_bot_token([t(""), t("  "), t("xoxb-c")]).as_deref(),
+            Some("xoxb-c")
+        );
+        // The stub sentinel means NOT connected -- and a deliberate --disconnect
+        // is never overridden by a staler persisted token further down the chain.
+        assert_eq!(
+            connected_local_bot_token([t(LOCAL_STUB_BOT_TOKEN), None, None]),
+            None
+        );
+        assert_eq!(
+            connected_local_bot_token([t(LOCAL_STUB_BOT_TOKEN), t("xoxb-real"), None]),
+            None
+        );
+        // Surrounding whitespace is trimmed off a real token.
+        assert_eq!(
+            connected_local_bot_token([t(" xoxb-real "), None, None]).as_deref(),
+            Some("xoxb-real")
+        );
+    }
+
+    #[test]
+    fn both_dry_run_plans_note_the_connected_transport_branch() {
+        // --dry-run never touches the network, so it cannot probe for a
+        // dispatcher; it must state the conditional instead (#770/ADR-0078).
+        let lines = dry_run_lines(&opts(Some("C123")), "10.1.2.3");
+        assert!(
+            lines.iter().any(|l| l.contains("no stub is bound")),
+            "cluster plan must note the connected branch: {lines:?}"
         );
     }
 

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -2216,6 +2216,32 @@ pub async fn discover_slack_bot_token(namespace: &str, release: &str) -> Result<
         })
 }
 
+/// Whether a `<release>-dispatcher` Deployment exists in `namespace` -- i.e. a
+/// real Slack workspace is connected (via `agentos cluster comms --slack`). In
+/// that case `cluster message` posts a real placeholder and routes the approval
+/// card + resumed reply over that connected transport rather than a throwaway
+/// stub (#770/ADR-0078). A kubectl failure (cluster unreachable, no such
+/// namespace) reads as NOT connected, so the caller safely falls back to the
+/// stub path instead of failing the whole command. `--ignore-not-found` makes an
+/// absent Deployment an empty success, so "connected" is exactly "non-empty
+/// output on a zero exit".
+pub async fn dispatcher_connected(namespace: &str, release: &str) -> bool {
+    let cmd = OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("-n"),
+            plain(namespace),
+            plain("get"),
+            plain("deployment"),
+            plain(format!("{release}-dispatcher")),
+            plain("--ignore-not-found"),
+            plain("-o"),
+            plain("name"),
+        ],
+    );
+    matches!(run_capture(&cmd).await, Ok((true, out, _)) if !out.trim().is_empty())
+}
+
 /// Read one data key out of a release's chart Secret, decoded server-side by
 /// kubectl's `base64decode` so the plaintext never lands in argv (#524). `None`
 /// when the Secret, the key, or the cluster is unreachable; the caller turns

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -2217,7 +2217,7 @@ pub async fn discover_slack_bot_token(namespace: &str, release: &str) -> Result<
 }
 
 /// Whether a `<release>-dispatcher` Deployment exists in `namespace` -- i.e. a
-/// real Slack workspace is connected (via `agentos cluster comms --slack`). In
+/// real Slack workspace is connected (via `curie cluster comms --slack`). In
 /// that case `cluster message` posts a real placeholder and routes the approval
 /// card + resumed reply over that connected transport rather than a throwaway
 /// stub (#770/ADR-0078). A kubectl failure (cluster unreachable, no such

--- a/cli/src/queue.rs
+++ b/cli/src/queue.rs
@@ -432,6 +432,20 @@ mod tests {
     }
 
     #[test]
+    fn synthetic_turn_omits_the_endpoint_for_the_connected_transport() {
+        // #770/ADR-0078: the connected-transport path posts a REAL placeholder and
+        // enqueues against its ts with NO per-turn endpoint, so the turn rides the
+        // worker's default (connected) transport -- exactly like a real mention.
+        let turn = synthetic_turn("C-real", "U-agentos-chat", "hi", "1.1", "1717.42", None);
+        assert!(turn.reply_handle.endpoint.is_none());
+        // The placeholder is the real Slack ts we posted, not a stub-minted one.
+        assert_eq!(turn.reply_handle.placeholder, "1717.42");
+        let value: serde_json::Value = serde_json::from_str(&payload_json(&turn).unwrap()).unwrap();
+        assert!(value["reply_handle"]["endpoint"].is_null());
+        assert_eq!(value["reply_handle"]["placeholder"], "1717.42");
+    }
+
+    #[test]
     fn synthetic_ids_are_distinct_and_slack_shaped() {
         let (thread_ts, placeholder_ts) = synthetic_thread_and_placeholder();
         assert_ne!(thread_ts, placeholder_ts);

--- a/cli/src/queue.rs
+++ b/cli/src/queue.rs
@@ -436,7 +436,7 @@ mod tests {
         // #770/ADR-0078: the connected-transport path posts a REAL placeholder and
         // enqueues against its ts with NO per-turn endpoint, so the turn rides the
         // worker's default (connected) transport -- exactly like a real mention.
-        let turn = synthetic_turn("C-real", "U-agentos-chat", "hi", "1.1", "1717.42", None);
+        let turn = synthetic_turn("C-real", "U-curie-chat", "hi", "1.1", "1717.42", None);
         assert!(turn.reply_handle.endpoint.is_none());
         // The placeholder is the real Slack ts we posted, not a stub-minted one.
         assert_eq!(turn.reply_handle.placeholder, "1717.42");

--- a/docs/adr/0078-approval-cards-over-connected-transport.md
+++ b/docs/adr/0078-approval-cards-over-connected-transport.md
@@ -36,6 +36,14 @@ change across a sacred boundary, not a passenger on the offline fix:
 
 ## Decision
 
+> **Mechanism superseded by ADR-0082.** The empty-`reply_handle.placeholder`
+> sentinel below cannot work: `ApprovalRequest.reply_placeholder` is
+> `min_length=1` in the frozen `packages/aci-protocol`, so such a turn is
+> rejected at approval-create and the pause escalates instead of posting a card.
+> ADR-0082 keeps this ADR's intent (the connected transport is the approval
+> surface) and replaces the mechanism: the CLI posts a REAL placeholder and
+> enqueues against its ts, needing no kernel or wire change.
+
 **When `message` runs against a connected transport (a running dispatcher),
 route the approval card and the resumed reply over the worker's default Slack
 transport instead of the throwaway stub.**

--- a/docs/adr/0082-connected-transport-approval-cards-via-a-real-placeholder.md
+++ b/docs/adr/0082-connected-transport-approval-cards-via-a-real-placeholder.md
@@ -1,0 +1,94 @@
+# 82. Connected-transport approval cards ride a real CLI-posted placeholder
+
+Date: 2026-07-24
+
+Status: Accepted
+
+## Context
+
+ADR-0078 adopted routing message-driven approval cards through the connected
+Slack transport (issue #770), and specified the mechanism as: the CLI enqueues
+with **no reply endpoint and an empty `reply_handle.placeholder`**, and the
+worker (kernel + `slack_sink`) recognizes that empty-placeholder sentinel and
+posts **top-level** instead of editing a placeholder. It called that a
+sacred-kernel change requiring an `in_requesting_channel` rework.
+
+Implementing it proved that mechanism **cannot work**: an empty placeholder is a
+**frozen-contract violation**. `packages/aci-protocol`'s `ApprovalRequest`
+constrains `reply_placeholder` to `min_length=1` (its test suite states the
+intent: "ApprovalRequest string fields min_length=1 (adopt the API's strict
+side)"). A turn carrying an empty placeholder is therefore rejected at
+approval-create, and the kernel's pause path **escalates instead of posting a
+card** — the exact opposite of #770's goal. This was caught by a kernel test
+written against the sentinel design, before any of it shipped.
+
+Representing "no placeholder" on the wire would mean an ACI protocol change
+(`PROTOCOL_VERSION` bump, `wire.lock`, regenerated Rust + TS), raised as a
+contract gap per AGENTS.md, **plus** the sacred-kernel rework. Both, to avoid
+posting one Slack message.
+
+## Decision
+
+**In connected mode the CLI posts a REAL placeholder message over the connected
+transport and enqueues the turn against that real `ts`.** No sentinel, no wire
+change, no kernel change.
+
+- `local`/`cluster message` detect a connected workspace — at cluster tier a
+  `<release>-dispatcher` Deployment (`ops::dispatcher_connected`), at local tier
+  a genuine `SLACK_BOT_TOKEN` rather than the `xoxb-dev` stub sentinel — and skip
+  minting the in-process stub.
+- They discover the workspace bot token (`CURIE_SLACK_BOT_TOKEN`, else the
+  release Secret's `slackBotToken` at cluster tier / the persisted secret at
+  local tier), `chat.postMessage` a real placeholder to the target channel, and
+  enqueue with `reply_handle.placeholder` = that real `ts` and
+  `reply_handle.endpoint` = `None`.
+- The turn is then **indistinguishable from a dispatcher-originated one**, so the
+  existing paths already do the right thing: the worker edits the real
+  placeholder in place over its default (connected) transport, the
+  requesting-channel approval card threads under it, and a resumed reply — even
+  long after the CLI exited — edits that same real message, because a real `ts`
+  supports `chat.update`.
+- The CLI cannot observe a reply that lands in Slack, so it reports the enqueue
+  and points the operator at the channel rather than waiting on a stub.
+- The zero-Slack path (ADR-0063) is untouched: with no connected workspace the
+  stub is still minted and kept alive exactly as today.
+
+**This supersedes ADR-0078's mechanism** (its empty-placeholder sentinel, its
+top-level-post rule, and its sacred-kernel `in_requesting_channel` rework).
+ADR-0078's *intent* — the connected transport is the durable, clickable approval
+surface, superseding ADR-0063's deferral of it — stands unchanged and is carried
+forward here.
+
+## Consequences
+
+- **The change is CLI-only** (`cli/src/message.rs`, `cli/src/slack.rs`,
+  `cli/src/ops.rs`). The kernel, `slack_sink`, and the ACI wire are untouched — a
+  far smaller blast radius, and it needs no sacred-module review or contract-gap
+  escalation.
+- **The CLI now holds a workspace bot token** in connected mode, discovered the
+  same masked way as the other release credentials and used only to post the
+  placeholder; it is never printed.
+- **One extra Slack API call per connected turn** (the placeholder post). That is
+  the whole cost of avoiding a wire + kernel change.
+- **A connected turn's reply is not visible in the CLI.** `message` confirms the
+  enqueue and names the channel; `--dry-run` states the conditional (it cannot
+  probe for a dispatcher without touching the network).
+- **Real-Slack E2E is the acceptance gate**: unit tests cover detection,
+  precedence, the dry-run plan, and the endpoint-less enqueue shape, but only a
+  connected workspace proves the card renders, threads, resolves on click, and
+  that the resumed reply edits the placeholder.
+
+## Alternatives considered
+
+1. **ADR-0078's empty-placeholder sentinel.** Rejected on a hard blocker: the
+   frozen `min_length=1` constraint above means the pause escalates instead of
+   posting a card. Would require an ACI wire change plus a sacred-kernel rework.
+2. **Add an optional "no placeholder" field to `ReplyHandle`.** The honest
+   version of alternative 1 — but still a frozen-contract change
+   (`PROTOCOL_VERSION` bump + regen + contract-gap escalation) and still needs the
+   kernel to learn a second reply mode. Posting one message from the CLI achieves
+   the same outcome with neither.
+3. **Keep the stub in connected mode and forward its replies into Slack.** Adds a
+   CLI-resident relay for messages the workspace can already deliver itself, and
+   leaves the resumed-reply-after-exit case broken (the stub dies with the
+   process) — the very failure #770 exists to fix.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -111,4 +111,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0079 | [Inbound triggers as a new event kind, ingested by the API](0079-inbound-triggers-as-a-new-event-kind.md) | Proposed |
 | 0080 | [Rename the project to Curie](0080-rename-to-curie.md) | Accepted |
 | 0081 | [A nightly graded parity ladder verifies the real-model promise CI cannot](0081-nightly-graded-parity-ladder.md) | Accepted |
+| 0082 | [Connected-transport approval cards ride a real CLI-posted placeholder](0082-connected-transport-approval-cards-via-a-real-placeholder.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Closes #770. Rebased onto the Curie rename; **code-complete**, with the real-Slack E2E as the remaining acceptance gate before merge.

Follows **ADR-0082** (in this PR), which supersedes ADR-0078's *mechanism* — see below.

## What
When a real Slack workspace is connected, `message` skips the throwaway stub and instead **posts a real placeholder over that transport**, enqueuing the turn against its **real `ts`** with **no per-turn endpoint**:

- **Detection** — cluster: a `<release>-dispatcher` Deployment (`ops::dispatcher_connected`, kubectl failure ⇒ "not connected", so it safely falls back). local: a genuine `SLACK_BOT_TOKEN` rather than the `xoxb-dev` stub sentinel `local comms --disconnect` restores.
- **Token** — `CURIE_SLACK_BOT_TOKEN`, else the release Secret's `slackBotToken` (cluster) / the persisted secret (local). Never printed.
- **Shared path** — one `enqueue_over_connected_transport` for both tiers, so they can't drift.
- **Outcome** — the turn is indistinguishable from a dispatcher-originated one, so the **existing** kernel/sink paths already edit the real placeholder in place, thread the approval card under it, and let a resumed reply `chat.update` it long after the CLI exited. The CLI reports the enqueue and names the channel (`MessageOutcomeOutput::Enqueued`).
- **Dry-run** — both plans state the connected-transport conditional (dry-run never touches the network, so it can't probe for a dispatcher).

## Why ADR-0082 supersedes 0078's mechanism
ADR-0078 merged (#923) **38 minutes before my pivot commit existed**, so main documents the empty-`reply_handle.placeholder` sentinel — which **cannot work**: `ApprovalRequest.reply_placeholder` is `min_length=1` in the frozen `packages/aci-protocol`, so such a turn is rejected at approval-create and the pause **escalates instead of posting a card** (a kernel test caught this before anything shipped). ADR-0082 keeps 0078's intent and records the mechanism that works, with a pointer added at 0078's Decision. Net effect: **no sacred-kernel change and no frozen-contract change** — the whole feature is CLI-only.

## Rebase note (a real bug it surfaced)
The Curie rename didn't sweep this unmerged branch, so the code read `AGENTOS_SLACK_BOT_TOKEN` while the already-merged error message says `CURIE_SLACK_BOT_TOKEN` — the override could never have matched. Fixed.

## Safety
Zero-Slack behavior is unchanged: with no connected workspace, the stub path runs exactly as today.

## Verify
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, **520 lib tests** (2 new: bot-token precedence/sentinel rejection, and the dry-run note), plus `scripts/check-docs.sh` clean (the #521 uniqueness gate caught an ADR number collision — renumbered 0080 → 0082).

## E2E gate (your throwaway app)
`message` a turn that trips an approval gate against the connected workspace: the placeholder posts, the card renders **threaded under it**, a click resolves, and the resumed reply edits the placeholder. Tell me what you see and I'll iterate.