### PR TITLE
Cap behavior-packs content size, reject oversized writes with 413

### DIFF
--- a/apps/api/src/agentos_api/config.py
+++ b/apps/api/src/agentos_api/config.py
@@ -219,6 +219,12 @@ class Settings(BaseSettings):
     # namespace are both bounded. Sizes are the serialized-JSON byte length.
     state_max_value_bytes: int = 64 * 1024  # 64 KiB per value
     state_max_namespace_bytes: int = 1024 * 1024  # 1 MiB per (agent, namespace)
+    # Cap on behavior-packs content per agent (#936, introduced by #883). Packs
+    # are stored on the agent row and injected verbatim into the runner context
+    # at each bind, so an uncapped pack bloats both the row and the prompt. Size
+    # is the serialized-JSON byte length of the whole packs config, mirroring the
+    # durable-state per-value cap above.
+    behavior_packs_max_bytes: int = 64 * 1024  # 64 KiB
     # Per-agent cap on the NUMBER of namespaces (#852). #840 made the namespace an
     # arbitrary model-supplied string, so without this a single sandbox could
     # create unbounded namespaces -- each under the byte caps -- bloating the

--- a/apps/api/src/agentos_api/routers/agents.py
+++ b/apps/api/src/agentos_api/routers/agents.py
@@ -19,6 +19,7 @@ from ..schemas import (
     BundleFiles,
     VersionCreate,
     VersionOut,
+    enforce_behavior_packs_size,
 )
 
 router = APIRouter(
@@ -78,6 +79,9 @@ def classify_integrity_error(exc: IntegrityError) -> tuple[int, str] | None:
 
 @router.post("", response_model=AgentOut, status_code=status.HTTP_201_CREATED)
 async def create_agent(data: AgentCreate, session: SessionDep) -> AgentOut:
+    # Reject oversized behavior packs (#936) before we touch the DB.
+    if data.behavior_packs is not None:
+        enforce_behavior_packs_size(data.behavior_packs)
     # name and repo_full_name are unique. A collision is a caller conflict (409),
     # not a server fault: catch the DB IntegrityError and map it, rather than
     # letting it bubble as an opaque 500. A non-unique violation (NOT NULL, FK)

--- a/apps/api/src/agentos_api/routers/control.py
+++ b/apps/api/src/agentos_api/routers/control.py
@@ -21,6 +21,7 @@ from ..schemas import (
     CostReport,
     KillState,
     ThreadResetState,
+    enforce_behavior_packs_size,
 )
 
 router = APIRouter(
@@ -160,6 +161,7 @@ async def put_behavior_packs(
     agent_id: uuid.UUID, config: BehaviorPacksConfig, session: SessionDep
 ) -> BehaviorPacksConfig:
     agent = await _load_agent(session, agent_id)
+    enforce_behavior_packs_size(config)
     updated = await crud.update_behavior_packs(session, agent, config.model_dump())
     return BehaviorPacksConfig.model_validate(updated.behavior_packs)
 

--- a/apps/api/src/agentos_api/schemas.py
+++ b/apps/api/src/agentos_api/schemas.py
@@ -1,5 +1,6 @@
 """Pydantic v2 request/response models for the API surface."""
 
+import json
 import re
 import uuid
 from datetime import datetime
@@ -11,6 +12,7 @@ from typing import Annotated, Any, Literal
 # ``ApprovalCreate``; ``EvalReport`` kept its name.
 from aci_protocol import ApprovalRequest as ApprovalRequest
 from aci_protocol import EvalReport as EvalReport
+from fastapi import HTTPException
 from plugin_format import is_reserved_boot_env_name
 from pydantic import (
     BaseModel,
@@ -22,6 +24,7 @@ from pydantic import (
     model_validator,
 )
 
+from .config import get_settings
 from .models import Environment
 
 # Slack channel IDs start with C (public/private channel), D (DM), or G (legacy
@@ -139,6 +142,24 @@ class BehaviorPacksConfig(BaseModel):
     help: HelpPackConfig = HelpPackConfig()
     settings: SettingsPackConfig = SettingsPackConfig()
     nav: NavPackConfig = NavPackConfig()
+
+
+def enforce_behavior_packs_size(config: BehaviorPacksConfig) -> None:
+    """Reject a behavior-packs write over the per-agent byte cap (#936).
+
+    Shared by both write paths (the PUT and the create) so the cap is a
+    property of the config, not of one endpoint. Size is the serialized-JSON
+    byte length of the whole config, the unit ``behavior_packs_max_bytes`` is
+    measured in (mirrors the durable-state ``_enforce_caps`` in state.py)."""
+    limit = get_settings().behavior_packs_max_bytes
+    size = len(
+        json.dumps(config.model_dump(), separators=(",", ":")).encode("utf-8")
+    )
+    if size > limit:
+        raise HTTPException(
+            413,
+            f"behavior packs are {size} bytes, over the {limit}-byte cap",
+        )
 
 
 def _validate_tool_names(value: list[str] | None) -> list[str] | None:

--- a/apps/api/tests/test_behavior_packs_size_cap.py
+++ b/apps/api/tests/test_behavior_packs_size_cap.py
@@ -1,0 +1,125 @@
+"""Behavior-packs content is size-capped (NOT YET IMPLEMENTED).
+
+A write whose serialized behavior-packs JSON exceeds `Settings.
+behavior_packs_max_bytes` (default 64 KiB) must be rejected with 413, on BOTH
+write paths: `PUT /agents/{id}/behavior-packs` and `POST /agents` create (when
+the create body includes `behavior_packs`). Mirrors the already-implemented
+`state_max_value_bytes` cap (`routers/state.py`'s `_enforce_caps`), which
+measures `len(json.dumps(value, separators=(",", ":")).encode("utf-8"))`.
+
+These tests currently FAIL (200/201 instead of 413) until the cap is added.
+"""
+
+from typing import Any
+
+from agentos_api.config import get_settings
+
+
+def _create_agent(client: Any, auth_headers: dict[str, str], **body: Any) -> dict[str, Any]:
+    resp = client.post(
+        "/agents",
+        json={"name": "packs-bot", "slack_channel": "C000PACKS1", **body},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()  # type: ignore[no-any-return]
+
+
+def _oversized_greeting_reply(default_cap_bytes: int = 64 * 1024) -> dict[str, Any]:
+    """A behavior-packs body whose serialized JSON clearly exceeds the default
+    64 KiB cap: an oversized `greeting.reply` string is the easiest lever."""
+    return {
+        "greeting": {
+            "enabled": True,
+            "phrases": ["hi"],
+            "reply": "x" * (default_cap_bytes + 1024),
+        }
+    }
+
+
+def test_put_oversized_behavior_packs_rejected_413(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers)
+    resp = client.put(
+        f"/agents/{agent['id']}/behavior-packs",
+        json=_oversized_greeting_reply(),
+        headers=auth_headers,
+    )
+    assert resp.status_code == 413, resp.text
+
+
+def test_create_agent_with_oversized_behavior_packs_rejected_413(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    resp = client.post(
+        "/agents",
+        json={
+            "name": "packs-bot-oversized",
+            "slack_channel": "C000PACKS2",
+            "behavior_packs": _oversized_greeting_reply(),
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 413, resp.text
+
+
+def test_put_behavior_packs_within_cap_ok(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent = _create_agent(client, auth_headers)
+    # Non-trivial (a few KB) but comfortably under the 64 KiB default cap, so a
+    # correctly-sized cap must not false-positive reject it.
+    config = {
+        "load": {"enabled": True, "lines": ["Working on it!"] * 20},
+        "tips": {"enabled": True, "tips": ["Ask me for the top 5"] * 20},
+        "greeting": {
+            "enabled": True,
+            "phrases": ["hey", "hello"],
+            "reply": "hello! " * 200,
+        },
+        "help": {"enabled": True, "phrases": ["help"], "reply": "here is help"},
+        "nav": {"enabled": True, "hub_label": "Help", "hub_command": "help"},
+    }
+    resp = client.put(
+        f"/agents/{agent['id']}/behavior-packs", json=config, headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = client.get(f"/agents/{agent['id']}/behavior-packs", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    got = resp.json()
+    assert got["load"]["lines"] == ["Working on it!"] * 20
+    assert got["greeting"]["reply"] == "hello! " * 200
+    assert got["nav"]["hub_command"] == "help"
+
+
+def test_put_behavior_packs_boundary_of_small_overridden_cap(
+    client: Any, auth_headers: dict[str, str], clean_db: None, monkeypatch: Any
+) -> None:
+    """Override the cap to a small value so the test does not depend on the
+    64 KiB default magnitude: a body over the small cap is 413, a body under
+    it is accepted. `get_settings` is `lru_cache`-d, so the cache must be
+    cleared after the env var change (and restored on teardown) or the
+    override never takes effect / leaks into other tests.
+    """
+    monkeypatch.setenv("BEHAVIOR_PACKS_MAX_BYTES", "1000")
+    get_settings.cache_clear()
+    try:
+        agent = _create_agent(client, auth_headers)
+
+        # Comfortably under the 1000-byte cap (serialized total ~870 bytes).
+        under = {"greeting": {"enabled": True, "phrases": [], "reply": "a" * 600}}
+        resp = client.put(
+            f"/agents/{agent['id']}/behavior-packs", json=under, headers=auth_headers
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Comfortably over the 1000-byte cap (serialized total ~1170 bytes).
+        over = {"greeting": {"enabled": True, "phrases": [], "reply": "a" * 900}}
+        resp = client.put(
+            f"/agents/{agent['id']}/behavior-packs", json=over, headers=auth_headers
+        )
+        assert resp.status_code == 413, resp.text
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
Behavior-packs content (greeting / tips / nav / help / settings) is stored on the agent row and injected verbatim into the runner context at each bind. The console behavior-packs PUT (#883) accepted arbitrarily large pack content with no size cap, so a multi-megabyte pack bloated both the row and the prompt with no bound (a self-inflicted, operator-authenticated DoS).

## Change
- New `behavior_packs_max_bytes` setting (default 64 KiB, mirroring the durable-state `state_max_value_bytes` per-value cap).
- Shared `enforce_behavior_packs_size` helper measures the serialized-JSON byte length of the whole packs config and raises 413 when over the cap.
- Enforced on both write paths: `PUT /agents/{id}/behavior-packs` and the sibling `POST /agents` create path.

## Review
- code-reviewer: APPROVE, 0 blocking
- scope-creep-reviewer: 0 orphan hunks
- security-reviewer: 0 blocking, confirmed no bypass path and correct pre-persist ordering
- Codex (execution pass): approved, ran tests/ruff/mypy green

## Done-check
- [x] Tests present and green (4 size-cap tests; full apps/api suite 437 passed, the one failure is a pre-existing Langfuse-env test unrelated to this change)
- [x] Guard demonstrated executing: oversized PUT and create both return 413
- [x] Sibling-path parity: both write paths routed through the shared helper; PATCH/`AgentUpdate` has no `behavior_packs`; bundle/git-flow never set it
- [x] Lint clean (ruff + mypy); OpenAPI drift clean (runtime 413, no schema change)

## Follow-up (out of scope)
The console UI (`apps/ui/.../WiredAgentBehaviorPacks.tsx`) does not yet surface the new 413 gracefully; worth a separate issue.

Closes #936
