### PR TITLE
Detect a value-type change in the OTel schema drift gate

### DIFF
--- a/runner/schema/otel-attributes.schema.json
+++ b/runner/schema/otel-attributes.schema.json
@@ -1,22 +1,22 @@
 {
   "$id": "https://schemas.agentos.dev/runner/otel-attributes/v1.json",
   "schema_version": "v1",
-  "keys": [
-    "agentos.sandbox_id",
-    "agentos.session_id",
-    "gen_ai.approval.decision",
-    "gen_ai.operation.name",
-    "gen_ai.request.model",
-    "gen_ai.tool.name",
-    "gen_ai.usage.cache_creation_input_tokens",
-    "gen_ai.usage.cache_read_input_tokens",
-    "gen_ai.usage.input_tokens",
-    "gen_ai.usage.output_tokens",
-    "langfuse.session.id",
-    "langfuse.trace.name",
-    "langfuse.user.id",
-    "model",
-    "schema.version",
-    "service.name"
-  ]
+  "keys": {
+    "agentos.sandbox_id": "str",
+    "agentos.session_id": "str",
+    "gen_ai.approval.decision": "str",
+    "gen_ai.operation.name": "str",
+    "gen_ai.request.model": "str",
+    "gen_ai.tool.name": "str",
+    "gen_ai.usage.cache_creation_input_tokens": "int",
+    "gen_ai.usage.cache_read_input_tokens": "int",
+    "gen_ai.usage.input_tokens": "int",
+    "gen_ai.usage.output_tokens": "int",
+    "langfuse.session.id": "str",
+    "langfuse.trace.name": "str",
+    "langfuse.user.id": "str",
+    "model": "str",
+    "schema.version": "str",
+    "service.name": "str"
+  }
 }

--- a/runner/src/agentos_runner/otel.py
+++ b/runner/src/agentos_runner/otel.py
@@ -20,6 +20,8 @@ Per ADR-0076, every attribute this module attaches comes from the closed
 with an unlisted key is a construction-time error, not a silent addition to the
 wire shape. ``SCHEMA_VERSION`` is bumped only when a key is removed, renamed, or
 changes value type; a new optional key is additive and does not bump it.
+``SPAN_ATTRIBUTE_VALUE_TYPES`` declares each key's value type, the mirror the
+drift gate diffs to catch a retype.
 """
 
 from __future__ import annotations
@@ -77,6 +79,34 @@ class SpanAttributeKey(StrEnum):
     AGENTOS_SESSION_ID = "agentos.session_id"
     AGENTOS_SANDBOX_ID = "agentos.sandbox_id"
     SCHEMA_VERSION_KEY = "schema.version"
+
+
+# ADR-0076 decision 2: a value-type change to an existing key is a breaking,
+# version-bump-worthy change exactly like a remove or rename, so it needs its
+# own source of truth to diff against -- the type half of the closed schema,
+# parallel to ``SpanAttributeKey`` being the key half. Every member above must
+# appear here exactly once, mapped to its value-type name ("str" or "int");
+# the ``gen_ai.usage.*`` token counts are the only "int" members (see
+# ``record_usage`` below and ``redact.py``'s "only str and int attributes are
+# set today").
+SPAN_ATTRIBUTE_VALUE_TYPES: Mapping[SpanAttributeKey, str] = {
+    SpanAttributeKey.TRACE_NAME: "str",
+    SpanAttributeKey.SESSION_ID: "str",
+    SpanAttributeKey.USER_ID: "str",
+    SpanAttributeKey.APPROVAL_DECISION: "str",
+    SpanAttributeKey.REQUEST_MODEL: "str",
+    SpanAttributeKey.MODEL: "str",
+    SpanAttributeKey.USAGE_INPUT_TOKENS: "int",
+    SpanAttributeKey.USAGE_OUTPUT_TOKENS: "int",
+    SpanAttributeKey.USAGE_CACHE_READ_INPUT_TOKENS: "int",
+    SpanAttributeKey.USAGE_CACHE_CREATION_INPUT_TOKENS: "int",
+    SpanAttributeKey.TOOL_NAME: "str",
+    SpanAttributeKey.OPERATION_NAME: "str",
+    SpanAttributeKey.SERVICE_NAME: "str",
+    SpanAttributeKey.AGENTOS_SESSION_ID: "str",
+    SpanAttributeKey.AGENTOS_SANDBOX_ID: "str",
+    SpanAttributeKey.SCHEMA_VERSION_KEY: "str",
+}
 
 
 # The ``usage`` mapping's own field names (SDK wire shape) to the span attribute

--- a/runner/tests/test_otel_schema_drift.py
+++ b/runner/tests/test_otel_schema_drift.py
@@ -5,27 +5,31 @@ Mirrors ADR-0074's committed-artifact-plus-CI-gate discipline for the CLI's
 (``otel.py``) is the single source of truth in code, this file's committed
 mirror (``runner/schema/otel-attributes.schema.json``) is the reviewed
 artifact, and the tests below fail loudly if the two diverge -- catching a
-new attribute key (or a bumped ``SCHEMA_VERSION``) that lands without an
-accompanying schema update. A real emitted-attribute contract test closes the
-loop by proving a live run's span attributes never escape the committed set.
+new attribute key, a bumped ``SCHEMA_VERSION``, or a value-TYPE change to an
+existing key (ADR-0076 decision 2; #934) that lands without an accompanying
+schema update. A real emitted-attribute contract test closes the loop by
+proving a live run's span attributes never escape the committed set, and
+that each emitted value's runtime type matches what was committed.
 
 Regenerate the committed file after a deliberate schema change by running, from
-the repo root: import ``json``, ``SCHEMA_VERSION`` and ``SpanAttributeKey``
-from ``agentos_runner.otel``, then write
-``{"id": "https://schemas.agentos.dev/runner/otel-attributes/v1.json",
-"schema_version": SCHEMA_VERSION, "keys": sorted(m.value for m in
-SpanAttributeKey)}`` as indented JSON to
-``runner/schema/otel-attributes.schema.json``.
+the repo root: import ``json``, ``SCHEMA_VERSION``, ``SpanAttributeKey``, and
+``SPAN_ATTRIBUTE_VALUE_TYPES`` from ``agentos_runner.otel``, then write
+``{"$id": "https://schemas.agentos.dev/runner/otel-attributes/v1.json",
+"schema_version": SCHEMA_VERSION, "keys": {member.value:
+SPAN_ATTRIBUTE_VALUE_TYPES[member] for member in sorted(SpanAttributeKey,
+key=lambda m: m.value)}}`` as indented JSON to
+``runner/schema/otel-attributes.schema.json`` (keys sorted by name for a
+stable diff).
 """
 
 import json
 from pathlib import Path
 
 import anyio
-from aci_protocol import Event
-from agentos_runner import RunTracer, SideEffectClassifier
+from aci_protocol import Event, OtelConfig
+from agentos_runner import RunTracer, SideEffectClassifier, build_tracer_provider
 from agentos_runner.fake import FakeModelSession
-from agentos_runner.otel import SCHEMA_VERSION, SpanAttributeKey
+from agentos_runner.otel import SCHEMA_VERSION, SPAN_ATTRIBUTE_VALUE_TYPES, SpanAttributeKey
 from agentos_runner.session import SessionRunner
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -38,14 +42,47 @@ def _committed_schema() -> dict:
     return json.loads(_SCHEMA_PATH.read_text())
 
 
+def _assert_value_type(committed: dict, key: str, value: object, where: str = "") -> None:
+    """Assert an emitted attribute's runtime type matches the committed type.
+
+    redact_span_attribute (redact.py:152-164) scrubs strings but passes every
+    other value through untouched, so a committed ``"int"`` key (the
+    ``gen_ai.usage.*`` token counts) stays an int on the wire -- this checks the
+    type actually emitted, catching a call-site retype (e.g. emitting ``model``
+    as an int) that forgot to update the declaration, not merely the type
+    redaction happened to preserve.
+    """
+    expected_type = committed[key]
+    assert type(value).__name__ == expected_type, (
+        f"{where}attribute {key!r} emitted as {type(value).__name__!r} but the "
+        f"committed schema declares {expected_type!r}"
+    )
+
+
 def test_committed_schema_matches_the_enum() -> None:
-    committed_keys = set(_committed_schema()["keys"])
-    code_keys = {member.value for member in SpanAttributeKey}
+    committed_keys = _committed_schema()["keys"]
+    code_keys = {member.value: SPAN_ATTRIBUTE_VALUE_TYPES[member] for member in SpanAttributeKey}
     assert code_keys == committed_keys, (
         "SpanAttributeKey (otel.py) and the committed schema "
-        f"({_SCHEMA_PATH}) have diverged -- a key was added or removed on one "
-        "side but not the other. Regenerate the committed file (see this "
-        "module's docstring) and commit it alongside the code change."
+        f"({_SCHEMA_PATH}) have diverged -- a key was added, removed, or "
+        "RETYPED on one side but not the other (a retyped value, e.g. an "
+        "attribute switching from str to int, trips this gate too). "
+        "Regenerate the committed file (see this module's docstring) and "
+        "commit it alongside the code change."
+    )
+
+
+def test_declared_value_types_cover_exactly_the_enum() -> None:
+    # Forces a new SpanAttributeKey member to also declare its value type,
+    # and forces every declared type to stay within the two types the runner
+    # actually emits today (see redact.py:152-164).
+    assert set(SPAN_ATTRIBUTE_VALUE_TYPES) == set(SpanAttributeKey), (
+        "SPAN_ATTRIBUTE_VALUE_TYPES (otel.py) must declare a value type for "
+        "every SpanAttributeKey member, no more and no fewer."
+    )
+    assert set(SPAN_ATTRIBUTE_VALUE_TYPES.values()) <= {"str", "int"}, (
+        "SPAN_ATTRIBUTE_VALUE_TYPES values must be one of {'str', 'int'} -- "
+        "the only value types the runner emits today."
     )
 
 
@@ -63,8 +100,12 @@ def test_a_real_run_only_emits_attributes_within_the_committed_schema() -> None:
     # The contract half: proves the enum's closure actually holds on the wire,
     # not just in the committed inventory. Drives a real turn (permission gate
     # + tool call + usage, the FakeModelSession default script) and asserts
-    # every attribute key on every emitted span is in the committed set.
-    committed_keys = set(_committed_schema()["keys"])
+    # every attribute key on every emitted span is in the committed set, and
+    # that each emitted value's runtime type matches the committed type for
+    # its key -- catching a call-site retype (e.g. emitting `model` as an int)
+    # that forgot to update the declaration.
+    committed = _committed_schema()["keys"]
+    committed_keys = set(committed)
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
@@ -94,3 +135,61 @@ def test_a_real_run_only_emits_attributes_within_the_committed_schema() -> None:
             f"span {span.name!r} emitted attribute key(s) outside the "
             f"committed schema: {emitted_keys - committed_keys}"
         )
+        for key, value in span.attributes.items():
+            _assert_value_type(committed, key, value, f"span {span.name!r} ")
+
+
+def test_every_declared_key_emits_its_committed_value_type() -> None:
+    # The real-run contract test above only exercises 9 of the 16 declared keys
+    # (the FakeModelSession default script never threads a session/sandbox id,
+    # an approval decision, or the prompt-cache usage fields through). This test
+    # closes that gap by driving every declared key through its real setter --
+    # the 12 span-level keys via RunTracer.run_span/record_usage/tool_span, and
+    # the 4 resource-level keys via build_tracer_provider -- so a call-site
+    # retype of any of the seven previously-unexercised keys (that also forgot
+    # to update SPAN_ATTRIBUTE_VALUE_TYPES) fails here instead of slipping past.
+    committed = _committed_schema()["keys"]
+    emitted: dict[str, object] = {}
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = RunTracer(provider)
+
+    with tracer.run_span(
+        trace_name="t",
+        model="fake-model",
+        session_id="s1",
+        user_id="U1",
+        approval_decision="approved",
+    ) as span:
+        span.record_usage(
+            {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "cache_read_input_tokens": 3,
+                "cache_creation_input_tokens": 4,
+            }
+        )
+        span.tool_span("Bash")
+
+    for finished in exporter.get_finished_spans():
+        if finished.attributes:
+            emitted.update(finished.attributes)
+
+    otel = OtelConfig(endpoint="http://localhost:24318")
+    resource_provider = build_tracer_provider(otel, "s1", "sandbox-abc")
+    assert resource_provider is not None
+    # The OTel SDK's own Resource.create() merges in ambient default attributes
+    # (telemetry.sdk.language/name/version) alongside the ones this module
+    # stamps; only the declared keys are this schema's concern.
+    resource_attrs = resource_provider.resource.attributes
+    emitted.update({key: value for key, value in resource_attrs.items() if key in committed})
+    resource_provider.shutdown()
+
+    exercised_keys = set(emitted)
+    missing = set(committed) - exercised_keys
+    assert not missing, f"declared key(s) not exercised by this test: {sorted(missing)}"
+
+    for key, value in emitted.items():
+        _assert_value_type(committed, key, value)


### PR DESCRIPTION
## What

The OTel schema drift gate (#902) mirrored `SpanAttributeKey`'s key **set** into the committed artifact but recorded **no value types**, so a retype of an existing key (e.g. `model` str -> int) passed green — even though ADR-0076 Decision 2 classifies "changing an existing key's value type" as a version-bump-worthy breaking change.

## Change

- **`otel.py`** — add `SPAN_ATTRIBUTE_VALUE_TYPES`, a declared per-key value-type map (`str`/`int`) covering exactly the enum. It is the *type* half of the closed schema's source of truth, parallel to the enum being the *key* half.
- **`otel-attributes.schema.json`** — `keys` becomes a sorted `{key: type}` object, so a retype now forces a reviewable artifact diff exactly like an add/remove does.
- **`test_otel_schema_drift.py`** — the gate now (1) compares committed keys **and types** to the declared map, (2) asserts the map covers exactly the enum, and (3) drives **all 16** declared keys through their real setters, asserting each emitted value's runtime type matches the committed type. That closes the loop so a *call-site* retype that forgets the declaration fails, not just a *declared* one.

Guard demonstrated firing on three retypes: an artifact/declaration mismatch, a call-site retype of an emitted key (`model`), and a call-site retype of a previously-unexercised resource key (`schema.version`).

## Done-check

- Failing tests committed before implementation; Code Reviewer + Scope Reviewer + Codex review all ran (0 scope orphans).
- Full runner suite: 469 passed, 4 skipped. `ruff` + `mypy` clean. doclint OK.
- Consolidation (`/simplify`) extracted a shared type-assertion helper; re-reviewed.

## Out of scope (follow-up)

Codex flagged that a *synchronized* retype (declaration + artifact regenerated together) still isn't blocked without a `SCHEMA_VERSION` bump. Forcing that automatically needs a committed baseline/wire-lock (the ADR-0074 pattern) — a larger, separate mechanism. ADR-0076 treats the version bump as a reviewer signal, and the ticket frames the fix as "and/or"; this PR delivers the artifact-diff-forces-review half. Worth a follow-up issue if we want the bump machine-enforced.

Closes #934