### PR TITLE
Make EOCD fast-path locator test tolerant of CPython 3.14

### DIFF
--- a/packages/plugin-format/tests/test_archive.py
+++ b/packages/plugin-format/tests/test_archive.py
@@ -685,8 +685,18 @@ def test_eocd_locator_uses_cpython_fast_path_when_signature_recurs_in_fields() -
     from plugin_format.archive import _reject_zip_over_member_count
 
     data = _fast_path_eocd_with_signature_in_offset_field(total_entries=3)
-    # Premise, by execution: CPython locates the real EOCD via its fast path.
-    assert zipfile.is_zipfile(io.BytesIO(data))
+    # Premise, by execution: CPython's `_EndRecData` fast path LOCATES the real
+    # trailing EOCD. A plain rfind would divert to the in-field signature and
+    # find no valid record. On 3.13 the located record opens cleanly
+    # (is_zipfile True); on 3.14 CPython's changed prepended-data handling raises
+    # ValueError while processing that same located record (issue #937). Both
+    # prove the fast path located it; only is_zipfile returning False -- meaning
+    # no EOCD was found at all -- would void the premise.
+    try:
+        located = zipfile.is_zipfile(io.BytesIO(data))
+    except ValueError:
+        located = True  # 3.14: reached prepended-data handling => record located
+    assert located, "CPython's fast path must locate the trailing EOCD"
     _reject_zip_over_member_count(data, max_members=10)  # must not raise
 
 


### PR DESCRIPTION
Makes the plugin-format archive test suite pass on CPython 3.14. `requires-python = ">=3.13"` admits 3.14, so a contributor whose `uv sync` picks 3.14 gets a red suite even though production is unaffected (CI pins 3.13, runner is `python:3.13-slim`).

Only one test failed: `test_eocd_locator_uses_cpython_fast_path_when_signature_recurs_in_fields`. The failure was in the test's **premise** assertion (`zipfile.is_zipfile(...)`), not the guard under test. On 3.14 CPython's changed `_handle_prepended_data` raises `ValueError: negative seek value -42` while processing the record its fast path already located; on 3.13 the same record opens cleanly. Both prove the fast path located the record, so the premise now accepts either, while a `False` return (no EOCD located) still fails the test. The guard's own assertion (`_reject_zip_over_member_count(..., max_members=10)  # must not raise`) is unchanged and unconditional.

Chose the issue's option 2 (make the test version-robust) over capping `requires-python`: it makes the whole package 3.14-forward-compatible rather than deferring, and matches the repo's "assert outcomes, not CPython internals" convention. The security assertion is not weakened.

## Done-check (quick tier)
- [x] Tests green: `packages/plugin-format` 49 passed on **3.13** and **3.14** (was 1 failed on 3.14)
- [x] Code Reviewer approved: 0 blocking; verified security assertion unchanged, mutation-catching power preserved (removing the guard's fast-path branch still fails the test)
- [x] Scope Reviewer approved: 0 findings; diff confined to the one sanctioned test (+12/-2)
- [x] Lint clean: `ruff check` + `ruff format --check` pass on the edited file
- [ ] N/A sibling-path parity: test-only, no production seam touched
- [ ] N/A guard demonstration: no guard introduced/modified
- [ ] N/A plan-doc / failing-tests-first / consolidation: build-tier only

Closes #937
