### PR TITLE
Ignore the TypeScript major in the UI dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,9 @@ updates:
     groups:
       pnpm:
         patterns: ["*"]
+    # TypeScript 7.0 is the Go-based tsgo rewrite; @typescript-eslint refuses it
+    # (peer ceiling <6.1.0) and our compiler-API test does not match its surface.
+    # Hold the major until the ecosystem catches up; minors/patches still update.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Adds a dependabot `ignore` for the `typescript` semver-major in the UI (`apps/ui`) npm group.

TypeScript 7.0 is the Go-based `tsgo` rewrite. `@typescript-eslint` refuses to run against it (peer ceiling `<6.1.0`) and `CliHint.parity.test.tsx`'s direct use of the TS compiler API does not match TS7's surface, so the grouped bump (#929, now closed) failed both lint and build. This holds the major until the ecosystem supports it, while minor/patch `typescript` updates keep flowing. Dependabot will re-propose the other UI bumps clean.
