### PR TITLE
Add a nightly graded parity ladder workflow

### DIFF
--- a/.github/workflows/nightly-graded-ladder.yaml
+++ b/.github/workflows/nightly-graded-ladder.yaml
@@ -1,0 +1,351 @@
+name: Nightly graded parity ladder
+
+# The graded sibling of ci.yaml's fake parity-ladder jobs (e2e-ladder,
+# e2e-ladder-cluster). Those run on every PR against the sealed fake-model
+# install, which ADR-0055 bounds to plumbing-only: a green there proves the
+# wiring, never that a real model given the weather bundle actually answers.
+# This workflow runs the SAME ladder mechanics LIVE against a real model over
+# OpenRouter, so the graded promise is verified continuously rather than only
+# by a manual source run before a release. See ADR-0081.
+on:
+  schedule:
+    - cron: "0 8 * * *"   # 08:00 UTC, off-peak; cron is always UTC
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "OpenRouter model route for the graded run"
+        required: false
+        default: "z-ai/glm-5.2"
+
+# Supersede an in-flight run when the same ref is pushed again so scheduled and
+# dispatch runs stop stacking.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege (#632): the nightly reads the checkout and consumes a secret;
+# it never writes back to the repo.
+permissions:
+  contents: read
+
+jobs:
+  # Mirror ci.yaml's rust-build: a standalone nightly has no upstream binary
+  # producer, so it builds the release binary itself and both ladder jobs
+  # download it as an artifact.
+  build-cli:
+    name: Build the curie release binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Toolchain
+        run: rustc --version
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cli
+      - name: Release build
+        run: cargo build --release --locked
+      - name: Upload curie binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: curie-x86_64-linux-${{ github.sha }}
+          path: cli/target/release/curie
+          if-no-files-found: error
+
+  # Graded sibling of ci.yaml's e2e-ladder: same skill + local rung mechanics,
+  # armed live against the real model instead of the fake fixture.
+  ladder-skill-local:
+    name: Graded parity ladder (skill + local, live model)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-cli
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Download the curie binary built by the build-cli job
+        uses: actions/download-artifact@v8
+        with:
+          name: curie-x86_64-linux-${{ github.sha }}
+          path: cli/target/release
+      - name: Make the binary executable
+        run: chmod +x cli/target/release/curie
+      # Image builds mirror e2e-ladder exactly: a named cache-only buildx
+      # builder that is NOT made the default (`use: false`) so the
+      # compose-triggered worker-local overlay build still resolves the
+      # `:ci-local` FROM bases from the plain docker builder's daemon store
+      # (#697/#791/#803). Same pinned actions and gha scopes as ci.yaml.
+      - name: Set up a cache-only buildx builder (named, NOT the default -- preserves compose FROM, #803)
+        id: laddercache
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          use: false
+      - name: Build the runner image locally (gha layer cache)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: runner/Dockerfile
+          builder: ${{ steps.laddercache.outputs.name }}
+          tags: curie-runner
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-runner
+          cache-to: type=gha,mode=max,scope=ladder-runner
+      - name: Retag the runner image for the compose worker (CURIE_RUNNER_IMAGE, no registry auth)
+        run: docker tag curie-runner ghcr.io/curie-eng/curie-runner:latest
+      - name: Build the api image locally (satisfies curie-api + curie-migrate, no registry auth)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          builder: ${{ steps.laddercache.outputs.name }}
+          tags: ghcr.io/curie-eng/curie-api:ci-local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-api
+          cache-to: type=gha,mode=max,scope=ladder-api
+      - name: Build the worker base image locally (satisfies the worker-local overlay's FROM, no registry auth)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/worker/Dockerfile
+          builder: ${{ steps.laddercache.outputs.name }}
+          tags: ghcr.io/curie-eng/curie-worker:ci-local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-worker
+          cache-to: type=gha,mode=max,scope=ladder-worker
+      # Live grading: CURIE_E2E_LIVE drops the fake fixture and the ladder reads
+      # the OpenRouter credential from CURIE_CREDENTIALS (the one env key the CLI
+      # reads; an sk-or- key auto-selects OPENROUTER_BASE_URL). The secret
+      # travels only as this env mapping, never on a run: or argv line.
+      - name: Graded parity ladder (skill + local rungs, live model)
+        env:
+          CURIE_BIN: cli/target/release/curie
+          CURIE_BASE_TAG: ci-local
+          CURIE_E2E_TIERS: skill,local
+          CURIE_E2E_LIVE: "1"
+          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
+          CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
+        run: bash cli/scripts/e2e-ladder.sh
+
+  # Graded sibling of ci.yaml's e2e-ladder-cluster: same kind substrate and
+  # round-trip mechanics, but the install is graded (not sealed) and the run
+  # step is armed live.
+  ladder-cluster:
+    name: Graded parity ladder (cluster rung on kind, live model)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-cli
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Download the curie binary built by the build-cli job
+        uses: actions/download-artifact@v8
+        with:
+          name: curie-x86_64-linux-${{ github.sha }}
+          path: cli/target/release
+      - name: Make the binary executable
+        run: chmod +x cli/target/release/curie
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.16.4
+      # GHA-layer-cached builds via a named buildx builder that is NOT made the
+      # default (`use: false`), same mechanism e2e-ladder documents. `load:
+      # true` exports each image into the local daemon store so `kind load`
+      # picks it up with no registry round trip. Only the four images the
+      # cluster round trip needs; the dispatcher is not deployed.
+      - name: Set up a cache-only buildx builder (named, NOT the default)
+        id: clustercache
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          use: false
+      - name: Build the api image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          builder: ${{ steps.clustercache.outputs.name }}
+          tags: curie-api:local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-api
+          cache-to: type=gha,mode=max,scope=ladder-api
+      - name: Build the worker image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/worker/Dockerfile
+          builder: ${{ steps.clustercache.outputs.name }}
+          tags: curie-worker:local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-worker
+          cache-to: type=gha,mode=max,scope=ladder-worker
+      - name: Build the ui image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/ui/Dockerfile
+          builder: ${{ steps.clustercache.outputs.name }}
+          tags: curie-ui:local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-ui
+          cache-to: type=gha,mode=max,scope=ladder-ui
+      - name: Build the runner image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: runner/Dockerfile
+          builder: ${{ steps.clustercache.outputs.name }}
+          tags: curie-runner:latest
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-runner
+          cache-to: type=gha,mode=max,scope=ladder-runner
+      # kind config: map the UI NodePort (chart default 30080) to the host so
+      # `cluster deploy`'s UI `/api` NodePort discovery -- which resolves the
+      # loopback kubeconfig host (127.0.0.1) -- reaches the in-cluster API.
+      - name: Write the kind cluster config
+        run: |
+          cat > kind-config.yaml <<'EOF'
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+            - role: control-plane
+              extraPortMappings:
+                - containerPort: 30080
+                  hostPort: 30080
+                  listenAddress: "127.0.0.1"
+                  protocol: TCP
+          EOF
+      # Disposable kind cluster. Pins both the action and the kind/node-image
+      # versions. The `kind` Docker network (created here) is the bridge every
+      # node container sits on; its gateway is the host address the in-cluster
+      # worker reaches the reply stub through, resolved below.
+      - name: Create the kind cluster
+        uses: helm/kind-action@v1.14.0
+        with:
+          version: v0.24.0
+          node_image: kindest/node:v1.31.0
+          cluster_name: curie-e2e
+          config: kind-config.yaml
+      # Load the four locally-built images into the node store so the install's
+      # pullPolicy Never overrides bind them with no registry pull.
+      - name: Load images into the kind cluster
+        run: |
+          set -euo pipefail
+          for img in curie-api:local curie-worker:local curie-ui:local curie-runner:latest; do
+            kind load docker-image "$img" --name curie-e2e
+          done
+      # The graded install. Unlike ci.yaml's cluster job (which seals the
+      # install credential-free, the plumbing-only path ADR-0055 bounds), this
+      # install is armed: no seal flag, the OpenRouter credential supplied via
+      # CURIE_CREDENTIALS env (cluster up masks it and adds fakeModel=false
+      # automatically), CURIE_MODEL env baked into the release as the runner's
+      # model (cluster up reads it from env; it has no --model flag), and
+      # --allow-egress-host openrouter (the provider KEYWORD, resolved to a /32
+      # host route at install time) so the default-deny runner sandbox can
+      # reach OpenRouter. The --set overrides repoint every first-party image at
+      # the just-loaded local tags with pullPolicy Never, force gVisor off (no
+      # runsc on kind nodes -- a real-model install fails closed without this),
+      # and drop the dispatcher (no Slack; its presence would trip the
+      # `cluster message` reply-hijack guard). The secret travels in env, never
+      # on argv.
+      - name: Install the platform (curie cluster up, graded)
+        env:
+          CURIE_BIN: cli/target/release/curie
+          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
+          CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
+        run: |
+          set -euo pipefail
+          "$CURIE_BIN" cluster up \
+            --chart charts/curie \
+            --dev \
+            --allow-egress-host openrouter \
+            --set security.gvisor.mode=off \
+            --set dispatcher.deploy=false \
+            --set api.image.repository=curie-api --set api.image.tag=local --set api.image.pullPolicy=Never \
+            --set worker.image.repository=curie-worker --set worker.image.tag=local --set worker.image.pullPolicy=Never \
+            --set ui.image.repository=curie-ui --set ui.image.tag=local --set ui.image.pullPolicy=Never \
+            --set agentSandbox.runner.image=curie-runner --set agentSandbox.runner.tag=latest --set agentSandbox.runner.imagePullPolicy=Never \
+            --set agentSandbox.runner.prewarm.imagePullPolicy=Never
+      # `cluster up` does not `helm --wait` (the argv stays a thin wrapper), so
+      # wait for the rollouts the round trip depends on before driving it.
+      # Langfuse and ClickHouse are intentionally NOT waited on -- a single
+      # graded turn does not need traces flushed, and they are the slowest pods
+      # to settle.
+      - name: Wait for the platform to become ready
+        run: |
+          set -euo pipefail
+          kubectl rollout status deploy/curie-api -n curie --timeout=300s
+          kubectl rollout status deploy/curie-worker -n curie --timeout=300s
+          kubectl rollout status deploy/curie-ui -n curie --timeout=300s
+          kubectl rollout status daemonset/curie-runner-prewarm -n curie --timeout=300s
+      # The pod-reachable host for the reply stub: the kind Docker network
+      # gateway. Every node container sits on this bridge, so a pod egressing
+      # through its node reaches the host here; the stub binds 0.0.0.0 and
+      # answers on it. Auto-detection (loopback API server) cannot produce this
+      # value on kind.
+      - name: Resolve the pod-reachable host for the reply stub
+        run: |
+          set -euo pipefail
+          # The kind bridge's IPv4 gateway is the host address every node -- and
+          # every pod egressing through its node -- can reach; the stub binds
+          # 0.0.0.0 and answers on it. The `kind` Docker network is frequently
+          # dual-stack, so IPAM.Config carries both an IPv4 and an IPv6 entry in
+          # an unspecified order (and an entry may omit Gateway) -- `index 0` is
+          # not reliably the IPv4 one. Read the gateway the control-plane node
+          # container actually got first, then fall back to ranging the
+          # network's IPAM for a dotted-quad gateway.
+          node="curie-e2e-control-plane"
+          gw="$(docker inspect "$node" --format '{{ .NetworkSettings.Networks.kind.Gateway }}' 2>/dev/null || true)"
+          if [[ ! "$gw" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+            gw="$(docker network inspect kind \
+                    --format '{{range .IPAM.Config}}{{println .Gateway}}{{end}}' 2>/dev/null \
+                  | grep -E '^[0-9]{1,3}(\.[0-9]{1,3}){3}$' | head -1 || true)"
+          fi
+          if [[ ! "$gw" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+            echo "could not resolve the kind network IPv4 gateway" >&2
+            echo "--- docker network inspect kind ---" >&2
+            docker network inspect kind >&2 || true
+            echo "--- docker inspect $node (.NetworkSettings.Networks) ---" >&2
+            docker inspect "$node" --format '{{json .NetworkSettings.Networks}}' >&2 || true
+            exit 1
+          fi
+          echo "kind network gateway (worker->stub reply host): $gw"
+          echo "CURIE_E2E_LISTEN_HOST=$gw" >> "$GITHUB_ENV"
+      # The cluster rung only, live: `cluster status` gate -> `cluster deploy`
+      # -> `cluster message` (reply asserted). The model is baked at install
+      # time, but apply_model_mode still hard-exits under CURIE_E2E_LIVE if no
+      # credential is in env, so CURIE_CREDENTIALS is supplied here too.
+      # CURIE_E2E_LISTEN_HOST was exported to the job env above.
+      - name: Graded parity ladder (cluster rung, live model)
+        env:
+          CURIE_BIN: cli/target/release/curie
+          CURIE_E2E_TIERS: cluster
+          CURIE_E2E_LIVE: "1"
+          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
+          CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
+        run: bash cli/scripts/e2e-ladder.sh
+      # Surface why on any failure above: pod states, recent events, and the
+      # worker/runner logs are what localize a reachability or scheduling break.
+      # Deliberately no `kubectl get secret`: the credential reaches the pod via
+      # secretKeyRef (not plaintext in the pod spec) and runner log redaction
+      # (#518) scrubs it, so this dump never surfaces the credential value.
+      - name: Dump cluster diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -A -o wide || true
+          kubectl get events -n curie --sort-by=.lastTimestamp | tail -50 || true
+          kubectl describe pods -n curie -l app.kubernetes.io/component=runner-sandbox || true
+          kubectl logs -n curie -l app.kubernetes.io/component=worker --tail=100 || true

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1,0 +1,241 @@
+//! ADR-0081 / issue #872: the nightly graded parity ladder is the workflow
+//! that runs the cold-start parity ladder (`curie dev e2e-ladder`) LIVE
+//! against a real model, not the sealed fake-model install `ci.yaml` runs on
+//! every PR. `ci.yaml`'s cluster ladder job installs with `--fake-model`
+//! (ADR-0055 bounds what that fake green means: plumbing only, never a graded
+//! turn). The nightly workflow sits on the opposite side of that seam: it
+//! must arm `CURIE_E2E_LIVE`, never seal the install, and carry the
+//! OpenRouter credential only as the one env key the runner reads.
+//!
+//! Grounding for the OpenRouter/env-key claims asserted below:
+//! - `docs/interfaces/model-provider/INTERFACE.md:73-76`: an `sk-or-` credential
+//!   auto-selects `OPENROUTER_BASE_URL`; no `ANTHROPIC_BASE_URL` is set for this
+//!   provider, and the real key travels as `ANTHROPIC_API_KEY` inside the
+//!   runner -- the CLI-facing input for that credential is `CURIE_CREDENTIALS`.
+//! - `cli/src/ops.rs:529-532`: `--allow-egress-host` takes the provider
+//!   KEYWORD `openrouter` (resolved to `openrouter.ai` at install time), never
+//!   a bare hostname like `openrouter.ai` itself.
+//!
+//! This file is a text-contract test against the workflow YAML AS TEXT (no
+//! `serde_yaml`, no new dependency -- std `fs` only), so it fails today
+//! because `.github/workflows/nightly-graded-ladder.yaml` does not exist yet.
+//! Each assertion targets a user-visible CI contract (arms live, opens
+//! egress, never seals, never leaks the secret), not Rust internals, so it
+//! survives a rename or reformat of the workflow as long as the contract
+//! holds. Deleting the workflow fails every assertion below except the CI
+//! sibling anchor (assertion group 3), which stays green against the
+//! existing `ci.yaml` and only breaks if someone arms `ci.yaml`'s fake seal
+//! off, proving the two workflows are pinned to opposite sides of the seam.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Read a workflow file's raw text, or an empty string when it does not exist
+/// yet. Assertions on an empty string fail with their own readable messages
+/// rather than panicking on a missing file, so a missing nightly workflow
+/// surfaces as a normal test failure naming the violated contract.
+fn workflow_text(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../.github/workflows")
+        .join(name);
+    fs::read_to_string(path).unwrap_or_default()
+}
+
+fn nightly() -> String {
+    workflow_text("nightly-graded-ladder.yaml")
+}
+
+fn ci() -> String {
+    workflow_text("ci.yaml")
+}
+
+fn count_lines_containing(text: &str, needle: &str) -> usize {
+    text.lines().filter(|line| line.contains(needle)).count()
+}
+
+// --- Assertion group 1: arms the GRADED path -------------------------------
+
+/// The nightly workflow must arm live grading with the exact double-quoted
+/// form, never a bare or unquoted `1` that a YAML parser could read as an
+/// integer instead of the string the ladder script compares against.
+#[test]
+fn nightly_arms_live_grading_with_the_exact_quoted_form() {
+    let text = nightly();
+    assert!(
+        text.contains("CURIE_E2E_LIVE: \"1\""),
+        "the nightly workflow must arm CURIE_E2E_LIVE with the exact quoted \
+         form `CURIE_E2E_LIVE: \"1\"` so the ladder runs live, not fake; \
+         file contents:\n{text}"
+    );
+}
+
+/// Every line referencing the OpenRouter secret must also assign
+/// `CURIE_CREDENTIALS:` on that same line, so the secret reaches the ladder
+/// only through the one env key the CLI reads (never bare, never aliased to
+/// a differently-named env var that could accidentally land on a `run:` line
+/// elsewhere).
+#[test]
+fn nightly_secret_reaches_the_ladder_only_as_curie_credentials() {
+    let text = nightly();
+    assert!(
+        text.contains("secrets.OPENROUTER_API_KEY"),
+        "the nightly workflow must reference secrets.OPENROUTER_API_KEY at \
+         least once to supply the live model credential; file contents:\n{text}"
+    );
+    for line in text.lines() {
+        if line.contains("secrets.OPENROUTER_API_KEY") {
+            assert!(
+                line.contains("CURIE_CREDENTIALS:"),
+                "every line referencing secrets.OPENROUTER_API_KEY must also \
+                 assign CURIE_CREDENTIALS: on that same line, so the secret \
+                 reaches the ladder only as that one env key: {line}"
+            );
+        }
+    }
+}
+
+/// The model default `z-ai/glm-5.2` must appear on a line that also names
+/// `CURIE_MODEL`, so the graded default is wired as the model the ladder
+/// actually calls, not just mentioned in a comment.
+#[test]
+fn nightly_wires_the_glm_default_model_via_curie_model() {
+    let text = nightly();
+    let has_model_line = text
+        .lines()
+        .any(|line| line.contains("z-ai/glm-5.2") && line.contains("CURIE_MODEL"));
+    assert!(
+        has_model_line,
+        "the nightly workflow must have a line containing both the model id \
+         z-ai/glm-5.2 and the CURIE_MODEL env key, wiring the default model \
+         into the ladder; file contents:\n{text}"
+    );
+}
+
+/// The nightly ladder must cover both tier sets: the fast `skill,local` rungs
+/// and the separate `cluster` rung. Accept either quoted or unquoted YAML
+/// scalars by checking substrings rather than exact-matching the whole line.
+#[test]
+fn nightly_covers_both_the_skill_local_and_cluster_tier_sets() {
+    let text = nightly();
+    assert!(
+        text.contains("skill,local"),
+        "the nightly workflow must set CURIE_E2E_TIERS to a value containing \
+         `skill,local` so the fast rungs run graded too; file contents:\n{text}"
+    );
+    let has_cluster_tiers = text.lines().any(|line| {
+        let normalized: String = line.split_whitespace().collect();
+        normalized.contains("CURIE_E2E_TIERS:cluster")
+            || normalized.contains("CURIE_E2E_TIERS:\"cluster\"")
+    });
+    assert!(
+        has_cluster_tiers,
+        "the nightly workflow must have a CURIE_E2E_TIERS: cluster (quoted or \
+         unquoted) line covering the cluster rung separately from \
+         skill,local; file contents:\n{text}"
+    );
+}
+
+// --- Assertion group 2: cluster graded install -----------------------------
+
+/// The cluster install must open egress to the `openrouter` provider keyword
+/// (resolved to `openrouter.ai` at install time by `cli/src/ops.rs:529-532`),
+/// and the workflow must never contain the sealed-install flag anywhere --
+/// proving the cluster rung is graded, not fake.
+#[test]
+fn nightly_cluster_install_opens_openrouter_egress_and_never_seals() {
+    let text = nightly();
+    assert!(
+        text.contains("--allow-egress-host openrouter"),
+        "the nightly workflow's cluster install must open egress with \
+         `--allow-egress-host openrouter` (the provider keyword, not a bare \
+         hostname) so the graded model call is reachable; file contents:\n{text}"
+    );
+    assert!(
+        !text.contains("--fake-model"),
+        "the nightly workflow must never seal the install with --fake-model \
+         anywhere in the file (including comments); a sealed install cannot \
+         be the graded ladder; file contents:\n{text}"
+    );
+}
+
+// --- Assertion group 3: sibling / negative parity (mandatory) --------------
+
+/// `ci.yaml`'s cluster ladder job DOES seal its install with `--fake-model`.
+/// This is the sibling anchor: it pins the two workflows on opposite sides of
+/// the fake/graded seam. This assertion passes today against the existing
+/// `ci.yaml` and fails only if someone arms ci.yaml graded (removing its
+/// `--fake-model`) or de-arms the nightly ladder, collapsing the seam this
+/// whole test file exists to guard.
+#[test]
+fn ci_yaml_still_seals_its_cluster_install_with_fake_model() {
+    let text = ci();
+    assert!(
+        text.contains("--fake-model"),
+        "ci.yaml must still contain --fake-model in its cluster ladder job; \
+         if this ever fails, either ci.yaml was accidentally armed graded or \
+         the fake/graded seam this test guards has collapsed; file \
+         contents:\n{text}"
+    );
+}
+
+// --- Assertion group 4: #632 secret posture --------------------------------
+
+/// The workflow must declare least-privilege `permissions:` with
+/// `contents: read`, so the nightly job cannot write back to the repo.
+#[test]
+fn nightly_declares_least_privilege_contents_read_permissions() {
+    let text = nightly();
+    assert!(
+        text.contains("permissions:"),
+        "the nightly workflow must declare a permissions: block (least \
+         privilege, #632); file contents:\n{text}"
+    );
+    assert!(
+        text.contains("contents: read"),
+        "the nightly workflow's permissions: block must include \
+         `contents: read`; file contents:\n{text}"
+    );
+}
+
+/// Every `actions/checkout` use must be paired with
+/// `persist-credentials: false`, so the checkout-injected token cannot
+/// override a differently-scoped credential used later in the job (the same
+/// class of hazard the checkout-credentials learning documents). Counting
+/// occurrences (rather than requiring exact adjacency) keeps the assertion
+/// robust to step reordering while still catching a checkout step that lacks
+/// the setting entirely.
+#[test]
+fn nightly_pairs_every_checkout_with_persist_credentials_false() {
+    let text = nightly();
+    let checkout_count = count_lines_containing(&text, "uses: actions/checkout");
+    assert!(
+        checkout_count > 0,
+        "the nightly workflow must use actions/checkout at least once; file \
+         contents:\n{text}"
+    );
+    let persist_false_count = count_lines_containing(&text, "persist-credentials: false");
+    assert!(
+        persist_false_count >= checkout_count,
+        "every actions/checkout use ({checkout_count}) must be paired with \
+         persist-credentials: false ({persist_false_count} found); a bare \
+         checkout leaves the job token in global git config for later steps \
+         to pick up; file contents:\n{text}"
+    );
+}
+
+/// The OpenRouter secret must never be echoed on a `run:` line. Combined with
+/// assertion group 1's "only as CURIE_CREDENTIALS:" check, this closes off
+/// the one remaining way the secret could leak into job logs.
+#[test]
+fn nightly_never_echoes_the_openrouter_secret_on_a_run_line() {
+    let text = nightly();
+    for line in text.lines() {
+        if line.contains("secrets.OPENROUTER_API_KEY") {
+            assert!(
+                !line.contains("run:"),
+                "the OpenRouter secret must never appear on a `run:` line \
+                 (it would be echoed into job logs): {line}"
+            );
+        }
+    }
+}

--- a/docs/adr/0081-nightly-graded-parity-ladder.md
+++ b/docs/adr/0081-nightly-graded-parity-ladder.md
@@ -1,0 +1,126 @@
+# 81. A nightly graded parity ladder verifies the real-model promise CI cannot
+
+Date: 2026-07-24
+
+Status: Accepted
+
+Read [ADR-0055](0055-the-fake-model-is-a-plumbing-fixture.md) for the fake/graded
+seam this ADR sits on the other side of, [ADR-0022](0022-eval-completeness-tier-parity-and-trace-promotion.md)
+for what a graded green means, and [ADR-0068](0068-eval-sweep-fails-loudly-on-zero-completed-turns.md)
+for the fail-loud-on-zero-completed-turns posture the graded rungs inherit.
+
+Implements [#872](https://github.com/curie-eng/curie/issues/872).
+
+## Context
+
+The parity ladder (`curie dev e2e-ladder`) chains three rungs -- skill, local,
+and cluster -- through the same cold-start round trip a user would take. In CI
+(`ci.yaml`'s `e2e-ladder` and `e2e-ladder-cluster` jobs) every rung runs against
+the fake model: the skill and local rungs default to it, and the cluster job
+seals the install credential-free. ADR-0055 bounds exactly what those greens
+mean: the fake model is a plumbing fixture, never a subject under test, so a
+green fake rung proves the wiring carries a turn and nothing about whether a real
+model, handed the weather bundle, actually answers.
+
+That leaves the graded promise -- "a real model given the bundle produces a
+correct answer end to end" -- verified only by a manual source run before a
+release (`CURIE_E2E_TIERS=all curie dev e2e-ladder` with `CURIE_E2E_LIVE=1`). A
+graded-path regression that the fake CI cannot see (a broken credential seam, a
+closed egress route, a model-mode wiring change) would surface only at the next
+release attempt, or in production. The gap is structural: the fake tier is
+correct to stay ungraded, so the graded signal has to come from somewhere else.
+
+## Decision
+
+**Run the parity ladder graded on a nightly schedule, in addition to the fake
+ladder on every PR.** A new scheduled workflow
+(`.github/workflows/nightly-graded-ladder.yaml`) runs the skill, local, and
+cluster rungs live against a real model over OpenRouter. It is the graded sibling
+of the two fake ladder jobs, reusing their mechanics rather than inventing new
+ones; the only job is to arm the model on the existing rungs.
+
+**Cadence and time.** Nightly at 08:00 UTC (`cron: "0 8 * * *"`), an off-peak
+slot. Nightly rather than per-PR because the graded run costs real model spend
+and most PRs do not touch the graded seam; nightly rather than per-release
+because a regression caught the morning after it lands is far cheaper to bisect
+than one discovered weeks later at release time. Cron is always UTC, noted in the
+workflow so the slot is not misread as local time.
+
+**Cost.** Measured at roughly $0.053 per full ladder pass on the default model,
+about $1.58 per month at nightly cadence (per #872). That price is why nightly is
+affordable insurance; a graded regression reaching a release is worth far more
+than a dollar a month of continuous verification.
+
+**Model default.** `z-ai/glm-5.2` routed through OpenRouter, overridable via a
+`workflow_dispatch` input for an ad hoc run against another route. An OpenRouter
+key auto-selects the OpenRouter base URL, so no provider wiring beyond the
+credential is needed.
+
+**Key posture (#632).** The budget-capped key lives in the repo secret
+`OPENROUTER_API_KEY` and reaches the ladder only as the `CURIE_CREDENTIALS` env
+mapping the CLI reads -- never on an argv or `run:` line. On the cluster rung
+`curie cluster up` consumes it from the environment, masks it, and adds the
+fakeModel-off and credential values to the install itself; the secret never lands
+in the Helm command line. The workflow declares least-privilege
+`permissions: contents: read`, sets `persist-credentials: false` on every
+checkout, pins every third-party action to the same commit SHA or tag the fake
+ladder jobs use, and keeps the failure-diagnostics dump free of any command that
+would print the credential value (the credential reaches the pod via secretKeyRef
+and runner log redaction scrubs it).
+
+**Trust boundary for the secret.** The workflow has no `pull_request` or
+`pull_request_target` trigger, only `schedule` and `workflow_dispatch`, so a fork
+PR has no path to the secret. `workflow_dispatch` requires repository write
+access, so only collaborators can trigger a run; a collaborator dispatching
+against a branch they control runs that branch's `cli/scripts/e2e-ladder.sh`,
+so confidentiality ultimately rests on the trusted-collaborator set rather than
+on branch protection. Residual risk is bounded: the key is budget-capped, and it
+is passed only as a step-scoped masked `env:` value, never on argv or a `run:`
+line. If the collaborator set grows, the available hardening is scoping the
+secret to a protected GitHub Environment with a default-branch deployment
+policy; that is out of scope here and the budget cap is the current control.
+
+**Substrate is kind, not k3s.** The manual pre-release run happened on k3s, but
+the CI-proven, gated cluster substrate is the kind job in `ci.yaml`. The nightly
+cluster rung mirrors that kind job rather than standing up k3s from scratch,
+because re-deriving a k3s install is out-of-scope risk against an already-working
+substrate. This divergence from the manual run is intentional and recorded here.
+
+**Fail loud, but only the skill rung is graded.** No `continue-on-error`
+anywhere, and no path gate (a nightly always runs). The skill rung is the one
+graded assertion in the ladder: it runs the weather eval cases and asserts a
+genuine graded outcome (`passed:1 failed:0`, with `plumbing_ok:0` confirming
+the grader itself ran rather than short-circuiting). The local and cluster
+rungs do not grade content; they assert the live path end to end -- the turn
+finalizes with a real reply through the full runner/worker plumbing -- and
+under a live model add a negative control that rejects the fake model's
+canned sentinel, proving a real model answered. Each rung still fails loud on
+its own terms: a bad grade fails the skill rung, and an empty reply, a
+non-finalized turn, or a sentinel reply fails the local or cluster rung. A
+missing or rotated-away secret renders as an empty string that the live-mode
+credential guard rejects with a hard exit, so a broken key fails loud rather
+than silently downgrading to fake. Each job carries a `timeout-minutes` cap so
+a hung turn cannot burn model budget up to the default six-hour ceiling. Job
+topology is not fully independent: `ladder-cluster` is its own job and always
+runs regardless of the other two, but `ladder-skill-local` runs the skill and
+local rungs in one job via a single `e2e-ladder.sh` invocation with
+`CURIE_E2E_TIERS: skill,local`, and the script runs tiers sequentially under
+`set -e`, so a skill failure stops that job before the local rung runs (this
+mirrors `ci.yaml`'s existing `e2e-ladder` job, which bundles the same two
+tiers). The fail-loud guarantee is unchanged -- any rung failing reddens the
+workflow -- but a skill failure can mask whether local would have passed.
+
+## Consequences
+
+- The graded promise is verified continuously, not once per release from memory.
+  A graded-path regression surfaces the next morning with a bounded blame window.
+- CI gains its first workflow that consumes a model-provider secret. The #632
+  posture above is the whole of the added attack surface; it is reviewed against
+  the entire action set the workflow pulls, not only the step that reads the key.
+- The fake ladder in `ci.yaml` is unchanged and stays the fast per-PR gate. The
+  two workflows are deliberately pinned to opposite sides of the ADR-0055 seam: a
+  contract test fails if the nightly is ever de-armed or the fake ladder armed.
+- A graded `local-release` rung (the sibling of `ci.yaml`'s `e2e-ladder-release`)
+  is deliberately deferred: #872 does not ask for it and it needs extra release
+  images built first. It can be filed as a follow-up if graded release-compose
+  coverage is later wanted.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,4 +110,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0078 | [Route message-driven approval cards through the connected Slack transport](0078-approval-cards-over-connected-transport.md) | Accepted |
 | 0079 | [Inbound triggers as a new event kind, ingested by the API](0079-inbound-triggers-as-a-new-event-kind.md) | Proposed |
 | 0080 | [Rename the project to Curie](0080-rename-to-curie.md) | Accepted |
+| 0081 | [A nightly graded parity ladder verifies the real-model promise CI cannot](0081-nightly-graded-parity-ladder.md) | Accepted |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
## What

Adds `.github/workflows/nightly-graded-ladder.yaml`, a scheduled nightly workflow that runs the parity ladder graded (real model via OpenRouter, GLM-5.2 by default) across the skill, local, and cluster rungs. CI today runs the ladder against the fake model only (every rung reports `plumbing OK`, per ADR-0055), so the graded promise is verified only by a manual source run before a release. This closes that gap at about five cents per pass.

The workflow is a near-mirror of the existing fake ladder jobs in `ci.yaml` (`rust-build`, `e2e-ladder`, `e2e-ladder-cluster`), armed for the real model:
- The OpenRouter key is consumed as a masked, step-scoped `CURIE_CREDENTIALS` env value under a least-privilege `contents: read` posture (issue #632 baseline). It is never on a `run:` line or the cluster install argv.
- The cluster rung installs unsealed (no fake-model seal), opens provider egress to OpenRouter (`--allow-egress-host openrouter`), and keeps gVisor off on the kind nodes.
- Fails loudly on any rung (no `continue-on-error`; per-job `timeout-minutes` cap a hung graded turn).

ADR-0081 records the decision (cadence, cost, key posture, kind-not-k3s substrate, model default, fail-loud). A contract test (`cli/tests/nightly_graded_ladder.rs`) pins the graded path and anchors the existing fake CI ladder on the opposite side of the fake/graded seam.

## Scale-ups

- **security** (first CI workflow consuming a model-provider secret): security review clean, zero blocking. The workflow has no `pull_request`/`pull_request_target` trigger, so fork PRs cannot reach the secret; `workflow_dispatch` is write-access gated, and residual risk is bounded by the budget-capped key. ADR-0081 records this trust boundary.
- **deployed-surface**: live CI verification of the graded run depends on the workflow existing on the default branch; it runs on the first nightly (or a manual `workflow_dispatch`) once merged. The graded ladder mechanics these jobs wire were already proven end-to-end by the manual source run documented in #872 (all three rungs `passed:1 failed:0`, `plumbing_ok:0`).

## Done-check

- [x] Failing contract test committed before the workflow
- [x] All edits by delegated sub-agents; no driver inline edits
- [x] No broadened return types (workflow + docs + test only)
- [x] Code Reviewer approved (0 blocking; ADR grading-accuracy finding fixed)
- [x] Scope Reviewer approved (0 findings; ADR is repo-mandated, not a passenger)
- [x] Sibling-path parity: skill/local/cluster armed; graded `local-release` rung deliberately deferred (follow-up)
- [x] Guard demonstrated: contract test executed failing on the un-armed workflow, passing once armed
- [x] Consolidation pass ran (one cleanup proposed then reverted for a compile break; net no change)
- [x] Codex review ran (driver-direct); findings triaged (one hallucinated egress claim rejected on verified citations)
- [x] Security Reviewer approved
- [ ] E2E: deferred to post-merge nightly / manual dispatch (see deployed-surface note)
- [x] Full cli test suite passes; actionlint clean; fmt clean

Closes #872
