### PR TITLE
Add a graded local-release rung to the nightly parity ladder

### DIFF
--- a/.github/workflows/nightly-graded-ladder.yaml
+++ b/.github/workflows/nightly-graded-ladder.yaml
@@ -135,6 +135,99 @@ jobs:
           CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
         run: bash cli/scripts/e2e-ladder.sh
 
+  # Graded sibling of ci.yaml's e2e-ladder-release (#947): the same
+  # generated-release-compose round trip, armed live. ci.yaml exercises this rung
+  # against the FAKE model only, so the compose.release.yaml parity seam -- the
+  # artifact a RELEASE binary's `curie local up` actually runs, derived from
+  # compose.dev.yaml by compose/generate_release_compose.py -- was the one rung
+  # never graded against a real model. `local-release` is deliberately NOT folded
+  # into CURIE_E2E_TIERS=all because the rung preflights that the release-pinned
+  # images already exist locally (a release binary has no checkout to build them
+  # from), so this job builds them first and then names the rung explicitly.
+  ladder-local-release:
+    name: Graded parity ladder (local-release, live model)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-cli
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Download the curie binary built by the build-cli job
+        uses: actions/download-artifact@v8
+        with:
+          name: curie-x86_64-linux-${{ github.sha }}
+          path: cli/target/release
+      - name: Make the binary executable
+        run: chmod +x cli/target/release/curie
+      # Image builds mirror e2e-ladder-release exactly: a named cache-only buildx
+      # builder that is NOT made the default (`use: false`) so the
+      # compose-triggered worker-local overlay build below still resolves its
+      # `:ci-local` FROM base from the plain docker builder's daemon store
+      # (#697/#791/#803). Same pinned actions and gha cache scopes as ci.yaml.
+      - name: Set up a cache-only buildx builder (named, NOT the default -- preserves compose FROM, #803)
+        id: releasecache
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          use: false
+      - name: Build the runner image locally (gha layer cache)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: runner/Dockerfile
+          builder: ${{ steps.releasecache.outputs.name }}
+          tags: curie-runner
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-runner
+          cache-to: type=gha,mode=max,scope=ladder-runner
+      - name: Retag the runner image for the compose worker (CURIE_RUNNER_IMAGE, no registry auth)
+        run: docker tag curie-runner ghcr.io/curie-eng/curie-runner:latest
+      - name: Build the api image locally (satisfies curie-api + curie-migrate, no registry auth)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          builder: ${{ steps.releasecache.outputs.name }}
+          tags: ghcr.io/curie-eng/curie-api:ci-local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-api
+          cache-to: type=gha,mode=max,scope=ladder-api
+      - name: Build the worker base image locally (satisfies the worker-local overlay's FROM, no registry auth)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/worker/Dockerfile
+          builder: ${{ steps.releasecache.outputs.name }}
+          tags: ghcr.io/curie-eng/curie-worker:ci-local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-worker
+          cache-to: type=gha,mode=max,scope=ladder-worker
+      # The generated release compose pins `:latest` images and carries no build
+      # directive, so satisfy those refs here: retag the api build, and build the
+      # worker-local overlay with plain `docker build` (it is the FROM consumer,
+      # so it must stay on the default plain-docker builder, #803).
+      - name: Tag the api image for the generated release compose (ghcr.io/curie-eng/curie-api:latest, no registry auth)
+        run: docker tag ghcr.io/curie-eng/curie-api:ci-local ghcr.io/curie-eng/curie-api:latest
+      - name: Build the worker-local overlay for the generated release compose (ghcr.io/curie-eng/curie-worker-local:latest, no registry auth)
+        run: docker build --build-arg BASE_TAG=ci-local -t ghcr.io/curie-eng/curie-worker-local:latest -f compose/worker-local.Dockerfile compose
+      # Live grading, same posture as the other rungs: CURIE_E2E_LIVE drops the
+      # fake fixture and the ladder reads the OpenRouter credential from
+      # CURIE_CREDENTIALS. The secret travels only as this env mapping, never on
+      # a run: or argv line. No CURIE_BASE_TAG here (unlike the skill+local job):
+      # this rung runs against the generated release compose, whose image refs are
+      # the `:latest` tags built above, not a base-tag override.
+      - name: Graded parity ladder (local-release rung against generated compose.release.yaml, live model)
+        env:
+          CURIE_BIN: cli/target/release/curie
+          CURIE_E2E_TIERS: local-release
+          CURIE_E2E_LIVE: "1"
+          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
+          CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
+        run: bash cli/scripts/e2e-ladder.sh
+
   # Graded sibling of ci.yaml's e2e-ladder-cluster: same kind substrate and
   # round-trip mechanics, but the install is graded (not sealed) and the run
   # step is armed live.


### PR DESCRIPTION
Closes #947. Follows #946 / ADR-0081's posture.

## Why
#946 armed the nightly graded ladder for **skill, local, cluster** but left the fourth rung, **`local-release`**, unarmed. That's the rung that runs against the **generated** release compose (`compose.release.yaml`, derived from `compose.dev.yaml` by `compose/generate_release_compose.py`) — the artifact a *release binary's* `curie local up` actually runs. CI covers it against the **fake model only**, so that parity seam was the one rung never graded against a real model.

## What
`ladder-local-release`, a graded sibling of `ci.yaml`'s `e2e-ladder-release`:
- Same image builds, including the **named cache-only buildx builder with `use: false`** so the compose-triggered worker-local overlay still resolves its `:ci-local` FROM base from the plain-docker daemon store (#697/#791/#803), and the same gha cache scopes.
- Same `curie-api:latest` retag + worker-local overlay build the generated file's pinned refs require (it carries no build directives).
- `CURIE_E2E_TIERS=local-release` with `CURIE_E2E_LIVE=1`, and the **same key posture as the other graded rungs** — the credential travels only as an env mapping, never on a `run:`/argv line.
- **No `CURIE_BASE_TAG`** here (unlike the skill+local job): this rung runs against the generated release compose, whose refs are the `:latest` tags built above.

`local-release` stays out of `CURIE_E2E_TIERS=all` by design (the rung preflights that the release-pinned images already exist, since a release binary has no checkout to build them from), so the job builds them first and names the rung explicitly.

## Verification
Rather than assume the build steps satisfy the rung's dynamic preflight, I ran the **real generator locally**: `docker compose -f <generated> --profile core config --images` demands exactly `ghcr.io/curie-eng/curie-api:latest` and `ghcr.io/curie-eng/curie-worker-local:latest` — both produced above (plus `curie-runner:latest` for the worker to spawn runners). `actionlint` clean; job graph is `build-cli → {skill-local, local-release, cluster}`.

Note: as a `schedule`/`workflow_dispatch` workflow this doesn't run on the PR — the first real exercise is the next nightly (or a manual `workflow_dispatch`).