### PR TITLE
Enforce one agent per Slack channel

### DIFF
--- a/apps/api/alembic/versions/0017_agent_channel_unique.py
+++ b/apps/api/alembic/versions/0017_agent_channel_unique.py
@@ -1,0 +1,66 @@
+"""one agent per Slack channel: unique agents.slack_channel (#38)
+
+`agents.slack_channel` was a plain non-unique column, so the API happily created
+N agents on one channel -- but the worker's binding resolver maps a channel to a
+single agent (`ORDER BY (environment='prod') DESC, deployed_at DESC`), so every
+agent after the winner was silently shadowed: deployed, healthy-looking, and
+never answering in Slack. Issue #38 asked for a decision between enforcing 1:1
+and supporting N-per-channel intentionally; 1:1 is the choice, matching what the
+resolver already assumes.
+
+A pre-existing install can already hold duplicates, and creating the constraint
+on that data fails with a bare `duplicate key value` naming one channel. Check
+first and raise an actionable error listing every offending channel, so the
+operator can re-point or delete the shadowed agents and re-run.
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-07-24
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0017"
+down_revision: str | None = "0016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+CONSTRAINT = "agents_slack_channel_key"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    duplicates = conn.execute(
+        sa.text(
+            f"""
+            SELECT slack_channel, count(*) AS n, string_agg(name, ', ' ORDER BY name) AS agents
+            FROM {SCHEMA}.agents
+            GROUP BY slack_channel
+            HAVING count(*) > 1
+            ORDER BY slack_channel
+            """
+        )
+    ).all()
+    if duplicates:
+        detail = "; ".join(
+            f"{row.slack_channel}: {row.n} agents ({row.agents})" for row in duplicates
+        )
+        raise RuntimeError(
+            "cannot enforce one agent per Slack channel (#38): these channels have "
+            f"more than one agent bound -- {detail}. Only one agent per channel can "
+            "ever respond (the worker's resolver picks prod-first, then the most "
+            "recently deployed, and shadows the rest), so the extras are already "
+            "inert. Re-point them to their own channels or delete them, then re-run "
+            "this migration."
+        )
+    op.create_unique_constraint(
+        CONSTRAINT, "agents", ["slack_channel"], schema=SCHEMA
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(CONSTRAINT, "agents", type_="unique", schema=SCHEMA)

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -40,7 +40,10 @@ class Agent(Base):
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
     name: Mapped[str] = mapped_column(unique=True)
-    slack_channel: Mapped[str]
+    # One agent per Slack channel (#38). The worker resolves a channel to an
+    # agent, so a second agent bound to the same channel could never respond --
+    # it would be silently shadowed. Enforced here so it fails at create time.
+    slack_channel: Mapped[str] = mapped_column(unique=True)
     # The GitHub repo (owner/name) whose pushes deploy this agent (J1).
     repo_full_name: Mapped[str | None] = mapped_column(
         default=None, unique=True, index=True

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -31,12 +31,18 @@ router = APIRouter(
 # exception -- there is no psycopg-style `.diag` namespace.
 _UNIQUE_VIOLATION = "23505"
 
-# The two real unique constraints on `agents` (from the alembic migrations),
-# mapped to the human message for each. Any other unique violation falls back
-# to a generic message.
+# The real unique constraints on `agents` (from the alembic migrations), mapped
+# to the human message for each. Any other unique violation falls back to a
+# generic message.
 _UNIQUE_CONSTRAINT_MESSAGES = {
     "agents_name_key": "an agent with that name already exists",
     "ix_agents_repo_full_name": "an agent for that repository already exists",
+    # #38: one agent per channel. Without this the create succeeded and the
+    # second agent was silently shadowed by the worker's resolver at runtime.
+    "agents_slack_channel_key": (
+        "another agent is already bound to that Slack channel; one agent per "
+        "channel (move or delete the other agent, or pick another channel)"
+    ),
 }
 
 
@@ -123,7 +129,21 @@ async def update_agent(
     if agent is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
     if data.slack_channel is not None:
-        agent = await crud.update_agent_channel(session, agent, data.slack_channel)
+        # slack_channel is unique (one agent per channel, #38), so this is the one
+        # PATCHable field that can collide with another agent. Classify it the same
+        # way create does -- a caller conflict is a 409, not an opaque 500 -- so the
+        # constraint cannot be sidestepped by creating on a free channel and then
+        # moving onto a taken one. (Before #38 no PATCHable field was unique, which
+        # is why this path had no IntegrityError handler.)
+        try:
+            agent = await crud.update_agent_channel(session, agent, data.slack_channel)
+        except IntegrityError as exc:
+            await session.rollback()
+            classified = classify_integrity_error(exc)
+            if classified is None:
+                raise
+            status_code, message = classified
+            raise HTTPException(status_code, message) from exc
     if data.model is not None:
         agent = await crud.update_agent_model(session, agent, data.model)
     if data.approval_required_tools is not None:

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -48,6 +48,42 @@ def test_duplicate_repo_is_409(
     assert dup.json()["detail"] == "an agent for that repository already exists"
 
 
+def test_duplicate_slack_channel_is_409(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """#38: one agent per channel. A second agent on a taken channel is refused
+    at create time, rather than being accepted and then silently shadowed by the
+    worker's resolver (which routes a channel to exactly one agent)."""
+
+    first = _create(client, auth_headers, name="chan-agent-a", slack_channel="C0EEEEEE5")
+    assert first.status_code == 201, first.text
+
+    dup = _create(client, auth_headers, name="chan-agent-b", slack_channel="C0EEEEEE5")
+    assert dup.status_code == 409, dup.text
+    assert "already bound to that Slack channel" in dup.json()["detail"]
+
+
+def test_patch_onto_taken_slack_channel_is_409(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """The update seam is fenced identically to create (#143's posture): the
+    constraint cannot be sidestepped by creating on a free channel and then
+    PATCHing onto a taken one."""
+
+    first = _create(client, auth_headers, name="patch-chan-a", slack_channel="C0FFFFFF6")
+    assert first.status_code == 201, first.text
+    second = _create(client, auth_headers, name="patch-chan-b", slack_channel="C0FFFFFF7")
+    assert second.status_code == 201, second.text
+
+    moved = client.patch(
+        f"/agents/{second.json()['id']}",
+        json={"slack_channel": "C0FFFFFF6"},
+        headers=auth_headers,
+    )
+    assert moved.status_code == 409, moved.text
+    assert "already bound to that Slack channel" in moved.json()["detail"]
+
+
 def test_agent_approval_required_tools_round_trip(
     client: Any, auth_headers: dict[str, str], clean_db: None
 ) -> None:

--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -216,9 +216,12 @@ class BindingResolver:
         if not rows:
             return None
         # The ORDER BY still picks one deterministic winner (prod-first, then most
-        # recent), but if more than one *agent* is bound to this channel the others
-        # silently never respond. Surface that instead of dropping them invisibly
-        # (#38). One agent with both a dev and a prod deployment active is two rows
+        # recent). Since #38 the API enforces one agent per channel (a unique
+        # constraint on agents.slack_channel, migration 0017), so two agents on one
+        # channel is no longer reachable through the write paths -- this stays as
+        # defense in depth for rows predating the constraint or written out of band,
+        # and because silently shadowing an agent is the failure mode #38 existed to
+        # kill. One agent with both a dev and a prod deployment active is two rows
         # but one agent, so count distinct agents, not rows.
         distinct_agents = {r["agent_id"] for r in rows}
         if len(distinct_agents) > 1:

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -27,7 +27,7 @@ from curie_worker.binding import (
 from curie_worker.config import WorkerConfig
 from curie_worker.sandbox_token import verify
 from sqlalchemy import text
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 _DB_URL = os.environ.get(
@@ -105,6 +105,30 @@ async def _seed_deployment(
             {"id": uuid.uuid4(), "agent_id": agent_id, "version_id": version_id,
              "env": environment, "status": status},
         )
+
+
+# The unique constraint migration 0017 adds for one-agent-per-channel (#38).
+# Dropping it is how the test below simulates a database whose constraint was
+# removed out of band, the only way the resolver's shadow branch is now
+# reachable. Safe because this suite runs serially (no pytest-xdist).
+_CHANNEL_CONSTRAINT = "agents_slack_channel_key"
+
+
+async def _set_channel_constraint(engine: AsyncEngine, *, present: bool) -> None:
+    async with engine.begin() as conn:
+        if present:
+            await conn.execute(
+                text(
+                    f"ALTER TABLE {_SCHEMA}.agents ADD CONSTRAINT {_CHANNEL_CONSTRAINT} "
+                    "UNIQUE (slack_channel)"
+                )
+            )
+        else:
+            await conn.execute(
+                text(
+                    f"ALTER TABLE {_SCHEMA}.agents DROP CONSTRAINT {_CHANNEL_CONSTRAINT}"
+                )
+            )
 
 
 async def _cleanup(engine: AsyncEngine, agent_ids: list[uuid.UUID]) -> None:
@@ -195,9 +219,23 @@ def test_prod_deployment_wins_over_dev() -> None:
     asyncio.run(go())
 
 
-def test_multiple_agents_on_one_channel_warns_and_picks_one(
+def test_multiple_agents_on_one_channel_is_refused_and_still_warns_if_forced(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    """#38 is fixed by PREVENTION, with the resolver warning kept as a net.
+
+    Two halves:
+
+    1. The invariant: a second agent bound to an already-bound channel is refused
+       by the database (migration 0017's unique constraint), so the silent-shadow
+       state is unreachable through any write path. This is the worker-side proof
+       of the same invariant the API asserts as a 409.
+    2. Defense in depth: the resolver still warns rather than silently dropping an
+       agent, for a database whose constraint was removed out of band. That branch
+       is only reachable by removing the constraint, which is exactly what this
+       half does (serial suite, restored in the finally).
+    """
+
     async def go() -> None:
         engine = create_async_engine(_DB_URL)
         try:
@@ -209,33 +247,54 @@ def test_multiple_agents_on_one_channel_warns_and_picks_one(
 
             token = uuid.uuid4().hex[:8]
             channel = f"C-{token}"
-            # Two distinct agents bound to the same channel, both active.
             a_prod = await _seed_agent(
                 engine, channel=channel, name=f"agent-a-{token}", max_usd=None, max_tokens=None
             )
-            a_dev = await _seed_agent(
-                engine, channel=channel, name=f"agent-b-{token}", max_usd=None, max_tokens=None
-            )
-            await _seed_deployment(
-                engine, agent_id=a_prod, environment="prod", bundle_ref="bundles/a.zip"
-            )
-            await _seed_deployment(
-                engine, agent_id=a_dev, environment="dev", bundle_ref="bundles/b.zip"
-            )
 
-            with caplog.at_level("WARNING"):
-                resolved = await _resolver(engine).resolve(channel)
+            # 1. Prevention: the duplicate insert is refused by the constraint.
+            with pytest.raises(IntegrityError):
+                await _seed_agent(
+                    engine,
+                    channel=channel,
+                    name=f"agent-b-{token}",
+                    max_usd=None,
+                    max_tokens=None,
+                )
 
-            # Deterministic winner (prod outranks dev) and a warning naming the
-            # shadowed agent, rather than a silent drop (#38).
-            assert resolved is not None
-            assert resolved.agent_id == a_prod
-            assert any(
-                "agents bound" in r.message and str(a_dev) in r.message
-                for r in caplog.records
-            )
+            # 2. The net: force the state the constraint now prevents.
+            await _set_channel_constraint(engine, present=False)
+            a_dev: uuid.UUID | None = None
+            try:
+                a_dev = await _seed_agent(
+                    engine,
+                    channel=channel,
+                    name=f"agent-b-{token}",
+                    max_usd=None,
+                    max_tokens=None,
+                )
+                await _seed_deployment(
+                    engine, agent_id=a_prod, environment="prod", bundle_ref="bundles/a.zip"
+                )
+                await _seed_deployment(
+                    engine, agent_id=a_dev, environment="dev", bundle_ref="bundles/b.zip"
+                )
 
-            await _cleanup(engine, [a_prod, a_dev])
+                with caplog.at_level("WARNING"):
+                    resolved = await _resolver(engine).resolve(channel)
+
+                # Deterministic winner (prod outranks dev) and a warning naming the
+                # shadowed agent, rather than a silent drop (#38).
+                assert resolved is not None
+                assert resolved.agent_id == a_prod
+                assert any(
+                    "agents bound" in r.message and str(a_dev) in r.message
+                    for r in caplog.records
+                )
+            finally:
+                # Delete the duplicates BEFORE restoring the constraint, or the
+                # ALTER TABLE would fail on the very rows this test created.
+                await _cleanup(engine, [a for a in (a_prod, a_dev) if a is not None])
+                await _set_channel_constraint(engine, present=True)
         finally:
             await engine.dispose()
 


### PR DESCRIPTION
Closes #38, taking **option 1: enforce 1:1**.

## The bug
The three layers disagreed and production failed **silently**: the schema let the API create N agents on one channel, but the worker's resolver maps a channel to exactly **one** agent (`ORDER BY (environment='prod') DESC, deployed_at DESC`). Every agent after the winner was deployed, healthy-looking, and never answered in Slack.

## The fix
- **Schema** — `agents.slack_channel` is `UNIQUE` (migration **0017**). A second agent on a taken channel fails at create time instead of becoming an inert shadow. 1:1 matches what the resolver already assumed.
- **Migration guard** — an existing install may already hold duplicates, where creating the constraint dies with a bare `duplicate key value` naming one channel. The migration checks first and raises an **actionable** error listing every offending channel *and its agents*, so the operator can re-point/delete the shadowed ones and re-run.
- **API** — the constraint gets a named 409 via the existing `classify_integrity_error` path: *"another agent is already bound to that Slack channel…"* — a caller conflict, not an opaque 500.
- **API gap this surfaced** — `PATCH /agents/{id}` had **no** `IntegrityError` handling at all (before this change no PATCHable field was unique), so moving an agent onto a taken channel **500'd**. It now classifies identically to create, closing the create-on-free-channel-then-PATCH-onto-taken bypass. **Caught by the new test, not by inspection.**
- **Worker** — the existing shadow warning stays as defense in depth (rows predating the constraint, or written out of band); its comment now records that the write paths can't produce that state.

## No CLI change needed
Its `multiple agents are deployed; pass --channel <id>` error already lists `name -> channel` pairs — and under 1:1, `--channel` genuinely disambiguates, so the dead end the issue described is now correct as written.

## Verification
- New tests: duplicate channel on **create** → 409; **PATCH** onto a taken channel → 409. Both run against **real Postgres** (disposable-DB conftest), which also **proves migration 0017 applies** — the 409s name `agents_slack_channel_key`.
- `test_agents.py` 26/26; `ruff` + `mypy` clean.
- The 6 failures elsewhere in `apps/api/tests` are **pre-existing** `*_integration.py` tests needing the compose dev stack — verified by re-running them with these changes stashed (identical failures).
- Untested branch, stated plainly: the migration's duplicate-guard **raise** path. Its query executes on every upgrade (it ran clean on the empty case, so the SQL is valid); only the "duplicates exist" branch has no automated cover.

## Operator note
This is a **breaking migration for any install that already has two agents on one channel** — by design, with the actionable error above. Those extra agents are already inert.