### PR TITLE
OTel redaction: make sequence-valued span attributes scrub and fail closed

### DIFF
--- a/runner/src/curie_runner/otel.py
+++ b/runner/src/curie_runner/otel.py
@@ -131,6 +131,25 @@ def _set(span: Any, key: SpanAttributeKey, value: object) -> None:
     span.set_attribute(key.value, redact_span_attribute(value))
 
 
+def _still_leaks(value: object) -> bool:
+    """Whether an attribute value still carries an unscrubbed secret.
+
+    Type-agnostic on purpose (#935). ADR-0076 decision 3 frames the export
+    validator as a universal backstop, but it only inspected ``str``, so a
+    sequence-valued attribute on an ALLOWED key slipped a secret past BOTH the
+    scrub and this validator — the two layers failing together, which is exactly
+    what defense in depth is supposed to prevent. ``str`` is itself a Sequence, so
+    it is matched first; anything that is neither a str nor a list/tuple (int,
+    float, bool) cannot carry a pattern match and is clean by construction.
+    """
+
+    if isinstance(value, str):
+        return redact_text(value) != value
+    if isinstance(value, (list, tuple)):
+        return any(_still_leaks(item) for item in value)
+    return False
+
+
 class _SchemaValidatingSpanProcessor(SpanProcessor):
     """Fail-closed export-time backstop (ADR-0076 decision 3).
 
@@ -138,7 +157,8 @@ class _SchemaValidatingSpanProcessor(SpanProcessor):
     closed ``SpanAttributeKey`` enum and the ``redact.py`` scrub; this processor
     exists for the call site that bypasses both by calling ``span.set_attribute``
     directly. On each span ending, it strips (does not replace) any attribute
-    whose key is outside the closed schema, or whose string value still matches
+    whose key is outside the closed schema, or whose value — or any element of a
+    sequence value (#935) — still matches
     an unscrubbed-secret pattern after the existing redaction pass — dropping the
     offending attribute rather than the whole span, so one bad key costs a single
     field of trace data rather than the whole record.
@@ -168,7 +188,7 @@ class _SchemaValidatingSpanProcessor(SpanProcessor):
         try:
             for key in list(attributes.keys()):
                 value = attributes[key]
-                still_leaks = isinstance(value, str) and redact_text(value) != value
+                still_leaks = _still_leaks(value)
                 if key not in self._ALLOWED_KEYS or still_leaks:
                     del attributes[key]
         finally:

--- a/runner/src/curie_runner/redact.py
+++ b/runner/src/curie_runner/redact.py
@@ -152,15 +152,23 @@ def redact_text(text: str) -> str:
 def redact_span_attribute(value: object) -> object:
     """Redact a span attribute value, preserving its type.
 
-    Strings are scrubbed; every other value (int, float, bool) passes through
-    untouched, so the ``gen_ai.usage.*`` token counts stay ints. Only str and int
-    attributes are set today. OTel also permits sequence values, and a sequence
-    would pass through here unscrubbed, so a caller that starts setting one must
-    extend this function and add its frozen vector.
+    Strings are scrubbed and sequences are scrubbed ELEMENTWISE, preserving the
+    container type (OTel requires a homogeneous sequence, so scrubbed str elements
+    stay str). Every other value (int, float, bool) passes through untouched, so
+    the ``gen_ai.usage.*`` token counts stay ints.
+
+    Sequences are handled here rather than left to a future caller (#935): only str
+    and int attributes are set today, but OTel permits sequence values, and relying
+    on whoever adds the first one to remember to extend this function is exactly
+    the defense-in-depth gap that issue closed. ``otel.py``'s export validator
+    recurses the same way as the backstop.
     """
 
     if isinstance(value, str):
         return redact_text(value)
+    if isinstance(value, (list, tuple)):
+        scrubbed = [redact_span_attribute(item) for item in value]
+        return tuple(scrubbed) if isinstance(value, tuple) else scrubbed
     return value
 
 

--- a/runner/tests/test_otel.py
+++ b/runner/tests/test_otel.py
@@ -270,6 +270,35 @@ def test_validator_strips_value_still_matching_an_unscrubbed_secret() -> None:
     assert "langfuse.trace.name" not in finished.attributes
 
 
+def test_validator_strips_sequence_value_hiding_an_unscrubbed_secret() -> None:
+    # #935: the validator is framed as a type-agnostic backstop (ADR-0076 decision
+    # 3), but it only inspected `str` values -- so a SEQUENCE-valued attribute on
+    # an allowed key carried a secret straight to the exporter, past both the scrub
+    # and this validator. OTel permits sequence values, so the backstop must
+    # recurse rather than trust that no call site ever sets one.
+    provider, exporter = _validated_exporter()
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("agent.run") as span:
+        span.set_attribute(
+            "langfuse.trace.name", ["sk-abcdefghijklmnopqrstuvwx", "clean"]
+        )
+
+    (finished,) = exporter.get_finished_spans()
+    assert "langfuse.trace.name" not in finished.attributes
+
+
+def test_validator_keeps_a_clean_sequence_value() -> None:
+    # The recursion must not become a blanket "drop all sequences": a clean
+    # sequence on an allowed key is legitimate telemetry and survives.
+    provider, exporter = _validated_exporter()
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("agent.run") as span:
+        span.set_attribute("langfuse.trace.name", ["curie-run:test", "clean"])
+
+    (finished,) = exporter.get_finished_spans()
+    assert finished.attributes["langfuse.trace.name"] == ("curie-run:test", "clean")
+
+
 def test_validator_leaves_clean_allowed_attributes_untouched() -> None:
     provider, exporter = _validated_exporter()
     tracer = provider.get_tracer("test")

--- a/runner/tests/test_redact.py
+++ b/runner/tests/test_redact.py
@@ -232,3 +232,26 @@ def test_ordinary_log_lines_are_untouched() -> None:
 def test_normal_prose_is_untouched() -> None:
     line = "The turn finished after two tool calls and the budget ceiling was not reached."
     assert redact_text(line) == line
+
+
+def test_redact_span_attribute_scrubs_inside_sequences() -> None:
+    # #935: sequences passed through the scrub untouched. OTel permits them, and a
+    # future sequence-valued attribute must not depend on someone remembering to
+    # extend this function -- so scrub elementwise, preserving the container type
+    # (OTel requires a homogeneous sequence, and str elements stay str).
+    scrubbed = redact_span_attribute(["sk-abcdefghijklmnopqrstuvwx", "clean"])
+    assert isinstance(scrubbed, list)
+    assert scrubbed[0] != "sk-abcdefghijklmnopqrstuvwx"
+    assert scrubbed[1] == "clean"
+
+    as_tuple = redact_span_attribute(("sk-abcdefghijklmnopqrstuvwx",))
+    assert isinstance(as_tuple, tuple)
+    assert as_tuple[0] != "sk-abcdefghijklmnopqrstuvwx"
+
+
+def test_redact_span_attribute_leaves_non_string_scalars_and_types_alone() -> None:
+    # Negative control: the token counts must stay ints, and a numeric sequence
+    # must not be stringified by the new recursion.
+    assert redact_span_attribute(12) == 12
+    assert redact_span_attribute(True) is True
+    assert redact_span_attribute([1, 2]) == [1, 2]


### PR DESCRIPTION
Closes #935.

## The hole
Sequence-valued (list/tuple) span attributes bypassed **both** redaction layers from the ADR-0076 epic:

- `redact_span_attribute` scrubbed only `isinstance(value, str)`
- the export validator's check was likewise `isinstance(value, str) and redact_text(value) != value`

So an **allowed** key carrying `["sk-ant-…", "clean"]` reached the OTLP exporter with the secret **verbatim** — the two layers failing *together*, which is precisely what defense in depth exists to prevent, and contradicts ADR-0076 decision 3's framing of the validator as a universal, type-agnostic backstop.

Not a live leak (nothing sets a sequence-valued attribute today), so this is about making the backstop real rather than assumed.

## Fix — both layers recurse
- **`redact.py`** — scrubs sequences **elementwise**, preserving container type (list→list, tuple→tuple; OTel requires a homogeneous sequence, so scrubbed `str` elements stay `str`). Deliberately handled here instead of leaving the old docstring's "a future caller must extend this function" — relying on whoever adds the first sequence attribute to remember *is* the gap.
- **`otel.py`** — the leak check moves into a `_still_leaks` helper that recurses into list/tuple. `str` is itself a `Sequence`, so it's matched first; `int`/`float`/`bool` can't carry a pattern match and are clean by construction.

## Verification (tests written first, observed failing)
I wrote the tests before the fix and **watched them fail on unfixed code** — the secret came through verbatim — then pass:

- validator **drops** a sequence hiding a secret on an allowed key;
- validator **keeps** a clean sequence, so the recursion isn't a blanket drop-all-sequences;
- scrub redacts inside **both list and tuple**, and leaves ints/bools and numeric sequences alone (negative control).

**473 runner tests pass**; `ruff` + `mypy` clean. No schema change, so the committed telemetry schema and its drift gate (`test_otel_schema_drift.py`) are untouched.