### PR TITLE
Assert the seam catalog's prose counts against the tree (#938)

### DIFF
--- a/tools/doclint/src/curie_doclint/__init__.py
+++ b/tools/doclint/src/curie_doclint/__init__.py
@@ -1,10 +1,13 @@
 """The interface-catalog citation linter and index/header generator (#452).
 
-Two phases run over the linted root (``docs/`` excluding ``docs/adr/``):
+Three phases run over the linted root (``docs/`` excluding ``docs/adr/``):
 
 1. Generate: regenerate the seam table in ``docs/interfaces.md`` and each seam
    doc's header blockquote from front-matter, comparing to what is on disk.
-2. Lint: walk every citation, assert no line coordinates, every path exists,
+2. Counts: assert the bare counts a seam doc states about the tree ("nine
+   runner modules import ``claude_agent_sdk``") against the tree itself, so
+   prose numbers cannot silently re-drift (#938, see ``counts.py``).
+3. Lint: walk every citation, assert no line coordinates, every path exists,
    every Python symbol resolves.
 
 ``main`` is a pure check by default (drift is a finding, nothing is written);
@@ -30,6 +33,7 @@ from .citation import (
     path_exists,
     scan_raw_line_ban,
 )
+from .counts import check_counts
 from .finding import Finding
 from .frontmatter import SeamMeta, parse_and_validate
 from .generate import (
@@ -95,6 +99,10 @@ def _lint_and_count(repo_root: Path) -> tuple[list[Finding], int]:
     cache = SymbolCache()
     findings: list[Finding] = []
     findings.extend(_check_generation(repo_root))
+    # Prose counts the catalog states about the tree (#938). Not a generated
+    # region: the numbers sit mid-sentence, so they are asserted against source
+    # rather than rewritten, and `--write` leaves them alone.
+    findings.extend(check_counts(repo_root))
     doc_findings, ignored = _check_docs(repo_root, cache)
     findings.extend(doc_findings)
     return findings, ignored

--- a/tools/doclint/src/curie_doclint/counts.py
+++ b/tools/doclint/src/curie_doclint/counts.py
@@ -1,0 +1,240 @@
+"""Source-derived counts embedded in seam-catalog prose (#938).
+
+ADR-0043's gate keeps the catalog's *citations*, *grades* and *generated
+regions* honest, but a seam doc also states bare counts of things in the tree
+-- "nine runner modules import ``claude_agent_sdk``", "32 committed schemas".
+Those were hand-written prose that nothing recomputed, so the count-drift class
+fired twice (#858, then #920's residual) before this module existed: a tenth
+importing module or a thirty-third schema left the doc asserting the opposite
+of reality while the gate stayed green.
+
+Each claim below pairs a **regex that locates the number in the prose** with a
+**counter that derives the truth from the tree**. There are two ways to fail,
+both loud:
+
+- the stated count disagrees with the tree -- the drift the class is named for;
+- the anchor phrase is gone, so the regex matches nothing.
+
+The second is what keeps the gate from going vacuous. A reworded sentence would
+otherwise silently stop being checked, leaving a green gate over unverified
+prose -- which is exactly the failure mode #938 was filed about, one level up.
+So rewording one of these sentences is a deliberate edit here too, and the
+finding says so.
+
+Counts are matched in either spelling: the prose writes small numbers as words
+("nine runner modules") and larger ones as digits ("32 committed schemas"), so
+both forms parse and either is accepted for the same value.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .finding import Finding
+
+# Number words the prose plausibly spells out. Past twenty the docs use digits,
+# and an unparseable token is reported rather than guessed at, so this map only
+# has to cover the range the house style actually writes as words.
+_NUMBER_WORDS: dict[str, int] = {
+    "zero": 0,
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+    "eleven": 11,
+    "twelve": 12,
+    "thirteen": 13,
+    "fourteen": 14,
+    "fifteen": 15,
+    "sixteen": 16,
+    "seventeen": 17,
+    "eighteen": 18,
+    "nineteen": 19,
+    "twenty": 20,
+}
+
+# A module counts as importing the SDK when it says so at import level, which
+# is the claim the prose makes ("imported across N runner modules"). A passing
+# mention in a comment or docstring is not an import and must not inflate it.
+_SDK_IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+claude_agent_sdk", re.MULTILINE)
+
+# Rust's plain unit-test attribute. `json_contract.rs` uses only this form
+# today; an async variant (`#[tokio::test]`) would need adding here as well as
+# to whatever the prose then claims.
+_RUST_TEST_RE = re.compile(r"#\[test\]")
+
+# The index is a listing OF the schemas, not one of them, so the count the
+# prose states ("32 committed schemas ... with an index") excludes it.
+_SCHEMA_INDEX_NAME = "index.json"
+
+
+def parse_count(token: str) -> int | None:
+    """Read a count written as digits or as an English number word.
+
+    Args:
+        token: The matched prose token, e.g. ``"32"`` or ``"nine"``.
+
+    Returns:
+        The integer value, or ``None`` when the token is neither digits nor a
+        known number word -- which the caller reports rather than guessing.
+    """
+    if token.isdigit():
+        return int(token)
+    return _NUMBER_WORDS.get(token.lower())
+
+
+def _count_sdk_importing_runner_modules(repo_root: Path) -> int:
+    """Count runner modules that import ``claude_agent_sdk`` at import level.
+
+    This is the leakage the harness seam grades itself on: every module here is
+    one the SDK is not yet walled off from.
+
+    Args:
+        repo_root: The repository root to resolve ``runner/src`` against.
+
+    Returns:
+        The number of ``.py`` files under ``runner/src`` carrying an SDK import.
+    """
+    src = repo_root / "runner" / "src"
+    return sum(
+        1
+        for path in sorted(src.rglob("*.py"))
+        if _SDK_IMPORT_RE.search(path.read_text(encoding="utf-8"))
+    )
+
+
+def _count_committed_cli_schemas(repo_root: Path) -> int:
+    """Count the committed CLI result schemas, excluding their index.
+
+    Args:
+        repo_root: The repository root to resolve ``cli/schema`` against.
+
+    Returns:
+        The number of ``*.json`` schema files under ``cli/schema``, not
+        counting ``index.json``, which lists them rather than being one.
+    """
+    schema_dir = repo_root / "cli" / "schema"
+    return sum(1 for path in schema_dir.glob("*.json") if path.name != _SCHEMA_INDEX_NAME)
+
+
+def _count_json_contract_tests(repo_root: Path) -> int:
+    """Count the tests validating real ``to_json()`` output against the schemas.
+
+    Args:
+        repo_root: The repository root to resolve the test file against.
+
+    Returns:
+        The number of ``#[test]`` attributes in ``cli/tests/json_contract.rs``,
+        or ``0`` when that file is absent.
+    """
+    path = repo_root / "cli" / "tests" / "json_contract.rs"
+    if not path.is_file():
+        return 0
+    return len(_RUST_TEST_RE.findall(path.read_text(encoding="utf-8")))
+
+
+@dataclass(frozen=True)
+class CountClaim:
+    """One count a seam doc states in prose, tied to its source of truth.
+
+    ``pattern`` must capture the count token in group 1 and may match more than
+    once -- a doc that repeats a count (the harness seam states its module
+    count twice) has every occurrence checked, so the two cannot disagree.
+    """
+
+    doc: str
+    label: str
+    pattern: re.Pattern[str]
+    counter: Callable[[Path], int]
+    source: str
+
+
+# Every count claim the seam catalog makes. Patterns are anchored on enough
+# surrounding words to hit only the claim: `committed schemas under` excludes
+# the same file's later "enforced by committed schemas and a drift gate", which
+# is prose about the schemas rather than a count of them.
+CLAIMS: tuple[CountClaim, ...] = (
+    CountClaim(
+        doc="docs/interfaces/harness-modelsession/INTERFACE.md",
+        label="runner modules importing claude_agent_sdk",
+        pattern=re.compile(r"(\S+)\s+runner\s+modules"),
+        counter=_count_sdk_importing_runner_modules,
+        source="`from`/`import claude_agent_sdk` in runner/src/**/*.py",
+    ),
+    CountClaim(
+        doc="docs/interfaces/cli-output/INTERFACE.md",
+        label="committed CLI result schemas",
+        pattern=re.compile(r"(\S+)\s+committed schemas under"),
+        counter=_count_committed_cli_schemas,
+        source="cli/schema/*.json excluding index.json",
+    ),
+    CountClaim(
+        doc="docs/interfaces/cli-output/INTERFACE.md",
+        label="json_contract output-validation tests",
+        pattern=re.compile(r"across\s+(\S+)\s+tests\s+in\s+`cli/tests/json_contract\.rs`"),
+        counter=_count_json_contract_tests,
+        source="#[test] in cli/tests/json_contract.rs",
+    ),
+)
+
+
+def check_counts(repo_root: Path, claims: tuple[CountClaim, ...] = CLAIMS) -> list[Finding]:
+    """Assert every prose count in the seam catalog against the tree (#938).
+
+    Args:
+        repo_root: The repository root the docs and sources are resolved under.
+        claims: The claims to check; defaults to the catalog's own [`CLAIMS`].
+
+    Returns:
+        One finding per claim that drifted or whose anchor phrase vanished, and
+        an empty list when every stated count matches the tree.
+    """
+    findings: list[Finding] = []
+
+    for claim in claims:
+        doc = repo_root / claim.doc
+        # Not every repo root carries every seam doc -- the doclint fixtures
+        # are a miniature tree. Whether a seam doc should exist at all is the
+        # catalog's own concern, not a count claim's, so a missing doc is
+        # skipped rather than reported here twice over.
+        if not doc.is_file():
+            continue
+
+        stated = claim.pattern.findall(doc.read_text(encoding="utf-8"))
+        if not stated:
+            findings.append(
+                Finding(
+                    claim.doc,
+                    claim.label,
+                    "no sentence states this count any more, so it is no longer "
+                    "verified. Restore the phrasing, or update this claim's pattern "
+                    "in tools/doclint/src/curie_doclint/counts.py "
+                    f"(source of truth: {claim.source}).",
+                )
+            )
+            continue
+
+        expected = claim.counter(repo_root)
+        # A set: a repeated count that is wrong the same way twice is one
+        # drift to fix, not two findings to read.
+        wrong = sorted({token for token in stated if parse_count(token) != expected})
+        if wrong:
+            findings.append(
+                Finding(
+                    claim.doc,
+                    claim.label,
+                    f"prose states {', '.join(repr(token) for token in wrong)} but the "
+                    f"tree has {expected} ({claim.source}). Update the prose to match.",
+                )
+            )
+
+    return findings

--- a/tools/doclint/tests/test_counts.py
+++ b/tools/doclint/tests/test_counts.py
@@ -1,0 +1,201 @@
+"""The seam-catalog count gate (#938).
+
+The counts a seam doc states about the tree ("nine runner modules import
+``claude_agent_sdk``", "32 committed schemas") were prose nothing recomputed,
+so the drift class fired twice -- #858, then #920's residual -- each time fixed
+by hand. These drive the real ``CLAIMS`` (real patterns, real counters) over
+miniature trees, so a pattern that stops matching the house phrasing fails here
+rather than in six months' review.
+
+Two failure modes matter equally and both are asserted: a count that disagrees
+with the tree, and an anchor phrase that vanished so nothing is checked at all.
+The second is the vacuity guard -- a silently-unchecked claim is the defect one
+level up from the one #938 reports.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from curie_doclint.counts import check_counts, parse_count
+
+from .conftest import Regenerate, RunLint, write
+
+_HARNESS_DOC = "docs/interfaces/harness-modelsession/INTERFACE.md"
+_CLI_OUTPUT_DOC = "docs/interfaces/cli-output/INTERFACE.md"
+
+
+def _sdk_module(name: str) -> tuple[str, str]:
+    """A runner module that imports the harness SDK at import level."""
+    return f"runner/src/curie_runner/{name}.py", "from claude_agent_sdk import Thing\n"
+
+
+def _harness_prose(count: str) -> str:
+    """The harness seam's sentence, in the house phrasing, stating ``count``."""
+    return (
+        "CLEAN, but the SDK is not yet confined to one module: "
+        f"{count} runner modules\nstill import it today.\n"
+    )
+
+
+def _cli_output_prose(schemas: str, tests: str) -> str:
+    """The cli-output seam's two sentences, in the house phrasing.
+
+    Both are written every time: the doc carries two claims, so omitting one
+    would (rightly) trip its vacuity guard and bury the claim under test.
+    """
+    return (
+        f"There are {schemas} committed schemas under `cli/schema/` with an index.\n"
+        f"All are validated against real `to_json()` output across {tests} tests in\n"
+        "`cli/tests/json_contract.rs`.\n"
+        "An agent is coupled to shapes enforced by committed schemas and a drift gate.\n"
+    )
+
+
+# --- the count disagrees with the tree: the named drift class --------------
+
+
+def test_matching_count_passes(tmp_path: Path) -> None:
+    # Positive control. Without this the suite could pass by reporting
+    # everything, which is no gate either.
+    write(tmp_path, *_sdk_module("a"))
+    write(tmp_path, *_sdk_module("b"))
+    write(tmp_path, _HARNESS_DOC, _harness_prose("two"))
+    assert check_counts(tmp_path) == []
+
+
+def test_drifted_count_is_reported(tmp_path: Path) -> None:
+    # The #858/#920 recurrence itself: a third importing module lands and the
+    # prose still says two. Before this gate, doc-lint stayed green here.
+    write(tmp_path, *_sdk_module("a"))
+    write(tmp_path, *_sdk_module("b"))
+    write(tmp_path, *_sdk_module("c"))
+    write(tmp_path, _HARNESS_DOC, _harness_prose("two"))
+    findings = check_counts(tmp_path)
+    assert len(findings) == 1
+    assert "'two'" in findings[0].reason
+    assert "3" in findings[0].reason
+
+
+def test_digits_and_number_words_are_both_accepted(tmp_path: Path) -> None:
+    # The house style spells small counts as words and larger ones as digits,
+    # so the same value must pass written either way.
+    write(tmp_path, *_sdk_module("a"))
+    write(tmp_path, *_sdk_module("b"))
+    write(tmp_path, _HARNESS_DOC, _harness_prose("2"))
+    assert check_counts(tmp_path) == []
+    assert parse_count("nine") == 9
+    assert parse_count("32") == 32
+    assert parse_count("many") is None
+
+
+def test_a_repeated_count_must_agree_in_every_place(tmp_path: Path) -> None:
+    # The real harness doc states its module count twice, in two different
+    # sentences. Checking only the first would let the second rot, which is
+    # how a "fixed" doc stays half wrong.
+    write(tmp_path, *_sdk_module("a"))
+    doc = _harness_prose("one") + "\nElsewhere: imported across seven runner modules.\n"
+    write(tmp_path, _HARNESS_DOC, doc)
+    findings = check_counts(tmp_path)
+    assert len(findings) == 1
+    assert "'seven'" in findings[0].reason
+
+
+# --- the anchor vanished: the vacuity guard --------------------------------
+
+
+def test_reworded_sentence_fails_rather_than_going_vacuous(tmp_path: Path) -> None:
+    # THE most important test here. A reworded sentence must not silently stop
+    # being checked -- a green gate over unverified prose is the failure mode
+    # #938 exists to close, and a skip would rebuild it one level up.
+    write(tmp_path, *_sdk_module("a"))
+    write(tmp_path, _HARNESS_DOC, "The SDK leaks into several modules today.\n")
+    findings = check_counts(tmp_path)
+    assert len(findings) == 1
+    assert "no longer verified" in findings[0].reason
+
+
+def test_absent_seam_doc_is_skipped(tmp_path: Path) -> None:
+    # A repo root that carries no seam docs at all (the miniature fixture tree)
+    # has no claims to check. Whether a seam doc should exist is the catalog's
+    # own concern, reported there, not duplicated as a count finding.
+    write(tmp_path, *_sdk_module("a"))
+    assert check_counts(tmp_path) == []
+
+
+# --- counter semantics -----------------------------------------------------
+
+
+def test_only_import_level_uses_count_as_importing_modules(tmp_path: Path) -> None:
+    # The prose claims modules that IMPORT the SDK. A module that merely names
+    # it in a comment is not one, or the count inflates on documentation edits.
+    write(tmp_path, *_sdk_module("real"))
+    write(
+        tmp_path,
+        "runner/src/curie_runner/mentions.py",
+        "# claude_agent_sdk is discussed here but never imported.\n",
+    )
+    write(tmp_path, _HARNESS_DOC, _harness_prose("one"))
+    assert check_counts(tmp_path) == []
+
+
+def test_schema_count_excludes_the_index_and_the_prose_mention(tmp_path: Path) -> None:
+    # Two traps in one. `index.json` lists the schemas rather than being one of
+    # them, and the same doc later says "enforced by committed schemas and a
+    # drift gate" -- prose ABOUT the schemas, not a count of them, which an
+    # under-anchored pattern would read as the count and choke on.
+    for name in ("kill", "resume", "budget"):
+        write(tmp_path, f"cli/schema/{name}.json", "{}\n")
+    write(tmp_path, "cli/schema/index.json", "{}\n")
+    write(tmp_path, "cli/tests/json_contract.rs", "#[test]\nfn a() {}\n")
+    write(tmp_path, _CLI_OUTPUT_DOC, _cli_output_prose(schemas="3", tests="one"))
+    assert check_counts(tmp_path) == []
+
+
+def test_json_contract_test_count_is_read_from_the_test_file(tmp_path: Path) -> None:
+    write(tmp_path, "cli/schema/kill.json", "{}\n")
+    write(
+        tmp_path,
+        "cli/tests/json_contract.rs",
+        "#[test]\nfn a() {}\n#[test]\nfn b() {}\n",
+    )
+    write(tmp_path, _CLI_OUTPUT_DOC, _cli_output_prose(schemas="1", tests="5"))
+    findings = check_counts(tmp_path)
+    assert len(findings) == 1
+    assert "'5'" in findings[0].reason
+    assert "2" in findings[0].reason
+
+
+# --- wired into the linter, not dead code ----------------------------------
+
+
+def test_count_drift_fails_through_the_cli(
+    clean_repo: Path, run_lint: RunLint, regenerate: Regenerate
+) -> None:
+    # The integration proof: the check runs as part of `curie dev docs-lint`,
+    # so a drifted count fails the real gate rather than only a unit test.
+    write(clean_repo, *_sdk_module("importer"))
+    write(
+        clean_repo,
+        _HARNESS_DOC,
+        "---\n"
+        "seam: Harness in-proc / ModelSession\n"
+        "kind: CLEAN\n"
+        "impls: 1 + fake\n"
+        "grade: not separately graded\n"
+        "epics:\n"
+        '  - "#25"\n'
+        "order: 99\n"
+        "---\n"
+        "\n# Harness\n\n"
+        "<!-- BEGIN GENERATED: header (curie dev docs-lint) -->\n"
+        "<!-- END GENERATED: header -->\n\n" + _harness_prose("six"),
+    )
+    # Regenerate first: a new seam doc legitimately changes the index and this
+    # doc's header, and that drift is a different finding than the one under
+    # test here.
+    regenerate(clean_repo)
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "runner modules importing claude_agent_sdk" in out
+    assert "'six'" in out


### PR DESCRIPTION
Fixes #938.

## Problem

Three counts the seam catalog states about the tree were hand-written prose that nothing recomputed:

- `harness-modelsession/INTERFACE.md` — "**nine** runner modules import `claude_agent_sdk`" (stated **twice**)
- `cli-output/INTERFACE.md` — "**32** committed schemas", "across **44** tests in `cli/tests/json_contract.rs`"

ADR-0043's gate covers citations, grades and generated regions — **not** embedded counts. So the drift class fired twice (#858, then #920's residual) and was fixed by hand both times. A 10th importing module or a 33rd schema would have left the docs asserting the opposite of reality with doc-lint still green.

## Fix — a `counts` phase in doclint

New `tools/doclint/src/curie_doclint/counts.py`. Each claim pairs a **regex locating the number in the prose** with a **counter deriving the truth from the tree**, and fails two ways, both loud:

1. **The stated count disagrees with the tree** — the named drift class.
2. **The anchor phrase is gone**, so nothing is checked any more.

The second is the vacuity guard and it is the point: a reworded sentence that silently stopped being verified would rebuild #938's own defect one level up. Rewording is therefore a deliberate edit in `counts.py` too, and the finding says exactly that.

Details worth flagging for review:

- **Not a generated region.** These numbers sit mid-sentence, so they are *asserted* rather than rewritten; `--write` leaves the prose alone and the sentences keep their voice.
- **Digits or number words.** The house style writes "nine runner modules" but "32 committed schemas", so both forms parse for the same value.
- **Patterns are anchored to hit only the claim.** `committed schemas under` deliberately excludes the same file's later *"enforced by committed schemas and a drift gate"* — prose *about* the schemas, not a count of them, which an under-anchored pattern would misread.
- **A repeated count is checked in every place** — the harness doc states its module count twice, and checking only the first would let the second rot.
- **Counting semantics match the claims**: import-level `from`/`import claude_agent_sdk` only (a comment mention is not an import); `cli/schema/*.json` minus `index.json` (the index lists the schemas rather than being one).

## Tests

`tools/doclint/tests/test_counts.py` — **10 cases** driving the *real* `CLAIMS` (real patterns, real counters) over miniature trees: drift reported, repeated count checked everywhere, the vacuity guard, a positive control, digits+words, import-level-only counting, the `index.json` and prose-mention traps, and one **CLI-level case proving the phase is wired into the linter** rather than being dead code.

## Verification

Both of the issue's failure scenarios executed against the **real repo**:

```
$ printf 'from claude_agent_sdk import Thing\n' > runner/src/curie_runner/_drift_probe.py
docs/interfaces/harness-modelsession/INTERFACE.md: runner modules importing claude_agent_sdk:
  prose states 'nine' but the tree has 10 (...). Update the prose to match.     exit=1

$ printf '{}\n' > cli/schema/_drift_probe.json
docs/interfaces/cli-output/INTERFACE.md: committed CLI result schemas:
  prose states '32' but the tree has 33 (...). Update the prose to match.
```

Removing the probes restores `exit=0`. Full suite green: **88 doclint tests**, `ruff`, `mypy` (162 files), and `scripts/check-docs.sh`.

No doc prose changed — all three counts verify true on main today; this only ties them to their sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)