### PR TITLE
Bump brace-expansion to 5.0.8 to clear the pnpm audit (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -629,9 +629,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.6:
     resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
@@ -1942,7 +1942,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2300,7 +2300,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Problem

The `pnpm audit (apps/ui)` job fails **on main**, and therefore on every open PR — including #952, which touches only Python files under `tools/doclint/`.

A newly-published high-severity advisory ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), DoS via unbounded brace expansion → OOM crash) covers `brace-expansion <= 5.0.7`. The lockfile pinned **5.0.7** transitively, via `minimatch` under both `eslint` and `typescript-eslint` (25 paths).

Reproduced on a clean `main` checkout with no changes, so this is repo-wide, not PR-specific. It is exactly the case the workflow's weekly cron exists to catch: *"Advisory databases change independently of the code, so re-run weekly to catch newly-published CVEs against dependencies that never changed."*

## Fix

Refresh the lockfile. **No `pnpm.overrides` needed**: `minimatch@10.2.5` declares `brace-expansion: ^5.0.5`, which `5.0.8` satisfies, so the patched version is reachable inside the existing range and the dependency graph is otherwise untouched.

Two process details worth flagging, both of which shaped the diff:

- **Regenerated with pnpm 9**, the version both CI workflows pin (`pnpm/action-setup` → `version: 9`), *not* the locally-installed pnpm 10. pnpm 10 writes extra `libc: [glibc]/[musl]` metadata onto the linux binding entries, which would have churned the diff with fields CI's pnpm never emits.
- **`pnpm update` rewrites `package.json` ranges as a side effect** (it bumped the testing-library and typescript minimums). That would have left the lockfile's `specifier:` fields disagreeing with the committed `package.json` and failed `--frozen-lockfile`. `package.json` was restored and the lockfile re-resolved against it.

Result: the committed diff is **three `brace-expansion` hunks and nothing else** — zero `specifier:` drift, zero `libc:` churn, `package.json` untouched.

## Verification

The audit job's exact two steps, run under **pnpm 9**:

```
$ pnpm install --frozen-lockfile   → exit 0   (lockfile in sync with package.json)
$ pnpm audit                       → No known vulnerabilities found   (exit 0)
```

Cross-checked that pnpm 10 also reads the lockfile as up to date ("Lockfile is up to date, resolution step is skipped"), and the installed tree resolves `brace-expansion@5.0.8`.

`apps/ui` on the bumped tree: `pnpm lint` clean, `pnpm typecheck` clean, `pnpm test` **143 tests / 24 files passed**.

## Note

Merging this unblocks the other open PRs; they will need a re-run (or a rebase) of the audit check to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)