### PR TITLE
Fail the seam count gate when a claim's doc is moved away

### DIFF
--- a/tools/doclint/src/curie_doclint/counts.py
+++ b/tools/doclint/src/curie_doclint/counts.py
@@ -9,17 +9,20 @@ importing module or a thirty-third schema left the doc asserting the opposite
 of reality while the gate stayed green.
 
 Each claim below pairs a **regex that locates the number in the prose** with a
-**counter that derives the truth from the tree**. There are two ways to fail,
-both loud:
+**counter that derives the truth from the tree**. There are three ways to
+fail, all loud:
 
 - the stated count disagrees with the tree -- the drift the class is named for;
-- the anchor phrase is gone, so the regex matches nothing.
+- the anchor phrase is gone, so the regex matches nothing;
+- (#956) the claim's doc no longer resolves under the catalog root -- moved or
+  renamed away, which would otherwise let a false count go unreachable.
 
-The second is what keeps the gate from going vacuous. A reworded sentence would
-otherwise silently stop being checked, leaving a green gate over unverified
-prose -- which is exactly the failure mode #938 was filed about, one level up.
-So rewording one of these sentences is a deliberate edit here too, and the
-finding says so.
+The second and third are what keep the gate from going vacuous. A reworded
+sentence, or a doc moved out from under its claim, would otherwise silently
+stop being checked, leaving a green gate over unverified prose -- which is
+exactly the failure mode #938 was filed about, one level up. So rewording one
+of these sentences, or renaming one of these docs, is a deliberate edit here
+too, and the finding says so.
 
 Counts are matched in either spelling: the prose writes small numbers as words
 ("nine runner modules") and larger ones as digits ("32 committed schemas"), so
@@ -75,6 +78,38 @@ _RUST_TEST_RE = re.compile(r"#\[test\]")
 # The index is a listing OF the schemas, not one of them, so the count the
 # prose states ("32 committed schemas ... with an index") excludes it.
 _SCHEMA_INDEX_NAME = "index.json"
+
+# This module's own path *within* the repository, used as the marker that
+# identifies a linted tree as the catalog.
+#
+# CLAIMS below are literals about THIS repository -- its own doc paths, its
+# own counters -- so they only bind when the tree being linted IS this
+# repository. Anywhere else (the doclint fixtures, a test's tmp tree) is a
+# miniature tree that legitimately carries none of the claimed docs, and a
+# missing doc there is not a defect.
+#
+# The question is asked of the LINT TARGET -- does the tree being linted carry
+# the doclint source? -- not of this module's own `__file__`. The two answers
+# differ under a built wheel, where `__file__` resolves into the virtualenv
+# rather than into any checkout, so a location-derived root would match no tree
+# at all and every claim would silently go back to being skipped: #956 rebuilt
+# one level up, with a green gate over unverified prose. Asking the target
+# answers identically from an editable workspace and from a wheel.
+_CATALOG_MARKER = Path("tools/doclint/src/curie_doclint/counts.py")
+
+
+def _is_catalog_root(repo_root: Path) -> bool:
+    """Report whether the tree being linted is the repository ``CLAIMS`` describe.
+
+    Args:
+        repo_root: The repository root being linted.
+
+    Returns:
+        ``True`` when that tree carries the doclint source at [`_CATALOG_MARKER`],
+        which only this repository does -- so a claimed doc missing there was
+        moved or renamed away rather than never present.
+    """
+    return (repo_root / _CATALOG_MARKER).is_file()
 
 
 def parse_count(token: str) -> int | None:
@@ -195,18 +230,35 @@ def check_counts(repo_root: Path, claims: tuple[CountClaim, ...] = CLAIMS) -> li
         claims: The claims to check; defaults to the catalog's own [`CLAIMS`].
 
     Returns:
-        One finding per claim that drifted or whose anchor phrase vanished, and
-        an empty list when every stated count matches the tree.
+        One finding per claim that drifted, whose anchor phrase vanished, or
+        (when ``repo_root`` is the catalog root) whose doc no longer resolves,
+        and an empty list when every stated count matches the tree.
     """
     findings: list[Finding] = []
+    is_catalog = _is_catalog_root(repo_root)
 
     for claim in claims:
         doc = repo_root / claim.doc
-        # Not every repo root carries every seam doc -- the doclint fixtures
-        # are a miniature tree. Whether a seam doc should exist at all is the
-        # catalog's own concern, not a count claim's, so a missing doc is
-        # skipped rather than reported here twice over.
         if not doc.is_file():
+            if is_catalog:
+                # CLAIMS are literals about this repository, so when repo_root
+                # IS the catalog root a missing doc was moved or renamed away,
+                # not legitimately absent -- the #956 defect: the skip below
+                # let a renamed seam doc launder a false count past the gate.
+                findings.append(
+                    Finding(
+                        claim.doc,
+                        claim.label,
+                        f"the seam doc has moved, so this claim ({claim.source}) is "
+                        "no longer verified. Restore the doc at this path, or update "
+                        f"this claim's doc path in {_CATALOG_MARKER}.",
+                    )
+                )
+            # Not every repo root carries every seam doc -- the doclint
+            # fixtures and a test's tmp tree are miniature trees. Whether a
+            # seam doc should exist at all is the catalog's own concern, not a
+            # count claim's, so outside the catalog root a missing doc is
+            # skipped rather than reported here twice over.
             continue
 
         stated = claim.pattern.findall(doc.read_text(encoding="utf-8"))
@@ -217,7 +269,7 @@ def check_counts(repo_root: Path, claims: tuple[CountClaim, ...] = CLAIMS) -> li
                     claim.label,
                     "no sentence states this count any more, so it is no longer "
                     "verified. Restore the phrasing, or update this claim's pattern "
-                    "in tools/doclint/src/curie_doclint/counts.py "
+                    f"in {_CATALOG_MARKER} "
                     f"(source of truth: {claim.source}).",
                 )
             )

--- a/tools/doclint/tests/test_counts.py
+++ b/tools/doclint/tests/test_counts.py
@@ -7,19 +7,21 @@ by hand. These drive the real ``CLAIMS`` (real patterns, real counters) over
 miniature trees, so a pattern that stops matching the house phrasing fails here
 rather than in six months' review.
 
-Two failure modes matter equally and both are asserted: a count that disagrees
-with the tree, and an anchor phrase that vanished so nothing is checked at all.
-The second is the vacuity guard -- a silently-unchecked claim is the defect one
-level up from the one #938 reports.
+Three failure modes matter equally and all are asserted: a count that disagrees
+with the tree, an anchor phrase that vanished so nothing is checked at all, and
+(#956) a seam doc that moved out from under its claim so the claim was skipped
+entirely. The last two are the vacuity guards -- a silently-unchecked claim is
+the defect one level up from the one #938 reports.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from curie_doclint.counts import check_counts, parse_count
+from curie_doclint import counts
+from curie_doclint.counts import CLAIMS, _CATALOG_MARKER, check_counts, parse_count
 
-from .conftest import Regenerate, RunLint, write
+from .conftest import REPO_ROOT, Regenerate, RunLint, write
 
 _HARNESS_DOC = "docs/interfaces/harness-modelsession/INTERFACE.md"
 _CLI_OUTPUT_DOC = "docs/interfaces/cli-output/INTERFACE.md"
@@ -113,6 +115,10 @@ def test_reworded_sentence_fails_rather_than_going_vacuous(tmp_path: Path) -> No
     findings = check_counts(tmp_path)
     assert len(findings) == 1
     assert "no longer verified" in findings[0].reason
+    # The remedy has to name where the claim lives or it is not actionable,
+    # and that path is interpolated rather than spelled out -- so assert it,
+    # else a dropped interpolation would render a broken sentence in silence.
+    assert str(_CATALOG_MARKER) in findings[0].reason
 
 
 def test_absent_seam_doc_is_skipped(tmp_path: Path) -> None:
@@ -121,6 +127,101 @@ def test_absent_seam_doc_is_skipped(tmp_path: Path) -> None:
     # own concern, reported there, not duplicated as a count finding.
     write(tmp_path, *_sdk_module("a"))
     assert check_counts(tmp_path) == []
+
+
+# --- the seam doc moved: the catalog-root guard (#956) ---------------------
+
+
+def test_a_missing_seam_doc_is_reported_under_the_catalog_root(tmp_path: Path) -> None:
+    # THE #956 defect. `CLAIMS` are literals about THIS repository, so when the
+    # tree being linted IS that repository a claim whose doc does not resolve
+    # was moved or renamed away, not legitimately absent. Skipping it there is
+    # how renaming `docs/interfaces/cli-output/` left the gate green over prose
+    # counts of 999 and 777.
+    write(tmp_path, *_sdk_module("a"))
+    write(tmp_path, _HARNESS_DOC, _harness_prose("one"))
+    write(tmp_path, str(_CATALOG_MARKER), "")
+    findings = check_counts(tmp_path)
+    assert [(finding.doc, finding.citation) for finding in findings] == [
+        (_CLI_OUTPUT_DOC, "committed CLI result schemas"),
+        (_CLI_OUTPUT_DOC, "json_contract output-validation tests"),
+    ]
+    for finding in findings:
+        assert "moved" in finding.reason
+        assert "no longer verified" in finding.reason
+        # As above: the remedy names the claim's home by interpolation, so
+        # nothing but this assertion stands between a dropped `{}` and a
+        # remedy sentence that tells the reader nothing.
+        assert str(_CATALOG_MARKER) in finding.reason
+
+
+def test_the_same_tree_is_silent_as_a_fixture_and_loud_as_the_catalog(
+    tmp_path: Path,
+) -> None:
+    # The escape hatch and the guard are one decision, so they are asserted
+    # against one tree. A miniature tree carries none of the seam docs by
+    # design and must stay silent; the same tree once it carries the doclint
+    # source -- the marker that makes it the catalog -- must report. Losing
+    # either half rebuilds #956 or breaks every fixture test in this file.
+    write(tmp_path, *_sdk_module("a"))
+    write(tmp_path, _HARNESS_DOC, _harness_prose("one"))
+    assert check_counts(tmp_path) == []
+    write(tmp_path, str(_CATALOG_MARKER), "")
+    assert check_counts(tmp_path) != []
+
+
+def test_a_renamed_doc_cannot_launder_a_false_count(tmp_path: Path) -> None:
+    # #956's own reproduction: the cli-output seam doc renamed to a sibling
+    # path, carrying prose that claims 999 schemas and 777 tests over a tree
+    # holding one of each. The rename must not be a way to make a false count
+    # unreachable -- the gate reports the claim's declared path either way.
+    write(tmp_path, *_sdk_module("a"))
+    write(tmp_path, _HARNESS_DOC, _harness_prose("one"))
+    write(tmp_path, "cli/schema/kill.json", "{}\n")
+    write(tmp_path, "cli/tests/json_contract.rs", "#[test]\nfn a() {}\n")
+    write(
+        tmp_path,
+        "docs/interfaces/cli-output-renamed/INTERFACE.md",
+        _cli_output_prose(schemas="999", tests="777"),
+    )
+    write(tmp_path, str(_CATALOG_MARKER), "")
+    findings = check_counts(tmp_path)
+    assert [finding.doc for finding in findings] == [_CLI_OUTPUT_DOC, _CLI_OUTPUT_DOC]
+    # The point being pinned: the gate reports the claim at its declared path
+    # rather than silently validating the renamed doc's false prose. If either
+    # false count leaked into a reason, the rename would have laundered it.
+    for finding in findings:
+        assert "999" not in finding.reason
+        assert "777" not in finding.reason
+
+
+def test_the_catalog_marker_names_the_real_doclint_source() -> None:
+    # The guard on the guard. A tree counts as the catalog when it carries the
+    # doclint source at `_CATALOG_MARKER`, so relocating that source would
+    # leave the marker naming a path no tree holds, no tree would ever be
+    # recognized, and every claim would silently go back to being skipped --
+    # #956 again, this time with a passing test suite. Pinning the marker
+    # against the imported module's own on-disk file reds CI on the move
+    # instead.
+    #
+    # This equality holds because the uv workspace installs curie-doclint
+    # editable, so counts.__file__ resolves inside the checkout at
+    # _CATALOG_MARKER. Under a non-editable install counts.__file__ would
+    # resolve into the site-packages copy instead, and this test FAILS LOUDLY
+    # rather than passing vacuously -- the correct direction for a guard on
+    # the guard. The production predicate _is_catalog_root deliberately does
+    # not depend on the install layout: it asks the lint target whether it
+    # carries the doclint source, not the installed copy, which is precisely
+    # why it survives a wheel install.
+    assert (REPO_ROOT / _CATALOG_MARKER).resolve() == Path(counts.__file__).resolve()
+
+
+def test_every_claim_doc_resolves_in_the_real_repository() -> None:
+    # The gate that actually reds CI when someone moves a seam doc: every
+    # claim's declared path exists in the real tree, and every count it states
+    # matches. This is the assertion the skip was hiding.
+    assert [claim.doc for claim in CLAIMS if not (REPO_ROOT / claim.doc).is_file()] == []
+    assert check_counts(REPO_ROOT) == []
 
 
 # --- counter semantics -----------------------------------------------------


### PR DESCRIPTION
The seam count gate skipped any claim whose seam doc was not found at its
hardcoded path, so renaming a seam doc left it passing green over arbitrarily
false counts. The issue's repro sets the cli-output counts to 999 and 777
behind a renamed directory and the gate still exits 0.

The skip could not simply become a failure: the doclint fixtures are a
miniature tree that legitimately carries none of the claim docs. Catalog
identity now comes from the lint target instead. A tree carrying the doclint
source IS the repository `CLAIMS` describe, so a claim whose doc does not
resolve there was moved or renamed rather than never present, and it is
reported by name. Miniature trees keep the skip.

## Demonstrated by execution

Running the issue's exact repro moves the gate from exit 0 to exit 1, naming
both affected claims. Loading the package from a copy outside any checkout
(wheel-shaped, module `__file__` in a temp dir) and linting the real checkout
also reports both claims, where deriving identity from the module's own
location would have computed a root of `.../jobs` and reported nothing.
Removing either remedy interpolation reds exactly the two tests that assert it.

## Why both a runtime guard and a test

`test_every_claim_doc_resolves_in_the_real_repository` alone would red CI on a
doc move, since `tools/doclint/tests` is in `testpaths`. The runtime guard is
what keeps `check_counts` non-vacuous for any caller rather than only the
pytest path, and it is what makes `curie dev docs-lint` fail locally on a
moved doc instead of only in CI.

## Out of scope, called out deliberately

- One hunk touches the pre-existing vanished-anchor remedy from #938 to
  interpolate the same marker constant. Outside this issue's criteria, changed
  so the two sibling messages in one function do not disagree in form. The
  rendered text is byte-identical; verified against the pre-change module.
- Nothing pins `CLAIMS` to the actual set of seam docs under
  `docs/interfaces/`, so a claim could still be dropped rather than moved.
  That is a residual hole one level up and wants its own issue: only 2 of 18
  seam docs carry claims, and closing it means inverting to doc-declared count
  markers, a different mechanism rather than a wider version of this one.
- `AGENTS.md` and `CONTRIBUTING.md` describe the docs gate but have never
  mentioned the count check at all (pre-existing since #938). Documenting only
  the half this PR adds would read incoherently, so neither was touched.

## Verification

`uv run --python 3.13 pytest -q tools/doclint/tests/` passes (93). `ruff`,
`mypy`, and `scripts/check-docs.sh` are clean. The full workspace suite has
267 pre-existing failures from the dev stack being down locally
(`ConnectionRefusedError` on Postgres, `EndpointConnectionError` on MinIO),
all in `apps/api` and `apps/worker`; none in doclint, and nothing outside
`tools/doclint/` imports `curie_doclint`.

Closes #956
