### PR TITLE
Thread the connected-transport turn on the real placeholder ts (#954)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -469,6 +469,14 @@ same thread:
 curie cluster message --channel CSIM123 --thread 1720000000.000100 "follow up question"
 ```
 
+Against a **connected** Slack workspace the thread ts is not synthetic: the CLI
+posts a real placeholder message to the channel and the printed thread ts is
+that placeholder's real Slack ts, so you can reply to it in Slack. Passing
+`--thread <ts>` there posts the placeholder into that existing thread, which
+means the ts must name a real message in the channel -- a thread ts carried over
+from a stub run will be rejected by Slack, and the command tells you to drop
+`--thread` to start a new one.
+
 ## `curie local message`: the same roundtrip against the compose stack
 
 `local message` drives the local compose stack (`curie local up`) instead of a

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -28,6 +28,7 @@ use std::process::Stdio;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
+use curie_aci_protocol::QueuedTurn;
 use redis::aio::MultiplexedConnection;
 
 use crate::api::{Agent, ApiClient};
@@ -90,6 +91,19 @@ fn resolve_api_key(raw: &str, env_value: Option<String>) -> String {
     env_value
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| DEFAULT_API_KEY.to_string())
+}
+
+/// An empty `--thread` is not a thread (#540's "empty is unset", applied to the
+/// thread ts): passed on, it enqueues a nonsense `conversation_id: ""` and puts a
+/// literal `"thread_ts": ""` in an outbound chat.postMessage body.
+///
+/// Applied at the [`message`] entry point every tier and transport funnels
+/// through, and again at the connected-transport leaf
+/// ([`enqueue_over_connected_transport`]), which is `pub` for integration tests
+/// and so cannot assume its callers normalized. The filter is idempotent, so
+/// applying it twice costs nothing.
+fn normalize_thread(thread: Option<String>) -> Option<String> {
+    thread.filter(|ts| !ts.is_empty())
 }
 
 /// clap `value_parser` for the CLUSTER tier's `--api-key` / `--valkey-password`
@@ -269,6 +283,41 @@ pub struct MessageOpts {
     /// Local mode only: platform API base URL for the channel lookup. None uses
     /// the compose API default ([`DEFAULT_LOCAL_API_URL`]).
     pub api_url: Option<String>,
+}
+
+/// Hand-written rather than derived: this type is `pub` in a `pub` module, so
+/// `Default` is public API and its values have to be the ones the crate actually
+/// declares. A derive would zero them, and those zeros are not benign --
+/// `timeout_secs: 0` is an instant deadline, and `api_key: ""` defeats the
+/// sentinel comparison against [`DEFAULT_API_KEY`] in
+/// [`crate::state::apply_continue`] that issue #540 exists to protect.
+///
+/// The genuinely-empty fields (`text`, `channel`, `thread`, `listen_host`,
+/// `user`, `stream`, `dry_run`, `local`, `api_url`) have no crate-level default:
+/// they are per-invocation values a caller must supply.
+impl Default for MessageOpts {
+    fn default() -> Self {
+        Self {
+            text: String::new(),
+            channel: None,
+            thread: None,
+            namespace: "curie".to_string(),
+            release: "curie".to_string(),
+            chart: "charts/curie".to_string(),
+            listen_host: None,
+            listen_port: DEFAULT_LISTEN_PORT,
+            valkey_local_port: DEFAULT_VALKEY_LOCAL_PORT,
+            valkey_password: DEFAULT_VALKEY_PASSWORD.to_string(),
+            api_local_port: DEFAULT_API_LOCAL_PORT,
+            api_key: DEFAULT_API_KEY.to_string(),
+            user: String::new(),
+            stream: String::new(),
+            timeout_secs: DEFAULT_TIMEOUT_SECS,
+            dry_run: false,
+            local: false,
+            api_url: None,
+        }
+    }
 }
 
 /// The tier string for a [`TurnVerb`], as surfaced in the `--json` `tier` field
@@ -1405,7 +1454,13 @@ fn connected_transport_dry_run_note() -> String {
 /// and the requesting-channel approval card threads under it on the EXISTING
 /// kernel/sink paths -- no per-turn endpoint means the turn rides the worker's
 /// default (connected) transport, exactly like a real mention.
-async fn enqueue_over_connected_transport(
+///
+/// Public only so the connected-transport COMPOSITION can be pinned by an
+/// integration test (`cli/tests/chat_enqueue.rs`): #954 was a wiring defect
+/// between two individually-correct leaves, so the coverage that matters drives
+/// this whole function against a real Valkey and a real HTTP Slack stub and reads
+/// back the bytes that landed on the stream. No other caller outside this module.
+pub async fn enqueue_over_connected_transport(
     opts: &MessageOpts,
     conn: &mut MultiplexedConnection,
     verb: TurnVerb,
@@ -1413,21 +1468,36 @@ async fn enqueue_over_connected_transport(
     bot_token: &str,
 ) -> Result<()> {
     let ui = crate::ui::ui();
-    let (channel, thread_ts, _synthetic_placeholder) =
-        resolve_targets(Some(channel), opts.thread.as_deref());
+    // An empty `--thread` is normalized away at the [`message`] entry point, and
+    // re-applied HERE because this function is `pub` (an integration test drives
+    // it directly, bypassing `message`), so it cannot assume its callers
+    // normalized. See [`normalize_thread`]. Anything present past this line names
+    // a real thread.
+    let explicit_thread = opts.thread.as_deref().filter(|ts| !ts.is_empty());
 
-    let placeholder_ts = crate::slack::post_placeholder(bot_token, &channel, "\u{2026}")
-        .await
-        .context("posting the placeholder to the connected Slack workspace")?;
+    let placeholder_ts =
+        crate::slack::post_placeholder(bot_token, channel, "\u{2026}", explicit_thread)
+            .await
+            .with_context(|| {
+                let mut context =
+                    "posting the placeholder to the connected Slack workspace".to_string();
+                // Slack rejects a thread_ts naming no real message, so a thread ts
+                // carried over from a stub turn (always synthetic) or from a
+                // pre-#954 connected turn now fails the whole command here --
+                // including when it arrived via --continue reading
+                // .curie/last-turn.json rather than an explicit --thread. Name that
+                // as the cause and say what undoes it, per ADR-0021.
+                if let Some(thread) = explicit_thread {
+                    context.push_str(&format!(
+                        ": if Slack rejected the thread, --thread {thread} names no message in \
+                         {channel}. Drop --thread (or re-run without --continue, which reuses the \
+                         last turn's thread ts) to start a new thread."
+                    ));
+                }
+                context
+            })?;
 
-    let event = synthetic_turn(
-        &channel,
-        &opts.user,
-        &opts.text,
-        &thread_ts,
-        &placeholder_ts,
-        None,
-    );
+    let event = connected_turn(channel, opts, explicit_thread, &placeholder_ts);
     let stream_id = xadd(conn, &opts.stream, &event).await?;
     ui.note(&format!(
         "enqueued {} on {} as {stream_id}",
@@ -1435,12 +1505,44 @@ async fn enqueue_over_connected_transport(
     ));
 
     // The reply, approval card, and any resumed reply land in Slack, not here.
-    persist_and_hint(opts, verb, &channel, &thread_ts);
+    persist_and_hint(opts, verb, channel, &event.conversation_id);
     ui.emit(&MessageOutcomeOutput::Enqueued {
-        channel,
-        thread: thread_ts,
+        channel: channel.to_string(),
+        thread: event.conversation_id,
     });
     Ok(())
+}
+
+/// The exact turn a connected-transport enqueue puts on the stream: its
+/// `conversation_id` is an explicit `--thread` when one was named, else the ts of
+/// the placeholder we just posted (a top-level message's own ts IS its thread
+/// root), and the reply handle's placeholder is always that real ts.
+///
+/// Both must be REAL Slack timestamps and must agree with where the placeholder
+/// landed (issue #954): the worker threads its requesting-channel approval card on
+/// `conversation_id` best-effort, so Slack silently drops a card threaded under a
+/// ts that names no message.
+///
+/// Assumption when a `--thread` IS named: that ts is a thread ROOT. A `--thread`
+/// naming a threaded reply would be re-parented by Slack onto the true parent,
+/// leaving `conversation_id` at the reply while the placeholder landed under its
+/// parent; we take the named ts at its word, since #954's stated behavior is that
+/// `--thread <ts>` makes `<ts>` the conversation_id.
+fn connected_turn(
+    channel: &str,
+    opts: &MessageOpts,
+    explicit_thread: Option<&str>,
+    placeholder_ts: &str,
+) -> QueuedTurn {
+    let conversation_id = explicit_thread.unwrap_or(placeholder_ts);
+    synthetic_turn(
+        channel,
+        &opts.user,
+        &opts.text,
+        conversation_id,
+        placeholder_ts,
+        None,
+    )
 }
 
 /// Resolve the target channel (and the sole-agent hint for resolve messages) for
@@ -1526,7 +1628,16 @@ async fn message_connected(opts: MessageOpts) -> Result<()> {
         .await
 }
 
-pub async fn message(opts: MessageOpts) -> Result<()> {
+pub async fn message(mut opts: MessageOpts) -> Result<()> {
+    // An empty `--thread` is normalized to `None` for every tier and transport,
+    // rather than at one leaf: this is the single entry point they all funnel
+    // through. See [`normalize_thread`] for why an empty ts is not a thread.
+    //
+    // Known wrinkle: this runs AFTER `state::apply_continue`, which resolves
+    // `thread: cli.thread.or_else(|| persisted)`. `Some("")` is a `Some`, so it
+    // wins there and the persisted thread never loads. `--continue --thread ""`
+    // therefore starts a NEW thread instead of resuming the recorded one.
+    opts.thread = normalize_thread(opts.thread);
     if opts.local {
         return message_local(opts).await;
     }
@@ -2671,6 +2782,45 @@ async fn eval_cluster(opts: EvalOpts, suite: EvalSuite) -> Result<()> {
 mod tests {
     use super::*;
 
+    /// An empty `--thread` must not survive as a thread: carried through, it
+    /// enqueues `conversation_id: ""` and puts a literal `"thread_ts": ""` in an
+    /// outbound chat.postMessage body. The rule is applied at two sites
+    /// ([`message`] and [`enqueue_over_connected_transport`]), both of which need
+    /// a live Valkey to drive, so this pins the rule itself where CI can run it.
+    #[test]
+    fn an_empty_thread_normalizes_to_no_thread() {
+        assert_eq!(normalize_thread(Some(String::new())), None);
+    }
+
+    /// The filter must not eat a real thread ts, and an already-absent thread
+    /// stays absent -- the two branches that make the guard safe to apply twice.
+    #[test]
+    fn a_named_thread_survives_normalization() {
+        assert_eq!(
+            normalize_thread(Some("1750000000.001900".to_string())),
+            Some("1750000000.001900".to_string())
+        );
+        assert_eq!(normalize_thread(None), None);
+    }
+
+    /// `Default` must hand back the crate's real defaults, not zeros: a caller
+    /// writing `MessageOpts { text, channel, ..Default::default() }` otherwise
+    /// gets an instant deadline and an empty api key that defeats the #540
+    /// sentinel comparison in `apply_continue`.
+    #[test]
+    fn default_message_opts_carry_the_crates_real_defaults() {
+        let opts = MessageOpts::default();
+        assert_eq!(opts.timeout_secs, DEFAULT_TIMEOUT_SECS);
+        assert_eq!(opts.api_key, DEFAULT_API_KEY);
+        assert_eq!(opts.listen_port, DEFAULT_LISTEN_PORT);
+        assert_eq!(opts.valkey_local_port, DEFAULT_VALKEY_LOCAL_PORT);
+        assert_eq!(opts.api_local_port, DEFAULT_API_LOCAL_PORT);
+        assert_eq!(opts.valkey_password, DEFAULT_VALKEY_PASSWORD);
+        assert_eq!(opts.namespace, "curie");
+        assert_eq!(opts.release, "curie");
+        assert_eq!(opts.chart, "charts/curie");
+    }
+
     /// The printed resolve hint must be runnable AS PRINTED. Every flag the
     /// server requires has to be on it: the mandatory `<AGENT>` positional,
     /// `--as`, and `--actor-channel` -- without the last one the default
@@ -3121,6 +3271,46 @@ mod tests {
             lines.iter().any(|l| l.contains("no stub is bound")),
             "cluster plan must note the connected branch: {lines:?}"
         );
+    }
+
+    #[test]
+    fn connected_turn_conversation_id_is_the_real_placeholder_ts() {
+        // Issue #954: with no --thread the connected path posts a TOP-LEVEL
+        // placeholder, and a top-level message's own ts is its thread root -- so
+        // the enqueued conversation_id must be exactly that placeholder ts. The
+        // pre-fix code fed a clock-derived synthetic thread here, which can never
+        // equal the ts Slack returned, so the card had nothing real to thread on.
+        // Asserting on the turn the enqueue actually builds is the point: the bug
+        // was the wiring, so wiring a synthetic thread back in must fail HERE.
+        let placeholder_ts = "1717171717.000900";
+        let turn = connected_turn("C-real", &opts(Some("C-real")), None, placeholder_ts);
+        assert_eq!(
+            turn.conversation_id, turn.reply_handle.placeholder,
+            "the connected turn must thread on the placeholder we actually posted"
+        );
+        assert_eq!(turn.conversation_id, placeholder_ts);
+        assert_eq!(turn.reply_handle.channel, "C-real");
+        // #770/ADR-0078: no per-turn endpoint, so the reply rides the connected
+        // transport.
+        assert!(turn.reply_handle.endpoint.is_none());
+    }
+
+    #[test]
+    fn connected_turn_conversation_id_is_the_explicit_thread() {
+        // With --thread <ts> the turn's conversation_id IS that thread, while the
+        // placeholder stays the distinct real message we posted into it. (The
+        // outbound post itself lives in slack::post_body, not here.)
+        let thread = "1717171717.000100";
+        let placeholder_ts = "1717171717.000900";
+        let turn = connected_turn(
+            "C-real",
+            &opts(Some("C-real")),
+            Some(thread),
+            placeholder_ts,
+        );
+        assert_eq!(turn.conversation_id, thread);
+        assert_eq!(turn.reply_handle.placeholder, placeholder_ts);
+        assert!(turn.reply_handle.endpoint.is_none());
     }
 
     #[test]

--- a/cli/src/slack.rs
+++ b/cli/src/slack.rs
@@ -21,14 +21,21 @@ fn api_base() -> String {
 }
 
 /// Post `text` to `channel` as the bot, returning the created message `ts` (the
-/// placeholder the worker then edits in place). The token is sent only in the
-/// Authorization header; it is never logged.
-pub async fn post_placeholder(bot_token: &str, channel: &str, text: &str) -> Result<String> {
+/// placeholder the worker then edits in place). `thread_ts` posts the placeholder
+/// INTO that thread; `None` posts it at the top level, where the created message's
+/// own `ts` is the thread root. The token is sent only in the Authorization
+/// header; it is never logged.
+pub async fn post_placeholder(
+    bot_token: &str,
+    channel: &str,
+    text: &str,
+    thread_ts: Option<&str>,
+) -> Result<String> {
     let base = api_base();
     let resp = reqwest::Client::new()
         .post(format!("{base}/chat.postMessage"))
         .bearer_auth(bot_token)
-        .json(&serde_json::json!({ "channel": channel, "text": text }))
+        .json(&post_body(channel, text, thread_ts))
         .send()
         .await
         .context("posting the approval-turn placeholder to Slack")?
@@ -36,6 +43,21 @@ pub async fn post_placeholder(bot_token: &str, channel: &str, text: &str) -> Res
         .await
         .context("decoding the Slack chat.postMessage response")?;
     parse_ts(&resp)
+}
+
+/// The `chat.postMessage` request body. `thread_ts` is an OPTIONAL Slack
+/// parameter: sending it threads the new message under that parent, omitting it
+/// posts at the top level. It must be OMITTED rather than sent as null when we
+/// have no parent -- a null would be a malformed value, not "no thread". Pure, so
+/// both branches are unit tested without a network round trip.
+fn post_body(channel: &str, text: &str, thread_ts: Option<&str>) -> serde_json::Value {
+    let mut body = serde_json::Map::new();
+    body.insert("channel".into(), channel.into());
+    body.insert("text".into(), text.into());
+    if let Some(thread_ts) = thread_ts {
+        body.insert("thread_ts".into(), thread_ts.into());
+    }
+    serde_json::Value::Object(body)
 }
 
 /// Extract the created message `ts` from a `chat.postMessage` response, turning
@@ -77,6 +99,30 @@ mod tests {
     #[test]
     fn parse_ts_errors_when_ok_but_no_ts() {
         assert!(parse_ts(&json!({"ok": true})).is_err());
+    }
+
+    #[test]
+    fn post_body_threads_the_placeholder_when_a_parent_is_given() {
+        // Observed behavior of the real dispatcher against real Slack
+        // (apps/dispatcher/src/curie_dispatcher/handlers.py:90-98,113): it passes
+        // `thread_ts=` to chat.postMessage so the placeholder lands IN the thread,
+        // and enqueues that same value as the turn's conversation_id.
+        let body = post_body("C-real", "\u{2026}", Some("1717171717.000100"));
+        assert_eq!(body["channel"], "C-real");
+        assert_eq!(body["thread_ts"], "1717171717.000100");
+    }
+
+    #[test]
+    fn post_body_omits_the_thread_key_entirely_at_top_level() {
+        // Same source: a root message carries no thread_ts at all, and its OWN ts
+        // is the thread root. The key must be absent, not null -- Slack would
+        // reject a null as a malformed thread_ts.
+        let body = post_body("C-real", "\u{2026}", None);
+        assert_eq!(body["channel"], "C-real");
+        assert!(
+            body.get("thread_ts").is_none(),
+            "thread_ts must be omitted, not null: {body}"
+        );
     }
 
     #[test]

--- a/cli/tests/chat_enqueue.rs
+++ b/cli/tests/chat_enqueue.rs
@@ -10,11 +10,21 @@
 use std::time::Duration;
 
 use curie::chat::{resolve_targets, SlackStub};
+use curie::message::{enqueue_over_connected_transport, MessageOpts};
 use curie::queue::{diagnostics, entry_acked, synthetic_turn, xadd, WORKER_GROUP};
+use curie::slack::post_placeholder;
+use curie::state::{load_turn, TurnContext, TurnVerb};
 use curie_aci_protocol::QueuedTurn;
 
 mod support;
-use support::{unique_stream, valkey_or_skip};
+use support::{unique_stream, valkey_or_skip, Response};
+
+/// `SLACK_API_BASE_URL` is process-global, so every test in this binary that
+/// redirects it holds this lock for the whole redirect. Without it two such tests
+/// running concurrently would each post at the other's stub (or, after the
+/// other's `remove_var`, at real Slack). A tokio mutex, not a std one, because
+/// the redirect is held across `await` points.
+static SLACK_BASE_URL_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[tokio::test]
 async fn xadd_lands_the_exact_seam_shape_on_real_valkey() {
@@ -119,22 +129,9 @@ async fn explicit_channel_and_thread_land_verbatim_on_the_wire() {
     );
     let stream_id = xadd(&mut conn, &stream, &event).await.unwrap();
 
-    let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
-        .arg(&stream)
-        .arg("-")
-        .arg("+")
-        .query_async(&mut conn)
-        .await
-        .unwrap();
-    let _: i64 = redis::cmd("DEL")
-        .arg(&stream)
-        .query_async(&mut conn)
-        .await
-        .unwrap();
+    let decoded = drain_one_turn(&mut conn, &stream).await;
 
     assert!(!stream_id.is_empty(), "XADD returned an id");
-    assert_eq!(entries.len(), 1, "exactly one entry enqueued");
-    let decoded: QueuedTurn = serde_json::from_str(&entries[0].1[0].1).unwrap();
     assert_eq!(
         decoded.reply_handle.channel, "CSIM12345",
         "the XADD'd payload keeps the exact channel the worker binds on"
@@ -175,22 +172,9 @@ async fn absent_channel_and_thread_fall_back_to_synthetic() {
     );
     let stream_id = xadd(&mut conn, &stream, &event).await.unwrap();
 
-    let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
-        .arg(&stream)
-        .arg("-")
-        .arg("+")
-        .query_async(&mut conn)
-        .await
-        .unwrap();
-    let _: i64 = redis::cmd("DEL")
-        .arg(&stream)
-        .query_async(&mut conn)
-        .await
-        .unwrap();
+    let decoded = drain_one_turn(&mut conn, &stream).await;
 
     assert!(!stream_id.is_empty(), "XADD returned an id");
-    assert_eq!(entries.len(), 1, "exactly one entry enqueued");
-    let decoded: QueuedTurn = serde_json::from_str(&entries[0].1[0].1).unwrap();
     assert!(
         decoded.reply_handle.channel.starts_with("C-SIM-"),
         "synthetic channel on the wire: {}",
@@ -371,4 +355,258 @@ async fn stub_captures_json_body_and_never_404s_other_methods() {
     assert_eq!(call.method, "chat.postMessage");
     assert_eq!(call.channel.as_deref(), Some("C2"));
     assert_eq!(call.text.as_deref(), Some("escalation"));
+}
+
+/// #954: `post_placeholder`'s `thread_ts` argument must actually reach the
+/// outbound `chat.postMessage` body. Only the pure `post_body` was covered, so a
+/// mutation dropping the argument inside `post_placeholder` (calling
+/// `post_body(channel, text, None)`) passed the whole suite with no lint. This
+/// drives the real client over real HTTP against the recording HTTP stub and pins
+/// both branches from the request bodies that actually went out.
+///
+/// Valkey-free by design: it is the only CI-executing coverage of this seam, and
+/// the Valkey-backed tests in this file skip where no compose stack runs.
+#[tokio::test]
+async fn post_placeholder_threads_the_outbound_post_only_when_a_thread_is_named() {
+    let _slack_base = SLACK_BASE_URL_LOCK.lock().await;
+    const NAMED_THREAD: &str = "1717171717.000100";
+    let slack =
+        support::serve(|_req| Response::json(200, r#"{"ok": true, "ts": "1717171717.000900"}"#));
+    std::env::set_var("SLACK_API_BASE_URL", &slack.base_url);
+
+    let ts = post_placeholder("xoxb-test", "C-real", "\u{2026}", Some(NAMED_THREAD))
+        .await
+        .expect("the stub answers ok with a ts");
+    assert!(!ts.is_empty(), "post_placeholder returned the created ts");
+
+    post_placeholder("xoxb-test", "C-real", "\u{2026}", None)
+        .await
+        .expect("the stub answers ok with a ts");
+
+    std::env::remove_var("SLACK_API_BASE_URL");
+
+    let posts = slack.recorded();
+    assert_eq!(posts.len(), 2, "exactly two placeholders posted");
+
+    assert_eq!(posts[0].path, "/chat.postMessage");
+    let threaded: serde_json::Value = serde_json::from_slice(&posts[0].body).unwrap();
+    assert_eq!(
+        threaded.get("channel").and_then(|v| v.as_str()),
+        Some("C-real")
+    );
+    assert_eq!(
+        threaded.get("thread_ts").and_then(|v| v.as_str()),
+        Some(NAMED_THREAD),
+        "the named thread must reach Slack, or the placeholder lands outside the thread"
+    );
+
+    assert_eq!(posts[1].path, "/chat.postMessage");
+    let top_level: serde_json::Value = serde_json::from_slice(&posts[1].body).unwrap();
+    assert_eq!(
+        top_level.get("thread_ts"),
+        None,
+        "a top-level placeholder must carry no thread_ts at all"
+    );
+}
+
+/// A `MessageOpts` for the connected-transport enqueue. The connected path binds
+/// no stub, forwards no port, and calls no platform API, so only `channel`,
+/// `thread`, `stream`, `user`, and `text` are asserted here. The rest are not
+/// unused: `persist_and_hint` reads `namespace`, `release`, `chart`,
+/// `listen_host`, `timeout_secs`, `api_url`, and `api_key` into
+/// `.curie/last-turn.json`, so they are consumed on this path, just not asserted.
+fn connected_opts(stream: &str, thread: Option<&str>) -> MessageOpts {
+    MessageOpts {
+        text: "what is the deploy status".to_string(),
+        channel: Some("C-REAL-CONNECTED".to_string()),
+        thread: thread.map(str::to_string),
+        user: "U-curie-message".to_string(),
+        stream: stream.to_string(),
+        ..Default::default()
+    }
+}
+
+/// Read the single entry on `stream` back as a `QueuedTurn`, deleting the stream
+/// first so a failed assertion never leaks it.
+async fn drain_one_turn(conn: &mut redis::aio::MultiplexedConnection, stream: &str) -> QueuedTurn {
+    let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
+        .arg(stream)
+        .arg("-")
+        .arg("+")
+        .query_async(conn)
+        .await
+        .unwrap();
+    let _: i64 = redis::cmd("DEL")
+        .arg(stream)
+        .query_async(conn)
+        .await
+        .unwrap();
+    assert_eq!(entries.len(), 1, "exactly one entry enqueued");
+    serde_json::from_str(&entries[0].1[0].1).unwrap()
+}
+
+/// Restores the process working directory when dropped, so a panicking
+/// assertion inside the scope cannot strand the rest of the binary in a temp
+/// directory.
+struct CwdGuard(std::path::PathBuf);
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.0);
+    }
+}
+
+/// Drive one real connected-transport enqueue against an HTTP Slack stub whose
+/// canned `chat.postMessage` response returns `canned_ts`, and hand back the turn
+/// that actually landed on the stream, the requests the stub recorded, and the
+/// turn context the enqueue persisted for `--continue`. The two cases below
+/// differ only in the thread they name and the ts Slack answers with.
+async fn enqueue_connected(
+    conn: &mut redis::aio::MultiplexedConnection,
+    thread: Option<&str>,
+    canned_ts: &'static str,
+) -> (QueuedTurn, Vec<support::Request>, TurnContext) {
+    let slack = support::serve(move |_req| {
+        Response::json(200, &format!(r#"{{"ok": true, "ts": "{canned_ts}"}}"#))
+    });
+    std::env::set_var("SLACK_API_BASE_URL", &slack.base_url);
+
+    // The real enqueue persists `.curie/last-turn.json` under the PROCESS
+    // working directory, so run it inside a throwaway dir: a plain `cargo test`
+    // must never clobber the developer's own saved turn and break their next
+    // `message --continue`. Declared before the guard so the guard (dropped
+    // first) restores the cwd before the temp dir is removed. The caller holds
+    // SLACK_BASE_URL_LOCK across this whole call, which serializes the cwd
+    // change against the only other test in this binary that touches
+    // process-global state.
+    let state_home = tempfile::tempdir().expect("temp dir for the persisted turn state");
+    let _cwd = CwdGuard(std::env::current_dir().expect("resolving the current working directory"));
+    std::env::set_current_dir(state_home.path()).expect("pointing the cwd at the temp dir");
+
+    let stream = unique_stream("curie:test:connected:");
+    let opts = connected_opts(&stream, thread);
+    enqueue_over_connected_transport(
+        &opts,
+        conn,
+        TurnVerb::Local,
+        "C-REAL-CONNECTED",
+        "xoxb-test",
+    )
+    .await
+    .expect("the connected enqueue completes against the stub and Valkey");
+
+    let saved = load_turn(state_home.path())
+        .expect("the persisted turn state parses")
+        .expect("the enqueue persisted a turn context");
+
+    let turn = drain_one_turn(conn, &stream).await;
+    let posts = slack.recorded();
+    std::env::remove_var("SLACK_API_BASE_URL");
+    (turn, posts, saved)
+}
+
+/// #954: the connected-transport enqueue is a COMPOSITION -- it posts a real
+/// Slack placeholder and then mints the turn that goes on the wire, and the bug
+/// was that the two disagreed (a real placeholder ts on the reply handle, a
+/// SYNTHETIC `conversation_id` beside it), so the worker's approval card could
+/// not thread under the placeholder. Pinning the turn builder alone did not close
+/// it: a mutation rebuilding the old `resolve_targets` wiring inside
+/// `enqueue_over_connected_transport` still passed the whole suite, leaving only
+/// an unused-function lint as the signal.
+///
+/// So drive the REAL `enqueue_over_connected_transport` against real Valkey with
+/// an HTTP stub standing in for Slack (the only external seam), and assert on the
+/// bytes that actually landed on the stream. The placeholder ts is the stub's
+/// canned wire response, never a value this test computed, so a turn built from a
+/// synthetic ts cannot match it.
+///
+/// Both cases live in one test because they share the process-global
+/// `SLACK_API_BASE_URL` redirect.
+#[tokio::test]
+async fn connected_transport_enqueues_the_real_placeholder_as_the_conversation_id() {
+    let _slack_base = SLACK_BASE_URL_LOCK.lock().await;
+    let Some(mut conn) =
+        valkey_or_skip("connected_transport_enqueues_the_real_placeholder_as_the_conversation_id")
+            .await
+    else {
+        return;
+    };
+
+    // --- No --thread: the placeholder's own ts IS the thread root, so it must be
+    // the conversation_id too.
+    const TOP_LEVEL_TS: &str = "1717171717.000700";
+    let (turn, posts, saved) = enqueue_connected(&mut conn, None, TOP_LEVEL_TS).await;
+
+    assert_eq!(
+        turn.conversation_id, TOP_LEVEL_TS,
+        "with no --thread the conversation_id must be the real placeholder ts \
+         Slack returned, not a synthetic one: the worker threads its approval card \
+         on conversation_id, and Slack drops a card threaded under a ts that names \
+         no message"
+    );
+    assert_eq!(
+        turn.conversation_id, turn.reply_handle.placeholder,
+        "the two coordinates on one turn must agree; #954 was exactly their disagreement"
+    );
+    assert_eq!(
+        turn.reply_handle.channel, "C-REAL-CONNECTED",
+        "the real channel rides the wire verbatim"
+    );
+    assert_eq!(
+        turn.reply_handle.endpoint, None,
+        "connected mode carries no per-turn endpoint, so the reply rides the \
+         workspace transport"
+    );
+    assert_eq!(posts.len(), 1, "exactly one placeholder posted");
+    let body: serde_json::Value = serde_json::from_slice(&posts[0].body).unwrap();
+    assert_eq!(posts[0].path, "/chat.postMessage");
+    assert_eq!(
+        body.get("channel").and_then(|v| v.as_str()),
+        Some("C-REAL-CONNECTED")
+    );
+    assert_eq!(
+        body.get("thread_ts"),
+        None,
+        "a top-level placeholder names no parent thread"
+    );
+    assert_eq!(
+        saved.thread_ts, TOP_LEVEL_TS,
+        "the persisted `--continue` coordinates must name the same real \
+         placeholder ts, or the next `message --continue` resumes a thread that \
+         names no Slack message"
+    );
+    assert_eq!(
+        saved.channel, "C-REAL-CONNECTED",
+        "the persisted turn records the real channel"
+    );
+
+    // --- Explicit --thread: the named ts is the conversation_id AND the outbound
+    // post must land inside that same thread. Both halves of the invariant, from
+    // the same run.
+    const NAMED_THREAD: &str = "1700000000.000123";
+    const IN_THREAD_TS: &str = "1717171717.000900";
+    let (turn, posts, saved) = enqueue_connected(&mut conn, Some(NAMED_THREAD), IN_THREAD_TS).await;
+
+    assert_eq!(
+        turn.conversation_id, NAMED_THREAD,
+        "an explicit --thread is the conversation_id verbatim"
+    );
+    assert_eq!(
+        turn.reply_handle.placeholder, IN_THREAD_TS,
+        "the reply handle still points at the real message Slack created inside \
+         that thread, so the worker edits the right message"
+    );
+    assert_eq!(posts.len(), 1, "exactly one placeholder posted");
+    let body: serde_json::Value = serde_json::from_slice(&posts[0].body).unwrap();
+    assert_eq!(
+        body.get("thread_ts").and_then(|v| v.as_str()),
+        Some(NAMED_THREAD),
+        "the outbound post must carry the named thread, or the placeholder lands \
+         outside the thread the turn claims to run in"
+    );
+    assert_eq!(
+        saved.thread_ts, NAMED_THREAD,
+        "the persisted `--continue` coordinates must name the thread the turn \
+         actually runs in, not the placeholder inside it"
+    );
 }


### PR DESCRIPTION
The connected-transport `message` path posted a real top-level Slack placeholder but enqueued a synthetic clock-derived `conversation_id`, so the approval card could not thread under the placeholder and a human reply produced a different kernel session key (cold sandbox, no history).

With no `--thread`, `conversation_id` is now the ts `chat.postMessage` returned (a top-level message's own ts is its thread root). With `--thread <ts>`, the placeholder is posted into that thread and `conversation_id` is that same ts. Both halves match what the dispatcher already does for a real mention, which is what ADR-0082 says this turn is "indistinguishable from".

The defect class is composition, not leaf logic, so the pin is an integration test that drives the real enqueue against real Valkey plus an HTTP Slack stub and asserts on the bytes that land on the stream. Reverting the wiring fails it on an assertion; a leaf-only test does not, verified by executing that mutation.

## Out-of-AC changes, called out deliberately

- Empty `--thread` normalizes to `None` for every transport (`normalize_thread`), applied at the `message()` entry point and again at the connected leaf, which is `pub` for the integration test and so cannot assume callers normalized. Previously `--thread ""` enqueued `conversation_id: ""`.
- The placeholder-post error now names `--thread`/`--continue` as the cause and says what to do: a synthetic thread ts carried over from a stub turn or a pre-fix `.curie/last-turn.json` now hard-fails where it used to succeed wrongly. ADR-0021 asks errors to carry a fix.
- `MessageOpts` gains a hand-written `Default`. A derived one would have shipped `timeout_secs: 0` (an instant deadline) and `api_key: ""`, which defeats the `DEFAULT_API_KEY` sentinel `--continue` relies on (#540).

## Known gap

The composition test is Valkey-backed and CI does not start the compose stack, so ACs 1 and 2 have no CI-executing coverage; the Valkey-free test covers the `--thread` pass-through in CI. This is pre-existing and unchanged here. ADR-0082 already defers this class to real-Slack E2E.

## Done-check

- [x] Failing tests committed before implementation: N/A (quick tier, one implementer wrote tests and code together)
- [x] All production edits performed by delegated sub-agents; no inline driver edits
- [x] Broadened return types: none. `post_placeholder` widened its parameter list only; its single caller was updated
- [x] Code Reviewer approved after two rounds. Round 1 REQUEST-CHANGES (2 major) and round 2 REQUEST-CHANGES (2 major) both fixed and re-verified
- [x] Scope Reviewer approved: 7 non-trivial hunks, 0 scope-creep on the original diff; later out-of-AC hunks are annotated above
- [x] Sibling-path parity: one shared helper serves both the `local` and `cluster` tiers, so both are fixed by one change. The three stub call sites are correct by design and were left alone, except the empty-thread normalization which now covers all four
- [x] Guard demonstration: mutation experiments executed, not read. Reverting the wiring fails on an assertion; dropping the thread argument inside `post_placeholder` fails its test; the pre-fix synthetic `conversation_id` fails the no-thread test
- [x] Consolidation pass ran: four cleanup reviewers, applied; `cli/src/chat.rs` reverted to zero diff as a result; suite and lint green after
- [x] Codex review ran (driver-direct, two passes). Caught a real side effect the static reviewers missed: the new test overwrote the developer's `cli/.curie/last-turn.json`. Fixed and verified by execution
- [x] Security Reviewer: not flagged
- [x] E2E Tester: not applicable. Real-Slack verification is not runnable here and ADR-0082 already scopes it to a connected workspace
- [x] Full test suite passes: 869 tests, and 869 again with Valkey unreachable (CI shape)
- [x] Lint clean on every edited file. One pre-existing `collapsible_match` failure in the untouched `src/interactive.rs` comes from a locally-installed clippy newer than CI's pinned toolchain

Closes #954.
