### PR TITLE
Validate every message outcome variant against its committed schema (#955)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -532,27 +532,32 @@ control flow are machine-first.
 machine-readable JSON object on **stdout** instead of empty output: the
 read/query verbs (`versions`, `memory`, `approvals`, `observability`), the
 lifecycle result verbs (`kill`, `resume`, `budget`, `reset-thread`, `delete`),
-and every verb's
-`--dry-run` plan (uniform shape `{"dry_run": true, "plan": [<lines>]}`) all
-route through one centralized emitter. The `message` verbs keep their own,
-more specific shapes: `curie local message` and `curie cluster message`
-emit one structured line per terminal state on stdout -- a completed turn
-emits `{"reply": ..., "thread": ..., "finalized": ...}` (the model's reply,
-which is null on a no-edit completion, plus the thread the turn ran under); a
-**timeout** emits `{"reply": null, "finalized": false, "timed_out": true}`
-before exiting 3 (transient); and `--json --dry-run` emits a planned-action
-descriptor `{"dry_run": true, "target": "local"|"cluster", "stream": ...,
-"channel": ..., "reply_endpoint": ...}` (`channel` is null when it would be
-resolved from the sole deployed agent). The three shapes are the `oneOf` in
-`cli/schema/message.schema.json`. Two verbs lag this contract on their
-real-path success output: `curie skill message`, and the operator verbs
-(`up`, `down`, `status`, `comms`) plus `deploy`, still print human text rather
-than JSON on success (tracked in #485). All human and log text (progress,
-notes, warnings) goes to **stderr**, so a plain `... --json | jq` yields clean
-data. On failure under `--json`, the error is emitted to stdout as
-`{"error": "<message>", "fix": "<hint>"|null}` instead of a prose message, so
-an agent can recover without parsing prose. `NO_COLOR`, `CLICOLOR`, and
-`--color=never` are honored on every command.
+and every verb's `--dry-run` plan (uniform shape `{"dry_run": true, "plan":
+[<lines>]}`) all route through one centralized emitter. The `message` verbs
+keep their own, more specific shapes: `curie local message` and `curie cluster
+message` emit one structured line per terminal state on stdout -- a completed
+turn emits `{"reply": ..., "thread": ..., "finalized": ...}` (the model's
+reply, which is null on a no-edit completion, plus the thread the turn ran
+under); a turn parked on a human approval gate emits `{"reply": ..., "thread":
+..., "finalized": false, "awaiting_approval": true}` (the worker posted an
+approval card rather than finalizing, and `reply` is the card's placeholder
+text if seen); a **timeout** emits `{"reply": null, "finalized": false,
+"timed_out": true}` before exiting 3 (transient); a turn **enqueued** onto the
+real Valkey stream in connected transport mode emits `{"status": "enqueued",
+"channel": ..., "thread": ...}` -- the CLI does not wait for the reply, so
+this is a terminal state of the command, not of the turn; and `--json
+--dry-run` emits a planned-action descriptor `{"dry_run": true, "target":
+"local"|"cluster", "stream": ..., "channel": ..., "reply_endpoint": ...}`
+(`channel` is null when it would be resolved from the sole deployed agent).
+The five shapes are the `oneOf` in `cli/schema/message.schema.json`. Two verbs
+lag this contract on their real-path success output: `curie skill message`,
+and the operator verbs (`up`, `down`, `status`, `comms`) plus `deploy`, still
+print human text rather than JSON on success (tracked in #485). All human and
+log text (progress, notes, warnings) goes to **stderr**, so a plain `...
+--json | jq` yields clean data. On failure under `--json`, the error is
+emitted to stdout as `{"error": "<message>", "fix": "<hint>"|null}` instead of
+a prose message, so an agent can recover without parsing prose. `NO_COLOR`,
+`CLICOLOR`, and `--color=never` are honored on every command.
 
 **Versioned result schemas.** Every agent-facing `--json` result maps to a
 committed JSON Schema under `cli/schema/` with an explicit version identity (the

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -226,6 +226,12 @@
       "version": 1
     },
     {
+      "result": "message_enqueued_json",
+      "kind": "builder",
+      "schema": "message.schema.json",
+      "version": 1
+    },
+    {
       "result": "error_json",
       "kind": "builder",
       "schema": "error.schema.json",

--- a/cli/schema/message.schema.json
+++ b/cli/schema/message.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.curietech.ai/cli/message/v1.json",
   "title": "curie local|cluster message --json",
-  "description": "The agent-facing payload of `curie local message --json` and `curie cluster message --json`. Exactly one of four terminal-state shapes is emitted per invocation: a reply object (the model's final reply text, the thread the turn ran under, and whether a reply was captured), an awaiting-approval object (the turn parked on a human approval gate), a timeout object (no reply captured before the deadline), or a dry-run descriptor (what a real run would enqueue). All keys are CLI-owned and locked.",
+  "description": "The agent-facing payload of `curie local message --json` and `curie cluster message --json`. Exactly one of five terminal-state shapes is emitted per invocation: a reply object (the model's final reply text, the thread the turn ran under, and whether a reply was captured), an awaiting-approval object (the turn parked on a human approval gate), a timeout object (no reply captured before the deadline), a dry-run descriptor (what a real run would enqueue), or an enqueued object (the turn was enqueued onto the real Valkey stream in connected transport mode and the CLI did not wait for a reply). All keys are CLI-owned and locked.",
   "oneOf": [
     {
       "title": "reply",
@@ -112,6 +112,28 @@
           ]
         },
         "reply_endpoint": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "title": "enqueued",
+      "description": "The terminal state when the turn was enqueued onto the real Valkey stream in connected transport mode: the CLI does not wait for the reply. `channel` is the resolved channel and `thread` is the thread the turn was enqueued under.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "channel",
+        "thread"
+      ],
+      "properties": {
+        "status": {
+          "const": "enqueued"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "thread": {
           "type": "string"
         }
       }

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -521,6 +521,26 @@ pub fn message_awaiting_approval_json(thread: &str, reply: Option<&str>) -> serd
     })
 }
 
+/// The machine-readable object for a turn handed to the **connected Slack
+/// transport** (#770/ADR-0078): the turn was enqueued and its reply lands in the
+/// workspace, so `status` is `enqueued` and the payload names the channel and
+/// thread to watch rather than carrying a reply.
+///
+/// A named builder rather than an inline `json!` literal because the `Enqueued`
+/// arm used to inline its payload, and an inlined arm is invisible to the
+/// builder-level contract gates -- nothing swept it against
+/// `cli/schema/message.schema.json`, so the payload shipped unschema'd (#955).
+/// Every arm of [`MessageOutcomeOutput::to_json`] routing through a pure builder
+/// is the property being restored; keep it uniform. Pure so it stays
+/// contract-testable against `cli/schema/message.schema.json`.
+pub fn message_enqueued_json(channel: &str, thread: &str) -> serde_json::Value {
+    serde_json::json!({
+        "status": "enqueued",
+        "channel": channel,
+        "thread": thread,
+    })
+}
+
 /// The machine-readable descriptor for `local`/`cluster message --json --dry-run`
 /// (issue #354): what a real run would enqueue, without touching the network.
 /// `target` is `"local"` or `"cluster"`, `channel` is null when it would be
@@ -582,7 +602,10 @@ impl crate::ui::CliOutput for MessageDryRunOutput {
 /// The terminal outcome of a real `local`/`cluster message` turn. `to_json` is
 /// the matching schema-gated builder; `render` reproduces the exact human view
 /// (the stdout answer for a reply, the stderr warning/diagnostics otherwise).
-enum MessageOutcomeOutput {
+///
+/// `pub` so `cli/tests/json_contract.rs` can construct each variant directly
+/// and validate `to_json()` against the committed schema (issue #955).
+pub enum MessageOutcomeOutput {
     /// The worker finalized the turn with reply text.
     Replied { thread: String, reply: String },
     /// The worker finished the turn but never edited the placeholder.
@@ -628,11 +651,9 @@ impl crate::ui::CliOutput for MessageOutcomeOutput {
                 message_awaiting_approval_json(thread, reply.as_deref())
             }
             MessageOutcomeOutput::TimedOut { .. } => message_timeout_json(),
-            MessageOutcomeOutput::Enqueued { channel, thread } => serde_json::json!({
-                "status": "enqueued",
-                "channel": channel,
-                "thread": thread,
-            }),
+            MessageOutcomeOutput::Enqueued { channel, thread } => {
+                message_enqueued_json(channel, thread)
+            }
         }
     }
 

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -4,12 +4,12 @@
 //! exist yet, so this file will not compile / the schema loads fail at red; the
 //! implementer creates the schemas alongside the `--json` wiring.
 
+use std::collections::BTreeSet;
+
 use curie::commands::{eval_json, status_json};
 use curie::evals::CaseOutcome;
 use curie::exit;
-use curie::message::{
-    message_awaiting_approval_json, message_dry_run_json, message_reply_json, message_timeout_json,
-};
+use curie::message::{message_dry_run_json, MessageOutcomeOutput};
 use curie::observability::{local_endpoints, Endpoint, ObservabilityOutput};
 use curie::ui::{CliOutput, DryRunPlan};
 use curie_aci_protocol::SessionStatus;
@@ -146,26 +146,278 @@ fn error_json_validates_against_error_schema() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// #955: the message-schema gate. THIS is the canonical statement of why the
+// section is shaped the way it is; everything below points back here instead of
+// restating it.
+//
+// These tests drive `MessageOutcomeOutput::to_json()` directly rather than the
+// underlying builder functions, so every enum variant is forced through the
+// committed `message.schema.json` gate regardless of whether its `to_json` arm
+// delegates to a schema-gated builder or inlines its own JSON literal.
+// `Enqueued` (#770/ADR-0078) is the proof case: its arm used to inline
+// `serde_json::json!({"status": "enqueued", ...})`, which the pre-#955
+// four-branch `oneOf` had no branch for and therefore REJECTED. It now
+// delegates to `message_enqueued_json` like its siblings (see that builder's
+// doc comment in `cli/src/message.rs`), but driving through `to_json()` here
+// still matters: it is what would catch a FUTURE arm that inlines the way
+// `Enqueued` once did. The schema carries an `enqueued` branch, and the tests
+// below are what pin that fix.
+//
+// Two mechanisms stop a future variant escaping the same way, and both are
+// deliberate. Compile-time exhaustiveness (the no-wildcard `match` in
+// `message_outcome_variant_name`) is the cheap trap: it fails the BUILD when a
+// variant is added with no arm. `message_outcome_samples_cover_every_declared_variant`
+// closes the other half at run time: a variant that gets an arm but no
+// constructed sample must fail too, so both additions are mandatory together.
+// That gate's expected set is DERIVED from the enum's own AST and must NOT be
+// replaced by a hand-written list of variant names -- such a list stays
+// trivially equal to whatever the test already covers, which is exactly how a
+// new inlined `to_json` arm would slip past the gate the way `Enqueued` did.
+
+// The `syn` walk that reads the enum's variants straight out of the source, in
+// the same `#[path = ...]` shape the sibling AST gates use
+// (`cli/tests/schema_inventory.rs`, `cli/tests/api_emit_parity.rs`).
+#[path = "support/enum_variants.rs"]
+mod enum_variants;
+
+/// The compiled `message.schema.json` validator. Every message-schema test
+/// below takes it from here rather than re-inlining the load + compile pair.
+fn message_validator() -> jsonschema::Validator {
+    validator(&load_schema("message.schema.json"))
+}
+
+/// The variant set of `MessageOutcomeOutput`, derived from the AST of
+/// `cli/src/message.rs` -- the enum definition itself, which is the only source
+/// of truth a developer adding a variant cannot forget to update. Deriving it
+/// rather than listing it by hand is deliberate; see the #955 section note
+/// above for why a hand-written list would defeat the gate.
+fn message_outcome_declared_variants() -> BTreeSet<String> {
+    let path = format!("{}/src/message.rs", env!("CARGO_MANIFEST_DIR"));
+    let src = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cli/src/message.rs must be readable at {path}: {e}"));
+    let names = enum_variants::variant_names(&src, "MessageOutcomeOutput");
+    assert!(
+        !names.is_empty(),
+        "no `enum MessageOutcomeOutput` found in {path}: the #955 coverage gate cannot derive \
+         its expected variant set, so it would pass vacuously"
+    );
+    names
+}
+
+/// The variant NAME (as spelled in the enum) of a constructed outcome, matched
+/// with **no wildcard arm** -- the compile-time half of the two-mechanism trap
+/// described in the #955 section note above. Do not add a wildcard arm.
+fn message_outcome_variant_name(value: &MessageOutcomeOutput) -> &'static str {
+    match value {
+        MessageOutcomeOutput::Replied { .. } => "Replied",
+        MessageOutcomeOutput::NoEdit { .. } => "NoEdit",
+        MessageOutcomeOutput::AwaitingApproval { .. } => "AwaitingApproval",
+        MessageOutcomeOutput::TimedOut { .. } => "TimedOut",
+        MessageOutcomeOutput::Enqueued { .. } => "Enqueued",
+    }
+}
+
+/// An awaiting-approval outcome, parameterized only by the reply text: `Some`
+/// models a parked worker that left placeholder text we could read, `None`
+/// models one that left nothing at all.
+fn awaiting_approval_outcome(reply: Option<&str>) -> MessageOutcomeOutput {
+    MessageOutcomeOutput::AwaitingApproval {
+        thread: "1700000000.000100".to_string(),
+        reply: reply.map(str::to_string),
+        tier: "workspace",
+        agent: None,
+        channel: "C123".to_string(),
+    }
+}
+
+/// One constructed instance of every `MessageOutcomeOutput` variant, reused
+/// by the schema-validation loop and the variant-coverage test below.
+fn message_outcome_samples() -> Vec<MessageOutcomeOutput> {
+    vec![
+        MessageOutcomeOutput::Replied {
+            thread: "1700000000.000100".to_string(),
+            reply: "the answer is 42".to_string(),
+        },
+        MessageOutcomeOutput::NoEdit {
+            thread: "1700000000.000100".to_string(),
+        },
+        awaiting_approval_outcome(Some("card text")),
+        MessageOutcomeOutput::TimedOut {
+            diagnostics: None,
+            resume_note: None,
+        },
+        MessageOutcomeOutput::Enqueued {
+            channel: "C123".to_string(),
+            thread: "1700000000.000100".to_string(),
+        },
+    ]
+}
+
 #[test]
-fn message_reply_json_validates_against_message_schema() {
-    let schema = load_schema("message.schema.json");
-    let v = validator(&schema);
+fn message_outcome_samples_cover_every_declared_variant() {
+    // The run-time half of the #955 two-mechanism trap; see the section note
+    // above. The expected set comes from the enum's own AST, never a list
+    // maintained here.
+    let declared = message_outcome_declared_variants();
+    let covered: BTreeSet<String> = message_outcome_samples()
+        .iter()
+        .map(|outcome| message_outcome_variant_name(outcome).to_string())
+        .collect();
+
+    let uncovered: Vec<&String> = declared.difference(&covered).collect();
+    assert!(
+        uncovered.is_empty(),
+        "MessageOutcomeOutput variant(s) {uncovered:?} are declared in \
+         cli/src/message.rs but have no sample in message_outcome_samples(), so \
+         their `to_json()` never reaches the message.schema.json gate (#955); \
+         add one constructed sample per variant"
+    );
+
+    let unknown: Vec<&String> = covered.difference(&declared).collect();
+    assert!(
+        unknown.is_empty(),
+        "message_outcome_variant_name() claims variant(s) {unknown:?} that \
+         cli/src/message.rs does not declare; each arm's name string must match \
+         its enum variant's spelling exactly, or the coverage check above is \
+         comparing against the wrong set"
+    );
+}
+
+// ─── The derived-variant walk's own teeth (#955) ─────────────────────────────
+// The gate above is only as honest as the set `variant_names` derives: a
+// silently-SHORT set makes the coverage comparison vacuously green, which is the
+// exact defect #955 exists to close. `enum_variants` therefore panics rather
+// than under-reporting, and the cases below prove each of those panics fires by
+// EXECUTION -- the same "guard rejects a violating input" convention the sibling
+// AST gates follow (`cli/tests/schema_inventory.rs`, `cli/tests/api_emit_parity.rs`),
+// over small inline source fixtures, since `variant_names` takes source text and
+// needs no file on disk. They live here, beside the `#[path]` include and the
+// real-tree assertion that consumes it, because that is where each sibling gate
+// keeps its own rejection cases.
+
+/// A well-formed declaration: the positive control. Without it the three
+/// rejection tests below would also pass against a walk that panicked
+/// unconditionally or derived garbage.
+const SAMPLE_ENUM_SRC: &str = r#"
+pub enum Sample {
+    Alpha { thread: String },
+    Beta,
+    Gamma(u8),
+}
+"#;
+
+#[test]
+fn variant_names_derives_every_variant_of_a_well_formed_enum() {
+    let expected: BTreeSet<String> = ["Alpha", "Beta", "Gamma"]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(
+        enum_variants::variant_names(SAMPLE_ENUM_SRC, "Sample"),
+        expected,
+        "the walk must enumerate every variant shape (struct, unit, tuple)"
+    );
+    // The absent-enum case is empty, NOT a panic: turning that into a failure is
+    // the caller's job (`message_outcome_declared_variants` asserts non-empty),
+    // and conflating the two would make the panics below unreadable.
+    assert!(
+        enum_variants::variant_names(SAMPLE_ENUM_SRC, "NotDeclared").is_empty(),
+        "an absent enum yields an empty set for the caller to reject"
+    );
+}
+
+#[test]
+#[should_panic(expected = "does not parse as Rust")]
+fn variant_names_panics_on_source_that_does_not_parse() {
+    // Silently returning nothing here is what the old walk did, and the caller
+    // then misreported it as "no enum found" -- an absent enum and an
+    // unparseable file must never look alike.
+    enum_variants::variant_names("pub enum Sample { Alpha,", "Sample");
+}
+
+#[test]
+#[should_panic(expected = "2 declarations of `enum Sample`")]
+fn variant_names_panics_on_a_second_declaration_of_the_same_enum() {
+    const TWO_DECLARATIONS_SRC: &str = r#"
+pub enum Sample {
+    Alpha,
+}
+
+mod fixtures {
+    pub enum Sample {
+        Beta,
+    }
+}
+"#;
+    // Unioned, these would describe neither enum, so the gate would compare the
+    // real `match` against a fiction.
+    enum_variants::variant_names(TWO_DECLARATIONS_SRC, "Sample");
+}
+
+#[test]
+#[should_panic(expected = "Sample::Beta")]
+fn variant_names_panics_on_a_cfg_gated_variant() {
+    const CFG_VARIANT_SRC: &str = r#"
+pub enum Sample {
+    Alpha,
+    #[cfg(unix)]
+    Beta,
+}
+"#;
+    // The walk reads text and cannot know whether `Beta` exists in the build the
+    // no-wildcard `match` is compiled into.
+    enum_variants::variant_names(CFG_VARIANT_SRC, "Sample");
+}
+
+#[test]
+#[should_panic(expected = "mod fixtures (enclosing enum Sample)")]
+fn variant_names_panics_on_an_enum_inside_a_cfg_gated_module() {
+    const CFG_MODULE_SRC: &str = r#"
+#[cfg(test)]
+mod fixtures {
+    pub enum Sample {
+        Alpha,
+    }
+}
+"#;
+    // An enclosing `#[cfg]` gates the declaration just as surely as one written
+    // on the enum itself; the expected message pins that it is the ENCLOSURE
+    // that was detected, not some other cfg position.
+    enum_variants::variant_names(CFG_MODULE_SRC, "Sample");
+}
+
+#[test]
+fn message_outcome_replied_validates_against_message_schema() {
+    let v = message_validator();
     // Replied case: a non-null reply and finalized true.
-    let replied = message_reply_json("1700000000.000100", Some("the answer is 42"));
+    let replied = MessageOutcomeOutput::Replied {
+        thread: "1700000000.000100".to_string(),
+        reply: "the answer is 42".to_string(),
+    }
+    .to_json();
     assert!(
         v.is_valid(&replied),
-        "message_reply_json (replied) must validate against message.schema.json: {replied}"
+        "MessageOutcomeOutput::Replied::to_json must validate against message.schema.json: {replied}"
     );
     // Pin the values, not just the types: the reply text must pass through, the
     // thread must echo the input, and finalized must track reply.is_some().
     assert_eq!(replied["reply"], serde_json::json!("the answer is 42"));
     assert_eq!(replied["thread"], serde_json::json!("1700000000.000100"));
     assert_eq!(replied["finalized"], serde_json::json!(true));
+}
+
+#[test]
+fn message_outcome_no_edit_validates_against_message_schema() {
+    let v = message_validator();
     // No-edit completion: reply null, finalized false, must also validate.
-    let no_edit = message_reply_json("1700000000.000100", None);
+    let no_edit = MessageOutcomeOutput::NoEdit {
+        thread: "1700000000.000100".to_string(),
+    }
+    .to_json();
     assert!(
         v.is_valid(&no_edit),
-        "message_reply_json (no edit) must validate against message.schema.json: {no_edit}"
+        "MessageOutcomeOutput::NoEdit::to_json must validate against message.schema.json: {no_edit}"
     );
     // Pin the no-edit values: null reply, thread passthrough, finalized false.
     assert!(
@@ -177,13 +429,16 @@ fn message_reply_json_validates_against_message_schema() {
 }
 
 #[test]
-fn message_timeout_json_validates_against_message_schema() {
-    let schema = load_schema("message.schema.json");
-    let v = validator(&schema);
-    let timed_out = message_timeout_json();
+fn message_outcome_timed_out_validates_against_message_schema() {
+    let v = message_validator();
+    let timed_out = MessageOutcomeOutput::TimedOut {
+        diagnostics: None,
+        resume_note: None,
+    }
+    .to_json();
     assert!(
         v.is_valid(&timed_out),
-        "message_timeout_json must validate against message.schema.json: {timed_out}"
+        "MessageOutcomeOutput::TimedOut::to_json must validate against message.schema.json: {timed_out}"
     );
     // Pin the timeout shape: null reply, finalized false, timed_out true.
     assert!(
@@ -195,9 +450,65 @@ fn message_timeout_json_validates_against_message_schema() {
 }
 
 #[test]
+fn message_outcome_awaiting_approval_validates_and_is_distinct() {
+    // #529: the awaiting-approval object is finalized:false + awaiting_approval:true,
+    // a distinct terminal state from a reply or a timeout.
+    let v = message_validator();
+    let awaiting = awaiting_approval_outcome(Some("card text")).to_json();
+    assert!(
+        v.is_valid(&awaiting),
+        "MessageOutcomeOutput::AwaitingApproval::to_json must validate against message.schema.json: {awaiting}"
+    );
+    assert_eq!(awaiting["finalized"], serde_json::json!(false));
+    assert_eq!(awaiting["awaiting_approval"], serde_json::json!(true));
+    assert_eq!(awaiting["reply"], serde_json::json!("card text"));
+    assert_eq!(awaiting["thread"], serde_json::json!("1700000000.000100"));
+}
+
+/// The no-reply approval card is a DISTINCT schema shape from the one above:
+/// the worker parked without any placeholder text we could read, so `reply` is
+/// JSON null (the branch allows both). Kept as its own test rather than a
+/// second entry in `message_outcome_samples()`, which must stay exactly one
+/// sample per variant for the AST-derived coverage gate to compare cleanly.
+#[test]
+fn message_outcome_awaiting_approval_with_no_reply_validates() {
+    let v = message_validator();
+    let awaiting = awaiting_approval_outcome(None).to_json();
+    assert!(
+        v.is_valid(&awaiting),
+        "an awaiting-approval payload with a null reply must validate against message.schema.json: {awaiting}"
+    );
+    assert!(
+        awaiting["reply"].is_null(),
+        "an unseen approval card carries a JSON null reply: {awaiting}"
+    );
+    assert_eq!(awaiting["finalized"], serde_json::json!(false));
+    assert_eq!(awaiting["awaiting_approval"], serde_json::json!(true));
+    assert_eq!(awaiting["thread"], serde_json::json!("1700000000.000100"));
+}
+
+#[test]
+fn message_outcome_enqueued_validates_against_message_schema() {
+    // The #955 proof case (see the section note above): this assertion fails
+    // again the moment the `enqueued` branch is dropped from the schema or
+    // `message_enqueued_json`'s output drifts away from it.
+    let v = message_validator();
+    let enqueued = MessageOutcomeOutput::Enqueued {
+        channel: "C123".to_string(),
+        thread: "1700000000.000100".to_string(),
+    }
+    .to_json();
+    assert!(
+        v.is_valid(&enqueued),
+        "MessageOutcomeOutput::Enqueued::to_json must validate against message.schema.json: {enqueued}"
+    );
+    assert_eq!(enqueued["channel"], serde_json::json!("C123"));
+    assert_eq!(enqueued["thread"], serde_json::json!("1700000000.000100"));
+}
+
+#[test]
 fn message_dry_run_json_validates_against_message_schema() {
-    let schema = load_schema("message.schema.json");
-    let v = validator(&schema);
+    let v = message_validator();
     // Explicit channel (local target).
     let with_channel = message_dry_run_json(
         "local",
@@ -226,54 +537,103 @@ fn message_dry_run_json_validates_against_message_schema() {
     assert_eq!(no_channel["target"], serde_json::json!("cluster"));
 }
 
+/// The direct statement of #955's acceptance criterion, carrying BOTH schema
+/// properties in a single pass over every emitted payload:
+///
+/// 1. **Every variant validates.** Each `MessageOutcomeOutput` variant's
+///    `to_json()`, plus the dry-run descriptor, clears the committed schema.
+/// 2. **Exactly one branch matches.** `message.schema.json`'s root schema is
+///    a BARE `oneOf` (no sibling keywords, no wrapping `allOf`/`$ref`), which
+///    is what makes `is_valid` and "matches exactly one branch" the same
+///    check here -- a payload satisfying two branches would fail validation,
+///    since it would make the emitted object ambiguous to an agent consumer
+///    discriminating on shape. That root shape is PINNED below rather than
+///    assumed: restructuring `message.schema.json` so the root is no longer a
+///    bare `oneOf` (wrapped in `allOf`, given sibling keywords, swapped for
+///    `anyOf`) turns this test red, instead of leaving `is_valid` quietly
+///    passing while the test's name overstates what it proves.
+///
+/// Driven off the SAME sample set the AST coverage gate checks, so coverage and
+/// validation cannot drift apart -- the coverage gate only proves a sample
+/// exists, and without this loop the per-variant tests that actually validate
+/// could be deleted one by one without the gate noticing. Those per-variant
+/// tests stay: they carry field-level assertions this loop does not.
 #[test]
-fn message_schema_variants_are_mutually_exclusive() {
-    // The schema is a oneOf; each builder's output must match exactly one variant.
+fn every_message_payload_matches_exactly_one_message_schema_branch() {
+    // Property 2's precondition, pinned: the root is a BARE `oneOf`, so
+    // "validates" and "matches exactly one branch" are the same check. Pure
+    // annotations may sit alongside it; any other keyword (`allOf`, `anyOf`,
+    // `type`, `$ref`, `not`) would change what `is_valid` means.
     let schema = load_schema("message.schema.json");
-    let v = validator(&schema);
-    for value in [
-        message_reply_json("1700000000.000100", Some("hi")),
-        message_reply_json("1700000000.000100", None),
-        message_awaiting_approval_json("1700000000.000100", Some("awaiting approval")),
-        message_awaiting_approval_json("1700000000.000100", None),
-        message_timeout_json(),
-        message_dry_run_json("local", "s", Some("C1"), "http://x/api/"),
-    ] {
+    let root = schema
+        .as_object()
+        .expect("message.schema.json's root must be a JSON object");
+    let branches = root
+        .get("oneOf")
+        .and_then(serde_json::Value::as_array)
+        .expect("message.schema.json's root must carry a `oneOf` array");
+    assert!(
+        branches.len() > 1,
+        "a single-branch `oneOf` makes `exactly one branch` a vacuous claim: {branches:#?}"
+    );
+    const ANNOTATIONS: [&str; 6] = [
+        "$schema",
+        "$id",
+        "$comment",
+        "title",
+        "description",
+        "$defs",
+    ];
+    let siblings: Vec<&str> = root
+        .keys()
+        .map(String::as_str)
+        .filter(|k| *k != "oneOf" && !ANNOTATIONS.contains(k))
+        .collect();
+    assert!(
+        siblings.is_empty(),
+        "message.schema.json's root must stay a bare `oneOf`; keyword(s) {siblings:?} beside it \
+         would stop `is_valid` meaning `matches exactly one branch`, which is what this test's \
+         name claims"
+    );
+
+    let v = message_validator();
+    for (label, value) in message_outcome_samples()
+        .iter()
+        .map(|outcome| {
+            (
+                format!(
+                    "MessageOutcomeOutput::{}::to_json",
+                    message_outcome_variant_name(outcome)
+                ),
+                outcome.to_json(),
+            )
+        })
+        .chain([(
+            "message_dry_run_json".to_string(),
+            message_dry_run_json("local", "s", Some("C1"), "http://x/api/"),
+        )])
+    {
         assert!(
             v.is_valid(&value),
-            "each builder output must satisfy the oneOf: {value}"
+            "{label} must satisfy exactly one branch of the message.schema.json oneOf: {value}"
         );
     }
 }
 
 #[test]
-fn message_awaiting_approval_json_validates_and_is_distinct() {
-    // #529: the awaiting-approval object is finalized:false + awaiting_approval:true,
-    // a distinct terminal state from a reply or a timeout.
-    let schema = load_schema("message.schema.json");
-    let v = validator(&schema);
-    let awaiting = message_awaiting_approval_json("1700000000.000100", Some("card text"));
-    assert!(
-        v.is_valid(&awaiting),
-        "awaiting-approval must validate against message.schema.json: {awaiting}"
-    );
-    assert_eq!(awaiting["finalized"], serde_json::json!(false));
-    assert_eq!(awaiting["awaiting_approval"], serde_json::json!(true));
-    assert_eq!(awaiting["reply"], serde_json::json!("card text"));
-    assert_eq!(awaiting["thread"], serde_json::json!("1700000000.000100"));
-}
-
-#[test]
 fn message_schema_gate_has_teeth() {
     // negative control: proves the schema gate discriminates
-    let schema = load_schema("message.schema.json");
-    let mut value = message_reply_json("1700000000.000100", Some("hi"));
+    let v = message_validator();
+    let mut value = MessageOutcomeOutput::Replied {
+        thread: "1700000000.000100".to_string(),
+        reply: "hi".to_string(),
+    }
+    .to_json();
     // Strip a required key; a schema with real teeth must now reject.
     value
         .as_object_mut()
-        .expect("message_reply_json returns a JSON object")
+        .expect("MessageOutcomeOutput::Replied::to_json returns a JSON object")
         .remove("reply");
-    let v = validator(&schema);
     assert!(
         !v.is_valid(&value),
         "message schema must reject an object missing the required `reply` key"

--- a/cli/tests/support/enum_variants.rs
+++ b/cli/tests/support/enum_variants.rs
@@ -1,0 +1,155 @@
+//! Enum-variant inventory from source, for the `MessageOutcomeOutput`
+//! schema-coverage gate (issue #955).
+//!
+//! Same shape as the sibling AST gates (`support/schema_inventory.rs`,
+//! `support/emit_parity.rs`): a pure, side-effect-free `syn` walk over the text
+//! of a `cli/src` file. The caller reads the file and asserts; this module never
+//! prints or touches the filesystem. It DOES panic, with a specific message, on
+//! the three inputs it cannot honestly enumerate (unparseable source, a second
+//! same-named enum, a `#[cfg]`-gated declaration) -- see `variant_names`.
+//!
+//! ## What gives it teeth
+//!
+//! "Every variant of `enum T`" is a *syntactic* property a `syn` walk enumerates
+//! exhaustively, so it is a source of truth a developer cannot forget to update:
+//! adding a variant to the enum IS updating it. That is exactly what #955 needs
+//! -- a hand-written list of expected variants in the test would go stale the
+//! moment a sixth variant lands, which is the drift the gate exists to catch.
+//!
+//! The corollary is that UNDER-reporting the variant set is the gate's worst
+//! failure: a set missing a variant makes the coverage comparison vacuously
+//! green. Every input this walk cannot enumerate faithfully therefore fails
+//! loudly rather than returning a quietly-short set.
+
+use std::collections::BTreeSet;
+
+use syn::visit::Visit;
+
+/// Collects the variant identifiers of every `enum` whose name matches `target`,
+/// including enums nested in module or fn bodies. That reach comes from
+/// `Visit::visit_file`'s own default walk over the parsed file (which needs the
+/// `full` + `visit` features the sibling walks already rely on), not from this
+/// visitor's `visit_item_enum` override recursing into itself below -- no item
+/// can nest inside an enum body, so that call can never reach another
+/// `ItemEnum`. It is kept anyway, matching the sibling walks' convention
+/// (`schema_inventory.rs`, `emit_parity.rs`) of always continuing the default
+/// walk from an override. The `visit_item_mod` override adds no reach either:
+/// it only records which enclosing modules are `#[cfg]`-gated while continuing
+/// that same default walk.
+struct VariantCollector<'a> {
+    target: &'a str,
+    names: BTreeSet<String>,
+    /// How many `enum <target>` declarations the walk saw. More than one and the
+    /// name no longer identifies a single set (see `variant_names`).
+    declarations: usize,
+    /// Declarations (`Enum`), variants (`Enum::Variant`), or enclosing modules
+    /// carrying a `#[cfg]`.
+    cfg_gated: BTreeSet<String>,
+    /// Names of the `#[cfg]`-gated modules enclosing the walk's current
+    /// position, innermost last. A declaration inside one exists only under that
+    /// cfg exactly as a declaration carrying its own `#[cfg]` does, so it is the
+    /// same failure -- and it is the likely real-world shape, since `#[cfg(test)]
+    /// mod tests` is where a second same-named enum usually lives.
+    cfg_mods: Vec<String>,
+}
+
+/// Does this item carry a `#[cfg(...)]` attribute directly, i.e. does its very
+/// existence depend on the compilation configuration? Enclosing `#[cfg]`s are
+/// tracked separately, by `cfg_mods`.
+fn is_cfg_gated(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| attr.path().is_ident("cfg"))
+}
+
+impl<'ast> Visit<'ast> for VariantCollector<'_> {
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        let gated = is_cfg_gated(&node.attrs);
+        if gated {
+            self.cfg_mods.push(node.ident.to_string());
+        }
+        syn::visit::visit_item_mod(self, node);
+        if gated {
+            self.cfg_mods.pop();
+        }
+    }
+
+    fn visit_item_enum(&mut self, node: &'ast syn::ItemEnum) {
+        if node.ident == self.target {
+            self.declarations += 1;
+            if is_cfg_gated(&node.attrs) {
+                self.cfg_gated.insert(self.target.to_string());
+            }
+            if let Some(module) = self.cfg_mods.last() {
+                self.cfg_gated
+                    .insert(format!("mod {module} (enclosing enum {})", self.target));
+            }
+            for variant in &node.variants {
+                if is_cfg_gated(&variant.attrs) {
+                    self.cfg_gated
+                        .insert(format!("{}::{}", self.target, variant.ident));
+                }
+                self.names.insert(variant.ident.to_string());
+            }
+        }
+        syn::visit::visit_item_enum(self, node);
+    }
+}
+
+/// Every variant identifier declared by `enum <target>` in `src`.
+///
+/// An absent enum yields an empty set -- the caller asserts the set is non-empty
+/// before using it, so a genuinely missing enum reads as a gate failure rather
+/// than as vacuous coverage. The three inputs that would instead produce a
+/// *plausible-looking but short* set panic here, each with its own message, so
+/// they can never be mistaken for the absent-enum case:
+///
+/// * `src` does not parse as Rust (the old walk silently returned nothing,
+///   which the caller then misreported as "no enum found");
+/// * two `enum <target>` declarations exist (their variants would union into a
+///   set matching neither, e.g. one real and one inside `#[cfg(test)] mod tests`);
+/// * the enum, one of its variants, or a module enclosing the declaration is
+///   `#[cfg]`-gated. This walk reads source text and does not model conditional
+///   compilation, while the consuming no-wildcard `match` is compiled under one
+///   specific cfg -- so the two sides would disagree about what exists.
+///
+/// The cfg detection is exactly those three positions: an attribute spelled
+/// `#[cfg(...)]` on the enum, on a variant, or on an enclosing `mod`. It does
+/// NOT see a `#[cfg]` on any other enclosing item (a gated `fn` whose body
+/// declares the enum), nor one applied indirectly through `#[cfg_attr(...)]`.
+/// Those shapes would be enumerated as if unconditional. Every failure mode
+/// above, and the module-enclosure case in particular, is proven by execution
+/// in `cli/tests/json_contract.rs`.
+pub fn variant_names(src: &str, target: &str) -> BTreeSet<String> {
+    let file = syn::parse_file(src).unwrap_or_else(|e| {
+        panic!(
+            "enum_variants: the source searched for `enum {target}` does not parse as Rust \
+             ({e}); the #955 coverage gate cannot derive a variant set from it. This is a \
+             PARSE failure, not an absent enum"
+        )
+    });
+    let mut collector = VariantCollector {
+        target,
+        names: BTreeSet::new(),
+        declarations: 0,
+        cfg_gated: BTreeSet::new(),
+        cfg_mods: Vec::new(),
+    };
+    collector.visit_file(&file);
+
+    assert!(
+        collector.declarations <= 1,
+        "enum_variants: {} declarations of `enum {target}` in one source; their variants would \
+         union into a set that describes no single enum, so the #955 coverage gate would compare \
+         against a fiction. Keep exactly one declaration of the gated enum name",
+        collector.declarations
+    );
+    assert!(
+        collector.cfg_gated.is_empty(),
+        "enum_variants: {:?} carry a `#[cfg(...)]` attribute; this walk reads source text and \
+         does not model conditional compilation, while the #955 coverage gate's no-wildcard \
+         `match` is compiled under one specific cfg -- the two would disagree about which \
+         variants exist. Un-gate the variant, or teach both sides the same cfg",
+        collector.cfg_gated
+    );
+
+    collector.names
+}

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -95,7 +95,18 @@ Nine, all in the CLI crate:
   longer schema-free: there are 32 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
   CliOutput`, and per-family output validation — all 32 are validated against real
-  `to_json()` output across 44 tests in `cli/tests/json_contract.rs`. An agent
+  `to_json()` output across 53 tests in `cli/tests/json_contract.rs`. Those tests
+  drive each output type's `to_json()` once per output variant rather than calling
+  the pure builder functions behind it, so a variant whose `to_json()` arm drifts
+  from the schema is caught even when the builder it delegates to still validates.
+  For the multi-variant `message` outcome the covered set is not hand-written: a
+  `syn` walk (`cli/tests/support/enum_variants.rs`) derives the variant names from
+  the enum declaration itself, so a sixth variant landing with no case turns the
+  gate red rather than passing vacuously (#955). Five of the added tests exercise
+  the walk's own rejection paths -- a source that fails to parse, a second
+  declaration of the same enum, a `#[cfg]`-gated variant, and an enum inside a
+  `#[cfg]`-gated module -- plus a positive control, so those rejections are now
+  proven by execution rather than asserted. An agent
   parsing this output is now coupled to shapes enforced by committed schemas and a
   drift gate, like the ACI (`packages/aci-protocol`, ADR-0017), not by tests alone.
 - **Not separately graded.** This is not one of the six swap-readiness Jobs in the


### PR DESCRIPTION
`curie local message --json` and `curie cluster message --json` emit `{status, channel, thread}` in connected transport mode, and that object was invalid against `cli/schema/message.schema.json`, the schema the binary itself publishes for the verb through `curie schema-index message`. Adding the missing `oneOf` branch is additive under ADR-0074 section 5, so the file is edited in place at v1.

The more useful half is why the gate missed it. It was aimed one level too high: the contract tests validated the four builder functions, and the inventory walk enumerates result types through `impl CliOutput for T`, never variants. `Enqueued` was the one arm that inlined its JSON instead of delegating to a builder, so it was invisible to both, and any future inlined arm would have escaped identically. The tests now drive `MessageOutcomeOutput::to_json()` per variant behind two traps: a no wildcard match makes a sixth variant a compile error, and the covered set is derived from the enum declaration by a `syn` walk rather than hand written, so a variant with no sample fails by name.

## Done check

- [x] **Failing tests committed before implementation.** The tests landed red: `cargo test --test json_contract` gave 45 passed, 2 failed, both on the enqueued payload, before the schema branch was added.
- [x] **All production code edits delegated.** Driver ran only git, cargo, and read only checks. Two temporary mutations used to demonstrate the guards were reverted and the tree verified clean.
- [N/A] **Broadened return types.** None. The only signature change is a new builder function.
- [x] **Code Reviewer approved** with file:line evidence, across three rounds. Round one returned REQUEST-CHANGES on two blocking findings (a lost `AwaitingApproval` no reply payload, and the schema's own description still saying four shapes); round two on one blocking finding (the new builder missing from the published inventory). All fixed and the fixes re-reviewed.
- [x] **Scope Reviewer approved.** Round one returned FAIL on a `MessageDryRunOutput` `pub` widening that bought no coverage; it was reverted. Final verdict PASS with one annotation, below.
- [x] **Sibling path parity.** The gate is wired to one enum by name while 19 of 30 `CliOutput` impls are enums. The other 18 were spot checked as currently correct, so this is a missing gate rather than a live defect, filed as #965 with the reason discovery is easy here but sample construction is the real design problem.
- [x] **Guard demonstration, by execution rather than by reading.** Removing the `Enqueued` sample fails naming `["Enqueued"]`; adding a sixth variant fails to compile with `error[E0004]`. Five further tests prove the walk's own refusals fire on a source that does not parse, a duplicate declaration, a cfg gated variant, and an enum inside a cfg gated module, plus a positive control.
- [x] **Consolidation pass ran.** `/simplify` collapsed two loops running the same predicate, replaced ten inlined schema load and compile pairs with one helper, and the applied diff was re-reviewed.
- [x] **Codex review ran** on the final diff and returned zero findings. Its earlier pass caught the one that mattered: the first version of the coverage assertion compared against a hand written list, so a sixth variant with a match arm but no sample passed vacuously.
- [N/A] **Security Reviewer.** No security surface.
- [x] **End to end against the built binary.** `curie schema-index message` emits a schema byte identical to the on disk file, with five branches, and the enqueued payload validates against exactly one of them.
- [x] **Full suite passes.** 869 tests, against 860 on base. `bash scripts/check-docs.sh` exits 0.
- [x] **Lint clean.** `cargo fmt --check` clean and `cargo clippy --all-targets -- -D warnings` reports zero findings on every edited file.

## Intentionally bundled, outside the acceptance criteria

The `Enqueued` arm is extracted into a `message_enqueued_json` builder so all five `to_json` arms route through a named pure builder, closing the root cause asymmetry the issue identifies; no acceptance criterion asks for it and the new per variant gate passes with or without it. The emitted object is byte identical, and its entry in the published inventory is declared alongside its siblings.

Closes #955
