### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,98 @@
+name: Bug report
+description: Something is broken or behaves differently than documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks for taking the time to file this. Issues are for bugs and
+        reproducible problems. If you are asking how to do something, please
+        use [Discussions Q&A](https://github.com/curie-eng/curie/discussions/categories/q-a)
+        instead, where the answer stays searchable.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you file
+      options:
+        - label: I searched existing issues and did not find this one.
+          required: true
+        - label: This is a bug, not a usage question.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `curie --version`, or the commit SHA if you built from source.
+      placeholder: "0.4.3, or 66d17f5f"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Which tier were you running?
+      description: >-
+        `skill` is a local runner session for one bundle, `local` is the
+        Docker Compose stack, `cluster` is a deployed Kubernetes release.
+      options:
+        - skill
+        - local
+        - cluster
+        - Not sure
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Linux x86_64
+        - macOS arm64
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you expect to happen, and what happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        The exact commands you ran, in order. A reproduction we can run
+        ourselves is the single most useful thing in this form.
+      placeholder: |
+        1. curie local up
+        2. curie local deploy --plugin-dir examples/...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output or logs
+      description: >-
+        Paste command output, stack traces, or logs. This is rendered as a
+        code block, so no backticks are needed.
+      render: shell
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: >-
+            I agree to follow this project's
+            [Code of Conduct](https://github.com/curie-eng/curie/blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or how-to help
+    url: https://github.com/curie-eng/curie/discussions/categories/q-a
+    about: >-
+      Ask in Discussions Q&A. Issues are for bugs and reproducible problems.
+      Answers there are searchable, so the next person finds them.
+  - name: Idea or proposal
+    url: https://github.com/curie-eng/curie/discussions/categories/ideas
+    about: >-
+      Talk a design through before it becomes an issue. Larger changes may
+      need an ADR under docs/adr/.
+  - name: Security vulnerability
+    url: https://github.com/curie-eng/curie/security/policy
+    about: >-
+      Do not open a public issue. Follow the private disclosure process in
+      SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,44 @@
+name: Documentation problem
+description: Something in the docs is wrong, missing, or misleading.
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Docs that sent you down the wrong path are a bug. Small corrections are
+        very welcome as a pull request instead of an issue.
+
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: The file path or URL, and a heading or line number if you have one.
+      placeholder: "QUICKSTART.md, the 'First run' section"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong
+      description: >-
+        What does it say, what did you expect it to say, and what happened when
+        you followed it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested wording
+      description: Optional, but the fastest path to a fix.
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: >-
+            I agree to follow this project's
+            [Code of Conduct](https://github.com/curie-eng/curie/blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,77 @@
+name: Feature request
+description: Propose a change or a new capability.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        If you are still forming the idea, start in
+        [Discussions Ideas](https://github.com/curie-eng/curie/discussions/categories/ideas)
+        instead. Open an issue once there is a concrete change to track.
+        Proposals that change how components talk to each other usually need
+        an ADR under `docs/adr/` first; see
+        [CONTRIBUTING.md](https://github.com/curie-eng/curie/blob/main/CONTRIBUTING.md).
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you file
+      options:
+        - label: I searched existing issues and discussions and did not find this one.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: >-
+        Describe the problem, not the solution. What are you unable to do
+        today, and what does that cost you?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should exist instead? Include the command or interface you imagine.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI
+        - Runner
+        - Dispatcher
+        - Worker
+        - Platform API
+        - UI
+        - Helm chart and Kubernetes
+        - Skills and plugin bundles
+        - Model routing
+        - Evals
+        - Docs
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: >-
+        Including "do nothing." Knowing what you ruled out and why helps us
+        weigh the proposal.
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: >-
+            I agree to follow this project's
+            [Code of Conduct](https://github.com/curie-eng/curie/blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- One paragraph: what changed, and why. Skip the play by play. -->
+
+## Related issue
+
+<!-- Closes #NNN. Use `Ref #NNN` if this does not fully close the issue. -->
+
+Closes #
+
+## Checklist
+
+- [ ] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
+- [ ] Docs updated if behavior changed.
+- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.


### PR DESCRIPTION
## Summary

Adds contributor facing GitHub templates so filed issues and pull requests arrive with the context a maintainer needs to act on them. Blank issues are disabled and routed to three forms: bug report, feature request, and documentation problem. The bug form captures the version, the parity tier (`skill`, `local`, `cluster`), the platform, and reproduction steps, since those four are what every triage round currently has to ask for. The feature form pushes early stage ideas to Discussions and flags that cross component proposals usually need an ADR under `docs/adr/` first. The pull request template is deliberately short: a summary, the linked issue, and a three item checklist.

## Notes

- `config.yml` contact links point at Discussions Q&A, Discussions Ideas, and the security policy. Verified all three resolve 200 against the public repo: Discussions is enabled (`has_discussions` is true) and both the `q-a` and `ideas` categories exist, so there is no merge prerequisite left here. If Discussions is ever turned off, those links become 404s.
- No DCO sign off checkbox. `CONTRIBUTING.md` still carries an open `TODO(maintainer)` on DCO versus CLA, so the PR template does not encode either choice yet. Worth revisiting once that decision lands.
- No `CODEOWNERS` file. Deliberately out of scope, since it changes review routing repo wide.
- No repo settings were changed.
- Templates reference `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, and `SECURITY.md`, all of which are present on `main`.
- `bash scripts/check-docs.sh` exits 0 on this branch.
