### PR TITLE
Name the conduct escalation contact

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,14 +61,11 @@ representative at an online or offline event.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at:
 
-<!-- TODO(maintainer): Decision 2 (issue #635) - conduct escalation contact.
-     Provide the reporting address or channel and who receives escalations.
-     Do not ship the placeholder below. Common choices: a dedicated conduct
-     email alias (for example conduct@your-domain), or a private form. State
-     the expected acknowledgement time if the project commits to one. -->
+**[conduct@curietech.net](mailto:conduct@curietech.net)**
 
-**TODO(maintainer): conduct escalation contact** (reporting address or channel
-to be set before the public announcement).
+Reports go to the project maintainers. This applies to every community space the
+project runs, including the repository, GitHub Discussions, and the community
+chat server.
 
 All complaints will be reviewed and investigated promptly and fairly.
 


### PR DESCRIPTION
Fills the last maintainer TODO in `CODE_OF_CONDUCT.md` ahead of the public
announcement.

Conduct concerns now have a named private reporting address,
`conduct@curietech.net`, replacing the placeholder. The page also states that
reports go to the project maintainers and that the policy covers the repository,
GitHub Discussions, and the community chat server, so the repo and the chat
server's posted rules do not drift apart.

This resolves a live inconsistency: the community chat rules already direct
people to `conduct@curietech.net`, while this page still said the address was to
be decided.

`scripts/check-docs.sh` exits 0 on this branch.

Remaining launch TODOs, not in this PR because both are open decisions rather
than tasks: whether outside pull requests are accepted and what scope is
welcome, and DCO versus CLA. Both are in `CONTRIBUTING.md`.

Ref #635