### PR TITLE
Add license and release badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Curie
 
 [![CI](https://github.com/curie-eng/curie/actions/workflows/ci.yaml/badge.svg)](https://github.com/curie-eng/curie/actions/workflows/ci.yaml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/curie-eng/curie)](https://github.com/curie-eng/curie/releases)
 
 Open-source, self-hostable developer platform for Slack-based agents. Connect
 Slack, author a Claude-Code-format plugin (skills + tools + MCP), deploy it as


### PR DESCRIPTION
## Summary
- Adds an Apache-2.0 license badge and a "latest release" (GitHub Releases) badge to the README header, alongside the existing CI badge.

Closes #990

## Test plan
- [x] Rendered README locally to confirm badge markdown/links are correct