### PR TITLE
Gate commit messages against AI attribution in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -502,6 +502,32 @@ jobs:
   # the generator's T1 substitutes for the build directive, both resolved
   # locally so `local up` never attempts a pull against a private GHCR ref.
   #
+  # AGENTS.md forbids naming an AI assistant in a commit message and forbids
+  # Co-Authored-By lines referencing AI. Nothing enforced it and it landed on main
+  # twice in one day (#952/#953, issue #962). Deliberately NOT path-gated: a commit
+  # message is wrong regardless of which files the PR touches. Scoped to the PR's
+  # OWN commits (base..head), so the ~29% of pre-gate history carrying the trailer
+  # is not retroactively enforced -- commits are immutable and a history rewrite is
+  # not worth it.
+  commit-messages:
+    name: Commit messages (no AI attribution)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          # The range needs both endpoints present locally.
+          fetch-depth: 0
+      # Prove the matcher still distinguishes attribution from mention before
+      # trusting its verdict; a gate that cannot fail is not a gate.
+      - name: Gate self-test (negative control)
+        run: bash scripts/check-commit-messages.sh --self-test
+      - name: Check the PR's commit messages
+        run: |
+          bash scripts/check-commit-messages.sh \
+            "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+
   # The three image builds here are GHA-layer-cached via a buildx builder that
   # is created but NOT made the default (`setup-buildx-action` with
   # `use: false`): two of the tags are consumed as Dockerfile FROM bases by a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,19 @@ commands.
 - Reference the relevant issue in the PR body (e.g. `Closes #123`).
 - **Never mention any AI assistant (Claude, Codex, GPT, etc.) or AI in general in
   commit messages, and never add `Co-Authored-By` lines referencing AI.**
+  CI enforces this on every PR (issue #962); check before pushing with:
+
+  ```bash
+  scripts/check-commit-messages.sh            # defaults to origin/main..HEAD
+  scripts/check-commit-messages.sh --self-test
+  ```
+
+  The gate flags *attribution*, not mention: a `Co-Authored-By` trailer naming an
+  assistant, the robot-emoji "Generated with" footer, or an attribution phrase next
+  to a bare assistant name. Technical references (`CLAUDE.md`, `claude_agent_sdk`,
+  `claude-sonnet-5`, `harness.claude`) are deliberately fine, and the script's
+  `--self-test` pins both halves so the distinction cannot silently rot. It checks
+  only the PR's own commits, so pre-gate history is not retroactively enforced.
 - No dashes/emdashes in prose content; no emojis in code or docs.
 
 ## Decisions: ADR vs. GitHub issue

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# AI-attribution gate on commit messages (issue #962). AGENTS.md's branch and
+# commit conventions forbid naming an AI assistant in a commit message and forbid
+# `Co-Authored-By` lines referencing AI, but nothing enforced it and it landed on
+# main twice in one day (#952, #953). This is that enforcement.
+#
+# WHAT IT FLAGS -- attribution, not mention. That distinction is the whole design:
+# 73 of the last 400 commit bodies legitimately contain the string "claude"
+# (`cli/CLAUDE.md`, `claude_agent_sdk`, `harness.claude`, "the Claude harness",
+# `claude-sonnet-5`), so a gate that failed on the NAME would red-flag a large
+# share of honest commits and be switched off within a week. Zero of those 400
+# subjects name an assistant; the real violation is a precise trailer:
+#
+#     Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+#
+# So three rules, each aimed at a claim of authorship:
+#   A. a `Co-Authored-By:` trailer naming an assistant or a vendor no-reply address
+#   B. the robot-emoji "Generated with" footer these tools append
+#   C. an attribution phrase ("generated with", "written by", ...) on the same line
+#      as a BARE assistant name -- bare meaning not part of an identifier, so
+#      `claude_agent_sdk`, `CLAUDE.md`, `claude-sonnet-5` and `harness.claude`
+#      never trip it.
+#
+# Usage:
+#   scripts/check-commit-messages.sh [<range>]   # default: origin/main..HEAD
+#   scripts/check-commit-messages.sh --self-test # prove the matcher is not vacuous
+set -euo pipefail
+
+# A bare assistant name: not preceded by [._/-] and not followed by [._-], so
+# every technical identifier form is excluded by construction.
+BARE_ASSISTANT='(^|[^A-Za-z0-9_./-])(claude|codex|copilot|chatgpt|gemini|devin)([^A-Za-z0-9_.-]|$)'
+ATTRIBUTION_PHRASE='(generated|authored|written|created|assisted|produced)[[:space:]]+(with|by)'
+COAUTHOR_AI='^[[:space:]]*co-authored-by:.*(claude|codex|copilot|chatgpt|gemini|devin|anthropic|openai|noreply@anthropic\.com)'
+ROBOT_FOOTER=$'\xf0\x9f\xa4\x96'  # the robot emoji these tools append
+
+# Echo the reason a line violates the convention, or nothing when it is clean.
+offending_reason() {
+    local line="$1"
+    if printf '%s' "$line" | grep -qiE "$COAUTHOR_AI"; then
+        echo "AI Co-Authored-By trailer"
+        return
+    fi
+    if printf '%s' "$line" | grep -qF "$ROBOT_FOOTER"; then
+        echo "robot-emoji AI generation footer"
+        return
+    fi
+    if printf '%s' "$line" | grep -qiE "$ATTRIBUTION_PHRASE" &&
+        printf '%s' "$line" | grep -qiE "$BARE_ASSISTANT"; then
+        echo "AI authorship attribution"
+        return
+    fi
+}
+
+self_test() {
+    local failures=0
+
+    # MUST be flagged: real attribution, including the exact trailer that landed.
+    local bad=(
+        "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+        "co-authored-by: Codex <noreply@openai.com>"
+        "${ROBOT_FOOTER} Generated with [Claude Code](https://claude.com/claude-code)"
+        "Generated with Claude"
+        "This patch was written by GitHub Copilot"
+    )
+    # MUST NOT be flagged: real lines from this repo's history and its vocabulary.
+    local good=(
+        "Update ARCHITECTURE.md section 8, apps/ui/README.md, and apps/ui/CLAUDE.md"
+        "(harness.claude -> curie_runner.plugin -> claude_agent_sdk), which is what pinned"
+        "Rebuild _KNOWN_BUILTIN_TOOLS from the tool registry in the Claude harness"
+        "pin claude-agent-sdk==0.2.110 and claude-sonnet-5"
+        "the spans generated with claude_agent_sdk stay schema-clean"
+        "Co-Authored-By: Alex Rao <arao@curietech.net>"
+    )
+
+    local line reason
+    for line in "${bad[@]}"; do
+        reason="$(offending_reason "$line")"
+        if [[ -z "$reason" ]]; then
+            echo "self-test FAIL: should have been flagged but was not: $line" >&2
+            failures=$((failures + 1))
+        fi
+    done
+    for line in "${good[@]}"; do
+        reason="$(offending_reason "$line")"
+        if [[ -n "$reason" ]]; then
+            echo "self-test FAIL: legitimate line flagged as '$reason': $line" >&2
+            failures=$((failures + 1))
+        fi
+    done
+
+    if ((failures)); then
+        echo "commit-message gate self-test: $failures case(s) wrong" >&2
+        exit 1
+    fi
+    echo "commit-message gate self-test: ${#bad[@]} caught, ${#good[@]} correctly ignored"
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+    self_test
+    exit 0
+fi
+
+range="${1:-origin/main..HEAD}"
+mapfile -t commits < <(git log --format=%H "$range" 2>/dev/null || true)
+if ((${#commits[@]} == 0)); then
+    echo "no commits in range '$range'; nothing to check"
+    exit 0
+fi
+
+violations=0
+for sha in "${commits[@]}"; do
+    while IFS= read -r line; do
+        reason="$(offending_reason "$line")"
+        if [[ -n "$reason" ]]; then
+            if ((violations == 0)); then
+                echo "AGENTS.md forbids naming an AI assistant in commit messages and" >&2
+                echo "forbids Co-Authored-By lines referencing AI (#962). Offending:" >&2
+                echo "" >&2
+            fi
+            printf '  %s (%s)\n    %s: %s\n' \
+                "$(git log -1 --format=%h "$sha")" \
+                "$(git log -1 --format=%s "$sha")" \
+                "$reason" "$line" >&2
+            violations=$((violations + 1))
+        fi
+    done < <(git log -1 --format=%B "$sha")
+done
+
+if ((violations)); then
+    echo "" >&2
+    echo "Amend or rebase to drop the line(s) above, then force-push the branch." >&2
+    echo "Check locally before pushing: scripts/check-commit-messages.sh" >&2
+    exit 1
+fi
+
+echo "commit messages clean: ${#commits[@]} commit(s) in $range carry no AI attribution"


### PR DESCRIPTION
Closes #962.

## The design decision the issue left open
The suggested shape was *"an AI `Co-Authored-By` trailer, **or an assistant name in the subject or body**"*. Matching the **name** is unusable in this repo, and I checked before building:

- **73 of the last 400 commit bodies** contain "claude" **legitimately** — `cli/CLAUDE.md`, `claude_agent_sdk`, `harness.claude`, "the Claude harness", `claude-sonnet-5`.
- **Zero of those 400 subjects** name an assistant.

A gate that failed on those would red-flag a large share of honest commits (including recent ones about the harness SDK boundary) and be switched off within a week. So it matches **attribution, not mention**, in three rules:

1. an AI co-author trailer,
2. the robot-emoji generation footer,
3. an attribution phrase ("generated with", "written by") on the same line as a **bare** assistant name — bare meaning not part of an identifier, so every technical form above is excluded by construction.

## Measured against real history, not asserted
Over the last 400 commits the gate flags **117, and every one is a genuine AI co-author trailer** — 107 + 9 of two Anthropic variants and 1 Copilot Autofix — with **zero false positives**.

That also corrects the issue's count: its grep was scoped to a narrow range, so this is **~29% of recent history**, not two commits.

## Scope and posture
- **PR's own commits only** (`base..head`): pre-gate history is not retroactively enforced. Commits are immutable and a rewrite isn't worth it.
- **Not path-gated** — a commit message is wrong regardless of which files changed.
- The job runs the script's **`--self-test` first** (5 attribution samples caught, 6 real repo lines correctly ignored), so a matcher that can no longer fail is itself a failure.
- **Advisory until made required:** it will show red but won't block merges until someone adds it to the branch ruleset's required checks — a repo-settings action like #915/#916/#917. That answers the issue's open question; say the word and I'll note it on #917.

## Verification
- Against the real offending commit `fcec9dd`: fails, naming the commit and quoting the trailer, exit 1.
- Against a clean range: passes.
- Self-test: 5 caught / 6 ignored. `shellcheck`, `actionlint`, and the docs gate all clean.
- The gate passes on this PR's own commit (I checked, since it discusses the very patterns it bans).

Documented in `AGENTS.md` beside the rule it enforces, with the local command — the issue's third AC.
