### PR TITLE
Readability pass on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,74 +2,237 @@
 
 [![CI](https://github.com/curie-eng/curie/actions/workflows/ci.yaml/badge.svg)](https://github.com/curie-eng/curie/actions/workflows/ci.yaml)
 
-Open-source, self-hostable developer platform for Slack-based agents. Connect
-Slack, author a Claude-Code-format plugin (skills + tools + MCP), deploy it as
-a versioned bot identity, and get traces, evals, budgets, and git-flow for
-free.
+Open-source(Apache 2.0), self-hostable developer platform for Slack-based agents. Connect Slack,
+author a Claude-Code-format plugin bundle(skills + tools + MCP), deploy it as a versioned bot
+identity and run it anywhere - in your development environment on your laptop or in production
+on your own Kubernetes cluster. Configure your model, so you can point an agent at Anthropic,
+OpenRouter, or a local model through Ollama. Get traces, evals, budgets, and git-flow deploys
+for free. One CLI, `curie`, drives all of it.
 
-New here? Start with [`QUICKSTART.md`](QUICKSTART.md) to get your first agent
-reply in about a minute. Then read [`docs/vision.md`](docs/vision.md) for what
-Curie is, who it is for, and what it could become. It is the north star we
-hold new features against.
+New here? [`Quickstart`](#quickstart) gets you a first agent reply in about a minute.
 
-"Relay" is this project's internal codename (repo, commits, internal docs);
-"curie" is the product-surface name — the CLI binary, the bot handle, the
-console. Both names refer to the same system.
+## Why your agent breaks when it leaves your laptop
 
-## What does Curie do?
+Local and production environments are usually different - a different Python version, a missing tool,
+a credential that exists in one place and not the other. Curie closes that gap with one mechanic:
+the same plugin bundle climbs three tiers.
 
-Your agent worked on your laptop and then broke once it was deployed. Curie is
-a harness that runs the same bundle format and the same `evals/cases.json`
-across three targets (`skill` on host Docker, `local` via docker compose, `cluster`
-on Kubernetes), so the ladder can surface environment differences before
-production when bundle content and grading behavior match. `local`
-and `cluster` use stored immutable versioned bundles. `skill` bind mounts the
-working bundle directory read only, but host edits can still change it, as
-tracked in [issue 1087](https://github.com/curie-eng/curie/issues/1087). A
-coding agent can already write a `skill.md`; what it cannot guarantee alone is
-that the skill behaves the same deployed as it did locally. That guarantee is
-the harness's job: the local loop is the production loop.
+- `skill` runs it directly, as a single container, no platform in front.
 
-A Slack `@mention` (or DM) is answered by a versioned plugin running in an
-isolated Kubernetes sandbox, with the run traced end to end and steerable
-mid-turn. A `git push` deploys that plugin under a bot identity: push to `dev`
-updates `@curie-dev`, merging to `prod` promotes the same built artifact to
-`@curie`. See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full
-component map, a message-flow sequence diagram, and the deploy-flow sequence
-diagram.
+- `local` runs it through the full platform via Docker Compose.
 
-## Why did my agent work locally but break once deployed?
+- `cluster` runs it through that same full platform on Kubernetes.
 
-Because "locally" and "deployed" were different runtimes: a different Python, a
-missing tool, an MCP server that resolved on your laptop and not in the cluster,
-a credential that was present in one place and absent in the other. Curie
-removes that gap by construction. The platform paths run immutable versioned
-bundles through the **same runner image** speaking the **same frozen ACI
-contract**; only the substrate underneath changes (in process, docker compose,
-Kubernetes). The `skill` path currently bind mounts its working directory, so
-host edits remain observable under
-[issue 1087](https://github.com/curie-eng/curie/issues/1087). With matching
-bundle content and grading behavior, a difference between tiers can identify an
-environment difference before users hit it. Start from the
-[target table](#which-target-do-i-want) and climb `skill` → `local` → `cluster`;
-each rung exercises the same bundle format on a heavier substrate, while
-`skill` continues to use its working directory.
+An environment difference then shows up as a bug while progressing through these tiers, not a surprise
+your users hit - letting you iterate fast locally and ship with confidence.
 
-## How do I test an agent the same way locally and on Kubernetes?
+`local` and `cluster` run immutable versioned bundles; `skill` bind mounts its working directory instead,
+so you can edit and iterate fast while building the plugin bundle.
 
-You run the **same `evals/cases.json`** at every tier. `curie skill eval`
-grades the bundle in process; the `local` and `cluster` targets drive the same
-cases through the real queue → worker → sandbox → runner path a Slack mention
-takes, so with matching bundle content and grading behavior, an eval that passes
-on your laptop and fails on the cluster can identify a deployment difference.
-The case shape and grading
-semantics are shared, while `skill` grades in Rust and `local` and `cluster`
-grade in Python; conformance fixtures hold those implementations together.
-[ADR 0022](docs/adr/0022-eval-completeness-tier-parity-and-trace-promotion.md)
-defers a single runner side grader. See
-[How do I develop and verify a change?](#how-do-i-develop-and-verify-a-change)
-for the per-package verify commands and
-[`cli/README.md`](cli/README.md) for the full `eval` reference across targets.
+Curie provides an environment guarantee while climbing the three tiers. It is not a behavior
+guarantee: production traffic can still behave differently than your test cases, and no platform can
+honestly promise otherwise.
+
+See [`ARCHITECTURE.md`](ARCHITECTURE.md#2-component-map) for the platform architecture and how the pieces fit together.
+See the [target table](#which-target-do-i-want) below for what each tier actually runs.
+
+## Quickstart
+
+### Prerequisites
+
+- **Docker + Compose v2**: for the dev stack and the local runner container.
+- **kubectl + helm**: only for the cluster-install path.
+
+### Building and deploying your first agent with Curie
+
+Get an [Anthropic API key](https://console.anthropic.com/) and export it once:
+
+```bash
+export CURIE_CREDENTIALS=sk-ant-...
+```
+
+Every step below reuses this same credential and the same bundle. If you don't have Docker installed,
+[install Docker](https://docs.docker.com/get-docker/) and make sure it's running - it is needed for steps 1-2.
+
+**1. Build and test**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/curie-eng/curie/main/get-curie.sh | bash
+curie init my-agent && cd my-agent
+```
+
+Take a look at what got scaffolded:
+
+```bash
+tree -a
+```
+```
+.
+├── .mcp.json
+├── evals
+│   └── cases.json
+└── skills
+    └── my-agent
+        └── SKILL.md
+```
+
+- `skills/my-agent/SKILL.md` - the agent's instructions: what it does, and when to use which tool.
+- `.mcp.json` - the MCP servers (tools) this agent can call.
+- `evals/cases.json` - the eval cases that grade this agent's behavior, at every tier.
+
+This is the Claude Code plugin format, verbatim - see [`packages/plugin-format/README.md`](packages/plugin-format/README.md#format-surface)
+for the shape Curie validates against.
+
+```bash
+curie skill up
+curie skill message "hello, are you there?"
+```
+
+A real reply streams back: no Slack, no platform yet. Edit `skills/my-agent/SKILL.md` and re-run to see your
+change answered. When done run the following command
+
+```bash
+curie skill down
+```
+
+This is the fastest inner loop of development and enables you to iterate and build your skills.
+
+**2. Full platform, still your laptop**
+
+Next hook up the agent into the full backend so that the message runs the real queue -> worker -> sandbox -> reply path.
+
+```bash
+curie local up
+curie local deploy --plugin-dir . --slack-channel C0123ABCD --api-url http://localhost:28000
+curie local message "hello, are you there?"
+```
+
+Then continue this conversation thread
+
+```bash
+curie local message --continue "what's 2 + 2?"
+```
+
+This is the same path a real Slack `@mention`
+takes - see [`docs/slack-local-runbook.md`](docs/slack-local-runbook.md) when you're ready to try it live.
+
+Visit the console at 
+
+```bash
+http://localhost:28080/?api=1
+```
+
+to see the whole conversation, its traces, metrics, and cost. The same console also surfaces logs,
+approvals, and memory, which get more relevant once this plugin is deployed on Kubernetes in production.
+
+When done run the following command
+
+```bash
+curie local down
+```
+
+**3. Real Kubernetes**
+
+Finally, deploy the bundle on Kubernetes.
+Point `kubectl`/`helm` at a cluster - k3s is the lasting recommendation; if you don't have a cluster
+handy, [install minikube](https://minikube.sigs.k8s.io/) and run the following command
+(See [`docs/operations.md`](docs/operations.md#choosing-a-cluster) for the tradeoffs between k3s and minikube):
+
+```bash
+minikube start
+```
+
+Then:
+
+```bash
+curie cluster up --allow-egress-host anthropic --set security.gvisor.mode=off
+curie cluster deploy --plugin-dir .
+curie cluster message "hello, are you there?"
+```
+
+`--set security.gvisor.mode=off` skips gVisor's extra kernel isolation, which a real-model install
+otherwise requires and minikube doesn't ship by default - drop it on a cluster that has `runsc`
+installed. 
+
+`--allow-egress-host` opens the model call; a credential alone doesn't, since the cluster sandbox is
+fail-closed by default (skill/local aren't).
+
+See [`docs/operations.md`](docs/operations.md#install-and-inspect) for cluster prerequisites and the full egress model.
+
+Then continue this conversation thread
+
+```bash
+curie cluster message --continue "what's 2 + 2?"
+```
+
+When done run the following command
+
+```bash
+curie cluster down --yes
+```
+
+**4. Ship it: your CI/CD**
+
+Connect this bundle's repo once (see [`docs/operations.md`](docs/operations.md#connecting-a-repo-for-git-flow-deploys)), then:
+
+```bash
+git push origin dev
+```
+
+Every push is stored as an immutable, versioned bundle and deployed under your `dev` bot
+automatically. Merging to prod promotes that same version, not a rebuild, so you always
+know exactly what's live and can roll back to any version.
+
+No Slack event loop, no queue, no sandbox plumbing to write. You asked the same bundle
+to run somewhere bigger, then told it to ship itself.
+
+Ready to make it real? See [`docs/slack-local-runbook.md`](docs/slack-local-runbook.md) to wire
+this bundle into an actual Slack workspace.
+
+Once this is live in `dev` or `prod`, `@mention` the bot in Slack like any teammate - see
+[`apps/dispatcher/README.md`](apps/dispatcher/README.md#runbook-point-it-at-a-real-slack-workspace-once-one-exists)'s runbook for connecting a real workspace to a deployed release.
+
+See [`QUICKSTART.md`](QUICKSTART.md) for the offline `--fake-model` path,
+the `examples/` bundles, and building Curie from source.
+
+## Which target do I want?
+
+Every CLI command that touches an environment takes a **target noun** in the
+middle: `skill`, `local`, or `cluster`. Pick the lightest one that answers your
+question.`curie init` is the exception: it scaffolds a plugin bundle on disk and
+targets no environment. The point of the three targets is that the same
+plugin bundle format and the same `evals/cases.json` run across all of them, so
+promoting `skill` → `local` → `cluster` is a parity ladder, not three separate
+setups. An eval that passes on your laptop and fails on the cluster is
+signal, not noise; each target's `eval` command is documented alongside it
+in [`cli/README.md`](cli/README.md).
+
+| Target    | What runs                                                                                                    | Slack    | Kubernetes | Verbs                                   | Reach for it to                                                                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------------------------ | -------- | ---------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `skill`   | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none     | none       | `up` `down` `status` `message` `eval`   | Iterate a plugin/skill against a local runner, the fastest development loop.                                                                                   |
+| `local`   | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker).                          | none     | none       | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
+| `cluster` | The platform on Kubernetes (a Helm release).                                                                 | optional | yes        | `up` `down` `status` `message` `deploy` | Operate and drive a deployed cluster release.                                                                                                      |
+
+The universal quartet `up`/`down`/`status`/`message` is on all three targets;
+`skill` adds `eval`, and `local`/`cluster` add `deploy`. Parity does not mean
+every capability is implemented at every tier: every verb is answered at every
+tier, with unsupported concepts returning a deterministic reason and an
+alternative, as defined in
+[ADR 0041](docs/adr/0041-every-verb-is-answered-at-every-tier.md).
+
+The distinction that matters: `skill` is the **runner-only** loop — it boots
+just the runner container and talks straight to its ACI HTTP surface with no
+platform in front. `local` and `cluster` put the **full platform** (queue,
+worker, sandbox) in front of the identical runner and ACI. A `message` on
+either therefore walks the same path a real Slack mention would take.
+
+See `cli/README.md` for the full command reference per target
+([`skill`](cli/README.md#skill-target-runner-only-fully-offline),
+[`local`](cli/README.md#local-target-full-platform-via-compose-no-slack),
+[`cluster`](cli/README.md#cluster-target-deployed-helm-release)),
+[`docs/slack-local-runbook.md`](docs/slack-local-runbook.md) for connecting local Slack, and
+[`docs/operations.md`](docs/operations.md) for cluster operations - the Quickstart above already
+walks through `skill`, `local`, and `cluster` end to end.
 
 ## Status
 
@@ -83,229 +246,9 @@ Forward-looking work is planned and tracked in
 [GitHub issues](https://github.com/curie-eng/curie/issues), with larger
 journeys filed as `epic`-labeled issues.
 
-## Component map
-
-| Component | Language | What it owns |
-|---|---|---|
-| [`apps/dispatcher`](apps/dispatcher/README.md) | Python (Slack Bolt) | Socket Mode ingestion: ack, dedupe, placeholder reply, enqueue |
-| [`apps/worker`](apps/worker/README.md) | Python (redis-py) | The concurrency kernel (routing, finish-race, steer/interrupt) + the Agent Sandbox substrate |
-| [`runner`](runner/README.md) | Python (claude-agent-sdk) | The streaming session server that implements the ACI contract inside a sandbox |
-| [`apps/api`](apps/api/README.md) | Python (FastAPI) | Agents/versions/deployments CRUD, plugin bundle pipeline, GitHub git-flow, Langfuse + pod-log proxies |
-| [`apps/ui`](apps/ui/README.md) | React (Vite + TS) | The Curie console: author, deploy, and observe agents |
-| [`cli`](cli/README.md) | Rust (clap + tokio) | The `curie` CLI: local emulation, evals, deploy, and the cluster operator lifecycle (`up`/`status`/`down`) |
-| [`charts/curie`](charts/curie/README.md) | Helm | The umbrella chart: Langfuse + Postgres + Valkey + ClickHouse + MinIO + OTel Collector + the Agent Sandbox substrate, with security rails on by default |
-| [`packages/aci-protocol`](packages/aci-protocol/README.md) | Python (frozen, codegen to TS + Rust) | The ACI session protocol every lane speaks |
-| [`packages/plugin-format`](packages/plugin-format/README.md) | Python (frozen, codegen to JSON Schema) | The Claude Code plugin bundle shape, verbatim |
-
-## Which target do I want?
-
-Every CLI command that touches an environment takes a **target noun** in the
-middle: `skill`, `local`, or `cluster`. Pick the lightest one that answers your
-question. (`curie init` is the exception: it scaffolds a bundle on disk and
-targets no environment.) The point of the three targets is that the same bundle
-format and the same `evals/cases.json` run across all of them, so promoting
-`skill` to `local` to `cluster` is a parity ladder, not three separate setups.
-
-| Target | What runs | Slack | Kubernetes | Verbs | Reach for it to |
-|---|---|---|---|---|---|
-| `skill` | Just the runner container on the host Docker daemon. No platform, no queue, no API, no Slack. Fully offline. | none | none | `up` `down` `status` `message` `eval` | Iterate a plugin/skill against a local runner, the fastest loop. |
-| `local` | The full platform via docker compose (Postgres + Valkey + Langfuse + API + worker). | none | none | `up` `down` `status` `message` `deploy` | Exercise the real queue -> worker -> sandbox -> reply product loop with zero Slack and zero Kubernetes. Its API is published on host port `28000`. |
-| `cluster` | The platform on Kubernetes (a Helm release). | optional | yes | `up` `down` `status` `message` `deploy` | Operate and drive a deployed cluster release. |
-
-The universal quartet `up`/`down`/`status`/`message` is on all three targets;
-`skill` adds `eval`, and `local`/`cluster` add `deploy`. Parity does not mean
-every capability is implemented at every tier: every verb is answered at every
-tier, with unsupported concepts returning a deterministic reason and an
-alternative, as defined in
-[ADR 0041](docs/adr/0041-every-verb-is-answered-at-every-tier.md).
-
-The distinction that matters: `skill` is the **runner-only** loop, it boots just
-the runner container and talks straight to its ACI HTTP surface with no platform
-in front. `local` and `cluster` put the **full platform** (queue, worker,
-sandbox) in front of the identical runner and ACI, so a `message` walks the same
-path a real Slack mention would take.
-
-**`skill` (runner-only, fully offline).** `curie skill up` boots the runner
-image in Docker (add `--fake-model` for a fully offline round-trip), then
-`curie skill message "..."` sends a synthetic Slack event to it and streams
-the NDJSON reply to your terminal. `curie skill eval` runs a plugin's
-`evals/cases.json` the same way. Abort a live `skill message` with Ctrl-C. This
-is the fastest inner loop for developing a plugin: zero Slack, zero platform,
-zero cluster. See `cli/README.md`.
-
-**`local` (full platform via compose, no Slack).** `curie local up` brings up
-the `full` compose profile by default. `curie local up --minimal` brings up
-the smaller `core` profile (API, worker, Postgres, Valkey, MinIO). Then
-`curie local deploy` pushes a bundle to the compose API, and
-`curie local message "..."` drives a message through the real
-queue -> worker -> sandboxed runner -> reply path with no Slack and no
-Kubernetes. The compose worker runs the fake model by default, but exporting
-`CLAUDE_CODE_OAUTH_TOKEN` (or `ANTHROPIC_API_KEY`) in your shell is enough for a
-real model -- `curie local up` flips to live automatically when a credential is
-present, matching `skill up`, so there is no manual `CURIE_FAKE_MODEL=0` step.
-See the local runbook below.
-
-**`cluster` (deployed Helm release).** `curie cluster up` installs the platform
-on Kubernetes and `curie cluster message "..."` drives the deployed release end
-to end with no Slack. See
-[How do I run my agent on a Kubernetes cluster?](#how-do-i-run-my-agent-on-a-kubernetes-cluster)
-and [`docs/operations.md`](docs/operations.md).
-
-**Real Slack (production).** With a workspace connected, `@mention` the bot in a
-channel or DM it: the dispatcher acks, posts a placeholder, and the worker routes
-the turn into a claimed sandbox; the placeholder is edited in place as the reply
-streams. This is the same platform the `local` and `cluster` targets exercise,
-with Slack in front. See `apps/dispatcher/README.md`'s runbook for pointing at a
-real workspace.
-
-**Connect a real Slack workspace (local).** The `local` target uses the Slack
-stub by default, but you can exercise real Slack routing, mentions and threads
-on the compose stack without a cluster. Export the two Slack tokens, empty
-`SLACK_API_BASE_URL` to un-wire the worker's Slack stub, and start the optional
-dispatcher:
-
-```bash
-export SLACK_APP_TOKEN=xapp-... SLACK_BOT_TOKEN=xoxb-...
-export SLACK_API_BASE_URL=          # empty un-wires the worker's Slack stub
-curie local up --slack
-
-# Raw Docker needs the base profile plus Slack (the dispatcher depends on
-# valkey, a core service), for either compose file:
-docker compose --profile full --profile slack -f compose.dev.yaml up -d
-docker compose --profile full --profile slack -f compose.release.yaml up -d
-```
-
-Slack allows exactly one Socket Mode owner per app token at a time, so do not
-also run a cluster dispatcher on the same Slack app: it is either/or per app.
-Because these are shell exports they persist for the session, so a later plain
-`curie local up` in the same shell keeps the worker pointed at real Slack
-(empty `SLACK_API_BASE_URL`) with the real bot token but no dispatcher feeding
-the queue; open a fresh shell (or `unset SLACK_API_BASE_URL`) to return to the
-Slack-free stub. For the full walkthrough (app creation from the manifest,
-channel binding, and troubleshooting) see
-[`docs/slack-local-runbook.md`](docs/slack-local-runbook.md).
-
-## Prerequisites
-
-- **[uv](https://docs.astral.sh/uv/)**: the Python workspace manager.
-- **Python 3.13** (the workspace requires `>=3.13`).
-- **Docker + Compose v2**: for the dev stack and the local runner container.
-- **Node.js 22 + [pnpm](https://pnpm.io/)**: for the UI.
-- **Rust toolchain** (stable, edition 2021, with `rustfmt` and `clippy`): only
-  for building the CLI from source. Skip it entirely if you download the
-  prebuilt CLI binary from Releases (the default install path below).
-- **kubectl + helm**: only for the cluster-install path (see
-  [How do I run my agent on a Kubernetes cluster?](#how-do-i-run-my-agent-on-a-kubernetes-cluster)).
-
-## Quickstart
-
-This is the short version — for immediate testing. For a real model, the
-offline local-model demo, building from source, and the full local/cluster
-runbooks, see the detailed walkthrough in [`QUICKSTART.md`](QUICKSTART.md).
-
-The fastest way in — for operators and coding agents alike — is the prebuilt
-release binary. It needs no Rust toolchain and no repo checkout. One command
-resolves the latest release, downloads the binary for your platform, verifies
-its signed checksum, and installs it to your PATH:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/curie-eng/curie/main/get-curie.sh | bash
-```
-
-The installer always verifies the sha256 and runs `cosign verify-blob` when
-cosign is on PATH (set `CURIE_REQUIRE_COSIGN=1` to require it). To run every
-download-verify-install step by hand instead, or to verify with `gh attestation`,
-[`docs/release-verification.md`](docs/release-verification.md#verify-the-cli-before-installing-it)
-owns the fully manual flow. Then, from a bundle directory:
-
-```bash
-curie init my-agent && cd my-agent
-curie skill up --fake-model    # offline scripted model, no credential
-curie skill message "hello, are you there?"
-curie skill down
-```
-
-That is the fastest inner loop: zero Slack, zero platform, zero cluster.
-
-**One-command middle mode** — the same bundle through the real product path
-(queue, worker, sandbox), still no host-run worker and no cluster:
-
-```bash
-curie local up   # full profile: stores + API + worker + Langfuse + UI
-curie local deploy --plugin-dir . --slack-channel C0123ABCD --api-url http://localhost:28000
-curie local message "what changed in the last deploy?"
-```
-
-Watch it land in the console UI at `http://localhost:28080/?api=1`. `local up`
-runs the fake model by default; export `CLAUDE_CODE_OAUTH_TOKEN` or
-`ANTHROPIC_API_KEY` beforehand for a real model. A release binary needs no
-repo checkout for either `local` or `cluster up` — it pulls the pinned chart
-release asset and pinned `compose.release.yaml` matching the binary version,
-caching both under `~/.cache/curie/`.
-
-See [`QUICKSTART.md`](QUICKSTART.md) for: a real model in more depth, the
-offline `--local-model` demo (Ollama, no Anthropic key), running on a
-Kubernetes cluster, the `examples/` bundles, and the contributor path for
-building Curie itself from a repo checkout.
-
-## How do I develop and verify a change?
-
-- **Python packages** are one `uv` workspace (root `pyproject.toml`); ruff,
-  mypy, and pytest run across all members from the repo root
-  (`uv sync && uv run pytest -q && uv run ruff check . && uv run mypy`; see
-  [`AGENTS.md`](AGENTS.md) for the full verify command reference). Integration
-  tests hit the real dev stack, never mocks of Postgres/Valkey/Langfuse.
-- **The Rust CLI** and **the UI** are verified independently; see
-  `cli/README.md` and `apps/ui/README.md` for their commands.
-- **Work on a feature branch per change**, cut from `main`; never commit to
-  `main` directly.
-- **Two frozen contracts** (`packages/aci-protocol`, `packages/plugin-format`)
-  gate every cross-language lane; changing either requires regenerating the
-  committed schema/TS/Rust artifacts and is enforced by a CI compat test.
-
-## How do I run my agent on a Kubernetes cluster?
-
-The same `curie` binary installs and runs the platform on a Kubernetes
-cluster, wrapping the umbrella Helm chart the way `linkerd` or `cilium` wrap
-theirs. A downloaded release binary resolves the pinned chart release asset for
-its version, and `curie local up` likewise resolves the pinned
-`compose.release.yaml`, caching both under `~/.cache/curie/` with no repo
-checkout needed.
-
-### Recommended setup
-
-Docker covers the `skill` and `local` rungs. For the `cluster` rung, we
-recommend a single node k3s cluster on a Linux host with at least 8 GB of
-memory. k3s default kube router networking enforces NetworkPolicy. The 4 GB
-profile is tight. The full promotion ladder therefore needs Docker, kubectl,
-Helm, and access to that cluster.
-
-kind and Minikube are fine for disposable tests, but k3s is the lasting
-recommendation. Their loopback API can require the documented listen host
-escape hatch. Real model workloads require `runsc` on every node unless gVisor
-is explicitly disabled. Fake model installation works without `runsc`. See
-[`docs/operations.md`](docs/operations.md) for setup details; `curie cluster up`
-remains the install path.
-
-Use `--chart <path>` when developing the chart locally. The short version:
-
-- `curie cluster up` runs `helm upgrade --install` of `charts/curie`; it reads
-  `CURIE_CREDENTIALS` (deprecated alias `CURIE_MODEL_CREDENTIALS`) to enable a real model (absent, the release
-  installs sealed with canned replies), and `--no-expose` keeps the UI and
-  Langfuse ClusterIP-only. The credential alone still leaves the runner sandbox
-  sealed against default-deny egress, so a real model stays unreachable until you
-  open its provider with `--allow-egress-host <provider>` (currently `anthropic`
-  or `openrouter`). `--allow-web-egress <CIDR>` (repeatable) opens runner egress
-  for skill web access (e.g. the weather example's live web search), additive to
-  the sealed default; `--allow-egress-host` is the model-provider convenience on
-  top of it. Connecting Slack is a raw `helm upgrade
-  --reuse-values` (not a CLI verb; the chart's `NOTES.txt` prints it).
-- `curie cluster status` reports release health and access URLs; `curie cluster down`
-  uninstalls and sweeps the runtime namespaces. Every verb takes `--dry-run`.
-- `curie cluster message "..."` drives a deployed release end to end with no Slack.
-
-Full runbook (the credential model, the Slack-connect command, and the
-zero-Slack `message` flow) is in [`docs/operations.md`](docs/operations.md).
+## Contributing to Curie
+See [`CONTRIBUTING.md`](CONTRIBUTING.md#development-setup) for the full contributor setup (uv, Python
+3.13, Node.js + pnpm, Rust toolchain) and verify commands.
 
 ## License and trademarks
 
@@ -321,18 +264,19 @@ requires it, and you are free to use Curie whether or not you do.
 
 ## Where do I go next?
 
-- [`ARCHITECTURE.md`](ARCHITECTURE.md) — the component diagram, the
-  message-flow and deploy-flow sequence diagrams, and the built/in-progress
-  split.
-- [`docs/adr/`](docs/adr/) — the load-bearing architecture decisions (Agent
-  Sandbox as substrate, stateless-first sessions, Langfuse as the
-  observability backbone, the frozen ACI, security rails as chart defaults,
-  adopt-not-build boundaries), each with the live-cluster evidence behind it.
-- [`docs/agents.md`](docs/agents.md): the verification contract for an agent
-  driving Curie. The exact commands that prove an outcome, and the rule that a
-  file existing or a string appearing in output is never evidence. This is for
-  an agent using Curie, not one working in this repo.
-- [`AGENTS.md`](AGENTS.md) — the operative rules for anyone (human or agent)
-  working in this repo: the verify commands, the dev stack, the
-  frozen-contract escalation rule, and the build gotchas. Each top-level
-  directory also has its own scoped `CLAUDE.md` with rules specific to that area.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md#2-component-map) -- the component diagram, the
+message-flow and deploy-flow sequence diagrams, and the built/in-progress
+split.
+- [docs/adr/](docs/adr/) -- the load-bearing architecture decisions (Agent
+Sandbox as substrate, stateless-first sessions, Langfuse as the
+observability backbone, the frozen ACI, security rails as chart defaults,
+adopt-not-build boundaries), each with the live-cluster evidence behind it.
+- [docs/agents.md](docs/agents.md): the verification contract for an agent
+driving Curie. The exact commands that prove an outcome, and the rule that a
+file existing or a string appearing in output is never evidence. This is for
+an agent using Curie, not one working in this repo.
+- [`AGENTS.md`](AGENTS.md) -- the operative rules for anyone (human or agent)
+working in this repo: the verify commands, the dev stack, the
+frozen-contract escalation rule, and the build gotchas. Each top-level
+directory also has its own scoped `CLAUDE.md` with rules specific to that area.
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -28,6 +28,18 @@ Prerequisites: `kubectl` and `helm` on PATH, pointed at a reachable cluster
 (the `agents.x-k8s.io` Agent Sandbox CRDs and a NetworkPolicy-enforcing CNI are
 installed by the chart's preflights; see `charts/curie/README.md`).
 
+## Choosing a cluster
+
+A single-node **k3s** cluster on a Linux host (8 GB+
+memory) is the lasting recommendation -- its default kube-router CNI enforces
+NetworkPolicy out of the box. **kind** and **minikube** work fine for
+disposable local tests, but their API server typically binds loopback, which
+can make it unreachable from a pod; if `cluster message` can't auto-detect a
+pod-reachable host, pass `--listen-host` explicitly (see `cli/README.md`).
+Real-model installs additionally require `runsc` (gVisor) on every node unless
+kernel isolation is explicitly disabled (`--set security.gvisor.mode=off`);
+fake-model installs work without it.
+
 ## Install and inspect
 
 - `curie cluster up` runs `helm upgrade --install` using the chart resolved
@@ -198,6 +210,34 @@ healthy.
 
 Without a deploy, `curie cluster message` fails with `no agents are deployed on
 the platform API`.
+
+## Connecting a repo for git-flow deploys
+
+Beyond `curie cluster deploy`, a bundle can also deploy automatically on every
+`git push`. Three things need to be true for a push to actually promote:
+
+1. **The agent's repo is set.** The webhook resolves which agent a push
+   belongs to by matching the payload's `repo.full_name` (owner/name) against
+   that agent's `repo_full_name`, set when the agent is created (console or
+   API) -- `curie cluster deploy` only pushes a bundle to an agent that
+   already exists, it does not set this field.
+2. **GitHub can reach the API.** Add a webhook, in the repo's GitHub settings,
+   to `<your-api-url>/github/webhook`. This requires the cluster's API to be
+   reachable from GitHub's servers (an ingress, a load balancer, or a tunnel);
+   how you expose it is an infrastructure decision this chart does not make
+   for you.
+3. **The webhook secret matches.** GitHub signs each delivery
+   (`x-hub-signature-256`), verified against the chart-managed
+   `githubWebhookSecret`. Retrieve the generated value from the same Secret
+   `cluster deploy` reads its API key from:
+   ```bash
+   kubectl get secret <release>-secrets -o jsonpath='{.data.githubWebhookSecret}' | base64 -d
+   ```
+   and paste it into the webhook's secret field.
+
+Once wired, a push to the agent's dev branch builds and deploys under its dev
+bot identity; a push or merge to its prod branch promotes that same built
+artifact without rebuilding.
 
 ## Driving a deployed cluster with zero Slack
 


### PR DESCRIPTION
## Summary

Applies the findings from the readability audit in #993 to README.md:

- Consolidated three near-verbatim restatements of the "same immutable bundle / runner image / frozen ACI contract runs identically across tiers" invariant into one canonical statement, with later mentions shortened to a half-sentence callback.
- Split long run-on sentences (18 total, previously >30 words) by converting enumerations into bullets and separating clauses joined by "so"/";"/em-dash.
- Expanded MCP on first use ("MCP, the Model Context Protocol"); gave ACI a short parenthetical gloss without duplicating the full definition, since ARCHITECTURE.md owns that (see #1000).
- Converted dense Q&A-header prose paragraphs to bulleted lists where they enumerated steps or options.

No technical claims, commands, flags, or links were changed — this is a structural/prose pass only.

Closes #1002

## Test plan

- [x] `git diff` reviewed manually: every markdown link and code span preserved
- [ ] Doc-lint / CI checks pass