### PR TITLE
Import-linter follow-ups: gate the frozen packages, fix the verify list and a count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ uv sync                 # once, and after any dependency change
 uv run pytest -q        # all workspace tests
 uv run ruff check .     # lint (auto-fix: uv run ruff check --fix .)
 uv run mypy             # type-check (strict; targets the src dirs)
+uv run lint-imports     # import boundaries (harness SDK containment, #950/#961)
 ```
 
 **Rust CLI:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
 [tool.importlinter]
 # ADR-0062 (#844 Phase 2): harness conformance gets teeth. The full contract that
 # ADR-0062 asks for -- no `claude_agent_sdk` import ANYWHERE outside the Claude
-# harness package -- cannot pass yet: ten `curie_runner` modules still import the
+# harness package -- cannot pass yet: nine `curie_runner` modules still import the
 # SDK directly (adapter, approval, check, fake, hooks, plugin, session, state,
 # translate), and confining them is Phase 2's refactor. These two contracts gate
 # the boundaries that are ALREADY clean, so they cannot rot back before that
@@ -69,6 +69,12 @@ root_packages = [
     "curie_worker",
     "curie_dispatcher",
     "curie_runner",
+    # The frozen contract packages (#961). Outside the graph, no contract could
+    # ever fire on them, which left the worst possible place for an SDK import
+    # ungated. Clean today; the contract below keeps them that way.
+    "aci_protocol",
+    "channel_protocol",
+    "plugin_format",
 ]
 # Required for the contracts below: `claude_agent_sdk` is an EXTERNAL package, and
 # import-linter only tracks imports that leave the root packages when told to.
@@ -81,6 +87,18 @@ include_external_packages = true
 name = "The platform never imports a harness SDK"
 type = "forbidden"
 source_modules = ["curie_api", "curie_worker", "curie_dispatcher"]
+forbidden_modules = ["claude_agent_sdk"]
+
+[[tool.importlinter.contracts]]
+# The frozen tri-language contracts (ADR-0005/0017/0036) are generated from
+# Pydantic models and consumed by Python, Rust and TypeScript. A vendor SDK
+# import here would bind the wire itself to one harness -- the single worst place
+# for one, and ADR-0031's whole premise. Gated separately from the platform
+# contract so the failure message says which invariant broke (#961, following
+# #950).
+name = "The frozen contract packages never import a harness SDK"
+type = "forbidden"
+source_modules = ["aci_protocol", "channel_protocol", "plugin_format"]
 forbidden_modules = ["claude_agent_sdk"]
 
 [[tool.importlinter.contracts]]


### PR DESCRIPTION
Closes #961. Three follow-ups from the post-merge review of #950 (my PR), all verified against the tree rather than taken on faith.

## 1. The frozen contract packages were outside the graph entirely
`aci_protocol`, `channel_protocol` and `plugin_format` were not `root_packages`, so **no contract could ever fire on them** — the worst possible place for a vendor SDK import was the one place that was ungated.

They're root packages now, with their **own** contract rather than an extension of the platform one, so a violation names the invariant that actually broke: the frozen tri-language wire (ADR-0005/0017/0036, and ADR-0031's whole premise) must not bind to a single harness.

That separation earns its keep in the probe below: an SDK import in `aci_protocol` trips **both** contracts (the platform imports the frozen packages, so it's a transitive violation there too) — but only the dedicated contract points at the frozen package as the *source* instead of blaming a downstream app.

## 2. AGENTS.md's "CI runs the same commands" was false
#950 added the import check inside the `Python (ruff + mypy + pytest)` job — a **required** check, also named in `release/authorize.py`'s `REQUIRED_CHECK_NAMES` — while AGENTS.md still listed only four commands. A contributor running exactly the documented four could red a required check with nothing local having surfaced it.

`uv run lint-imports` is now listed, as a raw command matching the `ruff`/`mypy` precedent rather than adding a `curie dev` wrapper. (The issue noted precedent cuts both ways; I took the lighter option since this is a single command with no repo-root discovery to hide.)

## 3. My comment said "ten" and listed nine
The tree has **nine** modules importing the SDK, and `docs/interfaces/harness-modelsession/INTERFACE.md` already said nine. My #950 comment said ten. Fixed.

## Verification
- With the frozen packages in the graph: **3 kept, 0 broken**.
- Appending `import claude_agent_sdk` to `packages/aci-protocol/src/aci_protocol/conformance.py` **breaks the new contract**; restoring returns to 3 kept, 0 broken. (Probe asserts the edit landed before trusting the result.)
- `scripts/check-docs.sh` clean.

## Known gap left open (deliberately)
#961 also notes that #952's gate verifies the harness doc's **count** but not the **nine names** beside it, so a rename or a swap keeps the count right and the list wrong. That's outside this issue's acceptance criteria, so I'm filing it as its own issue rather than letting it disappear when #961 closes.
