### PR TITLE
Install Node from the official image instead of the NodeSource apt repo

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -12,12 +12,27 @@
 # call), which is how the container smoke round-trips without a credential.
 # Python 3.13 is required by the frozen workspace packages; Node 22 is required
 # by the Claude Code CLI the SDK spawns. Base on python:3.13 and add Node.
+# Node comes from the official image rather than NodeSource's apt repo. That
+# repo's setup script (`deb.nodesource.com/setup_22.x`) started returning 403 to
+# everyone on 2026-07-27, which broke every runner-image build repo-wide: curl
+# failed, nodejs never installed, and the next line died with `npm: not found`.
+# Copying from the official image removes the third-party apt repo from the build
+# path entirely, pins the version by tag, and is architecture-correct by
+# construction (Docker resolves the matching platform, so an arm64 dev box and an
+# amd64 CI runner both work -- a hardcoded tarball URL would not).
+FROM node:22-bookworm-slim AS node
+
 FROM python:3.13-slim-bookworm
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
+# Only the Node bits, never all of /usr/local: the python base keeps its own
+# interpreter there, so a blanket copy would clobber it.
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # The Claude Code CLI the SDK spawns for a real (non-fake) session.


### PR DESCRIPTION
**Unblocks all CI.** `main` is currently red and every open PR fails the same two jobs.

## What broke
NodeSource's setup script (`deb.nodesource.com/setup_22.x`) began returning **403** on 2026-07-27. The runner image installs Node through it, so:

```
curl: (22) The requested URL returned error: 403
/bin/sh: 1: npm: not found
npm install -g @anthropic-ai/claude-code → exit 127
```

Blast radius: `Build runner image (no push)` and `Eval falsifiability gate` on **every** build. `main` was green at 22:26 and red at 22:46; PRs #1006, #1014, #1017, #1018 all fail identically.

**Not transient and not runner-IP rate limiting:** a re-run failed the same way, and the endpoint 403s from a developer machine too (`nodejs.org` returns 200). The dependency is simply gone.

## Fix
Copy Node from the official `node:22-bookworm-slim` image:

- removes the third-party apt repo from the build path, so the image no longer depends on an endpoint outside our control at build time;
- pins the version by tag instead of a setup script resolving whatever is current;
- **architecture-correct by construction** — Docker resolves the matching platform, so the amd64 CI runner and an arm64 dev box both work, where a hardcoded tarball URL would break one of them;
- copies **only the Node bits, never all of `/usr/local`** — the python base keeps its interpreter there and a blanket copy would clobber it.

`curl`/`ca-certificates` stay (other layers use them); `gnupg` was only there for the NodeSource signing key and is dropped.

## Verified by running it, not by exit 0
Built locally and exercised the image:

| check | result |
|---|---|
| `node -v` | v22.23.1 |
| `npm -v` | 10.9.8 |
| `python -V` | 3.13.14 (base intact) |
| `claude` | `/usr/local/bin/claude` |
| `mcp-server-github` | `/usr/local/bin/mcp-server-github` |
| `import curie_runner` | ok from the venv |

Closes the outage tracked in the issue filed alongside this PR.
